### PR TITLE
fix: warn user about unsaved node changes before running workflow

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/BuilderActions.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/BuilderActions.jsx
@@ -1,7 +1,8 @@
 import { Box, Button } from "@mui/material";
 import { LoadingButton } from "@mui/lab";
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
+import { ConfirmDialog } from "src/components/custom-dialog";
 import SvgColor from "src/components/svg-color";
 import Iconify from "src/components/iconify";
 import {
@@ -28,6 +29,7 @@ export default function BuilderActions({ width, hasNodes = true }) {
     setValidationErrorNodeIds,
     clearValidationErrors,
     clearAllExecutionStates,
+    isNodeFormDirty,
   } = useAgentPlaygroundStoreShallow((s) => ({
     isDraft: s.currentAgent?.is_draft ?? true,
     nodes: s.nodes,
@@ -37,6 +39,7 @@ export default function BuilderActions({ width, hasNodes = true }) {
     setValidationErrorNodeIds: s.setValidationErrorNodeIds,
     clearValidationErrors: s.clearValidationErrors,
     clearAllExecutionStates: s.clearAllExecutionStates,
+    isNodeFormDirty: s._isNodeFormDirty,
   }));
 
   const { hasRun, showOutput, outputPanelHeight, setShowOutput } =
@@ -59,7 +62,13 @@ export default function BuilderActions({ width, hasNodes = true }) {
     cancelLoadingTemplate: state.cancelLoadingTemplate,
   }));
 
-  const handleRunWorkflow = () => {
+  const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
+
+  const handleRunWorkflow = ({ skipDirtyCheck = false } = {}) => {
+    if (!skipDirtyCheck && isNodeFormDirty) {
+      setShowUnsavedDialog(true);
+      return;
+    }
     if (isDraft) {
       clearValidationErrors();
       clearAllExecutionStates();
@@ -219,6 +228,28 @@ export default function BuilderActions({ width, hasNodes = true }) {
         open={showStopConfirmDialog}
         onClose={handleCancelStop}
         onConfirm={handleConfirmStop}
+      />
+
+      {/* Unsaved node form changes dialog */}
+      <ConfirmDialog
+        open={showUnsavedDialog}
+        onClose={() => setShowUnsavedDialog(false)}
+        title="Unsaved Changes"
+        content="You have unsaved node changes. Running now will use the last saved configuration."
+        action={
+          <Button
+            size="small"
+            variant="contained"
+            color="error"
+            onClick={() => {
+              setShowUnsavedDialog(false);
+              handleRunWorkflow({ skipDirtyCheck: true });
+            }}
+            sx={{ paddingX: "24px" }}
+          >
+            Run Anyway
+          </Button>
+        }
       />
     </>
   );

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeDrawer.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeDrawer.jsx
@@ -71,14 +71,12 @@ export default function NodeDrawer({
     formState: { isDirty },
   } = methods;
 
-  // Sync dirty state to the store so ensureDraft() can show a discard dialog
-  // before creating a draft. Only tracked when the drawer is open on an active
-  // version — on drafts or when closed, the flag is always false.
-  const isActiveVersion = !currentAgent?.is_draft;
+  // Sync dirty state to the store so callers (ensureDraft, handleRunWorkflow)
+  // can detect unsaved form changes. Tracked whenever the drawer is open.
   useEffect(() => {
-    setNodeFormDirty(open && isActiveVersion && isDirty);
+    setNodeFormDirty(open && isDirty);
     return () => setNodeFormDirty(false);
-  }, [open, isDirty, isActiveVersion, setNodeFormDirty]);
+  }, [open, isDirty, setNodeFormDirty]);
 
   // After draft creation, the version ID changes and node IDs are remapped.
   // Sync activeNode to the remapped node by matching on label so that

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeDrawer.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeDrawer.jsx
@@ -75,8 +75,10 @@ export default function NodeDrawer({
   // can detect unsaved form changes. Tracked whenever the drawer is open.
   useEffect(() => {
     setNodeFormDirty(open && isDirty);
-    return () => setNodeFormDirty(false);
   }, [open, isDirty, setNodeFormDirty]);
+
+  // Clear on unmount so the flag doesn't persist across page navigations.
+  useEffect(() => () => setNodeFormDirty(false), [setNodeFormDirty]);
 
   // After draft creation, the version ID changes and node IDs are remapped.
   // Sync activeNode to the remapped node by matching on label so that

--- a/frontend/src/sections/agent-playground/store/agent-playground-store.js
+++ b/frontend/src/sections/agent-playground/store/agent-playground-store.js
@@ -226,7 +226,8 @@ export const useAgentPlaygroundStore = create(
       },
 
       // Tracks whether the NodeDrawer form has unsaved changes.
-      // Used by ensureDraft() to show a discard dialog before creating a draft.
+      // Used by ensureDraft() to show a discard dialog before creating a draft,
+      // and by BuilderActions to warn before running with stale config.
       _isNodeFormDirty: false,
       setNodeFormDirty: (dirty) => set({ _isNodeFormDirty: dirty }),
 


### PR DESCRIPTION
## Summary
- When "Run Agent Workflow" is clicked with unsaved node form changes, a confirmation dialog now appears warning that running will use the last saved configuration
- User can choose "Run Anyway" (proceeds with stale config) or cancel (go back to save)
- Broadened `_isNodeFormDirty` store flag to track on draft versions too (previously only active versions)
- Updated store comment to reflect the new consumer

## Migration note
Patch was rebased to match main's current snake_case field names (`is_draft`, `version_id`, etc.) — the PR's property accesses were adapted so main's rename is preserved. New UI logic (ConfirmDialog, `skipDirtyCheck` flow) applied on top unchanged.

## Linked Issue
Fixes [TH-3854](https://linear.app/future-agi/issue/TH-3854/prompt-user-for-confirmation-before-executing-if-agentprompt-form-has)

## Test plan
- [ ] Open node drawer, edit form (don't save), click "Run Agent Workflow" → dialog appears
- [ ] Click "Run Anyway" → dialog closes, workflow runs with last saved config
- [ ] Click cancel/X → dialog closes, user returns to form
- [ ] Save the form first, then click Run → no dialog, runs normally
- [ ] Close drawer without saving, click Run → no dialog (dirty flag clears on close)
- [ ] Test on both active and draft versions
- [ ] All 899 existing tests pass

---

_Migrated from future-agi/core-frontend#2637._