### PR TITLE
feat: support nested JSON path access (col.key) in eval and run promp…

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -237,32 +237,32 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       getEvalRequiredKeys(normalizedEvalData) ||
       [];
 
-    // When required_keys exist, use them as the authoritative variable list.
-    // This is critical for Jinja2 evals where extractJinjaVariables() only
-    // returns root names (e.g. "file") instead of the full expressions the
-    // backend expects (e.g. "file.code", "language | lower").
-    if (requiredKeys.length > 0) {
-      return [...new Set(requiredKeys)];
-    }
-
     if (evalType === "code") {
       return [];
     }
-    let templateVars;
-    if (templateFormat === "jinja") {
-      templateVars = extractJinjaVariables(instructions || "");
-    } else {
-      const matches =
-        (instructions || "").match(/\{\{\s*([^{}]+?)\s*\}\}/g) || [];
-      templateVars = matches.map((m) => m.replace(/\{\{|\}\}/g, "").trim());
+
+    // System evals + Jinja mode: use static required_keys.
+    // Jinja's extractJinjaVariables() only returns root names (e.g. "file")
+    // not full paths (e.g. "file.code"), so requiredKeys is authoritative.
+    if ((isSystemEval || templateFormat === "jinja") && requiredKeys.length > 0) {
+      return [...new Set(requiredKeys)];
     }
-    return [...new Set(templateVars)];
+
+    // User evals (mustache): prefer live extraction so mapping updates as user types.
+    const matches =
+      (instructions || "").match(/\{\{\s*([^{}]+?)\s*\}\}/g) || [];
+    const templateVars = matches.map((m) => m.replace(/\{\{|\}\}/g, "").trim());
+    if (templateVars.length > 0) return [...new Set(templateVars)];
+    // Fallback: stored required_keys (before instructions hydrate)
+    if (requiredKeys.length > 0) return [...new Set(requiredKeys)];
+    return [];
   }, [
     instructions,
     normalizedFullEval,
     normalizedEvalData,
     evalType,
     isComposite,
+    isSystemEval,
     compositeDetail,
     templateFormat,
   ]);
@@ -1202,6 +1202,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   onTemplateFormatChange={setTemplateFormat}
                   datasetColumns={datasetColumns}
                   datasetJsonSchemas={datasetJsonSchemas}
+                  mappedVariables={sourceMapping}
                   disabled={isInstructionsReadOnly}
                   modelSelectorDisabled={false}
                   mode={agentMode}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -777,6 +777,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     onTemplateFormatChange={setTemplateFormat}
                     datasetColumns={datasetColumns}
                     datasetJsonSchemas={datasetJsonSchemas}
