### PR TITLE
fix: Add API Call / HTTP Request Node

### DIFF
--- a/frontend/src/components/NodeEditor/ApiCallNode.jsx
+++ b/frontend/src/components/NodeEditor/ApiCallNode.jsx
@@ -1,0 +1,146 @@
+import React, { memo } from "react";
+import PropTypes from "prop-types";
+import { Box, Stack, Typography, TextField, MenuItem, Select, InputLabel, FormControl } from "@mui/material";
+import SvgColor from "src/components/svg-color";
+
+const ApiCallNode = ({ data, isEditing, onEdit }) => {
+  const { label, nodeConfig } = data;
+  
+  if (!isEditing) {
+    return (
+      <Box sx={{ minWidth: 200, p: 2 }}>
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              borderRadius: 0.5,
+              border: "1px solid",
+              borderColor: "divider",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+            }}
+          >
+            <SvgColor
+              src="/assets/icons/navbar/ic_api.svg"
+              sx={{
+                width: 16,
+                height: 16,
+                bgcolor: "blue.600",
+              }}
+            />
+          </Box>
+          <Typography variant="subtitle2" noWrap>
+            {label}
+          </Typography>
+        </Stack>
+        <Typography variant="body2" color="text.secondary">
+          {nodeConfig?.method || "GET"} {nodeConfig?.url || "https://api.example.com"}
+        </Typography>
+      </Box>
+    );
+  }
+
+  // Edit mode
+  const handleConfigChange = (field, value) => {
+    onEdit({
+      ...nodeConfig,
+      [field]: value
+    });
+  };
+
+  return (
+    <Box sx={{ minWidth: 300, p: 2 }}>
+      <TextField
+        label="Node Label"
+        fullWidth
+        value={label}
+        onChange={(e) => onEdit({ ...nodeConfig, label: e.target.value })}
+        sx={{ mb: 2 }}
+      />
+      
+      <FormControl fullWidth sx={{ mb: 2 }}>
+        <InputLabel>HTTP Method</InputLabel>
+        <Select
+          value={nodeConfig?.method || "GET"}
+          onChange={(e) => handleConfigChange("method", e.target.value)}
+        >
+          <MenuItem value="GET">GET</MenuItem>
+          <MenuItem value="POST">POST</MenuItem>
+          <MenuItem value="PUT">PUT</MenuItem>
+          <MenuItem value="DELETE">DELETE</MenuItem>
+          <MenuItem value="PATCH">PATCH</MenuItem>
+        </Select>
+      </FormControl>
+      
+      <TextField
+        label="URL"
+        fullWidth
+        value={nodeConfig?.url || ""}
+        onChange={(e) => handleConfigChange("url", e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      
+      <TextField
+        label="Headers (JSON)"
+        fullWidth
+        multiline
+        rows={3}
+        value={nodeConfig?.headers ? JSON.stringify(nodeConfig.headers, null, 2) : ""}
+        onChange={(e) => {
+          try {
+            const parsed = JSON.parse(e.target.value);
+            handleConfigChange("headers", parsed);
+          } catch (err) {
+            // If invalid JSON, just set as is for user to fix
+            handleConfigChange("headers", e.target.value);
+          }
+        }}
+        sx={{ mb: 2 }}
+      />
+      
+      <TextField
+        label="Body (JSON)"
+        fullWidth
+        multiline
+        rows={3}
+        value={nodeConfig?.body ? JSON.stringify(nodeConfig.body, null, 2) : ""}
+        onChange={(e) => {
+          try {
+            const parsed = JSON.parse(e.target.value);
+            handleConfigChange("body", parsed);
+          } catch (err) {
+            // If invalid JSON, just set as is for user to fix
+            handleConfigChange("body", e.target.value);
+          }
+        }}
+        sx={{ mb: 2 }}
+      />
+      
+      <TextField
+        label="Timeout (seconds)"
+        type="number"
+        fullWidth
+        value={nodeConfig?.timeout || 30}
+        onChange={(e) => handleConfigChange("timeout", parseInt(e.target.value) || 30)}
+        sx={{ mb: 2 }}
+      />
+    </Box>
+  );
+};
+
+ApiCallNode.propTypes = {
+  data: PropTypes.shape({
+    label: PropTypes.string,
+    nodeConfig: PropTypes.object,
+  }).isRequired,
+  isEditing: PropTypes.bool,
+  onEdit: PropTypes.func,
+};
+
+const MemoizedApiCallNode = memo(ApiCallNode);
+MemoizedApiCallNode.displayName = "ApiCallNode";
+
+export default MemoizedApiCallNode;

--- a/frontend/src/sections/agent-playground/utils/constants.js
+++ b/frontend/src/sections/agent-playground/utils/constants.js
@@ -4,6 +4,7 @@ export const NODE_X_OFFSET = 450;
 export const NODE_TYPES = {
   LLM_PROMPT: "llm_prompt",
   AGENT: "agent",
+  API_CALL: "api_call",
 };
 
 export const AGENT_NODE = {
@@ -23,6 +24,13 @@ export const NODE_TYPE_CONFIG = {
     color: "orange.500",
   },
   [NODE_TYPES.AGENT]: AGENT_NODE,
+  [NODE_TYPES.API_CALL]: {
+    id: NODE_TYPES.API_CALL,
+    title: "API Call",
+    description: "Make HTTP requests to external APIs",
+    iconSrc: "/assets/icons/navbar/ic_api.svg",
+    color: "blue.600",
+  },
 };
 
 export const AGENT_PLAYGROUND_TABS = [

--- a/futureagi/agentcc-gateway/internal/handlers/api_call.go
+++ b/futureagi/agentcc-gateway/internal/handlers/api_call.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/futureagi/agentcc-gateway/internal/models"
+	"github.com/futureagi/agentcc-gateway/internal/services"
+)
+
+// APICallHandler handles API call requests
+type APICallHandler struct {
+	httpClient *services.HTTPClient
+}
+
+// NewAPICallHandler creates a new API call handler
+func NewAPICallHandler() *APICallHandler {
+	return &APICallHandler{
+		httpClient: services.NewHTTPClient(),
+	}
+}
+
+// HandleAPICall executes an API call based on the provided configuration
+func (h *APICallHandler) HandleAPICall(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Parse request body
+	var apiCallReq models.APICallRequest
+	if err := json.NewDecoder(r.Body).Decode(&apiCallReq); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Create request configuration
+	config := services.RequestConfig{
+		Method:      apiCallReq.Method,
+		URL:         apiCallReq.URL,
+		Headers:     apiCallReq.Headers,
+		Body:        apiCallReq.Body,
+		ContentType: apiCallReq.ContentType,
+	}
+
+	// Set timeout
+	if apiCallReq.Timeout > 0 {
+		config.Timeout = time.Duration(apiCallReq.Timeout) * time.Second
+	} else {
+		config.Timeout = 30 * time.Second
+	}
+
+	// Execute request
+	response, err := h.httpClient.MakeRequest(ctx, config)
+	if err != nil {
+		http.Error(w, "API call failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Create response
+	apiCallResp := models.APICallResponse{
+		StatusCode: response.StatusCode,
+		Headers:    response.Headers,
+		Body:       response.Body,
+	}
+
+	// Send response
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(apiCallResp); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+}

--- a/futureagi/agentcc-gateway/internal/models/api_call.go
+++ b/futureagi/agentcc-gateway/internal/models/api_call.go
@@ -1,0 +1,18 @@
+package models
+
+// APICallRequest represents the request payload for an API call node
+type APICallRequest struct {
+	Method      string            `json:"method"`
+	URL         string            `json:"url"`
+	Headers     map[string]string `json:"headers"`
+	Body        interface{}       `json:"body"`
+	Timeout     int               `json:"timeout"`
+	ContentType string            `json:"content_type"`
+}
+
+// APICallResponse represents the response from an API call node
+type APICallResponse struct {
+	StatusCode int         `json:"status_code"`
+	Headers    interface{} `json:"headers"`
+	Body       interface{} `json:"body"`
+}

--- a/futureagi/agentcc-gateway/internal/routes/api_call.go
+++ b/futureagi/agentcc-gateway/internal/routes/api_call.go
@@ -1,0 +1,12 @@
+package routes
+
+import (
+	"net/http"
+
+	"github.com/futureagi/agentcc-gateway/internal/handlers"
+)
+
+// RegisterAPICallRoutes registers API call routes
+func RegisterAPICallRoutes(mux *http.ServeMux, apiCallHandler *handlers.APICallHandler) {
+	mux.HandleFunc("POST /api/v1/api-call", apiCallHandler.HandleAPICall)
+}

--- a/futureagi/agentcc-gateway/internal/services/http_client.go
+++ b/futureagi/agentcc-gateway/internal/services/http_client.go
@@ -1,0 +1,117 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// HTTPClient is a service for making HTTP requests
+type HTTPClient struct {
+	client *http.Client
+}
+
+// NewHTTPClient creates a new HTTP client with default settings
+func NewHTTPClient() *HTTPClient {
+	return &HTTPClient{
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// RequestConfig holds configuration for an HTTP request
+type RequestConfig struct {
+	Method      string            `json:"method"`
+	URL         string            `json:"url"`
+	Headers     map[string]string `json:"headers"`
+	Body        interface{}       `json:"body"`
+	Timeout     time.Duration     `json:"timeout"`
+	ContentType string            `json:"content_type"`
+}
+
+// Response holds the HTTP response data
+type Response struct {
+	StatusCode int         `json:"status_code"`
+	Headers    http.Header `json:"headers"`
+	Body       interface{} `json:"body"`
+}
+
+// MakeRequest executes an HTTP request
+func (c *HTTPClient) MakeRequest(ctx context.Context, config RequestConfig) (*Response, error) {
+	var bodyReader io.Reader
+
+	// Handle body serialization
+	if config.Body != nil {
+		var bodyBytes []byte
+		var err error
+
+		switch v := config.Body.(type) {
+		case string:
+			bodyBytes = []byte(v)
+		case []byte:
+			bodyBytes = v
+		default:
+			bodyBytes, err = json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal body: %w", err)
+			}
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, config.Method, config.URL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	for key, value := range config.Headers {
+		req.Header.Set(key, value)
+	}
+
+	// Set content-type header if not already set
+	if config.ContentType != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", config.ContentType)
+	}
+
+	// Set timeout
+	if config.Timeout > 0 {
+		ctx, cancel := context.WithTimeout(ctx, config.Timeout)
+		defer cancel()
+		req = req.WithContext(ctx)
+	}
+
+	// Make request
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Parse response body into JSON if possible
+	var parsedBody interface{}
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &parsedBody); err != nil {
+			// If JSON parsing fails, keep as raw bytes
+			parsedBody = string(respBody)
+		}
+	}
+
+	return &Response{
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header,
+		Body:       parsedBody,
+	}, nil
+}


### PR DESCRIPTION
## PR Update: API Call Node integration

This PR adds support for an **API Call / HTTP Request node** across the frontend and gateway layers.

### What changed

#### Frontend

- Adds a new `ApiCallNode` component for configuring HTTP requests from the agent playground.
- Adds `api_call` to the playground node type registry.
- Supports request method, URL, headers, JSON body, and timeout configuration.
- Cleans up unused imports so the new component does not introduce new lint errors.

#### Backend

- Adds API call request/response models.
- Adds an HTTP client service for executing configured outbound requests.
- Adds an API call handler.
- Adds route registration helper for the API call endpoint.
- Runs `gofmt` across all new Go files.

### Validation

#### Frontend

```bash
cd frontend
yarn install --frozen-lockfile
yarn lint
yarn test
yarn build

Results:

yarn lint passes with warnings only; no new lint errors.
yarn test passes: 102 test files, 1081 tests.
yarn build completes successfully.
Backend
cd futureagi/agentcc-gateway
go test ./internal/handlers ./internal/models ./internal/services ./internal/routes
go vet ./internal/handlers ./internal/models ./internal/services ./internal/routes

Results:

Targeted go test passes for the packages touched by this PR.
go vet still reports an existing unrelated issue in internal/models/errors_test.go:
call of Unmarshal passes non-pointer as second argument.
Notes for reviewers

This PR intentionally keeps the scope focused on adding the API Call node primitives and avoiding unrelated cleanup.

Known unrelated project warnings/failures were not changed here, including existing frontend lint warnings and the unrelated Go vet issue mentioned above.