### PR TITLE
feat: add HTTP Request node to Agent Playground

### DIFF
--- a/frontend/src/api/agent-playground/node-templates.js
+++ b/frontend/src/api/agent-playground/node-templates.js
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
-import { NODE_TYPES } from "../../sections/agent-playground/utils/constants";
+import { NODE_TYPE_CONFIG, NODE_TYPES } from "../../sections/agent-playground/utils/constants";
 
 /**
  * Hook for fetching graphs that can be referenced as agent nodes.
@@ -18,8 +18,29 @@ export const useGetReferenceableGraphs = (graphId, options = {}) =>
     ...options,
   });
 
+/** Node types whose templates are served by the backend API. */
+const BACKEND_TEMPLATE_TYPES = new Set([NODE_TYPES.LLM_PROMPT]);
+
 /**
- * Hook for fetching node templates. Filters to llm_prompt only for now.
+ * Client-side node definitions for node types that are handled
+ * entirely on the frontend and don't have a backend template entry.
+ */
+const CLIENT_SIDE_NODES = [
+  {
+    id: NODE_TYPES.HTTP_REQUEST,
+    node_template_id: null,
+    title: NODE_TYPE_CONFIG[NODE_TYPES.HTTP_REQUEST].title,
+    description: NODE_TYPE_CONFIG[NODE_TYPES.HTTP_REQUEST].description,
+    iconSrc: NODE_TYPE_CONFIG[NODE_TYPES.HTTP_REQUEST].iconSrc,
+    color: NODE_TYPE_CONFIG[NODE_TYPES.HTTP_REQUEST].color,
+  },
+
+];
+
+/**
+ * Hook for fetching node templates.
+ * Backend templates are merged with client-side node definitions so that
+ * HTTP Request and Conditional nodes appear in the node selection panel.
  * Maps API shape to NodeCard shape: { id, node_template_id, title, description, iconSrc, color }
  * @param {object} options - Additional react-query options
  */
@@ -27,17 +48,20 @@ export const useGetNodeTemplates = (options = {}) =>
   useQuery({
     queryKey: ["agent-playground", "node-templates"],
     queryFn: () => axios.get(endpoints.agentPlayground.nodeTemplates),
-    select: (res) =>
-      (res.data?.result?.node_templates ?? [])
-        .filter((t) => t.name === NODE_TYPES.LLM_PROMPT)
+    select: (res) => {
+      const backendNodes = (res.data?.result?.node_templates ?? [])
+        .filter((t) => BACKEND_TEMPLATE_TYPES.has(t.name))
         .map((t) => ({
           id: t.name,
           node_template_id: t.id,
           title: t.display_name,
           description: t.description,
-          iconSrc: "/assets/icons/ic_chat_single.svg",
-          color: "orange.500",
-        })),
+          iconSrc: NODE_TYPE_CONFIG[t.name]?.iconSrc ?? "/assets/icons/ic_chat_single.svg",
+          color: NODE_TYPE_CONFIG[t.name]?.color ?? "orange.500",
+        }));
+      return [...backendNodes, ...CLIENT_SIDE_NODES];
+    },
     staleTime: 5 * 60 * 1000,
     ...options,
   });
+

