### PR TITLE
feat(simulate): revamped chat simulation detail drawer (TH-4530)

### DIFF
--- a/frontend/src/components/ChatDetailDrawerV2/ChatAnalyticsView.jsx
+++ b/frontend/src/components/ChatDetailDrawerV2/ChatAnalyticsView.jsx
@@ -1,0 +1,406 @@
+import React, { useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  ButtonBase,
+  Collapse,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import Iconify from "src/components/iconify";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Formatters (mirrors CallAnalyticsView conventions so the two drawers
+// render values identically — e.g. "4.5s", "450ms", "$0.02").
+// ─────────────────────────────────────────────────────────────────────────────
+
+const fmtDuration = (seconds) => {
+  if (seconds == null || !Number.isFinite(Number(seconds))) return "—";
+  const n = Number(seconds);
+  if (n < 60) return `${n.toFixed(1)}s`;
+  const m = Math.floor(n / 60);
+  const s = Math.round(n % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
+};
+
+const fmtMs = (ms) => {
+  if (ms == null || !Number.isFinite(Number(ms))) return "—";
+  const n = Number(ms);
+  if (n >= 1000) return `${(n / 1000).toFixed(2)}s`;
+  return `${Math.round(n)}ms`;
+};
+
+const fmtMoney = (n) => {
+  if (n == null || !Number.isFinite(Number(n))) return "—";
+  const v = Number(n);
+  if (v === 0) return "$0.00";
+  return `$${v.toFixed(v < 0.1 ? 4 : 2)}`;
+};
+
+const fmtNumber = (n) => {
+  if (n == null || !Number.isFinite(Number(n))) return "—";
+  const v = Number(n);
+  if (v >= 1000) return `${(v / 1000).toFixed(1)}k`;
+  return String(v);
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared section header — same visual language as CallAnalyticsView.
+// Duplicated rather than extracted for now; if a third drawer ever needs
+// these, lift them into a shared kpi.jsx.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SectionLabel = ({ children }) => (
+  <Typography
+    sx={{
+      fontSize: 10,
+      fontWeight: 600,
+      color: "text.secondary",
+      textTransform: "uppercase",
+      letterSpacing: "0.06em",
+    }}
+  >
+    {children}
+  </Typography>
+);
+
+SectionLabel.propTypes = { children: PropTypes.node };
+
+const KpiCell = ({ label, value, hint, tone = "default" }) => {
+  const toneColor = {
+    default: "text.primary",
+    success: "success.main",
+    warn: (theme) =>
+      theme.palette.mode === "dark"
+        ? theme.palette.warning.main
+        : theme.palette.warning.darker,
+    danger: "error.main",
+  }[tone];
+  return (
+    <Tooltip
+      title={hint || ""}
+      placement="top"
+      arrow
+      disableHoverListener={!hint}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 0.25,
+          py: 0.75,
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: 10.5,
+            fontWeight: 600,
+            color: "text.secondary",
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {label}
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: 16,
+            fontWeight: 700,
+            color: toneColor,
+            lineHeight: 1.2,
+            whiteSpace: "nowrap",
+            fontFamily: "monospace",
+          }}
+        >
+          {value}
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+};
+
+KpiCell.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.node.isRequired,
+  hint: PropTypes.string,
+  tone: PropTypes.oneOf(["default", "success", "warn", "danger"]),
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chat-specific KPI derivations
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute chat KPIs from the detail payload. Multiple fallbacks because
+ * the chat serializer (TH-4525) is in flux — different deployments ship
+ * tokens/cost/latency on different keys. Every derived value can be null
+ * and `KpiCell` renders "—" gracefully.
+ */
+const useChatMetrics = (data) => {
+  return useMemo(() => {
+    const transcript = Array.isArray(data?.transcript) ? data.transcript : [];
+    const nonSystem = transcript.filter((t) => t.speakerRole !== "system");
+
+    const turnCount =
+      data?.turn_count ??
+      data?.turnCount ??
+      (nonSystem.length > 0 ? nonSystem.length : null);
+
+    // Tokens — try aggregates first, fall back to summing per-turn values.
+    const pickTokenSum = (keys) => {
+      let total = 0;
+      let found = false;
+      for (const t of transcript) {
+        for (const k of keys) {
+          const v = t?.[k];
+          if (v != null && Number.isFinite(Number(v))) {
+            total += Number(v);
+            found = true;
+            break;
+          }
+        }
+      }
+      return found ? total : null;
+    };
+
+    const tokensIn =
+      data?.input_tokens ??
+      data?.inputTokens ??
+      data?.prompt_tokens ??
+      data?.promptTokens ??
+      pickTokenSum(["input_tokens", "inputTokens", "prompt_tokens"]);
+
+    const tokensOut =
+      data?.output_tokens ??
+      data?.outputTokens ??
+      data?.completion_tokens ??
+      data?.completionTokens ??
+      pickTokenSum(["output_tokens", "outputTokens", "completion_tokens"]);
+
+    const totalTokens =
+      data?.total_tokens ??
+      data?.totalTokens ??
+      ((tokensIn ?? 0) + (tokensOut ?? 0) || null);
+
+    // Cost — direct field preferred; otherwise try the breakdown total.
+    const cost =
+      data?.cost ??
+      data?.total_cost ??
+      data?.totalCost ??
+      data?.customer_cost_breakdown?.total ??
+      null;
+
+    // Avg per-turn latency — prefer direct aggregate, else average
+    // per-turn latency values that exist on the transcript.
+    const avgLatency =
+      data?.avg_agent_latency_ms ??
+      data?.avg_latency_ms ??
+      data?.avgLatencyMs ??
+      (() => {
+        const latencies = nonSystem
+          .map((t) => t?.latency_ms ?? t?.latencyMs ?? t?.response_time_ms)
+          .filter((v) => v != null && Number.isFinite(Number(v)))
+          .map(Number);
+        if (latencies.length === 0) return null;
+        return latencies.reduce((a, b) => a + b, 0) / latencies.length;
+      })();
+
+    const duration =
+      data?.duration_seconds ??
+      data?.duration ??
+      data?.durationSeconds ??
+      null;
+
+    return {
+      duration,
+      turnCount,
+      tokensIn,
+      tokensOut,
+      totalTokens,
+      cost,
+      avgLatency,
+    };
+  }, [data]);
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// KPI strip
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ChatKpiStrip = ({ metrics }) => {
+  const {
+    duration,
+    turnCount,
+    tokensIn,
+    tokensOut,
+    totalTokens,
+    cost,
+    avgLatency,
+  } = metrics;
+
+  const cells = [
+    { label: "Duration", value: fmtDuration(duration), hint: "Chat length" },
+    { label: "Turns", value: fmtNumber(turnCount), hint: "Number of turns" },
+    {
+      label: "Tokens In",
+      value: fmtNumber(tokensIn),
+      hint: "Input / prompt tokens",
+    },
+    {
+      label: "Tokens Out",
+      value: fmtNumber(tokensOut),
+      hint: "Output / completion tokens",
+    },
+    {
+      label: "Total Tokens",
+      value: fmtNumber(totalTokens),
+      hint: "All tokens consumed",
+    },
+    {
+      label: "Avg Latency",
+      value: fmtMs(avgLatency),
+      hint: "Avg per-turn latency",
+    },
+    { label: "Cost", value: fmtMoney(cost), hint: "Total call cost" },
+  ];
+
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(100px, 1fr))",
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: "4px",
+        bgcolor: "background.paper",
+        overflow: "hidden",
+        "& > *": {
+          bgcolor: "background.paper",
+          px: 1.25,
+          borderRight: "1px solid",
+          borderBottom: "1px solid",
+          borderColor: "divider",
+        },
+      }}
+    >
+      {cells.map((c) => (
+        <KpiCell key={c.label} {...c} />
+      ))}
+    </Box>
+  );
+};
+
+ChatKpiStrip.propTypes = { metrics: PropTypes.object.isRequired };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Collapsible AI summary card — same behavior as voice.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AiSummaryCard = ({ summary }) => {
+  const [open, setOpen] = useState(false);
+  if (!summary || typeof summary !== "string" || !summary.trim()) return null;
+
+  return (
+    <Stack gap={0.5}>
+      <SectionLabel>AI summary</SectionLabel>
+      <ButtonBase
+        onClick={() => setOpen((v) => !v)}
+        sx={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 0.75,
+          px: 1.25,
+          py: 1,
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: "4px",
+          bgcolor: "background.paper",
+          width: "100%",
+          justifyContent: "flex-start",
+          textAlign: "left",
+          "&:hover": { bgcolor: "action.hover" },
+        }}
+      >
+        <Iconify
+          icon="mdi:creation"
+          width={14}
+          sx={{ color: "primary.main", flexShrink: 0 }}
+        />
+        <Typography
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            fontSize: 11,
+            color: "text.primary",
+            lineHeight: 1.4,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: open ? "normal" : "nowrap",
+          }}
+        >
+          {open ? summary : summary.slice(0, 140)}
+          {!open && summary.length > 140 ? "…" : null}
+        </Typography>
+        <Iconify
+          icon="mdi:chevron-down"
+          width={14}
+          sx={{
+            color: "text.disabled",
+            flexShrink: 0,
+            transform: open ? "rotate(180deg)" : "rotate(0deg)",
+            transition: "transform 120ms",
+          }}
+        />
+      </ButtonBase>
+      <Collapse in={open} unmountOnExit>
+        <Box sx={{ height: 2 }} />
+      </Collapse>
+    </Stack>
+  );
+};
+
+AiSummaryCard.propTypes = { summary: PropTypes.string };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main view
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ChatAnalyticsView = ({ data }) => {
+  const metrics = useChatMetrics(data);
+
+  const hasAnyMetric = Object.values(metrics).some((v) => v != null);
+  const analysisSummary = data?.call_summary || data?.callSummary;
+  const hasAny = hasAnyMetric || analysisSummary;
+
+  if (!hasAny) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: 160,
+        }}
+      >
+        <Typography sx={{ fontSize: 12, color: "text.disabled" }}>
+          No chat analytics data available
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack gap={2}>
+      {hasAnyMetric && <ChatKpiStrip metrics={metrics} />}
+      <AiSummaryCard summary={analysisSummary} />
+    </Stack>
+  );
+};
+
+ChatAnalyticsView.propTypes = {
+  data: PropTypes.object,
+};
+
+export default ChatAnalyticsView;

