### PR TITLE
feat: add HTTP Request and Conditional Routing nodes to Agent Playground

### DIFF
--- a/frontend/src/api/agent-playground/node-templates.js
+++ b/frontend/src/api/agent-playground/node-templates.js
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
-import { NODE_TYPES } from "../../sections/agent-playground/utils/constants";
+import { NODE_TYPE_CONFIG, NODE_TYPES } from "../../sections/agent-playground/utils/constants";
 
 /**
  * Hook for fetching graphs that can be referenced as agent nodes.
@@ -18,8 +18,36 @@ export const useGetReferenceableGraphs = (graphId, options = {}) =>
     ...options,
   });
 
+/** Node types whose templates are served by the backend API. */
+const BACKEND_TEMPLATE_TYPES = new Set([NODE_TYPES.LLM_PROMPT]);
+
 /**
- * Hook for fetching node templates. Filters to llm_prompt only for now.
+ * Client-side node definitions for node types that are handled
+ * entirely on the frontend and don't have a backend template entry.
+ */
+const CLIENT_SIDE_NODES = [
+  {
+    id: NODE_TYPES.HTTP_REQUEST,
+    node_template_id: null,
+    title: NODE_TYPE_CONFIG[NODE_TYPES.HTTP_REQUEST].title,
+    description: NODE_TYPE_CONFIG[NODE_TYPES.HTTP_REQUEST].description,
+    iconSrc: NODE_TYPE_CONFIG[NODE_TYPES.HTTP_REQUEST].iconSrc,
+    color: NODE_TYPE_CONFIG[NODE_TYPES.HTTP_REQUEST].color,
+  },
+  {
+    id: NODE_TYPES.CONDITIONAL,
+    node_template_id: null,
+    title: NODE_TYPE_CONFIG[NODE_TYPES.CONDITIONAL].title,
+    description: NODE_TYPE_CONFIG[NODE_TYPES.CONDITIONAL].description,
+    iconSrc: NODE_TYPE_CONFIG[NODE_TYPES.CONDITIONAL].iconSrc,
+    color: NODE_TYPE_CONFIG[NODE_TYPES.CONDITIONAL].color,
+  },
+];
+
+/**
+ * Hook for fetching node templates.
+ * Backend templates are merged with client-side node definitions so that
+ * HTTP Request and Conditional nodes appear in the node selection panel.
  * Maps API shape to NodeCard shape: { id, node_template_id, title, description, iconSrc, color }
  * @param {object} options - Additional react-query options
  */
@@ -27,17 +55,19 @@ export const useGetNodeTemplates = (options = {}) =>
   useQuery({
     queryKey: ["agent-playground", "node-templates"],
     queryFn: () => axios.get(endpoints.agentPlayground.nodeTemplates),
-    select: (res) =>
-      (res.data?.result?.node_templates ?? [])
-        .filter((t) => t.name === NODE_TYPES.LLM_PROMPT)
+    select: (res) => {
+      const backendNodes = (res.data?.result?.node_templates ?? [])
+        .filter((t) => BACKEND_TEMPLATE_TYPES.has(t.name))
         .map((t) => ({
           id: t.name,
           node_template_id: t.id,
           title: t.display_name,
           description: t.description,
-          iconSrc: "/assets/icons/ic_chat_single.svg",
-          color: "orange.500",
-        })),
+          iconSrc: NODE_TYPE_CONFIG[t.name]?.iconSrc ?? "/assets/icons/ic_chat_single.svg",
+          color: NODE_TYPE_CONFIG[t.name]?.color ?? "orange.500",
+        }));
+      return [...backendNodes, ...CLIENT_SIDE_NODES];
+    },
     staleTime: 5 * 60 * 1000,
     ...options,
   });

