### PR TITLE
feat: Storybook icon gallery for browsing local SVGs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ frontend/build/
 frontend/.next/
 frontend/out/
 frontend/storybook-static/
+frontend/src/components/icon-gallery/icon-manifest.json
 .vite/
 
 # Vite dev-server cache artifacts

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -1,3 +1,5 @@
+import iconManifestPlugin from "../plugins/vite-plugin-icon-manifest.mjs";
+
 /** @type { import('@storybook/react-vite').StorybookConfig } */
 const config = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
@@ -8,6 +10,10 @@ const config = {
   framework: {
     name: "@storybook/react-vite",
     options: {},
+  },
+  async viteFinal(config) {
+    config.plugins.push(iconManifestPlugin());
+    return config;
   },
 };
 export default config;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,8 +28,9 @@
     "re:build": "yarn rm:all && yarn install && node --max-old-space-size=8192 ./node_modules/.bin/vite build",
     "re:build-npm": "npm run rm:all && npm install && npm run build",
     "dev:host": "vite --host",
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "node --max-old-space-size=4096 ./node_modules/.bin/storybook build"
+    "generate-icons": "node scripts/generate-icon-manifest.mjs",
+    "storybook": "node scripts/generate-icon-manifest.mjs && storybook dev -p 6006",
+    "build-storybook": "node scripts/generate-icon-manifest.mjs && node --max-old-space-size=4096 ./node_modules/.bin/storybook build"
   },
   "dependencies": {
     "@dagrejs/dagre": "^1.1.5",

--- a/frontend/plugins/vite-plugin-icon-manifest.mjs
+++ b/frontend/plugins/vite-plugin-icon-manifest.mjs
@@ -1,0 +1,55 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Same directories the generation script scans (scripts/generate-icon-manifest.mjs)
+const ICON_DIRS = ["public/assets/icons", "public/icons"];
+
+export default function iconManifestPlugin() {
+  const root = process.cwd();
+  const scriptPath = resolve(root, "scripts/generate-icon-manifest.mjs");
+
+  function generate() {
+    return new Promise((res, rej) => {
+      execFile("node", [scriptPath], (err) => (err ? rej(err) : res()));
+    });
+  }
+
+  return {
+    name: "icon-manifest",
+    apply: "serve",
+    configureServer(server) {
+      const { logger } = server.config;
+      const dirsToWatch = ICON_DIRS.map((d) => resolve(root, d)).filter((d) =>
+        existsSync(d),
+      );
+
+      if (dirsToWatch.length === 0) return;
+
+      const isIconFile = (filePath) =>
+        filePath.endsWith(".svg") &&
+        dirsToWatch.some((dir) => filePath.startsWith(dir));
+
+      let pending = null;
+      const onChange = (filePath) => {
+        if (!isIconFile(filePath)) return;
+        clearTimeout(pending);
+        pending = setTimeout(async () => {
+          try {
+            logger.info("[icon-manifest] SVG change detected, regenerating...");
+            await generate();
+            const send = server.hot?.send ?? server.ws?.send;
+            send?.call(server.hot ?? server.ws, { type: "full-reload" });
+          } catch (err) {
+            logger.error(`[icon-manifest] Failed to regenerate: ${err.message}`);
+          }
+        }, 500);
+      };
+
+      server.watcher.add(dirsToWatch);
+      server.watcher.on("add", onChange);
+      server.watcher.on("unlink", onChange);
+      server.watcher.on("change", onChange);
+    },
+  };
+}

--- a/frontend/scripts/generate-icon-manifest.mjs
+++ b/frontend/scripts/generate-icon-manifest.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import { readdir, writeFile, mkdir } from "node:fs/promises";
+import { join, relative, dirname, basename, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const PUBLIC = join(ROOT, "public");
+const OUTPUT_DIR = join(ROOT, "src", "components", "icon-gallery");
+
+// Directories to scan for local SVGs
+const ICON_DIRS = ["assets/icons", "icons"];
+
+// ─── Local SVG Manifest ─────────────────────────────────────────────
+
+async function collectSvgFiles() {
+  const icons = [];
+
+  for (const iconDir of ICON_DIRS) {
+    const absDir = join(PUBLIC, iconDir);
+    let entries;
+    try {
+      entries = await readdir(absDir, { recursive: true, withFileTypes: true });
+    } catch {
+      continue; // directory doesn't exist, skip
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || extname(entry.name) !== ".svg") continue;
+
+      const entryPath = join(entry.parentPath ?? entry.path, entry.name);
+      const relFromPublic = "/" + relative(PUBLIC, entryPath);
+      const relFromIconDir = relative(absDir, entryPath);
+      const parts = relFromIconDir.split("/");
+      const category = parts.length > 1 ? parts[0] : "root";
+      const fileName = basename(entry.name, ".svg");
+
+      // Extract keywords from filename
+      const keywords = fileName
+        .replace(/^ic_/, "")
+        .split(/[_\-]/)
+        .filter((k) => k.length > 0)
+        .map((k) => k.toLowerCase());
+
+      icons.push({
+        filePath: relFromPublic,
+        fileName,
+        category,
+        keywords,
+        sourceDir: iconDir,
+      });
+    }
+  }
+
+  return icons;
+}
+
+function flagDuplicates(icons) {
+  const byName = new Map();
+  for (const icon of icons) {
+    const list = byName.get(icon.fileName) || [];
+    list.push(icon);
+    byName.set(icon.fileName, list);
+  }
+
+  const duplicateNames = new Set();
+  for (const [name, list] of byName) {
+    if (list.length > 1) {
+      duplicateNames.add(name);
+    }
+  }
+
+  return icons.map((icon) => ({
+    ...icon,
+    isDuplicate: duplicateNames.has(icon.fileName),
+    duplicateCount: duplicateNames.has(icon.fileName)
+      ? byName.get(icon.fileName).length
+      : 0,
+    duplicatePaths: duplicateNames.has(icon.fileName)
+      ? byName
+          .get(icon.fileName)
+          .map((d) => ({ filePath: d.filePath, category: d.category }))
+      : [],
+  }));
+}
+
+// ─── Main ────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("Generating icon manifests...\n");
+
+  // Ensure output directory exists
+  await mkdir(OUTPUT_DIR, { recursive: true });
+
+  // 1. Local SVG manifest
+  const rawIcons = await collectSvgFiles();
+  const icons = flagDuplicates(rawIcons);
+
+  const categories = [...new Set(icons.map((i) => i.category))].sort();
+  const duplicates = icons.filter((i) => i.isDuplicate);
+
+  const localManifest = {
+    generatedAt: new Date().toISOString(),
+    total: icons.length,
+    categories,
+    duplicateCount: duplicates.length,
+    icons,
+  };
+
+  await writeFile(
+    join(OUTPUT_DIR, "icon-manifest.json"),
+    JSON.stringify(localManifest, null, 2) + "\n"
+  );
+
+  console.log(`  Local SVGs: ${icons.length} icons in ${categories.length} categories`);
+  if (duplicates.length > 0) {
+    const uniqueDupNames = [...new Set(duplicates.map((d) => d.fileName))];
+    console.log(`  Duplicates: ${duplicates.length} files (${uniqueDupNames.length} unique names)`);
+  }
+
+  console.log("\nManifest written to src/components/icon-gallery/");
+}
+
+main().catch((err) => {
+  console.error("Error generating icon manifests:", err);
+  process.exit(1);
+});

