### PR TITLE
fix: j/k shortcuts swallow keystrokes in text inputs

### DIFF
--- a/frontend/src/sections/evals/components/EvalFeedbackTab.jsx
+++ b/frontend/src/sections/evals/components/EvalFeedbackTab.jsx
@@ -250,6 +250,12 @@ const EvalFeedbackTab = ({ templateId }) => {
   React.useEffect(() => {
     if (detailIndex === null) return;
     const handler = (e) => {
+      const tag = e.target?.tagName;
+      const isEditable =
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        e.target?.isContentEditable;
+      if (isEditable) return;
       if (e.key === "k") {
         e.preventDefault();
         setDetailIndex((i) => Math.max(0, (i ?? 0) - 1));

--- a/frontend/src/sections/evals/components/EvalFeedbackTab.jsx
+++ b/frontend/src/sections/evals/components/EvalFeedbackTab.jsx
@@ -18,6 +18,7 @@ import { useDebounce } from "src/hooks/use-debounce";
 import AddEvalsFeedbackDrawer from "src/sections/evals/EvalDetails/EvalsFeedback/AddEvalsFeedbackDrawer";
 
 import { useEvalFeedbackList } from "../hooks/useEvalFeedback";
+import { isEditableElement } from "src/utils/keyboardUtils";
 
 // ── Columns ──
 const useColumns = () =>
@@ -250,12 +251,8 @@ const EvalFeedbackTab = ({ templateId }) => {
   React.useEffect(() => {
     if (detailIndex === null) return;
     const handler = (e) => {
-      const tag = e.target?.tagName;
-      const isEditable =
-        tag === "INPUT" ||
-        tag === "TEXTAREA" ||
-        e.target?.isContentEditable;
-      if (isEditable) return;
+      if (e.repeat) return;
+      if (isEditableElement(e)) return;
       if (e.key === "k") {
         e.preventDefault();
         setDetailIndex((i) => Math.max(0, (i ?? 0) - 1));

--- a/frontend/src/sections/evals/components/EvalUsageTab.jsx
+++ b/frontend/src/sections/evals/components/EvalUsageTab.jsx
@@ -22,6 +22,7 @@ import DateTimeRangePicker from "src/sections/projects/DateTimeRangePicker";
 import AddEvalsFeedbackDrawer from "src/sections/evals/EvalDetails/EvalsFeedback/AddEvalsFeedbackDrawer";
 
 import { useEvalUsageChart, useEvalUsageLogs } from "../hooks/useEvalUsage";
+import { isEditableElement } from "src/utils/keyboardUtils";
 import UsageChart from "./UsageChart";
 
 // ── Inline stat ──
@@ -382,12 +383,8 @@ const EvalUsageTab = ({
   React.useEffect(() => {
     if (detailIndex === null) return;
     const handler = (e) => {
-      const tag = e.target?.tagName;
-      const isEditable =
-        tag === "INPUT" ||
-        tag === "TEXTAREA" ||
-        e.target?.isContentEditable;
-      if (isEditable) return;
+      if (e.repeat) return;
+      if (isEditableElement(e)) return;
       if (e.key === "k") {
         e.preventDefault();
         setDetailIndex((i) => Math.max(0, (i ?? 0) - 1));

--- a/frontend/src/sections/evals/components/EvalUsageTab.jsx
+++ b/frontend/src/sections/evals/components/EvalUsageTab.jsx
@@ -382,6 +382,12 @@ const EvalUsageTab = ({
   React.useEffect(() => {
     if (detailIndex === null) return;
     const handler = (e) => {
+      const tag = e.target?.tagName;
+      const isEditable =
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        e.target?.isContentEditable;
+      if (isEditable) return;
       if (e.key === "k") {
         e.preventDefault();
         setDetailIndex((i) => Math.max(0, (i ?? 0) - 1));

--- a/frontend/src/sections/tasks/components/TaskUsageTab.jsx
+++ b/frontend/src/sections/tasks/components/TaskUsageTab.jsx
@@ -847,6 +847,12 @@ const TaskUsageTab = ({ taskId }) => {
   useEffect(() => {
     if (detailIndex === null) return undefined;
     const handler = (e) => {
+      const tag = e.target?.tagName;
+      const isEditable =
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        e.target?.isContentEditable;
+      if (isEditable) return;
       if (e.key === "k") {
         e.preventDefault();
         setDetailIndex((i) => Math.max(0, (i ?? 0) - 1));

--- a/frontend/src/sections/tasks/components/TaskUsageTab.jsx
+++ b/frontend/src/sections/tasks/components/TaskUsageTab.jsx
@@ -23,6 +23,7 @@ import { useTaskUsageChart, useTaskUsageLogs } from "../hooks/useTaskUsage";
 import UsageChart from "src/sections/evals/components/UsageChart";
 import { JsonValueTree } from "src/sections/evals/components/DatasetTestMode";
 import { classifyTaskError } from "src/sections/common/EvalsTasks/classifyTaskError";
+import { isEditableElement } from "src/utils/keyboardUtils";
 
 // ── Inline stat ──
 const StatPill = ({ label, value, color }) => (
@@ -847,12 +848,8 @@ const TaskUsageTab = ({ taskId }) => {
   useEffect(() => {
     if (detailIndex === null) return undefined;
     const handler = (e) => {
-      const tag = e.target?.tagName;
-      const isEditable =
-        tag === "INPUT" ||
-        tag === "TEXTAREA" ||
-        e.target?.isContentEditable;
-      if (isEditable) return;
+      if (e.repeat) return;
+      if (isEditableElement(e)) return;
       if (e.key === "k") {
         e.preventDefault();
         setDetailIndex((i) => Math.max(0, (i ?? 0) - 1));

--- a/frontend/src/utils/keyboardUtils.js
+++ b/frontend/src/utils/keyboardUtils.js
@@ -1,0 +1,15 @@
+/**
+ * Returns true if the keyboard event target is an editable element.
+ * Used to guard keyboard shortcuts from firing while the user is typing.
+ *
+ * Covers: INPUT, TEXTAREA, SELECT, and any element with contentEditable.
+ */
+export function isEditableElement(e) {
+  const tag = e.target?.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    e.target?.isContentEditable
+  );
+}


### PR DESCRIPTION
Fixes #35

The `j`/`k` row navigation shortcuts use a `window` keydown listener with no check on where focus is. When the detail panel is open and you click into any text input or textarea (like the feedback comment field), `j` and `k` get intercepted before the browser can insert them. You type, nothing appears.

## Files changed

- `frontend/src/sections/evals/components/EvalFeedbackTab.jsx`
- `frontend/src/sections/evals/components/EvalUsageTab.jsx`
- `frontend/src/sections/tasks/components/TaskUsageTab.jsx`

Same bug and same fix in all three — they share the same keyboard shortcut pattern.