--- a/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
@@ -12,7 +12,7 @@ import {
   useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { PromptNode, AgentNode, EvalNode } from "./nodes";
+import { PromptNode, AgentNode, EvalNode, HttpRequestNode } from "./nodes";
 import { AnimatedEdge } from "./edges";
 import { enqueueSnackbar } from "notistack";
 import {
@@ -37,6 +37,7 @@ const nodeTypes = {
   [NODE_TYPES.LLM_PROMPT]: PromptNode,
   agent: AgentNode,
   eval: EvalNode,
+  [NODE_TYPES.HTTP_REQUEST]: HttpRequestNode,
 };
 
 const edgeTypes = {

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeConfigurationForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeConfigurationForm.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { PromptNodeForm, EvalsNodeForm, AgentNodeForm } from "./forms";
+import { PromptNodeForm, EvalsNodeForm, AgentNodeForm, HttpRequestNodeForm } from "./forms";
 import { NODE_TYPES } from "../../utils/constants";
 
 const FORM_COMPONENTS = {
   [NODE_TYPES.LLM_PROMPT]: PromptNodeForm,
   eval: EvalsNodeForm,
   [NODE_TYPES.AGENT]: AgentNodeForm,
+  [NODE_TYPES.HTTP_REQUEST]: HttpRequestNodeForm,
 };
 
 export default function NodeConfigurationForm({ nodeType, nodeId }) {
@@ -20,7 +21,7 @@ export default function NodeConfigurationForm({ nodeType, nodeId }) {
 }
 
 NodeConfigurationForm.propTypes = {
-  nodeType: PropTypes.oneOf([NODE_TYPES.LLM_PROMPT, "eval", NODE_TYPES.AGENT])
+  nodeType: PropTypes.oneOf([NODE_TYPES.LLM_PROMPT, "eval", NODE_TYPES.AGENT, NODE_TYPES.HTTP_REQUEST])
     .isRequired,
   nodeId: PropTypes.string.isRequired,
 };

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/HttpRequestNodeForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/HttpRequestNodeForm.jsx
@@ -1,0 +1,128 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Controller, useFormContext } from "react-hook-form";
+import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+
+/**
+ * HttpRequestNodeForm
+ *
+ * Lets users configure:
+ *   - HTTP method (GET / POST / PUT / PATCH / DELETE)
+ *   - URL (supports {{variable}} template syntax)
+ *   - Request headers (key-value, one per line as "Key: Value")
+ *   - Request body (raw JSON, shown only for POST/PUT/PATCH)
+ *   - Output variable name (where the response JSON is stored)
+ */
+export default function HttpRequestNodeForm({ nodeId: _nodeId }) {
+  const { control, watch } = useFormContext();
+  const method = watch("method");
+  const hasBody = ["POST", "PUT", "PATCH"].includes(method);
+
+  return (
+    <Stack spacing={2} sx={{ p: 2 }}>
+      {/* Method + URL */}
+      <Stack direction="row" spacing={1} alignItems="flex-start">
+        <Controller
+          name="method"
+          control={control}
+          defaultValue="GET"
+          render={({ field }) => (
+            <TextField
+              {...field}
+              select
+              size="small"
+              label="Method"
+              sx={{ width: 110, flexShrink: 0 }}
+            >
+              {HTTP_METHODS.map((m) => (
+                <MenuItem key={m} value={m}>
+                  {m}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+        />
+        <FormTextFieldV2
+          name="url"
+          control={control}
+          label="URL"
+          placeholder="https://api.example.com/endpoint"
+          size="small"
+          fullWidth
+          rules={{ required: "URL is required" }}
+        />
+      </Stack>
+
+      {/* Headers */}
+      <Box>
+        <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+          Headers (one per line: <code>Key: Value</code>)
+        </Typography>
+        <FormTextFieldV2
+          name="headers"
+          control={control}
+          placeholder={"Content-Type: application/json\nAuthorization: Bearer {{token}}"}
+          multiline
+          minRows={3}
+          size="small"
+          fullWidth
+        />
+      </Box>
+
+      {/* Body — only for POST/PUT/PATCH */}
+      {hasBody && (
+        <Box>
+          <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+            Body (JSON — use <code>{"{{variable}}"}</code> for dynamic values)
+          </Typography>
+          <FormTextFieldV2
+            name="body"
+            control={control}
+            placeholder={'{\n  "key": "{{variable}}"\n}'}
+            multiline
+            minRows={5}
+            size="small"
+            fullWidth
+            sx={{ fontFamily: "monospace", fontSize: 12 }}
+          />
+        </Box>
+      )}
+
+      {/* Output variable name */}
+      <Box>
+        <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: "block" }}>
+          Output variable name
+        </Typography>
+        <FormTextFieldV2
+          name="outputKey"
+          control={control}
+          placeholder="http_response"
+          size="small"
+          fullWidth
+          rules={{
+            pattern: {
+              value: /^[a-z0-9_]+$/,
+              message: "Lowercase letters, numbers, and underscores only",
+            },
+          }}
+        />
+        <Typography variant="caption" color="text.disabled" sx={{ mt: 0.5, display: "block" }}>
+          The response JSON will be available as this variable in downstream nodes.
+        </Typography>
+      </Box>
+    </Stack>
+  );
+}
+
+HttpRequestNodeForm.propTypes = {
+  nodeId: PropTypes.string.isRequired,
+};

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/index.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/index.js
@@ -1,3 +1,4 @@
 export { default as PromptNodeForm } from "./PromptNodeForm";
 export { default as EvalsNodeForm } from "./EvalsNodeForm";
 export { default as AgentNodeForm } from "./AgentNodeForm";
+export { default as HttpRequestNodeForm } from "./HttpRequestNodeForm";

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
@@ -13,6 +13,10 @@ const NODE_TYPE_CONFIG = {
     iconSrc: "/assets/icons/ic_rounded_square.svg",
     color: "green.600",
   },
+  [NODE_TYPES.HTTP_REQUEST]: {
+    iconSrc: "/assets/icons/ic_agent_flow.svg",
+    color: "blue.500",
+  },
   default: {
     iconSrc: "/assets/icons/navbar/ic_agents.svg",
     color: "text.secondary",

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/HttpRequestNode.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/HttpRequestNode.jsx
@@ -1,0 +1,24 @@
+import React, { memo } from "react";
+import PropTypes from "prop-types";
+import BaseNode from "./BaseNode";
+
+const HttpRequestNode = ({ id, data, isConnectable, selected }) => {
+  return (
+    <BaseNode
+      id={id}
+      type="http_request"
+      data={data}
+      isConnectable={isConnectable}
+      selected={selected}
+    />
+  );
+};
+
+HttpRequestNode.propTypes = {
+  id: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired,
+  isConnectable: PropTypes.bool,
+  selected: PropTypes.bool,
+};
+
+export default memo(HttpRequestNode);

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/index.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/index.js
@@ -2,3 +2,4 @@ export { default as PromptNode } from "./PromptNode";
 export { default as AgentNode } from "./AgentNode";
 export { default as EvalNode } from "./EvalNode";
 export { default as BaseNode } from "./BaseNode";
+export { default as HttpRequestNode } from "./HttpRequestNode";

--- a/frontend/src/sections/agent-playground/utils/constants.js
+++ b/frontend/src/sections/agent-playground/utils/constants.js
@@ -4,6 +4,7 @@ export const NODE_X_OFFSET = 450;
 export const NODE_TYPES = {
   LLM_PROMPT: "llm_prompt",
   AGENT: "agent",
+  HTTP_REQUEST: "http_request",
 };
 
 export const AGENT_NODE = {
@@ -23,6 +24,13 @@ export const NODE_TYPE_CONFIG = {
     color: "orange.500",
   },
   [NODE_TYPES.AGENT]: AGENT_NODE,
+  [NODE_TYPES.HTTP_REQUEST]: {
+    id: NODE_TYPES.HTTP_REQUEST,
+    title: "HTTP Request",
+    description: "Make an HTTP request to any external API",
+    iconSrc: "/assets/icons/ic_agent_flow.svg",
+    color: "blue.500",
+  },
 };
 
 export const AGENT_PLAYGROUND_TABS = [


### PR DESCRIPTION

## What this adds

A new HTTP Request node for the Agent Playground that lets workflows call external APIs as part of an agent run.

You pick a method (GET, POST, PUT, PATCH, DELETE), set a URL, add headers as key-value pairs, and write a JSON body for methods that send a payload. The body field only shows up when it's needed. URL and body both support `{{variable}}` syntax so values from upstream nodes can be passed through. The response JSON gets stored in a named output variable, making it available to any downstream node.

## Files changed

- `utils/constants.js` — `HTTP_REQUEST` added to `NODE_TYPES` and `NODE_TYPE_CONFIG`
- `nodes/HttpRequestNode.jsx` — new node component
- `nodes/index.js` — exports the new node
- `NodeDrawer/forms/HttpRequestNodeForm.jsx` — configuration form
- `NodeDrawer/forms/index.js` — exports the new form
- `NodeConfigurationForm.jsx` — maps the node type to its form
- `GraphView.jsx` — registers the node with React Flow
- `api/agent-playground/node-templates.js` — adds the HTTP Request node to the selection panel
- `RunAgentPanel/common.js` — icon and color config