### PR TITLE
TH-4589: Dashboard project breakdown fails on large data

### DIFF
--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -24,6 +24,7 @@ from tracer.serializers.dashboard import (
     DashboardSerializer,
     DashboardWidgetSerializer,
 )
+from tracer.views.dashboard import DashboardViewSet
 from tracer.services.clickhouse.query_builders.dashboard import (
     AGGREGATIONS,
     SYSTEM_METRICS,
@@ -894,6 +895,98 @@ class TestDashboardQueryExecution:
         assert response.status_code == 200
 
     @pytest.mark.django_db
+    @patch("tracer.views.dashboard.AnalyticsQueryService")
+    def test_query_action_project_breakdown_uses_longer_timeout(
+        self, mock_analytics_cls, auth_client, observe_project
+    ):
+        mock_service = MagicMock()
+        mock_result = MagicMock()
+        mock_result.data = [
+            {
+                "time_bucket": "2025-01-01T00:00:00",
+                "breakdown_value": str(observe_project.id),
+                "value": 123.45,
+            }
+        ]
+        mock_service.execute_ch_query.return_value = mock_result
+        mock_analytics_cls.return_value = mock_service
+
+        response = auth_client.post(
+            "/tracer/dashboard/query/",
+            {
+                "project_ids": [str(observe_project.id)],
+                "granularity": "day",
+                "time_range": {"preset": "7D"},
+                "metrics": [
+                    {
+                        "id": "latency",
+                        "name": "latency",
+                        "type": "system_metric",
+                        "aggregation": "avg",
+                    }
+                ],
+                "breakdowns": [{"type": "system_metric", "name": "project"}],
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+        _, kwargs = mock_service.execute_ch_query.call_args
+        assert kwargs["timeout_ms"] == 30000
+
+
+class TestDashboardTraceTimeoutSelection:
+    def test_default_trace_timeout_is_short(self):
+        viewset = DashboardViewSet()
+        timeout = viewset._get_trace_query_timeout_ms(
+            {
+                "metrics": [
+                    {
+                        "id": "latency",
+                        "name": "latency",
+                        "type": "system_metric",
+                        "aggregation": "avg",
+                    }
+                ],
+                "breakdowns": [],
+            }
+        )
+        assert timeout == 10000
+
+    def test_project_breakdown_uses_longer_timeout(self):
+        viewset = DashboardViewSet()
+        timeout = viewset._get_trace_query_timeout_ms(
+            {
+                "metrics": [
+                    {
+                        "id": "latency",
+                        "name": "latency",
+                        "type": "system_metric",
+                        "aggregation": "avg",
+                    }
+                ],
+                "breakdowns": [{"type": "system_metric", "name": "project"}],
+            }
+        )
+        assert timeout == 30000
+
+    def test_eval_metric_uses_longer_timeout(self):
+        viewset = DashboardViewSet()
+        timeout = viewset._get_trace_query_timeout_ms(
+            {
+                "metrics": [
+                    {
+                        "id": "eval1",
+                        "name": "accuracy",
+                        "type": "eval_metric",
+                        "aggregation": "avg",
+                    }
+                ],
+                "breakdowns": [],
+            }
+        )
+        assert timeout == 30000
+
+    @pytest.mark.django_db
     def test_query_action_missing_project_ids_still_works(self, auth_client):
         """Query endpoint accepts requests without project_ids (unified picker)."""
         response = auth_client.post(
@@ -1000,6 +1093,48 @@ class TestWidgetQueryExecution:
         assert response.status_code == 200
         data = response.json()["result"]
         assert "metrics" in data
+
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
+    @patch("tracer.views.dashboard.get_clickhouse_client")
+    def test_preview_query_project_breakdown_uses_longer_timeout(
+        self, mock_get_client, mock_enabled, auth_client, dashboard, observe_project
+    ):
+        mock_client = MagicMock()
+        mock_client.execute_read.return_value = (
+            [(datetime(2025, 1, 1), str(observe_project.id), 50.0)],
+            [
+                ("time_bucket", "DateTime"),
+                ("breakdown_value", "String"),
+                ("value", "Float64"),
+            ],
+            3.0,
+        )
+        mock_get_client.return_value = mock_client
+
+        response = auth_client.post(
+            f"/tracer/dashboard/{dashboard.id}/widgets/preview/",
+            {
+                "query_config": {
+                    "project_ids": [str(observe_project.id)],
+                    "granularity": "day",
+                    "time_range": {"preset": "7D"},
+                    "metrics": [
+                        {
+                            "id": "latency",
+                            "name": "latency",
+                            "type": "system_metric",
+                            "aggregation": "avg",
+                        }
+                    ],
+                    "breakdowns": [{"type": "system_metric", "name": "project"}],
+                }
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+        _, kwargs = mock_client.execute_read.call_args
+        assert kwargs["timeout_ms"] == 30000
 
     @pytest.mark.django_db
     @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -54,6 +54,18 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
             return DashboardCreateUpdateSerializer
         return DashboardSerializer
 
+    def _get_trace_query_timeout_ms(self, trace_config):
+        """Use a longer timeout for high-cardinality or wide trace queries."""
+        has_eval_metrics = any(
+            m.get("type") == "eval_metric" for m in trace_config.get("metrics", [])
+        )
+        has_project_breakdown = any(
+            bd.get("name") == "project"
+            for bd in trace_config.get("breakdowns", [])
+            if bd.get("source", "traces") in ("traces", "both", "all", "")
+        )
+        return 30000 if has_eval_metrics or has_project_breakdown else 10000
+
     def list(self, request, *args, **kwargs):
         try:
             queryset = self.get_queryset()
@@ -231,8 +243,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                 trace_config["workspace_id"] = str(request.workspace.id)
 
                 builder = DashboardQueryBuilder(trace_config)
-                # Eval metrics scan large tables — use longer timeout
-                query_timeout = 30000 if has_eval_metrics else 10000
+                query_timeout = self._get_trace_query_timeout_ms(trace_config)
                 for sql, params, metric_info in builder.build_all_queries():
                     metric_info["source"] = "traces"
                     result = analytics.execute_ch_query(
@@ -2303,9 +2314,12 @@ class DashboardWidgetViewSet(BaseModelViewSetMixin, ModelViewSet):
                         "Some project_ids are invalid or not in this workspace"
                     )
             builder = DashboardQueryBuilder(trace_config)
+            query_timeout = self._get_trace_query_timeout_ms(trace_config)
             for sql, params, metric_info in builder.build_all_queries():
                 metric_info["source"] = "traces"
-                rows, column_types, _ = ch_client.execute_read(sql, params)
+                rows, column_types, _ = ch_client.execute_read(
+                    sql, params, timeout_ms=query_timeout
+                )
                 col_names = [ct[0] for ct in column_types]
                 row_dicts = [dict(zip(col_names, row)) for row in rows]
                 metric_results.append((metric_info, row_dicts))


### PR DESCRIPTION
## Summary
- use a longer trace query timeout when project breakdown is requested
- apply the same timeout selection in both dashboard query and widget preview execution paths
- add timeout selection coverage for project breakdown and eval metrics

## Testing
-  (DB-backed cases blocked here by local Postgres sandbox restrictions)
- 