### PR TITLE
[Bugfix] Fix experiment feedback, evals sorting, and dataset add flow

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerDrawer.jsx
@@ -35,6 +35,7 @@ const EvalPickerContent = ({ onStepChange }) => {
     onClose,
     skipConfig,
     isEditMode,
+    keepOpenAfterSave,
   } = useEvalPickerContext();
 
   const [isSaving, setIsSaving] = useState(false);
@@ -90,7 +91,11 @@ const EvalPickerContent = ({ onStepChange }) => {
         } else {
           setSelectedEval(null);
           setStep("list");
-          onClose?.();
+          // When the host wants the picker to stay open (e.g. dataset
+          // adds, where the user often queues several evals back-to-back),
+          // skip the close so the user lands back on the list step
+          // without re-opening the drawer.
+          if (!keepOpenAfterSave) onClose?.();
         }
       } catch {
         // Keep on config screen if save fails
@@ -98,7 +103,14 @@ const EvalPickerContent = ({ onStepChange }) => {
         setIsSaving(false);
       }
     },
-    [isEditMode, onEvalAdded, onClose, setSelectedEval, setStep],
+    [
+      isEditMode,
+      onEvalAdded,
+      onClose,
+      setSelectedEval,
+      setStep,
+      keepOpenAfterSave,
+    ],
   );
 
   return (
@@ -264,6 +276,10 @@ const EvalPickerDrawer = ({
   // When set, at least one mapping field must reference this column ID.
   // Used in the optimization context to ensure the optimized column is scored.
   requiredColumnId = "",
+  // When true, the drawer stays open after a successful save so the user
+  // can queue more evals back-to-back. Used by dataset adds where the
+  // picker doubles as a multi-eval entry surface.
+  keepOpenAfterSave = false,
 }) => {
   const [currentStep, setCurrentStep] = useState("list");
 
@@ -313,6 +329,7 @@ const EvalPickerDrawer = ({
         skipConfig={skipConfig}
         lockedFilters={lockedFilters}
         requiredColumnId={requiredColumnId}
+        keepOpenAfterSave={keepOpenAfterSave}
       >
         <EvalPickerContent onStepChange={setCurrentStep} />
       </EvalPickerProvider>
@@ -337,6 +354,7 @@ EvalPickerDrawer.propTypes = {
   lockedFilters: PropTypes.object,
   sourcePreviewData: PropTypes.object,
   requiredColumnId: PropTypes.string,
+  keepOpenAfterSave: PropTypes.bool,
 };
 
 export default EvalPickerDrawer;

--- a/frontend/src/sections/common/EvalPicker/context/EvalPickerProvider.jsx
+++ b/frontend/src/sections/common/EvalPicker/context/EvalPickerProvider.jsx
@@ -32,6 +32,10 @@ const EvalPickerProvider = ({
   // When set, at least one mapping field must reference this column ID.
   // Used in the optimization context to ensure the optimized column is scored.
   requiredColumnId = "",
+  // When true, a successful save returns to the list step but does NOT
+  // close the drawer — used by dataset adds where the picker is also a
+  // multi-eval entry surface.
+  keepOpenAfterSave = false,
 }) => {
   const [step, setStep] = useState(initialEval ? "config" : "list");
   const [selectedEval, setSelectedEvalState] = useState(
@@ -85,6 +89,7 @@ const EvalPickerProvider = ({
         lockedFilters,
         isEditMode,
         requiredColumnId,
+        keepOpenAfterSave,
       }}
     >
       {children}
@@ -107,6 +112,7 @@ EvalPickerProvider.propTypes = {
   lockedFilters: PropTypes.object,
   sourcePreviewData: PropTypes.object,
   requiredColumnId: PropTypes.string,
+  keepOpenAfterSave: PropTypes.bool,
 };
 
 export default EvalPickerProvider;

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -543,6 +543,9 @@ const EvaluationDrawerChild = ({
           setEvalPickerOpen(false);
           setEditingEval(null);
         }}
+        // Dataset adds save-only — keep the picker open so the user can
+        // queue more evals back-to-back without re-opening the drawer.
+        keepOpenAfterSave={(module || "dataset") === "dataset"}
         initialEval={editingEval}
         source={module || "dataset"}
         sourceId={id || ""}
@@ -648,7 +651,10 @@ const EvaluationDrawerChild = ({
               model: isComposite ? undefined : evalConfig.model,
               // In the optimization context the optimizer runs evals itself —
               // skip the full-dataset run so adding an eval is near-instant.
-              run: module !== "run-optimization",
+              // Dataset adds are also save-only now: the user runs evals
+              // manually from the dataset grid rather than auto-running on
+              // add, which would otherwise queue work the user didn't ask for.
+              run: module !== "run-optimization" && module !== "dataset",
               // Mirror the workbench path: surface error_localizer at the top
               // level so EditAndRunUserEvalView can update eval_metric.error_localizer.
               error_localizer: runConfig.error_localizer_enabled ?? false,

--- a/frontend/src/sections/evals/components/EvalsListView.jsx
+++ b/frontend/src/sections/evals/components/EvalsListView.jsx
@@ -261,10 +261,11 @@ const mergeColumnOrder = (stored) => {
 };
 
 // Sort field map — frontend column id → backend sort key
+
 const SORT_FIELD_MAP = {
   name: "name",
   lastUpdated: "updated_at",
-  created_by_name: "created_at",
+  createdByName: "created_at",
 };
 
 // ── Component ──
@@ -504,6 +505,7 @@ const EvalsListView = () => {
         accessorKey: "created_by_name",
         header: "Created By",
         size: 150,
+        enableSorting: true,
         cell: ({ getValue }) => {
           const name = getValue() || "Unknown";
           const isSystem = name === "System";

--- a/frontend/src/sections/experiment-detail/ExperimentData/CustomExperimentColumnHeader.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/CustomExperimentColumnHeader.jsx
@@ -6,6 +6,8 @@ import { ShowComponent } from "src/components/show/ShowComponent";
 import SvgColor from "src/components/svg-color";
 import { getUniqueColorPalette } from "src/utils/utils";
 import { useRerunColumnInExperimentStoreShallow } from "./states";
+import { EXPERIMENT_COLUMN_STATUS } from "./constants";
+
 const iconStyle = {
   color: "text.secondary",
 };
@@ -152,7 +154,11 @@ export const CustomExperimentColumnHeader = (props) => {
           onClick={() => {
             setSelectedSourceId(col?.sourceId);
           }}
-          disabled={col?.status === "Running"}
+          disabled={[
+            EXPERIMENT_COLUMN_STATUS.RUNNING,
+            EXPERIMENT_COLUMN_STATUS.NOT_STARTED,
+            EXPERIMENT_COLUMN_STATUS.QUEUED,
+          ].includes(col?.status)}
           sx={{
             display: "none",
             ":hover ": {

--- a/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDetailDrawerContent.jsx
@@ -31,6 +31,8 @@ import NumericCell from "src/sections/common/DevelopCellRenderer/EvaluateCellRen
 import { OutputTypes } from "src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper";
 import ImageDatapointCard from "src/sections/common/ImageDatapointCard";
 import AgentFlowRenderer from "./AgentFlowRenderer";
+import { useAddEvaluationFeebackStore } from "src/sections/develop-detail/states";
+import AddEvaluationFeeback from "src/sections/develop-detail/DataTab/AddEvaluationFeeback/AddEvaluationFeeback";
 
 // Skeleton loader for loading states
 const SkeletonLoader = () => (
@@ -159,6 +161,7 @@ export default function ExperimentDetailDrawerContent({
   const theme = useTheme();
   const agTheme = useAgThemeWith(EXPERIMENT_DRAWER_THEME_PARAMS);
   const resizableRowRef = useRef(null);
+  const { setAddEvaluationFeeback } = useAddEvaluationFeebackStore();
 
   // Column grouping logic - separates individual columns from dataset columns
   const { individualCols: _individualCols, datasetCols } = useMemo(() => {
@@ -1040,8 +1043,20 @@ export default function ExperimentDetailDrawerContent({
           refreshGrid={refreshGrid}
           handleRefetchRowData={handleRefetchRowData}
           isRefetching={isPending}
+          onAddFeedbackClick={(evalData) => {
+            if (!evalData?.group?.id || !evalData?.id) return;
+            setAddEvaluationFeeback({
+              ...evalData,
+              userEvalMetricId: evalData?.group?.id,
+              sourceId: evalData?.id,
+              rowData: { rowId: row?.rowId },
+            });
+            setOpenDetailRow(null);
+          }}
         />
       )}
+
+      <AddEvaluationFeeback module="experiment" onRefreshGrid={refreshGrid} />
     </>
   );
 }

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1020,6 +1020,16 @@ export const endpoints = {
         `/model-hub/experiments/v2/${expId}/json-schema/`,
       getExperimentDerivedVariables: (expId) =>
         `/model-hub/experiments/v2/${expId}/derived-variables/`,
+      feedback: {
+        getTemplate: ( experimentId) =>
+          `/model-hub/experiments/v2/${experimentId}/feedback/get-template/`,
+        create: ( experimentId) =>
+          `/model-hub/experiments/v2/${experimentId}/feedback/`,
+        getDetails: ( experimentId) =>
+          `/model-hub/experiments/v2/${experimentId}/feedback/get-feedback-details/`,
+        submit: ( experimentId) =>
+          `/model-hub/experiments/v2/${experimentId}/feedback/submit-feedback/`,
+      },
     },
     apiKey: {
       create: "/model-hub/api-keys/",


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

Fixes three independent regressions in the evals/experiments UI:

1. Feedback flow in experiments: the experiment row drawer's "Add Feedback" button had no rendered drawer, and endpoints.develop.experiment.feedback.* was undefined in axios. Wired the endpoint group into axios.js and mounted <AddEvaluationFeeback module="experiment" /> from ExperimentDetailDrawerContent.
2. "Created By" sorting in evals list: SORT_FIELD_MAP keyed the column as created_by_name while the TanStack column id is createdByName, so clicks silently fell back to updated_at. Renamed the map key.
3. Dataset add-eval flow: adding an eval auto-ran and closed the drawer (taking the user back to the dataset grid). Switched the dataset path to send run: false and added a keepOpenAfterSave prop on EvalPickerDrawer so the picker returns to the list step instead of closing — users can queue more evals back-to-back and run them manually from the grid.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [A] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