+                    mappedVariables={sourceMapping}
                   />
                   {errors.instructions && (
                     <Typography variant="caption" color="error.main">

--- a/frontend/src/sections/develop-detail/Common/FieldSelection.jsx
+++ b/frontend/src/sections/develop-detail/Common/FieldSelection.jsx
@@ -33,9 +33,9 @@ const FieldSelection = ({
     // Note: dataType can be in col.dataType or col.col.dataType depending on context
     allColumns.forEach((col) => {
       const dataType = col?.dataType || col?.col?.dataType;
-      if (dataType === "json" && jsonSchemas?.[col?.field]) {
+      if (jsonSchemas?.[col?.field]?.keys?.length) {
         const schema = jsonSchemas[col?.field];
-        schema?.keys?.forEach((path) => {
+        schema.keys.forEach((path) => {
           baseOptions.push({
             label: `${col.headerName}.${path}`,
             value: `${col.field}.${path}`,

--- a/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
@@ -865,6 +865,7 @@ export const RunPromptForm = React.forwardRef(
                   updatedText,
                   matches,
                   allColumns,
+                  jsonSchemas,
                 );
                 updatedText = result.text;
                 inValidVariables.push(...result.invalidVariables);
@@ -987,6 +988,7 @@ export const RunPromptForm = React.forwardRef(
                   updatedText,
                   matches,
                   allColumns,
+                  jsonSchemas,
                 );
                 updatedText = result.text;
                 inValidVariables.push(...result.invalidVariables);

--- a/frontend/src/sections/develop-detail/RunPrompt/common.js
+++ b/frontend/src/sections/develop-detail/RunPrompt/common.js
@@ -255,10 +255,10 @@ export const extractVariableFromAllCols = (
         res[col.headerName] = ["1"];
       }
 
-      // For JSON columns, also add JSON paths from schema
-      if (col?.dataType === "json" && jsonSchemas?.[col?.field]) {
+      // Add JSON paths from schema (covers json columns + text columns with JSON values)
+      if (jsonSchemas?.[col?.field]?.keys?.length) {
         const schema = jsonSchemas[col?.field];
-        schema?.keys?.forEach((path) => {
+        schema.keys.forEach((path) => {
           const fullPath = `${col.headerName}.${path}`;
           if (!res[fullPath]) {
             res[fullPath] = ["1"];
@@ -322,10 +322,10 @@ export const getDropdownOptionsFromCols = (
       isJsonPath: false,
     });
 
-    // If this is a JSON column with schema, add nested paths
-    if (col?.dataType === "json" && jsonSchemas?.[col?.field]) {
+    // Add nested paths from schema (covers json columns + text columns with JSON values)
+    if (jsonSchemas?.[col?.field]?.keys?.length) {
       const schema = jsonSchemas[col?.field];
-      schema?.keys?.forEach((path) => {
+      schema.keys.forEach((path) => {
         options.push({
           id: `${col?.field}.${path}`,
           value: `${col?.headerName}.${path}`,
@@ -441,9 +441,8 @@ export function findInvalidVariables(
         (col) => normalize(col?.headerName) === normalize(baseColumn),
       );
 
-      if (column?.dataType === "json") {
-        // JSON column found - allow any path (will resolve at runtime)
-        // Schema validation is optional - if path doesn't exist, backend returns empty string
+      if (column && (column.dataType === "json" || jsonSchemas?.[column.field]?.keys?.length)) {
+        // Column has nested paths (json type or text with JSON values) — allow any path
         return;
       }
 
@@ -606,7 +605,7 @@ export const DUMMY_MODEL_PARAMS = [
  * @param {Array} allColumns - All columns in the dataset
  * @returns {Object} { text: string, invalidVariables: string[] }
  */
-export const replaceVariablesWithFields = (text, matches, allColumns) => {
+export const replaceVariablesWithFields = (text, matches, allColumns, jsonSchemas = {}) => {
   let updatedText = text;
   const invalidVariables = [];
 
@@ -637,7 +636,7 @@ export const replaceVariablesWithFields = (text, matches, allColumns) => {
           normalizeForComparison(baseColumn).toLowerCase(),
       );
 
-      if (jsonColumn?.dataType === "json") {
+      if (jsonColumn && (jsonColumn.dataType === "json" || jsonSchemas?.[jsonColumn.field]?.keys?.length)) {
         const replacePattern = new RegExp(
           `{{\\s*${rawVar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*}}`,
           "g",

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -247,6 +247,48 @@ function JsonEntryRow({ entryKey, entryValue, isObject, depth }) {
   );
 }
 
+// Walk a JSON value and extract dot-notation keys (max 3 levels deep).
+function extractKeysFromValue(raw) {
+  let parsed = null;
+  if (raw && typeof raw === "object") parsed = raw;
+  else if (typeof raw === "string" && raw.trim()) {
+    try { const p = JSON.parse(raw); if (p && typeof p === "object") parsed = p; } catch { /* not JSON */ }
+  }
+  if (!parsed) return [];
+  const keys = [];
+  const walk = (obj, prefix, depth) => {
+    if (depth > 3 || !obj || typeof obj !== "object") return;
+    if (Array.isArray(obj)) {
+      if (obj.length) { keys.push(`${prefix}[0]`); walk(obj[0], `${prefix}[0]`, depth + 1); }
+      return;
+    }
+    for (const k of Object.keys(obj)) {
+      const path = prefix ? `${prefix}.${k}` : k;
+      keys.push(path);
+      if (obj[k] && typeof obj[k] === "object") walk(obj[k], path, depth + 1);
+    }
+  };
+  walk(parsed, "", 0);
+  return keys;
+}
+
+// Resolve a dot/bracket path inside a parsed JSON value.
+function resolveNestedValue(raw, jsonPath) {
+  let parsed = null;
+  if (raw && typeof raw === "object") parsed = raw;
+  else if (typeof raw === "string") {
+    try { parsed = JSON.parse(raw); } catch { return raw; }
+  }
+  if (!parsed) return raw;
+  const parts = jsonPath.split(/[.\[\]]/).filter(Boolean);
+  let cur = parsed;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = /^\d+$/.test(p) ? (Array.isArray(cur) ? cur[parseInt(p, 10)] : undefined) : (typeof cur === "object" ? cur[p] : undefined);
+  }
+  return cur;
+}
+
 const DatasetTestMode = React.forwardRef(
   (
     {
@@ -292,6 +334,7 @@ const DatasetTestMode = React.forwardRef(
 
     // Dataset data
     const [columns, setColumns] = useState([]);
+    const [jsonSchemas, setJsonSchemas] = useState({});
     const [rows, setRows] = useState([]);
     const [totalRows, setTotalRows] = useState(0);
     const [currentRowIndex, setCurrentRowIndex] = useState(0);
@@ -423,6 +466,7 @@ const DatasetTestMode = React.forwardRef(
           const jsonSchemas = schemaRes.data?.result || {};
 
           setColumns(cols);
+          setJsonSchemas(jsonSchemas);
           setRows(tableRows);
           setTotalRows(total);
           setCurrentRowIndex(0);
@@ -511,37 +555,47 @@ const DatasetTestMode = React.forwardRef(
       return m;
     }, [extraColumns]);
 
-    // Column names for variable mapping dropdown
-    // When sourceColumns is provided (e.g. workbench mode), use those instead
-    // of dataset columns. sourceColumns may be objects with headerName/field or strings.
-    const columnNames = useMemo(() => {
+    // Build expanded column names (with JSON sub-paths) and name→ID
+    // lookup in one pass. Discovers nested keys from both the backend
+    // JSON schema AND runtime cell-value inspection of the current row.
+    const { columnNames, nameToId } = useMemo(() => {
       if (isWorkbenchMode) {
-        return sourceColumns.map((col) =>
+        const names = sourceColumns.map((col) =>
           typeof col === "string"
             ? col
             : col.headerName || col.field || col.name || col.label || "",
         );
+        return { columnNames: names, nameToId: {} };
       }
-      const base = columns
-        .filter((c) => c.id && c.name && !["id", "orgId"].includes(c.name))
-        .map((c) => c.name);
-      if (!extraColumns?.length) return base;
-      // Virtual columns ("Output", "Prompt Chain" for experiments) render
-      // first so they're prominent in the dropdown AND win auto-mapping
-      // ties — auto-map iterates columnNames in order and takes the first
-      // match, so real dataset columns that happen to collide with eval
-      // variable names shouldn't shadow the experiment virtuals.
+      const names = [];
+      const n2id = {};
+      const seen = new Set();
+      const add = (display, id) => {
+        if (seen.has(display)) return;
+        seen.add(display);
+        names.push(display);
+        if (id) n2id[display] = id;
+      };
+      columns.forEach((c) => {
+        if (!c.id || !c.name || ["id", "orgId"].includes(c.name)) return;
+        add(c.name, c.id);
+        // Collect sub-paths from backend schema + runtime cell values
+        const schemaPaths = jsonSchemas?.[c.id]?.keys || [];
+        const cell = currentRow?.[c.id];
+        const runtimePaths = cell ? extractKeysFromValue(cell?.cell_value ?? cell) : [];
+        const allPaths = new Set([...schemaPaths, ...runtimePaths]);
+        allPaths.forEach((path) => add(`${c.name}.${path}`, `${c.id}.${path}`));
+      });
+      if (!extraColumns?.length) return { columnNames: names, nameToId: n2id };
       const extras = (extraColumns || [])
-        .map((col) =>
-          typeof col === "string"
-            ? col
-            : col.headerName || col.field || col.name || col.label || "",
-        )
+        .map((col) => (typeof col === "string" ? col : col.headerName || col.field || col.name || col.label || ""))
         .filter(Boolean);
       const extraSet = new Set(extras);
-      const baseWithoutExtras = base.filter((n) => !extraSet.has(n));
-      return [...extras, ...baseWithoutExtras];
-    }, [columns, sourceColumns, extraColumns, isWorkbenchMode]);
+      return {
+        columnNames: [...extras, ...names.filter((n) => !extraSet.has(n))],
+        nameToId: n2id,
+      };
+    }, [columns, sourceColumns, extraColumns, isWorkbenchMode, jsonSchemas, currentRow]);
 
     // Workbench mode: map display name → field identifier (e.g. "model_output" → "output_prompt")
     const sourceNameToField = useMemo(() => {
@@ -557,17 +611,19 @@ const DatasetTestMode = React.forwardRef(
       return m;
     }, [sourceColumns, isWorkbenchMode]);
 
-    // Resolve UUID-based mapping values to column names (edit mode).
-    // The saved mapping uses column UUIDs but the dropdown shows names.
-    // Experiment virtual columns are also saved by field ("output",
-    // "prompt_chain"); resolve those to their display names too.
+    // Resolve UUID-based mapping values to display names (edit mode).
+    // Handles both plain UUIDs and "uuid.path" nested references.
     const uuidResolutionDone = React.useRef(false);
     useEffect(() => {
       if (!columns.length && !Object.keys(extraFieldToName).length) return;
       if (uuidResolutionDone.current) return;
       const idToName = {};
       columns.forEach((c) => {
-        if (c.id && c.name) idToName[c.id] = c.name;
+        if (!c.id || !c.name) return;
+        idToName[c.id] = c.name;
+        // Reverse-map nested IDs: "uuid.path" → "col.path"
+        const paths = jsonSchemas?.[c.id]?.keys || [];
+        paths.forEach((p) => { idToName[`${c.id}.${p}`] = `${c.name}.${p}`; });
       });
       setMapping((prev) => {
         const next = { ...prev };
@@ -575,18 +631,27 @@ const DatasetTestMode = React.forwardRef(
         Object.keys(next).forEach((variable) => {
           const val = next[variable];
           if (!val) return;
-          if (idToName[val]) {
-            next[variable] = idToName[val];
-            changed = true;
-          } else if (extraFieldToName[val]) {
-            next[variable] = extraFieldToName[val];
-            changed = true;
-          }
+          if (idToName[val]) { next[variable] = idToName[val]; changed = true; }
+          else if (extraFieldToName[val]) { next[variable] = extraFieldToName[val]; changed = true; }
         });
         if (changed) uuidResolutionDone.current = true;
         return changed ? next : prev;
       });
-    }, [columns, extraFieldToName]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [columns, extraFieldToName, jsonSchemas]);
+
+    // Prune stale mapping keys when variables list changes (instruction edits).
+    useEffect(() => {
+      if (!variables.length) return;
+      const varSet = new Set(variables);
+      setMapping((prev) => {
+        const pruned = {};
+        let changed = false;
+        Object.keys(prev).forEach((k) => {
+          if (varSet.has(k)) pruned[k] = prev[k]; else changed = true;
+        });
+        return changed ? pruned : prev;
+      });
+    }, [variables]);
 
     // Auto-map variables to columns when names match (case-insensitive)
     useEffect(() => {
@@ -665,23 +730,35 @@ const DatasetTestMode = React.forwardRef(
             }
           }
         } else {
-          // Dataset mode: mapping sends variable → actual cell values
-          // Map template variables to dataset columns
+          // Dataset mode: mapping sends variable → actual cell values.
+          // Supports nested paths (e.g. "col.key" → resolve from cell JSON).
           for (const variable of variables) {
             const mappedColName = mapping[variable];
             if (mappedColName && currentRow) {
-              const col = columns.find((c) => c.name === mappedColName);
+              let baseName = mappedColName;
+              let jsonPath = null;
+              const dot = mappedColName.indexOf(".");
+              const bracket = mappedColName.indexOf("[");
+              if (dot > 0 && (bracket < 0 || dot < bracket)) {
+                baseName = mappedColName.substring(0, dot);
+                jsonPath = mappedColName.substring(dot + 1);
+              } else if (bracket > 0) {
+                baseName = mappedColName.substring(0, bracket);
+                jsonPath = mappedColName.substring(bracket);
+              }
+              const col = columns.find((c) => c.name === baseName);
               if (col) {
                 const cell = currentRow[col.id];
-                evalMapping[variable] = cell?.cell_value ?? cell ?? "";
-                const dt = col.data_type || "text";
-                if (["image", "images"].includes(dt)) {
-                  inputDataTypes[variable] = "image";
-                } else if (dt === "audio") {
-                  inputDataTypes[variable] = "audio";
-                } else {
-                  inputDataTypes[variable] = "text";
+                let cellValue = cell?.cell_value ?? cell ?? "";
+                if (jsonPath) {
+                  const resolved = resolveNestedValue(cellValue, jsonPath);
+                  if (resolved !== undefined && resolved !== null) {
+                    cellValue = typeof resolved === "object" ? JSON.stringify(resolved) : String(resolved);
+                  }
                 }
+                evalMapping[variable] = cellValue;
+                const dt = col.data_type || "text";
+                inputDataTypes[variable] = ["image", "images"].includes(dt) ? "image" : dt === "audio" ? "audio" : "text";
               }
             }
           }
@@ -787,17 +864,9 @@ const DatasetTestMode = React.forwardRef(
       hasNonTemplateContext ||
       variables.every((v) => mapping[v]);
 
-    // Build a name→ID lookup so the save payload uses column UUIDs (which the
-    // backend's eval_runner expects) while the test playground uses names.
-    const nameToId = useMemo(() => {
-      const map = {};
-      columns.forEach((c) => {
-        if (c.id && c.name) map[c.name] = c.id;
-      });
-      return map;
-    }, [columns]);
-
-    // Mapping with column IDs for the save payload
+    // Mapping with column IDs for the save payload.
+    // nameToId (from columnMaps memo above) already handles nested paths.
+    // For freeSolo typed paths not in the map, resolve base column → uuid.
     const idMapping = useMemo(() => {
       const m = {};
       if (isWorkbenchMode) {
@@ -806,20 +875,22 @@ const DatasetTestMode = React.forwardRef(
         });
       } else {
         Object.entries(mapping).forEach(([variable, colName]) => {
-          // Extras resolve to their own field (e.g. "Output" → "output") and
-          // bypass the dataset UUID lookup since they don't exist in columns.
-          m[variable] =
-            extraNameToField[colName] || nameToId[colName] || colName;
+          if (extraNameToField[colName]) { m[variable] = extraNameToField[colName]; return; }
+          if (nameToId[colName]) { m[variable] = nameToId[colName]; return; }
+          // freeSolo: "col.typed_path" → "uuid.typed_path"
+          const dot = colName.indexOf(".");
+          const bracket = colName.indexOf("[");
+          const split = dot > 0 && (bracket < 0 || dot < bracket) ? dot : bracket > 0 ? bracket : -1;
+          if (split > 0) {
+            const base = colName.substring(0, split);
+            const baseId = nameToId[base];
+            if (baseId) { m[variable] = `${baseId}${colName.substring(split)}`; return; }
+          }
+          m[variable] = colName;
         });
       }
       return m;
-    }, [
-      mapping,
-      nameToId,
-      isWorkbenchMode,
-      sourceNameToField,
-      extraNameToField,
-    ]);
+    }, [mapping, nameToId, isWorkbenchMode, sourceNameToField, extraNameToField]);
     const isReady = (!!selectedDatasetId || isWorkbenchMode) && allMapped;
 
     useEffect(() => {
@@ -1264,6 +1335,7 @@ const DatasetTestMode = React.forwardRef(
                   />
                   <Autocomplete
                     size="small"
+                    freeSolo
                     options={
                       mapping[variable] &&
                       !columnNames.includes(mapping[variable])
@@ -1277,6 +1349,20 @@ const DatasetTestMode = React.forwardRef(
                         [variable]: val || "",
                       }))
                     }
+                    onBlur={(e) => {
+                      const val = e.target.value?.trim();
+                      if (val) setMapping((prev) => ({ ...prev, [variable]: val }));
+                    }}
+                    filterOptions={(opts, { inputValue }) => {
+                      const q = inputValue.toLowerCase();
+                      if (!q) return opts.filter((o) => !o.includes(".") && !o.includes("["));
+                      const showNested = q.includes(".") || q.includes("[");
+                      return opts.filter((o) => {
+                        const lower = o.toLowerCase();
+                        if (!showNested && (lower.includes(".") || lower.includes("["))) return false;
+                        return lower.startsWith(q);
+                      });
+                    }}
                     openOnFocus
                     autoHighlight
                     selectOnFocus
@@ -1308,6 +1394,7 @@ const DatasetTestMode = React.forwardRef(
                     )}
                     renderOption={(props, col) => {
                       const { key, ...rest } = props;
+                      const isNested = col.includes(".") || col.includes("[");
                       return (
                         <Box
                           component="li"
@@ -1317,6 +1404,7 @@ const DatasetTestMode = React.forwardRef(
                             ...rest.sx,
                             fontSize: "12px",
                             fontFamily: "monospace",
+                            ...(isNested && { pl: 3, color: "text.secondary" }),
                           }}
                         >
                           {col}

--- a/frontend/src/sections/evals/components/InstructionEditor.jsx
+++ b/frontend/src/sections/evals/components/InstructionEditor.jsx
@@ -56,10 +56,10 @@ function buildDropdownOptions(datasetColumns, jsonSchemas = {}) {
       isJsonPath: false,
     });
 
-    // Expand JSON columns with nested paths from schema
-    if (col.data_type === "json" && jsonSchemas?.[colId]) {
+    // Expand columns with nested paths from schema (json + text with JSON values)
+    if (jsonSchemas?.[colId]?.keys?.length) {
       const schema = jsonSchemas[colId];
-      schema?.keys?.forEach((path) => {
+      schema.keys.forEach((path) => {
         options.push({
           id: `${colId}.${path}`,
           value: `${col.name}.${path}`,
@@ -101,9 +101,9 @@ function buildValidVariableSet(datasetColumns, jsonSchemas = {}) {
     const colId = col.id || col.name;
     validSet.add(col.name.toLowerCase());
 
-    // Add JSON paths
-    if (col.data_type === "json" && jsonSchemas?.[colId]) {
-      jsonSchemas[colId]?.keys?.forEach((path) => {
+    // Add nested paths from schema (json + text with JSON values)
+    if (jsonSchemas?.[colId]?.keys?.length) {
+      jsonSchemas[colId].keys.forEach((path) => {
         validSet.add(`${col.name}.${path}`.toLowerCase());
       });
     }
@@ -245,6 +245,7 @@ const InstructionEditor = ({
   onTemplateFormatChange,
   datasetColumns = [],
   datasetJsonSchemas = {},
+  mappedVariables = {},
   // Pass-through ModelSelector lifted-state props — forwarded as-is so the
   // parent form can collect mode / internet / summary / connectors / KBs.
   mode,
@@ -307,16 +308,17 @@ const InstructionEditor = ({
     [datasetColumns, datasetJsonSchemas],
   );
 
-  // JSON column names (lowercase) — any path starting with these is valid
+  // Column names that have nested paths (lowercase) — any path starting with these is valid
   const jsonColumnNames = useMemo(() => {
     const s = new Set();
     datasetColumns.forEach((col) => {
-      if (col?.dataType === "json" && col?.name) {
+      const colId = col?.id || col?.name;
+      if (col?.name && datasetJsonSchemas?.[colId]?.keys?.length) {
         s.add(col.name.toLowerCase());
       }
     });
     return s;
-  }, [datasetColumns]);
+  }, [datasetColumns, datasetJsonSchemas]);
 
   // Jinja-aware input variable set: only top-level inputs (not loop/set vars)
   const jinjaInputVarSet = useMemo(() => {
@@ -325,7 +327,16 @@ const InstructionEditor = ({
     return new Set(vars.map((v) => v.toLowerCase()));
   }, [templateFormat, value]);
 
-  // Variable validator: checks if a variable name is a valid column, JSON path, or Jinja keyword
+  // Set of variable names that have been mapped to a column
+  const mappedVarSet = useMemo(() => {
+    const s = new Set();
+    Object.entries(mappedVariables || {}).forEach(([k, v]) => {
+      if (v) s.add(k.trim().toLowerCase());
+    });
+    return s;
+  }, [mappedVariables]);
+
+  // Variable validator: checks column match, mapped status, JSON path, or Jinja keyword
   const variableValidator = useCallback(
     (varName) => {
       const trimmed = varName.trim();
@@ -338,6 +349,9 @@ const InstructionEditor = ({
         const root = trimmed.split(/[.(\s|]/)[0].toLowerCase();
         if (!jinjaInputVarSet.has(root)) return null;
       }
+
+      // Variables mapped in the mapping panel are valid (green)
+      if (mappedVarSet.has(trimmed.toLowerCase())) return true;
 
       if (!hasDataset) return true; // No dataset → remaining vars are valid
 
@@ -361,6 +375,7 @@ const InstructionEditor = ({
       jsonColumnNames,
       templateFormat,
       jinjaInputVarSet,
+      mappedVarSet,
     ],
   );
 

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -14748,12 +14748,13 @@ def get_json_column_schemas(dataset):
     """
     from model_hub.utils.json_path_resolver import (
         extract_json_schema_for_column,
+        parse_json_safely,
     )
 
-    # Get JSON-type columns
+    # Get JSON-type columns + text columns that may contain JSON values
     json_columns = Column.objects.filter(
         dataset=dataset,
-        data_type="json",
+        data_type__in=["json", "text"],
         deleted=False,
     )
 
@@ -14772,16 +14773,25 @@ def get_json_column_schemas(dataset):
                 "sample": json_schema.get("sample"),
             }
         else:
-            # Extract schema from all cells (up to 500 for performance)
-            sample_cells = (
-                Cell.objects.filter(
-                    column=column,
-                    deleted=False,
-                )
+            # Extract schema from cells. For text columns, check a small
+            # sample first to avoid wasting time on non-JSON content.
+            base_qs = (
+                Cell.objects.filter(column=column, deleted=False)
                 .exclude(value__isnull=True)
                 .exclude(value="")
-                .values_list("value", flat=True)[:500]
             )
+
+            if column.data_type == "text":
+                # Quick check: peek at first 3 non-empty cells
+                peek = list(base_qs.values_list("value", flat=True)[:3])
+                has_json = any(
+                    parse_json_safely(v)[1] for v in peek
+                )
+                if not has_json:
+                    continue
+                sample_cells = list(base_qs.values_list("value", flat=True)[:500])
+            else:
+                sample_cells = list(base_qs.values_list("value", flat=True)[:500])
 
             if sample_cells:
                 schema = extract_json_schema_for_column(list(sample_cells))

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -311,6 +311,16 @@ def render_template(
         )
 
 
+class JsonStr(dict):
+    """Dict subclass that renders as its original JSON string via str()/Jinja.
+    Allows {{col.key}} via dict attribute access while {{col}} outputs the raw JSON."""
+    def __init__(self, data, raw):
+        super().__init__(data)
+        self._raw = raw
+    def __str__(self):
+        return self._raw
+
+
 def populate_placeholders(messages: list[dict], dataset_id, row_id, col_id, model_name):
     try:
         media_error = None
@@ -353,15 +363,17 @@ def populate_placeholders(messages: list[dict], dataset_id, row_id, col_id, mode
                     parts = column.name.split(".")
                     current = context
 
-                    # Determine the value to store - parse JSON columns for dot notation access
+                    # Determine the value to store - parse JSON for dot notation access.
+                    # For any column with a JSON string value, parse it into a
+                    # JsonStr dict so {{col.key}} works via Jinja attribute access
+                    # while {{col}} still renders as the original JSON string.
                     cell_value = cell.value if cell.value is not None else ""
-                    if column.data_type == "json" and cell_value:
+                    if cell_value and isinstance(cell_value, str):
                         from model_hub.utils.json_path_resolver import parse_json_safely
 
                         parsed_json, is_valid = parse_json_safely(cell_value)
-                        if is_valid:
-                            # Use parsed dict to enable {{column.property}} access
-                            cell_value = parsed_json
+                        if is_valid and isinstance(parsed_json, dict):
+                            cell_value = JsonStr(parsed_json, cell_value)
 
                     # Create nested objects
                     for i, part in enumerate(parts):


### PR DESCRIPTION
## Summary
Variables in eval and run prompt templates previously only supported top-level column references (`{{column}}`). Nested JSON path access (`{{column.key}}`, `{{column.nested.deep}}`, `{{column[0]}}`) was blocked at multiple layers — the backend schema endpoint only inspected `data_type="json"` columns, the frontend dropdown/validation/replacement functions all gated on `dataType === "json"`, and `populate_placeholders` only parsed JSON-typed cells.

This PR removes that gate everywhere: the schema endpoint now also discovers JSON structure in text columns, all frontend functions check for schema presence instead of column type, the eval variable mapping dropdown expands nested paths with runtime cell-value inspection, and the instruction editor turns mapped variables green.

## Linked issues
Closes #

## Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
- Created a dataset with a text column containing JSON values (`{"title": "hello", "count": 42}`)
- **Run Prompt**: typed `{{column.` in prompt editor → nested paths suggested → selected `{{column.title}}` → turned green → ran prompt → value resolved correctly
- **Eval (existing)**: opened eval config from dataset sidebar → typed `{{column.title}}` in instructions → appeared in variable mapping panel → mapped to `column.title` from dropdown → ran test → value resolved
- **Eval (new)**: created new eval with `{{my_var}}` → mapped to `column.title` in mapping panel → `{{my_var}}` turned green in editor → edited variable name in instructions → mapping panel updated live
- Verified backend sends `uuid.path` format and `process_mapping` / `populate_placeholders` resolve nested values correctly

## Screenshots / recordings (if UI)

## Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)