### PR TITLE
fix: global variables form not synced with API on first open

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/GlobalVariableDrawer.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/GlobalVariableDrawer.jsx
@@ -145,7 +145,6 @@ export default function GlobalVariableDrawer({ open, onClose }) {
     uploadedFileName,
     currentView,
     setCurrentView,
-    globalVariables,
     setGlobalVariables,
     // importDatasetDrawerOpen,
     // setImportDatasetDrawerOpen,
@@ -156,7 +155,6 @@ export default function GlobalVariableDrawer({ open, onClose }) {
     uploadedFileName: state.uploadedFileName,
     currentView: state.currentView,
     setCurrentView: state.setCurrentView,
-    globalVariables: state.globalVariables,
     setGlobalVariables: state.setGlobalVariables,
     // importDatasetDrawerOpen: state.importDatasetDrawerOpen,
     // setImportDatasetDrawerOpen: state.setImportDatasetDrawerOpen,
@@ -176,16 +174,16 @@ export default function GlobalVariableDrawer({ open, onClose }) {
     [datasetData],
   );
 
-  // Sync dataset variables to store when data arrives
+  // Sync dataset variables to store (for other consumers like useConnectedNodeVariables)
   useEffect(() => {
     if (datasetData && Object.keys(datasetVariables).length > 0) {
       setGlobalVariables(datasetVariables);
     }
   }, [datasetVariables, datasetData, setGlobalVariables]);
 
-  // Form management
+  // Form management — use API-derived data as source of truth, not the store
   const methods = useForm({
-    defaultValues: escapeKeys(globalVariables),
+    defaultValues: escapeKeys(datasetVariables),
     mode: "onChange",
   });
 
@@ -199,13 +197,13 @@ export default function GlobalVariableDrawer({ open, onClose }) {
   // Watch all form values
   const formValues = watch();
 
-  // Sync form when global variables change
+  // Sync form when API-derived variables change
   useEffect(() => {
-    reset(escapeKeys(globalVariables));
-  }, [globalVariables, reset]);
+    reset(escapeKeys(datasetVariables));
+  }, [datasetVariables, reset]);
 
   // Get variable keys for the ImportDatasetDrawer
-  const variableKeys = Object.keys(globalVariables);
+  const variableKeys = Object.keys(datasetVariables);
 
   // Handler called when ImportDatasetDrawer applies data
   // Using getValues instead of watch() to avoid new object reference on every render
@@ -253,7 +251,7 @@ export default function GlobalVariableDrawer({ open, onClose }) {
     setShowUploadJsonDialog(false);
     setShowConfirmDialog(false);
     setPendingRun(false);
-    reset(escapeKeys(globalVariables)); // Reset form to clean state
+    reset(escapeKeys(datasetVariables)); // Reset form to clean state
     uploadMutation.reset();
     onClose();
   };
@@ -322,6 +320,7 @@ export default function GlobalVariableDrawer({ open, onClose }) {
               isDirty={isDirty}
               cellMap={cellMap}
               graphId={graphId}
+              variables={datasetVariables}
             />
           </FormProvider>
         );
@@ -341,6 +340,7 @@ export default function GlobalVariableDrawer({ open, onClose }) {
               isDirty={isDirty}
               cellMap={cellMap}
               graphId={graphId}
+              variables={datasetVariables}
             />
           </FormProvider>
         );

--- a/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/ManualVariablesForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/ManualVariablesForm.jsx
@@ -73,20 +73,15 @@ export default function ManualVariablesForm({
   isDirty,
   cellMap,
   graphId,
+  variables = {},
 }) {
-  const {
-    globalVariables,
-    setGlobalVariables,
-    setOpen,
-    pendingRun,
-    setPendingRun,
-  } = useGlobalVariablesDrawerStoreShallow((s) => ({
-    globalVariables: s.globalVariables,
-    setGlobalVariables: s.setGlobalVariables,
-    setOpen: s.setOpen,
-    pendingRun: s.pendingRun,
-    setPendingRun: s.setPendingRun,
-  }));
+  const { setGlobalVariables, setOpen, pendingRun, setPendingRun } =
+    useGlobalVariablesDrawerStoreShallow((s) => ({
+      setGlobalVariables: s.setGlobalVariables,
+      setOpen: s.setOpen,
+      pendingRun: s.pendingRun,
+      setPendingRun: s.setPendingRun,
+    }));
 
   const { control, reset } = useFormContext();
   const { mutateAsync: updateCell } = useUpdateDatasetCell();
@@ -114,7 +109,7 @@ export default function ManualVariablesForm({
       // Find changed fields and update each cell via cellMap lookup
       const updates = [];
       for (const [key, value] of Object.entries(flatValues)) {
-        if (value === globalVariables[key]) continue;
+        if (value === variables[key]) continue;
         const cell = cellMap[key];
         if (cell) {
           updates.push(updateCell({ graphId, cellId: cell.id, value }));
@@ -137,7 +132,7 @@ export default function ManualVariablesForm({
     }
   };
 
-  const isEmpty = Object.keys(globalVariables).length === 0;
+  const isEmpty = Object.keys(variables).length === 0;
   if (isEmpty) {
     return (
       <Box sx={{ height: "calc(100vh - 100px)", width: "100%" }}>
@@ -162,7 +157,7 @@ export default function ManualVariablesForm({
       ) : (
         <Box>
           <Stack direction="column" spacing={2}>
-            {Object.keys(globalVariables).map((key) => (
+            {Object.keys(variables).map((key) => (
               <Controller
                 key={key}
                 name={escapeModelKey(key)}
@@ -215,4 +210,5 @@ ManualVariablesForm.propTypes = {
   isDirty: PropTypes.bool.isRequired,
   cellMap: PropTypes.object,
   graphId: PropTypes.string,
+  variables: PropTypes.object.isRequired,
 };

--- a/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/__tests__/ManualVariablesForm.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GlobalVariablesPanel/__tests__/ManualVariablesForm.test.jsx
@@ -42,6 +42,7 @@ function renderForm(props = {}, storeOverrides = {}) {
       country: { id: "cell-2", columnId: "col-2", value: "Japan" },
     },
     graphId: "graph-1",
+    variables: { city: "Tokyo", country: "Japan" },
     ...props,
   };
 
@@ -68,8 +69,8 @@ describe("ManualVariablesForm", () => {
     mockUpdateCell.mockResolvedValue({});
   });
 
-  it("renders empty state when globalVariables is empty", () => {
-    renderForm({}, { globalVariables: {} });
+  it("renders empty state when variables is empty", () => {
+    renderForm({ variables: {} });
     expect(screen.getByTestId("empty-variable")).toBeInTheDocument();
   });
 

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
@@ -411,6 +411,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
       <Box
         sx={{
           flex: 1,
+          height: "100%",
           display: "flex",
           alignItems: "center",
           justifyContent: "center",


### PR DESCRIPTION
## Summary
- The global variables form was not showing API data on first open due to a timing race between `useForm` initialization (with empty store `{}`) and the `reset` effect firing with a stale closure
- Fixed by making the API-derived `datasetVariables` (via `useMemo`) the direct source of truth for the form instead of going through the Zustand store
- `ManualVariablesForm` now receives variables as a prop instead of reading from the store
- Store is still updated for other consumers (`useConnectedNodeVariables`)
- Also fixes `NodeOutputDetail` empty state height

## Linked Issue
Fixes [TH-3855](https://linear.app/future-agi/issue/TH-3855/global-variable-input-fields-are-shown-inconsistently-across-workflow)

## Test plan
- [ ] Open the global variables drawer for the first time — all variables from API should appear immediately
- [ ] Close and reopen — data should still be correct
- [ ] Edit a variable, save — values persist correctly
- [ ] Run workflow with global variables — all variables should be prompted
- [ ] All 899 existing tests pass

---

_Migrated from future-agi/core-frontend#2636._