### PR TITLE
TH-4615: normalize composite eval type

### DIFF
--- a/futureagi/model_hub/utils/eval_list.py
+++ b/futureagi/model_hub/utils/eval_list.py
@@ -77,9 +77,10 @@ def derive_eval_type(template: "EvalTemplate") -> str:
 
     Uses the dedicated eval_type field if set.
     Falls back to tag/config-based detection for backward compatibility.
-    For composites, returns the union of child eval types (e.g. "code, llm").
+    For composites, returns a single normalized type so response schemas and
+    filters stay compatible with the 3-type contract.
     """
-    # Composite: return union of child eval types
+    # Composite: return a single canonical type
     if getattr(template, "template_type", "single") == "composite":
         return _derive_composite_eval_type(template)
 
@@ -108,7 +109,7 @@ def derive_eval_type(template: "EvalTemplate") -> str:
 
 
 def _derive_composite_eval_type(template: "EvalTemplate") -> str:
-    """Return comma-separated union of child eval types for a composite."""
+    """Return a single canonical eval type for a composite."""
     from model_hub.models.evals_metric import CompositeEvalChild
 
     child_types = list(
@@ -116,8 +117,23 @@ def _derive_composite_eval_type(template: "EvalTemplate") -> str:
         .select_related("child")
         .values_list("child__eval_type", flat=True)
     )
-    unique = sorted(set(t or "llm" for t in child_types))
-    return ", ".join(unique) if unique else "composite"
+    return infer_composite_eval_type(child_types)
+
+
+def infer_composite_eval_type(child_types: Iterable[str | None]) -> str:
+    """Collapse composite child types into one API-safe eval type.
+
+    Mixed composites still need a single `eval_type` because the API and DB
+    field only support `llm`, `code`, or `agent`. We use the strongest child
+    type present so agent-containing composites remain discoverable as agent
+    evals, code-only mixes remain code, and llm is the fallback.
+    """
+    normalized = {t if t in {"llm", "code", "agent"} else "llm" for t in child_types}
+    if "agent" in normalized:
+        return "agent"
+    if "code" in normalized:
+        return "code"
+    return "llm"
 
 
 def derive_output_type(template: "EvalTemplate") -> str:

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -2718,7 +2718,7 @@ class CompositeEvalCreateView(APIView):
             CompositeCreateRequest,
             CompositeCreateResponse,
         )
-        from model_hub.utils.eval_list import derive_eval_type
+        from model_hub.utils.eval_list import derive_eval_type, infer_composite_eval_type
 
         try:
             try:
@@ -2805,6 +2805,9 @@ class CompositeEvalCreateView(APIView):
                 config={},
                 description=req.description or "",
                 template_type="composite",
+                eval_type=infer_composite_eval_type(
+                    derive_eval_type(child) for child in children
+                ),
                 visible_ui=True,
                 aggregation_enabled=req.aggregation_enabled,
                 aggregation_function=req.aggregation_function,
@@ -3072,7 +3075,6 @@ class CompositeEvalDetailView(APIView):
                 parent.aggregation_function = req.aggregation_function
             if req.composite_child_axis is not None:
                 parent.composite_child_axis = req.composite_child_axis
-            parent.save()
 
             # Replace child list if provided
             if req.child_template_ids is not None:
@@ -3107,6 +3109,9 @@ class CompositeEvalDetailView(APIView):
                         except ValueError as ve:
                             return self._gm.bad_request(str(ve))
 
+                parent.eval_type = infer_composite_eval_type(
+                    derive_eval_type(child) for child in child_qs
+                )
                 # Soft-delete existing children links, then recreate
                 CompositeEvalChild.objects.filter(parent=parent, deleted=False).update(
                     deleted=True
@@ -3123,7 +3128,6 @@ class CompositeEvalDetailView(APIView):
                         weight=weights.get(child_id, 1.0),
                     )
             elif req.child_weights is not None:
-                # Update weights on existing children only
                 existing_links = CompositeEvalChild.objects.filter(
                     parent=parent, deleted=False
                 )
@@ -3132,6 +3136,8 @@ class CompositeEvalDetailView(APIView):
                     if cid in req.child_weights:
                         link.weight = req.child_weights[cid]
                         link.save(update_fields=["weight"])
+
+            parent.save()
 
             # Re-fetch children and return the updated detail response.
             links = list(


### PR DESCRIPTION
## Description

Normalize composite eval parent `eval_type` to a single API-safe value derived from child evals so mixed composites no longer emit invalid combined values or stale `llm` values in list/detail responses.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Configuration change

## Checklist

### Code Quality

- [ ] I have run `make pre-commit-all` and fixed all issues
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run `make test` successfully

### Django-Specific (if applicable)

- [ ] I have created/updated migrations if model changes were made
- [ ] I have run `python manage.py check` without errors
- [ ] Database migrations are reversible

### Documentation

- [ ] I have updated the documentation accordingly
- [x] I have added/updated docstrings for new/modified functions
- [ ] I have updated the CHANGELOG (if applicable)

### Security

- [x] My changes don't introduce security vulnerabilities
- [x] I have not committed any secrets or credentials
- [ ] I have run `make check-secrets` and addressed any issues

## Pre-commit Hooks

- [ ] ✅ Pre-commit hooks are installed (`make pre-commit-install`)
- [ ] ✅ All pre-commit checks pass (`make pre-commit-all`)

**If you haven't set up pre-commit yet:**
```bash
make pre-commit-install
make pre-commit-all
```

See [Pre-commit Setup Guide](../blob/main/docs/PRE_COMMIT_SETUP.md) for details.

## Related Issues

TH-4615

## Screenshots (if applicable)

N/A

## Additional Notes

- Composite parents now derive a canonical `eval_type` from child evals using `agent > code > llm`.
- Existing composite detail/list reads no longer trust a stale stored parent `eval_type`.
- Per request, local test-file edits were not included in this commit/PR.
- Focused helper tests for the new normalization logic passed via `.venv/bin/pytest`.
- Broader DB-backed Django tests could not be completed from this sandbox because the local test Postgres connection on `localhost:15432` is blocked.
