### PR TITLE
TH-4588: Dashboard metric value type does not update data

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -94,13 +94,17 @@ export default function WidgetChart({ widget, globalDateRange }) {
   const pieChartRef = useRef(null);
   const [pieConnectors, setPieConnectors] = useState([]);
 
-  // Re-query whenever widget.id or globalDateRange changes
-  const queryKey = `${widget.id}-${globalDateRange?.start || "default"}`;
+  // Re-query whenever the effective query config changes (including
+  // metric aggregation/value type), or when global date override changes.
+  const querySignature = useMemo(
+    () => JSON.stringify(queryConfig || {}),
+    [queryConfig],
+  );
   useEffect(() => {
     if (queryConfig?.metrics?.length > 0) {
       queryMutation.mutate(queryConfig);
     }
-  }, [queryKey]);
+  }, [querySignature, queryConfig]);
 
   const result = queryMutation.data?.data?.result;
   const series = useMemo(() => {


### PR DESCRIPTION
## Summary
- re-run widget queries when the effective dashboard query config changes
- include metric aggregation and value type changes in the re-fetch trigger

## Testing
- not run in this worktree (yarn run v1.22.22
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command. command unavailable here)