--- a/frontend/src/components/icon-gallery/IconGallery.jsx
+++ b/frontend/src/components/icon-gallery/IconGallery.jsx
@@ -1,0 +1,463 @@
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  TextField,
+  Chip,
+  Paper,
+  Tooltip,
+  Typography,
+  InputAdornment,
+} from "@mui/material";
+import Iconify from "src/components/iconify";
+import VirtualCard from "./VirtualCard";
+import iconManifest from "./icon-manifest.json";
+
+const ALL_CATEGORY = "__all__";
+
+function IconCard({ icon, onCopy, onCopyPath, showCategory, isGrouped }) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef(null);
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  const handleClick = useCallback(async () => {
+    const success = await onCopy(icon);
+    if (success === false) return;
+    setCopied(true);
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
+  }, [icon, onCopy]);
+
+  const handlePathCopy = useCallback(
+    async (e) => {
+      const success = await onCopyPath(e, icon);
+      if (success === false) return;
+      setCopied(true);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 1500);
+    },
+    [icon, onCopyPath],
+  );
+
+  return (
+    <Tooltip
+      title={
+        <Box>
+          <Typography
+            variant="caption"
+            display="block"
+            sx={{ fontFamily: "monospace" }}
+          >
+            {icon.filePath}
+          </Typography>
+          <Typography variant="caption" display="block" sx={{ mt: 0.5 }}>
+            Click to copy SvgColor usage
+          </Typography>
+          {icon.isDuplicate && (
+            <Box sx={{ mt: 0.5 }}>
+              <Typography
+                variant="caption"
+                display="block"
+                color="warning.main"
+                sx={{ fontWeight: 600 }}
+              >
+                Also exists at:
+              </Typography>
+              {icon.duplicatePaths
+                .filter((d) => d.filePath !== icon.filePath)
+                .map((d) => (
+                  <Typography
+                    key={d.filePath}
+                    variant="caption"
+                    display="block"
+                    sx={{ fontFamily: "monospace", fontSize: "0.65rem" }}
+                  >
+                    {d.filePath} ({d.category})
+                  </Typography>
+                ))}
+            </Box>
+          )}
+        </Box>
+      }
+      arrow
+    >
+      <Paper
+        elevation={0}
+        onClick={handleClick}
+        sx={{
+          p: 1.5,
+          flex: isGrouped ? 1 : undefined,
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          cursor: "pointer",
+          border: "1px solid",
+          borderColor: copied ? "success.main" : "divider",
+          borderRadius: 1,
+          transition: "all 0.15s",
+          position: "relative",
+          bgcolor: copied ? "success.lighter" : "transparent",
+          "&:hover": {
+            borderColor: copied ? "success.main" : "primary.main",
+            bgcolor: copied ? "success.lighter" : "action.hover",
+            "& .copy-hint": { opacity: 1 },
+          },
+        }}
+      >
+        {/* Copied overlay */}
+        {copied && (
+          <Box
+            sx={{
+              position: "absolute",
+              top: 4,
+              right: 4,
+              display: "flex",
+              alignItems: "center",
+              gap: 0.25,
+              color: "success.main",
+            }}
+          >
+            <Iconify icon="material-symbols:check-circle" width={14} />
+            <Typography
+              variant="caption"
+              sx={{ fontSize: "0.6rem", fontWeight: 600 }}
+            >
+              Copied
+            </Typography>
+          </Box>
+        )}
+
+        {/* Copy path button */}
+        {!copied && (
+          <Box
+            className="copy-hint"
+            onClick={handlePathCopy}
+            sx={{
+              position: "absolute",
+              top: 4,
+              left: 4,
+              color: "text.secondary",
+              opacity: 0,
+              transition: "opacity 0.15s",
+              cursor: "pointer",
+              "&:hover": { color: "primary.main" },
+            }}
+          >
+            <Iconify icon="material-symbols:content-copy-outline" width={12} />
+          </Box>
+        )}
+
+        {/* Icon preview */}
+        <Box
+          sx={{
+            width: 36,
+            height: 36,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            mb: 1,
+            borderRadius: 0.5,
+            backgroundImage:
+              "linear-gradient(45deg, #e0e0e0 25%, transparent 25%), linear-gradient(-45deg, #e0e0e0 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #e0e0e0 75%), linear-gradient(-45deg, transparent 75%, #e0e0e0 75%)",
+            backgroundSize: "8px 8px",
+            backgroundPosition: "0 0, 0 4px, 4px -4px, -4px 0px",
+          }}
+        >
+          <img
+            src={icon.filePath}
+            alt={icon.fileName}
+            style={{
+              maxWidth: 32,
+              maxHeight: 32,
+              objectFit: "contain",
+            }}
+            loading="lazy"
+          />
+        </Box>
+
+        {/* Filename */}
+        <Typography
+          variant="caption"
+          sx={{
+            textAlign: "center",
+            wordBreak: "break-all",
+            lineHeight: 1.2,
+            fontSize: "0.65rem",
+            color: "text.secondary",
+          }}
+        >
+          {icon.fileName}
+        </Typography>
+
+        {/* Category badge */}
+        {showCategory && (
+          <Typography
+            variant="caption"
+            sx={{
+              fontSize: "0.55rem",
+              color: "text.disabled",
+              mt: 0.25,
+            }}
+          >
+            {icon.category}
+          </Typography>
+        )}
+      </Paper>
+    </Tooltip>
+  );
+}
+
+IconCard.propTypes = {
+  icon: PropTypes.object.isRequired,
+  onCopy: PropTypes.func.isRequired,
+  onCopyPath: PropTypes.func.isRequired,
+  showCategory: PropTypes.bool,
+  isGrouped: PropTypes.bool,
+};
+
+export default function IconGallery({ defaultCategory }) {
+  const [search, setSearch] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState(
+    defaultCategory || ALL_CATEGORY,
+  );
+  const categories = useMemo(() => iconManifest.categories || [], []);
+
+  const categoryCounts = useMemo(() => {
+    const counts = new Map();
+    for (const icon of iconManifest.icons || []) {
+      counts.set(icon.category, (counts.get(icon.category) || 0) + 1);
+    }
+    return counts;
+  }, []);
+
+  const filteredIcons = useMemo(() => {
+    let icons = iconManifest.icons || [];
+
+    if (selectedCategory !== ALL_CATEGORY) {
+      icons = icons.filter((i) => i.category === selectedCategory);
+    }
+
+    if (search.trim()) {
+      const q = search.toLowerCase().trim();
+      icons = icons.filter(
+        (i) =>
+          i.fileName.toLowerCase().includes(q) ||
+          i.category.toLowerCase().includes(q) ||
+          i.keywords.some((k) => k.includes(q)),
+      );
+    }
+
+    return icons;
+  }, [search, selectedCategory]);
+
+  // Build layout items: singles + grouped duplicates
+  const layoutItems = useMemo(() => {
+    const items = [];
+    const seen = new Set();
+
+    for (const icon of filteredIcons) {
+      if (seen.has(icon.filePath)) continue;
+
+      if (icon.isDuplicate) {
+        if (seen.has(icon.fileName)) continue;
+        seen.add(icon.fileName);
+        // Collect all variants of this name that are in the filtered set
+        const group = filteredIcons.filter((f) => f.fileName === icon.fileName);
+        group.forEach((g) => seen.add(g.filePath));
+        if (group.length > 1) {
+          items.push({ type: "group", fileName: icon.fileName, icons: group });
+        } else {
+          items.push({ type: "single", icon });
+        }
+      } else {
+        seen.add(icon.filePath);
+        items.push({ type: "single", icon });
+      }
+    }
+
+    return items;
+  }, [filteredIcons]);
+
+  const handleCopy = useCallback(async (icon) => {
+    const code = `<SvgColor src="${icon.filePath}" sx={{ width: 24, height: 24 }} />`;
+    try {
+      await navigator.clipboard.writeText(code);
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const handleCopyPath = useCallback(async (e, icon) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(icon.filePath);
+    } catch {
+      return false;
+    }
+  }, []);
+
+  return (
+    <Box sx={{ p: 3 }}>
+      {/* Header */}
+      <Typography variant="h5" sx={{ mb: 1 }}>
+        Local SVG Icons
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        {filteredIcons.length} of {iconManifest.total} icons
+        {iconManifest.duplicateCount > 0 && (
+          <Chip
+            icon={
+              <Iconify icon="material-symbols:warning-outline" width={16} />
+            }
+            label={`${iconManifest.duplicateCount} duplicates`}
+            size="small"
+            color="warning"
+            variant="outlined"
+            sx={{ ml: 1 }}
+          />
+        )}
+      </Typography>
+
+      {/* Search */}
+      <TextField
+        fullWidth
+        size="small"
+        placeholder="Search icons by name or keyword..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <Iconify icon="material-symbols:search" width={20} />
+              </InputAdornment>
+            ),
+          },
+        }}
+        sx={{ mb: 2 }}
+      />
+
+      {/* Category filter */}
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mb: 3 }}>
+        <Chip
+          label={`All (${iconManifest.total})`}
+          size="small"
+          variant={selectedCategory === ALL_CATEGORY ? "filled" : "outlined"}
+          color={selectedCategory === ALL_CATEGORY ? "primary" : "default"}
+          onClick={() => setSelectedCategory(ALL_CATEGORY)}
+        />
+        {categories.map((cat) => (
+          <Chip
+            key={cat}
+            label={`${cat} (${categoryCounts.get(cat) || 0})`}
+            size="small"
+            variant={selectedCategory === cat ? "filled" : "outlined"}
+            color={selectedCategory === cat ? "primary" : "default"}
+            onClick={() => setSelectedCategory(cat)}
+          />
+        ))}
+      </Box>
+
+      {/* Icon grid */}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+          gridAutoRows: "160px",
+          gap: 1.5,
+        }}
+      >
+        {layoutItems.map((item) => {
+          if (item.type === "group") {
+            return (
+              <VirtualCard
+                key={`group-${item.fileName}`}
+                height={160}
+                style={{
+                  gridColumn: `span ${Math.min(item.icons.length, 3)}`,
+                }}
+              >
+                <Box
+                  sx={{
+                    border: "2px solid",
+                    borderColor: "warning.main",
+                    borderRadius: 1.5,
+                    p: 1,
+                    bgcolor: "warning.lighter",
+                    height: "100%",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 0.5,
+                      mb: 1,
+                      px: 0.5,
+                    }}
+                  >
+                    <Iconify
+                      icon="material-symbols:warning-outline"
+                      width={14}
+                      sx={{ color: "warning.main" }}
+                    />
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: "warning.dark",
+                        fontWeight: 600,
+                        fontSize: "0.65rem",
+                      }}
+                    >
+                      {item.icons.length} files named &quot;{item.fileName}
+                      &quot;
+                    </Typography>
+                  </Box>
+                  <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+                    {item.icons.map((variant) => (
+                      <IconCard
+                        key={variant.filePath}
+                        icon={variant}
+                        onCopy={handleCopy}
+                        onCopyPath={handleCopyPath}
+                        showCategory
+                        isGrouped
+                      />
+                    ))}
+                  </Box>
+                </Box>
+              </VirtualCard>
+            );
+          }
+
+          return (
+            <VirtualCard key={item.icon.filePath} height={160}>
+              <IconCard
+                icon={item.icon}
+                onCopy={handleCopy}
+                onCopyPath={handleCopyPath}
+                showCategory={selectedCategory === ALL_CATEGORY}
+              />
+            </VirtualCard>
+          );
+        })}
+      </Box>
+
+      {/* Empty state */}
+      {filteredIcons.length === 0 && (
+        <Box sx={{ textAlign: "center", py: 8 }}>
+          <Typography color="text.secondary">
+            No icons found matching &quot;{search}&quot;
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+IconGallery.propTypes = {
+  defaultCategory: PropTypes.string,
+};

--- a/frontend/src/components/icon-gallery/LocalIcons.stories.jsx
+++ b/frontend/src/components/icon-gallery/LocalIcons.stories.jsx
@@ -1,0 +1,16 @@
+import IconGallery from "./IconGallery";
+
+const meta = {
+  component: IconGallery,
+  title: "Design System/Icon Gallery/Local SVG Icons",
+  tags: ["!autodocs"],
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+export const AllIcons = {
+  args: {},
+};

--- a/frontend/src/components/icon-gallery/VirtualCard.jsx
+++ b/frontend/src/components/icon-gallery/VirtualCard.jsx
@@ -1,0 +1,40 @@
+import { useState, useEffect, useRef } from "react";
+import PropTypes from "prop-types";
+
+export default function VirtualCard({
+  height = 120,
+  children,
+  rootMargin = "200px",
+  style,
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) setIsVisible(true);
+      },
+      { rootMargin },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [rootMargin]);
+
+  return (
+    <div ref={ref} style={{ minHeight: height, height: "100%", ...style }}>
+      {isVisible ? children : null}
+    </div>
+  );
+}
+
+VirtualCard.propTypes = {
+  height: PropTypes.number,
+  children: PropTypes.node,
+  rootMargin: PropTypes.string,
+  style: PropTypes.object,
+};

--- a/frontend/src/components/icon-gallery/index.js
+++ b/frontend/src/components/icon-gallery/index.js
@@ -1,0 +1,1 @@
+export { default as IconGallery } from "./IconGallery";


### PR DESCRIPTION
## Summary

Adds a Storybook-based icon gallery that scans all local SVG icons under `public/assets/icons/` and `public/icons/`, groups them by directory, and renders them in a searchable, browsable grid. This makes it easy to discover which icons are available in the project without digging through the filesystem.

## How it works

1. **Build-time manifest generation** (`frontend/scripts/generate-icon-manifest.mjs`) — Walks the icon directories, collects every `.svg` path, and writes a JSON manifest (`public/icon-manifest.json`) listing all icons with their group (derived from directory name).

2. **Vite plugin for dev-time auto-reload** (`frontend/plugins/vite-plugin-icon-manifest.mjs`) — Hooks into Vite's dev server watcher. When an SVG is added, removed, or changed in the icon directories, it re-runs the manifest generator and triggers a full reload so the gallery stays in sync. Uses Vite's built-in watcher (no extra `chokidar` dependency).

3. **`<IconGallery />` component** (`frontend/src/components/icon-gallery/IconGallery.jsx`) — Fetches the manifest at runtime, renders icons grouped by folder with:
   - Text search filtering across icon names
   - Group filter chips
   - Click-to-copy import path
   - Responsive grid layout with virtualized cards (IntersectionObserver-based lazy rendering)

4. **Storybook story** (`frontend/src/components/icon-gallery/LocalIcons.stories.jsx`) — Exposes the gallery under `Components/IconGallery/Local Icons` in Storybook.

## Migration note

Squashed from 6 commits on core-frontend#2604 into one. The original PR's `package.json` tweak was adapted to match main's current scripts section (the old patch expected a trailing comma + `prepare: husky` that isn't on main). The icon-manifest `.gitignore` entry moved to the repo's **root** `.gitignore` (alongside `frontend/storybook-static/`) to match the new repo's convention of one centralized ignore file.

## Files changed

| File | Purpose |
|------|---------|
| `frontend/scripts/generate-icon-manifest.mjs` | CLI script to scan icon dirs and emit `icon-manifest.json` |
| `frontend/plugins/vite-plugin-icon-manifest.mjs` | Vite plugin — watches SVG changes, regenerates manifest |
| `frontend/src/components/icon-gallery/IconGallery.jsx` | Gallery UI component |
| `frontend/src/components/icon-gallery/VirtualCard.jsx` | Lazy-rendered icon card with IntersectionObserver |
| `frontend/src/components/icon-gallery/LocalIcons.stories.jsx` | Storybook story |
| `frontend/src/components/icon-gallery/index.js` | Re-exports |
| `frontend/.storybook/main.js` | Registers the Vite icon-manifest plugin for Storybook |
| `frontend/package.json` | Adds `generate-icons` script, hooks into `prestorybook` |
| `.gitignore` | Ignores the generated `icon-manifest.json` |

## Test plan

- [ ] Run `yarn storybook` from `frontend/` — gallery loads with all local icons grouped by folder
- [ ] Add/remove an SVG in `frontend/public/assets/icons/` — gallery auto-updates
- [ ] Search and group filter chips work correctly
- [ ] Click an icon card — copies the import path to clipboard

---

_Migrated from future-agi/core-frontend#2604._