### PR TITLE
ci: add auto-labeler for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,62 @@
+# Labels applied automatically based on changed file paths.
+# See https://github.com/actions/labeler
+
+# ── Backend ──
+backend:
+  - changed-files:
+      - any-glob-to-any-file: 'futureagi/**'
+
+# ── Frontend ──
+frontend:
+  - changed-files:
+      - any-glob-to-any-file: 'frontend/**'
+
+# ── Gateway ──
+gateway:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'futureagi/agentcc-gateway/**'
+          - 'futureagi/agentcc/**'
+
+# ── Evaluations ──
+evaluations:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'futureagi/agentic_eval/**'
+          - 'futureagi/evaluations/**'
+
+# ── Tracing ──
+tracing:
+  - changed-files:
+      - any-glob-to-any-file: 'futureagi/tracer/**'
+
+# ── Simulate ──
+simulate:
+  - changed-files:
+      - any-glob-to-any-file: 'futureagi/simulate/**'
+
+# ── Accounts / Auth ──
+auth:
+  - changed-files:
+      - any-glob-to-any-file: 'futureagi/accounts/**'
+
+# ── Datasets / Model Hub ──
+datasets:
+  - changed-files:
+      - any-glob-to-any-file: 'futureagi/model_hub/**'
+
+# ── Infrastructure ──
+infra:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'futureagi/docker-compose*'
+          - 'futureagi/Dockerfile*'
+          - 'futureagi/tfc/**'
+          - '.github/**'
+
+# ── Documentation ──
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'docs/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds [actions/labeler](https://github.com/actions/labeler) to automatically label PRs based on changed file paths. Labels applied: `backend`, `frontend`, `gateway`, `evaluations`, `tracing`, `simulate`, `auth`, `datasets`, `infra`, `docs`.

## Type of change

- [x] 🧹 Chore / refactor (no user-visible change)

## How was this tested?

- Label config validated against repo directory structure
- Workflow uses `actions/labeler@v5` (latest stable)

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] No hardcoded secrets, URLs, or PII