### PR TITLE
fix: consolidate dashboard analytics fixes

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -18,6 +18,7 @@ const escapeHtml = (str) => {
 };
 
 const CHART_HEIGHT_FALLBACK = 280;
+const DEFAULT_DECIMALS = 2;
 const COLORS = [
   "#7B56DB", // purple (primary)
   "#1ABCFE", // cyan
@@ -55,6 +56,69 @@ function getSeriesAverage(points = []) {
     count += 1;
   }
   return count > 0 ? total / count : null;
+}
+
+function getAutoDecimals(series = []) {
+  let minAbs = Infinity;
+  for (const s of series) {
+    for (const pt of s.data || []) {
+      const raw = typeof pt === "number" ? pt : pt?.y;
+      const value = Number(raw);
+      if (!Number.isFinite(value)) continue;
+      const abs = Math.abs(value);
+      if (abs > 0 && abs < minAbs) minAbs = abs;
+    }
+  }
+  if (minAbs === Infinity || minAbs >= 0.01) return DEFAULT_DECIMALS;
+  if (minAbs >= 0.001) return 3;
+  return 4;
+}
+
+const UNIT_LESS_AGGREGATIONS = new Set([
+  "count",
+  "count_distinct",
+  "pass_count",
+  "fail_count",
+]);
+
+function getSuggestedUnitConfig(metricConfigs = []) {
+  if (
+    metricConfigs.some((metric) =>
+      UNIT_LESS_AGGREGATIONS.has(metric?.aggregation),
+    )
+  ) {
+    return { unit: "", prefixSuffix: "prefix" };
+  }
+  const uniqueUnits = [...new Set(metricConfigs.map((metric) => metric?.unit).filter(Boolean))];
+  if (uniqueUnits.length !== 1) {
+    return { unit: "", prefixSuffix: "prefix" };
+  }
+  const [unit] = uniqueUnits;
+  if (unit === "$") return { unit, prefixSuffix: "prefix" };
+  if (unit === "%") return { unit, prefixSuffix: "suffix" };
+  return { unit: "", prefixSuffix: "prefix" };
+}
+
+function formatValueWithConfig(
+  val,
+  cfg,
+  { fallbackDecimals = DEFAULT_DECIMALS, includeUnit = true } = {},
+) {
+  if (val == null) return "-";
+  const num = Number(val);
+  if (!Number.isFinite(num)) return "-";
+  const dec = Math.max(0, Math.min(6, cfg?.decimals ?? fallbackDecimals));
+  const unit = includeUnit ? cfg?.unit || "" : "";
+  const prefixSuffix = cfg?.prefixSuffix || "prefix";
+  let str;
+  if (Boolean(cfg?.abbreviation ?? true) && Math.abs(num) >= 1000000) {
+    str = `${(num / 1000000).toFixed(dec)}M`;
+  } else if (Boolean(cfg?.abbreviation ?? true) && Math.abs(num) >= 1000) {
+    str = `${(num / 1000).toFixed(dec)}K`;
+  } else {
+    str = num.toFixed(dec);
+  }
+  return prefixSuffix === "suffix" ? `${str}${unit}` : `${unit}${str}`;
 }
 
 export default function WidgetChart({ widget, globalDateRange }) {
@@ -185,19 +249,19 @@ export default function WidgetChart({ widget, globalDateRange }) {
 
   // Compute Y-axis precision once from the data range so all ticks use the
   // same number of decimals (avoids "0.0 / 0.0 / 0.02" inconsistency).
-  const autoDecimals = useMemo(() => {
-    let minAbs = Infinity;
-    for (const s of chartSeries) {
-      for (const pt of s.data || []) {
-        const v = Math.abs(pt.y ?? pt);
-        if (v > 0 && v < minAbs) minAbs = v;
-      }
-    }
-    if (minAbs === Infinity || minAbs >= 0.1) return 1;
-    if (minAbs >= 0.01) return 2;
-    if (minAbs >= 0.001) return 3;
-    return 4;
-  }, [chartSeries]);
+  const autoDecimals = useMemo(() => getAutoDecimals(chartSeries), [chartSeries]);
+  const leftAxisFormatConfig = useMemo(() => {
+    const suggested = getSuggestedUnitConfig(result?.metrics || []);
+    const leftAxis = axisConfig?.leftY || {};
+    return {
+      ...leftAxis,
+      unit: leftAxis.unit || suggested.unit,
+      prefixSuffix:
+        leftAxis.unit || !suggested.unit
+          ? leftAxis.prefixSuffix || "prefix"
+          : suggested.prefixSuffix,
+    };
+  }, [axisConfig?.leftY, result?.metrics]);
 
   useEffect(() => {
     if (!isPie || !pieValues.length) {
@@ -252,6 +316,13 @@ export default function WidgetChart({ widget, globalDateRange }) {
     }, 400);
     return () => clearTimeout(timer);
   }, [isPie, pieValues, chartSeries]);
+
+  const isDark = theme.palette.mode === "dark";
+  const makeFormatter =
+    (cfg, fallbackDecimals = autoDecimals, includeUnit = true) =>
+    (val) =>
+      formatValueWithConfig(val, cfg, { fallbackDecimals, includeUnit });
+  const formatVal = makeFormatter(leftAxisFormatConfig);
 
   if (queryMutation.isPending) {
     return (
@@ -332,9 +403,7 @@ export default function WidgetChart({ widget, globalDateRange }) {
               >
                 {avg == null
                   ? "—"
-                  : avg >= 1000
-                    ? `${(avg / 1000).toFixed(1)}K`
-                    : avg.toFixed(1)}
+                  : formatVal(avg)}
               </Typography>
               <Typography variant="caption" color="text.secondary">
                 {s.name}
@@ -490,13 +559,10 @@ export default function WidgetChart({ widget, globalDateRange }) {
                         }}
                       >
                         {val != null
-                          ? val >= 1000
-                            ? val.toLocaleString(undefined, {
-                                maximumFractionDigits: 0,
-                              })
-                            : val % 1 === 0
-                              ? val
-                              : val.toFixed(2)
+                          ? formatValueWithConfig(val, leftAxisFormatConfig, {
+                              fallbackDecimals: autoDecimals,
+                              includeUnit: false,
+                            })
                           : "-"}
                       </td>
                     );
@@ -655,30 +721,16 @@ export default function WidgetChart({ widget, globalDateRange }) {
     );
   }
 
-  // Line / Column / Bar (+ stacked variants)
-  const isDark = theme.palette.mode === "dark";
-
-  const makeFormatter = (cfg) => (val) => {
-    if (val == null) return "-";
-    const dec = cfg?.decimals ?? 1;
-    const unit = cfg?.unit || "";
-    let str;
-    if (Boolean(cfg?.abbreviation ?? true) && Math.abs(val) >= 1000000)
-      str = `${(val / 1000000).toFixed(dec)}M`;
-    else if (Boolean(cfg?.abbreviation ?? true) && Math.abs(val) >= 1000)
-      str = `${(val / 1000).toFixed(dec)}K`;
-    else str = val.toFixed(dec);
-    return cfg?.prefixSuffix === "suffix" ? `${str}${unit}` : `${unit}${str}`;
-  };
-  const formatVal = makeFormatter(axisConfig?.leftY);
-
   // Bar chart — horizontal bar table
   if (isHorizontal) {
-    const barValues = chartSeries.map((s) => {
+    const barRows = chartSeries.map((s) => {
       const avg = getSeriesAverage(s.data);
-      return avg == null ? 0 : avg;
+      return {
+        value: avg,
+        numericValue: avg == null ? 0 : avg,
+      };
     });
-    const maxVal = Math.max(...barValues.map(Math.abs), 1);
+    const maxVal = Math.max(...barRows.map((row) => Math.abs(row.numericValue)), 1);
     return (
       <Box
         ref={containerRef}
@@ -760,7 +812,8 @@ export default function WidgetChart({ widget, globalDateRange }) {
         </Box>
         {/* Bar rows */}
         <Box sx={{ flex: 1, overflow: "auto", px: 2 }}>
-          {barValues.map((val, i) => {
+          {barRows.map((row, i) => {
+            const val = row.numericValue;
             const color = COLORS[i % COLORS.length];
             const pct = maxVal > 0 ? (Math.abs(val) / maxVal) * 100 : 0;
             const name = chartSeries[i]?.name || "";
@@ -836,7 +889,7 @@ export default function WidgetChart({ widget, globalDateRange }) {
                       flexShrink: 0,
                     }}
                   >
-                    {formatVal(val)}
+                    {row.value == null ? "—" : formatVal(row.value)}
                   </Typography>
                 </Box>
               </Box>

--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -6,19 +6,16 @@ import ReactApexChart from "react-apexcharts";
 import { useTheme } from "@mui/material/styles";
 import { useDashboardQuery } from "src/hooks/useDashboards";
 import { format } from "date-fns";
-
-const escapeHtml = (str) => {
-  if (typeof str !== "string") return str;
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-};
+import {
+  DEFAULT_DECIMALS,
+  escapeHtml,
+  formatValueWithConfig,
+  getAutoDecimals,
+  getSeriesAverage,
+  getSuggestedUnitConfig,
+} from "./widgetUtils";
 
 const CHART_HEIGHT_FALLBACK = 280;
-const DEFAULT_DECIMALS = 2;
 const COLORS = [
   "#7B56DB", // purple (primary)
   "#1ABCFE", // cyan
@@ -43,82 +40,6 @@ function getApexType(chartType) {
     pie: "pie",
   };
   return map[chartType] || "line";
-}
-
-function getSeriesAverage(points = []) {
-  let total = 0;
-  let count = 0;
-  for (const pt of points) {
-    if (pt?.y == null) continue;
-    const y = Number(pt.y);
-    if (!Number.isFinite(y)) continue;
-    total += y;
-    count += 1;
-  }
-  return count > 0 ? total / count : null;
-}
-
-function getAutoDecimals(series = []) {
-  let minAbs = Infinity;
-  for (const s of series) {
-    for (const pt of s.data || []) {
-      const raw = typeof pt === "number" ? pt : pt?.y;
-      const value = Number(raw);
-      if (!Number.isFinite(value)) continue;
-      const abs = Math.abs(value);
-      if (abs > 0 && abs < minAbs) minAbs = abs;
-    }
-  }
-  if (minAbs === Infinity || minAbs >= 0.01) return DEFAULT_DECIMALS;
-  if (minAbs >= 0.001) return 3;
-  return 4;
-}
-
-const UNIT_LESS_AGGREGATIONS = new Set([
-  "count",
-  "count_distinct",
-  "pass_count",
-  "fail_count",
-]);
-
-function getSuggestedUnitConfig(metricConfigs = []) {
-  if (
-    metricConfigs.some((metric) =>
-      UNIT_LESS_AGGREGATIONS.has(metric?.aggregation),
-    )
-  ) {
-    return { unit: "", prefixSuffix: "prefix" };
-  }
-  const uniqueUnits = [...new Set(metricConfigs.map((metric) => metric?.unit).filter(Boolean))];
-  if (uniqueUnits.length !== 1) {
-    return { unit: "", prefixSuffix: "prefix" };
-  }
-  const [unit] = uniqueUnits;
-  if (unit === "$") return { unit, prefixSuffix: "prefix" };
-  if (unit === "%") return { unit, prefixSuffix: "suffix" };
-  return { unit: "", prefixSuffix: "prefix" };
-}
-
-function formatValueWithConfig(
-  val,
-  cfg,
-  { fallbackDecimals = DEFAULT_DECIMALS, includeUnit = true } = {},
-) {
-  if (val == null) return "-";
-  const num = Number(val);
-  if (!Number.isFinite(num)) return "-";
-  const dec = Math.max(0, Math.min(6, cfg?.decimals ?? fallbackDecimals));
-  const unit = includeUnit ? cfg?.unit || "" : "";
-  const prefixSuffix = cfg?.prefixSuffix || "prefix";
-  let str;
-  if (Boolean(cfg?.abbreviation ?? true) && Math.abs(num) >= 1000000) {
-    str = `${(num / 1000000).toFixed(dec)}M`;
-  } else if (Boolean(cfg?.abbreviation ?? true) && Math.abs(num) >= 1000) {
-    str = `${(num / 1000).toFixed(dec)}K`;
-  } else {
-    str = num.toFixed(dec);
-  }
-  return prefixSuffix === "suffix" ? `${str}${unit}` : `${unit}${str}`;
 }
 
 export default function WidgetChart({ widget, globalDateRange }) {

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -75,6 +75,8 @@ const escapeCsvField = (field) => {
   return str;
 };
 
+const DEFAULT_DECIMALS = 2;
+
 const getSeriesAverage = (points = []) => {
   let total = 0;
   let count = 0;
@@ -86,6 +88,71 @@ const getSeriesAverage = (points = []) => {
     count += 1;
   }
   return count > 0 ? total / count : null;
+};
+
+const getAutoDecimals = (series = []) => {
+  let minAbs = Infinity;
+  for (const s of series) {
+    for (const pt of s.data || []) {
+      const raw = typeof pt === "number" ? pt : pt?.y;
+      const value = Number(raw);
+      if (!Number.isFinite(value)) continue;
+      const abs = Math.abs(value);
+      if (abs > 0 && abs < minAbs) minAbs = abs;
+    }
+  }
+  if (minAbs === Infinity || minAbs >= 0.01) return DEFAULT_DECIMALS;
+  if (minAbs >= 0.001) return 3;
+  return 4;
+};
+
+const UNIT_LESS_AGGREGATIONS = new Set([
+  "count",
+  "count_distinct",
+  "pass_count",
+  "fail_count",
+]);
+
+const getSuggestedUnitConfig = (metricConfigs = []) => {
+  if (
+    metricConfigs.some((metric) =>
+      UNIT_LESS_AGGREGATIONS.has(metric?.aggregation),
+    )
+  ) {
+    return { unit: "", prefixSuffix: "prefix" };
+  }
+  const uniqueUnits = [
+    ...new Set(metricConfigs.map((metric) => metric?.unit).filter(Boolean)),
+  ];
+  if (uniqueUnits.length !== 1) {
+    return { unit: "", prefixSuffix: "prefix" };
+  }
+  const [unit] = uniqueUnits;
+  if (unit === "$") return { unit, prefixSuffix: "prefix" };
+  if (unit === "%") return { unit, prefixSuffix: "suffix" };
+  return { unit: "", prefixSuffix: "prefix" };
+};
+
+const formatValueWithConfig = (
+  val,
+  cfg,
+  { fallbackDecimals = DEFAULT_DECIMALS, includeUnit = true } = {},
+) => {
+  if (val == null) return "-";
+  const num = Number(val);
+  if (!Number.isFinite(num)) return "-";
+  const dec = Math.max(0, Math.min(6, cfg?.decimals ?? fallbackDecimals));
+  const unit = includeUnit ? cfg?.unit || "" : "";
+  const prefixSuffix = cfg?.prefixSuffix || "prefix";
+  let str;
+  if (Boolean(cfg?.abbreviation ?? true) && Math.abs(num) >= 1000000) {
+    str = `${(num / 1000000).toFixed(dec)}M`;
+  } else if (Boolean(cfg?.abbreviation ?? true) && Math.abs(num) >= 1000) {
+    str = `${(num / 1000).toFixed(dec)}K`;
+  } else {
+    str = num.toFixed(dec);
+  }
+  return prefixSuffix === "suffix" ? `${str}${unit}` : `${unit}${str}`;
 };
 
 const TIME_PRESETS = [
@@ -530,9 +597,12 @@ function AxisSection({ title, config, onChange, theme, showReset, onReset }) {
           options={[
             {
               label: "\u2190 .0",
-              value: Math.max(0, (config.decimals || 1) - 1),
+              value: Math.max(0, (config.decimals ?? DEFAULT_DECIMALS) - 1),
             },
-            { label: ".00 \u2192", value: (config.decimals || 1) + 1 },
+            {
+              label: ".00 \u2192",
+              value: (config.decimals ?? DEFAULT_DECIMALS) + 1,
+            },
           ]}
           value={null}
           onChange={(v) => onChange("decimals", Math.max(0, Math.min(6, v)))}
@@ -553,18 +623,9 @@ function AxisSection({ title, config, onChange, theme, showReset, onReset }) {
         <Typography variant="body2" fontWeight={500}>
           {(() => {
             const sample = 1250000;
-            const abbr = config.abbreviation;
-            const dec = config.decimals ?? 1;
-            const val =
-              abbr && sample >= 1000000
-                ? `${(sample / 1000000).toFixed(dec)}M`
-                : abbr && sample >= 1000
-                  ? `${(sample / 1000).toFixed(dec)}K`
-                  : sample.toFixed(dec);
-            const unit = config.unit || "";
-            return config.prefixSuffix === "suffix"
-              ? `${val}${unit}`
-              : `${unit}${val}`;
+            return formatValueWithConfig(sample, config, {
+              fallbackDecimals: DEFAULT_DECIMALS,
+            });
           })()}
         </Typography>
       </Stack>
@@ -1235,7 +1296,7 @@ export default function WidgetEditorView() {
       unit: "",
       prefixSuffix: "prefix",
       abbreviation: true,
-      decimals: 1,
+      decimals: DEFAULT_DECIMALS,
       min: "",
       max: "",
       outOfBounds: "visible",
@@ -1247,7 +1308,7 @@ export default function WidgetEditorView() {
       unit: "",
       prefixSuffix: "prefix",
       abbreviation: true,
-      decimals: 1,
+      decimals: DEFAULT_DECIMALS,
       min: "",
       max: "",
       outOfBounds: "hidden",
@@ -1256,6 +1317,8 @@ export default function WidgetEditorView() {
     xAxis: { visible: true, label: "" },
     seriesAxis: {}, // { [seriesIndex]: "left" | "right" }
   });
+  const [hasAutoAppliedLeftAxisUnit, setHasAutoAppliedLeftAxisUnit] =
+    useState(false);
   const updateAxis = (axis, key, val) =>
     setAxisConfig((prev) => ({
       ...prev,
@@ -2002,6 +2065,46 @@ export default function WidgetEditorView() {
     return previewSeries.filter((_, i) => visibleSeries.has(i));
   }, [previewSeries, visibleSeries]);
 
+  const autoDecimals = useMemo(() => getAutoDecimals(chartSeries), [chartSeries]);
+  const suggestedLeftAxisUnit = useMemo(
+    () => getSuggestedUnitConfig(metrics),
+    [metrics],
+  );
+  const leftAxisFormatConfig = useMemo(() => {
+    const leftAxis = axisConfig.leftY || {};
+    return {
+      ...leftAxis,
+      unit: leftAxis.unit || suggestedLeftAxisUnit.unit,
+      prefixSuffix:
+        leftAxis.unit || !suggestedLeftAxisUnit.unit
+          ? leftAxis.prefixSuffix || "prefix"
+          : suggestedLeftAxisUnit.prefixSuffix,
+    };
+  }, [axisConfig.leftY, suggestedLeftAxisUnit]);
+
+  useEffect(() => {
+    if (
+      hasAutoAppliedLeftAxisUnit ||
+      axisConfig.leftY.unit ||
+      !suggestedLeftAxisUnit.unit
+    ) {
+      return;
+    }
+    setAxisConfig((prev) => ({
+      ...prev,
+      leftY: {
+        ...prev.leftY,
+        unit: suggestedLeftAxisUnit.unit,
+        prefixSuffix: suggestedLeftAxisUnit.prefixSuffix,
+      },
+    }));
+    setHasAutoAppliedLeftAxisUnit(true);
+  }, [
+    axisConfig.leftY.unit,
+    hasAutoAppliedLeftAxisUnit,
+    suggestedLeftAxisUnit,
+  ]);
+
   // Colors that match chartSeries — preserves original color assignment even when series are filtered out
   const chartColors = useMemo(() => {
     if (visibleSeries === null) return SERIES_COLORS;
@@ -2035,20 +2138,11 @@ export default function WidgetEditorView() {
 
   const isDark = theme.palette.mode === "dark";
   const formatValFn = useCallback(
-    (val) => {
-      if (val == null) return "-";
-      const cfg = axisConfig.leftY;
-      const dec = cfg.decimals ?? 1;
-      const unit = cfg.unit || "";
-      let str;
-      if (cfg.abbreviation && Math.abs(val) >= 1000000)
-        str = `${(val / 1000000).toFixed(dec)}M`;
-      else if (cfg.abbreviation && Math.abs(val) >= 1000)
-        str = `${(val / 1000).toFixed(dec)}K`;
-      else str = val.toFixed(dec);
-      return cfg.prefixSuffix === "suffix" ? `${str}${unit}` : `${unit}${str}`;
-    },
-    [axisConfig.leftY],
+    (val) =>
+      formatValueWithConfig(val, leftAxisFormatConfig, {
+        fallbackDecimals: autoDecimals,
+      }),
+    [autoDecimals, leftAxisFormatConfig],
   );
 
   const chartOptions = useMemo(() => {
@@ -2120,19 +2214,11 @@ export default function WidgetEditorView() {
         },
       };
     }
-    const makeFormatter = (cfg) => (val) => {
-      if (val == null) return "-";
-      const dec = cfg.decimals ?? 1;
-      const unit = cfg.unit || "";
-      let str;
-      if (cfg.abbreviation && Math.abs(val) >= 1000000)
-        str = `${(val / 1000000).toFixed(dec)}M`;
-      else if (cfg.abbreviation && Math.abs(val) >= 1000)
-        str = `${(val / 1000).toFixed(dec)}K`;
-      else str = val.toFixed(dec);
-      return cfg.prefixSuffix === "suffix" ? `${str}${unit}` : `${unit}${str}`;
-    };
-    const formatVal = makeFormatter(axisConfig.leftY);
+    const makeFormatter =
+      (cfg, fallbackDecimals = autoDecimals, includeUnit = true) =>
+      (val) =>
+        formatValueWithConfig(val, cfg, { fallbackDecimals, includeUnit });
+    const formatVal = makeFormatter(leftAxisFormatConfig);
     return {
       chart: {
         type: apexType,
@@ -2481,7 +2567,6 @@ export default function WidgetEditorView() {
           },
     };
   }, [
-    chartType,
     apexType,
     isStacked,
     isHorizontal,
@@ -2490,6 +2575,9 @@ export default function WidgetEditorView() {
     chartColors,
     theme,
     axisConfig,
+    autoDecimals,
+    isDark,
+    leftAxisFormatConfig,
     visibleSeries,
   ]);
 
@@ -2568,11 +2656,15 @@ export default function WidgetEditorView() {
     });
     const values = chartSeries.map((s) => {
       const avg = getSeriesAverage(s.data);
-      return avg == null ? 0 : avg;
+      return {
+        value: avg,
+        numericValue: avg == null ? 0 : avg,
+      };
     });
     return {
       categories,
-      series: [{ name: "Value", data: values }],
+      series: [{ name: "Value", data: values.map((item) => item.numericValue) }],
+      rows: values,
     };
   }, [isHorizontal, chartSeries]);
 
@@ -3265,7 +3357,8 @@ export default function WidgetEditorView() {
                           </Box>
                           {/* Bar rows */}
                           <Box sx={{ flex: 1, overflow: "auto", px: 2 }}>
-                            {barData.series[0].data.map((val, i) => {
+                            {barData.rows.map((row, i) => {
+                              const val = row.numericValue;
                               const origIdx =
                                 visibleSeries === null
                                   ? i
@@ -3279,7 +3372,8 @@ export default function WidgetEditorView() {
                                 ];
                               const pct =
                                 maxVal > 0 ? (Math.abs(val) / maxVal) * 100 : 0;
-                              const fmtVal = formatValFn(val);
+                              const fmtVal =
+                                row.value == null ? "—" : formatValFn(row.value);
                               return (
                                 <Box
                                   key={i}
@@ -3539,9 +3633,7 @@ export default function WidgetEditorView() {
                               >
                                 {avg == null
                                   ? "—"
-                                  : avg >= 1000
-                                    ? `${(avg / 1000).toFixed(1)}K`
-                                    : avg.toFixed(1)}
+                                  : formatValFn(avg)}
                               </Typography>
                               <Typography
                                 variant="body2"
@@ -4274,11 +4366,7 @@ export default function WidgetEditorView() {
                                 >
                                   {avg == null
                                     ? "—"
-                                    : avg >= 1000
-                                      ? avg.toLocaleString(undefined, {
-                                          maximumFractionDigits: 1,
-                                        })
-                                      : avg.toFixed(1)}
+                                    : formatValFn(avg)}
                                 </td>
                                 {s.data.map((pt, ci) => {
                                   if (!displayIndicesSet.has(ci)) return null;
@@ -5722,7 +5810,7 @@ export default function WidgetEditorView() {
                           unit: "",
                           prefixSuffix: "prefix",
                           abbreviation: true,
-                          decimals: 1,
+                          decimals: DEFAULT_DECIMALS,
                           min: "",
                           max: "",
                           outOfBounds: "visible",
@@ -5750,7 +5838,7 @@ export default function WidgetEditorView() {
                           unit: "",
                           prefixSuffix: "prefix",
                           abbreviation: true,
-                          decimals: 1,
+                          decimals: DEFAULT_DECIMALS,
                           min: "",
                           max: "",
                           outOfBounds: "hidden",

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -57,15 +57,14 @@ import { useSnackbar } from "src/components/snackbar";
 import { format } from "date-fns";
 import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
 
-const escapeHtml = (str) => {
-  if (typeof str !== "string") return str;
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-};
+import {
+  DEFAULT_DECIMALS,
+  escapeHtml,
+  formatValueWithConfig,
+  getAutoDecimals,
+  getSeriesAverage,
+  getSuggestedUnitConfig,
+} from "./widgetUtils";
 
 const escapeCsvField = (field) => {
   const str = String(field ?? "");
@@ -73,86 +72,6 @@ const escapeCsvField = (field) => {
     return `"${str.replace(/"/g, '""')}"`;
   }
   return str;
-};
-
-const DEFAULT_DECIMALS = 2;
-
-const getSeriesAverage = (points = []) => {
-  let total = 0;
-  let count = 0;
-  for (const pt of points) {
-    if (pt?.y == null) continue;
-    const y = Number(pt.y);
-    if (!Number.isFinite(y)) continue;
-    total += y;
-    count += 1;
-  }
-  return count > 0 ? total / count : null;
-};
-
-const getAutoDecimals = (series = []) => {
-  let minAbs = Infinity;
-  for (const s of series) {
-    for (const pt of s.data || []) {
-      const raw = typeof pt === "number" ? pt : pt?.y;
-      const value = Number(raw);
-      if (!Number.isFinite(value)) continue;
-      const abs = Math.abs(value);
-      if (abs > 0 && abs < minAbs) minAbs = abs;
-    }
-  }
-  if (minAbs === Infinity || minAbs >= 0.01) return DEFAULT_DECIMALS;
-  if (minAbs >= 0.001) return 3;
-  return 4;
-};
-
-const UNIT_LESS_AGGREGATIONS = new Set([
-  "count",
-  "count_distinct",
-  "pass_count",
-  "fail_count",
-]);
-
-const getSuggestedUnitConfig = (metricConfigs = []) => {
-  if (
-    metricConfigs.some((metric) =>
-      UNIT_LESS_AGGREGATIONS.has(metric?.aggregation),
-    )
-  ) {
-    return { unit: "", prefixSuffix: "prefix" };
-  }
-  const uniqueUnits = [
-    ...new Set(metricConfigs.map((metric) => metric?.unit).filter(Boolean)),
-  ];
-  if (uniqueUnits.length !== 1) {
-    return { unit: "", prefixSuffix: "prefix" };
-  }
-  const [unit] = uniqueUnits;
-  if (unit === "$") return { unit, prefixSuffix: "prefix" };
-  if (unit === "%") return { unit, prefixSuffix: "suffix" };
-  return { unit: "", prefixSuffix: "prefix" };
-};
-
-const formatValueWithConfig = (
-  val,
-  cfg,
-  { fallbackDecimals = DEFAULT_DECIMALS, includeUnit = true } = {},
-) => {
-  if (val == null) return "-";
-  const num = Number(val);
-  if (!Number.isFinite(num)) return "-";
-  const dec = Math.max(0, Math.min(6, cfg?.decimals ?? fallbackDecimals));
-  const unit = includeUnit ? cfg?.unit || "" : "";
-  const prefixSuffix = cfg?.prefixSuffix || "prefix";
-  let str;
-  if (Boolean(cfg?.abbreviation ?? true) && Math.abs(num) >= 1000000) {
-    str = `${(num / 1000000).toFixed(dec)}M`;
-  } else if (Boolean(cfg?.abbreviation ?? true) && Math.abs(num) >= 1000) {
-    str = `${(num / 1000).toFixed(dec)}K`;
-  } else {
-    str = num.toFixed(dec);
-  }
-  return prefixSuffix === "suffix" ? `${str}${unit}` : `${unit}${str}`;
 };
 
 const TIME_PRESETS = [

--- a/frontend/src/sections/dashboards/widgetUtils.js
+++ b/frontend/src/sections/dashboards/widgetUtils.js
@@ -1,0 +1,89 @@
+export const DEFAULT_DECIMALS = 2;
+
+export const escapeHtml = (str) => {
+  if (typeof str !== "string") return str;
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+};
+
+export const getSeriesAverage = (points = []) => {
+  let total = 0;
+  let count = 0;
+  for (const pt of points) {
+    if (pt?.y == null) continue;
+    const y = Number(pt.y);
+    if (!Number.isFinite(y)) continue;
+    total += y;
+    count += 1;
+  }
+  return count > 0 ? total / count : null;
+};
+
+export const getAutoDecimals = (series = []) => {
+  let minAbs = Infinity;
+  for (const s of series) {
+    for (const pt of s.data || []) {
+      const raw = typeof pt === "number" ? pt : pt?.y;
+      const value = Number(raw);
+      if (!Number.isFinite(value)) continue;
+      const abs = Math.abs(value);
+      if (abs > 0 && abs < minAbs) minAbs = abs;
+    }
+  }
+  if (minAbs === Infinity || minAbs >= 0.01) return DEFAULT_DECIMALS;
+  if (minAbs >= 0.001) return 3;
+  return 4;
+};
+
+const UNIT_LESS_AGGREGATIONS = new Set([
+  "count",
+  "count_distinct",
+  "pass_count",
+  "fail_count",
+]);
+
+export const getSuggestedUnitConfig = (metricConfigs = []) => {
+  if (
+    metricConfigs.some((metric) =>
+      UNIT_LESS_AGGREGATIONS.has(metric?.aggregation),
+    )
+  ) {
+    return { unit: "", prefixSuffix: "prefix" };
+  }
+  const uniqueUnits = [
+    ...new Set(metricConfigs.map((metric) => metric?.unit).filter(Boolean)),
+  ];
+  if (uniqueUnits.length !== 1) {
+    return { unit: "", prefixSuffix: "prefix" };
+  }
+  const [unit] = uniqueUnits;
+  if (unit === "$") return { unit, prefixSuffix: "prefix" };
+  if (unit === "%") return { unit, prefixSuffix: "suffix" };
+  return { unit: "", prefixSuffix: "prefix" };
+};
+
+export const formatValueWithConfig = (
+  val,
+  cfg,
+  { fallbackDecimals = DEFAULT_DECIMALS, includeUnit = true } = {},
+) => {
+  if (val == null) return "-";
+  const num = Number(val);
+  if (!Number.isFinite(num)) return "-";
+  const dec = Math.max(0, Math.min(6, cfg?.decimals ?? fallbackDecimals));
+  const unit = includeUnit ? cfg?.unit || "" : "";
+  const prefixSuffix = cfg?.prefixSuffix || "prefix";
+  let str;
+  if (Boolean(cfg?.abbreviation ?? true) && Math.abs(num) >= 1000000) {
+    str = `${(num / 1000000).toFixed(dec)}M`;
+  } else if (Boolean(cfg?.abbreviation ?? true) && Math.abs(num) >= 1000) {
+    str = `${(num / 1000).toFixed(dec)}K`;
+  } else {
+    str = num.toFixed(dec);
+  }
+  return prefixSuffix === "suffix" ? `${str}${unit}` : `${unit}${str}`;
+};

--- a/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
@@ -20,6 +20,13 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
 
 
+ANNOTATION_NUMERIC_VALUE_EXPR = (
+    "if(JSONHas(value, 'rating'), "
+    "JSONExtractFloat(value, 'rating'), "
+    "JSONExtractFloat(value, 'value'))"
+)
+
+
 class AnnotationGraphQueryBuilder(BaseQueryBuilder):
     """Build time-series annotation metric queries.
 
@@ -135,12 +142,12 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
     # ------------------------------------------------------------------
 
     def _build_float_query(self) -> Tuple[str, Dict[str, Any]]:
-        """avg(JSONExtractFloat(value, 'value')) per time bucket."""
+        """Average numeric/star annotation value per time bucket."""
         bucket_fn = self.time_bucket_expr(self.interval)
         query = f"""
         SELECT
             {bucket_fn}(created_at) AS time_bucket,
-            avg(JSONExtractFloat(value, 'value')) AS value
+            avg({ANNOTATION_NUMERIC_VALUE_EXPR}) AS value
         FROM {self.TABLE} FINAL
         WHERE _peerdb_is_deleted = 0
           AND label_id = toUUID(%(label_id)s)
@@ -197,7 +204,7 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
             avg(
                 CASE
                     WHEN has(
-                        JSONExtract(JSONExtractString(value, 'selected'), 'Array(String)'),
+                        JSONExtract(value, 'selected', 'Array(String)'),
                         %(choice_value)s
                     ) THEN 100.0
                     ELSE 0.0

--- a/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
@@ -18,12 +18,8 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
-
-
-ANNOTATION_NUMERIC_VALUE_EXPR = (
-    "if(JSONHas(value, 'rating'), "
-    "JSONExtractFloat(value, 'rating'), "
-    "JSONExtractFloat(value, 'value'))"
+from tracer.services.clickhouse.query_builders.expressions import (
+    annotation_numeric_value_expr,
 )
 
 
@@ -147,7 +143,7 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
         query = f"""
         SELECT
             {bucket_fn}(created_at) AS time_bucket,
-            avg({ANNOTATION_NUMERIC_VALUE_EXPR}) AS value
+            avg({annotation_numeric_value_expr()}) AS value
         FROM {self.TABLE} FINAL
         WHERE _peerdb_is_deleted = 0
           AND label_id = toUUID(%(label_id)s)

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -18,6 +18,10 @@ import re
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from tracer.services.clickhouse.query_builders.expressions import (
+    annotation_numeric_value_expr,
+)
+
 logger = logging.getLogger(__name__)
 
 # Allowed characters for ClickHouse map keys: alphanumeric, dots, underscores, hyphens
@@ -133,12 +137,6 @@ AGGREGATIONS: Dict[str, str] = {
     "count_distinct": "uniq({col})",
     "sum": "sum({col})",
 }
-
-ANNOTATION_NUMERIC_VALUE_EXPR = (
-    "if(JSONHas({alias}.value, 'rating'), "
-    "JSONExtractFloat({alias}.value, 'rating'), "
-    "JSONExtractFloat({alias}.value, 'value'))"
-)
 
 FILTER_OPERATORS: Dict[str, str] = {
     "less_than": "< %({prefix}{idx}_val)s",
@@ -791,7 +789,7 @@ class DashboardQueryBuilder:
             agg_expr = "count()"
         else:
             # Numeric/star: average of the float value
-            col_expr = ANNOTATION_NUMERIC_VALUE_EXPR.format(alias="a")
+            col_expr = annotation_numeric_value_expr(alias="a")
             agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
 
         select_parts = [f"{bucket_fn}(a.created_at) AS time_bucket"]
@@ -1112,12 +1110,12 @@ class DashboardQueryBuilder:
                 elif output_type in ("numeric", "star"):
                     val_expr = (
                         f"if({alias}.trace_id IS NULL, '(not set)', "
-                        f"toString(round({ANNOTATION_NUMERIC_VALUE_EXPR.format(alias=alias)}, 1)))"
+                        f"toString(round({annotation_numeric_value_expr(alias=alias)}, 1)))"
                     )
                 else:
                     val_expr = (
                         f"if({alias}.trace_id IS NULL, '(not set)', "
-                        f"toString({ANNOTATION_NUMERIC_VALUE_EXPR.format(alias=alias)}))"
+                        f"toString({annotation_numeric_value_expr(alias=alias)}))"
                     )
 
                 join_clause = (
@@ -1403,7 +1401,7 @@ class DashboardQueryBuilder:
                     f"SELECT toString(trace_id) FROM model_hub_score FINAL "
                     f"WHERE label_id = toUUID(%({label_id_key})s) "
                     f"AND organization_id = toUUID(%({ann_org_key})s) "
-                    f"AND {ANNOTATION_NUMERIC_VALUE_EXPR.format(alias='model_hub_score')} "
+                    f"AND {annotation_numeric_value_expr(alias='model_hub_score')} "
                     f"{op_symbol} %({val_key})s "
                     f"AND _peerdb_is_deleted = 0"
                     f")"

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -134,6 +134,12 @@ AGGREGATIONS: Dict[str, str] = {
     "sum": "sum({col})",
 }
 
+ANNOTATION_NUMERIC_VALUE_EXPR = (
+    "if(JSONHas({alias}.value, 'rating'), "
+    "JSONExtractFloat({alias}.value, 'rating'), "
+    "JSONExtractFloat({alias}.value, 'value'))"
+)
+
 FILTER_OPERATORS: Dict[str, str] = {
     "less_than": "< %({prefix}{idx}_val)s",
     "greater_than": "> %({prefix}{idx}_val)s",
@@ -180,7 +186,7 @@ def _prefix_spans_columns(clause: str) -> str:
     import re
 
     # Prefix bare column names (not already prefixed and not inside %(...))
-    for col in ("project_id", "_peerdb_is_deleted", "start_time"):
+    for col in ("project_id", "_peerdb_is_deleted", "start_time", "parent_span_id"):
         # Match bare column name not preceded by . or inside %(...)
         clause = re.sub(
             rf"(?<!\.)(?<!%\()(?<!\w){col}(?!\w)(?!s\))",
@@ -315,7 +321,10 @@ class DashboardQueryBuilder:
                 params,
             )
         _, col_expr = SYSTEM_METRICS[metric_name]
-        # Force count-based aggregation for non-numeric / identity metrics
+        # Project count should count distinct projects, not raw span rows.
+        if metric_name == "project" and aggregation == "count":
+            aggregation = "count_distinct"
+        # Force count-based aggregation for non-numeric / identity metrics.
         if metric_name in _COUNT_DISTINCT_METRICS and aggregation not in (
             "count",
             "count_distinct",
@@ -332,6 +341,8 @@ class DashboardQueryBuilder:
         where_clauses, params = self._build_where_clauses(
             "spans", "start_time", per_metric_filters, params
         )
+        if metric_name == "latency":
+            where_clauses.append("(parent_span_id IS NULL OR parent_span_id = '')")
 
         # Subquery filters from global + per-metric for non-system metrics
         subquery_clauses = self._build_subquery_filters(
@@ -780,7 +791,7 @@ class DashboardQueryBuilder:
             agg_expr = "count()"
         else:
             # Numeric/star: average of the float value
-            col_expr = "JSONExtractFloat(a.value, 'value')"
+            col_expr = ANNOTATION_NUMERIC_VALUE_EXPR.format(alias="a")
             agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
 
         select_parts = [f"{bucket_fn}(a.created_at) AS time_bucket"]
@@ -1099,9 +1110,15 @@ class DashboardQueryBuilder:
                 elif output_type == "text":
                     val_expr = f"if({alias}.trace_id IS NULL, '(not set)', JSONExtractString({alias}.value, 'text'))"
                 elif output_type in ("numeric", "star"):
-                    val_expr = f"if({alias}.trace_id IS NULL, '(not set)', toString(round(JSONExtractFloat({alias}.value, 'value'), 1)))"
+                    val_expr = (
+                        f"if({alias}.trace_id IS NULL, '(not set)', "
+                        f"toString(round({ANNOTATION_NUMERIC_VALUE_EXPR.format(alias=alias)}, 1)))"
+                    )
                 else:
-                    val_expr = f"if({alias}.trace_id IS NULL, '(not set)', toString(JSONExtractFloat({alias}.value, 'value')))"
+                    val_expr = (
+                        f"if({alias}.trace_id IS NULL, '(not set)', "
+                        f"toString({ANNOTATION_NUMERIC_VALUE_EXPR.format(alias=alias)}))"
+                    )
 
                 join_clause = (
                     f"LEFT JOIN model_hub_score AS {alias} "
@@ -1386,7 +1403,8 @@ class DashboardQueryBuilder:
                     f"SELECT toString(trace_id) FROM model_hub_score FINAL "
                     f"WHERE label_id = toUUID(%({label_id_key})s) "
                     f"AND organization_id = toUUID(%({ann_org_key})s) "
-                    f"AND JSONExtractFloat(value, 'value') {op_symbol} %({val_key})s "
+                    f"AND {ANNOTATION_NUMERIC_VALUE_EXPR.format(alias='model_hub_score')} "
+                    f"{op_symbol} %({val_key})s "
                     f"AND _peerdb_is_deleted = 0"
                     f")"
                 )

--- a/futureagi/tracer/services/clickhouse/query_builders/expressions.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/expressions.py
@@ -1,0 +1,23 @@
+"""Shared SQL expression helpers for ClickHouse query builders."""
+
+from typing import Optional
+
+
+def annotation_numeric_value_expr(alias: Optional[str] = None) -> str:
+    """Return the ClickHouse expression for a numeric annotation value.
+
+    Annotations may store the numeric value under either ``rating`` (star
+    ratings) or ``value`` (legacy/numeric). This helper returns the
+    ``if(JSONHas(...), ...)`` expression that picks whichever is present.
+
+    Args:
+        alias: Optional table alias. When provided, the column is
+            referenced as ``{alias}.value``; otherwise it's a bare
+            ``value`` reference.
+    """
+    prefix = f"{alias}." if alias else ""
+    return (
+        f"if(JSONHas({prefix}value, 'rating'), "
+        f"JSONExtractFloat({prefix}value, 'rating'), "
+        f"JSONExtractFloat({prefix}value, 'value'))"
+    )

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -891,7 +891,9 @@ class ClickHouseFilterBuilder:
                 self._params[p_hi] = filter_value[1]
                 return (
                     f"trace_id IN ({base_where} "
-                    f"AND JSONExtractFloat(value, 'value') BETWEEN %({p_lo})s AND %({p_hi})s)"
+                    f"AND if(JSONHas(value, 'rating'), "
+                    f"JSONExtractFloat(value, 'rating'), "
+                    f"JSONExtractFloat(value, 'value')) BETWEEN %({p_lo})s AND %({p_hi})s)"
                 )
             elif (
                 filter_op == "not_in_between"
@@ -904,13 +906,17 @@ class ClickHouseFilterBuilder:
                 self._params[p_hi] = filter_value[1]
                 return (
                     f"trace_id IN ({base_where} "
-                    f"AND JSONExtractFloat(value, 'value') NOT BETWEEN %({p_lo})s AND %({p_hi})s)"
+                    f"AND if(JSONHas(value, 'rating'), "
+                    f"JSONExtractFloat(value, 'rating'), "
+                    f"JSONExtractFloat(value, 'value')) NOT BETWEEN %({p_lo})s AND %({p_hi})s)"
                 )
             else:
                 self._params[param] = filter_value
                 return (
                     f"trace_id IN ({base_where} "
-                    f"AND JSONExtractFloat(value, 'value') {op} %({param})s)"
+                    f"AND if(JSONHas(value, 'rating'), "
+                    f"JSONExtractFloat(value, 'rating'), "
+                    f"JSONExtractFloat(value, 'value')) {op} %({param})s)"
                 )
 
         elif filter_type == "boolean":

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -4709,9 +4709,11 @@ class TestAnnotationGraphQueryBuilder:
         query, params = builder.build()
         assert isinstance(query, str)
         assert isinstance(params, dict)
-        # Post-revamp: annotations live in model_hub_score with a single
-        # JSON `value` column.  Float metric uses JSONExtractFloat.
+        # Post-revamp: numeric and star annotations live in model_hub_score
+        # and may store their value under either `value` or `rating`.
+        assert "JSONHas(value, 'rating')" in query
         assert "JSONExtractFloat(value, 'value')" in query
+        assert "JSONExtractFloat(value, 'rating')" in query
         assert "model_hub_score" in query
         assert "FINAL" in query
         assert "_peerdb_is_deleted = 0" in query
@@ -4783,7 +4785,8 @@ class TestAnnotationGraphQueryBuilder:
         )
         query, params = builder.build()
         assert "has(" in query
-        assert "JSONExtract" in query
+        assert "JSONExtract(value, 'selected', 'Array(String)')" in query
+        assert "JSONExtractString(value, 'selected')" not in query
         assert "choice_value" in params
         assert params["choice_value"] == "Good"
 
@@ -4800,7 +4803,7 @@ class TestAnnotationGraphQueryBuilder:
             value=None,
         )
         query, _ = builder.build()
-        assert "JSONExtractFloat(value, 'value')" in query
+        assert "JSONExtractFloat(value, 'rating')" in query
 
     def test_build_text_query(self):
         """Text output type should produce count() per time bucket."""
@@ -4831,7 +4834,7 @@ class TestAnnotationGraphQueryBuilder:
             output_type="unknown_type",
         )
         query, _ = builder.build()
-        assert "JSONExtractFloat(value, 'value')" in query
+        assert "JSONExtractFloat(value, 'rating')" in query
 
     def test_default_time_range(self):
         """When no dates provided, should default to 7-day range."""

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -458,6 +458,44 @@ class TestDashboardQueryBuilder:
         sql, _, _ = queries[0]
         assert "uniq(model)" in sql
 
+    def test_project_metric_count_uses_distinct_projects(self):
+        config = {
+            "project_ids": ["proj1", "proj2"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "project",
+                    "name": "project",
+                    "type": "system_metric",
+                    "aggregation": "count",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "uniq(project_id)" in sql
+
+    def test_latency_metric_uses_root_spans_only(self):
+        config = {
+            "project_ids": ["proj1"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "latency",
+                    "name": "latency",
+                    "type": "system_metric",
+                    "aggregation": "min",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "(parent_span_id IS NULL OR parent_span_id = '')" in sql
+
     def test_eval_metric_pass_rate_aggregation(self):
         config = {
             "project_ids": ["proj1"],
@@ -524,8 +562,31 @@ class TestDashboardQueryBuilder:
         builder = DashboardQueryBuilder(config)
         queries = builder.build_all_queries()
         sql, params, _ = queries[0]
-        assert "trace_annotation" in sql
-        assert "annotation_value_float" in sql
+        assert "model_hub_score" in sql
+        assert "JSONExtractFloat(a.value, 'value')" in sql
+        assert params["annotation_label_id"]
+
+    def test_annotation_star_metric_uses_rating_value(self):
+        config = {
+            "project_ids": ["proj1"],
+            "granularity": "day",
+            "time_range": {"preset": "30D"},
+            "metrics": [
+                {
+                    "id": "a_star",
+                    "name": "quality_star",
+                    "type": "annotation_metric",
+                    "label_id": str(uuid.uuid4()),
+                    "aggregation": "avg",
+                    "output_type": "star",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "model_hub_score" in sql
+        assert "JSONExtractFloat(a.value, 'rating')" in sql
 
     def test_custom_attribute_query(self):
         config = {
@@ -1405,7 +1466,7 @@ class TestFrontendPayloadSimulation:
         queries = builder.build_all_queries()
         assert len(queries) == 1
         sql, params, _ = queries[0]
-        assert "trace_annotation" in sql
+        assert "model_hub_score" in sql
         assert params["annotation_label_id"] == label_uuid
 
     # --- Custom attribute metrics ---


### PR DESCRIPTION
## Summary

This PR covers the widget value-type refresh, project breakdown timeout, average/null-bucket handling, project count semantics, latency root-span handling, decimal/unit formatting, and annotation query fixes. I kept the unrelated local edits out of the branch.

## Linked issues

TH-4588, TH-4589, TH-4598, TH-4600, TH-4601, TH-4602, TH-4609

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [x] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `yarn eslint src/sections/dashboards/WidgetChart.jsx src/sections/dashboards/WidgetEditorView.jsx`
- `set -a && source .env.test && set +a && .venv/bin/pytest tracer/tests/test_dashboard.py tracer/tests/test_clickhouse.py -q -k 'annotation or project_metric_count_uses_distinct_projects or latency_metric_uses_root_spans_only'`

## Screenshots / recordings (if UI)

Not captured.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
