### PR TITLE
feat(gateway/logs): add Request Explorer section with filtering and exporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,14 +95,16 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 
-# ML model weights & caches (never commit — these are multi-GB artifacts)
+# ML model weights & caches (never commit — these are multi-GB artifacts).
+# The weight *files* are caught by extension below; we deliberately do NOT
+# ignore any directory literally named `models/`, because Django apps, Go
+# packages, and frontend pages in this repo use that name for source code.
 *.safetensors
 *.bin
 *.pt
 *.pth
 *.gguf
 *.onnx
-models/
 model_cache/
 embedding_cache/
 checkpoints/

--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,8 @@ dumps/
 *.log
 logs/
 **/logs/
+!frontend/src/**/logs/
+!frontend/src/**/logs/**
 **celerybeat-schedule**
 staticfiles/
 media/

--- a/frontend/src/pages/dashboard/models/ConfigureAddAsNewDatasetModal.jsx
+++ b/frontend/src/pages/dashboard/models/ConfigureAddAsNewDatasetModal.jsx
@@ -1,0 +1,165 @@
+import { LoadingButton } from "@mui/lab";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import PropTypes from "prop-types";
+import React from "react";
+import { useForm } from "react-hook-form";
+import Iconify from "src/components/iconify";
+import { useSnackbar } from "src/components/snackbar";
+import axios, { endpoints } from "src/utils/axios";
+import { useParams, useNavigate } from "react-router-dom";
+import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
+import HelperText from "src/sections/develop-detail/Common/HelperText";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { invalidateDatasetListCache } from "src/utils/cacheUtils";
+import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
+
+const ConfigureAddAsNewDatasetModal = ({ open, onClose }) => {
+  const { enqueueSnackbar } = useSnackbar();
+  const navigate = useNavigate();
+  const { individualExperimentId } = useParams();
+  const queryClient = useQueryClient();
+
+  const { control, handleSubmit, reset, watch } = useForm({
+    defaultValues: {
+      datasetName: "",
+    },
+  });
+
+  const datasetName = watch("datasetName");
+
+  const { mutate: addDatasetMutation, isPending: loading } = useMutation({
+    mutationFn: () =>
+      axios.post(endpoints.develop.addAsNewDataset(individualExperimentId), {
+        name: datasetName,
+      }),
+    onSuccess: () => {
+      trackEvent(Events.ddNewDatasetCreated, {
+        [PropertyName.name]: datasetName,
+      });
+
+      enqueueSnackbar(`Dataset created Successfully`, {
+        variant: "success",
+      });
+
+      // Invalidate dataset list cache to ensure dropdown refreshes
+      invalidateDatasetListCache(queryClient);
+
+      setTimeout(() => {
+        navigate("/dashboard/develop/");
+      }, 200);
+    },
+  });
+
+  const handleSubmitForm = (data) => {
+    addDatasetMutation(data);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} PaperProps={{}} fullWidth>
+      <Box
+        component="form"
+        onSubmit={handleSubmit(handleSubmitForm)}
+        sx={{ padding: 2 }}
+      >
+        <DialogTitle
+          sx={{
+            gap: "2px",
+            display: "flex",
+            flexDirection: "column",
+            padding: 0,
+            margin: 0,
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Typography
+              variant="m2"
+              fontWeight={"fontWeightMedium"}
+              color={"text.primary"}
+            >
+              Add as new dataset
+            </Typography>
+            <IconButton onClick={handleClose}>
+              <Iconify icon="mdi:close" color="text.primary" />
+            </IconButton>
+          </Box>
+          <HelperText text="Save this derived dataset as a new dataset" />
+        </DialogTitle>
+
+        <DialogContent
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            margin: 0,
+            padding: 0,
+          }}
+        >
+          <Box sx={{ paddingTop: 2 }}>
+            <FormTextFieldV2
+              label="Dataset Name"
+              placeholder="Enter dataset name"
+              autoFocus
+              size="small"
+              control={control}
+              fieldName="datasetName"
+              fullWidth
+              required
+            />
+          </Box>
+        </DialogContent>
+
+        <DialogActions sx={{ padding: 0, marginTop: 4 }}>
+          <Button onClick={handleClose} variant="outlined">
+            <Typography
+              variant="s2"
+              fontWeight={"fontWeightSemiBold"}
+              color="text.disabled"
+            >
+              Cancel
+            </Typography>
+          </Button>
+          <LoadingButton
+            type="submit"
+            variant="contained"
+            autoFocus
+            color="primary"
+            sx={{
+              borderRadius: "10px",
+            }}
+            loading={loading} // Pass the loading state to the button
+          >
+            <Typography variant="s2" fontWeight={"fontWeightSemiBold"}>
+              Save
+            </Typography>
+          </LoadingButton>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+};
+
+ConfigureAddAsNewDatasetModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default ConfigureAddAsNewDatasetModal;

--- a/frontend/src/pages/dashboard/models/ConfigureDatasetModal.jsx
+++ b/frontend/src/pages/dashboard/models/ConfigureDatasetModal.jsx
@@ -1,0 +1,53 @@
+import { Box, Button, IconButton, Typography } from "@mui/material";
+import React from "react";
+import { ModalComponent } from "src/components/ModalComponent";
+import PropTypes from "prop-types";
+import Iconify from "src/components/iconify";
+import { useNavigate, useParams } from "react-router";
+
+const ConfigureDatasetModal = ({ open, onClose }) => {
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  return (
+    <ModalComponent open={open} onClose={onClose}>
+      <Box
+        sx={{
+          padding: 3,
+          display: "flex",
+          gap: "12px",
+          flexDirection: "column",
+          position: "relative",
+        }}
+      >
+        <IconButton
+          onClick={() => onClose()}
+          sx={{ position: "absolute", top: "12px", right: "12px" }}
+        >
+          <Iconify icon="mingcute:close-line" />
+        </IconButton>
+        <Typography variant="h5">Configure Dataset</Typography>
+        <Typography
+          variant="body1"
+          color="text.disabled"
+        >{`You haven't configured a dataset`}</Typography>
+        <Box sx={{ display: "flex", justifyContent: "end" }}>
+          <Button
+            startIcon={<Iconify icon="eva:diagonal-arrow-right-up-fill" />}
+            color="primary"
+            onClick={() => navigate(`/dashboard/models/${id}/datasets`)}
+          >
+            Configure Dataset
+          </Button>
+        </Box>
+      </Box>
+    </ModalComponent>
+  );
+};
+
+ConfigureDatasetModal.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+};
+
+export default ConfigureDatasetModal;

--- a/frontend/src/pages/dashboard/models/ConfigureMetricModal.jsx
+++ b/frontend/src/pages/dashboard/models/ConfigureMetricModal.jsx
@@ -1,0 +1,53 @@
+import { Box, Button, IconButton, Typography } from "@mui/material";
+import React from "react";
+import { ModalComponent } from "src/components/ModalComponent";
+import PropTypes from "prop-types";
+import Iconify from "src/components/iconify";
+import { useNavigate, useParams } from "react-router";
+
+const ConfigureMetricModal = ({ open, onClose }) => {
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  return (
+    <ModalComponent open={open} onClose={onClose}>
+      <Box
+        sx={{
+          padding: 3,
+          display: "flex",
+          gap: "12px",
+          flexDirection: "column",
+          position: "relative",
+        }}
+      >
+        <IconButton
+          onClick={() => onClose()}
+          sx={{ position: "absolute", top: "12px", right: "12px" }}
+        >
+          <Iconify icon="mingcute:close-line" />
+        </IconButton>
+        <Typography variant="h5">Define Metric</Typography>
+        <Typography
+          variant="body1"
+          color="text.disabled"
+        >{`You haven't defined a metric`}</Typography>
+        <Box sx={{ display: "flex", justifyContent: "end" }}>
+          <Button
+            startIcon={<Iconify icon="eva:diagonal-arrow-right-up-fill" />}
+            color="primary"
+            onClick={() => navigate(`/dashboard/models/${id}/custom-metrics`)}
+          >
+            Define Metric
+          </Button>
+        </Box>
+      </Box>
+    </ModalComponent>
+  );
+};
+
+ConfigureMetricModal.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+};
+
+export default ConfigureMetricModal;

--- a/frontend/src/pages/dashboard/models/CreateModelModal.jsx
+++ b/frontend/src/pages/dashboard/models/CreateModelModal.jsx
@@ -1,0 +1,115 @@
+import React from "react";
+import PropType from "prop-types";
+import { ModalComponent } from "src/components/ModalComponent";
+import { Box, FormControl, Typography } from "@mui/material";
+import { useForm } from "react-hook-form";
+import { FormSelectField } from "src/components/FormSelectField";
+import { CreateModelFormValidation } from "./validation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+import { LoadingButton } from "@mui/lab";
+import { useSnackbar } from "src/components/snackbar";
+import { useNavigate } from "react-router";
+import { ModelTypeOptions } from "src/utils/constant";
+import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
+
+const CreateModelModal = ({ open, onClose }) => {
+  const { enqueueSnackbar } = useSnackbar();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const { handleSubmit, control, reset } = useForm({
+    resolver: zodResolver(CreateModelFormValidation),
+    defaultValues: {
+      modelName: "",
+      modelTypeId: null,
+    },
+  });
+
+  const closeAndClear = () => {
+    reset();
+    onClose();
+  };
+
+  const { mutate: createModel, isPending } = useMutation({
+    mutationFn: (body) => axios.post(endpoints.model.create, body),
+    onSuccess: (data) => {
+      // trackEvent(Events.createModelComplete, {
+      //   //@ts-ignore
+      //   "Model Name": v?.modelName,
+      //   //@ts-ignore
+      //   "Model Type": ModelTypeOptions.find((o) => o.value === v.modelTypeId)
+      //     ?.label,
+      // });
+      enqueueSnackbar("Model created successfully", {
+        variant: "success",
+      });
+      queryClient.invalidateQueries({ queryKey: ["models"] });
+      closeAndClear();
+      // navigate to dataset tab
+      navigate(`/dashboard/models/${data.data.data.id}/datasets`);
+    },
+  });
+
+  const onSubmit = (formValues) => {
+    createModel(formValues);
+  };
+  return (
+    <ModalComponent open={open} onClose={closeAndClear}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Box
+          sx={{
+            padding: "20px",
+            display: "flex",
+            flexDirection: "column",
+            gap: 3,
+          }}
+        >
+          <Typography variant="h5">New model</Typography>
+          <FormControl fullWidth sx={{ flex: 1 }}>
+            <FormTextFieldV2
+              label="Name of model"
+              control={control}
+              fieldName="modelName"
+              placeholder="legal-docs-query-finetuned"
+              autoFocus
+            />
+          </FormControl>
+          <FormSelectField
+            label="Model type"
+            control={control}
+            fieldName="modelTypeId"
+            options={ModelTypeOptions}
+            placeholder="Generative LLM"
+            MenuProps={{
+              PaperProps: {
+                sx: {
+                  maxHeight: 224,
+                },
+              },
+            }}
+          />
+          <Box sx={{ display: "flex", justifyContent: "end", gap: "12px" }}>
+            <LoadingButton
+              loading={isPending}
+              variant="contained"
+              color="primary"
+              type="submit"
+            >
+              Create Model
+            </LoadingButton>
+            {/* <Button onClick={() => closeAndClear()}>Cancel</Button> */}
+          </Box>
+        </Box>
+      </form>
+    </ModalComponent>
+  );
+};
+
+CreateModelModal.propTypes = {
+  open: PropType.bool,
+  onClose: PropType.func,
+};
+
+export default CreateModelModal;

--- a/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/CreateUpdateCustomMetric.jsx
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/CreateUpdateCustomMetric.jsx
@@ -1,0 +1,401 @@
+import {
+  Box,
+  Button,
+  Drawer,
+  IconButton,
+  InputAdornment,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import React, { useRef, useState } from "react";
+import PropTypes from "prop-types";
+import Iconify from "src/components/iconify/iconify";
+import { DatasetSelector } from "./DatasetSelector";
+import "./CreateUpdateMetric.css";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+import { useForm } from "react-hook-form";
+import { useParams } from "react-router";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CreateMetricFormValidation } from "./validation";
+import LoadingButton from "@mui/lab/LoadingButton";
+import { useSnackbar } from "src/components/snackbar";
+import { useGetMetricOptions } from "../../../../../api/model/metric";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
+import { FormSelectField } from "src/components/FormSelectField";
+import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
+
+export const CreateUpdateCustomMetric = ({ show, onClose, updateData }) => {
+  return (
+    <>
+      <Drawer
+        anchor="right"
+        open={show}
+        onClose={onClose}
+        PaperProps={{
+          sx: {
+            height: "100vh",
+            width: "550px",
+            position: "fixed",
+            zIndex: 9999,
+            borderRadius: "10px",
+            backgroundColor: "background.paper",
+          },
+        }}
+        ModalProps={{
+          BackdropProps: {
+            style: { backgroundColor: "transparent" },
+          },
+        }}
+      >
+        <CustomMetricForm onClose={onClose} updateData={updateData} />
+      </Drawer>
+    </>
+  );
+};
+
+const evaluationTypeOptions = [
+  { label: "Output", value: "EVALUATE_CHAT" },
+  { label: "RAG Context", value: "EVALUATE_CONTEXT" },
+  { label: "RAG Ranking", value: "EVAL_CONTEXT_RANKING" },
+];
+
+const CustomMetricForm = React.forwardRef(({ onClose, updateData }, ref) => {
+  const { id } = useParams();
+  const queryClient = useQueryClient();
+  const { enqueueSnackbar } = useSnackbar();
+  const promptSnapshot = useRef("");
+
+  const mode = updateData ? "update" : "create";
+
+  // const [isTested, setIsTested] = useState(false);
+
+  const [suggestedPrompt, setSuggestedPrompt] = useState(null);
+
+  const { data: datasetOptions } = useGetMetricOptions(id);
+
+  const { mutate: createMetric, isPending: isLoadingCreate } = useMutation({
+    mutationFn: (body) => axios.post(`${endpoints.customMetric.create}`, body),
+    onSuccess: () => {
+      enqueueSnackbar("Custom Metric created successfully", {
+        variant: "success",
+      });
+      onClose();
+      queryClient.invalidateQueries({ queryKey: ["customMetric"] });
+      queryClient.invalidateQueries({ queryKey: ["model", id] });
+      queryClient.invalidateQueries({ queryKey: ["all-custom-metric", id] });
+    },
+    onError: (data) => {
+      if (typeof data?.result === "string") {
+        enqueueSnackbar({
+          message: data?.result,
+          variant: "error",
+          autoHideDuration: 5000,
+        });
+      }
+    },
+  });
+
+  const { mutate: editMetric, isPending: isLoadingEdit } = useMutation({
+    mutationFn: (body) => axios.post(`${endpoints.customMetric.edit}`, body),
+    onSuccess: () => {
+      enqueueSnackbar("Custom Metric Edited successfully", {
+        variant: "success",
+      });
+      onClose();
+      queryClient.invalidateQueries({ queryKey: ["customMetric"] });
+      queryClient.invalidateQueries({
+        queryKey: ["dataset-options", id, updateData.id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["metric-tag-options", id],
+      });
+    },
+  });
+
+  const { handleSubmit, control, watch, setValue, setError } = useForm({
+    resolver: zodResolver(CreateMetricFormValidation),
+    defaultValues: updateData
+      ? updateData
+      : {
+          name: "",
+          datasets: [],
+          metricType: 2,
+          evaluationType: null,
+        },
+  });
+
+  const { mutate: testMetric, isPending: isTesting } = useMutation({
+    mutationFn: (d) => axios.post(endpoints.customMetric.testMetric, d),
+    onSuccess: (data, v) => {
+      setSuggestedPrompt(data?.data?.prompts);
+      promptSnapshot.current = v?.prompt;
+    },
+    onError: (d) => {
+      promptSnapshot.current = null;
+      setError("prompt", { type: "custom", message: d.message });
+    },
+  });
+
+  const prompt = watch("prompt");
+
+  const onSubmit = (formValues) => {
+    if (mode === "create") {
+      createMetric({ ...formValues, modelId: id });
+      // trackEvent(Events.customMetricCreateComplete, trackObject(formValues));
+    } else {
+      editMetric({ ...formValues, id: updateData.id });
+      // trackEvent(Events.customMetricEditComplete, trackObject(formValues));
+    }
+  };
+
+  const testButtonDisabled =
+    !prompt?.length ||
+    (promptSnapshot.current && promptSnapshot.current === prompt);
+
+  const isTested = promptSnapshot.current && promptSnapshot.current === prompt;
+
+  return (
+    <>
+      <form
+        style={{ display: "flex", height: "100%" }}
+        ref={ref}
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <Box
+          sx={{
+            padding: 2,
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            zIndex: 21,
+          }}
+        >
+          <Box>
+            <Typography variant="subtitle1" color="text.disabled">
+              {mode === "create" ? "Create" : "Edit"} Custom Metric
+            </Typography>
+            <IconButton
+              onClick={() => onClose()}
+              sx={{ position: "absolute", top: "12px", right: "12px" }}
+            >
+              <Iconify icon="mingcute:close-line" />
+            </IconButton>
+          </Box>
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+              pt: 2,
+              flex: 1,
+            }}
+          >
+            <FormTextFieldV2
+              label="Name"
+              sx={{
+                "& .MuiInputBase-input": {
+                  // fontSize: "24px",
+                  fontWeight: 700,
+                },
+                "& .MuiInputLabel-root": {
+                  // fontSize: "24px", // Default font size
+                },
+              }}
+              autoFocus
+              placeholder="Untitled"
+              control={control}
+              fieldName="name"
+            />
+            <FormSelectField
+              control={control}
+              fieldName="evaluationType"
+              fullWidth
+              options={evaluationTypeOptions}
+              size="small"
+              label="Evaluation"
+            />
+            <DatasetSelector
+              datasetOptions={datasetOptions}
+              control={control}
+            />
+            {/* <EvaluationSelector control={control} /> */}
+            <Tooltip
+              open={Boolean(suggestedPrompt)}
+              placement="left-start"
+              slotProps={{
+                tooltip: {
+                  style: {
+                    backgroundColor: "var(--bg-paper)",
+                    maxWidth: "500px",
+                  },
+                },
+              }}
+              title={
+                <>
+                  <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+                    <IconButton
+                      onClick={() => setSuggestedPrompt(null)}
+                      size="small"
+                    >
+                      <Iconify icon="mingcute:close-line" width={16} />
+                    </IconButton>
+                  </Box>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 1.5,
+                      alignItems: "flex-end",
+                      paddingY: 1,
+                    }}
+                  >
+                    <TextField
+                      label={
+                        <Box sx={{ display: "flex", alignItems: "center" }}>
+                          <Iconify icon="tabler:bulb" /> Suggested Prompt
+                        </Box>
+                      }
+                      sx={{ width: "300px" }}
+                      multiline
+                      variant="filled"
+                      InputProps={{ readOnly: true }}
+                      value={suggestedPrompt}
+                    />
+                    <Box>
+                      <Button
+                        onClick={() => {
+                          setValue("prompt", suggestedPrompt);
+                          setSuggestedPrompt(false);
+                          promptSnapshot.current = suggestedPrompt;
+                        }}
+                        variant="contained"
+                        color="primary"
+                        size="small"
+                      >
+                        Use This
+                      </Button>
+                    </Box>
+                  </Box>
+                </>
+              }
+              disableFocusListener
+              disableHoverListener
+              disableTouchListener
+            >
+              <Box sx={{ flex: 1 }}>
+                <FormTextFieldV2
+                  control={control}
+                  fieldName="prompt"
+                  label="Define your metric"
+                  placeholder="Define your metric"
+                  fullWidth
+                  variant="filled"
+                  multiline
+                  rows={10}
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <Box
+                          sx={{
+                            backgroundColor: "background.paper",
+                            color: "text.secondary",
+                            fontSize: "0.75rem",
+                            width: "100%",
+                            marginBottom: "100px",
+                            whiteSpace: "normal",
+                            padding: "12px",
+                            borderRadius: "0 0px 8px 8px",
+                          }}
+                        >
+                          <Typography
+                            color="text.disabled"
+                            fontSize={12}
+                            fontWeight={600}
+                          >
+                            Define your metric in Natural Language
+                          </Typography>
+                          <Typography color="text.disabled" fontSize={12}>
+                            Eg:
+                            <br />
+                            1. Create metric to measure hallucination in the
+                            chat
+                            <br />
+                            2. Check if the chatbot can understand different
+                            languages and gives right answers
+                          </Typography>
+                        </Box>
+                      </InputAdornment>
+                    ),
+                  }}
+                  sx={{
+                    "& .MuiFilledInput-input	": {
+                      marginBottom: "100px",
+                    },
+                    "& .MuiFilledInput-root": {
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "stretch",
+                      "&:after, &:before": {
+                        display: "none",
+                      },
+                    },
+                    "& .MuiInputAdornment-root": {
+                      margin: 0,
+                      width: "100%",
+                    },
+                  }}
+                />
+              </Box>
+            </Tooltip>
+
+            <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
+              <LoadingButton
+                loading={isTesting}
+                variant="contained"
+                color="primary"
+                onClick={() => testMetric({ prompt })}
+                disabled={testButtonDisabled}
+                type="button"
+              >
+                Test metric
+              </LoadingButton>
+              <CustomTooltip
+                show={!isTested}
+                title={`Test metric before ${mode === "create" ? "Create" : "Edit"} metric`}
+                placement="top"
+                arrow
+              >
+                <Box>
+                  <LoadingButton
+                    disabled={!isTested}
+                    loading={isLoadingCreate || isLoadingEdit}
+                    variant="contained"
+                    color="primary"
+                    type="submit"
+                  >
+                    {mode === "create" ? "Create" : "Edit"} metric
+                  </LoadingButton>
+                </Box>
+              </CustomTooltip>
+            </Box>
+          </Box>
+        </Box>
+      </form>
+    </>
+  );
+});
+
+CustomMetricForm.propTypes = {
+  onClose: PropTypes.func,
+  updateData: PropTypes.object,
+};
+
+CustomMetricForm.displayName = "CustomMetricForm";
+
+CreateUpdateCustomMetric.propTypes = {
+  show: PropTypes.bool,
+  onClose: PropTypes.func,
+  updateData: PropTypes.object,
+};

--- a/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/CreateUpdateMetric.css
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/CreateUpdateMetric.css
@@ -1,0 +1,24 @@
+.define-metric-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
+}
+
+.define-metric-bottom-toolbar {
+  /* height: 54px; */
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  padding: 0px 4px 4px 4px;
+}
+
+.define-metric-bottom-toolbar-container {
+  width: 100%;
+  height: 100%;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  background-color: var(--bg-paper);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+}

--- a/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/DatasetSelector.jsx
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/DatasetSelector.jsx
@@ -1,0 +1,223 @@
+import {
+  Box,
+  Button,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from "@mui/material";
+import React, { useMemo, useState } from "react";
+import Iconify from "src/components/iconify/iconify";
+import PropTypes from "prop-types";
+import { useController, useFieldArray } from "react-hook-form";
+import { FormHelperText } from "@mui/material";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
+
+export const DatasetSelector = ({ datasetOptions, control }) => {
+  const [selected, setSelected] = useState({
+    selectedEnv: null,
+    selectedVersion: null,
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "datasets",
+  });
+
+  const disableAddDataset = useMemo(() => {
+    let disableAddDataset = false;
+
+    if (selected.selectedEnv && selected.selectedVersion) {
+      if (
+        fields.find(
+          (fld) =>
+            fld.environment === selected.selectedEnv &&
+            fld.modelVersion === selected.selectedVersion,
+        )
+      ) {
+        disableAddDataset = true;
+      }
+    }
+
+    return disableAddDataset;
+  }, [selected, fields]);
+
+  const { fieldState } = useController({
+    name: "datasets",
+    control,
+  });
+
+  const environmentOptions = useMemo(() => {
+    if (!datasetOptions) return [];
+
+    const set = new Set(datasetOptions.map((o) => o.environment));
+
+    return Array.from(set);
+  }, [datasetOptions]);
+
+  const versionOptions = useMemo(() => {
+    if (!datasetOptions) return [];
+    if (selected.selectedEnv) {
+      return datasetOptions.reduce((arr, { environment, version }) => {
+        if (environment === selected.selectedEnv && !arr.includes(version)) {
+          arr.push(version);
+        }
+        return arr;
+      }, []);
+    } else {
+      const set = new Set(datasetOptions.map((o) => o.version));
+      return Array.from(set);
+    }
+  }, [datasetOptions, selected]);
+
+  const setEnv = (e) => {
+    const newEnv = e.target.value;
+    setSelected(() => ({
+      selectedEnv: newEnv,
+      selectedVersion: "",
+    }));
+  };
+
+  const setVersion = (e) => {
+    const newVersion = e.target.value;
+
+    setSelected((ex) => ({
+      ...ex,
+      selectedVersion: newVersion,
+    }));
+  };
+
+  const addButtonActive = selected.selectedEnv && selected.selectedVersion;
+
+  const renderChips = () => {
+    if (!fields?.length) return <></>;
+
+    return (
+      <Box sx={{ display: "flex", gap: "16px", overflowX: "auto" }}>
+        {fields?.map(({ id }, index) => (
+          <ControlledChip
+            key={id}
+            index={index}
+            control={control}
+            remove={remove}
+          />
+        ))}
+      </Box>
+    );
+  };
+
+  const isError = Boolean(fieldState?.error?.message);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: "23px" }}>
+      <Box>
+        <Box sx={{ display: "flex", gap: 2 }}>
+          <Box sx={{ display: "flex", gap: "6px", flex: 1 }}>
+            <FormControl fullWidth size="small">
+              <InputLabel>Environment</InputLabel>
+              <Select
+                value={selected?.selectedEnv}
+                label="Environment"
+                placeholder="Select Environment"
+                onChange={setEnv}
+                MenuProps={{
+                  sx: {
+                    maxHeight: "280px",
+                  },
+                }}
+              >
+                {environmentOptions?.map((val) => (
+                  <MenuItem key={val} value={val}>
+                    {val}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <CustomTooltip
+              show={!selected.selectedEnv}
+              placement="bottom"
+              arrow
+              title="Select an environment first"
+            >
+              <FormControl fullWidth size="small">
+                <InputLabel>Version</InputLabel>
+                <Select
+                  value={selected?.selectedVersion}
+                  label="Version"
+                  onChange={setVersion}
+                  MenuProps={{
+                    sx: {
+                      maxHeight: "280px",
+                    },
+                  }}
+                  disabled={!selected.selectedEnv}
+                >
+                  {versionOptions?.map((ver) => (
+                    <MenuItem key={ver} value={ver}>
+                      {ver}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </CustomTooltip>
+          </Box>
+          <Button
+            variant="contained"
+            color="primary"
+            disabled={!addButtonActive || disableAddDataset}
+            onClick={() => {
+              append({
+                environment: selected.selectedEnv,
+                modelVersion: selected.selectedVersion,
+              });
+              setSelected({
+                selectedEnv: null,
+                selectedVersion: null,
+              });
+            }}
+            sx={{
+              "& .MuiButton-startIcon": {
+                margin: 0,
+              },
+            }}
+            startIcon={<Iconify icon="ic:round-plus" />}
+          ></Button>
+        </Box>
+        {isError && (
+          <FormHelperText error={true}>
+            {fieldState?.error?.message}
+          </FormHelperText>
+        )}
+      </Box>
+      {renderChips()}
+    </Box>
+  );
+};
+
+const ControlledChip = ({ control, index, remove }) => {
+  const { field } = useController({
+    name: `datasets.${index}`,
+    control,
+  });
+
+  return (
+    <Chip
+      color="primary"
+      variant="soft"
+      label={`${field.value.environment} | ${field.value.modelVersion}`}
+      onDelete={() => remove(index)}
+    />
+  );
+};
+
+ControlledChip.propTypes = {
+  control: PropTypes.object,
+  index: PropTypes.number,
+  remove: PropTypes.func,
+};
+
+DatasetSelector.propTypes = {
+  datasetOptions: PropTypes.object,
+  control: PropTypes.object,
+};

--- a/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/EvaluationSelector.jsx
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/EvaluationSelector.jsx
@@ -1,0 +1,63 @@
+import {
+  Box,
+  FormControlLabel,
+  FormGroup,
+  FormHelperText,
+  Radio,
+} from "@mui/material";
+import React from "react";
+import PropTypes from "prop-types";
+import { useController } from "react-hook-form";
+
+const EvaluationSelector = ({ control }) => {
+  const { field, fieldState } = useController({
+    control: control,
+    name: "evaluationType",
+  });
+
+  const isError = !!fieldState.error?.message;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", paddingX: 1 }}>
+      <FormGroup row>
+        <FormControlLabel
+          control={<Radio defaultChecked />}
+          label="Evaluate Output"
+          componentsProps={{ typography: { color: "text.disabled" } }}
+          checked={field.value === "EVALUATE_CHAT"}
+          onChange={(_, c) => field.onChange(c ? "EVALUATE_CHAT" : null)}
+        />
+        <FormControlLabel
+          control={<Radio />}
+          label="Evaluate Rag Context"
+          color="text.disabled"
+          componentsProps={{ typography: { color: "text.disabled" } }}
+          checked={field.value === "EVALUATE_CONTEXT"}
+          onChange={(_, c) => field.onChange(c ? "EVALUATE_CONTEXT" : null)}
+        />
+        {/* <FormControlLabel
+          control={<Radio />}
+          label="Evaluate Prompt Template"
+          color="text.disabled"
+          componentsProps={{ typography: { color: "text.disabled" } }}
+          checked={field.value === "EVALUATE_PROMPT_TEMPLATE"}
+          onChange={(_, c) =>
+            field.onChange(c ? "EVALUATE_PROMPT_TEMPLATE" : null)
+          }
+        /> */}
+        {/* <FormControlLabel  control={<Checkbox />} label="Evaluate context ranking" /> */}
+      </FormGroup>
+      {isError && (
+        <FormHelperText sx={{ marginTop: 0 }} error>
+          {fieldState.error?.message}
+        </FormHelperText>
+      )}
+    </Box>
+  );
+};
+
+EvaluationSelector.propTypes = {
+  control: PropTypes.object,
+};
+
+export default EvaluationSelector;

--- a/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/MetricOptionType.jsx
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/MetricOptionType.jsx
@@ -1,0 +1,50 @@
+import { Box, Button, FormHelperText } from "@mui/material";
+import React from "react";
+import PropTypes from "prop-types";
+import { useController } from "react-hook-form";
+
+export const MetricOptionType = ({ control, fieldName }) => {
+  const {
+    formState,
+    field: { onChange, value },
+  } = useController({ name: fieldName, control });
+  const isError = Boolean(formState.errors?.["datasets"]?.message);
+
+  return (
+    <Box
+      sx={{ backgroundColor: "action.hover" }}
+      className="define-metric-bottom-toolbar"
+    >
+      <Box className="define-metric-bottom-toolbar-container">
+        <Box sx={{ display: "flex", gap: 2 }}>
+          <Button
+            variant="soft"
+            size="small"
+            onClick={() => onChange(1)}
+            color={value === 1 ? "primary" : "inherit"}
+          >
+            Whole conversation
+          </Button>
+          <Button
+            variant="soft"
+            size="small"
+            onClick={() => onChange(2)}
+            color={value === 2 ? "primary" : "inherit"}
+          >
+            Step by step outputs
+          </Button>
+        </Box>
+        {isError && (
+          <FormHelperText error={true}>
+            {formState.errors?.["datasets"]?.message}
+          </FormHelperText>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+MetricOptionType.propTypes = {
+  control: PropTypes.any,
+  fieldName: PropTypes.string.isRequired,
+};

--- a/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/index.js
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/index.js
@@ -1,0 +1,2 @@
+export * from "./CreateUpdateCustomMetric";
+export * from "./DatasetSelector";

--- a/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/validation.js
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CreateUpdateCustomMetric/validation.js
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const CreateMetricFormValidation = z.object({
+  name: z
+    .string({ required_error: "Metric Name is required." })
+    .min(1, "Metric Name is required."),
+  prompt: z
+    .string({ required_error: "Please define a metric." })
+    .min(1, "Please define a metric."),
+  datasets: z
+    .array(
+      z.object({
+        environment: z.string(),
+        modelVersion: z.string(),
+      }),
+      {
+        required_error: "Please select a environment and version.",
+        message: "Please select a environment and version.",
+      },
+    )
+    .min(1, "Please select a environment and version."),
+  metricType: z.union([z.literal(1), z.literal(2)], {
+    message: "Please select model type.",
+    required_error: "Please select model type.",
+  }),
+  evaluationType: z
+    .string({
+      required_error: "Please select a option",
+      invalid_type_error: "Please select a option",
+    })
+    .min(1, "Please select a option"),
+});

--- a/frontend/src/pages/dashboard/models/CustomMetric/CustomMetric.jsx
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CustomMetric.jsx
@@ -1,0 +1,159 @@
+import {
+  Box,
+  Button,
+  CircularProgress,
+  InputAdornment,
+  LinearProgress,
+  TextField,
+} from "@mui/material";
+import React, { useState } from "react";
+import Iconify from "src/components/iconify/iconify";
+import CustomMetricTable from "./CustomMetricTable";
+import { CreateUpdateCustomMetric } from "./CreateUpdateCustomMetric";
+import { useQuery } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+import { useParams } from "react-router-dom";
+import { CustomMetricNoData } from "./CustomMetricNoData";
+import ConfigureDatasetModal from "../ConfigureDatasetModal";
+import { useGetModelDetail } from "src/api/model/model";
+
+const CustomMetric = () => {
+  const { id } = useParams();
+
+  const { data: modelDetails } = useGetModelDetail(id);
+
+  // @ts-ignore
+  const isMetricAdded = modelDetails?.isMetricAdded;
+  // @ts-ignore
+  const isDatasetAdded = modelDetails?.isDatasetAdded;
+
+  const [showCreateMetric, setShowCreateMetric] = useState(
+    isDatasetAdded && !isMetricAdded,
+  );
+  const [updateMetricData, setUpdateMetricData] = useState(null);
+
+  const [isConfigureDatasetOpen, setIsConfigureDatasetOpen] =
+    useState(!isDatasetAdded);
+
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const [paginationModel, setPaginationModel] = useState({
+    page: 0,
+    pageSize: 10,
+  });
+
+  const [sortModel, setSortModel] = useState([
+    {
+      field: "name",
+    },
+  ]);
+
+  const { isLoading, data } = useQuery({
+    queryKey: [
+      "customMetric",
+      paginationModel.page,
+      sortModel?.[0]?.sort,
+      searchQuery,
+      id,
+    ],
+    queryFn: () =>
+      axios.get(`${endpoints.customMetric.list}${id}/`, {
+        params: {
+          page: paginationModel.page + 1,
+          sort_order: sortModel?.[0]?.sort,
+          search_query: searchQuery,
+        },
+      }),
+    select: (d) => d.data,
+  });
+
+  return (
+    <Box sx={{ height: "calc(100vh - 135px)" }}>
+      <Box
+        sx={{
+          padding: 2.5,
+          display: "flex",
+          gap: 2,
+          width: "100%",
+        }}
+      >
+        <TextField
+          value={searchQuery}
+          onChange={(e) => {
+            // trackEvent(Events.customMetricSearch, {
+            //   "Search String": e.target.value,
+            // });
+            setSearchQuery(e.target.value);
+          }}
+          size="small"
+          sx={{ flex: 1 }}
+          placeholder="Search custom metrics"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Iconify
+                  icon="eva:search-fill"
+                  sx={{ color: "primary.main" }}
+                />
+              </InputAdornment>
+            ),
+            endAdornment: isLoading ? (
+              <InputAdornment position="end">
+                <CircularProgress size={20} color="primary" />
+              </InputAdornment>
+            ) : (
+              <></>
+            ),
+          }}
+        />
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => {
+            setShowCreateMetric(true);
+            // trackEvent(Events.customMetricCreateStart);
+          }}
+          id="add-metric-button"
+        >
+          Create custom metric
+        </Button>
+      </Box>
+      <ConfigureDatasetModal
+        open={isConfigureDatasetOpen}
+        onClose={() => setIsConfigureDatasetOpen(false)}
+      />
+      <CreateUpdateCustomMetric
+        show={showCreateMetric}
+        onClose={() => setShowCreateMetric(false)}
+      />
+      <CreateUpdateCustomMetric
+        show={Boolean(updateMetricData)}
+        onClose={() => setUpdateMetricData(null)}
+        updateData={updateMetricData}
+      />
+      {isLoading && <LinearProgress />}
+      {!isLoading && !data?.results?.length && <CustomMetricNoData />}
+      {!isLoading && Boolean(data?.results?.length) && (
+        <CustomMetricTable
+          customMetricData={data}
+          isLoading={isLoading}
+          paginationModel={paginationModel}
+          setPaginationModel={(v) => {
+            // trackEvent(Events.customMetricPaginationClicked, {
+            //   "Current Page Number": paginationModel?.page,
+            //   "New Page Number": v?.page,
+            // });
+            setPaginationModel(v);
+          }}
+          sortModel={sortModel}
+          setSortModel={setSortModel}
+          setUpdateMetricData={setUpdateMetricData}
+        />
+      )}
+    </Box>
+  );
+};
+
+CustomMetric.propTypes = {};
+
+export default CustomMetric;

--- a/frontend/src/pages/dashboard/models/CustomMetric/CustomMetricActionButtons.jsx
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CustomMetricActionButtons.jsx
@@ -1,0 +1,30 @@
+import { Box } from "@mui/material";
+import React from "react";
+import "./customMetric.css";
+import Iconify from "src/components/iconify/iconify";
+import CustomTooltip from "src/components/tooltip";
+import PropTypes from "prop-types";
+
+const CustomMetricActionButtons = ({ onEditClick }) => {
+  return (
+    <Box
+      className="custom-metric-action-cell"
+      sx={{ display: "flex", gap: 2, alignItems: "center" }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <CustomTooltip title="Edit" placement="top" arrow>
+        <Iconify
+          onClick={() => onEditClick()}
+          icon="solar:pen-bold"
+          sx={{ color: "primary.main" }}
+        />
+      </CustomTooltip>
+    </Box>
+  );
+};
+
+CustomMetricActionButtons.propTypes = {
+  onEditClick: PropTypes.func,
+};
+
+export default CustomMetricActionButtons;

--- a/frontend/src/pages/dashboard/models/CustomMetric/CustomMetricNoData.jsx
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CustomMetricNoData.jsx
@@ -1,0 +1,54 @@
+import { Box, Typography, useTheme } from "@mui/material";
+import React, { useEffect } from "react";
+import Xarrow, { useXarrow } from "react-xarrows";
+
+export const CustomMetricNoData = () => {
+  const updateXarrow = useXarrow();
+
+  const theme = useTheme();
+
+  useEffect(() => {
+    updateXarrow();
+  });
+  return (
+    <Box
+      sx={{
+        minHeight: "714px",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        position: "relative",
+      }}
+    >
+      <Box
+        sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+      >
+        <Box
+          component="img"
+          alt="empty content"
+          src={"/assets/icons/components/ic_extra_scroll.svg"}
+          sx={{ width: 1, maxWidth: 160 }}
+        />
+        <Typography
+          variant="subtitle1"
+          sx={{ width: "250px", textAlign: "center" }}
+          id="no-metric-text"
+        >
+          Once you create custom metric you will see it here
+        </Typography>
+        <Xarrow
+          start="no-metric-text"
+          end="add-metric-button"
+          dashness
+          strokeWidth={2}
+          color={theme.palette.primary.main}
+          startAnchor={{ position: "right", offset: { x: -50, y: 14 } }}
+          endAnchor={{ position: "bottom", offset: { x: 0, y: 10 } }}
+          tailShape="circle"
+          showTail
+          headShape="arrow1"
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/src/pages/dashboard/models/CustomMetric/CustomMetricTable.jsx
+++ b/frontend/src/pages/dashboard/models/CustomMetric/CustomMetricTable.jsx
@@ -1,0 +1,135 @@
+import { Box, Button, useTheme } from "@mui/material";
+import { DataGrid } from "@mui/x-data-grid";
+import React from "react";
+import PropTypes from "prop-types";
+import { useNavigate, useParams } from "react-router";
+import Iconify from "src/components/iconify";
+
+const getEvaluationType = (evalRagContext, evalPromptTemplate) => {
+  if (evalRagContext) return "EVALUATE_CONTEXT";
+  if (evalPromptTemplate) return "EVALUATE_PROMPT_TEMPLATE";
+  return "EVALUATE_CHAT";
+};
+
+const columns = ({ setUpdateMetricData }) => {
+  return [
+    { field: "name", headerName: "Metric Name", flex: 1 },
+    {
+      field: "text_prompt",
+      headerName: "Description",
+      flex: 1,
+      sortable: false,
+    },
+    {
+      field: "metric_type",
+      headerName: "Type",
+      flex: 1,
+      sortable: false,
+    },
+    {
+      field: "datasets",
+      headerName: "Datasets",
+      flex: 1,
+      sortable: false,
+    },
+    {
+      headerName: "",
+      sortable: false,
+      renderCell: ({ row }) => (
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          fullWidth
+          startIcon={
+            <Iconify
+              icon="solar:pen-bold"
+              sx={{ color: "common.white" }}
+              width={16}
+            />
+          }
+          onClick={(e) => {
+            e.stopPropagation();
+            // trackEvent(Events.customMetricEditStart);
+            setUpdateMetricData({
+              id: row.id,
+              name: row.name,
+              prompt: row.text_prompt,
+              metricType: row.metric_type === "StepwiseModelInference" ? 2 : 1,
+              datasets: row.raw_datasets,
+              evaluationType: getEvaluationType(
+                row.eval_rag_context,
+                row.eval_prompt_template,
+              ),
+            });
+          }}
+        >
+          Edit
+        </Button>
+      ),
+    },
+  ];
+};
+
+const CustomMetricTable = ({
+  customMetricData,
+  paginationModel,
+  setPaginationModel,
+  isLoading,
+  sortModel,
+  setSortModel,
+  setUpdateMetricData,
+}) => {
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  return (
+    <Box sx={{ width: "100%", height: "calc(100vh - 230px)" }}>
+      <DataGrid
+        rows={customMetricData?.results || []}
+        columns={columns({ setUpdateMetricData })}
+        sx={{
+          "& .MuiDataGrid-row:hover": {
+            cursor: "pointer",
+            backgroundColor: `${theme.palette.primary.main}07`,
+          },
+          height: "100%",
+          "& .MuiDataGrid-columnHeaders": {
+            fontSize: "12px",
+            padding: "8px",
+          },
+          "& .MuiDataGrid-cell": {
+            fontSize: "12px",
+            padding: "8px",
+          },
+        }}
+        rowCount={customMetricData?.count || 0}
+        paginationModel={paginationModel}
+        loading={isLoading}
+        paginationMode="server"
+        onPaginationModelChange={setPaginationModel}
+        disableRowSelectionOnClick
+        disableColumnFilter
+        disableColumnMenu
+        sortModel={sortModel}
+        onSortModelChange={(newSortModel) => setSortModel(newSortModel)}
+        onRowClick={(data) =>
+          navigate(`/dashboard/models/${id}/performance?metricId=${data.id}`)
+        }
+      />
+    </Box>
+  );
+};
+
+CustomMetricTable.propTypes = {
+  customMetricData: PropTypes.object,
+  paginationModel: PropTypes.any,
+  setPaginationModel: PropTypes.any,
+  isLoading: PropTypes.bool,
+  sortModel: PropTypes.object,
+  setSortModel: PropTypes.func,
+  setUpdateMetricData: PropTypes.func,
+};
+
+export default CustomMetricTable;

--- a/frontend/src/pages/dashboard/models/CustomMetric/customMetric.css
+++ b/frontend/src/pages/dashboard/models/CustomMetric/customMetric.css
@@ -1,0 +1,7 @@
+.custom-metric-action-cell{
+  display: none;
+}
+
+.MuiDataGrid-row:hover .custom-metric-action-cell {
+  display: block;
+}

--- a/frontend/src/pages/dashboard/models/DatasetContext.jsx
+++ b/frontend/src/pages/dashboard/models/DatasetContext.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useState } from "react";
+import PropTypes from "prop-types";
+
+export const DatasetContext = React.createContext({
+  datasetSelectMode: false,
+  setDatasetSelectMode: (_opt) => {},
+});
+
+const DatasetContextProvider = ({ children }) => {
+  const [datasetSelectMode, setDatasetSelectMode] = useState(false);
+
+  return (
+    <DatasetContext.Provider
+      value={{ datasetSelectMode, setDatasetSelectMode }}
+    >
+      {children}
+    </DatasetContext.Provider>
+  );
+};
+
+DatasetContextProvider.propTypes = {
+  children: PropTypes.any,
+};
+
+export { DatasetContextProvider };

--- a/frontend/src/pages/dashboard/models/DatasetDetail.jsx
+++ b/frontend/src/pages/dashboard/models/DatasetDetail.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Helmet } from "react-helmet-async";
+import { useParams } from "src/routes/hooks";
+import DatasetDetailView from "src/sections/model/dataset-detail/DatasetDetailView";
+import { DatasetContextProvider } from "./DatasetContext";
+
+const DatasetDetail = () => {
+  const { dataset } = useParams();
+
+  return (
+    <>
+      <Helmet>
+        <title>{dataset}</title>
+      </Helmet>
+      <DatasetContextProvider>
+        <DatasetDetailView />
+      </DatasetContextProvider>
+    </>
+  );
+};
+
+export default DatasetDetail;

--- a/frontend/src/pages/dashboard/models/ModelConfig/ConfigureDefaultDataset.jsx
+++ b/frontend/src/pages/dashboard/models/ModelConfig/ConfigureDefaultDataset.jsx
@@ -1,0 +1,161 @@
+import React, { useMemo } from "react";
+import { ModalComponent } from "src/components/ModalComponent";
+import PropTypes from "prop-types";
+import { Box, Typography } from "@mui/material";
+import { useForm } from "react-hook-form";
+import { FormSelectField } from "src/components/FormSelectField";
+import { useGetMetricOptions } from "../../../../api/model/metric";
+import { useParams } from "react-router";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { ConfigureDefaultDatasetValidation } from "./validation";
+import axios, { endpoints } from "src/utils/axios";
+import { LoadingButton } from "@mui/lab";
+import { useSnackbar } from "src/components/snackbar";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
+
+const ConfigureDefaultDataset = ({ open, onClose, modelDetails }) => {
+  const { id } = useParams();
+  const { baselineModelEnvironment, baselineModelVersion } = modelDetails;
+
+  const { enqueueSnackbar } = useSnackbar();
+  const queryClient = useQueryClient();
+
+  const isDefaultModelConfigured =
+    Boolean(baselineModelEnvironment) && Boolean(baselineModelVersion);
+
+  const { mutate: updateDefaultDataset, isPending } = useMutation({
+    mutationFn: (body) =>
+      axios.post(`${endpoints.model.updateDefaultDataset}${id}/`, body),
+    onSuccess: () => {
+      enqueueSnackbar("Default dataset configured", {
+        variant: "success",
+      });
+      queryClient.invalidateQueries({ queryKey: ["model", id] });
+      onClose();
+      // trackEvent(Events.configConfigureDefaultDatasetComplete, trackObject(v));
+    },
+  });
+
+  const { data: datasetOptions } = useGetMetricOptions(id);
+
+  const { handleSubmit, control, watch, setValue } = useForm({
+    resolver: zodResolver(ConfigureDefaultDatasetValidation),
+    defaultValues: isDefaultModelConfigured
+      ? {
+          environment: baselineModelEnvironment,
+          modelVersion: baselineModelVersion,
+        }
+      : {
+          environment: null,
+          modelVersion: null,
+        },
+  });
+
+  const selectedEnvironment = watch("environment");
+
+  const environmentOptions = useMemo(() => {
+    if (!datasetOptions) return [];
+
+    const set = new Set(datasetOptions.map((o) => o.environment));
+
+    return Array.from(set).map((v) => ({ label: v, value: v }));
+  }, [datasetOptions]);
+
+  const versionOptions = useMemo(() => {
+    if (!datasetOptions) return [];
+    if (selectedEnvironment) {
+      return datasetOptions.reduce((arr, { environment, version }) => {
+        if (environment === selectedEnvironment && !arr.includes(version)) {
+          arr.push({ label: version, value: version });
+        }
+        return arr;
+      }, []);
+    } else {
+      const set = new Set(datasetOptions.map((o) => o.version));
+      return Array.from(set).map((v) => ({ label: v, value: v }));
+    }
+  }, [datasetOptions, selectedEnvironment]);
+
+  const onSubmit = (formValues) => {
+    updateDefaultDataset(formValues);
+  };
+
+  return (
+    <ModalComponent open={open} onClose={onClose}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Box
+          sx={{
+            padding: 3,
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+          }}
+        >
+          <Typography variant="h5">Configure Default Dataset</Typography>
+          <FormSelectField
+            label="Model Environment"
+            control={control}
+            fieldName="environment"
+            options={environmentOptions || []}
+            placeholder="Production"
+            onChange={() => {
+              setValue("modelVersion", "");
+            }}
+            MenuProps={{
+              PaperProps: {
+                sx: {
+                  maxHeight: 224,
+                },
+              },
+            }}
+          />
+          <CustomTooltip
+            show={!selectedEnvironment}
+            placement="bottom"
+            arrow
+            title="Select an environment first"
+          >
+            <Box>
+              <FormSelectField
+                fullWidth
+                label="Model Version"
+                control={control}
+                fieldName="modelVersion"
+                options={versionOptions || []}
+                placeholder="V1.1"
+                MenuProps={{
+                  PaperProps: {
+                    sx: {
+                      maxHeight: 224,
+                    },
+                  },
+                }}
+                disabled={!selectedEnvironment}
+              />
+            </Box>
+          </CustomTooltip>
+
+          <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+            <LoadingButton
+              variant="contained"
+              color="primary"
+              type="submit"
+              loading={isPending}
+            >
+              Update Config
+            </LoadingButton>
+          </Box>
+        </Box>
+      </form>
+    </ModalComponent>
+  );
+};
+
+ConfigureDefaultDataset.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+  modelDetails: PropTypes.object,
+};
+
+export default ConfigureDefaultDataset;

--- a/frontend/src/pages/dashboard/models/ModelConfig/DeleteConfirm.jsx
+++ b/frontend/src/pages/dashboard/models/ModelConfig/DeleteConfirm.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@mui/material";
+import { LoadingButton } from "@mui/lab";
+
+const DeleteConfirm = ({ open, onClose, onDeleteClick, loading }) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Delete Model</DialogTitle>
+      <DialogContent>Are you sure you want to delete this model.</DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <LoadingButton
+          loading={loading}
+          variant="contained"
+          color="error"
+          onClick={() => {
+            onDeleteClick();
+            onClose();
+          }}
+        >
+          Delete
+        </LoadingButton>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+DeleteConfirm.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+  onDeleteClick: PropTypes.func,
+  loading: PropTypes.bool,
+};
+
+export default DeleteConfirm;

--- a/frontend/src/pages/dashboard/models/ModelConfig/ModeConfig.jsx
+++ b/frontend/src/pages/dashboard/models/ModelConfig/ModeConfig.jsx
@@ -1,0 +1,97 @@
+import { Box, Button, Card, Typography } from "@mui/material";
+import React, { useState } from "react";
+import ModelBaselineCard from "./ModelBaselineCard";
+import ModelPerformanceConfigCard from "./ModelPerformanceConfigCard";
+import DeleteConfirm from "./DeleteConfirm";
+import { useMutation } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+import { useParams } from "src/routes/hooks";
+import { useNavigate } from "react-router";
+import { useGetModelDetail } from "src/api/model/model";
+
+const ModeConfig = () => {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const { id } = useParams();
+
+  const { data: modelDetails } = useGetModelDetail(id);
+
+  //@ts-ignore
+  const { defaultMetric, isMetricAdded } = modelDetails;
+
+  const { mutate: onModelDelete, isPending: isDeleting } = useMutation({
+    mutationFn: () => axios.delete(endpoints.model.deleteModel(id)),
+    onSuccess: () => {
+      setDeleteOpen(false);
+      navigate("/dashboard/models");
+      // trackEvent(Events.configDeleteModelComplete);
+    },
+  });
+
+  const navigate = useNavigate();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 3.75,
+        paddingX: "20px",
+        paddingTop: "20px",
+        // paddingX: 3.75,
+        // paddingBottom: 3.75,
+      }}
+    >
+      <ModelBaselineCard modelDetails={modelDetails} />
+      <ModelPerformanceConfigCard
+        isMetricAdded={isMetricAdded}
+        defaultMetricId={defaultMetric}
+      />
+      <Card>
+        <Box
+          sx={{
+            padding: 2.5,
+            display: "flex",
+            justifyContent: "space-between",
+            borderBottom: 1,
+            borderColor: "divider",
+            alignItems: "center",
+          }}
+        >
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            Model Settings
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            p: 2.5,
+          }}
+        >
+          <Typography variant="body2">Delete modal</Typography>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => {
+              setDeleteOpen(true);
+              // trackEvent(Events.configDeleteModelStart);
+            }}
+          >
+            Delete
+          </Button>
+        </Box>
+      </Card>
+      <DeleteConfirm
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onDeleteClick={() => onModelDelete()}
+        loading={isDeleting}
+      />
+    </Box>
+  );
+};
+
+ModeConfig.propTypes = {};
+
+export default ModeConfig;

--- a/frontend/src/pages/dashboard/models/ModelConfig/ModelBaselineCard.jsx
+++ b/frontend/src/pages/dashboard/models/ModelConfig/ModelBaselineCard.jsx
@@ -1,0 +1,89 @@
+import { Box, Button, Card, Typography } from "@mui/material";
+import React, { useState } from "react";
+import CustomTooltip from "src/components/tooltip";
+import PropTypes from "prop-types";
+import ConfigureDefaultDataset from "./ConfigureDefaultDataset";
+
+const ModelBaselineCard = ({ modelDetails }) => {
+  const { isDatasetAdded, baselineModelEnvironment, baselineModelVersion } =
+    modelDetails;
+
+  const [isConfigureModalOpen, setIsConfigureModalOpen] = useState(false);
+
+  const isDefaultModelConfigured =
+    Boolean(baselineModelEnvironment) && Boolean(baselineModelVersion);
+
+  const renderConfigText = () => {
+    if (!isDatasetAdded) return "Add dataset to configure default dataset.";
+
+    if (!isDefaultModelConfigured)
+      return "Your model’s default dataset is not configured.";
+
+    return (
+      <>
+        Your model’s default dataset is{" "}
+        <Typography variant="body2" sx={{ fontWeight: 700 }} component="span">
+          {baselineModelEnvironment} {baselineModelVersion}
+        </Typography>
+      </>
+    );
+  };
+
+  return (
+    <Card>
+      <Box
+        sx={{
+          padding: 2.5,
+          display: "flex",
+          justifyContent: "space-between",
+          borderBottom: 1,
+          borderColor: "divider",
+          alignItems: "center",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            Dataset Config
+          </Typography>
+          {/* <CustomTooltip title="Informative text" placement="top" arrow>
+            <Iconify icon="eva:info-fill" sx={{ color: "divider" }} />
+          </CustomTooltip> */}
+        </Box>
+        <CustomTooltip
+          show={!isDatasetAdded}
+          title="Add dataset to configure default dataset"
+          placement="top"
+          arrow
+        >
+          <Box>
+            <Button
+              color="primary"
+              variant="contained"
+              disabled={!isDatasetAdded}
+              onClick={() => {
+                setIsConfigureModalOpen(true);
+                // trackEvent(Events.configConfigureDefaultDatasetStart);
+              }}
+            >
+              Configure Default Dataset
+            </Button>
+          </Box>
+        </CustomTooltip>
+      </Box>
+      <Typography variant="body2" sx={{ p: 2.5, pt: 2 }}>
+        {renderConfigText()}
+      </Typography>
+      <ConfigureDefaultDataset
+        open={isConfigureModalOpen}
+        onClose={() => setIsConfigureModalOpen(false)}
+        modelDetails={modelDetails}
+      />
+    </Card>
+  );
+};
+
+ModelBaselineCard.propTypes = {
+  modelDetails: PropTypes.object,
+};
+
+export default ModelBaselineCard;

--- a/frontend/src/pages/dashboard/models/ModelConfig/ModelPerformanceConfigCard.jsx
+++ b/frontend/src/pages/dashboard/models/ModelConfig/ModelPerformanceConfigCard.jsx
@@ -1,0 +1,108 @@
+import {
+  Box,
+  Card,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from "@mui/material";
+import React, { useState } from "react";
+import { useGetAllCustomMetrics } from "src/api/model/metric";
+import PropType from "prop-types";
+import { useParams } from "react-router";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+import { useSnackbar } from "src/components/snackbar";
+import LoadingButton from "@mui/lab/LoadingButton";
+import CustomTooltip from "src/components/tooltip";
+
+const ModelPerformanceConfigCard = ({ defaultMetricId, isMetricAdded }) => {
+  const { id } = useParams();
+
+  const { data: allCustomMetrics } = useGetAllCustomMetrics(id);
+
+  const { enqueueSnackbar } = useSnackbar();
+  const queryClient = useQueryClient();
+
+  const { mutate: updateMetricId, isPending } = useMutation({
+    mutationFn: (body) =>
+      axios.post(`${endpoints.model.updateMetric}${id}/`, body),
+    onSuccess: () => {
+      enqueueSnackbar("Default metric updated", { variant: "success" });
+      queryClient.invalidateQueries({ queryKey: ["model", id] });
+      // trackEvent(Events.configConfigureDefaultMetric, trackObject(v));
+    },
+  });
+
+  const [selectedMetricId, setSelectedMetricId] = useState(defaultMetricId);
+  return (
+    <Card>
+      <Box
+        sx={{
+          padding: 2.5,
+          display: "flex",
+          justifyContent: "space-between",
+          borderBottom: 1,
+          borderColor: "divider",
+          alignItems: "center",
+        }}
+      >
+        <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+          Performance Configs
+        </Typography>
+        <LoadingButton
+          color="primary"
+          variant="contained"
+          disabled={selectedMetricId === defaultMetricId}
+          onClick={() => updateMetricId({ metricId: selectedMetricId })}
+          loading={isPending}
+        >
+          Save
+        </LoadingButton>
+      </Box>
+      <Box sx={{ p: 2.5, display: "flex", gap: 3, flexDirection: "column" }}>
+        <Box sx={{ display: "flex", gap: 2, width: "100%" }}>
+          <CustomTooltip
+            show={!isMetricAdded}
+            placement="top"
+            title="Custom Metric is not created"
+            arrow
+            followCursor
+          >
+            <FormControl fullWidth size="small">
+              <InputLabel>Default Metric</InputLabel>
+              <Select
+                disabled={!allCustomMetrics?.length}
+                value={selectedMetricId}
+                onChange={(e) => setSelectedMetricId(e.target.value)}
+                label="Default Metric"
+                sx={{}}
+                MenuProps={{
+                  PaperProps: {
+                    sx: {
+                      maxHeight: 48 * 4.5 + 8, // Example: change this to your desired max height
+                    },
+                  },
+                }}
+              >
+                {allCustomMetrics?.map(({ id, name }) => (
+                  <MenuItem key={id} value={id}>
+                    {name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </CustomTooltip>
+        </Box>
+      </Box>
+    </Card>
+  );
+};
+
+ModelPerformanceConfigCard.propTypes = {
+  defaultMetricId: PropType.string,
+  isMetricAdded: PropType.bool,
+};
+
+export default ModelPerformanceConfigCard;

--- a/frontend/src/pages/dashboard/models/ModelConfig/validation.js
+++ b/frontend/src/pages/dashboard/models/ModelConfig/validation.js
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const ConfigureDefaultDatasetValidation = z.object({
+  environment: z
+    .string({
+      required_error: "Environment is required.",
+      invalid_type_error: "Environment is required.",
+    })
+    .min(1, "Environment is required."),
+  modelVersion: z
+    .string({
+      required_error: "Model Version is required.",
+      invalid_type_error: "Model Version is required.",
+    })
+    .min(1, "Model Version is required."),
+});

--- a/frontend/src/pages/dashboard/models/ModelDetail.jsx
+++ b/frontend/src/pages/dashboard/models/ModelDetail.jsx
@@ -1,0 +1,193 @@
+import { Box, Card, LinearProgress, Tab, Tabs, useTheme } from "@mui/material";
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import { Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
+import { HeaderComponent } from "src/sections/HeaderComponent";
+import { useGetMetricOptions } from "../../../api/model/metric";
+import { DatasetContext } from "./DatasetContext";
+import Label from "src/components/label";
+import { useGetModelDetail } from "src/api/model/model";
+import { useGetOptimization } from "src/api/model/optimize";
+
+function CustomTabPanel(props) {
+  const { children, value, panelValue, loading, ...other } = props;
+
+  return (
+    <div hidden={panelValue !== value} role="tabpanel" {...other}>
+      {loading && <LinearProgress />}
+      {value === panelValue && !loading && <Box>{children}</Box>}
+    </div>
+  );
+}
+
+CustomTabPanel.propTypes = {
+  children: PropTypes.node,
+  panelValue: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  loading: PropTypes.bool,
+};
+
+const allTabs = [
+  "performance",
+  "custom-metrics",
+  "datasets",
+  "optimize",
+  "config",
+  "report",
+];
+
+const ModelDetail = () => {
+  const { pathname } = useLocation();
+
+  const selectedTab = useMemo(() => {
+    return allTabs.reduce((acc, curr) => {
+      if (pathname.includes(curr)) acc = curr;
+      return acc;
+    }, null);
+  }, [pathname]);
+
+  const { id } = useParams();
+
+  const navigate = useNavigate();
+
+  const handleChange = (event, newValue) => {
+    setSelectedOptimization(null);
+    setDatasetSelectMode(false);
+    //@ts-ignore
+    navigate(`/dashboard/models/${id}/${newValue}`);
+  };
+
+  const [, setSelectedOptimization] = useState(null);
+
+  const { state } = useLocation();
+
+  const { isPending: isLoadingDatasetOptions } = useGetMetricOptions(id);
+
+  const {
+    data: modelDetails,
+    isPending: isLoadingModelDetails,
+    error,
+  } = useGetModelDetail(id);
+
+  const optimizationId = useMemo(() => {
+    const paths = pathname.split("/").filter(Boolean);
+
+    if (paths.includes("optimize") && paths.length === 5) {
+      return paths[paths.length - 1];
+    }
+    return null;
+  }, [pathname]);
+
+  const { data: optimizeData, isLoading: isLoadingOptimization } =
+    useGetOptimization(id, optimizationId, {
+      enabled: Boolean(optimizationId),
+    });
+
+  const loadingModelDetails =
+    isLoadingDatasetOptions || isLoadingModelDetails || isLoadingOptimization;
+
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (error) {
+      navigate("/dashboard/models");
+    }
+  }, [error]);
+
+  const links = useMemo(() => {
+    const l = [
+      {
+        name: "Model",
+        href: "/dashboard/models",
+      },
+      {
+        name:
+          state?.model?.userModelId || modelDetails?.userModelId || "New Model",
+        href: `/dashboard/models/${id}/performance`,
+      },
+    ];
+
+    const trailingRoute = pathname.split("/").splice(5);
+
+    const data = optimizeData?.name;
+
+    trailingRoute.forEach((r) => {
+      l.push({
+        name: state?.pathLabel || data || r,
+        href: pathname,
+      });
+    });
+
+    return l;
+  }, [state, modelDetails, id, pathname, optimizeData]);
+
+  const { setDatasetSelectMode } = useContext(DatasetContext);
+
+  function renderOutlet(condition) {
+    if (condition) return <></>;
+
+    return loadingModelDetails ? <LinearProgress /> : <Outlet />;
+  }
+
+  return (
+    <>
+      <HeaderComponent links={links} routeDepth={2} />
+      <Box
+        sx={{
+          paddingX: "20px",
+        }}
+      >
+        <Card
+          sx={{
+            width: "100%",
+            minHeight: selectedTab !== "config" ? "calc(100vh - 90px)" : "",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <Box
+            sx={{ borderBottom: 1, borderColor: "divider", paddingLeft: 2.5 }}
+          >
+            <Tabs
+              value={selectedTab}
+              onChange={handleChange}
+              aria-label="basic tabs example"
+              textColor="primary"
+              TabIndicatorProps={{
+                style: {
+                  backgroundColor: theme.palette.primary.main,
+                },
+              }}
+            >
+              <Tab label="Performance" value="performance" />
+              <Tab label="Custom Metrics" value="custom-metrics" />
+              <Tab
+                label="Datasets"
+                value="datasets"
+                onClick={() => {
+                  navigate(`/dashboard/models/${id}/datasets`);
+                }}
+              />
+              {modelDetails?.modelType === "GenerativeLLM" && (
+                <Tab
+                  label={
+                    <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+                      Optimize<Label color="primary">Alpha</Label>
+                    </Box>
+                  }
+                  value="optimize"
+                />
+              )}
+              <Tab label="Report" value="report" />
+              <Tab label="Config" value="config" />
+            </Tabs>
+          </Box>
+          {renderOutlet(selectedTab == "config")}
+        </Card>
+      </Box>
+      {renderOutlet(selectedTab !== "config")}
+    </>
+  );
+};
+
+export default ModelDetail;

--- a/frontend/src/pages/dashboard/models/Models.jsx
+++ b/frontend/src/pages/dashboard/models/Models.jsx
@@ -1,0 +1,132 @@
+import {
+  Box,
+  Button,
+  Card,
+  CircularProgress,
+  InputAdornment,
+  LinearProgress,
+  TextField,
+} from "@mui/material";
+import React, { useState } from "react";
+import { Helmet } from "react-helmet-async";
+import Iconify from "src/components/iconify";
+import ModelsTable from "./ModelsTable";
+import { HeaderComponent } from "src/sections/HeaderComponent";
+import { useQuery } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+import { ModelsNoData } from "./ModelsNoData";
+import { Xwrapper } from "react-xarrows";
+import CreateModelModal from "./CreateModelModal";
+
+function Models() {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
+  const [paginationModel, setPaginationModel] = useState({
+    page: 0,
+    pageSize: 10,
+  });
+
+  const [sortModel, setSortModel] = useState([
+    {
+      field: "name",
+    },
+  ]);
+
+  const { isLoading, data } = useQuery({
+    queryKey: [
+      "models",
+      paginationModel.page,
+      sortModel?.[0]?.sort,
+      searchQuery,
+    ],
+    queryFn: () =>
+      axios.get(endpoints.model.list, {
+        params: {
+          page: paginationModel.page + 1,
+          sort_order: sortModel?.[0]?.sort,
+          search_query: searchQuery,
+        },
+      }),
+    select: (d) => d.data,
+  });
+
+  return (
+    <>
+      <Helmet>
+        <title>Models</title>
+      </Helmet>
+
+      <HeaderComponent
+        links={[
+          {
+            name: "Model",
+            href: "/",
+          },
+        ]}
+      />
+      <Xwrapper>
+        <Box sx={{ paddingX: "20px" }}>
+          <Card>
+            <Box sx={{ padding: 2.5, display: "flex", gap: 2, width: "100%" }}>
+              <TextField
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                size="small"
+                sx={{ flex: 1 }}
+                placeholder="Search"
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <Iconify
+                        icon="eva:search-fill"
+                        sx={{ color: "primary.main" }}
+                      />
+                    </InputAdornment>
+                  ),
+                  endAdornment: isLoading ? (
+                    <InputAdornment position="end">
+                      <CircularProgress size={20} color="primary" />
+                    </InputAdornment>
+                  ) : (
+                    <></>
+                  ),
+                }}
+              />
+              <Button
+                id="add-models-button"
+                variant="contained"
+                color="primary"
+                onClick={() => {
+                  // trackEvent(Events.createModelStart);
+                  setShowCreateModal(true);
+                }}
+              >
+                Add Model
+              </Button>
+            </Box>
+            {isLoading && <LinearProgress />}
+            {!isLoading && !data?.results?.length && <ModelsNoData />}
+            {!isLoading && Boolean(data?.results?.length) && (
+              <ModelsTable
+                modelData={data}
+                isLoading={isLoading}
+                paginationModel={paginationModel}
+                setPaginationModel={setPaginationModel}
+                sortModel={sortModel}
+                setSortModel={setSortModel}
+              />
+            )}
+          </Card>
+          <CreateModelModal
+            open={showCreateModal}
+            onClose={() => setShowCreateModal(false)}
+          />
+        </Box>
+      </Xwrapper>
+    </>
+  );
+}
+
+export default Models;

--- a/frontend/src/pages/dashboard/models/ModelsNoData.jsx
+++ b/frontend/src/pages/dashboard/models/ModelsNoData.jsx
@@ -1,0 +1,54 @@
+import { Box, Typography, useTheme } from "@mui/material";
+import React, { useEffect } from "react";
+import Xarrow, { useXarrow } from "react-xarrows";
+
+export const ModelsNoData = () => {
+  const updateXarrow = useXarrow();
+
+  const theme = useTheme();
+
+  useEffect(() => {
+    updateXarrow();
+  });
+  return (
+    <Box
+      sx={{
+        minHeight: "714px",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        position: "relative",
+      }}
+    >
+      <Box
+        sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+      >
+        <Box
+          component="img"
+          alt="empty content"
+          src={"/assets/icons/components/ic_extra_scroll.svg"}
+          sx={{ width: 1, maxWidth: 160 }}
+        />
+        <Typography
+          variant="subtitle1"
+          sx={{ width: "250px", textAlign: "center" }}
+          id="no-models-text"
+        >
+          You need to create a Model.
+        </Typography>
+        <Xarrow
+          start="no-models-text"
+          end="add-models-button"
+          dashness
+          strokeWidth={2}
+          color={theme.palette.primary.main}
+          startAnchor={{ position: "right", offset: { x: -22, y: 0 } }}
+          endAnchor={{ position: "bottom", offset: { x: 0, y: 10 } }}
+          tailShape="circle"
+          showTail
+          headShape="arrow1"
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/src/pages/dashboard/models/ModelsTable.jsx
+++ b/frontend/src/pages/dashboard/models/ModelsTable.jsx
@@ -1,0 +1,178 @@
+import React from "react";
+import { DataGrid } from "@mui/x-data-grid";
+import { Box, useTheme } from "@mui/material";
+import Chart from "../../../components/charts/chart";
+import { useNavigate } from "react-router";
+import PropTypes from "prop-types";
+
+const chatOptions = (palette) => ({
+  chart: {
+    zoom: { enabled: false },
+    toolbar: {
+      show: false,
+    },
+    sparkline: {
+      enabled: true,
+    },
+  },
+  tooltip: {
+    enabled: false,
+  },
+  xaxis: {
+    min: 0,
+    axisBorder: {
+      show: false,
+    },
+    axisTicks: {
+      show: false,
+    },
+    labels: {
+      show: false,
+    },
+    floating: true,
+  },
+  yaxis: {
+    min: 0,
+    floating: true,
+    axisBorder: {
+      show: false,
+    },
+    axisTicks: {
+      show: false,
+    },
+    labels: {
+      show: false,
+    },
+  },
+  grid: {
+    show: false,
+  },
+  stroke: {
+    curve: "smooth",
+    width: 1.5,
+    colors: [palette.primary.main],
+  },
+  fill: {
+    type: "gradient",
+    gradient: {
+      shadeIntensity: 1,
+      opacityFrom: 0.7,
+      opacityTo: 0.9,
+      stops: [0, 90, 100],
+      colorStops: [
+        [
+          {
+            offset: 0.6,
+            color: palette.primary.light,
+            opacity: 1,
+          },
+          {
+            offset: 100,
+            color: "common.white",
+            opacity: 1,
+          },
+        ],
+      ],
+    },
+  },
+});
+
+const columns = (palette) => [
+  { field: "user_model_id", headerName: "Name", flex: 1 },
+  {
+    field: "model_type",
+    headerName: "Model Type",
+    flex: 1,
+    sortable: false,
+  },
+  {
+    field: "total_count",
+    headerName: "Volume",
+    flex: 1,
+    sortable: false,
+  },
+  {
+    field: "volume",
+    headerName: "Last 30 day volume",
+    renderCell: ({ value }) => {
+      return (
+        <Chart
+          series={[
+            {
+              name: "area",
+              data: value,
+            },
+          ]}
+          options={chatOptions(palette)}
+          height={68}
+          width="70%"
+          type="area"
+        />
+      );
+    },
+    sortable: false,
+    flex: 1,
+  },
+];
+
+const ModelsTable = ({
+  modelData,
+  paginationModel,
+  setPaginationModel,
+  isLoading,
+  sortModel,
+  setSortModel,
+}) => {
+  const navigate = useNavigate();
+  const theme = useTheme();
+
+  return (
+    <Box sx={{ height: "calc(100vh - 165px)", width: "100%" }}>
+      <DataGrid
+        rows={modelData?.results || []}
+        columns={columns(theme.palette)}
+        sx={{
+          "& .MuiDataGrid-row:hover": {
+            cursor: "pointer",
+            backgroundColor: `${theme.palette.primary.main}07`,
+          },
+          "& .MuiDataGrid-columnHeaders": {
+            fontSize: "12px",
+            padding: "8px",
+          },
+          "& .MuiDataGrid-cell": {
+            fontSize: "12px",
+            padding: "8px",
+          },
+        }}
+        rowCount={modelData?.count || 0}
+        paginationModel={paginationModel}
+        loading={isLoading}
+        paginationMode="server"
+        onPaginationModelChange={setPaginationModel}
+        disableRowSelectionOnClick
+        disableColumnFilter
+        disableColumnMenu
+        getRowHeight={() => 70}
+        onRowClick={({ id, row }) => {
+          navigate(`/dashboard/models/${id}/performance`, {
+            state: { model: row },
+          });
+        }}
+        sortModel={sortModel}
+        onSortModelChange={(newSortModel) => setSortModel(newSortModel)}
+      />
+    </Box>
+  );
+};
+
+ModelsTable.propTypes = {
+  modelData: PropTypes.object,
+  paginationModel: PropTypes.any,
+  setPaginationModel: PropTypes.any,
+  isLoading: PropTypes.bool,
+  sortModel: PropTypes.object,
+  setSortModel: PropTypes.func,
+};
+
+export default ModelsTable;

--- a/frontend/src/pages/dashboard/models/OptimizeDetail.jsx
+++ b/frontend/src/pages/dashboard/models/OptimizeDetail.jsx
@@ -1,0 +1,25 @@
+import { LinearProgress } from "@mui/material";
+import React from "react";
+import { Helmet } from "react-helmet-async";
+import { useParams } from "react-router";
+import { useGetOptimization } from "src/api/model/optimize";
+import OptimizeDetailView from "src/sections/model/optimize-detail/OptimizeDetailView";
+
+const OptimizeDetail = () => {
+  const { optimizeId, id } = useParams();
+
+  const { data, isPending } = useGetOptimization(id, optimizeId);
+
+  if (isPending) return <LinearProgress />;
+
+  return (
+    <>
+      <Helmet>
+        <title>{data?.name}</title>
+      </Helmet>
+      <OptimizeDetailView selectedOptimization={data} />
+    </>
+  );
+};
+
+export default OptimizeDetail;

--- a/frontend/src/pages/dashboard/models/Performance/AllTagsGraph.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/AllTagsGraph.jsx
@@ -1,0 +1,108 @@
+import { Box, useTheme } from "@mui/material";
+import _ from "lodash";
+import PropTypes from "prop-types";
+import React, { useEffect, useRef, useState } from "react";
+import ReactApexChart from "react-apexcharts";
+
+const AllTagsGraph = ({ data }) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+  const [chartWidth, setChartWidth] = useState(0);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target === containerRef.current) {
+          setChartWidth(entry.contentRect.width);
+        }
+      }
+    });
+
+    setChartWidth(containerRef.current.offsetWidth);
+
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
+
+    return () => {
+      if (containerRef.current) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        resizeObserver.unobserve(containerRef.current);
+      }
+    };
+  }, []);
+
+  const series = Object.entries(data).map(([name, graphData]) => ({
+    type: "line",
+    data: graphData,
+    color:
+      name === "good" ? theme.palette.success.light : theme.palette.error.light,
+    name: _.capitalize(name),
+  }));
+
+  const chartOptions = {
+    xaxis: {
+      type: "datetime",
+    },
+    yaxis: {
+      min: 0,
+      labels: {
+        formatter: (value) => Math.round(value),
+      },
+    },
+    legend: {
+      show: true,
+      position: "top",
+      horizontalAlign: "right",
+      offsetY: 20,
+    },
+    stroke: {
+      width: 3,
+      curve: "smooth", // This will make the line smooth
+    },
+    chart: {
+      background: "transparent",
+      foreColor: isDark ? "#a1a1aa" : undefined,
+      toolbar: {
+        show: true,
+        tools: {
+          download: false,
+          selection: false,
+          zoom: false,
+          zoomin: false,
+          zoomout: false,
+          pan: false,
+          reset: true,
+        },
+      },
+    },
+    theme: {
+      mode: isDark ? "dark" : "light",
+    },
+    tooltip: {
+      theme: isDark ? "dark" : "light",
+    },
+    grid: {
+      borderColor: isDark ? "#27272a" : undefined,
+    },
+  };
+
+  return (
+    <Box ref={containerRef} sx={{ width: "100%" }}>
+      <ReactApexChart
+        options={chartOptions}
+        series={series}
+        type="line"
+        width={chartWidth}
+        height={240}
+      />
+    </Box>
+  );
+};
+
+AllTagsGraph.propTypes = {
+  data: PropTypes.object,
+};
+
+export default AllTagsGraph;

--- a/frontend/src/pages/dashboard/models/Performance/ChatEvalRow.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/ChatEvalRow.jsx
@@ -1,0 +1,99 @@
+import { TableCell, TableRow, useTheme } from "@mui/material";
+import React from "react";
+import { interpolateColorBasedOnScore } from "src/utils/utils";
+import PerformanceTableInfo from "./PerformanceTableInfo";
+import PerformanceTableCell from "./PerformanceTableCell";
+import { format } from "date-fns";
+import PropTypes from "prop-types";
+import ModelInputOutputCell from "src/sections/model/ModelInputOutputCell";
+
+const ChatEvalRow = ({
+  row,
+  isProcessing,
+  setPerformanceDetail,
+  setSelectedTags,
+  setSelectedImages,
+}) => {
+  const theme = useTheme();
+
+  const onImageClick = (curUrl) => {
+    const images = [];
+    let defaultIdx = 0;
+    row.modelInput
+      ?.filter((o) => o["url"] !== undefined)
+      ?.forEach((url) => {
+        if (curUrl === url.url) defaultIdx = images.length;
+        images.push({ src: url.url });
+      });
+    row.modelOutput
+      ?.filter((o) => o["url"] !== undefined)
+      ?.forEach((url) => {
+        if (curUrl === url.url) defaultIdx = images.length;
+        images.push({ src: url.url });
+      });
+    setSelectedImages({ images, defaultIdx });
+  };
+
+  return (
+    <TableRow
+      hover
+      sx={{
+        "&:hover": {
+          cursor: "pointer",
+          backgroundColor: `${theme.palette.primary.main}`,
+        },
+      }}
+      onClick={() => {
+        if (isProcessing) return;
+        setPerformanceDetail(row);
+      }}
+    >
+      <TableCell
+        sx={{
+          padding: 0,
+          position: "relative",
+          width: "10px",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            width: "6px",
+            display: "inline-block",
+            backgroundColor: isProcessing
+              ? "white"
+              : interpolateColorBasedOnScore(row.score),
+          }}
+        />
+      </TableCell>
+      <ModelInputOutputCell
+        content={row.modelInput}
+        contentType={row.modelInputType}
+        onImageClick={onImageClick}
+      />
+
+      <ModelInputOutputCell
+        content={row.modelOutput}
+        contentType={row.modelOutputType}
+        onImageClick={onImageClick}
+      />
+
+      <PerformanceTableInfo row={row} setSelectedTags={setSelectedTags} />
+      <PerformanceTableCell sx={{ minWidth: 60 }}>
+        {format(new Date(row.date), "dd/MM/yyyy")}
+      </PerformanceTableCell>
+    </TableRow>
+  );
+};
+
+ChatEvalRow.propTypes = {
+  row: PropTypes.object,
+  isProcessing: PropTypes.bool,
+  setPerformanceDetail: PropTypes.func,
+  setSelectedTags: PropTypes.func,
+  setSelectedImages: PropTypes.func,
+};
+
+export default ChatEvalRow;

--- a/frontend/src/pages/dashboard/models/Performance/ContextEvalRow.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/ContextEvalRow.jsx
@@ -1,0 +1,96 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { TableCell, TableRow, useTheme } from "@mui/material";
+import PerformanceTableInfo from "./PerformanceTableInfo";
+import PerformanceTableCell from "./PerformanceTableCell";
+import { format } from "date-fns";
+import { interpolateColorBasedOnScore } from "src/utils/utils";
+import TruncatedText from "src/components/truncate-string/TruncateString";
+import ModelInputOutputCell from "src/sections/model/ModelInputOutputCell";
+
+const ContextEvalRow = ({
+  row,
+  isProcessing,
+  setPerformanceDetail,
+  setSelectedTags,
+  setSelectedImages,
+}) => {
+  const theme = useTheme();
+  const onImageClick = (curUrl) => {
+    const images = [];
+    let defaultIdx = 0;
+    row.modelInput
+      ?.filter((o) => o["url"] !== undefined)
+      ?.forEach((url) => {
+        if (curUrl === url.url) defaultIdx = images.length;
+        images.push({ src: url.url });
+      });
+    row.modelOutput
+      ?.filter((o) => o["url"] !== undefined)
+      ?.forEach((url) => {
+        if (curUrl === url.url) defaultIdx = images.length;
+        images.push({ src: url.url });
+      });
+    setSelectedImages({ images, defaultIdx });
+  };
+
+  return (
+    <TableRow
+      hover
+      key={row.id}
+      sx={{
+        "&:hover": {
+          cursor: "pointer",
+          backgroundColor: `${theme.palette.primary.main}`,
+        },
+      }}
+      onClick={() => {
+        if (isProcessing) return;
+        setPerformanceDetail(row);
+      }}
+    >
+      <TableCell
+        sx={{
+          padding: 0,
+          position: "relative",
+          width: "10px",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            width: "6px",
+            display: "inline-block",
+            backgroundColor: isProcessing
+              ? "white"
+              : interpolateColorBasedOnScore(row.score),
+          }}
+        />
+      </TableCell>
+      <ModelInputOutputCell
+        content={row.modelInput}
+        contentType={row.modelInputType}
+        onImageClick={onImageClick}
+      />
+      <PerformanceTableCell sx={{ minWidth: "250px" }}>
+        <TruncatedText maxLines={3}>{row?.context}</TruncatedText>
+      </PerformanceTableCell>
+      <PerformanceTableInfo row={row} setSelectedTags={setSelectedTags} />
+      <PerformanceTableCell sx={{ minWidth: 60 }}>
+        {format(new Date(row.date), "dd/MM/yyyy")}
+      </PerformanceTableCell>
+    </TableRow>
+  );
+};
+
+ContextEvalRow.propTypes = {
+  row: PropTypes.object,
+  isProcessing: PropTypes.bool,
+  setPerformanceDetail: PropTypes.func,
+  setSelectedTags: PropTypes.func,
+  setSelectedImages: PropTypes.func,
+};
+
+export default ContextEvalRow;

--- a/frontend/src/pages/dashboard/models/Performance/EvaluationDatePicker.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/EvaluationDatePicker.jsx
@@ -1,0 +1,246 @@
+import { Box, Button, Popover, useTheme } from "@mui/material";
+import React, { useState } from "react";
+import PropType from "prop-types";
+import { DateField } from "@mui/x-date-pickers";
+import {
+  PickersDay,
+  LocalizationProvider,
+  DateCalendar,
+} from "@mui/x-date-pickers";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { format, isValid, addMonths, isSameDay } from "date-fns";
+
+const formatDate = (date) => format(date, "yyyy-MM-dd HH:mm:ss");
+
+const EvaluationDatePicker = ({
+  open,
+  onClose,
+  anchorEl,
+  setDateFilter,
+  setDateOption,
+}) => {
+  const [focusedElement, setFocusedElement] = useState("start");
+  const [internalStartDate, setInternalStartDate] = useState(null);
+  const [internalEndDate, setInternalEndDate] = useState(null);
+
+  // For the two calendars, we use current month and next month
+  const [leftMonth, setLeftMonth] = useState(new Date());
+  const rightMonth = addMonths(leftMonth, 1);
+
+  const handleMonthChange = (newMonth) => {
+    setLeftMonth(newMonth);
+  };
+  const theme = useTheme();
+
+  const isButtonActive = isValid(internalStartDate) && isValid(internalEndDate);
+
+  // Custom day renderer to highlight selected dates
+  const renderDay = (date, selectedDates, pickersDayProps) => {
+    const isSelected =
+      (internalStartDate && isSameDay(date, internalStartDate)) ||
+      (internalEndDate && isSameDay(date, internalEndDate));
+
+    const isHighlighted =
+      internalStartDate &&
+      internalEndDate &&
+      date > internalStartDate &&
+      date < internalEndDate;
+
+    return (
+      <PickersDay
+        {...pickersDayProps}
+        selected={isSelected}
+        sx={{
+          ...(isHighlighted && {
+            backgroundColor: "rgba(25, 118, 210, 0.1)",
+            "&:hover": {
+              backgroundColor: "rgba(25, 118, 210, 0.2)",
+            },
+          }),
+          ...(isSelected && {
+            backgroundColor: "primary.main",
+            color: "common.white",
+            "&:hover": {
+              backgroundColor: "primary.dark",
+            },
+          }),
+        }}
+      />
+    );
+  };
+
+  // Handle date selection for either calendar
+  const handleDateSelection = (newDate) => {
+    if (focusedElement === "start" || !internalStartDate) {
+      setInternalStartDate(newDate);
+      setFocusedElement("end");
+    } else if (focusedElement === "end") {
+      // If the selected end date is before start date, swap them
+      if (newDate < internalStartDate) {
+        setInternalEndDate(internalStartDate);
+        setInternalStartDate(newDate);
+      } else {
+        setInternalEndDate(newDate);
+      }
+    }
+  };
+
+  return (
+    <Popover
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+      transformOrigin={{
+        vertical: "top",
+        horizontal: "left",
+      }}
+      anchorEl={anchorEl}
+      open={open}
+      onClose={onClose}
+    >
+      <Box
+        sx={{
+          padding: "16px",
+          width: "680px",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Date input fields */}
+        <Box sx={{ display: "flex", gap: "12px", marginBottom: "16px" }}>
+          <DateField
+            fullWidth
+            label="Start date"
+            onFocus={() => setFocusedElement("start")}
+            focused={focusedElement === "start"}
+            value={internalStartDate}
+            onChange={(newValue) => setInternalStartDate(newValue)}
+            format="dd-MM-yyyy"
+          />
+          <DateField
+            fullWidth
+            label="End date"
+            onFocus={() => setFocusedElement("end")}
+            focused={focusedElement === "end"}
+            value={internalEndDate}
+            onChange={(newValue) => setInternalEndDate(newValue)}
+            format="dd-MM-yyyy"
+          />
+        </Box>
+
+        {/* Dual calendars */}
+        <Box
+          sx={{
+            display: "flex",
+            borderTop: "1px solid var(--border-default)",
+            paddingTop: "8px",
+          }}
+        >
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <Box
+              sx={{
+                display: "flex",
+                width: "100%",
+                justifyContent: "space-between",
+                position: "relative",
+              }}
+            >
+              {/* Left calendar */}
+              <Box
+                sx={{
+                  flexBasis: "50%",
+                  borderRight: "1px dotted var(--border-default)",
+                  paddingRight: "8px",
+                }}
+              >
+                <DateCalendar
+                  views={["day"]}
+                  openTo="day"
+                  value={internalStartDate}
+                  onChange={handleDateSelection}
+                  renderDay={renderDay}
+                  defaultCalendarMonth={leftMonth}
+                  onMonthChange={handleMonthChange}
+                  sx={{
+                    "& .MuiPickersCalendarHeader-label": {
+                      textAlign: "center",
+                      width: "100%",
+                    },
+                  }}
+                />
+              </Box>
+
+              {/* Right calendar */}
+              <Box sx={{ flexBasis: "50%", paddingLeft: "8px" }}>
+                <DateCalendar
+                  views={["day"]}
+                  openTo="day"
+                  value={internalEndDate}
+                  onChange={handleDateSelection}
+                  renderDay={renderDay}
+                  defaultCalendarMonth={rightMonth}
+                  minDate={internalStartDate || undefined}
+                  sx={{
+                    "& .MuiPickersCalendarHeader-label": {
+                      textAlign: "center",
+                      width: "100%",
+                    },
+                  }}
+                />
+              </Box>
+            </Box>
+          </LocalizationProvider>
+        </Box>
+
+        {/* Apply button */}
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "flex-end",
+            width: "100%",
+            marginTop: theme.spacing(2),
+            gap: theme.spacing(1),
+          }}
+        >
+          <Button
+            size="small"
+            variant="outlined"
+            color="inherit"
+            onClick={onClose}
+            sx={{ width: theme.spacing(12), color: "text.disabled" }}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            color="primary"
+            disabled={!isButtonActive}
+            sx={{ width: theme.spacing(12) }}
+            onClick={() => {
+              setDateFilter([
+                formatDate(internalStartDate),
+                formatDate(internalEndDate),
+              ]);
+              setDateOption("Custom");
+              onClose();
+            }}
+          >
+            Apply
+          </Button>
+        </Box>
+      </Box>
+    </Popover>
+  );
+};
+
+EvaluationDatePicker.propTypes = {
+  open: PropType.bool,
+  onClose: PropType.func,
+  anchorEl: PropType.any,
+  setDateFilter: PropType.func,
+  setDateOption: PropType.func,
+};
+
+export default EvaluationDatePicker;

--- a/frontend/src/pages/dashboard/models/Performance/Performance.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/Performance.jsx
@@ -1,0 +1,617 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from "@mui/material";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import PerformanceTable from "./PerformanceTable";
+import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query";
+import { useLocation, useParams } from "react-router";
+import axios, { endpoints } from "src/utils/axios";
+import { useGetAllCustomMetrics } from "../../../../api/model/metric";
+import PerformanceGraph from "./PerformanceGraph";
+import {
+  endOfToday,
+  format,
+  startOfToday,
+  startOfYesterday,
+  startOfTomorrow,
+  sub,
+} from "date-fns";
+import { saveAs } from "file-saver";
+import { useSnackbar } from "src/components/snackbar";
+import PerformanceNoData from "./PerformanceNoData";
+import ConfigureDatasetModal from "../ConfigureDatasetModal";
+import ConfigureMetricModal from "../ConfigureMetricModal";
+import { AggregationOption, DateRangeButtonOptions } from "src/utils/constants";
+import { formatDate } from "src/utils/report-utils";
+import "yet-another-react-lightbox/styles.css";
+import { useGetModelDetail } from "src/api/model/model";
+import PerformanceSidebar from "./PerformanceSidebar/PerformanceSidebar";
+import { getRandomId } from "src/utils/utils";
+import PerformanceDetailSection from "./PerformanceTableHeader";
+import PerformanceTagDistribution from "./PerformanceTagDistribution";
+import PerformanceGraphDatapoints from "./PerformanceGraphDatapoints";
+import SaveReport from "./SaveReport";
+import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
+
+// const formatDate = (date) => format(date, "yyyy-MM-dd HH:mm:ss");
+
+const Performance = () => {
+  const customDatePickerAnc = useRef(null);
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+  const currentSnackbarData = useRef(null);
+
+  const { id } = useParams();
+
+  const { data: modelDetails } = useGetModelDetail(id);
+
+  const { state } = useLocation();
+
+  // @ts-ignore
+  const isMetricAdded = modelDetails?.isMetricAdded;
+  // @ts-ignore
+  const isDatasetAdded = modelDetails?.isDatasetAdded;
+
+  const isNoData = !isMetricAdded || !isDatasetAdded;
+
+  const searchParams = new URLSearchParams(location.search);
+
+  const { data: allCustomMetrics } = useGetAllCustomMetrics(id);
+
+  const [dateFilter, setDateFilter] = useState(() => {
+    if (state?.report?.startDate && state?.report?.endDate) {
+      return [
+        formatDate(new Date(state.report.startDate)),
+        formatDate(new Date(state.report.endDate)),
+      ];
+    }
+    return [
+      formatDate(
+        sub(new Date(), {
+          months: 6,
+        }),
+      ),
+      formatDate(endOfToday()),
+    ];
+  });
+  const [dateOption, setDateOption] = useState("6M");
+
+  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
+
+  const [selectedAggregation, setSelectedAggregation] = useState(() => {
+    if (state?.report?.aggregation) {
+      return state.report.aggregation;
+    }
+    return "daily";
+  });
+
+  const [isConfigureDatasetOpen, setIsConfigureDatasetOpen] =
+    useState(!isDatasetAdded);
+
+  const [selectedDataset, setSelectedDataset] = useState(0);
+
+  const [orderOption, setOrderOption] = useState("latest");
+
+  const [isDefineMetricOpen, setIsDefineMetricOpen] = useState(
+    () => isDatasetAdded && !isMetricAdded,
+  );
+
+  const [isSaveReportOpen, setIsSaveReportOpen] = useState(false);
+
+  const [selectedDatasets, setSelectedDatasets] = useState(() => {
+    if (state?.report) {
+      return state.report.datasets;
+    }
+
+    return [
+      {
+        id: getRandomId(),
+        metricId:
+          searchParams.get("metricId") || modelDetails?.defaultMetricId || "",
+        environment: "",
+        version: "",
+        filters: [],
+      },
+    ];
+  });
+
+  const [selectedFilters, setSelectedFilters] = useState(() => {
+    if (state?.report) {
+      return state.report.filters;
+    }
+    return [];
+  });
+
+  const [selectedBreakdown, setSelectedBreakdown] = useState(() => {
+    if (state?.report) {
+      return state.report.breakdown;
+    }
+    return [];
+  });
+
+  const [selectedDetailTab, setSelectedDetailTab] = useState("data");
+
+  const [selectedTagDistributionType, setSelectedTagDistributionType] =
+    useState("all");
+
+  const filterDatasets = (dataset) => {
+    return (
+      dataset.metricId.length > 0 &&
+      dataset.environment.length > 0 &&
+      dataset.version.length > 0
+    );
+  };
+
+  const filterFilters = (filter) => {
+    return filter.key.length > 0 && filter.values.length > 0;
+  };
+
+  const filterBreakdown = (breakdown) => {
+    return breakdown.key.length > 0 && breakdown.keyId.length > 0;
+  };
+
+  const validatedDatasets = selectedDatasets
+    .filter(filterDatasets)
+    .map((dataset) => ({
+      ...dataset,
+      filters: dataset.filters.filter(filterFilters),
+    }));
+  const validatedFilters = selectedFilters.filter(filterFilters);
+  const validatedBreakdown = selectedBreakdown.filter(filterBreakdown);
+
+  const selectedDatasetObj = validatedDatasets?.[selectedDataset];
+
+  useEffect(() => {
+    if (!selectedDatasets?.[0]?.metricId && allCustomMetrics?.length) {
+      setSelectedDatasets((datasets) =>
+        datasets.map((dataset, idx) => {
+          const obj = { ...dataset };
+          if (idx === 0) {
+            obj.metricId = allCustomMetrics?.[0]?.id;
+          }
+          return obj;
+        }),
+      );
+    }
+  }, [allCustomMetrics]);
+
+  const { data: graphData, isLoading: isLoadingGraphData } = useQuery({
+    queryKey: [
+      "performance",
+      validatedDatasets,
+      validatedFilters,
+      validatedBreakdown,
+      selectedAggregation,
+      dateFilter,
+    ],
+    queryFn: () =>
+      axios.post(`${endpoints.performance.graphData}${id}/`, {
+        startDate: dateFilter[0],
+        endDate: dateFilter[1],
+        aggBy: selectedAggregation,
+        datasets: validatedDatasets,
+        filters: validatedFilters,
+        breakdown: validatedBreakdown,
+      }),
+    select: (d) => d.data,
+    enabled: !isNoData && validatedDatasets.length > 0,
+  });
+
+  const { data: tagDistribution, isLoading: isLoadingTagDistribution } =
+    useQuery({
+      queryKey: [
+        "performance-tag-distribution",
+        validatedDatasets,
+        selectedDatasetObj,
+        selectedAggregation,
+        dateFilter,
+        selectedTagDistributionType,
+      ],
+      queryFn: () => {
+        return axios.post(`${endpoints.performance.getTagDistribution(id)}`, {
+          dataset: selectedDatasetObj,
+          filters: validatedFilters,
+          aggBy: selectedAggregation,
+          startDate: dateFilter[0],
+          endDate: dateFilter[1],
+          graphType: selectedTagDistributionType,
+        });
+      },
+      select: (d) => d.data?.result,
+      enabled:
+        !isNoData &&
+        validatedDatasets.length > 0 &&
+        selectedDetailTab === "tagDistribution",
+    });
+
+  const {
+    data: performanceDetails,
+    fetchNextPage,
+    isLoading,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: [
+      "performance-detail",
+      selectedDatasetObj,
+      validatedFilters,
+      validatedBreakdown,
+      selectedAggregation,
+      dateFilter,
+    ],
+    queryFn: ({ pageParam }) => {
+      return axios.post(`${endpoints.performance.tableData}${id}/`, {
+        startDate: dateFilter[0],
+        endDate: dateFilter[1],
+        aggBy: selectedAggregation,
+        dataset: selectedDatasetObj,
+        filters: validatedFilters,
+        breakdown: validatedBreakdown,
+        page: pageParam ? pageParam : null,
+        orderOption,
+        limit: 15,
+      });
+    },
+    getNextPageParam: (o) => (o.data.isNext === true ? o.data.page + 1 : null),
+    initialPageParam: 1,
+    enabled:
+      !isNoData && Boolean(selectedDatasetObj) && selectedDetailTab === "data",
+  });
+
+  const tableData = useMemo(
+    () =>
+      performanceDetails?.pages.reduce(
+        (acc, curr) => [...acc, ...curr.data.result],
+        [],
+      ) || [],
+    [performanceDetails],
+  );
+
+  const selectedMetric = allCustomMetrics?.find(
+    (cm) => cm.id === selectedDatasetObj?.metricId,
+  );
+
+  useEffect(() => {
+    const totalProcessingCount =
+      performanceDetails?.pages?.[0].data.processingCount || 0;
+    if (totalProcessingCount) {
+      if (
+        totalProcessingCount !== currentSnackbarData?.current?.processingCount
+      ) {
+        if (currentSnackbarData?.current?.key) {
+          closeSnackbar(currentSnackbarData?.current?.key);
+        }
+        const key = enqueueSnackbar({
+          variant: "info",
+          autoHideDuration: null,
+          message: `Processing ${totalProcessingCount} record${totalProcessingCount > 1 ? "s" : ""}`,
+        });
+        currentSnackbarData.current = {
+          key: key,
+          processingCount: totalProcessingCount,
+        };
+      }
+    }
+  }, [performanceDetails]);
+
+  useEffect(() => {
+    return () => {
+      if (currentSnackbarData?.current?.key)
+        closeSnackbar(currentSnackbarData?.current?.key);
+    };
+  }, []);
+
+  const { mutate: generateExport } = useMutation({
+    mutationFn: () => {
+      return axios.post(`${endpoints.performance.tableExport}${id}/`, {
+        dataset: {
+          startDate: dateFilter[0],
+          endDate: dateFilter[1],
+          aggBy: selectedAggregation,
+        },
+      });
+    },
+    onSuccess: (data) => {
+      enqueueSnackbar("Metric Performance Exported", {
+        variant: "success",
+      });
+      saveAs(new Blob([data.data], { type: "text/csv" }), "text.csv");
+    },
+  });
+
+  const handleDataOptionChange = (newOption) => {
+    let filter = null;
+    switch (newOption) {
+      case "Custom":
+        setIsDatePickerOpen(true);
+        return;
+      case "Today":
+        filter = [formatDate(startOfToday()), formatDate(startOfTomorrow())];
+        break;
+      case "Yesterday":
+        filter = [formatDate(startOfYesterday()), formatDate(startOfToday())];
+        break;
+      case "7D":
+        filter = [
+          formatDate(
+            sub(new Date(), {
+              days: 7,
+            }),
+          ),
+          formatDate(startOfTomorrow()),
+        ];
+        break;
+      case "30D":
+        filter = [
+          formatDate(
+            sub(new Date(), {
+              days: 30,
+            }),
+          ),
+          formatDate(startOfTomorrow()),
+        ];
+        break;
+      case "3M":
+        filter = [
+          formatDate(
+            sub(new Date(), {
+              months: 3,
+            }),
+          ),
+          formatDate(startOfTomorrow()),
+        ];
+        break;
+      case "6M":
+        filter = [
+          formatDate(
+            sub(new Date(), {
+              months: 6,
+            }),
+          ),
+          formatDate(startOfTomorrow()),
+        ];
+        break;
+      case "12M":
+        filter = [
+          formatDate(
+            sub(new Date(), {
+              months: 12,
+            }),
+          ),
+          formatDate(startOfTomorrow()),
+        ];
+        break;
+      default:
+        break;
+    }
+    if (filter) {
+      setDateFilter(filter);
+
+      // Convert to timestamps before calculation
+      const startDate = new Date(filter[0]).getTime();
+      const endDate = new Date(filter[1]).getTime();
+      const diffInDays = (endDate - startDate) / (1000 * 60 * 60 * 24);
+
+      // If difference is less than 2 days, set aggregation to hourly
+      if (diffInDays < 2) {
+        setSelectedAggregation("hourly");
+      }
+
+      // trackEvent(Events.metricPerformanceDateRangeChange, {
+      //   "Old Start Date": dateFilter?.[0],
+      //   "Old End Date": dateFilter?.[1],
+      //   "New Start Date": filter[0],
+      //   "New End Date": filter[1],
+      // });
+    }
+
+    setDateOption(newOption);
+  };
+
+  const getDateOptionTitle = (option, isSelected) => {
+    if (option === "Custom" && isSelected)
+      return `${format(new Date(dateFilter[0]), "dd/MM/yyyy")} - ${format(new Date(dateFilter[1]), "dd/MM/yyyy")}`;
+
+    return option;
+  };
+
+  if (isNoData)
+    return (
+      <Box sx={{ height: "100%", flex: 1, display: "flex" }}>
+        <ConfigureDatasetModal
+          open={isConfigureDatasetOpen}
+          onClose={() => setIsConfigureDatasetOpen(false)}
+        />
+        <ConfigureMetricModal
+          open={isDefineMetricOpen}
+          onClose={() => setIsDefineMetricOpen(false)}
+        />
+        <PerformanceNoData />
+      </Box>
+    );
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        width: "100%",
+        height: "calc(100vh - 140px)",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          flex: 1,
+          overflow: "auto",
+          paddingY: 2.5,
+          paddingLeft: 2.5,
+          paddingRight: 1,
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+            <ButtonGroup variant="outlined" color="inherit" size="small">
+              {DateRangeButtonOptions.map((option) => {
+                const selected = dateOption === option.title;
+                return (
+                  <Button
+                    sx={{
+                      // Adjust flex behavior
+                      backgroundColor: selected ? "action.hover" : undefined,
+                      fontWeight: selected ? 600 : 400,
+
+                      borderColor: "divider",
+                      borderWidth: "1px",
+                      px: 1.5, // Slightly more padding
+                      minWidth: 0,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      bgcolor: selected ? "action.hover" : undefined,
+                      "&:hover": {
+                        bgcolor: selected ? "action.hover" : "transparent",
+                        borderColor: "divider",
+                        transition:
+                          "background-color 0.2s ease, font-weight 0.2s ease, color 0.2s ease, border-color 0.2s ease",
+                      },
+                      height: "28px",
+                    }}
+                    ref={(ref) => {
+                      if (option.title === "Custom")
+                        customDatePickerAnc.current = ref;
+                    }}
+                    onClick={() => handleDataOptionChange(option.title)}
+                    key={option.title}
+                  >
+                    {getDateOptionTitle(option.title, selected, dateFilter)}
+                  </Button>
+                );
+              })}
+            </ButtonGroup>
+            <CustomDateRangePicker
+              open={isDatePickerOpen}
+              onClose={() => setIsDatePickerOpen(false)}
+              anchorEl={customDatePickerAnc?.current}
+              setDateFilter={setDateFilter}
+              setDateOption={setDateOption}
+            />
+            <FormControl fullWidth size="small" sx={{ width: 266 }}>
+              <InputLabel>Aggregation</InputLabel>
+              <Select
+                value={selectedAggregation}
+                onChange={(e) => {
+                  setSelectedAggregation(e.target.value);
+                  // trackEvent(Events.metricPerformanceAggregationChange, {
+                  //   "Old Aggregation": selectedAggregation,
+                  //   "New Aggregation": newAggregation,
+                  // });
+                }}
+                label="Aggregation"
+              >
+                {AggregationOption.map(({ label, value }) => (
+                  <MenuItem key={value} value={value}>
+                    {label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+          <Box>
+            <Button
+              size="small"
+              variant="soft"
+              onClick={() => setIsSaveReportOpen(true)}
+            >
+              Save Report
+            </Button>
+          </Box>
+        </Box>
+        {isLoadingGraphData || !graphData ? (
+          <Box
+            sx={{
+              height: "200px",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
+            <CircularProgress size={22} />
+          </Box>
+        ) : (
+          <PerformanceGraph data={graphData} />
+        )}
+        <PerformanceDetailSection
+          orderOption={orderOption}
+          setOrderOption={setOrderOption}
+          generateExport={generateExport}
+          datasets={validatedDatasets}
+          selectedDataset={selectedDataset}
+          setSelectedDataset={setSelectedDataset}
+          selectedDetailTab={selectedDetailTab}
+          setSelectedDetailTab={setSelectedDetailTab}
+        >
+          {selectedDetailTab === "data" && (
+            <PerformanceTable
+              tableData={tableData}
+              fetchNextPage={fetchNextPage}
+              isLoading={isLoading}
+              isFetchingNextPage={isFetchingNextPage}
+              setSelectedTags={() => {}}
+              selectedMetric={selectedMetric}
+            />
+          )}
+          {selectedDetailTab === "tagDistribution" && (
+            <PerformanceTagDistribution
+              tagDistribution={tagDistribution}
+              selectedTagDistributionType={selectedTagDistributionType}
+              setSelectedTagDistributionType={setSelectedTagDistributionType}
+              isLoading={isLoadingTagDistribution}
+            />
+          )}
+          {selectedDetailTab === "graphDatapoints" && (
+            <PerformanceGraphDatapoints
+              graphData={graphData}
+              selectedDataset={selectedDataset}
+            />
+          )}
+        </PerformanceDetailSection>
+      </Box>
+      <SaveReport
+        open={isSaveReportOpen}
+        onClose={() => setIsSaveReportOpen(false)}
+        datasets={validatedDatasets}
+        filters={validatedFilters}
+        breakdown={validatedBreakdown}
+        aggregation={selectedAggregation}
+        startDate={dateFilter[0]}
+        endDate={dateFilter[1]}
+      />
+      <PerformanceSidebar
+        selectedDatasets={selectedDatasets}
+        setSelectedDatasets={setSelectedDatasets}
+        selectedFilters={selectedFilters}
+        setSelectedFilters={setSelectedFilters}
+        selectedBreakdown={selectedBreakdown}
+        setSelectedBreakdown={setSelectedBreakdown}
+      />
+    </Box>
+  );
+};
+
+Performance.propTypes = {};
+
+export default Performance;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceDatePicker.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceDatePicker.jsx
@@ -1,0 +1,123 @@
+import { Box, Button, Popover } from "@mui/material";
+import React, { useMemo, useState } from "react";
+import PropType from "prop-types";
+import { DateField, DateCalendar } from "@mui/x-date-pickers";
+import { format, isValid } from "date-fns";
+
+const formatDate = (date) => format(date, "yyyy-MM-dd HH:mm:ss");
+
+const PerformanceDatePicker = ({
+  open,
+  onClose,
+  anchorEl,
+  setDateFilter,
+  setDateOption,
+  setStartDate,
+  setEndDate,
+}) => {
+  const [focusedElement, setFocusedElement] = useState("start");
+  const [internalStartDate, setInternalStartDate] = useState(null);
+  const [internalEndDate, setInternalEndDate] = useState(null);
+
+  const calendarValue = useMemo(() => {
+    if (focusedElement === "start") return internalStartDate;
+    if (focusedElement === "end") return internalEndDate;
+  }, [internalStartDate, internalEndDate, focusedElement]);
+
+  const isButtonActive = isValid(internalStartDate) && isValid(internalEndDate);
+
+  return (
+    <Popover
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+      transformOrigin={{
+        vertical: "top",
+        horizontal: "left",
+      }}
+      anchorEl={anchorEl}
+      open={open}
+      onClose={onClose}
+    >
+      <Box
+        sx={{
+          padding: "10px",
+          width: "340px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
+        <Box sx={{ display: "flex", gap: "12px" }}>
+          <DateField
+            fullWidth
+            label="Start date"
+            onFocus={() => setFocusedElement("start")}
+            focused={focusedElement === "start"}
+            value={internalStartDate}
+            onChange={(newValue) => setInternalStartDate(newValue)}
+            format="dd-MM-yyyy"
+          />
+          <DateField
+            fullWidth
+            label="End date"
+            onFocus={() => setFocusedElement("end")}
+            focused={focusedElement === "end"}
+            value={internalEndDate}
+            onChange={(newValue) => setInternalEndDate(newValue)}
+            format="dd-MM-yyyy"
+          />
+        </Box>
+        <DateCalendar
+          value={calendarValue}
+          onChange={(v) => {
+            if (focusedElement === "start") setInternalStartDate(v);
+            if (focusedElement === "end") setInternalEndDate(v);
+          }}
+        />
+        <Box
+          sx={{ display: "flex", justifyContent: "flex-end", width: "100%" }}
+        >
+          <Button
+            size="small"
+            variant="contained"
+            color="primary"
+            disabled={!isButtonActive}
+            onClick={() => {
+              setStartDate(internalStartDate);
+              setEndDate(internalEndDate);
+              setDateFilter([
+                formatDate(internalStartDate),
+                formatDate(internalEndDate),
+              ]);
+
+              // trackEvent(Events.metricPerformanceDateRangeChange, {
+              //   "Old Start Date": dateFilter?.[0],
+              //   "Old End Date": dateFilter?.[1],
+              //   "New Start Date": formatDate(internalStartDate),
+              //   "New End Date": formatDate(internalEndDate),
+              // });
+              setDateOption("Custom");
+              onClose();
+            }}
+          >
+            Apply
+          </Button>
+        </Box>
+      </Box>
+    </Popover>
+  );
+};
+
+PerformanceDatePicker.propTypes = {
+  open: PropType.bool,
+  onClose: PropType.func,
+  anchorEl: PropType.any,
+  setDateFilter: PropType.func,
+  setDateOption: PropType.func,
+  setStartDate: PropType.func,
+  setEndDate: PropType.func,
+};
+
+export default PerformanceDatePicker;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceDetail/ChatEvalDetails.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceDetail/ChatEvalDetails.jsx
@@ -1,0 +1,180 @@
+import { Box, Chip, Typography } from "@mui/material";
+import React from "react";
+import DetailItem from "./DetailItem";
+import CircularProgressWithLabel from "src/components/circular-progress-with-label/CircularProgressWithLabel";
+import {
+  getPerformanceTagColor,
+  getTabLabel,
+  interpolateColorBasedOnScore,
+} from "src/utils/utils";
+import Image from "src/components/image";
+import _ from "lodash";
+import PropTypes from "prop-types";
+
+const getScorePercentage = (s) => {
+  if (s <= 0) s = 0;
+  return s * 10;
+};
+
+const ChatEvalDetails = ({ performanceDetails, onImageClick }) => {
+  const renderTextOrImage = (contentType, content) => {
+    if (contentType === "text") {
+      return (
+        <Typography key={content} variant="body2">
+          {content}
+        </Typography>
+      );
+    } else {
+      const textContent = content?.filter(
+        (obj) => obj["image"] === undefined,
+      )?.[0]?.text;
+      const images = content?.filter((obj) => obj["text"] === undefined);
+      return (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          <Box key={content} sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+            {images?.map(({ url }) => (
+              <Image
+                height={130}
+                key={url}
+                src={url}
+                style={{ cursor: "pointer", borderRadius: "8px" }}
+                onClick={() => {
+                  onImageClick(url);
+                }}
+              />
+            ))}
+          </Box>
+          <Typography variant="body2">{textContent}</Typography>
+        </Box>
+      );
+    }
+  };
+
+  const renderPastChats = (contentType, info) => {
+    if (contentType === "text") {
+      return (
+        <Box>
+          <Typography variant="body2" fontWeight={600} component="span">
+            {_.capitalize(info.author.role)} {": "}
+          </Typography>
+          <Typography variant="body2" component="span">
+            {info.content}
+          </Typography>
+        </Box>
+      );
+    } else {
+      const textContent = info?.content?.filter(
+        (obj) => obj["image"] === undefined,
+      )?.[0]?.text;
+      const images = info?.content?.filter((obj) => obj["text"] === undefined);
+      return (
+        <Box>
+          <Typography variant="body2" fontWeight={600} component="span">
+            {_.capitalize(info.author.role)}
+          </Typography>
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+            {images?.map(({ url }) => (
+              <Image
+                height={130}
+                key={url}
+                src={url}
+                style={{ cursor: "pointer", borderRadius: "8px" }}
+              />
+            ))}
+          </Box>
+          <Typography variant="body2">{textContent}</Typography>
+        </Box>
+      );
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        paddingY: 3.75,
+        paddingX: 2,
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.5,
+      }}
+    >
+      <DetailItem
+        title="Model Input"
+        content={
+          <>
+            {performanceDetails?.pastInput?.map((inp) =>
+              renderPastChats(performanceDetails?.modelInputType, inp),
+            )}
+            {performanceDetails?.pastInput?.length ? (
+              <Typography variant="body2" fontWeight={600} component="span">
+                User :
+              </Typography>
+            ) : (
+              <></>
+            )}
+            {renderTextOrImage(
+              performanceDetails?.modelInputType,
+              performanceDetails?.modelInput,
+            )}
+          </>
+        }
+      />
+
+      <DetailItem
+        title="Model Output"
+        content={
+          <>
+            {renderTextOrImage(
+              performanceDetails?.modelOutputType,
+              performanceDetails?.modelOutput,
+            )}
+          </>
+        }
+      />
+
+      <DetailItem
+        title="Score"
+        content={
+          <CircularProgressWithLabel
+            color={interpolateColorBasedOnScore(performanceDetails?.score)}
+            value={getScorePercentage(performanceDetails?.score)}
+          />
+        }
+      />
+      <DetailItem
+        title="Explanation"
+        content={
+          <Typography variant="body2">
+            {performanceDetails?.explanation}
+          </Typography>
+        }
+      />
+      <DetailItem
+        title="Tags"
+        content={
+          <Box sx={{ display: "inline-flex", gap: 1, flexWrap: "wrap" }}>
+            {performanceDetails?.tags?.map((tag) => {
+              const color = getPerformanceTagColor(tag);
+              return (
+                <Chip
+                  variant="soft"
+                  size="small"
+                  color={color}
+                  key={tag}
+                  label={getTabLabel(tag)}
+                />
+              );
+            })}
+          </Box>
+        }
+      />
+    </Box>
+  );
+};
+
+ChatEvalDetails.propTypes = {
+  performanceDetails: PropTypes.object,
+  onImageClick: PropTypes.func,
+};
+
+export default ChatEvalDetails;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceDetail/ContextEvalDetails.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceDetail/ContextEvalDetails.jsx
@@ -1,0 +1,174 @@
+import { Box, Chip, Typography } from "@mui/material";
+import React from "react";
+import PropTypes from "prop-types";
+import Image from "src/components/image";
+import _ from "lodash";
+import CircularProgressWithLabel from "src/components/circular-progress-with-label/CircularProgressWithLabel";
+import {
+  getPerformanceTagColor,
+  getTabLabel,
+  interpolateColorBasedOnScore,
+} from "src/utils/utils";
+import DetailItem from "./DetailItem";
+
+const getScorePercentage = (s) => {
+  if (s <= 0) s = 0;
+  return s * 10;
+};
+
+const ContextEvalDetails = ({ performanceDetails, onImageClick }) => {
+  const renderTextOrImage = (contentType, content) => {
+    if (contentType === "text") {
+      return (
+        <Typography key={content} variant="body2">
+          {content}
+        </Typography>
+      );
+    } else {
+      const textContent = content?.filter(
+        (obj) => obj["image"] === undefined,
+      )?.[0]?.text;
+      const images = content?.filter((obj) => obj["text"] === undefined);
+      return (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          <Box key={content} sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+            {images?.map(({ url }) => (
+              <Image
+                height={130}
+                key={url}
+                src={url}
+                style={{ cursor: "pointer", borderRadius: "8px" }}
+                onClick={() => {
+                  onImageClick(url);
+                }}
+              />
+            ))}
+          </Box>
+          <Typography variant="body2">{textContent}</Typography>
+        </Box>
+      );
+    }
+  };
+
+  const renderPastChats = (contentType, info) => {
+    if (contentType === "text") {
+      return (
+        <Box>
+          <Typography variant="body2" fontWeight={600} component="span">
+            {_.capitalize(info.author.role)} {": "}
+          </Typography>
+          <Typography variant="body2" component="span">
+            {info.content}
+          </Typography>
+        </Box>
+      );
+    } else {
+      const textContent = info?.content?.filter(
+        (obj) => obj["image"] === undefined,
+      )?.[0]?.text;
+      const images = info?.content?.filter((obj) => obj["text"] === undefined);
+      return (
+        <Box>
+          <Typography variant="body2" fontWeight={600} component="span">
+            {_.capitalize(info.author.role)}
+          </Typography>
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+            {images?.map(({ url }) => (
+              <Image
+                height={130}
+                key={url}
+                src={url}
+                style={{ cursor: "pointer", borderRadius: "8px" }}
+              />
+            ))}
+          </Box>
+          <Typography variant="body2">{textContent}</Typography>
+        </Box>
+      );
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        paddingY: 3.75,
+        paddingX: 2,
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.5,
+      }}
+    >
+      <DetailItem
+        title="Model Input"
+        content={
+          <>
+            {performanceDetails?.pastInput?.map((inp) =>
+              renderPastChats(performanceDetails?.modelInputType, inp),
+            )}
+            {performanceDetails?.pastInput?.length ? (
+              <Typography variant="body2" fontWeight={600} component="span">
+                User :
+              </Typography>
+            ) : (
+              <></>
+            )}
+            {renderTextOrImage(
+              performanceDetails?.modelInputType,
+              performanceDetails?.modelInput,
+            )}
+          </>
+        }
+      />
+      <DetailItem
+        title="Context"
+        content={
+          <Typography variant="body2">{performanceDetails?.context}</Typography>
+        }
+      />
+
+      <DetailItem
+        title="Score"
+        content={
+          <CircularProgressWithLabel
+            color={interpolateColorBasedOnScore(performanceDetails?.score)}
+            value={getScorePercentage(performanceDetails?.score)}
+          />
+        }
+      />
+      <DetailItem
+        title="Explanation"
+        content={
+          <Typography variant="body2">
+            {performanceDetails?.explanation}
+          </Typography>
+        }
+      />
+      <DetailItem
+        title="Tags"
+        content={
+          <Box sx={{ display: "inline-flex", gap: 1, flexWrap: "wrap" }}>
+            {performanceDetails?.tags?.map((tag) => {
+              const color = getPerformanceTagColor(tag);
+              return (
+                <Chip
+                  variant="soft"
+                  size="small"
+                  color={color}
+                  key={tag}
+                  label={getTabLabel(tag)}
+                />
+              );
+            })}
+          </Box>
+        }
+      />
+    </Box>
+  );
+};
+
+ContextEvalDetails.propTypes = {
+  performanceDetails: PropTypes.object,
+  onImageClick: PropTypes.func,
+};
+
+export default ContextEvalDetails;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceDetail/DetailItem.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceDetail/DetailItem.jsx
@@ -1,0 +1,33 @@
+import { Box, Typography } from "@mui/material";
+import React from "react";
+import Iconify from "src/components/iconify";
+import PropTypes from "prop-types";
+
+const DetailItem = ({ title, content }) => {
+  return (
+    <Box sx={{ display: "flex", gap: "12px" }}>
+      <Box>
+        <Iconify
+          icon="solar:double-alt-arrow-right-bold-duotone"
+          color="primary.main"
+          width={24}
+        />
+      </Box>
+      <Box sx={{ gap: 1, display: "flex", flexDirection: "column" }}>
+        <Box>
+          <Typography fontSize={14} fontWeight={700} color="text.disabled">
+            {title}
+          </Typography>
+        </Box>
+        <Box>{content}</Box>
+      </Box>
+    </Box>
+  );
+};
+
+DetailItem.propTypes = {
+  title: PropTypes.string,
+  content: PropTypes.any,
+};
+
+export default DetailItem;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceDetail/PerformanceDetailDrawer.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceDetail/PerformanceDetailDrawer.jsx
@@ -1,0 +1,105 @@
+import { Drawer, IconButton } from "@mui/material";
+import React from "react";
+import PropTypes from "prop-types";
+import Iconify from "src/components/iconify";
+
+import _ from "lodash";
+import ChatEvalDetails from "./ChatEvalDetails";
+import ContextEvalDetails from "./ContextEvalDetails";
+import PromptTemplateEvalDetails from "./PromptTemplateEvalDetails";
+
+const PerformanceDetailDrawer = ({
+  evalType,
+  open,
+  onClose,
+  performanceDetails,
+  setSelectedImages,
+}) => {
+  const onImageClick = (curUrl) => {
+    const images = [];
+    let defaultIdx = 0;
+    performanceDetails.modelInput
+      ?.filter((o) => o["url"] !== undefined)
+      ?.forEach((url) => {
+        if (curUrl === url.url) defaultIdx = images.length;
+        images.push({ src: url.url });
+      });
+    performanceDetails.modelOutput
+      ?.filter((o) => o["url"] !== undefined)
+      ?.forEach((url) => {
+        if (curUrl === url.url) defaultIdx = images.length;
+        images.push({ src: url.url });
+      });
+    setSelectedImages({ images, defaultIdx });
+  };
+
+  const renderDetails = () => {
+    if (evalType === "EVALUATE_CHAT")
+      return (
+        <ChatEvalDetails
+          performanceDetails={performanceDetails}
+          onImageClick={onImageClick}
+        />
+      );
+    else if (
+      evalType === "EVALUATE_CONTEXT" ||
+      evalType === "EVALUATE_CONTEXT_RANKING"
+    ) {
+      return (
+        <ContextEvalDetails
+          performanceDetails={performanceDetails}
+          onImageClick={onImageClick}
+        />
+      );
+    } else if (evalType === "EVALUATE_PROMPT_TEMPLATE") {
+      return (
+        <PromptTemplateEvalDetails
+          performanceDetails={performanceDetails}
+          onImageClick={onImageClick}
+        />
+      );
+    }
+  };
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          height: "100vh",
+          width: "550px",
+          position: "fixed",
+          zIndex: 9999,
+          borderRadius: "10px",
+          backgroundColor: "background.paper",
+        },
+      }}
+      ModalProps={{
+        BackdropProps: {
+          style: { backgroundColor: "transparent" },
+        },
+      }}
+    >
+      <IconButton
+        onClick={() => onClose()}
+        sx={{ position: "absolute", top: "12px", right: "12px" }}
+      >
+        <Iconify icon="mingcute:close-line" />
+      </IconButton>
+      {renderDetails()}
+    </Drawer>
+  );
+};
+
+PerformanceDetailDrawer.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+  performanceDetails: PropTypes.object,
+  isContextEval: PropTypes.bool,
+  evalType: PropTypes.string,
+  setSelectedImages: PropTypes.func,
+};
+
+export default PerformanceDetailDrawer;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceDetail/PromptTemplateEvalDetails.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceDetail/PromptTemplateEvalDetails.jsx
@@ -1,0 +1,218 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Box, Chip, Typography } from "@mui/material";
+import Image from "src/components/image";
+import _ from "lodash";
+import CircularProgressWithLabel from "src/components/circular-progress-with-label/CircularProgressWithLabel";
+import {
+  getPerformanceTagColor,
+  getTabLabel,
+  interpolateColorBasedOnScore,
+} from "src/utils/utils";
+import DetailItem from "./DetailItem";
+
+const getScorePercentage = (s) => {
+  if (s <= 0) s = 0;
+  return s * 10;
+};
+
+const PromptTemplateEvalDetails = ({ performanceDetails, onImageClick }) => {
+  const renderTextOrImage = (contentType, content) => {
+    if (contentType === "text") {
+      return (
+        <Typography
+          sx={{ wordBreak: "break-all" }}
+          key={content}
+          variant="body2"
+        >
+          {content}
+        </Typography>
+      );
+    } else {
+      const textContent = content?.filter(
+        (obj) => obj["image"] === undefined,
+      )?.[0]?.text;
+      const images = content?.filter((obj) => obj["text"] === undefined);
+      return (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          <Box key={content} sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+            {images?.map(({ url }) => (
+              <Image
+                height={130}
+                key={url}
+                src={url}
+                style={{ cursor: "pointer", borderRadius: "8px" }}
+                onClick={() => onImageClick(url)}
+              />
+            ))}
+          </Box>
+          <Typography variant="body2">{textContent}</Typography>
+        </Box>
+      );
+    }
+  };
+
+  const renderPastChats = (contentType, info) => {
+    if (contentType === "text") {
+      return (
+        <Box>
+          <Typography variant="body2" fontWeight={600} component="span">
+            {_.capitalize(info.author.role)} {": "}
+          </Typography>
+          <Typography
+            variant="body2"
+            component="span"
+            sx={{ wordBreak: "break-all" }}
+          >
+            {info.content}
+          </Typography>
+        </Box>
+      );
+    } else {
+      const textContent = info?.content?.filter(
+        (obj) => obj["image"] === undefined,
+      )?.[0]?.text;
+      const images = info?.content?.filter((obj) => obj["text"] === undefined);
+      return (
+        <Box>
+          <Typography variant="body2" fontWeight={600} component="span">
+            {_.capitalize(info.author.role)}
+          </Typography>
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+            {images?.map(({ url }) => (
+              <Image
+                height={130}
+                key={url}
+                src={url}
+                style={{ cursor: "pointer", borderRadius: "8px" }}
+              />
+            ))}
+          </Box>
+          <Typography variant="body2">{textContent}</Typography>
+        </Box>
+      );
+    }
+  };
+
+  const renderVariables = () => {
+    if (performanceDetails?.variables) {
+      return Object.entries(performanceDetails?.variables).map(
+        ([key, value]) => (
+          <DetailItem
+            key={key}
+            title={key}
+            content={<Typography variant="body2">{value}</Typography>}
+          />
+        ),
+      );
+    }
+
+    return <></>;
+  };
+
+  return (
+    <Box
+      sx={{
+        paddingY: 3.75,
+        paddingX: 2,
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.5,
+      }}
+    >
+      <DetailItem
+        title="Model Input"
+        content={
+          <>
+            {performanceDetails?.pastInput?.map((inp) =>
+              renderPastChats(performanceDetails?.modelInputType, inp),
+            )}
+            {performanceDetails?.pastInput?.length ? (
+              <Typography variant="body2" fontWeight={600} component="span">
+                User :
+              </Typography>
+            ) : (
+              <></>
+            )}
+            {renderTextOrImage(
+              performanceDetails?.modelInputType,
+              performanceDetails?.modelInput,
+            )}
+          </>
+        }
+      />
+
+      <DetailItem
+        title="Model Output"
+        content={
+          <>
+            {renderTextOrImage(
+              performanceDetails?.modelOutputType,
+              performanceDetails?.modelOutput,
+            )}
+          </>
+        }
+      />
+      <DetailItem
+        title="Context"
+        content={
+          <Typography variant="body2">{performanceDetails?.context}</Typography>
+        }
+      />
+      <DetailItem
+        title="Prompt Template"
+        content={
+          <Typography variant="body2">
+            {performanceDetails?.promptTemplate
+              ? performanceDetails?.promptTemplate
+              : "-"}
+          </Typography>
+        }
+      />
+      {renderVariables()}
+      <DetailItem
+        title="Score"
+        content={
+          <CircularProgressWithLabel
+            color={interpolateColorBasedOnScore(performanceDetails?.score)}
+            value={getScorePercentage(performanceDetails?.score)}
+          />
+        }
+      />
+      <DetailItem
+        title="Explanation"
+        content={
+          <Typography variant="body2">
+            {performanceDetails?.explanation}
+          </Typography>
+        }
+      />
+      <DetailItem
+        title="Tags"
+        content={
+          <Box sx={{ display: "inline-flex", gap: 1, flexWrap: "wrap" }}>
+            {performanceDetails?.tags?.map((tag) => {
+              const color = getPerformanceTagColor(tag);
+              return (
+                <Chip
+                  variant="soft"
+                  size="small"
+                  color={color}
+                  key={tag}
+                  label={getTabLabel(tag)}
+                />
+              );
+            })}
+          </Box>
+        }
+      />
+    </Box>
+  );
+};
+
+PromptTemplateEvalDetails.propTypes = {
+  performanceDetails: PropTypes.object,
+  onImageClick: PropTypes.func,
+};
+
+export default PromptTemplateEvalDetails;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceDetailDrawer.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceDetailDrawer.jsx
@@ -1,0 +1,218 @@
+import { Box, Chip, Drawer, IconButton, Typography } from "@mui/material";
+import React from "react";
+import PropTypes from "prop-types";
+import Image from "src/components/image";
+import Iconify from "src/components/iconify";
+import {
+  getPerformanceTagColor,
+  getTabLabel,
+  interpolateColorBasedOnScore,
+} from "src/utils/utils";
+import _ from "lodash";
+import CircularProgressWithLabel from "src/components/circular-progress-with-label/CircularProgressWithLabel";
+
+const getScorePercentage = (s) => {
+  if (s <= 0) s = 0;
+  return s * 10;
+};
+
+const PerformanceDetailDrawer = ({
+  open,
+  onClose,
+  performanceDetails,
+  isContextEval,
+}) => {
+  const renderTextOrImage = (contentType, content) => {
+    return contentType === "text" ? (
+      <Typography key={content} variant="body2">
+        {content}
+      </Typography>
+    ) : (
+      <Box key={content} sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+        {content?.map(({ url }) => (
+          <Image
+            height={130}
+            key={url}
+            src={url}
+            style={{ cursor: "pointer", borderRadius: "8px" }}
+          />
+        ))}
+      </Box>
+    );
+  };
+
+  const renderPastChats = (contentType, info) => {
+    return contentType === "text" ? (
+      <>
+        <Typography variant="body2" fontWeight={600} component="span">
+          {_.capitalize(info.author.role)}
+        </Typography>
+        <Typography variant="body2" component="span">
+          {info.content}
+        </Typography>
+      </>
+    ) : (
+      <>
+        <Typography variant="body2" fontWeight={600} component="span">
+          {_.capitalize(info.author.role)}
+        </Typography>
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+          {info.content?.map(({ url }) => (
+            <Image
+              height={130}
+              key={url}
+              src={url}
+              style={{ cursor: "pointer", borderRadius: "8px" }}
+            />
+          ))}
+        </Box>
+      </>
+    );
+  };
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          height: "80vh",
+          width: "550px",
+          position: "fixed",
+          zIndex: 9999,
+          top: "10%",
+          right: 30,
+          borderRadius: "10px",
+          backgroundColor: "background.paper",
+        },
+      }}
+    >
+      <IconButton
+        onClick={() => onClose()}
+        sx={{ position: "absolute", top: "12px", right: "12px" }}
+      >
+        <Iconify icon="mingcute:close-line" />
+      </IconButton>
+      <Box
+        sx={{
+          paddingY: 3.75,
+          paddingX: 2,
+          display: "flex",
+          flexDirection: "column",
+          gap: 1.5,
+        }}
+      >
+        <DetailItem
+          title="Model Input"
+          content={
+            <>
+              {performanceDetails?.pastInput?.map((inp) =>
+                renderPastChats(performanceDetails?.modelInputType, inp),
+              )}
+              {renderTextOrImage(
+                performanceDetails?.modelInputType,
+                performanceDetails?.modelInput,
+              )}
+            </>
+          }
+        />
+        {isContextEval ? (
+          <DetailItem
+            title="Context"
+            content={
+              <Typography variant="body2">
+                {performanceDetails?.context}
+              </Typography>
+            }
+          />
+        ) : (
+          <DetailItem
+            title="Model Output"
+            content={
+              <>
+                {renderTextOrImage(
+                  performanceDetails?.modelOutputType,
+                  performanceDetails?.modelOutput,
+                )}
+              </>
+            }
+          />
+        )}
+
+        <DetailItem
+          title="Score"
+          content={
+            <CircularProgressWithLabel
+              color={interpolateColorBasedOnScore(performanceDetails?.score)}
+              value={getScorePercentage(performanceDetails?.score)}
+            />
+          }
+        />
+        <DetailItem
+          title="Explanation"
+          content={
+            <Typography variant="body2">
+              {performanceDetails?.explanation}
+            </Typography>
+          }
+        />
+        <DetailItem
+          title="Tags"
+          content={
+            <Box sx={{ display: "inline-flex", gap: 1, flexWrap: "wrap" }}>
+              {performanceDetails?.tags?.map((tag) => {
+                const color = getPerformanceTagColor(tag);
+                return (
+                  <Chip
+                    variant="soft"
+                    size="small"
+                    color={color}
+                    key={tag}
+                    label={getTabLabel(tag)}
+                  />
+                );
+              })}
+            </Box>
+          }
+        />
+      </Box>
+    </Drawer>
+  );
+};
+
+const DetailItem = ({ title, content }) => {
+  return (
+    <Box sx={{ display: "flex", gap: "12px" }}>
+      <Box>
+        <Iconify
+          icon="solar:double-alt-arrow-right-bold-duotone"
+          color="primary.main"
+          width={24}
+        />
+      </Box>
+      <Box sx={{ gap: 1, display: "flex", flexDirection: "column" }}>
+        <Box>
+          <Typography fontSize={14} fontWeight={700} color="text.disabled">
+            {title}
+          </Typography>
+        </Box>
+        <Box>{content}</Box>
+      </Box>
+    </Box>
+  );
+};
+
+DetailItem.propTypes = {
+  title: PropTypes.string,
+  content: PropTypes.any,
+};
+
+PerformanceDetailDrawer.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+  performanceDetails: PropTypes.object,
+  isContextEval: PropTypes.bool,
+};
+
+export default PerformanceDetailDrawer;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceGraph.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceGraph.jsx
@@ -1,0 +1,112 @@
+import { Box, useTheme } from "@mui/material";
+import React, { useEffect, useRef, useState } from "react";
+
+import ResizeObserver from "resize-observer-polyfill";
+import PropType from "prop-types";
+import ReactApexChart from "react-apexcharts";
+import { getColorFromSeed } from "src/utils/utils";
+
+const PerformanceGraph = ({ data }) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+  const [chartWidth, setChartWidth] = useState(0);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target === container) {
+          setChartWidth(entry.contentRect.width);
+        }
+      }
+    });
+
+    setChartWidth(container.offsetWidth);
+
+    resizeObserver.observe(container);
+
+    return () => {
+      resizeObserver.unobserve(container);
+    };
+  }, []);
+
+  const series = Object.entries(data).map(([name, graphData]) => ({
+    type: "line",
+    data: graphData,
+    color: getColorFromSeed(name),
+    name: name,
+  }));
+
+  const chartOptions = {
+    xaxis: {
+      type: "datetime",
+      labels: {
+        datetimeUTC: false,
+      },
+    },
+    yaxis: {
+      min: 0,
+      max: 100,
+      tickAmount: 5,
+      labels: {
+        formatter: (value) => Math.round(value),
+      },
+    },
+    legend: {
+      show: true,
+      position: "top",
+      horizontalAlign: "left",
+      offsetX: 18,
+      offsetY: 10,
+    },
+    stroke: {
+      width: 3,
+      curve: "smooth", // This will make the line smooth
+    },
+    chart: {
+      background: "transparent",
+      foreColor: isDark ? "#a1a1aa" : undefined,
+      toolbar: {
+        show: true,
+        tools: {
+          download: false,
+          selection: false,
+          zoom: false,
+          zoomin: false,
+          zoomout: false,
+          pan: false,
+          reset: true,
+        },
+      },
+    },
+    theme: {
+      mode: isDark ? "dark" : "light",
+    },
+    tooltip: {
+      theme: isDark ? "dark" : "light",
+    },
+    grid: {
+      borderColor: isDark ? "#27272a" : undefined,
+    },
+  };
+
+  return (
+    <Box ref={containerRef} sx={{ width: "100%" }}>
+      <ReactApexChart
+        options={chartOptions}
+        series={series}
+        type="line"
+        width={chartWidth}
+        height={240}
+      />
+    </Box>
+  );
+};
+
+PerformanceGraph.propTypes = {
+  data: PropType.object,
+};
+
+export default PerformanceGraph;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceGraphDatapoints.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceGraphDatapoints.jsx
@@ -1,0 +1,59 @@
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableHead,
+  TableRow,
+} from "@mui/material";
+import { format } from "date-fns";
+import PropTypes from "prop-types";
+import React from "react";
+import PerformanceTableCell from "./PerformanceTableCell";
+
+const PerformanceGraphDatapoints = ({ graphData, selectedDataset }) => {
+  const filteredGraphData = graphData
+    ? Object.entries(graphData)
+        .filter(([name]) => name.includes(`Dataset ${selectedDataset + 1}`))
+        .reduce((acu, [name, points]) => {
+          acu[name] = points;
+          return acu;
+        }, {})
+    : [];
+
+  return (
+    <Box sx={{ overflowX: "auto" }}>
+      <Table component={Paper}>
+        <TableHead>
+          <TableRow>
+            <PerformanceTableCell>Datapoint</PerformanceTableCell>
+            {Object.values(filteredGraphData)?.[0]?.map(([date]) => (
+              <PerformanceTableCell key={date}>
+                {format(new Date(date), "dd/MM/yy")}
+              </PerformanceTableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {Object.entries(filteredGraphData).map(([name, points]) => (
+            <TableRow key={name}>
+              <PerformanceTableCell>{name}</PerformanceTableCell>
+              {points.map(([date, score]) => (
+                <PerformanceTableCell key={date}>
+                  {Math.round(score)}
+                </PerformanceTableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+};
+
+PerformanceGraphDatapoints.propTypes = {
+  graphData: PropTypes.object,
+  selectedDataset: PropTypes.object,
+};
+
+export default PerformanceGraphDatapoints;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceNoData.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceNoData.jsx
@@ -1,0 +1,37 @@
+import { Box, Typography } from "@mui/material";
+import React from "react";
+
+const PerformanceNoData = () => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        position: "relative",
+        flex: 1,
+      }}
+    >
+      <Box
+        sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+      >
+        <Box
+          component="img"
+          alt="empty content"
+          src={"/assets/icons/components/ic_extra_scroll.svg"}
+          sx={{ width: 1, maxWidth: 160 }}
+        />
+        <Typography
+          variant="subtitle1"
+          sx={{ width: "250px", textAlign: "center" }}
+          id="no-dataset-text"
+        >
+          Once you add dataset and custom metric you will be able to see
+          performance metrics
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default PerformanceNoData;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/BreakdownCard.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/BreakdownCard.jsx
@@ -1,0 +1,104 @@
+import {
+  Box,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+} from "@mui/material";
+import React from "react";
+import Iconify from "src/components/iconify";
+import PropTypes from "prop-types";
+import { useQuery } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+import { useParams } from "react-router";
+
+const BreakdownCard = ({
+  index,
+  setBreakdown,
+  breakdown,
+  removeBreakdown,
+  cloneBreakdown,
+}) => {
+  const { id } = useParams();
+
+  const { data: allOptions } = useQuery({
+    queryFn: () => axios.get(endpoints.performance.getFilterOptions(id), {}),
+    queryKey: ["performance-filter-options", id, ""],
+    staleTime: 30 * 60 * 1000, // 30 min stale time
+    select: (d) => d.data?.result,
+  });
+
+  return (
+    <Paper
+      elevation={2}
+      sx={{ padding: "14px", display: "flex", flexDirection: "column", gap: 1 }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-end",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <IconButton size="small" onClick={() => cloneBreakdown(index)}>
+            <Iconify
+              icon="bxs:duplicate"
+              width={16}
+              height={16}
+              sx={{ color: "text.secondary" }}
+            />
+          </IconButton>
+          <IconButton size="small" onClick={() => removeBreakdown(index)}>
+            <Iconify
+              icon="solar:trash-bin-trash-bold"
+              width={16}
+              height={16}
+              sx={{ color: "text.secondary" }}
+            />
+          </IconButton>
+        </Box>
+      </Box>
+      <FormControl size="small">
+        <InputLabel>Breakdown</InputLabel>
+        <Select
+          label="Breakdown"
+          value={breakdown?.keyId || ""}
+          onChange={(e) => {
+            const keyId = e.target.value;
+            setBreakdown(index, (b) => ({
+              ...b,
+              key: allOptions?.properties.find((p) => p.id === keyId)?.name,
+              keyId,
+            }));
+          }}
+          MenuProps={{
+            PaperProps: {
+              style: {
+                maxHeight: "200px",
+              },
+            },
+          }}
+        >
+          {allOptions?.properties.map(({ name, id }) => (
+            <MenuItem value={id} key={id}>
+              {name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Paper>
+  );
+};
+
+BreakdownCard.propTypes = {
+  index: PropTypes.number,
+  setBreakdown: PropTypes.func,
+  breakdown: PropTypes.object,
+  removeBreakdown: PropTypes.func,
+  cloneBreakdown: PropTypes.func,
+};
+
+export default BreakdownCard;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/DatasetCard.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/DatasetCard.jsx
@@ -1,0 +1,314 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import {
+  Box,
+  Collapse,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  useTheme,
+} from "@mui/material";
+import PropTypes from "prop-types";
+import React, { useMemo, useState } from "react";
+import Iconify from "src/components/iconify";
+import Label from "src/components/label";
+import FilterSection from "./FilterCard/FilterSection";
+import {
+  useGetAllCustomMetrics,
+  useGetMetricOptions,
+} from "src/api/model/metric";
+import { useParams } from "react-router";
+import { useEffect } from "react";
+import { getRandomId } from "src/utils/utils";
+
+const DatasetCard = ({
+  index,
+  dataset,
+  setDataset,
+  cloneDataset,
+  removeDataset,
+}) => {
+  const [open, setOpen] = useState(true);
+
+  const theme = useTheme();
+
+  const { id } = useParams();
+
+  const { data: allCustomMetrics } = useGetAllCustomMetrics(id);
+
+  const selectedMetricId = dataset?.metricId;
+  const selectedEnv = dataset?.environment;
+  const selectedVersion = dataset?.version;
+
+  const { data: datasetOptions } = useGetMetricOptions(id, selectedMetricId, {
+    enabled: Boolean(selectedMetricId),
+  });
+
+  const environmentOptions = useMemo(() => {
+    if (!datasetOptions) return [];
+
+    const set = new Set(datasetOptions.map((o) => o.environment));
+
+    return Array.from(set);
+  }, [datasetOptions, selectedMetricId]);
+
+  const versionOptions = useMemo(() => {
+    if (!datasetOptions) return [];
+    if (selectedEnv) {
+      return datasetOptions.reduce((arr, { environment, version }) => {
+        if (environment === selectedEnv && !arr.includes(version)) {
+          arr.push(version);
+        }
+        return arr;
+      }, []);
+    } else {
+      const set = new Set(datasetOptions.map((o) => o.version));
+      return Array.from(set);
+    }
+  }, [datasetOptions, selectedMetricId, selectedEnv]);
+
+  useEffect(() => {
+    if (!datasetOptions || !selectedMetricId) return;
+    if (!selectedEnv?.length || !selectedVersion?.length) {
+      const dataset = datasetOptions?.[0];
+      setDataset(index, (d) => ({
+        ...d,
+        environment: dataset.environment,
+        version: dataset.version,
+      }));
+    }
+  }, [datasetOptions, selectedMetricId]);
+
+  const handleMetricChange = (e) => {
+    setDataset(index, (d) => ({
+      ...d,
+      metricId: e.target.value,
+      environment: "",
+      version: "",
+    }));
+  };
+
+  const handleEnvironmentChange = (e) => {
+    const newEnv = e.target.value;
+    setDataset(index, (d) => ({ ...d, environment: newEnv }));
+  };
+
+  const handleVersionChange = (e) => {
+    setDataset(index, (d) => ({ ...d, version: e.target.value }));
+  };
+
+  const addFilter = () => {
+    setDataset(index, (d) => ({
+      ...d,
+      filters: [
+        ...d.filters,
+        {
+          id: getRandomId(),
+          property: "",
+          operator: "equal",
+          values: [],
+          type: "",
+          datatype: "string",
+          key: "",
+          keyId: "",
+        },
+      ],
+    }));
+  };
+
+  const removeFilter = (idx) => {
+    setDataset(index, (d) => ({
+      ...d,
+      filters: d.filters.filter((_, i) => i !== idx),
+    }));
+  };
+
+  const cloneFilter = (idx) => {
+    setDataset(index, (d) => ({
+      ...d,
+      filters: [...d.filters, d.filters[idx]],
+    }));
+  };
+
+  const setFilter = (idx, update) => {
+    setDataset(index, (d) => {
+      const newFilters = [...d.filters];
+      if (typeof update === "function") {
+        newFilters[idx] = update(newFilters[idx]);
+      } else {
+        newFilters[idx] = update;
+      }
+      return { ...d, filters: newFilters };
+    });
+  };
+
+  return (
+    <Paper elevation={2} sx={{ display: "flex", flexDirection: "column" }}>
+      <Box
+        sx={{
+          padding: "14px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <Label variant="soft">Dataset {index + 1}</Label>
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <IconButton size="small" onClick={() => cloneDataset(index)}>
+            <Iconify
+              icon="bxs:duplicate"
+              width={16}
+              height={16}
+              sx={{ color: "text.secondary" }}
+            />
+          </IconButton>
+          <IconButton size="small" onClick={addFilter}>
+            <Iconify
+              width={16}
+              height={16}
+              icon="mingcute:filter-2-fill"
+              sx={{ color: "text.secondary" }}
+            />
+          </IconButton>
+
+          {index > 0 && (
+            <IconButton size="small" onClick={() => removeDataset(index)}>
+              <Iconify
+                icon="solar:trash-bin-trash-bold"
+                width={16}
+                height={16}
+                sx={{ color: "text.secondary" }}
+              />
+            </IconButton>
+          )}
+          <IconButton size="small" onClick={() => setOpen(!open)}>
+            <Iconify
+              width={16}
+              height={16}
+              icon="ci:chevron-down"
+              sx={{
+                color: "text.secondary",
+                transform: open ? "rotate(180deg)" : null,
+              }}
+            />
+          </IconButton>
+        </Box>
+      </Box>
+      <Collapse in={open} orientation="vertical">
+        <Box
+          sx={{
+            paddingTop: 1,
+            gap: "12px",
+            display: "flex",
+            flexDirection: "column",
+            paddingX: "14px",
+          }}
+        >
+          <FormControl size="small">
+            <InputLabel>Metric</InputLabel>
+            <Select
+              label="Metric"
+              value={dataset.metricId}
+              onChange={handleMetricChange}
+            >
+              {allCustomMetrics?.map(({ id, name }) => (
+                <MenuItem key={id} value={id}>
+                  {name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl size="small">
+            <InputLabel>Environment</InputLabel>
+            <Select
+              label="Environment"
+              value={selectedEnv}
+              onChange={handleEnvironmentChange}
+            >
+              {environmentOptions.map((o) => (
+                <MenuItem key={o} value={o}>
+                  {o}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl size="small">
+            <InputLabel>Version</InputLabel>
+            <Select
+              label="Version"
+              value={selectedVersion}
+              onChange={handleVersionChange}
+            >
+              {versionOptions.map((o) => (
+                <MenuItem key={o} value={o}>
+                  {o}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+        <Box
+          sx={{
+            paddingY: "14px",
+            gap: "14px",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          {dataset?.filters?.map((filter, i) => (
+            <Box
+              sx={{
+                borderTop: `2px solid ${theme.palette.background.neutral}`,
+                paddingX: "14px",
+                paddingTop: 1,
+              }}
+              key={filter.id}
+            >
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "flex-end",
+                }}
+              >
+                <IconButton size="small" onClick={() => cloneFilter(i)}>
+                  <Iconify
+                    icon="bxs:duplicate"
+                    width={16}
+                    height={16}
+                    sx={{ color: "text.secondary" }}
+                  />
+                </IconButton>
+
+                <IconButton size="small" onClick={() => removeFilter(i)}>
+                  <Iconify
+                    icon="solar:trash-bin-trash-bold"
+                    width={16}
+                    height={16}
+                    sx={{ color: "text.secondary" }}
+                  />
+                </IconButton>
+              </Box>
+              <FilterSection
+                filter={filter}
+                setFilter={(update) => setFilter(i, update)}
+              />
+            </Box>
+          ))}
+        </Box>
+      </Collapse>
+    </Paper>
+  );
+};
+
+DatasetCard.propTypes = {
+  index: PropTypes.number,
+  setDataset: PropTypes.func,
+  dataset: PropTypes.object,
+  cloneDataset: PropTypes.func,
+  removeDataset: PropTypes.func,
+};
+
+export default DatasetCard;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterCard.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterCard.jsx
@@ -1,0 +1,58 @@
+import { Box, IconButton, Paper } from "@mui/material";
+import PropTypes from "prop-types";
+import React from "react";
+import Iconify from "src/components/iconify";
+import FilterSection from "./FilterSection";
+
+const FilterCard = ({
+  index,
+  removeFilter,
+  cloneFilter,
+  setFilter,
+  filter,
+}) => {
+  return (
+    <Paper
+      elevation={2}
+      sx={{ padding: "14px", display: "flex", flexDirection: "column" }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-end",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <IconButton size="small" onClick={() => cloneFilter(index)}>
+            <Iconify
+              icon="bxs:duplicate"
+              width={16}
+              height={16}
+              sx={{ color: "text.secondary" }}
+            />
+          </IconButton>
+          <IconButton size="small" onClick={() => removeFilter(index)}>
+            <Iconify
+              icon="solar:trash-bin-trash-bold"
+              width={16}
+              height={16}
+              sx={{ color: "text.secondary" }}
+            />
+          </IconButton>
+        </Box>
+      </Box>
+      <FilterSection setFilter={setFilter} filter={filter} />
+    </Paper>
+  );
+};
+
+FilterCard.propTypes = {
+  index: PropTypes.number,
+  removeFilter: PropTypes.func,
+  cloneFilter: PropTypes.func,
+  setFilter: PropTypes.func,
+  filter: PropTypes.object,
+};
+
+export default FilterCard;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterListComponents.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterListComponents.jsx
@@ -1,0 +1,40 @@
+import {
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  styled,
+} from "@mui/material";
+
+export const FilterList = styled(List)(() => ({
+  padding: 0,
+}));
+
+export const FilterListItem = styled(ListItem)(() => ({
+  padding: 0,
+}));
+
+export const FilterListItemButton = styled(ListItemButton)(() => ({
+  padding: "6px 8px 6px 8px",
+  "&:hover": {
+    borderRadius: "6px",
+    backgroundColor: "action.hover",
+  },
+  "&.Mui-selected": {
+    borderRadius: "6px",
+    backgroundColor: "action.hover",
+
+    "&:hover": {
+      borderRadius: "6px",
+      backgroundColor: "action.hover",
+    },
+  },
+}));
+
+export const FilterListItemText = styled(ListItemText)(() => ({
+  ".MuiListItemText-primary": {
+    fontWeight: 400,
+    fontSize: "14px",
+    color: "text.primary",
+  },
+}));

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterOperator.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterOperator.jsx
@@ -1,0 +1,79 @@
+import { Box, Menu, MenuItem, Typography } from "@mui/material";
+import React, { useRef, useState } from "react";
+import Iconify from "src/components/iconify";
+import PropTypes from "prop-types";
+import { NumberFilterOperators } from "src/utils/constants";
+
+const FilterOperator = ({ operator, setOperator, dataType }) => {
+  const dropDownRef = useRef();
+  const [isDropdownOpen, setDropDownOpen] = useState(false);
+
+  const selectedOperator = NumberFilterOperators.find(
+    (o) => o.value === operator,
+  );
+
+  const currentLabel = dataType === "string" ? "is" : selectedOperator.label;
+
+  const disabled = dataType === "string";
+
+  return (
+    <>
+      <Box
+        ref={dropDownRef}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          cursor: disabled ? "auto" : "pointer",
+        }}
+        onClick={() => {
+          if (disabled) return;
+          setDropDownOpen(true);
+        }}
+      >
+        <Typography color="text.disabled" typography="caption">
+          {currentLabel}
+        </Typography>
+        {!disabled && (
+          <Iconify
+            icon="ion:chevron-down"
+            color="text.disabled"
+            sx={{ transform: isDropdownOpen ? "rotate(180deg)" : "" }}
+          />
+        )}
+      </Box>
+
+      <Menu
+        open={isDropdownOpen}
+        onClose={() => setDropDownOpen(false)}
+        anchorEl={dropDownRef?.current}
+        PaperProps={{
+          style: {
+            width: `${dropDownRef?.current?.clientWidth}px`,
+            maxHeight: 150,
+          },
+        }}
+      >
+        {NumberFilterOperators.map(({ label, value }) => (
+          <MenuItem
+            onClick={() => {
+              setOperator(value);
+              setDropDownOpen(false);
+            }}
+            key={value}
+          >
+            {label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+FilterOperator.propTypes = {
+  operator: PropTypes.string,
+  setOperator: PropTypes.func,
+  dataType: PropTypes.string,
+};
+
+export default FilterOperator;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterOptionsPopover.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterOptionsPopover.jsx
@@ -1,0 +1,338 @@
+import {
+  Box,
+  Checkbox,
+  Chip,
+  Divider,
+  InputAdornment,
+  Popover,
+  TextField,
+} from "@mui/material";
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import Iconify from "src/components/iconify";
+import {
+  FilterList,
+  FilterListItem,
+  FilterListItemButton,
+  FilterListItemText,
+} from "./FilterListComponents";
+import { useQuery } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+import { useParams } from "react-router";
+import { useDebounce } from "src/hooks/use-debounce";
+import { getPerformanceTagColor, getTabLabel } from "src/utils/utils";
+
+const LeftSidebarOptions = [
+  { label: "All", value: "all" },
+  { label: "Performance Metric", value: "performanceMetric" },
+  { label: "Property", value: "properties" },
+  { label: "Meta Tags", value: "metaTags" },
+  { label: "Performance Tags", value: "performanceTags" },
+];
+
+const FilterOptionsPopover = ({ open, onClose, ancElem, onSelect, filter }) => {
+  const { id } = useParams();
+
+  const [selectedAggregation, setSelectedAggregation] = useState("all");
+
+  const [searchText, setSearchText] = useState("");
+
+  const debouncedSearchText = useDebounce(searchText);
+
+  const { data: allOptions } = useQuery({
+    queryFn: () =>
+      axios.get(endpoints.performance.getFilterOptions(id), {
+        params: { search_query: debouncedSearchText },
+      }),
+    queryKey: ["performance-filter-options", id, debouncedSearchText],
+    staleTime: 30 * 60 * 1000, // 30 min stale time
+    select: (d) => d.data?.result,
+  });
+
+  const renderOptions = () => {
+    const components = [];
+
+    if (
+      selectedAggregation === "all" ||
+      selectedAggregation === "performanceMetric"
+    ) {
+      if (
+        selectedAggregation === "all" &&
+        allOptions?.performanceMetric?.length
+      )
+        components.push(
+          <FilterListItem>
+            <FilterListItemText
+              sx={{
+                fontWeight: 600,
+                fontSize: "12px",
+                color: "text.disabled",
+                paddingLeft: 1,
+              }}
+            >
+              Performance metric
+            </FilterListItemText>
+          </FilterListItem>,
+        );
+      allOptions?.performanceMetric.forEach(({ name, id }) => {
+        components.push(
+          <FilterListItem key={id}>
+            <FilterListItemButton
+              onClick={() => {
+                onSelect({
+                  datatype: "number",
+                  operator: "equal",
+                  type: "performanceMetric",
+                  values: [],
+                  key: name,
+                  keyId: id,
+                });
+                onClose();
+              }}
+            >
+              <FilterListItemText>{name}</FilterListItemText>
+            </FilterListItemButton>
+          </FilterListItem>,
+        );
+      });
+    }
+
+    if (selectedAggregation === "all" || selectedAggregation === "properties") {
+      if (selectedAggregation === "all" && allOptions?.properties?.length)
+        components.push(
+          <FilterListItem>
+            <FilterListItemText
+              sx={{
+                fontWeight: 600,
+                fontSize: "12px",
+                color: "text.disabled",
+                paddingLeft: 1,
+              }}
+            >
+              Properties
+            </FilterListItemText>
+          </FilterListItem>,
+        );
+      allOptions?.properties.forEach(({ name, id, datatype, values }) => {
+        components.push(
+          <FilterListItem key={id}>
+            <FilterListItemButton
+              onClick={() => {
+                onSelect({
+                  type: "property",
+                  datatype: datatype,
+                  operator: "equal",
+                  values: [],
+                  key: name,
+                  keyId: id,
+                  options: values,
+                });
+                onClose();
+              }}
+            >
+              <FilterListItemText>{name}</FilterListItemText>
+            </FilterListItemButton>
+          </FilterListItem>,
+        );
+      });
+    }
+
+    if (selectedAggregation === "all" || selectedAggregation === "metaTags") {
+      if (selectedAggregation === "all" && allOptions?.metaTags?.length)
+        components.push(
+          <FilterListItem>
+            <FilterListItemText
+              sx={{
+                fontWeight: 600,
+                fontSize: "12px",
+                color: "text.disabled",
+                paddingLeft: 1,
+              }}
+            >
+              Meta Tags
+            </FilterListItemText>
+          </FilterListItem>,
+        );
+      allOptions?.metaTags.forEach((tag) => {
+        components.push(
+          <FilterListItem key={tag}>
+            <FilterListItemButton>
+              <FilterListItemText>{tag}</FilterListItemText>
+            </FilterListItemButton>
+          </FilterListItem>,
+        );
+      });
+    }
+
+    if (
+      selectedAggregation === "all" ||
+      selectedAggregation === "performanceTags"
+    ) {
+      if (selectedAggregation === "all" && allOptions?.performanceTags?.length)
+        components.push(
+          <FilterListItem>
+            <FilterListItemText
+              sx={{
+                fontWeight: 600,
+                fontSize: "12px",
+                color: "text.disabled",
+                paddingLeft: 1,
+              }}
+            >
+              Performance Tags
+            </FilterListItemText>
+          </FilterListItem>,
+        );
+      allOptions?.performanceTags.forEach((tag) => {
+        const color = getPerformanceTagColor(tag);
+        const selected = filter.values.includes(tag);
+
+        const handleChange = () => {
+          onSelect((e) => ({
+            type: "performanceTag",
+            datatype: "string",
+            operator: "equal",
+            key: "Performance Tag",
+            keyId: "",
+            values: selected
+              ? e.values.filter((t) => t !== tag)
+              : [...e.values, tag],
+          }));
+          onClose();
+        };
+
+        components.push(
+          <FilterListItem key={tag}>
+            <FilterListItemButton sx={{ display: "flex", gap: 1 }}>
+              <Checkbox
+                checked={selected}
+                size="small"
+                sx={{ p: 0 }}
+                onChange={handleChange}
+              />
+              <Chip
+                variant="soft"
+                color={color}
+                key={tag}
+                label={getTabLabel(tag)}
+                clickable
+                size="small"
+                sx={{
+                  fontSize: "11px",
+                }}
+                onClick={handleChange}
+              />
+            </FilterListItemButton>
+          </FilterListItem>,
+        );
+      });
+    }
+    return components;
+  };
+
+  return (
+    <Popover
+      anchorEl={ancElem}
+      open={open}
+      onClose={onClose}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "right",
+      }}
+      transformOrigin={{
+        vertical: "top",
+        horizontal: "right",
+      }}
+    >
+      <Box
+        sx={{
+          width: "519px",
+          height: "362px",
+          padding: 0.5,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <Box>
+          <TextField
+            size="small"
+            sx={{ flex: 1 }}
+            placeholder="Search metric..."
+            fullWidth
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Iconify
+                    icon="eva:search-fill"
+                    sx={{ color: "text.disabled" }}
+                  />
+                </InputAdornment>
+              ),
+            }}
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+          />
+        </Box>
+
+        <Box
+          sx={{
+            display: "flex",
+            paddingTop: 0.5,
+            gap: 0.5,
+            flex: 1,
+            overflow: "auto",
+          }}
+        >
+          <Box
+            sx={{
+              width: "170px",
+              display: "flex",
+              flexDirection: "column",
+              gap: 0.5,
+              height: "100%",
+              overflow: "auto",
+            }}
+          >
+            <FilterList sx={{ flex: 1 }}>
+              {LeftSidebarOptions.map(({ label, value }) => {
+                const selected = selectedAggregation === value;
+                return (
+                  <FilterListItem key={value}>
+                    <FilterListItemButton
+                      selected={selected}
+                      onClick={() => setSelectedAggregation(value)}
+                    >
+                      <FilterListItemText
+                        sx={{
+                          ".MuiListItemText-primary": {
+                            fontWeight: selected ? 600 : 400,
+                          },
+                        }}
+                      >
+                        {label}
+                      </FilterListItemText>
+                    </FilterListItemButton>
+                  </FilterListItem>
+                );
+              })}
+            </FilterList>
+          </Box>
+          <Divider orientation="vertical" flexItem />
+          <Box sx={{ flex: 1, overflow: "auto", height: "100%" }}>
+            <FilterList sx={{ flex: 1 }}>{renderOptions()}</FilterList>
+          </Box>
+        </Box>
+      </Box>
+    </Popover>
+  );
+};
+
+FilterOptionsPopover.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+  ancElem: PropTypes.any,
+  onSelect: PropTypes.func,
+  filter: PropTypes.object,
+};
+
+export default FilterOptionsPopover;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterSection.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterSection.jsx
@@ -1,0 +1,168 @@
+import {
+  Box,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  Typography,
+} from "@mui/material";
+import PropTypes from "prop-types";
+import React, { useRef, useState } from "react";
+import FilterOperator from "./FilterOperator";
+import FilterValue from "./FilterValue";
+import FilterOptionsPopover from "./FilterOptionsPopover";
+import { getPerformanceTagColor, getTabLabel } from "src/utils/utils";
+
+const FilterSection = ({ setFilter, filter }) => {
+  const [isFilterOptionsOpen, setIsFilterOptionsOpen] = useState(false);
+
+  const filterSelectRef = useRef(null);
+
+  const renderSelect = () => {
+    if (filter?.type === "performanceTag") {
+      return (
+        <FormControl size="small">
+          <InputLabel>Performance Tag</InputLabel>
+          <Select
+            label="Performance Tag"
+            open={isFilterOptionsOpen}
+            onClose={() => setIsFilterOptionsOpen(false)}
+            onOpen={() => setIsFilterOptionsOpen(true)}
+            ref={filterSelectRef}
+            value={filter?.values || []}
+            multiple
+            input={<OutlinedInput label="Performance Tag" />}
+            MenuProps={{
+              PaperProps: {
+                style: {
+                  display: "none",
+                },
+              },
+            }}
+            renderValue={(selected) => (
+              <Box
+                sx={{
+                  display: "flex",
+                  gap: 0.5,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {selected.slice(0, 1).map((value) => (
+                  <Chip
+                    variant="soft"
+                    color={getPerformanceTagColor(value)}
+                    key={value}
+                    label={getTabLabel(value)}
+                    size="small"
+                    sx={{
+                      fontSize: "11px",
+                    }}
+                  />
+                ))}
+                {Boolean(selected.length - 1) && (
+                  <Typography variant="subtitle" color="text.disabled">
+                    + {selected.length - 1} more
+                  </Typography>
+                )}
+              </Box>
+            )}
+          >
+            {filter?.values.map((t) => (
+              <MenuItem value={t} key={t} />
+            ))}
+          </Select>
+        </FormControl>
+      );
+    }
+    return (
+      <FormControl size="small">
+        <InputLabel>Property</InputLabel>
+        <Select
+          label="Property"
+          open={isFilterOptionsOpen}
+          onClose={() => setIsFilterOptionsOpen(false)}
+          onOpen={() => {
+            setIsFilterOptionsOpen(true);
+          }}
+          ref={filterSelectRef}
+          value={filter?.key || ""}
+          MenuProps={{
+            PaperProps: {
+              style: {
+                display: "none",
+              },
+            },
+          }}
+        >
+          <MenuItem value={filter?.key}>{filter?.key}</MenuItem>
+        </Select>
+      </FormControl>
+    );
+  };
+
+  return (
+    <Box
+      sx={{
+        paddingTop: 1,
+        gap: 1,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {renderSelect()}
+      {filter?.type !== "performanceTag" && (
+        <>
+          <FilterOperator
+            operator={filter?.operator || "equal"}
+            setOperator={(newOperator) => {
+              setFilter((prev) => ({
+                ...prev,
+                operator: newOperator,
+              }));
+            }}
+            dataType={filter.datatype}
+          />
+          <FilterValue
+            dataType={filter.datatype}
+            options={filter?.options || []}
+            updateFilter={(updaterFn) =>
+              setFilter((prev) => {
+                const updated = updaterFn(prev);
+                return {
+                  ...prev,
+                  values: updated.values,
+                };
+              })
+            }
+            value={filter?.values || []}
+            disabled={false}
+          />
+        </>
+      )}
+      <FilterOptionsPopover
+        ancElem={filterSelectRef?.current}
+        open={isFilterOptionsOpen}
+        onClose={() => setIsFilterOptionsOpen(false)}
+        onSelect={(update) => {
+          setFilter((existingFilter) => {
+            let newFilter = update;
+            if (typeof update === "function")
+              newFilter = update(existingFilter);
+            return { ...existingFilter, ...newFilter };
+          });
+        }}
+        filter={filter}
+      />
+    </Box>
+  );
+};
+
+FilterSection.propTypes = {
+  setFilter: PropTypes.func,
+  filter: PropTypes.object,
+};
+
+export default FilterSection;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterValue.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/FilterCard/FilterValue.jsx
@@ -1,0 +1,156 @@
+import { Box, Checkbox, InputAdornment, Menu, TextField } from "@mui/material";
+import React, { useRef, useState } from "react";
+import PropType from "prop-types";
+import Iconify from "src/components/iconify";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
+
+const FilterValue = ({ value, updateFilter, dataType, options, disabled }) => {
+  const inputValue = dataType === "string" ? value?.join(", ") : value[0] || "";
+
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const dropDownRef = useRef();
+
+  return (
+    <>
+      <CustomTooltip
+        show={disabled}
+        title="Select a property first"
+        placement="bottom"
+        arrow
+      >
+        <TextField
+          disabled={disabled}
+          ref={dropDownRef}
+          value={inputValue}
+          variant="filled"
+          size="small"
+          placeholder={dataType === "string" ? "Select Value" : "Enter Value"}
+          hiddenLabel
+          inputProps={{
+            readOnly: dataType === "string",
+            style: { cursor: dataType === "string" ? "pointer" : "auto" },
+          }}
+          onClick={() => {
+            if (dataType !== "string") return;
+            setIsDropdownOpen(true);
+          }}
+          onChange={(e) => {
+            updateFilter((o) => ({ ...o, values: [e.target.value] }));
+          }}
+          type={dataType === "string" ? "text" : "number"}
+        />
+      </CustomTooltip>
+
+      <Menu
+        open={isDropdownOpen}
+        onClose={() => setIsDropdownOpen(false)}
+        anchorEl={dropDownRef?.current}
+        PaperProps={{
+          style: {
+            width: `${dropDownRef?.current?.clientWidth}px`,
+            maxHeight: 150,
+          },
+        }}
+      >
+        <Box sx={{ paddingY: 0.5 }}>
+          <TextField
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Iconify icon="eva:search-fill" color="divider" />
+                </InputAdornment>
+              ),
+            }}
+            placeholder="value"
+            variant="outlined"
+            label="Search"
+            size="small"
+            fullWidth
+          />
+        </Box>
+        <Box
+          sx={{
+            maxHeight: "100px",
+            overflowY: "auto",
+          }}
+        >
+          <ValueOption
+            selected={value?.length === options?.length}
+            label="Select all"
+            onChange={(e) => {
+              if (e.target.checked) {
+                updateFilter((o) => ({
+                  ...o,
+                  values: [...options],
+                }));
+              } else {
+                updateFilter((o) => ({ ...o, values: [] }));
+              }
+            }}
+          />
+          {options.map((opt) => {
+            const selected = Boolean(value?.find((v) => v === opt));
+            return (
+              <ValueOption
+                selected={selected}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    updateFilter((o) => {
+                      const new_filter = {
+                        ...o,
+                        values: [...(o.values || []), opt],
+                      };
+                      return new_filter;
+                    });
+                  } else {
+                    updateFilter((o) => {
+                      return {
+                        ...o,
+                        values: (o.values || []).filter((v) => v !== opt),
+                      };
+                    });
+                  }
+                }}
+                key={opt}
+                label={opt}
+              />
+            );
+          })}
+        </Box>
+      </Menu>
+    </>
+  );
+};
+
+const ValueOption = ({ label, selected, onChange }) => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        cursor: "pointer",
+      }}
+      component="label"
+    >
+      <Checkbox checked={selected} onChange={onChange} />
+      {label}
+    </Box>
+  );
+};
+
+ValueOption.propTypes = {
+  label: PropType.string,
+  selected: PropType.bool,
+  onChange: PropType.func,
+};
+
+FilterValue.propTypes = {
+  value: PropType.string,
+  updateFilter: PropType.func,
+  dataType: PropType.string,
+  options: PropType.array,
+  disabled: PropType.bool,
+};
+
+export default FilterValue;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/PerformanceSidebar.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/PerformanceSidebar.jsx
@@ -1,0 +1,167 @@
+import { Box, useTheme } from "@mui/material";
+import React from "react";
+import SidebarOption from "./SidebarOption";
+import DatasetCard from "./DatasetCard";
+import FilterCard from "./FilterCard/FilterCard";
+import PropTypes from "prop-types";
+import { getRandomId } from "src/utils/utils";
+import BreakdownCard from "./BreakdownCard";
+
+const PerformanceSidebar = ({
+  selectedDatasets,
+  setSelectedDatasets,
+  selectedFilters,
+  setSelectedFilters,
+  selectedBreakdown,
+  setSelectedBreakdown,
+}) => {
+  const theme = useTheme();
+
+  const setDataset = (idx, dataset) => {
+    const newDatasets = [...selectedDatasets];
+    let newDataset = dataset;
+    if (typeof dataset === "function") {
+      newDataset = dataset(newDatasets[idx]);
+    }
+    newDatasets[idx] = newDataset;
+    setSelectedDatasets(newDatasets);
+  };
+
+  const cloneDataset = (idx) => {
+    setSelectedDatasets([...selectedDatasets, selectedDatasets[idx]]);
+  };
+
+  const removeDataset = (idx) => {
+    setSelectedDatasets(selectedDatasets.filter((_, i) => i !== idx));
+  };
+
+  const addDataset = () => {
+    setSelectedDatasets([
+      ...selectedDatasets,
+      {
+        id: getRandomId(),
+        metricId: "",
+        environment: "",
+        version: "",
+        filters: [],
+      },
+    ]);
+  };
+
+  const addFilter = () => {
+    setSelectedFilters([
+      ...selectedFilters,
+      {
+        id: getRandomId(),
+        operator: "equal",
+        values: [],
+        type: "",
+        datatype: "string",
+        key: "",
+        keyId: "",
+      },
+    ]);
+  };
+
+  const removeFilter = (idx) => {
+    setSelectedFilters(selectedFilters.filter((_, i) => i !== idx));
+  };
+
+  const cloneFilter = (idx) => {
+    setSelectedFilters([...selectedFilters, selectedFilters[idx]]);
+  };
+
+  const setFilter = (idx, update) => {
+    const newFilters = [...selectedFilters];
+    if (typeof update === "function") {
+      newFilters[idx] = update(newFilters[idx]);
+    } else {
+      newFilters[idx] = update;
+    }
+    setSelectedFilters(newFilters);
+  };
+
+  const addBreakdown = () => {
+    setSelectedBreakdown([
+      ...selectedBreakdown,
+      { id: getRandomId(), key: "", keyId: "" },
+    ]);
+  };
+
+  const removeBreakdown = (idx) => {
+    setSelectedBreakdown(selectedBreakdown.filter((_, i) => i !== idx));
+  };
+
+  const setBreakdown = (idx, update) => {
+    const newBreakdowns = [...selectedBreakdown];
+    if (typeof update === "function") {
+      newBreakdowns[idx] = update(newBreakdowns[idx]);
+    } else {
+      newBreakdowns[idx] = update;
+    }
+    setSelectedBreakdown(newBreakdowns);
+  };
+
+  const cloneBreakdown = (idx) => {
+    setSelectedBreakdown([...selectedBreakdown, selectedBreakdown[idx]]);
+  };
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: "action.hover",
+        paddingX: "16px",
+        overflow: "auto",
+        borderLeft: `1px solid ${theme.palette.divider}`,
+      }}
+    >
+      <SidebarOption title="Performance" onAddClick={addDataset}>
+        {selectedDatasets.map((dataset, idx) => (
+          <DatasetCard
+            key={dataset.id}
+            index={idx}
+            setDataset={setDataset}
+            dataset={dataset}
+            cloneDataset={cloneDataset}
+            removeDataset={removeDataset}
+          />
+        ))}
+      </SidebarOption>
+      <SidebarOption title="Filters" onAddClick={addFilter}>
+        {selectedFilters.map((filter, idx) => (
+          <FilterCard
+            key={filter.id}
+            index={idx}
+            removeFilter={removeFilter}
+            cloneFilter={cloneFilter}
+            setFilter={(update) => setFilter(idx, update)}
+            filter={filter}
+          />
+        ))}
+      </SidebarOption>
+      <SidebarOption title="Breakdown" onAddClick={addBreakdown}>
+        {selectedBreakdown.map((breakdown, idx) => (
+          <BreakdownCard
+            key={breakdown.id}
+            index={idx}
+            setBreakdown={setBreakdown}
+            breakdown={breakdown}
+            removeBreakdown={removeBreakdown}
+            cloneBreakdown={cloneBreakdown}
+          />
+        ))}
+      </SidebarOption>
+    </Box>
+  );
+};
+
+PerformanceSidebar.propTypes = {
+  selectedDatasets: PropTypes.array,
+  setSelectedDatasets: PropTypes.func,
+  selectedFilters: PropTypes.array,
+  setSelectedFilters: PropTypes.func,
+  selectedBreakdown: PropTypes.array,
+  setSelectedBreakdown: PropTypes.func,
+};
+
+export default PerformanceSidebar;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/SidebarOption.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceSidebar/SidebarOption.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Box, IconButton, Typography } from "@mui/material";
+import Iconify from "src/components/iconify";
+
+const SidebarOption = ({ title, onAddClick, children }) => {
+  return (
+    <Box
+      sx={{
+        padding: 1,
+        width: "270px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+      }}
+    >
+      <Box
+        sx={{
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <Typography color="text.disabled" fontWeight={700} fontSize="16px">
+          {title}
+        </Typography>
+        <IconButton color="primary" onClick={() => onAddClick()}>
+          <Iconify icon="mingcute:add-line" />
+        </IconButton>
+      </Box>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+        {children}
+      </Box>
+    </Box>
+  );
+};
+
+SidebarOption.propTypes = {
+  title: PropTypes.string.isRequired,
+  onAddClick: PropTypes.func.isRequired,
+  children: PropTypes.node,
+};
+
+export default SidebarOption;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceTable.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceTable.jsx
@@ -1,0 +1,200 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import {
+  Box,
+  CircularProgress,
+  LinearProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from "@mui/material";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import PropType from "prop-types";
+import PerformanceTableCell from "./PerformanceTableCell";
+import {
+  chatContextColumns,
+  chatEvalColumns,
+  postPromptTemplateColumns,
+  prePromptTemplateColumns,
+} from "src/utils/constant";
+import ChatEvalRow from "./ChatEvalRow";
+import ContextEvalRow from "./ContextEvalRow";
+import PromptTemplateEvalRow from "./PromptTemplateEvalRow";
+import Lightbox from "yet-another-react-lightbox";
+import "yet-another-react-lightbox/styles.css";
+import PerformanceDetailDrawer from "./PerformanceDetail/PerformanceDetailDrawer";
+
+const PerformanceTable = ({
+  tableData,
+  fetchNextPage,
+  isLoading,
+  isFetchingNextPage,
+  setSelectedTags,
+  selectedMetric,
+}) => {
+  const tableContainerRef = useRef(null);
+  const [performanceDetail, setPerformanceDetail] = useState(null);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!tableContainerRef.current || isLoading || isFetchingNextPage) return;
+
+      const { scrollTop, scrollHeight, clientHeight } =
+        tableContainerRef.current;
+      if (scrollTop + clientHeight >= scrollHeight - 5) {
+        fetchNextPage();
+      }
+    };
+
+    const container = tableContainerRef.current;
+    if (container) {
+      container.addEventListener("scroll", handleScroll);
+    }
+
+    return () => {
+      if (container) {
+        container.removeEventListener("scroll", handleScroll);
+      }
+    };
+  }, [tableData]);
+
+  const columns = useMemo(() => {
+    if (selectedMetric?.evaluationType === "EVALUATE_CHAT") {
+      return chatEvalColumns;
+    } else if (
+      selectedMetric?.evaluationType === "EVALUATE_CONTEXT" ||
+      selectedMetric?.evaluationType === "EVALUATE_CONTEXT_RANKING"
+    ) {
+      return chatContextColumns;
+    } else if (selectedMetric?.evaluationType === "EVALUATE_PROMPT_TEMPLATE") {
+      const cols = [...prePromptTemplateColumns];
+
+      // eslint-disable-next-line react/prop-types
+      // if (tableData?.[0]?.variables) {
+      //   // eslint-disable-next-line react/prop-types
+      //   Object.keys(tableData?.[0]?.variables).forEach((key) => {
+      //     cols.push({ id: cols.length + 1, headerName: key });
+      //   });
+      // }
+      postPromptTemplateColumns.forEach((k) => {
+        cols.push({ id: cols.length + 1, headerName: k.headerName });
+      });
+      return cols;
+    }
+    return [];
+  }, [selectedMetric?.evaluationType, tableData]);
+
+  const [selectedImages, setSelectedImages] = useState(null);
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <PerformanceDetailDrawer
+        open={Boolean(performanceDetail)}
+        onClose={() => setPerformanceDetail(null)}
+        performanceDetails={performanceDetail}
+        evalType={selectedMetric?.evaluationType}
+        setSelectedImages={setSelectedImages}
+      />
+      <TableContainer
+        sx={{ height: "calc(100vh - 170px)" }}
+        ref={tableContainerRef}
+      >
+        <Table stickyHeader sx={{ minWidth: 960 }}>
+          <TableHead>
+            <TableRow>
+              {columns.map((headCell) => (
+                <PerformanceTableCell key={headCell.id} sx={{ flex: 1 }}>
+                  {headCell.headerName}
+                </PerformanceTableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableRow>
+            <TableCell colSpan={columns.length} sx={{ padding: 0, margin: 0 }}>
+              {isLoading && <LinearProgress />}
+            </TableCell>
+          </TableRow>
+          <TableBody>
+            {tableData?.map((row) => {
+              const isProcessing = !row?.score;
+              if (selectedMetric?.evaluationType === "EVALUATE_CHAT")
+                return (
+                  <ChatEvalRow
+                    key={row.id}
+                    row={row}
+                    isProcessing={isProcessing}
+                    setPerformanceDetail={setPerformanceDetail}
+                    setSelectedTags={setSelectedTags}
+                    setSelectedImages={setSelectedImages}
+                  />
+                );
+              else if (
+                selectedMetric?.evaluationType === "EVALUATE_CONTEXT" ||
+                selectedMetric?.evaluationType === "EVALUATE_CONTEXT_RANKING"
+              ) {
+                return (
+                  <ContextEvalRow
+                    key={row.id}
+                    row={row}
+                    isProcessing={isProcessing}
+                    setPerformanceDetail={setPerformanceDetail}
+                    setSelectedTags={setSelectedTags}
+                    setSelectedImages={setSelectedImages}
+                  />
+                );
+              } else if (
+                selectedMetric?.evaluationType === "EVALUATE_PROMPT_TEMPLATE"
+              ) {
+                return (
+                  <PromptTemplateEvalRow
+                    key={row.id}
+                    row={row}
+                    isProcessing={isProcessing}
+                    setPerformanceDetail={setPerformanceDetail}
+                    setSelectedTags={setSelectedTags}
+                    setSelectedImages={setSelectedImages}
+                  />
+                );
+              }
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Lightbox
+        open={Boolean(selectedImages)}
+        close={() => {
+          setSelectedImages(null);
+        }}
+        slides={selectedImages?.images}
+        index={selectedImages?.defaultIdx}
+      />
+      {isFetchingNextPage && (
+        <Box sx={{ display: "flex", justifyContent: "center" }}>
+          <CircularProgress size={30} />
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+PerformanceTable.propTypes = {
+  tableData: PropType.arrayOf(
+    PropType.shape({
+      id: PropType.string,
+      modelInput: PropType.string,
+      modelOutput: PropType.string,
+      score: PropType.oneOfType([PropType.string, PropType.number]),
+      explanation: PropType.string,
+      date: PropType.string,
+    }),
+  ),
+  fetchNextPage: PropType.func,
+  isLoading: PropType.bool,
+  isFetchingNextPage: PropType.bool,
+  setSelectedTags: PropType.func,
+  selectedMetric: PropType.object,
+};
+
+export default PerformanceTable;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceTableCell.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceTableCell.jsx
@@ -1,0 +1,9 @@
+import { TableCell, styled } from "@mui/material";
+import React from "react";
+
+const PerformanceTableCell = styled(TableCell)({
+  padding: "8px",
+  fontSize: "12px",
+});
+
+export default PerformanceTableCell;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceTableHeader.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceTableHeader.jsx
@@ -1,0 +1,160 @@
+import {
+  Box,
+  Divider,
+  MenuItem,
+  Popover,
+  Tab,
+  Tabs,
+  useTheme,
+} from "@mui/material";
+import React, { useRef, useState } from "react";
+import PropTypes from "prop-types";
+
+const options = [
+  { label: "Latest", value: "latest" },
+  { label: "Earliest", value: "earliest" },
+  { label: "Low to high score", value: "lowestScore" },
+  { label: "High to low score", value: "highestScore" },
+];
+
+const secondaryTabs = [
+  { label: "Data", value: "data" },
+  { label: "Tag Distribution", value: "tagDistribution" },
+  { label: "Graph Datapoints", value: "graphDatapoints" },
+];
+
+const PerformanceDetailSection = ({
+  orderOption,
+  setOrderOption,
+  selectedDataset,
+  setSelectedDataset,
+  datasets,
+  selectedDetailTab,
+  setSelectedDetailTab,
+  children,
+}) => {
+  const [isSortOpen, setSortOpen] = useState(false);
+
+  const sortRef = useRef();
+
+  const theme = useTheme();
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
+        <Tabs
+          value={selectedDataset}
+          onChange={(e, value) => setSelectedDataset(value)}
+          textColor="primary"
+          TabIndicatorProps={{
+            style: {
+              backgroundColor: theme.palette.primary.main,
+            },
+          }}
+        >
+          {datasets.map((dataset, idx) => (
+            <Tab label={`Dataset ${idx + 1}`} value={idx} key={idx} />
+          ))}
+        </Tabs>
+      </Box>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          borderBottom: 1,
+          borderColor: "divider",
+          alignItems: "center",
+        }}
+      >
+        <Tabs
+          value={selectedDetailTab}
+          onChange={(e, value) => setSelectedDetailTab(value)}
+          textColor="primary"
+          TabIndicatorProps={{
+            style: {
+              backgroundColor: theme.palette.primary.main,
+            },
+          }}
+        >
+          {secondaryTabs.map(({ label, value }) => (
+            <Tab label={label} value={value} key={value} />
+          ))}
+        </Tabs>
+        <Divider />
+        <Box sx={{ display: "flex", gap: 1 }}>
+          {/* <Button
+            ref={sortRef}
+            startIcon={
+              <Iconify icon="bi:filter-left" sx={{ color: "primary.main" }} />
+            }
+            size="small"
+            onClick={() => setSortOpen(true)}
+          >
+            Sort
+          </Button> */}
+          {/* <Button
+            variant="soft"
+            size="small"
+            onClick={() => {
+              trackEvent(Events.metricPerformanceExportClick);
+              generateExport();
+            }}
+          >
+            Export
+          </Button> */}
+        </Box>
+      </Box>
+      <Box sx={{ paddingY: 1 }}>{children}</Box>
+
+      <Popover
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+        anchorEl={sortRef?.current}
+        open={isSortOpen}
+        onClose={() => setSortOpen(false)}
+      >
+        {options.map(({ label, value }) => (
+          <MenuItem
+            selected={value === orderOption}
+            onClick={() => {
+              // trackEvent(Events.metricPerformanceSortChange, {
+              //   "Old Sort": orderOption,
+              //   "New Sort": value,
+              // });
+              setOrderOption(value);
+              setSortOpen(false);
+            }}
+            key={label}
+          >
+            {label}
+          </MenuItem>
+        ))}
+      </Popover>
+    </Box>
+  );
+};
+
+PerformanceDetailSection.propTypes = {
+  generateExport: PropTypes.func,
+  orderOption: PropTypes.string,
+  setOrderOption: PropTypes.func,
+  selectedDataset: PropTypes.number,
+  setSelectedDataset: PropTypes.func,
+  datasets: PropTypes.array,
+  selectedDetailTab: PropTypes.string,
+  setSelectedDetailTab: PropTypes.func,
+  children: PropTypes.node,
+};
+
+export default PerformanceDetailSection;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceTableInfo.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceTableInfo.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+import PropType from "prop-types";
+import PerformanceTableCell from "./PerformanceTableCell";
+import { Box, Chip } from "@mui/material";
+import {
+  getPerformanceTagColor,
+  getScorePercentage,
+  getTabLabel,
+  interpolateColorBasedOnScore,
+} from "src/utils/utils";
+import CircularProgressWithLabel from "src/components/circular-progress-with-label/CircularProgressWithLabel";
+import TruncatedText from "src/components/truncate-string/TruncateString";
+
+const PerformanceTableInfo = ({ row, setSelectedTags }) => {
+  const isProcessing = !row?.score;
+
+  if (isProcessing) {
+    return (
+      <PerformanceTableCell colSpan={3}>
+        <Box sx={{ display: "flex", justifyContent: "center" }}>
+          <Chip label="Processing" color="success" size="small" />
+        </Box>
+      </PerformanceTableCell>
+    );
+  }
+
+  return (
+    <>
+      <PerformanceTableCell>
+        <CircularProgressWithLabel
+          color={interpolateColorBasedOnScore(row.score)}
+          value={getScorePercentage(row.score)}
+        />
+      </PerformanceTableCell>
+      <PerformanceTableCell sx={{ minWidth: "250px" }}>
+        <TruncatedText maxLines={3}>{row.explanation}</TruncatedText>
+      </PerformanceTableCell>
+      <PerformanceTableCell>
+        <Box
+          sx={{
+            display: "flex",
+            gap: 1,
+            flexWrap: "wrap",
+            height: "100%",
+            width: "500px",
+          }}
+        >
+          {row?.tags?.map((tag) => {
+            const color = getPerformanceTagColor(tag);
+            return (
+              <Chip
+                variant="soft"
+                color={color}
+                key={tag}
+                label={getTabLabel(tag)}
+                clickable
+                size="small"
+                sx={{
+                  fontSize: "11px",
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setSelectedTags((existingArr) => {
+                    if (existingArr.includes(tag)) {
+                      return existingArr.filter((t) => t !== tag);
+                    } else {
+                      return [...existingArr, tag];
+                    }
+                  });
+                }}
+              />
+            );
+          })}
+        </Box>
+      </PerformanceTableCell>
+    </>
+  );
+};
+
+PerformanceTableInfo.propTypes = {
+  row: PropType.object,
+  setSelectedTags: PropType.func,
+};
+
+export default PerformanceTableInfo;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceTagDistribution.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceTagDistribution.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  FormControl,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Select,
+} from "@mui/material";
+import TopTagsGraph from "./TopTagsGraph";
+import AllTagsGraph from "./AllTagsGraph";
+
+const tagDistributionTypes = [
+  { label: "All Tags", value: "all" },
+  { label: "Good Tags", value: "good" },
+  { label: "Bad Tags", value: "bad" },
+];
+
+const PerformanceTagDistribution = ({
+  tagDistribution,
+  selectedTagDistributionType,
+  setSelectedTagDistributionType,
+  isLoading,
+}) => {
+  return (
+    <>
+      {isLoading && <LinearProgress />}
+      <Paper elevation={2} sx={{ padding: 2 }}>
+        <FormControl size="small" sx={{ minWidth: "216px" }}>
+          <Select
+            size="small"
+            value={selectedTagDistributionType}
+            onChange={(e) => setSelectedTagDistributionType(e.target.value)}
+          >
+            {tagDistributionTypes.map(({ label, value }) => (
+              <MenuItem key={value} value={value}>
+                {label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {selectedTagDistributionType === "all" && !isLoading && (
+          <AllTagsGraph data={tagDistribution} />
+        )}
+        {selectedTagDistributionType === "good" && !isLoading && (
+          <TopTagsGraph data={tagDistribution} type="good" />
+        )}
+        {selectedTagDistributionType === "bad" && !isLoading && (
+          <TopTagsGraph data={tagDistribution} type="bad" />
+        )}
+      </Paper>
+    </>
+  );
+};
+
+PerformanceTagDistribution.propTypes = {
+  tagDistribution: PropTypes.object,
+  selectedTagDistributionType: PropTypes.string,
+  setSelectedTagDistributionType: PropTypes.func,
+  isLoading: PropTypes.bool,
+};
+export default PerformanceTagDistribution;

--- a/frontend/src/pages/dashboard/models/Performance/PerformanceTagSelect.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PerformanceTagSelect.jsx
@@ -1,0 +1,143 @@
+import {
+  Box,
+  Checkbox,
+  Chip,
+  FormControl,
+  InputLabel,
+  ListSubheader,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  TextField,
+  Typography,
+} from "@mui/material";
+import React from "react";
+import PropTypes from "prop-types";
+import { getPerformanceTagColor, getTabLabel } from "src/utils/utils";
+
+const PerformanceTagSelect = ({
+  selectedTags,
+  setSelectedTags,
+  tagSearchQuery,
+  searchedTagOptions,
+  setTagSearchQuery,
+}) => {
+  return (
+    <FormControl size="small" sx={{ width: 250 }}>
+      <InputLabel>Tag</InputLabel>
+      <Select
+        placeholder="Select Tags"
+        value={selectedTags}
+        onChange={(e) => {
+          const {
+            target: { value },
+          } = e;
+          setSelectedTags(typeof value === "string" ? value.split(",") : value);
+          // trackEvent(Events.metricPerformanceSelectedTagChange, {
+          //   "Selected Tags": value,
+          // });
+        }}
+        label="Tag"
+        multiple
+        input={<OutlinedInput label="Tag" />}
+        MenuProps={{
+          autoFocus: false,
+          PaperProps: {
+            style: {
+              maxHeight: 260,
+              display: "flex",
+              flexDirection: "column",
+            },
+          },
+        }}
+        renderValue={(selected) => (
+          <Box
+            sx={{
+              display: "flex",
+              gap: 0.5,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {selected.slice(0, 1).map((value) => (
+              <Chip
+                variant="soft"
+                color={getPerformanceTagColor(value)}
+                key={value}
+                label={getTabLabel(value)}
+                size="small"
+                sx={{
+                  fontSize: "11px",
+                }}
+              />
+            ))}
+            {Boolean(selected.length - 1) && (
+              <Typography variant="subtitle" color="text.disabled">
+                + {selected.length - 1} more
+              </Typography>
+            )}
+          </Box>
+        )}
+      >
+        <ListSubheader
+          sx={{ padding: 1, paddingBottom: 0 }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <TextField
+            value={tagSearchQuery}
+            onChange={(e) => {
+              e.stopPropagation();
+              setTagSearchQuery(e.target.value);
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            size="small"
+            fullWidth
+            placeholder="Search Tags"
+          />
+        </ListSubheader>
+        {searchedTagOptions
+          ?.sort((a, b) => {
+            if (
+              selectedTags.includes(a.value) &&
+              !selectedTags.includes(b.value)
+            )
+              return -1;
+            if (
+              !selectedTags.includes(a.value) &&
+              selectedTags.includes(b.value)
+            )
+              return 1;
+            return 0;
+          })
+          .map(({ label, value }) => {
+            const color = getPerformanceTagColor(label);
+            return (
+              <MenuItem key={value} value={value}>
+                <Checkbox checked={selectedTags.includes(value)} />
+                <Chip
+                  variant="soft"
+                  color={color}
+                  key={label}
+                  label={getTabLabel(label)}
+                  size="small"
+                  sx={{
+                    fontSize: "11px",
+                  }}
+                />
+              </MenuItem>
+            );
+          })}
+      </Select>
+    </FormControl>
+  );
+};
+
+PerformanceTagSelect.propTypes = {
+  selectedTags: PropTypes.array,
+  setSelectedTags: PropTypes.func,
+  tagSearchQuery: PropTypes.string,
+  searchedTagOptions: PropTypes.array,
+  setTagSearchQuery: PropTypes.func,
+};
+
+export default PerformanceTagSelect;

--- a/frontend/src/pages/dashboard/models/Performance/PromptTemplateEvalRow.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/PromptTemplateEvalRow.jsx
@@ -1,0 +1,109 @@
+import { TableCell, TableRow, useTheme } from "@mui/material";
+import React from "react";
+import PropTypes from "prop-types";
+import { interpolateColorBasedOnScore } from "src/utils/utils";
+import PerformanceTableCell from "./PerformanceTableCell";
+import ShortString from "src/components/ShortString/ShortString";
+import PerformanceTableInfo from "./PerformanceTableInfo";
+import { format } from "date-fns";
+import TruncatedText from "src/components/truncate-string/TruncateString";
+import ModelInputOutputCell from "src/sections/model/ModelInputOutputCell";
+
+const PromptTemplateEvalRow = ({
+  row,
+  isProcessing,
+  setPerformanceDetail,
+  setSelectedTags,
+  setSelectedImages,
+}) => {
+  const theme = useTheme();
+
+  const onImageClick = (curUrl) => {
+    const images = [];
+    let defaultIdx = 0;
+    row.modelInput
+      ?.filter((o) => o["url"] !== undefined)
+      ?.forEach((url) => {
+        if (curUrl === url.url) defaultIdx = images.length;
+        images.push({ src: url.url });
+      });
+    row.modelOutput
+      ?.filter((o) => o["url"] !== undefined)
+      ?.forEach((url) => {
+        if (curUrl === url.url) defaultIdx = images.length;
+        images.push({ src: url.url });
+      });
+    setSelectedImages({ images, defaultIdx });
+  };
+
+  return (
+    <TableRow
+      hover
+      sx={{
+        "&:hover": {
+          cursor: "pointer",
+          backgroundColor: `${theme.palette.primary.main}`,
+        },
+      }}
+      onClick={() => {
+        if (isProcessing) return;
+        setPerformanceDetail(row);
+      }}
+    >
+      <TableCell
+        sx={{
+          padding: 0,
+          position: "relative",
+          width: "10px",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            width: "6px",
+            display: "inline-block",
+            backgroundColor: isProcessing
+              ? "white"
+              : interpolateColorBasedOnScore(row.score),
+          }}
+        />
+      </TableCell>
+      <ModelInputOutputCell
+        content={row.modelInput}
+        contentType={row.modelInputType}
+        onImageClick={onImageClick}
+      />
+      <ModelInputOutputCell
+        content={row.modelOutput}
+        contentType={row.modelOutputType}
+        onImageClick={onImageClick}
+      />
+
+      <PerformanceTableCell sx={{ minWidth: "250px" }}>
+        <TruncatedText maxLines={3}>{row?.context}</TruncatedText>
+      </PerformanceTableCell>
+      <PerformanceTableCell>
+        <ShortString sx={{ minWidth: "200px" }} maxLength={70}>
+          {row?.promptTemplate ? row?.promptTemplate : "-"}
+        </ShortString>
+      </PerformanceTableCell>
+      {/* {renderVariables()} */}
+      <PerformanceTableInfo row={row} setSelectedTags={setSelectedTags} />
+      <PerformanceTableCell sx={{ minWidth: 60 }}>
+        {format(new Date(row.date), "dd/MM/yyyy")}
+      </PerformanceTableCell>
+    </TableRow>
+  );
+};
+
+PromptTemplateEvalRow.propTypes = {
+  row: PropTypes.object,
+  isProcessing: PropTypes.bool,
+  setPerformanceDetail: PropTypes.func,
+  setSelectedTags: PropTypes.func,
+  setSelectedImages: PropTypes.func,
+};
+
+export default PromptTemplateEvalRow;

--- a/frontend/src/pages/dashboard/models/Performance/SaveReport.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/SaveReport.jsx
@@ -1,0 +1,107 @@
+import { LoadingButton } from "@mui/lab";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@mui/material";
+import { useMutation } from "@tanstack/react-query";
+import PropTypes from "prop-types";
+import React from "react";
+import { useForm } from "react-hook-form";
+import axios, { endpoints } from "src/utils/axios";
+import { enqueueSnackbar } from "src/components/snackbar";
+import { useParams } from "react-router";
+import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
+
+const SaveReport = ({
+  open,
+  onClose,
+  datasets,
+  filters,
+  breakdown,
+  aggregation,
+  startDate,
+  endDate,
+}) => {
+  const { control, handleSubmit, reset } = useForm({
+    defaultValues: {
+      name: "",
+    },
+  });
+
+  const { id } = useParams();
+
+  const onCloseClick = () => {
+    reset();
+    onClose();
+  };
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (d) => axios.post(endpoints.performanceReport.create(id), d),
+    onSuccess: () => {
+      enqueueSnackbar("Report saved successfully", { variant: "success" });
+      onCloseClick();
+    },
+  });
+
+  const onSubmit = (d) => {
+    mutate({
+      name: d.name,
+      datasets,
+      filters,
+      breakdown,
+      aggregation,
+      startDate,
+      endDate,
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={onCloseClick} fullWidth maxWidth="xs">
+      <DialogTitle>Save Report</DialogTitle>
+      <DialogContent>
+        <Box sx={{ paddingY: 1 }}>
+          <FormTextFieldV2
+            fullWidth
+            size="small"
+            label="Report Name"
+            placeholder="Enter report name"
+            control={control}
+            fieldName="name"
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" size="small" onClick={onCloseClick}>
+          Cancel
+        </Button>
+        <LoadingButton
+          loading={isPending}
+          variant="contained"
+          size="small"
+          type="submit"
+          color="primary"
+          onClick={handleSubmit(onSubmit)}
+        >
+          Save
+        </LoadingButton>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+SaveReport.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  datasets: PropTypes.object,
+  filters: PropTypes.object,
+  breakdown: PropTypes.object,
+  aggregation: PropTypes.string,
+  startDate: PropTypes.string,
+  endDate: PropTypes.string,
+};
+
+export default SaveReport;

--- a/frontend/src/pages/dashboard/models/Performance/TopTagsGraph.jsx
+++ b/frontend/src/pages/dashboard/models/Performance/TopTagsGraph.jsx
@@ -1,0 +1,98 @@
+import { Box, useTheme } from "@mui/material";
+import PropTypes from "prop-types";
+import React, { useEffect, useRef, useState } from "react";
+import ReactApexChart from "react-apexcharts";
+import { getTabLabel } from "src/utils/utils";
+
+const TopTagsGraph = ({ data, type }) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+  const [chartWidth, setChartWidth] = useState(0);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target === container) {
+          setChartWidth(entry.contentRect.width);
+        }
+      }
+    });
+
+    setChartWidth(container.offsetWidth);
+    resizeObserver.observe(container);
+
+    return () => {
+      resizeObserver.unobserve(container);
+    };
+  }, []);
+
+  const series = [
+    {
+      type: "bar",
+      data: data.map((d) => ({ x: getTabLabel(d[0]), y: d[1] })),
+      color:
+        type === "good"
+          ? theme.palette.success.light
+          : theme.palette.error.light,
+      name: "Tag Count",
+    },
+  ];
+
+  const chartOptions = {
+    chart: {
+      background: "transparent",
+      foreColor: isDark ? "#a1a1aa" : undefined,
+      toolbar: {
+        show: true,
+        tools: {
+          download: false,
+          selection: false,
+          zoom: false,
+          zoomin: false,
+          zoomout: false,
+          pan: false,
+          reset: true,
+        },
+      },
+    },
+    theme: {
+      mode: isDark ? "dark" : "light",
+    },
+    tooltip: {
+      theme: isDark ? "dark" : "light",
+    },
+    grid: {
+      borderColor: isDark ? "#27272a" : undefined,
+    },
+    xaxis: {
+      labels: {
+        trim: true,
+        style: {
+          //   fontSize: "10px",
+        },
+      },
+    },
+  };
+
+  return (
+    <Box ref={containerRef} sx={{ width: "100%" }}>
+      <ReactApexChart
+        options={chartOptions}
+        series={series}
+        type="bar"
+        width={chartWidth}
+        height={400}
+      />
+    </Box>
+  );
+};
+
+TopTagsGraph.propTypes = {
+  data: PropTypes.object,
+  type: PropTypes.string,
+};
+
+export default TopTagsGraph;

--- a/frontend/src/pages/dashboard/models/PerformanceReport/PerformanceReport.jsx
+++ b/frontend/src/pages/dashboard/models/PerformanceReport/PerformanceReport.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Helmet } from "react-helmet-async";
+import PerformanceReportView from "src/sections/model/performance-report/PerformanceReportView";
+
+const PerformanceReport = () => {
+  return (
+    <>
+      <Helmet>
+        <title>Performance Report</title>
+      </Helmet>
+      <PerformanceReportView />
+    </>
+  );
+};
+
+export default PerformanceReport;

--- a/frontend/src/pages/dashboard/models/validation.js
+++ b/frontend/src/pages/dashboard/models/validation.js
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const CreateModelFormValidation = z.object({
+  modelName: z
+    .string({ required_error: "Model Name is required." })
+    .min(1, "Model Name is required."),
+  modelTypeId: z.number({
+    invalid_type_error: "Model Type is required.",
+    required_error: "Model Type is required",
+  }),
+});

--- a/frontend/src/sections/gateway/logs/FilterPanel.jsx
+++ b/frontend/src/sections/gateway/logs/FilterPanel.jsx
@@ -1,0 +1,411 @@
+import React, { useState, useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  Drawer,
+  Stack,
+  Typography,
+  TextField,
+  Button,
+  IconButton,
+  Switch,
+  FormControlLabel,
+  InputAdornment,
+  Autocomplete,
+} from "@mui/material";
+import Iconify from "src/components/iconify";
+import { useAvailableModels } from "../hooks/useAvailableModels";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PANEL_WIDTH = 380;
+
+const EMPTY_STATE = {
+  startedAfter: "",
+  startedBefore: "",
+  model: "",
+  provider: "",
+  statusCodeMin: "",
+  statusCodeMax: "",
+  minLatency: "",
+  maxLatency: "",
+  minCost: "",
+  maxCost: "",
+  userId: "",
+  sessionId: "",
+  isError: false,
+  cacheHit: false,
+  guardrailTriggered: false,
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const FilterPanel = ({ open, onClose, filters, onApply }) => {
+  const availableModels = useAvailableModels();
+  const [local, setLocal] = useState({ ...EMPTY_STATE });
+
+  // Sync props -> local state when the panel opens
+  useEffect(() => {
+    if (open) {
+      setLocal({
+        startedAfter: filters.startedAfter || "",
+        startedBefore: filters.startedBefore || "",
+        model: filters.model || "",
+        provider: filters.provider || "",
+        statusCodeMin: filters.statusCodeMin || "",
+        statusCodeMax: filters.statusCodeMax || "",
+        minLatency: filters.minLatency || "",
+        maxLatency: filters.maxLatency || "",
+        minCost: filters.minCost || "",
+        maxCost: filters.maxCost || "",
+        userId: filters.userId || "",
+        sessionId: filters.sessionId || "",
+        isError: filters.isError === "true",
+        cacheHit: filters.cacheHit === "true",
+        guardrailTriggered: filters.guardrailTriggered === "true",
+      });
+    }
+  }, [open, filters]);
+
+  // --- Field updaters -------------------------------------------------------
+  const handleText = useCallback(
+    (key) => (event) => {
+      setLocal((prev) => ({ ...prev, [key]: event.target.value }));
+    },
+    [],
+  );
+
+  const handleSwitch = useCallback(
+    (key) => (event) => {
+      setLocal((prev) => ({ ...prev, [key]: event.target.checked }));
+    },
+    [],
+  );
+
+  // --- Apply ----------------------------------------------------------------
+  const handleApply = useCallback(() => {
+    // Build a clean filter object -- only include non-empty values
+    const out = {};
+
+    // Preserve non-filter URL params
+    if (filters.view) out.view = filters.view;
+    if (filters.search) out.search = filters.search;
+
+    if (local.startedAfter) out.startedAfter = local.startedAfter;
+    if (local.startedBefore) out.startedBefore = local.startedBefore;
+    if (local.model) out.model = local.model;
+    if (local.provider) out.provider = local.provider;
+    if (local.statusCodeMin) out.statusCodeMin = local.statusCodeMin;
+    if (local.statusCodeMax) out.statusCodeMax = local.statusCodeMax;
+    if (local.minLatency) out.minLatency = local.minLatency;
+    if (local.maxLatency) out.maxLatency = local.maxLatency;
+    if (local.minCost) out.minCost = local.minCost;
+    if (local.maxCost) out.maxCost = local.maxCost;
+    if (local.userId) out.userId = local.userId;
+    if (local.sessionId) out.sessionId = local.sessionId;
+    if (local.isError) out.isError = "true";
+    if (local.cacheHit) out.cacheHit = "true";
+    if (local.guardrailTriggered) out.guardrailTriggered = "true";
+
+    onApply(out);
+  }, [local, filters.view, filters.search, onApply]);
+
+  // --- Clear ----------------------------------------------------------------
+  const handleClear = useCallback(() => {
+    setLocal({ ...EMPTY_STATE });
+  }, []);
+
+  // =========================================================================
+  // Render
+  // =========================================================================
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      sx={{
+        "& .MuiDrawer-paper": { width: PANEL_WIDTH },
+      }}
+    >
+      {/* ---- Header ---- */}
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        p={2}
+        borderBottom={1}
+        borderColor="divider"
+      >
+        <Typography variant="h6">Filters</Typography>
+        <IconButton onClick={onClose} edge="end">
+          <Iconify icon="mdi:close" width={20} />
+        </IconButton>
+      </Stack>
+
+      {/* ---- Body ---- */}
+      <Box p={2} sx={{ overflowY: "auto", flex: 1 }}>
+        <Stack spacing={3}>
+          {/* Date range */}
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Date Range
+            </Typography>
+            <Stack spacing={1.5}>
+              <TextField
+                label="Start Date"
+                type="datetime-local"
+                size="small"
+                fullWidth
+                value={local.startedAfter}
+                onChange={handleText("startedAfter")}
+                InputLabelProps={{ shrink: true }}
+              />
+              <TextField
+                label="End Date"
+                type="datetime-local"
+                size="small"
+                fullWidth
+                value={local.startedBefore}
+                onChange={handleText("startedBefore")}
+                InputLabelProps={{ shrink: true }}
+              />
+            </Stack>
+          </Box>
+
+          {/* Model */}
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Model
+            </Typography>
+            <Autocomplete
+              freeSolo
+              options={availableModels}
+              inputValue={local.model}
+              onInputChange={(_, val) =>
+                setLocal((prev) => ({ ...prev, model: val }))
+              }
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  size="small"
+                  fullWidth
+                  placeholder="e.g., gpt-4o, claude-3-opus"
+                  helperText="Comma-separated model names"
+                />
+              )}
+            />
+          </Box>
+
+          {/* Provider */}
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Provider
+            </Typography>
+            <TextField
+              size="small"
+              fullWidth
+              placeholder="e.g., openai, anthropic"
+              helperText="Comma-separated provider names"
+              value={local.provider}
+              onChange={handleText("provider")}
+            />
+          </Box>
+
+          {/* Status code range */}
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Status Code
+            </Typography>
+            <Stack direction="row" spacing={1}>
+              <TextField
+                label="Min"
+                type="number"
+                size="small"
+                fullWidth
+                value={local.statusCodeMin}
+                onChange={handleText("statusCodeMin")}
+                inputProps={{ min: 100, max: 599 }}
+              />
+              <TextField
+                label="Max"
+                type="number"
+                size="small"
+                fullWidth
+                value={local.statusCodeMax}
+                onChange={handleText("statusCodeMax")}
+                inputProps={{ min: 100, max: 599 }}
+              />
+            </Stack>
+          </Box>
+
+          {/* Latency range */}
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Latency
+            </Typography>
+            <Stack direction="row" spacing={1}>
+              <TextField
+                label="Min (ms)"
+                type="number"
+                size="small"
+                fullWidth
+                value={local.minLatency}
+                onChange={handleText("minLatency")}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">ms</InputAdornment>
+                  ),
+                }}
+              />
+              <TextField
+                label="Max (ms)"
+                type="number"
+                size="small"
+                fullWidth
+                value={local.maxLatency}
+                onChange={handleText("maxLatency")}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">ms</InputAdornment>
+                  ),
+                }}
+              />
+            </Stack>
+          </Box>
+
+          {/* Cost range */}
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Cost
+            </Typography>
+            <Stack direction="row" spacing={1}>
+              <TextField
+                label="Min ($)"
+                type="number"
+                size="small"
+                fullWidth
+                value={local.minCost}
+                onChange={handleText("minCost")}
+                inputProps={{ step: "0.001" }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">$</InputAdornment>
+                  ),
+                }}
+              />
+              <TextField
+                label="Max ($)"
+                type="number"
+                size="small"
+                fullWidth
+                value={local.maxCost}
+                onChange={handleText("maxCost")}
+                inputProps={{ step: "0.001" }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">$</InputAdornment>
+                  ),
+                }}
+              />
+            </Stack>
+          </Box>
+
+          {/* User ID */}
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              User ID
+            </Typography>
+            <TextField
+              size="small"
+              fullWidth
+              placeholder="e.g., user_123"
+              value={local.userId}
+              onChange={handleText("userId")}
+            />
+          </Box>
+
+          {/* Session ID */}
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Session ID
+            </Typography>
+            <TextField
+              size="small"
+              fullWidth
+              placeholder="e.g., sess_abc"
+              value={local.sessionId}
+              onChange={handleText("sessionId")}
+            />
+          </Box>
+
+          {/* Boolean toggles */}
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Flags
+            </Typography>
+            <Stack spacing={0.5}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={local.isError}
+                    onChange={handleSwitch("isError")}
+                  />
+                }
+                label="Errors only"
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={local.cacheHit}
+                    onChange={handleSwitch("cacheHit")}
+                  />
+                }
+                label="Cache hits only"
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={local.guardrailTriggered}
+                    onChange={handleSwitch("guardrailTriggered")}
+                  />
+                }
+                label="Guardrail triggered"
+              />
+            </Stack>
+          </Box>
+        </Stack>
+      </Box>
+
+      {/* ---- Footer ---- */}
+      <Stack
+        direction="row"
+        spacing={2}
+        p={2}
+        borderTop={1}
+        borderColor="divider"
+        sx={{ position: "sticky", bottom: 0, bgcolor: "background.paper" }}
+      >
+        <Button variant="text" onClick={handleClear} sx={{ flex: 1 }}>
+          Clear All
+        </Button>
+        <Button variant="contained" onClick={handleApply} sx={{ flex: 1 }}>
+          Apply
+        </Button>
+      </Stack>
+    </Drawer>
+  );
+};
+
+FilterPanel.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  filters: PropTypes.object.isRequired,
+  onApply: PropTypes.func.isRequired,
+};
+
+export default FilterPanel;

--- a/frontend/src/sections/gateway/logs/RequestDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/logs/RequestDetailDrawer.jsx
@@ -1,0 +1,694 @@
+import React, { useState, useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  Drawer,
+  Stack,
+  Typography,
+  IconButton,
+  Tabs,
+  Tab,
+  Chip,
+  CircularProgress,
+  Alert,
+  Button,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Skeleton,
+  Tooltip,
+  Card,
+  CardContent,
+} from "@mui/material";
+import Iconify from "src/components/iconify";
+import useRequestDetail from "./hooks/useRequestDetail";
+import FeedbackWidget from "../guardrails/FeedbackWidget";
+import { formatCost } from "../utils/formatters";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DRAWER_WIDTH = { xs: "100vw", sm: "60vw" };
+const DRAWER_MIN_WIDTH = 400;
+const DRAWER_MAX_WIDTH = 800;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getStatusChipColor(code) {
+  if (code >= 200 && code < 300) return "success";
+  if (code >= 400 && code < 500) return "warning";
+  if (code >= 500 && code < 600) return "error";
+  return "default";
+}
+
+function getLatencyColor(ms) {
+  if (ms < 500) return "success.main";
+  if (ms <= 2000) return "warning.main";
+  return "error.main";
+}
+
+function formatFullTimestamp(iso) {
+  if (!iso) return "N/A";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return "N/A";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSON viewer sub-component
+// ---------------------------------------------------------------------------
+
+JsonViewer.propTypes = {
+  data: PropTypes.any,
+  label: PropTypes.string,
+};
+
+function JsonViewer({ data, label }) {
+  const raw = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(raw).catch(() => {});
+  }, [raw]);
+
+  return (
+    <Box sx={{ position: "relative" }}>
+      {label && (
+        <Typography variant="subtitle2" gutterBottom>
+          {label}
+        </Typography>
+      )}
+      <Box
+        sx={{
+          bgcolor: "background.neutral",
+          p: 2,
+          borderRadius: 1,
+          overflow: "auto",
+          maxHeight: 400,
+          position: "relative",
+        }}
+      >
+        <Tooltip title="Copy" placement="top" arrow>
+          <IconButton
+            size="small"
+            onClick={handleCopy}
+            sx={{ position: "absolute", top: 8, right: 8 }}
+          >
+            <Iconify icon="mdi:content-copy" width={18} />
+          </IconButton>
+        </Tooltip>
+        <pre
+          style={{
+            margin: 0,
+            fontFamily: "monospace",
+            fontSize: "0.8rem",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+          }}
+        >
+          <code>{raw || "null"}</code>
+        </pre>
+      </Box>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Headers accordion sub-component
+// ---------------------------------------------------------------------------
+
+HeadersAccordion.propTypes = {
+  title: PropTypes.string.isRequired,
+  headers: PropTypes.object,
+};
+
+function HeadersAccordion({ title, headers }) {
+  if (!headers || Object.keys(headers).length === 0) {
+    return (
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<Iconify icon="mdi:chevron-down" width={20} />}
+        >
+          <Typography variant="subtitle2">{title}</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography variant="body2" color="text.secondary">
+            No headers available
+          </Typography>
+        </AccordionDetails>
+      </Accordion>
+    );
+  }
+
+  return (
+    <Accordion>
+      <AccordionSummary
+        expandIcon={<Iconify icon="mdi:chevron-down" width={20} />}
+      >
+        <Typography variant="subtitle2">{title}</Typography>
+      </AccordionSummary>
+      <AccordionDetails sx={{ p: 0 }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Header</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Value</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {Object.entries(headers).map(([key, value]) => (
+              <TableRow key={key}>
+                <TableCell sx={{ fontFamily: "monospace", fontSize: "0.8rem" }}>
+                  {key}
+                </TableCell>
+                <TableCell
+                  sx={{
+                    fontFamily: "monospace",
+                    fontSize: "0.8rem",
+                    wordBreak: "break-all",
+                  }}
+                >
+                  {typeof value === "object"
+                    ? JSON.stringify(value)
+                    : String(value)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab panels
+// ---------------------------------------------------------------------------
+
+OverviewTab.propTypes = { log: PropTypes.object.isRequired };
+
+function OverviewTab({ log }) {
+  const flags = [
+    {
+      key: "isStream",
+      label: "Streaming",
+      value: log.is_stream ?? log.isStream,
+      icon: <Iconify icon="mdi:arrow-right-bold-outline" width={18} />,
+    },
+    {
+      key: "cacheHit",
+      label: "Cache Hit",
+      value: log.cache_hit,
+      icon: <Iconify icon="mdi:cached" width={18} />,
+    },
+    {
+      key: "fallbackUsed",
+      label: "Fallback Used",
+      value: log.fallback_used ?? log.fallbackUsed,
+      icon: <Iconify icon="mdi:swap-horizontal" width={18} />,
+    },
+    {
+      key: "guardrailTriggered",
+      label: "Guardrail Triggered",
+      value: log.guardrail_triggered ?? log.guardrailTriggered,
+      icon: <Iconify icon="mdi:shield-outline" width={18} />,
+    },
+    {
+      key: "isError",
+      label: "Error",
+      value: log.is_error,
+      icon: <Iconify icon="mdi:alert-circle-outline" width={18} />,
+    },
+  ];
+
+  return (
+    <Stack spacing={3} p={2}>
+      {/* Flags */}
+      <Box>
+        <Typography variant="subtitle2" gutterBottom>
+          Flags
+        </Typography>
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          {flags.map((f) => (
+            <Chip
+              key={f.key}
+              icon={f.icon}
+              label={`${f.label}: ${f.value ? "Yes" : "No"}`}
+              size="small"
+              variant="outlined"
+              color={f.value ? "success" : "default"}
+            />
+          ))}
+        </Stack>
+      </Box>
+
+      {/* Routing info */}
+      <Box>
+        <Typography variant="subtitle2" gutterBottom>
+          Routing
+        </Typography>
+        <Stack spacing={0.5}>
+          <Typography variant="body2">
+            <strong>Strategy:</strong>{" "}
+            {log.routing_strategy || log.routingStrategy || "Default"}
+          </Typography>
+          <Typography variant="body2">
+            <strong>Resolved Model:</strong>{" "}
+            {log.resolved_model || log.resolvedModel || log.model || "N/A"}
+          </Typography>
+        </Stack>
+        {log.is_error && log.error_message && (
+          <Alert severity="error" sx={{ mt: 1 }}>
+            {log.error_message}
+          </Alert>
+        )}
+      </Box>
+
+      {/* Identity */}
+      <Box>
+        <Typography variant="subtitle2" gutterBottom>
+          Identity
+        </Typography>
+        <Stack spacing={0.5}>
+          <Typography variant="body2">
+            <strong>API Key:</strong> {log.api_key_id || log.apiKeyId || "N/A"}
+          </Typography>
+          <Typography variant="body2">
+            <strong>User ID:</strong> {log.user_id || log.userId || "N/A"}
+          </Typography>
+          <Typography variant="body2">
+            <strong>Session ID:</strong> {log.session_id || "N/A"}
+          </Typography>
+        </Stack>
+      </Box>
+    </Stack>
+  );
+}
+
+RequestTab.propTypes = { log: PropTypes.object.isRequired };
+
+function RequestTab({ log }) {
+  return (
+    <Stack spacing={2} p={2}>
+      <JsonViewer data={log.request_body} label="Request Body" />
+      <HeadersAccordion
+        title="Request Headers"
+        headers={log.request_headers ?? log.requestHeaders}
+      />
+    </Stack>
+  );
+}
+
+ResponseTab.propTypes = { log: PropTypes.object.isRequired };
+
+function ResponseTab({ log }) {
+  return (
+    <Stack spacing={2} p={2}>
+      <JsonViewer data={log.response_body} label="Response Body" />
+      <HeadersAccordion
+        title="Response Headers"
+        headers={log.response_headers ?? log.responseHeaders}
+      />
+    </Stack>
+  );
+}
+
+MetadataTab.propTypes = { log: PropTypes.object.isRequired };
+
+function MetadataTab({ log }) {
+  const entries = Object.entries(log.metadata || {});
+
+  if (entries.length === 0) {
+    return (
+      <Stack alignItems="center" py={4}>
+        <Typography variant="body2" color="text.secondary">
+          No metadata
+        </Typography>
+      </Stack>
+    );
+  }
+
+  return (
+    <Box p={2}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ fontWeight: 600 }}>Key</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>Value</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {entries.map(([key, value]) => (
+            <TableRow key={key}>
+              <TableCell>{key}</TableCell>
+              <TableCell sx={{ wordBreak: "break-all" }}>
+                {typeof value === "object"
+                  ? JSON.stringify(value)
+                  : String(value)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}
+
+GuardrailsTab.propTypes = { log: PropTypes.object.isRequired };
+
+function GuardrailsTab({ log }) {
+  let raw = log.guardrail_results ?? log.guardrailResults;
+  if (typeof raw === "string") {
+    try {
+      raw = JSON.parse(raw);
+    } catch {
+      raw = null;
+    }
+  }
+
+  // Support both formats:
+  // 1. Object: { action: "block", checks: [{name, action, score, ...}] }
+  // 2. Array (legacy): [{name, action, score, ...}]
+  let overallAction = null;
+  let checks = [];
+
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    overallAction = raw.action;
+    checks = Array.isArray(raw.checks) ? raw.checks : [];
+  } else if (Array.isArray(raw)) {
+    checks = raw;
+  }
+
+  if (checks.length === 0) {
+    return (
+      <Box p={2}>
+        <Alert severity="info">
+          A guardrail was triggered on this request but no detailed check
+          results are available.
+        </Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={2} p={2}>
+      {/* Overall action banner */}
+      {overallAction && (
+        <Alert
+          severity={overallAction === "block" ? "error" : "warning"}
+          icon={
+            <Iconify
+              icon={
+                overallAction === "block"
+                  ? "mdi:shield-off-outline"
+                  : "mdi:shield-alert-outline"
+              }
+              width={22}
+            />
+          }
+        >
+          Request was{" "}
+          <strong>{overallAction === "block" ? "blocked" : "warned"}</strong> by
+          guardrails
+        </Alert>
+      )}
+
+      {/* Individual check cards */}
+      {checks.map((gr, idx) => (
+        <Card key={idx} variant="outlined">
+          <CardContent>
+            <Stack spacing={1}>
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Typography variant="subtitle2">{gr.name}</Typography>
+                <Chip
+                  label={gr.action}
+                  size="small"
+                  color={gr.action === "block" ? "error" : "warning"}
+                  variant="outlined"
+                />
+              </Stack>
+              {(gr.score != null || gr.confidence != null) && (
+                <Typography variant="body2" color="text.secondary">
+                  Score: {gr.score ?? gr.confidence}
+                  {gr.threshold != null ? ` / Threshold: ${gr.threshold}` : ""}
+                </Typography>
+              )}
+              {(gr.latencyMs ?? gr.latency_ms) != null && (
+                <Typography variant="body2" color="text.secondary">
+                  Latency: {gr.latencyMs ?? gr.latency_ms}ms
+                </Typography>
+              )}
+              {(gr.message || gr.details) && (
+                <Typography variant="body2" color="text.secondary">
+                  {gr.message || gr.details}
+                </Typography>
+              )}
+              <FeedbackWidget requestLogId={log.id} checkName={gr.name} />
+            </Stack>
+          </CardContent>
+        </Card>
+      ))}
+    </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+const RequestDetailDrawer = ({ logId, open, onClose }) => {
+  const { data, isLoading, error, refetch } = useRequestDetail(logId);
+  const [activeTab, setActiveTab] = useState(0);
+
+  // Reset tab when a new log is selected
+  useEffect(() => {
+    setActiveTab(0);
+  }, [logId]);
+
+  const log = data?.result ?? data ?? null;
+
+  // Build the dynamic tab list -- conditionally include Guardrails
+  const showGuardrails = log?.guardrailTriggered;
+  const tabs = [
+    { label: "Overview", value: 0 },
+    { label: "Request", value: 1 },
+    { label: "Response", value: 2 },
+    { label: "Metadata", value: 3 },
+  ];
+  if (showGuardrails) {
+    tabs.push({ label: "Guardrails", value: 4 });
+  }
+
+  // =========================================================================
+  // Render
+  // =========================================================================
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      sx={{
+        "& .MuiDrawer-paper": {
+          width: DRAWER_WIDTH,
+          minWidth: DRAWER_MIN_WIDTH,
+          maxWidth: DRAWER_MAX_WIDTH,
+        },
+      }}
+    >
+      {/* ---- Header ---- */}
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        p={2}
+        borderBottom={1}
+        borderColor="divider"
+      >
+        <Stack spacing={0.5} sx={{ minWidth: 0 }}>
+          {isLoading ? (
+            <>
+              <Skeleton variant="text" width={200} />
+              <Skeleton variant="text" width={140} />
+            </>
+          ) : log ? (
+            <>
+              <Tooltip
+                title={log.request_id || log.requestId || log.id}
+                placement="top"
+                arrow
+              >
+                <Typography variant="h6" noWrap>
+                  {(log.request_id || log.requestId || log.id || "").slice(
+                    0,
+                    20,
+                  )}
+                  {(log.request_id || log.requestId || log.id || "").length > 20
+                    ? "..."
+                    : ""}
+                </Typography>
+              </Tooltip>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Typography variant="body2" color="text.secondary">
+                  {log.model}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {log.provider}
+                </Typography>
+                <Chip
+                  label={log.status_code}
+                  size="small"
+                  variant="outlined"
+                  color={getStatusChipColor(log.status_code)}
+                />
+              </Stack>
+            </>
+          ) : null}
+        </Stack>
+
+        <IconButton onClick={onClose} edge="end">
+          <Iconify icon="mdi:close" width={20} />
+        </IconButton>
+      </Stack>
+
+      {/* ---- Summary bar ---- */}
+      {isLoading ? (
+        <Stack direction="row" spacing={3} p={2}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Box key={i}>
+              <Skeleton variant="text" width={60} />
+              <Skeleton variant="text" width={80} />
+            </Box>
+          ))}
+        </Stack>
+      ) : log ? (
+        <Stack
+          direction="row"
+          spacing={3}
+          p={2}
+          sx={{ bgcolor: "action.hover" }}
+        >
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Latency
+            </Typography>
+            <Typography
+              variant="body2"
+              fontWeight={600}
+              sx={{
+                color:
+                  (log.latency_ms ?? log.latencyMs) != null
+                    ? getLatencyColor(log.latency_ms ?? log.latencyMs)
+                    : undefined,
+              }}
+            >
+              {(log.latency_ms ?? log.latencyMs) != null
+                ? `${log.latency_ms ?? log.latencyMs}ms`
+                : "N/A"}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Tokens
+            </Typography>
+            <Typography variant="body2" fontWeight={600}>
+              {log.input_tokens ?? 0} in / {log.output_tokens ?? 0} out
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Cost
+            </Typography>
+            <Typography variant="body2" fontWeight={600}>
+              {formatCost(log.cost)}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Started
+            </Typography>
+            <Typography variant="body2" fontWeight={600}>
+              {formatFullTimestamp(log.started_at ?? log.startedAt)}
+            </Typography>
+          </Box>
+        </Stack>
+      ) : null}
+
+      {/* ---- Error state ---- */}
+      {error && (
+        <Box p={2}>
+          <Alert
+            severity="error"
+            action={
+              <Button color="inherit" size="small" onClick={() => refetch()}>
+                Retry
+              </Button>
+            }
+          >
+            Failed to load request details: {error.message || "Unknown error"}
+          </Alert>
+        </Box>
+      )}
+
+      {/* ---- Loading spinner ---- */}
+      {isLoading && (
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          flex={1}
+          py={8}
+        >
+          <CircularProgress />
+        </Box>
+      )}
+
+      {/* ---- Detail content ---- */}
+      {!isLoading && log && (
+        <>
+          <Tabs
+            value={activeTab}
+            onChange={(_e, v) => setActiveTab(v)}
+            variant="scrollable"
+            scrollButtons="auto"
+            sx={{ px: 2, borderBottom: 1, borderColor: "divider" }}
+          >
+            {tabs.map((t) => (
+              <Tab key={t.value} label={t.label} value={t.value} />
+            ))}
+          </Tabs>
+
+          <Box sx={{ flex: 1, overflowY: "auto" }}>
+            {activeTab === 0 && <OverviewTab log={log} />}
+            {activeTab === 1 && <RequestTab log={log} />}
+            {activeTab === 2 && <ResponseTab log={log} />}
+            {activeTab === 3 && <MetadataTab log={log} />}
+            {activeTab === 4 && showGuardrails && <GuardrailsTab log={log} />}
+          </Box>
+        </>
+      )}
+    </Drawer>
+  );
+};
+
+RequestDetailDrawer.propTypes = {
+  logId: PropTypes.string,
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default RequestDetailDrawer;

--- a/frontend/src/sections/gateway/logs/RequestExplorerSection.jsx
+++ b/frontend/src/sections/gateway/logs/RequestExplorerSection.jsx
@@ -1,0 +1,322 @@
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  Box,
+  Stack,
+  Button,
+  Tabs,
+  Tab,
+  TextField,
+  Badge,
+  InputAdornment,
+  Chip,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import Iconify from "src/components/iconify";
+import SectionHeader from "../components/SectionHeader";
+import { GATEWAY_ICONS } from "../constants/gatewayIcons";
+import axiosInstance, { endpoints } from "src/utils/axios";
+import useFilters from "./hooks/useFilters";
+import RequestTable from "./RequestTable";
+import RequestDetailDrawer from "./RequestDetailDrawer";
+import FilterPanel from "./FilterPanel";
+import SessionExplorer from "./SessionExplorer";
+
+// ---------------------------------------------------------------------------
+// Quick filter definitions
+// ---------------------------------------------------------------------------
+const QUICK_FILTERS = [
+  { label: "All", key: "all" },
+  { label: "Errors", key: "errors", params: { isError: "true" } },
+  { label: "Slow (>1s latency)", key: "slow", params: { minLatency: "1000" } },
+  { label: "Cache Hits", key: "cache", params: { cache_hit: "true" } },
+  {
+    label: "Guardrails",
+    key: "guardrails",
+    params: { guardrailTriggered: "true" },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Return the key of the currently-active quick filter, or "all". */
+function activeQuickFilter(filters) {
+  if (filters.isError === "true") return "errors";
+  if (filters.minLatency === "1000") return "slow";
+  if (filters.cacheHit === "true") return "cache";
+  if (filters.guardrailTriggered === "true") return "guardrails";
+  return "all";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const RequestExplorerSection = () => {
+  // --- URL-synced filters ---------------------------------------------------
+  const { filters, setFilter, setFilters, clearFilters, activeFilterCount } =
+    useFilters();
+
+  // --- Local UI state -------------------------------------------------------
+  const [selectedLogId, setSelectedLogId] = useState(null);
+  const [filterPanelOpen, setFilterPanelOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState(filters.search || "");
+  const [exportAnchor, setExportAnchor] = useState(null);
+  const [isExporting, setIsExporting] = useState(false);
+
+  // --- Debounced search -----------------------------------------------------
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchValue !== (filters.search || "")) {
+        setFilter("search", searchValue || undefined);
+      }
+    }, 300);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchValue]);
+
+  // Keep the controlled input in sync when the URL changes externally
+  // (e.g. browser back/forward or clearing filters).
+  useEffect(() => {
+    setSearchValue(filters.search || "");
+  }, [filters.search]);
+
+  // --- View tab -------------------------------------------------------------
+  const currentView = filters.view || "requests";
+
+  const handleViewChange = useCallback(
+    (_event, newValue) => {
+      setFilter("view", newValue === "requests" ? undefined : newValue);
+    },
+    [setFilter],
+  );
+
+  // --- Quick filters --------------------------------------------------------
+  const activeQF = useMemo(() => activeQuickFilter(filters), [filters]);
+
+  const handleQuickFilter = useCallback(
+    (qf) => {
+      if (qf.key === "all") {
+        clearFilters();
+        return;
+      }
+      // Clear conflicting boolean/range params, then apply this quick filter
+      const cleaned = { view: filters.view, search: filters.search };
+      Object.entries(qf.params).forEach(([k, v]) => {
+        cleaned[k] = v;
+      });
+      setFilters(cleaned);
+    },
+    [filters.view, filters.search, clearFilters, setFilters],
+  );
+
+  // --- Export ---------------------------------------------------------------
+  const handleExportOpen = (event) => setExportAnchor(event.currentTarget);
+  const handleExportClose = () => setExportAnchor(null);
+
+  const handleExport = useCallback(
+    async (format) => {
+      setExportAnchor(null);
+      setIsExporting(true);
+      try {
+        const params = {};
+        if (filters.search) params.search = filters.search;
+        if (filters.model) params.model = filters.model;
+        if (filters.provider) params.provider = filters.provider;
+        if (filters.startedAfter) params.started_after = filters.startedAfter;
+        if (filters.startedBefore)
+          params.started_before = filters.startedBefore;
+        if (filters.isError) params.is_error = filters.isError;
+        if (filters.cacheHit) params.cache_hit = filters.cacheHit;
+        if (filters.guardrailTriggered)
+          params.guardrail_triggered = filters.guardrailTriggered;
+        if (filters.minLatency) params.min_latency = filters.minLatency;
+        if (filters.maxLatency) params.max_latency = filters.maxLatency;
+        if (filters.minCost) params.min_cost = filters.minCost;
+        if (filters.maxCost) params.max_cost = filters.maxCost;
+        if (filters.userId) params.user_id = filters.userId;
+        if (filters.sessionId) params.session_id = filters.sessionId;
+        if (filters.gatewayId) params.gateway_id = filters.gatewayId;
+        if (filters.apiKeyId) params.api_key_id = filters.apiKeyId;
+        if (filters.requestId) params.request_id = filters.requestId;
+        if (filters.isStream) params.is_stream = filters.isStream;
+        if (filters.minTokens) params.min_tokens = filters.minTokens;
+        if (filters.maxTokens) params.max_tokens = filters.maxTokens;
+        if (filters.fallbackUsed) params.fallback_used = filters.fallbackUsed;
+        if (filters.sort) params.ordering = filters.sort;
+        if (filters.statusCode) params.status_code = filters.statusCode;
+
+        params.export_format = format;
+
+        const response = await axiosInstance.get(
+          endpoints.gateway.requestLogExport,
+          { params, responseType: "blob" },
+        );
+
+        const dateStr = new Date().toISOString().split("T")[0];
+        const filename = `agentcc-logs-${dateStr}.${format}`;
+        const blobUrl = URL.createObjectURL(response.data);
+        const link = document.createElement("a");
+        link.href = blobUrl;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(blobUrl);
+      } catch {
+        // Silently handle -- could add a snackbar notification in the future
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [filters],
+  );
+
+  // --- Filter panel apply ---------------------------------------------------
+  const handleApplyFilters = useCallback(
+    (newFilters) => {
+      setFilters(newFilters);
+      setFilterPanelOpen(false);
+    },
+    [setFilters],
+  );
+
+  // =========================================================================
+  // Render
+  // =========================================================================
+  return (
+    <Box p={3}>
+      {/* ---- Header ---- */}
+      <SectionHeader
+        icon={GATEWAY_ICONS.logs}
+        title="Request Logs"
+        subtitle="Search and inspect individual gateway requests"
+      >
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<Iconify icon="mdi:download-outline" width={20} />}
+          onClick={handleExportOpen}
+          disabled={isExporting}
+        >
+          {isExporting ? "Exporting..." : "Export"}
+        </Button>
+
+        <Menu
+          anchorEl={exportAnchor}
+          open={Boolean(exportAnchor)}
+          onClose={handleExportClose}
+          anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+          transformOrigin={{ vertical: "top", horizontal: "right" }}
+        >
+          <MenuItem onClick={() => handleExport("csv")}>
+            <ListItemIcon>
+              <Iconify icon="mdi:file-document-outline" width={18} />
+            </ListItemIcon>
+            <ListItemText>Export CSV</ListItemText>
+          </MenuItem>
+          <MenuItem onClick={() => handleExport("json")}>
+            <ListItemIcon>
+              <Iconify icon="mdi:code-json" width={18} />
+            </ListItemIcon>
+            <ListItemText>Export JSON</ListItemText>
+          </MenuItem>
+        </Menu>
+      </SectionHeader>
+
+      {/* ---- Search + Filters button ---- */}
+      <Stack direction="row" spacing={2} alignItems="center" mb={2}>
+        <TextField
+          placeholder="Search model, provider, request ID..."
+          size="small"
+          fullWidth
+          value={searchValue}
+          onChange={(e) => setSearchValue(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Iconify icon="eva:search-outline" width={18} />
+              </InputAdornment>
+            ),
+          }}
+        />
+        <Badge badgeContent={activeFilterCount} color="primary">
+          <Button
+            variant="outlined"
+            startIcon={<Iconify icon="mdi:filter-outline" width={20} />}
+            onClick={() => setFilterPanelOpen(true)}
+            sx={{ whiteSpace: "nowrap" }}
+          >
+            Filters
+          </Button>
+        </Badge>
+      </Stack>
+
+      {/* ---- Quick filter chips ---- */}
+      <Stack
+        direction="row"
+        spacing={1}
+        mb={2}
+        sx={{ overflowX: "auto", pb: 0.5 }}
+      >
+        {QUICK_FILTERS.map((qf) => (
+          <Chip
+            key={qf.key}
+            label={qf.label}
+            size="medium"
+            variant={activeQF === qf.key ? "filled" : "outlined"}
+            color={activeQF === qf.key ? "primary" : "default"}
+            onClick={() => handleQuickFilter(qf)}
+          />
+        ))}
+      </Stack>
+
+      {/* ---- Tabs: Requests | Sessions ---- */}
+      <Tabs
+        value={currentView}
+        onChange={handleViewChange}
+        variant="standard"
+        sx={{ mb: 2 }}
+      >
+        <Tab label="Requests" value="requests" />
+        <Tab label="Sessions" value="sessions" />
+      </Tabs>
+
+      {/* ---- Main content ---- */}
+      {currentView === "requests" ? (
+        <RequestTable
+          filters={filters}
+          setFilter={setFilter}
+          setFilters={setFilters}
+          onSelectLog={(logId) => setSelectedLogId(logId)}
+        />
+      ) : (
+        <SessionExplorer
+          filters={filters}
+          onRequestClick={(logId) => setSelectedLogId(logId)}
+        />
+      )}
+
+      {/* ---- Detail drawer ---- */}
+      <RequestDetailDrawer
+        logId={selectedLogId}
+        open={Boolean(selectedLogId)}
+        onClose={() => setSelectedLogId(null)}
+      />
+
+      {/* ---- Filter panel drawer ---- */}
+      <FilterPanel
+        open={filterPanelOpen}
+        onClose={() => setFilterPanelOpen(false)}
+        filters={filters}
+        onApply={handleApplyFilters}
+      />
+    </Box>
+  );
+};
+
+export default RequestExplorerSection;

--- a/frontend/src/sections/gateway/logs/RequestTable.jsx
+++ b/frontend/src/sections/gateway/logs/RequestTable.jsx
@@ -1,0 +1,435 @@
+import React, { useCallback, useMemo } from "react";
+import PropTypes from "prop-types";
+import {
+  Card,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TablePagination,
+  TableSortLabel,
+  Typography,
+  Chip,
+  Skeleton,
+  Stack,
+  Tooltip,
+  Alert,
+  Button,
+} from "@mui/material";
+import Iconify from "src/components/iconify";
+import useRequestLogs from "./hooks/useRequestLogs";
+import { formatCost } from "../utils/formatters";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const COLUMNS = [
+  { id: "startedAt", label: "Timestamp", width: 180, sortable: true },
+  { id: "model", label: "Model", width: 140, sortable: false },
+  { id: "provider", label: "Provider", width: 120, sortable: false },
+  { id: "statusCode", label: "Status", width: 80, sortable: true },
+  { id: "latencyMs", label: "Latency", width: 100, sortable: true },
+  { id: "cost", label: "Cost", width: 100, sortable: true },
+  { id: "totalTokens", label: "Tokens", width: 120, sortable: true },
+  { id: "sessionId", label: "Session ID", width: 130, sortable: false },
+];
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getStatusChipColor(code) {
+  if (code === 246) return "warning"; // guardrail warn
+  if (code === 446) return "error"; // guardrail block
+  if (code >= 200 && code < 300) return "success";
+  if (code >= 400 && code < 500) return "error";
+  if (code >= 500 && code < 600) return "error";
+  return "default";
+}
+
+function getLatencyColor(ms) {
+  if (ms < 500) return "success.dark";
+  if (ms <= 2000) return "warning.dark";
+  return "error.main";
+}
+
+function formatTimestamp(iso) {
+  if (!iso) return "N/A";
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+  } catch {
+    return "N/A";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Memoised row component
+// ---------------------------------------------------------------------------
+
+const RequestRow = React.memo(function RequestRow({ log, onClick }) {
+  const isGuardrailBlock = log.status_code === 446;
+  const isGuardrailWarn = log.status_code === 246;
+  const isError =
+    !isGuardrailBlock &&
+    !isGuardrailWarn &&
+    (log.is_error || (log.status_code && log.status_code >= 400));
+
+  const isErrorRow = isError || isGuardrailBlock;
+  const isWarnRow = isGuardrailWarn;
+
+  return (
+    <TableRow
+      hover
+      onClick={() => onClick(log.id)}
+      sx={{
+        cursor: "pointer",
+        ...(isErrorRow && {
+          boxShadow: "inset 3px 0 0 0 #FF5630",
+          "& > td": {
+            backgroundColor: "rgba(255, 86, 48, 0.14) !important",
+          },
+          "&:hover > td": {
+            backgroundColor: "rgba(255, 86, 48, 0.22) !important",
+          },
+        }),
+        ...(isWarnRow && {
+          boxShadow: "inset 3px 0 0 0 #FFAB00",
+          "& > td": {
+            backgroundColor: "rgba(255, 171, 0, 0.12) !important",
+          },
+          "&:hover > td": {
+            backgroundColor: "rgba(255, 171, 0, 0.20) !important",
+          },
+        }),
+      }}
+    >
+      {/* Timestamp */}
+      <TableCell sx={{ whiteSpace: "nowrap" }}>
+        <Typography variant="body2">
+          {formatTimestamp(log.startedAt)}
+        </Typography>
+      </TableCell>
+
+      {/* Model */}
+      <TableCell>
+        <Typography variant="body2" noWrap>
+          {log.model || "-"}
+        </Typography>
+      </TableCell>
+
+      {/* Provider */}
+      <TableCell>
+        <Typography variant="body2" noWrap>
+          {log.provider || "-"}
+        </Typography>
+      </TableCell>
+
+      {/* Status */}
+      <TableCell>
+        <Chip
+          label={log.status_code ?? "-"}
+          size="small"
+          variant="outlined"
+          color={getStatusChipColor(log.status_code)}
+        />
+      </TableCell>
+
+      {/* Latency */}
+      <TableCell>
+        <Typography
+          variant="body2"
+          sx={{
+            color:
+              log.latencyMs != null
+                ? getLatencyColor(log.latencyMs)
+                : undefined,
+            fontWeight: 500,
+          }}
+        >
+          {log.latencyMs != null ? `${log.latencyMs}ms` : "-"}
+        </Typography>
+      </TableCell>
+
+      {/* Cost */}
+      <TableCell>
+        <Typography variant="body2">{formatCost(log.cost)}</Typography>
+      </TableCell>
+
+      {/* Tokens */}
+      <TableCell>
+        <Tooltip
+          title={`Total: ${log.total_tokens ?? 0}`}
+          placement="top"
+          arrow
+        >
+          <Typography variant="body2">
+            {log.input_tokens ?? 0} / {log.output_tokens ?? 0}
+          </Typography>
+        </Tooltip>
+      </TableCell>
+
+      {/* Session ID */}
+      <TableCell>
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          <Typography variant="body2" noWrap sx={{ maxWidth: 100 }}>
+            {log.session_id || "-"}
+          </Typography>
+
+          {/* Flag icons */}
+          {log.cache_hit && (
+            <Tooltip title="Cache Hit" arrow>
+              <Iconify
+                icon="mdi:cached"
+                width={16}
+                sx={{ color: "info.main" }}
+              />
+            </Tooltip>
+          )}
+          {log.guardrailTriggered && (
+            <Tooltip title="Guardrail Triggered" arrow>
+              <Iconify
+                icon="mdi:shield-outline"
+                width={16}
+                sx={{ color: "warning.dark" }}
+              />
+            </Tooltip>
+          )}
+          {log.fallbackUsed && (
+            <Tooltip title="Fallback Used" arrow>
+              <Iconify
+                icon="mdi:swap-horizontal"
+                width={16}
+                sx={{ color: "secondary.main" }}
+              />
+            </Tooltip>
+          )}
+        </Stack>
+      </TableCell>
+    </TableRow>
+  );
+});
+
+RequestRow.propTypes = {
+  log: PropTypes.object.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+const RequestTable = ({ filters, setFilter, setFilters, onSelectLog }) => {
+  // Pagination state derived from filters (URL params)
+  const page = parseInt(filters.page, 10) || 1;
+  const pageSize = parseInt(filters.pageSize, 10) || 25;
+  const sort = filters.sort || "-started_at";
+
+  const { data, isLoading, error, refetch } = useRequestLogs({
+    filters,
+    page,
+    pageSize,
+  });
+
+  const results = data?.result?.results ?? data?.results ?? [];
+  const totalCount = data?.result?.count ?? data?.count ?? 0;
+
+  // --- Sort handler ---------------------------------------------------------
+  const handleSort = useCallback(
+    (columnId) => {
+      const fieldMap = {
+        startedAt: "started_at",
+        statusCode: "status_code",
+        latencyMs: "latency_ms",
+        cost: "cost",
+        totalTokens: "total_tokens",
+      };
+      const apiField = fieldMap[columnId] || columnId;
+      const currentField = sort.replace(/^-/, "");
+      const isDesc = sort.startsWith("-");
+
+      const newSort =
+        currentField === apiField
+          ? isDesc
+            ? apiField
+            : `-${apiField}`
+          : `-${apiField}`;
+
+      setFilters({ ...filters, sort: newSort, page: "1" });
+    },
+    [sort, filters, setFilters],
+  );
+
+  // --- Pagination handlers --------------------------------------------------
+  const handlePageChange = useCallback(
+    (_event, newPage) => {
+      setFilter("page", String(newPage + 1)); // MUI is 0-indexed
+    },
+    [setFilter],
+  );
+
+  const handleRowsPerPageChange = useCallback(
+    (event) => {
+      setFilters({
+        ...filters,
+        pageSize: String(event.target.value),
+        page: "1",
+      });
+    },
+    [filters, setFilters],
+  );
+
+  // --- Current sort state for header indicators -----------------------------
+  const sortField = sort.replace(/^-/, "");
+  const sortDir = sort.startsWith("-") ? "desc" : "asc";
+
+  const fieldMap = useMemo(
+    () => ({
+      startedAt: "started_at",
+      statusCode: "status_code",
+      latencyMs: "latency_ms",
+      cost: "cost",
+      totalTokens: "total_tokens",
+    }),
+    [],
+  );
+
+  // =========================================================================
+  // Render
+  // =========================================================================
+
+  return (
+    <Card>
+      {/* Error state */}
+      {error && (
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" size="small" onClick={() => refetch()}>
+              Retry
+            </Button>
+          }
+          sx={{ borderRadius: 0 }}
+        >
+          Failed to load request logs: {error.message || "Unknown error"}
+        </Alert>
+      )}
+
+      <TableContainer sx={{ maxHeight: "calc(100vh - 360px)" }}>
+        <Table stickyHeader size="small">
+          {/* ---- Header ---- */}
+          <TableHead>
+            <TableRow>
+              {COLUMNS.map((col) => (
+                <TableCell
+                  key={col.id}
+                  sx={{ width: col.width, fontWeight: 600 }}
+                >
+                  {col.sortable ? (
+                    <TableSortLabel
+                      active={sortField === (fieldMap[col.id] || col.id)}
+                      direction={
+                        sortField === (fieldMap[col.id] || col.id)
+                          ? sortDir
+                          : "desc"
+                      }
+                      onClick={() => handleSort(col.id)}
+                    >
+                      {col.label}
+                    </TableSortLabel>
+                  ) : (
+                    col.label
+                  )}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+
+          <TableBody>
+            {/* ---- Loading skeleton ---- */}
+            {isLoading &&
+              Array.from({ length: 10 }).map((_, idx) => (
+                <TableRow key={`skeleton-${idx}`}>
+                  {COLUMNS.map((col) => (
+                    <TableCell key={col.id}>
+                      {col.id === "statusCode" ? (
+                        <Skeleton
+                          variant="rectangular"
+                          width={40}
+                          height={20}
+                          sx={{ borderRadius: 1 }}
+                        />
+                      ) : (
+                        <Skeleton variant="text" width="80%" />
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+
+            {/* ---- Data rows ---- */}
+            {!isLoading &&
+              results.length > 0 &&
+              results.map((log) => (
+                <RequestRow key={log.id} log={log} onClick={onSelectLog} />
+              ))}
+
+            {/* ---- Empty state ---- */}
+            {!isLoading && !error && results.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={COLUMNS.length}>
+                  <Stack alignItems="center" spacing={1.5} py={6}>
+                    <Iconify
+                      icon="mdi:magnify-remove-outline"
+                      width={48}
+                      sx={{ color: "text.disabled" }}
+                    />
+                    <Typography variant="h6" color="text.secondary">
+                      No requests found
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Try adjusting your filters or check that your gateway is
+                      forwarding logs.
+                    </Typography>
+                  </Stack>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* ---- Pagination ---- */}
+      <TablePagination
+        component="div"
+        count={totalCount}
+        page={page - 1}
+        rowsPerPage={pageSize}
+        rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+        onPageChange={handlePageChange}
+        onRowsPerPageChange={handleRowsPerPageChange}
+      />
+    </Card>
+  );
+};
+
+RequestTable.propTypes = {
+  filters: PropTypes.object.isRequired,
+  setFilter: PropTypes.func.isRequired,
+  setFilters: PropTypes.func.isRequired,
+  onSelectLog: PropTypes.func.isRequired,
+};
+
+export default RequestTable;

--- a/frontend/src/sections/gateway/logs/SessionExplorer.jsx
+++ b/frontend/src/sections/gateway/logs/SessionExplorer.jsx
@@ -1,0 +1,407 @@
+import React, { useState, useCallback } from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  Card,
+  Stack,
+  Typography,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TablePagination,
+  ToggleButton,
+  ToggleButtonGroup,
+  CircularProgress,
+  Skeleton,
+  Tooltip,
+} from "@mui/material";
+import Iconify from "src/components/iconify";
+import { useQuery } from "@tanstack/react-query";
+import axiosInstance, { endpoints } from "src/utils/axios";
+import useSessions from "./hooks/useSessions";
+import { formatCost } from "../utils/formatters";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50];
+
+const SORT_OPTIONS = [
+  { value: "newest", label: "Newest" },
+  { value: "most_requests", label: "Most Requests" },
+  { value: "highest_cost", label: "Highest Cost" },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTimestamp(iso) {
+  if (!iso) return "N/A";
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  } catch {
+    return "N/A";
+  }
+}
+
+function getStatusChipColor(code) {
+  if (code >= 200 && code < 300) return "success";
+  if (code >= 400 && code < 500) return "warning";
+  if (code >= 500 && code < 600) return "error";
+  return "default";
+}
+
+function getLatencyColor(ms) {
+  if (ms < 500) return "success.main";
+  if (ms <= 2000) return "warning.main";
+  return "error.main";
+}
+
+// ---------------------------------------------------------------------------
+// Expanded session detail (lazy-loaded requests)
+// ---------------------------------------------------------------------------
+
+SessionDetail.propTypes = {
+  sessionId: PropTypes.string.isRequired,
+  onRequestClick: PropTypes.func.isRequired,
+};
+
+function SessionDetail({ sessionId, onRequestClick }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["agentcc-session-detail", sessionId],
+    queryFn: async () => {
+      const res = await axiosInstance.get(
+        endpoints.gateway.requestLogSessionDetail(sessionId),
+      );
+      return res.data;
+    },
+    enabled: Boolean(sessionId),
+    staleTime: 60000,
+  });
+
+  const requests = data?.result?.results ?? data?.results ?? [];
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" py={3}>
+        <CircularProgress size={28} />
+      </Box>
+    );
+  }
+
+  if (requests.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" py={2} px={1}>
+        No requests found for this session.
+      </Typography>
+    );
+  }
+
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell sx={{ fontWeight: 600 }}>Timestamp</TableCell>
+          <TableCell sx={{ fontWeight: 600 }}>Request ID</TableCell>
+          <TableCell sx={{ fontWeight: 600 }}>Model</TableCell>
+          <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
+          <TableCell sx={{ fontWeight: 600 }}>Latency</TableCell>
+          <TableCell sx={{ fontWeight: 600 }}>Cost</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {requests.map((req) => (
+          <TableRow
+            key={req.id}
+            hover
+            sx={{ cursor: "pointer" }}
+            onClick={() => onRequestClick(req.id)}
+          >
+            <TableCell sx={{ whiteSpace: "nowrap" }}>
+              {formatTimestamp(req.startedAt)}
+            </TableCell>
+            <TableCell>
+              <Tooltip title={req.requestId || req.id} placement="top" arrow>
+                <Typography variant="body2" noWrap sx={{ maxWidth: 120 }}>
+                  {(req.requestId || req.id || "").slice(0, 12)}...
+                </Typography>
+              </Tooltip>
+            </TableCell>
+            <TableCell>{req.model || "-"}</TableCell>
+            <TableCell>
+              <Chip
+                label={req.status_code ?? "-"}
+                size="small"
+                variant="outlined"
+                color={getStatusChipColor(req.status_code)}
+              />
+            </TableCell>
+            <TableCell>
+              <Typography
+                variant="body2"
+                sx={{
+                  color:
+                    req.latencyMs != null
+                      ? getLatencyColor(req.latencyMs)
+                      : undefined,
+                }}
+              >
+                {req.latencyMs != null ? `${req.latencyMs}ms` : "-"}
+              </Typography>
+            </TableCell>
+            <TableCell>{formatCost(req.cost)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+const SessionExplorer = ({ filters, onRequestClick }) => {
+  const [sortBy, setSortBy] = useState("newest");
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
+  const [expandedSession, setExpandedSession] = useState(null);
+
+  // Map the UI sort value to API ordering param
+  const orderingMap = {
+    newest: "-last_request_at",
+    most_requests: "-request_count",
+    highest_cost: "-total_cost",
+  };
+
+  const { data, isLoading } = useSessions({
+    ...filters,
+    page: String(page),
+    pageSize: String(pageSize),
+    sessionSort: orderingMap[sortBy],
+  });
+
+  const sessions = data?.result?.results ?? data?.results ?? [];
+  const totalCount = data?.result?.count ?? data?.count ?? 0;
+
+  // --- Handlers -------------------------------------------------------------
+  const handleSortChange = useCallback((_event, newValue) => {
+    if (newValue) {
+      setSortBy(newValue);
+      setPage(1);
+    }
+  }, []);
+
+  const handleAccordionChange = useCallback(
+    (sessionId) => (_event, isExpanded) => {
+      setExpandedSession(isExpanded ? sessionId : null);
+    },
+    [],
+  );
+
+  const handlePageChange = useCallback((_event, newPage) => {
+    setPage(newPage + 1);
+  }, []);
+
+  const handleRowsPerPageChange = useCallback((event) => {
+    setPageSize(parseInt(event.target.value, 10));
+    setPage(1);
+  }, []);
+
+  // =========================================================================
+  // Render
+  // =========================================================================
+
+  return (
+    <Card>
+      {/* ---- Sort controls ---- */}
+      <Stack
+        direction="row"
+        spacing={2}
+        p={2}
+        borderBottom={1}
+        borderColor="divider"
+        alignItems="center"
+      >
+        <Typography variant="body2" color="text.secondary">
+          Sort by:
+        </Typography>
+        <ToggleButtonGroup
+          value={sortBy}
+          exclusive
+          onChange={handleSortChange}
+          size="small"
+        >
+          {SORT_OPTIONS.map((opt) => (
+            <ToggleButton key={opt.value} value={opt.value}>
+              {opt.label}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Stack>
+
+      {/* ---- Loading skeletons ---- */}
+      {isLoading && (
+        <Stack spacing={1} p={2}>
+          {Array.from({ length: 5 }).map((_, idx) => (
+            <Box key={idx}>
+              <Skeleton
+                variant="rectangular"
+                height={56}
+                sx={{ borderRadius: 1 }}
+              />
+            </Box>
+          ))}
+        </Stack>
+      )}
+
+      {/* ---- Session list ---- */}
+      {!isLoading && sessions.length > 0 && (
+        <Box>
+          {sessions.map((session) => (
+            <Accordion
+              key={session.session_id}
+              expanded={expandedSession === session.session_id}
+              onChange={handleAccordionChange(session.session_id)}
+              disableGutters
+              sx={{
+                "&:before": { display: "none" },
+                borderBottom: 1,
+                borderColor: "divider",
+              }}
+            >
+              <AccordionSummary
+                expandIcon={<Iconify icon="mdi:chevron-down" width={20} />}
+              >
+                <Stack
+                  direction="row"
+                  spacing={2}
+                  alignItems="center"
+                  width="100%"
+                  sx={{ overflow: "hidden", pr: 1 }}
+                >
+                  <Tooltip title={session.session_id} placement="top" arrow>
+                    <Typography
+                      variant="subtitle2"
+                      noWrap
+                      sx={{ minWidth: 140 }}
+                    >
+                      {(session.session_id || "").slice(0, 16)}
+                      {(session.session_id || "").length > 16 ? "..." : ""}
+                    </Typography>
+                  </Tooltip>
+
+                  <Chip
+                    label={`${session.request_count} requests`}
+                    size="small"
+                    variant="outlined"
+                  />
+
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    noWrap
+                    sx={{ maxWidth: 200 }}
+                  >
+                    {(session.models || []).join(", ") || "-"}
+                  </Typography>
+
+                  <Typography variant="body2" noWrap>
+                    {session.total_tokens?.toLocaleString() ?? 0} tokens
+                  </Typography>
+
+                  <Typography variant="body2" noWrap>
+                    {formatCost(session.total_cost)}
+                  </Typography>
+
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    noWrap
+                    sx={{ ml: "auto" }}
+                  >
+                    {formatTimestamp(session.firstRequestAt)} -{" "}
+                    {formatTimestamp(session.lastRequestAt)}
+                  </Typography>
+
+                  {session.errorCount > 0 && (
+                    <Chip
+                      label={`${session.errorCount} errors`}
+                      size="small"
+                      color="error"
+                      variant="outlined"
+                    />
+                  )}
+                </Stack>
+              </AccordionSummary>
+
+              <AccordionDetails sx={{ p: 0 }}>
+                {expandedSession === session.session_id && (
+                  <SessionDetail
+                    sessionId={session.session_id}
+                    onRequestClick={onRequestClick}
+                  />
+                )}
+              </AccordionDetails>
+            </Accordion>
+          ))}
+        </Box>
+      )}
+
+      {/* ---- Empty state ---- */}
+      {!isLoading && sessions.length === 0 && (
+        <Stack alignItems="center" spacing={1.5} py={6}>
+          <Iconify
+            icon="mdi:group"
+            width={48}
+            sx={{ color: "text.disabled" }}
+          />
+          <Typography variant="h6" color="text.secondary">
+            No sessions found
+          </Typography>
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            textAlign="center"
+            maxWidth={400}
+          >
+            Requests with session IDs appear here. Check that your gateway is
+            configured to capture session IDs.
+          </Typography>
+        </Stack>
+      )}
+
+      {/* ---- Pagination ---- */}
+      <TablePagination
+        component="div"
+        count={totalCount}
+        page={page - 1}
+        rowsPerPage={pageSize}
+        rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+        onPageChange={handlePageChange}
+        onRowsPerPageChange={handleRowsPerPageChange}
+      />
+    </Card>
+  );
+};
+
+SessionExplorer.propTypes = {
+  filters: PropTypes.object.isRequired,
+  onRequestClick: PropTypes.func.isRequired,
+};
+
+export default SessionExplorer;

--- a/frontend/src/sections/gateway/logs/hooks/useFilters.js
+++ b/frontend/src/sections/gateway/logs/hooks/useFilters.js
@@ -1,0 +1,131 @@
+import { useMemo, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+
+// ---------------------------------------------------------------------------
+// Bidirectional mapping: camelCase <-> snake_case URL param names.
+// Keys that are identical in both conventions (model, provider, ordering)
+// are intentionally omitted -- they pass through unchanged.
+// ---------------------------------------------------------------------------
+const CAMEL_TO_SNAKE = {
+  gatewayId: "gateway_id",
+  startedAfter: "started_after",
+  startedBefore: "started_before",
+  minLatency: "min_latency",
+  maxLatency: "max_latency",
+  minCost: "min_cost",
+  maxCost: "max_cost",
+  isError: "is_error",
+  cacheHit: "cache_hit",
+  guardrailTriggered: "guardrail_triggered",
+  statusCode: "status_code",
+  userId: "user_id",
+  sessionId: "session_id",
+  apiKeyId: "api_key_id",
+};
+
+// Keys that are NOT content filters (excluded from active filter count).
+const NON_CONTENT_KEYS = new Set([
+  "view",
+  "page",
+  "pageSize",
+  "sort",
+  "search",
+]);
+
+// Build the reverse map once at module load time.
+const SNAKE_TO_CAMEL = Object.fromEntries(
+  Object.entries(CAMEL_TO_SNAKE).map(([camel, snake]) => [snake, camel]),
+);
+
+/** Convert a camelCase filter key to its snake_case URL param name. */
+function toUrlKey(camelKey) {
+  return CAMEL_TO_SNAKE[camelKey] || camelKey;
+}
+
+/** Convert a snake_case URL param name to its camelCase JS key. */
+function fromUrlKey(snakeKey) {
+  return SNAKE_TO_CAMEL[snakeKey] || snakeKey;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Syncs filter state with the browser URL search params.
+ *
+ * URL params use snake_case; the returned `filters` object uses camelCase.
+ *
+ * @returns {{
+ *   filters: Object,
+ *   setFilter: (key: string, value: string|null|undefined) => void,
+ *   setFilters: (obj: Object) => void,
+ *   clearFilters: () => void,
+ *   activeFilterCount: number,
+ * }}
+ */
+export default function useFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Build a camelCase filters object from the current URL params.
+  const filters = useMemo(() => {
+    const obj = {};
+    for (const [snakeKey, value] of searchParams.entries()) {
+      const camelKey = fromUrlKey(snakeKey);
+      obj[camelKey] = value;
+    }
+    return obj;
+  }, [searchParams]);
+
+  // Set a single filter. Passing null / undefined removes it.
+  const setFilter = useCallback(
+    (key, value) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          const urlKey = toUrlKey(key);
+
+          if (value === null || value === undefined || value === "") {
+            next.delete(urlKey);
+          } else {
+            next.set(urlKey, value);
+          }
+
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  // Replace all URL params with the provided object.
+  // null / undefined / empty-string values are omitted.
+  const setFilters = useCallback(
+    (obj) => {
+      const next = new URLSearchParams();
+
+      Object.entries(obj).forEach(([key, value]) => {
+        if (value === null || value === undefined || value === "") return;
+        const urlKey = toUrlKey(key);
+        next.set(urlKey, value);
+      });
+
+      setSearchParams(next, { replace: true });
+    },
+    [setSearchParams],
+  );
+
+  // Remove every filter param from the URL.
+  const clearFilters = useCallback(() => {
+    setSearchParams(new URLSearchParams(), { replace: true });
+  }, [setSearchParams]);
+
+  // Count of content-filter values (exclude pagination/sort/view/search).
+  const activeFilterCount = useMemo(
+    () => Object.keys(filters).filter((k) => !NON_CONTENT_KEYS.has(k)).length,
+    [filters],
+  );
+
+  return { filters, setFilter, setFilters, clearFilters, activeFilterCount };
+}

--- a/frontend/src/sections/gateway/logs/hooks/useRequestDetail.js
+++ b/frontend/src/sections/gateway/logs/hooks/useRequestDetail.js
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import axiosInstance, { endpoints } from "src/utils/axios";
+
+/**
+ * Fetches the full detail for a single request log entry.
+ *
+ * @param {string|null|undefined} logId - The ID of the request log to fetch.
+ * @returns {{ data: Object|undefined, isLoading: boolean, error: Error|null }}
+ */
+export default function useRequestDetail(logId) {
+  return useQuery({
+    queryKey: ["requestLogDetail", logId],
+    queryFn: async () => {
+      const res = await axiosInstance.get(
+        endpoints.gateway.requestLogDetail(logId),
+      );
+      return res.data;
+    },
+    enabled: Boolean(logId),
+  });
+}

--- a/frontend/src/sections/gateway/logs/hooks/useRequestLogs.js
+++ b/frontend/src/sections/gateway/logs/hooks/useRequestLogs.js
@@ -1,0 +1,93 @@
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import axiosInstance, { endpoints } from "src/utils/axios";
+
+// ---------------------------------------------------------------------------
+// Maps camelCase filter keys to the snake_case param names expected by the API.
+// Keys that are already identical in both conventions are omitted.
+// ---------------------------------------------------------------------------
+const FILTER_KEY_MAP = {
+  gatewayId: "gateway_id",
+  statusCode: "status_code",
+  isError: "is_error",
+  cacheHit: "cache_hit",
+  guardrailTriggered: "guardrail_triggered",
+  userId: "user_id",
+  sessionId: "session_id",
+  apiKeyId: "api_key_id",
+  minLatency: "min_latency",
+  maxLatency: "max_latency",
+  minCost: "min_cost",
+  maxCost: "max_cost",
+  startedAfter: "started_after",
+  startedBefore: "started_before",
+};
+
+/**
+ * Convert a camelCase filters object into query-param-ready snake_case params.
+ * Null / undefined / empty-string values are omitted.
+ */
+export function buildFilterParams(filters = {}) {
+  const params = {};
+
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value === null || value === undefined || value === "") return;
+    const paramKey = FILTER_KEY_MAP[key] || key;
+    params[paramKey] = value;
+  });
+
+  return params;
+}
+
+/**
+ * Fetches paginated request logs with optional filters.
+ *
+ * @param {Object}  options
+ * @param {Object}  [options.filters={}]   - camelCase filter values
+ * @param {number}  [options.page=1]       - 1-based page number
+ * @param {number}  [options.pageSize=25]  - rows per page
+ * @returns {{ data: Object|undefined, isLoading: boolean, error: Error|null, refetch: Function }}
+ */
+export default function useRequestLogs({
+  filters = {},
+  page = 1,
+  pageSize = 25,
+} = {}) {
+  const sort = filters.sort || "-started_at";
+  const searchTerm = (filters.search || "").trim();
+
+  return useQuery({
+    queryKey: ["requestLogs", filters, page, pageSize],
+    queryFn: async () => {
+      const params = {
+        ...buildFilterParams(filters),
+        page,
+        limit: pageSize,
+        ordering: sort,
+      };
+
+      // Remove keys that are URL-only, not API params
+      delete params.sort;
+      delete params.view;
+      delete params.pageSize;
+      delete params.search;
+
+      // Use the dedicated search endpoint when a search term is present
+      if (searchTerm.length >= 2) {
+        params.q = searchTerm;
+        const res = await axiosInstance.get(
+          endpoints.gateway.requestLogSearch,
+          {
+            params,
+          },
+        );
+        return res.data;
+      }
+
+      const res = await axiosInstance.get(endpoints.gateway.requestLogs, {
+        params,
+      });
+      return res.data;
+    },
+    placeholderData: keepPreviousData,
+  });
+}

--- a/frontend/src/sections/gateway/logs/hooks/useSessions.js
+++ b/frontend/src/sections/gateway/logs/hooks/useSessions.js
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import axiosInstance, { endpoints } from "src/utils/axios";
+import { buildFilterParams } from "./useRequestLogs";
+
+/**
+ * Fetches paginated session aggregation data.
+ *
+ * @param {Object}  options
+ * @param {Object}  [options.filters={}]    - camelCase filter values (same shape as useRequestLogs)
+ * @param {number}  [options.page=1]        - 1-based page number
+ * @param {number}  [options.pageSize=25]   - rows per page
+ * @param {boolean} [options.enabled=true]  - controls whether the query fires
+ * @returns {{ data: Object|undefined, isLoading: boolean, error: Error|null }}
+ */
+export default function useSessions({
+  filters = {},
+  page = 1,
+  pageSize = 25,
+  enabled = true,
+} = {}) {
+  return useQuery({
+    queryKey: ["requestLogSessions", filters, page, pageSize],
+    queryFn: async () => {
+      const params = {
+        ...buildFilterParams(filters),
+        page,
+        limit: pageSize,
+      };
+
+      const res = await axiosInstance.get(
+        endpoints.gateway.requestLogSessions,
+        { params },
+      );
+      return res.data;
+    },
+    enabled: Boolean(enabled),
+  });
+}

--- a/futureagi/accounts/models/__init__.py
+++ b/futureagi/accounts/models/__init__.py
@@ -1,0 +1,9 @@
+from accounts.models.audit_log import AuditLog
+from accounts.models.aws_marketplace import AWSMarketplaceCustomer
+from accounts.models.organization import Organization
+from accounts.models.organization_invite import OrganizationInvite
+from accounts.models.recovery_code import RecoveryCode
+from accounts.models.totp_device import UserTOTPDevice
+from accounts.models.user import CustomUserManager, OrgApiKey, User
+from accounts.models.webauthn_credential import WebAuthnCredential
+from accounts.models.workspace import Workspace

--- a/futureagi/accounts/models/audit_log.py
+++ b/futureagi/accounts/models/audit_log.py
@@ -1,0 +1,89 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+
+
+class AuditAction:
+    """Known audit actions. CharField is not DB-enforced, so new actions can be
+    added without a migration — but always define them here first."""
+
+    MEMBER_INVITED = "member.invited"
+    MEMBER_REMOVED = "member.removed"
+    MEMBER_ROLE_UPDATED = "member.role_updated"
+    MEMBER_REACTIVATED = "member.reactivated"
+    MEMBER_DEACTIVATED = "member.deactivated"
+    INVITE_RESENT = "invite.resent"
+    INVITE_CANCELLED = "invite.cancelled"
+    WS_MEMBER_ADDED = "workspace_member.added"
+    WS_MEMBER_REMOVED = "workspace_member.removed"
+    WS_MEMBER_ROLE_UPDATED = "workspace_member.role_updated"
+
+    CHOICES = [
+        (MEMBER_INVITED, "Member Invited"),
+        (MEMBER_REMOVED, "Member Removed"),
+        (MEMBER_ROLE_UPDATED, "Member Role Updated"),
+        (MEMBER_REACTIVATED, "Member Reactivated"),
+        (MEMBER_DEACTIVATED, "Member Deactivated"),
+        (INVITE_RESENT, "Invite Resent"),
+        (INVITE_CANCELLED, "Invite Cancelled"),
+        (WS_MEMBER_ADDED, "Workspace Member Added"),
+        (WS_MEMBER_REMOVED, "Workspace Member Removed"),
+        (WS_MEMBER_ROLE_UPDATED, "Workspace Member Role Updated"),
+    ]
+
+
+class AuditScope:
+    ORGANIZATION = "organization"
+    WORKSPACE = "workspace"
+
+    CHOICES = [
+        (ORGANIZATION, "Organization"),
+        (WORKSPACE, "Workspace"),
+    ]
+
+
+class AuditLog(BaseModel):
+    """Immutable audit trail for RBAC changes."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        "accounts.Organization",
+        on_delete=models.CASCADE,
+        related_name="audit_logs",
+    )
+    actor = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="+",
+    )
+
+    # What happened
+    action = models.CharField(max_length=64, choices=AuditAction.CHOICES)
+    scope = models.CharField(max_length=32, choices=AuditScope.CHOICES)
+
+    # Target entity ID — can reference User, OrganizationInvite, Workspace,
+    # etc. depending on the action. Not a ForeignKey because it spans tables.
+    target_id = models.UUIDField(db_index=True)
+
+    # Before/after snapshot
+    changes = models.JSONField(default=dict, blank=True)
+
+    # Extra context (IP, user-agent, invite token, etc.)
+    metadata = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        db_table = "accounts_audit_log"
+        ordering = ("-created_at",)
+        indexes = [
+            models.Index(
+                fields=["organization", "scope", "-created_at"],
+                name="audit_org_scope_ts",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.action} by {self.actor_id} at {self.created_at}"

--- a/futureagi/accounts/models/auth_token.py
+++ b/futureagi/accounts/models/auth_token.py
@@ -1,0 +1,33 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+
+
+class AuthTokenType(models.TextChoices):
+    ACCESS = "access"
+    REFRESH = "refresh"
+
+
+class AuthToken(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user = models.ForeignKey(
+        "accounts.User", on_delete=models.CASCADE, related_name="auth_tokens"
+    )
+    last_used_at = models.DateTimeField(null=True, blank=True)
+    auth_type = models.CharField(
+        max_length=255, blank=True, null=True, choices=AuthTokenType.choices
+    )
+    is_active = models.BooleanField(default=True)
+
+    def __str__(self):
+        return f"Auth Token {self.id}"
+
+    class Meta:
+        db_table = "accounts_auth_token"
+        ordering = ["-created_at"]
+
+
+AUTH_TOKEN_EXPIRATION_TIME_IN_MINUTES = 2 * 24 * 60  # 2 days
+REFRESH_TOKEN_EXPIRATION_TIME_IN_SECONDS = 7 * 24 * 60 * 60  # 7 days

--- a/futureagi/accounts/models/aws_marketplace.py
+++ b/futureagi/accounts/models/aws_marketplace.py
@@ -1,0 +1,76 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.organization import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class SubscriptionStatus(models.TextChoices):
+    SUBSCRIBE_SUCCESS = ("subscribe-success", "Subscribe Success")
+    SUBSCRIBE_PENDING = ("subscribe-pending", "Subscribe Pending")
+    SUBSCRIBE_FAIL = ("subscribe-fail", "Subscribe Fail")
+    UNSUBSCRIBE_PENDING = ("unsubscribe-pending", "Unsubscribe Pending")
+    UNSUBSCRIBE_SUCCESS = ("unsubscribe-success", "Unsubscribe Success")
+
+
+class AWSMarketplaceCustomer(BaseModel):
+    """
+    Model to store AWS Marketplace customer information
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # AWS Marketplace fields
+    customer_identifier = models.CharField(
+        max_length=255, unique=True, help_text="AWS Marketplace Customer Identifier"
+    )
+    customer_aws_account_id = models.CharField(
+        max_length=255, help_text="Customer's AWS Account ID"
+    )
+    product_code = models.CharField(
+        max_length=255, help_text="AWS Marketplace Product Code"
+    )
+
+    # Additional AWS Marketplace data
+    product_id = models.CharField(
+        max_length=255, null=True, blank=True, help_text="AWS Marketplace Product ID"
+    )
+    agreement_id = models.CharField(
+        max_length=255, null=True, blank=True, help_text="AWS Marketplace Agreement ID"
+    )
+
+    # Subscription details
+    subscription_status = models.CharField(
+        max_length=50,
+        choices=SubscriptionStatus.choices,
+        default=SubscriptionStatus.SUBSCRIBE_PENDING,
+    )
+
+    # Entitlement information (for contract products)
+    entitlements = models.JSONField(
+        default=dict, help_text="Current entitlements from AWS Marketplace"
+    )
+
+    # Links to our system
+    organization = models.OneToOneField(
+        Organization,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="aws_marketplace_customer",
+    )
+
+    # Metadata
+    registration_token = models.TextField(
+        null=True, blank=True, help_text="Last registration token received"
+    )
+
+    def __str__(self):
+        return (
+            f"AWS Customer {self.customer_identifier} - {self.customer_aws_account_id}"
+        )
+
+    class Meta:
+        verbose_name = "AWS Marketplace Customer"
+        verbose_name_plural = "AWS Marketplace Customers"

--- a/futureagi/accounts/models/organization.py
+++ b/futureagi/accounts/models/organization.py
@@ -1,0 +1,28 @@
+import uuid
+
+from django.db import models
+
+
+class Organization(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    name = models.CharField(max_length=255)
+    display_name = models.CharField(max_length=255, blank=True)
+    is_new = models.BooleanField(default=True)
+    # Backfilled to True for all existing orgs in 0015_backfill_rbac_data.py
+    ws_enabled = models.BooleanField(default=True)
+    region = models.CharField(max_length=16, default="us")
+
+    # 2FA enforcement
+    require_2fa = models.BooleanField(default=False)
+    require_2fa_grace_period_days = models.PositiveSmallIntegerField(default=7)
+    require_2fa_enforced_at = models.DateTimeField(null=True, blank=True)
+
+    def __str__(self):
+        return self.name
+
+    def save(self, *args, **kwargs):
+        # If display_name is not provided, default to the value of name
+        if not self.display_name:
+            self.display_name = self.name
+        super().save(*args, **kwargs)

--- a/futureagi/accounts/models/organization_invite.py
+++ b/futureagi/accounts/models/organization_invite.py
@@ -1,0 +1,171 @@
+import uuid
+from datetime import timedelta
+
+from django.db import models, transaction
+from django.utils import timezone
+
+from tfc.constants.levels import INVITE_VALIDITY_DAYS, Level
+from tfc.utils.base_model import BaseModel
+
+
+class InviteStatus:
+    PENDING = "Pending"
+    ACCEPTED = "Accepted"
+    CANCELLED = "Cancelled"
+    EXPIRED = "Expired"
+
+
+class OrganizationInvite(BaseModel):
+    """
+    Invite to an organization.
+
+    Status field tracks the invite lifecycle:
+    - Pending: invite is active and awaiting acceptance
+    - Accepted: user accepted the invite
+    - Cancelled: admin cancelled the invite
+    - Expired: derived — pending invite past INVITE_VALIDITY_DAYS
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    organization = models.ForeignKey(
+        "accounts.Organization",
+        on_delete=models.CASCADE,
+        related_name="invites",
+    )
+
+    target_email = models.EmailField(db_index=True)
+
+    # Integer org-level being offered (Owner=15, Admin=8, Member=3, Viewer=1)
+    level = models.PositiveSmallIntegerField(choices=Level.CHOICES)
+
+    # Workspace access to grant on accept: [{workspace_id: <uuid>, level: <int>}]
+    workspace_access = models.JSONField(default=list, blank=True)
+
+    invited_by = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="sent_invites",
+    )
+
+    status = models.CharField(
+        max_length=16,
+        default=InviteStatus.PENDING,
+        db_index=True,
+    )
+
+    message = models.TextField(blank=True, default="")
+
+    class Meta:
+        db_table = "accounts_organization_invite"
+        ordering = ("-created_at",)
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "target_email"],
+                condition=models.Q(status="Pending"),
+                name="unique_pending_invite_per_org_email",
+            ),
+        ]
+
+    def __str__(self):
+        return f"Invite {self.target_email} → {self.organization.name} (level={self.level})"
+
+    # ------------------------------------------------------------------
+    # Derived state
+    # ------------------------------------------------------------------
+
+    @property
+    def is_expired(self):
+        if self.status != InviteStatus.PENDING:
+            return False
+        return timezone.now() > self.created_at + timedelta(days=INVITE_VALIDITY_DAYS)
+
+    @property
+    def effective_status(self):
+        """Return status, upgrading Pending → Expired if past validity window."""
+        if self.status == InviteStatus.PENDING and self.is_expired:
+            return InviteStatus.EXPIRED
+        return self.status
+
+    # ------------------------------------------------------------------
+    # Accept flow
+    # ------------------------------------------------------------------
+
+    def accept(self, user):
+        """
+        Atomically:
+        1. Create OrganizationMembership (with integer level).
+        2. Create WorkspaceMembership for each entry in workspace_access.
+        3. Mark this invite as accepted.
+
+        Raises ValueError if the invite is expired or not pending.
+        """
+        if self.status != InviteStatus.PENDING:
+            raise ValueError("This invite is no longer pending.")
+        if self.is_expired:
+            raise ValueError("This invite has expired.")
+
+        from accounts.models.organization_membership import OrganizationMembership
+        from accounts.models.workspace import Workspace, WorkspaceMembership
+
+        with transaction.atomic():
+            # 1. Create or update org membership
+            # Use all_objects to include soft-deleted rows — BaseModel.delete()
+            # only sets deleted=True, leaving the DB row and unique constraint
+            # intact, which would cause IntegrityError with objects manager.
+            org_membership, created = (
+                OrganizationMembership.all_objects.update_or_create(
+                    user=user,
+                    organization=self.organization,
+                    defaults={
+                        "level": self.level,
+                        "role": Level.to_org_string(self.level),
+                        "invited_by": self.invited_by,
+                        "is_active": True,
+                        "deleted": False,
+                        "deleted_at": None,
+                    },
+                )
+            )
+
+            # 2. Create workspace memberships
+            for ws_entry in self.workspace_access:
+                ws_id = ws_entry.get("workspace_id")
+                ws_level = ws_entry.get("level", Level.WORKSPACE_VIEWER)
+                try:
+                    workspace = Workspace.objects.get(
+                        id=ws_id, organization=self.organization
+                    )
+                except Workspace.DoesNotExist:
+                    continue  # workspace deleted between invite and accept
+
+                WorkspaceMembership.all_objects.update_or_create(
+                    workspace=workspace,
+                    user=user,
+                    defaults={
+                        "level": ws_level,
+                        "role": Level.to_ws_role(ws_level),
+                        "organization_membership": org_membership,
+                        "invited_by": self.invited_by,
+                        "is_active": True,
+                        "deleted": False,
+                        "deleted_at": None,
+                    },
+                )
+
+            # 3. Add to user's invited_organizations M2M
+            user.invited_organizations.add(self.organization)
+
+            # 4. Mark invite as accepted
+            self.status = InviteStatus.ACCEPTED
+            self.save(update_fields=["status"])
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def refresh_expiration(self):
+        """Reset expiration by updating created_at to now."""
+        self.created_at = timezone.now()
+        self.save(update_fields=["created_at"])

--- a/futureagi/accounts/models/organization_membership.py
+++ b/futureagi/accounts/models/organization_membership.py
@@ -1,0 +1,93 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.organization import Organization
+from tfc.constants.levels import Level
+from tfc.constants.roles import OrganizationRoles
+from tfc.utils.base_model import BaseModel
+
+
+class OrganizationMembership(BaseModel):
+    """
+    Model to handle users being members of multiple organizations.
+    Each user can have different roles in different organizations.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # User and organization relationship
+    user = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.CASCADE,
+        related_name="organization_memberships",
+    )
+
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="user_memberships"
+    )
+
+    # Role in this specific organization (legacy — kept for backward compat)
+    role = models.CharField(
+        max_length=20,
+        choices=OrganizationRoles.choices,
+        default=OrganizationRoles.MEMBER,
+    )
+
+    # Integer level (new RBAC) — Owner=15, Admin=8, Member=3, Viewer=1
+    level = models.PositiveSmallIntegerField(
+        choices=Level.CHOICES,
+        null=True,
+        blank=True,
+        help_text="Integer RBAC level. Null means legacy role string is authoritative.",
+    )
+
+    # Who invited this user to the organization
+    invited_by = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="invited_organization_members",
+    )
+
+    # When they joined
+    joined_at = models.DateTimeField(auto_now_add=True)
+
+    # Whether this membership is active
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        db_table = "accounts_organization_membership"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "organization"],
+                condition=models.Q(deleted=False),
+                name="unique_active_org_membership",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.user.email} - {self.organization.name} ({self.role})"
+
+    @property
+    def level_or_legacy(self):
+        """
+        Return the integer level. If `level` is not yet backfilled,
+        derive it from the legacy `role` string.
+        """
+        if self.level is not None:
+            return self.level
+        return Level.STRING_TO_LEVEL.get(self.role, 0)
+
+    def save(self, *args, **kwargs):
+        # Ensure user is added to invited_organizations ManyToMany field
+        if self.is_active and self.pk is None:  # New active membership
+            # Add to user's invited_organizations when creating
+            self.user.invited_organizations.add(self.organization)
+        super().save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        # Remove user from invited_organizations ManyToMany field
+        self.user.invited_organizations.remove(self.organization)
+        super().delete(*args, **kwargs)

--- a/futureagi/accounts/models/recovery_code.py
+++ b/futureagi/accounts/models/recovery_code.py
@@ -1,0 +1,23 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.user import User
+from tfc.utils.base_model import BaseModel
+
+
+class RecoveryCode(BaseModel):
+    """Single-use backup recovery codes for 2FA.
+    Codes are hashed before storage (like passwords).
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name="recovery_codes"
+    )
+    code_hash = models.CharField(max_length=255)
+    is_used = models.BooleanField(default=False)
+    used_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "accounts_recovery_code"

--- a/futureagi/accounts/models/totp_device.py
+++ b/futureagi/accounts/models/totp_device.py
@@ -1,0 +1,24 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.user import User
+from tfc.utils.base_model import BaseModel
+
+
+class UserTOTPDevice(BaseModel):
+    """Stores a user's TOTP secret for authenticator-app-based 2FA.
+    One device per user (unique constraint on user).
+    Secret is Fernet-encrypted at rest.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user = models.OneToOneField(
+        User, on_delete=models.CASCADE, related_name="totp_device"
+    )
+    secret_encrypted = models.TextField()
+    confirmed = models.BooleanField(default=False)
+    last_used_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "accounts_user_totp_device"

--- a/futureagi/accounts/models/user.py
+++ b/futureagi/accounts/models/user.py
@@ -1,0 +1,334 @@
+import uuid
+
+from django.contrib.auth.models import (
+    AbstractBaseUser,
+    BaseUserManager,
+    PermissionsMixin,
+)
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.organization_membership import OrganizationMembership
+from accounts.models.workspace import Workspace
+from tfc.constants.roles import OrganizationRoles, RoleMapping
+from tfc.utils.base_model import BaseModel
+
+
+class CustomUserManager(BaseUserManager):
+    def create_user(self, email, password=None, **extra_fields):
+        if not email:
+            raise ValueError("The Email field must be set")
+        email = self.normalize_email(email)
+        user = self.model(email=email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, email, password=None, **extra_fields):
+        extra_fields.setdefault("is_staff", True)
+        extra_fields.setdefault("is_superuser", True)
+
+        if extra_fields.get("is_staff") is not True:
+            raise ValueError("Superuser must have is_staff=True.")
+        if extra_fields.get("is_superuser") is not True:
+            raise ValueError("Superuser must have is_superuser=True.")
+
+        return self.create_user(email, password, **extra_fields)
+
+
+class User(AbstractBaseUser, PermissionsMixin):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    email = models.EmailField(unique=True)
+    name = models.CharField(max_length=255)
+    is_active = models.BooleanField(default=True)
+    is_staff = models.BooleanField(default=False)
+    invited_by = models.ForeignKey(
+        "self", on_delete=models.CASCADE, null=True, default=None
+    )
+
+    organization_role = models.CharField(
+        max_length=20,
+        choices=OrganizationRoles.choices,
+        default=OrganizationRoles.OWNER,
+        null=True,
+        blank=True,
+    )
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="members",
+    )
+
+    # Additional organizations where they are invited members
+    invited_organizations = models.ManyToManyField(
+        Organization,
+        through="OrganizationMembership",
+        through_fields=("user", "organization"),
+        related_name="invited_members",
+        blank=True,
+    )
+
+    objects = CustomUserManager()
+
+    config = models.JSONField(default=dict, blank=True)
+
+    # Onboarding fields
+    role = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="User's job role (e.g., Data Scientist, ML Engineer, or custom role)",
+    )
+    goals = models.JSONField(
+        null=True,
+        blank=True,
+        default=None,
+        help_text="List of user's goals for using the platform",
+    )
+
+    USERNAME_FIELD = "email"
+    REQUIRED_FIELDS = [
+        "name"
+    ]  # For the createsuperuser management command. You can add fields here, but remember, they will be prompted for when creating a superuser. Email is not included here because it's already the USERNAME_FIELD.
+
+    def __str__(self):
+        return self.email
+
+    # --- Multi-org helpers ---
+
+    def get_membership(self, organization):
+        """Get the active OrganizationMembership for a specific org, or None."""
+        try:
+            return OrganizationMembership.no_workspace_objects.get(
+                user=self, organization=organization, is_active=True
+            )
+        except OrganizationMembership.DoesNotExist:
+            return None
+
+    def get_membership_level(self, organization):
+        """Get integer RBAC level for a specific org."""
+        membership = self.get_membership(organization)
+        if membership:
+            return membership.level_or_legacy
+        # Fallback: legacy FK (only for users with no membership records for this org)
+        # This covers truly legacy accounts created before the membership table existed.
+        # Users with deactivated memberships should NOT get this fallback.
+        if self.organization_id and self.organization_id == organization.id:
+            # Only use fallback if user has no membership records at all for this org
+            has_any_membership = OrganizationMembership.no_workspace_objects.filter(
+                user=self, organization=organization
+            ).exists()
+            if not has_any_membership:
+                from tfc.constants.levels import Level
+
+                return Level.STRING_TO_LEVEL.get(self.organization_role, Level.VIEWER)
+        return None
+
+    # --- Organization access ---
+
+    def can_access_organization(self, organization):
+        """Check if user has access to a specific organization.
+
+        Uses OrganizationMembership as source of truth.
+        """
+        return OrganizationMembership.no_workspace_objects.filter(
+            user=self, organization=organization, is_active=True
+        ).exists()
+
+    def get_organization_role(self, organization=None):
+        """Get user's role in the given organization.
+
+        Queries OrganizationMembership for the target org.
+        Falls back to legacy user.organization_role only for truly legacy accounts
+        (users with no membership records at all for this org).
+        """
+        target_org = organization or self.organization
+        if not target_org:
+            return None
+
+        membership = self.get_membership(target_org)
+        if membership:
+            return membership.role
+
+        # Fallback: legacy field (only for truly legacy accounts)
+        # Users with deactivated memberships should NOT get this fallback.
+        if self.organization_id and self.organization_id == target_org.id:
+            # Only use fallback if user has no membership records at all for this org
+            has_any_membership = OrganizationMembership.no_workspace_objects.filter(
+                user=self, organization=target_org
+            ).exists()
+            if not has_any_membership:
+                return self.organization_role
+        return None
+
+    def has_global_workspace_access(self, organization=None):
+        """Check if user's role in the given org grants global workspace access."""
+        role = self.get_organization_role(organization)
+        if not role:
+            return False
+
+        from tfc.constants.roles import RolePermissions
+
+        return role in RolePermissions.GLOBAL_ACCESS_ROLES
+
+    def is_workspace_only_user(self, organization=None):
+        """Check if user only has workspace-specific access."""
+        return not self.has_global_workspace_access(organization)
+
+    # --- Workspace access ---
+
+    def can_access_workspace(self, workspace):
+        """Check if user can access a specific workspace."""
+        from accounts.models.workspace import WorkspaceMembership
+
+        org = workspace.organization
+
+        if not self.can_access_organization(org):
+            return False
+
+        if self.has_global_workspace_access(org):
+            return True
+
+        # Use no_workspace_objects to avoid workspace-scoped filtering,
+        # which would prevent cross-workspace access checks.
+        return WorkspaceMembership.no_workspace_objects.filter(
+            user=self, workspace=workspace, is_active=True
+        ).exists()
+
+    def get_workspace_role(self, workspace):
+        """Get user's role for a specific workspace."""
+        org = workspace.organization
+        org_role = self.get_organization_role(org)
+
+        if org_role and self.has_global_workspace_access(org):
+            return RoleMapping.get_workspace_role(org_role)
+
+        # Check specific workspace membership (use no_workspace_objects to
+        # avoid workspace-scoped filtering during cross-workspace checks)
+        try:
+            from accounts.models.workspace import WorkspaceMembership
+
+            membership = WorkspaceMembership.no_workspace_objects.get(
+                user=self, workspace=workspace, is_active=True
+            )
+            # Prefer level-based role (new RBAC) over legacy role string
+            if membership.level is not None:
+                from tfc.constants.levels import Level
+
+                _level_to_role = {
+                    Level.WORKSPACE_ADMIN: OrganizationRoles.WORKSPACE_ADMIN,
+                    Level.WORKSPACE_MEMBER: OrganizationRoles.WORKSPACE_MEMBER,
+                    Level.WORKSPACE_VIEWER: OrganizationRoles.WORKSPACE_VIEWER,
+                }
+                return _level_to_role.get(membership.level, membership.role)
+            # Coerce the raw role string to an OrganizationRoles enum member
+            # so callers always get a consistent type (enum, not str).
+            try:
+                return OrganizationRoles(membership.role)
+            except ValueError:
+                return membership.role
+        except Exception:
+            return None
+
+    def can_write_to_workspace(self, workspace):
+        """Check if user can write to a specific workspace."""
+        if not self.can_access_workspace(workspace):
+            return False
+
+        role = self.get_workspace_role(workspace)
+        if not role:
+            return False
+
+        from tfc.constants.roles import RolePermissions
+
+        return role in RolePermissions.WRITE_ACCESS_ROLES
+
+    def can_read_from_workspace(self, workspace):
+        """Check if user can read from a specific workspace."""
+        if not self.can_access_workspace(workspace):
+            return False
+
+        role = self.get_workspace_role(workspace)
+        if not role:
+            return False
+
+        from tfc.constants.roles import RolePermissions
+
+        return role in RolePermissions.READ_ACCESS_ROLES
+
+    @property
+    def has_2fa_enabled(self):
+        """True if user has at least one confirmed 2FA method."""
+        try:
+            has_totp = self.totp_device.confirmed
+        except Exception:
+            has_totp = False
+        has_passkey = self.webauthn_credentials.exists()
+        return has_totp or has_passkey
+
+
+class OrgApiKey(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=100, default="system_org_key")
+    api_key = models.CharField(max_length=255, unique=True)
+    secret_key = models.CharField(max_length=255)
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="api_keys"
+    )
+
+    type = models.CharField(
+        max_length=50,
+        default="system",
+        choices=[("system", "System"), ("user", "User"), ("mcp", "MCP")],
+    )
+    enabled = models.BooleanField(default=True)
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="user_secret_key",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="ws_api_keys",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "type"],
+                condition=models.Q(type="system", deleted=False),
+                name="unique_system_api_key_per_org_not_deleted",
+                violation_error_message="Only one system API key is allowed per organization.",
+            )
+        ]
+
+    def __str__(self):
+        if self.organization.display_name:
+            return f"{self.organization.display_name} API Key"
+        return f"{self.organization.name} API Key"
+
+    def save(self, *args, **kwargs):
+        if not self.api_key:
+            self.api_key = self.generate_api_key()
+        if not self.secret_key:
+            self.secret_key = self.generate_secret_key()
+        super().save(*args, **kwargs)
+
+    @staticmethod
+    def generate_api_key():
+        # Implement your logic for generating a unique API key
+        return uuid.uuid4().hex
+
+    @staticmethod
+    def generate_secret_key():
+        # Implement your logic for generating a secret key
+        return uuid.uuid4().hex

--- a/futureagi/accounts/models/webauthn_credential.py
+++ b/futureagi/accounts/models/webauthn_credential.py
@@ -1,0 +1,29 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.user import User
+from tfc.utils.base_model import BaseModel
+
+
+class WebAuthnCredential(BaseModel):
+    """Stores a registered WebAuthn/passkey credential.
+    A user can have multiple credentials (e.g., laptop + phone + security key).
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name="webauthn_credentials"
+    )
+    name = models.CharField(max_length=255, default="")
+    credential_id = models.TextField(unique=True)
+    public_key = models.TextField()
+    sign_count = models.PositiveIntegerField(default=0)
+    transports = models.JSONField(default=list)
+    aaguid = models.CharField(max_length=36, blank=True, default="")
+    backup_eligible = models.BooleanField(default=False)
+    backup_state = models.BooleanField(default=False)
+    last_used_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "accounts_webauthn_credential"

--- a/futureagi/accounts/models/workspace.py
+++ b/futureagi/accounts/models/workspace.py
@@ -1,0 +1,111 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.organization import Organization
+from tfc.constants.levels import Level
+from tfc.constants.roles import OrganizationRoles
+from tfc.utils.base_model import BaseModel
+
+
+class Workspace(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    display_name = models.CharField(max_length=255, blank=True)
+    description = models.TextField(blank=True)
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="workspaces"
+    )
+    is_active = models.BooleanField(default=True)
+    is_default = models.BooleanField(default=False)
+    created_by = models.ForeignKey(
+        "accounts.User", on_delete=models.CASCADE, related_name="created_workspaces"
+    )
+
+    class Meta:
+        unique_together = [["organization", "name"]]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "is_default"],
+                condition=models.Q(is_default=True),
+                name="unique_default_workspace_per_org",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.organization.name} - {self.name}"
+
+    def save(self, *args, **kwargs):
+        # If display_name is not provided, default to the value of name
+        if not self.display_name:
+            self.display_name = self.name
+        super().save(*args, **kwargs)
+
+
+class WorkspaceMembership(BaseModel):
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    workspace = models.ForeignKey(
+        Workspace, on_delete=models.CASCADE, related_name="memberships"
+    )
+    user = models.ForeignKey(
+        "accounts.User", on_delete=models.CASCADE, related_name="workspace_memberships"
+    )
+    role = models.CharField(
+        max_length=20,
+        choices=OrganizationRoles.choices,
+        default=OrganizationRoles.WORKSPACE_MEMBER,
+    )
+
+    # Integer level (new RBAC) — Workspace Admin=8, Member=3, Viewer=1
+    level = models.PositiveSmallIntegerField(
+        choices=Level.WORKSPACE_CHOICES,
+        null=True,
+        blank=True,
+        help_text="Integer RBAC level. Null means legacy role string is authoritative.",
+    )
+
+    # Link to the org membership — CASCADE ensures no orphan ws memberships
+    organization_membership = models.ForeignKey(
+        "accounts.OrganizationMembership",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="workspace_memberships",
+        help_text="Nullable during transition; backfill migration will populate.",
+    )
+
+    # Who granted this workspace access
+    granted_by = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="granted_workspace_memberships",
+    )
+    granted_at = models.DateTimeField(auto_now_add=True, null=True)
+
+    invited_by = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="invited_workspace_members",
+    )
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        unique_together = [["workspace", "user"]]
+
+    def __str__(self):
+        return f"{self.user.email} - {self.workspace.name} ({self.role})"
+
+    @property
+    def level_or_legacy(self):
+        """
+        Return the integer level. If `level` is not yet backfilled,
+        derive it from the legacy `role` string.
+        """
+        if self.level is not None:
+            return self.level
+        return Level.STRING_TO_LEVEL.get(self.role, Level.WORKSPACE_VIEWER)

--- a/futureagi/agent_playground/models/__init__.py
+++ b/futureagi/agent_playground/models/__init__.py
@@ -1,0 +1,41 @@
+from agent_playground.models.choices import (
+    GraphExecutionStatus,
+    GraphVersionStatus,
+    NodeExecutionStatus,
+    NodeType,
+    PortDirection,
+    PortMode,
+)
+from agent_playground.models.edge import Edge
+from agent_playground.models.execution_data import ExecutionData
+from agent_playground.models.graph import Graph
+from agent_playground.models.graph_dataset import GraphDataset
+from agent_playground.models.graph_execution import GraphExecution
+from agent_playground.models.graph_version import GraphVersion
+from agent_playground.models.node import Node
+from agent_playground.models.node_connection import NodeConnection
+from agent_playground.models.node_execution import NodeExecution
+from agent_playground.models.node_template import NodeTemplate
+from agent_playground.models.port import Port
+from agent_playground.models.prompt_template_node import PromptTemplateNode
+
+__all__ = [
+    "GraphExecutionStatus",
+    "GraphVersionStatus",
+    "NodeExecutionStatus",
+    "NodeType",
+    "PortDirection",
+    "PortMode",
+    "Graph",
+    "GraphDataset",
+    "GraphVersion",
+    "NodeTemplate",
+    "Node",
+    "NodeConnection",
+    "PromptTemplateNode",
+    "Port",
+    "Edge",
+    "GraphExecution",
+    "NodeExecution",
+    "ExecutionData",
+]

--- a/futureagi/agent_playground/models/choices.py
+++ b/futureagi/agent_playground/models/choices.py
@@ -1,0 +1,58 @@
+import re
+
+from django.db import models
+
+# Characters reserved for dot-notation variable syntax (e.g. {{Node1.response[0]}}).
+# Forbidden in node names and output port display_names.
+RESERVED_NAME_CHARS = frozenset(".[]{}")
+RESERVED_NAME_RE = re.compile(r"[.\[\]{}]")
+
+
+class NodeType(models.TextChoices):
+    """Node type choices"""
+
+    SUBGRAPH = "subgraph", "Subgraph"
+    ATOMIC = "atomic", "Atomic"
+
+
+class GraphVersionStatus(models.TextChoices):
+    """GraphVersion status choices"""
+
+    DRAFT = "draft", "Draft"
+    ACTIVE = "active", "Active"
+    INACTIVE = "inactive", "Inactive"
+
+
+class PortDirection(models.TextChoices):
+    """Port direction choices"""
+
+    INPUT = "input", "Input"
+    OUTPUT = "output", "Output"
+
+
+class PortMode(models.TextChoices):
+    """Port creation mode for NodeTemplate"""
+
+    STRICT = "strict", "Strict"
+    EXTENSIBLE = "extensible", "Extensible"
+    DYNAMIC = "dynamic", "Dynamic"
+
+
+class GraphExecutionStatus(models.TextChoices):
+    """GraphExecution specific status choices"""
+
+    PENDING = "pending", "Pending"
+    RUNNING = "running", "Running"
+    SUCCESS = "success", "Success"
+    FAILED = "failed", "Failed"
+    CANCELLED = "cancelled", "Cancelled"
+
+
+class NodeExecutionStatus(models.TextChoices):
+    """NodeExecution specific status choices"""
+
+    PENDING = "pending", "Pending"
+    RUNNING = "running", "Running"
+    SUCCESS = "success", "Success"
+    FAILED = "failed", "Failed"
+    SKIPPED = "skipped", "Skipped"

--- a/futureagi/agent_playground/models/edge.py
+++ b/futureagi/agent_playground/models/edge.py
@@ -1,0 +1,128 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from agent_playground.models.choices import PortDirection
+from agent_playground.models.graph_version import GraphVersion
+from agent_playground.models.port import Port
+from agent_playground.utils.graph_validation import would_create_cycle
+from tfc.utils.base_model import BaseModel
+
+
+class Edge(BaseModel):
+    """
+    Data flow connection within a GraphVersion.
+
+    Edge Connection Rules:
+    - Fan-Out (Broadcast): ✅ ALLOWED - One output port can connect to multiple input ports
+    - Fan-In (Merge): ❌ BLOCKED - One input port can only receive from ONE source
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    graph_version = models.ForeignKey(
+        GraphVersion, on_delete=models.CASCADE, related_name="edges"
+    )
+    source_port = models.ForeignKey(
+        Port, on_delete=models.CASCADE, related_name="outgoing_edges"
+    )
+    target_port = models.ForeignKey(
+        Port, on_delete=models.CASCADE, related_name="incoming_edges"
+    )
+
+    class Meta:
+        db_table = "agent_playground_edge"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["source_port", "target_port"],
+                condition=models.Q(deleted=False),
+                name="unique_edge_connection",
+            ),
+            models.UniqueConstraint(
+                fields=["target_port"],
+                condition=models.Q(deleted=False),
+                name="unique_input_connection",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["graph_version"]),
+            models.Index(fields=["source_port"]),
+            models.Index(fields=["target_port"]),
+        ]
+
+    def __str__(self):
+        return f"{self.source_port.node.name}.{self.source_port.key} → {self.target_port.node.name}.{self.target_port.key}"
+
+    def _validate_source_port_direction(self) -> None:
+        """
+        Validate if the source port is an output port.
+        """
+        if self.source_port.direction != PortDirection.OUTPUT:
+            raise ValidationError("Source port must be an output port")
+
+    def _validate_target_port_direction(self) -> None:
+        """
+        Validate if the target port is an input port.
+        """
+        if self.target_port.direction != PortDirection.INPUT:
+            raise ValidationError("Target port must be an input port")
+
+    def _validate_source_port_graph_version(self) -> None:
+        """
+        Validate if the source port's node belongs to the edge's graph version.
+        """
+        if self.source_port.node.graph_version != self.graph_version:
+            raise ValidationError("Source port node must belong to this graph version")
+
+    def _validate_target_port_graph_version(self) -> None:
+        """
+        Validate if the target port's node belongs to the edge's graph version.
+        """
+        if self.target_port.node.graph_version != self.graph_version:
+            raise ValidationError("Target port node must belong to this graph version")
+
+    def _validate_no_cycle(self) -> None:
+        """
+        Validate that this edge would not create a cycle in the graph.
+        """
+        if would_create_cycle(
+            source_node_id=self.source_port.node_id,
+            target_node_id=self.target_port.node_id,
+            graph_version_id=self.graph_version_id,
+            exclude_edge_id=self.pk,
+        ):
+            raise ValidationError("This edge would create a cycle in the graph")
+
+    def _validate_node_connection_exists(self) -> None:
+        """
+        Validate that a NodeConnection exists between the source and target nodes.
+        """
+        from agent_playground.models.node_connection import NodeConnection
+
+        exists = NodeConnection.no_workspace_objects.filter(
+            graph_version=self.graph_version,
+            source_node_id=self.source_port.node_id,
+            target_node_id=self.target_port.node_id,
+        ).exists()
+        if not exists:
+            raise ValidationError(
+                "A NodeConnection between the source and target nodes must exist before creating an edge"
+            )
+
+    def clean(self):
+        """
+        Validate the edge connections.
+        """
+        super().clean()
+
+        self._validate_source_port_direction()
+        self._validate_target_port_direction()
+        self._validate_source_port_graph_version()
+        self._validate_target_port_graph_version()
+        self._validate_node_connection_exists()
+        self._validate_no_cycle()
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)

--- a/futureagi/agent_playground/models/execution_data.py
+++ b/futureagi/agent_playground/models/execution_data.py
@@ -1,0 +1,93 @@
+import uuid
+
+import jsonschema
+from django.db import models
+
+from agent_playground.models.node import Node
+from agent_playground.models.node_execution import NodeExecution
+from agent_playground.models.port import Port
+from tfc.utils.base_model import BaseModel
+
+
+class ExecutionData(BaseModel):
+    """
+    Validated data payload linked to Port contract.
+
+    This model connects runtime data to design-time contracts for lineage and validation.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    node_execution = models.ForeignKey(
+        NodeExecution, on_delete=models.CASCADE, related_name="execution_data"
+    )
+    node = models.ForeignKey(
+        Node,
+        on_delete=models.PROTECT,
+        related_name="execution_data",
+    )
+    port = models.ForeignKey(
+        Port,
+        on_delete=models.PROTECT,
+        related_name="execution_data",
+    )
+
+    payload = models.JSONField(help_text="The actual data")
+    validation_errors = models.JSONField(
+        null=True,
+        blank=True,
+    )
+    is_valid = models.BooleanField(
+        default=True,
+    )
+
+    class Meta:
+        db_table = "agent_playground_execution_data"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["node_execution", "port"],
+                condition=models.Q(deleted=False),
+                name="unique_node_execution_port",
+            )
+        ]
+        indexes = [
+            models.Index(fields=["node_execution"]),
+            models.Index(fields=["node"]),  # Query by design-time node
+            models.Index(fields=["port"]),  # Critical for lineage queries
+            models.Index(
+                fields=["is_valid", "port"]
+            ),  # Find validation failures by port
+        ]
+
+    def __str__(self):
+        return f"Data for {self.port} ({'valid' if self.is_valid else 'invalid'})"
+
+    def validate_payload(self):
+        """
+        Validate payload against port's data_schema.
+        Returns (is_valid, errors)
+        """
+        if not self.port.data_schema:
+            return True, None
+
+        try:
+            jsonschema.validate(instance=self.payload, schema=self.port.data_schema)
+            return True, None
+        except jsonschema.ValidationError as e:
+            return False, {
+                "message": e.message,
+                "path": list(e.path),
+                "schema_path": list(e.schema_path),
+            }
+
+    def save(self, *args, **kwargs):
+        # Auto-validate payload on save
+        is_valid, errors = self.validate_payload()
+        self.is_valid = is_valid
+        self.validation_errors = errors
+
+        # Denormalize node from node_execution
+        if not self.node_id:
+            self.node = self.node_execution.node
+
+        super().save(*args, **kwargs)

--- a/futureagi/agent_playground/models/graph.py
+++ b/futureagi/agent_playground/models/graph.py
@@ -1,0 +1,93 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from accounts.models import Organization, User, Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class Graph(BaseModel):
+    """
+    Identity container for agent graphs.
+
+    Graphs can be referenced by other graphs via subgraph nodes.
+    Template graphs (is_template=True) are system-defined reusable blueprints
+    with no organization, workspace, or created_by.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agent_playground_graphs",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="agent_playground_graphs",
+        null=True,
+        blank=True,
+    )
+
+    name = models.CharField(max_length=255, help_text="Display name")
+    description = models.TextField(null=True, blank=True)
+    is_template = models.BooleanField(default=False)
+
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="created_agent_playground_graphs",
+        null=True,
+        blank=True,
+    )
+    collaborators = models.ManyToManyField(
+        User,
+        related_name="collaborated_agent_playground_graphs",
+        blank=True,
+    )
+
+    class Meta:
+        db_table = "agent_playground_graph"
+        indexes = [
+            models.Index(fields=["workspace"]),
+            models.Index(fields=["organization"]),
+            models.Index(fields=["is_template"]),
+        ]
+
+    def __str__(self):
+        return self.name
+
+    def clean(self):
+        super().clean()
+        if self.is_template:
+            if self.organization_id or self.workspace_id or self.created_by_id:
+                raise ValidationError(
+                    "Template graphs must not have organization, workspace, or created_by."
+                )
+        else:
+            if not self.organization_id:
+                raise ValidationError("Non-template graphs must have an organization.")
+            if not self.created_by_id:
+                raise ValidationError(
+                    "Non-template graphs must have a created_by user."
+                )
+        if self.created_by_id and self.organization_id:
+            if not self.created_by.can_access_organization(self.organization):
+                raise ValidationError(
+                    "created_by user must belong to the same organization as the graph."
+                )
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        is_new = self._state.adding
+        super().save(*args, **kwargs)
+        if is_new and self.created_by_id:
+            self.collaborators.add(self.created_by)
+
+    def add_collaborator(self, user):
+        """Add a collaborator to this graph."""
+        self.collaborators.add(user)

--- a/futureagi/agent_playground/models/graph_dataset.py
+++ b/futureagi/agent_playground/models/graph_dataset.py
@@ -1,0 +1,34 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+
+
+class GraphDataset(BaseModel):
+    """
+    Links a Graph to its auto-created Dataset.
+
+    OneToOne relationship: each Graph gets exactly one Dataset
+    for storing input variable rows used in batch execution.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    graph = models.OneToOneField(
+        "agent_playground.Graph",
+        on_delete=models.CASCADE,
+        related_name="graph_dataset",
+    )
+
+    dataset = models.OneToOneField(
+        "model_hub.Dataset",
+        on_delete=models.CASCADE,
+        related_name="graph_dataset",
+    )
+
+    class Meta:
+        db_table = "agent_playground_graph_dataset"
+
+    def __str__(self):
+        return f"GraphDataset(graph={self.graph_id}, dataset={self.dataset_id})"

--- a/futureagi/agent_playground/models/graph_execution.py
+++ b/futureagi/agent_playground/models/graph_execution.py
@@ -1,0 +1,68 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from agent_playground.models.choices import GraphExecutionStatus
+from agent_playground.models.graph_version import GraphVersion
+from tfc.utils.base_model import BaseModel
+
+
+class GraphExecution(BaseModel):
+    """
+    An execution instance of a GraphVersion.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    graph_version = models.ForeignKey(
+        GraphVersion, on_delete=models.PROTECT, related_name="executions"
+    )
+
+    parent_node_execution = models.ForeignKey(
+        "NodeExecution",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="child_graph_executions",
+        help_text="If the graph is a module, the parent node calling this",
+    )
+
+    status = models.CharField(
+        max_length=20,
+        choices=GraphExecutionStatus.choices,
+        default=GraphExecutionStatus.PENDING,
+    )
+    input_payload = models.JSONField(default=dict, blank=True, null=True)
+    output_payload = models.JSONField(default=dict, blank=True, null=True)
+
+    started_at = models.DateTimeField(null=True, blank=True)
+    completed_at = models.DateTimeField(null=True, blank=True)
+    error_message = models.TextField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agent_playground_graph_execution"
+        indexes = [
+            models.Index(fields=["graph_version", "status"]),
+            models.Index(fields=["parent_node_execution"]),
+        ]
+
+    def __str__(self):
+        return f"Execution of {self.graph_version} ({self.status})"
+
+    def _validate_payload_is_dict(self, field_name: str) -> None:
+        """Validate the payload field is a dict (or None)."""
+        value = getattr(self, field_name)
+        if value is not None and not isinstance(value, dict):
+            raise ValidationError(f"{field_name} must be a dict")
+
+    def clean(self):
+        """Validate the graph execution."""
+        super().clean()
+
+        self._validate_payload_is_dict("input_payload")
+        self._validate_payload_is_dict("output_payload")
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)

--- a/futureagi/agent_playground/models/graph_version.py
+++ b/futureagi/agent_playground/models/graph_version.py
@@ -1,0 +1,146 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from agent_playground.models.choices import (
+    GraphVersionStatus,
+    NodeType,
+    PortDirection,
+    PortMode,
+)
+from agent_playground.models.graph import Graph
+from tfc.utils.base_model import BaseModel
+
+
+class GraphVersion(BaseModel):
+    """
+    Immutable snapshot of the graph structure.
+
+    Status Lifecycle:
+    - "draft": Work in progress. Auto-saved. Not executable. Multiple allowed per Graph.
+    - "active": Current production version. This version executes when the graph runs. Max 1 per Graph.
+    - "inactive": Historical versions. Available for rollback. Multiple allowed per Graph.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    graph = models.ForeignKey(Graph, on_delete=models.CASCADE, related_name="versions")
+
+    version_number = models.PositiveIntegerField()  # Monotonic (1, 2, 3...)
+    status = models.CharField(
+        max_length=20,
+        choices=GraphVersionStatus.choices,
+        default=GraphVersionStatus.DRAFT,
+        help_text="Version status (inactive for historical versions)",
+    )
+    tags = models.JSONField(default=list)
+    commit_message = models.TextField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agent_playground_graph_version"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["graph", "version_number"],
+                condition=models.Q(deleted=False),
+                name="unique_graph_version_number",
+            )
+        ]
+        indexes = [
+            models.Index(fields=["graph", "status"]),
+        ]
+
+    def __str__(self):
+        return f"{self.graph.name} v{self.version_number} ({self.status})"
+
+    def _validate_unique_exposed_port_display_names(self) -> None:
+        """Validate that unconnected output ports have unique display_names across the version."""
+        from agent_playground.models.edge import Edge
+        from agent_playground.models.port import Port
+
+        output_ports = list(
+            Port.no_workspace_objects.filter(
+                node__graph_version=self,
+                direction=PortDirection.OUTPUT,
+            ).select_related("node")
+        )
+        if not output_ports:
+            return
+
+        connected_output_port_ids = set(
+            Edge.no_workspace_objects.filter(graph_version=self).values_list(
+                "source_port_id", flat=True
+            )
+        )
+
+        seen: dict[str, str] = {}  # display_name -> node name
+        for port in output_ports:
+            if port.id not in connected_output_port_ids:
+                if port.display_name in seen:
+                    raise ValidationError(
+                        f"Duplicate exposed output port display name "
+                        f"'{port.display_name}' found on nodes "
+                        f"'{seen[port.display_name]}' and '{port.node.name}'. "
+                        f"All exposed output port display names must be unique "
+                    )
+                seen[port.display_name] = port.node.name
+
+    def _validate_single_active_version(self) -> None:
+        """Validate that there's at most one active version per graph."""
+        existing = (
+            GraphVersion.no_workspace_objects.filter(graph=self.graph, status="active")
+            .exclude(id=self.id)
+            .exists()
+        )
+        if existing:
+            raise ValidationError("Only one active version allowed per graph")
+
+    def _validate_template_port_completeness(self) -> None:
+        """Validate that STRICT and EXTENSIBLE mode nodes have all required template keys."""
+        from agent_playground.models.node import Node
+        from agent_playground.models.port import Port
+
+        nodes = Node.no_workspace_objects.filter(
+            graph_version=self,
+            type=NodeType.ATOMIC,
+            node_template__isnull=False,
+        ).select_related("node_template")
+
+        for node in nodes:
+            template = node.node_template
+            for direction, definition_field, mode_field in [
+                ("input", "input_definition", "input_mode"),
+                ("output", "output_definition", "output_mode"),
+            ]:
+                mode = getattr(template, mode_field)
+                if mode not in (PortMode.STRICT, PortMode.EXTENSIBLE):
+                    continue
+
+                definition_keys = {
+                    d["key"] for d in getattr(template, definition_field)
+                }
+                port_keys = set(
+                    Port.no_workspace_objects.filter(
+                        node=node, direction=direction
+                    ).values_list("key", flat=True)
+                )
+                missing = definition_keys - port_keys
+                if missing:
+                    raise ValidationError(
+                        f"Missing required template port keys "
+                        f"{sorted(missing)} on {mode}-mode {direction} "
+                        f"of node '{node.name}'"
+                    )
+
+    def clean(self):
+        super().clean()
+
+        self._validate_unique_exposed_port_display_names()
+
+        if self.status == "active":
+            self._validate_single_active_version()
+            self._validate_template_port_completeness()
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)

--- a/futureagi/agent_playground/models/node.py
+++ b/futureagi/agent_playground/models/node.py
@@ -1,0 +1,249 @@
+import uuid
+
+import jsonschema
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from agent_playground.models.choices import (
+    RESERVED_NAME_CHARS,
+    GraphVersionStatus,
+    NodeType,
+)
+from agent_playground.models.graph_version import GraphVersion
+from agent_playground.models.node_template import NodeTemplate
+from tfc.utils.base_model import BaseModel
+
+
+class Node(BaseModel):
+    """
+    Atomic unit of execution or Subgraph reference.
+
+    Node Categories:
+    - Atomic Nodes: type="atomic". ref_graph_version MUST be None.
+                   node_template MUST be set. Execute a single operation.
+    - Subgraph Nodes: type="subgraph". ref_graph_version MUST be set (active or inactive versions only).
+                   node_template MUST be None. Execute another Graph.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    graph_version = models.ForeignKey(
+        GraphVersion, on_delete=models.CASCADE, related_name="nodes"
+    )
+    node_template = models.ForeignKey(
+        NodeTemplate,
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="nodes",
+        help_text="If set: References a node template (for atomic nodes). Null for subgraph nodes.",
+    )
+    ref_graph_version = models.ForeignKey(
+        GraphVersion,
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="referenced_by_nodes",
+        help_text="If set: This node references a reusable subgraph",
+    )
+
+    type = models.CharField(
+        max_length=20,
+        choices=NodeType.choices,
+        help_text="'subgraph' for subgraph nodes, 'atomic' for nodes using a NodeTemplate",
+    )
+    name = models.CharField(max_length=255, help_text="Display name")
+    config = models.JSONField(
+        default=dict,
+        help_text="Node-specific configuration (validated against node_template.config_schema for atomic nodes)",
+    )
+
+    # TODO: Need to add a Validation for this structure
+    position = models.JSONField(
+        default=dict, help_text='UI coordinates {"x": 0, "y": 0}'
+    )
+
+    class Meta:
+        db_table = "agent_playground_node"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["graph_version", "name"],
+                condition=models.Q(deleted=False),
+                name="unique_node_name_per_graph_version",
+            )
+        ]
+        indexes = [
+            models.Index(fields=["graph_version", "type"]),
+            models.Index(fields=["ref_graph_version"]),
+            models.Index(fields=["node_template"]),
+        ]
+
+    def __str__(self):
+        return f"{self.name} ({self.type})"
+
+    def _validate_subgraph_node_fields(self) -> None:
+        """
+        Validate subgraph node fields.
+
+        Subgraph nodes must have ref_graph_version set and NO node_template.
+        """
+        if self.type != NodeType.SUBGRAPH:
+            return
+        if not self.ref_graph_version:
+            raise ValidationError("Subgraph nodes must have ref_graph_version set")
+        if self.node_template:
+            raise ValidationError("Subgraph nodes cannot have node_template")
+
+    def _validate_atomic_node_fields(self) -> None:
+        """
+        Validate atomic node fields.
+
+        Atomic nodes must have node_template set and NO ref_graph_version.
+        """
+        if self.type != NodeType.ATOMIC:
+            return
+        if not self.node_template:
+            raise ValidationError("Atomic nodes must have node_template set")
+        if self.ref_graph_version:
+            raise ValidationError("Atomic nodes cannot have ref_graph_version")
+
+    def _validate_config_schema(self) -> None:
+        """
+        Validate config against node_template's config_schema for atomic nodes.
+
+        Atomic nodes must have a valid config schema.
+        Skipped when a PromptTemplateNode exists (config lives in PTV snapshot).
+        """
+        if self.type != NodeType.ATOMIC or not self.node_template:
+            return
+        # Skip validation if config is managed by PromptTemplateNode
+        if self.pk:
+            from agent_playground.models.prompt_template_node import PromptTemplateNode
+
+            if PromptTemplateNode.no_workspace_objects.filter(node_id=self.pk).exists():
+                return
+        try:
+            jsonschema.validate(
+                instance=self.config, schema=self.node_template.config_schema
+            )
+        except jsonschema.ValidationError as e:
+            raise ValidationError(f"Invalid config: {e.message}")
+
+    def _validate_subgraph_node_config(self) -> None:
+        """
+        Validate subgraph nodes have empty config.
+
+        Subgraph nodes don't have a config_schema (no node_template),
+        so config must be empty.
+        """
+        if self.type != NodeType.SUBGRAPH:
+            return
+        if self.config:
+            raise ValidationError("Subgraph nodes must have empty config")
+
+    def _validate_no_self_reference(self) -> None:
+        """
+        Validate no self-reference.
+
+        ref_graph_version must belong to a different graph (no self-reference).
+        """
+        if not self.ref_graph_version:
+            return
+        if self.ref_graph_version.graph_id == self.graph_version.graph_id:
+            raise ValidationError(
+                "Subgraph nodes cannot reference versions of the same graph"
+            )
+
+    def _validate_ref_is_validated_version(self) -> None:
+        """
+        Validate ref_graph_version is a validated version (active or inactive).
+
+        ref_graph_version must be either active or inactive. Draft versions are
+        excluded because they haven't been validated yet.
+        """
+        if not self.ref_graph_version:
+            return
+
+        if self.ref_graph_version.status not in (
+            GraphVersionStatus.ACTIVE,
+            GraphVersionStatus.INACTIVE,
+        ):
+            raise ValidationError(
+                "Subgraph nodes can only reference active or inactive versions. "
+                "Draft versions cannot be referenced."
+            )
+
+    def _validate_single_version_per_graph(self) -> None:
+        """
+        Validate only one version of each external graph can be referenced per graph_version.
+
+        Only one version of each external graph can be referenced per graph_version.
+        """
+        if not self.ref_graph_version:
+            return
+        existing_ref = (
+            Node.no_workspace_objects.filter(
+                graph_version=self.graph_version,
+                ref_graph_version__graph=self.ref_graph_version.graph,
+                type=NodeType.SUBGRAPH,
+            )
+            .exclude(id=self.id)
+            .first()
+        )
+
+        if (
+            existing_ref
+            and existing_ref.ref_graph_version_id != self.ref_graph_version_id
+        ):
+            raise ValidationError(
+                f"This graph already references a different version of '{self.ref_graph_version.graph.name}'"
+            )
+
+    def _validate_no_graph_reference_cycle(self) -> None:
+        """
+        Validate that adding this subgraph reference would not create a
+        circular dependency between graphs.
+        """
+        if self.type != NodeType.SUBGRAPH or not self.ref_graph_version:
+            return
+        from agent_playground.utils.graph_validation import (
+            would_create_graph_reference_cycle,
+        )
+
+        if would_create_graph_reference_cycle(
+            source_graph_id=self.graph_version.graph_id,
+            target_graph_id=self.ref_graph_version.graph_id,
+        ):
+            raise ValidationError(
+                "This reference would create a circular dependency between graphs"
+            )
+
+    def _validate_name_chars(self) -> None:
+        """Reject node names containing reserved characters used in dot-notation."""
+        bad = RESERVED_NAME_CHARS.intersection(self.name)
+        if bad:
+            raise ValidationError(
+                f"Node name cannot contain reserved characters: {sorted(bad)}"
+            )
+
+    def clean(self):
+        """
+        Validate node type, template, and reference consistency.
+        """
+        super().clean()
+
+        self._validate_name_chars()
+        self._validate_subgraph_node_fields()
+        self._validate_atomic_node_fields()
+        self._validate_config_schema()
+        self._validate_subgraph_node_config()
+        self._validate_no_self_reference()
+        self._validate_ref_is_validated_version()
+        self._validate_single_version_per_graph()
+        self._validate_no_graph_reference_cycle()
+
+    def save(self, *args, **kwargs):
+        skip_validation = kwargs.pop("skip_validation", False)
+        if not skip_validation:
+            self.clean()
+        super().save(*args, **kwargs)

--- a/futureagi/agent_playground/models/node_connection.py
+++ b/futureagi/agent_playground/models/node_connection.py
@@ -1,0 +1,70 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from agent_playground.models.graph_version import GraphVersion
+from agent_playground.models.node import Node
+from tfc.utils.base_model import BaseModel
+
+
+class NodeConnection(BaseModel):
+    """
+    Directed node-to-node connection within a GraphVersion.
+
+    A NodeConnection declares that two nodes are connected at the node level.
+    Edges (port-to-port connections) between nodes require a corresponding
+    NodeConnection to exist first.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    graph_version = models.ForeignKey(
+        GraphVersion, on_delete=models.CASCADE, related_name="node_connections"
+    )
+    source_node = models.ForeignKey(
+        Node, on_delete=models.CASCADE, related_name="outgoing_connections"
+    )
+    target_node = models.ForeignKey(
+        Node, on_delete=models.CASCADE, related_name="incoming_connections"
+    )
+
+    class Meta:
+        db_table = "agent_playground_node_connection"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["source_node", "target_node"],
+                condition=models.Q(deleted=False),
+                name="unique_node_connection",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["graph_version"]),
+            models.Index(fields=["source_node"]),
+            models.Index(fields=["target_node"]),
+        ]
+
+    def __str__(self):
+        return f"{self.source_node.name} → {self.target_node.name}"
+
+    def _validate_no_self_connection(self) -> None:
+        if self.source_node_id == self.target_node_id:
+            raise ValidationError("A node cannot connect to itself")
+
+    def _validate_source_node_graph_version(self) -> None:
+        if self.source_node.graph_version_id != self.graph_version_id:
+            raise ValidationError("Source node must belong to this graph version")
+
+    def _validate_target_node_graph_version(self) -> None:
+        if self.target_node.graph_version_id != self.graph_version_id:
+            raise ValidationError("Target node must belong to this graph version")
+
+    def clean(self):
+        super().clean()
+        self._validate_no_self_connection()
+        self._validate_source_node_graph_version()
+        self._validate_target_node_graph_version()
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)

--- a/futureagi/agent_playground/models/node_execution.py
+++ b/futureagi/agent_playground/models/node_execution.py
@@ -1,0 +1,48 @@
+import uuid
+
+from django.db import models
+
+from agent_playground.models.choices import NodeExecutionStatus
+from agent_playground.models.graph_execution import GraphExecution
+from agent_playground.models.node import Node
+from tfc.utils.base_model import BaseModel
+
+
+class NodeExecution(BaseModel):
+    """
+    Execution of a single node within a GraphExecution.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    graph_execution = models.ForeignKey(
+        GraphExecution, on_delete=models.CASCADE, related_name="node_executions"
+    )
+    node = models.ForeignKey(Node, on_delete=models.PROTECT, related_name="executions")
+
+    status = models.CharField(
+        max_length=20,
+        choices=NodeExecutionStatus.choices,
+        default=NodeExecutionStatus.PENDING,
+    )
+
+    started_at = models.DateTimeField(null=True, blank=True)
+    completed_at = models.DateTimeField(null=True, blank=True)
+    error_message = models.TextField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agent_playground_node_execution"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["graph_execution", "node"],
+                condition=models.Q(deleted=False),
+                name="unique_graph_execution_node",
+            )
+        ]
+        indexes = [
+            models.Index(fields=["graph_execution", "status"]),
+            models.Index(fields=["node"]),
+        ]
+
+    def __str__(self):
+        return f"{self.node.name} execution ({self.status})"

--- a/futureagi/agent_playground/models/node_template.py
+++ b/futureagi/agent_playground/models/node_template.py
@@ -1,0 +1,134 @@
+import uuid
+
+import jsonschema
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from agent_playground.models.choices import PortMode
+from tfc.utils.base_model import BaseModel
+
+
+class NodeTemplate(BaseModel):
+    """
+    Registry of available node types with their port definitions and configuration.
+
+    Port Modes:
+    - "strict": Only template-defined ports allowed. No customization.
+    - "extensible": Template defines required ports. Users can add additional custom ports.
+    - "dynamic": Template defines no ports. Users define all ports based on their use case.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    name = models.CharField(max_length=100)
+    display_name = models.CharField(max_length=255)
+    description = models.TextField(max_length=1000)
+    icon = models.URLField(max_length=1000, null=True, blank=True)
+    categories = models.JSONField(default=list)
+
+    # Port definitions
+    input_definition = models.JSONField(default=list)
+    output_definition = models.JSONField(default=list)
+    input_mode = models.CharField(
+        max_length=20,
+        choices=PortMode.choices,
+    )
+    output_mode = models.CharField(
+        max_length=20,
+        choices=PortMode.choices,
+    )
+
+    config_schema = models.JSONField(
+        default=dict, help_text="JSON Schema for Node.config validation"
+    )
+
+    class Meta:
+        db_table = "agent_playground_node_template"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["name"],
+                condition=models.Q(deleted=False),
+                name="unique_node_template_name",
+            )
+        ]
+        indexes = [
+            models.Index(fields=["categories"]),
+            models.Index(fields=["name"]),
+        ]
+
+    def __str__(self):
+        return f"{self.display_name} ({self.name})"
+
+    def _validate_field_is_list(self, field_name: str) -> None:
+        """Validate the field value is a list."""
+        value = getattr(self, field_name)
+        if not isinstance(value, list):
+            raise ValidationError(f"{field_name} must be a list")
+
+    def _validate_dynamic_mode_empty_definitions(self) -> None:
+        """Validate dynamic mode has empty port definitions."""
+        if self.input_mode == PortMode.DYNAMIC and self.input_definition:
+            raise ValidationError(
+                "Dynamic input mode should have empty input_definition"
+            )
+        if self.output_mode == PortMode.DYNAMIC and self.output_definition:
+            raise ValidationError(
+                "Dynamic output mode should have empty output_definition"
+            )
+
+    def _validate_port_definition_format(self, field_name: str) -> None:
+        """Validate each port definition has 'key' and 'data_schema'."""
+        port_definitions = getattr(self, field_name)
+        for port_spec in port_definitions:
+            if "key" not in port_spec or "data_schema" not in port_spec:
+                raise ValidationError(
+                    f"Each {field_name} entry must have 'key' and 'data_schema'"
+                )
+
+    def _validate_config_schema(self) -> None:
+        """Validate the config schema is a valid JSON Schema."""
+        try:
+            jsonschema.Draft7Validator.check_schema(self.config_schema)
+        except jsonschema.SchemaError as e:
+            raise ValidationError(f"Invalid config_schema: {e.message}")
+
+    def _validate_no_duplicate_definition_keys(self, field_name: str) -> None:
+        """Validate no duplicate keys within a port definition list."""
+        port_definitions = getattr(self, field_name)
+        seen_keys: set[str] = set()
+        for port_spec in port_definitions:
+            key = port_spec.get("key")
+            if key is not None and key in seen_keys:
+                raise ValidationError(f"Duplicate key '{key}' in {field_name}")
+            seen_keys.add(key)
+
+    def _validate_no_reserved_keys(self, field_name: str) -> None:
+        """Validate that template definitions do not use the reserved 'custom' key."""
+        port_definitions = getattr(self, field_name)
+        for port_spec in port_definitions:
+            if port_spec.get("key") == "custom":
+                raise ValidationError(
+                    f"'custom' is a reserved port key and cannot be used in {field_name}"
+                )
+
+    def clean(self):
+        """
+        Validate the node template configuration.
+        """
+        super().clean()
+
+        self._validate_field_is_list("categories")
+        self._validate_field_is_list("input_definition")
+        self._validate_field_is_list("output_definition")
+        self._validate_dynamic_mode_empty_definitions()
+        self._validate_port_definition_format("input_definition")
+        self._validate_port_definition_format("output_definition")
+        self._validate_no_duplicate_definition_keys("input_definition")
+        self._validate_no_duplicate_definition_keys("output_definition")
+        self._validate_no_reserved_keys("input_definition")
+        self._validate_no_reserved_keys("output_definition")
+        self._validate_config_schema()
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)

--- a/futureagi/agent_playground/models/port.py
+++ b/futureagi/agent_playground/models/port.py
@@ -1,0 +1,182 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from agent_playground.models.choices import (
+    RESERVED_NAME_CHARS,
+    NodeType,
+    PortDirection,
+    PortMode,
+)
+from agent_playground.models.node import Node
+from tfc.utils.base_model import BaseModel
+
+
+class Port(BaseModel):
+    """
+    Type contract for data flow.
+
+    Ports define the inputs and outputs of nodes and provide JSON Schema validation
+    for data flowing through the graph.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    node = models.ForeignKey(Node, on_delete=models.CASCADE, related_name="ports")
+
+    key = models.CharField(
+        max_length=100, help_text="Identifier (e.g., 'prompt', 'result')"
+    )
+    display_name = models.CharField(
+        max_length=100,
+        help_text="User-facing name for the port",
+    )
+    direction = models.CharField(max_length=10, choices=PortDirection.choices)
+    data_schema = models.JSONField(default=dict, help_text="JSON Schema for validation")
+    required = models.BooleanField(default=True)
+    default_value = models.JSONField(null=True, blank=True)
+    metadata = models.JSONField(default=dict)
+    ref_port = models.ForeignKey(
+        "self",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="referencing_ports",
+        help_text="For subgraph node ports: links to the corresponding port in the child graph",
+    )
+
+    class Meta:
+        db_table = "agent_playground_port"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["node", "key"],
+                condition=models.Q(deleted=False) & ~models.Q(key="custom"),
+                name="unique_node_port_key",
+            ),
+            models.UniqueConstraint(
+                fields=["node", "display_name"],
+                condition=models.Q(deleted=False),
+                name="unique_node_port_display_name",
+            ),
+        ]
+        indexes = [models.Index(fields=["node", "direction"])]
+
+    @property
+    def routing_key(self) -> str:
+        """Key used for data routing.
+
+        Template ports use `key` (matches runner's hardcoded dict keys).
+        Custom ports use `display_name` (unique per node, user-defined).
+        """
+        return self.display_name if self.key == "custom" else self.key
+
+    def _validate_ref_port(self) -> None:
+        """Validate ref_port constraints for subgraph node ports.
+
+        Rules:
+        - ref_port is only allowed on subgraph node ports (node.type == "subgraph")
+        - ref_port must belong to a node in node.ref_graph_version
+        - Direction must match (input→input, output→output)
+        """
+        if not self.ref_port_id:
+            return
+
+        if self.node.type != NodeType.SUBGRAPH:
+            raise ValidationError("ref_port is only allowed on ports of subgraph nodes")
+
+        if not self.node.ref_graph_version_id:
+            raise ValidationError(
+                "Subgraph node must have ref_graph_version set to use ref_port"
+            )
+
+        if self.ref_port.node.graph_version_id != self.node.ref_graph_version_id:
+            raise ValidationError(
+                "ref_port must belong to a node in the subgraph's referenced graph version"
+            )
+
+        if self.ref_port.direction != self.direction:
+            raise ValidationError(
+                f"ref_port direction mismatch: this port is '{self.direction}' "
+                f"but ref_port is '{self.ref_port.direction}'"
+            )
+
+    def _validate_subgraph_port_key(self) -> None:
+        """Subgraph nodes must use key='custom' for all ports."""
+        if self.node.type == NodeType.SUBGRAPH and self.key != "custom":
+            raise ValidationError(
+                f"Subgraph node '{self.node.name}' port key must be "
+                f"'custom', got '{self.key}'"
+            )
+
+    def _validate_key_against_template(self) -> None:
+        """Validate port key against the node template's port mode.
+
+        - STRICT: key must be in template definition keys
+        - EXTENSIBLE: key must be in template definition keys OR be "custom"
+        - DYNAMIC: key must be "custom"
+        """
+        if self.node.type != NodeType.ATOMIC or not self.node.node_template:
+            return
+
+        template = self.node.node_template
+        if self.direction == PortDirection.INPUT:
+            mode = template.input_mode
+            definition = template.input_definition
+        else:
+            mode = template.output_mode
+            definition = template.output_definition
+
+        definition_keys = {d["key"] for d in definition}
+
+        if mode == PortMode.DYNAMIC:
+            if self.key != "custom":
+                raise ValidationError(
+                    f"Port key '{self.key}' is not allowed on "
+                    f"dynamic-mode {self.direction} of node '{self.node.name}'. "
+                    f"All keys must be 'custom'"
+                )
+        elif mode == PortMode.STRICT:
+            if self.key not in definition_keys:
+                raise ValidationError(
+                    f"Port key '{self.key}' is not allowed on "
+                    f"strict-mode {self.direction} of node '{self.node.name}'. "
+                    f"Allowed keys: {sorted(definition_keys)}"
+                )
+        elif mode == PortMode.EXTENSIBLE:
+            if self.key != "custom" and self.key not in definition_keys:
+                raise ValidationError(
+                    f"Port key '{self.key}' is not allowed on "
+                    f"extensible-mode {self.direction} of node '{self.node.name}'. "
+                    f"Allowed keys: {sorted(definition_keys)} or 'custom'"
+                )
+
+    def __str__(self):
+        return f"{self.node.name}.{self.key} ({self.direction})"
+
+    def _validate_display_name_chars(self) -> None:
+        """Reject output port display_names containing reserved characters.
+
+        Input ports are allowed to contain these characters because their
+        display_name IS the full variable string (e.g. "Node1.response.data").
+        """
+        if self.direction != PortDirection.OUTPUT:
+            return
+        bad = RESERVED_NAME_CHARS.intersection(self.display_name)
+        if bad:
+            raise ValidationError(
+                f"Output port display_name cannot contain reserved characters: {sorted(bad)}"
+            )
+
+    def clean(self):
+        super().clean()
+        self._validate_display_name_chars()
+        self._validate_ref_port()
+        self._validate_subgraph_port_key()
+        self._validate_key_against_template()
+
+    def save(self, *args, **kwargs):
+        skip_validation = kwargs.pop("skip_validation", False)
+        if not skip_validation:
+            self.clean()
+        super().save(*args, **kwargs)

--- a/futureagi/agent_playground/models/prompt_template_node.py
+++ b/futureagi/agent_playground/models/prompt_template_node.py
@@ -1,0 +1,75 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+
+
+class PromptTemplateNode(BaseModel):
+    """
+    Links a Node to a PromptTemplate and PromptVersion from model_hub.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    node = models.OneToOneField(
+        "agent_playground.Node",
+        on_delete=models.CASCADE,
+        related_name="prompt_template_node",
+    )
+
+    prompt_template = models.ForeignKey(
+        "model_hub.PromptTemplate",
+        on_delete=models.CASCADE,
+        related_name="prompt_template_nodes",
+    )
+
+    prompt_version = models.ForeignKey(
+        "model_hub.PromptVersion",
+        on_delete=models.CASCADE,
+        related_name="prompt_template_nodes",
+    )
+
+    class Meta:
+        db_table = "agent_playground_prompt_template_node"
+
+    def __str__(self):
+        return (
+            f"PromptTemplateNode(node={self.node_id}, "
+            f"template={self.prompt_template_id}, "
+            f"version={self.prompt_version_id})"
+        )
+
+    def clean(self):
+        super().clean()
+        if (
+            self.prompt_template_id
+            and self.prompt_version_id
+            and self.prompt_version.original_template_id != self.prompt_template_id
+        ):
+            raise ValidationError(
+                "prompt_version must belong to the specified prompt_template."
+            )
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)
+        self._update_output_port_schema()
+
+    def _update_output_port_schema(self):
+        """Update the node's output port data_schema based on the linked PromptVersion's response_format."""
+        from agent_playground.models.port import Port
+        from agent_playground.services.engine.utils.json_path import (
+            get_output_schema_for_response_format,
+        )
+
+        config = self.prompt_version.prompt_config_snapshot or {}
+        response_format = config.get("configuration", {}).get("response_format")
+        data_schema = get_output_schema_for_response_format(response_format)
+
+        Port.no_workspace_objects.filter(
+            node=self.node,
+            key="response",
+            direction="output",
+        ).update(data_schema=data_schema)

--- a/futureagi/agent_playground/tests/models/test_edge.py
+++ b/futureagi/agent_playground/tests/models/test_edge.py
@@ -1,0 +1,768 @@
+"""
+Tests for the Edge model.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+
+from agent_playground.models import Edge, GraphVersion, Node, Port
+from agent_playground.models.choices import (
+    GraphVersionStatus,
+    NodeType,
+    PortDirection,
+)
+from agent_playground.models.node_connection import NodeConnection
+
+
+@pytest.mark.unit
+class TestEdgeCreation:
+    """Tests for Edge model creation."""
+
+    def test_edge_creation_success(
+        self, db, graph_version, node, second_node, output_port, second_node_input_port
+    ):
+        """Valid edge between output->input."""
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_node=node,
+            target_node=second_node,
+        )
+        edge = Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+        assert edge.id is not None
+        assert edge.source_port == output_port
+        assert edge.target_port == second_node_input_port
+
+
+@pytest.mark.unit
+class TestEdgeDirectionValidation:
+    """Tests for edge port direction validation."""
+
+    def test_edge_source_must_be_output(
+        self, db, graph_version, input_port, second_node_input_port
+    ):
+        """source_port.direction must be OUTPUT."""
+        edge = Edge(
+            graph_version=graph_version,
+            source_port=input_port,  # Wrong - should be output
+            target_port=second_node_input_port,
+        )
+        with pytest.raises(ValidationError, match="Source port must be an output port"):
+            edge.clean()
+
+    def test_edge_target_must_be_input(
+        self, db, graph_version, output_port, second_node_output_port
+    ):
+        """target_port.direction must be INPUT."""
+        edge = Edge(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_output_port,  # Wrong - should be input
+        )
+        with pytest.raises(ValidationError, match="Target port must be an input port"):
+            edge.clean()
+
+
+@pytest.mark.unit
+class TestEdgeGraphVersionValidation:
+    """Tests for edge graph version validation."""
+
+    def test_edge_source_must_belong_to_graph_version(
+        self, db, graph_version, second_node_input_port, graph, node_template
+    ):
+        """source_port.node.graph_version must match edge's graph_version."""
+        # Create another graph version
+        other_version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=99,
+            status=GraphVersionStatus.INACTIVE,
+        )
+        other_node = Node.no_workspace_objects.create(
+            graph_version=other_version,
+            node_template=node_template,
+            type="atomic",
+            name="Other Node",
+            config={},
+        )
+        other_output = Port.no_workspace_objects.create(
+            node=other_node,
+            key="output1",
+            display_name="output1",
+            direction=PortDirection.OUTPUT,
+        )
+
+        edge = Edge(
+            graph_version=graph_version,
+            source_port=other_output,  # Different graph version
+            target_port=second_node_input_port,
+        )
+        with pytest.raises(
+            ValidationError, match="Source port node must belong to this graph version"
+        ):
+            edge.clean()
+
+    def test_edge_target_must_belong_to_graph_version(
+        self, db, graph_version, output_port, graph, node_template
+    ):
+        """target_port.node.graph_version must match edge's graph_version."""
+        # Create another graph version
+        other_version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=99,
+            status=GraphVersionStatus.INACTIVE,
+        )
+        other_node = Node.no_workspace_objects.create(
+            graph_version=other_version,
+            node_template=node_template,
+            type="atomic",
+            name="Other Node",
+            config={},
+        )
+        other_input = Port.no_workspace_objects.create(
+            node=other_node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+
+        edge = Edge(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=other_input,  # Different graph version
+        )
+        with pytest.raises(
+            ValidationError, match="Target port node must belong to this graph version"
+        ):
+            edge.clean()
+
+
+@pytest.mark.unit
+class TestEdgeUniqueConstraint:
+    """Tests for Edge unique constraints."""
+
+    def test_edge_unique_connection(
+        self, db, graph_version, node, second_node, output_port, second_node_input_port
+    ):
+        """UniqueConstraint on (source, target)."""
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_node=node,
+            target_node=second_node,
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+
+        with pytest.raises(IntegrityError):
+            Edge.no_workspace_objects.create(
+                graph_version=graph_version,
+                source_port=output_port,
+                target_port=second_node_input_port,  # Duplicate connection
+            )
+
+    def test_edge_fan_in_blocked(
+        self, db, graph_version, second_node_input_port, node, second_node, third_node
+    ):
+        """One input port cannot have multiple sources (fan-in blocked)."""
+        # Create two output ports from different nodes (not the target node)
+        output1 = Port.no_workspace_objects.create(
+            node=node,
+            key="output1",
+            display_name="output1",
+            direction=PortDirection.OUTPUT,
+        )
+        output2 = Port.no_workspace_objects.create(
+            node=third_node,
+            key="output1",
+            display_name="output1",
+            direction=PortDirection.OUTPUT,
+        )
+
+        # Create NodeConnections
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_node=node,
+            target_node=second_node,
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_node=third_node,
+            target_node=second_node,
+        )
+
+        # Create first edge to input
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output1,
+            target_port=second_node_input_port,
+        )
+
+        # Try to create second edge to same input - should fail
+        with pytest.raises(IntegrityError):
+            Edge.no_workspace_objects.create(
+                graph_version=graph_version,
+                source_port=output2,
+                target_port=second_node_input_port,  # Same target - fan-in blocked
+            )
+
+    def test_edge_fan_out_allowed(
+        self, db, graph_version, output_port, node, second_node, node_template
+    ):
+        """One output port can connect to multiple inputs (fan-out allowed)."""
+        # Create first input
+        input1 = Port.no_workspace_objects.create(
+            node=second_node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+
+        # Create third node with another input
+        third_node = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            node_template=node_template,
+            type="atomic",
+            name="Third Node",
+            config={},
+        )
+        input2 = Port.no_workspace_objects.create(
+            node=third_node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+
+        # Create NodeConnections
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_node=node,
+            target_node=second_node,
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_node=node,
+            target_node=third_node,
+        )
+
+        # Create edges from same output to multiple inputs
+        edge1 = Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=input1,
+        )
+        edge2 = Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,  # Same source
+            target_port=input2,  # Different target
+        )
+        assert edge1.source_port == edge2.source_port
+
+    def test_edge_unique_allows_deleted(
+        self, db, graph_version, node, second_node, output_port, second_node_input_port
+    ):
+        """Soft-deleted edges don't block uniqueness."""
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_node=node,
+            target_node=second_node,
+        )
+        edge1 = Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+        edge1.delete()  # Soft delete
+
+        # Should be able to create same connection
+        edge2 = Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+        assert edge2.id is not None
+
+
+@pytest.mark.unit
+class TestEdgeCascadeDelete:
+    """Tests for Edge cascade delete behavior."""
+
+    def test_edge_cascade_delete_graph_version(self, db, edge, graph_version):
+        """Deleting version cascades to edges."""
+        edge_id = edge.id
+
+        # Hard delete the graph version
+        GraphVersion.all_objects.filter(id=graph_version.id).delete()
+
+        # Edge should be gone
+        assert not Edge.all_objects.filter(id=edge_id).exists()
+
+    def test_edge_cascade_delete_source_port(self, db, edge, output_port):
+        """Deleting source port cascades to edge."""
+        edge_id = edge.id
+
+        # Hard delete the source port
+        Port.all_objects.filter(id=output_port.id).delete()
+
+        # Edge should be gone
+        assert not Edge.all_objects.filter(id=edge_id).exists()
+
+    def test_edge_cascade_delete_target_port(self, db, edge, second_node_input_port):
+        """Deleting target port cascades to edge."""
+        edge_id = edge.id
+
+        # Hard delete the target port
+        Port.all_objects.filter(id=second_node_input_port.id).delete()
+
+        # Edge should be gone
+        assert not Edge.all_objects.filter(id=edge_id).exists()
+
+
+@pytest.mark.unit
+class TestEdgeCycleValidation:
+    """Tests for cycle detection during edge validation."""
+
+    def test_self_loop_rejected(self, db, graph_version, node, output_port, input_port):
+        """An edge from a node back to itself is rejected (NC validation fires first)."""
+        edge = Edge(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=input_port,
+        )
+        with pytest.raises(ValidationError, match="NodeConnection"):
+            edge.clean()
+
+    def test_two_node_cycle_rejected(
+        self,
+        db,
+        graph_version,
+        node,
+        second_node,
+        output_port,
+        second_node_input_port,
+        second_node_output_port,
+        input_port,
+    ):
+        """A→B exists, B→A is rejected."""
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_node=node,
+            target_node=second_node,
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_node=second_node,
+            target_node=node,
+        )
+        reverse_edge = Edge(
+            graph_version=graph_version,
+            source_port=second_node_output_port,
+            target_port=input_port,
+        )
+        with pytest.raises(
+            ValidationError, match="This edge would create a cycle in the graph"
+        ):
+            reverse_edge.clean()
+
+    def test_three_node_cycle_rejected(
+        self,
+        db,
+        graph_version,
+        node,
+        second_node,
+        third_node,
+        output_port,
+        second_node_input_port,
+        second_node_output_port,
+        third_node_input_port,
+        third_node_output_port,
+        input_port,
+    ):
+        """A→B→C exists, C→A is rejected."""
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=node, target_node=second_node
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=second_node, target_node=third_node
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=second_node_output_port,
+            target_port=third_node_input_port,
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=third_node, target_node=node
+        )
+        closing_edge = Edge(
+            graph_version=graph_version,
+            source_port=third_node_output_port,
+            target_port=input_port,
+        )
+        with pytest.raises(
+            ValidationError, match="This edge would create a cycle in the graph"
+        ):
+            closing_edge.clean()
+
+    def test_valid_chain_accepted(
+        self,
+        db,
+        graph_version,
+        node,
+        second_node,
+        third_node,
+        output_port,
+        second_node_input_port,
+        second_node_output_port,
+        third_node_input_port,
+    ):
+        """A→B exists, B→C is valid (no cycle)."""
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=node, target_node=second_node
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=second_node, target_node=third_node
+        )
+        chain_edge = Edge(
+            graph_version=graph_version,
+            source_port=second_node_output_port,
+            target_port=third_node_input_port,
+        )
+        chain_edge.clean()  # Should not raise
+
+    def test_fan_out_accepted(
+        self,
+        db,
+        graph_version,
+        node,
+        second_node,
+        third_node,
+        output_port,
+        second_node_input_port,
+        third_node_input_port,
+    ):
+        """A→B exists, A→C is valid (fan-out, no cycle)."""
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=node, target_node=second_node
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=node, target_node=third_node
+        )
+        fan_out_edge = Edge(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=third_node_input_port,
+        )
+        fan_out_edge.clean()  # Should not raise
+
+    def test_diamond_dag_accepted(
+        self,
+        db,
+        graph_version,
+        node,
+        output_port,
+        second_node,
+        second_node_input_port,
+        second_node_output_port,
+        third_node,
+        third_node_input_port,
+        third_node_output_port,
+        dynamic_node_template,
+    ):
+        """Diamond DAG: A→B, A→C, B→D exists, C→D is valid."""
+        # Create fourth node (D) with dynamic template to allow multiple input ports
+        fourth_node = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            node_template=dynamic_node_template,
+            type=NodeType.ATOMIC,
+            name="Fourth Node",
+            config={},
+            position={"x": 700, "y": 100},
+        )
+        fourth_input_1 = Port.no_workspace_objects.create(
+            node=fourth_node,
+            key="custom",
+            display_name="Input From B",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        fourth_input_2 = Port.no_workspace_objects.create(
+            node=fourth_node,
+            key="custom",
+            display_name="Input From C",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Create NodeConnections
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=node, target_node=second_node
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=node, target_node=third_node
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_node=second_node,
+            target_node=fourth_node,
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=third_node, target_node=fourth_node
+        )
+
+        # A→B
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+        # A→C
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=third_node_input_port,
+        )
+        # B→D
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=second_node_output_port,
+            target_port=fourth_input_1,
+        )
+        # C→D should be valid (diamond, not cycle)
+        diamond_edge = Edge(
+            graph_version=graph_version,
+            source_port=third_node_output_port,
+            target_port=fourth_input_2,
+        )
+        diamond_edge.clean()  # Should not raise
+
+    def test_soft_deleted_edge_ignored(
+        self,
+        db,
+        graph_version,
+        node,
+        second_node,
+        output_port,
+        second_node_input_port,
+        second_node_output_port,
+        input_port,
+    ):
+        """Soft-deleted A→B should not block B→A."""
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=node, target_node=second_node
+        )
+        edge_ab = Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+        edge_ab.delete()  # Soft delete
+
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=second_node, target_node=node
+        )
+        reverse_edge = Edge(
+            graph_version=graph_version,
+            source_port=second_node_output_port,
+            target_port=input_port,
+        )
+        reverse_edge.clean()  # Should not raise
+
+    def test_other_graph_version_ignored(
+        self,
+        db,
+        graph,
+        graph_version,
+        node,
+        second_node,
+        output_port,
+        second_node_input_port,
+        node_template,
+    ):
+        """A→B in version 1, B→A in version 2 is valid (different versions)."""
+        # A→B in graph_version
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version, source_node=node, target_node=second_node
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version,
+            source_port=output_port,
+            target_port=second_node_input_port,
+        )
+
+        # Create version 2 with its own nodes and ports
+        version2 = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=10,
+            status=GraphVersionStatus.DRAFT,
+        )
+        node_b2 = Node.no_workspace_objects.create(
+            graph_version=version2,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Node B v2",
+            config={},
+        )
+        node_a2 = Node.no_workspace_objects.create(
+            graph_version=version2,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Node A v2",
+            config={},
+        )
+        b2_output = Port.no_workspace_objects.create(
+            node=node_b2,
+            key="output1",
+            display_name="output1",
+            direction=PortDirection.OUTPUT,
+        )
+        a2_input = Port.no_workspace_objects.create(
+            node=node_a2,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+
+        # B→A in version 2 should be valid
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version2, source_node=node_b2, target_node=node_a2
+        )
+        cross_version_edge = Edge(
+            graph_version=version2,
+            source_port=b2_output,
+            target_port=a2_input,
+        )
+        cross_version_edge.clean()  # Should not raise
+
+
+@pytest.mark.unit
+class TestEdgeCycleValidationNullWorkspace:
+    """Tests for cycle detection when graph has workspace=None."""
+
+    def test_self_loop_rejected_null_workspace(
+        self,
+        db,
+        graph_version_no_ws,
+        node_a_no_ws,
+        node_a_no_ws_output,
+        node_a_no_ws_input,
+    ):
+        """Self-loop on a node in a graph with no workspace is rejected (NC validation fires first)."""
+        edge = Edge(
+            graph_version=graph_version_no_ws,
+            source_port=node_a_no_ws_output,
+            target_port=node_a_no_ws_input,
+        )
+        with pytest.raises(ValidationError, match="NodeConnection"):
+            edge.clean()
+
+    def test_two_node_cycle_rejected_null_workspace(
+        self,
+        db,
+        graph_version_no_ws,
+        node_a_no_ws,
+        node_b_no_ws,
+        node_a_no_ws_output,
+        node_a_no_ws_input,
+        node_b_no_ws_input,
+        node_b_no_ws_output,
+    ):
+        """A->B exists, B->A is rejected (null workspace)."""
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version_no_ws,
+            source_node=node_a_no_ws,
+            target_node=node_b_no_ws,
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version_no_ws,
+            source_port=node_a_no_ws_output,
+            target_port=node_b_no_ws_input,
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version_no_ws,
+            source_node=node_b_no_ws,
+            target_node=node_a_no_ws,
+        )
+        reverse_edge = Edge(
+            graph_version=graph_version_no_ws,
+            source_port=node_b_no_ws_output,
+            target_port=node_a_no_ws_input,
+        )
+        with pytest.raises(
+            ValidationError, match="This edge would create a cycle in the graph"
+        ):
+            reverse_edge.clean()
+
+    def test_valid_chain_accepted_null_workspace(
+        self,
+        db,
+        graph_version_no_ws,
+        node_a_no_ws,
+        node_b_no_ws,
+        node_a_no_ws_output,
+        node_b_no_ws_input,
+        node_b_no_ws_output,
+        node_template,
+    ):
+        """A->B exists, B->C is valid (null workspace, no cycle)."""
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version_no_ws,
+            source_node=node_a_no_ws,
+            target_node=node_b_no_ws,
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=graph_version_no_ws,
+            source_port=node_a_no_ws_output,
+            target_port=node_b_no_ws_input,
+        )
+        # Create node C
+        node_c = Node.no_workspace_objects.create(
+            graph_version=graph_version_no_ws,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Node C (no ws)",
+            config={},
+            position={"x": 500, "y": 100},
+        )
+        node_c_input = Port.no_workspace_objects.create(
+            node=node_c,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=graph_version_no_ws,
+            source_node=node_b_no_ws,
+            target_node=node_c,
+        )
+        chain_edge = Edge(
+            graph_version=graph_version_no_ws,
+            source_port=node_b_no_ws_output,
+            target_port=node_c_input,
+        )
+        chain_edge.clean()  # Should not raise

--- a/futureagi/agent_playground/tests/models/test_execution_data.py
+++ b/futureagi/agent_playground/tests/models/test_execution_data.py
@@ -1,0 +1,319 @@
+"""
+Tests for the ExecutionData model.
+"""
+
+import pytest
+from django.db import IntegrityError, models
+
+from agent_playground.models import ExecutionData, Node, NodeExecution, Port
+from agent_playground.models.choices import PortDirection
+
+
+@pytest.mark.unit
+class TestExecutionDataCreation:
+    """Tests for ExecutionData model creation."""
+
+    def test_execution_data_creation_success(self, db, node_execution):
+        """Basic creation."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        data = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="test value",
+        )
+        assert data.id is not None
+        assert data.node_execution == node_execution
+        assert data.port == port
+
+
+@pytest.mark.unit
+class TestExecutionDataUniqueConstraint:
+    """Tests for ExecutionData unique constraints."""
+
+    def test_execution_data_unique_per_port(self, db, node_execution):
+        """UniqueConstraint on (node_execution, port)."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+        ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="first",
+        )
+
+        with pytest.raises(IntegrityError):
+            ExecutionData.no_workspace_objects.create(
+                node_execution=node_execution,
+                port=port,  # Duplicate
+                payload="second",
+            )
+
+    def test_execution_data_unique_allows_deleted(self, db, node_execution):
+        """Soft-deleted execution data don't block uniqueness."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+        data1 = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="first",
+        )
+        data1.delete()  # Soft delete
+
+        # Should be able to create another data for same port
+        data2 = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="second",
+        )
+        assert data2.id is not None
+
+
+@pytest.mark.unit
+class TestExecutionDataPayloadValidation:
+    """Tests for ExecutionData payload validation."""
+
+    def test_execution_data_auto_validates_payload(self, db, node_execution):
+        """save() runs validate_payload()."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        data = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="valid string",
+        )
+        assert data.is_valid is True
+        assert data.validation_errors is None
+
+    def test_execution_data_valid_payload_is_valid_true(self, db, node_execution):
+        """Matching schema sets is_valid=True."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        data = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="a valid string",
+        )
+        assert data.is_valid is True
+
+    def test_execution_data_invalid_payload_is_valid_false(self, db, node_execution):
+        """Non-matching schema sets is_valid=False."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "integer"},
+        )
+        data = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="not an integer",  # Invalid
+        )
+        assert data.is_valid is False
+
+    def test_execution_data_validation_errors_populated(self, db, node_execution):
+        """validation_errors contains details for invalid data."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "number"},
+        )
+        data = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="not a number",
+        )
+        assert data.is_valid is False
+        assert data.validation_errors is not None
+        assert "message" in data.validation_errors
+
+    def test_execution_data_empty_schema_always_valid(self, db, node_execution):
+        """Empty data_schema = always valid."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            data_schema={},  # Empty schema
+        )
+        data = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload={"anything": "goes", "even": [1, 2, 3]},
+        )
+        assert data.is_valid is True
+        assert data.validation_errors is None
+
+    def test_execution_data_complex_schema_validation(self, db, node_execution):
+        """Complex schema validation works correctly."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            data_schema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "age": {"type": "integer"},
+                },
+                "required": ["name"],
+            },
+        )
+        # Valid payload
+        valid_data = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload={"name": "John", "age": 30},
+        )
+        assert valid_data.is_valid is True
+
+    def test_execution_data_complex_schema_missing_required(self, db, node_execution):
+        """Missing required field fails validation."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            data_schema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                },
+                "required": ["name"],
+            },
+        )
+        # Invalid - missing required field
+        invalid_data = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload={"other": "field"},
+        )
+        assert invalid_data.is_valid is False
+
+
+@pytest.mark.unit
+class TestExecutionDataDenormalization:
+    """Tests for ExecutionData node denormalization."""
+
+    def test_execution_data_denormalizes_node(self, db, node_execution):
+        """save() sets node from node_execution.node."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+        data = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="test",
+        )
+        assert data.node == node_execution.node
+
+    def test_execution_data_node_not_overwritten_if_set(self, db, node_execution):
+        """If node_id is already set, it's not overwritten."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+        data = ExecutionData(
+            node_execution=node_execution,
+            node=node_execution.node,  # Explicitly set
+            port=port,
+            payload="test",
+        )
+        data.save()
+        assert data.node == node_execution.node
+
+
+@pytest.mark.unit
+class TestExecutionDataCascadeDelete:
+    """Tests for ExecutionData cascade delete behavior."""
+
+    def test_execution_data_cascade_delete_node_execution(self, db, node_execution):
+        """Deleting node_execution cascades to execution data."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+        data = ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="test",
+        )
+        data_id = data.id
+
+        # Hard delete the node execution
+        NodeExecution.all_objects.filter(id=node_execution.id).delete()
+
+        # Execution data should be gone
+        assert not ExecutionData.all_objects.filter(id=data_id).exists()
+
+
+@pytest.mark.unit
+class TestExecutionDataProtectDelete:
+    """Tests for ExecutionData PROTECT delete behavior."""
+
+    def test_execution_data_protect_delete_node(self, db, node_execution):
+        """Cannot delete node with execution data (PROTECT)."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+        ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="test",
+        )
+
+        with pytest.raises((IntegrityError, models.ProtectedError)):
+            Node.all_objects.filter(id=node_execution.node.id).delete()
+
+    def test_execution_data_protect_delete_port(self, db, node_execution):
+        """Cannot delete port with execution data (PROTECT)."""
+        port = Port.no_workspace_objects.create(
+            node=node_execution.node,
+            key="output1",
+            display_name="output1",
+            direction=PortDirection.OUTPUT,
+        )
+        ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=port,
+            payload="test",
+        )
+
+        with pytest.raises((IntegrityError, models.ProtectedError)):
+            Port.all_objects.filter(id=port.id).delete()

--- a/futureagi/agent_playground/tests/models/test_graph.py
+++ b/futureagi/agent_playground/tests/models/test_graph.py
@@ -1,0 +1,285 @@
+"""
+Tests for the Graph model.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from accounts.models.organization import Organization
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+from agent_playground.models import Graph
+from tfc.utils.audit import mute_audit_signals
+
+
+@pytest.mark.unit
+class TestGraphCreation:
+    """Tests for Graph model creation."""
+
+    def test_graph_creation_success(self, db, organization, workspace, user):
+        """Basic creation with valid data."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="My Graph",
+            description="A test graph",
+            created_by=user,
+        )
+        assert graph.id is not None
+        assert graph.name == "My Graph"
+        assert graph.organization == organization
+        assert graph.workspace == workspace
+        assert graph.created_by == user
+        assert graph.is_template is False
+
+    def test_graph_str(self, db, organization, workspace, user):
+        """__str__ returns graph name."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="My Graph",
+            created_by=user,
+        )
+        assert str(graph) == "My Graph"
+
+
+@pytest.mark.unit
+class TestGraphCascadeDelete:
+    """Tests for Graph cascade delete behavior."""
+
+    def test_graph_cascade_delete_organization(self, db, organization, workspace, user):
+        """Deleting org cascades to graphs."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="To Be Deleted",
+            created_by=user,
+        )
+        graph_id = graph.id
+
+        # Hard delete the organization via queryset (bypasses soft delete).
+        # Mute audit signals: the post_delete signal on OrganizationMembership
+        # tries to create an AuditLog referencing the org that's being deleted.
+        with mute_audit_signals():
+            Organization.objects.filter(id=organization.id).delete()
+
+        # Graph should be gone (cascade)
+        assert not Graph.all_objects.filter(id=graph_id).exists()
+
+    def test_graph_cascade_delete_workspace(self, db, organization, workspace, user):
+        """Deleting workspace cascades to graphs."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="To Be Deleted",
+            created_by=user,
+        )
+        graph_id = graph.id
+
+        # Hard delete workspace via queryset (bypasses soft delete)
+        Workspace.all_objects.filter(id=workspace.id).delete()
+
+        # Graph should be gone (cascade)
+        assert not Graph.all_objects.filter(id=graph_id).exists()
+
+
+@pytest.mark.unit
+class TestGraphCreatedBy:
+    """Tests for Graph.created_by field."""
+
+    def test_created_by_set_on_creation(self, graph, user):
+        """created_by is set correctly on the fixture graph."""
+        assert graph.created_by == user
+
+    def test_created_by_wrong_org_raises(self, db, organization, workspace):
+        """created_by from different org raises ValidationError."""
+        other_org = Organization.objects.create(name="Other Org")
+        other_user = User.objects.create_user(
+            email="other@test.com",
+            password="testpassword123",
+            name="Other",
+            organization=other_org,
+        )
+        graph = Graph(
+            organization=organization,
+            workspace=workspace,
+            name="X",
+            created_by=other_user,
+        )
+        with pytest.raises(ValidationError, match="same organization"):
+            graph.full_clean()
+
+    def test_created_by_cascade_delete(self, db, organization, workspace, user):
+        """Deleting user cascades to graphs."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Cascade Test Graph",
+            created_by=user,
+        )
+        graph_id = graph.id
+
+        User.objects.filter(id=user.id).delete()
+        assert not Graph.all_objects.filter(id=graph_id).exists()
+
+
+@pytest.mark.unit
+class TestGraphCollaborators:
+    """Tests for Graph.collaborators M2M field."""
+
+    def test_add_collaborators(self, db, graph, organization):
+        """A graph can have multiple collaborators (creator + 2 added)."""
+        collab1 = User.objects.create_user(
+            email="c1@test.com",
+            password="testpassword123",
+            name="Collab 1",
+            organization=organization,
+        )
+        collab2 = User.objects.create_user(
+            email="c2@test.com",
+            password="testpassword123",
+            name="Collab 2",
+            organization=organization,
+        )
+        graph.collaborators.add(collab1, collab2)
+        assert graph.collaborators.count() == 3
+
+    def test_creator_is_collaborator_by_default(self, graph, user):
+        """Creator is auto-added as collaborator."""
+        assert graph.collaborators.count() == 1
+        assert user in graph.collaborators.all()
+
+    def test_remove_collaborator(self, db, graph, organization):
+        """Collaborators can be removed (creator remains)."""
+        collab = User.objects.create_user(
+            email="c1@test.com",
+            password="testpassword123",
+            name="Collab 1",
+            organization=organization,
+        )
+        graph.collaborators.add(collab)
+        graph.collaborators.remove(collab)
+        assert graph.collaborators.count() == 1
+
+    def test_collaborator_delete_does_not_delete_graph(self, db, graph, organization):
+        """Deleting a collaborator user removes M2M link but not the graph."""
+        collab = User.objects.create_user(
+            email="c1@test.com",
+            password="testpassword123",
+            name="Collab 1",
+            organization=organization,
+        )
+        graph.collaborators.add(collab)
+        User.objects.filter(id=collab.id).delete()
+        graph.refresh_from_db()  # graph still exists
+        assert graph.collaborators.count() == 1  # creator remains
+
+    def test_add_collaborator(self, db, graph, organization):
+        """add_collaborator adds user to collaborators."""
+        collab = User.objects.create_user(
+            email="c1@test.com",
+            password="testpassword123",
+            name="Collab",
+            organization=organization,
+        )
+        graph.add_collaborator(collab)
+        assert collab in graph.collaborators.all()
+
+    def test_reverse_relation(self, db, graph, organization):
+        """Collaborators can access graphs via reverse relation."""
+        collab = User.objects.create_user(
+            email="c1@test.com",
+            password="testpassword123",
+            name="Collab 1",
+            organization=organization,
+        )
+        graph.collaborators.add(collab)
+        assert graph in collab.collaborated_agent_playground_graphs.all()
+
+
+@pytest.mark.unit
+class TestGraphIsTemplate:
+    """Tests for Graph.is_template field and validation."""
+
+    def test_template_graph_creation_success(self, db):
+        """Template graph with org=None, workspace=None, created_by=None succeeds."""
+        graph = Graph.no_workspace_objects.create(
+            organization=None,
+            workspace=None,
+            name="System Template",
+            description="A system template",
+            is_template=True,
+            created_by=None,
+        )
+        assert graph.id is not None
+        assert graph.is_template is True
+        assert graph.organization is None
+        assert graph.created_by is None
+        assert graph.collaborators.count() == 0
+
+    def test_template_with_org_raises(self, db, organization):
+        """Template graph with organization set raises ValidationError."""
+        graph = Graph(
+            organization=organization,
+            workspace=None,
+            name="Bad Template",
+            is_template=True,
+            created_by=None,
+        )
+        with pytest.raises(ValidationError, match="Template graphs must not have"):
+            graph.full_clean()
+
+    def test_template_with_created_by_raises(self, db, user):
+        """Template graph with created_by set raises ValidationError."""
+        graph = Graph(
+            organization=None,
+            workspace=None,
+            name="Bad Template",
+            is_template=True,
+            created_by=user,
+        )
+        with pytest.raises(ValidationError, match="Template graphs must not have"):
+            graph.full_clean()
+
+    def test_non_template_without_org_raises(self, db):
+        """Non-template graph without organization raises ValidationError."""
+        graph = Graph(
+            organization=None,
+            workspace=None,
+            name="Bad Graph",
+            is_template=False,
+            created_by=None,
+        )
+        with pytest.raises(
+            ValidationError, match="Non-template graphs must have an organization"
+        ):
+            graph.full_clean()
+
+    def test_non_template_without_created_by_raises(self, db, organization):
+        """Non-template graph without created_by raises ValidationError."""
+        graph = Graph(
+            organization=organization,
+            workspace=None,
+            name="Bad Graph",
+            is_template=False,
+            created_by=None,
+        )
+        with pytest.raises(
+            ValidationError, match="Non-template graphs must have a created_by"
+        ):
+            graph.full_clean()
+
+    def test_non_template_with_org_and_user_succeeds(
+        self, db, organization, workspace, user
+    ):
+        """Non-template graph with org and created_by succeeds."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Normal Graph",
+            is_template=False,
+            created_by=user,
+        )
+        graph.full_clean()
+        assert graph.is_template is False
+        assert graph.organization == organization

--- a/futureagi/agent_playground/tests/models/test_graph_dataset.py
+++ b/futureagi/agent_playground/tests/models/test_graph_dataset.py
@@ -1,0 +1,71 @@
+"""Tests for GraphDataset model."""
+
+import pytest
+from django.db import IntegrityError
+
+from agent_playground.models.graph import Graph
+from agent_playground.models.graph_dataset import GraphDataset
+from model_hub.models.develop_dataset import Dataset
+
+
+@pytest.mark.unit
+class TestGraphDatasetModel:
+    """Tests for the GraphDataset model."""
+
+    def test_create_graph_dataset(self, graph_dataset, graph, dataset):
+        """Creating a GraphDataset links a graph and dataset."""
+        assert graph_dataset.graph_id == graph.id
+        assert graph_dataset.dataset_id == dataset.id
+
+    def test_str_representation(self, graph_dataset, graph, dataset):
+        """__str__ includes both graph and dataset UUIDs."""
+        expected = f"GraphDataset(graph={graph.id}, dataset={dataset.id})"
+        assert str(graph_dataset) == expected
+
+    def test_unique_graph_constraint(
+        self, graph_dataset, graph, organization, workspace, user
+    ):
+        """Cannot link a second dataset to the same graph."""
+        other_dataset = Dataset.no_workspace_objects.create(
+            name="Other Dataset",
+            organization=organization,
+            workspace=workspace,
+            user=user,
+            source="graph",
+            model_type="GenerativeLLM",
+        )
+        with pytest.raises(IntegrityError):
+            GraphDataset.no_workspace_objects.create(
+                graph=graph,
+                dataset=other_dataset,
+            )
+
+    def test_unique_dataset_constraint(
+        self, graph_dataset, dataset, organization, workspace, user
+    ):
+        """Cannot link a second graph to the same dataset."""
+        other_graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Other Graph",
+            created_by=user,
+        )
+        with pytest.raises(IntegrityError):
+            GraphDataset.no_workspace_objects.create(
+                graph=other_graph,
+                dataset=dataset,
+            )
+
+    def test_reverse_accessor_from_graph(self, graph_dataset, graph):
+        """Graph has a graph_dataset reverse accessor."""
+        assert graph.graph_dataset == graph_dataset
+
+    def test_reverse_accessor_from_dataset(self, graph_dataset, dataset):
+        """Dataset has a graph_dataset reverse accessor."""
+        assert dataset.graph_dataset == graph_dataset
+
+    def test_soft_delete_hides_from_no_workspace_objects(self, graph_dataset):
+        """Soft-deleted GraphDataset is hidden by no_workspace_objects."""
+        gd_id = graph_dataset.id
+        graph_dataset.delete()  # soft-delete
+        assert not GraphDataset.no_workspace_objects.filter(id=gd_id).exists()

--- a/futureagi/agent_playground/tests/models/test_graph_execution.py
+++ b/futureagi/agent_playground/tests/models/test_graph_execution.py
@@ -1,0 +1,146 @@
+"""
+Tests for the GraphExecution model.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, models
+
+from agent_playground.models import GraphExecution, GraphVersion, NodeExecution
+from agent_playground.models.choices import (
+    GraphExecutionStatus,
+    NodeExecutionStatus,
+)
+
+
+@pytest.mark.unit
+class TestGraphExecutionCreation:
+    """Tests for GraphExecution model creation."""
+
+    def test_graph_execution_creation_success(self, db, active_graph_version):
+        """Basic creation."""
+        execution = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+            input_payload={"test": "data"},
+        )
+        assert execution.id is not None
+        assert execution.graph_version == active_graph_version
+
+    def test_graph_execution_default_status_pending(self, db, active_graph_version):
+        """status defaults to PENDING."""
+        execution = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+        )
+        assert execution.status == GraphExecutionStatus.PENDING
+
+
+@pytest.mark.unit
+class TestGraphExecutionStatusValidation:
+    """Tests for GraphExecution status validation."""
+
+    def test_graph_execution_all_statuses_valid(self, db, active_graph_version):
+        """PENDING, RUNNING, SUCCESS, FAILED, CANCELLED are all valid."""
+        statuses = [
+            GraphExecutionStatus.PENDING,
+            GraphExecutionStatus.RUNNING,
+            GraphExecutionStatus.SUCCESS,
+            GraphExecutionStatus.FAILED,
+            GraphExecutionStatus.CANCELLED,
+        ]
+        for status in statuses:
+            execution = GraphExecution.no_workspace_objects.create(
+                graph_version=active_graph_version,
+                status=status,
+            )
+            execution.full_clean()
+            assert execution.status == status
+
+
+@pytest.mark.unit
+class TestGraphExecutionPayloadValidation:
+    """Tests for GraphExecution payload validation."""
+
+    def test_graph_execution_input_payload_must_be_dict(self, db, active_graph_version):
+        """clean() validates input_payload is dict type."""
+        execution = GraphExecution(
+            graph_version=active_graph_version,
+            input_payload="not_a_dict",  # Invalid
+        )
+        with pytest.raises(ValidationError, match="input_payload must be a dict"):
+            execution.clean()
+
+    def test_graph_execution_output_payload_must_be_dict(
+        self, db, active_graph_version
+    ):
+        """clean() validates output_payload is dict type."""
+        execution = GraphExecution(
+            graph_version=active_graph_version,
+            output_payload="not_a_dict",  # Invalid
+        )
+        with pytest.raises(ValidationError, match="output_payload must be a dict"):
+            execution.clean()
+
+    def test_graph_execution_payload_allows_none(self, db, active_graph_version):
+        """None is valid for payloads."""
+        execution = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+            input_payload=None,
+            output_payload=None,
+        )
+        execution.clean()  # Should not raise
+        assert execution.input_payload is None
+        assert execution.output_payload is None
+
+    def test_graph_execution_payload_allows_empty_dict(self, db, active_graph_version):
+        """Empty dict is valid for payloads."""
+        execution = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+            input_payload={},
+            output_payload={},
+        )
+        execution.clean()
+        assert execution.input_payload == {}
+        assert execution.output_payload == {}
+
+
+@pytest.mark.unit
+class TestGraphExecutionDeleteBehavior:
+    """Tests for GraphExecution delete behavior."""
+
+    def test_graph_execution_protect_delete_graph_version(
+        self, db, active_graph_version
+    ):
+        """Cannot delete version with executions (PROTECT)."""
+        GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+        )
+
+        with pytest.raises((IntegrityError, models.ProtectedError)):
+            GraphVersion.all_objects.filter(id=active_graph_version.id).delete()
+
+    def test_graph_execution_cascade_delete_parent(
+        self, db, active_graph_version, node_in_active_version
+    ):
+        """Deleting parent_node_execution cascades to child graph executions."""
+        # Create a parent graph execution and node execution
+        parent_execution = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+        )
+        parent_node_execution = NodeExecution.no_workspace_objects.create(
+            graph_execution=parent_execution,
+            node=node_in_active_version,
+            status=NodeExecutionStatus.RUNNING,
+        )
+
+        # Create child graph execution
+        child_execution = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+            parent_node_execution=parent_node_execution,
+        )
+        child_id = child_execution.id
+
+        # Hard delete the parent node execution
+        NodeExecution.all_objects.filter(id=parent_node_execution.id).delete()
+
+        # Child execution should be gone
+        assert not GraphExecution.all_objects.filter(id=child_id).exists()

--- a/futureagi/agent_playground/tests/models/test_graph_version.py
+++ b/futureagi/agent_playground/tests/models/test_graph_version.py
@@ -1,0 +1,359 @@
+"""
+Tests for the GraphVersion model.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+
+from agent_playground.models import Edge, Graph, GraphVersion, Node, Port
+from agent_playground.models.choices import GraphVersionStatus, PortMode
+from agent_playground.models.node_connection import NodeConnection
+from agent_playground.models.node_template import NodeTemplate
+
+
+@pytest.mark.unit
+class TestGraphVersionCreation:
+    """Tests for GraphVersion model creation."""
+
+    def test_graph_version_creation_success(self, db, graph):
+        """Basic creation."""
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+            tags=["test"],
+        )
+        assert version.id is not None
+        assert version.version_number == 1
+        assert version.status == GraphVersionStatus.DRAFT
+        assert version.graph == graph
+
+    def test_graph_version_draft_status(self, db, graph):
+        """status=DRAFT is valid."""
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+            tags=["test"],
+        )
+        version.full_clean()
+        assert version.status == GraphVersionStatus.DRAFT
+
+    def test_graph_version_active_status(self, db, graph):
+        """status=ACTIVE is valid."""
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.ACTIVE,
+            tags=["production"],
+        )
+        version.full_clean()
+        assert version.status == GraphVersionStatus.ACTIVE
+
+    def test_graph_version_inactive_status(self, db, graph):
+        """status=INACTIVE for historical versions."""
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.INACTIVE,
+            tags=["archived"],
+        )
+        version.full_clean()
+        assert version.status == GraphVersionStatus.INACTIVE
+
+
+@pytest.mark.unit
+class TestGraphVersionUniqueConstraint:
+    """Tests for GraphVersion unique constraints."""
+
+    def test_graph_version_unique_version_number(self, db, graph):
+        """UniqueConstraint on (graph, version_number)."""
+        GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+
+        with pytest.raises(IntegrityError):
+            GraphVersion.no_workspace_objects.create(
+                graph=graph,
+                version_number=1,
+                status=GraphVersionStatus.DRAFT,
+            )
+
+    def test_graph_version_unique_allows_deleted(self, db, graph):
+        """Soft-deleted versions don't block uniqueness."""
+        version1 = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        version1.delete()  # Soft delete
+
+        # Should be able to create another version with same number
+        version2 = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        assert version2.id is not None
+        assert version2.version_number == 1
+
+
+@pytest.mark.unit
+class TestGraphVersionActiveConstraint:
+    """Tests for only one active version per graph."""
+
+    def test_graph_version_only_one_active(self, db, graph):
+        """clean() prevents multiple active versions."""
+        GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.ACTIVE,
+        )
+
+        version2 = GraphVersion(
+            graph=graph,
+            version_number=2,
+            status=GraphVersionStatus.ACTIVE,
+        )
+        with pytest.raises(
+            ValidationError, match="Only one active version allowed per graph"
+        ):
+            version2.full_clean()
+
+    def test_graph_version_multiple_drafts_allowed(self, db, graph):
+        """Multiple drafts per graph OK."""
+        GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        version2 = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=2,
+            status=GraphVersionStatus.DRAFT,
+            tags=["test"],
+        )
+        version2.full_clean()  # Should not raise
+        assert version2.status == GraphVersionStatus.DRAFT
+
+
+@pytest.mark.unit
+class TestGraphVersionCascadeDelete:
+    """Tests for GraphVersion cascade delete behavior."""
+
+    def test_graph_version_cascade_delete_graph(self, db, graph):
+        """Deleting graph cascades to versions."""
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        version_id = version.id
+
+        # Hard delete the graph
+        Graph.all_objects.filter(id=graph.id).delete()
+
+        # Version should be gone
+        assert not GraphVersion.all_objects.filter(id=version_id).exists()
+
+
+@pytest.mark.unit
+class TestGraphVersionActivationValidation:
+    """Tests for exposed output port display_name uniqueness on activation."""
+
+    @pytest.fixture
+    def dynamic_template(self, db):
+        """Dynamic template for activation tests needing arbitrary port keys."""
+        return NodeTemplate.no_workspace_objects.create(
+            name="activation_test_template",
+            display_name="Activation Test Template",
+            description="Template for activation tests",
+            categories=["testing"],
+            input_definition=[],
+            output_definition=[],
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={},
+        )
+
+    def test_activation_succeeds_with_unique_output_display_names(
+        self, db, graph, dynamic_template
+    ):
+        """Two output ports with same key but different display_name — activation succeeds."""
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph, version_number=10, status=GraphVersionStatus.DRAFT
+        )
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=dynamic_template,
+            type="atomic",
+            name="Node A",
+            config={},
+        )
+        node_b = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=dynamic_template,
+            type="atomic",
+            name="Node B",
+            config={},
+        )
+        Port.no_workspace_objects.create(
+            node=node_a,
+            key="custom",
+            display_name="Node A Response",
+            direction="output",
+        )
+        Port.no_workspace_objects.create(
+            node=node_b,
+            key="custom",
+            display_name="Node B Response",
+            direction="output",
+        )
+        version.status = GraphVersionStatus.ACTIVE
+        version.save()  # Should not raise
+
+    def test_activation_blocked_with_duplicate_output_display_names(
+        self, db, graph, dynamic_template
+    ):
+        """Two unconnected output ports with same display_name — activation blocked."""
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph, version_number=11, status=GraphVersionStatus.DRAFT
+        )
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=dynamic_template,
+            type="atomic",
+            name="Node A",
+            config={},
+        )
+        node_b = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=dynamic_template,
+            type="atomic",
+            name="Node B",
+            config={},
+        )
+        Port.no_workspace_objects.create(
+            node=node_a,
+            key="custom",
+            display_name="response",
+            direction="output",
+        )
+        Port.no_workspace_objects.create(
+            node=node_b,
+            key="custom",
+            display_name="response",
+            direction="output",
+        )
+        version.status = GraphVersionStatus.ACTIVE
+        with pytest.raises(
+            ValidationError, match="Duplicate exposed output port display name"
+        ):
+            version.save()
+
+    def test_activation_allows_duplicate_input_display_names(
+        self, db, graph, dynamic_template
+    ):
+        """Two unconnected input ports with same display_name — activation succeeds (broadcast)."""
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph, version_number=12, status=GraphVersionStatus.DRAFT
+        )
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=dynamic_template,
+            type="atomic",
+            name="Node A",
+            config={},
+        )
+        node_b = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=dynamic_template,
+            type="atomic",
+            name="Node B",
+            config={},
+        )
+        Port.no_workspace_objects.create(
+            node=node_a,
+            key="custom",
+            display_name="prompt",
+            direction="input",
+        )
+        Port.no_workspace_objects.create(
+            node=node_b,
+            key="custom",
+            display_name="prompt",
+            direction="input",
+        )
+        version.status = GraphVersionStatus.ACTIVE
+        version.save()  # Should not raise
+
+    def test_activation_allows_connected_outputs_with_same_display_name(
+        self, db, graph, dynamic_template
+    ):
+        """Connected output ports with same display_name are fine (they're not exposed)."""
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph, version_number=13, status=GraphVersionStatus.DRAFT
+        )
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=dynamic_template,
+            type="atomic",
+            name="Node A",
+            config={},
+        )
+        node_b = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=dynamic_template,
+            type="atomic",
+            name="Node B",
+            config={},
+        )
+        out_a = Port.no_workspace_objects.create(
+            node=node_a,
+            key="custom",
+            display_name="response",
+            direction="output",
+        )
+        in_b = Port.no_workspace_objects.create(
+            node=node_b,
+            key="custom",
+            display_name="input1",
+            direction="input",
+        )
+        # Also create an unconnected output on node_b with same display_name
+        Port.no_workspace_objects.create(
+            node=node_b,
+            key="custom",
+            display_name="response",
+            direction="output",
+        )
+        # Connect node_a output to node_b input — node_a's "response" is now connected
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_a, target_node=node_b
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_a,
+            target_port=in_b,
+        )
+        # Only node_b's "response" output is unconnected, so no duplicate
+        version.status = GraphVersionStatus.ACTIVE
+        version.save()  # Should not raise
+
+    def test_activation_with_no_ports(self, db, graph, dynamic_template):
+        """Activation succeeds when version has no ports (dynamic template)."""
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph, version_number=14, status=GraphVersionStatus.DRAFT
+        )
+        Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=dynamic_template,
+            type="atomic",
+            name="Empty Node",
+            config={},
+        )
+        version.status = GraphVersionStatus.ACTIVE
+        version.save()  # Should not raise

--- a/futureagi/agent_playground/tests/models/test_models_integration.py
+++ b/futureagi/agent_playground/tests/models/test_models_integration.py
@@ -1,0 +1,1308 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from agent_playground.models import (
+    Edge,
+    ExecutionData,
+    Graph,
+    GraphExecution,
+    GraphVersion,
+    Node,
+    NodeExecution,
+    NodeTemplate,
+    Port,
+)
+from agent_playground.models.choices import (
+    GraphExecutionStatus,
+    GraphVersionStatus,
+    NodeExecutionStatus,
+    NodeType,
+    PortDirection,
+    PortMode,
+)
+from agent_playground.models.node_connection import NodeConnection
+
+
+@pytest.mark.integration
+class TestGraphConstructionWorkflow:
+    """Test building a complete graph from scratch as a cohesive workflow."""
+
+    def test_build_complete_graph(self, db, organization, workspace, user):
+        """Build Graph → Version → 2 Nodes → Ports → Edge and verify all relationships."""
+        # 1. Create graph
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Complete Graph",
+            created_by=user,
+        )
+
+        # 2. Create version
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+
+        # 3. Create node template
+        template = NodeTemplate.no_workspace_objects.create(
+            name="integration_template",
+            display_name="Integration Template",
+            description="Template for integration tests",
+            categories=["test"],
+            input_definition=[{"key": "in", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "out", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={"type": "object", "properties": {}},
+        )
+
+        # 4. Create two nodes
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="Node A",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        node_b = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="Node B",
+            config={},
+            position={"x": 200, "y": 0},
+        )
+
+        # 5. Create ports
+        out_a = Port.no_workspace_objects.create(
+            node=node_a,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+        in_b = Port.no_workspace_objects.create(
+            node=node_b,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+
+        # 6. Create edge
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_a, target_node=node_b
+        )
+        edge = Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_a,
+            target_port=in_b,
+        )
+
+        # Verify all relationships
+        assert version.graph == graph
+        assert node_a.graph_version == version
+        assert node_b.graph_version == version
+        assert out_a.node == node_a
+        assert in_b.node == node_b
+        assert edge.source_port == out_a
+        assert edge.target_port == in_b
+        assert edge.graph_version == version
+
+        # Verify reverse relationships
+        assert version in graph.versions.all()
+        assert node_a in version.nodes.all()
+        assert node_b in version.nodes.all()
+        assert out_a in node_a.ports.all()
+        assert in_b in node_b.ports.all()
+        assert edge in version.edges.all()
+
+        # Verify property traversals via graph
+        assert version.graph.organization == organization
+        assert version.graph.workspace == workspace
+
+    def test_add_third_node_extends_graph(self, db, organization, workspace, user):
+        """Extend an existing 2-node graph with a third node + edges, verify DAG."""
+        # Build initial 2-node graph: A → B
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Extendable Graph",
+            created_by=user,
+        )
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        template = NodeTemplate.no_workspace_objects.create(
+            name="extend_template",
+            display_name="Extend Template",
+            description="For extension test",
+            categories=["test"],
+            input_definition=[{"key": "in", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "out", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={},
+        )
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="A",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        node_b = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="B",
+            config={},
+            position={"x": 200, "y": 0},
+        )
+        out_a = Port.no_workspace_objects.create(
+            node=node_a,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+        in_b = Port.no_workspace_objects.create(
+            node=node_b,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        out_b = Port.no_workspace_objects.create(
+            node=node_b,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_a, target_node=node_b
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_a,
+            target_port=in_b,
+        )
+
+        # Add Node C: B → C  (extends the DAG)
+        node_c = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="C",
+            config={},
+            position={"x": 400, "y": 0},
+        )
+        in_c = Port.no_workspace_objects.create(
+            node=node_c,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_b, target_node=node_c
+        )
+        edge_bc = Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_b,
+            target_port=in_c,
+        )
+
+        # Verify extended graph
+        assert version.nodes.count() == 3
+        assert version.edges.count() == 2
+        assert edge_bc.source_port.node == node_b
+        assert edge_bc.target_port.node == node_c
+
+        # Verify DAG: edge validation passes (no cycle in A → B → C)
+        edge_bc.full_clean()
+
+    def test_build_graph_with_ports_on_start_and_end_nodes(
+        self, db, organization, workspace, user
+    ):
+        """Build A → B → C chain with input port on start node and output port on end node."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Start-End Ports Graph",
+            created_by=user,
+        )
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        template = NodeTemplate.no_workspace_objects.create(
+            name="start_end_template",
+            display_name="Start-End Template",
+            description="For start/end port test",
+            categories=["test"],
+            input_definition=[{"key": "in", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "out", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={},
+        )
+
+        # Create three nodes
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="A",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        node_b = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="B",
+            config={},
+            position={"x": 200, "y": 0},
+        )
+        node_c = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="C",
+            config={},
+            position={"x": 400, "y": 0},
+        )
+
+        # Start node A: input port (graph entry) + output port
+        in_a = Port.no_workspace_objects.create(
+            node=node_a,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        out_a = Port.no_workspace_objects.create(
+            node=node_a,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Middle node B: input + output ports
+        in_b = Port.no_workspace_objects.create(
+            node=node_b,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        out_b = Port.no_workspace_objects.create(
+            node=node_b,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        # End node C: input port + output port (graph exit)
+        in_c = Port.no_workspace_objects.create(
+            node=node_c,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        out_c = Port.no_workspace_objects.create(
+            node=node_c,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Create edges: A.out → B.in, B.out → C.in
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_a, target_node=node_b
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_b, target_node=node_c
+        )
+        edge_ab = Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_a,
+            target_port=in_b,
+        )
+        edge_bc = Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_b,
+            target_port=in_c,
+        )
+
+        # All ports exist on their respective nodes
+        assert in_a in node_a.ports.all()
+        assert out_a in node_a.ports.all()
+        assert in_b in node_b.ports.all()
+        assert out_b in node_b.ports.all()
+        assert in_c in node_c.ports.all()
+        assert out_c in node_c.ports.all()
+
+        # Start node's input port has no incoming edges
+        assert not Edge.no_workspace_objects.filter(target_port=in_a).exists()
+
+        # End node's output port has no outgoing edges
+        assert not Edge.no_workspace_objects.filter(source_port=out_c).exists()
+
+        # Edge validation passes (valid DAG)
+        edge_ab.full_clean()
+        edge_bc.full_clean()
+
+        # Port counts per node
+        assert node_a.ports.count() == 2
+        assert node_b.ports.count() == 2
+        assert node_c.ports.count() == 2
+
+    def test_build_diamond_dag(self, db, organization, workspace, user):
+        """Build diamond DAG: A → B, A → C, B → D, C → D with fan-out and fan-in."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Diamond DAG",
+            created_by=user,
+        )
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        template = NodeTemplate.no_workspace_objects.create(
+            name="diamond_template",
+            display_name="Diamond Template",
+            description="For diamond DAG test",
+            categories=["test"],
+            input_definition=[{"key": "in", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "out", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={},
+        )
+
+        # Node A: 1 output port (fan-out)
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="A",
+            config={},
+            position={"x": 200, "y": 0},
+        )
+        out_a = Port.no_workspace_objects.create(
+            node=node_a,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Node B: 1 input, 1 output
+        node_b = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="B",
+            config={},
+            position={"x": 0, "y": 200},
+        )
+        in_b = Port.no_workspace_objects.create(
+            node=node_b,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        out_b = Port.no_workspace_objects.create(
+            node=node_b,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Node C: 1 input, 1 output
+        node_c = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="C",
+            config={},
+            position={"x": 400, "y": 200},
+        )
+        in_c = Port.no_workspace_objects.create(
+            node=node_c,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        out_c = Port.no_workspace_objects.create(
+            node=node_c,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Node D: 2 input ports (separate for fan-in), no fan-in violation
+        # Use a dynamic template since D needs multiple input ports
+        dynamic_template = NodeTemplate.no_workspace_objects.create(
+            name="diamond_dynamic_template",
+            display_name="Diamond Dynamic Template",
+            description="For diamond DAG node D (multiple inputs)",
+            categories=["test"],
+            input_definition=[],
+            output_definition=[],
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={},
+        )
+        node_d = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=dynamic_template,
+            type=NodeType.ATOMIC,
+            name="D",
+            config={},
+            position={"x": 200, "y": 400},
+        )
+        in_d_from_b = Port.no_workspace_objects.create(
+            node=node_d,
+            key="custom",
+            display_name="in_from_b",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        in_d_from_c = Port.no_workspace_objects.create(
+            node=node_d,
+            key="custom",
+            display_name="in_from_c",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Edges: A.out → B.in, A.out → C.in (fan-out), B.out → D.in_from_b, C.out → D.in_from_c
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_a, target_node=node_b
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_a, target_node=node_c
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_b, target_node=node_d
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_c, target_node=node_d
+        )
+        edge_ab = Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_a,
+            target_port=in_b,
+        )
+        edge_ac = Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_a,
+            target_port=in_c,
+        )
+        edge_bd = Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_b,
+            target_port=in_d_from_b,
+        )
+        edge_cd = Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_c,
+            target_port=in_d_from_c,
+        )
+
+        # 4 nodes, 4 edges
+        assert version.nodes.count() == 4
+        assert version.edges.count() == 4
+
+        # Fan-out: A.out has 2 outgoing edges
+        assert Edge.no_workspace_objects.filter(source_port=out_a).count() == 2
+
+        # No fan-in violation: each D input port has exactly 1 incoming edge
+        assert Edge.no_workspace_objects.filter(target_port=in_d_from_b).count() == 1
+        assert Edge.no_workspace_objects.filter(target_port=in_d_from_c).count() == 1
+
+        # All edges pass full_clean() (no cycles)
+        edge_ab.full_clean()
+        edge_ac.full_clean()
+        edge_bd.full_clean()
+        edge_cd.full_clean()
+
+    def test_cycle_detection_rejects_back_edge(self, db, organization, workspace, user):
+        """Adding C → A to chain A → B → C should raise ValidationError for cycle."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Cycle Back Edge Graph",
+            created_by=user,
+        )
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        template = NodeTemplate.no_workspace_objects.create(
+            name="cycle_back_template",
+            display_name="Cycle Back Template",
+            description="For back-edge cycle test",
+            categories=["test"],
+            input_definition=[{"key": "in", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "out", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={},
+        )
+
+        # Create nodes A, B, C with ports
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="A",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        in_a = Port.no_workspace_objects.create(
+            node=node_a,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        out_a = Port.no_workspace_objects.create(
+            node=node_a,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        node_b = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="B",
+            config={},
+            position={"x": 200, "y": 0},
+        )
+        in_b = Port.no_workspace_objects.create(
+            node=node_b,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        out_b = Port.no_workspace_objects.create(
+            node=node_b,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        node_c = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="C",
+            config={},
+            position={"x": 400, "y": 0},
+        )
+        in_c = Port.no_workspace_objects.create(
+            node=node_c,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        out_c = Port.no_workspace_objects.create(
+            node=node_c,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Create valid chain: A → B → C
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_a, target_node=node_b
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_b, target_node=node_c
+        )
+        NodeConnection.no_workspace_objects.create(
+            graph_version=version, source_node=node_c, target_node=node_a
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_a,
+            target_port=in_b,
+        )
+        Edge.no_workspace_objects.create(
+            graph_version=version,
+            source_port=out_b,
+            target_port=in_c,
+        )
+
+        # Attempt back edge C → A — should create a cycle
+        back_edge = Edge(
+            graph_version=version,
+            source_port=out_c,
+            target_port=in_a,
+        )
+        with pytest.raises(ValidationError, match="cycle"):
+            back_edge.full_clean()
+
+    def test_cycle_detection_rejects_self_loop(self, db, organization, workspace, user):
+        """Connecting a node's output to its own input should raise ValidationError."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Self Loop Graph",
+            created_by=user,
+        )
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        template = NodeTemplate.no_workspace_objects.create(
+            name="self_loop_template",
+            display_name="Self Loop Template",
+            description="For self-loop cycle test",
+            categories=["test"],
+            input_definition=[{"key": "in", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "out", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={},
+        )
+
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="A",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        in_a = Port.no_workspace_objects.create(
+            node=node_a,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        out_a = Port.no_workspace_objects.create(
+            node=node_a,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Attempt self-loop: A.out → A.in
+        self_loop = Edge(
+            graph_version=version,
+            source_port=out_a,
+            target_port=in_a,
+        )
+        with pytest.raises(ValidationError, match="NodeConnection"):
+            self_loop.full_clean()
+
+
+@pytest.mark.integration
+class TestSoftDeleteBehavior:
+    """Test soft-delete behavior and its effect on related objects."""
+
+    def test_soft_delete_node_preserves_related(
+        self,
+        db,
+        graph_version,
+        node_template,
+    ):
+        """Soft-deleting a node preserves ports and edges in all_objects."""
+        node = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Soft Delete Node",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        port = Port.no_workspace_objects.create(
+            node=node,
+            key="output1",
+            display_name="output1",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+        port_id = port.id
+        node_id = node.id
+
+        # Soft-delete the node (model.delete() sets deleted=True)
+        node.delete()
+
+        # Node is soft-deleted: gone from no_workspace_objects, still in all_objects
+        assert not Node.no_workspace_objects.filter(id=node_id).exists()
+        assert Node.all_objects.filter(id=node_id).exists()
+
+        # Port still exists in all_objects (soft delete doesn't cascade)
+        assert Port.all_objects.filter(id=port_id).exists()
+        # Port is also still visible in no_workspace_objects (not soft-deleted itself)
+        assert Port.no_workspace_objects.filter(id=port_id).exists()
+
+
+@pytest.mark.integration
+class TestExecutionLifecycle:
+    """Test the full execution lifecycle across GraphExecution → NodeExecution → ExecutionData."""
+
+    def test_full_execution_creates_data_for_all_nodes(
+        self,
+        db,
+        organization,
+        workspace,
+        user,
+    ):
+        """Build execution chain: GraphExecution → NodeExecution per node → ExecutionData per port."""
+        # Build a graph with 2 nodes, each with an input and output port
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Execution Graph",
+            created_by=user,
+        )
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.ACTIVE,
+        )
+        template = NodeTemplate.no_workspace_objects.create(
+            name="exec_template",
+            display_name="Exec Template",
+            description="For execution test",
+            categories=["test"],
+            input_definition=[{"key": "in", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "out", "data_schema": {"type": "integer"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={},
+        )
+        node_a = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="Exec Node A",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        node_b = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="Exec Node B",
+            config={},
+            position={"x": 200, "y": 0},
+        )
+
+        # Create ports for both nodes
+        port_a_in = Port.no_workspace_objects.create(
+            node=node_a,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        port_a_out = Port.no_workspace_objects.create(
+            node=node_a,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "integer"},
+        )
+        port_b_in = Port.no_workspace_objects.create(
+            node=node_b,
+            key="in",
+            display_name="in",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        port_b_out = Port.no_workspace_objects.create(
+            node=node_b,
+            key="out",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "integer"},
+        )
+
+        # Create execution chain
+        graph_exec = GraphExecution.no_workspace_objects.create(
+            graph_version=version,
+            status=GraphExecutionStatus.RUNNING,
+            input_payload={"query": "test"},
+        )
+        node_exec_a = NodeExecution.no_workspace_objects.create(
+            graph_execution=graph_exec,
+            node=node_a,
+            status=NodeExecutionStatus.SUCCESS,
+        )
+        node_exec_b = NodeExecution.no_workspace_objects.create(
+            graph_execution=graph_exec,
+            node=node_b,
+            status=NodeExecutionStatus.SUCCESS,
+        )
+
+        # Create execution data for all ports
+        data_a_in = ExecutionData.no_workspace_objects.create(
+            node_execution=node_exec_a,
+            port=port_a_in,
+            payload="hello",
+        )
+        data_a_out = ExecutionData.no_workspace_objects.create(
+            node_execution=node_exec_a,
+            port=port_a_out,
+            payload=42,
+        )
+        data_b_in = ExecutionData.no_workspace_objects.create(
+            node_execution=node_exec_b,
+            port=port_b_in,
+            payload="world",
+        )
+        data_b_out = ExecutionData.no_workspace_objects.create(
+            node_execution=node_exec_b,
+            port=port_b_out,
+            payload=99,
+        )
+
+        # Verify execution chain
+        assert graph_exec.node_executions.count() == 2
+        assert node_exec_a.execution_data.count() == 2
+        assert node_exec_b.execution_data.count() == 2
+
+        # Verify payload validation ran correctly
+        assert data_a_in.is_valid is True  # "hello" matches {"type": "string"}
+        assert data_a_out.is_valid is True  # 42 matches {"type": "integer"}
+        assert data_b_in.is_valid is True
+        assert data_b_out.is_valid is True
+
+    def test_execution_data_denormalization_correct(
+        self,
+        db,
+        organization,
+        workspace,
+        node_template,
+        user,
+    ):
+        """Verify node field is auto-set from node_execution.node across all data."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Denorm Graph",
+            created_by=user,
+        )
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.ACTIVE,
+        )
+        node = Node.no_workspace_objects.create(
+            graph_version=version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Denorm Node",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        port_in = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        port_out = Port.no_workspace_objects.create(
+            node=node,
+            key="output1",
+            display_name="output1",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        graph_exec = GraphExecution.no_workspace_objects.create(
+            graph_version=version,
+            status=GraphExecutionStatus.RUNNING,
+        )
+        node_exec = NodeExecution.no_workspace_objects.create(
+            graph_execution=graph_exec,
+            node=node,
+            status=NodeExecutionStatus.RUNNING,
+        )
+
+        # Create ExecutionData WITHOUT setting node — should be auto-denormalized
+        data_in = ExecutionData.no_workspace_objects.create(
+            node_execution=node_exec,
+            port=port_in,
+            payload="test input",
+        )
+        data_out = ExecutionData.no_workspace_objects.create(
+            node_execution=node_exec,
+            port=port_out,
+            payload="test output",
+        )
+
+        # Both should have node auto-set from node_execution.node
+        assert data_in.node == node
+        assert data_out.node == node
+        assert data_in.node_id == node.id
+        assert data_out.node_id == node.id
+
+
+@pytest.mark.integration
+class TestSubgraphNodeIntegration:
+    """Test subgraph node reference chains across graphs."""
+
+    def test_graph_references_active_subgraph(self, db, organization, workspace, user):
+        """Build a graph with a subgraph node referencing an active version of another graph."""
+        # Create referenced graph with active version
+        ref_graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Referenced Graph",
+            created_by=user,
+        )
+        ref_version = GraphVersion.no_workspace_objects.create(
+            graph=ref_graph,
+            version_number=1,
+            status=GraphVersionStatus.ACTIVE,
+        )
+
+        # Create main graph
+        main_graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Main Graph",
+            created_by=user,
+        )
+        main_version = GraphVersion.no_workspace_objects.create(
+            graph=main_graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+
+        # Create a node template for atomic nodes
+        template = NodeTemplate.no_workspace_objects.create(
+            name="subgraph_test_template",
+            display_name="Subgraph Test Template",
+            description="For subgraph integration test",
+            categories=["test"],
+            input_definition=[{"key": "in", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "out", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={},
+        )
+
+        # Create an atomic node and a subgraph node in the main graph
+        atomic_node = Node.no_workspace_objects.create(
+            graph_version=main_version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="Atomic Node",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        subgraph_node = Node.no_workspace_objects.create(
+            graph_version=main_version,
+            ref_graph_version=ref_version,
+            type=NodeType.SUBGRAPH,
+            name="Subgraph Node",
+            config={},
+            position={"x": 200, "y": 0},
+        )
+
+        # Validate passes
+        subgraph_node.clean()
+
+        # Verify reference chain
+        assert subgraph_node.ref_graph_version == ref_version
+        assert subgraph_node.ref_graph_version.graph == ref_graph
+        assert subgraph_node.ref_graph_version.status == GraphVersionStatus.ACTIVE
+
+        # Both nodes belong to the main version
+        assert atomic_node.graph_version == main_version
+        assert subgraph_node.graph_version == main_version
+        assert main_version.nodes.count() == 2
+
+    def test_version_promotion_workflow(self, db, organization, workspace, user):
+        """DRAFT → ACTIVE promotion of referenced version, verify subgraph node still valid."""
+        # Create referenced graph with v1 as active
+        ref_graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Promotable Graph",
+            created_by=user,
+        )
+        v1 = GraphVersion.no_workspace_objects.create(
+            graph=ref_graph,
+            version_number=1,
+            status=GraphVersionStatus.ACTIVE,
+        )
+
+        # Create main graph that references v1
+        main_graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Ref Graph",
+            created_by=user,
+        )
+        main_version = GraphVersion.no_workspace_objects.create(
+            graph=main_graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        subgraph_node = Node.no_workspace_objects.create(
+            graph_version=main_version,
+            ref_graph_version=v1,
+            type=NodeType.SUBGRAPH,
+            name="Subgraph Ref",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+
+        # Subgraph node validates with v1 as active
+        subgraph_node.clean()
+
+        # Now create v2 as draft, then promote it to active (demoting v1)
+        v2 = GraphVersion.no_workspace_objects.create(
+            graph=ref_graph,
+            version_number=2,
+            status=GraphVersionStatus.DRAFT,
+        )
+
+        # Demote v1 to inactive, promote v2 to active
+        v1.status = GraphVersionStatus.INACTIVE
+        v1.save()
+        v2.status = GraphVersionStatus.ACTIVE
+        v2.clean()
+        v2.save()
+
+        # Verify v2 is now active, v1 is inactive
+        v1.refresh_from_db()
+        v2.refresh_from_db()
+        assert v1.status == GraphVersionStatus.INACTIVE
+        assert v2.status == GraphVersionStatus.ACTIVE
+
+        # The subgraph node still references v1, which is now inactive
+        # Validation should PASS because inactive versions are now allowed
+        subgraph_node.refresh_from_db()
+        subgraph_node.clean()  # Should not raise
+        assert subgraph_node.ref_graph_version.status == GraphVersionStatus.INACTIVE
+
+
+@pytest.mark.integration
+class TestCrossGraphCycleIntegration:
+    """Test cross-graph cycle detection in integration scenarios."""
+
+    def test_cross_graph_cycle_rejected_in_save(
+        self, db, organization, workspace, user
+    ):
+        """Cross-graph cycle is rejected when saving a subgraph node."""
+        graph_a = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Graph A",
+            created_by=user,
+        )
+        graph_b = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Graph B",
+            created_by=user,
+        )
+
+        ver_a = GraphVersion.no_workspace_objects.create(
+            graph=graph_a,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        active_a = GraphVersion.no_workspace_objects.create(
+            graph=graph_a,
+            version_number=2,
+            status=GraphVersionStatus.ACTIVE,
+        )
+        ver_b = GraphVersion.no_workspace_objects.create(
+            graph=graph_b,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        active_b = GraphVersion.no_workspace_objects.create(
+            graph=graph_b,
+            version_number=2,
+            status=GraphVersionStatus.ACTIVE,
+        )
+
+        # A -> B
+        Node.no_workspace_objects.create(
+            graph_version=ver_a,
+            ref_graph_version=active_b,
+            type=NodeType.SUBGRAPH,
+            name="A->B",
+            config={},
+        )
+
+        # B -> A should fail on save
+        with pytest.raises(ValidationError, match="circular dependency"):
+            Node.no_workspace_objects.create(
+                graph_version=ver_b,
+                ref_graph_version=active_a,
+                type=NodeType.SUBGRAPH,
+                name="B->A",
+                config={},
+            )
+
+    def test_template_reference_no_cycle(
+        self, db, organization, workspace, user, active_template_graph_version
+    ):
+        """Referencing a template graph should not create cycles."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="User Graph",
+            created_by=user,
+        )
+        version = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+
+        # User graph references template - should succeed
+        node = Node.no_workspace_objects.create(
+            graph_version=version,
+            ref_graph_version=active_template_graph_version,
+            type=NodeType.SUBGRAPH,
+            name="Template Ref",
+            config={},
+        )
+        node.clean()  # Should not raise
+
+
+@pytest.mark.integration
+class TestGraphVersionPromotion:
+    """Test graph version promotion with the active constraint when nodes/edges exist."""
+
+    def test_only_one_active_version_with_nodes(
+        self,
+        db,
+        organization,
+        workspace,
+        user,
+    ):
+        """Two versions with nodes; promote second; verify first is demoted."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Promotion Graph",
+            created_by=user,
+        )
+        template = NodeTemplate.no_workspace_objects.create(
+            name="promotion_template",
+            display_name="Promotion Template",
+            description="For promotion test",
+            categories=["test"],
+            input_definition=[],
+            output_definition=[],
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={},
+        )
+
+        # Create v1 as active with nodes
+        v1 = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.ACTIVE,
+        )
+        node_v1 = Node.no_workspace_objects.create(
+            graph_version=v1,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="V1 Node",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        Port.no_workspace_objects.create(
+            node=node_v1,
+            key="custom",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Create v2 as draft with nodes
+        v2 = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=2,
+            status=GraphVersionStatus.DRAFT,
+        )
+        node_v2 = Node.no_workspace_objects.create(
+            graph_version=v2,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="V2 Node",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        Port.no_workspace_objects.create(
+            node=node_v2,
+            key="custom",
+            display_name="out",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+        )
+
+        # Trying to promote v2 while v1 is still active should fail
+        v2.status = GraphVersionStatus.ACTIVE
+        with pytest.raises(
+            ValidationError, match="Only one active version allowed per graph"
+        ):
+            v2.clean()
+
+        # Demote v1, then promote v2
+        v1.status = GraphVersionStatus.INACTIVE
+        v1.save()
+
+        v2.status = GraphVersionStatus.ACTIVE
+        v2.clean()  # Should pass now
+        v2.save()
+
+        # Verify final state
+        v1.refresh_from_db()
+        v2.refresh_from_db()
+        assert v1.status == GraphVersionStatus.INACTIVE
+        assert v2.status == GraphVersionStatus.ACTIVE
+
+        # Both versions' nodes still exist independently
+        assert v1.nodes.count() == 1
+        assert v2.nodes.count() == 1
+        assert v1.nodes.first().name == "V1 Node"
+        assert v2.nodes.first().name == "V2 Node"

--- a/futureagi/agent_playground/tests/models/test_node.py
+++ b/futureagi/agent_playground/tests/models/test_node.py
@@ -1,0 +1,619 @@
+"""
+Tests for the Node model.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, models
+
+from agent_playground.models import Graph, GraphVersion, Node, NodeTemplate
+from agent_playground.models.choices import (
+    GraphVersionStatus,
+    NodeType,
+    PortMode,
+)
+
+
+@pytest.mark.unit
+class TestAtomicNodeCreation:
+    """Tests for atomic Node creation."""
+
+    def test_atomic_node_creation_success(self, db, graph_version, node_template):
+        """Atomic node with template."""
+        node = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Atomic Node",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        node.clean()
+        assert node.id is not None
+        assert node.type == NodeType.ATOMIC
+        assert node.node_template == node_template
+
+    def test_atomic_node_requires_template(self, db, graph_version):
+        """type=ATOMIC must have node_template."""
+        node = Node(
+            graph_version=graph_version,
+            node_template=None,  # Missing template
+            type=NodeType.ATOMIC,
+            name="Invalid Atomic",
+            config={},
+        )
+        with pytest.raises(
+            ValidationError, match="Atomic nodes must have node_template set"
+        ):
+            node.clean()
+
+    def test_atomic_node_forbids_ref_graph_version(
+        self, db, graph_version, node_template, active_referenced_graph_version
+    ):
+        """type=ATOMIC cannot have ref_graph_version."""
+        node = Node(
+            graph_version=graph_version,
+            node_template=node_template,
+            ref_graph_version=active_referenced_graph_version,  # Should not be set
+            type=NodeType.ATOMIC,
+            name="Invalid Atomic",
+            config={},
+        )
+        with pytest.raises(
+            ValidationError, match="Atomic nodes cannot have ref_graph_version"
+        ):
+            node.clean()
+
+
+@pytest.mark.unit
+class TestAtomicNodeConfigValidation:
+    """Tests for atomic node config validation."""
+
+    def test_atomic_node_config_validates_against_schema(self, db, graph_version):
+        """Config must match template schema."""
+        template = NodeTemplate.no_workspace_objects.create(
+            name="schema_template",
+            display_name="Schema Template",
+            description="Template with schema",
+            categories=["test"],
+            input_definition=[],
+            output_definition=[],
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                },
+                "required": ["name"],
+            },
+        )
+        node = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="Valid Config Node",
+            config={"name": "test"},  # Valid config
+        )
+        node.clean()  # Should not raise
+        assert node.config["name"] == "test"
+
+    def test_atomic_node_invalid_config_fails(self, db, graph_version):
+        """Invalid config raises ValidationError."""
+        template = NodeTemplate.no_workspace_objects.create(
+            name="strict_schema_template",
+            display_name="Strict Schema Template",
+            description="Template with strict schema",
+            categories=["test"],
+            input_definition=[],
+            output_definition=[],
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={
+                "type": "object",
+                "properties": {
+                    "count": {"type": "integer"},
+                },
+                "required": ["count"],
+            },
+        )
+        node = Node(
+            graph_version=graph_version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="Invalid Config Node",
+            config={"count": "not_an_integer"},  # Invalid - should be integer
+        )
+        with pytest.raises(ValidationError, match="Invalid config"):
+            node.clean()
+
+
+@pytest.mark.unit
+class TestSubgraphNodeCreation:
+    """Tests for subgraph Node creation."""
+
+    def test_subgraph_node_creation_success(
+        self, db, graph_version, active_referenced_graph_version
+    ):
+        """Subgraph node with ref_graph_version."""
+        node = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            ref_graph_version=active_referenced_graph_version,
+            type=NodeType.SUBGRAPH,
+            name="Subgraph Node",
+            config={},
+        )
+        node.clean()
+        assert node.id is not None
+        assert node.type == NodeType.SUBGRAPH
+        assert node.ref_graph_version == active_referenced_graph_version
+
+    def test_subgraph_node_requires_ref_graph_version(self, db, graph_version):
+        """type=SUBGRAPH must have ref_graph_version."""
+        node = Node(
+            graph_version=graph_version,
+            ref_graph_version=None,  # Missing ref
+            type=NodeType.SUBGRAPH,
+            name="Invalid Subgraph",
+            config={},
+        )
+        with pytest.raises(
+            ValidationError, match="Subgraph nodes must have ref_graph_version set"
+        ):
+            node.clean()
+
+    def test_subgraph_node_forbids_template(
+        self, db, graph_version, node_template, active_referenced_graph_version
+    ):
+        """type=SUBGRAPH cannot have node_template."""
+        node = Node(
+            graph_version=graph_version,
+            node_template=node_template,  # Should not be set
+            ref_graph_version=active_referenced_graph_version,
+            type=NodeType.SUBGRAPH,
+            name="Invalid Subgraph",
+            config={},
+        )
+        with pytest.raises(
+            ValidationError, match="Subgraph nodes cannot have node_template"
+        ):
+            node.clean()
+
+    def test_subgraph_node_requires_empty_config(
+        self, db, graph_version, active_referenced_graph_version
+    ):
+        """Subgraph nodes must have empty config."""
+        node = Node(
+            graph_version=graph_version,
+            ref_graph_version=active_referenced_graph_version,
+            type=NodeType.SUBGRAPH,
+            name="Subgraph With Config",
+            config={"some": "config"},  # Should be empty
+        )
+        with pytest.raises(
+            ValidationError, match="Subgraph nodes must have empty config"
+        ):
+            node.clean()
+
+
+@pytest.mark.unit
+class TestSubgraphNodeReferenceValidation:
+    """Tests for subgraph node reference validation."""
+
+    def test_subgraph_node_no_self_reference(self, db, organization, workspace, user):
+        """Cannot reference own graph."""
+        graph = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Self Ref Graph",
+            created_by=user,
+        )
+        version1 = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=1,
+            status=GraphVersionStatus.DRAFT,
+        )
+        version2 = GraphVersion.no_workspace_objects.create(
+            graph=graph,
+            version_number=2,
+            status=GraphVersionStatus.ACTIVE,
+        )
+
+        node = Node(
+            graph_version=version1,
+            ref_graph_version=version2,  # Same graph
+            type=NodeType.SUBGRAPH,
+            name="Self Reference",
+            config={},
+        )
+        with pytest.raises(
+            ValidationError,
+            match="Subgraph nodes cannot reference versions of the same graph",
+        ):
+            node.clean()
+
+    def test_subgraph_node_ref_must_be_validated(
+        self, db, graph_version, referenced_graph_version
+    ):
+        """ref_graph_version.status must be ACTIVE or INACTIVE (not DRAFT)."""
+        # referenced_graph_version is DRAFT by default
+        node = Node(
+            graph_version=graph_version,
+            ref_graph_version=referenced_graph_version,  # Draft, not validated
+            type=NodeType.SUBGRAPH,
+            name="Draft Reference",
+            config={},
+        )
+        with pytest.raises(
+            ValidationError,
+            match="Subgraph nodes can only reference active or inactive versions",
+        ):
+            node.clean()
+
+    def test_subgraph_node_can_reference_inactive(
+        self, db, graph_version, referenced_graph
+    ):
+        """Subgraph nodes can reference inactive versions (previously active)."""
+        # Create an inactive version
+        inactive_version = GraphVersion.no_workspace_objects.create(
+            graph=referenced_graph,
+            version_number=3,
+            status=GraphVersionStatus.INACTIVE,
+        )
+
+        # Should succeed
+        node = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            ref_graph_version=inactive_version,
+            type=NodeType.SUBGRAPH,
+            name="Inactive Reference",
+            config={},
+        )
+        node.clean()  # Should not raise
+        assert node.ref_graph_version == inactive_version
+        assert node.ref_graph_version.status == GraphVersionStatus.INACTIVE
+
+    @pytest.mark.parametrize(
+        "status,should_pass",
+        [
+            (GraphVersionStatus.ACTIVE, True),
+            (GraphVersionStatus.INACTIVE, True),
+            (GraphVersionStatus.DRAFT, False),
+        ],
+    )
+    def test_subgraph_node_reference_by_status(
+        self, db, graph_version, referenced_graph, status, should_pass
+    ):
+        """Test subgraph node validation across all GraphVersion statuses."""
+        test_version = GraphVersion.no_workspace_objects.create(
+            graph=referenced_graph,
+            version_number=10,
+            status=status,
+        )
+
+        node = Node(
+            graph_version=graph_version,
+            ref_graph_version=test_version,
+            type=NodeType.SUBGRAPH,
+            name=f"Ref {status}",
+            config={},
+        )
+
+        if should_pass:
+            node.clean()  # Should not raise
+            assert node.ref_graph_version.status == status
+        else:
+            with pytest.raises(
+                ValidationError,
+                match="Subgraph nodes can only reference active or inactive versions",
+            ):
+                node.clean()
+
+    def test_subgraph_node_single_version_per_graph(
+        self, db, graph_version, active_referenced_graph_version, referenced_graph
+    ):
+        """Only one version of external graph can be referenced per graph_version."""
+        # Create first subgraph node
+        Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            ref_graph_version=active_referenced_graph_version,
+            type=NodeType.SUBGRAPH,
+            name="First Subgraph",
+            config={},
+        )
+
+        # Deactivate the first active version before creating another active one
+        active_referenced_graph_version.status = GraphVersionStatus.INACTIVE
+        active_referenced_graph_version.save()
+
+        # Create another active version of the same referenced graph
+        another_version = GraphVersion.no_workspace_objects.create(
+            graph=referenced_graph,
+            version_number=3,
+            status=GraphVersionStatus.ACTIVE,
+        )
+
+        # Try to create second subgraph node referencing different version of same graph
+        node2 = Node(
+            graph_version=graph_version,
+            ref_graph_version=another_version,
+            type=NodeType.SUBGRAPH,
+            name="Second Subgraph",
+            config={},
+        )
+        with pytest.raises(
+            ValidationError, match="This graph already references a different version"
+        ):
+            node2.clean()
+
+
+@pytest.mark.unit
+class TestCrossGraphCycleDetection:
+    """Tests for cross-graph cycle detection in subgraph nodes."""
+
+    def test_direct_cycle_rejected(self, db, organization, workspace, user):
+        """A refs B, B refs A -> rejected."""
+        graph_a = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Graph A",
+            created_by=user,
+        )
+        graph_b = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Graph B",
+            created_by=user,
+        )
+
+        version_a = GraphVersion.no_workspace_objects.create(
+            graph=graph_a, version_number=1, status=GraphVersionStatus.DRAFT
+        )
+        active_version_a = GraphVersion.no_workspace_objects.create(
+            graph=graph_a, version_number=2, status=GraphVersionStatus.ACTIVE
+        )
+        version_b = GraphVersion.no_workspace_objects.create(
+            graph=graph_b, version_number=1, status=GraphVersionStatus.DRAFT
+        )
+        active_version_b = GraphVersion.no_workspace_objects.create(
+            graph=graph_b, version_number=2, status=GraphVersionStatus.ACTIVE
+        )
+
+        # A refs B (succeeds)
+        Node.no_workspace_objects.create(
+            graph_version=version_a,
+            ref_graph_version=active_version_b,
+            type=NodeType.SUBGRAPH,
+            name="A -> B",
+            config={},
+        )
+
+        # B refs A (should fail - cycle)
+        node_ba = Node(
+            graph_version=version_b,
+            ref_graph_version=active_version_a,
+            type=NodeType.SUBGRAPH,
+            name="B -> A",
+            config={},
+        )
+        with pytest.raises(ValidationError, match="circular dependency"):
+            node_ba.clean()
+
+    def test_transitive_cycle_rejected(self, db, organization, workspace, user):
+        """A->B->C, C->A -> rejected."""
+        graph_a = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Graph A",
+            created_by=user,
+        )
+        graph_b = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Graph B",
+            created_by=user,
+        )
+        graph_c = Graph.no_workspace_objects.create(
+            organization=organization,
+            workspace=workspace,
+            name="Graph C",
+            created_by=user,
+        )
+
+        ver_a = GraphVersion.no_workspace_objects.create(
+            graph=graph_a, version_number=1, status=GraphVersionStatus.DRAFT
+        )
+        active_a = GraphVersion.no_workspace_objects.create(
+            graph=graph_a, version_number=2, status=GraphVersionStatus.ACTIVE
+        )
+        ver_b = GraphVersion.no_workspace_objects.create(
+            graph=graph_b, version_number=1, status=GraphVersionStatus.DRAFT
+        )
+        active_b = GraphVersion.no_workspace_objects.create(
+            graph=graph_b, version_number=2, status=GraphVersionStatus.ACTIVE
+        )
+        ver_c = GraphVersion.no_workspace_objects.create(
+            graph=graph_c, version_number=1, status=GraphVersionStatus.DRAFT
+        )
+        active_c = GraphVersion.no_workspace_objects.create(
+            graph=graph_c, version_number=2, status=GraphVersionStatus.ACTIVE
+        )
+
+        # A -> B
+        Node.no_workspace_objects.create(
+            graph_version=ver_a,
+            ref_graph_version=active_b,
+            type=NodeType.SUBGRAPH,
+            name="A -> B",
+            config={},
+        )
+        # B -> C
+        Node.no_workspace_objects.create(
+            graph_version=ver_b,
+            ref_graph_version=active_c,
+            type=NodeType.SUBGRAPH,
+            name="B -> C",
+            config={},
+        )
+        # C -> A should fail
+        node_ca = Node(
+            graph_version=ver_c,
+            ref_graph_version=active_a,
+            type=NodeType.SUBGRAPH,
+            name="C -> A",
+            config={},
+        )
+        with pytest.raises(ValidationError, match="circular dependency"):
+            node_ca.clean()
+
+    def test_diamond_no_cycle_allowed(self, db, organization, workspace, user):
+        """A->B, A->C, B->D, C->D -> allowed (diamond, no cycle)."""
+        graphs = {}
+        versions = {}
+        active_versions = {}
+        for name in ["A", "B", "C", "D"]:
+            g = Graph.no_workspace_objects.create(
+                organization=organization,
+                workspace=workspace,
+                name=f"Graph {name}",
+                created_by=user,
+            )
+            graphs[name] = g
+            versions[name] = GraphVersion.no_workspace_objects.create(
+                graph=g,
+                version_number=1,
+                status=GraphVersionStatus.DRAFT,
+            )
+            active_versions[name] = GraphVersion.no_workspace_objects.create(
+                graph=g,
+                version_number=2,
+                status=GraphVersionStatus.ACTIVE,
+            )
+
+        # A->B, A->C
+        Node.no_workspace_objects.create(
+            graph_version=versions["A"],
+            ref_graph_version=active_versions["B"],
+            type=NodeType.SUBGRAPH,
+            name="A -> B",
+            config={},
+        )
+        Node.no_workspace_objects.create(
+            graph_version=versions["A"],
+            ref_graph_version=active_versions["C"],
+            type=NodeType.SUBGRAPH,
+            name="A -> C",
+            config={},
+        )
+        # B->D
+        Node.no_workspace_objects.create(
+            graph_version=versions["B"],
+            ref_graph_version=active_versions["D"],
+            type=NodeType.SUBGRAPH,
+            name="B -> D",
+            config={},
+        )
+        # C->D should succeed (diamond, not a cycle)
+        node_cd = Node.no_workspace_objects.create(
+            graph_version=versions["C"],
+            ref_graph_version=active_versions["D"],
+            type=NodeType.SUBGRAPH,
+            name="C -> D",
+            config={},
+        )
+        node_cd.clean()  # Should not raise
+
+
+@pytest.mark.unit
+class TestSubgraphNodeTemplateReference:
+    """Tests for subgraph nodes referencing template graphs."""
+
+    def test_subgraph_referencing_template_active_version(
+        self, db, graph_version, active_template_graph_version
+    ):
+        """Subgraph node referencing template's active version succeeds."""
+        node = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            ref_graph_version=active_template_graph_version,
+            type=NodeType.SUBGRAPH,
+            name="Template Ref",
+            config={},
+        )
+        node.clean()  # Should not raise
+        assert node.ref_graph_version == active_template_graph_version
+
+    def test_subgraph_referencing_template_non_active_version_fails(
+        self, db, graph_version, template_graph
+    ):
+        """Subgraph node referencing template's non-active version fails."""
+        draft_version = GraphVersion.no_workspace_objects.create(
+            graph=template_graph,
+            version_number=2,
+            status=GraphVersionStatus.DRAFT,
+        )
+        node = Node(
+            graph_version=graph_version,
+            ref_graph_version=draft_version,
+            type=NodeType.SUBGRAPH,
+            name="Bad Template Ref",
+            config={},
+        )
+        with pytest.raises(
+            ValidationError,
+            match="Subgraph nodes can only reference active or inactive versions",
+        ):
+            node.clean()
+
+
+@pytest.mark.unit
+class TestNodeCascadeDelete:
+    """Tests for Node cascade delete behavior."""
+
+    def test_node_cascade_delete_graph_version(self, db, node, graph_version):
+        """Deleting version cascades to nodes."""
+        node_id = node.id
+
+        # Hard delete the graph version
+        GraphVersion.all_objects.filter(id=graph_version.id).delete()
+
+        # Node should be gone
+        assert not Node.all_objects.filter(id=node_id).exists()
+
+
+@pytest.mark.unit
+class TestNodeNameCharValidation:
+    """Tests for _validate_name_chars — reserved characters in node names."""
+
+    @pytest.mark.parametrize("char", [".", "[", "]", "{", "}"])
+    def test_rejects_reserved_char_in_name(
+        self, db, graph_version, node_template, char
+    ):
+        node = Node(
+            graph_version=graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name=f"Bad{char}Name",
+            config={},
+        )
+        with pytest.raises(ValidationError, match="reserved characters"):
+            node.clean()
+
+    def test_allows_clean_name(self, db, graph_version, node_template):
+        node = Node(
+            graph_version=graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Good_Name-123",
+            config={},
+        )
+        node.clean()  # should not raise
+
+    def test_allows_spaces_and_dashes(self, db, graph_version, node_template):
+        node = Node(
+            graph_version=graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="My Node - v2",
+            config={},
+        )
+        node.clean()  # should not raise

--- a/futureagi/agent_playground/tests/models/test_node_execution.py
+++ b/futureagi/agent_playground/tests/models/test_node_execution.py
@@ -1,0 +1,157 @@
+"""
+Tests for the NodeExecution model.
+"""
+
+import pytest
+from django.db import IntegrityError, models
+
+from agent_playground.models import GraphExecution, Node, NodeExecution
+from agent_playground.models.choices import NodeExecutionStatus
+
+
+@pytest.mark.unit
+class TestNodeExecutionCreation:
+    """Tests for NodeExecution model creation."""
+
+    def test_node_execution_creation_success(
+        self, db, graph_execution, node_in_active_version
+    ):
+        """Basic creation."""
+        execution = NodeExecution.no_workspace_objects.create(
+            graph_execution=graph_execution,
+            node=node_in_active_version,
+        )
+        assert execution.id is not None
+        assert execution.graph_execution == graph_execution
+        assert execution.node == node_in_active_version
+
+    def test_node_execution_default_status_pending(
+        self, db, graph_execution, node_in_active_version
+    ):
+        """status defaults to PENDING."""
+        execution = NodeExecution.no_workspace_objects.create(
+            graph_execution=graph_execution,
+            node=node_in_active_version,
+        )
+        assert execution.status == NodeExecutionStatus.PENDING
+
+
+@pytest.mark.unit
+class TestNodeExecutionStatusValidation:
+    """Tests for NodeExecution status validation."""
+
+    def test_node_execution_all_statuses_valid(
+        self, db, graph_execution, node_in_active_version
+    ):
+        """PENDING, RUNNING, SUCCESS, FAILED, SKIPPED are all valid."""
+        statuses = [
+            NodeExecutionStatus.PENDING,
+            NodeExecutionStatus.RUNNING,
+            NodeExecutionStatus.SUCCESS,
+            NodeExecutionStatus.FAILED,
+            NodeExecutionStatus.SKIPPED,
+        ]
+        for idx, status in enumerate(statuses):
+            # Need to create a new node for each to avoid unique constraint
+            node = Node.no_workspace_objects.create(
+                graph_version=node_in_active_version.graph_version,
+                node_template=node_in_active_version.node_template,
+                type=node_in_active_version.type,
+                name=f"Node {idx}",
+                config={},
+            )
+            execution = NodeExecution.no_workspace_objects.create(
+                graph_execution=graph_execution,
+                node=node,
+                status=status,
+            )
+            execution.full_clean()
+            assert execution.status == status
+
+
+@pytest.mark.unit
+class TestNodeExecutionUniqueConstraint:
+    """Tests for NodeExecution unique constraints."""
+
+    def test_node_execution_unique_per_graph_execution(
+        self, db, graph_execution, node_in_active_version
+    ):
+        """UniqueConstraint on (graph_execution, node)."""
+        NodeExecution.no_workspace_objects.create(
+            graph_execution=graph_execution,
+            node=node_in_active_version,
+        )
+
+        with pytest.raises(IntegrityError):
+            NodeExecution.no_workspace_objects.create(
+                graph_execution=graph_execution,
+                node=node_in_active_version,  # Duplicate
+            )
+
+    def test_node_execution_unique_allows_deleted(
+        self, db, graph_execution, node_in_active_version
+    ):
+        """Soft-deleted node executions don't block uniqueness."""
+        execution1 = NodeExecution.no_workspace_objects.create(
+            graph_execution=graph_execution,
+            node=node_in_active_version,
+        )
+        execution1.delete()  # Soft delete
+
+        # Should be able to create another execution for same node
+        execution2 = NodeExecution.no_workspace_objects.create(
+            graph_execution=graph_execution,
+            node=node_in_active_version,
+        )
+        assert execution2.id is not None
+
+    def test_node_execution_same_node_different_graph_executions(
+        self, db, active_graph_version, node_in_active_version
+    ):
+        """Same node can have executions in different graph executions."""
+        exec1 = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version
+        )
+        exec2 = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version
+        )
+
+        node_exec1 = NodeExecution.no_workspace_objects.create(
+            graph_execution=exec1,
+            node=node_in_active_version,
+        )
+        node_exec2 = NodeExecution.no_workspace_objects.create(
+            graph_execution=exec2,
+            node=node_in_active_version,
+        )
+        assert node_exec1.node == node_exec2.node
+        assert node_exec1.graph_execution != node_exec2.graph_execution
+
+
+@pytest.mark.unit
+class TestNodeExecutionCascadeDelete:
+    """Tests for NodeExecution cascade delete behavior."""
+
+    def test_node_execution_cascade_delete_graph_execution(
+        self, db, node_execution, graph_execution
+    ):
+        """Deleting graph_execution cascades to node executions."""
+        node_exec_id = node_execution.id
+
+        # Hard delete the graph execution
+        GraphExecution.all_objects.filter(id=graph_execution.id).delete()
+
+        # Node execution should be gone
+        assert not NodeExecution.all_objects.filter(id=node_exec_id).exists()
+
+
+@pytest.mark.unit
+class TestNodeExecutionProtectDelete:
+    """Tests for NodeExecution PROTECT delete behavior."""
+
+    def test_node_execution_protect_delete_node(
+        self, db, node_execution, node_in_active_version
+    ):
+        """Cannot delete node with executions (PROTECT)."""
+        with pytest.raises((IntegrityError, models.ProtectedError)):
+            Node.all_objects.filter(id=node_in_active_version.id).delete()

--- a/futureagi/agent_playground/tests/models/test_node_template.py
+++ b/futureagi/agent_playground/tests/models/test_node_template.py
@@ -1,0 +1,321 @@
+"""
+Tests for the NodeTemplate model.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+
+from agent_playground.models import NodeTemplate
+from agent_playground.models.choices import PortMode
+
+
+@pytest.mark.unit
+class TestNodeTemplateCreation:
+    """Tests for NodeTemplate model creation."""
+
+    def test_node_template_creation_success(self, db):
+        """Basic creation with valid data."""
+        template = NodeTemplate.no_workspace_objects.create(
+            name="my_template",
+            display_name="My Template",
+            description="A test template",
+            categories=["testing"],
+            input_definition=[{"key": "input1", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "output1", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={"type": "object"},
+        )
+        assert template.id is not None
+        assert template.name == "my_template"
+
+
+@pytest.mark.unit
+class TestNodeTemplateUniqueConstraint:
+    """Tests for NodeTemplate unique constraints."""
+
+    def test_node_template_unique_name(self, db, node_template):
+        """name field unique constraint."""
+        with pytest.raises(IntegrityError):
+            NodeTemplate.no_workspace_objects.create(
+                name=node_template.name,  # Duplicate
+                display_name="Another Template",
+                description="Another description",
+                categories=["other"],
+                input_definition=[],
+                output_definition=[],
+                input_mode=PortMode.DYNAMIC,
+                output_mode=PortMode.DYNAMIC,
+                config_schema={"type": "object"},
+            )
+
+
+@pytest.mark.unit
+class TestNodeTemplateFieldValidation:
+    """Tests for NodeTemplate field validation."""
+
+    def test_node_template_categories_must_be_list(self, db):
+        """clean() validates categories is list."""
+        template = NodeTemplate(
+            name="invalid_categories",
+            display_name="Invalid Categories",
+            description="Test",
+            categories="not_a_list",  # Invalid
+            input_definition=[],
+            output_definition=[],
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={"type": "object"},
+        )
+        with pytest.raises(ValidationError, match="categories must be a list"):
+            template.clean()
+
+    def test_node_template_input_definition_must_be_list(self, db):
+        """clean() validates input_definition is list."""
+        template = NodeTemplate(
+            name="invalid_input",
+            display_name="Invalid Input",
+            description="Test",
+            categories=["test"],
+            input_definition="not_a_list",  # Invalid
+            output_definition=[],
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={"type": "object"},
+        )
+        with pytest.raises(ValidationError, match="input_definition must be a list"):
+            template.clean()
+
+    def test_node_template_output_definition_must_be_list(self, db):
+        """clean() validates output_definition is list."""
+        template = NodeTemplate(
+            name="invalid_output",
+            display_name="Invalid Output",
+            description="Test",
+            categories=["test"],
+            input_definition=[],
+            output_definition="not_a_list",  # Invalid
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={"type": "object"},
+        )
+        with pytest.raises(ValidationError, match="output_definition must be a list"):
+            template.clean()
+
+
+@pytest.mark.unit
+class TestNodeTemplateDynamicMode:
+    """Tests for DYNAMIC mode port validation."""
+
+    def test_node_template_dynamic_input_empty_definition(self, db):
+        """DYNAMIC input mode requires empty input_definition."""
+        template = NodeTemplate(
+            name="dynamic_with_input",
+            display_name="Dynamic With Input",
+            description="Test",
+            categories=["test"],
+            input_definition=[{"key": "should_be_empty", "data_schema": {}}],  # Invalid
+            output_definition=[],
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={"type": "object"},
+        )
+        with pytest.raises(
+            ValidationError,
+            match="Dynamic input mode should have empty input_definition",
+        ):
+            template.clean()
+
+    def test_node_template_dynamic_output_empty_definition(self, db):
+        """DYNAMIC output mode requires empty output_definition."""
+        template = NodeTemplate(
+            name="dynamic_with_output",
+            display_name="Dynamic With Output",
+            description="Test",
+            categories=["test"],
+            input_definition=[],
+            output_definition=[
+                {"key": "should_be_empty", "data_schema": {}}
+            ],  # Invalid
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={"type": "object"},
+        )
+        with pytest.raises(
+            ValidationError,
+            match="Dynamic output mode should have empty output_definition",
+        ):
+            template.clean()
+
+
+@pytest.mark.unit
+class TestNodeTemplateStrictExtensibleMode:
+    """Tests for STRICT and EXTENSIBLE mode port validation."""
+
+    def test_node_template_strict_mode_with_definitions(self, db):
+        """STRICT mode allows definitions."""
+        template = NodeTemplate.no_workspace_objects.create(
+            name="strict_template",
+            display_name="Strict Template",
+            description="Test",
+            categories=["test"],
+            input_definition=[{"key": "input1", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "output1", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={"type": "object"},
+        )
+        template.clean()  # Should not raise
+        assert len(template.input_definition) == 1
+        assert len(template.output_definition) == 1
+
+    def test_node_template_extensible_mode_with_definitions(self, db):
+        """EXTENSIBLE mode allows definitions."""
+        template = NodeTemplate.no_workspace_objects.create(
+            name="extensible_template",
+            display_name="Extensible Template",
+            description="Test",
+            categories=["test"],
+            input_definition=[{"key": "input1", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "output1", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.EXTENSIBLE,
+            output_mode=PortMode.EXTENSIBLE,
+            config_schema={"type": "object"},
+        )
+        template.clean()  # Should not raise
+        assert template.input_mode == PortMode.EXTENSIBLE
+
+
+@pytest.mark.unit
+class TestNodeTemplatePortDefinitionFormat:
+    """Tests for port definition format validation."""
+
+    def test_node_template_port_definition_requires_key(self, db):
+        """Each port definition needs 'key' field."""
+        template = NodeTemplate(
+            name="missing_key",
+            display_name="Missing Key",
+            description="Test",
+            categories=["test"],
+            input_definition=[{"data_schema": {"type": "string"}}],  # Missing 'key'
+            output_definition=[],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={"type": "object"},
+        )
+        with pytest.raises(
+            ValidationError, match="Each .* entry must have 'key' and 'data_schema'"
+        ):
+            template.clean()
+
+    def test_node_template_port_definition_requires_data_schema(self, db):
+        """Each port definition needs 'data_schema' field."""
+        template = NodeTemplate(
+            name="missing_schema",
+            display_name="Missing Schema",
+            description="Test",
+            categories=["test"],
+            input_definition=[{"key": "input1"}],  # Missing 'data_schema'
+            output_definition=[],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={"type": "object"},
+        )
+        with pytest.raises(
+            ValidationError, match="Each .* entry must have 'key' and 'data_schema'"
+        ):
+            template.clean()
+
+
+@pytest.mark.unit
+class TestNodeTemplateDuplicateAndReservedKeys:
+    """Tests for duplicate definition keys and reserved key validation."""
+
+    def test_node_template_duplicate_definition_keys_fails(self, db):
+        """input_definition with two entries having the same key should fail."""
+        template = NodeTemplate(
+            name="dup_keys",
+            display_name="Dup Keys",
+            description="Test",
+            categories=["test"],
+            input_definition=[
+                {"key": "prompt", "data_schema": {"type": "string"}},
+                {"key": "prompt", "data_schema": {"type": "string"}},
+            ],
+            output_definition=[{"key": "output1", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={"type": "object"},
+        )
+        with pytest.raises(
+            ValidationError, match="Duplicate key 'prompt' in input_definition"
+        ):
+            template.clean()
+
+    def test_node_template_reserved_custom_key_fails(self, db):
+        """input_definition with key='custom' should fail."""
+        template = NodeTemplate(
+            name="reserved_key",
+            display_name="Reserved Key",
+            description="Test",
+            categories=["test"],
+            input_definition=[
+                {"key": "custom", "data_schema": {"type": "string"}},
+            ],
+            output_definition=[{"key": "output1", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.EXTENSIBLE,
+            output_mode=PortMode.STRICT,
+            config_schema={"type": "object"},
+        )
+        with pytest.raises(
+            ValidationError,
+            match="'custom' is a reserved port key and cannot be used in input_definition",
+        ):
+            template.clean()
+
+
+@pytest.mark.unit
+class TestNodeTemplateConfigSchema:
+    """Tests for config_schema validation."""
+
+    def test_node_template_valid_config_schema(self, db):
+        """Valid JSON Schema passes."""
+        template = NodeTemplate.no_workspace_objects.create(
+            name="valid_schema",
+            display_name="Valid Schema",
+            description="Test",
+            categories=["test"],
+            input_definition=[{"key": "input1", "data_schema": {"type": "string"}}],
+            output_definition=[{"key": "output1", "data_schema": {"type": "string"}}],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "count": {"type": "integer"},
+                },
+                "required": ["name"],
+            },
+        )
+        template.clean()  # Should not raise
+        assert template.config_schema["type"] == "object"
+
+    def test_node_template_invalid_config_schema(self, db):
+        """Invalid JSON Schema raises error."""
+        template = NodeTemplate(
+            name="invalid_schema",
+            display_name="Invalid Schema",
+            description="Test",
+            categories=["test"],
+            input_definition=[],
+            output_definition=[],
+            input_mode=PortMode.DYNAMIC,
+            output_mode=PortMode.DYNAMIC,
+            config_schema={
+                "type": "invalid_type",  # Invalid type
+            },
+        )
+        with pytest.raises(ValidationError, match="Invalid config_schema"):
+            template.clean()

--- a/futureagi/agent_playground/tests/models/test_port.py
+++ b/futureagi/agent_playground/tests/models/test_port.py
@@ -1,0 +1,521 @@
+"""
+Tests for the Port model.
+
+Note: The `node` fixture uses a STRICT-mode template with keys 'input1' and 'output1'.
+Tests that need arbitrary keys use the `dynamic_node` fixture (DYNAMIC-mode template).
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+
+from agent_playground.models import Node, Port
+from agent_playground.models.choices import NodeType, PortDirection
+
+
+@pytest.mark.unit
+class TestPortCreation:
+    """Tests for Port model creation."""
+
+    def test_port_creation_success(self, db, node):
+        """Basic port creation."""
+        port = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Input 1",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+        )
+        assert port.id is not None
+        assert port.key == "input1"
+        assert port.node == node
+
+    def test_port_direction_input(self, db, node):
+        """direction=INPUT valid."""
+        port = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Input 1",
+            direction=PortDirection.INPUT,
+            data_schema={"type": "string"},
+            metadata={"label": "Input"},
+        )
+        port.full_clean()
+        assert port.direction == PortDirection.INPUT
+
+    def test_port_direction_output(self, db, node):
+        """direction=OUTPUT valid."""
+        port = Port.no_workspace_objects.create(
+            node=node,
+            key="output1",
+            display_name="Output 1",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+            metadata={"label": "Output"},
+        )
+        port.full_clean()
+        assert port.direction == PortDirection.OUTPUT
+
+
+@pytest.mark.unit
+class TestPortUniqueConstraint:
+    """Tests for Port unique constraints."""
+
+    def test_port_unique_key_per_node(self, db, node):
+        """UniqueConstraint on (node, key)."""
+        Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Input 1",
+            direction=PortDirection.INPUT,
+        )
+
+        with pytest.raises(IntegrityError):
+            Port.no_workspace_objects.create(
+                node=node,
+                key="input1",  # Duplicate key
+                display_name="Input 1 Copy",
+                direction=PortDirection.INPUT,  # Same direction, same key
+            )
+
+    def test_port_unique_allows_deleted(self, db, node):
+        """Soft-deleted ports don't block uniqueness."""
+        port1 = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Input 1",
+            direction=PortDirection.INPUT,
+        )
+        port1.delete()  # Soft delete
+
+        # Should be able to create another port with same key
+        port2 = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Input 1",
+            direction=PortDirection.INPUT,
+        )
+        assert port2.id is not None
+        assert port2.key == "input1"
+
+    def test_port_same_key_different_nodes(self, db, node, second_node):
+        """Same key allowed on different nodes."""
+        port1 = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Input 1",
+            direction=PortDirection.INPUT,
+        )
+        port2 = Port.no_workspace_objects.create(
+            node=second_node,
+            key="input1",  # Same key, different node
+            display_name="Input 1",
+            direction=PortDirection.INPUT,
+        )
+        assert port1.key == port2.key
+        assert port1.node != port2.node
+
+
+@pytest.mark.unit
+class TestPortCascadeDelete:
+    """Tests for Port cascade delete behavior."""
+
+    def test_port_cascade_delete_node(self, db, node):
+        """Deleting node cascades to ports."""
+        port = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Input 1",
+            direction=PortDirection.INPUT,
+        )
+        port_id = port.id
+
+        # Hard delete the node
+        Node.all_objects.filter(id=node.id).delete()
+
+        # Port should be gone
+        assert not Port.all_objects.filter(id=port_id).exists()
+
+
+@pytest.mark.unit
+class TestPortDefaultValues:
+    """Tests for Port default values."""
+
+    def test_port_default_values(self, db, node):
+        """required=True, data_schema={}, metadata={}."""
+        port = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Input 1",
+            direction=PortDirection.INPUT,
+        )
+        assert port.required is True
+        assert port.data_schema == {}
+        assert port.metadata == {}
+        assert port.default_value is None
+
+
+@pytest.mark.unit
+class TestPortDisplayName:
+    """Tests for Port display_name field."""
+
+    def test_display_name_explicit(self, db, node):
+        """display_name can be set explicitly."""
+        port = Port.no_workspace_objects.create(
+            node=node,
+            key="output1",
+            display_name="LLM Response",
+            direction=PortDirection.OUTPUT,
+        )
+        assert port.display_name == "LLM Response"
+        assert port.key == "output1"
+
+    def test_display_name_unique_per_node(self, db, node):
+        """UniqueConstraint on (node, display_name)."""
+        Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Same Name",
+            direction=PortDirection.INPUT,
+        )
+        with pytest.raises(IntegrityError):
+            Port.no_workspace_objects.create(
+                node=node,
+                key="output1",
+                display_name="Same Name",  # Duplicate display_name
+                direction=PortDirection.OUTPUT,
+            )
+
+    def test_display_name_same_across_different_nodes(self, db, node, second_node):
+        """Same display_name allowed on different nodes."""
+        port1 = Port.no_workspace_objects.create(
+            node=node,
+            key="output1",
+            display_name="Response",
+            direction=PortDirection.OUTPUT,
+        )
+        port2 = Port.no_workspace_objects.create(
+            node=second_node,
+            key="output1",
+            display_name="Response",
+            direction=PortDirection.OUTPUT,
+        )
+        assert port1.display_name == port2.display_name
+        assert port1.node != port2.node
+
+    def test_display_name_unique_allows_deleted(self, db, node):
+        """Soft-deleted ports don't block display_name uniqueness."""
+        port1 = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Reusable Name",
+            direction=PortDirection.INPUT,
+        )
+        port1.delete()  # Soft delete
+
+        port2 = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="Reusable Name",
+            direction=PortDirection.INPUT,
+        )
+        assert port2.display_name == "Reusable Name"
+
+
+@pytest.mark.unit
+class TestPortCustomKeyConstraint:
+    """Tests for key='custom' exemption from unique_node_port_key constraint."""
+
+    def test_multiple_custom_key_ports_allowed(self, db, dynamic_node):
+        """Multiple ports with key='custom' on the same node are allowed."""
+        port1 = Port.no_workspace_objects.create(
+            node=dynamic_node,
+            key="custom",
+            display_name="Custom Port 1",
+            direction=PortDirection.INPUT,
+        )
+        port2 = Port.no_workspace_objects.create(
+            node=dynamic_node,
+            key="custom",
+            display_name="Custom Port 2",
+            direction=PortDirection.INPUT,
+        )
+        assert port1.key == "custom"
+        assert port2.key == "custom"
+        assert port1.id != port2.id
+
+    def test_non_custom_key_still_unique(self, db, node):
+        """Non-custom keys are still unique per node."""
+        Port.no_workspace_objects.create(
+            node=node,
+            key="output1",
+            display_name="Response 1",
+            direction=PortDirection.OUTPUT,
+        )
+        with pytest.raises(IntegrityError):
+            Port.no_workspace_objects.create(
+                node=node,
+                key="output1",  # Duplicate non-custom key
+                display_name="Response 2",
+                direction=PortDirection.OUTPUT,
+            )
+
+
+@pytest.mark.unit
+class TestPortRefPort:
+    """Tests for Port.ref_port FK and validation."""
+
+    def test_ref_port_valid_on_subgraph_node(
+        self, db, subgraph_node, active_referenced_graph_version, node_template
+    ):
+        """ref_port on a subgraph node port pointing to child graph port is valid."""
+        # Create a port in the child graph
+        child_node = Node.no_workspace_objects.create(
+            graph_version=active_referenced_graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Child Node",
+            config={},
+        )
+        child_port = Port.no_workspace_objects.create(
+            node=child_node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+
+        # Create a subgraph node port with ref_port
+        subgraph_port = Port(
+            node=subgraph_node,
+            key="custom",
+            display_name="My Input",
+            direction=PortDirection.INPUT,
+            ref_port=child_port,
+        )
+        subgraph_port.save()
+
+        assert subgraph_port.ref_port == child_port
+        assert subgraph_port.ref_port_id == child_port.id
+
+    def test_ref_port_rejected_on_atomic_node(self, db, node, second_node):
+        """ref_port is not allowed on atomic node ports."""
+        other_port = Port.no_workspace_objects.create(
+            node=second_node,
+            key="output1",
+            display_name="output1",
+            direction=PortDirection.OUTPUT,
+        )
+
+        port = Port(
+            node=node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+            ref_port=other_port,
+        )
+        with pytest.raises(ValidationError, match="only allowed on ports of subgraph"):
+            port.save()
+
+    def test_ref_port_direction_mismatch_rejected(
+        self, db, subgraph_node, active_referenced_graph_version, node_template
+    ):
+        """ref_port with direction mismatch is rejected."""
+        child_node = Node.no_workspace_objects.create(
+            graph_version=active_referenced_graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Child Node",
+            config={},
+        )
+        child_output_port = Port.no_workspace_objects.create(
+            node=child_node,
+            key="output1",
+            display_name="output1",
+            direction=PortDirection.OUTPUT,
+        )
+
+        # Try to create an INPUT port referencing an OUTPUT child port
+        port = Port(
+            node=subgraph_node,
+            key="custom",
+            display_name="My Input",
+            direction=PortDirection.INPUT,
+            ref_port=child_output_port,
+        )
+        with pytest.raises(ValidationError, match="direction mismatch"):
+            port.save()
+
+    def test_ref_port_wrong_graph_version_rejected(
+        self,
+        db,
+        subgraph_node,
+        graph_version,
+        node_template,
+    ):
+        """ref_port must belong to a node in the referenced graph version."""
+        # Create a port in the SAME graph version (not the child graph)
+        same_graph_node = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Same Graph Node",
+            config={},
+        )
+        wrong_port = Port.no_workspace_objects.create(
+            node=same_graph_node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+
+        port = Port(
+            node=subgraph_node,
+            key="custom",
+            display_name="My Input",
+            direction=PortDirection.INPUT,
+            ref_port=wrong_port,
+        )
+        with pytest.raises(ValidationError, match="referenced graph version"):
+            port.save()
+
+    def test_ref_port_null_by_default(self, db, node):
+        """ref_port defaults to None."""
+        port = Port.no_workspace_objects.create(
+            node=node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+        assert port.ref_port is None
+        assert port.ref_port_id is None
+
+    def test_two_subgraph_nodes_same_graph_different_ref_ports(
+        self,
+        db,
+        graph_version,
+        active_referenced_graph_version,
+        node_template,
+    ):
+        """Two subgraph nodes referencing the same graph can have ports
+        with different display_names pointing to the same child ports."""
+        # Create child graph port
+        child_node = Node.no_workspace_objects.create(
+            graph_version=active_referenced_graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Child Node",
+            config={},
+        )
+        child_input = Port.no_workspace_objects.create(
+            node=child_node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+
+        # Create two subgraph nodes referencing the same graph
+        subgraph_node_1 = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            ref_graph_version=active_referenced_graph_version,
+            type=NodeType.SUBGRAPH,
+            name="Subgraph Instance 1",
+            config={},
+        )
+        subgraph_node_2 = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            ref_graph_version=active_referenced_graph_version,
+            type=NodeType.SUBGRAPH,
+            name="Subgraph Instance 2",
+            config={},
+        )
+
+        # Both can have ports referencing the same child port
+        port1 = Port(
+            node=subgraph_node_1,
+            key="custom",
+            display_name="First Input",
+            direction=PortDirection.INPUT,
+            ref_port=child_input,
+        )
+        port1.save()
+
+        port2 = Port(
+            node=subgraph_node_2,
+            key="custom",
+            display_name="Second Input",
+            direction=PortDirection.INPUT,
+            ref_port=child_input,
+        )
+        port2.save()
+
+        assert port1.ref_port_id == child_input.id
+        assert port2.ref_port_id == child_input.id
+        assert port1.display_name != port2.display_name
+
+    def test_ref_port_set_null_on_delete(
+        self, db, subgraph_node, active_referenced_graph_version, node_template
+    ):
+        """When the referenced port is hard-deleted, ref_port is set to NULL."""
+        child_node = Node.no_workspace_objects.create(
+            graph_version=active_referenced_graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Child Node",
+            config={},
+        )
+        child_port = Port.no_workspace_objects.create(
+            node=child_node,
+            key="input1",
+            display_name="input1",
+            direction=PortDirection.INPUT,
+        )
+
+        subgraph_port = Port(
+            node=subgraph_node,
+            key="custom",
+            display_name="My Input",
+            direction=PortDirection.INPUT,
+            ref_port=child_port,
+        )
+        subgraph_port.save()
+
+        # Hard delete the child port
+        Port.all_objects.filter(id=child_port.id).delete()
+
+        subgraph_port.refresh_from_db()
+        assert subgraph_port.ref_port_id is None
+
+
+@pytest.mark.unit
+class TestPortDisplayNameCharValidation:
+    """Tests for _validate_display_name_chars — reserved characters in output port names."""
+
+    @pytest.mark.parametrize("char", [".", "[", "]", "{", "}"])
+    def test_rejects_reserved_char_in_output_display_name(self, db, dynamic_node, char):
+        port = Port(
+            node=dynamic_node,
+            key="custom",
+            display_name=f"bad{char}name",
+            direction=PortDirection.OUTPUT,
+        )
+        with pytest.raises(ValidationError, match="reserved characters"):
+            port.clean()
+
+    def test_allows_reserved_char_in_input_display_name(self, db, dynamic_node):
+        """Input ports are allowed to have dot-notation display_names."""
+        port = Port(
+            node=dynamic_node,
+            key="custom",
+            display_name="Node1.response.data",
+            direction=PortDirection.INPUT,
+        )
+        port.clean()  # should not raise
+
+    def test_allows_clean_output_display_name(self, db, dynamic_node):
+        port = Port(
+            node=dynamic_node,
+            key="custom",
+            display_name="good_name",
+            direction=PortDirection.OUTPUT,
+        )
+        port.clean()  # should not raise

--- a/futureagi/agent_playground/tests/models/test_prompt_template_node.py
+++ b/futureagi/agent_playground/tests/models/test_prompt_template_node.py
@@ -1,0 +1,121 @@
+"""Tests for PromptTemplateNode model."""
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+
+from agent_playground.models.choices import NodeType
+from agent_playground.models.node import Node
+from agent_playground.models.prompt_template_node import PromptTemplateNode
+
+
+@pytest.mark.unit
+class TestPromptTemplateNodeModel:
+    """Tests for the PromptTemplateNode model."""
+
+    def test_create_prompt_template_node(
+        self, prompt_template_node, node, prompt_template, prompt_version
+    ):
+        """Creating a PromptTemplateNode links node, template, and version."""
+        assert prompt_template_node.node_id == node.id
+        assert prompt_template_node.prompt_template_id == prompt_template.id
+        assert prompt_template_node.prompt_version_id == prompt_version.id
+
+    def test_str_representation(
+        self, prompt_template_node, node, prompt_template, prompt_version
+    ):
+        """__str__ includes node, template, and version UUIDs."""
+        expected = (
+            f"PromptTemplateNode(node={node.id}, "
+            f"template={prompt_template.id}, "
+            f"version={prompt_version.id})"
+        )
+        assert str(prompt_template_node) == expected
+
+    def test_unique_node_constraint(
+        self, prompt_template_node, node, prompt_template, prompt_version
+    ):
+        """Cannot create two PromptTemplateNode rows for the same Node."""
+        with pytest.raises(IntegrityError):
+            PromptTemplateNode.no_workspace_objects.create(
+                node=node,
+                prompt_template=prompt_template,
+                prompt_version=prompt_version,
+            )
+
+    def test_reverse_accessor_from_node(self, prompt_template_node, node):
+        """Node has a prompt_template_node reverse accessor."""
+        assert node.prompt_template_node == prompt_template_node
+
+    def test_multiple_nodes_same_template(
+        self,
+        prompt_template_node,
+        second_node,
+        prompt_template,
+        prompt_version,
+    ):
+        """Two different nodes can reference the same PromptTemplate/PromptVersion."""
+        ptn2 = PromptTemplateNode.no_workspace_objects.create(
+            node=second_node,
+            prompt_template=prompt_template,
+            prompt_version=prompt_version,
+        )
+        assert ptn2.prompt_template_id == prompt_template.id
+        assert ptn2.prompt_version_id == prompt_version.id
+
+    def test_version_must_belong_to_template(
+        self, node, prompt_template, other_prompt_version
+    ):
+        """Creating with a version from a different template raises ValidationError."""
+        with pytest.raises(ValidationError):
+            PromptTemplateNode.no_workspace_objects.create(
+                node=node,
+                prompt_template=prompt_template,
+                prompt_version=other_prompt_version,
+            )
+
+    def test_cascade_delete_node(self, prompt_template_node, node):
+        """Hard-deleting the node cascades and deletes the bridge row."""
+        ptn_id = prompt_template_node.id
+        Node.no_workspace_objects.filter(
+            id=node.id
+        ).delete()  # hard delete via queryset
+        assert not PromptTemplateNode.no_workspace_objects.filter(id=ptn_id).exists()
+
+    def test_cascade_soft_delete_prompt_template(
+        self, prompt_template_node, prompt_template, node
+    ):
+        """Soft-deleting a PromptTemplate cascades to linked nodes."""
+        # Soft delete the template
+        prompt_template.deleted = True
+        prompt_template.save()
+
+        # Reload node - should be soft-deleted
+        node.refresh_from_db()
+        assert node.deleted is True
+
+        # PTN should also be soft-deleted
+        prompt_template_node.refresh_from_db()
+        assert prompt_template_node.deleted is True
+
+    def test_cascade_soft_delete_prompt_version(
+        self, prompt_template_node, prompt_version, node
+    ):
+        """Soft-deleting a PromptVersion cascades to linked nodes."""
+        # Soft delete the version
+        prompt_version.deleted = True
+        prompt_version.save()
+
+        # Reload node - should be soft-deleted
+        node.refresh_from_db()
+        assert node.deleted is True
+
+        # PTN should also be soft-deleted
+        prompt_template_node.refresh_from_db()
+        assert prompt_template_node.deleted is True
+
+    def test_soft_delete_hides_from_queryset(self, prompt_template_node):
+        """Soft-deleted PromptTemplateNode is hidden by no_workspace_objects."""
+        ptn_id = prompt_template_node.id
+        prompt_template_node.delete()  # soft-delete
+        assert not PromptTemplateNode.no_workspace_objects.filter(id=ptn_id).exists()

--- a/futureagi/agentcc-gateway/internal/models/assistants.go
+++ b/futureagi/agentcc-gateway/internal/models/assistants.go
@@ -1,0 +1,179 @@
+package models
+
+import "encoding/json"
+
+// AssistantsRunUsage holds usage data extracted from run completion responses.
+type AssistantsRunUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// ExtractModelFromBody parses a JSON body just enough to extract the "model" field.
+// Returns empty string if no model field is present or on parse error.
+func ExtractModelFromBody(body []byte) string {
+	var m struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return ""
+	}
+	return m.Model
+}
+
+// ReplaceModelInBody replaces the "model" field in a JSON body with a new value.
+// Returns the original body unchanged if there is no model field.
+func ReplaceModelInBody(body []byte, newModel string) ([]byte, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+	if _, ok := raw["model"]; !ok {
+		return body, nil
+	}
+	modelJSON, err := json.Marshal(newModel)
+	if err != nil {
+		return nil, err
+	}
+	raw["model"] = modelJSON
+	return json.Marshal(raw)
+}
+
+// ExtractStreamFromBody parses the "stream" field from a JSON body.
+// Returns false if not present or on parse error.
+func ExtractStreamFromBody(body []byte) bool {
+	var m struct {
+		Stream bool `json:"stream"`
+	}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return false
+	}
+	return m.Stream
+}
+
+// ExtractRunUsage parses the "usage" object from a run response body.
+// Returns nil if no usage field is present or run is not completed.
+func ExtractRunUsage(body []byte) *AssistantsRunUsage {
+	var m struct {
+		Usage *AssistantsRunUsage `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil
+	}
+	return m.Usage
+}
+
+// ExtractMessageContent extracts text content from a Create Message request body.
+// Content can be a string or an array of content parts.
+func ExtractMessageContent(body []byte) string {
+	var m struct {
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(body, &m); err != nil || m.Content == nil {
+		return ""
+	}
+	return extractContentFromRaw(m.Content)
+}
+
+// ExtractThreadMessagesContent extracts text from initial messages in a Create Thread request.
+func ExtractThreadMessagesContent(body []byte) string {
+	var m struct {
+		Messages []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return ""
+	}
+	var result string
+	for _, msg := range m.Messages {
+		if msg.Content != nil {
+			if text := extractContentFromRaw(msg.Content); text != "" {
+				if result != "" {
+					result += "\n"
+				}
+				result += text
+			}
+		}
+	}
+	return result
+}
+
+// ExtractRunAdditionalMessagesContent extracts text from additional_messages in a Create Run request.
+func ExtractRunAdditionalMessagesContent(body []byte) string {
+	var m struct {
+		AdditionalMessages []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"additional_messages"`
+	}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return ""
+	}
+	var result string
+	for _, msg := range m.AdditionalMessages {
+		if msg.Content != nil {
+			if text := extractContentFromRaw(msg.Content); text != "" {
+				if result != "" {
+					result += "\n"
+				}
+				result += text
+			}
+		}
+	}
+	return result
+}
+
+// ExtractThreadAndRunMessagesContent extracts text from thread.messages in a Create Thread-and-Run request.
+func ExtractThreadAndRunMessagesContent(body []byte) string {
+	var m struct {
+		Thread struct {
+			Messages []struct {
+				Content json.RawMessage `json:"content"`
+			} `json:"messages"`
+		} `json:"thread"`
+	}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return ""
+	}
+	var result string
+	for _, msg := range m.Thread.Messages {
+		if msg.Content != nil {
+			if text := extractContentFromRaw(msg.Content); text != "" {
+				if result != "" {
+					result += "\n"
+				}
+				result += text
+			}
+		}
+	}
+	return result
+}
+
+// extractContentFromRaw handles content that can be a string or array of content parts.
+func extractContentFromRaw(raw json.RawMessage) string {
+	// Try as string first.
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+
+	// Try as array of content parts.
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		var result string
+		for _, p := range parts {
+			if p.Type == "text" && p.Text != "" {
+				if result != "" {
+					result += "\n"
+				}
+				result += p.Text
+			}
+		}
+		return result
+	}
+
+	return ""
+}

--- a/futureagi/agentcc-gateway/internal/models/assistants_test.go
+++ b/futureagi/agentcc-gateway/internal/models/assistants_test.go
@@ -1,0 +1,273 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractModelFromBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"valid model", `{"model":"gpt-4o","instructions":"help"}`, "gpt-4o"},
+		{"missing model", `{"instructions":"help"}`, ""},
+		{"empty body", `{}`, ""},
+		{"malformed json", `{invalid`, ""},
+		{"empty string", ``, ""},
+		{"model with prefix", `{"model":"openai/gpt-4o"}`, "openai/gpt-4o"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractModelFromBody([]byte(tt.body))
+			if got != tt.want {
+				t.Errorf("ExtractModelFromBody() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReplaceModelInBody(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		newModel string
+		wantErr  bool
+		check    func(t *testing.T, result []byte)
+	}{
+		{
+			name:     "replace existing model",
+			body:     `{"model":"openai/gpt-4o","instructions":"help"}`,
+			newModel: "gpt-4o",
+			check: func(t *testing.T, result []byte) {
+				got := ExtractModelFromBody(result)
+				if got != "gpt-4o" {
+					t.Errorf("model = %q, want %q", got, "gpt-4o")
+				}
+			},
+		},
+		{
+			name:     "body without model unchanged",
+			body:     `{"instructions":"help"}`,
+			newModel: "gpt-4o",
+			check: func(t *testing.T, result []byte) {
+				got := ExtractModelFromBody(result)
+				if got != "" {
+					t.Errorf("model = %q, want empty", got)
+				}
+			},
+		},
+		{
+			name:     "preserves other fields",
+			body:     `{"model":"old","name":"test","instructions":"help"}`,
+			newModel: "new",
+			check: func(t *testing.T, result []byte) {
+				got := ExtractModelFromBody(result)
+				if got != "new" {
+					t.Errorf("model = %q, want %q", got, "new")
+				}
+				// Check instructions are preserved.
+				var m struct{ Instructions string `json:"instructions"` }
+				if err := jsonUnmarshal(result, &m); err == nil && m.Instructions != "help" {
+					t.Errorf("instructions not preserved")
+				}
+			},
+		},
+		{
+			name:    "malformed json",
+			body:    `{invalid`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ReplaceModelInBody([]byte(tt.body), tt.newModel)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.check != nil && err == nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+func TestExtractStreamFromBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"stream true", `{"stream":true}`, true},
+		{"stream false", `{"stream":false}`, false},
+		{"missing stream", `{"model":"gpt-4o"}`, false},
+		{"malformed json", `{invalid`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractStreamFromBody([]byte(tt.body))
+			if got != tt.want {
+				t.Errorf("ExtractStreamFromBody() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractRunUsage(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want *AssistantsRunUsage
+	}{
+		{
+			name: "valid usage",
+			body: `{"id":"run_123","status":"completed","usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150}}`,
+			want: &AssistantsRunUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+		},
+		{
+			name: "missing usage",
+			body: `{"id":"run_123","status":"in_progress"}`,
+			want: nil,
+		},
+		{
+			name: "null usage",
+			body: `{"id":"run_123","usage":null}`,
+			want: nil,
+		},
+		{
+			name: "malformed json",
+			body: `{invalid`,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractRunUsage([]byte(tt.body))
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("ExtractRunUsage() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("ExtractRunUsage() = nil, want non-nil")
+			}
+			if got.PromptTokens != tt.want.PromptTokens || got.CompletionTokens != tt.want.CompletionTokens || got.TotalTokens != tt.want.TotalTokens {
+				t.Errorf("ExtractRunUsage() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractMessageContent(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"string content", `{"role":"user","content":"hello world"}`, "hello world"},
+		{
+			"array content with text",
+			`{"role":"user","content":[{"type":"text","text":"hello"},{"type":"text","text":"world"}]}`,
+			"hello\nworld",
+		},
+		{
+			"mixed content types",
+			`{"role":"user","content":[{"type":"text","text":"hello"},{"type":"image_url","image_url":{"url":"http://x"}}]}`,
+			"hello",
+		},
+		{"empty content", `{"role":"user"}`, ""},
+		{"malformed json", `{invalid`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractMessageContent([]byte(tt.body))
+			if got != tt.want {
+				t.Errorf("ExtractMessageContent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractThreadMessagesContent(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"multiple messages",
+			`{"messages":[{"role":"user","content":"msg1"},{"role":"user","content":"msg2"}]}`,
+			"msg1\nmsg2",
+		},
+		{"no messages", `{}`, ""},
+		{"empty messages", `{"messages":[]}`, ""},
+		{
+			"mixed content types",
+			`{"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]},{"role":"user","content":"world"}]}`,
+			"hello\nworld",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractThreadMessagesContent([]byte(tt.body))
+			if got != tt.want {
+				t.Errorf("ExtractThreadMessagesContent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractRunAdditionalMessagesContent(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"with additional messages",
+			`{"model":"gpt-4o","additional_messages":[{"role":"user","content":"extra"}]}`,
+			"extra",
+		},
+		{"without additional messages", `{"model":"gpt-4o"}`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractRunAdditionalMessagesContent([]byte(tt.body))
+			if got != tt.want {
+				t.Errorf("ExtractRunAdditionalMessagesContent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractThreadAndRunMessagesContent(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"nested thread messages",
+			`{"model":"gpt-4o","thread":{"messages":[{"role":"user","content":"hello from thread"}]}}`,
+			"hello from thread",
+		},
+		{"no thread", `{"model":"gpt-4o"}`, ""},
+		{"empty thread messages", `{"model":"gpt-4o","thread":{"messages":[]}}`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractThreadAndRunMessagesContent([]byte(tt.body))
+			if got != tt.want {
+				t.Errorf("ExtractThreadAndRunMessagesContent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// jsonUnmarshal is a test helper using the standard library.
+func jsonUnmarshal(data []byte, v interface{}) error {
+	return json.Unmarshal(data, v)
+}

--- a/futureagi/agentcc-gateway/internal/models/audio.go
+++ b/futureagi/agentcc-gateway/internal/models/audio.go
@@ -1,0 +1,49 @@
+package models
+
+// SpeechRequest represents an OpenAI-compatible text-to-speech request.
+type SpeechRequest struct {
+	Model          string   `json:"model"`
+	Input          string   `json:"input"`
+	Voice          string   `json:"voice"`                    // "alloy"|"echo"|"fable"|"onyx"|"nova"|"shimmer"
+	ResponseFormat string   `json:"response_format,omitempty"` // "mp3"|"opus"|"aac"|"flac"|"wav"|"pcm"
+	Speed          *float64 `json:"speed,omitempty"`           // 0.25 to 4.0
+}
+
+// TranscriptionRequest represents an OpenAI-compatible audio transcription request.
+type TranscriptionRequest struct {
+	Model          string   `json:"model"`
+	FileData       []byte   `json:"-"`                         // Audio file bytes (from multipart)
+	FileName       string   `json:"-"`                         // Original filename
+	Language       string   `json:"language,omitempty"`        // ISO-639-1
+	ResponseFormat string   `json:"response_format,omitempty"` // "json"|"text"|"srt"|"verbose_json"|"vtt"
+	Temperature    *float64 `json:"temperature,omitempty"`
+}
+
+// TranscriptionResponse represents an OpenAI-compatible transcription response.
+type TranscriptionResponse struct {
+	Text string `json:"text"`
+}
+
+// TranslationRequest represents an OpenAI-compatible audio translation request.
+// Translates audio in any language to English text.
+type TranslationRequest struct {
+	Model          string   `json:"model"`
+	FileData       []byte   `json:"-"`                         // Audio file bytes (from multipart)
+	FileName       string   `json:"-"`                         // Original filename
+	Prompt         string   `json:"prompt,omitempty"`          // Optional text to guide translation
+	ResponseFormat string   `json:"response_format,omitempty"` // "json"|"text"|"srt"|"verbose_json"|"vtt"
+	Temperature    *float64 `json:"temperature,omitempty"`
+}
+
+// TranslationResponse represents an OpenAI-compatible translation response.
+type TranslationResponse struct {
+	Text string `json:"text"`
+}
+
+// AudioStreamChunk represents a single chunk in a streaming TTS response.
+type AudioStreamChunk struct {
+	Index       int    `json:"index"`
+	ContentType string `json:"content_type"`
+	Data        string `json:"data"` // base64-encoded audio bytes
+	Done        bool   `json:"done,omitempty"`
+}

--- a/futureagi/agentcc-gateway/internal/models/audio_test.go
+++ b/futureagi/agentcc-gateway/internal/models/audio_test.go
@@ -1,0 +1,225 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSpeechRequestMarshalRoundTrip(t *testing.T) {
+	speed := 1.5
+	req := SpeechRequest{
+		Model:          "tts-1-hd",
+		Input:          "Hello, how are you?",
+		Voice:          "alloy",
+		ResponseFormat: "opus",
+		Speed:          &speed,
+	}
+
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	for _, key := range []string{"model", "input", "voice", "response_format", "speed"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("expected key %q in marshaled JSON", key)
+		}
+	}
+}
+
+func TestSpeechRequestUnmarshal(t *testing.T) {
+	input := `{
+		"model": "tts-1",
+		"input": "Testing speech synthesis.",
+		"voice": "nova",
+		"response_format": "aac",
+		"speed": 0.75
+	}`
+
+	var req SpeechRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if req.Model != "tts-1" {
+		t.Errorf("Model = %q, want %q", req.Model, "tts-1")
+	}
+	if req.Input != "Testing speech synthesis." {
+		t.Errorf("Input = %q, want %q", req.Input, "Testing speech synthesis.")
+	}
+	if req.Voice != "nova" {
+		t.Errorf("Voice = %q, want %q", req.Voice, "nova")
+	}
+	if req.ResponseFormat != "aac" {
+		t.Errorf("ResponseFormat = %q, want %q", req.ResponseFormat, "aac")
+	}
+	if req.Speed == nil || *req.Speed != 0.75 {
+		t.Errorf("Speed = %v, want 0.75", req.Speed)
+	}
+}
+
+func TestSpeechRequestOmitEmpty(t *testing.T) {
+	req := SpeechRequest{
+		Model: "tts-1",
+		Input: "Hello",
+		Voice: "echo",
+	}
+
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	for _, key := range []string{"response_format", "speed"} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("key %q should be omitted when zero/nil", key)
+		}
+	}
+
+	// Required fields must be present.
+	for _, key := range []string{"model", "input", "voice"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("required key %q should be present", key)
+		}
+	}
+}
+
+func TestTranscriptionRequestMarshalRoundTrip(t *testing.T) {
+	temp := 0.2
+	req := TranscriptionRequest{
+		Model:          "whisper-1",
+		FileData:       []byte("fake-audio-data"),
+		FileName:       "recording.mp3",
+		Language:       "en",
+		ResponseFormat: "verbose_json",
+		Temperature:    &temp,
+	}
+
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	// FileData and FileName are json:"-", so they must NOT appear.
+	for _, key := range []string{"FileData", "file_data", "FileName", "file_name"} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("key %q should not be in marshaled JSON (tagged with json:\"-\")", key)
+		}
+	}
+
+	// JSON-serializable fields must be present.
+	for _, key := range []string{"model", "language", "response_format", "temperature"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("expected key %q in marshaled JSON", key)
+		}
+	}
+}
+
+func TestTranscriptionRequestUnmarshal(t *testing.T) {
+	input := `{
+		"model": "whisper-1",
+		"language": "fr",
+		"response_format": "srt",
+		"temperature": 0.3
+	}`
+
+	var req TranscriptionRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if req.Model != "whisper-1" {
+		t.Errorf("Model = %q, want %q", req.Model, "whisper-1")
+	}
+	if req.Language != "fr" {
+		t.Errorf("Language = %q, want %q", req.Language, "fr")
+	}
+	if req.ResponseFormat != "srt" {
+		t.Errorf("ResponseFormat = %q, want %q", req.ResponseFormat, "srt")
+	}
+	if req.Temperature == nil || *req.Temperature != 0.3 {
+		t.Errorf("Temperature = %v, want 0.3", req.Temperature)
+	}
+
+	// FileData and FileName should remain zero since they are not JSON-populated.
+	if len(req.FileData) != 0 {
+		t.Errorf("FileData should be empty, got %v", req.FileData)
+	}
+	if req.FileName != "" {
+		t.Errorf("FileName should be empty, got %q", req.FileName)
+	}
+}
+
+func TestTranscriptionRequestOmitEmpty(t *testing.T) {
+	req := TranscriptionRequest{
+		Model: "whisper-1",
+	}
+
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	for _, key := range []string{"language", "response_format", "temperature"} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("key %q should be omitted when zero/nil", key)
+		}
+	}
+
+	if _, ok := raw["model"]; !ok {
+		t.Error("required key \"model\" should be present")
+	}
+}
+
+func TestTranscriptionResponseMarshalRoundTrip(t *testing.T) {
+	resp := TranscriptionResponse{
+		Text: "Hello, this is a test transcription.",
+	}
+
+	data, err := json.Marshal(&resp)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var got TranscriptionResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if got.Text != "Hello, this is a test transcription." {
+		t.Errorf("Text = %q, want %q", got.Text, "Hello, this is a test transcription.")
+	}
+}
+
+func TestTranscriptionResponseUnmarshal(t *testing.T) {
+	input := `{"text": "The quick brown fox jumps over the lazy dog."}`
+
+	var resp TranscriptionResponse
+	if err := json.Unmarshal([]byte(input), &resp); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if resp.Text != "The quick brown fox jumps over the lazy dog." {
+		t.Errorf("Text = %q, want %q", resp.Text, "The quick brown fox jumps over the lazy dog.")
+	}
+}

--- a/futureagi/agentcc-gateway/internal/models/batch_provider.go
+++ b/futureagi/agentcc-gateway/internal/models/batch_provider.go
@@ -1,0 +1,32 @@
+package models
+
+// BatchRequest represents a single request within a provider-level batch.
+type BatchRequest struct {
+	CustomID string                `json:"custom_id"`
+	Method   string                `json:"method"`   // POST
+	URL      string                `json:"url"`       // /v1/chat/completions
+	Body     ChatCompletionRequest `json:"body"`
+}
+
+// ProviderBatchStatus represents the unified status of a provider-level batch.
+type ProviderBatchStatus struct {
+	ID           string `json:"id"`
+	Status       string `json:"status"` // queued, processing, completed, failed, cancelled, expired
+	Total        int    `json:"total"`
+	Completed    int    `json:"completed"`
+	Failed       int    `json:"failed"`
+	OutputFileID string `json:"output_file_id,omitempty"`
+	ErrorFileID  string `json:"error_file_id,omitempty"`
+	CreatedAt    int64  `json:"created_at"`
+	CompletedAt  *int64 `json:"completed_at,omitempty"`
+}
+
+// Provider batch status constants.
+const (
+	BatchStatusQueued     = "queued"
+	BatchStatusProcessing = "processing"
+	BatchStatusCompleted  = "completed"
+	BatchStatusFailed     = "failed"
+	BatchStatusCancelled  = "cancelled"
+	BatchStatusExpired    = "expired"
+)

--- a/futureagi/agentcc-gateway/internal/models/completion.go
+++ b/futureagi/agentcc-gateway/internal/models/completion.go
@@ -1,0 +1,183 @@
+package models
+
+import "encoding/json"
+
+// CompletionRequest represents an OpenAI-compatible legacy text completion request.
+// This is the /v1/completions format (prompt-based, not message-based).
+type CompletionRequest struct {
+	Model            string          `json:"model"`
+	Prompt           json.RawMessage `json:"prompt"`
+	MaxTokens        *int            `json:"max_tokens,omitempty"`
+	Temperature      *float64        `json:"temperature,omitempty"`
+	TopP             *float64        `json:"top_p,omitempty"`
+	N                *int            `json:"n,omitempty"`
+	Stream           bool            `json:"stream,omitempty"`
+	StreamOptions    *StreamOptions  `json:"stream_options,omitempty"`
+	Stop             json.RawMessage `json:"stop,omitempty"`
+	PresencePenalty  *float64        `json:"presence_penalty,omitempty"`
+	FrequencyPenalty *float64        `json:"frequency_penalty,omitempty"`
+	LogitBias        map[string]int  `json:"logit_bias,omitempty"`
+	Logprobs         *int            `json:"logprobs,omitempty"`
+	Echo             bool            `json:"echo,omitempty"`
+	Suffix           string          `json:"suffix,omitempty"`
+	BestOf           *int            `json:"best_of,omitempty"`
+	User             string          `json:"user,omitempty"`
+	Seed             *int            `json:"seed,omitempty"`
+}
+
+// PromptString extracts the prompt as a single string.
+// Handles both string and string array formats.
+func (r *CompletionRequest) PromptString() string {
+	if r.Prompt == nil {
+		return ""
+	}
+
+	// Try string first.
+	var s string
+	if err := json.Unmarshal(r.Prompt, &s); err == nil {
+		return s
+	}
+
+	// Try string array — join with newlines.
+	var arr []string
+	if err := json.Unmarshal(r.Prompt, &arr); err == nil {
+		result := ""
+		for i, p := range arr {
+			if i > 0 {
+				result += "\n"
+			}
+			result += p
+		}
+		return result
+	}
+
+	return string(r.Prompt)
+}
+
+// ToChatRequest converts a legacy completion request to a chat completion request.
+// The prompt is wrapped into a single user message.
+func (r *CompletionRequest) ToChatRequest() *ChatCompletionRequest {
+	promptStr := r.PromptString()
+	content, _ := json.Marshal(promptStr)
+
+	chatReq := &ChatCompletionRequest{
+		Model: r.Model,
+		Messages: []Message{
+			{
+				Role:    "user",
+				Content: content,
+			},
+		},
+		Temperature:      r.Temperature,
+		TopP:             r.TopP,
+		N:                r.N,
+		Stream:           r.Stream,
+		StreamOptions:    r.StreamOptions,
+		Stop:             r.Stop,
+		MaxTokens:        r.MaxTokens,
+		PresencePenalty:   r.PresencePenalty,
+		FrequencyPenalty:  r.FrequencyPenalty,
+		LogitBias:        r.LogitBias,
+		User:             r.User,
+		Seed:             r.Seed,
+	}
+
+	return chatReq
+}
+
+// CompletionResponse represents an OpenAI-compatible legacy text completion response.
+type CompletionResponse struct {
+	ID                string             `json:"id"`
+	Object            string             `json:"object"`
+	Created           int64              `json:"created"`
+	Model             string             `json:"model"`
+	Choices           []CompletionChoice `json:"choices"`
+	Usage             *Usage             `json:"usage,omitempty"`
+	SystemFingerprint string             `json:"system_fingerprint,omitempty"`
+}
+
+// CompletionChoice represents a single completion choice.
+type CompletionChoice struct {
+	Index        int              `json:"index"`
+	Text         string           `json:"text"`
+	FinishReason string           `json:"finish_reason"`
+	Logprobs     *json.RawMessage `json:"logprobs"`
+}
+
+// CompletionResponseFromChat converts a chat completion response to the legacy format.
+func CompletionResponseFromChat(chatResp *ChatCompletionResponse) *CompletionResponse {
+	choices := make([]CompletionChoice, len(chatResp.Choices))
+	for i, c := range chatResp.Choices {
+		// Extract text content from the message.
+		text := ""
+		if c.Message.Content != nil {
+			var s string
+			if err := json.Unmarshal(c.Message.Content, &s); err == nil {
+				text = s
+			} else {
+				text = string(c.Message.Content)
+			}
+		}
+
+		choices[i] = CompletionChoice{
+			Index:        c.Index,
+			Text:         text,
+			FinishReason: c.FinishReason,
+			Logprobs:     c.Logprobs,
+		}
+	}
+
+	return &CompletionResponse{
+		ID:                chatResp.ID,
+		Object:            "text_completion",
+		Created:           chatResp.Created,
+		Model:             chatResp.Model,
+		Choices:           choices,
+		Usage:             chatResp.Usage,
+		SystemFingerprint: chatResp.SystemFingerprint,
+	}
+}
+
+// CompletionStreamChunk represents a streaming chunk for the legacy completions format.
+type CompletionStreamChunk struct {
+	ID                string                   `json:"id"`
+	Object            string                   `json:"object"`
+	Created           int64                    `json:"created"`
+	Model             string                   `json:"model"`
+	Choices           []CompletionStreamChoice `json:"choices"`
+	Usage             *Usage                   `json:"usage,omitempty"`
+	SystemFingerprint string                   `json:"system_fingerprint,omitempty"`
+}
+
+// CompletionStreamChoice represents a streaming choice in the legacy format.
+type CompletionStreamChoice struct {
+	Index        int     `json:"index"`
+	Text         string  `json:"text"`
+	FinishReason *string `json:"finish_reason"`
+}
+
+// CompletionStreamChunkFromChat converts a chat stream chunk to the legacy format.
+func CompletionStreamChunkFromChat(chunk StreamChunk) CompletionStreamChunk {
+	choices := make([]CompletionStreamChoice, len(chunk.Choices))
+	for i, c := range chunk.Choices {
+		text := ""
+		if c.Delta.Content != nil {
+			text = *c.Delta.Content
+		}
+		choices[i] = CompletionStreamChoice{
+			Index:        c.Index,
+			Text:         text,
+			FinishReason: c.FinishReason,
+		}
+	}
+
+	return CompletionStreamChunk{
+		ID:                chunk.ID,
+		Object:            "text_completion",
+		Created:           chunk.Created,
+		Model:             chunk.Model,
+		Choices:           choices,
+		Usage:             chunk.Usage,
+		SystemFingerprint: chunk.SystemFingerprint,
+	}
+}

--- a/futureagi/agentcc-gateway/internal/models/completion_test.go
+++ b/futureagi/agentcc-gateway/internal/models/completion_test.go
@@ -1,0 +1,201 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCompletionRequest_PromptString(t *testing.T) {
+	tests := []struct {
+		name     string
+		prompt   string // raw JSON
+		expected string
+	}{
+		{
+			name:     "string prompt",
+			prompt:   `"Hello, world!"`,
+			expected: "Hello, world!",
+		},
+		{
+			name:     "string array prompt",
+			prompt:   `["Hello", "World"]`,
+			expected: "Hello\nWorld",
+		},
+		{
+			name:     "single element array",
+			prompt:   `["Just one"]`,
+			expected: "Just one",
+		},
+		{
+			name:     "empty string",
+			prompt:   `""`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &CompletionRequest{
+				Prompt: json.RawMessage(tt.prompt),
+			}
+			got := req.PromptString()
+			if got != tt.expected {
+				t.Errorf("PromptString() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCompletionRequest_PromptString_Nil(t *testing.T) {
+	req := &CompletionRequest{}
+	if got := req.PromptString(); got != "" {
+		t.Errorf("PromptString() with nil prompt = %q, want empty", got)
+	}
+}
+
+func TestCompletionRequest_ToChatRequest(t *testing.T) {
+	temp := 0.7
+	maxTok := 100
+	req := &CompletionRequest{
+		Model:       "gpt-3.5-turbo-instruct",
+		Prompt:      json.RawMessage(`"Say hello"`),
+		Temperature: &temp,
+		MaxTokens:   &maxTok,
+		User:        "user-123",
+	}
+
+	chatReq := req.ToChatRequest()
+
+	if chatReq.Model != "gpt-3.5-turbo-instruct" {
+		t.Errorf("Model = %q, want %q", chatReq.Model, "gpt-3.5-turbo-instruct")
+	}
+	if len(chatReq.Messages) != 1 {
+		t.Fatalf("Messages length = %d, want 1", len(chatReq.Messages))
+	}
+	if chatReq.Messages[0].Role != "user" {
+		t.Errorf("Message role = %q, want %q", chatReq.Messages[0].Role, "user")
+	}
+
+	var content string
+	if err := json.Unmarshal(chatReq.Messages[0].Content, &content); err != nil {
+		t.Fatalf("failed to unmarshal message content: %v", err)
+	}
+	if content != "Say hello" {
+		t.Errorf("Message content = %q, want %q", content, "Say hello")
+	}
+
+	if chatReq.Temperature == nil || *chatReq.Temperature != 0.7 {
+		t.Error("Temperature not propagated correctly")
+	}
+	if chatReq.MaxTokens == nil || *chatReq.MaxTokens != 100 {
+		t.Error("MaxTokens not propagated correctly")
+	}
+	if chatReq.User != "user-123" {
+		t.Errorf("User = %q, want %q", chatReq.User, "user-123")
+	}
+}
+
+func TestCompletionResponseFromChat(t *testing.T) {
+	content, _ := json.Marshal("Hello there!")
+	chatResp := &ChatCompletionResponse{
+		ID:      "chatcmpl-123",
+		Object:  "chat.completion",
+		Created: 1700000000,
+		Model:   "gpt-3.5-turbo",
+		Choices: []Choice{
+			{
+				Index:        0,
+				Message:      Message{Role: "assistant", Content: content},
+				FinishReason: "stop",
+			},
+		},
+		Usage: &Usage{
+			PromptTokens:     5,
+			CompletionTokens: 3,
+			TotalTokens:      8,
+		},
+	}
+
+	resp := CompletionResponseFromChat(chatResp)
+
+	if resp.Object != "text_completion" {
+		t.Errorf("Object = %q, want %q", resp.Object, "text_completion")
+	}
+	if resp.ID != "chatcmpl-123" {
+		t.Errorf("ID = %q, want %q", resp.ID, "chatcmpl-123")
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("Choices length = %d, want 1", len(resp.Choices))
+	}
+	if resp.Choices[0].Text != "Hello there!" {
+		t.Errorf("Text = %q, want %q", resp.Choices[0].Text, "Hello there!")
+	}
+	if resp.Choices[0].FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want %q", resp.Choices[0].FinishReason, "stop")
+	}
+	if resp.Usage == nil || resp.Usage.TotalTokens != 8 {
+		t.Error("Usage not propagated correctly")
+	}
+}
+
+func TestCompletionStreamChunkFromChat(t *testing.T) {
+	content := "Hi"
+	finish := "stop"
+	chunk := StreamChunk{
+		ID:      "chatcmpl-456",
+		Object:  "chat.completion.chunk",
+		Created: 1700000001,
+		Model:   "gpt-3.5-turbo",
+		Choices: []StreamChoice{
+			{
+				Index: 0,
+				Delta: Delta{Content: &content},
+			},
+			{
+				Index:        1,
+				Delta:        Delta{},
+				FinishReason: &finish,
+			},
+		},
+	}
+
+	completionChunk := CompletionStreamChunkFromChat(chunk)
+
+	if completionChunk.Object != "text_completion" {
+		t.Errorf("Object = %q, want %q", completionChunk.Object, "text_completion")
+	}
+	if len(completionChunk.Choices) != 2 {
+		t.Fatalf("Choices length = %d, want 2", len(completionChunk.Choices))
+	}
+	if completionChunk.Choices[0].Text != "Hi" {
+		t.Errorf("Choices[0].Text = %q, want %q", completionChunk.Choices[0].Text, "Hi")
+	}
+	if completionChunk.Choices[1].Text != "" {
+		t.Errorf("Choices[1].Text = %q, want empty", completionChunk.Choices[1].Text)
+	}
+	if completionChunk.Choices[1].FinishReason == nil || *completionChunk.Choices[1].FinishReason != "stop" {
+		t.Error("FinishReason not propagated for choice 1")
+	}
+}
+
+func TestCompletionRequest_JSON_RoundTrip(t *testing.T) {
+	input := `{"model":"gpt-3.5-turbo-instruct","prompt":"Hello","max_tokens":50,"temperature":0.5,"stream":false}`
+
+	var req CompletionRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if req.Model != "gpt-3.5-turbo-instruct" {
+		t.Errorf("Model = %q", req.Model)
+	}
+	if req.PromptString() != "Hello" {
+		t.Errorf("PromptString() = %q", req.PromptString())
+	}
+	if req.MaxTokens == nil || *req.MaxTokens != 50 {
+		t.Error("MaxTokens not parsed")
+	}
+	if req.Stream {
+		t.Error("Stream should be false")
+	}
+}

--- a/futureagi/agentcc-gateway/internal/models/context.go
+++ b/futureagi/agentcc-gateway/internal/models/context.go
@@ -1,0 +1,266 @@
+package models
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// GuardrailResult captures a single guardrail check that was triggered.
+// Stored on RequestContext by the guardrails plugin for downstream logging.
+type GuardrailResult struct {
+	Name      string  `json:"name"`
+	Score     float64 `json:"score"`
+	Threshold float64 `json:"threshold"`
+	Action    string  `json:"action"` // "block", "warn", or "log"
+	Message   string  `json:"message"`
+}
+
+// TraceSnapshot is an immutable copy of RequestContext fields needed by
+// async operations (logging, mirroring) after the handler returns.
+// This avoids races when the original RequestContext is released to the pool.
+type TraceSnapshot struct {
+	RequestID        string
+	TraceID          string
+	StartTime        time.Time
+	Model            string
+	ResolvedModel    string
+	Provider         string
+	Request          *ChatCompletionRequest
+	Response         *ChatCompletionResponse
+	IsStream         bool
+	Metadata         map[string]string
+	SessionID        string
+	UserID           string
+	Flags            RequestFlags
+	Timings          map[string]time.Duration
+	Errors           []error
+	GuardrailResults []GuardrailResult
+	RequestHeaders   http.Header
+}
+
+// RequestContext carries request state through the plugin pipeline.
+// Allocated from a sync.Pool and returned after the request completes.
+type RequestContext struct {
+	RequestID     string
+	TraceID       string
+	StartTime     time.Time
+	Model         string
+	ResolvedModel string
+	Provider      string
+	Request       *ChatCompletionRequest
+	Response      *ChatCompletionResponse
+	IsStream      bool
+	Metadata      map[string]string
+	SessionID     string
+	UserID        string
+	Flags         RequestFlags
+	Timings       map[string]time.Duration
+	Errors        []error
+
+	// mu protects Timings and Metadata during parallel post-plugin execution.
+	mu sync.Mutex
+
+	// RequestHeaders stores the original HTTP request headers for logging.
+	RequestHeaders http.Header
+
+	// EndpointType identifies the API endpoint: "chat", "embedding", "image",
+	// "speech", "transcription", or "rerank". Defaults to "chat".
+	EndpointType string
+
+	// Guardrail results — populated by the guardrails plugin with triggered checks.
+	GuardrailResults []GuardrailResult
+
+	// Multimodal request/response pairs — only one pair is set per request.
+	EmbeddingRequest  *EmbeddingRequest
+	EmbeddingResponse *EmbeddingResponse
+	ImageRequest      *ImageRequest
+	ImageResponse     *ImageResponse
+	SpeechRequest     *SpeechRequest
+	TranscriptionReq  *TranscriptionRequest
+	TranscriptionResp *TranscriptionResponse
+	RerankRequest     *RerankRequest
+	RerankResponse    *RerankResponse
+	TranslationReq    *TranslationRequest
+	TranslationResp   *TranslationResponse
+	SearchRequest     *SearchRequest
+	SearchResponse    *SearchResponse
+	OCRRequest        *OCRRequest
+	OCRResponse       *OCRResponse
+
+	// Per-org model map: model name → provider ID override.
+	OrgModelMap map[string]string
+
+	// Per-org model fallback chains: model → ordered fallback models.
+	OrgModelFallbacks map[string][]string
+}
+
+type RequestFlags struct {
+	CacheHit           bool
+	GuardrailTriggered bool
+	FallbackUsed       bool
+	Timeout            bool
+	ShortCircuited     bool
+}
+
+var requestContextPool = sync.Pool{
+	New: func() any {
+		return &RequestContext{
+			Metadata: make(map[string]string, 8),
+			Timings:  make(map[string]time.Duration, 8),
+			Errors:   make([]error, 0, 4),
+		}
+	},
+}
+
+// AcquireRequestContext gets a RequestContext from the pool.
+func AcquireRequestContext() *RequestContext {
+	rc := requestContextPool.Get().(*RequestContext)
+	rc.StartTime = time.Now()
+	rc.EndpointType = "chat"
+	return rc
+}
+
+// Release returns the RequestContext to the pool after resetting it.
+func (rc *RequestContext) Release() {
+	rc.RequestID = ""
+	rc.TraceID = ""
+	rc.StartTime = time.Time{}
+	rc.Model = ""
+	rc.ResolvedModel = ""
+	rc.Provider = ""
+	rc.Request = nil
+	rc.Response = nil
+	rc.IsStream = false
+	rc.SessionID = ""
+	rc.UserID = ""
+	rc.Flags = RequestFlags{}
+	rc.EndpointType = ""
+	rc.EmbeddingRequest = nil
+	rc.EmbeddingResponse = nil
+	rc.ImageRequest = nil
+	rc.ImageResponse = nil
+	rc.SpeechRequest = nil
+	rc.TranscriptionReq = nil
+	rc.TranscriptionResp = nil
+	rc.RerankRequest = nil
+	rc.RerankResponse = nil
+	rc.TranslationReq = nil
+	rc.TranslationResp = nil
+	rc.SearchRequest = nil
+	rc.SearchResponse = nil
+	rc.OCRRequest = nil
+	rc.OCRResponse = nil
+	rc.OrgModelMap = nil
+	rc.OrgModelFallbacks = nil
+	rc.GuardrailResults = rc.GuardrailResults[:0]
+	rc.RequestHeaders = nil
+
+	// Reuse maps by clearing them (keeps allocated memory).
+	for k := range rc.Metadata {
+		delete(rc.Metadata, k)
+	}
+	for k := range rc.Timings {
+		delete(rc.Timings, k)
+	}
+	rc.Errors = rc.Errors[:0]
+
+	requestContextPool.Put(rc)
+}
+
+// Elapsed returns the time since the request started.
+func (rc *RequestContext) Elapsed() time.Duration {
+	return time.Since(rc.StartTime)
+}
+
+// Snapshot creates an immutable copy of the RequestContext for async operations.
+// Call this before Release() when data is needed after the handler returns.
+func (rc *RequestContext) Snapshot() *TraceSnapshot {
+	meta := make(map[string]string, len(rc.Metadata))
+	for k, v := range rc.Metadata {
+		meta[k] = v
+	}
+	timings := make(map[string]time.Duration, len(rc.Timings))
+	for k, v := range rc.Timings {
+		timings[k] = v
+	}
+	errs := make([]error, len(rc.Errors))
+	copy(errs, rc.Errors)
+	grResults := make([]GuardrailResult, len(rc.GuardrailResults))
+	copy(grResults, rc.GuardrailResults)
+
+	return &TraceSnapshot{
+		RequestID:        rc.RequestID,
+		TraceID:          rc.TraceID,
+		StartTime:        rc.StartTime,
+		Model:            rc.Model,
+		ResolvedModel:    rc.ResolvedModel,
+		Provider:         rc.Provider,
+		Request:          rc.Request,
+		Response:         rc.Response,
+		IsStream:         rc.IsStream,
+		Metadata:         meta,
+		SessionID:        rc.SessionID,
+		UserID:           rc.UserID,
+		Flags:            rc.Flags,
+		Timings:          timings,
+		Errors:           errs,
+		GuardrailResults: grResults,
+		RequestHeaders:   rc.RequestHeaders.Clone(),
+	}
+}
+
+// AddError appends a non-fatal error.
+func (rc *RequestContext) AddError(err error) {
+	rc.Errors = append(rc.Errors, err)
+}
+
+// RecordTiming records a named duration. Thread-safe for parallel post-plugins.
+func (rc *RequestContext) RecordTiming(name string, d time.Duration) {
+	rc.mu.Lock()
+	rc.Timings[name] = d
+	rc.mu.Unlock()
+}
+
+// SetMetadata sets a metadata key. Thread-safe for parallel post-plugins.
+func (rc *RequestContext) SetMetadata(key, value string) {
+	rc.mu.Lock()
+	rc.Metadata[key] = value
+	rc.mu.Unlock()
+}
+
+// Context key types for storing request-scoped values.
+type contextKey int
+
+const (
+	ContextKeyRequestID contextKey = iota
+	ContextKeyTraceID
+	ContextKeyRequestContext
+)
+
+// WithRequestID stores the request ID in context.
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, ContextKeyRequestID, id)
+}
+
+// GetRequestID retrieves the request ID from context.
+func GetRequestID(ctx context.Context) string {
+	if id, ok := ctx.Value(ContextKeyRequestID).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// WithRequestContext stores the RequestContext in context.
+func WithRequestContext(ctx context.Context, rc *RequestContext) context.Context {
+	return context.WithValue(ctx, ContextKeyRequestContext, rc)
+}
+
+// GetRequestContext retrieves the RequestContext from context.
+func GetRequestContext(ctx context.Context) *RequestContext {
+	if rc, ok := ctx.Value(ContextKeyRequestContext).(*RequestContext); ok {
+		return rc
+	}
+	return nil
+}

--- a/futureagi/agentcc-gateway/internal/models/context_test.go
+++ b/futureagi/agentcc-gateway/internal/models/context_test.go
@@ -1,0 +1,104 @@
+package models
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRequestContextPool(t *testing.T) {
+	// Acquire and release multiple times to test pool reuse.
+	for i := 0; i < 100; i++ {
+		rc := AcquireRequestContext()
+		if rc == nil {
+			t.Fatal("AcquireRequestContext returned nil")
+		}
+		if rc.StartTime.IsZero() {
+			t.Error("StartTime should be set on acquire")
+		}
+
+		rc.RequestID = "test-id"
+		rc.Model = "gpt-4o"
+		rc.Metadata["key"] = "value"
+		rc.Timings["test"] = time.Millisecond
+		rc.AddError(ErrInternal("test"))
+
+		rc.Release()
+	}
+}
+
+func TestRequestContextReleaseClearsFields(t *testing.T) {
+	rc := AcquireRequestContext()
+	rc.RequestID = "test"
+	rc.Model = "gpt-4o"
+	rc.Metadata["key"] = "value"
+	rc.Timings["test"] = time.Millisecond
+	rc.AddError(ErrInternal("test"))
+	rc.Flags.CacheHit = true
+
+	rc.Release()
+
+	// Get it back from the pool.
+	rc2 := AcquireRequestContext()
+	defer rc2.Release()
+
+	if rc2.RequestID != "" {
+		t.Errorf("RequestID should be empty, got %q", rc2.RequestID)
+	}
+	if rc2.Model != "" {
+		t.Errorf("Model should be empty, got %q", rc2.Model)
+	}
+	if len(rc2.Metadata) != 0 {
+		t.Errorf("Metadata should be empty, got %v", rc2.Metadata)
+	}
+	if len(rc2.Timings) != 0 {
+		t.Errorf("Timings should be empty, got %v", rc2.Timings)
+	}
+	if len(rc2.Errors) != 0 {
+		t.Errorf("Errors should be empty, got %v", rc2.Errors)
+	}
+	if rc2.Flags.CacheHit {
+		t.Error("Flags should be zeroed")
+	}
+}
+
+func TestContextHelpers(t *testing.T) {
+	ctx := context.Background()
+
+	// RequestID
+	ctx = WithRequestID(ctx, "req-123")
+	if id := GetRequestID(ctx); id != "req-123" {
+		t.Errorf("GetRequestID = %q, want %q", id, "req-123")
+	}
+
+	// RequestContext
+	rc := AcquireRequestContext()
+	defer rc.Release()
+	rc.RequestID = "test"
+
+	ctx = WithRequestContext(ctx, rc)
+	got := GetRequestContext(ctx)
+	if got == nil || got.RequestID != "test" {
+		t.Error("GetRequestContext should return the stored context")
+	}
+
+	// Missing values return defaults.
+	if id := GetRequestID(context.Background()); id != "" {
+		t.Errorf("GetRequestID on empty ctx = %q, want empty", id)
+	}
+	if rc := GetRequestContext(context.Background()); rc != nil {
+		t.Error("GetRequestContext on empty ctx should return nil")
+	}
+}
+
+func TestRequestContextElapsed(t *testing.T) {
+	rc := AcquireRequestContext()
+	defer rc.Release()
+
+	time.Sleep(5 * time.Millisecond)
+	elapsed := rc.Elapsed()
+
+	if elapsed < 5*time.Millisecond {
+		t.Errorf("Elapsed = %v, want >= 5ms", elapsed)
+	}
+}

--- a/futureagi/agentcc-gateway/internal/models/embedding.go
+++ b/futureagi/agentcc-gateway/internal/models/embedding.go
@@ -1,0 +1,33 @@
+package models
+
+import "encoding/json"
+
+// EmbeddingRequest represents an OpenAI-compatible embedding request.
+type EmbeddingRequest struct {
+	Model          string          `json:"model"`
+	Input          json.RawMessage `json:"input"`           // string or []string
+	EncodingFormat string          `json:"encoding_format,omitempty"` // "float" | "base64"
+	Dimensions     *int            `json:"dimensions,omitempty"`
+	User           string          `json:"user,omitempty"`
+}
+
+// EmbeddingResponse represents an OpenAI-compatible embedding response.
+type EmbeddingResponse struct {
+	Object string          `json:"object"` // "list"
+	Data   []EmbeddingData `json:"data"`
+	Model  string          `json:"model"`
+	Usage  *EmbeddingUsage `json:"usage"`
+}
+
+// EmbeddingData is a single embedding result.
+type EmbeddingData struct {
+	Object    string          `json:"object"` // "embedding"
+	Index     int             `json:"index"`
+	Embedding json.RawMessage `json:"embedding"` // []float64 or base64 string
+}
+
+// EmbeddingUsage tracks token usage for embedding requests.
+type EmbeddingUsage struct {
+	PromptTokens int `json:"prompt_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}

--- a/futureagi/agentcc-gateway/internal/models/embedding_test.go
+++ b/futureagi/agentcc-gateway/internal/models/embedding_test.go
@@ -1,0 +1,196 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestEmbeddingRequestMarshalRoundTrip(t *testing.T) {
+	dims := 1536
+	req := EmbeddingRequest{
+		Model:          "text-embedding-3-small",
+		Input:          json.RawMessage(`["hello world","goodbye"]`),
+		EncodingFormat: "float",
+		Dimensions:     &dims,
+		User:           "user-123",
+	}
+
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	for _, key := range []string{"model", "input", "encoding_format", "dimensions", "user"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("expected key %q in marshaled JSON", key)
+		}
+	}
+}
+
+func TestEmbeddingRequestUnmarshal(t *testing.T) {
+	input := `{
+		"model": "text-embedding-3-small",
+		"input": ["hello", "world"],
+		"encoding_format": "base64",
+		"dimensions": 256,
+		"user": "u-1"
+	}`
+
+	var req EmbeddingRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if req.Model != "text-embedding-3-small" {
+		t.Errorf("Model = %q, want %q", req.Model, "text-embedding-3-small")
+	}
+	if req.EncodingFormat != "base64" {
+		t.Errorf("EncodingFormat = %q, want %q", req.EncodingFormat, "base64")
+	}
+	if req.Dimensions == nil || *req.Dimensions != 256 {
+		t.Errorf("Dimensions = %v, want 256", req.Dimensions)
+	}
+	if req.User != "u-1" {
+		t.Errorf("User = %q, want %q", req.User, "u-1")
+	}
+	if req.Input == nil {
+		t.Error("Input should not be nil")
+	}
+}
+
+func TestEmbeddingRequestUnmarshalStringInput(t *testing.T) {
+	input := `{"model":"text-embedding-ada-002","input":"single string"}`
+
+	var req EmbeddingRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if req.Model != "text-embedding-ada-002" {
+		t.Errorf("Model = %q, want %q", req.Model, "text-embedding-ada-002")
+	}
+
+	var s string
+	if err := json.Unmarshal(req.Input, &s); err != nil {
+		t.Fatalf("Input is not a string: %v", err)
+	}
+	if s != "single string" {
+		t.Errorf("Input = %q, want %q", s, "single string")
+	}
+}
+
+func TestEmbeddingRequestOmitEmpty(t *testing.T) {
+	req := EmbeddingRequest{
+		Model: "text-embedding-3-small",
+		Input: json.RawMessage(`"hello"`),
+	}
+
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	for _, key := range []string{"encoding_format", "dimensions", "user"} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("key %q should be omitted when zero/nil", key)
+		}
+	}
+
+	// Required fields must be present.
+	for _, key := range []string{"model", "input"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("required key %q should be present", key)
+		}
+	}
+}
+
+func TestEmbeddingResponseMarshalRoundTrip(t *testing.T) {
+	usage := &EmbeddingUsage{PromptTokens: 10, TotalTokens: 10}
+	resp := EmbeddingResponse{
+		Object: "list",
+		Data: []EmbeddingData{
+			{
+				Object:    "embedding",
+				Index:     0,
+				Embedding: json.RawMessage(`[0.1,0.2,0.3]`),
+			},
+		},
+		Model: "text-embedding-3-small",
+		Usage: usage,
+	}
+
+	data, err := json.Marshal(&resp)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var got EmbeddingResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if got.Object != "list" {
+		t.Errorf("Object = %q, want %q", got.Object, "list")
+	}
+	if got.Model != "text-embedding-3-small" {
+		t.Errorf("Model = %q, want %q", got.Model, "text-embedding-3-small")
+	}
+	if len(got.Data) != 1 {
+		t.Fatalf("Data length = %d, want 1", len(got.Data))
+	}
+	if got.Data[0].Object != "embedding" {
+		t.Errorf("Data[0].Object = %q, want %q", got.Data[0].Object, "embedding")
+	}
+	if got.Data[0].Index != 0 {
+		t.Errorf("Data[0].Index = %d, want 0", got.Data[0].Index)
+	}
+	if got.Usage == nil {
+		t.Fatal("Usage should not be nil")
+	}
+	if got.Usage.PromptTokens != 10 {
+		t.Errorf("Usage.PromptTokens = %d, want 10", got.Usage.PromptTokens)
+	}
+	if got.Usage.TotalTokens != 10 {
+		t.Errorf("Usage.TotalTokens = %d, want 10", got.Usage.TotalTokens)
+	}
+}
+
+func TestEmbeddingResponseUnmarshal(t *testing.T) {
+	input := `{
+		"object": "list",
+		"data": [
+			{"object": "embedding", "index": 0, "embedding": [0.001, 0.002]},
+			{"object": "embedding", "index": 1, "embedding": [0.003, 0.004]}
+		],
+		"model": "text-embedding-ada-002",
+		"usage": {"prompt_tokens": 5, "total_tokens": 5}
+	}`
+
+	var resp EmbeddingResponse
+	if err := json.Unmarshal([]byte(input), &resp); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if resp.Object != "list" {
+		t.Errorf("Object = %q, want %q", resp.Object, "list")
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("Data length = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[1].Index != 1 {
+		t.Errorf("Data[1].Index = %d, want 1", resp.Data[1].Index)
+	}
+	if resp.Usage == nil || resp.Usage.PromptTokens != 5 {
+		t.Errorf("Usage.PromptTokens = %v, want 5", resp.Usage)
+	}
+}

--- a/futureagi/agentcc-gateway/internal/models/errors.go
+++ b/futureagi/agentcc-gateway/internal/models/errors.go
@@ -1,0 +1,123 @@
+package models
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+)
+
+// Error types matching OpenAI's error format.
+const (
+	ErrTypeInvalidRequest = "invalid_request_error"
+	ErrTypeAuthentication = "authentication_error"
+	ErrTypePermission     = "permission_error"
+	ErrTypeNotFound       = "not_found"
+	ErrTypeTimeout        = "timeout_error"
+	ErrTypeRateLimit      = "rate_limit_error"
+	ErrTypeGuardrail      = "guardrail_error"
+	ErrTypeServer         = "server_error"
+	ErrTypeUpstream       = "upstream_error"
+	ErrTypeGatewayTimeout = "gateway_timeout"
+)
+
+// ErrorResponse is the OpenAI-compatible error response body.
+type ErrorResponse struct {
+	Error ErrorDetail `json:"error"`
+}
+
+type ErrorDetail struct {
+	Message string  `json:"message"`
+	Type    string  `json:"type"`
+	Param   *string `json:"param"`
+	Code    string  `json:"code"`
+}
+
+// APIError is an error that carries HTTP status and OpenAI error details.
+type APIError struct {
+	Status  int
+	Type    string
+	Code    string
+	Message string
+	Param   *string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Common error constructors.
+
+func ErrBadRequest(code, message string) *APIError {
+	return &APIError{Status: http.StatusBadRequest, Type: ErrTypeInvalidRequest, Code: code, Message: message}
+}
+
+func ErrUnauthorized(message string) *APIError {
+	return &APIError{Status: http.StatusUnauthorized, Type: ErrTypeAuthentication, Code: "invalid_api_key", Message: message}
+}
+
+func ErrForbidden(message string) *APIError {
+	return &APIError{Status: http.StatusForbidden, Type: ErrTypePermission, Code: "permission_denied", Message: message}
+}
+
+func ErrNotFound(code, message string) *APIError {
+	return &APIError{Status: http.StatusNotFound, Type: ErrTypeNotFound, Code: code, Message: message}
+}
+
+func ErrRequestTimeout(message string) *APIError {
+	return &APIError{Status: http.StatusRequestTimeout, Type: ErrTypeTimeout, Code: "request_timeout", Message: message}
+}
+
+func ErrTooManyRequests(message string) *APIError {
+	return &APIError{Status: http.StatusTooManyRequests, Type: ErrTypeRateLimit, Code: "rate_limit_exceeded", Message: message}
+}
+
+func ErrServiceUnavailable(message string) *APIError {
+	return &APIError{Status: http.StatusServiceUnavailable, Type: ErrTypeServer, Code: "all_providers_unavailable", Message: message}
+}
+
+func ErrInternal(message string) *APIError {
+	return &APIError{Status: http.StatusInternalServerError, Type: ErrTypeServer, Code: "internal_error", Message: message}
+}
+
+func ErrUpstreamProvider(status int, message string) *APIError {
+	return &APIError{Status: http.StatusBadGateway, Type: ErrTypeUpstream, Code: fmt.Sprintf("provider_%d", status), Message: message}
+}
+
+func ErrGatewayTimeout(message string) *APIError {
+	return &APIError{Status: http.StatusGatewayTimeout, Type: ErrTypeGatewayTimeout, Code: "gateway_timeout", Message: message}
+}
+
+func ErrGuardrailBlocked(code, message string) *APIError {
+	return &APIError{Status: http.StatusForbidden, Type: ErrTypeGuardrail, Code: code, Message: message}
+}
+
+// WriteError writes an OpenAI-compatible error JSON response.
+func WriteError(w http.ResponseWriter, err *APIError) {
+	resp := ErrorResponse{
+		Error: ErrorDetail{
+			Message: err.Message,
+			Type:    err.Type,
+			Code:    err.Code,
+			Param:   err.Param,
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(err.Status)
+	json.NewEncoder(w).Encode(resp)
+}
+
+// WriteErrorFromError writes an error response from a generic error.
+// Uses errors.As for interface satisfaction and sanitizes non-APIError types
+// to avoid leaking internal Go error details to clients.
+func WriteErrorFromError(w http.ResponseWriter, err error) {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		WriteError(w, apiErr)
+		return
+	}
+	// Log the real error server-side, return a generic message to the client.
+	slog.Warn("internal error sanitized for client", "error", err)
+	WriteError(w, ErrInternal("internal server error"))
+}

--- a/futureagi/agentcc-gateway/internal/models/errors_test.go
+++ b/futureagi/agentcc-gateway/internal/models/errors_test.go
@@ -1,0 +1,114 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        *APIError
+		wantStatus int
+		wantType   string
+		wantCode   string
+	}{
+		{
+			name:       "bad request",
+			err:        ErrBadRequest("invalid_model", "model not found"),
+			wantStatus: 400,
+			wantType:   ErrTypeInvalidRequest,
+			wantCode:   "invalid_model",
+		},
+		{
+			name:       "unauthorized",
+			err:        ErrUnauthorized("invalid API key"),
+			wantStatus: 401,
+			wantType:   ErrTypeAuthentication,
+			wantCode:   "invalid_api_key",
+		},
+		{
+			name:       "rate limit",
+			err:        ErrTooManyRequests("rate limit exceeded"),
+			wantStatus: 429,
+			wantType:   ErrTypeRateLimit,
+			wantCode:   "rate_limit_exceeded",
+		},
+		{
+			name:       "internal",
+			err:        ErrInternal("something broke"),
+			wantStatus: 500,
+			wantType:   ErrTypeServer,
+			wantCode:   "internal_error",
+		},
+		{
+			name:       "upstream",
+			err:        ErrUpstreamProvider(500, "provider error"),
+			wantStatus: 502,
+			wantType:   ErrTypeUpstream,
+			wantCode:   "provider_500",
+		},
+		{
+			name:       "gateway timeout",
+			err:        ErrGatewayTimeout("timed out"),
+			wantStatus: 504,
+			wantType:   ErrTypeGatewayTimeout,
+			wantCode:   "gateway_timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			WriteError(w, tt.err)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+
+			var resp ErrorResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("failed to parse response: %v", err)
+			}
+
+			if resp.Error.Type != tt.wantType {
+				t.Errorf("type = %q, want %q", resp.Error.Type, tt.wantType)
+			}
+			if resp.Error.Code != tt.wantCode {
+				t.Errorf("code = %q, want %q", resp.Error.Code, tt.wantCode)
+			}
+
+			if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+				t.Errorf("content-type = %q, want application/json", ct)
+			}
+		})
+	}
+}
+
+func TestAPIErrorImplementsError(t *testing.T) {
+	err := ErrBadRequest("test", "test message")
+	var e error = err
+	if e.Error() == "" {
+		t.Error("Error() should return non-empty string")
+	}
+}
+
+func TestWriteErrorFromError(t *testing.T) {
+	t.Run("api error", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		WriteErrorFromError(w, ErrBadRequest("test", "test"))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("generic error", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		WriteErrorFromError(w, json.Unmarshal([]byte("invalid"), nil))
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+		}
+	})
+}

--- a/futureagi/agentcc-gateway/internal/models/files.go
+++ b/futureagi/agentcc-gateway/internal/models/files.go
@@ -1,0 +1,25 @@
+package models
+
+// FileObject represents an uploaded file in the OpenAI Files API format.
+type FileObject struct {
+	ID        string `json:"id"`
+	Object    string `json:"object"` // always "file"
+	Bytes     int    `json:"bytes"`
+	CreatedAt int64  `json:"created_at"`
+	Filename  string `json:"filename"`
+	Purpose   string `json:"purpose"`
+	Status    string `json:"status,omitempty"` // "uploaded", "processed", "error"
+}
+
+// FileListResponse is the response for GET /v1/files.
+type FileListResponse struct {
+	Object string       `json:"object"` // "list"
+	Data   []FileObject `json:"data"`
+}
+
+// FileDeleteResponse is the response for DELETE /v1/files/{file_id}.
+type FileDeleteResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"` // "file"
+	Deleted bool   `json:"deleted"`
+}

--- a/futureagi/agentcc-gateway/internal/models/image.go
+++ b/futureagi/agentcc-gateway/internal/models/image.go
@@ -1,0 +1,26 @@
+package models
+
+// ImageRequest represents an OpenAI-compatible image generation request.
+type ImageRequest struct {
+	Model          string `json:"model"`
+	Prompt         string `json:"prompt"`
+	N              *int   `json:"n,omitempty"`
+	Size           string `json:"size,omitempty"`            // "256x256"|"512x512"|"1024x1024"|"1792x1024"|"1024x1792"
+	Quality        string `json:"quality,omitempty"`         // "standard"|"hd"
+	ResponseFormat string `json:"response_format,omitempty"` // "url"|"b64_json"
+	Style          string `json:"style,omitempty"`           // "natural"|"vivid"
+	User           string `json:"user,omitempty"`
+}
+
+// ImageResponse represents an OpenAI-compatible image generation response.
+type ImageResponse struct {
+	Created int64       `json:"created"`
+	Data    []ImageData `json:"data"`
+}
+
+// ImageData is a single generated image.
+type ImageData struct {
+	URL           string `json:"url,omitempty"`
+	B64JSON       string `json:"b64_json,omitempty"`
+	RevisedPrompt string `json:"revised_prompt,omitempty"`
+}

--- a/futureagi/agentcc-gateway/internal/models/image_test.go
+++ b/futureagi/agentcc-gateway/internal/models/image_test.go
@@ -1,0 +1,198 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestImageRequestMarshalRoundTrip(t *testing.T) {
+	n := 2
+	req := ImageRequest{
+		Model:          "dall-e-3",
+		Prompt:         "A sunset over mountains",
+		N:              &n,
+		Size:           "1024x1024",
+		Quality:        "hd",
+		ResponseFormat: "url",
+		Style:          "vivid",
+		User:           "user-42",
+	}
+
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	for _, key := range []string{"model", "prompt", "n", "size", "quality", "response_format", "style", "user"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("expected key %q in marshaled JSON", key)
+		}
+	}
+}
+
+func TestImageRequestUnmarshal(t *testing.T) {
+	input := `{
+		"model": "dall-e-3",
+		"prompt": "A cat wearing a hat",
+		"n": 1,
+		"size": "1792x1024",
+		"quality": "standard",
+		"response_format": "b64_json",
+		"style": "natural",
+		"user": "u-99"
+	}`
+
+	var req ImageRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if req.Model != "dall-e-3" {
+		t.Errorf("Model = %q, want %q", req.Model, "dall-e-3")
+	}
+	if req.Prompt != "A cat wearing a hat" {
+		t.Errorf("Prompt = %q, want %q", req.Prompt, "A cat wearing a hat")
+	}
+	if req.N == nil || *req.N != 1 {
+		t.Errorf("N = %v, want 1", req.N)
+	}
+	if req.Size != "1792x1024" {
+		t.Errorf("Size = %q, want %q", req.Size, "1792x1024")
+	}
+	if req.Quality != "standard" {
+		t.Errorf("Quality = %q, want %q", req.Quality, "standard")
+	}
+	if req.ResponseFormat != "b64_json" {
+		t.Errorf("ResponseFormat = %q, want %q", req.ResponseFormat, "b64_json")
+	}
+	if req.Style != "natural" {
+		t.Errorf("Style = %q, want %q", req.Style, "natural")
+	}
+	if req.User != "u-99" {
+		t.Errorf("User = %q, want %q", req.User, "u-99")
+	}
+}
+
+func TestImageRequestOmitEmpty(t *testing.T) {
+	req := ImageRequest{
+		Model:  "dall-e-3",
+		Prompt: "A dog",
+	}
+
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	for _, key := range []string{"n", "size", "quality", "response_format", "style", "user"} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("key %q should be omitted when zero/nil", key)
+		}
+	}
+
+	// Required fields must be present.
+	for _, key := range []string{"model", "prompt"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("required key %q should be present", key)
+		}
+	}
+}
+
+func TestImageResponseMarshalRoundTrip(t *testing.T) {
+	resp := ImageResponse{
+		Created: 1700000000,
+		Data: []ImageData{
+			{
+				URL:           "https://example.com/image.png",
+				RevisedPrompt: "A beautiful sunset over the mountains",
+			},
+		},
+	}
+
+	data, err := json.Marshal(&resp)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var got ImageResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if got.Created != 1700000000 {
+		t.Errorf("Created = %d, want 1700000000", got.Created)
+	}
+	if len(got.Data) != 1 {
+		t.Fatalf("Data length = %d, want 1", len(got.Data))
+	}
+	if got.Data[0].URL != "https://example.com/image.png" {
+		t.Errorf("Data[0].URL = %q, want %q", got.Data[0].URL, "https://example.com/image.png")
+	}
+	if got.Data[0].RevisedPrompt != "A beautiful sunset over the mountains" {
+		t.Errorf("Data[0].RevisedPrompt = %q, want %q", got.Data[0].RevisedPrompt, "A beautiful sunset over the mountains")
+	}
+}
+
+func TestImageResponseUnmarshal(t *testing.T) {
+	input := `{
+		"created": 1700000001,
+		"data": [
+			{"url": "https://img.example.com/1.png", "revised_prompt": "revised one"},
+			{"b64_json": "aGVsbG8=", "revised_prompt": "revised two"}
+		]
+	}`
+
+	var resp ImageResponse
+	if err := json.Unmarshal([]byte(input), &resp); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if resp.Created != 1700000001 {
+		t.Errorf("Created = %d, want 1700000001", resp.Created)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("Data length = %d, want 2", len(resp.Data))
+	}
+	if resp.Data[0].URL != "https://img.example.com/1.png" {
+		t.Errorf("Data[0].URL = %q, want %q", resp.Data[0].URL, "https://img.example.com/1.png")
+	}
+	if resp.Data[1].B64JSON != "aGVsbG8=" {
+		t.Errorf("Data[1].B64JSON = %q, want %q", resp.Data[1].B64JSON, "aGVsbG8=")
+	}
+}
+
+func TestImageDataOmitEmpty(t *testing.T) {
+	imgData := ImageData{
+		URL: "https://example.com/img.png",
+	}
+
+	data, err := json.Marshal(&imgData)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	if _, ok := raw["b64_json"]; ok {
+		t.Error("b64_json should be omitted when empty")
+	}
+	if _, ok := raw["revised_prompt"]; ok {
+		t.Error("revised_prompt should be omitted when empty")
+	}
+	if _, ok := raw["url"]; !ok {
+		t.Error("url should be present")
+	}
+}

--- a/futureagi/agentcc-gateway/internal/models/ocr.go
+++ b/futureagi/agentcc-gateway/internal/models/ocr.go
@@ -1,0 +1,85 @@
+package models
+
+import "net/http"
+
+// OCRDocument represents a document to be processed by OCR.
+type OCRDocument struct {
+	Type        string `json:"type"`
+	DocumentURL string `json:"document_url,omitempty"`
+	ImageURL    string `json:"image_url,omitempty"`
+}
+
+// OCRRequest represents an OCR API request.
+type OCRRequest struct {
+	Model              string      `json:"model"`
+	Document           OCRDocument `json:"document"`
+	IncludeImageBase64 bool        `json:"include_image_base64"`
+	Pages              *int        `json:"pages,omitempty"`
+	ImageLimit         *int        `json:"image_limit,omitempty"`
+}
+
+// Validate checks that the OCR request is valid.
+func (r *OCRRequest) Validate() *APIError {
+	if r.Model == "" {
+		return ErrBadRequest("missing_model", "model is required")
+	}
+	if r.Document.Type != "document_url" && r.Document.Type != "image_url" {
+		return &APIError{Status: http.StatusBadRequest, Type: ErrTypeInvalidRequest, Code: "invalid_document_type", Message: "document.type must be 'document_url' or 'image_url'"}
+	}
+	if r.Document.Type == "document_url" && r.Document.DocumentURL == "" {
+		return ErrBadRequest("missing_document_url", "document.document_url is required when type is 'document_url'")
+	}
+	if r.Document.Type == "image_url" && r.Document.ImageURL == "" {
+		return ErrBadRequest("missing_image_url", "document.image_url is required when type is 'image_url'")
+	}
+	if r.Pages != nil && *r.Pages <= 0 {
+		return ErrBadRequest("invalid_pages", "pages must be greater than 0")
+	}
+	if r.ImageLimit != nil && *r.ImageLimit <= 0 {
+		return ErrBadRequest("invalid_image_limit", "image_limit must be greater than 0")
+	}
+	return nil
+}
+
+// OCRBoundingBox represents a bounding box for an image region.
+type OCRBoundingBox struct {
+	X      float64 `json:"x"`
+	Y      float64 `json:"y"`
+	Width  float64 `json:"width"`
+	Height float64 `json:"height"`
+}
+
+// OCRImage represents an extracted image from OCR processing.
+type OCRImage struct {
+	ImageBase64 string          `json:"image_base64,omitempty"`
+	BBox        *OCRBoundingBox `json:"bbox,omitempty"`
+}
+
+// OCRDimensions represents page dimensions.
+type OCRDimensions struct {
+	DPI    int `json:"dpi"`
+	Height int `json:"height"`
+	Width  int `json:"width"`
+}
+
+// OCRPage represents a single page of OCR output.
+type OCRPage struct {
+	Index      int            `json:"index"`
+	Markdown   string         `json:"markdown"`
+	Images     []OCRImage     `json:"images,omitempty"`
+	Dimensions *OCRDimensions `json:"dimensions,omitempty"`
+}
+
+// OCRUsage represents OCR processing usage info.
+type OCRUsage struct {
+	PagesProcessed int `json:"pages_processed"`
+	DocSizeBytes   int `json:"doc_size_bytes"`
+}
+
+// OCRResponse represents an OCR API response.
+type OCRResponse struct {
+	Object    string    `json:"object"`
+	Model     string    `json:"model"`
+	Pages     []OCRPage `json:"pages"`
+	UsageInfo *OCRUsage `json:"usage_info,omitempty"`
+}

--- a/futureagi/agentcc-gateway/internal/models/request.go
+++ b/futureagi/agentcc-gateway/internal/models/request.go
@@ -1,0 +1,149 @@
+package models
+
+import "encoding/json"
+
+// ChatCompletionRequest represents an OpenAI-compatible chat completion request.
+type ChatCompletionRequest struct {
+	Model            string          `json:"model"`
+	Messages         []Message       `json:"messages"`
+	Temperature      *float64        `json:"temperature,omitempty"`
+	TopP             *float64        `json:"top_p,omitempty"`
+	N                *int            `json:"n,omitempty"`
+	Stream           bool            `json:"stream,omitempty"`
+	StreamOptions    *StreamOptions  `json:"stream_options,omitempty"`
+	Stop             json.RawMessage `json:"stop,omitempty"`
+	MaxTokens        *int            `json:"max_tokens,omitempty"`
+	MaxCompletionTokens *int         `json:"max_completion_tokens,omitempty"`
+	PresencePenalty  *float64        `json:"presence_penalty,omitempty"`
+	FrequencyPenalty *float64        `json:"frequency_penalty,omitempty"`
+	LogitBias        map[string]int  `json:"logit_bias,omitempty"`
+	Logprobs         *bool           `json:"logprobs,omitempty"`
+	TopLogprobs      *int            `json:"top_logprobs,omitempty"`
+	User             string          `json:"user,omitempty"`
+	Seed             *int            `json:"seed,omitempty"`
+	Tools            []Tool          `json:"tools,omitempty"`
+	ToolChoice       json.RawMessage `json:"tool_choice,omitempty"`
+	ResponseFormat   *ResponseFormat `json:"response_format,omitempty"`
+	ServiceTier      string          `json:"service_tier,omitempty"`
+	Modalities       []string        `json:"modalities,omitempty"`
+	Audio            *AudioConfig    `json:"audio,omitempty"`
+
+	// Extra captures unknown fields for pass-through to providers.
+	Extra map[string]json.RawMessage `json:"-"`
+}
+
+// AudioConfig represents OpenAI's audio configuration for chat completions
+// with audio output modality.
+type AudioConfig struct {
+	Voice  string `json:"voice,omitempty"`
+	Format string `json:"format,omitempty"` // "pcm16"|"mp3"|"opus"|"flac"|"wav"
+}
+
+// UnmarshalJSON implements custom unmarshaling to capture unknown fields.
+func (r *ChatCompletionRequest) UnmarshalJSON(data []byte) error {
+	// Unmarshal known fields using a type alias to avoid recursion.
+	type Alias ChatCompletionRequest
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	// Unmarshal all fields into a map to find extras.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	known := map[string]bool{
+		"model": true, "messages": true, "temperature": true, "top_p": true,
+		"n": true, "stream": true, "stream_options": true, "stop": true,
+		"max_tokens": true, "max_completion_tokens": true,
+		"presence_penalty": true, "frequency_penalty": true,
+		"logit_bias": true, "logprobs": true, "top_logprobs": true,
+		"user": true, "seed": true, "tools": true, "tool_choice": true,
+		"response_format": true, "service_tier": true,
+		"modalities": true, "audio": true,
+	}
+
+	for k, v := range raw {
+		if !known[k] {
+			if r.Extra == nil {
+				r.Extra = make(map[string]json.RawMessage)
+			}
+			r.Extra[k] = v
+		}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements custom marshaling to include extra fields.
+func (r ChatCompletionRequest) MarshalJSON() ([]byte, error) {
+	type Alias ChatCompletionRequest
+	data, err := json.Marshal((*Alias)(&r))
+	if err != nil {
+		return nil, err
+	}
+	if len(r.Extra) == 0 {
+		return data, nil
+	}
+	// Merge extra fields into the JSON object.
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	for k, v := range r.Extra {
+		obj[k] = v
+	}
+	return json.Marshal(obj)
+}
+
+type Message struct {
+	Role           string          `json:"role"`
+	Content        json.RawMessage `json:"content,omitempty"`
+	Name           string          `json:"name,omitempty"`
+	ToolCalls      []ToolCall      `json:"tool_calls,omitempty"`
+	ToolCallID     string          `json:"tool_call_id,omitempty"`
+	// ThinkingBlocks carries Anthropic extended-thinking content blocks on the
+	// canonical OpenAI Message.  Non-standard field (LiteLLM convention); present
+	// only when the upstream provider returned thinking blocks.  JSON key is
+	// "thinking_blocks" (omitempty) so round-trips through providers that do not
+	// understand it are silent.
+	ThinkingBlocks json.RawMessage `json:"thinking_blocks,omitempty"`
+}
+
+type ToolCall struct {
+	ID       string       `json:"id"`
+	Type     string       `json:"type"`
+	Function FunctionCall `json:"function"`
+}
+
+type FunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type Tool struct {
+	Type     string       `json:"type"`
+	Function ToolFunction `json:"function"`
+}
+
+type ToolFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+	Strict      *bool           `json:"strict,omitempty"`
+}
+
+type ResponseFormat struct {
+	Type       string          `json:"type"`
+	JSONSchema json.RawMessage `json:"json_schema,omitempty"`
+}
+
+type StreamOptions struct {
+	IncludeUsage bool `json:"include_usage,omitempty"`
+}

--- a/futureagi/agentcc-gateway/internal/models/request_test.go
+++ b/futureagi/agentcc-gateway/internal/models/request_test.go
@@ -1,0 +1,114 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestChatCompletionRequestMarshalRoundTrip(t *testing.T) {
+	input := `{
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "system", "content": "You are a helpful assistant."},
+			{"role": "user", "content": "Hello!"}
+		],
+		"temperature": 0.7,
+		"max_tokens": 100,
+		"stream": false,
+		"unknown_field": "should be preserved"
+	}`
+
+	var req ChatCompletionRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if req.Model != "gpt-4o" {
+		t.Errorf("Model = %q, want %q", req.Model, "gpt-4o")
+	}
+	if len(req.Messages) != 2 {
+		t.Errorf("Messages length = %d, want 2", len(req.Messages))
+	}
+	if req.Temperature == nil || *req.Temperature != 0.7 {
+		t.Errorf("Temperature = %v, want 0.7", req.Temperature)
+	}
+	if req.MaxTokens == nil || *req.MaxTokens != 100 {
+		t.Errorf("MaxTokens = %v, want 100", req.MaxTokens)
+	}
+	if req.Stream {
+		t.Error("Stream should be false")
+	}
+
+	// Unknown fields preserved.
+	if req.Extra == nil {
+		t.Fatal("Extra should not be nil")
+	}
+	if _, ok := req.Extra["unknown_field"]; !ok {
+		t.Error("unknown_field should be in Extra")
+	}
+
+	// Re-marshal and verify unknown_field is included.
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	json.Unmarshal(data, &raw)
+
+	if _, ok := raw["unknown_field"]; !ok {
+		t.Error("unknown_field should be in marshaled output")
+	}
+	if _, ok := raw["model"]; !ok {
+		t.Error("model should be in marshaled output")
+	}
+}
+
+func TestChatCompletionRequestMinimal(t *testing.T) {
+	input := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+
+	var req ChatCompletionRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if req.Model != "gpt-4o" {
+		t.Errorf("Model = %q, want %q", req.Model, "gpt-4o")
+	}
+	if len(req.Messages) != 1 {
+		t.Errorf("Messages length = %d, want 1", len(req.Messages))
+	}
+	if req.Extra != nil && len(req.Extra) > 0 {
+		t.Errorf("Extra should be empty, got %v", req.Extra)
+	}
+}
+
+func TestChatCompletionRequestWithTools(t *testing.T) {
+	input := `{
+		"model": "gpt-4o",
+		"messages": [{"role": "user", "content": "What's the weather?"}],
+		"tools": [
+			{
+				"type": "function",
+				"function": {
+					"name": "get_weather",
+					"description": "Get weather info",
+					"parameters": {"type": "object", "properties": {"city": {"type": "string"}}}
+				}
+			}
+		],
+		"tool_choice": "auto"
+	}`
+
+	var req ChatCompletionRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if len(req.Tools) != 1 {
+		t.Fatalf("Tools length = %d, want 1", len(req.Tools))
+	}
+	if req.Tools[0].Function.Name != "get_weather" {
+		t.Errorf("Tool name = %q, want %q", req.Tools[0].Function.Name, "get_weather")
+	}
+}

--- a/futureagi/agentcc-gateway/internal/models/rerank.go
+++ b/futureagi/agentcc-gateway/internal/models/rerank.go
@@ -1,0 +1,34 @@
+package models
+
+// RerankRequest represents a reranking request (Cohere-compatible format).
+type RerankRequest struct {
+	Model           string   `json:"model"`
+	Query           string   `json:"query"`
+	Documents       []string `json:"documents"`
+	TopN            *int     `json:"top_n,omitempty"`
+	ReturnDocuments bool     `json:"return_documents,omitempty"`
+}
+
+// RerankResponse represents a reranking response.
+type RerankResponse struct {
+	ID      string         `json:"id"`
+	Results []RerankResult `json:"results"`
+	Meta    *RerankMeta    `json:"meta,omitempty"`
+}
+
+// RerankResult is a single reranked document.
+type RerankResult struct {
+	Index          int             `json:"index"`
+	RelevanceScore float64         `json:"relevance_score"`
+	Document       *RerankDocument `json:"document,omitempty"`
+}
+
+// RerankDocument is a document in a rerank result.
+type RerankDocument struct {
+	Text string `json:"text"`
+}
+
+// RerankMeta contains billing metadata for rerank requests.
+type RerankMeta struct {
+	BilledUnits map[string]int `json:"billed_units,omitempty"`
+}

--- a/futureagi/agentcc-gateway/internal/models/rerank_test.go
+++ b/futureagi/agentcc-gateway/internal/models/rerank_test.go
@@ -1,0 +1,249 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRerankRequestMarshalRoundTrip(t *testing.T) {
+	topN := 3
+	req := RerankRequest{
+		Model:           "rerank-english-v3.0",
+		Query:           "What is the capital of France?",
+		Documents:       []string{"Paris is the capital.", "Berlin is in Germany.", "France is in Europe."},
+		TopN:            &topN,
+		ReturnDocuments: true,
+	}
+
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	for _, key := range []string{"model", "query", "documents", "top_n", "return_documents"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("expected key %q in marshaled JSON", key)
+		}
+	}
+}
+
+func TestRerankRequestUnmarshal(t *testing.T) {
+	input := `{
+		"model": "rerank-multilingual-v3.0",
+		"query": "machine learning",
+		"documents": ["doc one", "doc two", "doc three"],
+		"top_n": 2,
+		"return_documents": true
+	}`
+
+	var req RerankRequest
+	if err := json.Unmarshal([]byte(input), &req); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if req.Model != "rerank-multilingual-v3.0" {
+		t.Errorf("Model = %q, want %q", req.Model, "rerank-multilingual-v3.0")
+	}
+	if req.Query != "machine learning" {
+		t.Errorf("Query = %q, want %q", req.Query, "machine learning")
+	}
+	if len(req.Documents) != 3 {
+		t.Fatalf("Documents length = %d, want 3", len(req.Documents))
+	}
+	if req.Documents[0] != "doc one" {
+		t.Errorf("Documents[0] = %q, want %q", req.Documents[0], "doc one")
+	}
+	if req.TopN == nil || *req.TopN != 2 {
+		t.Errorf("TopN = %v, want 2", req.TopN)
+	}
+	if !req.ReturnDocuments {
+		t.Error("ReturnDocuments should be true")
+	}
+}
+
+func TestRerankRequestOmitEmpty(t *testing.T) {
+	req := RerankRequest{
+		Model:     "rerank-english-v3.0",
+		Query:     "test query",
+		Documents: []string{"doc"},
+	}
+
+	data, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	for _, key := range []string{"top_n", "return_documents"} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("key %q should be omitted when zero/nil", key)
+		}
+	}
+
+	// Required fields must be present.
+	for _, key := range []string{"model", "query", "documents"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("required key %q should be present", key)
+		}
+	}
+}
+
+func TestRerankResponseMarshalRoundTrip(t *testing.T) {
+	resp := RerankResponse{
+		ID: "rerank-abc123",
+		Results: []RerankResult{
+			{
+				Index:          0,
+				RelevanceScore: 0.95,
+				Document:       &RerankDocument{Text: "Paris is the capital."},
+			},
+			{
+				Index:          2,
+				RelevanceScore: 0.72,
+				Document:       &RerankDocument{Text: "France is in Europe."},
+			},
+		},
+		Meta: &RerankMeta{
+			BilledUnits: map[string]int{"search_units": 1},
+		},
+	}
+
+	data, err := json.Marshal(&resp)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var got RerankResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if got.ID != "rerank-abc123" {
+		t.Errorf("ID = %q, want %q", got.ID, "rerank-abc123")
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("Results length = %d, want 2", len(got.Results))
+	}
+	if got.Results[0].Index != 0 {
+		t.Errorf("Results[0].Index = %d, want 0", got.Results[0].Index)
+	}
+	if got.Results[0].RelevanceScore != 0.95 {
+		t.Errorf("Results[0].RelevanceScore = %f, want 0.95", got.Results[0].RelevanceScore)
+	}
+	if got.Results[0].Document == nil || got.Results[0].Document.Text != "Paris is the capital." {
+		t.Errorf("Results[0].Document.Text = %v, want %q", got.Results[0].Document, "Paris is the capital.")
+	}
+	if got.Results[1].Index != 2 {
+		t.Errorf("Results[1].Index = %d, want 2", got.Results[1].Index)
+	}
+	if got.Meta == nil {
+		t.Fatal("Meta should not be nil")
+	}
+	if got.Meta.BilledUnits["search_units"] != 1 {
+		t.Errorf("Meta.BilledUnits[search_units] = %d, want 1", got.Meta.BilledUnits["search_units"])
+	}
+}
+
+func TestRerankResponseUnmarshal(t *testing.T) {
+	input := `{
+		"id": "rerank-xyz",
+		"results": [
+			{"index": 1, "relevance_score": 0.88, "document": {"text": "relevant doc"}},
+			{"index": 0, "relevance_score": 0.55}
+		],
+		"meta": {"billed_units": {"search_units": 2}}
+	}`
+
+	var resp RerankResponse
+	if err := json.Unmarshal([]byte(input), &resp); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if resp.ID != "rerank-xyz" {
+		t.Errorf("ID = %q, want %q", resp.ID, "rerank-xyz")
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("Results length = %d, want 2", len(resp.Results))
+	}
+	if resp.Results[0].RelevanceScore != 0.88 {
+		t.Errorf("Results[0].RelevanceScore = %f, want 0.88", resp.Results[0].RelevanceScore)
+	}
+	if resp.Results[0].Document == nil || resp.Results[0].Document.Text != "relevant doc" {
+		t.Errorf("Results[0].Document.Text = %v, want %q", resp.Results[0].Document, "relevant doc")
+	}
+	if resp.Results[1].Document != nil {
+		t.Error("Results[1].Document should be nil when not provided")
+	}
+	if resp.Meta == nil || resp.Meta.BilledUnits["search_units"] != 2 {
+		t.Errorf("Meta.BilledUnits = %v, want search_units=2", resp.Meta)
+	}
+}
+
+func TestRerankResponseOmitEmpty(t *testing.T) {
+	resp := RerankResponse{
+		ID: "rerank-minimal",
+		Results: []RerankResult{
+			{Index: 0, RelevanceScore: 0.5},
+		},
+	}
+
+	data, err := json.Marshal(&resp)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	if _, ok := raw["meta"]; ok {
+		t.Error("meta should be omitted when nil")
+	}
+
+	// Check nested result omitempty.
+	var results []map[string]json.RawMessage
+	if err := json.Unmarshal(raw["results"], &results); err != nil {
+		t.Fatalf("Unmarshal results error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results length = %d, want 1", len(results))
+	}
+	if _, ok := results[0]["document"]; ok {
+		t.Error("document should be omitted when nil")
+	}
+
+	// Required fields must be present.
+	for _, key := range []string{"id", "results"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("required key %q should be present", key)
+		}
+	}
+}
+
+func TestRerankMetaOmitEmpty(t *testing.T) {
+	meta := RerankMeta{}
+
+	data, err := json.Marshal(&meta)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal raw error: %v", err)
+	}
+
+	if _, ok := raw["billed_units"]; ok {
+		t.Error("billed_units should be omitted when nil map")
+	}
+}

--- a/futureagi/agentcc-gateway/internal/models/response.go
+++ b/futureagi/agentcc-gateway/internal/models/response.go
@@ -1,0 +1,117 @@
+package models
+
+import "encoding/json"
+
+// ChatCompletionResponse represents an OpenAI-compatible chat completion response.
+type ChatCompletionResponse struct {
+	ID                string   `json:"id"`
+	Object            string   `json:"object"`
+	Created           int64    `json:"created"`
+	Model             string   `json:"model"`
+	Choices           []Choice `json:"choices"`
+	Usage             *Usage   `json:"usage,omitempty"`
+	SystemFingerprint string   `json:"system_fingerprint,omitempty"`
+	ServiceTier       string   `json:"service_tier,omitempty"`
+}
+
+type Choice struct {
+	Index        int              `json:"index"`
+	Message      Message          `json:"message"`
+	FinishReason string           `json:"finish_reason"`
+	Logprobs     *json.RawMessage `json:"logprobs,omitempty"`
+}
+
+type Usage struct {
+	PromptTokens            int              `json:"prompt_tokens"`
+	CompletionTokens        int              `json:"completion_tokens"`
+	TotalTokens             int              `json:"total_tokens"`
+	PromptTokensDetails     *json.RawMessage `json:"prompt_tokens_details,omitempty"`
+	CompletionTokensDetails *json.RawMessage `json:"completion_tokens_details,omitempty"`
+}
+
+// StreamChunk represents a single SSE chunk in a streaming response.
+type StreamChunk struct {
+	ID                string               `json:"id"`
+	Object            string               `json:"object"`
+	Created           int64                `json:"created"`
+	Model             string               `json:"model"`
+	Choices           []StreamChoice       `json:"choices"`
+	Usage             *Usage               `json:"usage,omitempty"`
+	AgentccMetadata     *AgentccStreamMetadata `json:"agentcc_metadata,omitempty"`
+	SystemFingerprint string               `json:"system_fingerprint,omitempty"`
+}
+
+type AgentccStreamMetadata struct {
+	Cost      float64 `json:"cost"`
+	LatencyMs int64   `json:"latency_ms"`
+}
+
+type StreamChoice struct {
+	Index        int     `json:"index"`
+	Delta        Delta   `json:"delta"`
+	FinishReason *string `json:"finish_reason"`
+}
+
+type Delta struct {
+	Role      string          `json:"role,omitempty"`
+	Content   *string         `json:"content,omitempty"`
+	ToolCalls []ToolCallDelta `json:"tool_calls,omitempty"`
+}
+
+type ToolCallDelta struct {
+	Index    int           `json:"index"`
+	ID       string        `json:"id,omitempty"`
+	Type     string        `json:"type,omitempty"`
+	Function *FunctionCall `json:"function,omitempty"`
+}
+
+// ModelObject represents a model in the /v1/models response.
+type ModelObject struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
+}
+
+// ModelListResponse is the response for GET /v1/models.
+type ModelListResponse struct {
+	Object string        `json:"object"`
+	Data   []ModelObject `json:"data"`
+}
+
+// EnrichedModelObject adds pricing, capabilities, and limits to the base model object.
+type EnrichedModelObject struct {
+	ID              string           `json:"id"`
+	Object          string           `json:"object"`
+	Created         int64            `json:"created"`
+	OwnedBy         string           `json:"owned_by"`
+	MaxInputTokens  int              `json:"max_input_tokens,omitempty"`
+	MaxOutputTokens int              `json:"max_output_tokens,omitempty"`
+	Pricing         *ModelPricingAPI `json:"pricing,omitempty"`
+	Capabilities    *ModelCapsAPI    `json:"capabilities,omitempty"`
+	Mode            string           `json:"mode,omitempty"`
+	Deprecated      bool             `json:"deprecated,omitempty"`
+}
+
+// ModelPricingAPI is the API representation of model pricing (per million tokens).
+type ModelPricingAPI struct {
+	InputPerMTokens       float64 `json:"input_per_m_tokens"`
+	OutputPerMTokens      float64 `json:"output_per_m_tokens"`
+	CachedInputPerMTokens float64 `json:"cached_input_per_m_tokens,omitempty"`
+}
+
+// ModelCapsAPI is the API representation of model capabilities.
+type ModelCapsAPI struct {
+	Vision          bool `json:"vision"`
+	FunctionCalling bool `json:"function_calling"`
+	Streaming       bool `json:"streaming"`
+	ResponseSchema  bool `json:"response_schema"`
+	PromptCaching   bool `json:"prompt_caching"`
+	Reasoning       bool `json:"reasoning"`
+}
+
+// EnrichedModelListResponse is the enriched response for GET /v1/models.
+type EnrichedModelListResponse struct {
+	Object string                `json:"object"`
+	Data   []EnrichedModelObject `json:"data"`
+}

--- a/futureagi/agentcc-gateway/internal/models/responses.go
+++ b/futureagi/agentcc-gateway/internal/models/responses.go
@@ -1,0 +1,95 @@
+package models
+
+import "encoding/json"
+
+// ResponsesRequest represents an OpenAI Responses API request (POST /v1/responses).
+type ResponsesRequest struct {
+	Model              string          `json:"model"`
+	Input              json.RawMessage `json:"input"`
+	Instructions       string          `json:"instructions,omitempty"`
+	Tools              json.RawMessage `json:"tools,omitempty"`
+	PreviousResponseID string          `json:"previous_response_id,omitempty"`
+	Stream             bool            `json:"stream,omitempty"`
+	Temperature        *float64        `json:"temperature,omitempty"`
+	TopP               *float64        `json:"top_p,omitempty"`
+	MaxOutputTokens    *int            `json:"max_output_tokens,omitempty"`
+	Store              *bool           `json:"store,omitempty"`
+	Metadata           json.RawMessage `json:"metadata,omitempty"`
+	User               string          `json:"user,omitempty"`
+	// Pass-through fields for the provider.
+	Extra map[string]json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON implements custom unmarshaling to capture unknown fields.
+func (r *ResponsesRequest) UnmarshalJSON(data []byte) error {
+	type Alias ResponsesRequest
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	known := map[string]bool{
+		"model": true, "input": true, "instructions": true, "tools": true,
+		"previous_response_id": true, "stream": true, "temperature": true,
+		"top_p": true, "max_output_tokens": true, "store": true,
+		"metadata": true, "user": true,
+	}
+
+	for k, v := range raw {
+		if !known[k] {
+			if r.Extra == nil {
+				r.Extra = make(map[string]json.RawMessage)
+			}
+			r.Extra[k] = v
+		}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements custom marshaling to include extra fields.
+func (r ResponsesRequest) MarshalJSON() ([]byte, error) {
+	type Alias ResponsesRequest
+	data, err := json.Marshal((*Alias)(&r))
+	if err != nil {
+		return nil, err
+	}
+	if len(r.Extra) == 0 {
+		return data, nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	for k, v := range r.Extra {
+		obj[k] = v
+	}
+	return json.Marshal(obj)
+}
+
+// ResponsesResponse represents an OpenAI Responses API response.
+// This is intentionally kept as json.RawMessage because the response format
+// is complex and varies by provider. The gateway passes it through.
+type ResponsesResponse struct {
+	ID          string          `json:"id"`
+	Object      string          `json:"object"`
+	Model       string          `json:"model"`
+	Status      string          `json:"status"`
+	Output      json.RawMessage `json:"output"`
+	Usage       json.RawMessage `json:"usage,omitempty"`
+	CreatedAt   float64         `json:"created_at"`
+	RawResponse json.RawMessage `json:"-"` // Full raw response for storage/retrieval
+}
+
+// ResponsesStore stores responses for retrieval via GET /v1/responses/{id}.
+// In-memory implementation with TTL-based expiry.
+type ResponsesStore struct{}

--- a/futureagi/agentcc-gateway/internal/models/search.go
+++ b/futureagi/agentcc-gateway/internal/models/search.go
@@ -1,0 +1,82 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// SearchRequest represents a search API request.
+type SearchRequest struct {
+	QueryRaw           json.RawMessage `json:"query"`
+	SearchProvider     string          `json:"search_provider"`
+	MaxResults         int             `json:"max_results"`
+	SearchDomainFilter []string        `json:"search_domain_filter,omitempty"`
+	MaxTokensPerPage   int             `json:"max_tokens_per_page"`
+	Country            string          `json:"country,omitempty"`
+}
+
+// QueryString returns the query as a single string.
+func (r *SearchRequest) QueryString() (string, error) {
+	var s string
+	if err := json.Unmarshal(r.QueryRaw, &s); err == nil {
+		return s, nil
+	}
+	// Try as array, return first.
+	var arr []string
+	if err := json.Unmarshal(r.QueryRaw, &arr); err == nil && len(arr) > 0 {
+		return arr[0], nil
+	}
+	return "", &APIError{Status: http.StatusBadRequest, Type: ErrTypeInvalidRequest, Code: "invalid_query", Message: "query must be a string or array of strings"}
+}
+
+// QueryStrings returns the query as a slice of strings.
+func (r *SearchRequest) QueryStrings() ([]string, error) {
+	var arr []string
+	if err := json.Unmarshal(r.QueryRaw, &arr); err == nil {
+		return arr, nil
+	}
+	var s string
+	if err := json.Unmarshal(r.QueryRaw, &s); err == nil {
+		return []string{s}, nil
+	}
+	return nil, &APIError{Status: http.StatusBadRequest, Type: ErrTypeInvalidRequest, Code: "invalid_query", Message: "query must be a string or array of strings"}
+}
+
+// IsMultiQuery returns true if the query is an array.
+func (r *SearchRequest) IsMultiQuery() bool {
+	return len(r.QueryRaw) > 0 && r.QueryRaw[0] == '['
+}
+
+// Validate checks that the search request is valid.
+func (r *SearchRequest) Validate() *APIError {
+	if len(r.QueryRaw) == 0 {
+		return ErrBadRequest("missing_query", "query is required")
+	}
+	if r.SearchProvider == "" {
+		return ErrBadRequest("missing_search_provider", "search_provider is required")
+	}
+	if r.MaxResults < 0 || r.MaxResults > 20 {
+		return ErrBadRequest("invalid_max_results", "max_results must be between 1 and 20")
+	}
+	if len(r.SearchDomainFilter) > 20 {
+		return ErrBadRequest("too_many_domains", "search_domain_filter must have at most 20 entries")
+	}
+	return nil
+}
+
+// SearchResponse represents a search API response.
+type SearchResponse struct {
+	Object         string          `json:"object"`
+	SearchProvider string          `json:"search_provider"`
+	Query          json.RawMessage `json:"query"`
+	Results        []SearchResult  `json:"results"`
+}
+
+// SearchResult represents a single search result.
+type SearchResult struct {
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	Snippet     string `json:"snippet"`
+	Date        string `json:"date,omitempty"`
+	LastUpdated string `json:"last_updated,omitempty"`
+}

--- a/futureagi/agentcc-gateway/internal/models/tokens.go
+++ b/futureagi/agentcc-gateway/internal/models/tokens.go
@@ -1,0 +1,15 @@
+package models
+
+// CountTokensRequest represents a token counting request.
+type CountTokensRequest struct {
+	Model    string    `json:"model"`
+	Messages []Message `json:"messages"`
+}
+
+// CountTokensResponse represents a token counting response.
+type CountTokensResponse struct {
+	Model            string `json:"model"`
+	TokenCount       int    `json:"token_count"`
+	MaxContextTokens int    `json:"max_context_tokens,omitempty"`
+	RemainingTokens  int    `json:"remaining_tokens,omitempty"`
+}

--- a/futureagi/agentcc-gateway/internal/models/video.go
+++ b/futureagi/agentcc-gateway/internal/models/video.go
@@ -1,0 +1,49 @@
+package models
+
+// VideoGenerationRequest is the provider-facing video generation request.
+type VideoGenerationRequest struct {
+	Model               string          `json:"model"`
+	Prompt              string          `json:"prompt"`
+	InputImage          *InputImageData `json:"input_image,omitempty"`
+	Duration            float64         `json:"duration,omitempty"`
+	Width               int             `json:"width,omitempty"`
+	Height              int             `json:"height,omitempty"`
+	FPS                 int             `json:"fps,omitempty"`
+	NumVariants         int             `json:"n,omitempty"`
+	Style               string          `json:"style,omitempty"`
+	AspectRatio         string          `json:"aspect_ratio,omitempty"`
+	RemixSourceVideoURL string          `json:"remix_source_video_url,omitempty"`
+}
+
+// InputImageData represents decoded image data for video generation.
+type InputImageData struct {
+	Data      []byte `json:"-"`
+	MediaType string `json:"media_type"`
+	URL       string `json:"url,omitempty"`
+}
+
+// VideoSubmitResponse is the provider's response after submitting a video job.
+type VideoSubmitResponse struct {
+	ProviderJobID    string `json:"provider_job_id"`
+	Status           string `json:"status"`
+	EstimatedSeconds int    `json:"estimated_seconds,omitempty"`
+}
+
+// VideoStatusResponse is the provider's response for video job status.
+type VideoStatusResponse struct {
+	ProviderJobID string                `json:"provider_job_id"`
+	Status        string                `json:"status"`
+	Progress      int                   `json:"progress"`
+	Videos        []ProviderVideoOutput `json:"videos,omitempty"`
+	Error         string                `json:"error,omitempty"`
+}
+
+// ProviderVideoOutput represents a single video output from a provider.
+type ProviderVideoOutput struct {
+	URL             string  `json:"url"`
+	ContentType     string  `json:"content_type"`
+	DurationSeconds float64 `json:"duration_seconds"`
+	Width           int     `json:"width"`
+	Height          int     `json:"height"`
+	FileSizeBytes   int64   `json:"file_size_bytes"`
+}

--- a/futureagi/agentcc/models/__init__.py
+++ b/futureagi/agentcc/models/__init__.py
@@ -1,0 +1,34 @@
+from agentcc.models.api_key import AgentccAPIKey
+from agentcc.models.blocklist import AgentccBlocklist
+from agentcc.models.custom_property import AgentccCustomPropertySchema
+from agentcc.models.email_alert import AgentccEmailAlert
+from agentcc.models.guardrail_feedback import AgentccGuardrailFeedback
+from agentcc.models.guardrail_policy import AgentccGuardrailPolicy
+from agentcc.models.org_config import AgentccOrgConfig
+from agentcc.models.project import AgentccProject
+from agentcc.models.provider_credential import AgentccProviderCredential
+from agentcc.models.request_log import AgentccRequestLog
+from agentcc.models.routing_policy import AgentccRoutingPolicy
+from agentcc.models.session import AgentccSession
+from agentcc.models.shadow_experiment import AgentccShadowExperiment
+from agentcc.models.shadow_result import AgentccShadowResult
+from agentcc.models.webhook import AgentccWebhook, AgentccWebhookEvent
+
+__all__ = [
+    "AgentccProject",
+    "AgentccAPIKey",
+    "AgentccRequestLog",
+    "AgentccOrgConfig",
+    "AgentccGuardrailPolicy",
+    "AgentccBlocklist",
+    "AgentccGuardrailFeedback",
+    "AgentccSession",
+    "AgentccWebhook",
+    "AgentccWebhookEvent",
+    "AgentccCustomPropertySchema",
+    "AgentccRoutingPolicy",
+    "AgentccEmailAlert",
+    "AgentccShadowExperiment",
+    "AgentccShadowResult",
+    "AgentccProviderCredential",
+]

--- a/futureagi/agentcc/models/api_key.py
+++ b/futureagi/agentcc/models/api_key.py
@@ -1,0 +1,84 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization, User
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccAPIKey(BaseModel):
+    ACTIVE = "active"
+    REVOKED = "revoked"
+    EXPIRED = "expired"
+
+    STATUS_CHOICES = [
+        (ACTIVE, "Active"),
+        (REVOKED, "Revoked"),
+        (EXPIRED, "Expired"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_api_keys",
+        blank=False,
+        null=False,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="agentcc_api_keys",
+        null=True,
+        blank=True,
+    )
+    project = models.ForeignKey(
+        "prism.AgentccProject",
+        on_delete=models.SET_NULL,
+        related_name="api_keys",
+        null=True,
+        blank=True,
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        related_name="agentcc_api_keys",
+        null=True,
+        blank=True,
+    )
+    gateway_key_id = models.CharField(max_length=255)
+    key_prefix = models.CharField(max_length=20, blank=True, default="")
+    key_hash = models.CharField(max_length=64, blank=True, default="")
+    name = models.CharField(max_length=255)
+    owner = models.CharField(max_length=255, blank=True, default="")
+    status = models.CharField(
+        max_length=20,
+        choices=STATUS_CHOICES,
+        default=ACTIVE,
+    )
+    allowed_models = models.JSONField(default=list, blank=True)
+    allowed_providers = models.JSONField(default=list, blank=True)
+    metadata = models.JSONField(default=dict, blank=True)
+    last_used_at = models.DateTimeField(null=True, blank=True)
+    expires_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agentcc_api_key"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["gateway_key_id"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_api_key_id",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+            models.Index(fields=["gateway_key_id"]),
+            models.Index(fields=["key_hash"]),
+            models.Index(fields=["status"]),
+        ]
+
+    def __str__(self):
+        return f"{self.name} ({self.key_prefix}...)"

--- a/futureagi/agentcc/models/blocklist.py
+++ b/futureagi/agentcc/models/blocklist.py
@@ -1,0 +1,38 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccBlocklist(BaseModel):
+    """Named word blocklist for guardrail checks. Org-scoped."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_blocklists",
+    )
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    words = models.JSONField(default=list, blank=True)
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        db_table = "agentcc_blocklist"
+        ordering = ["name"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_blocklist_name",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+        ]
+
+    def __str__(self):
+        return f"{self.name} ({len(self.words)} words)"

--- a/futureagi/agentcc/models/custom_property.py
+++ b/futureagi/agentcc/models/custom_property.py
@@ -1,0 +1,63 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccCustomPropertySchema(BaseModel):
+    """Custom property schema definition for request log metadata validation."""
+
+    TYPE_STRING = "string"
+    TYPE_NUMBER = "number"
+    TYPE_BOOLEAN = "boolean"
+    TYPE_ENUM = "enum"
+
+    TYPE_CHOICES = [
+        (TYPE_STRING, "String"),
+        (TYPE_NUMBER, "Number"),
+        (TYPE_BOOLEAN, "Boolean"),
+        (TYPE_ENUM, "Enum"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_custom_property_schemas",
+    )
+    project = models.ForeignKey(
+        "prism.AgentccProject",
+        on_delete=models.CASCADE,
+        related_name="custom_property_schemas",
+        null=True,
+        blank=True,
+    )
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    property_type = models.CharField(
+        max_length=20,
+        choices=TYPE_CHOICES,
+        default=TYPE_STRING,
+    )
+    required = models.BooleanField(default=False)
+    allowed_values = models.JSONField(default=list, blank=True)
+    default_value = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agentcc_custom_property_schema"
+        ordering = ["name"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_custom_property_name",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+        ]
+
+    def __str__(self):
+        return f"{self.name} ({self.property_type})"

--- a/futureagi/agentcc/models/email_alert.py
+++ b/futureagi/agentcc/models/email_alert.py
@@ -1,0 +1,57 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccEmailAlert(BaseModel):
+    """Email alert configuration for gateway event notifications."""
+
+    PROVIDER_CHOICES = [
+        ("sendgrid", "SendGrid"),
+        ("resend", "Resend"),
+        ("smtp", "SMTP"),
+    ]
+
+    EVENT_CHOICES = [
+        ("budget.exceeded", "Budget Exceeded"),
+        ("error.occurred", "Error Occurred"),
+        ("error.rate_spike", "Error Rate Spike"),
+        ("guardrail.triggered", "Guardrail Triggered"),
+        ("latency.spike", "Latency Spike"),
+        ("cost.threshold", "Cost Threshold"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_email_alerts",
+    )
+    name = models.CharField(max_length=255)
+    recipients = models.JSONField(default=list, blank=True)
+    events = models.JSONField(default=list, blank=True)
+    thresholds = models.JSONField(default=dict, blank=True)
+    provider = models.CharField(
+        max_length=20, choices=PROVIDER_CHOICES, default="sendgrid"
+    )
+    encrypted_config = models.BinaryField(null=True, blank=True)
+    is_active = models.BooleanField(default=True)
+    cooldown_minutes = models.IntegerField(default=5)
+    last_triggered_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agentcc_email_alert"
+        ordering = ["name"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_email_alert_name_per_org",
+            ),
+        ]
+
+    def __str__(self):
+        return f"EmailAlert({self.name})"

--- a/futureagi/agentcc/models/guardrail_feedback.py
+++ b/futureagi/agentcc/models/guardrail_feedback.py
@@ -1,0 +1,60 @@
+import uuid
+
+from django.conf import settings
+from django.db import models
+
+from accounts.models import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccGuardrailFeedback(BaseModel):
+    """User feedback on guardrail decisions — correct, false positive, etc."""
+
+    CORRECT = "correct"
+    FALSE_POSITIVE = "false_positive"
+    FALSE_NEGATIVE = "false_negative"
+    UNSURE = "unsure"
+
+    FEEDBACK_CHOICES = [
+        (CORRECT, "Correct"),
+        (FALSE_POSITIVE, "False Positive"),
+        (FALSE_NEGATIVE, "False Negative"),
+        (UNSURE, "Unsure"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_guardrail_feedback",
+    )
+    request_log = models.ForeignKey(
+        "prism.AgentccRequestLog",
+        on_delete=models.CASCADE,
+        related_name="guardrail_feedback",
+    )
+    check_name = models.CharField(max_length=255)
+    feedback = models.CharField(
+        max_length=20,
+        choices=FEEDBACK_CHOICES,
+    )
+    comment = models.TextField(blank=True, default="")
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="agentcc_guardrail_feedback",
+    )
+
+    class Meta:
+        db_table = "agentcc_guardrail_feedback"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["organization"]),
+            models.Index(fields=["request_log"]),
+            models.Index(fields=["check_name"]),
+        ]
+
+    def __str__(self):
+        return f"{self.check_name}: {self.feedback}"

--- a/futureagi/agentcc/models/guardrail_policy.py
+++ b/futureagi/agentcc/models/guardrail_policy.py
@@ -1,0 +1,74 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccGuardrailPolicy(BaseModel):
+    """
+    Reusable, named guardrail policy — a collection of guardrail checks
+    that can be scoped to global, per-project, or per-key level.
+    Policies are merged into the org config and pushed to the gateway.
+    """
+
+    SCOPE_GLOBAL = "global"
+    SCOPE_PROJECT = "project"
+    SCOPE_KEY = "key"
+    SCOPE_CHOICES = [
+        (SCOPE_GLOBAL, "Global"),
+        (SCOPE_PROJECT, "Project"),
+        (SCOPE_KEY, "Key"),
+    ]
+
+    MODE_ENFORCE = "enforce"
+    MODE_MONITOR = "monitor"
+    MODE_CHOICES = [
+        (MODE_ENFORCE, "Enforce"),
+        (MODE_MONITOR, "Monitor"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_guardrail_policies",
+    )
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    scope = models.CharField(
+        max_length=20,
+        choices=SCOPE_CHOICES,
+        default=SCOPE_GLOBAL,
+    )
+    checks = models.JSONField(default=list, blank=True)
+    encrypted_check_configs = models.BinaryField(null=True, blank=True)
+    mode = models.CharField(
+        max_length=20,
+        choices=MODE_CHOICES,
+        default=MODE_ENFORCE,
+    )
+    is_active = models.BooleanField(default=True)
+    priority = models.IntegerField(default=100)
+    applied_keys = models.JSONField(default=list, blank=True)
+    applied_projects = models.JSONField(default=list, blank=True)
+
+    class Meta:
+        db_table = "agentcc_guardrail_policy"
+        ordering = ["priority", "name"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_guardrail_policy_name",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+        ]
+
+    def __str__(self):
+        return (
+            f"{self.name} ({self.scope}, {'active' if self.is_active else 'inactive'})"
+        )

--- a/futureagi/agentcc/models/org_config.py
+++ b/futureagi/agentcc/models/org_config.py
@@ -1,0 +1,110 @@
+import uuid
+
+from django.conf import settings
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from agentcc.org_config_defaults import default_cost_tracking_config
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccOrgConfig(BaseModel):
+    """
+    Per-organization gateway configuration. Each org gets its own provider API
+    keys, guardrail pipeline, and routing strategy. Configs are versioned —
+    only one version is active at a time per org.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_org_configs",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="agentcc_org_configs",
+        null=True,
+        blank=True,
+    )
+    version = models.PositiveIntegerField(default=1)
+
+    # Per-org guardrail pipeline (which checks, thresholds, actions)
+    guardrails = models.JSONField(default=dict, blank=True)
+
+    # Per-org routing strategy (strategy, fallbacks, conditional routes)
+    routing = models.JSONField(default=dict, blank=True)
+
+    # Per-org cache config (backend, semantic, edge, TTL)
+    cache = models.JSONField(default=dict, blank=True)
+
+    # Per-org rate limiting (RPM/TPM limits per org, key, model, user)
+    rate_limiting = models.JSONField(default=dict, blank=True)
+
+    # Per-org spend budgets (limits, periods, thresholds)
+    budgets = models.JSONField(default=dict, blank=True)
+
+    # Per-org cost tracking (custom pricing overrides)
+    cost_tracking = models.JSONField(default=default_cost_tracking_config, blank=True)
+
+    # Per-org IP access control (allow/deny lists)
+    ip_acl = models.JSONField(default=dict, blank=True)
+
+    # Per-org alerting (rules + notification channels)
+    alerting = models.JSONField(default=dict, blank=True)
+
+    # Per-org PII privacy/redaction (mode + patterns)
+    privacy = models.JSONField(default=dict, blank=True)
+
+    # Per-org tool/function calling policy (allow/deny lists)
+    tool_policy = models.JSONField(default=dict, blank=True)
+
+    # Per-org MCP config (servers, guardrails, tool rate limits)
+    mcp = models.JSONField(default=dict, blank=True)
+
+    # Per-org A2A config (agent card, external agent registry, auth, skills)
+    a2a = models.JSONField(default=dict, blank=True)
+
+    # Per-org audit logging (sinks, severity, categories)
+    audit = models.JSONField(default=dict, blank=True)
+
+    # Per-org model database overrides (custom token limits, pricing, capabilities)
+    model_database = models.JSONField(default=dict, blank=True)
+
+    # Per-org model map (model name → provider ID aliasing)
+    model_map = models.JSONField(default=dict, blank=True)
+
+    is_active = models.BooleanField(default=True)
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="agentcc_org_configs",
+    )
+    change_description = models.TextField(blank=True, default="")
+
+    class Meta:
+        db_table = "agentcc_org_config"
+        ordering = ["-version"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "version"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_org_config_version",
+            ),
+            models.UniqueConstraint(
+                fields=["organization"],
+                condition=models.Q(deleted=False, is_active=True),
+                name="unique_agentcc_org_config_active",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization", "-version"]),
+            models.Index(fields=["organization", "is_active"]),
+        ]
+
+    def __str__(self):
+        return f"OrgConfig {self.organization_id} v{self.version} ({'active' if self.is_active else 'inactive'})"

--- a/futureagi/agentcc/models/project.py
+++ b/futureagi/agentcc/models/project.py
@@ -1,0 +1,52 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccProject(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_projects",
+        blank=False,
+        null=False,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="agentcc_projects",
+        null=True,
+        blank=True,
+    )
+    tracer_project = models.OneToOneField(
+        "tracer.Project",
+        on_delete=models.SET_NULL,
+        related_name="agentcc_project",
+        null=True,
+        blank=True,
+    )
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    config = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        db_table = "agentcc_project"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_project_per_org",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+        ]
+
+    def __str__(self):
+        return self.name

--- a/futureagi/agentcc/models/prompt_template.py
+++ b/futureagi/agentcc/models/prompt_template.py
@@ -1,0 +1,66 @@
+import uuid
+
+from django.conf import settings
+from django.db import models
+
+from accounts.models import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccPromptTemplate(BaseModel):
+    """Prompt template integrated with the gateway for variable substitution."""
+
+    ENV_DEV = "dev"
+    ENV_STAGING = "staging"
+    ENV_PROD = "prod"
+
+    ENV_CHOICES = [
+        (ENV_DEV, "Development"),
+        (ENV_STAGING, "Staging"),
+        (ENV_PROD, "Production"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_prompt_templates",
+    )
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    version = models.PositiveIntegerField(default=1)
+    template = models.TextField()
+    variables = models.JSONField(default=list, blank=True)
+    model = models.CharField(max_length=255, blank=True, default="")
+    environment = models.CharField(
+        max_length=20,
+        choices=ENV_CHOICES,
+        default=ENV_DEV,
+    )
+    is_active = models.BooleanField(default=True)
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="agentcc_prompt_templates",
+    )
+
+    class Meta:
+        db_table = "agentcc_prompt_template"
+        ordering = ["name", "-version"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name", "version", "environment"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_prompt_template_version",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+            models.Index(fields=["name"]),
+            models.Index(fields=["environment"]),
+        ]
+
+    def __str__(self):
+        return f"{self.name} v{self.version} ({self.environment})"

--- a/futureagi/agentcc/models/provider_credential.py
+++ b/futureagi/agentcc/models/provider_credential.py
@@ -1,0 +1,74 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccProviderCredential(BaseModel):
+    """
+    Encrypted provider credential for the Agentcc gateway.
+
+    Stores provider API keys (e.g. OpenAI, Anthropic) using Fernet field-level
+    encryption.  Non-sensitive config (base_url, models, timeouts) is stored in
+    plain-text fields for easy querying and display.
+
+    Replaces the old ``AgentccOrgConfig.providers`` JSONField which stored
+    credentials as plaintext inside a JSON blob.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_provider_credentials",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="agentcc_provider_credentials",
+        null=True,
+        blank=True,
+    )
+
+    # Provider identity
+    provider_name = models.CharField(max_length=100)  # "openai", "anthropic", etc.
+    display_name = models.CharField(max_length=255, blank=True, default="")
+
+    # Encrypted credentials — Fernet-encrypted dict, e.g. {"api_key": "sk-..."}
+    # Use CredentialManager.encrypt() / .decrypt() from integrations.
+    encrypted_credentials = models.BinaryField()
+
+    # Non-sensitive provider config
+    base_url = models.URLField(max_length=500, blank=True, default="")
+    api_format = models.CharField(max_length=50, default="openai")
+    models_list = models.JSONField(
+        default=list, blank=True
+    )  # ["gpt-4o", "gpt-4o-mini"]
+    default_timeout_seconds = models.IntegerField(default=60)
+    max_concurrent = models.IntegerField(default=100)
+    conn_pool_size = models.IntegerField(default=100)
+    extra_config = models.JSONField(default=dict, blank=True)
+
+    is_active = models.BooleanField(default=True)
+    last_rotated_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agentcc_provider_credential"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "provider_name"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_provider_per_org",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+            models.Index(fields=["provider_name"]),
+        ]
+
+    def __str__(self):
+        return f"{self.provider_name} ({self.organization_id})"

--- a/futureagi/agentcc/models/request_log.py
+++ b/futureagi/agentcc/models/request_log.py
@@ -1,0 +1,71 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccRequestLog(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_request_logs",
+        blank=False,
+        null=False,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="agentcc_request_logs",
+        null=True,
+        blank=True,
+    )
+    request_id = models.CharField(max_length=255, blank=True, default="")
+    model = models.CharField(max_length=255, blank=True, default="")
+    provider = models.CharField(max_length=255, blank=True, default="")
+    resolved_model = models.CharField(max_length=255, blank=True, default="")
+    latency_ms = models.IntegerField(default=0)
+    started_at = models.DateTimeField(null=True, blank=True)
+    input_tokens = models.IntegerField(default=0)
+    output_tokens = models.IntegerField(default=0)
+    total_tokens = models.IntegerField(default=0)
+    cost = models.DecimalField(max_digits=12, decimal_places=6, default=0)
+    status_code = models.IntegerField(default=0)
+    is_stream = models.BooleanField(default=False)
+    is_error = models.BooleanField(default=False)
+    error_message = models.TextField(blank=True, default="")
+    cache_hit = models.BooleanField(default=False)
+    fallback_used = models.BooleanField(default=False)
+    guardrail_triggered = models.BooleanField(default=False)
+    api_key_id = models.CharField(max_length=255, blank=True, default="")
+    user_id = models.CharField(max_length=255, blank=True, default="")
+    session_id = models.CharField(max_length=255, blank=True, default="")
+    routing_strategy = models.CharField(max_length=100, blank=True, default="")
+    metadata = models.JSONField(default=dict, blank=True)
+
+    # Phase 5.2: Full request/response data for detail view
+    request_body = models.JSONField(null=True, blank=True)
+    response_body = models.JSONField(null=True, blank=True)
+    request_headers = models.JSONField(null=True, blank=True)
+    response_headers = models.JSONField(null=True, blank=True)
+    guardrail_results = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agentcc_request_log"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["organization", "-started_at"]),
+            models.Index(fields=["model"]),
+            models.Index(fields=["provider"]),
+            models.Index(fields=["api_key_id"]),
+            models.Index(fields=["status_code"]),
+            models.Index(fields=["is_error"]),
+            models.Index(fields=["session_id"]),
+            models.Index(fields=["user_id"]),
+        ]
+
+    def __str__(self):
+        return f"{self.request_id} ({self.model})"

--- a/futureagi/agentcc/models/routing_policy.py
+++ b/futureagi/agentcc/models/routing_policy.py
@@ -1,0 +1,48 @@
+import uuid
+
+from django.conf import settings
+from django.db import models
+
+from accounts.models import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccRoutingPolicy(BaseModel):
+    """Standalone routing policy with version history."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_routing_policies",
+    )
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    version = models.PositiveIntegerField(default=1)
+    config = models.JSONField(default=dict, blank=True)
+    is_active = models.BooleanField(default=True)
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="agentcc_routing_policies",
+    )
+
+    class Meta:
+        db_table = "agentcc_routing_policy"
+        ordering = ["name", "-version"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name", "version"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_routing_policy_version",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+            models.Index(fields=["name"]),
+        ]
+
+    def __str__(self):
+        return f"{self.name} v{self.version} ({'active' if self.is_active else 'inactive'})"

--- a/futureagi/agentcc/models/session.py
+++ b/futureagi/agentcc/models/session.py
@@ -1,0 +1,60 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccSession(BaseModel):
+    """Explicit session for grouping related requests."""
+
+    ACTIVE = "active"
+    CLOSED = "closed"
+
+    STATUS_CHOICES = [
+        (ACTIVE, "Active"),
+        (CLOSED, "Closed"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_sessions",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="agentcc_sessions",
+        null=True,
+        blank=True,
+    )
+    session_id = models.CharField(max_length=255)
+    name = models.CharField(max_length=255, blank=True, default="")
+    status = models.CharField(
+        max_length=20,
+        choices=STATUS_CHOICES,
+        default=ACTIVE,
+    )
+    metadata = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        db_table = "agentcc_session"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "session_id"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_session_id",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+            models.Index(fields=["session_id"]),
+            models.Index(fields=["status"]),
+        ]
+
+    def __str__(self):
+        return f"Session {self.session_id} ({self.status})"

--- a/futureagi/agentcc/models/shadow_experiment.py
+++ b/futureagi/agentcc/models/shadow_experiment.py
@@ -1,0 +1,75 @@
+import uuid
+
+from django.conf import settings
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccShadowExperiment(BaseModel):
+    """Represents a shadow testing experiment that mirrors production traffic to a secondary model."""
+
+    STATUS_ACTIVE = "active"
+    STATUS_PAUSED = "paused"
+    STATUS_COMPLETED = "completed"
+    STATUS_CHOICES = [
+        (STATUS_ACTIVE, "Active"),
+        (STATUS_PAUSED, "Paused"),
+        (STATUS_COMPLETED, "Completed"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_shadow_experiments",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="agentcc_shadow_experiments",
+        null=True,
+        blank=True,
+    )
+    name = models.CharField(max_length=128)
+    description = models.TextField(blank=True, default="")
+    source_model = models.CharField(
+        max_length=255, help_text="Production model being tested against"
+    )
+    shadow_model = models.CharField(
+        max_length=255, help_text="Shadow model receiving mirrored traffic"
+    )
+    shadow_provider = models.CharField(
+        max_length=128, help_text="Provider for the shadow model"
+    )
+    sample_rate = models.FloatField(
+        default=0.1, help_text="Fraction of traffic to mirror (0.0–1.0)"
+    )
+    status = models.CharField(
+        max_length=16, choices=STATUS_CHOICES, default=STATUS_ACTIVE
+    )
+    total_comparisons = models.IntegerField(default=0)
+    config = models.JSONField(null=True, blank=True, help_text="Extra configuration")
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="agentcc_shadow_experiments",
+    )
+
+    class Meta:
+        db_table = "agentcc_shadow_experiment"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_shadow_experiment_name",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.name} ({self.source_model} → {self.shadow_model})"

--- a/futureagi/agentcc/models/shadow_result.py
+++ b/futureagi/agentcc/models/shadow_result.py
@@ -1,0 +1,55 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccShadowResult(BaseModel):
+    """A single captured shadow comparison: production response vs shadow response."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    experiment = models.ForeignKey(
+        "prism.AgentccShadowExperiment",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="results",
+    )
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_shadow_results",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="agentcc_shadow_results",
+        null=True,
+        blank=True,
+    )
+    request_id = models.CharField(max_length=255, db_index=True)
+    source_model = models.CharField(max_length=255)
+    shadow_model = models.CharField(max_length=255)
+    source_response = models.TextField(blank=True, default="")
+    shadow_response = models.TextField(blank=True, default="")
+    source_latency_ms = models.IntegerField(default=0)
+    shadow_latency_ms = models.IntegerField(default=0)
+    source_tokens = models.IntegerField(default=0)
+    shadow_tokens = models.IntegerField(default=0)
+    source_status_code = models.IntegerField(default=200)
+    shadow_status_code = models.IntegerField(default=200)
+    shadow_error = models.TextField(blank=True, default="")
+    prompt_hash = models.CharField(max_length=64, blank=True, default="", db_index=True)
+
+    class Meta:
+        db_table = "agentcc_shadow_result"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["experiment", "-created_at"]),
+        ]
+
+    def __str__(self):
+        return f"Shadow result {self.request_id} ({self.source_model} vs {self.shadow_model})"

--- a/futureagi/agentcc/models/webhook.py
+++ b/futureagi/agentcc/models/webhook.py
@@ -1,0 +1,103 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class AgentccWebhook(BaseModel):
+    """Outbound webhook endpoint for event notifications."""
+
+    EVENT_CHOICES = [
+        ("request.completed", "Request Completed"),
+        ("guardrail.triggered", "Guardrail Triggered"),
+        ("budget.exceeded", "Budget Exceeded"),
+        ("error.occurred", "Error Occurred"),
+        ("batch.completed", "Batch Completed"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_webhooks",
+    )
+    name = models.CharField(max_length=255)
+    url = models.URLField(max_length=2048)
+    secret = models.CharField(max_length=255, blank=True, default="")
+    events = models.JSONField(default=list, blank=True)
+    is_active = models.BooleanField(default=True)
+    headers = models.JSONField(default=dict, blank=True)
+    description = models.TextField(blank=True, default="")
+
+    class Meta:
+        db_table = "agentcc_webhook"
+        ordering = ["name"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name"],
+                condition=models.Q(deleted=False),
+                name="unique_agentcc_webhook_name",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+        ]
+
+    def __str__(self):
+        return f"{self.name} → {self.url}"
+
+
+class AgentccWebhookEvent(BaseModel):
+    """Individual webhook event delivery record."""
+
+    PENDING = "pending"
+    DELIVERED = "delivered"
+    FAILED = "failed"
+    DEAD_LETTER = "dead_letter"
+
+    STATUS_CHOICES = [
+        (PENDING, "Pending"),
+        (DELIVERED, "Delivered"),
+        (FAILED, "Failed"),
+        (DEAD_LETTER, "Dead Letter"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agentcc_webhook_events",
+    )
+    webhook = models.ForeignKey(
+        AgentccWebhook,
+        on_delete=models.CASCADE,
+        related_name="webhook_events",
+    )
+    event_type = models.CharField(max_length=50)
+    payload = models.JSONField(default=dict)
+    status = models.CharField(
+        max_length=20,
+        choices=STATUS_CHOICES,
+        default=PENDING,
+    )
+    attempts = models.IntegerField(default=0)
+    max_attempts = models.IntegerField(default=5)
+    last_attempt_at = models.DateTimeField(null=True, blank=True)
+    last_response_code = models.IntegerField(null=True, blank=True)
+    last_error = models.TextField(blank=True, default="")
+    next_retry_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agentcc_webhook_event"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["organization"]),
+            models.Index(fields=["webhook"]),
+            models.Index(fields=["status"]),
+            models.Index(fields=["next_retry_at"]),
+        ]
+
+    def __str__(self):
+        return f"{self.event_type} → {self.webhook.name} ({self.status})"

--- a/futureagi/api_docs/models/Create Dummy.bru
+++ b/futureagi/api_docs/models/Create Dummy.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Create Dummy
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{host}}:{{port}}/model-hub/ai-models/create-dummy/
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/futureagi/api_docs/models/Create a ai model Copy.bru
+++ b/futureagi/api_docs/models/Create a ai model Copy.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Create a ai model Copy
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{host}}:{{port}}/model-hub/ai_models/update-baseline/:model-id/
+  body: json
+  auth: bearer
+}
+
+params:path {
+  model-id: 6488a093-7091-49c1-99ac-718a08302ace
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+body:json {
+  {
+      "environment" : "Training",
+      "modelVersion" : "1.1"
+  }
+}

--- a/futureagi/api_docs/models/Create a ai model.bru
+++ b/futureagi/api_docs/models/Create a ai model.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Create a ai model
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{host}}:{{port}}/model-hub/ai_models/create/
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+body:json {
+  {
+      "modelName" : "This is a test modelds",
+      "modelTypeId" : 2
+  }
+}

--- a/futureagi/api_docs/models/Create a custom ai model.bru
+++ b/futureagi/api_docs/models/Create a custom ai model.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Create a custom ai model
+  type: http
+  seq: 9
+}
+
+post {
+  url: http://localhost:8000/model-hub/custom_models/create/
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+body:json {
+  {
+      "model_name" : "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      "model_provider": "bedrock",
+      "input_token_cost": "5",
+      "output_token_cost": "2",
+      "config_json":{
+        "access_key_id": "{{aws_access_key_id}}",
+        "secret_access_key": "{{aws_secret_access_key}}",
+        "region_name": "us-east-1"
+      }
+  }
+}

--- a/futureagi/api_docs/models/Custom model view.bru
+++ b/futureagi/api_docs/models/Custom model view.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Custom model view
+  type: http
+  seq: 13
+}
+
+get {
+  url: http://localhost:8000/model-hub/custom-models/:model_id/
+  body: none
+  auth: bearer
+}
+
+params:path {
+  model_id: 87ad397e-eb3b-4069-a6f3-3be44fa6ed96
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/futureagi/api_docs/models/Get Model Voices.bru
+++ b/futureagi/api_docs/models/Get Model Voices.bru
@@ -1,0 +1,53 @@
+meta {
+  name: Get Model Voices
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{base_url}}/model-hub/api/model_voices/?model=openai/tts-1
+  body: none
+  auth: inherit
+}
+
+params:query {
+  model: openai/tts-1
+}
+
+docs {
+  # Get Model Voices
+
+  Retrieves the available voices and audio formats for a specific TTS model.
+
+  ## Query Parameters
+  - `model` (required): The model name (e.g., `openai/tts-1`, `gemini/gemini-2.5-flash-preview-tts`)
+
+  ## Response
+  ```json
+  {
+    "model_name": "openai/tts-1",
+    "provider": "openai",
+    "supported_voices": ["alloy", "echo", "fable", "onyx", "nova", "shimmer"],
+    "supported_formats": ["mp3", "opus", "aac", "flac", "wav", "pcm"],
+    "default_voice": "alloy",
+    "default_format": "mp3"
+  }
+  ```
+
+  ## Examples
+
+  ### OpenAI TTS
+  ```
+  GET /model-hub/api/model_voices/?model=openai/tts-1
+  ```
+
+  ### Gemini TTS
+  ```
+  GET /model-hub/api/model_voices/?model=gemini/gemini-2.5-flash-preview-tts
+  ```
+
+  ### GPT-4o Audio
+  ```
+  GET /model-hub/api/model_voices/?model=gpt-4o-audio-preview
+  ```
+}

--- a/futureagi/api_docs/models/Get all custom models.bru
+++ b/futureagi/api_docs/models/Get all custom models.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get all custom models
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{host}}/model-hub/custom-models/?page=1
+  body: none
+  auth: bearer
+}
+
+params:query {
+  page: 1
+  ~sort_order: asc
+  ~search_query: zt
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/futureagi/api_docs/models/Get all models List.bru
+++ b/futureagi/api_docs/models/Get all models List.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get all models List
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{host}}:{{port}}/model-hub/ai-models/list/?page=1&limit=5
+  body: none
+  auth: bearer
+}
+
+params:query {
+  page: 1
+  limit: 5
+  ~search_query: test
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/futureagi/api_docs/models/Get all models.bru
+++ b/futureagi/api_docs/models/Get all models.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get all models
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}:{{port}}/model-hub/ai-models/?page=1
+  body: none
+  auth: bearer
+}
+
+params:query {
+  page: 1
+  ~sort_order: asc
+  ~search_query: zt
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/futureagi/api_docs/models/Get custom model by id.bru
+++ b/futureagi/api_docs/models/Get custom model by id.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get custom model by id
+  type: http
+  seq: 10
+}
+
+get {
+  url: http://localhost:8000/model-hub/custom-models/:model_id/
+  body: none
+  auth: bearer
+}
+
+params:path {
+  model_id: 87ad397e-eb3b-4069-a6f3-3be44fa6ed96
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/futureagi/api_docs/models/Get model by id.bru
+++ b/futureagi/api_docs/models/Get model by id.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get model by id
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{host}}:{{port}}/model-hub/ai-models/:model_id/
+  body: none
+  auth: bearer
+}
+
+params:path {
+  model_id: 299a5bd0-fb7d-4c11-bb3d-369242048a32
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/futureagi/api_docs/models/Log model inference.bru
+++ b/futureagi/api_docs/models/Log model inference.bru
@@ -1,0 +1,47 @@
+meta {
+  name: Log model inference
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{host}}:{{port}}/log/model/
+  body: json
+  auth: none
+}
+
+headers {
+  X-Api-Key: {{api_key}}
+  X-Secret-Key: {{secret_key}}
+}
+
+body:json {
+  {
+      "prediction_timestamp": 1715543537,
+      "model_id": "xpUfDhqNKs",
+      "model_type": 10,
+      "environment": 1,
+      "model_version": "1.1",
+      "batch_id": "1",
+      "prediction_id": "something",
+      "prediction_label": {
+          "content": "The 2020 World Series was played in Texas at Globe Life Field in Arlington.",
+          "role": "assistant"
+        },
+      "actual_label": {},
+      "features": { "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Who won the world series in 2020?"},
+      {"role": "assistant", "content": "The Los Angeles Dodgers won the World Series in 2020."},
+      {"role": "user", "content": "Where was it played?"}
+    ]},
+      "embedding_features": null,
+      "shap_values": null,
+      "tags": null,
+      "eval_results": {
+          "metric1": {
+              "score": 1
+          }
+      }
+  }
+}

--- a/futureagi/api_docs/models/delete custom model by id.bru
+++ b/futureagi/api_docs/models/delete custom model by id.bru
@@ -1,0 +1,19 @@
+meta {
+  name: delete custom model by id
+  type: http
+  seq: 12
+}
+
+delete {
+  url: http://localhost:8000/model-hub/custom_models/delete/:model_id/
+  body: none
+  auth: bearer
+}
+
+params:path {
+  model_id: 08c3bcb6-2ef0-45ef-8995-0b92829b779c
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/futureagi/api_docs/models/delete model by id.bru
+++ b/futureagi/api_docs/models/delete model by id.bru
@@ -1,0 +1,19 @@
+meta {
+  name: delete model by id
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{host}}:{{port}}/model-hub/ai-models/:model_id/
+  body: none
+  auth: bearer
+}
+
+params:path {
+  model_id: 299a5bd0-fb7d-4c11-bb3d-369242048a32
+}
+
+auth:bearer {
+  token: {{access_token}}
+}

--- a/futureagi/integrations/models/__init__.py
+++ b/futureagi/integrations/models/__init__.py
@@ -1,0 +1,14 @@
+from integrations.models.integration_connection import (
+    ConnectionStatus,
+    IntegrationConnection,
+    IntegrationPlatform,
+)
+from integrations.models.sync_log import SyncLog, SyncStatus
+
+__all__ = [
+    "IntegrationConnection",
+    "IntegrationPlatform",
+    "ConnectionStatus",
+    "SyncLog",
+    "SyncStatus",
+]

--- a/futureagi/integrations/models/integration_connection.py
+++ b/futureagi/integrations/models/integration_connection.py
@@ -1,0 +1,125 @@
+import uuid
+
+from django.conf import settings as django_settings
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+
+
+class IntegrationPlatform(models.TextChoices):
+    LANGFUSE = "langfuse", "Langfuse"
+    DATADOG = "datadog", "Datadog"
+    POSTHOG = "posthog", "PostHog"
+    PAGERDUTY = "pagerduty", "PagerDuty"
+    MIXPANEL = "mixpanel", "Mixpanel"
+    CLOUD_STORAGE = "cloud_storage", "Cloud Storage"
+    MESSAGE_QUEUE = "message_queue", "Message Queue"
+    LINEAR = "linear", "Linear"
+
+
+class ConnectionStatus(models.TextChoices):
+    ACTIVE = "active", "Active"
+    PAUSED = "paused", "Paused"
+    ERROR = "error", "Error"
+    SYNCING = "syncing", "Syncing"
+    BACKFILLING = "backfilling", "Backfilling"
+
+
+class IntegrationConnection(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # Ownership
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="integration_connections",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="integration_connections",
+    )
+    created_by = models.ForeignKey(
+        django_settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="created_integrations",
+    )
+
+    # Platform configuration
+    platform = models.CharField(
+        max_length=50,
+        choices=IntegrationPlatform.choices,
+    )
+    display_name = models.CharField(max_length=255)
+    host_url = models.URLField(max_length=500)
+    encrypted_credentials = models.BinaryField()
+    ca_certificate = models.TextField(null=True, blank=True)
+
+    # Project mapping
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="integration_connections",
+    )
+    external_project_name = models.CharField(max_length=255)
+
+    # Sync state machine
+    status = models.CharField(
+        max_length=20,
+        choices=ConnectionStatus.choices,
+        default=ConnectionStatus.ACTIVE,
+    )
+    status_message = models.TextField(null=True, blank=True)
+    last_synced_at = models.DateTimeField(null=True, blank=True)
+    sync_cursor = models.JSONField(default=dict, blank=True)
+    sync_interval_seconds = models.PositiveIntegerField(
+        default=300,
+        validators=[MinValueValidator(60), MaxValueValidator(1800)],
+    )
+    last_error_notified_at = models.DateTimeField(null=True, blank=True)
+
+    # Backfill state
+    backfill_from = models.DateTimeField(null=True, blank=True)
+    backfill_completed = models.BooleanField(default=False)
+    backfill_progress = models.JSONField(default=dict, blank=True)
+
+    # Counters
+    total_traces_synced = models.PositiveIntegerField(default=0)
+    total_spans_synced = models.PositiveIntegerField(default=0)
+    total_scores_synced = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        db_table = "integrations_connection"
+        indexes = [
+            models.Index(
+                fields=["organization", "platform", "status"],
+                name="idx_intconn_org_plat_status",
+            ),
+            models.Index(
+                fields=["status", "last_synced_at"],
+                name="idx_intconn_status_lastsync",
+            ),
+        ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=[
+                    "organization",
+                    "workspace",
+                    "platform",
+                    "external_project_name",
+                ],
+                condition=models.Q(deleted=False),
+                name="uq_intconn_org_ws_plat_extproj",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.get_platform_display()}: {self.display_name} ({self.status})"

--- a/futureagi/integrations/models/sync_log.py
+++ b/futureagi/integrations/models/sync_log.py
@@ -1,0 +1,62 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+
+
+class SyncStatus(models.TextChoices):
+    SUCCESS = "success", "Success"
+    PARTIAL = "partial", "Partial"
+    FAILED = "failed", "Failed"
+    RATE_LIMITED = "rate_limited", "Rate Limited"
+    NO_NEW_DATA = "no_new_data", "No New Data"
+
+
+class SyncLog(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    connection = models.ForeignKey(
+        "integrations.IntegrationConnection",
+        on_delete=models.CASCADE,
+        related_name="sync_logs",
+    )
+
+    status = models.CharField(
+        max_length=20,
+        choices=SyncStatus.choices,
+        default=SyncStatus.PARTIAL,
+    )
+    started_at = models.DateTimeField()
+    completed_at = models.DateTimeField(null=True, blank=True)
+
+    # Operation counts
+    traces_fetched = models.PositiveIntegerField(default=0)
+    traces_created = models.PositiveIntegerField(default=0)
+    traces_updated = models.PositiveIntegerField(default=0)
+    spans_synced = models.PositiveIntegerField(default=0)
+    scores_synced = models.PositiveIntegerField(default=0)
+
+    # Error details
+    error_message = models.TextField(null=True, blank=True)
+    error_details = models.JSONField(default=dict, blank=True)
+
+    # Time window queried
+    sync_from = models.DateTimeField(null=True, blank=True)
+    sync_to = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "integrations_sync_log"
+        ordering = ("-started_at",)
+        indexes = [
+            models.Index(
+                fields=["connection", "started_at"],
+                name="idx_synclog_conn_started",
+            ),
+            models.Index(
+                fields=["connection", "status"],
+                name="idx_synclog_conn_status",
+            ),
+        ]
+
+    def __str__(self):
+        return f"SyncLog {self.id} ({self.status}) for {self.connection_id}"

--- a/futureagi/mcp_server/models/__init__.py
+++ b/futureagi/mcp_server/models/__init__.py
@@ -1,0 +1,15 @@
+from mcp_server.models.connection import MCPConnection
+from mcp_server.models.oauth_client import MCPOAuthClient
+from mcp_server.models.oauth_code import MCPOAuthCode
+from mcp_server.models.session import MCPSession
+from mcp_server.models.tool_config import MCPToolGroupConfig
+from mcp_server.models.usage import MCPUsageRecord
+
+__all__ = [
+    "MCPConnection",
+    "MCPSession",
+    "MCPToolGroupConfig",
+    "MCPUsageRecord",
+    "MCPOAuthClient",
+    "MCPOAuthCode",
+]

--- a/futureagi/mcp_server/models/connection.py
+++ b/futureagi/mcp_server/models/connection.py
@@ -1,0 +1,60 @@
+import uuid
+
+from django.db import models
+
+from mcp_server.constants import CONNECTION_MODE_CHOICES
+from tfc.utils.base_model import BaseModel
+
+
+class MCPConnection(BaseModel):
+    """Represents a user's MCP configuration for a workspace."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.CASCADE,
+        related_name="mcp_connections",
+    )
+    organization = models.ForeignKey(
+        "accounts.Organization",
+        on_delete=models.CASCADE,
+        related_name="mcp_connections",
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="mcp_connections",
+    )
+    connection_mode = models.CharField(
+        max_length=20,
+        choices=CONNECTION_MODE_CHOICES,
+        default="remote",
+    )
+    is_active = models.BooleanField(default=True)
+    oauth_token_encrypted = models.TextField(null=True, blank=True)
+    oauth_refresh_token_encrypted = models.TextField(null=True, blank=True)
+    oauth_token_expires_at = models.DateTimeField(null=True, blank=True)
+    api_key = models.ForeignKey(
+        "accounts.OrgApiKey",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="mcp_connections",
+    )
+    client_name = models.CharField(max_length=100, blank=True, default="")
+    client_version = models.CharField(max_length=50, blank=True, default="")
+
+    class Meta:
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "workspace"],
+                condition=models.Q(deleted=False),
+                name="unique_mcp_connection_per_user_workspace",
+            ),
+        ]
+
+    def __str__(self):
+        return f"MCPConnection({self.user}, {self.workspace})"

--- a/futureagi/mcp_server/models/oauth_client.py
+++ b/futureagi/mcp_server/models/oauth_client.py
@@ -1,0 +1,21 @@
+import uuid
+
+from django.db import models
+
+
+class MCPOAuthClient(models.Model):
+    """Registered OAuth client applications (Cursor, Claude Code, etc.)."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    client_id = models.CharField(max_length=100, unique=True)
+    client_secret_hash = models.CharField(max_length=255)
+    name = models.CharField(max_length=100)
+    redirect_uris = models.JSONField(default=list)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"MCPOAuthClient({self.name})"

--- a/futureagi/mcp_server/models/oauth_code.py
+++ b/futureagi/mcp_server/models/oauth_code.py
@@ -1,0 +1,47 @@
+import uuid
+from datetime import timedelta
+
+from django.db import models
+from django.utils import timezone
+
+
+class MCPOAuthCode(models.Model):
+    """Temporary authorization codes (10 min TTL)."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    code = models.CharField(max_length=64, unique=True, db_index=True)
+    client = models.ForeignKey(
+        "mcp_server.MCPOAuthClient",
+        on_delete=models.CASCADE,
+        related_name="auth_codes",
+    )
+    user = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.CASCADE,
+        related_name="mcp_auth_codes",
+    )
+    organization = models.ForeignKey(
+        "accounts.Organization",
+        on_delete=models.CASCADE,
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+    )
+    redirect_uri = models.URLField()
+    scope = models.JSONField(default=list)  # List of tool group slugs
+    state = models.CharField(max_length=256, blank=True, default="")
+    created_at = models.DateTimeField(auto_now_add=True)
+    used = models.BooleanField(default=False)
+
+    @property
+    def is_expired(self):
+        return timezone.now() > self.created_at + timedelta(minutes=10)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"MCPOAuthCode({self.client.name}, {self.user})"

--- a/futureagi/mcp_server/models/session.py
+++ b/futureagi/mcp_server/models/session.py
@@ -1,0 +1,67 @@
+import uuid
+
+from django.db import models
+
+from mcp_server.constants import SESSION_STATUS_CHOICES, TRANSPORT_CHOICES
+
+
+class MCPSession(models.Model):
+    """Tracks active and historical MCP sessions."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    connection = models.ForeignKey(
+        "mcp_server.MCPConnection",
+        on_delete=models.CASCADE,
+        related_name="sessions",
+    )
+    user = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.CASCADE,
+        related_name="mcp_sessions",
+    )
+    organization = models.ForeignKey(
+        "accounts.Organization",
+        on_delete=models.CASCADE,
+        related_name="mcp_sessions",
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="mcp_sessions",
+    )
+    status = models.CharField(
+        max_length=20,
+        choices=SESSION_STATUS_CHOICES,
+        default="active",
+    )
+    transport = models.CharField(
+        max_length=20,
+        choices=TRANSPORT_CHOICES,
+        default="streamable_http",
+    )
+    client_name = models.CharField(max_length=100, blank=True, default="")
+    client_version = models.CharField(max_length=50, blank=True, default="")
+    client_os = models.CharField(max_length=50, blank=True, default="")
+    started_at = models.DateTimeField(auto_now_add=True)
+    last_activity_at = models.DateTimeField(auto_now=True)
+    ended_at = models.DateTimeField(null=True, blank=True)
+    tool_call_count = models.PositiveIntegerField(default=0)
+    error_count = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        ordering = ["-started_at"]
+        indexes = [
+            models.Index(
+                fields=["user", "status"],
+                name="idx_mcp_session_user_status",
+            ),
+            models.Index(
+                fields=["organization", "status"],
+                name="idx_mcp_session_org_status",
+            ),
+        ]
+
+    def __str__(self):
+        return f"MCPSession({self.id}, {self.status})"

--- a/futureagi/mcp_server/models/tool_config.py
+++ b/futureagi/mcp_server/models/tool_config.py
@@ -1,0 +1,30 @@
+import uuid
+
+from django.db import models
+
+from mcp_server.constants import DEFAULT_TOOL_GROUPS
+from tfc.utils.base_model import BaseModel
+
+
+class MCPToolGroupConfig(BaseModel):
+    """Stores which tool groups are enabled for a connection."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    connection = models.OneToOneField(
+        "mcp_server.MCPConnection",
+        on_delete=models.CASCADE,
+        related_name="tool_config",
+    )
+    enabled_groups = models.JSONField(default=list)
+    disabled_tools = models.JSONField(default=list)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def save(self, *args, **kwargs):
+        if not self.enabled_groups:
+            self.enabled_groups = list(DEFAULT_TOOL_GROUPS)
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"MCPToolGroupConfig({self.connection})"

--- a/futureagi/mcp_server/models/usage.py
+++ b/futureagi/mcp_server/models/usage.py
@@ -1,0 +1,69 @@
+import uuid
+
+from django.db import models
+
+from mcp_server.constants import RESPONSE_STATUS_CHOICES
+
+
+class MCPUsageRecord(models.Model):
+    """Individual tool call records for analytics and auditing."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    session = models.ForeignKey(
+        "mcp_server.MCPSession",
+        on_delete=models.CASCADE,
+        related_name="usage_records",
+    )
+    organization = models.ForeignKey(
+        "accounts.Organization",
+        on_delete=models.CASCADE,
+        related_name="mcp_usage",
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="mcp_usage",
+    )
+    user = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.CASCADE,
+        related_name="mcp_usage",
+    )
+    tool_name = models.CharField(max_length=100, db_index=True)
+    tool_group = models.CharField(max_length=50)
+    request_params = models.JSONField(default=dict)
+    response_status = models.CharField(
+        max_length=20,
+        choices=RESPONSE_STATUS_CHOICES,
+    )
+    error_message = models.TextField(blank=True, default="")
+    latency_ms = models.PositiveIntegerField(default=0)
+    embedded_agent_used = models.BooleanField(default=False)
+    embedded_agent_tokens = models.PositiveIntegerField(default=0)
+    called_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-called_at"]
+        indexes = [
+            models.Index(
+                fields=["organization", "called_at"],
+                name="idx_mcp_usage_org_time",
+            ),
+            models.Index(
+                fields=["session", "called_at"],
+                name="idx_mcp_usage_session_time",
+            ),
+            models.Index(
+                fields=["tool_name", "called_at"],
+                name="idx_mcp_usage_tool_time",
+            ),
+            models.Index(
+                fields=["user", "called_at"],
+                name="idx_mcp_usage_user_time",
+            ),
+        ]
+
+    def __str__(self):
+        return f"MCPUsageRecord({self.tool_name}, {self.response_status})"

--- a/futureagi/model_hub/models/__init__.py
+++ b/futureagi/model_hub/models/__init__.py
@@ -1,0 +1,32 @@
+from .ai_model import AIModel
+from .annotation import AnnotationTask, ClickHouseAnnotation
+from .annotation_queues import (
+    AnnotationQueue,
+    AnnotationQueueAnnotator,
+    AnnotationQueueLabel,
+    AutomationRule,
+    ItemAnnotation,
+    QueueItem,
+)
+from .column_config import ColumnConfig
+from .conversations import Conversation, Message, Node
+from .dataset_insight_meta import DatasetInsightMeta
+from .dataset_optimization_step import DatasetOptimizationStep
+from .dataset_optimization_trial import DatasetOptimizationTrial
+from .dataset_optimization_trial_item import (
+    DatasetOptimizationItemEvaluation,
+    DatasetOptimizationTrialItem,
+)
+from .dataset_properties import DatasetProperties
+from .develop import DevelopAI
+from .evaluation import Evaluation
+from .insight import Insight
+from .insight_status import InsightStatus
+from .kb import KnowledgeBase
+from .metric import Metric
+from .monitor_alert import MonitorAlert
+from .monitors import Monitor
+from .optimize_dataset import OptimizeDataset
+from .performance_report import PerformanceReport
+from .prompt import Prompt
+from .score import Score

--- a/futureagi/model_hub/models/ai_model.py
+++ b/futureagi/model_hub/models/ai_model.py
@@ -1,0 +1,168 @@
+"""
+# Note: Moving the extra field down
+# model_performance_positive_class = models.CharField(
+#     max_length=100, default=None, blank=True, null=True
+# )
+# model_performance_at_k = models.CharField(
+#     max_length=100, default=None, blank=True, null=True
+# )
+# version = models.CharField(max_length=255)
+# environment = models.CharField(max_length=100, choices=EnvTypes.choices)
+# baseline_model_environment = models.CharField(
+# max_length=100, choices=EnvTypes.choices
+# )
+# baseline_model_version = models.CharField(max_length=255)
+# baseline_model_batch = models.CharField(max_length=100)
+"""
+
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class ActiveManager(models.Manager):
+    def get_queryset(self):
+        # Override the get_queryset method to filter out deleted objects
+        return super().get_queryset().filter(deleted=False)
+
+
+class AIModel(models.Model):
+    class ModelTypes(models.TextChoices):
+        NUMERIC = "Numeric", "Numeric"
+        SCORE_CATEGORICAL = "ScoreCategorical", "Score Categorical"
+        RANKING = "Ranking", "Ranking"
+        BINARY_CF = "BinaryClassification", "Binary Classification"
+        REGRESSION = "Regression", "Regression"
+        OBJECT_DETECTION = "ObjectDetection", "Object Detection"
+        SEGMENTATION = "Segmentation", "Segmentation"
+        GENERATIVE_LLM = "GenerativeLLM", "Generative LLM"
+        GENERATIVE_IMAGE = "GenerativeImage", "Generative Image"
+        GENERATIVE_VIDEO = "GenerativeVideo", "Generative Video"
+        TTS = "TTS", "TTS"
+        STT = "STT", "STT"
+        MULTI_MODAL = "MultiModal", "Multi Modal"
+
+        @classmethod
+        def get_model_types(cls, num):
+            if num == 1:
+                return cls.NUMERIC
+            if num == 2:
+                return cls.SCORE_CATEGORICAL
+            if num == 3:
+                return cls.RANKING
+            if num == 4:
+                return cls.BINARY_CF
+            if num == 5:
+                return cls.REGRESSION
+            if num == 6:
+                return cls.OBJECT_DETECTION
+            if num == 7:
+                return cls.SEGMENTATION
+            if num == 8:
+                return cls.GENERATIVE_LLM
+            if num == 9:
+                return cls.GENERATIVE_IMAGE
+            if num == 10:
+                return cls.GENERATIVE_VIDEO
+            if num == 11:
+                return cls.TTS
+            if num == 12:
+                return cls.STT
+            if num == 13:
+                return cls.MULTI_MODAL
+
+        @classmethod
+        def get_model_num(cls, model_type):
+            for num, choice in enumerate(cls.choices, start=1):
+                if choice[0] == model_type:
+                    return num
+            return None  # Return None or raise an error if not found
+
+    class EnvTypes(models.TextChoices):
+        PRODUCTION = "Production", "Production"
+        TRAINING = "Training", "Training"
+        VALIDATION = "Validation", "Validation"
+        CORPUS = "Corpus", "Corpus"
+
+        @classmethod
+        def get_env_types(cls, num):
+            if num == 1:
+                return cls.TRAINING
+            if num == 2:
+                return cls.VALIDATION
+            if num == 3:
+                return cls.PRODUCTION
+            if num == 4:
+                return cls.CORPUS
+
+        @classmethod
+        def get_env_num_types(cls, typ):
+            if typ == cls.TRAINING:
+                return 1
+            if typ == cls.VALIDATION:
+                return 2
+            if typ == cls.PRODUCTION:
+                return 3
+            if typ == cls.CORPUS:
+                return 4
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    user_model_id = models.CharField(max_length=255)
+    deleted = models.BooleanField(default=False)
+
+    model_type = models.CharField(max_length=100, choices=ModelTypes.choices)
+
+    default_metric = models.ForeignKey(
+        "Metric",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="defaulted_by",
+    )
+
+    baseline_model_environment = models.CharField(
+        max_length=100,
+        choices=EnvTypes.choices,
+        default=None,
+        blank=True,
+        null=True,
+    )
+    baseline_model_version = models.CharField(
+        max_length=255, default=None, blank=True, null=True
+    )
+    # baseline_model_batch = models.CharField(max_length=100)
+
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="ai_models"
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="ai_models",
+        null=True,
+        blank=True,
+    )
+
+    # Use the custom manager to filter deleted=False by default
+    objects = ActiveManager()
+
+    # Optional: Add a default manager for accessing all objects, including deleted ones
+    all_objects = models.Manager()
+
+    class Meta:
+        unique_together = ["organization", "user_model_id", "deleted"]
+
+    def __str__(self):
+        return str(self.id)
+
+
+class CriteriaCache(BaseModel):
+    text_prompt = models.TextField(unique=True)
+    criteria_breakdown = models.JSONField()
+
+    def __str__(self):
+        return self.text_prompt

--- a/futureagi/model_hub/models/annotation.py
+++ b/futureagi/model_hub/models/annotation.py
@@ -1,0 +1,49 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import User
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models import AIModel
+
+
+class AnnotationTask(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    task_name = models.CharField(max_length=255)
+    assigned_users = models.ManyToManyField(User, related_name="annotation_tasks")
+    ai_model = models.ForeignKey(
+        AIModel, on_delete=models.CASCADE, related_name="annotation_tasks"
+    )
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="organization"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="annotation_tasks",
+        null=True,
+        blank=True,
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    is_deleted = models.BooleanField(default=False)
+
+    def __str__(self):
+        return f"Annotation Task {self.id}"
+
+
+class ClickHouseAnnotation(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    uuid: models.CharField = models.CharField(
+        max_length=36
+    )  # UUIDs are 36 characters long
+    annotation_task = models.ForeignKey(
+        AnnotationTask,
+        on_delete=models.CASCADE,
+        related_name="clickhouse_annotations",
+    )
+    is_annotated = models.BooleanField(default=False)
+
+    def __str__(self):
+        return self.uuid

--- a/futureagi/model_hub/models/annotation_queues.py
+++ b/futureagi/model_hub/models/annotation_queues.py
@@ -1,0 +1,520 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.db.models import Q
+
+from accounts.models.organization import Organization
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+from model_hub.models.choices import (
+    AnnotationQueueStatusChoices,
+    AnnotatorRole,
+    AssignmentStrategy,
+    QueueItemSourceType,
+    QueueItemStatus,
+)
+from model_hub.models.develop_annotations import AnnotationsLabels
+from tfc.utils.base_model import BaseModel
+
+VALID_STATUS_TRANSITIONS = {
+    AnnotationQueueStatusChoices.DRAFT.value: {
+        AnnotationQueueStatusChoices.ACTIVE.value,
+    },
+    AnnotationQueueStatusChoices.ACTIVE.value: {
+        AnnotationQueueStatusChoices.PAUSED.value,
+        AnnotationQueueStatusChoices.COMPLETED.value,
+    },
+    AnnotationQueueStatusChoices.PAUSED.value: {
+        AnnotationQueueStatusChoices.ACTIVE.value,
+        AnnotationQueueStatusChoices.COMPLETED.value,
+    },
+    AnnotationQueueStatusChoices.COMPLETED.value: {
+        AnnotationQueueStatusChoices.ACTIVE.value,
+        AnnotationQueueStatusChoices.PAUSED.value,
+    },
+}
+
+
+class AnnotationQueue(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    description = models.TextField(null=True, blank=True)
+    instructions = models.TextField(null=True, blank=True)
+    status = models.CharField(
+        max_length=20,
+        choices=AnnotationQueueStatusChoices.get_choices(),
+        default=AnnotationQueueStatusChoices.DRAFT.value,
+    )
+    assignment_strategy = models.CharField(
+        max_length=20,
+        choices=AssignmentStrategy.get_choices(),
+        default=AssignmentStrategy.MANUAL.value,
+    )
+    annotations_required = models.IntegerField(default=1)
+    reservation_timeout_minutes = models.IntegerField(default=60)
+    requires_review = models.BooleanField(default=False)
+    auto_assign = models.BooleanField(
+        default=False,
+        help_text="When enabled, all queue members can annotate any item without explicit assignment.",
+    )
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="annotation_queues",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="annotation_queues",
+        null=True,
+        blank=True,
+    )
+    project = models.ForeignKey(
+        "tracer.Project",
+        on_delete=models.CASCADE,
+        related_name="annotation_queues",
+        null=True,
+        blank=True,
+    )
+    dataset = models.ForeignKey(
+        "model_hub.Dataset",
+        on_delete=models.CASCADE,
+        related_name="annotation_queues",
+        null=True,
+        blank=True,
+    )
+    agent_definition = models.ForeignKey(
+        "simulate.AgentDefinition",
+        on_delete=models.CASCADE,
+        related_name="annotation_queues",
+        null=True,
+        blank=True,
+    )
+    is_default = models.BooleanField(default=False)
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="created_annotation_queues",
+    )
+    labels = models.ManyToManyField(
+        AnnotationsLabels,
+        through="AnnotationQueueLabel",
+        related_name="queues",
+        blank=True,
+    )
+    annotators = models.ManyToManyField(
+        User,
+        through="AnnotationQueueAnnotator",
+        related_name="assigned_annotation_queues",
+        blank=True,
+    )
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name"],
+                condition=Q(
+                    deleted=False,
+                    project__isnull=True,
+                    dataset__isnull=True,
+                    agent_definition__isnull=True,
+                ),
+                name="unique_active_queue_name_org",
+            ),
+            models.UniqueConstraint(
+                fields=["organization", "name", "project"],
+                condition=Q(deleted=False, project__isnull=False),
+                name="unique_active_queue_name_org_project",
+            ),
+            models.UniqueConstraint(
+                fields=["organization", "name", "dataset"],
+                condition=Q(deleted=False, dataset__isnull=False),
+                name="unique_active_queue_name_org_dataset",
+            ),
+            models.UniqueConstraint(
+                fields=["organization", "name", "agent_definition"],
+                condition=Q(deleted=False, agent_definition__isnull=False),
+                name="unique_active_queue_name_org_agent",
+            ),
+            models.UniqueConstraint(
+                fields=["project"],
+                condition=Q(deleted=False, is_default=True, project__isnull=False),
+                name="unique_default_queue_per_project",
+            ),
+            models.UniqueConstraint(
+                fields=["dataset"],
+                condition=Q(deleted=False, is_default=True, dataset__isnull=False),
+                name="unique_default_queue_per_dataset",
+            ),
+            models.UniqueConstraint(
+                fields=["agent_definition"],
+                condition=Q(
+                    deleted=False, is_default=True, agent_definition__isnull=False
+                ),
+                name="unique_default_queue_per_agent",
+            ),
+        ]
+
+    def __str__(self):
+        return f"AnnotationQueue: {self.name}"
+
+
+class AnnotationQueueLabel(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    queue = models.ForeignKey(
+        AnnotationQueue,
+        on_delete=models.CASCADE,
+        related_name="queue_labels",
+    )
+    label = models.ForeignKey(
+        AnnotationsLabels,
+        on_delete=models.CASCADE,
+        related_name="queue_memberships",
+    )
+    required = models.BooleanField(default=True)
+    order = models.IntegerField(default=0)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["queue", "label"],
+                condition=Q(deleted=False),
+                name="unique_active_queue_label",
+            )
+        ]
+
+    def __str__(self):
+        return f"QueueLabel: {self.queue_id} - {self.label_id}"
+
+
+class AnnotationQueueAnnotator(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    queue = models.ForeignKey(
+        AnnotationQueue,
+        on_delete=models.CASCADE,
+        related_name="queue_annotators",
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="annotation_queue_assignments",
+    )
+    role = models.CharField(
+        max_length=20,
+        choices=AnnotatorRole.get_choices(),
+        default=AnnotatorRole.ANNOTATOR.value,
+    )
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["queue", "user"],
+                condition=Q(deleted=False),
+                name="unique_active_queue_annotator",
+            )
+        ]
+
+    def __str__(self):
+        return f"QueueAnnotator: {self.queue_id} - {self.user_id} ({self.role})"
+
+
+# Source FK field name mapping for QueueItem
+SOURCE_TYPE_FK_MAP = {
+    QueueItemSourceType.DATASET_ROW.value: "dataset_row",
+    QueueItemSourceType.TRACE.value: "trace",
+    QueueItemSourceType.OBSERVATION_SPAN.value: "observation_span",
+    QueueItemSourceType.PROTOTYPE_RUN.value: "prototype_run",
+    QueueItemSourceType.CALL_EXECUTION.value: "call_execution",
+    QueueItemSourceType.TRACE_SESSION.value: "trace_session",
+}
+
+
+class QueueItem(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    queue = models.ForeignKey(
+        AnnotationQueue,
+        on_delete=models.CASCADE,
+        related_name="items",
+    )
+    source_type = models.CharField(
+        max_length=50,
+        choices=QueueItemSourceType.get_choices(),
+    )
+    status = models.CharField(
+        max_length=20,
+        choices=QueueItemStatus.get_choices(),
+        default=QueueItemStatus.PENDING.value,
+    )
+    priority = models.IntegerField(default=0)
+    order = models.IntegerField(default=0)
+    metadata = models.JSONField(default=dict, blank=True)
+    # Deprecated: single-assignee FK. Use assigned_users M2M instead.
+    assigned_to = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="assigned_queue_items",
+    )
+    assigned_users = models.ManyToManyField(
+        User,
+        through="QueueItemAssignment",
+        related_name="multi_assigned_queue_items",
+        blank=True,
+    )
+
+    # Reservation fields
+    reserved_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="reserved_queue_items",
+    )
+    reserved_at = models.DateTimeField(null=True, blank=True)
+    reservation_expires_at = models.DateTimeField(null=True, blank=True)
+
+    # Review fields
+    review_status = models.CharField(max_length=20, null=True, blank=True)
+    reviewed_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="reviewed_queue_items",
+    )
+    reviewed_at = models.DateTimeField(null=True, blank=True)
+    review_notes = models.TextField(null=True, blank=True)
+
+    # Source references — only one populated per item
+    dataset_row = models.ForeignKey(
+        "model_hub.Row",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="queue_items",
+    )
+    trace = models.ForeignKey(
+        "tracer.Trace",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="queue_items",
+    )
+    observation_span = models.ForeignKey(
+        "tracer.ObservationSpan",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="queue_items",
+    )
+    prototype_run = models.ForeignKey(
+        "model_hub.RunPrompter",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="queue_items",
+    )
+    call_execution = models.ForeignKey(
+        "simulate.CallExecution",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="queue_items",
+    )
+    trace_session = models.ForeignKey(
+        "tracer.TraceSession",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="queue_items",
+    )
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="queue_items",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="queue_items",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["queue", "status"]),
+            models.Index(fields=["queue", "source_type"]),
+        ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["queue", "dataset_row"],
+                condition=Q(deleted=False, dataset_row__isnull=False),
+                name="unique_queue_dataset_row",
+            ),
+            models.UniqueConstraint(
+                fields=["queue", "trace"],
+                condition=Q(deleted=False, trace__isnull=False),
+                name="unique_queue_trace",
+            ),
+            models.UniqueConstraint(
+                fields=["queue", "observation_span"],
+                condition=Q(deleted=False, observation_span__isnull=False),
+                name="unique_queue_observation_span",
+            ),
+            models.UniqueConstraint(
+                fields=["queue", "prototype_run"],
+                condition=Q(deleted=False, prototype_run__isnull=False),
+                name="unique_queue_prototype_run",
+            ),
+            models.UniqueConstraint(
+                fields=["queue", "call_execution"],
+                condition=Q(deleted=False, call_execution__isnull=False),
+                name="unique_queue_call_execution",
+            ),
+            models.UniqueConstraint(
+                fields=["queue", "trace_session"],
+                condition=Q(deleted=False, trace_session__isnull=False),
+                name="unique_queue_trace_session",
+            ),
+        ]
+
+    def clean(self):
+        super().clean()
+        fk_field = SOURCE_TYPE_FK_MAP.get(self.source_type)
+        if not fk_field:
+            raise ValidationError(f"Invalid source_type: {self.source_type}")
+        if getattr(self, f"{fk_field}_id") is None:
+            raise ValidationError(
+                f"source_type '{self.source_type}' requires '{fk_field}' to be set."
+            )
+        # Ensure no other source FK is set
+        for st, field in SOURCE_TYPE_FK_MAP.items():
+            if field != fk_field and getattr(self, f"{field}_id") is not None:
+                raise ValidationError(
+                    f"Only '{fk_field}' should be set for source_type '{self.source_type}', "
+                    f"but '{field}' is also set."
+                )
+
+    def __str__(self):
+        return f"QueueItem: {self.id} ({self.source_type})"
+
+
+class QueueItemAssignment(BaseModel):
+    """Through model for multi-annotator assignment on queue items."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    queue_item = models.ForeignKey(
+        QueueItem,
+        on_delete=models.CASCADE,
+        related_name="assignments",
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="queue_item_assignments",
+    )
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["queue_item", "user"],
+                condition=Q(deleted=False),
+                name="unique_active_queue_item_assignment",
+            )
+        ]
+
+    def __str__(self):
+        return f"QueueItemAssignment: {self.queue_item_id} - {self.user_id}"
+
+
+class ItemAnnotation(BaseModel):
+    """Stores one annotation value per label per item per annotator."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    queue_item = models.ForeignKey(
+        QueueItem,
+        on_delete=models.CASCADE,
+        related_name="annotations",
+    )
+    annotator = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="item_annotations",
+    )
+    label = models.ForeignKey(
+        AnnotationsLabels,
+        on_delete=models.CASCADE,
+        related_name="item_annotations",
+    )
+    value = models.JSONField(default=dict)
+    score_source = models.CharField(max_length=20, default="human")
+    notes = models.TextField(null=True, blank=True)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="item_annotations",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="item_annotations",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["queue_item", "annotator", "label"],
+                condition=Q(deleted=False),
+                name="unique_item_annotation_per_label_per_annotator",
+            )
+        ]
+        indexes = [
+            models.Index(fields=["queue_item", "annotator"]),
+        ]
+
+    def __str__(self):
+        return f"ItemAnnotation: {self.id} (item={self.queue_item_id}, label={self.label_id})"
+
+
+class AutomationRule(BaseModel):
+    """Rule-based auto-routing of items to annotation queues."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    queue = models.ForeignKey(
+        AnnotationQueue,
+        on_delete=models.CASCADE,
+        related_name="automation_rules",
+    )
+    source_type = models.CharField(
+        max_length=50,
+        choices=QueueItemSourceType.get_choices(),
+    )
+    conditions = models.JSONField(default=dict)
+    enabled = models.BooleanField(default=True)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="automation_rules",
+    )
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="created_automation_rules",
+    )
+    last_triggered_at = models.DateTimeField(null=True, blank=True)
+    trigger_count = models.IntegerField(default=0)
+
+    def __str__(self):
+        return f"AutomationRule: {self.name} (queue={self.queue_id})"

--- a/futureagi/model_hub/models/api_key.py
+++ b/futureagi/model_hub/models/api_key.py
@@ -1,0 +1,305 @@
+import base64
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from accounts.models import Organization, User
+from accounts.models.workspace import Workspace
+from model_hub.models.choices import LiteLlmModelProvider
+from tfc.settings import settings
+from tfc.utils.base_model import BaseModel
+
+
+def validate_model_provider_choice(value):
+    valid_choices = [choice.value for choice in LiteLlmModelProvider]
+    if value not in valid_choices and not value == "custom":
+        raise ValidationError(
+            f"Invalid provider choice. Valid choices are: {', '.join(valid_choices)}"
+        )
+
+
+def mask_key(key):
+    if isinstance(key, str):
+        if key:
+            if len(key) <= 8:
+                visible_chars = min(4, len(key))
+                return key[:visible_chars] + "*" * max(len(key) - visible_chars, 4)
+            return key[:4] + "*" * min(max(len(key) - 8, 0), 10) + key[-4:]
+        return key
+    elif isinstance(key, dict):
+        masked_json = {}
+        for key_id, value in key.items():
+            if isinstance(value, str) and value:
+                masked_json[key_id] = value[0:4] + "*" * (6) + value[-4:]
+            elif isinstance(value, dict):
+                # Recursively mask nested dictionaries
+                masked_json[key_id] = mask_key(value)
+            elif isinstance(value, list):
+                # Recursively mask nested lists
+                masked_json[key_id] = [mask_key(item) for item in value]
+            else:
+                # For other types, keep as-is
+                masked_json[key_id] = value
+        return masked_json
+    elif isinstance(key, list):
+        # Handle lists by masking each item
+        return [mask_key(item) for item in key]
+    else:
+        # For other types, return as-is
+        return key
+
+
+class ApiKey(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="api_key_org",
+        blank=True,
+        null=True,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="api_keys",
+        null=True,
+        blank=True,
+    )
+    provider = models.CharField(
+        max_length=50, validators=[validate_model_provider_choice]
+    )
+    key = models.CharField(max_length=2500, null=True, blank=True)
+    config_json = models.JSONField(null=True, blank=True)
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, null=True, blank=True, default=None
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._actual_key = None
+        self._actual_json = {}
+        if self.key:
+            self._actual_key = self.decrypt_key()
+        if self.config_json:
+            self._actual_json = self.decrypt_json(self.config_json)
+
+    def encrypt_key(self, key):
+        if not key:
+            return None
+        # Use a secret salt from settings
+        salt = settings.SECRET_KEY[:16].encode()
+        # Combine salt and key, then encode
+        salted = salt + key.encode()
+        encoded = base64.b64encode(salted).decode()
+        return encoded
+
+    def decrypt_key(self):
+        if not self.key:
+            return None
+        try:
+            # Decode the stored value
+            decoded = base64.b64decode(self.key)
+            # Remove the salt (first 16 bytes)
+            actual_key = decoded[16:].decode()
+            return actual_key
+        except Exception:
+            return None
+
+    @property
+    def actual_key(self):
+        return self._actual_key
+
+    @property
+    def actual_json(self):
+        return self._actual_json
+
+    @property
+    def masked_actual_key(self):
+        if not self.actual_key:
+            if self.actual_json:
+                return mask_key(self.actual_json)
+            else:
+                return None
+        return mask_key(self.actual_key)
+
+    def clean(self):
+        super().clean()
+        validate_model_provider_choice(self.provider)
+
+    def save(self, *args, **kwargs):
+        if self.key and not self.key.startswith(b"gAAAAA".decode()):
+            self._actual_key = self.key
+            self.key = self.encrypt_key(self.key)
+        if self.config_json and not all(
+            v.startswith(b"gAAAAA".decode()) for v in self.config_json.values()
+        ):
+            self._actual_json = self.config_json
+            self.config_json = self.encrypt_json(self.config_json)
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    def encrypt_json(self, config_json):
+        encrypted_json = {}
+        for key in config_json.keys():
+            encrypted_json[key] = self._encrypt_value(config_json[key])
+        return encrypted_json
+
+    def _encrypt_value(self, value):
+        """Recursively encrypt values, handling nested structures"""
+        if isinstance(value, dict):
+            # Recursively encrypt nested dictionaries
+            encrypted_dict = {}
+            for k, v in value.items():
+                encrypted_dict[k] = self._encrypt_value(v)
+            return encrypted_dict
+        elif isinstance(value, list):
+            # Recursively encrypt nested lists
+            return [self._encrypt_value(item) for item in value]
+        elif isinstance(value, str):
+            # Only encrypt string values
+            return self.encrypt_key(value)
+        else:
+            # For other types (int, float, bool, etc.), return as-is
+            return value
+
+    def get_decrypted_json_key(self, json_key):
+        if not json_key:
+            return None
+        try:
+            # Decode the stored value
+            decoded = base64.b64decode(json_key)
+            # Remove the salt (first 16 bytes)
+            actual_key = decoded[16:].decode()
+            return actual_key
+        except Exception:
+            return None
+
+    def decrypt_json(self, json_key=None):
+        actual_key = {}
+        if not json_key:
+            json_key = self.config_json
+        if json_key is not None:
+            for key in json_key.keys():
+                key_val = self._decrypt_value(json_key[key])
+                actual_key.update({key: key_val})
+        return actual_key
+
+    def _decrypt_value(self, value):
+        """Recursively decrypt values, handling nested structures"""
+        if isinstance(value, dict):
+            # Recursively decrypt nested dictionaries
+            decrypted_dict = {}
+            for k, v in value.items():
+                decrypted_dict[k] = self._decrypt_value(v)
+            return decrypted_dict
+        elif isinstance(value, list):
+            # Recursively decrypt nested lists
+            return [self._decrypt_value(item) for item in value]
+        elif isinstance(value, str):
+            # Only decrypt encrypted string values
+            return self.get_decrypted_json_key(value)
+        else:
+            # For other types (int, float, bool, etc.), return as-is
+            return value
+
+
+class SecretType(models.TextChoices):  # pragma: allowlist secret
+    API_KEY = "API_KEY", "API Key"
+    PASSWORD = "PASSWORD", "Password"  # pragma: allowlist secret
+    TOKEN = "TOKEN", "Token"
+    OTHER = "OTHER", "Other"
+
+
+def validate_secret_type(value):
+    valid_choices = [choice.value for choice in SecretType]
+    if value not in valid_choices:
+        raise ValidationError(
+            f"Invalid secret type. Valid choices are: {', '.join(valid_choices)}"
+        )
+
+
+class SecretModel(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    description = models.TextField(null=True, blank=True)
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="organization_secrets",
+        blank=True,
+        null=True,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="secrets",
+        null=True,
+        blank=True,
+    )
+
+    secret_type = models.CharField(
+        max_length=50,
+        choices=SecretType.choices,
+        validators=[validate_secret_type],
+        default=SecretType.OTHER,
+    )
+
+    key = models.CharField(max_length=2500, null=True, blank=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._actual_key = None
+        if self.key:
+            self._actual_key = self.decrypt_key()
+
+    def encrypt_key(self, key):
+        if not key:
+            return None
+        # Use a secret salt from settings
+        salt = settings.SECRET_KEY[:16].encode()
+        # Combine salt and key, then encode
+        salted = salt + key.encode()
+        encoded = base64.b64encode(salted).decode()
+        return encoded
+
+    def decrypt_key(self):
+        if not self.key:
+            return None
+        try:
+            # Decode the stored value
+            decoded = base64.b64decode(self.key)
+            # Remove the salt (first 16 bytes)
+            actual_key = decoded[16:].decode()
+            return actual_key
+        except Exception:
+            return None
+
+    @property
+    def actual_key(self):
+        return self._actual_key
+
+    def clean(self):
+        super().clean()
+        validate_secret_type(self.secret_type)
+
+    def save(self, *args, **kwargs):
+        if self.key and not self.key.startswith(b"gAAAAA".decode()):
+            self._actual_key = self.key
+            self.key = self.encrypt_key(self.key)
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    class Meta:
+        db_table = "secrets"
+        ordering = ["-created_at"]
+        unique_together = [
+            "organization",
+            "workspace",
+            "name",
+        ]  # Ensure unique names within an organization and workspace
+
+    def __str__(self):
+        return f"{self.name} ({self.organization.display_name if self.organization.display_name else self.organization.name if self.organization else 'No Org'})"

--- a/futureagi/model_hub/models/auto_generate_events_run.py
+++ b/futureagi/model_hub/models/auto_generate_events_run.py
@@ -1,0 +1,14 @@
+from django.db import models
+
+from model_hub.models import AIModel
+
+
+class AutoGenerateEventsRun(models.Model):
+    ai_model = models.ForeignKey(
+        AIModel, on_delete=models.CASCADE, related_name="auto_generate_runs"
+    )
+    last_run_at = models.DateTimeField(auto_now=True)
+    total_events = models.IntegerField(default=0)
+
+    class Meta:
+        unique_together = ("ai_model",)

--- a/futureagi/model_hub/models/choices.py
+++ b/futureagi/model_hub/models/choices.py
@@ -1,0 +1,1499 @@
+import base64
+import io
+import json
+import mimetypes
+import re
+import traceback
+import wave
+from datetime import datetime
+from enum import Enum
+from urllib.parse import urlparse
+
+import pandas as pd
+import requests
+import structlog
+from PIL import Image
+
+logger = structlog.get_logger(__name__)
+from django.db import models
+
+from agentic_eval.core_evals.fi_evals.eval_type import (
+    FunctionEvalTypeId,
+    FutureAgiEvalTypeId,
+    GroundedEvalTypeId,
+    LlmEvalTypeId,
+)
+
+
+class ModalityType(str, Enum):
+    """Modality filter values for prompt API endpoints."""
+
+    CHAT = "chat"
+    AUDIO = "audio"
+    STT = "stt"
+    ALL = "all"
+
+    @classmethod
+    def default(cls):
+        return cls.CHAT
+
+
+class ModelTypes(Enum):
+    NUMERIC = "Numeric"
+    SCORE_CATEGORICAL = "ScoreCategorical"
+    RANKING = "Ranking"
+    BINARY_CF = "BinaryClassification"
+    REGRESSION = "Regression"
+    OBJECT_DETECTION = "ObjectDetection"
+    SEGMENTATION = "Segmentation"
+    GENERATIVE_LLM = "GenerativeLLM"
+    GENERATIVE_IMAGE = "GenerativeImage"
+    GENERATIVE_VIDEO = "GenerativeVideo"
+    TTS = "TTS"
+    STT = "STT"
+    MULTI_MODAL = "MultiModal"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class ModelChoices(Enum):
+    TURING_LARGE = "turing_large"
+    TURING_SMALL = "turing_small"
+    PROTECT = "protect"
+    PROTECT_FLASH = "protect_flash"
+    TURING_FLASH = "turing_flash"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class DataTypeChoices(Enum):
+    TEXT = "text"
+    BOOLEAN = "boolean"
+    INTEGER = "integer"
+    FLOAT = "float"
+    JSON = "json"
+    ARRAY = "array"
+    IMAGE = "image"
+    IMAGES = "images"  # Multiple images stored as JSON array
+    DATETIME = "datetime"
+    AUDIO = "audio"
+    DOCUMENT = "document"
+    OTHERS = "others"
+    PERSONA = "persona"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class AnnotationTypeChoices(Enum):
+    TEXT = "text"
+    NUMERIC = "numeric"
+    CATEGORICAL = "categorical"
+    STAR = "star"
+    THUMBS_UP_DOWN = "thumbs_up_down"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class AnnotationQueueStatusChoices(Enum):
+    DRAFT = "draft"
+    ACTIVE = "active"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class QueueItemSourceType(Enum):
+    DATASET_ROW = "dataset_row"
+    TRACE = "trace"
+    OBSERVATION_SPAN = "observation_span"
+    PROTOTYPE_RUN = "prototype_run"
+    CALL_EXECUTION = "call_execution"
+    TRACE_SESSION = "trace_session"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class QueueItemStatus(Enum):
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    SKIPPED = "skipped"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class ScoreSource(Enum):
+    HUMAN = "human"
+    API = "api"
+    AUTO = "auto"
+    IMPORTED = "imported"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class AssignmentStrategy(Enum):
+    MANUAL = "manual"
+    ROUND_ROBIN = "round_robin"
+    LOAD_BALANCED = "load_balanced"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class AnnotatorRole(Enum):
+    ANNOTATOR = "annotator"
+    REVIEWER = "reviewer"
+    MANAGER = "manager"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class BooleanChoices(Enum):
+    TRUE = "true"
+    FALSE = "false"
+    TRUE_OPTIONS = [
+        "true",
+        "True",
+        "TRUE",
+        "1",
+        "yes",
+        "Yes",
+        "YES",
+        "Passed",
+        "Passed",
+        "PASSED",
+    ]
+    FALSE_OPTIONS = [
+        "false",
+        "False",
+        "FALSE",
+        "0",
+        "no",
+        "No",
+        "NO",
+        "Failed",
+        "Failed",
+        "FAILED",
+    ]
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class DateTimeFormatChoices(Enum):
+    OPTIONS = [
+        "%Y-%m-%d",  # 2024-03-21
+        "%Y-%m-%d %H:%M:%S",  # 2024-03-21 15:30:45
+        "%Y-%m-%d %H:%M",  # 2024-03-21 15:30
+        "%d/%m/%Y",  # 21/03/2024
+        "%d/%m/%Y %H:%M:%S",  # 21/03/2024 15:30:45
+        "%d/%m/%Y %H:%M",  # 21/03/2024 15:30
+        "%m/%d/%Y",  # 03/21/2024
+        "%m/%d/%Y %H:%M:%S",  # 03/21/2024 15:30:45
+        "%m/%d/%Y %H:%M",  # 03/21/2024 15:30
+        "%Y/%m/%d",  # 2024/03/21
+        "%Y/%m/%d %H:%M:%S",  # 2024/03/21 15:30:45
+        "%Y/%m/%d %H:%M",  # 2024/03/21 15:30
+        "%d-%m-%Y",  # 21-03-2024
+        "%d-%m-%Y %H:%M:%S",  # 21-03-2024 15:30:45
+        "%d-%m-%Y %H:%M",  # 21-03-2024 15:30
+        "%m-%d-%Y",  # 03-21-2024
+        "%m-%d-%Y %H:%M:%S",  # 03-21-2024 15:30:45
+        "%m-%d-%Y %H:%M",  # 03-21-2024 15:30
+        "%Y%m%d",  # 20240321
+        "%Y%m%d%H%M%S",  # 20240321153045
+        "%b %d %Y",  # Mar 21 2024
+        "%b %d %Y %H:%M:%S",  # Mar 21 2024 15:30:45
+        "%B %d %Y",  # March 21 2024
+        "%B %d %Y %H:%M:%S",  # March 21 2024 15:30:45
+    ]
+
+
+class SourceChoices(Enum):
+    EVALUATION = "evaluation"
+    EVALUATION_TAGS = "evaluation_tags"
+    EVALUATION_REASON = "evaluation_reason"
+
+    RUN_PROMPT = "run_prompt"
+    EXPERIMENT = "experiment"
+    OPTIMISATION = "optimisation"
+
+    EXPERIMENT_EVALUATION = "experiment_evaluation"
+    EXPERIMENT_EVALUATION_TAGS = "experiment_evaluation_tags"
+
+    OPTIMISATION_EVALUATION = "optimisation_evaluation"
+    ANNOTATION_LABEL = "annotation_label"
+    OPTIMISATION_EVALUATION_TAGS = "optimisation_evaluation_tags"
+
+    EXTRACTED_JSON = "extracted_json"
+    CLASSIFICATION = "classification"
+    EXTRACTED_ENTITIES = "extracted_entities"
+    API_CALL = "api_call"
+    PYTHON_CODE = "python_code"
+    VECTOR_DB = "vector_db"
+    CONDITIONAL = "conditional"
+    EVAL_PLAYGROUND = "eval_playground"
+
+    OTHERS = "OTHERS"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class DatasetSourceChoices(Enum):
+    DEMO = "demo"
+    BUILD = "build"
+    SDK = "sdk"
+    OBSERVE = "observe"
+    KNOWLEDGE_BASE = "knowledge_base"
+    SCENARIO = "scenario"
+    EXPERIMENT_SNAPSHOT = "experiment_snapshot"
+    GRAPH = "graph"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class FeedbackSourceChoices(Enum):
+    DATASET = "dataset"
+    PROMPT = "prompt"
+    SDK = "sdk"
+    TRACE = "trace"
+    EXPERIMENT = "experiment"
+    OBSERVE = "observe"
+    EVAL_PLAYGROUND = "eval_playground"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class EvalSourceChoices(Enum):
+    EVALUATION = "evaluation"
+    EXPERIMENT = "experiment"
+    OPTIMISATION = "optimisation"
+    EXPERIMENT_EVALUATION = "experiment_evaluation"
+    OPTIMISATION_EVALUATION = "optimisation_evaluation"
+    OTHERS = "OTHERS"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class CellStatus(Enum):
+    ERROR = "error"
+    RUNNING = "running"
+    PASS = "pass"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class OwnerChoices(Enum):
+    SYSTEM = "system"
+    USER = "user"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+def get_data_type_choice(num):
+    data_type_map = {
+        1: DataTypeChoices.TEXT,
+        2: DataTypeChoices.BOOLEAN,
+        3: DataTypeChoices.INTEGER,
+        4: DataTypeChoices.FLOAT,
+        5: DataTypeChoices.JSON,
+    }
+    return data_type_map.get(num, None)
+
+
+def get_source_choice(num):
+    source_map = {
+        1: SourceChoices.EVALUATION,
+        2: SourceChoices.RUN_PROMPT,
+    }
+    return source_map.get(num, None)
+
+
+def get_model_types(num):
+    model_type_map = {
+        1: ModelTypes.NUMERIC,
+        2: ModelTypes.SCORE_CATEGORICAL,
+        3: ModelTypes.RANKING,
+        4: ModelTypes.BINARY_CF,
+        5: ModelTypes.REGRESSION,
+        6: ModelTypes.OBJECT_DETECTION,
+        7: ModelTypes.SEGMENTATION,
+        8: ModelTypes.GENERATIVE_LLM,
+        9: ModelTypes.GENERATIVE_IMAGE,
+        10: ModelTypes.GENERATIVE_VIDEO,
+        11: ModelTypes.TTS,
+        12: ModelTypes.STT,
+        13: ModelTypes.MULTI_MODAL,
+    }
+    return model_type_map.get(num, None)  # Return None if num is not found
+
+
+def get_metrics_name_choices():
+    # Collect all choices from each Enum class and combine them
+    choices = []
+    for eval_enum in [
+        LlmEvalTypeId,
+        FutureAgiEvalTypeId,
+        FunctionEvalTypeId,
+        GroundedEvalTypeId,
+    ]:
+        choices.extend(
+            [
+                (member.value, member.name.replace("_", " ").title())
+                for member in eval_enum
+            ]
+        )
+    return choices
+
+
+def _get_audio_mime_types():
+    """Get comprehensive list of audio MIME types"""
+    return {
+        "audio/mpeg",
+        "audio/mp3",
+        "audio/wav",
+        "audio/wave",
+        "audio/x-wav",
+        "audio/flac",
+        "audio/x-flac",
+        "audio/ogg",
+        "audio/vorbis",
+        "audio/aac",
+        "audio/mp4",
+        "audio/m4a",
+        "audio/x-m4a",
+        "audio/aiff",
+        "audio/x-aiff",
+        "audio/au",
+        "audio/basic",
+        "audio/webm",
+        "audio/opus",
+        "audio/amr",
+        "audio/3gpp",
+    }
+
+
+def _get_audio_extensions():
+    """Get comprehensive list of audio file extensions"""
+    return {
+        ".mp3",
+        ".wav",
+        ".flac",
+        ".ogg",
+        ".aac",
+        ".m4a",
+        ".wma",
+        ".aiff",
+        ".aif",
+        ".au",
+        ".snd",
+        ".opus",
+        ".webm",
+        ".amr",
+        ".3gp",
+        ".mp2",
+        ".mp1",
+        ".ape",
+        ".mpc",
+        ".wv",
+        ".dts",
+        ".ac3",
+        ".mid",
+        ".midi",
+        ".ra",
+        ".rm",
+    }
+
+
+def _get_image_mime_types():
+    """Get comprehensive list of image MIME types"""
+    return {
+        "image/jpeg",
+        "image/jpg",
+        "image/png",
+        "image/gif",
+        "image/bmp",
+        "image/webp",
+        "image/svg+xml",
+        "image/tiff",
+        "image/tif",
+        "image/ico",
+        "image/x-icon",
+        "image/vnd.microsoft.icon",
+    }
+
+
+def _get_image_extensions():
+    """Get comprehensive list of image file extensions"""
+    return {
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".gif",
+        ".bmp",
+        ".webp",
+        ".svg",
+        ".tiff",
+        ".tif",
+        ".ico",
+        ".heic",
+        ".heif",
+        ".avif",
+    }
+
+
+def is_audio_url(url):
+    """
+    Thread-safe audio URL detection using MIME type guessing.
+    Alternative to HTTP requests for better performance.
+    """
+    try:
+        url_lower = url.lower()
+
+        # Check file extension
+        audio_extensions = _get_audio_extensions()
+        if any(url_lower.endswith(ext) for ext in audio_extensions):
+            return True
+
+        # Check MIME type based on URL
+        mime_type, _ = mimetypes.guess_type(url)
+        if mime_type and mime_type.lower() in _get_audio_mime_types():
+            return True
+
+        # Check for common audio URL patterns
+        audio_patterns = [
+            "/audio/",
+            "/sound/",
+            "/music/",
+            "/media/",
+            "audio=",
+            "sound=",
+            "music=",
+            ".mp3",
+            ".wav",
+        ]
+        if any(pattern in url_lower for pattern in audio_patterns):
+            return True
+
+        return False
+
+    except Exception:
+        return False
+
+
+def is_document_url(url):
+    """
+    Check if a URL is a valid document URL that points to a downloadable document.
+    Returns True if the URL is accessible and serves a document, False otherwise.
+    Uses patterns and types from the existing codebase for consistency.
+    """
+    try:
+        if not isinstance(url, str):
+            return False
+
+        # Check for data URLs
+        if url.startswith("data:application/") or url.startswith("data:text/"):
+            return True
+
+        # Check for HTTP/HTTPS URLs
+        if url.startswith(("http://", "https://")):
+            # Parse the URL to validate its structure
+            parsed_url = urlparse(url)
+            if not parsed_url.netloc:  # No domain/host
+                return False
+
+            # Make a HEAD request to check if the URL is accessible
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+            }
+            response = requests.head(
+                url, headers=headers, timeout=10, allow_redirects=True
+            )
+
+            if response.status_code != 200:
+                return False
+
+            # Check if the response indicates it's a downloadable document
+            content_type = response.headers.get("content-type", "").lower()
+            content_length = response.headers.get("content-length")
+
+            # If content-length is 0 or very small, it's probably not a real file
+            if content_length and int(content_length) < 100:
+                return False
+
+            # Use document types from the existing codebase
+            document_mime_types = {
+                "application/pdf",
+                "application/msword",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "application/vnd.ms-excel",
+                "application/vnd.ms-powerpoint",
+                "text/plain",
+                "text/rtf",
+                "application/rtf",
+                "text/html",
+                "application/xml",
+                "text/csv",
+                "application/octet-stream",
+                "application/zip",
+                "application/x-zip-compressed",
+                # Additional document types
+                "application/vnd.ms-word.document.12",
+                "application/vnd.ms-excel.12",
+                "application/vnd.ms-powerpoint.12",
+                "text/markdown",
+                "application/json",
+                "application/javascript",
+                "text/javascript",
+                "text/css",
+                "text/xml",
+            }
+
+            # Check if content-type indicates it's a document
+            if content_type in document_mime_types:
+                return True
+
+            # If content-type doesn't match, check file extensions
+            path_lower = parsed_url.path.lower()
+            document_extensions = {
+                ".pdf",
+                ".doc",
+                ".docx",
+                ".txt",
+                ".rtf",
+                ".xls",
+                ".xlsx",
+                ".ppt",
+                ".pptx",
+                ".csv",
+                ".html",
+                ".htm",
+                ".xml",
+                ".zip",
+                ".rar",
+                ".7z",
+                ".md",
+                ".markdown",
+                ".json",
+                ".js",
+                ".css",
+            }
+
+            if any(path_lower.endswith(ext) for ext in document_extensions):
+                return True
+
+            # If content-type doesn't match, check URL patterns from existing codebase
+            url_lower = url.lower()
+            document_patterns = [
+                "/document/",
+                "/doc/",
+                "/file/",
+                "/download/",
+                "/attachment/",
+                "document=",
+                "doc=",
+                "file=",
+                "download=",
+                "attachment=",
+            ]
+
+            if any(pattern in url_lower for pattern in document_patterns):
+                return True
+
+        return False
+
+    except Exception:
+        return False
+
+
+def is_image_url(url):
+    """
+    Thread-safe image URL detection using MIME type guessing.
+    Alternative to HTTP requests for better performance.
+    """
+    try:
+        url_lower = url.lower()
+
+        # Check file extension
+        image_extensions = _get_image_extensions()
+        if any(url_lower.endswith(ext) for ext in image_extensions):
+            return True
+
+        # Check MIME type based on URL
+        mime_type, _ = mimetypes.guess_type(url)
+        if mime_type and mime_type.lower() in _get_image_mime_types():
+            return True
+
+        # Check for common image URL patterns
+        image_patterns = [
+            "/image/",
+            "/img/",
+            "/photo/",
+            "/picture/",
+            "/media/",
+            "image=",
+            "img=",
+            "photo=",
+            "picture=",
+        ]
+        if any(pattern in url_lower for pattern in image_patterns):
+            return True
+
+        return False
+
+    except Exception:
+        return False
+
+
+def _check_for_images(column_values):
+    """
+    Check if column contains multiple image URLs.
+    Supports two formats:
+    1. JSON array of URLs: ["url1", "url2"]
+    2. Comma-separated URLs: url1, url2
+
+    Returns True if ALL non-null values are lists of valid image URLs.
+    """
+    from model_hub.utils.image_utils import parse_image_urls
+
+    try:
+        non_null_values = column_values.dropna()
+        if non_null_values.empty:
+            return False
+
+        for val in non_null_values:
+            val_str = str(val).strip()
+
+            parts = parse_image_urls(val_str)
+
+            # Must contain a comma for comma-separated to be considered multi-image
+            if not val_str.startswith("[") and "," not in val_str:
+                return False
+
+            # Need at least 2 parts to be "images" (multiple)
+            if len(parts) < 2:
+                return False
+
+            # Each part must be a valid image URL
+            for part in parts:
+                if not is_image_url(part):
+                    return False
+
+        return True
+    except Exception:
+        logger.exception("Error in _check_for_images")
+        return False
+
+
+def is_base64_audio(data):
+    """
+    Thread-safe audio detection using file signatures and built-in libraries.
+    No external dependencies like pydub required.
+    """
+    try:
+        # Check if it's a valid string first
+        if not isinstance(data, str):
+            return False
+
+        # Check for data:audio prefix (data URLs)
+        if data.startswith("data:audio"):
+            return True
+
+        # Try to decode base64
+        try:
+            audio_data = base64.b64decode(data)
+        except Exception:
+            return False
+
+        # Check for common audio file signatures (magic numbers)
+        audio_signatures = [
+            # WAV files
+            (b"RIFF", 0, b"WAVE", 8),  # RIFF header + WAVE format
+            # MP3 files
+            (b"ID3", 0),  # ID3v2 header
+            (b"\xff\xfb", 0),  # MP3 frame sync (MPEG-1 Layer 3)
+            (b"\xff\xf3", 0),  # MP3 frame sync (MPEG-1 Layer 3)
+            (b"\xff\xf2", 0),  # MP3 frame sync (MPEG-2 Layer 3)
+            # FLAC files
+            (b"fLaC", 0),  # FLAC signature
+            # OGG files
+            (b"OggS", 0),  # OGG signature
+            # M4A/AAC files
+            (b"ftypM4A", 4),  # M4A container
+            (b"ftypisom", 4),  # ISO Base Media
+            (b"ftypmp42", 4),  # MP4 v2
+            # AIFF files
+            (b"FORM", 0, b"AIFF", 8),  # AIFF signature
+            # AU files
+            (b".snd", 0),  # AU/SND signature
+        ]
+
+        # Check each signature
+        for signature_info in audio_signatures:
+            if len(signature_info) == 2:
+                # Simple signature check
+                signature, offset = signature_info
+                if len(audio_data) > offset + len(signature):
+                    if audio_data[offset : offset + len(signature)] == signature:
+                        return True
+            elif len(signature_info) == 4:
+                # Compound signature check (like RIFF + WAVE)
+                sig1, offset1, sig2, offset2 = signature_info
+                if (
+                    len(audio_data) > max(offset1 + len(sig1), offset2 + len(sig2))
+                    and audio_data[offset1 : offset1 + len(sig1)] == sig1
+                    and audio_data[offset2 : offset2 + len(sig2)] == sig2
+                ):
+                    return True
+
+        # Additional check for WAV files using wave module (built-in)
+        try:
+            audio_file = io.BytesIO(audio_data)
+            with wave.open(audio_file, "rb") as wav_file:
+                # If we can open it as WAV, it's valid audio
+                return wav_file.getnframes() > 0
+        except Exception:
+            pass
+
+        return False
+
+    except Exception:
+        return False
+
+
+def _check_for_audio(column_values):
+    try:
+        audio_extensions = [
+            # Common audio formats
+            ".wav",
+            ".mp3",
+            ".flac",
+            ".ogg",
+            ".m4a",
+            ".aac",
+            ".aiff",
+            ".aif",
+            ".au",
+            ".opus",
+            # Additional formats
+            ".wma",
+            ".mp2",
+            ".mp1",
+            ".ape",
+            ".mpc",
+            ".wv",
+            ".dts",
+            ".ac3",
+            ".amr",
+            ".mid",
+            ".midi",
+            ".ra",
+            ".rm",
+            ".3gp",
+            ".aac",
+            ".act",
+            ".awb",
+            ".dct",
+            # Less common but still used formats
+            ".gsm",
+            ".iklax",
+            ".ivs",
+            ".mmf",
+            ".mxmf",
+            ".tta",
+            ".voc",
+            ".vox",
+            ".xm",
+            ".caf",
+            ".dss",
+            ".dvf",
+            ".iklax",
+            ".m4b",
+            ".m4p",
+            ".nmf",
+            ".nsf",
+            ".sln",
+            # Raw audio formats
+            ".raw",
+            ".pcm",
+            ".snd",
+            ".rf64",
+            # Professional audio formats
+            ".w64",
+            ".sds",
+            ".paf",
+            ".sd2",
+            ".caf",
+            ".wve",
+            ".mka",
+            ".aa3",
+            ".oma",
+        ]
+
+        # Check if ALL non-null values are audio
+        non_null_values = column_values.dropna()
+        if non_null_values.empty:
+            return False
+
+        for val in non_null_values:
+            is_audio = False
+
+            if isinstance(val, dict) and "path" in val:
+                if val["path"] is not None:
+                    is_audio = any(
+                        val["path"].lower().endswith(ext) for ext in audio_extensions
+                    )
+                elif "sampling_rate" in val:
+                    is_audio = True
+            elif isinstance(val, str) and val.startswith("http"):
+                # Option 1: Use thread-safe URL analysis (recommended)
+                is_audio = is_audio_url(val)
+
+            elif isinstance(val, str) and is_base64_audio(val):
+                is_audio = True
+
+            # If any value is not audio, return False
+            if not is_audio:
+                return False
+
+        # If we reach here, all values are audio
+        return True
+
+    except Exception:
+        logger.exception("Error in _check_for_audio")
+        return False
+
+
+def is_base64_image(data):
+    try:
+        image_data = base64.b64decode(data)
+        Image.open(io.BytesIO(image_data))
+        return True
+    except Exception:
+        return False
+
+
+def _check_for_image(column_values):
+    try:
+        # Check if ALL non-null values are images
+        non_null_values = column_values.dropna()
+        if non_null_values.empty:
+            return False
+
+        for val in non_null_values:
+            is_image = False
+
+            if isinstance(val, Image.Image):
+                is_image = True
+            elif isinstance(val, str) and val.startswith("data:image"):
+                is_image = True
+            elif isinstance(val, str) and (
+                val.startswith("http://") or val.startswith("https://")
+            ):
+                # Skip if value contains comma - likely multiple URLs (handled by _check_for_images)
+                if "," in val:
+                    return False
+                # Option 1: Use thread-safe URL analysis (recommended)
+                is_image = is_image_url(val)
+
+            elif isinstance(val, str) and is_base64_image(val):
+                is_image = True
+
+            # If any value is not an image, return False
+            if not is_image:
+                return False
+
+        # If we reach here, all values are images
+        return True
+
+    except Exception:
+        logger.exception("Error in _check_for_image")
+        return False
+
+
+def _all_valid_json_strings(str_values):
+    """
+    Check if all string values are valid JSON objects (dicts) or arrays containing objects.
+    Pure arrays like [], [1,2,3], ["a","b"] should be ARRAY type, not JSON.
+    Only complex structures (objects or arrays of objects) should be JSON.
+    """
+    if not str_values:
+        return False
+
+    has_complex_structure = False
+    for val in str_values:
+        try:
+            parsed = json.loads(val)
+            # Only consider it JSON if it's a dict or list
+            if isinstance(parsed, dict):
+                has_complex_structure = True
+            elif isinstance(parsed, list):
+                # Check if list contains any dicts (complex objects)
+                if any(isinstance(item, dict) for item in parsed):
+                    has_complex_structure = True
+                # Pure arrays (empty or with primitives) should not be JSON
+            else:
+                # Primitives (int, float, str, bool, None) should not be classified as JSON
+                return False
+        except (ValueError, TypeError):
+            return False
+
+    # Only return True if we found at least one complex structure (dict or array of dicts)
+    return has_complex_structure
+
+
+def _is_integer_string_column(str_values):
+    """
+    Check if all string values can be parsed as integers.
+    Handles strings like "123", "456" from CSV files.
+    """
+    if not str_values:
+        return False
+    for val in str_values:
+        try:
+            # Must be a valid integer (not float)
+            int(val)
+
+        except (ValueError, TypeError):
+            return False
+    return True
+
+
+def _is_float_string_column(str_values):
+    """
+    Check if all string values can be parsed as floats.
+    Handles strings like "123.45", "67.89" from CSV files.
+    """
+    if not str_values:
+        return False
+    for val in str_values:
+        try:
+            float(val)
+        except (ValueError, TypeError):
+            return False
+
+    return True
+
+
+def _is_boolean_string_column(str_values):
+    """
+    Check if all string values are boolean representations.
+    Handles strings like "true", "false", "True", "False", "TRUE", "FALSE" from CSV files.
+    """
+    if not str_values:
+        return False
+    boolean_values = {"true", "false", "0", "1"}
+    for val in str_values:
+        if val and val.lower() not in boolean_values:
+            return False
+    return True
+
+
+def _is_strict_datetime_column(str_values):
+    """
+    Stricter datetime detection - require date-like patterns,
+    not just anything pd.to_datetime can parse.
+    """
+    if not str_values:
+        return False
+
+    date_pattern = re.compile(
+        r"^\d{4}[-/]\d{1,2}[-/]\d{1,2}"  # YYYY-MM-DD or YYYY/MM/DD
+        r"|^\d{1,2}[-/]\d{1,2}[-/]\d{4}"  # DD-MM-YYYY or MM/DD/YYYY
+        r"|^\d{4}-\d{2}-\d{2}T"  # ISO format with time
+    )
+    for val in str_values:
+        if not date_pattern.match(val.strip()):
+            return False
+    return True
+
+
+def _is_array_column(str_values):
+    """
+    Check for actual array syntax (brackets), not just commas.
+    Only detects simple arrays - arrays containing objects should be JSON.
+    """
+    if not str_values:
+        return False
+    for val in str_values:
+        stripped = val.strip()
+        # Must start with [ and end with ]
+        if not (stripped.startswith("[") and stripped.endswith("]")):
+            return False
+        # Check if it's a simple array (not containing JSON objects)
+        # Try to parse as JSON and check if it contains dicts
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                # If any element is a dict, this should be JSON, not ARRAY
+                if any(isinstance(item, dict) for item in parsed):
+                    return False
+        except (ValueError, TypeError):
+            # Not valid JSON, but has bracket syntax - treat as array
+            # This handles Python-style arrays like "['a', 'b']" (single quotes)
+            pass
+    return True
+
+
+# Base64 prefixes for common image formats (raw base64 without data URL prefix)
+# These are the first few characters of base64-encoded image data
+IMAGE_BASE64_PREFIXES = (
+    "iVBORw0KGgo",  # PNG  - starts with bytes 89 50 4E 47 (‰PNG)
+    "/9j/",  # JPEG - starts with bytes FF D8 FF
+    "R0lGOD",  # GIF  - starts with bytes 47 49 46 (GIF87a or GIF89a)
+    "UklGR",  # WebP - starts with bytes 52 49 46 46 (RIFF)
+    "Qk",  # BMP  - starts with bytes 42 4D (BM)
+)
+
+# Base64 prefixes for common audio formats (raw base64 without data URL prefix)
+AUDIO_BASE64_PREFIXES = (
+    "SUQz",  # MP3 with ID3 tag - starts with bytes 49 44 33 (ID3)
+    "//uQ",  # MP3 without ID3 - starts with bytes FF FB
+    "T2dnU",  # OGG  - starts with bytes 4F 67 67 53 (OggS)
+    "UklGR",  # WAV  - starts with bytes 52 49 46 46 (RIFF)
+    "ZkxhQ",  # FLAC - starts with bytes 66 4C 61 43 (fLaC)
+)
+
+
+def _check_media_strings(str_values, media_type):
+    """
+    Check if all string values are data URLs or base64 for the given media type.
+    media_type should be 'image' or 'audio'.
+
+    Supports detection of:
+    - Data URLs (e.g., "data:image/png;base64,...")
+    - Raw base64-encoded media data (detected via format-specific prefixes)
+    """
+    if not str_values:
+        return False
+    for val in str_values:
+        if media_type == "image":
+            is_data_url = val.startswith("data:image")
+            is_raw_base64 = val.startswith(IMAGE_BASE64_PREFIXES)
+            if not (is_data_url or is_raw_base64):
+                return False
+        elif media_type == "audio":
+            is_data_url = val.startswith("data:audio")
+            is_raw_base64 = val.startswith(AUDIO_BASE64_PREFIXES)
+            if not (is_data_url or is_raw_base64):
+                return False
+    return True
+
+
+def _classify_url_column(str_values):
+    """
+    Classify a column of URLs by checking if all are of the same media type.
+    """
+    all_audio_urls = all(is_audio_url(url) for url in str_values)
+    all_image_urls = all(is_image_url(url) for url in str_values)
+    all_document_urls = all(is_document_url(url) for url in str_values)
+
+    if all_audio_urls:
+        return DataTypeChoices.AUDIO.value
+    elif all_image_urls:
+        return DataTypeChoices.IMAGE.value
+    elif all_document_urls:
+        return DataTypeChoices.DOCUMENT.value
+    else:
+        return DataTypeChoices.TEXT.value
+
+
+def determine_data_type(column_values):
+    """
+    Determine the data type of a pandas column for dataset schema inference.
+    """
+    logger.info("Determining data type for column")
+    logger.debug("column_values", column_values=column_values)
+
+    if column_values.dropna().empty:
+        return DataTypeChoices.TEXT.value  # Default type if the column is empty
+
+    # 1. Check pandas dtype first (fast path for properly typed data)
+    if column_values.dtype == bool:
+        return DataTypeChoices.BOOLEAN.value
+
+    if pd.api.types.is_integer_dtype(column_values):
+        return DataTypeChoices.INTEGER.value
+
+    if pd.api.types.is_float_dtype(column_values):
+        return DataTypeChoices.FLOAT.value
+
+    if pd.api.types.is_datetime64_any_dtype(column_values):
+        return DataTypeChoices.DATETIME.value
+
+    # 2. Check for audio/image objects (HuggingFace datasets)
+    if _check_for_audio(column_values):
+        return DataTypeChoices.AUDIO.value
+
+    if _check_for_image(column_values):
+        return DataTypeChoices.IMAGE.value
+
+    # 3. Check if values are Python list/dict objects (parsed JSON from pd.read_json)
+    non_null = column_values.dropna()
+    if len(non_null) > 0 and all(isinstance(val, (dict, list)) for val in non_null):
+        # Distinguish between pure arrays and complex JSON
+        all_are_lists = all(isinstance(val, list) for val in non_null)
+        if all_are_lists:
+            # Check if any list contains dicts (complex objects)
+            has_complex_content = any(
+                any(isinstance(item, dict) for item in val) for val in non_null if val
+            )
+            if not has_complex_content:
+                return DataTypeChoices.ARRAY.value
+        return DataTypeChoices.JSON.value
+
+    # 4. Convert to string for further checks
+    str_values = column_values.astype(str)
+    non_null_strs = [v for v in str_values.dropna() if v]
+
+    # Check if all values are comma-separated image URLs (multiple images)
+    # This must come BEFORE the array check to properly detect image arrays
+    if _check_for_images(column_values):
+        return DataTypeChoices.IMAGES.value
+
+    # 5. Check for string representations of primitive types (from CSV)
+    # Boolean strings: "true", "false", "True", "False", etc.
+    if _is_boolean_string_column(non_null_strs):
+        return DataTypeChoices.BOOLEAN.value
+
+    # Integer strings: "123", "456", etc.
+    if _is_integer_string_column(non_null_strs):
+        return DataTypeChoices.INTEGER.value
+
+    # Float strings: "123.45", "67.89", etc.
+    if _is_float_string_column(non_null_strs):
+        return DataTypeChoices.FLOAT.value
+
+    # 6. Check for image/audio data URLs and base64
+    if _check_media_strings(non_null_strs, "image"):
+        return DataTypeChoices.IMAGE.value
+    if _check_media_strings(non_null_strs, "audio"):
+        return DataTypeChoices.AUDIO.value
+
+    # 7. Check for document/image/audio URLs
+    if non_null_strs and all(
+        v.startswith("http://") or v.startswith("https://") for v in non_null_strs
+    ):
+        return _classify_url_column(non_null_strs)
+
+    # 8. Datetime check with stricter validation (regex-based, not pd.to_datetime)
+    if _is_strict_datetime_column(non_null_strs):
+        return DataTypeChoices.DATETIME.value
+
+    # 9. Array check - bracket syntax [a,b,c] - BEFORE JSON to catch simple arrays
+    if _is_array_column(non_null_strs):
+        return DataTypeChoices.ARRAY.value
+
+    # 10. JSON check - only for objects or arrays containing objects
+    if _all_valid_json_strings(non_null_strs):
+        return DataTypeChoices.JSON.value
+
+    return DataTypeChoices.TEXT.value  # Default to TEXT if none of the conditions match
+
+
+def determine_cell_type(value):
+    # Handle pandas Series/arrays and regular values safely
+    try:
+        if pd.isna(value):
+            return DataTypeChoices.TEXT.value  # Default type if the value is empty
+    except (ValueError, TypeError):
+        # If pd.isna fails (e.g., for pandas Series), try alternative approach
+        if value is None or (hasattr(value, "__len__") and len(value) == 0):
+            return DataTypeChoices.TEXT.value  # Default type if the value is empty
+
+    # Check if value is boolean
+    if isinstance(value, bool):
+        return DataTypeChoices.BOOLEAN.value
+
+    # Check if value is integer
+    if isinstance(value, int):
+        return DataTypeChoices.INTEGER.value
+
+    # Check if value is float
+    if isinstance(value, float):
+        return DataTypeChoices.FLOAT.value
+
+    # Check if value is already a datetime object
+    if isinstance(value, datetime | pd.Timestamp):
+        return DataTypeChoices.DATETIME.value
+
+    # Convert to string for further checks
+    str_value = str(value)
+
+    # Check if string is a date
+    try:
+        pd.to_datetime(str_value)
+        return DataTypeChoices.DATETIME.value
+    except ValueError:
+        pass  # Not a date, continue with other checks
+
+    # Check if value is JSON
+    try:
+        json.loads(str_value)
+        return DataTypeChoices.JSON.value
+    except ValueError:
+        pass  # Invalid JSON; continue check for other types
+
+    # Check if value is array (assuming comma-separated values)
+    if "," in str_value:
+        return DataTypeChoices.ARRAY.value
+
+    # Check if value is image bytes (assuming base64 encoded)
+    if str_value.startswith(("data:image", "iVBORw0KGgo")):
+        return DataTypeChoices.IMAGE.value
+
+    # Check if value is image URL
+    url_pattern = re.compile(
+        r"https?://\S+(?:jpg|jpeg|png|gif|bmp|webp)", re.IGNORECASE
+    )
+    if url_pattern.match(str_value):
+        return DataTypeChoices.IMAGE.value
+
+    return DataTypeChoices.TEXT.value  # Default to TEXT if none of the conditions match
+
+
+class LiteLlmModelProvider(Enum):
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    AZURE = "azure"
+    # AZURE_AI = "azure_ai"
+    VERTEX_AI = "vertex_ai"
+    PALM = "palm"
+    GEMINI = "gemini"
+    COHERE = "cohere"
+    HUGGINGFACE = "huggingface"
+    TEXT_COMPLETION_OPENAI = "text-completion-openai"
+    # VERTEX_AI_EMBEDDING_MODELS = "vertex_ai-embedding-models"
+    TOGETHER_AI = "together_ai"
+    REPLICATE = "replicate"
+    CEREBRAS = "cerebras"
+    # VERTEX_AI_ANTHROPIC_MODELS = "vertex_ai-anthropic_models"
+    COHERE_CHAT = "cohere_chat"
+    FRIENDLIAI = "friendliai"
+    FIREWORKS_AI = "fireworks_ai"
+    # VERTEX_AI_MISTRAL_MODELS = "vertex_ai-mistral_models"
+    ANYSCALE = "anyscale"
+    TEXT_COMPLETION_CODESTRAL = "text-completion-codestral"
+    NLP_CLOUD = "nlp_cloud"
+    OPENROUTER = "openrouter"
+    CLOUDFLARE = "cloudflare"
+    DEEPSEEK = "deepseek"
+    ALEPH_ALPHA = "aleph_alpha"
+    FIREWORKS_AI_EMBEDDING_MODELS = "fireworks_ai-embedding-models"
+    MISTRAL = "mistral"
+    BEDROCK = "bedrock"
+    OLLAMA = "ollama"
+    DEEPINFRA = "deepinfra"
+    DATABRICKS = "databricks"
+    # VERTEX_AI_TEXT_MODELS = "vertex_ai-text-models"
+    # VERTEX_AI_IMAGE_MODELS = "vertex_ai-image-models"
+    # VERTEX_AI_CODE_TEXT_MODELS = "vertex_ai-code-text-models"
+    # VERTEX_AI_LLAMA_MODELS = "vertex_ai-llama_models"
+    # VERTEX_AI_LANGUAGE_MODELS = "vertex_ai-language-models"
+    # VERTEX_AI_VISION_MODELS = "vertex_ai-vision-models"
+    VOYAGE = "voyage"
+    # VERTEX_AI_AI21_MODELS = "vertex_ai-ai21_models"
+    GROQ = "groq"
+    CODESTRAL = "codestral"
+    PERPLEXITY = "perplexity"
+    AI21 = "ai21"
+    SAGEMAKER = "sagemaker"
+    ELEVENLABS = "elevenlabs"
+    DEEPGRAM = "deepgram"
+    INWORLD = "inworld"
+    RIME = "rime"
+    NEUPHONIC = "neuphonic"
+    HUME = "hume"
+    CARTESIA = "cartesia"
+    LMNT = "lmnt"
+    # VERTEX_AI_CHAT_MODELS = "vertex_ai-chat-models"
+    # VERTEX_AI_CODE_CHAT_MODELS = "vertex_ai-code-chat-models"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class ProviderLogoUrls(Enum):
+    OPENAI = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/openai-icon.png"
+    ANTHROPIC = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/claude-ai-icon.png"
+    AZURE = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/azure-icon.png"
+    AZURE_AI = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/azure-icon.png"
+    VERTEX_AI = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    PALM = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/palm.png"
+    GEMINI = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/google-gemini-icon.png"
+    COHERE = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/cohere-small.png"
+    HUGGINGFACE = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/hugginface.png"
+    TEXT_COMPLETION_OPENAI = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/openai-icon.png"
+    VERTEX_AI_EMBEDDING_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    TOGETHER_AI = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/together-small.png"
+    REPLICATE = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/replicate-small.svg"
+    CEREBRAS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/Cerebras.jpg"
+    VERTEX_AI_ANTHROPIC_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    COHERE_CHAT = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/cohere-small.png"
+    FRIENDLIAI = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/friendliai-small.jpeg"
+    FIREWORKS_AI = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/fireworks-small.jpeg"
+    VERTEX_AI_MISTRAL_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    ANYSCALE = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/anyscale-small.png"
+    TEXT_COMPLETION_CODESTRAL = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/mistral-ai-icon.png"
+    NLP_CLOUD = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/NLP+Cloud.png"
+    OPENROUTER = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/openrouter.png"
+    CLOUDFLARE = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/cloudflare-icon.png"
+    DEEPSEEK = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/deep-seek-small.png"
+    ALEPH_ALPHA = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/aleph-alpha-small.jpeg"
+    FIREWORKS_AI_EMBEDDING_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/fireworks-small.jpeg"
+    MISTRAL = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/mistral-ai-icon.png"
+    BEDROCK = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/bedrock-small.svg"
+    OLLAMA = (
+        "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/ollama.png"
+    )
+    DEEPINFRA = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/deepinfram-small.jpeg"
+    DATABRICKS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/databricks-small.png"
+    VERTEX_AI_TEXT_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    VERTEX_AI_IMAGE_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    VERTEX_AI_CODE_TEXT_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    VERTEX_AI_LLAMA_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    VERTEX_AI_LANGUAGE_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    VERTEX_AI_VISION_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    VOYAGE = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/Voyage+ai.png"
+    VERTEX_AI_AI21_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    GROQ = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/groq-small.png"
+    CODESTRAL = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/mistral-ai-icon.png"
+    PERPLEXITY = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/perplexity-ai-icon.png"
+    AI21 = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/ai21-small.png"
+    SAGEMAKER = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/Sagemaker.png"
+    VERTEX_AI_CHAT_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    VERTEX_AI_CODE_CHAT_MODELS = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/vertex+ai.png"
+    ELEVENLABS = "https://fi-content-dev.s3.ap-south-1.amazonaws.com/provider-logos/elevenlabs-small.png"
+    DEEPGRAM = "https://fi-content-dev.s3.ap-south-1.amazonaws.com/provider-logos/deepgram-small.png"
+    INWORLD = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/inworld-small.png"
+    RIME = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/rime-small.png"
+    NEUPHONIC = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/neuphonic-small.png"
+    HUME = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/hume-small.png"
+    CARTESIA = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/cartesia-small.png"
+    LMNT = "https://fi-image-assets.s3.ap-south-1.amazonaws.com/provider-logos/lmnt-small.png"
+
+    @classmethod
+    def get_url_by_provider(cls, provider_name):
+        try:
+            # Convert provider name to match enum format
+            enum_name = provider_name.upper().replace("-", "_")
+            return cls[enum_name].value
+        except KeyError:
+            return None
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class DatasetStatus(Enum):
+    PARTIAL_EXTRACTED = "PartialDataExtracted"
+    COMPLETED = "Completed"
+    PARTIAL_UPLOAD = "PartialUploadProgress"
+    RUNNING = "Running"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class StatusType(Enum):
+    NOT_STARTED = "NotStarted"
+    QUEUED = "Queued"
+    RUNNING = "Running"
+    COMPLETED = "Completed"
+    EDITING = "Editing"
+    INACTIVE = "Inactive"
+    FAILED = "Failed"
+    PARTIAL_RUN = "PartialRun"
+    EXPERIMENT_EVALUATION = "ExperimentEvaluation"
+    UPLOADING = "Uploading"
+    PARTIAL_EXTRACTED = "PartialExtracted"
+    PROCESSING = "Processing"
+    DELETING = "Deleting"
+    PARTIAL_COMPLETED = "PartialCompleted"
+    OPTIMIZATION_EVALUATION = "OptimizationEvaluation"
+    ERROR = "Error"
+    CANCELLED = "Cancelled"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class EnvTypes(Enum):
+    PRODUCTION = "Production"
+    TRAINING = "Training"
+    VALIDATION = "Validation"
+    CORPUS = "Corpus"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class EvalExplanationSummaryStatus(models.TextChoices):
+    PENDING = "pending", "Pending"
+    RUNNING = "running", "Running"
+    COMPLETED = "completed", "Completed"
+    FAILED = "failed", "Failed"
+    INSUFFICIENT_DATA = "insufficient_data", "Insufficient Data"
+
+
+class EvalOutputType(Enum):
+    PASS_FAIL = "Pass/Fail"
+    SCORE = "score"
+    NUMERIC = "numeric"
+    REASON = "reason"
+    CHOICES = "choices"
+    EMPTY = ""
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class EvalTemplateType(Enum):
+    LLM = "Llm"
+    FUTUREAGI = "Futureagi"
+    FUNCTION = "Function"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]

--- a/futureagi/model_hub/models/column_config.py
+++ b/futureagi/model_hub/models/column_config.py
@@ -1,0 +1,44 @@
+import uuid
+
+from django.db import models
+from django.utils import timezone
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+
+
+class ColumnConfig(models.Model):
+    class TableName(models.TextChoices):
+        DATASET = "Dataset", "Dataset"
+        DATASET_DETAIL = "DatasetDetail", "Dataset Detail"
+        OPTIMIZE_DATASET = "OptimizeDataset", "Optimize Dataset"
+        OPTIMIZE_DATASET_RIGHT_ANSWER = (
+            "OptimizeDatasetRightAnswer",
+            "Optimize Dataset Right Answer",
+        )
+        OPTIMIZE_DATASET_PROMPT_TEMPLATE_EXPLORE = (
+            "OptimizeDatasetPromptTemplateExplore",
+            "Optimize Dataset Prompt Template Explore",
+        )
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(default=timezone.now)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    table_name = models.CharField(max_length=100, choices=TableName.choices)
+    identifier = models.CharField(max_length=255)
+    columns = models.JSONField(null=True)
+
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="column_configs"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="column_configs",
+        null=True,
+        blank=True,
+    )
+
+    def __str__(self):
+        return str(self.id)

--- a/futureagi/model_hub/models/conversations.py
+++ b/futureagi/model_hub/models/conversations.py
@@ -1,0 +1,130 @@
+"""
+UPDATE model_hub_message
+SET updated_at = NOW()
+WHERE updated_at IS NULL;
+"""
+
+import json
+import uuid
+
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class NodeManager(models.Manager):
+    """Custom manager for Node model with tree traversal capabilities."""
+
+    def get_all_parent_messages(self, node_id, formatter):
+        """Fetch all parent messages from a node up to the root using recursive CTE."""
+        query = """
+            WITH RECURSIVE node_tree AS (
+                SELECT n.id, n.parent_node_id, m.content, m.author , n.created_at
+                FROM model_hub_node n
+                LEFT JOIN model_hub_message m ON n.message_id = m.id
+                WHERE n.id = %s
+                UNION ALL
+                SELECT n.id, n.parent_node_id, m.content, m.author , n.created_at
+                FROM model_hub_node n
+                LEFT JOIN model_hub_message m ON n.message_id = m.id
+                INNER JOIN node_tree nt ON n.id = nt.parent_node_id
+            )
+            SELECT id, content,author
+            FROM node_tree
+            WHERE content IS NOT NULL
+            ORDER BY created_at ASC;
+        """
+        nodes = self.raw(query, [node_id])
+        if formatter is not None:
+            return [
+                {
+                    "content": formatter(json.loads(node.content)),
+                    "author": json.loads(node.author),
+                }
+                for node in nodes
+            ]
+        else:
+            return [json.loads(node.content) for node in nodes]
+
+
+class Conversation(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user_provided_id = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+    )
+    title = models.CharField(max_length=255)
+    root_node = models.OneToOneField(
+        "Node",
+        on_delete=models.SET_NULL,
+        related_name="root_conversation",
+        null=True,
+        blank=True,
+    )
+    metadata = models.JSONField(default=dict, blank=True)
+
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="conversations"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="conversations",
+        null=True,
+        blank=True,
+    )
+
+    def __str__(self):
+        return self.title
+
+
+class Node(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user_provided_id = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+    )
+    conversation = models.ForeignKey(
+        Conversation, on_delete=models.CASCADE, related_name="nodes"
+    )
+    parent_node = models.ForeignKey(
+        "self",
+        on_delete=models.SET_NULL,
+        related_name="child_nodes",
+        null=True,
+        blank=True,
+    )
+    # child_node = models.ForeignKey(
+    #     "self", on_delete=models.SET_NULL, related_name="parent", null=True, blank=True
+    # )
+    message = models.OneToOneField(
+        "Message",
+        on_delete=models.SET_NULL,
+        related_name="node",
+        null=True,
+        blank=True,
+    )
+
+    objects = NodeManager()
+
+    def __str__(self):
+        return str(self.id)
+
+
+class Message(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user_provided_id = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+    )
+    author = models.JSONField(default=list, blank=True)
+    content = models.JSONField(default=list, blank=True)
+    metadata = models.JSONField(default=dict, blank=True)
+
+    def __str__(self):
+        return str(self.id)

--- a/futureagi/model_hub/models/custom_models.py
+++ b/futureagi/model_hub/models/custom_models.py
@@ -1,0 +1,58 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization, User
+from accounts.models.workspace import Workspace
+from model_hub.models.api_key import ApiKey, validate_model_provider_choice
+from tfc.utils.base_model import BaseModel
+
+
+class CustomAIModel(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    user_model_id = models.CharField(max_length=255, null=False)
+    deleted = models.BooleanField(default=False)
+    key_config = models.JSONField(null=True, blank=True)
+    provider = models.CharField(
+        max_length=50, validators=[validate_model_provider_choice], null=False
+    )
+    input_token_cost = models.FloatField(null=False)
+    output_token_cost = models.FloatField(null=False)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
+
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="custom_ai_models"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="custom_ai_models",
+        null=True,
+        blank=True,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._actual_json = {}
+        if self.key_config:
+            self._actual_json = ApiKey().decrypt_json(self.key_config)
+
+    def save(self, *args, **kwargs):
+        # if self.key_config and not all(
+        #     [v.startswith(b"gAAAAA".decode()) for v in self.key_config.values()]
+        # ):
+        self._actual_json = self.key_config
+        self.key_config = ApiKey().encrypt_json(self.key_config)
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    @property
+    def actual_json(self):
+        return self._actual_json
+
+    class Meta:
+        unique_together = ["organization", "user_model_id", "deleted"]
+
+    def __str__(self):
+        return str(self.id)

--- a/futureagi/model_hub/models/dataset_insight_meta.py
+++ b/futureagi/model_hub/models/dataset_insight_meta.py
@@ -1,0 +1,234 @@
+"""
+# Usage examples
+meta = DatasetInsightMeta()
+
+# All these are valid:
+add_insight_option(meta, "languages", ["Python", "JavaScript"])
+add_insight_option(meta, "scores", [0.95, 0.87, 0.76])
+add_insight_option(meta, "counts", [1, 2, 3])
+add_insight_option(meta, "mixed", ["high", 0.99, 1])
+
+# These will raise ValidationError:
+add_insight_option(meta, "invalid", [{"dict": "not allowed"}])  # Type error: dict not allowed
+add_insight_option(meta, "", ["value"])  # Empty key
+add_insight_option(meta, "dupes", ["a", "a"])  # Duplicate values
+"""
+
+import uuid
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.db import models
+from pydantic import BaseModel, Field, RootModel, validator
+
+from accounts.models import Organization
+
+
+class EnvTypes(models.TextChoices):
+    PRODUCTION = "Production", "Production"
+    TRAINING = "Training", "Training"
+    VALIDATION = "Validation", "Validation"
+    CORPUS = "Corpus", "Corpus"
+
+    @classmethod
+    def get_env_types(cls, num):
+        if num == 1:
+            return cls.TRAINING
+        if num == 2:
+            return cls.VALIDATION
+        if num == 3:
+            return cls.PRODUCTION
+        if num == 4:
+            return cls.CORPUS
+
+    @classmethod
+    def validate_env_type(cls, env_type: str) -> None:
+        if env_type not in [choice[0] for choice in cls.choices]:
+            raise ValidationError(
+                f"Invalid environment type: {env_type}. Must be one of {[choice[0] for choice in cls.choices]}"
+            )
+
+
+class InsightOptionsSchema(RootModel):
+    """Pydantic schema for insight_options JSON field"""
+
+    root: dict[str, list[str | float | int]] = Field(default_factory=dict)
+
+    @validator("root")
+    def validate_structure(
+        cls, v: dict[str, Any]
+    ) -> dict[str, list[str | float | int]]:
+        """Validate the entire structure matches Dict[str, List[Union[str, float, int]]]"""
+        for key, value in v.items():
+            # Validate key is string
+            if not isinstance(key, str):
+                raise ValueError(f"Key must be string, got {type(key)}")
+
+            # Validate value is list
+            if not isinstance(value, list):
+                raise ValueError(
+                    f"Value for key '{key}' must be a list, got {type(value)}"
+                )
+
+            # Validate all elements in list are of allowed types
+            for item in value:
+                if not isinstance(item, str | float | int):
+                    raise ValueError(
+                        f"Items in list for key '{key}' must be string, float, or int. "
+                        f"Got {type(item)} for value: {item}"
+                    )
+
+            # Validate uniqueness
+            if len(value) != len(
+                set(map(str, value))
+            ):  # Convert to string for comparison
+                raise ValueError(f"Values in list for key '{key}' must be unique")
+
+            # Validate non-empty key
+            if not key.strip():
+                raise ValueError("Keys cannot be empty strings")
+
+        return v
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "chat_language": ["English", "Spanish"],
+                "scores": [0.95, 0.87, 0.76],
+                "counts": [1, 2, 3],
+                "mixed_values": ["high", 0.99, 1],
+            }
+        }
+
+
+class PropertyMetadata(BaseModel):
+    """Schema for each property's metadata"""
+
+    explanation: str
+
+
+class InsightMetaSchema(RootModel):
+    """Pydantic schema for insight_meta JSON field"""
+
+    root: dict[str, PropertyMetadata] = Field(default_factory=dict)
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "tone": {"explanation": "Represents the tone of the conversation"},
+                "sentiment": {"explanation": "Indicates the sentiment analysis result"},
+            }
+        }
+
+
+class DatasetInsightMeta(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now_add=True)
+    model = models.ForeignKey(
+        "AIModel",
+        on_delete=models.CASCADE,
+        related_name="model_dataset_insight_meta",
+    )
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="dataset_insight_meta",
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="dataset_insight_meta",
+        null=True,
+        blank=True,
+    )
+    insight_options = models.JSONField(null=True)
+    insight_meta = models.JSONField(null=True)
+    environment = models.CharField(
+        max_length=100,
+        choices=EnvTypes.choices,
+        default=None,
+        blank=True,
+        null=True,
+    )
+    version = models.CharField(max_length=255, default=None, blank=True, null=True)
+
+    def clean_insight_options(self) -> None:
+        """Validate insight_options using Pydantic schema"""
+        if self.insight_options is not None:
+            try:
+                # Validate using Pydantic schema
+                InsightOptionsSchema(root=self.insight_options)
+            except ValueError as e:
+                raise ValidationError(
+                    f"Invalid insight_options format: {str(e)}"
+                ) from e
+
+    def clean_insight_meta(self) -> None:
+        """Validate insight_meta using Pydantic schema"""
+        if self.insight_meta is not None:
+            try:
+                InsightMetaSchema(root=self.insight_meta)
+            except ValueError as e:
+                raise ValidationError(f"Invalid insight_meta format: {str(e)}") from e
+
+    def clean_environment(self) -> None:
+        """Validate environment is one of the allowed choices"""
+        if self.environment is not None:
+            EnvTypes.validate_env_type(self.environment)
+
+    def clean(self) -> None:
+        """Validate the model"""
+        super().clean()
+        self.clean_insight_options()
+        self.clean_insight_meta()
+        self.clean_environment()
+
+    def save(self, *args: Any, **kwargs: Any) -> None:
+        """Save the model with validation"""
+        self.clean()
+        super().save(*args, **kwargs)
+
+    @property
+    def typed_insight_options(self) -> dict[str, list[str | float | int]]:
+        """Get type-checked insight_options"""
+        if self.insight_options is None:
+            return {}
+        validated = InsightOptionsSchema(root=self.insight_options)
+        return validated.root
+
+    def update_insight_options(
+        self, new_options: dict[str, list[str | float | int]]
+    ) -> None:
+        """Update insight_options with type checking"""
+        validated = InsightOptionsSchema(root=new_options)
+        self.insight_options = validated.root
+
+    @property
+    def typed_insight_meta(self) -> dict[str, PropertyMetadata]:
+        """Get type-checked insight_meta"""
+        if self.insight_meta is None:
+            return {}
+        validated = InsightMetaSchema(root=self.insight_meta)
+        return validated.root
+
+    def __str__(self):
+        return str(self.id)
+
+
+def add_insight_option(
+    meta: DatasetInsightMeta, key: str, values: list[str | float | int]
+) -> None:
+    current_options = meta.typed_insight_options
+
+    if key in current_options:
+        # Merge and deduplicate values
+        # Convert to strings for comparison, but keep original values
+        existing_values = set(map(str, current_options[key]))
+        new_values = [v for v in values if str(v) not in existing_values]
+        current_options[key] = current_options[key] + new_values
+    else:
+        current_options[key] = values
+
+    meta.update_insight_options(current_options)
+    meta.save()

--- a/futureagi/model_hub/models/dataset_optimization_step.py
+++ b/futureagi/model_hub/models/dataset_optimization_step.py
@@ -1,0 +1,53 @@
+import uuid
+
+from django.db import models
+
+from model_hub.models.optimize_dataset import OptimizeDataset
+from tfc.utils.base_model import BaseModel
+
+
+class DatasetOptimizationStep(BaseModel):
+    """
+    Represents a single step within a dataset optimization run.
+    Follows the same pattern as simulate.models.AgentPromptOptimiserRunStep.
+    """
+
+    class Status(models.TextChoices):
+        PENDING = "pending", "Pending"
+        RUNNING = "running", "Running"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    optimization_run = models.ForeignKey(
+        OptimizeDataset, on_delete=models.CASCADE, related_name="steps"
+    )
+    step_number = models.IntegerField()
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, null=True)
+    status = models.CharField(
+        max_length=20, choices=Status.choices, default=Status.PENDING
+    )
+    metadata = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        db_table = "dataset_optimization_step"
+        unique_together = ("optimization_run", "step_number")
+
+    def __str__(self):
+        return f"{self.optimization_run.id} - {self.name} - {self.status}"
+
+    def mark_as_running(self):
+        """Mark the optimization step as running"""
+        self.status = self.Status.RUNNING
+        self.save(update_fields=["status", "updated_at"])
+
+    def mark_as_completed(self):
+        """Mark the optimization step as completed"""
+        self.status = self.Status.COMPLETED
+        self.save(update_fields=["status", "updated_at"])
+
+    def mark_as_failed(self):
+        """Mark the optimization step as failed"""
+        self.status = self.Status.FAILED
+        self.save(update_fields=["status", "updated_at"])

--- a/futureagi/model_hub/models/dataset_optimization_trial.py
+++ b/futureagi/model_hub/models/dataset_optimization_trial.py
@@ -1,0 +1,34 @@
+import uuid
+
+from django.db import models
+
+from model_hub.models.optimize_dataset import OptimizeDataset
+from tfc.utils.base_model import BaseModel
+
+
+class DatasetOptimizationTrial(BaseModel):
+    """
+    Represents a single trial in a dataset optimization run.
+    Follows the same pattern as simulate.models.PromptTrial.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    optimization_run = models.ForeignKey(
+        OptimizeDataset,
+        on_delete=models.CASCADE,
+        related_name="trials",
+    )
+    trial_number = models.IntegerField()
+    is_baseline = models.BooleanField(default=False)
+    prompt = models.TextField(null=True, blank=True)
+    average_score = models.FloatField()
+    metadata = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        db_table = "dataset_optimization_trial"
+        unique_together = ("optimization_run", "trial_number")
+        ordering = ["trial_number"]
+
+    def __str__(self):
+        label = "Baseline" if self.is_baseline else f"Trial {self.trial_number}"
+        return f"{self.optimization_run_id} - {label} (score: {self.average_score:.2f})"

--- a/futureagi/model_hub/models/dataset_optimization_trial_item.py
+++ b/futureagi/model_hub/models/dataset_optimization_trial_item.py
@@ -1,0 +1,93 @@
+import uuid
+
+from django.db import models
+
+from model_hub.models.dataset_optimization_trial import DatasetOptimizationTrial
+from model_hub.models.evals_metric import UserEvalMetric
+from tfc.utils.base_model import BaseModel
+
+
+class DatasetOptimizationTrialItem(BaseModel):
+    """
+    Represents the result for a single dataset row within a DatasetOptimizationTrial.
+
+    Each trial runs the prompt against multiple dataset rows.
+    This model stores the result for each row, including
+    the overall score, reason, and the input/output of the evaluation.
+
+    Equivalent to simulate.models.TrialItemResult.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    trial = models.ForeignKey(
+        DatasetOptimizationTrial,
+        on_delete=models.CASCADE,
+        related_name="trial_items",
+    )
+    # Row identifier from the dataset (can be row index or UUID)
+    row_id = models.CharField(max_length=255)
+    score = models.FloatField()
+    reason = models.TextField(null=True, blank=True)
+    input_text = models.TextField(null=True, blank=True)
+    output_text = models.TextField(null=True, blank=True)
+    filled_prompt = models.TextField(null=True, blank=True)
+    metadata = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        db_table = "dataset_optimization_trial_item"
+        unique_together = ("trial", "row_id")
+        indexes = [
+            models.Index(
+                fields=["trial"],
+                name="idx_ds_opt_trial_item_trial",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.trial_id} - row:{self.row_id} (score: {self.score:.2f})"
+
+
+class DatasetOptimizationItemEvaluation(BaseModel):
+    """
+    Represents an individual evaluation score from a specific evaluator.
+
+    Each TrialItem may have multiple evaluations (one per configured eval metric),
+    e.g., is_helpful, accuracy, etc.
+    This provides granular breakdowns of how each evaluation metric scored.
+
+    Equivalent to simulate.models.ComponentEvaluation.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    trial_item = models.ForeignKey(
+        DatasetOptimizationTrialItem,
+        on_delete=models.CASCADE,
+        related_name="evaluations",
+    )
+    # Reference to the UserEvalMetric (which contains the EvalTemplate)
+    eval_metric = models.ForeignKey(
+        UserEvalMetric,
+        on_delete=models.CASCADE,
+        related_name="dataset_optimization_evaluations",
+    )
+    score = models.FloatField()
+    reason = models.TextField(null=True, blank=True)
+
+    class Meta:
+        db_table = "dataset_optimization_item_evaluation"
+        indexes = [
+            models.Index(
+                fields=["trial_item", "eval_metric"],
+                name="idx_dsopt_eval_item_metric",
+            ),
+            models.Index(
+                fields=["eval_metric"],
+                name="idx_dsopt_eval_metric",
+            ),
+        ]
+
+    def __str__(self):
+        eval_name = (
+            self.eval_metric.template.name if self.eval_metric.template else "unknown"
+        )
+        return f"{self.trial_item_id} - {eval_name} (score: {self.score:.2f})"

--- a/futureagi/model_hub/models/dataset_properties.py
+++ b/futureagi/model_hub/models/dataset_properties.py
@@ -1,0 +1,85 @@
+import uuid
+
+from django.contrib.postgres.fields import ArrayField
+from django.db import models
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import Field, validator
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.ai_model import AIModel
+from tfc.utils.base_model import BaseModel
+
+
+class DatasetPropertiesValidation(PydanticBaseModel):
+    id: uuid.UUID | None = None
+    model_id: uuid.UUID
+    environment: str = Field(..., min_length=1, max_length=255)
+    version: str = Field(..., min_length=1, max_length=255)
+    name: str = Field(..., min_length=1, max_length=255)
+    datatype: str = Field(..., min_length=1, max_length=255)
+    values: list[str] = Field(default_factory=list)
+    explanation: str = Field(..., min_length=1, max_length=255)
+    organization_id: uuid.UUID
+
+    @validator("datatype")
+    def validate_datatype(cls, v):
+        allowed_types = ["numeric", "string", "boolean", "date"]
+        if v.lower() not in allowed_types:
+            raise ValueError(f"datatype must be one of {allowed_types}")
+        return v.lower()
+
+    class Config:
+        from_attributes = True
+        protected_namespaces = ()
+
+
+class DatasetProperties(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    model = models.ForeignKey(
+        AIModel, on_delete=models.CASCADE, related_name="model_properties"
+    )
+    environment = models.CharField(max_length=255)
+    version = models.CharField(max_length=255)
+
+    name = models.CharField(max_length=255)
+    datatype = models.CharField(max_length=255)
+    values: list[str] = ArrayField(models.CharField(), blank=True, default=[])
+    explanation = models.CharField(max_length=255)
+
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="properties"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="dataset_properties",
+        null=True,
+        blank=True,
+    )
+
+    def __str__(self):
+        return self.name
+
+    def validate_data(self):
+        try:
+            validation_data = {
+                "id": self.id,
+                "model_id": self.model.id,  # Access id through model relationship
+                "environment": self.environment,
+                "version": self.version,
+                "name": self.name,
+                "datatype": self.datatype,
+                "values": self.values,
+                "explanation": self.explanation,
+                "organization_id": self.organization.id,  # Access id through organization relationship
+            }
+            return DatasetPropertiesValidation(**validation_data)
+        except AttributeError as e:
+            raise ValueError(f"Missing required field: {str(e)}") from e
+        except Exception as e:
+            raise ValueError(f"Validation failed: {str(e)}") from e
+
+    def save(self, *args, **kwargs):
+        self.validate_data()  # Validate before saving
+        super().save(*args, **kwargs)

--- a/futureagi/model_hub/models/develop.py
+++ b/futureagi/model_hub/models/develop.py
@@ -1,0 +1,31 @@
+import uuid
+
+from django.contrib.postgres.fields import ArrayField
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class DevelopAI(BaseModel):
+    class DevelopType(models.TextChoices):
+        RAG = "rag", "RAG"
+        PROMPT = "prompt", "Prompt"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    develop_type = models.CharField(max_length=10, choices=DevelopType.choices)
+    knowledge_base = models.ForeignKey("KnowledgeBase", on_delete=models.CASCADE)
+    unique_data_columns = ArrayField(
+        models.CharField(max_length=255), blank=True, null=True
+    )
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="develop_ais"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="develop_ais",
+        null=True,
+        blank=True,
+    )

--- a/futureagi/model_hub/models/develop_annotations.py
+++ b/futureagi/model_hub/models/develop_annotations.py
@@ -1,0 +1,339 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.db.models import Q
+
+from accounts.models.organization import Organization
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+from model_hub.models.choices import AnnotationTypeChoices
+from model_hub.models.develop_dataset import Column, Dataset
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+
+
+class Annotations(BaseModel):
+    class SummaryStatus:
+        RUNNING = "Running"
+        COMPLETED = "Completed"
+
+    class SummaryAnnotationType:
+        AUTO = "Auto"
+        MANUAL = "Manual"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    assigned_users = models.ManyToManyField(User, related_name="annotations")
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="annotations_org"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="annotations",
+        null=True,
+        blank=True,
+    )
+    dataset = models.ForeignKey(
+        Dataset, on_delete=models.CASCADE, null=True, blank=True
+    )
+
+    labels = models.ManyToManyField(
+        "AnnotationsLabels", related_name="annotation_label", blank=True
+    )
+    columns = models.ManyToManyField(
+        Column, related_name="annotation_columns", blank=True
+    )
+    static_fields = models.JSONField(default=list, blank=True)
+    response_fields = models.JSONField(default=list, blank=True)
+    responses = models.IntegerField(default=1)
+    summary = models.JSONField(
+        default=dict, blank=True, null=True
+    )  # storing label_required
+    lowest_unfinished_row = models.IntegerField(default=0)
+
+    def validate_static_fields(self):
+        if self.static_fields:
+            if not isinstance(self.static_fields, list):
+                raise ValidationError("static_fields must be a list")
+
+            valid_types = ["plain_text", "markdown"]
+            valid_views = ["default_collapsed", "default_open"]
+
+            for field in self.static_fields:
+                if not isinstance(field, dict):
+                    raise ValidationError("Each static field must be a dictionary")
+
+                column_id = field.get("column_id")
+                if not column_id:
+                    raise ValidationError("Each static field must have a column_id")
+
+                try:
+                    column = Column.objects.get(id=column_id, deleted=False)
+                    if column.dataset != self.dataset:
+                        raise ValidationError(
+                            f"Column ID {column_id} does not belong to the dataset"
+                        )
+                except Column.DoesNotExist as e:
+                    raise ValidationError(
+                        f"Column ID {column_id} is not valid or is deleted"
+                    ) from e
+
+                if "type" not in field or field["type"] not in valid_types:
+                    raise ValidationError(
+                        f"type must be one of: {', '.join(valid_types)}"
+                    )
+
+                if "view" not in field or field["view"] not in valid_views:
+                    raise ValidationError(
+                        f"view must be one of: {', '.join(valid_views)}"
+                    )
+
+    def validate_response_fields(self):
+        if self.response_fields:
+            if not isinstance(self.response_fields, list):
+                raise ValidationError("response_fields must be a list")
+
+            valid_types = ["plain_text", "markdown"]
+            valid_views = ["default_collapsed", "default_open"]
+            valid_edit = ["editable", "not_editable"]
+
+            for field in self.response_fields:
+                if not isinstance(field, dict):
+                    raise ValidationError("Each response field must be a dictionary")
+
+                column_id = field.get("column_id")
+                if not column_id:
+                    raise ValidationError("Each response field must have a column_id")
+
+                try:
+                    column = Column.objects.get(id=column_id, deleted=False)
+                    if column.dataset != self.dataset:
+                        raise ValidationError(
+                            f"Column ID {column_id} does not belong to the dataset"
+                        )
+                except Column.DoesNotExist as e:
+                    raise ValidationError(
+                        f"Column ID {column_id} is not valid or is deleted"
+                    ) from e
+
+                if "type" not in field or field["type"] not in valid_types:
+                    raise ValidationError(
+                        f"type must be one of: {', '.join(valid_types)}"
+                    )
+
+                if "view" not in field or field["view"] not in valid_views:
+                    raise ValidationError(
+                        f"view must be one of: {', '.join(valid_views)}"
+                    )
+
+                if "edit" not in field or field["edit"] not in valid_edit:
+                    raise ValidationError(
+                        f"edit must be one of: {', '.join(valid_edit)}"
+                    )
+
+    def validate_assigned_users(self):
+        organization = self.organization
+        responses = self.responses
+
+        users = self.assigned_users.all()
+        if responses > len(users):
+            raise ValidationError(
+                "Responses cannot be greater than the number of annotaters"
+            )
+
+        for user in users:
+            if user.organization != organization:
+                raise ValidationError(
+                    f"User {user.name} does not belong to the organization."
+                )
+
+    def validate_labels(self):
+        organization = self.organization
+        for label in self.labels.all():
+            if label.organization != organization:
+                raise ValidationError(
+                    f"Label {label.name} does not belong to the organization."
+                )
+
+    def clean(self):
+        super().clean()
+        self.validate_static_fields()
+        self.validate_response_fields()
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"Annotation Task {self.id}"
+
+
+def validate_annotation_type_choice(value):
+    valid_choices = [choice.value for choice in AnnotationTypeChoices]
+    if value not in valid_choices:
+        raise ValidationError(
+            f"Invalid annotation type choice. Valid choices are: {', '.join(valid_choices)}"
+        )
+
+
+class AnnotationsLabels(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    type = models.CharField(
+        max_length=255,
+        choices=AnnotationTypeChoices.get_choices(),
+        validators=[validate_annotation_type_choice],
+    )
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="annotations_labels"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="annotations_labels",
+        null=True,
+        blank=True,
+    )
+    # New fields for type-specific settings
+    settings = models.JSONField(default=dict, blank=True)
+    description = models.TextField(null=True, blank=True)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="annotations_labels",
+        null=True,
+        blank=True,
+    )
+    metadata = models.JSONField(default=dict, blank=True, null=True)
+    allow_notes = models.BooleanField(default=False)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name", "type", "project", "workspace"],
+                condition=Q(deleted=False),
+                name="unique_active_label_org_name_type_project",
+            )
+        ]
+
+    def validate_settings(self):
+        if self.settings:
+            if self.type == AnnotationTypeChoices.NUMERIC.value:
+                required_fields = {"min", "max", "step_size", "display_type"}
+                if not all(field in self.settings for field in required_fields):
+                    raise ValidationError(
+                        f"Numeric type requires {required_fields} settings"
+                    )
+                for field in ["min", "max", "step_size"]:
+                    if self.settings.get(field) is None:
+                        raise ValidationError(f"{field} cannot be null")
+                    if not isinstance(self.settings.get(field), int | float):
+                        raise ValidationError(f"{field} must be an float")
+                if self.settings["min"] >= self.settings["max"]:
+                    raise ValidationError("min must be less than max")
+                if not isinstance(
+                    self.settings.get("display_type"), str
+                ) or self.settings["display_type"] not in ["slider", "button"]:
+                    raise ValidationError(
+                        "display_type must be either 'slider' or 'button'"
+                    )
+
+            elif self.type == AnnotationTypeChoices.TEXT.value:
+                required_fields = {"placeholder", "max_length", "min_length"}
+                if not all(field in self.settings for field in required_fields):
+                    raise ValidationError(
+                        f"Text type requires {required_fields} settings"
+                    )
+                if "placeholder" in self.settings and not isinstance(
+                    self.settings["placeholder"], str
+                ):
+                    raise ValidationError("placeholder must be a string")
+                if "max_length" in self.settings and not isinstance(
+                    self.settings["max_length"], int
+                ):
+                    raise ValidationError("max_length must be an integer")
+                if "min_length" in self.settings and not isinstance(
+                    self.settings["min_length"], int
+                ):
+                    raise ValidationError("min_length must be an integer")
+                if (
+                    "min_length" in self.settings
+                    and "max_length" in self.settings
+                    and self.settings["min_length"] >= self.settings["max_length"]
+                ):
+                    raise ValidationError("min_length must be less than max_length")
+
+            elif self.type == AnnotationTypeChoices.CATEGORICAL.value:
+                required_fields = {
+                    "rule_prompt",
+                    "multi_choice",
+                    "options",
+                    "auto_annotate",
+                    "strategy",
+                }
+                if not all(field in self.settings for field in required_fields):
+                    raise ValidationError(
+                        f"Categorical type requires {required_fields} settings"
+                    )
+                if not isinstance(self.settings["options"], list):
+                    raise ValidationError("options must be a list")
+                for option in self.settings["options"]:
+                    if not isinstance(option, dict) or "label" not in option:
+                        raise ValidationError(
+                            "Each option must be a dictionary with a 'label' field"
+                        )
+                if len(self.settings["options"]) < 2:
+                    raise ValidationError("There must be at least two options")
+                if not isinstance(self.settings["multi_choice"], bool):
+                    raise ValidationError("multi_choice must be a boolean")
+                if not isinstance(self.settings["rule_prompt"], str):
+                    raise ValidationError("rule_prompt must be a string")
+                if self.settings["strategy"] not in ["Rag", None]:
+                    raise ValidationError("Strategy must be 'Rag' or None.")
+                if self.settings["strategy"] == "Rag":
+                    pass
+                    # if "query" not in self.settings or not isinstance(
+                    #     self.settings["query"], str
+                    # ):
+                    #     raise ValidationError(
+                    #         "When strategy is 'Rag', 'query' must be a string and is required."
+                    #     )
+                    # if "query_col" not in self.settings or not isinstance(
+                    #     self.settings["query_col"], str
+                    # ):
+                    #     raise ValidationError(
+                    #         "When strategy is 'Rag', 'query_col' must be a string and is required."
+                    #     )
+                if not isinstance(self.settings["auto_annotate"], bool):
+                    raise ValidationError("auto_annotate must be a boolean")
+
+            elif self.type == AnnotationTypeChoices.STAR.value:
+                required_fields = {"no_of_stars"}
+                if not all(field in self.settings for field in required_fields):
+                    raise ValidationError(
+                        f"Star type requires {required_fields} settings"
+                    )
+                if not isinstance(self.settings["no_of_stars"], int):
+                    raise ValidationError("no_of_stars must be an integer")
+                if self.settings["no_of_stars"] < 1:
+                    raise ValidationError("no_of_stars must be greater than 0")
+
+            elif self.type == AnnotationTypeChoices.THUMBS_UP_DOWN.value:
+                pass
+
+            else:
+                raise ValidationError(f"Invalid annotation label type: {self.type}")
+
+    def clean(self):
+        super().clean()
+        validate_annotation_type_choice(self.type)
+        self.validate_settings()
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"Annotation Label {self.id}"

--- a/futureagi/model_hub/models/develop_dataset.py
+++ b/futureagi/model_hub/models/develop_dataset.py
@@ -1,0 +1,385 @@
+import json
+import uuid
+
+import pydantic
+import structlog
+from django.contrib.postgres.fields import ArrayField
+from django.contrib.postgres.indexes import GinIndex
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.db.models import Q
+
+from accounts.models.organization import Organization
+from accounts.models.user import User
+
+logger = structlog.get_logger(__name__)
+from model_hub.models.choices import (
+    CellStatus,
+    DatasetSourceChoices,
+    DataTypeChoices,
+    EvalExplanationSummaryStatus,
+    ModelTypes,
+    SourceChoices,
+    StatusType,
+)
+from tfc.utils.base_model import BaseModel
+
+
+# Pydantic schema for eval reasons
+class EvalReasonSchema(pydantic.BaseModel):
+    theme: str = pydantic.Field(
+        ..., description="Theme or category of the evaluation reason"
+    )
+    triggers: list[str] = pydantic.Field(
+        default_factory=list, description="List of trigger conditions"
+    )
+    evidence_summary: str = pydantic.Field(
+        ..., description="Summary of evidence for this evaluation"
+    )
+    guidance: str = pydantic.Field(..., description="Guidance or recommendations")
+    confidence: str = pydantic.Field(
+        ..., description="Confidence level (e.g., high, medium, low)"
+    )
+    eval_template_id: str = pydantic.Field(
+        ..., description="Evaluation template identifier"
+    )
+
+
+def validate_eval_reasons(value):
+    """Validator function for eval_reasons JSONField"""
+    try:
+        # Handle both dict and json dumps
+        if isinstance(value, str):
+            json_data = json.loads(value)
+        else:
+            json_data = value
+
+        # If it's not a list, wrap it in a list for validation
+        if not isinstance(json_data, dict):
+            raise ValidationError("eval_reasons must be a dict of dictionaries")
+
+        # Validate each item in the list
+        for item in json_data:
+            if not isinstance(json_data[item], dict):
+                raise ValidationError("Each item in eval_reasons must be a dictionary")
+            for i in range(len(json_data[item]["summary"])):
+                EvalReasonSchema(**json_data[item]["summary"][i])
+
+    except pydantic.ValidationError as e:
+        raise ValidationError(f"Invalid eval_reasons format: {e}")  # noqa: B904
+    except json.JSONDecodeError:
+        raise ValidationError("Invalid JSON format")  # noqa: B904
+    except (TypeError, ValueError) as e:
+        raise ValidationError(f"Invalid eval_reasons data: {e}")  # noqa: B904
+
+
+def validate_model_type_choice(value):
+    valid_choices = [choice.value for choice in ModelTypes]
+    if value not in valid_choices:
+        raise ValidationError(
+            f"Invalid model type choice. Valid choices are: {', '.join(valid_choices)}"
+        )
+
+
+def validate_dataset_source_choice(value):
+    valid_choices = [choice.value for choice in DatasetSourceChoices]
+    if value not in valid_choices:
+        raise ValidationError(
+            f"Invalid source choice. Valid choices are: {', '.join(valid_choices)}"
+        )
+
+
+class Dataset(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    source = models.CharField(
+        max_length=50,
+        choices=DatasetSourceChoices.get_choices(),
+        validators=[validate_dataset_source_choice],
+        default=DatasetSourceChoices.BUILD.value,
+    )
+    name = models.CharField(max_length=2000)
+    column_order = ArrayField(
+        models.CharField(max_length=100),  # Specify the max length for each tag
+        blank=True,  # Allows an empty list as a default
+        default=list,  # Uses an empty list as the default value
+    )
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="dataset_org"
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="datasets",
+        null=True,
+        blank=True,
+    )
+    model_type = models.CharField(
+        max_length=50,
+        choices=ModelTypes.get_choices(),
+        validators=[validate_model_type_choice],
+        default=ModelTypes.GENERATIVE_LLM.value,
+    )
+    column_config = models.JSONField(
+        default=dict, blank=True, null=True
+    )  # todo: add structure validation in pydantic
+    dataset_config = models.JSONField(default=dict, blank=True, null=True)
+    # Store validated_data for synthetic dataset creation/editing
+    synthetic_dataset_config = models.JSONField(default=dict, blank=True, null=True)
+    eval_reasons = models.JSONField(default=list, blank=True, null=True)
+    eval_reason_last_updated = models.DateTimeField(null=True, blank=True)
+    eval_reason_status = models.CharField(
+        max_length=20,
+        choices=EvalExplanationSummaryStatus.choices,
+        default=EvalExplanationSummaryStatus.PENDING,
+    )
+
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="datasets_user",
+        null=True,
+        blank=True,
+        default=None,
+    )
+
+    class Meta(BaseModel.Meta):
+        indexes = [
+            models.Index(fields=["organization", "workspace"]),
+            models.Index(fields=["source"]),
+            models.Index(
+                fields=["organization", "deleted", "source"],
+                name="dataset_org_del_source_idx",
+            ),
+        ]
+
+    def clean(self):
+        super().clean()
+        validate_model_type_choice(self.model_type)
+        # validate_eval_reasons(self.eval_reasons)
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        if (
+            self.column_order
+        ):  # todo: while column delete need to handle column_config value also.
+            # Convert all values to UUID objects
+            try:
+                uuids = [uuid.UUID(value) for value in self.column_order]
+            except ValueError:
+                raise ValidationError("Invalid UUID in column_order")  # noqa: B904
+
+            # Check which UUIDs exist in the Column table
+            existing_ids = set(
+                Column.objects.filter(id__in=uuids).values_list("id", flat=True)
+            )
+
+            # Filter out missing UUIDs
+            original_count = len(uuids)
+            uuids = [uid for uid in uuids if uid in existing_ids]
+            if original_count != len(uuids):
+                missing = set(self.column_order) - {str(uid) for uid in uuids}
+                logger.warning(f"Ignoring missing UUIDs: {missing}")
+            # Update the cleaned column_order
+            self.column_order = [str(uid) for uid in uuids]
+
+        super().save(*args, **kwargs)
+
+
+def validate_source_choice(value):
+    valid_choices = [choice.value for choice in SourceChoices]
+    if value not in valid_choices:
+        raise ValidationError(
+            f"Invalid source choice. Valid choices are: {', '.join(valid_choices)}"
+        )
+
+
+def validate_data_type_choice(value):
+    valid_choices = [choice.value for choice in DataTypeChoices]
+    if value not in valid_choices:
+        raise ValidationError(
+            f"Invalid data type choice. Valid choices are: {', '.join(valid_choices)}"
+        )
+
+
+class Column(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=2000)
+    data_type = models.CharField(
+        max_length=50,
+        choices=DataTypeChoices.get_choices(),
+        validators=[validate_data_type_choice],
+    )
+    dataset = models.ForeignKey(
+        Dataset, on_delete=models.CASCADE, null=True, blank=True
+    )
+    source = models.CharField(
+        max_length=50,
+        choices=SourceChoices.get_choices(),
+        validators=[validate_source_choice],
+    )
+    source_id = models.CharField(max_length=2000, blank=True, null=True)
+    metadata = models.JSONField(default=dict, blank=True, null=True)
+    status = models.CharField(
+        max_length=50,
+        choices=StatusType.get_choices(),
+        default=StatusType.COMPLETED.value,
+    )
+
+    class Meta(BaseModel.Meta):
+        indexes = [
+            models.Index(fields=["dataset"]),
+        ]
+
+    def clean(self):
+        super().clean()
+        validate_source_choice(self.source)
+        validate_data_type_choice(self.data_type)
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+
+class Row(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    dataset = models.ForeignKey(Dataset, on_delete=models.CASCADE)
+    order = models.IntegerField()
+    metadata = models.JSONField(default=dict, blank=True, null=True)
+
+    class Meta(BaseModel.Meta):
+        indexes = [
+            models.Index(fields=["dataset", "order"]),
+            models.Index(
+                fields=["dataset", "deleted"],
+                name="row_dataset_deleted_idx",
+            ),
+        ]
+
+
+def validate_cell_choice(value):
+    valid_choices = [choice.value for choice in CellStatus]
+    if value not in valid_choices:
+        raise ValidationError(
+            f"Invalid model type choice. Valid choices are: {', '.join(valid_choices)}"
+        )
+
+
+# Pydantic schema for column metadata
+class ColumnMetadataSchema(pydantic.BaseModel):
+    audio_duration_seconds: float = pydantic.Field(..., ge=0.0)
+
+
+def validate_column_metadata(value):
+    """Validator function for JSONField"""
+    try:
+        # Handle both dict and json dumps
+        if isinstance(value, str):
+            json_data = json.loads(value)
+        else:
+            json_data = value
+
+        ColumnMetadataSchema(**json_data)
+    except pydantic.ValidationError as e:
+        raise ValidationError(f"Invalid column_metadata format: {e}")  # noqa: B904
+    except json.JSONDecodeError:
+        raise ValidationError("Invalid JSON format")  # noqa: B904
+
+
+class Cell(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    dataset = models.ForeignKey(
+        Dataset, on_delete=models.CASCADE, null=True, blank=True
+    )
+    column = models.ForeignKey(Column, on_delete=models.CASCADE)
+    row = models.ForeignKey(Row, on_delete=models.CASCADE)
+    value = models.TextField(null=True, blank=True)
+    value_infos = models.JSONField(default=list, blank=True, null=True)
+    feedback_info = models.JSONField(
+        default=dict, blank=True, null=True
+    )  # description , annotation {user_id , auto_annotate , verified,label_id,annotation_id}
+    status = models.CharField(
+        max_length=50,
+        choices=CellStatus.get_choices(),
+        validators=[validate_cell_choice],
+        default=CellStatus.PASS.value,
+    )
+    column_metadata = models.JSONField(
+        default=dict, blank=True, null=True, validators=[validate_column_metadata]
+    )
+    prompt_tokens = models.IntegerField(null=True, blank=True)
+    completion_tokens = models.IntegerField(null=True, blank=True)
+    response_time = models.FloatField(null=True, blank=True)
+
+    class Meta(BaseModel.Meta):
+        indexes = [
+            models.Index(fields=["row", "column", "dataset"]),
+            GinIndex(
+                fields=["value"],
+                opclasses=["gin_trgm_ops"],
+                name="model_hub_cell_value_trgm_idx",
+                condition=Q(deleted=False, status="pass", value__isnull=False)
+                & ~Q(value=""),
+            ),
+        ]
+
+    def clean(self):
+        super().clean()
+        validate_cell_choice(self.status)
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+
+def validate_status_choices(value):
+    valid_choices = [choice.value for choice in StatusType]
+    if value not in valid_choices:
+        raise ValidationError(
+            f"Invalid status choice. Valid choices are: {', '.join(valid_choices)}"
+        )
+
+
+class Files(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=5000)
+    status = models.CharField(
+        choices=StatusType.get_choices(),
+        validators=[validate_status_choices],
+        default=StatusType.PROCESSING.value,
+    )
+    metadata = models.JSONField(default=dict, blank=True, null=True)
+    updated_by = models.CharField(max_length=5000, blank=True, null=True)
+    uploaded_url = models.URLField(max_length=5000)
+
+    def __str__(self):
+        return self.name
+
+
+class KnowledgeBaseFile(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=5000)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="knowledge_base",
+        default=1,
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="knowledge_base_files",
+        null=True,
+        blank=True,
+    )
+    status = models.CharField(
+        choices=StatusType.get_choices(),
+        validators=[validate_status_choices],
+        default=StatusType.PROCESSING.value,
+    )
+    last_error = models.CharField(max_length=10000, blank=True, null=True)
+    files = models.ManyToManyField(Files, related_name="knowledge_base_files")
+    created_by = models.CharField(max_length=5000, blank=True, null=True)
+    size = models.BigIntegerField(blank=True, null=True)
+
+    def __str__(self):
+        return self.name

--- a/futureagi/model_hub/models/develop_optimisation.py
+++ b/futureagi/model_hub/models/develop_optimisation.py
@@ -1,0 +1,145 @@
+import uuid
+from uuid import UUID
+
+from django.contrib.postgres.fields import ArrayField
+from django.core.exceptions import ValidationError
+from django.db import models
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import Field, RootModel
+from pydantic import ValidationError as PydanticValidationError
+from pydantic import validator
+
+from model_hub.models.choices import StatusType
+from model_hub.models.develop_dataset import Column, Dataset
+from model_hub.models.evals_metric import UserEvalMetric
+from tfc.utils.base_model import BaseModel
+
+
+class ModelConfig(PydanticBaseModel):
+    model_name: str
+    temperature: float | None = Field(None, ge=0, le=2)
+    frequency_penalty: float | None = Field(None, ge=-2, le=2)
+    presence_penalty: float | None = Field(None, ge=-2, le=2)
+    max_tokens: int | None = Field(None, gt=0)
+    top_p: float | None = Field(None, ge=0, le=1)
+    response_format: dict | None = None
+    tool_choice: str | None = None
+    tools: list[dict] | None = None
+
+
+class UserEvalTemplateMapping(RootModel):
+    root: dict[UUID, UUID]
+
+    @validator("root")
+    def validate_uuids(cls, v):
+        # Convert string UUIDs to UUID objects and validate
+        try:
+            return {UUID(str(k)): UUID(str(v)) for k, v in v.items()}
+        except ValueError:
+            raise ValueError("Invalid UUID format in mapping")  # noqa: B904
+
+
+def validate_model_config(value):
+    if value:
+        try:
+            # Enforce type and schema validation on model_config by creating an instance of ModelConfig
+            ModelConfig.model_validate(value)  # This uses Pydantic's strict validation
+        except PydanticValidationError as e:
+            raise ValidationError(f"Invalid model configuration: {str(e)}") from e
+
+
+def validate_template_mapping(value):
+    if value:
+        try:
+            UserEvalTemplateMapping.model_validate(value)
+        except Exception as e:
+            raise ValidationError(
+                f"Invalid user eval template mapping: {str(e)}"
+            ) from e
+
+
+class OptimizationDataset(BaseModel):
+    OPTIMIZE_TYPE_CHOICES = [
+        ("PROMPT_TEMPLATE", "Prompt Template"),
+        ("RIGHT_ANSWER", "Right Answer"),
+        ("RAG_PROMPT_TEMPLATE", "Rag Prompt Template"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=2000)
+    prompt_name = models.CharField(max_length=2000, blank=True, null=True, default="")
+    optimize_type = models.CharField(max_length=50, choices=OPTIMIZE_TYPE_CHOICES)
+    optimized_k_prompts = ArrayField(models.TextField(), blank=True, null=True)
+    messages = ArrayField(
+        models.JSONField(),
+        default=list,
+        help_text="List of messages with format [{'role': 'user/assistant', 'content': 'text'}]",
+        blank=True,
+        null=True,
+    )
+    criteria_breakdown = ArrayField(
+        models.CharField(),
+        default=list,
+        blank=True,
+    )
+    status = models.CharField(
+        max_length=50,
+        choices=StatusType.get_choices(),
+        default=StatusType.NOT_STARTED.value,
+    )
+
+    user_eval_template_ids = models.ManyToManyField(
+        UserEvalMetric, blank=True, related_name="optimization_datasets_evals"
+    )
+
+    model_config = models.JSONField(
+        null=True, blank=True, default=None, validators=[validate_model_config]
+    )
+
+    user_eval_template_mapping = models.JSONField(
+        null=True, blank=True, validators=[validate_template_mapping]
+    )
+
+    dataset = models.ForeignKey(
+        Dataset, on_delete=models.CASCADE, related_name="optimizations_dataset"
+    )
+    column = models.ForeignKey(
+        Column,
+        on_delete=models.CASCADE,
+        related_name="optimizations_col",
+        blank=True,
+        null=True,
+    )
+    generated_column_id = models.ManyToManyField(
+        Column, blank=True, related_name="optimization_columns"
+    )
+
+    def __str__(self):
+        return f"{self.name} - {self.optimize_type} - {self.status}"
+
+    def save(self, *args, **kwargs):
+        if self.model_config:
+            validate_model_config(self.model_config)
+        if self.user_eval_template_mapping:
+            validate_template_mapping(self.user_eval_template_mapping)
+        super().save(*args, **kwargs)
+
+    # def save(self, *args, **kwargs):
+    #     # Run full_clean() before saving to enforce validators
+    #     self.full_clean()
+    #     super().save(*args, **kwargs)
+
+    # # Uncomment and update the clean method
+    # def clean(self):
+    #     super().clean()
+    # if self.model_config:
+    #     try:
+    #         ModelConfig.model_validate(self.model_config)
+    #     except Exception as e:
+    #         raise ValidationError(f"Invalid model configuration: {str(e)}")
+
+    # if self.user_eval_template_mapping:
+    #     try:
+    #         UserEvalTemplateMapping.model_validate(self.user_eval_template_mapping)
+    #     except Exception as e:
+    #         raise ValidationError(f"Invalid user eval template mapping: {str(e)}")

--- a/futureagi/model_hub/models/error_localizer_model.py
+++ b/futureagi/model_hub/models/error_localizer_model.py
@@ -1,0 +1,107 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.evals_metric import EvalTemplate
+from tfc.utils.base_model import BaseModel
+
+
+class ErrorLocalizerStatus(models.TextChoices):
+    PENDING = "pending", "Pending"
+    RUNNING = "running", "Running"
+    COMPLETED = "completed", "Completed"
+    FAILED = "failed", "Failed"
+    SKIPPED = "skipped", "Skipped"
+
+
+class ErrorLocalizerSource(models.TextChoices):
+    DATASET = "dataset", "Dataset"
+    OBSERVE = "observe", "Observe"
+    PLAYGROUND = "playground", "Playground"
+    SIMULATE = "simulate", "Simulate"
+    STANDALONE = "standalone", "Standalone"
+
+
+class ErrorLocalizerTask(BaseModel):
+    """
+    Model to track error localization tasks and their results.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    eval_template = models.ForeignKey(
+        EvalTemplate, on_delete=models.CASCADE, null=True, blank=True
+    )
+    source = models.CharField(
+        max_length=255,
+        choices=ErrorLocalizerSource.choices,
+        default=ErrorLocalizerSource.DATASET,
+    )
+    source_id = models.UUIDField(null=True, blank=True)
+    status = models.CharField(
+        max_length=20,
+        choices=ErrorLocalizerStatus.choices,
+        default=ErrorLocalizerStatus.PENDING,
+    )
+
+    input_data = models.JSONField(default=dict, blank=True)
+    input_keys = models.JSONField(default=list, blank=True)
+    input_types = models.JSONField(default=dict, blank=True)
+    eval_result = models.JSONField(default=dict, blank=True)
+    eval_explanation = models.JSONField(default=dict, blank=True)
+    rule_prompt = models.TextField(null=True, blank=True)
+
+    error_analysis = models.JSONField(default=dict, blank=True)
+    selected_input_key = models.CharField(max_length=2000, null=True, blank=True)
+    error_message = models.TextField(null=True, blank=True)
+
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, null=True, blank=True
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="error_localizer_tasks",
+        null=True,
+        blank=True,
+    )
+    metadata = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        db_table = "error_localizer_task"
+        indexes = [models.Index(fields=["source_id"]), models.Index(fields=["status"])]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["source_id"],
+                condition=models.Q(deleted=False),
+                name="unique_source_id",
+            ),
+        ]
+
+    def __str__(self):
+        return f"ErrorLocalizerTask {self.id} - {self.status}"
+
+    def mark_as_running(self):
+        """Mark the task as running."""
+        self.status = ErrorLocalizerStatus.RUNNING
+        self.save(update_fields=["status"])
+
+    def mark_as_completed(self, error_analysis, selected_input_key):
+        """Mark the task as completed with results."""
+        self.status = ErrorLocalizerStatus.COMPLETED
+        self.error_analysis = error_analysis
+        self.selected_input_key = selected_input_key
+        self.save(update_fields=["status", "error_analysis", "selected_input_key"])
+
+    def mark_as_failed(self, error_message):
+        """Mark the task as failed with an error message."""
+        self.status = ErrorLocalizerStatus.FAILED
+        self.error_message = error_message
+        self.save(update_fields=["status", "error_message"])
+
+    def mark_as_skipped(self, reason):
+        """Mark the task as skipped with a reason."""
+        self.status = ErrorLocalizerStatus.SKIPPED
+        self.error_message = reason
+        self.save(update_fields=["status", "error_message"])

--- a/futureagi/model_hub/models/eval_groups.py
+++ b/futureagi/model_hub/models/eval_groups.py
@@ -1,0 +1,124 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class History(BaseModel):
+    """
+    Generic history table to track actions on various entities
+    """
+
+    SOURCE_TYPE_CHOICES = [
+        ("EVAL_GROUP", "Eval Group"),
+        # Add other source types as needed
+    ]
+
+    ACTION_CHOICES = [
+        ("ADD", "Add"),
+        ("DELETE", "Delete"),
+        # Add other actions as needed
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    source_id = models.UUIDField(help_text="ID of the source entity")
+    source_type = models.CharField(max_length=50, choices=SOURCE_TYPE_CHOICES)
+    action = models.CharField(max_length=20, choices=ACTION_CHOICES)
+    action_by = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="history_actions",
+        help_text="User who performed the action",
+    )
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="history_records",
+        null=True,
+        blank=True,
+        help_text="Organization where the action was performed",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="history_records",
+        null=True,
+        blank=True,
+        help_text="Workspace where the action was performed",
+    )
+    reference_id = models.UUIDField(
+        help_text="ID of the referenced entity (e.g., eval_template_id)"
+    )
+
+    def __str__(self):
+        return f"History {self.id}"
+
+    class Meta:
+        db_table = "model_hub_history"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["source_id", "source_type", "created_at"]),
+            models.Index(fields=["reference_id", "action"]),
+            models.Index(fields=["action_by", "created_at"]),
+            models.Index(fields=["organization", "workspace", "created_at"]),
+        ]
+
+
+class EvalGroup(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="eval_groups",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="eval_groups",
+        null=True,
+        blank=True,
+    )
+
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="eval_groups",
+        null=True,
+        blank=True,
+    )
+
+    description = models.TextField(null=True, blank=True)
+
+    # Many-to-many relationship with EvalTemplate
+    eval_templates = models.ManyToManyField(
+        "model_hub.EvalTemplate",  # Use string reference to avoid circular import
+        related_name="eval_groups",
+        blank=True,
+    )
+
+    is_sample = models.BooleanField(default=False)
+
+    def __str__(self):
+        return f"Eval Group {self.id}"
+
+    class Meta:
+        db_table = "model_hub_eval_group"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["name", "workspace"],
+                condition=models.Q(deleted=False),
+                name="unique_eval_group_name_workspace_not_deleted",
+            )
+        ]
+
+        indexes = [
+            models.Index(fields=["organization", "workspace", "created_at"]),
+        ]

--- a/futureagi/model_hub/models/evals_metric.py
+++ b/futureagi/model_hub/models/evals_metric.py
@@ -1,0 +1,865 @@
+import re
+import uuid
+from typing import Any, Literal
+
+from django.contrib.postgres.fields import ArrayField
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import models, transaction
+from django.db.models import Max, Q
+from pydantic import BaseModel, validator
+
+from accounts.models.organization import Organization
+from accounts.models.user import User
+from model_hub.models.choices import (
+    FeedbackSourceChoices,
+    ModelChoices,
+    OwnerChoices,
+    StatusType,
+)
+from model_hub.models.develop_dataset import Column, Dataset, KnowledgeBaseFile
+from model_hub.models.eval_groups import (  # Commented out to avoid circular import
+    EvalGroup,
+)
+from tfc.utils.base_model import BaseModel as ModelBaseModel
+
+
+def validate_eval_name(value):
+    cleaned_name = value.strip()
+
+    if cleaned_name == "":
+        raise DjangoValidationError("Name cannot be empty.")
+
+    if not re.match(r"^[0-9a-z_-]+$", cleaned_name):
+        raise DjangoValidationError(
+            "Name can only contain lowercase alphabets, numbers, hyphens (-), or underscores (_)."
+        )
+
+    if (
+        cleaned_name.startswith("-")
+        or cleaned_name.startswith("_")
+        or cleaned_name.endswith("-")
+        or cleaned_name.endswith("_")
+    ):
+        raise DjangoValidationError(
+            "Name cannot start or end with hyphens (-) or underscores (_)."
+        )
+
+    if "_-" in cleaned_name or "-_" in cleaned_name:
+        raise DjangoValidationError(
+            "Name cannot contain consecutive separators (_- or -_)."
+        )
+
+    return cleaned_name
+
+
+class ConfigParam(BaseModel):
+    type: str
+    default: Any | None = None
+
+
+class ConfigParamsDesc(BaseModel):
+    text: str | None = None
+    response: str | None = None
+    rule_prompt: str | None = None
+    choices: str | None = None
+    input: str | None = None
+    multi_choice: str | None = None
+    output: str | None = None
+    expected_response: str | None = None
+    criteria: str | None = None
+    context: str | None = None
+    query: str | None = None
+    actual_json: str | None = None
+    expected_json: str | None = None
+    code: str | None = None
+    model: str | None = None
+    prompt: str | None = None
+    eval_prompt: str | None = None
+    system_prompt: str | None = None
+    grading_criteria: str | None = None
+
+
+class EvalConfigModel(BaseModel):
+    required_keys: list[str] | None = None
+    optional_keys: list[str] | None = None
+    output: Literal["Pass/Fail", "score", "reason", "choices", ""] | None = None
+    eval_type_id: str | None = None
+    config: dict[str, ConfigParam] | None = None
+    config_params_desc: ConfigParamsDesc | None = None
+    config_params_option: dict[str, list[str]] | None = None
+    config_params_constraints: dict[str, str] | None = None
+
+    class Config:
+        extra = "forbid"  # Prevents additional fields from being included
+
+
+class EvalTemplate(ModelBaseModel):
+    """
+    Template containing configurations and eval types for evaluation.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=2000)
+    description = models.CharField(max_length=1000, blank=True, null=True, default="")
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="template_org",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="eval_templates",
+        null=True,
+        blank=True,
+    )
+    owner = models.CharField(
+        max_length=50,
+        choices=OwnerChoices.get_choices(),
+        default=OwnerChoices.SYSTEM.value,
+    )
+    eval_tags = ArrayField(
+        models.CharField(max_length=100),  # Specify the max length for each tag
+        blank=True,  # Allows an empty list as a default
+        default=list,  # Uses an empty list as the default value
+    )
+    config = models.JSONField(default=dict, blank=True)
+    eval_id = models.IntegerField(default=0)
+    criteria = models.CharField(max_length=100000, blank=True, default="", null=True)
+    choices = models.JSONField(default=list, blank=True, null=True)
+    multi_choice = models.BooleanField(default=False, null=True)
+    model = models.CharField(max_length=255, null=True, blank=True)
+    visible_ui = models.BooleanField(default=True)
+    proxy_agi = models.BooleanField(default=True)
+    evaluator_id = models.UUIDField(max_length=255, null=True, blank=True)
+
+    # --- Template Type (Phase 7) ---
+    template_type = models.CharField(
+        max_length=20,
+        default="single",
+        help_text="single or composite",
+    )
+
+    # --- Eval Type ---
+    eval_type = models.CharField(
+        max_length=10,
+        choices=[("agent", "Agent"), ("llm", "LLM"), ("code", "Code")],
+        default="llm",
+        help_text="Evaluator type: agent (Falcon AI powered), llm (LLM-as-a-judge), code (custom code)",
+    )
+
+    # --- Permissions ---
+    allow_edit = models.BooleanField(
+        default=True,
+        help_text="Whether users can edit this eval template. False for system evals.",
+    )
+    allow_copy = models.BooleanField(
+        default=True,
+        help_text="Whether users can duplicate/copy this eval template.",
+    )
+
+    # --- Scoring Revamp Fields (Phase 2) ---
+    output_type_normalized = models.CharField(
+        max_length=20,
+        null=True,
+        blank=True,
+        help_text="Normalized output type: pass_fail, percentage, deterministic",
+    )
+    pass_threshold = models.FloatField(
+        null=True,
+        blank=True,
+        default=0.5,
+        help_text="Score >= threshold means pass. Range 0.0-1.0",
+    )
+    choice_scores = models.JSONField(
+        null=True,
+        blank=True,
+        help_text='Maps choice labels to 0-1 scores: {"Yes": 1.0, "No": 0.0}',
+    )
+
+    # --- Error Localization (Phase 19) ---
+    error_localizer_enabled = models.BooleanField(
+        default=False,
+        help_text="Enable error localization to pinpoint which input parts caused eval failures.",
+    )
+
+    # --- Composite Aggregation (Phase 7G) ---
+    aggregation_enabled = models.BooleanField(
+        default=True,
+        help_text="Enable score aggregation for composite evals. When False, children run independently.",
+    )
+    aggregation_function = models.CharField(
+        max_length=20,
+        default="weighted_avg",
+        choices=[
+            ("weighted_avg", "Weighted Average"),
+            ("avg", "Average"),
+            ("min", "Minimum"),
+            ("max", "Maximum"),
+            ("pass_rate", "Pass Rate"),
+        ],
+        help_text="Aggregation function for composite eval scores.",
+    )
+    composite_child_axis = models.CharField(
+        max_length=20,
+        blank=True,
+        default="",
+        choices=[
+            ("pass_fail", "Pass / Fail"),
+            ("percentage", "Score"),
+            ("choices", "Choices"),
+            ("code", "Code"),
+        ],
+        help_text="For composite evals: which tab/axis children must belong to. Enforces homogeneity.",
+    )
+
+    def clean(self):
+        super().clean()
+        if self.owner == OwnerChoices.USER.value:
+            validate_eval_name(self.name)
+            if (
+                EvalTemplate.objects.filter(
+                    name=self.name, organization=self.organization, deleted=False
+                )
+                .exclude(id=self.id)
+                .exists()
+            ):
+                raise DjangoValidationError(
+                    f"Eval template with name {self.name} already exists for organization."
+                )
+            if (
+                EvalTemplate.no_workspace_objects.filter(
+                    name=self.name, owner=OwnerChoices.SYSTEM.value, deleted=False
+                )
+                .exclude(id=self.id)
+                .exists()
+            ):
+                raise DjangoValidationError(
+                    f"Eval template with name {self.name} already exists for system."
+                )
+        # try:
+        #     EvalConfigModel(**self.config)
+        # except ValidationError as e:
+        #     raise DjangoValidationError(f"Invalid config format: {str(e)}")
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+
+class UserEvalConfigModel(BaseModel):
+    mapping: dict[str, str] | None = (
+        None  # Allows any key names with UUID string values or None
+    )
+    config: dict[str, str] | None = None  # Allows any config parameters or None
+
+    class Config:
+        extra = "forbid"  # Prevents additional fields from being included
+
+    @validator("mapping")
+    def validate_mapping(cls, v):
+        if v is not None and not isinstance(v, dict):
+            raise ValueError("mapping must be a dictionary")
+        return v
+
+    @validator("config")
+    def validate_config(cls, v):
+        if v is not None and not isinstance(v, dict):
+            raise ValueError("config must be a dictionary")
+        return v
+
+
+class UserEvalMetric(ModelBaseModel):
+    @classmethod
+    def get_metrics_using_column(
+        cls, organization_id: str, column_id: str
+    ) -> list["UserEvalMetric"]:
+        """
+        Returns a list of UserEvalMetric instances that use the specified column_id
+        in their config mapping, regardless of the mapping key.
+
+        Args:
+            organization_id: The ID of the organization to filter metrics
+            column_id: The UUID of the column to search for in config mappings
+
+        Returns:
+            List of UserEvalMetric instances that use the specified column
+        """
+        column = Column.objects.filter(
+            id=column_id, dataset__organization_id=organization_id
+        ).first()
+        if column:
+            metrics = cls.objects.filter(
+                organization_id=organization_id,
+                deleted=False,
+                show_in_sidebar=True,
+                dataset=column.dataset,
+            )
+        else:
+            metrics = cls.objects.filter(
+                organization_id=organization_id, deleted=False, show_in_sidebar=True
+            )
+
+        def check_value_in_dict(d: dict, search_value: str) -> bool:
+            """Helper function to check if value exists in dictionary values, including template strings."""
+            for value in d.values():
+                if isinstance(value, str):
+                    if search_value in value or f"{{{{{search_value}}}}}" in value:
+                        return True
+                elif isinstance(value, dict):
+                    if check_value_in_dict(value, search_value):
+                        return True
+            return False
+
+        return [
+            metric
+            for metric in metrics
+            if (
+                metric.config.get("mapping")
+                and check_value_in_dict(metric.config["mapping"], str(column_id))
+            )
+            or (
+                metric.config.get("config")
+                and check_value_in_dict(metric.config["config"], str(column_id))
+            )
+        ]
+
+    """
+    Stores individual user-specific variable values required to run the metric.
+    """
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=2000)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="user_template_org",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="user_eval_metrics",
+        null=True,
+        blank=True,
+    )
+    template = models.ForeignKey(
+        EvalTemplate,
+        on_delete=models.CASCADE,
+        related_name="user_metrics",
+        help_text="Link to the metric template configuration.",
+    )
+    dataset = models.ForeignKey(Dataset, on_delete=models.CASCADE)
+    config = models.JSONField(default=dict, blank=True)
+    status = models.CharField(
+        max_length=100,
+        default=StatusType.INACTIVE.value,
+        choices=StatusType.get_choices(),
+    )
+    show_in_sidebar = models.BooleanField(default=True)
+    source_id = models.CharField(max_length=255, null=True, blank=True, default="")
+    column_deleted = models.BooleanField(default=False)
+    error_localizer = models.BooleanField(default=False)
+    kb_id = models.UUIDField(null=True, blank=True)
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="evaluation_user",
+        null=True,
+        blank=True,
+        default=None,
+    )
+    model = models.CharField(
+        max_length=255, null=True, blank=True, default=ModelChoices.TURING_LARGE.value
+    )
+
+    eval_group = models.ForeignKey(
+        EvalGroup, on_delete=models.CASCADE, null=True, blank=True
+    )
+
+    # --- Composite Eval (Phase 7 wiring) ---
+    composite_weight_overrides = models.JSONField(
+        null=True,
+        blank=True,
+        default=None,
+        help_text=(
+            "Per-binding weight overrides for composite child evals. "
+            'Maps {"<child_template_id>": <weight float>}. '
+            "When null, runners fall back to CompositeEvalChild.weight on the template. "
+            "Ignored for single evals."
+        ),
+    )
+
+    def clean(self):
+        super().clean()
+        # try:
+        #     UserEvalConfigModel(**self.config)
+        # except ValidationError as e:
+        #     raise DjangoValidationError(f"Invalid config format: {str(e)}")
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+
+class Feedback(ModelBaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    source = models.CharField(
+        max_length=50, choices=FeedbackSourceChoices.get_choices()
+    )
+    source_id = models.CharField(max_length=255)
+    user_eval_metric = models.ForeignKey(
+        UserEvalMetric, on_delete=models.CASCADE, null=True, blank=True
+    )
+    eval_template = models.ForeignKey(
+        EvalTemplate, on_delete=models.CASCADE, null=True, blank=True
+    )
+    value = models.TextField()  # Store value as text, convert as needed
+    explanation = models.TextField(blank=True, null=True)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    row_id = models.CharField(max_length=255, null=True, blank=True)
+    action_type = models.CharField(max_length=255, null=True, blank=True)
+    feedback_improvement = models.TextField(blank=True, null=True)
+    custom_eval_config_id = models.UUIDField(null=True, blank=True)
+
+    organization = models.ForeignKey(
+        "accounts.Organization",
+        on_delete=models.CASCADE,
+        related_name="feedbacks",
+        null=True,  # Nullable for migration compatibility
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="feedbacks",
+        null=True,  # Nullable (workspace is optional)
+        blank=True,
+    )
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["organization", "eval_template"]),
+            models.Index(fields=["workspace", "eval_template"]),
+        ]
+
+    def clean(self):
+        super().clean()
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+
+class EvalSettings(ModelBaseModel):
+    eval_id = models.UUIDField(null=True, blank=True)
+    column_config = ArrayField(
+        models.JSONField(max_length=100), blank=True, default=list
+    )
+    source = models.CharField(max_length=50, blank=True)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
+
+    class Meta:
+        db_table = "eval_settings"
+        unique_together = ("eval_id", "source", "user")
+
+
+class Evaluator(ModelBaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    eval_template = models.ForeignKey(
+        EvalTemplate, on_delete=models.CASCADE, related_name="evaluators"
+    )
+    name = models.CharField(max_length=2000, blank=True, null=True)
+    description = models.TextField(blank=True, null=True)
+    config = models.JSONField(default=dict, blank=True, null=True)
+    source = models.CharField(max_length=100, null=True, blank=True, default="")
+    error_localizer = models.BooleanField(default=False)
+    kb = models.ForeignKey(
+        KnowledgeBaseFile, on_delete=models.CASCADE, null=True, blank=True
+    )
+    eval_tags = ArrayField(
+        models.CharField(max_length=100), blank=True, null=True, default=list
+    )
+    criteria = models.CharField(max_length=2000, blank=True, default="", null=True)
+    choices = models.JSONField(default=list, blank=True, null=True)
+    multi_choice = models.BooleanField(default=False, null=True)
+    model = models.CharField(
+        max_length=255, null=True, blank=True, default=ModelChoices.TURING_LARGE.value
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="evaluator_user",
+        null=True,
+        blank=True,
+        default=None,
+    )
+
+
+# =============================================================================
+# Eval Template Versioning (Phase 5)
+# =============================================================================
+
+
+class EvalTemplateVersionManager(models.Manager):
+    """Custom manager for EvalTemplateVersion with helper methods."""
+
+    def create_version(
+        self,
+        eval_template,
+        prompt_messages=None,
+        config_snapshot=None,
+        criteria=None,
+        model=None,
+        user=None,
+        organization=None,
+        workspace=None,
+    ):
+        """
+        Create a new version for an eval template.
+        Auto-increments version_number based on existing versions.
+        Uses select_for_update to prevent race conditions.
+        """
+        from django.db import transaction
+
+        with transaction.atomic():
+            # Lock the template row to prevent concurrent version creation
+            last_version = (
+                self.filter(eval_template=eval_template)
+                .select_for_update()
+                .order_by("-version_number")
+                .values_list("version_number", flat=True)
+                .first()
+            )
+            next_version = (last_version or 0) + 1
+            is_first = next_version == 1
+
+            version = self.create(
+                eval_template=eval_template,
+                version_number=next_version,
+                prompt_messages=prompt_messages or [],
+                config_snapshot=config_snapshot or {},
+                criteria=criteria or "",
+                model=model or "",
+                is_default=is_first,
+                created_by=user,
+                organization=organization,
+                workspace=workspace,
+            )
+
+            return version
+
+    def get_default(self, eval_template):
+        """Get the default (active) version for a template."""
+        return self.filter(eval_template=eval_template, is_default=True).first()
+
+
+class EvalTemplateVersion(ModelBaseModel):
+    """
+    Immutable version snapshot of an EvalTemplate's configuration.
+
+    Each version captures the prompt/instructions, config, model, and criteria
+    at a point in time. Versions are numbered sequentially (1, 2, 3...).
+    One version per template is marked as default (the active version).
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    eval_template = models.ForeignKey(
+        EvalTemplate,
+        on_delete=models.CASCADE,
+        related_name="versions",
+    )
+    version_number = models.IntegerField(
+        help_text="Sequential version number (1, 2, 3...)",
+    )
+    prompt_messages = models.JSONField(
+        default=list,
+        blank=True,
+        help_text='Prompt messages: [{"role": "system", "content": "..."}]',
+    )
+    config_snapshot = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Snapshot of the template config at this version",
+    )
+    criteria = models.TextField(
+        blank=True,
+        default="",
+        help_text="Instructions/criteria text at this version",
+    )
+    model = models.CharField(
+        max_length=255,
+        blank=True,
+        default="",
+        help_text="Model used at this version",
+    )
+    is_default = models.BooleanField(
+        default=False,
+        help_text="Whether this is the active/default version",
+    )
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="eval_versions",
+    )
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="eval_versions",
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="eval_versions",
+    )
+
+    objects = EvalTemplateVersionManager()
+
+    # Keep all_objects for accessing all versions including deleted
+    all_objects = models.Manager()
+
+    class Meta:
+        db_table = "model_hub_eval_template_version"
+        ordering = ["-version_number"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["eval_template", "version_number"],
+                condition=Q(deleted=False),
+                name="unique_version_per_template",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["eval_template", "is_default"]),
+            models.Index(fields=["eval_template", "version_number"]),
+        ]
+
+    def __str__(self):
+        return f"V{self.version_number} of {self.eval_template_id}"
+
+
+# =============================================================================
+# Composite Eval (Phase 7)
+# =============================================================================
+
+
+class CompositeEvalChild(ModelBaseModel):
+    """
+    Through-model linking a parent composite EvalTemplate to its child eval templates.
+    Maintains ordering and optional version pinning.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    parent = models.ForeignKey(
+        EvalTemplate,
+        on_delete=models.CASCADE,
+        related_name="composite_children",
+        help_text="The composite (parent) eval template",
+    )
+    child = models.ForeignKey(
+        EvalTemplate,
+        on_delete=models.CASCADE,
+        related_name="composite_parents",
+        help_text="The child eval template included in this composite",
+    )
+    order = models.IntegerField(
+        default=0,
+        help_text="Display order within the composite (0-indexed)",
+    )
+    pinned_version = models.ForeignKey(
+        EvalTemplateVersion,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        help_text="Optionally pin to a specific version of the child eval",
+    )
+    weight = models.FloatField(
+        default=1.0,
+        help_text="Weight for weighted aggregation (0.0-10.0)",
+    )
+
+    class Meta:
+        db_table = "model_hub_composite_eval_child"
+        ordering = ["order"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["parent", "child"],
+                condition=Q(deleted=False),
+                name="unique_child_per_composite",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["parent", "order"]),
+        ]
+
+    def __str__(self):
+        return f"Child #{self.order} of {self.parent_id}"
+
+
+# =============================================================================
+# Ground Truth (Phase 9)
+# =============================================================================
+
+
+class EvalGroundTruth(ModelBaseModel):
+    """
+    Stores ground truth data for an eval template.
+    Data is stored as JSON rows with column headers.
+    Embeddings are generated asynchronously for similarity-based retrieval.
+    """
+
+    EMBEDDING_STATUS_CHOICES = [
+        ("pending", "Pending"),
+        ("processing", "Processing"),
+        ("completed", "Completed"),
+        ("failed", "Failed"),
+    ]
+
+    STORAGE_TYPE_CHOICES = [
+        ("db", "Database"),
+        ("s3", "S3"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    eval_template = models.ForeignKey(
+        EvalTemplate,
+        on_delete=models.CASCADE,
+        related_name="ground_truths",
+    )
+    name = models.CharField(max_length=255, help_text="Ground truth dataset name")
+    description = models.TextField(
+        blank=True,
+        default="",
+        help_text="Optional description of the dataset",
+    )
+    file_name = models.CharField(
+        max_length=500,
+        blank=True,
+        default="",
+        help_text="Original uploaded file name",
+    )
+    columns = models.JSONField(
+        default=list,
+        blank=True,
+        help_text='Column headers: ["input", "expected_output", ...]',
+    )
+    data = models.JSONField(
+        default=list,
+        blank=True,
+        help_text='Row data: [{"input": "...", "expected_output": "..."}, ...]',
+    )
+    row_count = models.IntegerField(default=0)
+    variable_mapping = models.JSONField(
+        null=True,
+        blank=True,
+        help_text='Maps eval variables to ground truth columns: {"ground_truth": "expected_output"}',
+    )
+    role_mapping = models.JSONField(
+        null=True,
+        blank=True,
+        help_text=(
+            "Maps semantic roles to GT columns for few-shot formatting: "
+            '{"input": "question_col", "expected_output": "answer_col", '
+            '"score": "score_col", "reasoning": "notes_col"}'
+        ),
+    )
+
+    # Embedding fields
+    embedding_status = models.CharField(
+        max_length=20,
+        choices=EMBEDDING_STATUS_CHOICES,
+        default="pending",
+        help_text="Status of embedding generation for this dataset",
+    )
+    embedding_model = models.CharField(
+        max_length=100,
+        default="text-embedding-3-small",
+        help_text="Model used for generating embeddings",
+    )
+    embedded_row_count = models.IntegerField(
+        default=0,
+        help_text="Number of rows that have been embedded so far",
+    )
+
+    # Storage fields
+    storage_type = models.CharField(
+        max_length=10,
+        choices=STORAGE_TYPE_CHOICES,
+        default="db",
+        help_text="Where the raw data is stored (db for small, s3 for large)",
+    )
+    s3_key = models.CharField(
+        max_length=1000,
+        blank=True,
+        default="",
+        help_text="S3 object key if storage_type='s3'",
+    )
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="eval_ground_truths",
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="eval_ground_truths",
+    )
+
+    class Meta:
+        db_table = "model_hub_eval_ground_truth"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["eval_template", "created_at"]),
+        ]
+
+    def __str__(self):
+        return f"GroundTruth '{self.name}' for {self.eval_template_id}"
+
+
+class EvalGroundTruthEmbedding(models.Model):
+    """
+    Stores per-row embeddings for ground truth similarity search.
+    One embedding per row in the parent ground truth dataset.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    ground_truth = models.ForeignKey(
+        EvalGroundTruth,
+        on_delete=models.CASCADE,
+        related_name="embeddings",
+    )
+    row_index = models.IntegerField(
+        help_text="Index of this row in the parent dataset's data array",
+    )
+    text_content = models.TextField(
+        help_text="The text that was embedded (concatenated column values)",
+    )
+    embedding = models.JSONField(
+        help_text="Embedding vector as list of floats",
+    )
+    row_data = models.JSONField(
+        help_text="The full row dict from the parent dataset",
+    )
+
+    class Meta:
+        db_table = "model_hub_eval_ground_truth_embedding"
+        ordering = ["row_index"]
+        indexes = [
+            models.Index(fields=["ground_truth", "row_index"]),
+        ]
+        unique_together = [("ground_truth", "row_index")]
+
+    def __str__(self):
+        return f"Embedding row {self.row_index} of GT {self.ground_truth_id}"

--- a/futureagi/model_hub/models/evaluation.py
+++ b/futureagi/model_hub/models/evaluation.py
@@ -1,0 +1,170 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.user import User
+from model_hub.models.error_localizer_model import ErrorLocalizerTask
+from model_hub.models.evals_metric import EvalTemplate
+from tfc.utils.base_model import BaseModel
+
+
+class StatusChoices(models.TextChoices):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class Evaluation(BaseModel):
+    """
+    Model to store evaluation configuration, execution data, and results.
+    This model handles both the input data required to run an evaluation
+    AND stores the complete results from the evaluation process.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="evaluations",
+        null=True,
+        blank=True,
+    )
+    eval_template = models.ForeignKey(EvalTemplate, on_delete=models.CASCADE)
+
+    model_name = models.CharField(
+        max_length=2000, null=True, blank=True, help_text="Model used for evaluation"
+    )
+    input_data = models.JSONField(
+        null=True, blank=True, help_text="Input data for the evaluation"
+    )
+    eval_config = models.JSONField(
+        null=True, blank=True, help_text="Configuration parameters for evaluation"
+    )
+
+    # --- EVALUATION RESULTS ---
+    data = models.JSONField(
+        null=True, blank=True, help_text="Raw data from evaluation result"
+    )
+    reason = models.TextField(null=True, blank=True)
+    runtime = models.FloatField(null=True, blank=True, help_text="Runtime in seconds")
+    model = models.CharField(max_length=2000, null=True, blank=True)
+    metrics = models.JSONField(null=True, blank=True)
+    metadata = models.JSONField(null=True, blank=True)
+    output_type = models.CharField(max_length=50, null=True, blank=True)
+    value = models.TextField(null=True, blank=True, help_text="Formatted output value")
+
+    # --- STATUS AND ERROR TRACKING ---
+    status = models.CharField(
+        max_length=50, choices=StatusChoices.choices, default=StatusChoices.PENDING
+    )
+    error_message = models.TextField(null=True, blank=True)
+
+    # --- OUTPUT TYPE SPECIFIC FIELDS ---
+    output_bool = models.BooleanField(null=True, blank=True)
+    output_float = models.FloatField(null=True, blank=True)
+    output_str = models.TextField(null=True, blank=True)
+    output_str_list = models.JSONField(null=True, blank=True)
+
+    # --- Tracing ---
+    trace_data = models.JSONField(null=True, blank=True)
+
+    # --- Error Localizer ---
+    error_localizer_enabled = models.BooleanField(default=False)
+    error_localizer = models.ForeignKey(
+        ErrorLocalizerTask, on_delete=models.CASCADE, null=True, blank=True
+    )
+
+    # --- Composite Eval (Phase 7 wiring) ---
+    parent_evaluation = models.ForeignKey(
+        "self",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="child_evaluations",
+        help_text=(
+            "When this row is a child result inside a composite eval run, "
+            "points to the aggregate (parent) Evaluation row. Null for single "
+            "evals and for composites with aggregation_enabled=False."
+        ),
+    )
+
+    class Meta:
+        db_table = "model_hub_evaluation"
+        ordering = ["-created_at"]
+
+        indexes = [
+            models.Index(fields=["organization"]),
+            models.Index(fields=["eval_template"]),
+            models.Index(fields=["status"]),
+            models.Index(fields=["error_localizer_enabled"]),
+            models.Index(fields=["error_localizer"]),
+            models.Index(fields=["parent_evaluation"]),
+        ]
+
+    def __str__(self):
+        template_name = self.eval_template.name if self.eval_template else "Unknown"
+        return f"Evaluation {self.id} - {template_name} ({self.status})"
+
+    def save(self, *args, **kwargs):
+        """
+        Override save to automatically populate type-specific output fields
+        based on the value and output type, following the inline_evals logic.
+        """
+        if self.value is not None:
+            try:
+                data = self.value
+
+                if isinstance(data, float) or isinstance(data, int):
+                    self.output_float = float(data)
+                elif isinstance(data, bool) or data in [["Passed"], ["Failed"]]:
+                    self.output_bool = (
+                        True if data == "Passed" or data is True else False
+                    )
+                elif isinstance(data, list):
+                    self.output_str_list = data
+                elif isinstance(data, str) and data in ["Passed", "Failed"]:
+                    self.output_bool = True if data == "Passed" else False
+                else:
+                    self.output_str = str(data)
+
+            except Exception:
+                self.output_str = str(self.value)
+
+        super().save(*args, **kwargs)
+
+    def update_with_result(self, eval_result):
+        """
+        Update the evaluation instance with results from the evaluation execution.
+        """
+        self.data = eval_result.get("data")
+        self.reason = eval_result.get("reason", "")
+        self.runtime = eval_result.get("runtime", 0)
+        self.model = eval_result.get("model")
+        self.metrics = eval_result.get("metrics")
+        self.metadata = eval_result.get("metadata")
+        self.output_type = eval_result.get("output")
+        self.value = eval_result.get("value")
+
+        if eval_result.get("failure"):
+            self.status = StatusChoices.FAILED
+            self.error_message = eval_result.get("failure")
+        else:
+            self.status = StatusChoices.COMPLETED
+
+        self.save()
+
+    def mark_as_processing(self):
+        """Mark evaluation as currently processing."""
+        self.status = StatusChoices.PROCESSING
+        self.save(update_fields=["status", "updated_at"])
+
+    def mark_as_failed(self, error_message):
+        """Mark evaluation as failed with error message."""
+        self.status = StatusChoices.FAILED
+        self.error_message = error_message
+        self.save(update_fields=["status", "error_message", "updated_at"])

--- a/futureagi/model_hub/models/experiments.py
+++ b/futureagi/model_hub/models/experiments.py
@@ -1,0 +1,397 @@
+import uuid
+from typing import Union
+
+from django.core.exceptions import ValidationError
+from django.db import models
+from pydantic import BaseModel as PydanticBaseModel
+
+from accounts.models import User
+from model_hub.models.choices import StatusType
+from model_hub.models.develop_dataset import Column, Dataset, Row
+from model_hub.models.evals_metric import UserEvalMetric
+from model_hub.models.run_prompt import ModelConfig, PromptTemplate, PromptVersion
+from tfc.utils.base_model import BaseModel
+
+
+class Message(PydanticBaseModel):
+    role: str
+    content: str | list[dict]
+
+
+class ModelSpec(PydanticBaseModel):
+    """Model specification for experiments - supports both string and object formats"""
+
+    name: str
+    config: dict | None = None
+    display_name: str | None = None
+
+
+class PromptConfig(PydanticBaseModel):
+    name: str
+    messages: list[Message]
+    model: list[Union[str, ModelSpec]]  # Accept both string and dict formats
+    configuration: ModelConfig
+
+
+def validate_prompt_config(value):
+    try:
+        if isinstance(value, list):
+            [PromptConfig(**item) for item in value]
+        return value
+    except Exception as e:
+        raise ValidationError(f"Invalid prompt config format: {str(e)}")  # noqa: B904
+
+
+class ExperimentDatasetTable(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    name = models.CharField(max_length=2000)
+    legacy_prompt_config = models.JSONField(default=dict, db_column="prompt_config")
+    exclude_values = models.JSONField(default=dict)
+    status = models.CharField(
+        max_length=50,
+        choices=StatusType.get_choices(),
+        default=StatusType.NOT_STARTED.value,
+    )
+
+    columns = models.ManyToManyField(
+        Column, blank=True, related_name="experiments_dataset_column"
+    )
+
+    # New FK to replace M2M (kept alongside M2M until migration completes)
+    experiment = models.ForeignKey(
+        "ExperimentsTable",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="experiment_datasets",
+    )
+
+    # Config is linked via reverse OneToOne from ExperimentPromptConfig/ExperimentAgentConfig.
+    # Access: edt.prompt_config or edt.agent_config
+
+    def __str__(self):
+        return f"{self.name}"
+
+    def get_columns_from_experiment(self):
+        if self.experiment:
+            return self.experiment.column
+        return None
+
+
+class ExperimentsTable(BaseModel):
+    EXPERIMENT_TYPE_CHOICES = [
+        ("llm", "LLM"),
+        ("tts", "TTS"),
+        ("stt", "STT"),
+        ("image", "Image"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    dataset = models.ForeignKey(
+        Dataset, on_delete=models.CASCADE, related_name="experiments_dataset"
+    )
+    column = models.ForeignKey(Column, on_delete=models.CASCADE, null=True, blank=True)
+    prompt_config = models.JSONField(default=list, validators=[validate_prompt_config])
+    status = models.CharField(
+        max_length=50,
+        choices=StatusType.get_choices(),
+        default=StatusType.NOT_STARTED.value,
+    )
+
+    user_eval_template_ids = models.ManyToManyField(
+        UserEvalMetric, blank=True, related_name="experiments_evaluation_ids"
+    )
+
+    experiments_datasets = models.ManyToManyField(
+        ExperimentDatasetTable, blank=True, related_name="experiments_datasets_created"
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="experiments_user",
+        null=True,
+        blank=True,
+        default=None,
+    )
+
+    # New fields for V2
+    snapshot_dataset = models.ForeignKey(
+        Dataset,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="experiment_snapshots",
+    )
+    experiment_type = models.CharField(
+        max_length=50,
+        choices=EXPERIMENT_TYPE_CHOICES,
+        default="llm",
+        help_text="Determines how the experiment executes: llm, tts, stt, or image.",
+    )
+
+    def __str__(self):
+        return f"{self.name}"
+
+    def save(self, *args, **kwargs):
+        if self.prompt_config:
+            validate_prompt_config(self.prompt_config)
+        super().save(*args, **kwargs)
+
+
+class ExperimentPromptConfig(BaseModel):
+    """
+    Stores prompt configuration for an experiment. Used for ALL experiment types.
+    - For experiment_type=llm: links to PromptTemplate + PromptVersion (messages locked).
+    - For experiment_type=tts|stt|image: prompt_template/prompt_version are null, messages stored inline.
+
+    Linked 1:1 to ExperimentDatasetTable. Access experiment via experiment_dataset.experiment.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    experiment_dataset = models.OneToOneField(
+        ExperimentDatasetTable,
+        on_delete=models.CASCADE,
+        related_name="prompt_config",
+    )
+
+    # LLM experiments: link to PromptTemplate/PromptVersion (messages locked from PromptVersion)
+    # TTS/STT/Image experiments: both are null
+    prompt_template = models.ForeignKey(
+        PromptTemplate,
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="experiment_prompt_configs",
+    )
+    prompt_version = models.ForeignKey(
+        PromptVersion,
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="experiment_prompt_configs",
+    )
+
+    name = models.CharField(max_length=2000)
+    model = models.CharField(
+        max_length=2000,
+        help_text="Single model name (e.g., 'gpt-5', 'openai/tts-1-hd').",
+    )
+    model_display_name = models.CharField(
+        max_length=2000,
+        null=True,
+        blank=True,
+        help_text="Optional display name for the model.",
+    )
+    model_config = models.JSONField(
+        default=dict,
+        help_text='Inline config from model spec dict (e.g., {"voice": "alloy"} for TTS). Empty for string-format models.',
+    )
+    model_params = models.JSONField(
+        default=dict,
+        help_text='Per-model params from modelParams[model_name]: {"temperature": 0.5, "maxTokens": 4085, "providers": "openai", "logoUrl": "..."}',
+    )
+    configuration = models.JSONField(
+        default=dict,
+        help_text='Tools config: {"toolChoice": "auto", "tools": [...]}',
+    )
+    output_format = models.CharField(
+        max_length=50,
+        default="string",
+        help_text="Output format: string, object, audio, image.",
+    )
+    order = models.PositiveIntegerField(
+        default=0,
+        help_text="Deterministic processing order.",
+    )
+
+    # TTS/STT/Image: messages stored inline (null for LLM experiments)
+    messages = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Inline messages for tts/stt/image experiments. Null when prompt_version is set.",
+    )
+
+    # STT-specific
+    voice_input_column = models.ForeignKey(
+        Column,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="experiment_stt_configs",
+        help_text="STT only: references dataset column containing audio data to transcribe.",
+    )
+
+    class Meta:
+        ordering = ["order"]
+
+    def __str__(self):
+        return f"{self.name}"
+
+    def get_messages(self):
+        """
+        Returns messages: locked from PromptVersion if set, otherwise inline.
+        """
+        if self.prompt_version:
+            return self.prompt_version.prompt_config_snapshot
+        return self.messages
+
+
+class ExperimentAgentConfig(BaseModel):
+    """
+    Links an experiment to a Graph/GraphVersion from agent_playground.
+    Only used when experiment_type=llm. Configuration is frozen (GraphVersion is immutable).
+
+    Linked 1:1 to ExperimentDatasetTable. Access experiment via experiment_dataset.experiment.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    experiment_dataset = models.OneToOneField(
+        ExperimentDatasetTable,
+        on_delete=models.CASCADE,
+        related_name="agent_config",
+    )
+    graph = models.ForeignKey(
+        "agent_playground.Graph",
+        on_delete=models.PROTECT,
+        related_name="experiment_agent_configs",
+    )
+    graph_version = models.ForeignKey(
+        "agent_playground.GraphVersion",
+        on_delete=models.PROTECT,
+        related_name="experiment_agent_configs",
+    )
+    name = models.CharField(max_length=2000)
+    order = models.PositiveIntegerField(
+        default=0,
+        help_text="Processing order.",
+    )
+
+    class Meta:
+        ordering = ["order"]
+
+    def __str__(self):
+        return f"{self.name}"
+
+
+class ExperimentComparison(BaseModel):
+    experiment = models.ForeignKey(
+        ExperimentsTable, on_delete=models.CASCADE, related_name="comparisons"
+    )
+    experiment_dataset = models.ForeignKey(
+        ExperimentDatasetTable, on_delete=models.CASCADE, null=True, blank=True
+    )
+
+    # Weights
+    response_time_weight = models.FloatField()
+    scores_weight = models.JSONField(default=dict, null=True, blank=True)
+    total_tokens_weight = models.FloatField()
+    completion_tokens_weight = models.FloatField()
+
+    # Raw Metrics
+    avg_completion_tokens = models.FloatField()
+    avg_total_tokens = models.FloatField()
+    avg_response_time = models.FloatField()
+    avg_score = models.FloatField(null=True)
+
+    # Normalized Scores
+    normalized_completion_tokens = models.FloatField()
+    normalized_total_tokens = models.FloatField()
+    normalized_response_time = models.FloatField()
+    normalized_score = models.FloatField(null=True)
+
+    # Final Results
+    overall_rating = models.FloatField(default=0.0)
+    rank = models.IntegerField(default=1)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+
+class PendingRowTask(BaseModel):
+    """
+    Model to store row processing tasks for batching with concurrency limits.
+    Similar to CreateCallExecution pattern for managing concurrent task execution.
+    """
+
+    class TaskStatus(models.TextChoices):
+        REGISTERED = "registered", "Registered"
+        PROCESSING = "processing", "Processing"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+
+    row = models.ForeignKey(
+        Row,
+        on_delete=models.CASCADE,
+        related_name="pending_row_tasks",
+        help_text="The row to process",
+    )
+
+    column = models.ForeignKey(
+        Column,
+        on_delete=models.CASCADE,
+        related_name="pending_row_tasks",
+        help_text="The column this row processing belongs to",
+    )
+
+    dataset = models.ForeignKey(
+        Dataset,
+        on_delete=models.CASCADE,
+        related_name="pending_row_tasks",
+        help_text="The dataset this row processing belongs to",
+    )
+
+    experiment = models.ForeignKey(
+        ExperimentsTable,
+        on_delete=models.CASCADE,
+        related_name="pending_row_tasks",
+        help_text="The experiment this row processing belongs to",
+    )
+
+    messages = models.JSONField(help_text="The messages to use for processing the row")
+
+    model = models.CharField(
+        max_length=255, help_text="The model to use for processing"
+    )
+
+    model_config = models.JSONField(
+        help_text="The model configuration to use for processing"
+    )
+
+    output_format = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="The output format for the response",
+    )
+
+    run_prompt_config = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="The run prompt configuration",
+    )
+
+    status = models.CharField(
+        max_length=255,
+        choices=TaskStatus.choices,
+        default=TaskStatus.REGISTERED,
+        help_text="The status of the row processing task",
+    )
+
+    class Meta:
+        ordering = ["created_at"]
+        indexes = [
+            models.Index(
+                fields=["status", "created_at"]
+            ),  # For process_pending_row_tasks query
+            models.Index(
+                fields=["experiment_id", "status"]
+            ),  # For per-experiment count queries
+            models.Index(
+                fields=["column_id", "status"]
+            ),  # For check_and_update_column_status
+            models.Index(
+                fields=["row_id", "column_id", "dataset_id", "experiment_id", "status"]
+            ),  # For process_row_task lookup
+        ]

--- a/futureagi/model_hub/models/insight.py
+++ b/futureagi/model_hub/models/insight.py
@@ -1,0 +1,151 @@
+import uuid
+from enum import Enum
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.db import models
+from pydantic import BaseModel, Field, RootModel
+
+from accounts.models import Organization
+
+
+class EnvironmentType(str, Enum):
+    """Valid environment types"""
+
+    PRODUCTION = "Production"
+    TRAINING = "Training"
+    VALIDATION = "Validation"
+    CORPUS = "Corpus"
+
+
+class DatasetConfig(BaseModel):
+    """Configuration for a single dataset"""
+
+    environment: EnvironmentType
+    model_version: str = Field(alias="version")  # Maps to "version" in input data
+
+    class Config:
+        protected_namespaces = ()
+
+
+class DatasetSchema(RootModel):
+    """Schema for datasets JSON field"""
+
+    root: list[DatasetConfig] = Field(default_factory=list)
+
+    class Config:
+        populate_by_name = True  # Allows both "version" and "model_version"
+        json_schema_extra = {
+            "example": [{"environment": "Production", "version": "v1"}]
+        }
+
+
+class InsightOptionsSelectedSchema(BaseModel):
+    """Schema for insight_options_selected JSON field"""
+
+    distribution_key: list[str] = Field(alias="breakdown")
+    filter: list[dict[str, Any]]
+    metrics: list[str] | None = Field(
+        default_factory=list
+    )  # Made optional with default empty list
+
+    class Config:
+        populate_by_name = True
+        json_schema_extra = {
+            "example": {
+                "distribution_key": ["programming-language", "chat_language"],
+                "filter": [
+                    {
+                        "key": "age",
+                        "value": [60],
+                        "data_type": "number",
+                        "operator": ">",
+                    }
+                ],
+                "metrics": ["metric_id_1", "metric_id_2"],  # Optional field
+            }
+        }
+
+
+class Insight(models.Model):
+    class MetricTypes(models.TextChoices):
+        WHOLE_USER_OUTPUT = "WholeUserOutput", "Whole User Output"
+        STEPWISE_MODEL_INFERENCE = (
+            "StepwiseModelInference",
+            "Stepwise Model Inference",
+        )
+
+        @classmethod
+        def get_metric_type(cls, num):
+            if num == 1:
+                return cls.WHOLE_USER_OUTPUT
+            if num == 2:
+                return cls.STEPWISE_MODEL_INFERENCE
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now_add=True)
+    name = models.CharField(max_length=255)
+    model = models.ForeignKey(
+        "AIModel", on_delete=models.CASCADE, related_name="model_insights"
+    )
+    datasets = models.JSONField(null=True)
+    text_prompt = models.TextField()
+    metric_type = models.CharField(max_length=100, choices=MetricTypes.choices)
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="insights"
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="insights",
+        null=True,
+        blank=True,
+    )
+    insight_options_selected = models.JSONField(null=True)
+
+    def __str__(self):
+        return str(self.id)
+
+    def clean_datasets(self) -> None:
+        """Validate datasets using Pydantic schema"""
+        if self.datasets is not None:
+            try:
+                DatasetSchema(root=self.datasets)
+            except ValueError as e:
+                raise ValidationError(f"Invalid datasets format: {str(e)}") from e
+
+    def clean_insight_options_selected(self) -> None:
+        """Validate insight_options_selected using Pydantic schema"""
+        if self.insight_options_selected is not None:
+            try:
+                InsightOptionsSelectedSchema(**self.insight_options_selected)
+            except ValueError as e:
+                raise ValidationError(  # noqa: B904
+                    f"Invalid insight_options_selected format: {str(e)}"
+                )
+
+    def clean(self) -> None:
+        """Validate the model"""
+        super().clean()
+        self.clean_datasets()
+        self.clean_insight_options_selected()
+
+    @property
+    def typed_datasets(self) -> list[DatasetConfig]:
+        """Get type-checked datasets"""
+        if self.datasets is None:
+            return []
+        validated = DatasetSchema(root=self.datasets)
+        return validated.root
+
+    @property
+    def typed_insight_options_selected(self) -> InsightOptionsSelectedSchema:
+        """Get type-checked insight_options_selected"""
+        if self.insight_options_selected is None:
+            return InsightOptionsSelectedSchema(
+                distribution_key=[],
+                filter=[],
+                # metrics will default to empty list
+            )
+        return InsightOptionsSelectedSchema(**self.insight_options_selected)

--- a/futureagi/model_hub/models/insight_status.py
+++ b/futureagi/model_hub/models/insight_status.py
@@ -1,0 +1,23 @@
+import uuid
+
+from django.db import models
+
+
+class InsightStatus(models.Model):
+    class StatusTypes(models.TextChoices):
+        STEP_1 = "Step1", "Step 1"
+        STEP_2 = "Step2", "Step 2"
+        STEP_3 = "Step3", "Step 3"
+        COMPLETED = "Completed", "Completed"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now_add=True)
+    insight = models.ForeignKey(
+        "Insight", on_delete=models.CASCADE, related_name="insight_status"
+    )
+    status = models.CharField(max_length=100, choices=StatusTypes.choices)
+    message = models.TextField()
+
+    def __str__(self):
+        return str(self.id)

--- a/futureagi/model_hub/models/kb.py
+++ b/futureagi/model_hub/models/kb.py
@@ -1,0 +1,38 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class KnowledgeBase(BaseModel):
+    class EmbeddingModelChoices(models.TextChoices):
+        BGE_SMALL_EN_1_5 = "BAAI/bge-small-en-v1.5", "BAAI/bge-small-en-v1.5"
+        # Add more embedding model choices as needed
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=2000)
+    embedding_model = models.CharField(
+        max_length=50,
+        choices=EmbeddingModelChoices.choices,
+        default=EmbeddingModelChoices.BGE_SMALL_EN_1_5,
+    )
+    chunk_size = models.PositiveIntegerField()
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="knowledge_bases",
+        default=1,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="knowledge_bases",
+        null=True,
+        blank=True,
+    )
+
+    def __str__(self):
+        return self.name

--- a/futureagi/model_hub/models/metric.py
+++ b/futureagi/model_hub/models/metric.py
@@ -1,0 +1,100 @@
+import uuid
+
+from django.contrib.postgres.fields import ArrayField
+from django.db import models
+from django.utils import timezone
+
+
+class Metric(models.Model):
+    class MetricTypes(models.TextChoices):
+        WHOLE_USER_OUTPUT = "WholeUserOutput", "Whole User Output"
+        STEPWISE_MODEL_INFERENCE = (
+            "StepwiseModelInference",
+            "Stepwise Model Inference",
+        )
+
+        @classmethod
+        def get_metric_type(cls, num):
+            if num == 1:
+                return cls.WHOLE_USER_OUTPUT
+            if num == 2:
+                return cls.STEPWISE_MODEL_INFERENCE
+
+    class EvalMetricTypes(models.TextChoices):
+        EVAL_CONTEXT = "EvalRagContext", "Eval Rag Context"
+        EVAL_RAG_OUTPUT = "EvalRagOutput", "Eval Rag Output"
+        EVAL_PROMPT_TEMPLATE = "EvalPromptTemplate", "Eval Prompt Template"
+        EVAL_OUTPUT = "EvalOutput", "Eval Output"
+        EVAL_CONTEXT_RANKING = "EvalRagContextRanking", "Eval Rag Context Ranking"
+
+        @classmethod
+        def get_eval_metric_type(cls, num):
+            if num == 1:
+                return cls.EVAL_CONTEXT
+            if num == 2:
+                return cls.EVAL_RAG_OUTPUT
+            if num == 3:
+                return cls.EVAL_PROMPT_TEMPLATE
+            if num == 4:
+                return cls.EVAL_OUTPUT
+            if num == 5:
+                return cls.EVAL_CONTEXT_RANKING
+
+    class UsedIn(models.TextChoices):
+        MODEL = "model", "Model"
+        DEVELOP = "develop", "Develop"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=100)
+    created_at = models.DateTimeField(default=timezone.now)
+    updated_at = models.DateTimeField(auto_now=True)
+    text_prompt = models.TextField()
+    criteria_breakdown = ArrayField(
+        models.CharField(),
+        default=list,
+        blank=True,
+    )
+    model = models.ForeignKey(
+        "AIModel", on_delete=models.CASCADE, related_name="metrics"
+    )
+    develop = models.ForeignKey(
+        "DevelopAI",
+        on_delete=models.CASCADE,
+        related_name="metrics",
+        null=True,
+        blank=True,
+    )
+    metric_type = models.CharField(max_length=100, choices=MetricTypes.choices)
+    used_in = models.CharField(
+        max_length=10, choices=UsedIn.choices, default=UsedIn.MODEL
+    )
+    evaluation_type = models.CharField(
+        max_length=100,
+        choices=EvalMetricTypes.choices,
+        default=EvalMetricTypes.EVAL_OUTPUT,
+    )
+    datasets = models.JSONField(null=True)
+    eval_rag_context = models.BooleanField(default=False)
+    eval_rag_output = models.BooleanField(default=False)
+    eval_prompt_template = models.BooleanField(default=False)
+    tags = ArrayField(models.CharField(), blank=True, default=list)
+
+    def __str__(self):
+        return self.name
+
+
+def add_unique_tags(instance, new_tags):
+    # Ensure new_tags is a list of strings
+    if not isinstance(new_tags, list):
+        new_tags = [new_tags]
+
+    # Convert to set to remove duplicates within new_tags
+    new_tags_set = set(new_tags)
+    # Remove tags that already exist in the instance
+    unique_new_tags = list(new_tags_set - set(instance.tags))
+
+    if unique_new_tags:
+        instance.tags += unique_new_tags
+        instance.save()
+        return True
+    return False

--- a/futureagi/model_hub/models/metric_prompt_checker.py
+++ b/futureagi/model_hub/models/metric_prompt_checker.py
@@ -1,0 +1,23 @@
+import uuid
+
+from django.db import models
+
+
+class PromptChecker(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user_prompt = models.TextField(default=None, null=True, blank=True)
+    ai_prompt = models.TextField(default=None, null=True, blank=True)
+    explanation = models.TextField(default=None, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    version = models.CharField(max_length=100, default="v1")
+    model_name = models.CharField(
+        max_length=100, default="anthropic/claude-3.5-sonnet:beta"
+    )
+    ambiguity = models.BooleanField(default=True)
+    deleted = models.BooleanField(default=False)
+    metadata = models.JSONField(default=dict, blank=True)
+    choices = models.JSONField(default=list, blank=True)
+    multi_choice = models.BooleanField(default=False)
+
+    def __str__(self):
+        return str(self.id)

--- a/futureagi/model_hub/models/monitor_alert.py
+++ b/futureagi/model_hub/models/monitor_alert.py
@@ -1,0 +1,18 @@
+from django.db import models
+
+from model_hub.models.monitors import Monitor
+
+
+class MonitorAlert(models.Model):
+    triggered_value = models.FloatField(
+        help_text="Value at which the alert is triggered"
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    monitor = models.ForeignKey(
+        Monitor, on_delete=models.CASCADE, related_name="monitor_alerts"
+    )
+
+    def __str__(self):
+        return self.triggered_value

--- a/futureagi/model_hub/models/monitors.py
+++ b/futureagi/model_hub/models/monitors.py
@@ -1,0 +1,33 @@
+from django.db import models
+
+from model_hub.models import AIModel
+
+
+class Monitor(models.Model):
+    class MonitorTypes(models.TextChoices):
+        ANALYTICS = "Analytics", "Analytics"
+        DATA_DRIFT = "DataDrift", "Data Drift"
+        PERFORMANCE = "Performance", "Performance"
+
+    status = models.BooleanField(
+        default=False, help_text="Indicates if the alert is executed"
+    )
+    name = models.CharField(max_length=255, help_text="Name of the monitor")
+    monitor_type = models.CharField(max_length=100, choices=MonitorTypes.choices)
+    dimension = models.CharField(max_length=255, help_text="Dimension of the monitor")
+    metric = models.CharField(max_length=255, help_text="Metric used by the monitor")
+    current_value = models.FloatField(help_text="Current value of the metric")
+    trigger_value = models.FloatField(help_text="Value at which the alert is triggered")
+    is_mute = models.BooleanField(
+        default=False, help_text="Indicates if the monitor is muted"
+    )
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    ai_model = models.ForeignKey(
+        AIModel, on_delete=models.CASCADE, related_name="monitors"
+    )
+
+    def __str__(self):
+        return self.name

--- a/futureagi/model_hub/models/openai_tools.py
+++ b/futureagi/model_hub/models/openai_tools.py
@@ -1,0 +1,69 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.core.validators import MinLengthValidator
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+def validate_config(value):
+    # Required structure for the config JSON field
+    required_keys = {"parameters"}
+    parameter_keys = {"type", "properties", "required"}
+
+    # Check top-level keys
+    if not all(key in value for key in required_keys):
+        raise ValidationError(
+            "Config must contain 'name', 'description', and 'parameters' keys."
+        )
+
+    # Validate 'parameters' structure
+    parameters = value.get("parameters", {})
+    if not isinstance(parameters, dict) or not all(
+        key in parameters for key in parameter_keys
+    ):
+        raise ValidationError(
+            "The 'parameters' key must contain 'type', 'properties', and 'required' keys."
+        )
+
+    # Check if 'parameters' has the correct types
+    if parameters.get("type") != "object" or not isinstance(
+        parameters.get("properties", {}), dict
+    ):
+        raise ValidationError(
+            "Invalid 'parameters' structure: 'type' must be 'object', and 'properties' must be a dictionary."
+        )
+    if not isinstance(parameters.get("required", []), list):
+        raise ValidationError("'required' must be a list in 'parameters'.")
+
+
+class Tools(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(
+        max_length=255, unique=True, validators=[MinLengthValidator(1)]
+    )
+    description = models.TextField(max_length=255, validators=[MinLengthValidator(1)])
+    config = models.JSONField()
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="tools_org",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="tools",
+        null=True,
+        blank=True,
+    )
+    config_type = models.CharField(
+        max_length=50, choices=[("json", "JSON"), ("yaml", "YAML")], default="json"
+    )
+
+    def __str__(self):
+        return self.name

--- a/futureagi/model_hub/models/optimize_dataset.py
+++ b/futureagi/model_hub/models/optimize_dataset.py
@@ -1,0 +1,206 @@
+import uuid
+
+from django.contrib.postgres.fields import ArrayField
+from django.db import models
+
+from model_hub.models.kb import KnowledgeBase
+from tfc.utils.base_model import BaseModel
+
+
+class OptimizeDataset(BaseModel):
+    class OptimizeType(models.TextChoices):
+        TEMPLATE = "PromptTemplate", "Prompt Template"
+        RIGHT_ANSWER = "RightAnswer", "Right Answer"
+        RAG_TEMPLATE = "RagPromptTemplate", "Rag Prompt Template"
+
+        @classmethod
+        def get_optimize_types(cls, num):
+            if num == 1:
+                return cls.TEMPLATE
+            if num == 2:
+                return cls.RIGHT_ANSWER
+            if num == 3:
+                return cls.RAG_TEMPLATE
+
+        @classmethod
+        def get_optim_num_types(cls, typ):
+            if typ == cls.TEMPLATE:
+                return 1
+            if typ == cls.RIGHT_ANSWER:
+                return 2
+            if typ == cls.RAG_TEMPLATE:
+                return 3
+
+    class EnvTypes(models.TextChoices):
+        PRODUCTION = "Production", "Production"
+        TRAINING = "Training", "Training"
+        VALIDATION = "Validation", "Validation"
+        CORPUS = "Corpus", "Corpus"
+
+        @classmethod
+        def get_env_types(cls, num):
+            if num == 1:
+                return cls.TRAINING
+            if num == 2:
+                return cls.VALIDATION
+            if num == 3:
+                return cls.PRODUCTION
+            if num == 4:
+                return cls.CORPUS
+
+        @classmethod
+        def get_env_num_types(cls, typ):
+            if typ == cls.TRAINING:
+                return 1
+            if typ == cls.VALIDATION:
+                return 2
+            if typ == cls.PRODUCTION:
+                return 3
+            if typ == cls.CORPUS:
+                return 4
+
+    class StatusType(models.TextChoices):
+        NOT_STARTED = "not_started", "Not Started"
+        PENDING = "pending", "Pending"
+        RUNNING = "running", "Running"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+        CANCELLED = "cancelled", "Cancelled"
+
+    class OptimizerAlgorithm(models.TextChoices):
+        RANDOM_SEARCH = "random_search", "Random Search"
+        BAYESIAN = "bayesian", "Bayesian"
+        METAPROMPT = "metaprompt", "Metaprompt"
+        PROTEGI = "protegi", "Protegi"
+        PROMPTWIZARD = "promptwizard", "PromptWizard"
+        GEPA = "gepa", "GEPA"
+
+    class UsedInChoices(models.TextChoices):
+        MODEL = "model", "Model"
+        DEVELOP = "develop", "Develop"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    # Note: created_at, updated_at, deleted, deleted_at are inherited from BaseModel
+    name = models.CharField(max_length=255)
+    optimize_type = models.CharField(max_length=255, choices=OptimizeType.choices)
+    metrics = models.ManyToManyField(
+        "Metric", related_name="optimize_dataset", null=True, blank=True
+    )
+    start_date = models.DateTimeField(null=True)
+    end_date = models.DateTimeField(null=True)
+    knowledge_base_filters = models.JSONField(default=list, blank=True, null=True)
+    knowledge_base_metrics = models.JSONField(default=list, blank=True, null=True)
+    variables = models.JSONField(default=dict, blank=True, null=True)
+    knowledge_base = models.ForeignKey(
+        KnowledgeBase,
+        on_delete=models.CASCADE,
+        related_name="optimize_knowledge_base",
+        null=True,
+        blank=True,
+    )
+    # model = models.CharField(max_length=255)
+    model = models.ForeignKey(
+        "AIModel", on_delete=models.CASCADE, null=True, blank=True
+    )
+    optimized_k_prompts = ArrayField(models.TextField(), null=True)
+    environment = models.CharField(max_length=100, choices=EnvTypes.choices)
+    prompt = models.CharField(max_length=2000, null=True, blank=True)
+    eval_instructions = models.JSONField(
+        default=dict,  # Default value is an empty dictionary
+        blank=True,
+        null=True,
+    )
+    criteria_breakdown = ArrayField(
+        models.CharField(),
+        default=list,
+        blank=True,
+    )
+    version = models.CharField(max_length=255)
+    status = models.CharField(
+        max_length=100, default=StatusType.RUNNING, choices=StatusType.choices
+    )
+    used_in = models.CharField(
+        max_length=10,
+        choices=UsedInChoices.choices,
+        default=UsedInChoices.MODEL,
+        blank=True,
+        null=True,
+    )
+    develop = models.ForeignKey(
+        "DevelopAI",  # Ensure this matches the related model's class name
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="optimize_datasets",
+    )
+    # New fields for optimizer workflow (matching simulation flow)
+    optimizer_algorithm = models.CharField(
+        max_length=50,
+        choices=OptimizerAlgorithm.choices,
+        null=True,
+        blank=True,
+    )
+    optimizer_config = models.JSONField(
+        default=dict,
+        blank=True,
+        null=True,
+        help_text="Optimizer-specific configuration (num_trials, etc.)",
+    )
+    optimizer_model = models.ForeignKey(
+        "AIModel",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="optimizer_runs",
+        help_text="Model used for optimization (separate from eval model)",
+    )
+    column = models.ForeignKey(
+        "Column",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="optimization_runs",
+        help_text="Column being optimized",
+    )
+    error_message = models.TextField(null=True, blank=True)
+    best_score = models.FloatField(null=True, blank=True)
+    baseline_score = models.FloatField(null=True, blank=True)
+    user_eval_template_ids = models.ManyToManyField(
+        "UserEvalMetric",
+        related_name="dataset_optimization_runs",
+        blank=True,
+        help_text="Evaluation templates to optimize for",
+    )
+
+    def __str__(self):
+        return str(self.name)
+
+    def mark_as_pending(self):
+        """Mark the optimization run as pending"""
+        self.status = self.StatusType.PENDING
+        self.save(update_fields=["status"])
+
+    def mark_as_running(self):
+        """Mark the optimization run as running"""
+        self.status = self.StatusType.RUNNING
+        self.save(update_fields=["status"])
+
+    def mark_as_completed(self):
+        """Mark the optimization run as completed"""
+        self.status = self.StatusType.COMPLETED
+        self.save(update_fields=["status"])
+
+    def mark_as_failed(self, error_message=None):
+        """Mark the optimization run as failed"""
+        self.status = self.StatusType.FAILED
+        if error_message:
+            self.error_message = error_message
+            self.save(update_fields=["status", "error_message"])
+        else:
+            self.save(update_fields=["status"])
+
+    def mark_as_cancelled(self):
+        """Mark the optimization run as cancelled"""
+        self.status = self.StatusType.CANCELLED
+        self.error_message = "Cancelled by user"
+        self.save(update_fields=["status", "error_message"])

--- a/futureagi/model_hub/models/performance_report.py
+++ b/futureagi/model_hub/models/performance_report.py
@@ -1,0 +1,36 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.ai_model import AIModel
+from tfc.utils.base_model import BaseModel
+
+
+class PerformanceReport(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    model = models.ForeignKey(
+        AIModel, on_delete=models.CASCADE, related_name="performance_reports"
+    )
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="performance_reports"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="performance_reports",
+        null=True,
+        blank=True,
+    )
+
+    name = models.CharField(max_length=255)
+    datasets = models.JSONField(default=list)
+    filters = models.JSONField(default=list)
+    breakdown = models.JSONField(default=list)
+    aggregation = models.CharField(max_length=255)
+    start_date = models.DateTimeField()
+    end_date = models.DateTimeField()
+
+    def __str__(self):
+        return self.name

--- a/futureagi/model_hub/models/prompt.py
+++ b/futureagi/model_hub/models/prompt.py
@@ -1,0 +1,66 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+
+
+class Prompt(BaseModel):
+    class UsedIn(models.TextChoices):
+        DEVELOP = "develop", "Develop"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    common_id = models.UUIDField(default=uuid.uuid4, editable=False)
+    content = models.TextField()
+    variables = models.JSONField(default=list)
+    is_current = models.BooleanField(default=True)
+    version = models.PositiveIntegerField(default=1)
+    used_in = models.CharField(
+        max_length=20, choices=UsedIn.choices, default=UsedIn.DEVELOP
+    )
+    develop = models.ForeignKey(
+        "DevelopAI",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="prompts",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"Prompt {self.id} (v{self.version})"
+
+    def save(self, *args, **kwargs):
+        if not self.pk:  # New prompt
+            super().save(*args, **kwargs)
+        else:  # Existing prompt
+            old_instance = Prompt.objects.get(pk=self.pk)
+            if (
+                old_instance.content != self.content
+                or old_instance.variables != self.variables
+            ):
+                # Create a new version
+                new_version = Prompt(
+                    content=self.content,
+                    variables=self.variables,
+                    common_id=self.common_id,
+                    is_current=True,
+                    version=self.version + 1,
+                    used_in=self.used_in,
+                    develop=self.develop,
+                )
+                new_version.save()
+
+                # Update the old version
+                self.is_current = False
+                super().save(*args, **kwargs)
+            else:
+                super().save(*args, **kwargs)
+
+    def get_current_version(self):
+        return Prompt.objects.filter(common_id=self.common_id, is_current=True).first()
+
+    def get_version_history(self):
+        return Prompt.objects.filter(common_id=self.common_id).order_by("-version")

--- a/futureagi/model_hub/models/prompt_base_template.py
+++ b/futureagi/model_hub/models/prompt_base_template.py
@@ -1,0 +1,63 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class PromptBaseTemplate(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="prompt_base_templates",
+        null=True,
+        blank=True,
+    )
+    is_sample = models.BooleanField(default=False)
+    prompt_version = models.ForeignKey(
+        "model_hub.PromptVersion",
+        on_delete=models.CASCADE,
+        related_name="prompt_base_templates",
+        null=True,
+        blank=True,
+    )
+    category = models.CharField(max_length=255, null=True, blank=True)
+    prompt_config_snapshot = models.JSONField(default=list, null=True, blank=True)
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="prompt_base_templates",
+        null=True,
+        blank=True,
+    )
+
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="prompt_base_templates",
+        null=True,
+        blank=True,
+    )
+
+    def __str__(self):
+        return f"Prompt Base Template {self.id}"
+
+    class Meta:
+        db_table = "model_hub_prompt_base_template"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["name", "organization", "workspace"],
+                condition=models.Q(deleted=False),
+                name="unique_prompt_base_template_name_organization_workspace_not_deleted",
+            )
+        ]
+
+        indexes = [
+            models.Index(fields=["organization", "workspace", "created_at"]),
+        ]

--- a/futureagi/model_hub/models/prompt_folders.py
+++ b/futureagi/model_hub/models/prompt_folders.py
@@ -1,0 +1,64 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class PromptFolder(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="prompt_folders",
+        null=True,
+        blank=True,
+    )
+
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="prompt_folders",
+        null=True,
+        blank=True,
+    )
+
+    parent_folder = models.ForeignKey(
+        "self",
+        on_delete=models.CASCADE,
+        related_name="child_folders",
+        null=True,
+        blank=True,
+    )
+
+    is_sample = models.BooleanField(default=False)
+
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="prompt_folders",
+        null=True,
+        blank=True,
+    )
+
+    def __str__(self):
+        return f"Prompt Folder {self.id}"
+
+    class Meta:
+        db_table = "model_hub_prompt_folder"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["name", "organization", "workspace"],
+                condition=models.Q(deleted=False),
+                name="unique_prompt_folder_name_organization_workspace_not_deleted",
+            )
+        ]
+
+        indexes = [
+            models.Index(fields=["organization", "workspace", "created_at"]),
+        ]

--- a/futureagi/model_hub/models/prompt_label.py
+++ b/futureagi/model_hub/models/prompt_label.py
@@ -1,0 +1,84 @@
+import uuid
+from enum import Enum
+
+from django.db import models
+from django.db.models import Q
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class LabelTypeChoices(Enum):
+    SYSTEM = "system"
+    CUSTOM = "custom"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class PromptLabel(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="prompt_labels",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="prompt_labels",
+        null=True,
+        blank=True,
+    )
+    name = models.CharField(max_length=2000)
+    type = models.CharField(max_length=20, choices=LabelTypeChoices.get_choices())
+    metadata = models.JSONField(default=dict, null=True, blank=True)
+
+    def __str__(self):
+        return self.name
+
+    @classmethod
+    def create_default_system_labels(cls):
+        """Create default system labels: Production, Staging, Development for the given organization."""
+        default_labels = ["Production", "Staging", "Development"]
+        created_labels = []
+        for label_name in default_labels:
+            label, created = cls.objects.get_or_create(
+                name=label_name,
+                organization=None,
+                defaults={
+                    "type": LabelTypeChoices.SYSTEM.value,
+                    "metadata": {
+                        "description": f"Default {label_name.lower()} environment label"
+                    },
+                },
+            )
+            if created:
+                created_labels.append(label)
+        return created_labels
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["organization", "name", "workspace"],
+                condition=Q(deleted=False),
+                name="unique_label_name_per_org_active",
+            ),
+            models.UniqueConstraint(
+                fields=["name"],
+                condition=Q(
+                    organization__isnull=True,
+                    type=LabelTypeChoices.SYSTEM.value,
+                    deleted=False,
+                ),
+                name="unique_global_system_label_name",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization", "type"]),
+            models.Index(fields=["name"]),
+        ]

--- a/futureagi/model_hub/models/run_prompt.py
+++ b/futureagi/model_hub/models/run_prompt.py
@@ -1,0 +1,391 @@
+import uuid
+from enum import Enum
+from uuid import uuid4
+
+from django.contrib.postgres.fields import ArrayField
+from django.core.exceptions import ValidationError
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import validator
+
+from accounts.models import User
+from accounts.models.organization import Organization
+from model_hub.models.choices import StatusType
+from model_hub.models.develop_dataset import Dataset, KnowledgeBaseFile
+from model_hub.models.eval_groups import EvalGroup
+from model_hub.models.evals_metric import EvalTemplate
+from model_hub.models.openai_tools import Tools
+from model_hub.models.prompt_base_template import PromptBaseTemplate
+from model_hub.models.prompt_folders import PromptFolder
+from model_hub.models.prompt_label import PromptLabel
+from tfc.utils.base_model import BaseModel
+
+
+class RunPrompter(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
+    # Required fields
+    dataset = models.ForeignKey(Dataset, on_delete=models.CASCADE)
+    model = models.CharField(max_length=2000)
+    name = models.CharField(max_length=2000)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="run_prompt_org",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="run_prompts",
+        null=True,
+        blank=True,
+    )
+    concurrency = models.IntegerField(
+        default=5,
+        validators=[MinValueValidator(1), MaxValueValidator(10)],
+        help_text="Concurrency level, default is 5. Maximum 10.",
+    )
+
+    # Messages field
+    messages = ArrayField(
+        models.JSONField(),
+        default=list,
+        help_text="List of messages with format [{'role': 'user/assistant', 'content': 'text'}]",
+    )
+
+    # Optional fields with validation
+    OUTPUT_FORMAT_CHOICES = [
+        ("array", "array"),
+        ("string", "string"),
+        ("number", "number"),
+        ("object", "object"),
+        ("audio", "audio"),
+        ("image", "image"),
+    ]
+    output_format = models.CharField(
+        max_length=10,
+        choices=OUTPUT_FORMAT_CHOICES,
+        default="string",
+        help_text="Output format type. Defaults to 'string'.",
+    )
+    temperature = models.FloatField(
+        null=True,
+        blank=True,
+        default=None,
+        validators=[MinValueValidator(0.0), MaxValueValidator(2.0)],
+        help_text="Controls the randomness. Value between 0 and 2.",
+    )
+    frequency_penalty = models.FloatField(
+        null=True,
+        blank=True,
+        default=None,
+        validators=[MinValueValidator(-2.0), MaxValueValidator(2.0)],
+        help_text="Penalty for word repetition. Value between -2 and 2.",
+    )
+    presence_penalty = models.FloatField(
+        null=True,
+        blank=True,
+        default=None,
+        validators=[MinValueValidator(-2.0), MaxValueValidator(2.0)],
+        help_text="Penalty for new word usage. Value between -2 and 2.",
+    )
+    max_tokens = models.IntegerField(
+        null=True,
+        blank=True,
+        default=None,
+        validators=[MinValueValidator(1), MaxValueValidator(65536)],
+        help_text="Maximum number of tokens to generate. Null = use provider default.",
+    )
+    top_p = models.FloatField(
+        null=True,
+        blank=True,
+        default=None,
+        validators=[MinValueValidator(0.0), MaxValueValidator(1.0)],
+        help_text="Controls diversity via nucleus sampling. Value between 0 and 1.",
+    )
+    response_format = models.JSONField(
+        blank=True,
+        null=True,
+        help_text="JSON schema for response format if required. Defaults to None.",
+    )
+
+    TOOL_CHOICES = [
+        ("auto", "auto"),
+        ("required", "required"),
+        (None, None),
+    ]
+    tool_choice = models.CharField(
+        max_length=10,
+        choices=TOOL_CHOICES,
+        blank=True,
+        null=True,
+        help_text="Tool selection mode: 'auto' or 'required'.",
+    )
+    tools = models.ManyToManyField(Tools, blank=True, related_name="runprompters")
+
+    status = models.CharField(
+        max_length=100,
+        default=StatusType.NOT_STARTED.value,
+        choices=StatusType.get_choices(),
+    )
+
+    run_prompt_config = models.JSONField(null=True, blank=True, default=dict)
+
+    def clean(self):
+        super().clean()
+
+        # Custom validation for messages structure
+        if not isinstance(self.messages, list) or not all(
+            isinstance(msg, dict)
+            and "role" in msg
+            and msg["role"] in {"user", "assistant", "system"}
+            and "content" in msg
+            and isinstance(msg["content"], str)
+            for msg in self.messages
+        ):
+            raise ValidationError(
+                "Messages must be a list of dicts with 'role' (user/assistant/system) and 'content' (string)."
+            )
+
+    class Meta:
+        verbose_name = "Litellm Evaluation"
+        verbose_name_plural = "Litellm Evaluations"
+
+    def __str__(self):
+        return f"{self.name}"
+
+
+class ModelConfig(PydanticBaseModel):
+    temperature: float | str | None = None
+    frequency_penalty: float | str | None = None
+    presence_penalty: float | str | None = None
+    max_tokens: int | str | None = None
+    top_p: float | None | None = None
+    response_format: dict | str | uuid.UUID | None = None
+    tool_choice: str | dict | None | None = None
+    tools: list[uuid.UUID] | None = None
+
+    @validator("tools")
+    def validate_tools(cls, v):
+        if v is not None:
+            tool_ids = set(Tools.objects.values_list("id", flat=True))
+            for tool_id in v:
+                if tool_id not in tool_ids:
+                    raise ValueError(f"Tool with ID {tool_id} does not exist")
+        return v
+
+    @validator("response_format")
+    def validate_response_format(cls, rf):
+        if rf is not None:
+            if isinstance(rf, uuid.UUID):
+                response_format_ids = set(
+                    UserResponseSchema.objects.values_list("id", flat=True)
+                )
+                if rf not in response_format_ids:
+                    raise ValueError(f"Response format with ID {rf} does not exist")
+        return rf
+
+
+class Message(PydanticBaseModel):
+    role: str
+    content: str
+
+
+class PromptConfig(PydanticBaseModel):
+    messages: list[Message]
+    model: str
+    variable_names: dict | None | None = None
+    configuration: ModelConfig
+    providers: str | None = None
+
+
+def validate_prompt_config(value):
+    try:
+        if isinstance(value, list):
+            [PromptConfig(**item) for item in value]
+        return value
+    except Exception as e:
+        raise ValidationError(f"Invalid prompt config format: {str(e)}")  # noqa: B904
+
+
+class PromptTemplate(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
+    name = models.CharField(max_length=2000)
+    description = models.TextField(blank=True, null=True)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="prompt_templates",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="prompt_templates",
+        null=True,
+        blank=True,
+    )
+    variable_names = models.JSONField(default=list, null=True, blank=True)
+    placeholders = models.JSONField(default=dict, null=True, blank=True)
+    collaborators = models.ManyToManyField(User, related_name="user_prompts")
+    prompt_folder = models.ForeignKey(
+        PromptFolder,
+        on_delete=models.CASCADE,
+        related_name="prompt_templates",
+        null=True,
+        blank=True,
+    )
+    is_sample = models.BooleanField(default=False)
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="prompt_templates",
+        null=True,
+        blank=True,
+    )
+
+
+class PromptVersion(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
+    # Remove the prompt_template ForeignKey since we have the snapshot
+    prompt_config_snapshot = models.JSONField(default=list, null=True, blank=True)
+    template_version = models.CharField(
+        max_length=50
+    )  # Store the version for reference
+    original_template = models.ForeignKey(
+        PromptTemplate,
+        on_delete=models.CASCADE,
+        related_name="all_executions",
+        null=True,
+    )
+    output = models.JSONField(default=list, null=True, blank=True)
+    variable_names = models.JSONField(default=dict, null=True, blank=True)
+    metadata = models.JSONField(default=dict, null=True, blank=True)
+    evaluation_results = models.JSONField(default=dict, null=True, blank=True)
+    evaluation_configs = models.JSONField(default=list, null=True, blank=True)
+    commit_message = models.TextField(null=True, blank=True, default="")
+    is_default = models.BooleanField(default=False)
+    is_draft = models.BooleanField(default=False)
+    labels = models.ManyToManyField(
+        PromptLabel, related_name="prompt_versions", blank=True
+    )
+    prompt_base_template = models.ForeignKey(
+        PromptBaseTemplate,
+        on_delete=models.CASCADE,
+        related_name="prompt_versions",
+        null=True,
+        blank=True,
+    )
+
+    placeholders = models.JSONField(default=dict, null=True, blank=True)
+
+    class Meta:
+        # Ensure unique version per template to prevent duplicates
+        unique_together = [("original_template", "template_version")]
+        ordering = ["-created_at"]
+
+    def save(self, *args, **kwargs):
+        if self.is_default:
+            PromptVersion.objects.filter(
+                original_template=self.original_template
+            ).exclude(id=self.id).update(is_default=False)
+
+        super().save(*args, **kwargs)
+
+    def add_label(self, label):
+        """Add a label to this prompt version, preventing duplicates"""
+        if not self.labels.filter(id=label.id).exists():
+            self.labels.add(label)
+
+    def remove_label(self, label):
+        """Remove a label from this prompt version"""
+        self.labels.remove(label)
+
+
+class SchemaTypeChoices(Enum):
+    JSON = "json"
+    YAML = "yaml"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class UserResponseSchema(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
+    name = models.CharField(max_length=2000)
+    description = models.TextField(blank=True, null=True, default="")
+    schema = models.JSONField(default=dict)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="custom_response_schemas",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="custom_response_schemas",
+        null=True,
+        blank=True,
+    )
+    schema_type = models.CharField(
+        blank=True,
+        null=True,
+        choices=SchemaTypeChoices.get_choices(),
+        default=SchemaTypeChoices.JSON.value,
+    )
+
+    class Meta:
+        # Add constraints to ensure name uniqueness within an organization
+        constraints = [
+            models.UniqueConstraint(
+                fields=["name", "organization", "workspace"],
+                name="unique_schema_name_per_organization",
+            )
+        ]
+
+    def __str__(self):
+        return self.name
+
+
+class PromptEvalConfig(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
+    name = models.CharField(max_length=2000, blank=True, null=True)
+    eval_template = models.ForeignKey(
+        EvalTemplate, on_delete=models.CASCADE, related_name="prompt_eval_configs"
+    )
+    prompt_template = models.ForeignKey(
+        PromptTemplate, on_delete=models.CASCADE, related_name="prompt_eval_configs"
+    )
+    mapping = models.JSONField(default=dict, blank=True, null=True)
+    config = models.JSONField(default=dict, blank=True, null=True)
+    kb = models.ForeignKey(
+        KnowledgeBaseFile, on_delete=models.CASCADE, null=True, blank=True
+    )
+    error_localizer = models.BooleanField(default=False)
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="prompt_eval_configs",
+        null=True,
+        blank=True,
+    )
+    status = models.CharField(
+        max_length=50,
+        choices=StatusType.get_choices(),
+        default=StatusType.COMPLETED.value,
+    )
+
+    eval_group = models.ForeignKey(
+        EvalGroup,
+        on_delete=models.CASCADE,
+        related_name="prompt_eval_configs",
+        null=True,
+        blank=True,
+        default=None,
+    )

--- a/futureagi/model_hub/models/score.py
+++ b/futureagi/model_hub/models/score.py
@@ -1,0 +1,260 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.db.models import Q
+
+from accounts.models.organization import Organization
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+
+# Re-export from the single canonical definition in annotation_queues.
+# Kept as an alias so existing imports (e.g. ``from model_hub.models.score
+# import SCORE_SOURCE_FK_MAP``) continue to work.
+from model_hub.models.annotation_queues import (  # noqa: E402, F401
+    SOURCE_TYPE_FK_MAP as SCORE_SOURCE_FK_MAP,
+)
+from model_hub.models.choices import QueueItemSourceType, ScoreSource
+from model_hub.models.develop_annotations import AnnotationsLabels
+from tfc.utils.base_model import BaseModel
+
+
+class Score(BaseModel):
+    """
+    Universal annotation/score primitive.
+
+    Attaches to exactly ONE source object via source_type discriminator + FK.
+    Whether created from an annotation queue, inline annotation on a trace,
+    or programmatically via API — it's the same Score object, visible everywhere.
+
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # ── Source reference (exactly one FK populated) ──────────────────────
+    source_type = models.CharField(
+        max_length=30,
+        choices=QueueItemSourceType.get_choices(),
+    )
+    trace = models.ForeignKey(
+        "tracer.Trace",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="scores",
+    )
+    observation_span = models.ForeignKey(
+        "tracer.ObservationSpan",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="scores",
+    )
+    trace_session = models.ForeignKey(
+        "tracer.TraceSession",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="scores",
+    )
+    call_execution = models.ForeignKey(
+        "simulate.CallExecution",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="scores",
+    )
+    prototype_run = models.ForeignKey(
+        "model_hub.RunPrompter",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="scores",
+    )
+    dataset_row = models.ForeignKey(
+        "model_hub.Row",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="scores",
+    )
+
+    # ── What was scored ──────────────────────────────────────────────────
+    label = models.ForeignKey(
+        AnnotationsLabels,
+        on_delete=models.CASCADE,
+        related_name="scores",
+    )
+    value = models.JSONField()
+
+    # ── Who scored it ────────────────────────────────────────────────────
+    annotator = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="scores",
+    )
+    score_source = models.CharField(
+        max_length=20,
+        choices=ScoreSource.get_choices(),
+        default=ScoreSource.HUMAN.value,
+    )
+    notes = models.TextField(null=True, blank=True)
+
+    # ── Queue provenance (optional) ─────────────────────────────────────
+    queue_item = models.ForeignKey(
+        "model_hub.QueueItem",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="scores",
+    )
+
+    # ── Scoping ──────────────────────────────────────────────────────────
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="scores",
+    )
+    project = models.ForeignKey(
+        "model_hub.DevelopAI",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="scores",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="scores",
+    )
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["trace", "label"]),
+            models.Index(fields=["observation_span", "label"]),
+            models.Index(fields=["trace_session", "label"]),
+            models.Index(fields=["call_execution", "label"]),
+            models.Index(fields=["source_type", "label", "created_at"]),
+            models.Index(fields=["dataset_row", "label"]),
+            models.Index(fields=["prototype_run", "label"]),
+            models.Index(fields=["queue_item"]),
+        ]
+        constraints = [
+            # One score per (source, label, annotator)
+            models.UniqueConstraint(
+                fields=["trace", "label", "annotator"],
+                condition=Q(deleted=False, trace__isnull=False),
+                name="unique_score_trace_label_annotator",
+            ),
+            models.UniqueConstraint(
+                fields=["observation_span", "label", "annotator"],
+                condition=Q(deleted=False, observation_span__isnull=False),
+                name="unique_score_span_label_annotator",
+            ),
+            models.UniqueConstraint(
+                fields=["trace_session", "label", "annotator"],
+                condition=Q(deleted=False, trace_session__isnull=False),
+                name="unique_score_session_label_annotator",
+            ),
+            models.UniqueConstraint(
+                fields=["call_execution", "label", "annotator"],
+                condition=Q(deleted=False, call_execution__isnull=False),
+                name="unique_score_call_label_annotator",
+            ),
+            models.UniqueConstraint(
+                fields=["prototype_run", "label", "annotator"],
+                condition=Q(deleted=False, prototype_run__isnull=False),
+                name="unique_score_run_label_annotator",
+            ),
+            models.UniqueConstraint(
+                fields=["dataset_row", "label", "annotator"],
+                condition=Q(deleted=False, dataset_row__isnull=False),
+                name="unique_score_row_label_annotator",
+            ),
+            # Duplicate constraints for NULL annotator (PostgreSQL NULL != NULL)
+            models.UniqueConstraint(
+                fields=["trace", "label"],
+                condition=Q(
+                    deleted=False,
+                    trace__isnull=False,
+                    annotator__isnull=True,
+                ),
+                name="unique_score_trace_label_null_annotator",
+            ),
+            models.UniqueConstraint(
+                fields=["observation_span", "label"],
+                condition=Q(
+                    deleted=False,
+                    observation_span__isnull=False,
+                    annotator__isnull=True,
+                ),
+                name="unique_score_span_label_null_annotator",
+            ),
+            models.UniqueConstraint(
+                fields=["trace_session", "label"],
+                condition=Q(
+                    deleted=False,
+                    trace_session__isnull=False,
+                    annotator__isnull=True,
+                ),
+                name="unique_score_session_label_null_annotator",
+            ),
+            models.UniqueConstraint(
+                fields=["call_execution", "label"],
+                condition=Q(
+                    deleted=False,
+                    call_execution__isnull=False,
+                    annotator__isnull=True,
+                ),
+                name="unique_score_call_label_null_annotator",
+            ),
+            models.UniqueConstraint(
+                fields=["prototype_run", "label"],
+                condition=Q(
+                    deleted=False,
+                    prototype_run__isnull=False,
+                    annotator__isnull=True,
+                ),
+                name="unique_score_run_label_null_annotator",
+            ),
+            models.UniqueConstraint(
+                fields=["dataset_row", "label"],
+                condition=Q(
+                    deleted=False,
+                    dataset_row__isnull=False,
+                    annotator__isnull=True,
+                ),
+                name="unique_score_row_label_null_annotator",
+            ),
+        ]
+
+    def clean(self):
+        super().clean()
+        fk_field = SCORE_SOURCE_FK_MAP.get(self.source_type)
+        if not fk_field:
+            raise ValidationError(f"Invalid source_type: {self.source_type}")
+        if getattr(self, f"{fk_field}_id") is None:
+            raise ValidationError(
+                f"source_type '{self.source_type}' requires '{fk_field}' to be set."
+            )
+        # Ensure no other source FK is set
+        for st, field in SCORE_SOURCE_FK_MAP.items():
+            if field != fk_field and getattr(self, f"{field}_id") is not None:
+                raise ValidationError(
+                    f"Only '{fk_field}' should be set for source_type '{self.source_type}', "
+                    f"but '{field}' is also set."
+                )
+
+    def __str__(self):
+        return f"Score: {self.id} ({self.source_type}, label={self.label_id})"
+
+    def get_source_id(self):
+        """Return the ID of the populated source FK."""
+        fk_field = SCORE_SOURCE_FK_MAP.get(self.source_type)
+        if fk_field:
+            return getattr(self, f"{fk_field}_id")
+        return None

--- a/futureagi/model_hub/models/tts_voices.py
+++ b/futureagi/model_hub/models/tts_voices.py
@@ -1,0 +1,46 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.core.validators import MinLengthValidator
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class VoiceTypeChoices(models.TextChoices):
+    SYSTEM = "system", "System"
+    CUSTOM = "custom", "Custom"
+
+
+class TTSVoice(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255, validators=[MinLengthValidator(1)])
+    description = models.TextField(max_length=255, blank=True, default="")
+
+    voice_id = models.CharField(max_length=255, validators=[MinLengthValidator(1)])
+    provider = models.CharField(max_length=255, validators=[MinLengthValidator(1)])
+    model = models.CharField(max_length=255, validators=[MinLengthValidator(1)])
+    voice_type = models.CharField(
+        max_length=255,
+        choices=VoiceTypeChoices.choices,
+        default=VoiceTypeChoices.CUSTOM,
+    )
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="tts_voices_org",
+        null=True,
+        blank=True,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="tts_voices",
+        null=True,
+        blank=True,
+    )
+
+    def __str__(self):
+        return self.name

--- a/futureagi/simulate/models/__init__.py
+++ b/futureagi/simulate/models/__init__.py
@@ -1,0 +1,54 @@
+from .agent_definition import AgentDefinition, ProviderCredentials
+from .agent_optimiser import AgentOptimiser
+from .agent_optimiser_run import AgentOptimiserRun
+from .agent_prompt_optimiser_run import AgentPromptOptimiserRun
+from .agent_prompt_optimiser_run_step import AgentPromptOptimiserRunStep
+from .agent_version import AgentVersion
+from .call_log_entry import CallLogEntry
+from .chat_message import ChatMessageModel
+from .chat_simulator import ChatSimulatorAssistant, ChatSimulatorSession
+from .component_evaluation import ComponentEvaluation
+from .eval_config import SimulateEvalConfig
+from .persona import Persona
+from .prompt_trial import PromptTrial
+from .run_test import RunTest
+from .scenario_graph import NodeType, ScenarioGraph
+from .scenarios import Scenarios
+from .simulation_phone_number import SimulationPhoneNumber
+from .simulator_agent import SimulatorAgent
+from .test_execution import (
+    CallExecution,
+    CallExecutionSnapshot,
+    CallTranscript,
+    TestExecution,
+)
+from .trial_item_result import TrialItemResult
+
+__all__ = [
+    "Scenarios",
+    "AgentDefinition",
+    "ProviderCredentials",
+    "AgentOptimiser",
+    "AgentOptimiserRun",
+    "AgentPromptOptimiserRun",
+    "AgentPromptOptimiserRunStep",
+    "AgentVersion",
+    "ComponentEvaluation",
+    "PromptTrial",
+    "SimulatorAgent",
+    "RunTest",
+    "SimulateEvalConfig",
+    "TestExecution",
+    "CallExecution",
+    "CallTranscript",
+    "CallExecutionSnapshot",
+    "CallLogEntry",
+    "ScenarioGraph",
+    "NodeType",
+    "SimulationPhoneNumber",
+    "Persona",
+    "ChatMessageModel",
+    "ChatSimulatorAssistant",
+    "ChatSimulatorSession",
+    "TrialItemResult",
+]

--- a/futureagi/simulate/models/agent_definition.py
+++ b/futureagi/simulate/models/agent_definition.py
@@ -1,0 +1,302 @@
+import uuid
+
+from django.contrib.postgres.fields import ArrayField
+from django.db import models
+
+from accounts.models import Organization
+from model_hub.models.develop_dataset import KnowledgeBaseFile
+from tfc.utils.base_model import BaseModel
+from tracer.models.observability_provider import ObservabilityProvider
+
+
+class AgentDefinitionAuthenticationChoices(models.TextChoices):
+    API_KEY = "api_key", "Api Key"
+
+
+class AgentTypeChoices(models.TextChoices):
+    VOICE = "voice", "Voice"
+    TEXT = "text", "Text"
+
+
+class AgentDefinition(BaseModel):
+    """
+    Model to store AI agent definitions for simulation
+    """
+
+    class LanguageChoices(models.TextChoices):
+        ARABIC = "ar", "Arabic"
+        BULGARIAN = "bg", "Bulgarian"
+        CHINESE_SIMPLIFIED = "zh", "Chinese Simplified"
+        CZECH = "cs", "Czech"
+        DANISH = "da", "Danish"
+        DUTCH = "nl", "Dutch"
+        ENGLISH = "en", "English"
+        FINNISH = "fi", "Finnish"
+        FRENCH = "fr", "French"
+        GERMAN = "de", "German"
+        GREEK = "el", "Greek"
+        HINDI = "hi", "Hindi"
+        HUNGARIAN = "hu", "Hungarian"
+        INDONESIAN = "id", "Indonesian"
+        ITALIAN = "it", "Italian"
+        JAPANESE = "ja", "Japanese"
+        KOREAN = "ko", "Korean"
+        MALAY = "ms", "Malay"
+        NORWEGIAN = "no", "Norwegian"
+        POLISH = "pl", "Polish"
+        PORTUGUESE = "pt", "Portuguese"
+        ROMANIAN = "ro", "Romanian"
+        RUSSIAN = "ru", "Russian"
+        SLOVAK = "sk", "Slovak"
+        SPANISH = "es", "Spanish"
+        SWEDISH = "sv", "Swedish"
+        TURKISH = "tr", "Turkish"
+        UKRAINIAN = "uk", "Ukrainian"
+        VIETNAMESE = "vi", "Vietnamese"
+
+    # Alias for backwards compatibility (many call sites use AgentDefinition.AgentTypeChoices)
+    AgentTypeChoices = AgentTypeChoices
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    agent_name = models.CharField(max_length=255, help_text="Name of the AI agent")
+
+    agent_type = models.CharField(
+        max_length=255,
+        choices=AgentTypeChoices.choices,
+        default=AgentTypeChoices.VOICE,
+    )
+
+    contact_number = models.CharField(
+        max_length=50,
+        help_text="Phone number associated with the AI agent",
+        blank=True,
+        null=True,
+    )
+
+    inbound = models.BooleanField(help_text="Whether the agent handles inbound calls")
+
+    description = models.TextField(
+        help_text="Detailed description of the AI agent's purpose and capabilities"
+    )
+
+    assistant_id = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        help_text="External identifier for the assistant",
+    )
+
+    provider = models.CharField(
+        max_length=255, blank=True, null=True, help_text="Provider of the AI agent"
+    )
+
+    language = models.CharField(
+        max_length=2,
+        choices=LanguageChoices.choices,
+        help_text="Language of the agent",
+        null=True,
+        blank=True,
+    )
+
+    languages = ArrayField(
+        models.CharField(
+            max_length=2,
+            choices=LanguageChoices.choices,
+            help_text="Language of the agent",
+        ),
+        blank=True,
+        null=True,
+    )
+
+    websocket_url = models.URLField(
+        max_length=500,
+        blank=True,
+        null=True,
+        help_text="WebSocket URL for real-time communication with the agent",
+    )
+
+    websocket_headers = models.JSONField(
+        blank=True,
+        null=True,
+        default=dict,
+        help_text="Headers to be sent to the websocket server",
+    )
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agent_definitions",
+        help_text="Organization this agent definition belongs to",
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="agent_definitions",
+        null=True,
+        blank=True,
+    )
+
+    knowledge_base = models.ForeignKey(
+        KnowledgeBaseFile, on_delete=models.CASCADE, null=True, blank=True
+    )
+
+    api_key = models.CharField(
+        max_length=255, null=True, blank=True, help_text="API key for the agent"
+    )
+
+    observability_provider = models.OneToOneField(
+        ObservabilityProvider,
+        on_delete=models.CASCADE,
+        related_name="agent_definition",
+        blank=True,
+        null=True,
+    )
+
+    authentication_method = models.CharField(
+        choices=AgentDefinitionAuthenticationChoices,
+        default=AgentDefinitionAuthenticationChoices.API_KEY,
+        blank=True,
+        null=True,
+    )
+
+    model = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        help_text="Model of the agent",
+    )
+
+    model_details = models.JSONField(
+        blank=True,
+        null=True,
+        help_text="Details of the model",
+        default=dict,
+    )
+
+    class Meta:
+        db_table = "simulate_agent_definition"
+        verbose_name = "Agent Definition"
+        verbose_name_plural = "Agent Definitions"
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"{self.agent_name} - {self.contact_number}"
+
+    @property
+    def active_version(self):
+        """Get the currently active version of this agent"""
+        return self.versions.filter(status="active").first()
+
+    @property
+    def latest_version(self):
+        """Get the latest version of this agent"""
+        return self.versions.order_by("-version_number").first()
+
+    @property
+    def version_count(self):
+        """Get the total number of versions for this agent"""
+        return self.versions.count()
+
+    def get_version(self, id):
+        """Get the currently active version of this agent"""
+        return self.versions.filter(id=id).first()
+
+    def create_version(
+        self, description, commit_message, release_notes=None, status="draft"
+    ):
+        """Create a new version of this agent"""
+        from .agent_version import AgentVersion
+
+        # Create a new version
+        version = AgentVersion.objects.create(
+            agent_definition=self,
+            organization=self.organization,
+            commit_message=commit_message,
+            description=description,
+            release_notes=release_notes,
+            status=status,
+            workspace=self.workspace,
+        )
+
+        return version
+
+    def get_version_history(self):
+        """Get all versions of this agent ordered by version number"""
+        return self.versions.order_by("-version_number")
+
+
+class ProviderCredentials(BaseModel):
+    """Encrypted credential storage for voice providers.
+
+    Centralises all provider credentials (VAPI, Retell, LiveKit) in one
+    table with Fernet encryption at rest. One-to-one with AgentDefinition.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    class ProviderType(models.TextChoices):
+        VAPI = "vapi", "Vapi"
+        RETELL = "retell", "Retell"
+        LIVEKIT = "livekit", "LiveKit"
+
+    agent_definition = models.OneToOneField(
+        AgentDefinition,
+        on_delete=models.CASCADE,
+        related_name="credentials",
+    )
+    provider_type = models.CharField(
+        max_length=50,
+        choices=ProviderType.choices,
+    )
+
+    # Encrypted credential fields (stored as enc::-prefixed ciphertext)
+    api_key = models.TextField(blank=True, default="")
+    api_secret = models.TextField(blank=True, default="")
+
+    # Non-secret fields (plaintext)
+    assistant_id = models.CharField(max_length=255, blank=True, default="")
+    server_url = models.URLField(max_length=500, blank=True, default="")
+    agent_name = models.CharField(max_length=255, blank=True, default="")
+    config_json = models.JSONField(blank=True, null=True, default=dict)
+    max_concurrency = models.PositiveIntegerField(blank=True, null=True, default=5)
+
+    class Meta:
+        db_table = "simulate_provider_credentials"
+        verbose_name = "Provider Credentials"
+        verbose_name_plural = "Provider Credentials"
+
+    def __str__(self):
+        return f"{self.provider_type} credentials for {self.agent_definition}"
+
+    def save(self, *args, **kwargs):
+        """Encrypt secrets before saving."""
+        from agentcc.services.credential_manager import encrypt_token
+
+        if self.api_key and not self.api_key.startswith("enc::"):
+            self.api_key = encrypt_token(self.api_key)
+        if self.api_secret and not self.api_secret.startswith("enc::"):
+            self.api_secret = encrypt_token(self.api_secret)
+        super().save(*args, **kwargs)
+
+    def get_api_key(self) -> str:
+        """Return decrypted API key."""
+        from agentcc.services.credential_manager import decrypt_token
+
+        return decrypt_token(self.api_key)
+
+    def get_api_secret(self) -> str:
+        """Return decrypted API secret."""
+        from agentcc.services.credential_manager import decrypt_token
+
+        return decrypt_token(self.api_secret)
+
+    def get_masked_api_key(self) -> str:
+        """Return masked API key for display."""
+        from agentcc.services.credential_manager import mask_key
+
+        return mask_key(self.get_api_key())
+
+    def get_masked_api_secret(self) -> str:
+        """Return masked API secret for display."""
+        return "********" if self.api_secret else ""

--- a/futureagi/simulate/models/agent_optimiser.py
+++ b/futureagi/simulate/models/agent_optimiser.py
@@ -1,0 +1,56 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+
+
+class AgentOptimiser(BaseModel):
+    """
+    Reusable agent optimiser configuration/instance.
+    Represents a specific optimiser that can be used across different test executions.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    name = models.CharField(
+        max_length=255,
+        help_text="Name of the agent optimiser",
+    )
+
+    description = models.TextField(
+        null=True,
+        blank=True,
+        help_text="Description of what this optimiser does",
+    )
+
+    configuration = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Configuration settings for this optimiser",
+    )
+
+    class Meta:
+        db_table = "agent_optimiser"
+
+    def __str__(self):
+        return f"{self.name}"
+
+    @property
+    def total_runs(self):
+        """Get total number of runs for this optimiser"""
+        return self.runs.count()
+
+    @property
+    def successful_runs(self):
+        """Get count of successful runs"""
+        from simulate.models.agent_optimiser_run import AgentOptimiserRun
+
+        return self.runs.filter(
+            status=AgentOptimiserRun.OptimiserStatus.COMPLETED
+        ).count()
+
+    @property
+    def latest_run(self):
+        """Get the latest run for this optimiser"""
+        return self.runs.order_by("-created_at").first()

--- a/futureagi/simulate/models/agent_optimiser_run.py
+++ b/futureagi/simulate/models/agent_optimiser_run.py
@@ -1,0 +1,70 @@
+import uuid
+
+from django.db import models
+from django.utils import timezone
+
+from simulate.models.agent_optimiser import AgentOptimiser
+from tfc.utils.base_model import BaseModel
+
+
+class AgentOptimiserRun(BaseModel):
+    """
+    Individual execution/run of an agent optimiser.
+    Tracks the complete lifecycle of a single optimization run.
+    """
+
+    class OptimiserStatus(models.TextChoices):
+        PENDING = "pending", "Pending"
+        RUNNING = "running", "Running"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+        CANCELLED = "cancelled", "Cancelled"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    agent_optimiser = models.ForeignKey(
+        AgentOptimiser, on_delete=models.CASCADE, related_name="runs"
+    )
+
+    status = models.CharField(
+        max_length=20,
+        choices=OptimiserStatus.choices,
+        default=OptimiserStatus.PENDING,
+    )
+
+    input_data = models.JSONField(default=dict, blank=True)
+
+    result = models.JSONField(null=True, blank=True)
+
+    metadata = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agent_optimiser_run"
+        indexes = [
+            models.Index(fields=["status"], name="idx_optimiser_run_status"),
+        ]
+
+    def __str__(self):
+        return f"{self.agent_optimiser.name} - {self.status}"
+
+    def mark_as_running(self):
+        """Mark the optimiser run as running"""
+        self.status = self.OptimiserStatus.RUNNING
+        self.save(update_fields=["status", "updated_at"])
+
+    def mark_as_completed(self, result=None):
+        """Mark the optimiser run as completed"""
+        self.status = self.OptimiserStatus.COMPLETED
+        if result:
+            self.result = result
+        self.save(update_fields=["status", "result", "updated_at"])
+
+    def mark_as_failed(self, error_info=None):
+        """Mark the optimiser run as failed"""
+        self.status = self.OptimiserStatus.FAILED
+        if error_info:
+            # Store error info in metadata
+            if not self.metadata:
+                self.metadata = {}
+            self.metadata["error"] = error_info
+        self.save(update_fields=["status", "metadata", "updated_at"])

--- a/futureagi/simulate/models/agent_prompt_optimiser_run.py
+++ b/futureagi/simulate/models/agent_prompt_optimiser_run.py
@@ -1,0 +1,91 @@
+import uuid
+
+from django.db import models
+
+from simulate.models.agent_optimiser import AgentOptimiser
+from simulate.models.agent_optimiser_run import AgentOptimiserRun
+from simulate.models.test_execution import TestExecution
+from tfc.utils.base_model import BaseModel
+
+
+class AgentPromptOptimiserRun(BaseModel):
+    """
+    Represents a single run of an agent prompt optimiser.
+    It takes inputs from a test execution and an agent optimiser run.
+    """
+
+    class OptimiserType(models.TextChoices):
+        RANDOM_SEARCH = "random_search", "Random Search"
+        GEPA = "gepa", "GEPA"
+        PROTEGI = "protegi", "Protegi"
+        BAYESIAN = "bayesian", "Bayesian"
+        METAPROMPT = "metaprompt", "Metaprompt"
+        PROMPTWIZARD = "promptwizard", "PromptWizard"
+
+    class Status(models.TextChoices):
+        PENDING = "pending", "Pending"
+        RUNNING = "running", "Running"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    agent_optimiser = models.ForeignKey(
+        AgentOptimiser, on_delete=models.CASCADE, related_name="prompt_optimiser_runs"
+    )
+    agent_optimiser_run = models.ForeignKey(
+        AgentOptimiserRun,
+        on_delete=models.CASCADE,
+        related_name="prompt_optimiser_runs",
+    )
+    test_execution = models.ForeignKey(
+        TestExecution, on_delete=models.CASCADE, related_name="prompt_optimiser_runs"
+    )
+    optimiser_type = models.CharField(max_length=50, choices=OptimiserType.choices)
+    model = models.CharField(
+        max_length=255, help_text="LLM model used for the optimiser run"
+    )
+    status = models.CharField(
+        max_length=20, choices=Status.choices, default=Status.PENDING
+    )
+    result = models.JSONField(null=True, blank=True)
+    error_message = models.TextField(null=True, blank=True)
+    configuration = models.JSONField(null=True)
+
+    class Meta:
+        db_table = "agent_prompt_optimiser_run"
+        indexes = [
+            models.Index(fields=["status"], name="idx_prompt_opt_run_status"),
+            models.Index(
+                fields=["test_execution", "status"],
+                name="idx_prompt_opt_run_test_status",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.agent_optimiser.name} - {self.id} - {self.status}"
+
+    def mark_as_running(self):
+        """Mark the prompt optimiser run as running"""
+        self.status = self.Status.RUNNING
+        self.save(update_fields=["status", "updated_at"])
+
+    def mark_as_completed(self):
+        """Mark the prompt optimiser run as completed"""
+        self.status = self.Status.COMPLETED
+        self.save(update_fields=["status", "updated_at"])
+
+    def mark_as_failed(self, error_message: str = None):
+        """Mark the prompt optimiser run as failed"""
+        self.status = self.Status.FAILED
+        self.error_message = error_message
+        self.save(update_fields=["status", "error_message", "updated_at"])
+
+    def get_next_step_number(self) -> int:
+        """
+        Calculates the next available step number for this run.
+        """
+        last_step = self.steps.order_by("-step_number").first()
+        if last_step:
+            return last_step.step_number + 1
+        return 1

--- a/futureagi/simulate/models/agent_prompt_optimiser_run_step.py
+++ b/futureagi/simulate/models/agent_prompt_optimiser_run_step.py
@@ -1,0 +1,52 @@
+import uuid
+
+from django.db import models
+
+from simulate.models.agent_prompt_optimiser_run import AgentPromptOptimiserRun
+from tfc.utils.base_model import BaseModel
+
+
+class AgentPromptOptimiserRunStep(BaseModel):
+    """
+    Represents a single step within an agent prompt optimiser run.
+    """
+
+    class Status(models.TextChoices):
+        PENDING = "pending", "Pending"
+        RUNNING = "running", "Running"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    agent_prompt_optimiser_run = models.ForeignKey(
+        AgentPromptOptimiserRun, on_delete=models.CASCADE, related_name="steps"
+    )
+    step_number = models.IntegerField()
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, null=True)
+    status = models.CharField(
+        max_length=20, choices=Status.choices, default=Status.PENDING
+    )
+    metadata = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        db_table = "agent_prompt_optimiser_run_step"
+        unique_together = ("agent_prompt_optimiser_run", "step_number")
+
+    def __str__(self):
+        return f"{self.agent_prompt_optimiser_run.id} - {self.name} - {self.status}"
+
+    def mark_as_running(self):
+        """Mark the optimiser run step as running"""
+        self.status = self.Status.RUNNING
+        self.save(update_fields=["status", "updated_at"])
+
+    def mark_as_completed(self):
+        """Mark the optimiser run step as completed"""
+        self.status = self.Status.COMPLETED
+        self.save(update_fields=["status", "updated_at"])
+
+    def mark_as_failed(self):
+        """Mark the optimiser run step as failed"""
+        self.status = self.Status.FAILED
+        self.save(update_fields=["status", "updated_at"])

--- a/futureagi/simulate/models/agent_version.py
+++ b/futureagi/simulate/models/agent_version.py
@@ -1,0 +1,259 @@
+import uuid
+
+from django.conf import settings
+from django.db import models
+
+from accounts.models import Organization
+from simulate.pydantic_schemas.agent_version import AgentConfigurationSnapshot
+from tfc.utils.base_model import BaseModel
+
+
+class AgentVersion(BaseModel):
+    """
+    Model to store different versions of agent definitions
+    """
+
+    class StatusChoices(models.TextChoices):
+        DRAFT = "draft", "Draft"
+        ACTIVE = "active", "Active"
+        ARCHIVED = "archived", "Archived"
+        DEPRECATED = "deprecated", "Deprecated"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # Version information
+    version_number = models.PositiveIntegerField(
+        help_text="Version number of the agent"
+    )
+
+    version_name = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        help_text="Human-readable version name (e.g., 'v1.2.3')",
+    )
+
+    status = models.CharField(
+        max_length=20,
+        choices=StatusChoices.choices,
+        default=StatusChoices.DRAFT,
+        help_text="Current status of this version",
+    )
+
+    # Performance metrics
+    score = models.DecimalField(
+        max_digits=3,
+        decimal_places=1,
+        blank=True,
+        null=True,
+        help_text="Performance score (0.0 to 10.0)",
+    )
+
+    test_count = models.PositiveIntegerField(
+        default=0, help_text="Number of tests run for this version"
+    )
+
+    pass_rate = models.DecimalField(
+        max_digits=5,
+        decimal_places=2,
+        blank=True,
+        null=True,
+        help_text="Test pass rate percentage",
+    )
+
+    # Version details
+    description = models.TextField(help_text="Description of changes in this version")
+
+    commit_message = models.TextField(
+        help_text="Commit message for the agent version",
+        null=True,
+        blank=True,
+    )
+
+    release_notes = models.TextField(
+        blank=True, null=True, help_text="Detailed release notes for this version"
+    )
+
+    # Relationships
+    agent_definition = models.ForeignKey(
+        "simulate.AgentDefinition",
+        on_delete=models.CASCADE,
+        related_name="versions",
+        help_text="Parent agent definition",
+    )
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="agent_versions",
+        help_text="Organization this version belongs to",
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="agent_versions",
+        null=True,
+        blank=True,
+    )
+
+    # Configuration snapshot (JSON field to store the exact configuration at this version)
+    configuration_snapshot = models.JSONField(
+        default=dict, help_text="Snapshot of agent configuration at this version"
+    )
+
+    class Meta:
+        db_table = "simulate_agent_version"
+        verbose_name = "Agent Version"
+        verbose_name_plural = "Agent Versions"
+        ordering = ["-version_number"]
+        unique_together = ["agent_definition", "version_number"]
+
+    def __str__(self):
+        return f"{self.agent_definition.agent_name} - v{self.version_number}"
+
+    def save(self, *args, **kwargs):
+        # Auto-generate version number if not provided
+        if not self.version_number:
+            latest_version = (
+                AgentVersion.objects.filter(agent_definition=self.agent_definition)
+                .order_by("-version_number")
+                .first()
+            )
+
+            if latest_version:
+                self.version_number = latest_version.version_number + 1
+            else:
+                self.version_number = 1
+
+        # Auto-generate version name if not provided
+        if not self.version_name:
+            self.version_name = f"v{self.version_number}"
+
+        # Create a snapshot of the current configuration
+        if not self.configuration_snapshot:
+            self.configuration_snapshot = self.create_snapshot(
+                commit_message=self.commit_message
+            )
+
+        super().save(*args, **kwargs)
+
+    @property
+    def is_active(self):
+        """Check if this version is currently active"""
+        return self.status == self.StatusChoices.ACTIVE
+
+    @property
+    def is_latest(self):
+        """Check if this is the latest version"""
+        latest = (
+            AgentVersion.objects.filter(agent_definition=self.agent_definition)
+            .order_by("-version_number")
+            .first()
+        )
+        return self == latest if latest else False
+
+    def activate(self):
+        """Activate this version and deactivate others"""
+        # Deactivate all other versions of this agent
+        AgentVersion.objects.filter(agent_definition=self.agent_definition).exclude(
+            id=self.id
+        ).update(status=self.StatusChoices.ARCHIVED)
+
+        # Activate this version
+        self.status = self.StatusChoices.ACTIVE
+        self.save()
+
+    def create_snapshot(self, commit_message):
+        """Create a snapshot of the current agent configuration"""
+        agent = self.agent_definition
+
+        knowledge_base_value = (
+            str(agent.knowledge_base_id) if agent.knowledge_base_id else None
+        )
+
+        # Read credentials from ProviderCredentials (decrypted),
+        # fall back to AgentDefinition fields for backward compat.
+        api_key = agent.api_key or getattr(self.agent_definition, "api_key", "")
+        assistant_id = agent.assistant_id or ""
+        livekit_url = ""
+        livekit_api_key = ""
+        livekit_api_secret = ""
+        livekit_agent_name = ""
+        livekit_config_json = None
+        livekit_max_concurrency = settings.DEFAULT_LIVEKIT_MAX_CONCURRENCY
+
+        try:
+            creds = self.agent_definition.credentials
+            if creds:
+                decrypted_key = creds.get_api_key()
+                if decrypted_key:
+                    api_key = decrypted_key
+                if creds.assistant_id:
+                    assistant_id = creds.assistant_id
+                if creds.provider_type == "livekit":
+                    livekit_url = creds.server_url or ""
+                    livekit_api_key = decrypted_key or ""
+                    livekit_api_secret = creds.get_api_secret() or ""
+                    livekit_agent_name = creds.agent_name or ""
+                    livekit_config_json = creds.config_json
+                    livekit_max_concurrency = (
+                        creds.max_concurrency
+                        or settings.DEFAULT_LIVEKIT_MAX_CONCURRENCY
+                    )
+        except self.agent_definition.__class__.credentials.RelatedObjectDoesNotExist:
+            pass
+
+        schema = AgentConfigurationSnapshot(
+            api_key=agent.api_key or "",
+            inbound=agent.inbound,
+            language=agent.language,
+            languages=agent.languages,
+            provider=agent.provider,
+            agent_name=agent.agent_name,
+            agent_type=agent.agent_type,
+            description=agent.description,
+            assistant_id=agent.assistant_id,
+            authentication_method=agent.authentication_method or "",
+            commit_message=commit_message,
+            contact_number=agent.contact_number,
+            knowledge_base=knowledge_base_value,
+            observability_enabled=getattr(
+                agent.observability_provider, "enabled", False
+            ),
+            model=agent.model,
+            model_details=agent.model_details,
+            livekit_url=livekit_url,
+            livekit_api_key=livekit_api_key,
+            livekit_api_secret=livekit_api_secret,
+            livekit_agent_name=livekit_agent_name,
+            livekit_config_json=livekit_config_json or None,
+            livekit_max_concurrency=livekit_max_concurrency,
+        )
+
+        snake = schema.model_dump(exclude_none=True)
+        return snake
+
+    def restore_from_snapshot(self):
+        """Restore agent definition from this version's snapshot"""
+        if not self.configuration_snapshot:
+            raise ValueError("No configuration snapshot available")
+
+        # Snapshot stores FK values as plain strings (UUIDs); map them to the
+        # attname (_id suffix) so Django doesn't raise ValueError on assignment.
+        _FK_REMAP = {
+            "knowledge_base": "knowledge_base_id",
+            "organization": "organization_id",
+            "workspace": "workspace_id",
+        }
+
+        skip = {"id", "created_at", "updated_at", "deleted", "deleted_at"}
+
+        for field, value in self.configuration_snapshot.items():
+            attr = _FK_REMAP.get(field, field)
+            if attr in skip:
+                continue
+            if hasattr(self.agent_definition, attr):
+                setattr(self.agent_definition, attr, value)
+
+        self.agent_definition.save()
+        return self.agent_definition

--- a/futureagi/simulate/models/call_log_entry.py
+++ b/futureagi/simulate/models/call_log_entry.py
@@ -1,0 +1,93 @@
+import uuid
+
+from django.db import models  # type: ignore[import-not-found]
+
+from tfc.utils.base_model import BaseModel
+
+
+class CallLogEntry(BaseModel):
+    class LogSource(models.TextChoices):
+        AGENT = "agent", "Agent"
+        CUSTOMER = "customer", "Customer"
+
+    class Provider(models.TextChoices):
+        VAPI = "vapi", "Vapi"
+        RETELL = "retell", "Retell"
+
+    """
+    Stores a single structured log record for a call execution.
+    The entire payload from Vapi is persisted in `payload` for traceability,
+    while key fields are duplicated for efficient querying.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    call_execution = models.ForeignKey(
+        "simulate.CallExecution",
+        on_delete=models.CASCADE,
+        related_name="log_entries",
+        help_text="Call execution the log entry belongs to",
+    )
+    source = models.CharField(
+        max_length=16,
+        choices=LogSource.choices,
+        default=LogSource.AGENT,
+        help_text="Source of the log entry (agent or customer)",
+    )
+    provider = models.CharField(
+        max_length=16,
+        choices=Provider.choices,
+        default=Provider.VAPI,
+        help_text="Provider of the log entry (vapi or retell)",
+    )
+    logged_at = models.DateTimeField(
+        help_text="Timestamp of the log entry (UTC)", db_index=True
+    )
+    level = models.IntegerField(
+        help_text="Numeric severity level of the log entry (e.g., 30=INFO)"
+    )
+    severity_text = models.CharField(
+        max_length=32,
+        blank=True,
+        help_text="Human-readable severity text (e.g., INFO, WARN)",
+    )
+    category = models.CharField(
+        max_length=128, blank=True, help_text="Category of the log entry"
+    )
+    body = models.CharField(
+        max_length=1024,
+        blank=True,
+        help_text="Short message body for the log entry",
+    )
+    attributes = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Structured attributes parsed from the log entry",
+    )
+    payload = models.JSONField(
+        help_text="Full log entry payload as returned by Vapi for auditing"
+    )
+
+    class Meta:
+        db_table = "simulate_call_log_entry"
+        verbose_name = "Call Log Entry"
+        verbose_name_plural = "Call Log Entries"
+        ordering = ["-logged_at"]
+        indexes = [
+            models.Index(
+                fields=["call_execution", "logged_at"],
+                name="idx_calllog_exec_time",
+            ),
+            models.Index(
+                fields=["call_execution", "source", "logged_at"],
+                name="idx_calllog_exec_src",
+            ),
+            models.Index(fields=["category"], name="idx_calllogentry_category"),
+            models.Index(fields=["body"], name="idx_calllogentry_body"),
+        ]
+
+    def __str__(self) -> str:
+        return (
+            f"{self.call_execution_id} [{self.source}] @ "
+            f"{self.logged_at.isoformat()} - {self.body}"
+        )

--- a/futureagi/simulate/models/chat_message.py
+++ b/futureagi/simulate/models/chat_message.py
@@ -1,0 +1,104 @@
+import uuid
+
+from django.db import models  # type: ignore[import-not-found]
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from simulate.models.test_execution import CallExecution
+from tfc.utils.base_model import BaseModel
+
+
+class ChatMessageModel(BaseModel):
+    """
+    Model to store chat messages for call executions.
+    Stores both input and output messages from chat sessions.
+    """
+
+    class RoleChoices(models.TextChoices):
+        USER = "user", "User"
+        ASSISTANT = "assistant", "Assistant"
+        TOOL = "tool", "Tool"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    call_execution = models.ForeignKey(
+        CallExecution,
+        on_delete=models.CASCADE,
+        related_name="chat_messages",
+        help_text="The call execution this chat message belongs to",
+    )
+
+    role = models.CharField(
+        max_length=20,
+        choices=RoleChoices.choices,
+        help_text="Role of the message sender (user or assistant)",
+    )
+
+    messages = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="List of extracted message content strings",
+    )
+
+    content = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="Full message content as list of dictionaries (ChatMessage objects)",
+    )
+
+    session_id = models.CharField(
+        max_length=255,
+        help_text="VAPI chat session ID",
+    )
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="chat_messages",
+        help_text="Organization this chat message belongs to",
+    )
+
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="chat_messages",
+        help_text="Workspace this chat message belongs to",
+    )
+
+    tool_calls = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="List of tool calls used for the message",
+    )
+
+    # Message-level metrics (individual columns for better query performance)
+    tokens = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Token count for this message (calculated from content)",
+    )
+    latency_ms = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Latency in milliseconds for this message (from SDK)",
+    )
+
+    class Meta:
+        db_table = "simulate_chat_message"
+        verbose_name = "Chat Message"
+        verbose_name_plural = "Chat Messages"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(
+                fields=["call_execution", "created_at"],
+                name="idx_chatmsg_exec_time",
+            ),
+            models.Index(
+                fields=["session_id", "created_at"],
+                name="idx_chatmsg_session_time",
+            ),
+            models.Index(fields=["role"], name="idx_chatmsg_role"),
+        ]
+
+    def __str__(self):
+        return f"{self.role} - {self.call_execution_id} - {self.created_at}"

--- a/futureagi/simulate/models/chat_simulator.py
+++ b/futureagi/simulate/models/chat_simulator.py
@@ -1,0 +1,70 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class ChatSimulatorAssistant(BaseModel):
+    """Persistent config for a chat simulator assistant (simulator persona)."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=512)
+    system_prompt = models.TextField()
+    model = models.CharField(max_length=512)
+    temperature = models.FloatField(default=0.9)
+    max_tokens = models.IntegerField(default=800)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="chat_simulator_assistants",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="chat_simulator_assistants",
+    )
+
+    class Meta:
+        app_label = "simulate"
+
+
+class ChatSimulatorSession(BaseModel):
+    """Persistent state for a chat simulation session."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    assistant = models.ForeignKey(
+        ChatSimulatorAssistant,
+        on_delete=models.CASCADE,
+        related_name="sessions",
+    )
+    call_execution = models.OneToOneField(
+        "simulate.CallExecution",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="chat_simulator_session",
+    )
+    messages = models.JSONField(default=list)
+    status = models.CharField(max_length=50, default="active")
+    has_chat_ended = models.BooleanField(default=False)
+    total_tokens = models.IntegerField(default=0)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="chat_simulator_sessions",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="chat_simulator_sessions",
+    )
+
+    class Meta:
+        app_label = "simulate"

--- a/futureagi/simulate/models/component_evaluation.py
+++ b/futureagi/simulate/models/component_evaluation.py
@@ -1,0 +1,47 @@
+import uuid
+
+from django.db import models
+
+from simulate.models.eval_config import SimulateEvalConfig
+from simulate.models.trial_item_result import TrialItemResult
+from tfc.utils.base_model import BaseModel
+
+
+class ComponentEvaluation(BaseModel):
+    """
+    Represents an individual evaluation score from component_evals.
+
+    Each TrialItemResult may have multiple component evaluations,
+    e.g., levenshtein_similarity, rouge_score, etc.
+    This provides granular breakdowns of how each evaluation metric scored.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    trial_item_result = models.ForeignKey(
+        TrialItemResult,
+        on_delete=models.CASCADE,
+        related_name="component_evaluations",
+    )
+    eval_config = models.ForeignKey(
+        SimulateEvalConfig,
+        on_delete=models.CASCADE,
+        related_name="component_evaluations",
+    )
+    score = models.FloatField()
+    reason = models.TextField(null=True, blank=True)
+
+    class Meta:
+        db_table = "component_evaluation"
+        indexes = [
+            models.Index(
+                fields=["trial_item_result", "eval_config"],
+                name="idx_comp_eval_trial_config",
+            ),
+            models.Index(
+                fields=["eval_config"],
+                name="idx_comp_eval_config",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.trial_item_result.id} - {self.eval_config.name} (score: {self.score:.2f})"

--- a/futureagi/simulate/models/eval_config.py
+++ b/futureagi/simulate/models/eval_config.py
@@ -1,0 +1,55 @@
+import uuid
+
+from django.db import models
+
+from model_hub.models.choices import StatusType
+from model_hub.models.develop_dataset import KnowledgeBaseFile
+from model_hub.models.eval_groups import EvalGroup
+from model_hub.models.evals_metric import EvalTemplate
+from tfc.utils.base_model import BaseModel
+from tracer.models.custom_eval_config import ModelChoices
+
+from .run_test import RunTest
+
+
+class SimulateEvalConfig(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    eval_template = models.ForeignKey(
+        EvalTemplate,
+        on_delete=models.CASCADE,
+        related_name="simulate_eval_configs",
+        blank=False,
+        null=False,
+    )
+    name = models.CharField(max_length=255, blank=True, null=True)
+    config = models.JSONField(default=dict, blank=True, null=True)
+    mapping = models.JSONField(default=dict, blank=True, null=True)
+    run_test = models.ForeignKey(
+        RunTest, on_delete=models.CASCADE, related_name="simulate_eval_configs"
+    )
+    filters = models.JSONField(default=dict, blank=True, null=True)
+    error_localizer = models.BooleanField(default=False)
+    kb_id = models.ForeignKey(
+        KnowledgeBaseFile, on_delete=models.CASCADE, null=True, blank=True
+    )
+    model = models.CharField(
+        max_length=255, choices=ModelChoices.choices, blank=True, null=True
+    )
+    status = models.CharField(
+        max_length=50,
+        choices=StatusType.get_choices(),
+        default=StatusType.COMPLETED.value,
+    )
+
+    eval_group = models.ForeignKey(
+        EvalGroup, on_delete=models.CASCADE, null=True, blank=True
+    )
+
+    def __str__(self):
+        return f"Run Test Eval Config {self.id}"
+
+    class Meta:
+        db_table = "simulate_eval_config"
+        verbose_name = "Simulate Eval Config"
+        verbose_name_plural = "Simulate Eval Configs"
+        ordering = ["-created_at"]

--- a/futureagi/simulate/models/persona.py
+++ b/futureagi/simulate/models/persona.py
@@ -1,0 +1,462 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from simulate.models.agent_definition import AgentTypeChoices
+from tfc.utils.base_model import BaseModel
+
+
+class Persona(BaseModel):
+    """
+    Model to store persona configurations for simulations.
+    Supports both system-level (platform-wide) and workspace-level (user-created) personas.
+    """
+
+    class PersonaType(models.TextChoices):
+        SYSTEM = "system", "System"
+        WORKSPACE = "workspace", "Workspace"
+
+    # Reference choices (not enforced, just for guidance)
+    class GenderChoices(models.TextChoices):
+        MALE = "male", "Male"
+        FEMALE = "female", "Female"
+
+    class AgeGroupChoices(models.TextChoices):
+        AGE_18_25 = "18-25", "18-25"
+        AGE_25_32 = "25-32", "25-32"
+        AGE_32_40 = "32-40", "32-40"
+        AGE_40_50 = "40-50", "40-50"
+        AGE_50_60 = "50-60", "50-60"
+        AGE_60_PLUS = "60+", "60+"
+
+    class LocationChoices(models.TextChoices):
+        UNITED_STATES = "United States", "United States"
+        CANADA = "Canada", "Canada"
+        UNITED_KINGDOM = "United Kingdom", "United Kingdom"
+        AUSTRALIA = "Australia", "Australia"
+        INDIA = "India", "India"
+
+    class ProfessionChoices(models.TextChoices):
+        STUDENT = "Student", "Student"
+        TEACHER = "Teacher", "Teacher"
+        ENGINEER = "Engineer", "Engineer"
+        DOCTOR = "Doctor", "Doctor"
+        NURSE = "Nurse", "Nurse"
+        BUSINESS_OWNER = "Business Owner", "Business Owner"
+        MANAGER = "Manager", "Manager"
+        SALES_REPRESENTATIVE = "Sales Representative", "Sales Representative"
+        CUSTOMER_SERVICE = "Customer Service", "Customer Service"
+        TECHNICIAN = "Technician", "Technician"
+        CONSULTANT = "Consultant", "Consultant"
+        ACCOUNTANT = "Accountant", "Accountant"
+        MARKETING_PROFESSIONAL = "Marketing Professional", "Marketing Professional"
+        RETIRED = "Retired", "Retired"
+        HOMEMAKER = "Homemaker", "Homemaker"
+        FREELANCER = "Freelancer", "Freelancer"
+        OTHER = "Other", "Other"
+
+    class PersonalityChoices(models.TextChoices):
+        FRIENDLY_COOPERATIVE = "Friendly and cooperative", "Friendly and cooperative"
+        PROFESSIONAL_FORMAL = "Professional and formal", "Professional and formal"
+        CAUTIOUS_SKEPTICAL = "Cautious and skeptical", "Cautious and skeptical"
+        IMPATIENT_DIRECT = "Impatient and direct", "Impatient and direct"
+        DETAIL_ORIENTED = "Detail-oriented", "Detail-oriented"
+        EASY_GOING = "Easy-going", "Easy-going"
+        ANXIOUS = "Anxious", "Anxious"
+        CONFIDENT = "Confident", "Confident"
+        ANALYTICAL = "Analytical", "Analytical"
+        EMOTIONAL = "Emotional", "Emotional"
+        RESERVED = "Reserved", "Reserved"
+        TALKATIVE = "Talkative", "Talkative"
+
+    class CommunicationStyleChoices(models.TextChoices):
+        DIRECT_CONCISE = "Direct and concise", "Direct and concise"
+        DETAILED_ELABORATE = "Detailed and elaborate", "Detailed and elaborate"
+        CASUAL_FRIENDLY = "Casual and friendly", "Casual and friendly"
+        FORMAL_POLITE = "Formal and polite", "Formal and polite"
+        TECHNICAL = "Technical", "Technical"
+        SIMPLE_CLEAR = "Simple and clear", "Simple and clear"
+        QUESTIONING = "Questioning", "Questioning"
+        ASSERTIVE = "Assertive", "Assertive"
+        PASSIVE = "Passive", "Passive"
+        COLLABORATIVE = "Collaborative", "Collaborative"
+
+    class AccentChoices(models.TextChoices):
+        AMERICAN = "American", "American"
+        AUSTRALIAN = "Australian", "Australian"
+        INDIAN = "Indian", "Indian"
+        CANADIAN = "Canadian", "Canadian"
+        NEUTRAL = "Neutral", "Neutral"
+
+    class LanguageChoices(models.TextChoices):
+        ENGLISH = "English", "English"
+        HINDI = "Hindi", "Hindi"
+
+    class ConversationSpeedChoices(models.TextChoices):
+        VERY_SLOW = "0.5", "Very slow"
+        SLOW = "0.75", "Slow"
+        MODERATE = "1.0", "Moderate"
+        FAST = "1.25", "Fast"
+        VERY_FAST = "1.5", "Very fast"
+
+    SimulationTypeChoices = AgentTypeChoices
+
+    class PunctuationChoices(models.TextChoices):
+        CLEAN = "clean", "Clean"
+        MINIMAL = "minimal", "Minimal"
+        EXPRESSIVE = "expressive", "Expressive"
+        ERRATIC = "erratic", "Erratic"
+
+    class EmojiUsageChoices(models.TextChoices):
+        NEVER = "never", "Never"
+        LIGHT = "light", "Light"
+        REGULAR = "regular", "Regular"
+        HEAVY = "heavy", "Heavy"
+
+    class StandardUsageChoices(models.TextChoices):
+        NONE = "none", "None"
+        MODERATE = "moderate", "Moderate"
+        HEAVY = "heavy", "Heavy"
+        LIGHT = "light", "Light"
+
+    class PersonaToneChoices(models.TextChoices):
+        FORMAL = "formal", "Formal"
+        CASUAL = "casual", "Casual"
+        NEUTRAL = "neutral", "Neutral"
+
+    class PersonaVerbosityChoices(models.TextChoices):
+        BRIEF = "brief", "Brief"
+        BALANCED = "balanced", "Balanced"
+        DETAILED = "detailed", "Detailed"
+
+    class TypoLevelChoices(models.TextChoices):
+        NONE = "none", "None"
+        RARE = "rare", "Rare"
+        OCCASIONAL = "occasional", "Occasional"
+        FREQUENT = "frequent", "Frequent"
+
+    # Primary fields
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    persona_type = models.CharField(
+        max_length=20,
+        choices=PersonaType.choices,
+        default=PersonaType.WORKSPACE,
+        help_text="Type of persona (system or workspace-level)",
+    )
+
+    persona_id = models.IntegerField(
+        default=0, help_text="Unique identifier for system personas (e.g., 1, 2, 3)"
+    )
+
+    name = models.CharField(max_length=255, help_text="Name of the persona")
+
+    description = models.TextField(
+        blank=True, null=True, help_text="Description of the persona"
+    )
+
+    # Organization and Workspace
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="personas",
+        null=True,
+        blank=True,
+        help_text="Organization this persona belongs to (null for system personas)",
+    )
+
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="personas",
+        null=True,
+        blank=True,
+        help_text="Workspace this persona belongs to (null for system personas)",
+    )
+
+    # Basic Information (choices are reference only, not enforced)
+    # All fields support multiple values as lists
+    gender = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of genders for the persona (e.g., ['male'], ['female'])",
+    )
+
+    age_group = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of age groups for the persona (e.g., ['18-25'], ['25-32'])",
+    )
+
+    occupation = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of occupations/professions for the persona (e.g., ['Engineer'], ['Teacher'])",
+    )
+
+    location = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of locations for the persona (e.g., ['United States'], ['Canada'])",
+    )
+
+    # Behavioral Profile
+    personality = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of personality types for the persona (e.g., ['Friendly and cooperative'])",
+    )
+
+    communication_style = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of communication styles for the persona (e.g., ['Direct and concise'])",
+    )
+
+    # Speech Profile
+    multilingual = models.BooleanField(
+        default=False,
+        null=True,
+        help_text="Whether the persona supports multiple languages",
+    )
+
+    languages = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of languages the persona speaks (e.g., ['English', 'Hindi'])",
+    )
+
+    accent = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of accents for the persona (e.g., ['American'], ['Australian'])",
+    )
+
+    conversation_speed = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of conversation speeds (e.g., ['1.0'], ['1.25'])",
+    )
+
+    # Advanced Settings
+    background_sound = models.BooleanField(
+        default=False,
+        null=True,
+        blank=True,
+        help_text="Whether background sound is enabled (null=not specified, True/False for enabled/disabled)",
+    )
+
+    finished_speaking_sensitivity = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of sensitivities for detecting when persona finished speaking (e.g., ['5'], ['6'])",
+    )
+
+    interrupt_sensitivity = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of sensitivities for allowing interruptions (e.g., ['5'], ['6'])",
+    )
+
+    # Keywords/Tags for the persona
+    keywords = models.JSONField(
+        default=list,
+        blank=True,
+        null=True,
+        help_text="List of keywords/tags describing the persona (e.g., ['Knowledgeable', 'Patient', 'Helpful'])",
+    )
+
+    # Additional metadata
+    metadata = models.JSONField(
+        default=dict,
+        blank=True,
+        null=True,
+        help_text="Additional metadata for the persona (speech clarity, base emotion, etc.)",
+    )
+
+    # Additional instructions for persona behavior
+    additional_instruction = models.TextField(
+        blank=True,
+        null=True,
+        help_text="Additional instructions for how this persona should behave",
+    )
+
+    # System-level persona flag
+    is_default = models.BooleanField(
+        default=False,
+        null=True,
+        help_text="Whether this is a default/recommended persona",
+    )
+
+    simulation_type = models.CharField(
+        max_length=20,
+        choices=SimulationTypeChoices.choices,
+        default=SimulationTypeChoices.VOICE,
+        help_text="Type of simulation for the persona",
+    )
+
+    punctuation = models.CharField(
+        max_length=20,
+        choices=PunctuationChoices.choices,
+        help_text="Punctuation style for the persona",
+        null=True,
+        blank=True,
+    )
+
+    slang_usage = models.CharField(
+        max_length=20,
+        choices=StandardUsageChoices.choices,
+        help_text="Slang usage for the persona",
+        null=True,
+        blank=True,
+    )
+
+    typos_frequency = models.CharField(
+        max_length=20,
+        choices=TypoLevelChoices.choices,
+        help_text="Typos frequency for the persona",
+        null=True,
+        blank=True,
+    )
+
+    regional_mix = models.CharField(
+        max_length=20,
+        choices=StandardUsageChoices.choices,
+        help_text="Regional mix for the persona",
+        null=True,
+        blank=True,
+    )
+
+    emoji_usage = models.CharField(
+        max_length=20,
+        choices=EmojiUsageChoices.choices,
+        help_text="Emoji usage for the persona",
+        null=True,
+        blank=True,
+    )
+
+    tone = models.CharField(
+        max_length=20,
+        choices=PersonaToneChoices.choices,
+        help_text="Tone for the persona",
+        null=True,
+        blank=True,
+    )
+
+    verbosity = models.CharField(
+        max_length=20,
+        choices=PersonaVerbosityChoices.choices,
+        help_text="Verbosity for the persona",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        db_table = "simulate_personas"
+        verbose_name = "Persona"
+        verbose_name_plural = "Personas"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["persona_type"]),
+            models.Index(fields=["organization", "workspace"]),
+        ]
+        constraints = [
+            # System personas should not have organization or workspace
+            models.CheckConstraint(
+                check=(
+                    models.Q(
+                        persona_type="system",
+                        organization__isnull=True,
+                        workspace__isnull=True,
+                    )
+                    | models.Q(persona_type="workspace")
+                ),
+                name="system_persona_no_org_workspace",
+            ),
+            # Workspace personas must have organization
+            models.CheckConstraint(
+                check=(
+                    models.Q(persona_type="workspace", organization__isnull=False)
+                    | models.Q(persona_type="system")
+                ),
+                name="workspace_persona_has_org",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.name} ({self.get_persona_type_display()})"
+
+    def clean(self):
+        """Custom validation - minimal validation for now"""
+        if not self.name or not self.name.strip():
+            raise ValidationError({"name": "Name cannot be empty or just whitespace."})
+
+        # Validate system personas don't have organization/workspace
+        if self.persona_type == self.PersonaType.SYSTEM:
+            if self.organization or self.workspace:
+                raise ValidationError(
+                    {
+                        "persona_type": "System personas cannot be associated with an organization or workspace."
+                    }
+                )
+
+        # Validate workspace personas have organization
+        if self.persona_type == self.PersonaType.WORKSPACE:
+            if not self.organization:
+                raise ValidationError(
+                    {
+                        "organization": "Workspace personas must be associated with an organization."
+                    }
+                )
+
+    def to_voice_mapper_dict(self):
+        """
+        Convert persona to dictionary format expected by voice_mapper.py
+        Takes the first value from each list field or uses a default
+        """
+        return {
+            "gender": self.gender[0] if self.gender else "male",
+            "age_group": self.age_group[0] if self.age_group else "18-25",
+            "profession": self.occupation[0] if self.occupation else "Other",
+            "location": self.location[0] if self.location else "United States",
+            "personality": (
+                self.personality[0] if self.personality else "Friendly and cooperative"
+            ),
+            "communication_style": (
+                self.communication_style[0]
+                if self.communication_style
+                else "Direct and concise"
+            ),
+            "accent": self.accent[0] if self.accent else "Neutral",
+            "language": self.languages[0] if self.languages else "English",
+            "conversation_speed": (
+                self.conversation_speed[0] if self.conversation_speed else "1.0"
+            ),
+            "background_sound": (
+                str(self.background_sound).lower()
+                if self.background_sound is not None
+                else "false"
+            ),
+            "finished_speaking_sensitivity": (
+                self.finished_speaking_sensitivity[0]
+                if self.finished_speaking_sensitivity
+                else "5"
+            ),
+            "interrupt_sensitivity": (
+                self.interrupt_sensitivity[0] if self.interrupt_sensitivity else "5"
+            ),
+        }

--- a/futureagi/simulate/models/prompt_trial.py
+++ b/futureagi/simulate/models/prompt_trial.py
@@ -1,0 +1,33 @@
+import uuid
+
+from django.db import models
+
+from simulate.models.agent_prompt_optimiser_run import AgentPromptOptimiserRun
+from tfc.utils.base_model import BaseModel
+
+
+class PromptTrial(BaseModel):
+    """
+    Represents a single trial in an agent prompt optimiser run.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    agent_prompt_optimiser_run = models.ForeignKey(
+        AgentPromptOptimiserRun,
+        on_delete=models.CASCADE,
+        related_name="trials",
+    )
+    trial_number = models.IntegerField()
+    is_baseline = models.BooleanField(default=False)
+    prompt = models.TextField(null=True, blank=True)
+    average_score = models.FloatField()
+    metadata = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        db_table = "prompt_trial"
+        unique_together = ("agent_prompt_optimiser_run", "trial_number")
+        ordering = ["trial_number"]
+
+    def __str__(self):
+        label = "Baseline" if self.is_baseline else f"Trial {self.trial_number}"
+        return f"{self.agent_prompt_optimiser_run_id} - {label} (score: {self.average_score:.2f})"

--- a/futureagi/simulate/models/run_test.py
+++ b/futureagi/simulate/models/run_test.py
@@ -1,0 +1,187 @@
+import uuid
+
+from django.contrib.postgres.fields import ArrayField
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from simulate.models.agent_version import AgentVersion
+from tfc.utils.base_model import BaseModel
+
+from .agent_definition import AgentDefinition
+from .scenarios import Scenarios
+from .simulator_agent import SimulatorAgent
+
+
+class RunTest(BaseModel):
+    """
+    Model to store test runs with agent definitions, scenarios, and evaluations
+    """
+
+    class SourceTypes(models.TextChoices):
+        AGENT_DEFINITION = "agent_definition", "Agent Definition"
+        PROMPT = "prompt", "Prompt"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    name = models.CharField(max_length=255, help_text="Name of the test run")
+
+    description = models.TextField(
+        blank=True, null=True, help_text="Description of the test run"
+    )
+
+    agent_definition = models.ForeignKey(
+        AgentDefinition,
+        on_delete=models.CASCADE,
+        related_name="run_tests",
+        help_text="Agent definition for this test run",
+        null=True,
+        blank=True,
+    )
+
+    agent_version = models.ForeignKey(
+        AgentVersion,
+        on_delete=models.CASCADE,
+        related_name="run_tests",
+        help_text="Agent version for this test run",
+        null=True,
+        blank=True,
+    )
+
+    source_type = models.CharField(
+        max_length=20,
+        choices=SourceTypes.choices,
+        default=SourceTypes.AGENT_DEFINITION,
+        help_text="Source type for the test run: agent_definition or prompt",
+    )
+
+    prompt_template = models.ForeignKey(
+        "model_hub.PromptTemplate",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="run_tests",
+        help_text="Prompt template for this test run (only for prompt source type)",
+    )
+
+    prompt_version = models.ForeignKey(
+        "model_hub.PromptVersion",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="run_tests",
+        help_text="Prompt version for this test run (only for prompt source type)",
+    )
+
+    scenarios = models.ManyToManyField(
+        Scenarios, related_name="run_tests", help_text="Scenarios to run in this test"
+    )
+
+    dataset_row_ids: ArrayField = ArrayField(
+        models.CharField(max_length=255),
+        blank=True,
+        default=list,
+        help_text="IDs of dataset rows to run evaluations on",
+    )
+
+    simulator_agent = models.ForeignKey(
+        SimulatorAgent,
+        on_delete=models.CASCADE,
+        related_name="run_tests",
+        null=True,
+        blank=True,
+        help_text="Simulator agent for this test run (derived from scenarios)",
+    )
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="run_tests",
+        help_text="Organization this test run belongs to",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="run_tests",
+        null=True,
+        blank=True,
+    )
+
+    enable_tool_evaluation = models.BooleanField(
+        default=False, help_text="Enable automatic tool evaluation for this test run"
+    )
+
+    class Meta:
+        db_table = "simulate_run_test"
+        verbose_name = "Run Test"
+        verbose_name_plural = "Run Tests"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(
+                fields=["organization_id"], name="idx_runtest_organization_id"
+            ),
+        ]
+
+    def __str__(self):
+        if self.agent_definition:
+            return f"{self.name} - {self.agent_definition.agent_name}"
+        return self.name
+
+
+class CreateCallExecution(BaseModel):
+    """
+    Model to store call count
+    """
+
+    class CallStatus(models.TextChoices):
+        PENDING = "pending", "Pending"
+        REGISTERED = "registered", "Registered"
+        ONGOING = "ongoing", "Ongoing"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+        CANCELLED = "cancelled", "Cancelled"
+
+    phone_number_id = models.CharField(
+        max_length=255, help_text="The phone number ID to create the call execution for"
+    )
+
+    to_number = models.CharField(
+        max_length=255, help_text="The phone number to create the call execution for"
+    )
+
+    system_prompt = models.TextField(
+        help_text="The system prompt to create the call execution for"
+    )
+
+    metadata = models.JSONField(
+        help_text="The metadata to create the call execution for"
+    )
+
+    voice_settings = models.JSONField(
+        help_text="The voice settings to create the call execution for"
+    )
+
+    call_execution = models.ForeignKey(
+        "simulate.CallExecution",
+        on_delete=models.CASCADE,
+        related_name="create_call_executions",
+        help_text="The call execution this call count belongs to",
+    )
+
+    status = models.CharField(
+        max_length=255,
+        choices=CallStatus.choices,
+        default=CallStatus.REGISTERED,
+        help_text="The status of the call execution ",
+    )
+
+    class Meta:
+        db_table = "simulate_createcallexecution"
+        verbose_name = "Create Call Execution"
+        verbose_name_plural = "Create Call Executions"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(
+                fields=["status", "deleted", "created_at"], name="idx_createcall_status"
+            ),
+        ]

--- a/futureagi/simulate/models/scenario_graph.py
+++ b/futureagi/simulate/models/scenario_graph.py
@@ -1,0 +1,100 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from tfc.utils.base_model import BaseModel
+
+
+class ScenarioGraph(BaseModel):
+    """Main graph container that groups related cases"""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # Foreign keys
+    scenario = models.ForeignKey(
+        "simulate.Scenarios",
+        on_delete=models.CASCADE,
+        related_name="graphs",
+        help_text="Scenario that owns this graph",
+    )
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="scenario_graphs",
+        help_text="Organization this graph belongs to",
+    )
+
+    # Graph metadata
+    name = models.CharField(max_length=255, help_text="Graph name")
+    description = models.TextField(
+        blank=True, default="", help_text="Optional description"
+    )
+
+    version = models.IntegerField(default=1)
+    is_active = models.BooleanField(default=True)
+
+    # Graph configuration (not the actual data)
+    graph_config = models.JSONField(
+        default=dict, help_text="Graph settings, styling, etc."
+    )
+
+    class Meta:
+        db_table = "simulate_scenario_graph"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["scenario", "is_active"]),
+            models.Index(fields=["organization", "is_active"]),
+        ]
+
+    def __str__(self):
+        return f"{self.name} (v{self.version})"
+
+    @property
+    def total_cases(self):
+        """Get total number of active cases in this graph"""
+        return self.cases.filter(is_active=True).count()
+
+    def get_cases_ordered(self):
+        """Get all active cases ordered by their order field"""
+        return self.cases.filter(is_active=True).order_by("order")
+
+
+# Node types constants for reference
+class NodeType:
+    """Constants for scenario node types"""
+
+    START = "start"
+    MESSAGE = "message"
+    CONDITION = "condition"
+    END = "end"
+
+    # All valid node types
+    ALL_TYPES = [START, MESSAGE, CONDITION, END]
+
+    # Terminal node types (nodes that end a conversation path)
+    TERMINAL_TYPES = [END]
+
+    # Non-terminal node types
+    NON_TERMINAL_TYPES = [START, MESSAGE, CONDITION]
+
+    @classmethod
+    def is_valid(cls, node_type: str) -> bool:
+        """Check if a node type is valid"""
+        return node_type in cls.ALL_TYPES
+
+    @classmethod
+    def is_terminal(cls, node_type: str) -> bool:
+        """Check if a node type is terminal"""
+        return node_type in cls.TERMINAL_TYPES
+
+    @classmethod
+    def get_display_name(cls, node_type: str) -> str:
+        """Get display name for a node type"""
+        display_names = {
+            cls.START: "Start",
+            cls.MESSAGE: "Message",
+            cls.CONDITION: "Condition",
+            cls.END: "End",
+        }
+        return display_names.get(node_type, node_type.title())

--- a/futureagi/simulate/models/scenarios.py
+++ b/futureagi/simulate/models/scenarios.py
@@ -1,0 +1,136 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.choices import StatusType
+from tfc.utils.base_model import BaseModel
+
+
+class Scenarios(BaseModel):
+    """
+    Model to store different types of simulation scenarios
+    """
+
+    class ScenarioTypes(models.TextChoices):
+        GRAPH = "graph", "Graph"
+        SCRIPT = "script", "Script"
+        DATASET = "dataset", "Dataset"
+
+    class SourceTypes(models.TextChoices):
+        AGENT_DEFINITION = "agent_definition", "Agent Definition"
+        PROMPT = "prompt", "Prompt"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    name = models.CharField(max_length=255, help_text="Name of the scenario")
+
+    description = models.TextField(
+        blank=True, null=True, help_text="Optional description of the scenario"
+    )
+
+    source = models.TextField(help_text="Source content or reference for the scenario")
+
+    scenario_type = models.CharField(
+        max_length=20,
+        choices=ScenarioTypes.choices,
+        default=ScenarioTypes.DATASET,
+        help_text="Type of scenario (graph, script, or dataset)",
+    )
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="scenarios",
+        help_text="Organization this scenario belongs to",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="scenarios",
+        null=True,
+        blank=True,
+    )
+
+    dataset = models.ForeignKey(
+        "model_hub.Dataset",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="scenarios",
+        help_text="Dataset associated with this scenario (only for dataset type scenarios)",
+    )
+
+    agent_definition = models.ForeignKey(
+        "simulate.AgentDefinition",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="scenarios",
+        help_text="Agent definition associated with this scenario",
+    )
+
+    source_type = models.CharField(
+        max_length=20,
+        choices=SourceTypes.choices,
+        default=SourceTypes.AGENT_DEFINITION,
+        help_text="Source type for the scenario: agent_definition or prompt",
+    )
+
+    prompt_template = models.ForeignKey(
+        "model_hub.PromptTemplate",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="scenarios",
+        help_text="Prompt template associated with this scenario (only for prompt source type)",
+    )
+
+    prompt_version = models.ForeignKey(
+        "model_hub.PromptVersion",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="scenarios",
+        help_text="Prompt version associated with this scenario (only for prompt source type)",
+    )
+
+    simulator_agent = models.ForeignKey(
+        "simulate.SimulatorAgent",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="scenarios",
+        help_text="Simulator agent associated with this scenario",
+    )
+
+    metadata = models.JSONField(
+        default=dict, blank=True, help_text="Metadata associated with this scenario"
+    )
+    status = models.CharField(
+        max_length=50,
+        choices=StatusType.get_choices(),
+        default=StatusType.RUNNING.value,
+        help_text="Status of the scenario",
+    )
+
+    class Meta:
+        db_table = "simulate_scenarios"
+        verbose_name = "Scenario"
+        verbose_name_plural = "Scenarios"
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"{self.name}"
+
+    def clean(self):
+        """Custom validation"""
+        if not self.name.strip():
+            raise ValidationError({"name": "Name cannot be empty or just whitespace."})
+
+        if not self.source.strip():
+            raise ValidationError(
+                {"source": "Source cannot be empty or just whitespace."}
+            )

--- a/futureagi/simulate/models/simulation_phone_number.py
+++ b/futureagi/simulate/models/simulation_phone_number.py
@@ -1,0 +1,80 @@
+import uuid
+
+from django.db import models
+from django.utils import timezone
+
+from tfc.utils.base_model import BaseModel
+
+
+class SimulationPhoneNumber(BaseModel):
+    """
+    Model to manage phone number pool for simulation calls
+    Tracks phone numbers, their usage status, and call direction
+    """
+
+    class CallDirection(models.TextChoices):
+        INBOUND = "inbound", "Inbound"
+        OUTBOUND = "outbound", "Outbound"
+
+    class PhoneStatus(models.TextChoices):
+        IDLE = "idle", "Idle"
+        IN_USE = "in_use", "In Use"
+        DISABLED = "disabled", "Disabled"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    phone_number = models.CharField(
+        max_length=20,
+        unique=True,
+        help_text="Phone number in E.164 format (e.g., +15551234567)",
+    )
+
+    provider_phone_id = models.CharField(max_length=255, unique=True)
+
+    call_direction = models.CharField(
+        max_length=20, choices=CallDirection.choices, default=CallDirection.OUTBOUND
+    )
+
+    status = models.CharField(
+        max_length=20, choices=PhoneStatus.choices, default=PhoneStatus.IDLE
+    )
+
+    current_call_execution = models.ForeignKey(
+        "simulate.CallExecution",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="assigned_phone_number",
+        help_text="The call execution currently using this phone number",
+    )
+
+    last_used_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "simulate_phone_numbers"
+        indexes = [
+            models.Index(fields=["call_direction", "status", "last_used_at"]),
+            models.Index(fields=["status", "call_direction"]),
+            models.Index(fields=["phone_number"]),
+        ]
+
+    def __str__(self):
+        return f"{self.phone_number} ({self.get_call_direction_display()}) - {self.get_status_display()}"
+
+    def mark_in_use(self, call_execution):
+        """Mark this phone number as in use"""
+        self.status = self.PhoneStatus.IN_USE
+        self.current_call_execution = call_execution
+        self.last_used_at = timezone.now()
+        self.save()
+
+    def mark_idle(self):
+        """Mark this phone number as idle and available"""
+        self.status = self.PhoneStatus.IDLE
+        self.current_call_execution = None
+        self.save()
+
+    @property
+    def is_available(self):
+        """Check if this phone number is available for use"""
+        return self.status == self.PhoneStatus.IDLE

--- a/futureagi/simulate/models/simulator_agent.py
+++ b/futureagi/simulate/models/simulator_agent.py
@@ -1,0 +1,77 @@
+import uuid
+
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class SimulatorAgent(BaseModel):
+    """Model for simulator agents with voice and conversation settings"""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255, help_text="Name of the simulator agent")
+    prompt = models.TextField(help_text="System prompt for the agent")
+    voice_provider = models.CharField(
+        max_length=100, help_text="Voice service provider"
+    )
+    voice_name = models.CharField(max_length=100, help_text="Specific voice to use")
+    interrupt_sensitivity = models.FloatField(
+        validators=[MinValueValidator(0.0), MaxValueValidator(11.0)],
+        default=0.5,
+        help_text="Sensitivity for interruption detection (0-1)",
+    )
+    conversation_speed = models.FloatField(
+        validators=[MinValueValidator(0.1), MaxValueValidator(2.0)],
+        default=1.0,
+        help_text="Speed of conversation (0.1-3.0)",
+    )
+    finished_speaking_sensitivity = models.FloatField(
+        validators=[MinValueValidator(0.0), MaxValueValidator(11.0)],
+        default=0.5,
+        help_text="Sensitivity for detecting when speaker has finished (0-1)",
+    )
+    model = models.CharField(max_length=100, help_text="LLM model to use")
+    llm_temperature = models.FloatField(
+        validators=[MinValueValidator(0.0), MaxValueValidator(2.0)],
+        default=0.7,
+        help_text="Temperature setting for LLM (0-2)",
+    )
+    max_call_duration_in_minutes = models.IntegerField(
+        validators=[MinValueValidator(0), MaxValueValidator(180)],
+        default=30,
+        help_text="Maximum call duration in minutes (1-180)",
+    )
+    initial_message_delay = models.IntegerField(
+        validators=[MinValueValidator(0), MaxValueValidator(60)],
+        default=0,
+        help_text="Delay before initial message in seconds (0-60)",
+    )
+    initial_message = models.TextField(
+        blank=True,
+        default="",
+        help_text="Initial message to send when conversation starts",
+    )
+
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="simulator_agents",
+        help_text="Organization this simulator agent belongs to",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="simulator_agents",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        db_table = "simulator_agents"
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return self.name

--- a/futureagi/simulate/models/test_execution.py
+++ b/futureagi/simulate/models/test_execution.py
@@ -1,0 +1,796 @@
+import uuid
+
+from django.db import models  # type: ignore[import-not-found]
+from django.utils import timezone  # type: ignore[import-not-found]
+
+from simulate.models.agent_optimiser import AgentOptimiser
+from simulate.models.agent_version import AgentVersion
+from simulate.models.run_test import RunTest
+from simulate.semantics import validate_provider_sent_objects
+from tfc.utils.base_model import BaseModel, Deprecated
+
+from .agent_definition import AgentDefinition, AgentTypeChoices
+from .scenarios import Scenarios
+from .simulator_agent import SimulatorAgent
+
+
+class EvalExplanationSummaryStatus(models.TextChoices):
+    PENDING = "pending", "Pending"
+    RUNNING = "running", "Running"
+    COMPLETED = "completed", "Completed"
+    FAILED = "failed", "Failed"
+
+
+class TestExecution(BaseModel):
+    """
+    Model to store test execution results
+    """
+
+    class ExecutionStatus(models.TextChoices):
+        PENDING = "pending", "Pending"
+        RUNNING = "running", "Running"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+        CANCELLED = "cancelled", "Cancelled"
+        CANCELLING = "cancelling", "Cancelling"
+        EVALUATING = "evaluating", "Evaluating"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    run_test = models.ForeignKey(
+        RunTest,
+        on_delete=models.CASCADE,
+        related_name="executions",
+        help_text="The run test being executed",
+    )
+
+    status = models.CharField(
+        max_length=20,
+        choices=ExecutionStatus.choices,
+        default=ExecutionStatus.PENDING,
+        help_text="Current status of the test execution",
+    )
+
+    started_at = models.DateTimeField(
+        default=timezone.now, help_text="When the test execution started"
+    )
+
+    completed_at = models.DateTimeField(
+        null=True, blank=True, help_text="When the test execution completed"
+    )
+
+    total_scenarios = models.IntegerField(
+        default=0, help_text="Total number of scenarios in this execution"
+    )
+
+    scenario_ids = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="List of scenario IDs that were executed in this run",
+    )
+
+    total_calls = models.IntegerField(
+        default=0, help_text="Total number of calls to be made"
+    )
+
+    completed_calls = models.IntegerField(
+        default=0, help_text="Number of successfully completed calls"
+    )
+
+    failed_calls = models.IntegerField(default=0, help_text="Number of failed calls")
+
+    execution_metadata = models.JSONField(
+        default=dict, blank=True, help_text="Additional metadata about the execution"
+    )
+
+    picked_up_by_executor = models.BooleanField(
+        default=False,
+        help_text="Whether the test execution was picked up by the executor",
+    )
+
+    # New fields for storing simulator and agent definition used
+    simulator_agent = models.ForeignKey(
+        SimulatorAgent,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="test_executions_simulation",
+        help_text="Simulator agent used for this test execution",
+    )
+
+    agent_definition = models.ForeignKey(
+        AgentDefinition,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="test_executions_agent",
+        help_text="Agent definition used for this test execution",
+    )
+
+    agent_version = models.ForeignKey(
+        AgentVersion,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="test_executions_agent_version",
+        help_text="Agent version used for this test execution",
+    )
+
+    eval_explanation_summary = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Evaluation explanation summary for each eval config",
+    )
+
+    eval_explanation_summary_last_updated = models.DateTimeField(
+        null=True,
+        blank=True,
+    )
+
+    eval_explanation_summary_status = models.CharField(
+        max_length=20,
+        choices=EvalExplanationSummaryStatus.choices,
+        default=EvalExplanationSummaryStatus.PENDING,
+        help_text="Status of the evaluation explanation summary",
+    )
+
+    agent_optimiser = models.ForeignKey(
+        AgentOptimiser,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="test_executions",
+        help_text="Agent optimiser used for this test execution",
+    )
+
+    error_reason = models.CharField(blank=True, null=True)
+
+    class Meta:
+        db_table = "simulate_test_execution"
+        verbose_name = "Test Execution"
+        verbose_name_plural = "Test Executions"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(
+                fields=["status", "picked_up_by_executor"], name="idx_status_executor"
+            ),
+            models.Index(fields=["run_test_id"], name="idx_testexecution_run_test_id"),
+        ]
+
+    def __str__(self):
+        return f"{self.run_test.name} - {self.status}"
+
+    @property
+    def duration_seconds(self):
+        """Calculate total duration in seconds by summing all call execution durations"""
+        total_duration = 0
+        for call in self.calls.all():
+            if call.duration_seconds is not None:
+                total_duration += call.duration_seconds
+        return int(total_duration) if total_duration > 0 else None
+
+    @property
+    def success_rate(self):
+        """Calculate success rate as percentage"""
+        if self.total_calls > 0:
+            return (self.completed_calls / self.total_calls) * 100
+        return 0
+
+
+class CallExecution(BaseModel):
+    """
+    Model to store individual call execution details
+    """
+
+    class CallStatus(models.TextChoices):
+        PENDING = "pending", "Pending"
+        REGISTERED = "queued", "Queued"
+        ONGOING = "ongoing", "Ongoing"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+        ANALYZING = "analyzing", "Analyzing"
+        CANCELLED = "cancelled", "Cancelled"
+
+    # Reuse agent type choices (voice/text) to avoid repeating the same values across models.
+    SimulationCallType = AgentTypeChoices
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    test_execution = models.ForeignKey(
+        TestExecution,
+        on_delete=models.CASCADE,
+        related_name="calls",
+        help_text="The test execution this call belongs to",
+    )
+
+    simulation_call_type = models.CharField(
+        max_length=20,
+        choices=SimulationCallType.choices,
+        default=SimulationCallType.VOICE,
+        help_text="Type of simulation call",
+    )
+
+    scenario = models.ForeignKey(
+        Scenarios,
+        on_delete=models.CASCADE,
+        related_name="call_executions",
+        help_text="The scenario this call belongs to",
+    )
+
+    phone_number = models.CharField(
+        max_length=20,
+        null=True,
+        blank=True,
+        help_text="Phone number called (null for TEXT/chat simulations)",
+    )
+
+    service_provider_call_id = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="Service provider call ID for tracking",
+    )
+
+    status = models.CharField(
+        max_length=20,
+        choices=CallStatus.choices,
+        default=CallStatus.PENDING,
+        help_text="Current status of the call",
+    )
+
+    started_at = models.DateTimeField(
+        null=True, blank=True, help_text="When the call started"
+    )
+
+    completed_at = models.DateTimeField(
+        null=True, blank=True, help_text="When the call completed"
+    )
+
+    duration_seconds = models.IntegerField(
+        null=True, blank=True, help_text="Duration of the call in seconds"
+    )
+
+    recording_url = models.URLField(
+        max_length=500, null=True, blank=True, help_text="URL to the call recording"
+    )
+
+    cost_cents = models.IntegerField(
+        null=True, blank=True, help_text="Cost of the call in cents"
+    )
+
+    call_metadata = models.JSONField(
+        default=dict, blank=True, help_text="Additional metadata about the call"
+    )
+
+    error_message = models.TextField(
+        null=True, blank=True, help_text="Error message if the call failed"
+    )
+
+    # Additional fields for storing complete call data
+    provider_call_data = models.JSONField(
+        null=True,
+        blank=True,
+        validators=[validate_provider_sent_objects],
+        help_text="Complete call data from the provider. Format: dict[provider_name, data] where provider_name must be from SupportedProviders",
+    )
+
+    monitor_call_data = models.JSONField(
+        null=True, blank=True, help_text="Monitor call data from API"
+    )
+
+    logs_ingested_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="When call logs were last ingested from the provider",
+    )
+
+    logs_summary = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Lightweight summary of ingested call logs (e.g., counts by level)",
+    )
+
+    customer_logs_summary = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Summary of customer call logs (e.g., counts by level)",
+    )
+
+    stereo_recording_url = models.URLField(
+        max_length=500,
+        null=True,
+        blank=True,
+        help_text="Stereo recording URL from Vapi",
+    )
+
+    customer_log_url = models.URLField(
+        max_length=10000,
+        null=True,
+        blank=True,
+        help_text="Customer call log URL from the service provider",
+    )
+
+    call_summary = models.TextField(
+        null=True, blank=True, help_text="Call summary from the service"
+    )
+
+    ended_reason = models.CharField(
+        max_length=10000, null=True, blank=True, help_text="Reason why the call ended"
+    )
+
+    # Cost breakdown fields
+    stt_cost_cents = models.IntegerField(
+        null=True, blank=True, help_text="STT cost in cents"
+    )
+
+    llm_cost_cents = models.IntegerField(
+        null=True, blank=True, help_text="LLM cost in cents"
+    )
+
+    tts_cost_cents = models.IntegerField(
+        null=True, blank=True, help_text="TTS cost in cents"
+    )
+
+    storage_cost_cents = models.FloatField(
+        null=True, blank=True, help_text="S3 recording storage cost in cents"
+    )
+
+    vapi_cost_cents = Deprecated(
+        models.IntegerField(
+            null=True, blank=True, help_text="Vapi platform cost in cents"
+        )
+    )
+
+    # Performance metrics
+    overall_score = models.FloatField(
+        null=True, blank=True, help_text="Overall call performance score"
+    )
+
+    response_time_ms = models.IntegerField(
+        null=True, blank=True, help_text="Average response time in milliseconds"
+    )
+
+    # Additional call details
+    assistant_id = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="Assistant ID used for the call (system side)",
+    )
+
+    customer_number = models.CharField(
+        max_length=20,
+        null=True,
+        blank=True,
+        help_text="Customer phone number (E.164 format)",
+    )
+
+    call_type = models.CharField(
+        max_length=50,
+        null=True,
+        blank=True,
+        help_text="Type of call (e.g., outboundPhoneCall)",
+    )
+
+    ended_at = models.DateTimeField(
+        null=True, blank=True, help_text="When the call ended"
+    )
+
+    # Analysis and evaluation fields
+    analysis_data = models.JSONField(
+        null=True, blank=True, help_text="Call analysis data from the service provider"
+    )
+
+    evaluation_data = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Call evaluation data from the service provider",
+    )
+
+    # Message and transcript metadata
+    message_count = models.IntegerField(
+        null=True, blank=True, help_text="Number of messages in the call"
+    )
+
+    transcript_available = models.BooleanField(
+        default=False, help_text="Whether transcript is available"
+    )
+
+    recording_available = models.BooleanField(
+        default=False, help_text="Whether recording is available"
+    )
+
+    row_id = models.UUIDField(
+        null=True,
+        blank=True,
+        help_text="Row ID from the dataset if this call is from a dataset scenario",
+    )
+
+    eval_outputs = models.JSONField(
+        null=True, blank=True, help_text="Evaluation output"
+    )
+
+    tool_outputs = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Tool evaluation output - separate from standard evaluations",
+    )
+
+    agent_version = models.ForeignKey(
+        AgentVersion,
+        on_delete=models.CASCADE,
+        related_name="call_executions",
+        null=True,
+    )
+
+    customer_call_id = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="Customer call ID if available",
+    )
+    customer_cost_cents = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Total customer-reported cost in cents",
+    )
+    customer_cost_breakdown = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Detailed cost breakdown from customer call data",
+    )
+    customer_latency_metrics = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Latency metrics from customer call data",
+    )
+    # Conversation Metrics Fields
+    avg_agent_latency_ms = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Average agent latency in milliseconds (time taken by agent to respond after user's pause)",
+    )
+
+    user_interruption_count = models.IntegerField(
+        null=True, blank=True, help_text="Number of times user interrupted the AI"
+    )
+
+    user_interruption_rate = models.FloatField(
+        null=True,
+        blank=True,
+        help_text="Rate of user interruptions (interruptions per minute)",
+    )
+
+    user_wpm = models.FloatField(
+        null=True, blank=True, help_text="User's words per minute"
+    )
+
+    bot_wpm = models.FloatField(
+        null=True, blank=True, help_text="Bot's words per minute"
+    )
+
+    talk_ratio = models.FloatField(
+        null=True,
+        blank=True,
+        help_text="Ratio of bot speaking time to user speaking time",
+    )
+
+    ai_interruption_count = models.IntegerField(
+        null=True, blank=True, help_text="Number of times AI interrupted the user"
+    )
+
+    ai_interruption_rate = models.FloatField(
+        null=True,
+        blank=True,
+        help_text="Rate of AI interruptions (interruptions per minute)",
+    )
+
+    avg_stop_time_after_interruption_ms = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text="Average stop time after user interruption in milliseconds",
+    )
+
+    conversation_metrics_data = models.JSONField(
+        null=True, blank=True, help_text="Detailed conversation metrics data"
+    )
+
+    def clean(self):
+        """
+        Validate model fields including custom validators for JSONFields.
+        This ensures Pydantic validation runs on provider_call_data.
+        """
+        super().clean()
+        # Django will automatically call field validators, including validate_provider_call_data
+
+    # Fields that get reset by reset_to_default - used for bulk_update operations
+    RESET_FIELDS = [
+        "monitor_call_data",
+        "provider_call_data",
+        "service_provider_call_id",
+        "customer_call_id",
+        "status",
+        "started_at",
+        "completed_at",
+        "ended_at",
+        "duration_seconds",
+        "recording_url",
+        "stereo_recording_url",
+        "cost_cents",
+        "stt_cost_cents",
+        "llm_cost_cents",
+        "tts_cost_cents",
+        "vapi_cost_cents",
+        "call_summary",
+        "ended_reason",
+        "overall_score",
+        "response_time_ms",
+        "assistant_id",
+        "customer_number",
+        "call_type",
+        "analysis_data",
+        "evaluation_data",
+        "message_count",
+        "transcript_available",
+        "recording_available",
+        "eval_outputs",
+        "tool_outputs",
+        "avg_agent_latency_ms",
+        "user_interruption_count",
+        "user_interruption_rate",
+        "user_wpm",
+        "bot_wpm",
+        "talk_ratio",
+        "ai_interruption_count",
+        "ai_interruption_rate",
+        "avg_stop_time_after_interruption_ms",
+        "conversation_metrics_data",
+    ]
+
+    def reset_to_default(self, save: bool = True):
+        """
+        Reset call execution fields to their default values for rerun.
+
+        Args:
+            save: If True (default), saves the model after resetting.
+                  Set to False for bulk operations where you'll call bulk_update.
+        """
+        self.monitor_call_data = None
+        # Clear provider-neutral metadata and payloads so reruns re-fetch data
+        self.provider_call_data = None
+        self.service_provider_call_id = None
+        self.customer_call_id = None
+        self.status = CallExecution.CallStatus.PENDING
+        self.started_at = None
+        self.completed_at = None
+        self.ended_at = None
+        self.duration_seconds = None
+        self.recording_url = None
+        self.stereo_recording_url = None
+        self.cost_cents = None
+        self.stt_cost_cents = None
+        self.llm_cost_cents = None
+        self.tts_cost_cents = None
+        self.storage_cost_cents = None
+        self.vapi_cost_cents = None
+        self.call_summary = None
+        self.ended_reason = None
+        self.overall_score = None
+        self.response_time_ms = None
+        self.assistant_id = None
+        self.customer_number = None
+        self.call_type = None
+        self.analysis_data = None
+        self.evaluation_data = None
+        self.message_count = None
+        self.transcript_available = False
+        self.recording_available = False
+        self.eval_outputs = {}
+        self.tool_outputs = {}
+        self.avg_agent_latency_ms = None
+        self.user_interruption_count = None
+        self.user_interruption_rate = None
+        self.user_wpm = None
+        self.bot_wpm = None
+        self.talk_ratio = None
+        self.ai_interruption_count = None
+        self.ai_interruption_rate = None
+        self.avg_stop_time_after_interruption_ms = None
+        self.conversation_metrics_data = None
+
+        if not isinstance(self.call_metadata, dict):
+            self.call_metadata = {}
+        self.call_metadata.pop("eval_started", None)
+        self.call_metadata.pop("eval_completed", None)
+        self.call_metadata.pop("processing_skipped", None)
+        self.call_metadata.pop("processing_skip_reason", None)
+
+        if save:
+            self.save()
+
+    class Meta:
+        db_table = "simulate_call_execution"
+        verbose_name = "Call Execution"
+        verbose_name_plural = "Call Executions"
+        ordering = ["-updated_at"]
+        indexes = [
+            models.Index(fields=["status"], name="idx_callexecution_status"),
+            models.Index(
+                fields=["test_execution", "status"],
+                name="idx_callexec_testexec_status",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.phone_number} - {self.status}"
+
+    @property
+    def is_successful(self):
+        """Check if the call was successful"""
+        return self.status == self.CallStatus.COMPLETED
+
+    @property
+    def is_failed(self):
+        """Check if the call failed"""
+        return self.status in [self.CallStatus.FAILED, self.CallStatus.CANCELLED]
+
+
+class CallTranscript(BaseModel):
+    """
+    Model to store call transcript data
+    """
+
+    class SpeakerRole(models.TextChoices):
+        USER = "user", "User"
+        ASSISTANT = "assistant", "Assistant"
+        SYSTEM = "system", "System"
+        TOOL_CALLS = "tool_calls", "Tool Calls"
+        TOOL_CALL_RESULT = "tool_call_result", "Tool Call Result"
+        UNKNOWN = "unknown", "Unknown"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    call_execution = models.ForeignKey(
+        CallExecution,
+        on_delete=models.CASCADE,
+        related_name="transcripts",
+        help_text="The call execution this transcript belongs to",
+    )
+
+    speaker_role = models.CharField(
+        max_length=20,
+        choices=SpeakerRole.choices,
+        default=SpeakerRole.UNKNOWN,
+        help_text="Role of the speaker (user or assistant)",
+    )
+
+    content = models.TextField(help_text="Transcript content")
+
+    start_time_ms = models.BigIntegerField(
+        default=0, help_text="Start time of this transcript segment in milliseconds"
+    )
+
+    end_time_ms = models.BigIntegerField(
+        default=0, help_text="End time of this transcript segment in milliseconds"
+    )
+
+    confidence_score = models.FloatField(
+        default=1.0, help_text="Confidence score for this transcript segment"
+    )
+
+    class Meta:
+        db_table = "simulate_call_transcript"
+        verbose_name = "Call Transcript"
+        verbose_name_plural = "Call Transcripts"
+        ordering = ["start_time_ms"]
+
+    def __str__(self):
+        return f"{self.speaker_role} - {self.content[:50]}..."
+
+
+class CallExecutionSnapshot(BaseModel):
+    """
+    Model to store historical snapshots of call executions before reruns
+    """
+
+    class RerunType(models.TextChoices):
+        EVAL_ONLY = "eval_only", "Evaluation Only"
+        CALL_AND_EVAL = "call_and_eval", "Call and Evaluation"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    call_execution = models.ForeignKey(
+        CallExecution,
+        on_delete=models.CASCADE,
+        related_name="snapshots",
+        help_text="The call execution this snapshot belongs to",
+    )
+
+    snapshot_timestamp = models.DateTimeField(
+        auto_now_add=True, help_text="When this snapshot was created"
+    )
+
+    rerun_type = models.CharField(
+        max_length=20,
+        choices=RerunType.choices,
+        help_text="Type of rerun that triggered this snapshot",
+    )
+
+    # Call execution data at the time of snapshot
+    service_provider_call_id = models.CharField(max_length=50, null=True, blank=True)
+    status = models.CharField(max_length=20, null=True, blank=True)
+    started_at = models.DateTimeField(null=True, blank=True)
+    completed_at = models.DateTimeField(null=True, blank=True)
+    ended_at = models.DateTimeField(null=True, blank=True)
+    duration_seconds = models.IntegerField(null=True, blank=True)
+    recording_url = models.URLField(max_length=500, null=True, blank=True)
+    stereo_recording_url = models.URLField(max_length=500, null=True, blank=True)
+
+    # Cost data
+    cost_cents = models.IntegerField(null=True, blank=True)
+    stt_cost_cents = Deprecated(models.IntegerField(null=True, blank=True))
+    llm_cost_cents = Deprecated(models.IntegerField(null=True, blank=True))
+    tts_cost_cents = Deprecated(models.IntegerField(null=True, blank=True))
+    vapi_cost_cents = Deprecated(models.IntegerField(null=True, blank=True))
+
+    # Call details
+    call_summary = models.TextField(null=True, blank=True)
+    ended_reason = models.CharField(max_length=10000, null=True, blank=True)
+    overall_score = models.FloatField(null=True, blank=True)
+    response_time_ms = models.IntegerField(null=True, blank=True)
+    assistant_id = models.CharField(max_length=255, null=True, blank=True)
+    customer_number = models.CharField(max_length=20, null=True, blank=True)
+    call_type = models.CharField(max_length=50, null=True, blank=True)
+    message_count = models.IntegerField(null=True, blank=True)
+    transcript_available = models.BooleanField(default=False)
+    recording_available = models.BooleanField(default=False)
+
+    # JSON fields for complex data
+    analysis_data = models.JSONField(null=True, blank=True)
+    evaluation_data = models.JSONField(null=True, blank=True)
+    eval_outputs = models.JSONField(null=True, blank=True)
+    tool_outputs = models.JSONField(null=True, blank=True)
+    provider_call_data = models.JSONField(
+        null=True,
+        blank=True,
+        validators=[validate_provider_sent_objects],
+    )
+    monitor_call_data = models.JSONField(null=True, blank=True)
+
+    # Conversation metrics
+    avg_agent_latency_ms = models.IntegerField(null=True, blank=True)
+    user_interruption_count = models.IntegerField(null=True, blank=True)
+    user_interruption_rate = models.FloatField(null=True, blank=True)
+    user_wpm = models.FloatField(null=True, blank=True)
+    bot_wpm = models.FloatField(null=True, blank=True)
+    talk_ratio = models.FloatField(null=True, blank=True)
+    ai_interruption_count = models.IntegerField(null=True, blank=True)
+    ai_interruption_rate = models.FloatField(null=True, blank=True)
+    avg_stop_time_after_interruption_ms = models.IntegerField(null=True, blank=True)
+    conversation_metrics_data = models.JSONField(null=True, blank=True)
+
+    # Transcripts snapshot (stored as JSON since they're historical)
+    transcripts = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="Snapshot of transcripts at the time of rerun",
+    )
+
+    def clean(self):
+        super().clean()
+
+    class Meta:
+        db_table = "simulate_call_execution_snapshot"
+        verbose_name = "Call Execution Snapshot"
+        verbose_name_plural = "Call Execution Snapshots"
+        ordering = ["-snapshot_timestamp"]
+        indexes = [
+            models.Index(
+                fields=["call_execution", "-snapshot_timestamp"],
+                name="idx_snapshot_call_time",
+            ),
+            models.Index(fields=["rerun_type"], name="idx_snapshot_rerun_type"),
+        ]
+
+    def __str__(self):
+        return f"Snapshot of {self.call_execution.id} at {self.snapshot_timestamp}"

--- a/futureagi/simulate/models/trial_item_result.py
+++ b/futureagi/simulate/models/trial_item_result.py
@@ -1,0 +1,47 @@
+import uuid
+
+from django.db import models
+
+from simulate.models.prompt_trial import PromptTrial
+from simulate.models.test_execution import CallExecution
+from tfc.utils.base_model import BaseModel
+
+
+class TrialItemResult(BaseModel):
+    """
+    Represents the result for a single CallExecution within a PromptTrial.
+
+    Each PromptTrial runs the prompt against multiple CallExecutions.
+    This model stores the result for each CallExecution, including
+    the overall score, reason, and the input/output of the simulated conversation.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    prompt_trial = models.ForeignKey(
+        PromptTrial,
+        on_delete=models.CASCADE,
+        related_name="trial_items",
+    )
+    call_execution = models.ForeignKey(
+        CallExecution,
+        on_delete=models.CASCADE,
+        related_name="trial_item_results",
+    )
+    score = models.FloatField()
+    reason = models.TextField(null=True, blank=True)
+    input_text = models.TextField(null=True, blank=True)
+    output_text = models.TextField(null=True, blank=True)
+    metadata = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        db_table = "trial_item_result"
+        unique_together = ("prompt_trial", "call_execution")
+        indexes = [
+            models.Index(
+                fields=["prompt_trial"],
+                name="idx_trial_item_prompt_trial",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.prompt_trial_id} - {self.call_execution_id} (score: {self.score:.2f})"

--- a/futureagi/tracer/models/custom_eval_config.py
+++ b/futureagi/tracer/models/custom_eval_config.py
@@ -1,0 +1,114 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.develop_dataset import KnowledgeBaseFile
+from model_hub.models.eval_groups import EvalGroup
+from model_hub.models.evals_metric import EvalTemplate
+from model_hub.models.evaluation import Evaluation
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+
+
+class ModelChoices(models.TextChoices):
+    TURING_LARGE = "turing_large", "Turing Large"
+    TURING_SMALL = "turing_small", "Turing Small"
+    PROTECT = "protect", "Protect"
+    PROTECT_FLASH = "protect_flash", "Protect Flash"
+    TURING_FLASH = "turing_flash", "Turing Flash"
+
+
+class EvalOutputType(models.TextChoices):
+    PASS_FAIL = "Pass/Fail", "Pass/Fail"
+    SCORE = "score", "Score"
+    CHOICES = "choices", "Choices"
+
+
+class CustomEvalConfig(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    eval_template = models.ForeignKey(
+        EvalTemplate,
+        on_delete=models.CASCADE,
+        related_name="custom_eval_configs",
+        blank=False,
+        null=False,
+    )
+    name = models.CharField(max_length=255, blank=True, null=True)
+    config = models.JSONField(default=dict, blank=True, null=True)
+    mapping = models.JSONField(default=dict, blank=True, null=True)
+    project = models.ForeignKey(
+        Project, on_delete=models.CASCADE, related_name="custom_eval_configs"
+    )
+    filters = models.JSONField(default=dict, blank=True, null=True)
+    error_localizer = models.BooleanField(default=False)
+    kb_id = models.ForeignKey(
+        KnowledgeBaseFile, on_delete=models.CASCADE, null=True, blank=True
+    )
+    model = models.CharField(
+        max_length=255, choices=ModelChoices.choices, blank=True, null=True
+    )
+    eval_group = models.ForeignKey(
+        EvalGroup, on_delete=models.CASCADE, null=True, blank=True
+    )
+
+    def __str__(self):
+        return f"Custom Eval Config {self.id}"
+
+    class Meta:
+        db_table = "tracer_custom_eval_config"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["name", "project"],
+                condition=models.Q(deleted=False),
+                name="unique_name_project_idx",
+            )
+        ]
+        indexes = [
+            models.Index(fields=["project", "created_at"]),
+            models.Index(fields=["eval_template"]),
+            models.Index(fields=["project", "name"]),
+        ]
+
+
+class InLineEvalStatus(models.TextChoices):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class InlineEval(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="inline_evals",
+        null=True,
+        blank=True,
+    )
+    span_id = models.CharField(max_length=255)
+    custom_eval_name = models.CharField(max_length=255)
+    evaluation = models.ForeignKey(
+        Evaluation,
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        related_name="inline_evals",
+    )
+    status = models.CharField(
+        max_length=255,
+        choices=InLineEvalStatus.choices,
+        default=InLineEvalStatus.PENDING,
+    )
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["organization"]),
+            models.Index(fields=["span_id"]),
+            models.Index(fields=["status", "span_id"]),
+        ]

--- a/futureagi/tracer/models/dashboard.py
+++ b/futureagi/tracer/models/dashboard.py
@@ -1,0 +1,69 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class Dashboard(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="dashboards",
+        blank=False,
+        null=False,
+    )
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="created_dashboards",
+    )
+    updated_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="updated_dashboards",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["workspace", "-created_at"]),
+        ]
+
+    def __str__(self):
+        return self.name
+
+
+class DashboardWidget(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    dashboard = models.ForeignKey(
+        Dashboard,
+        on_delete=models.CASCADE,
+        related_name="widgets",
+    )
+    name = models.CharField(max_length=255, default="Untitled")
+    description = models.TextField(blank=True, default="")
+    position = models.IntegerField(default=0)
+    width = models.IntegerField(default=12)
+    height = models.IntegerField(default=4)
+    query_config = models.JSONField(default=dict)
+    chart_config = models.JSONField(default=dict)
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="created_dashboard_widgets",
+    )
+
+    class Meta:
+        ordering = ["position", "created_at"]
+
+    def __str__(self):
+        return f"{self.dashboard.name} - {self.name}"

--- a/futureagi/tracer/models/eval_ci_cd.py
+++ b/futureagi/tracer/models/eval_ci_cd.py
@@ -1,0 +1,74 @@
+import uuid
+
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.evaluation import Evaluation
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+
+
+class EvaluationRun(BaseModel):
+    """
+    Represents a single CI/CD evaluation run for a specific version of a project.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project, on_delete=models.CASCADE, related_name="evaluation_runs"
+    )
+    version = models.CharField(
+        max_length=255,
+        help_text="The version identifier, e.g., a git commit hash or version tag.",
+    )
+    eval_data = models.JSONField(default=dict, blank=True, null=True)
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="evaluation_runs",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        db_table = "tracer_evaluation_run"
+        unique_together = ("project", "version")
+        indexes = [
+            models.Index(fields=["project", "version"]),
+        ]
+
+    def __str__(self):
+        return f"Run for {self.project.name} - {self.version}"
+
+
+class EvaluationResult(BaseModel):
+    """
+    Links an individual Evaluation to a specific EvaluationRun.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    evaluation_run = models.ForeignKey(
+        EvaluationRun, on_delete=models.CASCADE, related_name="results"
+    )
+    evaluation = models.OneToOneField(
+        Evaluation, on_delete=models.CASCADE, related_name="ci_cd_result"
+    )
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="evaluation_results",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        db_table = "tracer_evaluation_result"
+        indexes = [
+            models.Index(fields=["evaluation_run"]),
+        ]
+
+    def __str__(self):
+        return f"Result for Run {self.evaluation_run.id}"

--- a/futureagi/tracer/models/eval_task.py
+++ b/futureagi/tracer/models/eval_task.py
@@ -1,0 +1,89 @@
+import uuid
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+from tfc.utils.base_model import BaseModel
+from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.project import Project
+
+
+class RunType(models.TextChoices):
+    CONTINUOUS = "continuous", _("Continuous")
+    HISTORICAL = "historical", _("Historical")
+
+
+class EvalTaskStatus(models.TextChoices):
+    PENDING = "pending", _("Pending")
+    RUNNING = "running", _("Running")
+    COMPLETED = "completed", _("Completed")
+    FAILED = (
+        "failed",
+        _("Failed"),
+    )
+    PAUSED = "paused", _("Paused")
+    DELETED = "deleted", _("Deleted")
+
+
+class EvalTask(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="eval_tasks",
+        blank=False,
+        null=False,
+    )
+    name = models.CharField(max_length=255, blank=True, null=True)
+    filters = models.JSONField(default=dict, blank=True, null=True)
+    sampling_rate = models.FloatField(default=100.0, blank=True, null=True)
+    last_run = models.DateTimeField(blank=True, null=True)
+    spans_limit = models.IntegerField(default=1000, blank=True, null=True)
+    run_type = models.CharField(
+        max_length=255, choices=RunType.choices, blank=True, null=True
+    )
+    status = models.CharField(
+        max_length=255, choices=EvalTaskStatus.choices, blank=True, null=True
+    )
+    start_time = models.DateTimeField(blank=True, null=True)
+    end_time = models.DateTimeField(blank=True, null=True)
+    evals_details = models.JSONField(default=list, blank=True, null=True)
+    evals = models.ManyToManyField(
+        CustomEvalConfig, related_name="eval_tasks", blank=True, null=True
+    )
+    failed_spans = models.JSONField(default=list, blank=True, null=True)
+
+    def __str__(self):
+        return f"Eval Task {self.id}"
+
+    class Meta:
+        db_table = "tracer_eval_task"
+        ordering = ["-created_at"]
+
+
+class EvalTaskLogger(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    eval_task = models.ForeignKey(
+        EvalTask,
+        on_delete=models.CASCADE,
+        related_name="eval_task_loggers",
+        blank=False,
+        null=False,
+    )
+    offset = models.IntegerField(default=0, blank=True, null=True)
+    errors = models.JSONField(default=list, blank=True, null=True)
+    spanids_processed = models.JSONField(default=list, blank=True, null=True)
+    status = models.CharField(
+        max_length=255, choices=EvalTaskStatus.choices, blank=True, null=True
+    )
+
+    def __str__(self):
+        return f"Eval Task Logger {self.id}"
+
+    class Meta:
+        db_table = "tracer_eval_task_logger"
+        ordering = ["-created_at"]
+
+
+MAX_EVAL_RUNS_IN_TASK = 50
+EVAL_TASK_LOGGER_LIMIT = 10

--- a/futureagi/tracer/models/external_eval_config.py
+++ b/futureagi/tracer/models/external_eval_config.py
@@ -1,0 +1,108 @@
+import uuid
+
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.evals_metric import EvalTemplate
+from tfc.utils.base_model import BaseModel
+from tracer.models.custom_eval_config import ModelChoices
+
+
+class PlatformChoices(models.TextChoices):
+    LANGFUSE = "langfuse"
+
+
+class StatusChoices(models.TextChoices):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ExternalEvalConfig(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="external_eval_configs",
+        null=True,
+        blank=True,
+    )
+
+    eval_template = models.ForeignKey(EvalTemplate, on_delete=models.CASCADE)
+    name = models.CharField(
+        max_length=255, help_text="Name of the external eval config"
+    )
+    config = models.JSONField(default=dict, blank=True, null=True)
+    mapping = models.JSONField(default=dict)
+    model = models.CharField(
+        max_length=255, choices=ModelChoices.choices, blank=True, null=True
+    )
+
+    eval_results = models.JSONField(default=dict, blank=True, null=True)
+    error_message = models.TextField(null=True, blank=True)
+    logs = models.JSONField(default=list, blank=True, null=True)
+
+    platform = models.CharField(max_length=255, choices=PlatformChoices.choices)
+    credentials = models.JSONField(default=dict)
+    status = models.CharField(max_length=255, choices=StatusChoices.choices)
+
+    @classmethod
+    def get_required_credentials(cls, platform):
+        """
+        Returns the required credentials for a given platform.
+        Override this method to add new platforms and their required credentials.
+        """
+        required_credentials = {
+            PlatformChoices.LANGFUSE: [
+                "langfuse_secret_key",
+                "langfuse_public_key",
+                "langfuse_host",
+            ],
+            # Add more platforms here as needed:
+        }
+        return required_credentials.get(platform, [])
+
+    def clean(self):
+        super().clean()
+        if self.platform:
+            required_keys = self.get_required_credentials(self.platform)
+            if required_keys:
+                missing_keys = [
+                    key for key in required_keys if key not in self.credentials
+                ]
+                if missing_keys:
+                    raise ValidationError(
+                        {
+                            "credentials": f"Missing required credentials for {self.platform} platform: {', '.join(missing_keys)}"
+                        }
+                    )
+
+                invalid_value_keys = [
+                    key for key in required_keys if not self.credentials.get(key)
+                ]
+                if invalid_value_keys:
+                    raise ValidationError(
+                        {
+                            "credentials": f"Values for these credentials cannot be null or empty for {self.platform} platform: {', '.join(invalid_value_keys)}"
+                        }
+                    )
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"External Eval Config {self.id}"
+
+    class Meta:
+        db_table = "tracer_external_eval_config"
+        indexes = [
+            models.Index(fields=["status"]),
+            models.Index(fields=["platform"]),
+            models.Index(fields=["organization"]),
+        ]
+        ordering = ["-created_at"]

--- a/futureagi/tracer/models/imagine_analysis.py
+++ b/futureagi/tracer/models/imagine_analysis.py
@@ -1,0 +1,68 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+from tracer.models.saved_view import SavedView
+
+
+class ImagineAnalysis(BaseModel):
+    """Stores dynamic analysis results per trace + widget.
+
+    Each record represents one LLM analysis for a specific widget
+    in a saved Imagine view, run against a specific trace.
+    """
+
+    STATUS_CHOICES = (
+        ("pending", "Pending"),
+        ("running", "Running"),
+        ("completed", "Completed"),
+        ("failed", "Failed"),
+    )
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    saved_view = models.ForeignKey(
+        SavedView,
+        on_delete=models.CASCADE,
+        related_name="imagine_analyses",
+    )
+    widget_id = models.CharField(max_length=100)
+    trace_id = models.CharField(max_length=255)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="imagine_analyses",
+    )
+    organization = models.ForeignKey(
+        "accounts.Organization",
+        on_delete=models.CASCADE,
+        related_name="imagine_analyses",
+    )
+
+    prompt = models.TextField()
+    content = models.TextField(null=True, blank=True)
+
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="pending")
+    error = models.TextField(null=True, blank=True)
+    workflow_id = models.CharField(max_length=255, null=True, blank=True)
+
+    class Meta:
+        db_table = "tracer_imagine_analysis"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["saved_view", "widget_id", "trace_id"],
+                condition=models.Q(deleted=False),
+                name="unique_imagine_analysis_per_widget_trace",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["saved_view", "trace_id"]),
+            models.Index(fields=["trace_id", "status"]),
+        ]
+
+    def __str__(self):
+        return f"Analysis {self.widget_id} for trace {self.trace_id[:8]}"

--- a/futureagi/tracer/models/monitor.py
+++ b/futureagi/tracer/models/monitor.py
@@ -1,0 +1,167 @@
+import uuid
+
+from django.contrib.postgres.fields import ArrayField
+from django.core.validators import MinValueValidator
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.user import User
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+
+
+class ComparisonOperatorChoices(models.TextChoices):
+    """Choices for comparison operators used in threshold conditions."""
+
+    GREATER_THAN = "greater_than", "Greater than"
+    LESS_THAN = "less_than", "Less than"
+    # GREATER_OR_EQUAL = "greater_or_equal_to", "Greater or equal to"
+    # LESS_OR_EQUAL = "less_than_or_equal_to", "Less than or equal to"
+
+
+class MonitorMetricTypeChoices(models.TextChoices):
+    """Choices for different types of metrics that can be monitored."""
+
+    # Error-related metrics
+    COUNT_OF_ERRORS = "count_of_errors", "Count of errors"
+    ERROR_RATES_FOR_FUNCTION_CALLING = (
+        "error_rates_for_function_calling",
+        "Error rates for function calling",
+    )
+    ERROR_FREE_SESSION_RATES = "error_free_session_rates", "Error free session rates"
+    # USER_EXPERIENCE_ERROR = "user_experience_error", "User experience error" # TODO: need to add a sep col for this in trace similar to session_id
+    SERVICE_PROVIDER_ERROR_RATES = (
+        "service_provider_error_rates",
+        "Service provider error rates",
+    )
+    LLM_API_FAILURE_RATES = "llm_api_failure_rates", "LLM API failure rates"
+
+    # Performance metrics
+    SPAN_RESPONSE_TIME = "span_response_time", "Span response time"
+    LLM_RESPONSE_TIME = "llm_response_time", "LLM response time"
+
+    # Usage and cost metrics
+    TOKEN_USAGE = "token_usage", "Token usage"
+    DAILY_TOKENS_SPENT = "daily_tokens_spent", "Daily tokens spent"
+    MONTHLY_TOKENS_SPENT = "monthly_tokens_spent", "Monthly tokens spent"
+    # CREDIT_EXHAUSTION = "credit_exhaustion", "Credit exhaustion" # we don't have this data in the db yet, removed for now
+
+    # Other metrics
+    EVALUATION_METRICS = "evaluation_metrics", "Evaluation metrics"
+    # RATE_LIMIT_ALERT = "rate_limit_alert", "Rate limit alert" # we don't have this data in the db yet, removed for now
+
+
+class ThresholdCalculationMethodChoices(models.TextChoices):
+    """Choices for how threshold values are calculated or determined."""
+
+    STATIC = "static", "Static"
+    PERCENTAGE_CHANGE = "percentage_change", "Percentage Change"
+    # ANOMALY_DETECTION = "anomaly_detection", "Anomaly Detection"
+
+
+class UserAlertMonitor(BaseModel):
+    """Model for user-defined alert monitors that track various metrics."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+
+    # Metric configuration
+    metric_type = models.CharField(max_length=100, choices=MonitorMetricTypeChoices)
+    metric = models.CharField(
+        max_length=2556,
+        help_text="Id of the evaluation template.",
+        null=True,
+        blank=True,
+    )
+
+    # Organization and project
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="user_alert_monitors",
+        null=True,
+        blank=True,
+    )
+    created_by = models.ForeignKey(
+        User, on_delete=models.CASCADE, null=True, blank=True
+    )
+    project = models.ForeignKey(
+        Project, on_delete=models.CASCADE, null=True, blank=True
+    )
+
+    # Threshold configuration
+    threshold_operator = models.CharField(
+        max_length=100, choices=ComparisonOperatorChoices
+    )
+    threshold_type = models.CharField(
+        max_length=50,
+        choices=ThresholdCalculationMethodChoices,
+        default=ThresholdCalculationMethodChoices.PERCENTAGE_CHANGE.value,
+        help_text="Method to set the threshold for the monitor (Static or Percentage change).",
+    )
+    threshold_metric_value = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="For choice and pass/fail evals, the specific metric value to monitor.",
+    )
+    critical_threshold_value = models.FloatField(
+        validators=[MinValueValidator(0.0)], null=True, blank=True
+    )  # will be null for anomaly detection , for percentage change it will be the percentage value, for static it will be the value
+    warning_threshold_value = models.FloatField(
+        validators=[MinValueValidator(0.0)], null=True, blank=True
+    )  # will be null for anomaly detection , for percentage change it will be the percentage value, for static it will be the value
+
+    # Alert frequency and timing
+    alert_frequency = models.IntegerField(
+        validators=[MinValueValidator(5)],
+        default=60,
+        help_text="Frequency of alert checks in minutes.",
+    )
+    auto_threshold_time_window = models.PositiveIntegerField(
+        default=60 * 24 * 7,  # 1 week
+        help_text="For auto-thresholding. The time window in minutes to calculate the historical mean",
+    )
+    last_checked_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="The last time the monitor was checked for alerts.",
+    )
+
+    # Notification settings
+    notification_emails: ArrayField = ArrayField(models.EmailField(), default=list)
+    slack_webhook_url = models.URLField(null=True, blank=True)
+    slack_notes = models.TextField(null=True, blank=True)
+
+    # Monitor state and configuration
+    is_mute = models.BooleanField(default=False)
+    filters = models.JSONField(default=dict, blank=True, null=True)
+    logs: ArrayField = ArrayField(
+        models.JSONField(default=dict), default=list, blank=True, null=True
+    )
+
+    def __str__(self):
+        return self.name
+
+
+class AlertTypeChoices(models.TextChoices):
+    """Choices for different types of alerts."""
+
+    CRITICAL = "critical", "Critical"
+    WARNING = "warning", "Warning"
+
+
+class UserAlertMonitorLog(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    alert = models.ForeignKey(UserAlertMonitor, on_delete=models.CASCADE)
+    type = models.CharField(max_length=100, choices=AlertTypeChoices)
+    message = models.TextField()
+    resolved = models.BooleanField(default=False)
+    resolved_at = models.DateTimeField(null=True, blank=True)
+    resolved_by = models.ForeignKey(
+        User, on_delete=models.CASCADE, null=True, blank=True
+    )
+    link = models.URLField(null=True, blank=True)
+    time_window_start = models.DateTimeField(null=True, blank=True)
+    time_window_end = models.DateTimeField(null=True, blank=True)

--- a/futureagi/tracer/models/observability_provider.py
+++ b/futureagi/tracer/models/observability_provider.py
@@ -1,0 +1,61 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+
+
+class ProviderChoices(models.TextChoices):
+    VAPI = "vapi", "Vapi"
+    ELEVEN_LABS = "eleven_labs", "Eleven Labs"
+    RETELL = "retell", "Retell"
+    LIVEKIT = "livekit", "LiveKit"
+    OTHERS = "others", "Others"
+
+
+class ObservabilityProvider(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="observability_providers",
+    )
+    provider = models.CharField(
+        max_length=255,
+        choices=ProviderChoices.choices,
+    )
+    enabled = models.BooleanField(default=True)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="observability_providers",
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="observability_providers",
+    )
+    last_fetched_at = models.DateTimeField(null=True, blank=True)
+    metadata = models.JSONField(default=dict, blank=True, null=True)
+
+    class Meta:
+        db_table = "tracer_observability_provider"
+        indexes = [
+            models.Index(
+                fields=[
+                    "project",
+                    "last_fetched_at",
+                    "enabled",
+                    "organization",
+                    "workspace",
+                ]
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.provider} for {self.project.name}"

--- a/futureagi/tracer/models/observation_span.py
+++ b/futureagi/tracer/models/observation_span.py
@@ -1,0 +1,298 @@
+import uuid
+
+from django.contrib.postgres.indexes import GinIndex
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from accounts.models import Organization
+from model_hub.models.choices import StatusType
+from model_hub.models.prompt_label import PromptLabel
+from model_hub.models.run_prompt import PromptVersion
+from tfc.utils.base_model import BaseModel
+from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.project import Project
+from tracer.models.project_version import ProjectVersion
+from tracer.models.trace import Trace
+
+
+def validate_span_status(value):
+    valid_choices = [choice[0] for choice in ObservationSpan.SPAN_STATUS]
+    if value not in valid_choices:
+        raise ValidationError(
+            f"Invalid span status. Valid choices are: {', '.join(valid_choices)}"
+        )
+
+
+class UserIdType(models.TextChoices):
+    EMAIL = "email", "Email"
+    PHONE = "phone", "Phone"
+    UUID = "uuid", "UUID"
+    CUSTOM = "custom", "Custom"
+
+
+class EndUser(BaseModel):
+    """ """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+    )
+    workspace = models.ForeignKey(
+        "accounts.Workspace",
+        on_delete=models.CASCADE,
+        related_name="end_users",
+        null=True,
+        blank=True,
+    )
+    user_id = models.CharField(max_length=255, null=False, blank=False)
+    user_id_type = models.CharField(
+        max_length=50,
+        null=True,
+        blank=True,
+        choices=UserIdType.choices,
+    )
+    user_id_hash = models.CharField(max_length=255, null=True, blank=True)
+    metadata = models.JSONField(null=True, blank=True)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+    )
+
+    class Meta:
+        unique_together = ("project", "organization", "user_id", "user_id_type")
+
+
+class ObservationSpan(BaseModel):
+    OBSERVATION_SPAN_TYPES = (
+        ("tool", "Tool"),
+        ("chain", "Chain"),
+        ("llm", "LLM"),
+        ("retriever", "Retriever"),
+        ("embedding", "Embedding"),
+        ("agent", "Agent"),
+        ("reranker", "Reranker"),
+        ("unknown", "Unknown"),
+        ("guardrail", "Guardrail"),
+        ("evaluator", "Evaluator"),
+        ("conversation", "Conversation"),
+    )
+
+    OBSERVATION_SPAN_LOGGER_STATUS = (
+        ("COMPLETED", "completed"),
+        ("ERROR", "error"),
+    )
+
+    SPAN_STATUS = (
+        ("UNSET", "unset"),
+        ("OK", "ok"),
+        ("ERROR", "error"),
+    )
+
+    id = models.CharField(primary_key=True, max_length=255, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="observation_spans",
+        null=False,
+        blank=False,
+    )
+    project_version = models.ForeignKey(
+        ProjectVersion,
+        on_delete=models.CASCADE,
+        related_name="observation_spans",
+        null=True,
+        blank=True,
+    )
+    trace = models.ForeignKey(
+        Trace,
+        on_delete=models.CASCADE,
+        related_name="observation_spans",
+        null=False,
+        blank=False,
+    )
+    parent_span_id = models.CharField(max_length=255, null=True, blank=True)
+    name = models.CharField(max_length=2000, null=False, blank=False)
+    observation_type = models.CharField(
+        max_length=20, choices=OBSERVATION_SPAN_TYPES, null=False, blank=False
+    )
+    operation_name = models.CharField(
+        max_length=100,
+        null=True,
+        blank=True,
+        help_text="Operation type within span kind (e.g., chat, image_generation, speech_to_text)",
+    )
+    start_time = models.DateTimeField(null=True, blank=True)
+    end_time = models.DateTimeField(null=True, blank=True)
+
+    input = models.JSONField(null=True, blank=True)
+    output = models.JSONField(null=True, blank=True)
+
+    model = models.CharField(max_length=255, null=True, blank=True)
+    model_parameters = models.JSONField(null=True, blank=True)
+    latency_ms = models.IntegerField(null=True, blank=True)
+
+    org_id = models.UUIDField(blank=True, null=True)
+    org_user_id = models.UUIDField(null=True, blank=True)
+
+    prompt_tokens = models.IntegerField(null=True, blank=True)
+    completion_tokens = models.IntegerField(null=True, blank=True)
+    total_tokens = models.IntegerField(null=True, blank=True)
+    response_time = models.FloatField(null=True, blank=True)
+
+    eval_id = models.CharField(max_length=255, null=True, blank=True)
+    cost = models.FloatField(null=True, blank=True)
+    status = models.CharField(
+        max_length=20,
+        choices=SPAN_STATUS,
+        null=True,
+        blank=True,
+        validators=[validate_span_status],
+    )
+    status_message = models.TextField(null=True, blank=True)
+    tags = models.JSONField(default=list, blank=True, null=True)
+    metadata = models.JSONField(null=True, blank=True)
+    span_events = models.JSONField(default=list, blank=True, null=True)
+
+    provider = models.CharField(max_length=255, null=True, blank=True)
+
+    input_images = models.JSONField(default=list, blank=True, null=True)
+    eval_input = models.JSONField(default=list, blank=True, null=True)
+
+    eval_attributes = models.JSONField(default=dict, blank=True, null=True)
+    custom_eval_config = models.ForeignKey(
+        CustomEvalConfig,
+        on_delete=models.CASCADE,
+        related_name="observation_spans",
+        blank=True,
+        null=True,
+    )
+    # TODO(tech-debt): eval_status on the span is a design flaw. It's a denormalized
+    # snapshot that goes stale when evals are added/removed. Status should be derived
+    # from EvalLogger rows (per-eval-per-span) rather than a single flag here.
+    # See: run_evals_on_spans() in span.py, eval_observation_span_runner() in eval.py.
+    eval_status = models.CharField(
+        max_length=50,
+        choices=[(status.value, status.value) for status in StatusType],
+        null=True,
+        blank=True,
+        default=StatusType.INACTIVE.value,
+    )
+
+    end_user = models.ForeignKey(
+        EndUser,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        default=None,
+    )
+
+    prompt_version = models.ForeignKey(
+        PromptVersion,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        default=None,
+    )
+
+    prompt_label = models.ForeignKey(
+        PromptLabel,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        default=None,
+    )
+
+    # GenAI Schema Foundation - Flexible attribute storage
+    span_attributes = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Raw OTEL span attributes in their original form. "
+        "Stored for ClickHouse migration and future-proofing.",
+    )
+    resource_attributes = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Raw OTEL resource attributes (service.name, project info, etc.)",
+    )
+    semconv_source = models.CharField(
+        max_length=50,
+        default="traceai",
+        help_text="Semantic convention source: traceai, otel_genai, openinference, openllmetry",
+    )
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        db_table = "tracer_observation_span"
+        ordering = ["-start_time"]
+
+        indexes = [
+            models.Index(fields=["trace", "created_at"]),
+            models.Index(fields=["project", "created_at"]),
+            models.Index(fields=["project_version"]),
+            models.Index(fields=["parent_span_id"]),
+            models.Index(fields=["observation_type"]),
+            models.Index(fields=["custom_eval_config"]),
+            GinIndex(fields=["metadata"]),
+            models.Index(fields=["start_time"]),
+            models.Index(fields=["trace", "start_time"]),
+            # GenAI Schema Foundation indexes
+            GinIndex(fields=["span_attributes"], name="tracer_obse_span_at_gin"),
+        ]
+
+
+class EvalLogger(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    trace = models.ForeignKey(
+        Trace,
+        on_delete=models.CASCADE,
+        related_name="eval_logs",
+        null=False,
+        blank=False,
+    )
+    observation_span = models.ForeignKey(
+        ObservationSpan,
+        on_delete=models.CASCADE,
+        related_name="eval_logs",
+        null=False,
+        blank=False,
+    )
+    eval_type_id = models.CharField(max_length=255, null=True, blank=True)
+    output_metadata = models.JSONField(null=True, blank=True)
+    results_tags = models.JSONField(default=list, blank=True)
+    results_explanation = models.JSONField(default=dict, blank=True)
+    eval_tags = models.JSONField(default=list, blank=True)
+    eval_explanation = models.TextField(null=True, blank=True)
+    output_bool = models.BooleanField(null=True, blank=True)
+    output_float = models.FloatField(null=True, blank=True)
+    output_str = models.TextField(null=True, blank=True)
+    output_str_list = models.JSONField(default=list, blank=True)
+    eval_id = models.CharField(max_length=255, null=True, blank=True)
+    eval_task_id = models.CharField(max_length=255, null=True, blank=True)
+    custom_eval_config = models.ForeignKey(
+        CustomEvalConfig,
+        on_delete=models.CASCADE,
+        related_name="eval_loggers",
+        blank=True,
+        null=True,
+    )
+    error = models.BooleanField(default=False)
+    error_message = models.TextField(null=True, blank=True)
+
+    def __str__(self):
+        return f"Eval Log {self.id}"
+
+    class Meta:
+        db_table = "tracer_eval_logger"
+        ordering = ["-created_at"]
+
+        indexes = [
+            models.Index(fields=["trace", "created_at"]),
+            models.Index(fields=["observation_span"]),
+            models.Index(fields=["custom_eval_config"]),
+            models.Index(fields=["output_bool"]),
+            models.Index(fields=["output_float"]),
+            models.Index(fields=["error"]),
+        ]

--- a/futureagi/tracer/models/project.py
+++ b/futureagi/tracer/models/project.py
@@ -1,0 +1,179 @@
+import uuid
+from enum import Enum
+from typing import List, Optional
+
+from django.db import models
+from pydantic import BaseModel as PydanticBaseModel
+
+from accounts.models import Organization, User
+from accounts.models.workspace import Workspace
+from model_hub.models.ai_model import AIModel
+from tfc.utils.base_model import BaseModel
+
+PROJECT_TYPES = (
+    ("experiment", "Experiment"),
+    ("observe", "Observe"),
+)
+
+
+class ProjectSourceChoices(Enum):
+    DEMO = "demo"
+    PROTOTYPE = "prototype"
+    SIMULATOR = "simulator"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class Project(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="projects",
+        blank=False,
+        null=False,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="projects",
+        null=True,
+        blank=True,
+    )
+    model_type = models.CharField(
+        max_length=50, choices=AIModel.ModelTypes.choices, null=False, blank=False
+    )
+    name = models.CharField(max_length=255, null=False, blank=False)
+    trace_type = models.CharField(
+        max_length=20, choices=PROJECT_TYPES, null=False, blank=False
+    )
+    metadata = models.JSONField(null=True, blank=True)
+    config = models.JSONField(default=list, null=True, blank=True)
+    session_config = models.JSONField(default=list, null=True, blank=True)
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="projects_user",
+        null=True,
+        blank=True,
+        default=None,
+    )
+    source = models.CharField(
+        max_length=20,
+        choices=ProjectSourceChoices.get_choices(),
+        null=False,
+        blank=False,
+        default=ProjectSourceChoices.PROTOTYPE.value,
+    )
+    tags = models.JSONField(default=list, blank=True)
+
+    def clean(self):
+        super().clean()
+        if self.metadata is None:
+            self.metadata = {}  # Ensure metadata is a dictionary
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        db_table = "tracer_project"
+        ordering = ["-updated_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["name", "trace_type", "organization", "workspace"],
+                condition=models.Q(deleted=False),
+                name="unique_project_per_org_type",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["organization"]),
+            models.Index(fields=["model_type"]),
+            models.Index(fields=["trace_type"]),
+            models.Index(fields=["organization", "name", "trace_type"]),
+        ]
+
+
+class TranscriptEntry(PydanticBaseModel):
+    id: Optional[str] = None
+    role: Optional[str] = None
+    content: Optional[str] = None
+    time: Optional[str] = None
+    duration: Optional[float] = None
+
+
+class MonoRecording(PydanticBaseModel):
+    combined_url: Optional[str] = None
+    customer_url: Optional[str] = None
+    assistant_url: Optional[str] = None
+
+
+class Recording(PydanticBaseModel):
+    mono: Optional[MonoRecording] = None
+    stereo_url: Optional[str] = None
+
+
+class MessageEntry(PydanticBaseModel):
+    role: Optional[str] = None
+    time: Optional[float] = None
+    source: Optional[str] = None
+    end_time: Optional[float] = None
+    message: Optional[str] = None
+    duration: Optional[float] = None
+    seconds_from_start: Optional[float] = None
+    metadata: Optional[dict] = None
+
+
+class AnalysisData(PydanticBaseModel):
+    summary: Optional[str] = None
+    success_evaluation: Optional[str] = None
+
+
+class CostBreakdown(PydanticBaseModel):
+    stt: Optional[float] = None
+    llm: Optional[float] = None
+    tts: Optional[float] = None
+    vapi: Optional[float] = None
+    transport: Optional[float] = None
+    total: Optional[float] = None
+
+
+class VoiceCallLogs(PydanticBaseModel):
+    id: Optional[str] = None
+    phone_number: Optional[str] = None
+    customer_name: Optional[str] = None
+    call_id: Optional[str] = None
+    status: Optional[str] = None
+    started_at: Optional[str] = None
+    duration_seconds: Optional[int] = None
+    recording_url: Optional[str] = None
+    cost_cents: Optional[float] = None
+    cost_breakdown: Optional[CostBreakdown] = None
+    call_metadata: Optional[dict] = {}
+    error_message: Optional[str] = None
+    transcript: Optional[List[TranscriptEntry]] = None
+    created_at: Optional[str] = None
+    recording: Optional[Recording] = None
+    stereo_recording_url: Optional[str] = None
+    call_summary: Optional[str] = None
+    ended_reason: Optional[str] = None
+    overall_score: Optional[float] = None
+    response_time_ms: Optional[float] = None
+    response_time_seconds: Optional[float] = None
+    messages: Optional[List[MessageEntry]] = None
+    assistant_id: Optional[str] = None
+    assistant_phone_number: Optional[str] = None
+    call_type: Optional[str] = None
+    ended_at: Optional[str] = None
+    analysis_data: Optional[AnalysisData] = None
+    evaluation_data: Optional[dict] = None
+    message_count: Optional[int] = None
+    transcript_available: Optional[bool] = None
+    recording_available: Optional[bool] = None
+    observation_span: Optional[List[dict]] = None
+    talk_ratio: Optional[dict] = None

--- a/futureagi/tracer/models/project_version.py
+++ b/futureagi/tracer/models/project_version.py
@@ -1,0 +1,84 @@
+import uuid
+
+from django.db import models
+
+from model_hub.models.develop_annotations import Annotations
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+
+
+class ProjectVersion(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="versions",
+        blank=False,
+        null=False,
+    )
+    name = models.CharField(max_length=255, blank=False, null=False)
+    version = models.CharField(
+        max_length=10, blank=False, null=False
+    )  # Stores v1, v2, v3 etc
+    start_time = models.DateTimeField(null=True, blank=True)
+    end_time = models.DateTimeField(null=True, blank=True)
+    error = models.JSONField(null=True, blank=True)
+    metadata = models.JSONField(null=True, blank=True)
+    eval_tags = models.JSONField(null=True, blank=True, default=list)
+    avg_eval_score = models.FloatField(null=True, blank=True)
+    config = models.JSONField(null=True, blank=True, default=list)
+    annotations = models.ForeignKey(
+        Annotations,
+        on_delete=models.CASCADE,
+        related_name="annotations",
+        blank=True,
+        null=True,
+    )
+
+    def __str__(self):
+        return f"{self.project.name} - {self.version}"
+
+    class Meta:
+        db_table = "tracer_project_version"
+        ordering = ["-created_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["project", "version"],
+                condition=models.Q(deleted=False),
+                name="unique_version_per_project",
+            )
+        ]
+        indexes = [
+            models.Index(fields=["project", "version"]),
+            models.Index(fields=["project", "created_at"]),
+            models.Index(fields=["start_time"]),
+            models.Index(fields=["end_time"]),
+        ]
+
+
+class ProjectVersionWinner(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="version_winner",
+        blank=False,
+        null=False,
+    )
+    eval_config = models.JSONField(null=True, blank=True)
+    winner_version = models.ForeignKey(
+        ProjectVersion,
+        on_delete=models.CASCADE,
+        related_name="winner_version",
+        blank=False,
+        null=False,
+    )
+    version_mapper = models.JSONField(null=True, blank=True)
+
+    class Meta:
+        db_table = "tracer_project_version_winner"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["project", "created_at"]),
+            models.Index(fields=["winner_version"]),
+        ]

--- a/futureagi/tracer/models/replay_session.py
+++ b/futureagi/tracer/models/replay_session.py
@@ -1,0 +1,60 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+
+
+class ReplayType(models.TextChoices):
+    SESSION = "session", "Session"
+    TRACE = "trace", "Trace"
+
+
+class ReplaySessionStep(models.TextChoices):
+    INIT = "init", "Init"
+    GENERATING = "generating", "Generating Scenario"
+    COMPLETED = "completed", "Completed"
+
+
+class ReplaySession(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="replay_sessions",
+    )
+    replay_type = models.CharField(max_length=255, choices=ReplayType.choices)
+    ids = models.JSONField(null=True, blank=True)
+    select_all = models.BooleanField(default=False)
+
+    current_step = models.CharField(
+        max_length=20,
+        choices=ReplaySessionStep.choices,
+        default=ReplaySessionStep.INIT,
+    )
+
+    agent_definition = models.ForeignKey(
+        "simulate.AgentDefinition",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="replay_sessions",
+    )
+    scenario = models.ForeignKey(
+        "simulate.Scenarios",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="replay_sessions",
+    )
+    run_test = models.ForeignKey(
+        "simulate.RunTest",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="replay_sessions",
+    )
+
+    def __str__(self):
+        return f"ReplaySession {self.id} - {self.project.name} ({self.current_step})"

--- a/futureagi/tracer/models/saved_view.py
+++ b/futureagi/tracer/models/saved_view.py
@@ -1,0 +1,87 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.user import User
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+
+
+class SavedView(BaseModel):
+    TAB_TYPE_CHOICES = (
+        ("traces", "Traces"),
+        ("spans", "Spans"),
+        ("voice", "Voice"),
+        ("imagine", "Imagine"),
+        ("users", "Users"),
+        ("user_detail", "User Detail"),
+    )
+
+    VISIBILITY_CHOICES = (
+        ("personal", "Personal"),
+        ("project", "Project"),
+    )
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="saved_views",
+        blank=True,
+        null=True,
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        related_name="saved_views",
+        blank=False,
+        null=False,
+    )
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="created_saved_views",
+    )
+    updated_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="updated_saved_views",
+    )
+    name = models.CharField(max_length=255)
+    tab_type = models.CharField(max_length=20, choices=TAB_TYPE_CHOICES)
+    visibility = models.CharField(
+        max_length=20, choices=VISIBILITY_CHOICES, default="personal"
+    )
+    position = models.IntegerField(default=0)
+    icon = models.CharField(max_length=50, blank=True, null=True)
+    config = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        db_table = "tracer_saved_view"
+        ordering = ["position", "created_at"]
+        indexes = [
+            models.Index(fields=["project", "created_by", "visibility"]),
+            models.Index(fields=["project", "visibility"]),
+            models.Index(fields=["workspace", "created_by", "tab_type"]),
+        ]
+        constraints = [
+            # Uniqueness for project-scoped views
+            models.UniqueConstraint(
+                fields=["project", "created_by", "name"],
+                condition=models.Q(deleted=False, project__isnull=False),
+                name="unique_saved_view_name_per_user_project",
+            ),
+            # Uniqueness for workspace-scoped (project-null) views, per tab_type
+            models.UniqueConstraint(
+                fields=["workspace", "created_by", "tab_type", "name"],
+                condition=models.Q(deleted=False, project__isnull=True),
+                name="unique_saved_view_name_per_user_workspace",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.name} ({self.tab_type})"

--- a/futureagi/tracer/models/shared_link.py
+++ b/futureagi/tracer/models/shared_link.py
@@ -1,0 +1,133 @@
+import secrets
+import uuid
+
+from django.db import models
+from django.utils import timezone
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from tfc.utils.base_model import BaseModel
+
+
+class ResourceType(models.TextChoices):
+    TRACE = "trace", "Trace"
+    DASHBOARD = "dashboard", "Dashboard"
+    EVAL_RUN = "eval_run", "Eval Run"
+    DATASET = "dataset", "Dataset"
+    PROJECT = "project", "Project"
+
+
+class AccessType(models.TextChoices):
+    PUBLIC = "public", "Anyone with the link"
+    RESTRICTED = "restricted", "Only specific people"
+
+
+def generate_share_token():
+    return secrets.token_urlsafe(32)
+
+
+class SharedLink(BaseModel):
+    """
+    A shareable link to any platform resource.
+    Supports public (no auth) and restricted (email ACL) access.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # What is being shared
+    resource_type = models.CharField(max_length=20, choices=ResourceType.choices)
+    resource_id = models.CharField(max_length=255, db_index=True)
+
+    # Unguessable token for the share URL
+    token = models.CharField(
+        max_length=64, unique=True, db_index=True, default=generate_share_token
+    )
+
+    # Access mode
+    access_type = models.CharField(
+        max_length=16, choices=AccessType.choices, default=AccessType.RESTRICTED
+    )
+
+    # Creator and ownership
+    created_by = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.CASCADE,
+        related_name="created_shared_links",
+    )
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="shared_links"
+    )
+    workspace = models.ForeignKey(
+        Workspace,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="shared_links",
+    )
+
+    # Expiry (null = never)
+    expires_at = models.DateTimeField(null=True, blank=True)
+
+    # Revocation flag
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        ordering = ("-created_at",)
+        indexes = [
+            models.Index(fields=["resource_type", "resource_id"]),
+        ]
+
+    def __str__(self):
+        return f"SharedLink({self.resource_type}:{self.resource_id[:8]}, {self.access_type})"
+
+    @property
+    def is_expired(self):
+        if not self.expires_at:
+            return False
+        return timezone.now() > self.expires_at
+
+    @property
+    def is_accessible(self):
+        return self.is_active and not self.is_expired and not self.deleted
+
+    @property
+    def share_url_path(self):
+        return f"/shared/{self.token}"
+
+
+class SharedLinkAccess(BaseModel):
+    """
+    ACL entry for restricted shared links.
+    Each row grants one email/user access to view the shared resource.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    shared_link = models.ForeignKey(
+        SharedLink, on_delete=models.CASCADE, related_name="access_list"
+    )
+
+    # The person who has access
+    user = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="shared_link_access",
+    )
+    email = models.EmailField(db_index=True)
+
+    # Who granted this access
+    granted_by = models.ForeignKey(
+        "accounts.User",
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="granted_shared_access",
+    )
+
+    class Meta:
+        unique_together = [["shared_link", "email"]]
+        ordering = ("-created_at",)
+
+    def __str__(self):
+        return f"Access({self.email} → {self.shared_link_id})"

--- a/futureagi/tracer/models/span_notes.py
+++ b/futureagi/tracer/models/span_notes.py
@@ -1,0 +1,22 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.user import User
+from tfc.utils.base_model import BaseModel
+from tracer.models.observation_span import ObservationSpan
+
+
+class SpanNotes(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    span = models.ForeignKey(
+        ObservationSpan, on_delete=models.CASCADE, related_name="notes"
+    )
+    notes = models.TextField()
+    created_by_user = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name="span_notes_created"
+    )
+    created_by_annotator = models.CharField(max_length=255, null=False, blank=False)
+
+    def __str__(self):
+        return f"Span Notes {self.id}"

--- a/futureagi/tracer/models/trace.py
+++ b/futureagi/tracer/models/trace.py
@@ -1,0 +1,66 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+from tracer.models.project_version import ProjectVersion
+from tracer.models.trace_session import TraceSession
+
+
+class TraceErrorAnalysisStatus(models.TextChoices):
+    """Status for trace error analysis processing"""
+
+    PENDING = ("pending",)  # Not yet processed
+    PROCESSING = ("processing",)  # Currently being analyzed
+    COMPLETED = ("completed",)  # Successfully analyzed
+    SKIPPED = ("skipped",)  # Skipped analysis
+    FAILED = ("failed",)
+
+
+class Trace(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="traces",
+        blank=False,
+        null=False,
+    )
+    project_version = models.ForeignKey(
+        ProjectVersion,
+        on_delete=models.CASCADE,
+        related_name="traces",
+        blank=True,
+        null=True,
+    )
+    name = models.CharField(max_length=2000, blank=True, null=True)
+    metadata = models.JSONField(null=True, blank=True)
+    input = models.JSONField(null=True, blank=True)
+    output = models.JSONField(null=True, blank=True)
+    error = models.JSONField(null=True, blank=True)
+    session = models.ForeignKey(
+        TraceSession,
+        on_delete=models.CASCADE,
+        related_name="traces",
+        blank=True,
+        null=True,
+    )
+    external_id = models.CharField(max_length=255, null=True, blank=True)
+    tags = models.JSONField(default=list, blank=True)
+    error_analysis_status = models.CharField(
+        max_length=20,
+        default=TraceErrorAnalysisStatus.PENDING,
+        choices=TraceErrorAnalysisStatus.choices,
+    )
+
+    class Meta:
+        db_table = "tracer_trace"
+        ordering = ["-created_at"]
+
+        indexes = [
+            models.Index(fields=["project", "created_at"]),
+            models.Index(fields=["project_version"]),
+            models.Index(fields=["session"]),
+            models.Index(fields=["external_id"]),
+        ]

--- a/futureagi/tracer/models/trace_annotation.py
+++ b/futureagi/tracer/models/trace_annotation.py
@@ -1,0 +1,62 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.user import User
+from model_hub.models.develop_annotations import AnnotationsLabels
+from tfc.utils.base_model import BaseModel
+from tracer.models.observation_span import ObservationSpan
+from tracer.models.trace import Trace
+
+
+class TraceAnnotation(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    trace = models.ForeignKey(
+        Trace,
+        on_delete=models.CASCADE,
+        related_name="annotation_labels",
+        null=True,
+        blank=True,
+    )
+    annotation_label = models.ForeignKey(
+        AnnotationsLabels,
+        on_delete=models.CASCADE,
+        related_name="trace_annotation",
+        blank=False,
+        null=False,
+    )
+    annotation_value = models.CharField(max_length=255, blank=True, null=True)
+    observation_span = models.ForeignKey(
+        ObservationSpan,
+        on_delete=models.CASCADE,
+        related_name="trace_annotation",
+        null=True,
+        blank=True,
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="trace_annotation",
+        null=True,
+        blank=True,
+    )
+    annotation_value_bool = models.BooleanField(null=True, blank=True)
+    annotation_value_float = models.FloatField(null=True, blank=True)
+    annotation_value_str_list = models.JSONField(default=list, blank=True, null=True)
+
+    updated_by = models.CharField(max_length=255, null=True, blank=True)
+
+    def __str__(self):
+        return f"Trace Annotation {self.id}"
+
+    class Meta:
+        db_table = "trace_annotation"
+        ordering = ["-created_at"]
+
+        indexes = [
+            # Add this!
+            models.Index(fields=["observation_span", "annotation_label", "created_at"]),
+            models.Index(fields=["annotation_label", "created_at"]),
+            models.Index(fields=["annotation_value_float"]),
+            models.Index(fields=["annotation_value_bool"]),
+        ]

--- a/futureagi/tracer/models/trace_error_analysis.py
+++ b/futureagi/tracer/models/trace_error_analysis.py
@@ -1,0 +1,489 @@
+import uuid
+
+from django.db import models
+
+from accounts.models.user import User
+from tfc.utils.base_model import BaseModel
+from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.models.observation_span import EvalLogger, ObservationSpan
+from tracer.models.project import Project
+from tracer.models.trace import Trace
+from tracer.models.trace_scan import TraceScanIssue
+
+
+class Priority(models.TextChoices):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    URGENT = "urgent"
+
+
+class TraceErrorAnalysis(BaseModel):
+    """Stores comprehensive error analysis results for traces"""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    trace = models.ForeignKey(
+        Trace,
+        on_delete=models.CASCADE,
+        related_name="error_analyses",
+        null=False,
+        blank=False,
+    )
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="error_analyses",
+        null=False,
+        blank=False,
+    )
+
+    # Analysis metadata
+    analysis_date = models.DateTimeField(auto_now_add=True)
+    agent_version = models.CharField(max_length=50, default="1.0")
+    memory_enhanced = models.BooleanField(default=False)
+
+    # Summary metrics
+    overall_score = models.FloatField(null=True, blank=True)
+    total_errors = models.IntegerField(default=0)
+    high_impact_errors = models.IntegerField(default=0)
+    medium_impact_errors = models.IntegerField(default=0)
+    low_impact_errors = models.IntegerField(default=0)
+    recommended_priority = models.CharField(max_length=20, default="LOW")
+
+    # Detailed scores - updated to match new scoring categories
+    factual_grounding_score = models.FloatField(null=True, blank=True)
+    factual_grounding_reason = models.TextField(null=True, blank=True)
+
+    privacy_and_safety_score = models.FloatField(null=True, blank=True)
+    privacy_and_safety_reason = models.TextField(null=True, blank=True)
+
+    instruction_adherence_score = models.FloatField(null=True, blank=True)
+    instruction_adherence_reason = models.TextField(null=True, blank=True)
+
+    optimal_plan_execution_score = models.FloatField(null=True, blank=True)
+    optimal_plan_execution_reason = models.TextField(null=True, blank=True)
+
+    # Insights and recommendations
+    insights = models.TextField(null=True, blank=True)
+    memory_context = models.JSONField(default=dict, blank=True)
+
+    # Error grouping
+    grouped_errors_count = models.IntegerField(default=0)
+
+    class Meta:
+        db_table = "tracer_trace_error_analysis"
+        ordering = ["-analysis_date"]
+        indexes = [
+            models.Index(fields=["trace", "analysis_date"]),
+            models.Index(fields=["project", "analysis_date"]),
+            models.Index(fields=["overall_score"]),
+            models.Index(fields=["recommended_priority"]),
+            models.Index(fields=["total_errors"]),
+        ]
+
+
+class TraceErrorDetail(BaseModel):
+    """Stores individual error details from analysis with new structure"""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    analysis = models.ForeignKey(
+        TraceErrorAnalysis,
+        on_delete=models.CASCADE,
+        related_name="error_details",
+        null=False,
+        blank=False,
+    )
+
+    # Error identification
+    error_id = models.CharField(
+        max_length=20, null=False, blank=False
+    )  # E001, E002, etc.
+    cluster_id = models.CharField(
+        max_length=20, null=True, blank=True
+    )  # C01, C02, etc.
+
+    # Error classification - updated for new taxonomy structure
+    category = models.CharField(
+        max_length=200, null=False, blank=False
+    )  # Full category path: "Thinking & Response Issues > Hallucination Errors > Hallucinated Content"
+
+    # Error details
+    impact: models.CharField = models.CharField(
+        max_length=20, default="MEDIUM"
+    )  # HIGH, MEDIUM, LOW
+    urgency_to_fix = models.CharField(
+        max_length=20, default="HIGH"
+    )  # IMMEDIATE, HIGH, MEDIUM, LOW
+
+    # Location and evidence
+    location_spans = models.JSONField(default=list, blank=True)  # List of span IDs
+    evidence_snippets = models.JSONField(
+        default=list, blank=True
+    )  # List of evidence texts
+    description = models.TextField(null=True, blank=True)
+
+    # Root causes and recommendations - new fields
+    root_causes = models.JSONField(
+        default=list, blank=True
+    )  # List of root cause descriptions
+    recommendation = models.TextField(null=True, blank=True)
+    immediate_fix = models.TextField(null=True, blank=True)
+
+    # Trace impact
+    trace_impact = models.TextField(null=True, blank=True)
+    trace_assessment = models.TextField(null=True, blank=True)
+
+    # Analysis metadata
+    llm_analysis = models.TextField(null=True, blank=True)
+    memory_enhanced = models.BooleanField(default=False)
+
+    class Meta:
+        db_table = "tracer_trace_error_detail"
+        ordering = ["error_id"]
+        indexes = [
+            models.Index(fields=["analysis", "error_id"]),
+            models.Index(fields=["category"]),
+            models.Index(fields=["impact"]),
+            models.Index(fields=["urgency_to_fix"]),
+            models.Index(fields=["cluster_id"]),
+        ]
+
+
+class FeedIssueStatus(models.TextChoices):
+    ESCALATING = "escalating"
+    FOR_REVIEW = "for_review"
+    ACKNOWLEDGED = "acknowledged"
+    RESOLVED = "resolved"
+
+
+class ClusterSource(models.TextChoices):
+    SCANNER = "scanner"
+    EVAL = "eval"
+
+
+class TraceErrorGroup(BaseModel):
+    """Stores grouped error information — each row = one Feed issue."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="error_groups",
+        null=False,
+        blank=False,
+        default=None,
+    )
+
+    # --- Feed fields (new) ---
+    source = models.CharField(
+        max_length=20,
+        choices=ClusterSource.choices,
+        default=ClusterSource.SCANNER,
+    )
+    issue_group = models.CharField(
+        max_length=100,
+        null=True,
+        blank=True,
+        help_text='Scanner: "Tool Failures", Eval: eval name',
+    )
+    issue_category = models.CharField(
+        max_length=100,
+        null=True,
+        blank=True,
+        help_text='Scanner: "Language-only", Eval: criteria or null',
+    )
+    fix_layer = models.CharField(
+        max_length=50,
+        null=True,
+        blank=True,
+        help_text='"Tools" / "Prompt" / "Orchestration" / "Guardrails"',
+    )
+    title = models.TextField(
+        null=True,
+        blank=True,
+        help_text="Descriptive issue title",
+    )
+    status = models.CharField(
+        max_length=20,
+        choices=FeedIssueStatus.choices,
+        default=FeedIssueStatus.ESCALATING,
+    )
+    eval_config = models.ForeignKey(
+        CustomEvalConfig,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="error_groups",
+        help_text="For eval-sourced clusters",
+    )
+    success_trace = models.ForeignKey(
+        Trace,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="success_for_groups",
+        help_text="Precomputed nearest success trace",
+    )
+
+    # --- Existing fields (backwards compat) ---
+    cluster_id = models.CharField(max_length=20, null=False, blank=False)
+    error_type = models.CharField(max_length=200, null=False, blank=False)
+
+    total_events = models.IntegerField(default=0)
+    unique_traces = models.IntegerField(default=0)
+    unique_users = models.IntegerField(default=0)
+    first_seen = models.DateTimeField(null=True, blank=True)
+    last_seen = models.DateTimeField(null=True, blank=True)
+
+    error_ids = models.JSONField(default=list, blank=True)
+    combined_impact = models.CharField(max_length=20, default="MEDIUM")
+    combined_description = models.TextField(null=True, blank=True)
+    error_count = models.IntegerField(default=0)
+    trace_impact = models.TextField(null=True, blank=True)
+
+    # Ticket Management
+    assignee = models.ForeignKey(
+        User,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="assigned_error_groups",
+    )
+    priority = models.CharField(
+        max_length=20, default=Priority.MEDIUM, choices=Priority.choices
+    )
+    external_issue_url = models.URLField(
+        max_length=500,
+        null=True,
+        blank=True,
+        help_text="URL of linked external issue (Linear, GitHub, Jira, etc.)",
+    )
+    external_issue_id = models.CharField(
+        max_length=100,
+        null=True,
+        blank=True,
+        help_text="External issue identifier (e.g. TH-123, #456)",
+    )
+
+    class Meta:
+        db_table = "tracer_trace_error_group"
+        ordering = ["cluster_id"]
+        indexes = [
+            models.Index(fields=["project", "cluster_id"]),
+            models.Index(fields=["error_type"]),
+            models.Index(fields=["combined_impact"]),
+            models.Index(fields=["project", "source"]),
+            models.Index(fields=["project", "issue_group"]),
+            models.Index(fields=["status"]),
+        ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["project", "cluster_id"],
+                condition=models.Q(deleted=False),
+                name="unique_project_cluster_if_not_deleted",
+            ),
+        ]
+
+
+class AnalysisErrorGroup(BaseModel):
+    """Stores error groups generated by the agent during single trace analysis
+
+    This is different from TraceErrorGroup which is used for cross-trace clustering.
+    This model stores the 'grouped_errors' that are generated during individual
+    trace analysis by the agent.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    analysis = models.ForeignKey(
+        TraceErrorAnalysis,
+        on_delete=models.CASCADE,
+        related_name="analysis_error_groups",  # Different related_name
+        null=False,
+        blank=False,
+    )
+
+    # Group identification (within this single trace analysis)
+    cluster_id = models.CharField(
+        max_length=20, null=False, blank=False
+    )  # C01, C02, etc.
+    error_type = models.CharField(max_length=200, null=False, blank=False)
+
+    # Group details
+    error_ids = models.JSONField(
+        default=list, blank=True
+    )  # List of error IDs in this group
+    affected_spans = models.JSONField(default=list, blank=True)  # List of span IDs
+    combined_impact = models.CharField(max_length=20, default="MEDIUM")
+    combined_description = models.TextField(null=True, blank=True)
+    error_count = models.IntegerField(default=0)
+    trace_impact = models.TextField(null=True, blank=True)
+
+    class Meta:
+        db_table = "tracer_analysis_error_group"  # Different table
+        ordering = ["cluster_id"]
+        indexes = [
+            models.Index(fields=["analysis", "cluster_id"]),
+            models.Index(fields=["error_type"]),
+            models.Index(fields=["combined_impact"]),
+        ]
+
+
+class ErrorPattern(BaseModel):
+    """Stores learned error patterns for semantic memory with updated structure"""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="error_patterns",
+        null=False,
+        blank=False,
+    )
+
+    # Pattern identification
+    pattern_type = models.CharField(
+        max_length=50, null=False, blank=False
+    )  # tool_error, format_error, etc.
+    category = models.CharField(
+        max_length=200, null=False, blank=False
+    )  # Full category path
+    subcategory = models.CharField(max_length=100, null=False, blank=False)
+    specific_error = models.CharField(
+        max_length=100, null=True, blank=True
+    )  # Specific error name
+
+    # Pattern details
+    pattern_description = models.TextField(null=True, blank=True)
+    frequency = models.IntegerField(default=1)
+    first_seen = models.DateTimeField(auto_now_add=True)
+    last_seen = models.DateTimeField(auto_now=True)
+
+    # Context information
+    tool_name = models.CharField(max_length=100, null=True, blank=True)
+    span_type = models.CharField(max_length=50, null=True, blank=True)
+    input_pattern = models.TextField(null=True, blank=True)
+    output_pattern = models.TextField(null=True, blank=True)
+
+    # Recommendations and fixes - updated fields
+    recommendation = models.TextField(null=True, blank=True)
+    immediate_fix = models.TextField(null=True, blank=True)
+    root_causes = models.JSONField(default=list, blank=True)  # List of root causes
+
+    # Metadata
+    confidence_score = models.FloatField(default=0.0)
+    is_resolved = models.BooleanField(default=False)
+    resolution_date = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "tracer_error_pattern"
+        ordering = ["-frequency", "-last_seen"]
+        indexes = [
+            models.Index(fields=["project", "category"]),
+            models.Index(fields=["pattern_type", "frequency"]),
+            models.Index(fields=["tool_name"]),
+            models.Index(fields=["is_resolved"]),
+            models.Index(fields=["confidence_score"]),
+        ]
+
+
+class ErrorMemory(BaseModel):
+    """Stores episodic and semantic memory for error analysis"""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="error_memories",
+        null=False,
+        blank=False,
+    )
+
+    # Memory type
+    memory_type = models.CharField(
+        max_length=20, null=False, blank=False
+    )  # episodic, semantic
+
+    # Memory content
+    memory_key = models.CharField(
+        max_length=200, null=False, blank=False
+    )  # e.g., "tool_usage_pattern", "similar_traces"
+    memory_data = models.JSONField(default=dict, blank=True)
+
+    # Memory metadata
+    created_date = models.DateTimeField(auto_now_add=True)
+    last_updated = models.DateTimeField(auto_now=True)
+    memory_window_days = models.IntegerField(default=30)
+    is_active = models.BooleanField(default=True)
+
+    # Usage tracking
+    access_count = models.IntegerField(default=0)
+    last_accessed = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "tracer_error_memory"
+        ordering = ["-last_updated"]
+        indexes = [
+            models.Index(fields=["project", "memory_type"]),
+            models.Index(fields=["memory_key"]),
+            models.Index(fields=["is_active"]),
+            models.Index(fields=["last_updated"]),
+        ]
+
+
+class ErrorClusterTraces(BaseModel):
+    """Stores the traces that are clustered together, with provenance."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    trace = models.ForeignKey(
+        Trace,
+        on_delete=models.CASCADE,
+        related_name="error_cluster_traces",
+        null=True,
+        blank=True,
+    )
+
+    span = models.ForeignKey(
+        ObservationSpan,
+        on_delete=models.CASCADE,
+        related_name="error_cluster_spans",
+        null=True,
+        blank=True,
+    )
+    cluster = models.ForeignKey(
+        TraceErrorGroup,
+        on_delete=models.CASCADE,
+        related_name="clusters",
+        null=False,
+        blank=False,
+    )
+
+    # Provenance — which finding caused this trace to join the cluster
+    scan_issue = models.ForeignKey(
+        "tracer.TraceScanIssue",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="cluster_memberships",
+        help_text="Scanner finding that caused membership",
+    )
+    eval_logger = models.ForeignKey(
+        EvalLogger,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="cluster_memberships",
+        help_text="Eval result that caused membership",
+    )
+
+    class Meta:
+        db_table = "tracer_error_cluster_traces"
+        unique_together = [["cluster", "trace", "span"]]
+        indexes = [
+            models.Index(fields=["cluster", "trace"]),
+            models.Index(fields=["cluster"]),
+            models.Index(fields=["trace"]),
+            models.Index(fields=["span"]),
+            models.Index(fields=["scan_issue"]),
+            models.Index(fields=["eval_logger"]),
+        ]

--- a/futureagi/tracer/models/trace_error_analysis_task.py
+++ b/futureagi/tracer/models/trace_error_analysis_task.py
@@ -1,0 +1,73 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+from tracer.models.trace import Trace
+
+
+class TraceErrorTaskStatus:
+    """Status choices for trace error task"""
+
+    RUNNING = "running"  # Currently processing traces
+    WAITING = "waiting"  # Active but no new traces to process
+    PAUSED = "paused"  # User paused it
+
+    CHOICES = [
+        (RUNNING, "Running"),
+        (WAITING, "Waiting"),
+        (PAUSED, "Paused"),
+    ]
+
+
+class TraceErrorAnalysisTask(BaseModel):
+    """
+    One task per project that continuously analyzes traces based on sampling rate
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # One task per project
+    project = models.OneToOneField(
+        Project, on_delete=models.CASCADE, related_name="trace_error_task"
+    )
+
+    # Configuration (what user sets from UI)
+    sampling_rate = models.FloatField(
+        default=0.1, help_text="Percentage of traces to analyze (0-1)"  # 10% by default
+    )
+
+    # Status tracking
+    status = models.CharField(
+        max_length=20,
+        default=TraceErrorTaskStatus.WAITING,  # Start in waiting state
+        choices=TraceErrorTaskStatus.CHOICES,
+    )
+
+    # Execution tracking
+    last_run_at = models.DateTimeField(null=True, blank=True)
+    last_trace_analyzed = models.ForeignKey(
+        Trace,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="last_analyzed_by_task",
+    )
+
+    # Statistics
+    total_traces_analyzed = models.IntegerField(default=0)
+    total_errors_found = models.IntegerField(default=0)
+    failed_analyses = models.IntegerField(default=0)
+
+    # Proper relationship for failed traces
+    failed_traces = models.ManyToManyField(
+        Trace, blank=True, related_name="failed_error_analyses"
+    )
+
+    class Meta:
+        db_table = "tracer_trace_error_analysis_task"
+        unique_together = [["project", "deleted"]]  # Only one active task per project
+
+    def __str__(self):
+        return f"Error Analysis Task for {self.project.name} - {self.status}"

--- a/futureagi/tracer/models/trace_scan.py
+++ b/futureagi/tracer/models/trace_scan.py
@@ -1,0 +1,180 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+from tracer.models.trace import Trace
+
+
+class TraceScanStatus(models.TextChoices):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ScanIssueConfidence(models.TextChoices):
+    HIGH = "H"
+    MEDIUM = "M"
+    LOW = "L"
+
+
+class TraceScanConfig(BaseModel):
+    """Per-project scanning configuration."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.OneToOneField(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="scan_config",
+    )
+    sampling_rate = models.FloatField(
+        default=0.1, help_text="0.0-1.0, fraction of traces to scan"
+    )
+    enabled = models.BooleanField(default=True)
+    scan_version = models.CharField(max_length=20, default="v7.2")
+
+    class Meta:
+        db_table = "tracer_trace_scan_config"
+
+    def __str__(self):
+        return f"ScanConfig({self.project.name}, rate={self.sampling_rate})"
+
+
+class TraceScanResult(BaseModel):
+    """One result per scanned trace — stores scanner output."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    trace = models.ForeignKey(
+        Trace,
+        on_delete=models.CASCADE,
+        related_name="scan_results",
+    )
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="scan_results",
+    )
+    status = models.CharField(
+        max_length=20,
+        choices=TraceScanStatus.choices,
+        default=TraceScanStatus.PENDING,
+    )
+    has_issues = models.BooleanField(default=False)
+    key_moments = models.JSONField(
+        default=list,
+        blank=True,
+        help_text='[{"kevinified": "...", "verbatim": "..."}]',
+    )
+    meta = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="{tools_called, tools_available, turn_count}",
+    )
+    scan_version = models.CharField(max_length=20, default="v7.2")
+    error_message = models.TextField(null=True, blank=True)
+
+    class Meta:
+        db_table = "tracer_trace_scan_result"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["project", "created_at"]),
+            models.Index(fields=["trace"]),
+            models.Index(fields=["status"]),
+            models.Index(fields=["has_issues"]),
+        ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["trace"],
+                condition=models.Q(deleted=False),
+                name="unique_scan_result_per_trace",
+            ),
+        ]
+
+    def __str__(self):
+        return f"ScanResult({self.trace_id}, {self.status})"
+
+
+class TraceScanIssue(BaseModel):
+    """Individual issue found by the scanner — one-to-many from TraceScanResult."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    scan_result = models.ForeignKey(
+        TraceScanResult,
+        on_delete=models.CASCADE,
+        related_name="issues",
+    )
+    category = models.CharField(
+        max_length=100, help_text='Subcategory e.g. "Language-only"'
+    )
+    group = models.CharField(
+        max_length=100, help_text='Scanner group e.g. "Tool Failures"'
+    )
+    fix_layer = models.CharField(
+        max_length=50,
+        help_text='"Tools" / "Prompt" / "Orchestration" / "Guardrails"',
+    )
+    confidence = models.CharField(
+        max_length=2,
+        choices=ScanIssueConfidence.choices,
+        default=ScanIssueConfidence.MEDIUM,
+    )
+    brief = models.TextField(help_text="Short description of the issue")
+    cluster = models.ForeignKey(
+        "tracer.TraceErrorGroup",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="scan_issues",
+        help_text="Assigned after clustering",
+    )
+
+    class Meta:
+        db_table = "tracer_trace_scan_issue"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["scan_result"]),
+            models.Index(fields=["group"]),
+            models.Index(fields=["category"]),
+            models.Index(fields=["fix_layer"]),
+            models.Index(fields=["confidence"]),
+        ]
+
+    def __str__(self):
+        return f"ScanIssue({self.category}, {self.confidence})"
+
+
+class ProjectCapability(BaseModel):
+    """Auto-discovered task types from root input clustering."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="capabilities",
+    )
+    title = models.CharField(
+        max_length=255, help_text='Auto-generated: "Refund Processing"'
+    )
+    trace_count = models.IntegerField(default=0)
+    success_rate = models.FloatField(
+        default=0.0, help_text="0.0-1.0, traces without issues / total"
+    )
+    centroid_id = models.CharField(
+        max_length=255,
+        help_text="Reference to ClickHouse centroid for this capability cluster",
+    )
+    first_seen = models.DateTimeField(null=True, blank=True)
+    last_seen = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "tracer_project_capability"
+        ordering = ["-trace_count"]
+        indexes = [
+            models.Index(fields=["project", "created_at"]),
+            models.Index(fields=["project", "success_rate"]),
+        ]
+
+    def __str__(self):
+        return f"{self.title} ({self.project.name})"

--- a/futureagi/tracer/models/trace_session.py
+++ b/futureagi/tracer/models/trace_session.py
@@ -1,0 +1,26 @@
+import uuid
+
+from django.db import models
+
+from tfc.utils.base_model import BaseModel
+from tracer.models.project import Project
+
+
+class TraceSession(BaseModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="sessions",
+        blank=False,
+        null=False,
+    )
+    bookmarked = models.BooleanField(default=False)
+    name = models.CharField(max_length=255, blank=True, null=True)
+
+    def __str__(self):
+        return f"Session {self.id}"
+
+    class Meta:
+        db_table = "trace_session"
+        ordering = ["-created_at"]


### PR DESCRIPTION


<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

- Implemented RequestExplorerSection component for viewing and filtering request logs.
- Added RequestTable component to display logs in a tabular format with pagination and sorting.
- Created SessionExplorer component to explore sessions and their associated requests.
- Introduced hooks for managing filters (useFilters), fetching request logs (useRequestLogs), and fetching session data (useSessions).
- Added utility hooks for fetching request details (useRequestDetail) and session details.
- Implemented quick filters for common log queries (e.g., errors, slow requests).
- Integrated export functionality for logs in CSV and JSON formats.
- Enhanced UI with loading states, error handling, and responsive design.

## Linked issues

## Type of change

- [] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
