### PR TITLE
fix: normalize agentcc cache.default_ttl to int seconds on push

### DIFF
--- a/futureagi/agentcc/org_config_defaults.py
+++ b/futureagi/agentcc/org_config_defaults.py
@@ -2,9 +2,27 @@ DEFAULT_COST_TRACKING = {"enabled": True}
 
 DEFAULT_CACHE = {
     "enabled": False,
-    "default_ttl": "5m",
+    "default_ttl": 300,
     "max_entries": 10000,
 }
+
+_DURATION_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def _coerce_ttl_seconds(value):
+    if isinstance(value, bool):
+        return DEFAULT_CACHE["default_ttl"]
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v.isdigit():
+            return int(v)
+        if len(v) >= 2 and v[-1] in _DURATION_UNITS and v[:-1].isdigit():
+            return int(v[:-1]) * _DURATION_UNITS[v[-1]]
+    return DEFAULT_CACHE["default_ttl"]
 
 
 def default_cost_tracking_config():
@@ -29,4 +47,5 @@ def normalize_cache_config(value):
     normalized = value.copy()
     for key, default in DEFAULT_CACHE.items():
         normalized.setdefault(key, default)
+    normalized["default_ttl"] = _coerce_ttl_seconds(normalized.get("default_ttl"))
     return normalized

--- a/futureagi/agentcc/services/config_push.py
+++ b/futureagi/agentcc/services/config_push.py
@@ -7,6 +7,7 @@ import structlog
 from django.conf import settings as django_settings
 
 from agentcc.models import AgentccOrgConfig
+from agentcc.org_config_defaults import normalize_cache_config
 from agentcc.services.gateway_client import GatewayClientError, get_gateway_client
 
 logger = structlog.get_logger(__name__)
@@ -437,7 +438,7 @@ def _build_payload(org_id, config):
         "providers": _assemble_providers(org_id),
         "guardrails": _transform_guardrails(config.guardrails, org_id=org_id),
         "routing": config.routing,
-        "cache": config.cache,
+        "cache": normalize_cache_config(config.cache),
         "rate_limiting": config.rate_limiting,
         "budgets": _transform_budgets(config.budgets),
         "cost_tracking": config.cost_tracking,


### PR DESCRIPTION
## Summary

Test-playground / config push was returning 400 for orgs whose `AgentccOrgConfig.cache` still carried the string default `"5m"`. The gateway's per-tenant `CacheConfig.default_ttl` is `int` seconds (`agentcc-gateway/internal/tenant/config.go:212`), so the JSON unmarshal failed with `cannot unmarshal string into Go struct field CacheConfig.cache.default_ttl of type int`. Fix: change the default to `300` (int seconds) and normalize the cache config at push time so existing rows with `"5m"` style values are coerced to ints — no data migration needed. The gateway's static YAML path is untouched (it uses `time.Duration` and still accepts `5m`).

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Reproduced on a secondary org via `POST /agentcc/gateways/default/test-playground/` — gateway returned 400 with the unmarshal error before the fix.
- After the fix, `normalize_cache_config` coerces `"5m"` → `300`, `"30s"` → `30`, `"1h"` → `3600`, plain digit strings, ints, and floats; falls back to the int default for unparseable values.
- Verified `_build_payload` now wraps `config.cache` with `normalize_cache_config(...)` before sending.
- New orgs seed `cache.default_ttl = 300`.

## Screenshots / recordings (if UI)

N/A — backend-only.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)