### PR TITLE
TH-4598: Average is wrong when a Breakdown is added

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -44,6 +44,19 @@ function getApexType(chartType) {
   return map[chartType] || "line";
 }
 
+function getSeriesAverage(points = []) {
+  let total = 0;
+  let count = 0;
+  for (const pt of points) {
+    if (pt?.y == null) continue;
+    const y = Number(pt.y);
+    if (!Number.isFinite(y)) continue;
+    total += y;
+    count += 1;
+  }
+  return count > 0 ? total / count : null;
+}
+
 export default function WidgetChart({ widget, globalDateRange }) {
   const theme = useTheme();
   const queryMutation = useDashboardQuery();
@@ -310,15 +323,18 @@ export default function WidgetChart({ widget, globalDateRange }) {
         sx={{ width: "100%", height: "100%", minHeight: 0 }}
       >
         {series.map((s, i) => {
-          const total = s.data.reduce((sum, pt) => sum + (pt.y || 0), 0);
-          const avg = s.data.length ? total / s.data.length : 0;
+          const avg = getSeriesAverage(s.data);
           return (
             <Box key={i} sx={{ textAlign: "center" }}>
               <Typography
                 variant="h3"
                 sx={{ color: COLORS[i % COLORS.length] }}
               >
-                {avg >= 1000 ? `${(avg / 1000).toFixed(1)}K` : avg.toFixed(1)}
+                {avg == null
+                  ? "—"
+                  : avg >= 1000
+                    ? `${(avg / 1000).toFixed(1)}K`
+                    : avg.toFixed(1)}
               </Typography>
               <Typography variant="caption" color="text.secondary">
                 {s.name}
@@ -659,8 +675,8 @@ export default function WidgetChart({ widget, globalDateRange }) {
   // Bar chart — horizontal bar table
   if (isHorizontal) {
     const barValues = chartSeries.map((s) => {
-      const total = s.data.reduce((sum, pt) => sum + (pt.y || 0), 0);
-      return s.data.length ? total / s.data.length : 0;
+      const avg = getSeriesAverage(s.data);
+      return avg == null ? 0 : avg;
     });
     const maxVal = Math.max(...barValues.map(Math.abs), 1);
     return (
@@ -1054,7 +1070,7 @@ export default function WidgetChart({ widget, globalDateRange }) {
       };
     })(),
     markers: {
-      size: 0,
+      size: apexType === "line" || apexType === "area" ? 4 : 0,
       strokeWidth: 2,
       strokeColors: isDark ? theme.palette.background.paper : "#fff",
       hover: { size: 6, sizeOffset: 3 },

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -75,6 +75,19 @@ const escapeCsvField = (field) => {
   return str;
 };
 
+const getSeriesAverage = (points = []) => {
+  let total = 0;
+  let count = 0;
+  for (const pt of points) {
+    if (pt?.y == null) continue;
+    const y = Number(pt.y);
+    if (!Number.isFinite(y)) continue;
+    total += y;
+    count += 1;
+  }
+  return count > 0 ? total / count : null;
+};
+
 const TIME_PRESETS = [
   { label: "Custom", value: "custom" },
   { label: "30 mins", value: "30m" },
@@ -2387,7 +2400,7 @@ export default function WidgetEditorView() {
         };
       })(),
       markers: {
-        size: 0,
+        size: apexType === "line" || apexType === "area" ? 4 : 0,
         strokeWidth: 2,
         strokeColors: isDark ? theme.palette.background.paper : "#fff",
         hover: { size: 6, sizeOffset: 3 },
@@ -2554,8 +2567,8 @@ export default function WidgetEditorView() {
       return name.length > 25 ? name.slice(0, 22) + "..." : name;
     });
     const values = chartSeries.map((s) => {
-      const total = s.data.reduce((sum, pt) => sum + (pt.y || 0), 0);
-      return s.data.length ? total / s.data.length : 0;
+      const avg = getSeriesAverage(s.data);
+      return avg == null ? 0 : avg;
     });
     return {
       categories,
@@ -2840,13 +2853,10 @@ export default function WidgetEditorView() {
                 ),
               ];
               const rows = previewSeries.map((s) => {
-                const avg = s.data.length
-                  ? s.data.reduce((sum, pt) => sum + (pt.y || 0), 0) /
-                    s.data.length
-                  : 0;
+                const avg = getSeriesAverage(s.data);
                 return [
                   s.name,
-                  avg.toFixed(2),
+                  avg == null ? "—" : avg.toFixed(2),
                   ...s.data.map((pt) => (pt.y != null ? pt.y : "")),
                 ];
               });
@@ -2879,13 +2889,10 @@ export default function WidgetEditorView() {
                 ),
               ];
               const rows = previewSeries.map((s) => {
-                const avg = s.data.length
-                  ? s.data.reduce((sum, pt) => sum + (pt.y || 0), 0) /
-                    s.data.length
-                  : 0;
+                const avg = getSeriesAverage(s.data);
                 return [
                   s.name,
-                  avg.toFixed(2),
+                  avg == null ? "—" : avg.toFixed(2),
                   ...s.data.map((pt) => (pt.y != null ? pt.y : "")),
                 ];
               });
@@ -3521,11 +3528,7 @@ export default function WidgetEditorView() {
                         sx={{ height: "100%" }}
                       >
                         {chartSeries.map((s, i) => {
-                          const total = s.data.reduce(
-                            (sum, pt) => sum + (pt.y || 0),
-                            0,
-                          );
-                          const avg = s.data.length ? total / s.data.length : 0;
+                          const avg = getSeriesAverage(s.data);
                           return (
                             <Box key={i} sx={{ textAlign: "center" }}>
                               <Typography
@@ -3534,9 +3537,11 @@ export default function WidgetEditorView() {
                                   color: chartColors[i % chartColors.length],
                                 }}
                               >
-                                {avg >= 1000
-                                  ? `${(avg / 1000).toFixed(1)}K`
-                                  : avg.toFixed(1)}
+                                {avg == null
+                                  ? "—"
+                                  : avg >= 1000
+                                    ? `${(avg / 1000).toFixed(1)}K`
+                                    : avg.toFixed(1)}
                               </Typography>
                               <Typography
                                 variant="body2"
@@ -3960,11 +3965,6 @@ export default function WidgetEditorView() {
                 {chartSeries.map((s, i) => {
                   const origIdx = previewSeries.indexOf(s);
                   const idx = origIdx >= 0 ? origIdx : i;
-                  const total = s.data.reduce(
-                    (sum, pt) => sum + (pt.y || 0),
-                    0,
-                  );
-                  const _avg = s.data.length ? total / s.data.length : 0;
                   return (
                     <Box
                       key={i}
@@ -4048,19 +4048,13 @@ export default function WidgetEditorView() {
                         .includes(tableSearch.toLowerCase()),
                   )
                   .sort((a, b) => {
-                    const avgA = previewSeries[a].data.length
-                      ? previewSeries[a].data.reduce(
-                          (s, p) => s + (p.y || 0),
-                          0,
-                        ) / previewSeries[a].data.length
-                      : 0;
-                    const avgB = previewSeries[b].data.length
-                      ? previewSeries[b].data.reduce(
-                          (s, p) => s + (p.y || 0),
-                          0,
-                        ) / previewSeries[b].data.length
-                      : 0;
-                    return avgB - avgA;
+                    const avgA = getSeriesAverage(previewSeries[a].data);
+                    const avgB = getSeriesAverage(previewSeries[b].data);
+                    const scoreA =
+                      avgA == null ? Number.NEGATIVE_INFINITY : avgA;
+                    const scoreB =
+                      avgB == null ? Number.NEGATIVE_INFINITY : avgB;
+                    return scoreB - scoreA;
                   });
 
                 return (
@@ -4219,12 +4213,7 @@ export default function WidgetEditorView() {
                             const s = previewSeries[si];
                             const checked =
                               visibleSeries === null || visibleSeries.has(si);
-                            const avg = s.data.length
-                              ? s.data.reduce(
-                                  (sum, pt) => sum + (pt.y || 0),
-                                  0,
-                                ) / s.data.length
-                              : 0;
+                            const avg = getSeriesAverage(s.data);
                             const color =
                               SERIES_COLORS[si % SERIES_COLORS.length];
                             return (
@@ -4283,11 +4272,13 @@ export default function WidgetEditorView() {
                                     borderLeft: `1px solid ${theme.palette.divider}`,
                                   }}
                                 >
-                                  {avg >= 1000
-                                    ? avg.toLocaleString(undefined, {
-                                        maximumFractionDigits: 1,
-                                      })
-                                    : avg.toFixed(1)}
+                                  {avg == null
+                                    ? "—"
+                                    : avg >= 1000
+                                      ? avg.toLocaleString(undefined, {
+                                          maximumFractionDigits: 1,
+                                        })
+                                      : avg.toFixed(1)}
                                 </td>
                                 {s.data.map((pt, ci) => {
                                   if (!displayIndicesSet.has(ci)) return null;

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -947,7 +947,7 @@ class DashboardQueryBuilder:
                     elif hasattr(ts, "tzinfo") and ts.tzinfo is None:
                         ts = ts.replace(tzinfo=timezone.utc)
                     ts = ts.isoformat()
-                val = row.get("value", 0)
+                val = row.get("value")
                 if isinstance(val, float):
                     val = round(val, 6)
                 series_data[breakdown_key][ts] = val
@@ -966,7 +966,8 @@ class DashboardQueryBuilder:
                 )[:MAX_SERIES]
                 series_data = dict(ranked)
 
-            # Fill in missing time buckets with 0
+            # Fill in missing time buckets with null so consumers can
+            # distinguish missing values from real zeros.
             series = []
             for name in sorted(series_data.keys()):
                 data_map = series_data[name]
@@ -975,7 +976,9 @@ class DashboardQueryBuilder:
                     filled.append(
                         {
                             "timestamp": bucket_ts,
-                            "value": data_map.get(bucket_ts, 0),
+                            "value": data_map[bucket_ts]
+                            if bucket_ts in data_map
+                            else None,
                         }
                     )
                 series.append({"name": name, "data": filled})
@@ -1420,7 +1423,7 @@ def _generate_time_buckets(
     """Generate all time bucket ISO strings between *start* and *end*.
 
     Mirrors the ClickHouse ``toStartOf*`` bucketing so that the response
-    includes every expected bucket — even those with no data (filled with 0).
+    includes every expected bucket — even those with no data (filled with null).
     """
     buckets: List[str] = []
     if granularity == "minute":

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard_base.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard_base.py
@@ -119,7 +119,7 @@ class DashboardQueryBuilderBase:
                 elif hasattr(ts, "tzinfo") and ts.tzinfo is None:
                     ts = ts.replace(tzinfo=timezone.utc)
                 ts = ts.isoformat()
-            val = row.get("value", 0)
+            val = row.get("value")
             if isinstance(val, float):
                 val = round(val, 6)
             series_data[breakdown_key][ts] = val
@@ -175,7 +175,11 @@ class DashboardQueryBuilderBase:
                 filled.append(
                     {
                         "timestamp": bucket_ts,
-                        "value": data_map.get(bucket_ts, 0),
+                        # Preserve missing buckets as null so frontend can
+                        # distinguish "no data" from a real 0 value.
+                        "value": data_map[bucket_ts]
+                        if bucket_ts in data_map
+                        else None,
                     }
                 )
             series.append({"name": name, "data": filled})

--- a/futureagi/tracer/services/clickhouse/query_builders/dataset_dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dataset_dashboard.py
@@ -98,7 +98,7 @@ DATASET_AGGREGATIONS: Dict[str, str] = {
 
 # Breakdown dimensions for dataset workflow
 DATASET_BREAKDOWN_COLUMNS: Dict[str, str] = {
-    "dataset": "dictGet('dataset_dict', 'name', c.dataset_id)",
+    "dataset": "toString(c.dataset_id)",
     "eval_template": "dictGet('column_dict', 'name', c.column_id)",
     "column_name": "dictGet('column_dict', 'name', c.column_id)",
     "cell_status": "c.status",
@@ -106,7 +106,7 @@ DATASET_BREAKDOWN_COLUMNS: Dict[str, str] = {
 
 # Filter dimensions for dataset workflow
 DATASET_FILTER_COLUMNS: Dict[str, str] = {
-    "dataset": "dictGet('dataset_dict', 'name', c.dataset_id)",
+    "dataset": "toString(c.dataset_id)",
     "column_name": "dictGet('column_dict', 'name', c.column_id)",
     "column_source": "dictGet('column_dict', 'source', c.column_id)",
     "cell_status": "c.status",
@@ -497,6 +497,13 @@ class DatasetQueryBuilder(DashboardQueryBuilderBase):
             return col
         return None
 
+    @staticmethod
+    def _dataset_scope_subquery() -> str:
+        return (
+            "SELECT id FROM model_hub_dataset FINAL "
+            "WHERE _peerdb_is_deleted = 0 AND deleted = 0"
+        )
+
     def _build_base_where(self, params: dict) -> List[str]:
         clauses = [
             "c._peerdb_is_deleted = 0",
@@ -505,7 +512,10 @@ class DatasetQueryBuilder(DashboardQueryBuilderBase):
         ]
         if self.workspace_id:
             clauses.append(
-                "dictGet('dataset_dict', 'workspace_id', c.dataset_id) = toUUID(%(workspace_id)s)"
+                "c.dataset_id IN ("
+                f"{self._dataset_scope_subquery()} "
+                "AND workspace_id = toUUID(%(workspace_id)s)"
+                ")"
             )
         if self.dataset_ids:
             clauses.append("c.dataset_id IN %(dataset_ids)s")
@@ -526,6 +536,35 @@ class DatasetQueryBuilder(DashboardQueryBuilderBase):
 
             if f_type != "system_metric":
                 # Dataset filters only support system_metric dimensions for now
+                continue
+
+            if f_name == "dataset":
+                if op in ("is_set", "is_not_set"):
+                    clauses.append(
+                        "c.dataset_id IS NOT NULL"
+                        if op == "is_set"
+                        else "c.dataset_id IS NULL"
+                    )
+                    continue
+
+                if val is None or val == "" or val == []:
+                    continue
+
+                if op in ("between", "not_between"):
+                    continue
+
+                op_tpl = FILTER_OPERATORS.get(op)
+                if op_tpl:
+                    param_key = f"df_{idx}_val"
+                    op_sql = op_tpl.format(prefix="df_", idx=idx)
+                    clauses.append(
+                        "c.dataset_id IN ("
+                        f"{self._dataset_scope_subquery()} "
+                        f"AND name {op_sql}"
+                        ")"
+                    )
+                    params[param_key] = _coerce_filter_value(val, op)
+                    idx += 1
                 continue
 
             col = DATASET_FILTER_COLUMNS.get(f_name)

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -401,6 +401,111 @@ class TestDashboardQueryBuilder:
         sql, _, _ = queries[0]
         assert "output_bool" in sql
 
+    def test_system_metric_sum_aggregation(self):
+        config = {
+            "project_ids": ["proj1"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "cost",
+                    "name": "cost",
+                    "type": "system_metric",
+                    "aggregation": "sum",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "sum(cost)" in sql
+
+    def test_system_metric_median_aggregation(self):
+        config = {
+            "project_ids": ["proj1"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "latency",
+                    "name": "latency",
+                    "type": "system_metric",
+                    "aggregation": "median",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "quantile(0.5)(latency_ms)" in sql
+
+    def test_system_metric_count_distinct_aggregation(self):
+        config = {
+            "project_ids": ["proj1"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "model",
+                    "name": "model",
+                    "type": "system_metric",
+                    "aggregation": "count_distinct",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "uniq(model)" in sql
+
+    def test_eval_metric_pass_rate_aggregation(self):
+        config = {
+            "project_ids": ["proj1"],
+            "organization_id": str(uuid.uuid4()),
+            "workspace_id": str(uuid.uuid4()),
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "e_pass_rate",
+                    "name": "accuracy",
+                    "type": "eval_metric",
+                    "config_id": str(uuid.uuid4()),
+                    "output_type": "PASS_FAIL",
+                    "aggregation": "pass_rate",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "countIf(" in sql
+        assert "/ nullIf(count(), 0)" in sql
+
+    def test_eval_metric_fail_count_aggregation(self):
+        config = {
+            "project_ids": ["proj1"],
+            "organization_id": str(uuid.uuid4()),
+            "workspace_id": str(uuid.uuid4()),
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "e_fail_count",
+                    "name": "accuracy",
+                    "type": "eval_metric",
+                    "config_id": str(uuid.uuid4()),
+                    "output_type": "PASS_FAIL",
+                    "aggregation": "fail_count",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "countIf(" in sql
+        assert "AS value" in sql
+
     def test_annotation_metric_query(self):
         config = {
             "project_ids": ["proj1"],
@@ -688,9 +793,9 @@ class TestDashboardQueryBuilderFormatResults:
         series = result["metrics"][0]["series"]
         assert len(series) == 1
         assert series[0]["name"] == "total"
-        # All buckets filled with 0 (Jan 1, 2, 3)
+        # All buckets filled with null (Jan 1, 2, 3)
         assert len(series[0]["data"]) == 3
-        assert all(d["value"] == 0 for d in series[0]["data"])
+        assert all(d["value"] is None for d in series[0]["data"])
 
     def test_format_with_data(self):
         config = {
@@ -726,10 +831,10 @@ class TestDashboardQueryBuilderFormatResults:
         series = metrics[0]["series"]
         assert len(series) == 1
         assert series[0]["name"] == "total"
-        # 4 day buckets (Jan 1-4), 2 with data + 2 filled with 0
+        # 4 day buckets (Jan 1-4), 2 with data + 2 filled with null
         assert len(series[0]["data"]) == 4
-        non_zero = [d for d in series[0]["data"] if d["value"] != 0]
-        assert len(non_zero) == 2
+        non_null = [d for d in series[0]["data"] if d["value"] is not None]
+        assert len(non_null) == 2
         assert metrics[0]["unit"] == "ms"
 
     def test_format_with_breakdown(self):
@@ -895,6 +1000,28 @@ class TestDashboardQueryExecution:
         assert response.status_code == 200
 
     @pytest.mark.django_db
+    def test_query_action_missing_project_ids_still_works(self, auth_client):
+        """Query endpoint accepts requests without project_ids (unified picker)."""
+        response = auth_client.post(
+            "/tracer/dashboard/query/",
+            {
+                "granularity": "day",
+                "time_range": {"preset": "7D"},
+                "metrics": [
+                    {
+                        "id": "latency",
+                        "name": "latency",
+                        "type": "system_metric",
+                        "aggregation": "avg",
+                        "source": "traces",
+                    }
+                ],
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.django_db
     @patch("tracer.views.dashboard.AnalyticsQueryService")
     def test_query_action_project_breakdown_uses_longer_timeout(
         self, mock_analytics_cls, auth_client, observe_project
@@ -986,28 +1113,6 @@ class TestDashboardTraceTimeoutSelection:
         )
         assert timeout == 30000
 
-    @pytest.mark.django_db
-    def test_query_action_missing_project_ids_still_works(self, auth_client):
-        """Query endpoint accepts requests without project_ids (unified picker)."""
-        response = auth_client.post(
-            "/tracer/dashboard/query/",
-            {
-                "granularity": "day",
-                "time_range": {"preset": "7D"},
-                "metrics": [
-                    {
-                        "id": "latency",
-                        "name": "latency",
-                        "type": "system_metric",
-                        "aggregation": "avg",
-                        "source": "traces",
-                    }
-                ],
-            },
-            format="json",
-        )
-        assert response.status_code == 200
-
 
 # ===========================================================================
 # Widget Query Execution (mocked ClickHouse)
@@ -1091,8 +1196,6 @@ class TestWidgetQueryExecution:
             format="json",
         )
         assert response.status_code == 200
-        data = response.json()["result"]
-        assert "metrics" in data
 
     @pytest.mark.django_db
     @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
@@ -1135,6 +1238,8 @@ class TestWidgetQueryExecution:
         assert response.status_code == 200
         _, kwargs = mock_client.execute_read.call_args
         assert kwargs["timeout_ms"] == 30000
+        data = response.json()["result"]
+        assert "metrics" in data
 
     @pytest.mark.django_db
     @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
@@ -1649,11 +1754,11 @@ class TestFrontendPayloadSimulation:
         assert result["metrics"][0]["unit"] == "ms"
         assert result["metrics"][1]["name"] == "cost"
         assert result["metrics"][1]["unit"] == "$"
-        # 3 day buckets (Jan 1-3), 2 with data + 1 filled with 0
+        # 3 day buckets (Jan 1-3), 2 with data + 1 filled with null
         data = result["metrics"][0]["series"][0]["data"]
         assert len(data) == 3
-        non_zero = [d for d in data if d["value"] != 0]
-        assert len(non_zero) == 2
+        non_null = [d for d in data if d["value"] is not None]
+        assert len(non_null) == 2
 
 
 # ===========================================================================

--- a/futureagi/tracer/tests/test_dataset_dashboard.py
+++ b/futureagi/tracer/tests/test_dataset_dashboard.py
@@ -206,9 +206,9 @@ class TestDatasetDimensions:
         expected = {"dataset", "column_name", "column_source", "cell_status"}
         assert set(DATASET_FILTER_COLUMNS.keys()) == expected
 
-    def test_breakdown_columns_use_dict_lookups(self):
+    def test_breakdown_columns_use_supported_expressions(self):
         for name, expr in DATASET_BREAKDOWN_COLUMNS.items():
-            assert "c." in expr or "dictGet" in expr
+            assert "c." in expr or "dictGet" in expr or "toString" in expr
 
 
 # ============================================================================
@@ -490,7 +490,7 @@ class TestDatasetBreakdowns:
         builder = DatasetQueryBuilder(system_metric_config)
         sql, _ = builder.build_metric_query(system_metric_config["metrics"][0])
         assert "breakdown_value" in sql
-        assert "dataset_dict" in sql
+        assert "toString(c.dataset_id)" in sql
         assert "GROUP BY" in sql
 
     def test_eval_template_breakdown(self, system_metric_config):
@@ -545,9 +545,17 @@ class TestDatasetFilters:
         ]
         builder = DatasetQueryBuilder(system_metric_config)
         sql, params = builder.build_metric_query(system_metric_config["metrics"][0])
-        assert "dataset_dict" in sql
+        assert "FROM model_hub_dataset FINAL" in sql
+        assert "AND name IN %(df_0_val)s" in sql
         assert "IN" in sql
         assert "df_0_val" in params
+
+    def test_workspace_filter_uses_dataset_table(self, system_metric_config):
+        builder = DatasetQueryBuilder(system_metric_config)
+        sql, params = builder.build_metric_query(system_metric_config["metrics"][0])
+        assert "SELECT id FROM model_hub_dataset FINAL" in sql
+        assert "workspace_id = toUUID(%(workspace_id)s)" in sql
+        assert "workspace_id" in params
 
     def test_cell_status_filter(self, system_metric_config):
         system_metric_config["filters"] = [
@@ -812,7 +820,7 @@ class TestDatasetResultFormatting:
         result = builder.format_results([(metric_info, rows)])
         series = result["metrics"][0]["series"]
         # Find the data point with the matching timestamp
-        found = [d for d in series[0]["data"] if d["value"] != 0]
+        found = [d for d in series[0]["data"] if d["value"] is not None]
         assert len(found) == 1
         assert found[0]["value"] == round(1.23456789012345, 6)
 

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1901,15 +1901,33 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                 if not col_expr:
                     return self._gm.success_response({"values": []})
 
-                sql = (
-                    f"SELECT DISTINCT {col_expr} AS val "
-                    f"FROM model_hub_cell AS c FINAL "
-                    f"WHERE c._peerdb_is_deleted = 0 "
-                    f"AND dictGet('dataset_dict', 'workspace_id', c.dataset_id) = toUUID(%(workspace_id)s) "
-                    f"AND {col_expr} != '' "
-                    f"ORDER BY val "
-                    f"LIMIT 500"
-                )
+                if metric_name == "dataset":
+                    sql = (
+                        "SELECT DISTINCT name AS val "
+                        "FROM model_hub_dataset FINAL "
+                        "WHERE _peerdb_is_deleted = 0 "
+                        "AND deleted = 0 "
+                        "AND workspace_id = toUUID(%(workspace_id)s) "
+                        "AND name != '' "
+                        "ORDER BY val "
+                        "LIMIT 500"
+                    )
+                else:
+                    sql = (
+                        f"SELECT DISTINCT {col_expr} AS val "
+                        f"FROM model_hub_cell AS c FINAL "
+                        f"WHERE c._peerdb_is_deleted = 0 "
+                        f"AND c.dataset_id IN ("
+                        f"SELECT id FROM model_hub_dataset FINAL "
+                        f"WHERE _peerdb_is_deleted = 0 "
+                        f"AND deleted = 0 "
+                        f"AND workspace_id = toUUID(%(workspace_id)s)"
+                        f") "
+                        f"AND {col_expr} != '' "
+                        f"ORDER BY val "
+                        f"LIMIT 500"
+                    )
+
                 result = analytics.execute_ch_query(
                     sql, {"workspace_id": workspace_id}, timeout_ms=5000
                 )


### PR DESCRIPTION
## Summary
- preserve missing dashboard buckets as null instead of zero
- compute frontend dashboard averages from non-null buckets only and show em dash for empty rows
- keep sparse line and area series visible with markers
- route dataset dashboard workspace filtering and dataset-name lookups through model_hub_dataset instead of dataset_dict

## Testing
- 
- 
- frontend lint not run in this worktree because yarn run v1.22.22
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command. is unavailable here