### PR TITLE
[TH-2625] Fix stale row selection on dataset switch and tab change

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -563,6 +563,17 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
   );
   isProcessingSyntheticData;
 
+  // Reset row selection when dataset changes or component unmounts (tab switch)
+  useEffect(() => {
+    useDevelopSelectedRowsStore.getState().setToggledNodes([]);
+    useDevelopSelectedRowsStore.getState().setSelectAll(false);
+    gridApiRef.current?.api?.deselectAll();
+    return () => {
+      useDevelopSelectedRowsStore.getState().setToggledNodes([]);
+      useDevelopSelectedRowsStore.getState().setSelectAll(false);
+    };
+  }, [dataset]);
+
   useEffect(() => {
     const dataSource = getDataSource(
       queryClient,

--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopDataSelectionActive.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopDataSelectionActive.jsx
@@ -246,13 +246,13 @@ const DevelopDataSelectionActive = () => {
 
   const unCheckedHandler = () => {
     resetSelectedRows();
-    gridApi.current.deselectAll();
+    gridApi.current?.deselectAll();
   };
 
   const selectedCount = useMemo(() => {
-    const context = gridApi.current.getGridOption("context");
+    const context = gridApi.current?.getGridOption("context");
     if (selectAll) {
-      return context.totalRowCount - toggledNodes.length;
+      return (context?.totalRowCount ?? 0) - toggledNodes.length;
     } else {
       return toggledNodes.length;
     }


### PR DESCRIPTION
## Summary
- Row selection (`selectAll` + `toggledNodes`) in Zustand store was persisting across dataset switches and tab changes, causing stale `selectedAllRows: true` in API payloads (delete, duplicate, copy) and a crash (`Cannot read properties of undefined (reading 'totalRowCount')`) when switching back to data tab
- Added `useEffect` cleanup in `DevelopDataV2` to reset selection on dataset change and unmount
- Added null guards in `DevelopDataSelectionActive` for stale grid API ref

Fixes TH-2625

## Linear Ticket
[TH-2625](https://linear.app/future-agi/issue/TH-2625/on-all-selection-row-if-i-change-dataset-then-also-it-is-all-selected)

## Files Changed
- `frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx`
- `frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopDataSelectionActive.jsx`

## Test plan
- [ ] Select rows → switch dataset from dropdown → verify selection clears
- [ ] Select all → switch to experiment tab → switch back to data tab → verify no crash
- [ ] Select rows → perform delete → verify correct rows deleted (no stale selectAll)

---

_Migrated from future-agi/core-frontend#2609._