--- a/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
@@ -12,7 +12,7 @@ import {
   useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { PromptNode, AgentNode, EvalNode } from "./nodes";
+import { PromptNode, AgentNode, EvalNode, HttpRequestNode, ConditionalNode } from "./nodes";
 import { AnimatedEdge } from "./edges";
 import { enqueueSnackbar } from "notistack";
 import {
@@ -37,6 +37,8 @@ const nodeTypes = {
   [NODE_TYPES.LLM_PROMPT]: PromptNode,
   agent: AgentNode,
   eval: EvalNode,
+  [NODE_TYPES.HTTP_REQUEST]: HttpRequestNode,
+  [NODE_TYPES.CONDITIONAL]: ConditionalNode,
 };
 
 const edgeTypes = {

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeConfigurationForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeConfigurationForm.jsx
@@ -1,12 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { PromptNodeForm, EvalsNodeForm, AgentNodeForm } from "./forms";
+import {
+  PromptNodeForm,
+  EvalsNodeForm,
+  AgentNodeForm,
+  HttpRequestNodeForm,
+  ConditionalNodeForm,
+} from "./forms";
 import { NODE_TYPES } from "../../utils/constants";
 
 const FORM_COMPONENTS = {
   [NODE_TYPES.LLM_PROMPT]: PromptNodeForm,
   eval: EvalsNodeForm,
   [NODE_TYPES.AGENT]: AgentNodeForm,
+  [NODE_TYPES.HTTP_REQUEST]: HttpRequestNodeForm,
+  [NODE_TYPES.CONDITIONAL]: ConditionalNodeForm,
 };
 
 export default function NodeConfigurationForm({ nodeType, nodeId }) {
@@ -20,7 +28,12 @@ export default function NodeConfigurationForm({ nodeType, nodeId }) {
 }
 
 NodeConfigurationForm.propTypes = {
-  nodeType: PropTypes.oneOf([NODE_TYPES.LLM_PROMPT, "eval", NODE_TYPES.AGENT])
-    .isRequired,
+  nodeType: PropTypes.oneOf([
+    NODE_TYPES.LLM_PROMPT,
+    "eval",
+    NODE_TYPES.AGENT,
+    NODE_TYPES.HTTP_REQUEST,
+    NODE_TYPES.CONDITIONAL,
+  ]).isRequired,
   nodeId: PropTypes.string.isRequired,
 };

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/ConditionalNodeForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/ConditionalNodeForm.jsx
@@ -1,0 +1,111 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Controller, useFormContext } from "react-hook-form";
+import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
+
+const OPERATORS = [
+  { value: "eq", label: "equals (==)" },
+  { value: "neq", label: "not equals (!=)" },
+  { value: "gt", label: "greater than (>)" },
+  { value: "gte", label: "greater than or equal (>=)" },
+  { value: "lt", label: "less than (<)" },
+  { value: "lte", label: "less than or equal (<=)" },
+  { value: "contains", label: "contains" },
+  { value: "not_contains", label: "does not contain" },
+  { value: "is_empty", label: "is empty" },
+  { value: "is_not_empty", label: "is not empty" },
+];
+
+const NO_VALUE_OPERATORS = ["is_empty", "is_not_empty"];
+
+/**
+ * ConditionalNodeForm
+ *
+ * Lets users define a single condition:
+ *   left operand  [operator]  right operand
+ *
+ * Both operands support {{variable}} syntax to reference upstream node outputs.
+ * The "true" output handle fires when the condition passes; "false" otherwise.
+ */
+export default function ConditionalNodeForm({ nodeId: _nodeId }) {
+  const { control, watch } = useFormContext();
+  const operator = watch("operator");
+  const needsRightOperand = !NO_VALUE_OPERATORS.includes(operator);
+
+  return (
+    <Stack spacing={2} sx={{ p: 2 }}>
+      <Typography variant="body2" color="text.secondary">
+        The <strong>true</strong> branch runs when the condition passes; the{" "}
+        <strong>false</strong> branch runs otherwise.
+      </Typography>
+
+      {/* Left operand */}
+      <Box>
+        <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+          Left operand
+        </Typography>
+        <FormTextFieldV2
+          name="leftOperand"
+          control={control}
+          placeholder="{{variable}} or a literal value"
+          size="small"
+          fullWidth
+          rules={{ required: "Left operand is required" }}
+        />
+      </Box>
+
+      {/* Operator */}
+      <Box>
+        <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+          Operator
+        </Typography>
+        <Controller
+          name="operator"
+          control={control}
+          defaultValue="eq"
+          render={({ field }) => (
+            <TextField {...field} select size="small" fullWidth>
+              {OPERATORS.map((op) => (
+                <MenuItem key={op.value} value={op.value}>
+                  {op.label}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+        />
+      </Box>
+
+      {/* Right operand — hidden for unary operators */}
+      {needsRightOperand && (
+        <Box>
+          <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+            Right operand
+          </Typography>
+          <FormTextFieldV2
+            name="rightOperand"
+            control={control}
+            placeholder="{{variable}} or a literal value"
+            size="small"
+            fullWidth
+            rules={{ required: "Right operand is required" }}
+          />
+        </Box>
+      )}
+
+      <Typography variant="caption" color="text.disabled">
+        Use <code>{"{{variable_name}}"}</code> to reference outputs from upstream nodes.
+      </Typography>
+    </Stack>
+  );
+}
+
+ConditionalNodeForm.propTypes = {
+  nodeId: PropTypes.string.isRequired,
+};

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/HttpRequestNodeForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/HttpRequestNodeForm.jsx
@@ -1,0 +1,128 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Controller, useFormContext } from "react-hook-form";
+import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+
+/**
+ * HttpRequestNodeForm
+ *
+ * Lets users configure:
+ *   - HTTP method (GET / POST / PUT / PATCH / DELETE)
+ *   - URL (supports {{variable}} template syntax)
+ *   - Request headers (key-value, one per line as "Key: Value")
+ *   - Request body (raw JSON, shown only for POST/PUT/PATCH)
+ *   - Output variable name (where the response JSON is stored)
+ */
+export default function HttpRequestNodeForm({ nodeId: _nodeId }) {
+  const { control, watch } = useFormContext();
+  const method = watch("method");
+  const hasBody = ["POST", "PUT", "PATCH"].includes(method);
+
+  return (
+    <Stack spacing={2} sx={{ p: 2 }}>
+      {/* Method + URL */}
+      <Stack direction="row" spacing={1} alignItems="flex-start">
+        <Controller
+          name="method"
+          control={control}
+          defaultValue="GET"
+          render={({ field }) => (
+            <TextField
+              {...field}
+              select
+              size="small"
+              label="Method"
+              sx={{ width: 110, flexShrink: 0 }}
+            >
+              {HTTP_METHODS.map((m) => (
+                <MenuItem key={m} value={m}>
+                  {m}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+        />
+        <FormTextFieldV2
+          name="url"
+          control={control}
+          label="URL"
+          placeholder="https://api.example.com/endpoint"
+          size="small"
+          fullWidth
+          rules={{ required: "URL is required" }}
+        />
+      </Stack>
+
+      {/* Headers */}
+      <Box>
+        <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+          Headers (one per line: <code>Key: Value</code>)
+        </Typography>
+        <FormTextFieldV2
+          name="headers"
+          control={control}
+          placeholder={"Content-Type: application/json\nAuthorization: Bearer {{token}}"}
+          multiline
+          minRows={3}
+          size="small"
+          fullWidth
+        />
+      </Box>
+
+      {/* Body — only for POST/PUT/PATCH */}
+      {hasBody && (
+        <Box>
+          <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+            Body (JSON — use <code>{"{{variable}}"}</code> for dynamic values)
+          </Typography>
+          <FormTextFieldV2
+            name="body"
+            control={control}
+            placeholder={'{\n  "key": "{{variable}}"\n}'}
+            multiline
+            minRows={5}
+            size="small"
+            fullWidth
+            sx={{ fontFamily: "monospace", fontSize: 12 }}
+          />
+        </Box>
+      )}
+
+      {/* Output variable name */}
+      <Box>
+        <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+          Output variable name
+        </Typography>
+        <FormTextFieldV2
+          name="outputKey"
+          control={control}
+          placeholder="http_response"
+          size="small"
+          fullWidth
+          rules={{
+            pattern: {
+              value: /^[a-z0-9_]+$/,
+              message: "Lowercase letters, numbers, and underscores only",
+            },
+          }}
+        />
+        <Typography variant="caption" color="text.disabled" sx={{ mt: 0.5, display: "block" }}>
+          The response JSON will be available as this variable in downstream nodes.
+        </Typography>
+      </Box>
+    </Stack>
+  );
+}
+
+HttpRequestNodeForm.propTypes = {
+  nodeId: PropTypes.string.isRequired,
+};

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/index.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/index.js
@@ -1,3 +1,5 @@
 export { default as PromptNodeForm } from "./PromptNodeForm";
 export { default as EvalsNodeForm } from "./EvalsNodeForm";
 export { default as AgentNodeForm } from "./AgentNodeForm";
+export { default as HttpRequestNodeForm } from "./HttpRequestNodeForm";
+export { default as ConditionalNodeForm } from "./ConditionalNodeForm";

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
@@ -13,6 +13,14 @@ const NODE_TYPE_CONFIG = {
     iconSrc: "/assets/icons/ic_rounded_square.svg",
     color: "green.600",
   },
+  [NODE_TYPES.HTTP_REQUEST]: {
+    iconSrc: "/assets/icons/ic_agent_flow.svg",
+    color: "blue.500",
+  },
+  [NODE_TYPES.CONDITIONAL]: {
+    iconSrc: "/assets/icons/ic_branch.svg",
+    color: "purple.500",
+  },
   default: {
     iconSrc: "/assets/icons/navbar/ic_agents.svg",
     color: "text.secondary",

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/ConditionalNode.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/ConditionalNode.jsx
@@ -1,0 +1,289 @@
+import React, { memo } from "react";
+import { Handle, Position } from "@xyflow/react";
+import { alpha, Box, IconButton, Stack, Typography } from "@mui/material";
+import PropTypes from "prop-types";
+import SvgColor from "src/components/svg-color";
+import NodeSelectionPopper from "../../components/NodeSelectionPopper";
+import { NODE_TYPE_CONFIG, NODE_TYPES } from "../../utils/constants";
+import useBaseNodeState from "./hooks/useBaseNodeState";
+import useBaseNodeStyles from "./hooks/useBaseNodeStyles";
+import useBaseNodeActions from "./hooks/useBaseNodeActions";
+import StartIndicator from "./StartIndicator";
+import "../agent-graph.css";
+
+const handleBaseStyle = {
+  width: 10,
+  height: 10,
+  background: "var(--bg-paper)",
+};
+
+/**
+ * ConditionalNode
+ *
+ * Visually identical to BaseNode but exposes two output handles:
+ *   - "true"  (top-right)  — taken when the condition evaluates to truthy
+ *   - "false" (bottom-right) — taken when the condition evaluates to falsy
+ *
+ * The condition itself is configured in ConditionalNodeForm via the node drawer.
+ */
+const ConditionalNode = ({
+  id,
+  data,
+  isConnectable,
+  selected: _UI_SELECTED_NODE,
+}) => {
+  const { label, preview } = data;
+  const typeConfig = NODE_TYPE_CONFIG[NODE_TYPES.CONDITIONAL] ?? {};
+  const iconColor = typeConfig.color ?? "purple.500";
+
+  const state = useBaseNodeState({ id, data });
+  const {
+    hasIncomingEdge,
+    isRunning,
+    isCompleted,
+    isError,
+    isWorkflowRunning,
+  } = state;
+
+  const { boxSx, borderColor, theme } = useBaseNodeStyles(state);
+
+  const actions = useBaseNodeActions({ id, ...state });
+  const {
+    handleNodeClick,
+    handleAddClick,
+    handlePopperClose,
+    handleNodeSelect,
+    handleDeleteClick,
+    popperOpen,
+    addButtonRef,
+  } = actions;
+
+  return (
+    <Box sx={{ position: "relative" }}>
+      <Box onClick={handleNodeClick} sx={boxSx}>
+        {isRunning && (
+          <svg
+            width="100%"
+            height="100%"
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              pointerEvents: "none",
+            }}
+          >
+            <rect
+              x="0.75"
+              y="0.75"
+              width="calc(100% - 1.5px)"
+              height="calc(100% - 1.5px)"
+              rx="4"
+              fill="none"
+              stroke={theme.palette.green[500]}
+              strokeWidth="1.5"
+              strokeDasharray="8 4"
+              strokeDashoffset="0"
+              style={{ animation: "dash-around 2s linear infinite" }}
+            />
+          </svg>
+        )}
+
+        {!hasIncomingEdge && (
+          <StartIndicator
+            isWorkflowRunning={isWorkflowRunning}
+            isRunning={isRunning}
+            isCompleted={isCompleted}
+            isError={isError}
+          />
+        )}
+
+        {/* Input handle */}
+        <Handle
+          type="target"
+          position={Position.Left}
+          id="input"
+          isConnectable={preview ? false : isConnectable}
+          style={{
+            ...handleBaseStyle,
+            border: `1px solid ${borderColor}`,
+            left: -5,
+            top: "50%",
+          }}
+        />
+
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          sx={{ flex: 1, minWidth: 0, width: 200, maxWidth: 200 }}
+        >
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              borderRadius: 0.5,
+              border: "1px solid",
+              borderColor: "divider",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+            }}
+          >
+            <SvgColor
+              src={typeConfig.iconSrc ?? "/assets/icons/ic_branch.svg"}
+              sx={{ width: 16, height: 16, bgcolor: iconColor }}
+            />
+          </Box>
+          <Typography
+            typography="s2_1"
+            fontWeight="fontWeightMedium"
+            color="text.primary"
+            noWrap
+          >
+            {label}
+          </Typography>
+          {!preview && !isWorkflowRunning && (
+            <IconButton
+              className="node-delete-btn"
+              sx={{
+                color: "red.500",
+                bgcolor: "background.paper",
+                borderRadius: 0.5,
+                border: "1px solid",
+                borderColor: "red.500",
+                marginLeft: "auto",
+                p: 0.5,
+                position: "absolute",
+                right: 4,
+                top: "50%",
+                transform: "translateY(-50%)",
+                "&:hover": {
+                  bgcolor: (t) =>
+                    t.palette.mode === "dark"
+                      ? alpha(t.palette.red[800], 0.3)
+                      : "red.50",
+                },
+              }}
+              onClick={handleDeleteClick}
+            >
+              <SvgColor
+                src="/assets/icons/ic_delete.svg"
+                sx={{ width: 16, height: 16 }}
+              />
+            </IconButton>
+          )}
+        </Stack>
+
+        {/* True output handle — top-right */}
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="true"
+          isConnectable={preview ? false : isConnectable}
+          style={{
+            ...handleBaseStyle,
+            border: `1px solid ${borderColor}`,
+            right: -5,
+            top: "30%",
+          }}
+        />
+
+        {/* False output handle — bottom-right */}
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="false"
+          isConnectable={preview ? false : isConnectable}
+          style={{
+            ...handleBaseStyle,
+            border: `1px solid ${borderColor}`,
+            right: -5,
+            top: "70%",
+          }}
+        />
+      </Box>
+
+      {/* Branch labels */}
+      <Typography
+        variant="caption"
+        sx={{
+          position: "absolute",
+          right: -40,
+          top: "22%",
+          color: "success.main",
+          fontSize: 10,
+          pointerEvents: "none",
+        }}
+      >
+        true
+      </Typography>
+      <Typography
+        variant="caption"
+        sx={{
+          position: "absolute",
+          right: -42,
+          top: "62%",
+          color: "error.main",
+          fontSize: 10,
+          pointerEvents: "none",
+        }}
+      >
+        false
+      </Typography>
+
+      {!preview && !isWorkflowRunning && (
+        <Box
+          ref={addButtonRef}
+          onClick={handleAddClick}
+          sx={{
+            position: "absolute",
+            right: -50,
+            top: "50%",
+            transform: "translateY(-50%)",
+            width: 24,
+            height: 24,
+            borderRadius: "50%",
+            border: "1px solid",
+            borderColor: "blue.500",
+            backgroundColor: "background.paper",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: "pointer",
+            transition: "all 0.2s",
+            "&:hover": {
+              borderColor: "blue.600",
+              bgcolor: (t) =>
+                t.palette.mode === "dark" ? "black.800" : "blue.100",
+            },
+            zIndex: 30,
+          }}
+        >
+          <SvgColor
+            src="/assets/icons/ic_add.svg"
+            sx={{ width: 20, height: 20, bgcolor: "blue.500" }}
+          />
+        </Box>
+      )}
+
+      {!preview && (
+        <NodeSelectionPopper
+          open={popperOpen}
+          anchorEl={addButtonRef.current}
+          onClose={handlePopperClose}
+          onNodeSelect={handleNodeSelect}
+        />
+      )}
+    </Box>
+  );
+};
+
+ConditionalNode.propTypes = {
+  id: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired,
+  isConnectable: PropTypes.bool,
+  selected: PropTypes.bool,
+};
+
+export default memo(ConditionalNode);

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/HttpRequestNode.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/HttpRequestNode.jsx
@@ -1,0 +1,24 @@
+import React, { memo } from "react";
+import PropTypes from "prop-types";
+import BaseNode from "./BaseNode";
+
+const HttpRequestNode = ({ id, data, isConnectable, selected }) => {
+  return (
+    <BaseNode
+      id={id}
+      type="http_request"
+      data={data}
+      isConnectable={isConnectable}
+      selected={selected}
+    />
+  );
+};
+
+HttpRequestNode.propTypes = {
+  id: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired,
+  isConnectable: PropTypes.bool,
+  selected: PropTypes.bool,
+};
+
+export default memo(HttpRequestNode);

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/index.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/index.js
@@ -2,3 +2,5 @@ export { default as PromptNode } from "./PromptNode";
 export { default as AgentNode } from "./AgentNode";
 export { default as EvalNode } from "./EvalNode";
 export { default as BaseNode } from "./BaseNode";
+export { default as HttpRequestNode } from "./HttpRequestNode";
+export { default as ConditionalNode } from "./ConditionalNode";

--- a/frontend/src/sections/agent-playground/utils/constants.js
+++ b/frontend/src/sections/agent-playground/utils/constants.js
@@ -4,6 +4,8 @@ export const NODE_X_OFFSET = 450;
 export const NODE_TYPES = {
   LLM_PROMPT: "llm_prompt",
   AGENT: "agent",
+  HTTP_REQUEST: "http_request",
+  CONDITIONAL: "conditional",
 };
 
 export const AGENT_NODE = {
@@ -23,6 +25,20 @@ export const NODE_TYPE_CONFIG = {
     color: "orange.500",
   },
   [NODE_TYPES.AGENT]: AGENT_NODE,
+  [NODE_TYPES.HTTP_REQUEST]: {
+    id: NODE_TYPES.HTTP_REQUEST,
+    title: "HTTP Request",
+    description: "Make an HTTP request to any external API",
+    iconSrc: "/assets/icons/ic_agent_flow.svg",
+    color: "blue.500",
+  },
+  [NODE_TYPES.CONDITIONAL]: {
+    id: NODE_TYPES.CONDITIONAL,
+    title: "Conditional",
+    description: "Route workflow based on a condition",
+    iconSrc: "/assets/icons/ic_branch.svg",
+    color: "purple.500",
+  },
 };
 
 export const AGENT_PLAYGROUND_TABS = [


### PR DESCRIPTION
Closes #29
Closes #28

## What this adds

Two new node types for the Agent Playground.

**HTTP Request node** — lets workflows call external APIs as part of an agent run. You pick a method, set a URL, add headers, write a JSON body (for POST/PUT/PATCH), and name an output variable where the response gets stored for downstream nodes. URL and body both support `{{variable}}` syntax so they can pull values from earlier nodes.

**Conditional Routing node** — branches the workflow based on a condition. You set a left operand, pick an operator (equals, contains, greater than, is empty, etc.), and set a right operand. The canvas shows two output handles — `true` at the top, `false` at the bottom — so you can wire each branch to a different next node. Unary operators like `is empty` hide the right operand field since they don't need one.

## Files changed

- `utils/constants.js` — two new entries in `NODE_TYPES` and `NODE_TYPE_CONFIG`
- `nodes/HttpRequestNode.jsx` — new node component
- `nodes/ConditionalNode.jsx` — new node component with dual output handles and branch labels
- `nodes/index.js` — exports both nodes
- `NodeDrawer/forms/HttpRequestNodeForm.jsx` — configuration form for the HTTP node
- `NodeDrawer/forms/ConditionalNodeForm.jsx` — condition builder form
- `NodeDrawer/forms/index.js` — exports both forms
- `NodeConfigurationForm.jsx` — maps the two new node types to their forms
- `GraphView.jsx` — registers both nodes with React Flow
- `api/agent-playground/node-templates.js` — merges client-side node definitions into the node selection panel alongside backend templates
- `RunAgentPanel/common.js` — adds icon and color config for both node types