### PR TITLE
fix: exclude legacy experiment colums from non-snapshot dataset views …

### DIFF
--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -2043,7 +2043,14 @@ class GetDatasetTableView(APIView):
             # the dataset; use column_order only for sorting.
             column_order = dataset.column_order or []
             column_order_set = set(column_order)
-            all_columns = list(Column.objects.filter(dataset=dataset, deleted=False))
+            qs = Column.objects.filter(dataset=dataset, deleted=False)
+            if dataset.source != DatasetSourceChoices.EXPERIMENT_SNAPSHOT.value:
+                qs = qs.exclude(source__in=[
+                    SourceChoices.EXPERIMENT.value,
+                    SourceChoices.EXPERIMENT_EVALUATION.value,
+                    SourceChoices.EXPERIMENT_EVALUATION_TAGS.value,
+                ])
+            all_columns = list(qs)
             columns_map = {str(col.id): col for col in all_columns}
 
             # Names of EVALUATION_REASON columns in this dataset. Reason columns
@@ -2683,7 +2690,14 @@ class GetRowDataView(APIView):
             error_messages = []
             cells = Cell.objects.filter(row__in=rows, deleted=False)
             column_order = dataset.column_order or []
-            all_columns = list(Column.objects.filter(dataset=dataset, deleted=False))
+            qs = Column.objects.filter(dataset=dataset, deleted=False)
+            if dataset.source != DatasetSourceChoices.EXPERIMENT_SNAPSHOT.value:
+                qs = qs.exclude(source__in=[
+                    SourceChoices.EXPERIMENT.value,
+                    SourceChoices.EXPERIMENT_EVALUATION.value,
+                    SourceChoices.EXPERIMENT_EVALUATION_TAGS.value,
+                ])
+            all_columns = list(qs)
             columns_map = {str(col.id): col for col in all_columns}
 
             # Apply filters if any
@@ -6065,6 +6079,11 @@ class DownloadDatasetView(APIView):
             dataset = get_object_or_404(Dataset, id=dataset_id)
 
             # Get all columns in the correct order
+            _exp_sources = [
+                SourceChoices.EXPERIMENT.value,
+                SourceChoices.EXPERIMENT_EVALUATION.value,
+                SourceChoices.EXPERIMENT_EVALUATION_TAGS.value,
+            ]
             column_order = dataset.column_order or []
             if column_order:
                 from django.db.models import Case, IntegerField, Value, When
@@ -6088,6 +6107,8 @@ class DownloadDatasetView(APIView):
                 columns = Column.objects.filter(
                     dataset_id=dataset_id, deleted=False
                 ).order_by("id")
+            if dataset.source != DatasetSourceChoices.EXPERIMENT_SNAPSHOT.value:
+                columns = columns.exclude(source__in=_exp_sources)
 
             # Create DataFrame
             rows = Row.objects.filter(dataset=dataset, deleted=False).order_by("order")
@@ -11447,6 +11468,7 @@ class GetBaseColumnsView(APIView):
 
             # Get all columns per dataset in a single query
             excluded_sources = [
+                SourceChoices.EXPERIMENT.value,
                 SourceChoices.EXPERIMENT_EVALUATION_TAGS.value,
                 SourceChoices.EVALUATION_TAGS.value,
                 SourceChoices.OPTIMISATION_EVALUATION_TAGS.value,


### PR DESCRIPTION
## Summary                           

  Legacy experiment data was causing experiment-related columns (`EXPERIMENT`,                  
  `EXPERIMENT_EVALUATION`, `EXPERIMENT_EVALUATION_TAGS`) to leak into regular dataset views and
  downloads. This patch excludes those columns from all relevant endpoints                      
  (`GetDatasetTableView`, `GetRowDataView`, `DownloadDatasetView`, `GetBaseColumnsView`) unless
  the dataset is an experiment snapshot, where they belong.

  ## Linked issues

  Closes #

  ## Type of change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work  
  as expected)
  - [ ] 📖 Documentation only                                                                   
  - [ ] 🧹 Chore / refactor (no user-visible change)                                          
  - [ ] 🚀 Performance improvement
  - [ ] 🧪 Test-only change                                                                     
   
  ## How was this tested?                                                                       
                                                                                              
  - Verified that regular datasets no longer return experiment-related columns in table view,   
  row data, and download endpoints
  - Verified that experiment snapshot datasets still return experiment columns as expected      
                                                                                                
  ## Screenshots / recordings (if UI)
                                                                                                
  N/A — backend-only change.                                                                  

  ## Checklist

  - [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)                        
  - [ ] I've added tests that prove my fix is effective or that my feature works
  - [x] `make check-all` / `yarn check-all` passes locally                                      
  - [x] I've updated the documentation where relevant                                         
  - [x] No hardcoded secrets, URLs, or PII                                                      
  - [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)