--- a/frontend/src/components/ChatDetailDrawerV2/ChatDetailDrawerV2.jsx
+++ b/frontend/src/components/ChatDetailDrawerV2/ChatDetailDrawerV2.jsx
@@ -1,0 +1,305 @@
+import React, { useCallback, useState } from "react";
+import PropTypes from "prop-types";
+import { Box, CircularProgress, Stack } from "@mui/material";
+import { enqueueSnackbar } from "notistack";
+
+import VoiceDrawerHeader from "src/components/VoiceDetailDrawerV2/VoiceDrawerHeader";
+import ChatLeftPanel from "./ChatLeftPanel";
+import ChatRightPanel from "./ChatRightPanel";
+
+/**
+ * Chat-specific peer of `VoiceDetailDrawerV2`. Shares the same outer shell
+ * (header, resizable drawer width, resizable inner divider, fullscreen)
+ * so chat and voice simulations look like sibling surfaces.
+ *
+ * Intentionally narrower scope than the voice drawer — out of scope for
+ * this PR (tracked as follow-ups): Imagine/Saved Views tabs, Share dialog,
+ * Add-to-dataset, Add-to-queue, full-page chat route, and tag editing on
+ * trace records.
+ *
+ * Content-only: rendered inside the outer MUI flex container provided by
+ * `TestDetailSideDrawer`, same way `VoiceDetailDrawerV2` is.
+ *
+ * Layout:
+ *   ┌─ Header ─────────────────────────────────┐
+ *   │  ┌─────────────┐  │  ┌─────────────────┐ │
+ *   │  │ Transcript/ │  │  │ Call Analytics  │ │
+ *   │  │ Path tabs   │  │  │ / Evals / ...   │ │
+ *   │  └─────────────┘  │  └─────────────────┘ │
+ *   └──────────────────────────────────────────┘
+ */
+const ChatDetailDrawerV2 = ({
+  data,
+  onClose,
+  onPrev,
+  onNext,
+  hasPrev,
+  hasNext,
+  isFetching,
+  onAnnotate,
+  onCompareBaseline,
+  scenarioId,
+  isLoading = false,
+  initialFullscreen = false,
+  // When embedded (e.g. inside the annotation workspace content panel),
+  // hide the outer drawer chrome — the header bar — and just render the
+  // chat body so it fits the host's layout. Mirrors VoiceDetailDrawerV2.
+  embedded = false,
+}) => {
+  const [leftPanelWidth, setLeftPanelWidth] = useState(50); // percentage
+  const [isFullscreen, setIsFullscreen] = useState(initialFullscreen);
+  const [drawerWidth, setDrawerWidth] = useState(60);
+
+  // ── Drag handler for resizable inner divider ──────────────────────────
+  const handleDragStart = useCallback(
+    (e) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = leftPanelWidth;
+      const container = e.target.closest("[data-chat-drawer-content]");
+      if (!container) return;
+      const containerWidth = container.offsetWidth;
+
+      const onMouseMove = (moveEvent) => {
+        const diff = moveEvent.clientX - startX;
+        const newPct = startWidth + (diff / containerWidth) * 100;
+        setLeftPanelWidth(Math.min(70, Math.max(25, newPct)));
+      };
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      };
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [leftPanelWidth],
+  );
+
+  // ── Download raw data ─────────────────────────────────────────────────
+  const handleDownload = useCallback(() => {
+    if (!data) return;
+    try {
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `chat-${data?.id || data?.trace_id || "unknown"}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      enqueueSnackbar("Chat data downloaded", { variant: "success" });
+    } catch {
+      enqueueSnackbar("Failed to download chat data", { variant: "error" });
+    }
+  }, [data]);
+
+  // Unified action handler — routes the Actions dropdown. Only two
+  // actions are wired for chat in this PR: annotate + download.
+  const handleChatAction = useCallback(
+    (actionId) => {
+      switch (actionId) {
+        case "annotate":
+          onAnnotate?.();
+          break;
+        case "download":
+          handleDownload();
+          break;
+        default:
+          break;
+      }
+    },
+    [onAnnotate, handleDownload],
+  );
+
+  return (
+    <Box
+      sx={{
+        position: "relative",
+        display: "flex",
+        flexDirection: "column",
+        width: isFullscreen ? "100vw" : `${drawerWidth}vw`,
+        height: "100vh",
+        minHeight: "100vh",
+        bgcolor: "background.paper",
+        overflow: "hidden",
+      }}
+    >
+      {/* Left-edge resize handle — drag to resize the drawer. Matches
+          VoiceDetailDrawerV2's drag-to-resize interaction. */}
+      {!isFullscreen && !initialFullscreen && (
+        <Box
+          onMouseDown={(e) => {
+            e.preventDefault();
+            const startX = e.clientX;
+            const startWidth = drawerWidth;
+            const onMove = (moveE) => {
+              const diff = startX - moveE.clientX;
+              const newWidth = startWidth + (diff / window.innerWidth) * 100;
+              setDrawerWidth(Math.min(95, Math.max(30, newWidth)));
+            };
+            const onUp = () => {
+              document.removeEventListener("mousemove", onMove);
+              document.removeEventListener("mouseup", onUp);
+              document.body.style.cursor = "";
+              document.body.style.userSelect = "";
+            };
+            document.body.style.cursor = "col-resize";
+            document.body.style.userSelect = "none";
+            document.addEventListener("mousemove", onMove);
+            document.addEventListener("mouseup", onUp);
+          }}
+          sx={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: 4,
+            cursor: "col-resize",
+            zIndex: 10,
+            "&:hover": { bgcolor: "primary.main", opacity: 0.3 },
+          }}
+        />
+      )}
+
+      {/* Header — omitted in embedded mode so the host view owns its own chrome. */}
+      {!embedded && (
+        <VoiceDrawerHeader
+          callId={data?.provider_call_id || data?.id || data?.trace_id}
+          onClose={onClose}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={hasPrev}
+          hasNext={hasNext}
+          onFullscreen={
+            initialFullscreen
+              ? undefined
+              : () => setIsFullscreen((prev) => !prev)
+          }
+          isFullscreen={isFullscreen}
+          onDownload={handleDownload}
+          // Relabel the shared header row / tooltip / toast for chat.
+          idLabel="Chat ID"
+          copyTooltip="Copy Chat ID"
+          copyToastMessage="Chat ID copied"
+          // Share + open-in-new-tab are voice-only for now; omit so those
+          // header buttons don't render.
+        />
+      )}
+
+      {/* Main content */}
+      <Box
+        data-chat-drawer-content
+        sx={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "row",
+          overflow: "hidden",
+          minHeight: 0,
+        }}
+      >
+        {isLoading || isFetching === "initial" ? (
+          <Box
+            sx={{
+              flex: 1,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <CircularProgress size={28} />
+          </Box>
+        ) : (
+          <>
+            {/* Left Panel */}
+            <Box
+              sx={{
+                width: `${leftPanelWidth}%`,
+                minWidth: 0,
+                overflow: "hidden",
+                display: "flex",
+                flexDirection: "column",
+                borderRight: "1px solid",
+                borderColor: "divider",
+              }}
+            >
+              <ChatLeftPanel data={data} scenarioId={scenarioId} />
+            </Box>
+
+            {/* Resizable divider */}
+            <Box
+              onMouseDown={handleDragStart}
+              sx={{
+                width: 8,
+                cursor: "col-resize",
+                flexShrink: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                "&:hover .divider-dots": { opacity: 1 },
+                "&:active .divider-dots": { opacity: 1 },
+              }}
+            >
+              <Stack
+                className="divider-dots"
+                spacing={0.4}
+                sx={{ opacity: 0.4, transition: "opacity 150ms" }}
+              >
+                {[0, 1, 2, 3, 4, 5].map((i) => (
+                  <Box
+                    key={i}
+                    sx={{
+                      width: 3,
+                      height: 3,
+                      borderRadius: "50%",
+                      bgcolor: "text.disabled",
+                    }}
+                  />
+                ))}
+              </Stack>
+            </Box>
+
+            {/* Right Panel */}
+            <Box
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                overflow: "hidden",
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <ChatRightPanel
+                data={data}
+                onCompareBaseline={onCompareBaseline}
+                onAction={handleChatAction}
+              />
+            </Box>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+ChatDetailDrawerV2.propTypes = {
+  data: PropTypes.object,
+  onClose: PropTypes.func.isRequired,
+  onPrev: PropTypes.func,
+  onNext: PropTypes.func,
+  hasPrev: PropTypes.bool,
+  hasNext: PropTypes.bool,
+  isFetching: PropTypes.string,
+  onAnnotate: PropTypes.func,
+  onCompareBaseline: PropTypes.func,
+  scenarioId: PropTypes.string,
+  isLoading: PropTypes.bool,
+  initialFullscreen: PropTypes.bool,
+  embedded: PropTypes.bool,
+};
+
+export default ChatDetailDrawerV2;

--- a/frontend/src/components/ChatDetailDrawerV2/ChatDetailsBar.jsx
+++ b/frontend/src/components/ChatDetailDrawerV2/ChatDetailsBar.jsx
@@ -1,0 +1,205 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import { Box, Stack } from "@mui/material";
+import { fDateTime } from "src/utils/format-time";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
+import VoiceActionsDropdown, {
+  VOICE_ACTIONS,
+} from "src/components/VoiceDetailDrawerV2/VoiceActionsDropdown";
+
+/**
+ * Chat-specific top bar for the chat detail drawer. Renders the action
+ * dropdown + a compact metric-chip strip, mirroring `CallDetailsBar` from
+ * the voice drawer but only showing fields that make sense for chat
+ * (no Phone, no Provider, no "Type: Inbound" since every chat is a text
+ * session, no trace-tag editing for now — out of scope per TH-4530).
+ */
+
+/**
+ * Responsive metric chip. The value cell gets a `min-width: 0` + ellipsis
+ * so long strings (notably ended_reason, which is a free-form sentence)
+ * truncate instead of blowing past the drawer's right edge. The max-width
+ * scales with the drawer via container queries: wider drawer → longer
+ * visible value. Full text is always available via tooltip on hover.
+ */
+const MetricChip = ({ label, value }) => {
+  const fullText =
+    typeof value === "string" || typeof value === "number"
+      ? String(value)
+      : "";
+  return (
+    <CustomTooltip
+      show={!!fullText}
+      title={fullText}
+      arrow
+      size="small"
+      type="black"
+      placement="top"
+    >
+      <Box
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 0.5,
+          px: 1,
+          py: 0.25,
+          bgcolor: "background.neutral",
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: "2px",
+          minWidth: 64,
+          // Chip itself shouldn't outgrow the parent row. Clamp to the
+          // drawer width and let the parent flex-wrap break to a new
+          // line once there's no room.
+          maxWidth: "100%",
+          fontSize: 11,
+          color: "text.primary",
+          lineHeight: "16px",
+        }}
+      >
+        <Box component="span" sx={{ flexShrink: 0, whiteSpace: "nowrap" }}>
+          {label} :
+        </Box>
+        <Box
+          component="span"
+          sx={{
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {value}
+        </Box>
+      </Box>
+    </CustomTooltip>
+  );
+};
+
+MetricChip.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.node.isRequired,
+};
+
+const formatDuration = (seconds) => {
+  if (seconds == null) return null;
+  const n = Number(seconds);
+  if (!Number.isFinite(n)) return null;
+  const m = Math.floor(n / 60);
+  const s = Math.round(n % 60);
+  if (m === 0) return `${s}s`;
+  return `${m}m ${s}s`;
+};
+
+const formatMs = (ms) => {
+  if (ms == null) return null;
+  const n = Number(ms);
+  if (!Number.isFinite(n) || n === 0) return null;
+  return n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`;
+};
+
+const formatCost = (cost) => {
+  if (cost == null) return null;
+  const n = Number(cost);
+  if (!Number.isFinite(n)) return null;
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+};
+
+// Out of the voice action set, chat only wires Annotate + Download for now.
+const CHAT_ACTIONS = VOICE_ACTIONS.filter((a) =>
+  ["annotate", "download"].includes(a.id),
+);
+
+const ChatDetailsBar = ({ data, onAction }) => {
+  const chips = useMemo(() => {
+    const out = [];
+
+    const status = data?.status;
+    if (status) {
+      out.push({
+        label: "Status",
+        value: String(status).replace(/_/g, " "),
+      });
+    }
+
+    const duration = formatDuration(data?.duration_seconds ?? data?.duration);
+    if (duration) out.push({ label: "Duration", value: duration });
+
+    const avgLatency = formatMs(
+      data?.avg_agent_latency_ms ?? data?.avg_latency_ms ?? data?.avg_latency,
+    );
+    if (avgLatency) out.push({ label: "Avg Latency", value: avgLatency });
+
+    const turns = data?.turn_count ?? data?.turnCount;
+    if (turns != null) out.push({ label: "Turns", value: String(turns) });
+
+    const totalTokens = data?.total_tokens ?? data?.totalTokens;
+    if (totalTokens != null) {
+      out.push({ label: "Tokens", value: String(totalTokens) });
+    }
+
+    const cost = formatCost(data?.cost ?? data?.total_cost);
+    if (cost) out.push({ label: "Cost", value: cost });
+
+    const timestamp = data?.timestamp || data?.created_at;
+    if (timestamp) out.push({ label: "When", value: fDateTime(timestamp) });
+
+    if (data?.ended_reason) {
+      out.push({
+        label: "Ended",
+        value: data.ended_reason,
+      });
+    }
+    return out;
+  }, [data]);
+
+  if (chips.length === 0 && !onAction) return null;
+
+  return (
+    <Box
+      sx={{
+        px: 1.25,
+        py: 1,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        bgcolor: "background.default",
+        flexShrink: 0,
+      }}
+    >
+      {onAction && (
+        <Stack direction="row" justifyContent="flex-end" sx={{ mb: 0.75 }}>
+          <VoiceActionsDropdown onAction={onAction} actions={CHAT_ACTIONS} />
+        </Stack>
+      )}
+
+      {chips.length > 0 && (
+        <Stack
+          direction="row"
+          alignItems="center"
+          gap={0.5}
+          sx={{
+            flexWrap: "wrap",
+            // Constrain the row to the bar's content width so children
+            // with maxWidth: 100% have something to clamp against; lets
+            // long chips (e.g. "Ended: ...") wrap to a new line instead
+            // of overflowing horizontally.
+            minWidth: 0,
+            width: "100%",
+          }}
+        >
+          {chips.map((c) => (
+            <MetricChip key={c.label} label={c.label} value={c.value} />
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+};
+
+ChatDetailsBar.propTypes = {
+  data: PropTypes.object,
+  onAction: PropTypes.func,
+};
+
+export default ChatDetailsBar;

--- a/frontend/src/components/ChatDetailDrawerV2/ChatLeftPanel.jsx
+++ b/frontend/src/components/ChatDetailDrawerV2/ChatLeftPanel.jsx
@@ -1,0 +1,131 @@
+import React, { useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import { Box, Stack } from "@mui/material";
+import CompactTabs from "src/components/VoiceDetailDrawerV2/CompactTabs";
+import PathAnalysisView from "src/components/VoiceDetailDrawerV2/PathAnalysisView";
+import { ShowComponent } from "src/components/show";
+import LoadingStateComponent from "src/components/CallLogsDetailDrawer/LoadingStateComponent";
+import { getLoadingStateWithRespectiveStatus } from "src/sections/test-detail/common";
+import ChatTranscriptView from "./ChatTranscriptView";
+
+const TABS = {
+  TRANSCRIPT: "transcript",
+  CHECKLIST: "checklist",
+  GRAPH: "graph",
+};
+
+const PATH_VIEW_MODE = {
+  [TABS.CHECKLIST]: "checklist",
+  [TABS.GRAPH]: "graph",
+};
+
+/**
+ * Chat drawer left panel. Mirrors `VoiceLeftPanel` structure so the
+ * chat drawer feels identical to the voice one, but without the voice-
+ * specific recording waveform — chat transcripts are self-contained.
+ *
+ * Tabs:
+ *   - Transcript: `ChatTranscriptView` — role-aligned bubbles.
+ *   - Checklist / Graph: `PathAnalysisView` reused as-is. It's driven by
+ *     the scenario id + execution id, not by voice-specific fields, so
+ *     chat path analysis comes for free.
+ */
+const ChatLeftPanel = ({ data, scenarioId }) => {
+  const isSimulate = data?.module === "simulate";
+  const [currentTab, setCurrentTab] = useState(TABS.TRANSCRIPT);
+
+  const { isCallInProgress, message: loadingMessage } =
+    getLoadingStateWithRespectiveStatus(
+      data?.status,
+      data?.simulation_call_type || data?.simulationCallType,
+    );
+
+  const showPathTabs = isSimulate && !!data?.id;
+
+  const tabs = useMemo(() => {
+    const t = [
+      {
+        label: "Transcript",
+        value: TABS.TRANSCRIPT,
+        icon: "mdi:file-document-outline",
+      },
+    ];
+    if (showPathTabs) {
+      t.push({
+        label: "Checklist",
+        value: TABS.CHECKLIST,
+        icon: "mdi:format-list-checks",
+      });
+      t.push({
+        label: "Graph",
+        value: TABS.GRAPH,
+        icon: "mdi:graph-outline",
+      });
+    }
+    return t;
+  }, [showPathTabs]);
+
+  const isTranscriptTab = currentTab === TABS.TRANSCRIPT;
+  const isPathTab = currentTab === TABS.CHECKLIST || currentTab === TABS.GRAPH;
+
+  return (
+    <Stack
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        minHeight: 0,
+      }}
+    >
+      <Box sx={{ px: 1.25, flexShrink: 0 }}>
+        <CompactTabs
+          value={currentTab}
+          onChange={(_, value) => setCurrentTab(value)}
+          tabs={tabs}
+        />
+      </Box>
+
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          overflow: "auto",
+          px: 1.25,
+          pt: 1,
+          pb: 1,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <ShowComponent condition={isCallInProgress}>
+          <LoadingStateComponent message={loadingMessage} />
+        </ShowComponent>
+
+        <ShowComponent condition={!isCallInProgress}>
+          <>
+            <ShowComponent condition={isTranscriptTab}>
+              <ChatTranscriptView data={data} />
+            </ShowComponent>
+            <ShowComponent condition={isPathTab && showPathTabs}>
+              <PathAnalysisView
+                data={data}
+                scenarioId={scenarioId}
+                openedExecutionId={data?.id}
+                enabled={isPathTab}
+                viewMode={PATH_VIEW_MODE[currentTab]}
+                onRequestTranscript={() => setCurrentTab(TABS.TRANSCRIPT)}
+              />
+            </ShowComponent>
+          </>
+        </ShowComponent>
+      </Box>
+    </Stack>
+  );
+};
+
+ChatLeftPanel.propTypes = {
+  data: PropTypes.object.isRequired,
+  scenarioId: PropTypes.string,
+};
+
+export default ChatLeftPanel;

--- a/frontend/src/components/ChatDetailDrawerV2/ChatRightPanel.jsx
+++ b/frontend/src/components/ChatDetailDrawerV2/ChatRightPanel.jsx
@@ -1,0 +1,405 @@
+import React, { useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import { Box, Button, Stack } from "@mui/material";
+import CompactTabs from "src/components/VoiceDetailDrawerV2/CompactTabs";
+import AttributesTable from "src/components/VoiceDetailDrawerV2/AttributesTable";
+import MessagesView from "src/components/VoiceDetailDrawerV2/MessagesView";
+import ScenarioView from "src/components/VoiceDetailDrawerV2/ScenarioView";
+import Iconify from "src/components/iconify";
+import { ShowComponent } from "src/components/show";
+import {
+  getCompareBaselineTooltipTitle,
+  getLoadingStateWithRespectiveStatus,
+  TestRunExecutionStatus,
+} from "src/sections/test-detail/common";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
+import ScoresListSection from "src/components/ScoresListSection/ScoresListSection";
+import EvalsTabView from "src/components/traceDetail/EvalsTabView";
+import { openFixWithFalcon } from "src/sections/falcon-ai/helpers/openFixWithFalcon";
+import LoadingStateComponent from "src/components/CallLogsDetailDrawer/LoadingStateComponent";
+import { getSpanAttributes } from "src/components/traceDetailDrawer/DrawerRightRenderer/getSpanData";
+import ChatAnalyticsView from "./ChatAnalyticsView";
+import ChatDetailsBar from "./ChatDetailsBar";
+
+const TABS = {
+  ANALYTICS: "analytics",
+  EVALUATIONS: "evaluations",
+  MESSAGES: "messages",
+  ATTRIBUTES: "attributes",
+  ANNOTATIONS: "annotations",
+  SCENARIO: "scenario",
+};
+
+/**
+ * Chat drawer right panel. Mirrors `VoiceRightPanel` structure so the two
+ * drawers feel like the same product — same `CallDetailsBar` chip strip,
+ * same `CompactTabs` nav, same Evals/Messages/Attributes/Annotations/
+ * Scenario panes (all data-agnostic components).
+ *
+ * Differences from voice:
+ *   - "Call Analytics" uses `ChatAnalyticsView` (chat KPIs: turns,
+ *     tokens, cost, avg latency) instead of voice's Latency pipeline /
+ *     voice KPI strip.
+ *   - No "Logs" tab — chat doesn't have a vapi/callLogs equivalent yet.
+ *   - Eval normalization logic mirrors `VoiceRightPanel.normalizedEvals`.
+ */
+const ChatRightPanel = ({ data, onCompareBaseline, onAction }) => {
+  const [currentTab, setCurrentTab] = useState(TABS.ANALYTICS);
+  const isSimulate = data?.module === "simulate";
+
+  // Prefer the conversation root span (same logic as VoiceRightPanel).
+  const observationSpan = useMemo(() => {
+    const spans = data?.observation_span;
+    if (!Array.isArray(spans) || spans.length === 0) return undefined;
+    return (
+      spans.find(
+        (s) => !s?.parent_span_id && s?.observation_type === "conversation",
+      ) ||
+      spans.find((s) => !s?.parent_span_id) ||
+      spans[0]
+    );
+  }, [data?.observation_span]);
+
+  const canCompare =
+    isSimulate && !!onCompareBaseline && !!data?.session_id;
+
+  const { isCallInProgress, message: loadingMessage } =
+    getLoadingStateWithRespectiveStatus(
+      data?.status,
+      data?.simulation_call_type || data?.simulationCallType,
+    );
+
+  const messagesList = useMemo(() => {
+    if (Array.isArray(data?.messages)) return data.messages;
+    if (Array.isArray(data?.transcript)) {
+      return data.transcript.map((t) => ({
+        role: t.speakerRole || t.role,
+        content: t.message || t.content || t.text,
+        ...t,
+      }));
+    }
+    return [];
+  }, [data]);
+
+  const hasScenarioData =
+    isSimulate &&
+    !!data?.scenario_columns &&
+    Object.keys(data.scenario_columns).length > 0;
+
+  const tabs = useMemo(() => {
+    const t = [
+      {
+        label: "Chat Analytics",
+        value: TABS.ANALYTICS,
+        icon: "mdi:chart-line",
+      },
+      {
+        label: "Evals",
+        value: TABS.EVALUATIONS,
+        icon: "mdi:checkbox-marked-circle-outline",
+      },
+      {
+        label: "Messages",
+        value: TABS.MESSAGES,
+        icon: "mdi:message-text-outline",
+      },
+      {
+        label: "Attributes",
+        value: TABS.ATTRIBUTES,
+        icon: "mdi:code-json",
+      },
+      {
+        label: "Annotations",
+        value: TABS.ANNOTATIONS,
+        icon: "mdi:pencil-outline",
+      },
+    ];
+    if (hasScenarioData) {
+      t.push({
+        label: "Scenario",
+        value: TABS.SCENARIO,
+        icon: "mdi:script-text-outline",
+      });
+    }
+    return t;
+  }, [hasScenarioData]);
+
+  // Eval normalization — mirrors VoiceRightPanel.normalizedEvals byte-for-byte
+  // so the Evals pane renders consistently across both drawers. If this logic
+  // ever changes, update both (or lift into a shared helper).
+  const evalRows = useMemo(() => {
+    if (isSimulate) {
+      return data?.eval_metrics || data?.eval_outputs || null;
+    }
+    return data?.eval_outputs || observationSpan?.evals_metrics || null;
+  }, [isSimulate, data, observationSpan]);
+
+  const normalizedEvals = useMemo(() => {
+    if (!evalRows) return [];
+    const rows = Array.isArray(evalRows)
+      ? evalRows.map((e, i) => [e?.id || `eval-${i}`, e])
+      : Object.entries(evalRows);
+
+    return rows.map(([id, e], i) => {
+      const rawValue = e?.score ?? e?.output ?? e?.value;
+      let score = null;
+      let scoreLabel;
+
+      if (typeof rawValue === "number") {
+        score =
+          rawValue <= 1 ? Math.round(rawValue * 100) : Math.round(rawValue);
+      } else if (typeof rawValue === "boolean") {
+        score = rawValue ? 100 : 0;
+        scoreLabel = rawValue ? "Pass" : "Fail";
+      } else if (typeof rawValue === "string") {
+        const lower = rawValue.toLowerCase();
+        if (lower.includes("pass") || lower === "true") {
+          score = 100;
+          scoreLabel = "Pass";
+        } else if (lower.includes("fail") || lower === "false") {
+          score = 0;
+          scoreLabel = "Fail";
+        } else {
+          scoreLabel =
+            rawValue.length > 24 ? `${rawValue.slice(0, 24)}…` : rawValue;
+        }
+      }
+
+      return {
+        id: `eval-${id}-${i}`,
+        eval_name: e?.name || e?.metric || String(id),
+        score,
+        score_label: scoreLabel,
+        explanation: e?.reason || e?.explanation,
+        cell_id: e?.cell_id || e?.cellId,
+        error_analysis:
+          e?.error_analysis || e?.errorAnalysis || e?.error_details,
+        error_localizer_status:
+          e?.error_localizer_status || e?.errorLocalizerStatus,
+        selected_input_key: e?.selected_input_key || e?.selectedInputKey,
+        datapoint: e?.datapoint || {
+          selectedInputKey: e?.selected_input_key || e?.selectedInputKey,
+          selected_input_key: e?.selected_input_key || e?.selectedInputKey,
+          inputData: e?.input_data || e?.inputData,
+          input_data: e?.input_data || e?.inputData,
+          inputTypes: e?.input_types || e?.inputTypes,
+          input_types: e?.input_types || e?.inputTypes,
+        },
+      };
+    });
+  }, [evalRows]);
+
+  const traceId = data?.trace_id || data?.id;
+  const annotationSources = useMemo(() => {
+    if (isSimulate) {
+      return {
+        sourceType: "call_execution",
+        sourceId: data?.id,
+      };
+    }
+    const span = data?.observation_span?.[0];
+    return {
+      sourceType: span?.id ? "observation_span" : "trace",
+      sourceId: span?.id || traceId,
+      secondarySourceType: span?.id ? "trace" : undefined,
+      secondarySourceId: span?.id ? traceId : undefined,
+    };
+  }, [isSimulate, data, traceId]);
+
+  const attributesObj = useMemo(() => {
+    return (
+      observationSpan?.span_attributes ||
+      data?.attributes ||
+      data?.trace_details?.attributes ||
+      observationSpan ||
+      null
+    );
+  }, [data, observationSpan]);
+
+  return (
+    <Stack
+      sx={{
+        minHeight: 300,
+        height: "100%",
+        containerType: "inline-size",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+      }}
+    >
+      <ChatDetailsBar data={data} onAction={onAction} />
+
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        gap={1}
+        sx={{ flexShrink: 0, px: 1.25, minWidth: 0 }}
+      >
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <CompactTabs
+            value={currentTab}
+            onChange={(_, value) => setCurrentTab(value)}
+            tabs={tabs}
+          />
+        </Box>
+        {canCompare && (
+          <CustomTooltip
+            show={data?.status !== TestRunExecutionStatus.COMPLETED}
+            title={getCompareBaselineTooltipTitle(data?.status)}
+            type="black"
+            arrow
+            placement="bottom"
+            size="small"
+          >
+            <span>
+              <Button
+                variant="outlined"
+                color="primary"
+                size="small"
+                disabled={data?.status !== TestRunExecutionStatus.COMPLETED}
+                startIcon={<Iconify icon="mdi:swap-horizontal" width={14} />}
+                onClick={() => onCompareBaseline(true)}
+                sx={{
+                  whiteSpace: "nowrap",
+                  fontSize: 11,
+                  height: 26,
+                  textTransform: "none",
+                }}
+              >
+                Compare with baseline
+              </Button>
+            </span>
+          </CustomTooltip>
+        )}
+      </Stack>
+
+      <ShowComponent condition={isCallInProgress}>
+        <LoadingStateComponent message={loadingMessage} />
+      </ShowComponent>
+
+      <ShowComponent condition={!isCallInProgress}>
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            width: "100%",
+            overflow: "auto",
+            px: 1.25,
+            py: 1,
+          }}
+        >
+          <ShowComponent condition={currentTab === TABS.ANALYTICS}>
+            <ChatAnalyticsView data={data} />
+          </ShowComponent>
+
+          <ShowComponent condition={currentTab === TABS.EVALUATIONS}>
+            <EvalsTabView
+              evals={normalizedEvals}
+              emptyMessage="No evaluations for this chat"
+              showSpanColumn={false}
+              onFixWithFalcon={({ level, ev, failingEvals, allEvals }) => {
+                const projectId = data?.project_id;
+                const callId = data?.id;
+                if (level === "eval" && ev) {
+                  openFixWithFalcon({
+                    level: "eval",
+                    context: {
+                      trace_id: traceId,
+                      call_id: callId,
+                      span_id: ev.spanId || ev.observation_span_id,
+                      eval_log_id:
+                        ev.eval_log_id || ev.cell_id || ev.log_id,
+                      custom_eval_config_id:
+                        ev.custom_eval_config_id || ev.eval_config_id,
+                      eval_name: ev.eval_name,
+                      score: ev.score,
+                      explanation: ev.explanation || ev.eval_explanation,
+                      project_id: projectId,
+                      module: data?.module,
+                    },
+                  });
+                  return;
+                }
+                const total = (allEvals || []).length;
+                const passCount = (allEvals || []).filter(
+                  (e) => e.score != null && e.score >= 50,
+                ).length;
+                openFixWithFalcon({
+                  level: "chat",
+                  context: {
+                    trace_id: traceId,
+                    call_id: callId,
+                    project_id: projectId,
+                    module: data?.module,
+                    evals_summary: `${passCount}/${total} passed`,
+                    failing_evals: (failingEvals || []).map((e) => ({
+                      name: e.eval_name,
+                      score: e.score,
+                    })),
+                  },
+                });
+              }}
+            />
+          </ShowComponent>
+
+          <ShowComponent condition={currentTab === TABS.MESSAGES}>
+            <MessagesView messages={messagesList} />
+          </ShowComponent>
+
+          <ShowComponent condition={currentTab === TABS.ATTRIBUTES}>
+            <AttributesTable attributes={attributesObj} />
+          </ShowComponent>
+
+          <ShowComponent condition={currentTab === TABS.ANNOTATIONS}>
+            <ScoresListSection
+              sourceType={annotationSources.sourceType}
+              sourceId={annotationSources.sourceId}
+              secondarySourceType={annotationSources.secondarySourceType}
+              secondarySourceId={annotationSources.secondarySourceId}
+              title=""
+              renderActions={
+                onAction ? (
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={
+                      <Iconify icon="mingcute:add-line" width={14} />
+                    }
+                    onClick={() => onAction("annotate")}
+                    sx={{
+                      textTransform: "none",
+                      fontSize: 12,
+                      fontWeight: 500,
+                      borderColor: "divider",
+                      color: "text.primary",
+                      borderRadius: "4px",
+                      px: 1.5,
+                      py: 0.25,
+                    }}
+                  >
+                    Add Label
+                  </Button>
+                ) : null
+              }
+            />
+          </ShowComponent>
+
+          <ShowComponent
+            condition={currentTab === TABS.SCENARIO && hasScenarioData}
+          >
+            <ScenarioView data={data} />
+          </ShowComponent>
+        </Box>
+      </ShowComponent>
+    </Stack>
+  );
+};
+
+ChatRightPanel.propTypes = {
+  data: PropTypes.object.isRequired,
+  onCompareBaseline: PropTypes.func,
+  onAction: PropTypes.func,
+};
+
+export default ChatRightPanel;

--- a/frontend/src/components/ChatDetailDrawerV2/ChatTranscriptView.jsx
+++ b/frontend/src/components/ChatDetailDrawerV2/ChatTranscriptView.jsx
@@ -1,0 +1,279 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import { Box, Skeleton, Stack, Typography, keyframes } from "@mui/material";
+import Iconify from "src/components/iconify";
+import TranscriptView from "src/components/VoiceDetailDrawerV2/TranscriptView";
+
+/**
+ * Chat transcript panel for the revamped chat drawer.
+ *
+ * Reuses the voice drawer's `TranscriptView` to get feature parity with
+ * voice — search box, All/Assistant/Customer filters, per-turn timestamps,
+ * interrupt/silence markers, keyboard navigation. Because chat transcripts
+ * don't have audio, the `useVoiceAudioStore` reads inside `TranscriptView`
+ * resolve to nullish `currentTime`/`duration`, which keeps `playingIdx` at
+ * -1 and simply disables the audio-sync highlight. Everything else works
+ * identically for text-only turns.
+ *
+ * Responsibilities on top of `TranscriptView`:
+ *   - Filter `speakerRole === "system"` turns.
+ *   - Show a skeleton-bubble loading animation while `data.transcript` is
+ *     not yet hydrated (the chat serializer populates fields incrementally
+ *     per TH-4525, so we prefer "loading" over a misleading terminal
+ *     empty-state).
+ */
+
+// Soft pulse for the bubbles so they feel alive next to MUI's skeleton wave.
+const pulse = keyframes`
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.65; }
+`;
+
+const BUBBLE_WIDTHS = [220, 160, 260, 180, 240];
+
+const SkeletonBubble = ({ align, delay = 0, width }) => (
+  <Stack
+    direction="row"
+    sx={{
+      width: "100%",
+      justifyContent: align === "right" ? "flex-end" : "flex-start",
+      animation: `${pulse} 1.6s ease-in-out infinite`,
+      animationDelay: `${delay}ms`,
+    }}
+  >
+    <Stack
+      sx={{
+        maxWidth: "70%",
+        minWidth: 140,
+        gap: 0.5,
+      }}
+    >
+      <Skeleton
+        variant="rounded"
+        animation="wave"
+        height={44}
+        width={width}
+        sx={{
+          borderRadius:
+            align === "right"
+              ? "12px 12px 4px 12px"
+              : "12px 12px 12px 4px",
+          bgcolor: (theme) =>
+            theme.palette.mode === "dark"
+              ? "rgba(255,255,255,0.06)"
+              : "rgba(0,0,0,0.06)",
+        }}
+      />
+      <Skeleton
+        variant="text"
+        animation="wave"
+        width={56}
+        sx={{
+          alignSelf: align === "right" ? "flex-end" : "flex-start",
+          fontSize: 10,
+          opacity: 0.6,
+        }}
+      />
+    </Stack>
+  </Stack>
+);
+
+SkeletonBubble.propTypes = {
+  align: PropTypes.oneOf(["left", "right"]).isRequired,
+  delay: PropTypes.number,
+  width: PropTypes.number,
+};
+
+const TranscriptLoading = () => (
+  <Stack
+    flex={1}
+    spacing={1.5}
+    sx={{
+      width: "100%",
+      py: 2,
+      pr: 1,
+      overflow: "hidden",
+    }}
+  >
+    <SkeletonBubble align="left" delay={0} width={BUBBLE_WIDTHS[0]} />
+    <SkeletonBubble align="right" delay={120} width={BUBBLE_WIDTHS[1]} />
+    <SkeletonBubble align="left" delay={240} width={BUBBLE_WIDTHS[2]} />
+    <SkeletonBubble align="right" delay={360} width={BUBBLE_WIDTHS[3]} />
+    <SkeletonBubble align="left" delay={480} width={BUBBLE_WIDTHS[4]} />
+
+    <Stack
+      direction="row"
+      alignItems="center"
+      justifyContent="center"
+      spacing={1}
+      sx={{ pt: 1.5 }}
+    >
+      <Iconify
+        icon="svg-spinners:3-dots-bounce"
+        width={20}
+        sx={{ color: "text.secondary" }}
+      />
+      <Typography
+        typography="s3"
+        color="text.secondary"
+        sx={{ letterSpacing: "0.01em" }}
+      >
+        Loading transcript…
+      </Typography>
+    </Stack>
+  </Stack>
+);
+
+// Pull the text body out of a chat turn. The chat serializer uses
+// `messages[0]` as the turn content (see
+// `src/sections/test/CallLogs/common.js → getContentMessage`), while the
+// voice serializer sets `content` directly. `enrichTurns` inside
+// `TranscriptView` only looks at content/message/text — without this
+// pre-flatten the voice transcript renderer shows rows with empty bodies.
+// Derive a "seconds since start of chat" offset from whatever timestamp
+// shape the chat turn carries. TranscriptView's enrichTurns reads
+// startTimeSeconds / startTime / start / time / timestamp — chat turns
+// usually ship `created_at` (ISO string) per message, which isn't in
+// that list. We normalize to epoch-milliseconds here; enrichTurns' own
+// epoch-normalization pass then rebases the minimum timestamp to 0
+// (that's how voice simulate transcripts are handled), so the first
+// chat turn lands at 0:00 and later turns show offsets relative to it.
+const extractChatTimestampMs = (turn) => {
+  if (!turn) return null;
+  const candidates = [
+    turn.startTimeSeconds,
+    turn.start_time_seconds,
+    turn.startTime,
+    turn.start_time,
+    turn.start,
+    turn.timestamp,
+    turn.timeStamp,
+    turn.created_at,
+    turn.createdAt,
+    turn.time,
+  ];
+  for (const raw of candidates) {
+    if (raw == null) continue;
+    if (typeof raw === "number" && Number.isFinite(raw)) {
+      // Interpret as seconds if small (< 10^10), else already ms. Both
+      // shapes work with enrichTurns — we just return whatever the first
+      // meaningful field is.
+      return raw;
+    }
+    if (typeof raw === "string") {
+      // Numeric string?
+      const asNum = Number(raw);
+      if (Number.isFinite(asNum) && /^\s*-?\d+(\.\d+)?\s*$/.test(raw)) {
+        return asNum;
+      }
+      const parsed = Date.parse(raw);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return null;
+};
+
+const extractChatContent = (turn) => {
+  if (!turn) return "";
+  if (typeof turn.content === "string" && turn.content) return turn.content;
+  if (typeof turn.message === "string" && turn.message) return turn.message;
+  if (typeof turn.text === "string" && turn.text) return turn.text;
+  const messages = turn.messages;
+  if (Array.isArray(messages) && messages.length > 0) {
+    const first = messages[0];
+    if (typeof first === "string") return first;
+    if (first && typeof first === "object") {
+      return (
+        first.content ||
+        first.message ||
+        first.text ||
+        (typeof first.value === "string" ? first.value : "") ||
+        ""
+      );
+    }
+  }
+  return "";
+};
+
+// Rough word count for a chat turn. Chat transcripts don't carry per-turn
+// durations, so `TranscriptView.TalkRatioBar` computes 0% for every role
+// and the legend dots disappear. Seeding each turn's `duration` with its
+// word count gives the shared code a non-zero signal to work with, so the
+// row reads (semantically correctly) "Customer 55% · Assistant 45%" —
+// i.e. share of words instead of share of speaking time. This is also
+// where the inline color legend comes from: the TalkRatioBar renders a
+// colored dot + role label + percentage per speaker.
+const countWords = (text) => {
+  if (!text || typeof text !== "string") return 0;
+  return text.trim().split(/\s+/).filter(Boolean).length;
+};
+
+const ChatTranscriptView = ({ data }) => {
+  const filteredTranscript = useMemo(() => {
+    const transcript = data?.transcript;
+    if (!Array.isArray(transcript)) return [];
+    return transcript
+      .filter((item) => item.speakerRole !== "system")
+      .map((item) => {
+        const ts = extractChatTimestampMs(item);
+        const content = extractChatContent(item);
+        const existingDuration =
+          typeof item.duration === "number" && Number.isFinite(item.duration)
+            ? item.duration
+            : null;
+        return {
+          ...item,
+          // Flatten chat-shaped `messages[0]` into a plain `content`
+          // field so TranscriptView's enrichTurns/getContent picks it up.
+          content,
+          // Synthesize a `startTimeSeconds` in enrichTurns' native shape
+          // so it renders a turn timestamp next to each row. The epoch
+          // -> offset-seconds normalization inside enrichTurns rebases
+          // the earliest value to 0, so the first turn reads 0:00 and
+          // later turns show clock offsets from it.
+          ...(ts != null ? { startTimeSeconds: ts } : {}),
+          // Seed a word-count "duration" so TalkRatioBar can render
+          // the inline color legend (dot + role + %). Only fall back to
+          // this when the turn doesn't already carry a real duration.
+          ...(existingDuration == null
+            ? { duration: countWords(content) }
+            : {}),
+        };
+      });
+  }, [data?.transcript]);
+
+  // No terminal empty-state for now. The chat simulation serializer is
+  // still in flux (TH-4525) and today frequently returns no transcript
+  // on completed chats even though the conversation actually has
+  // messages. Showing a "No messages in this chat" terminal state there
+  // is misleading; the skeleton loader is both accurate (data is still
+  // being populated) and kinder to the user. Revisit once TH-4525 lands
+  // and `transcript: []` on a completed chat is reliably meaningful.
+  if (filteredTranscript.length === 0) {
+    return <TranscriptLoading />;
+  }
+
+  return (
+    <Box sx={{ flex: 1, minHeight: 0, display: "flex" }}>
+      <TranscriptView
+        transcript={filteredTranscript}
+        // Repurpose TranscriptView's TalkRatioBar as a compact speaker
+        // legend: no "TALK RATIO" label, no percentages, left-aligned
+        // (reads as a simple speaker-color legend). Audio-only timeline
+        // strip is also hidden (chat has no speaker timeline) along
+        // with the voice-specific "Xs silence" inline markers.
+        hideTimelineStrip
+        hideTalkRatioLabel
+        hideTalkRatioPercentages
+        talkRatioLegendAlign="left"
+        hideSilenceMarkers
+      />
+    </Box>
+  );
+};
+
+ChatTranscriptView.propTypes = {
+  data: PropTypes.object,
+};
+
+export default ChatTranscriptView;

--- a/frontend/src/components/ChatDetailDrawerV2/index.js
+++ b/frontend/src/components/ChatDetailDrawerV2/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ChatDetailDrawerV2";

--- a/frontend/src/components/VoiceDetailDrawerV2/PathAnalysisView.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/PathAnalysisView.jsx
@@ -1521,14 +1521,58 @@ const PathStepNode = React.memo(({ data }) => {
     <Tooltip
       arrow
       placement="top"
+      // Give the tooltip a solid surface (instead of MUI's translucent
+      // grey). Works for both dark and light themes: background matches
+      // the drawer's paper color, border uses divider, and all three
+      // text rows use primary / secondary / primary-ish tones rather
+      // than "text.disabled" (which renders as muddy grey on grey in
+      // dark mode and is what made the prompt text unreadable). Same
+      // fix applies to the voice drawer — `PathStepNode` is shared.
+      componentsProps={{
+        tooltip: {
+          sx: {
+            bgcolor: "background.paper",
+            color: "text.primary",
+            border: "1px solid",
+            borderColor: "divider",
+            boxShadow: (theme) =>
+              theme.palette.mode === "dark"
+                ? "0 6px 20px rgba(0,0,0,0.5)"
+                : "0 4px 12px rgba(0,0,0,0.12)",
+            p: 1,
+            maxWidth: 320,
+          },
+        },
+        arrow: {
+          sx: {
+            color: "background.paper",
+            "&::before": {
+              border: "1px solid",
+              borderColor: "divider",
+              backgroundColor: "background.paper",
+            },
+          },
+        },
+      }}
       title={
         <Box sx={{ maxWidth: 280 }}>
-          <Typography sx={{ fontSize: 11, fontWeight: 700 }}>
+          <Typography
+            sx={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: "text.primary",
+            }}
+          >
             {data?.name}
           </Typography>
           {opener && (
             <Typography
-              sx={{ fontSize: 10, mt: 0.25, color: "text.secondary" }}
+              sx={{
+                fontSize: 10,
+                mt: 0.5,
+                color: "text.secondary",
+                lineHeight: 1.4,
+              }}
             >
               “{opener.slice(0, 160)}
               {opener.length > 160 ? "…" : ""}”
@@ -1537,10 +1581,11 @@ const PathStepNode = React.memo(({ data }) => {
           {prompt && (
             <Typography
               sx={{
-                fontSize: 9.5,
+                fontSize: 10,
                 mt: 0.5,
-                color: "text.disabled",
+                color: "text.secondary",
                 fontStyle: "italic",
+                lineHeight: 1.4,
               }}
             >
               {prompt.slice(0, 180)}

--- a/frontend/src/components/VoiceDetailDrawerV2/TranscriptView.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/TranscriptView.jsx
@@ -85,7 +85,25 @@ const useSpeakerColors = () => {
 // same role in this legend. Any other role still shows up but trails.
 const TALK_ROLE_ORDER = ["user", "assistant", "system", "tool"];
 
-const TalkRatioBar = ({ totals, colors }) => {
+// Display labels for the TALK RATIO legend. Internal role keys (`user`,
+// `assistant`, …) don't always read naturally — the search filter tabs
+// above display `user` as "Customer", so the legend uses the same
+// mapping for visual consistency. Override with the `roleLabels` prop.
+const DEFAULT_ROLE_LABELS = {
+  user: "Customer",
+  assistant: "Assistant",
+  system: "System",
+  tool: "Tool",
+};
+
+const TalkRatioBar = ({
+  totals,
+  colors,
+  hideLabel = false,
+  hidePercentages = false,
+  legendAlign = "left",
+  roleLabels = DEFAULT_ROLE_LABELS,
+}) => {
   const total = totals.total || 1;
   const segments = Object.entries(totals.byRole)
     .filter(([, v]) => v > 0)
@@ -98,19 +116,33 @@ const TalkRatioBar = ({ totals, colors }) => {
     });
 
   return (
-    <Stack direction="row" alignItems="center" gap={1} sx={{ minWidth: 0 }}>
-      <Typography
+    <Stack
+      direction="row"
+      alignItems="center"
+      gap={1}
+      sx={{ minWidth: 0, width: "100%" }}
+    >
+      {!hideLabel && (
+        <Typography
+          sx={{
+            fontSize: 10,
+            fontWeight: 600,
+            color: "text.secondary",
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+          }}
+        >
+          Talk ratio
+        </Typography>
+      )}
+      <Stack
+        direction="row"
+        gap={1.25}
         sx={{
-          fontSize: 10,
-          fontWeight: 600,
-          color: "text.secondary",
-          textTransform: "uppercase",
-          letterSpacing: "0.04em",
+          flexWrap: "wrap",
+          ...(legendAlign === "right" ? { ml: "auto" } : {}),
         }}
       >
-        Talk ratio
-      </Typography>
-      <Stack direction="row" gap={1.25} sx={{ flexWrap: "wrap" }}>
         {segments.map(([role, val]) => (
           <Stack key={role} direction="row" alignItems="center" gap={0.5}>
             <Box
@@ -128,7 +160,12 @@ const TalkRatioBar = ({ totals, colors }) => {
                 textTransform: "capitalize",
               }}
             >
-              {role} {Math.round((val / total) * 100)}%
+              {(() => {
+                const label = roleLabels?.[role] || role;
+                return hidePercentages
+                  ? label
+                  : `${label} ${Math.round((val / total) * 100)}%`;
+              })()}
             </Typography>
           </Stack>
         ))}
@@ -140,6 +177,10 @@ const TalkRatioBar = ({ totals, colors }) => {
 TalkRatioBar.propTypes = {
   totals: PropTypes.object.isRequired,
   colors: PropTypes.object.isRequired,
+  hideLabel: PropTypes.bool,
+  hidePercentages: PropTypes.bool,
+  legendAlign: PropTypes.oneOf(["left", "right"]),
+  roleLabels: PropTypes.object,
 };
 
 const SpeakerTimelineStrip = ({
@@ -488,7 +529,29 @@ const FILTERS = [
   { id: "user", label: "Customer" },
 ];
 
-const TranscriptView = ({ transcript, onAnnotate }) => {
+const TranscriptView = ({
+  transcript,
+  onAnnotate,
+  // Header-row customization hooks used by the chat drawer to repurpose
+  // the voice TalkRatioBar as a compact speaker legend:
+  //   - hideTimelineStrip: drop the orange/white bar below the TALK RATIO
+  //     row (chat doesn't have a speaker timeline derived from audio).
+  //   - hideTalkRatioPercentages: render only colored-dot + role label
+  //     (no percentage text) — keeps the row reading as a legend, not
+  //     a stats row.
+  //   - talkRatioLegendAlign: "right" pushes the legend chips to the end
+  //     of the row so TALK RATIO sits left-aligned with the legend on
+  //     the opposite side.
+  hideTimelineStrip = false,
+  hideTalkRatioLabel = false,
+  hideTalkRatioPercentages = false,
+  talkRatioLegendAlign = "left",
+  // "Silence" is a voice concept (dead air between speaker turns). For
+  // chat transcripts the gap between messages is just response latency,
+  // not silence — so the chat drawer passes true here to suppress the
+  // inline silence dividers.
+  hideSilenceMarkers = false,
+}) => {
   const colors = useSpeakerColors();
 
   const seekTo = useVoiceAudioStore((s) => s.seekTo);
@@ -689,16 +752,26 @@ const TranscriptView = ({ transcript, onAnnotate }) => {
         flexDirection: "column",
       }}
     >
-      {/* Header: talk ratio + timeline strip — flat, no wrapper border */}
+      {/* Header: talk ratio + timeline strip — flat, no wrapper border.
+          Chat drawer hides the timeline strip (no audio-backed speaker
+          timeline) and uses the talk-ratio row as a compact legend. */}
       <Stack gap={0.75} sx={{ flexShrink: 0 }}>
-        <TalkRatioBar totals={totals} colors={colors} />
-        <SpeakerTimelineStrip
-          turns={turns}
+        <TalkRatioBar
+          totals={totals}
           colors={colors}
-          duration={duration}
-          currentTime={currentTime}
-          onSeek={handleSeek}
+          hideLabel={hideTalkRatioLabel}
+          hidePercentages={hideTalkRatioPercentages}
+          legendAlign={talkRatioLegendAlign}
         />
+        {!hideTimelineStrip && (
+          <SpeakerTimelineStrip
+            turns={turns}
+            colors={colors}
+            duration={duration}
+            currentTime={currentTime}
+            onSeek={handleSeek}
+          />
+        )}
       </Stack>
 
       {/* Toolbar: search + filter pills */}
@@ -830,9 +903,11 @@ const TranscriptView = ({ transcript, onAnnotate }) => {
         ) : (
           filteredTurns.map((turn, i) => (
             <React.Fragment key={turn.id}>
-              {turn.silenceBefore != null && turn.silenceBefore > 0.3 && (
-                <SilenceGap seconds={turn.silenceBefore} />
-              )}
+              {!hideSilenceMarkers &&
+                turn.silenceBefore != null &&
+                turn.silenceBefore > 0.3 && (
+                  <SilenceGap seconds={turn.silenceBefore} />
+                )}
               <MemoTurnRow
                 ref={(el) => (rowRefs.current[i] = el)}
                 turn={turn}
@@ -896,6 +971,11 @@ const TranscriptView = ({ transcript, onAnnotate }) => {
 TranscriptView.propTypes = {
   transcript: PropTypes.array,
   onAnnotate: PropTypes.func,
+  hideTimelineStrip: PropTypes.bool,
+  hideTalkRatioLabel: PropTypes.bool,
+  hideTalkRatioPercentages: PropTypes.bool,
+  talkRatioLegendAlign: PropTypes.oneOf(["left", "right"]),
+  hideSilenceMarkers: PropTypes.bool,
 };
 
 export default TranscriptView;

--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceDrawerHeader.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceDrawerHeader.jsx
@@ -93,6 +93,11 @@ const VoiceDrawerHeader = ({
   onOpenNewTab,
   onDownload,
   onShare,
+  // Customizes the ID row label (e.g. "Call ID" for voice, "Chat ID"
+  // for chat). Defaults to "Call ID" so existing callers don't change.
+  idLabel = "Call ID",
+  copyTooltip = "Copy Call ID",
+  copyToastMessage = "Call ID copied",
 }) => {
   // Keyboard: ArrowUp = previous call, ArrowDown = next call.
   // Arrows (not j/k) because TranscriptView owns j/k for turn-level nav inside a call.
@@ -124,7 +129,7 @@ const VoiceDrawerHeader = ({
   const handleCopy = () => {
     if (!callId) return;
     navigator.clipboard.writeText(callId).then(() => {
-      enqueueSnackbar("Call ID copied", {
+      enqueueSnackbar(copyToastMessage, {
         variant: "info",
         autoHideDuration: 1500,
       });
@@ -168,7 +173,7 @@ const VoiceDrawerHeader = ({
               whiteSpace: "nowrap",
             }}
           >
-            Call ID :
+            {idLabel} :
           </Typography>
           <Typography
             noWrap
@@ -181,7 +186,7 @@ const VoiceDrawerHeader = ({
           >
             {callId || "-"}
           </Typography>
-          <Tooltip title="Copy Call ID" arrow placement="bottom">
+          <Tooltip title={copyTooltip} arrow placement="bottom">
             <Box
               component="button"
               onClick={handleCopy}
@@ -295,6 +300,9 @@ VoiceDrawerHeader.propTypes = {
   onOpenNewTab: PropTypes.func,
   onDownload: PropTypes.func,
   onShare: PropTypes.func,
+  idLabel: PropTypes.string,
+  copyTooltip: PropTypes.string,
+  copyToastMessage: PropTypes.string,
 };
 
 export default React.memo(VoiceDrawerHeader);

--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
@@ -28,6 +28,7 @@ import {
   useVoiceCallDetail,
 } from "src/sections/agents/helper";
 import VoiceDetailDrawerV2 from "src/components/VoiceDetailDrawerV2";
+import ChatDetailDrawerV2 from "src/components/ChatDetailDrawerV2";
 const BaselineVsReplayHeader = lazy(() => import("./BasLineCompare/Header"));
 
 const TestDetailSideDrawerChild = ({
@@ -451,8 +452,40 @@ const TestDetailSideDrawerChild = ({
         />
       </ShowComponent>
 
+      {/* TH-4530: chat simulate rows now route to the revamped
+          ChatDetailDrawerV2 instead of falling through to the legacy
+          LeftSection + LeftSectionBottom grid below. Gated on the
+          simulate module + compareReplay off — comparison flow still
+          uses the legacy path for now. */}
       <ShowComponent
-        condition={isFetching !== "initial" && !(isVoiceCall && !compareReplay)}
+        condition={
+          isFetching !== "initial" &&
+          urlModule === "simulate" &&
+          isChatSim &&
+          !compareReplay
+        }
+      >
+        <ChatDetailDrawerV2
+          data={mergedData}
+          onClose={onClose}
+          onPrev={() => navigateRecord("prev")}
+          onNext={() => navigateRecord("next")}
+          hasPrev={(updatedRowIndex ?? 0) > 0}
+          hasNext={totalCount ? (updatedRowIndex ?? 0) < totalCount - 1 : true}
+          isFetching={isFetching}
+          onAnnotate={() => setAnnotationSidebarOpen(true)}
+          onCompareBaseline={setCompareReplay}
+          scenarioId={scenarioId}
+          isLoading={isVoiceDetailLoading}
+        />
+      </ShowComponent>
+
+      <ShowComponent
+        condition={
+          isFetching !== "initial" &&
+          !(isVoiceCall && !compareReplay) &&
+          !(urlModule === "simulate" && isChatSim && !compareReplay)
+        }
       >
         <Box
           sx={{


### PR DESCRIPTION
## Summary

Chat simulations were still rendering through the legacy `CallLogsDetailDrawer` / `LeftSection` path — voice-style fields, empty "No recording found" block, TTFW/Interrupts tiles, no parity with the revamped voice drawer (`VoiceDetailDrawerV2`). This PR adds a chat-native peer (`ChatDetailDrawerV2`) and routes chat-sim rows to it.

Closes [TH-4530](https://linear.app/future-agi/issue/TH-4530).

## What's new — \`frontend/src/components/ChatDetailDrawerV2/\`

- **\`ChatDetailDrawerV2\`** — outer container (header, resizable width, fullscreen, inner divider). Reuses the shared \`VoiceDrawerHeader\` with chat-specific labels (\"Chat ID\", \"Copy Chat ID\", \"Chat ID copied\").
- **\`ChatLeftPanel\`** — Transcript / Checklist / Graph tabs. Reuses the data-driven \`PathAnalysisView\` for Checklist/Graph (chat path analysis comes for free).
- **\`ChatTranscriptView\`** — reuses the voice \`TranscriptView\` (search, filter tabs, keyboard nav, per-turn timestamps). Flattens chat-specific shapes (\`messages[0]\` → \`content\`, \`created_at\` → \`startTimeSeconds\`, word-count as a synthetic duration so the inline speaker legend has signal). Skeleton bubble loader while \`transcript\` is missing from the payload (TH-4525). Hides the voice-only timeline strip, \"TALK RATIO\" label, percentages, and per-turn silence markers.
- **\`ChatRightPanel\`** — Chat Analytics / Evals / Messages / Attributes / Annotations / Scenario tabs. Drops the voice-only Logs tab. Eval normalization mirrors \`VoiceRightPanel\`.
- **\`ChatAnalyticsView\`** — chat-specific KPI strip (Duration, Turns, Tokens In/Out, Total Tokens, Avg Latency, Cost) + AI summary card. Replaces voice's Latency pipeline / Cost breakdown.
- **\`ChatDetailsBar\`** — top chip strip (Status, Duration, Avg Latency, Turns, Tokens, Cost, When, Ended). Long values truncate with ellipsis and reveal full text via hover tooltip so the bar stays within drawer width at any size. \`VoiceActionsDropdown\` filtered to Annotate + Download only.

## Shared voice components — backwards-compatible knobs

All defaults preserve voice behavior, so no regressions.

- **\`VoiceDrawerHeader\`** — configurable \`idLabel\` / \`copyTooltip\` / \`copyToastMessage\`.
- **\`TranscriptView\`** — \`hideTimelineStrip\`, \`hideTalkRatioLabel\`, \`hideTalkRatioPercentages\`, \`talkRatioLegendAlign\`, \`hideSilenceMarkers\`, plus \`roleLabels\` so the legend reads consistent with the search filter tabs (\"Customer\" / \"Assistant\").
- **\`PathAnalysisView.PathStepNode\`** — opaque hover tooltip with \`text.primary\` rows on \`background.paper\` so dark-mode content is readable (was \`text.disabled\` over translucent grey).

## Wiring

- \`TestDetailSideDrawer\` routes simulate+chat (non-compareReplay) rows to \`ChatDetailDrawerV2\`. Legacy fallback condition extended to exclude chat sims. Voice-sim / observe / compare-replay paths are unchanged.

## Out of scope (deferred)

Imagine tab, Saved Views, Share dialog, Add-to-dataset, Add-to-queue, chat logs tab, full-page chat route.

## Test plan

- [ ] Open a chat simulation execution → drawer routes to \`ChatDetailDrawerV2\` (not the legacy two-column grid)
- [ ] Visual parity with voice on header / chip strip / right-panel tabs
- [ ] Transcript renders with speaker legend (Customer / Assistant), per-turn timestamps, search + filter pills, keyboard navigation
- [ ] No "No recording", no TTFW/Interrupts, no per-turn silence markers
- [ ] \`ChatDetailsBar\` Ended chip truncates with ellipsis when drawer is narrow; full text in tooltip on hover
- [ ] Path \`Checklist\` / \`Graph\` tabs work for scenario-driven chats; node hover tooltip readable in dark mode
- [ ] No regressions on voice (sim + observe) — same drawer, same tabs, same metrics