### PR TITLE
fix(TH-4577): Add items selectAll undefined.length crash + bundled fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,24 +91,17 @@ TEMPORAL_NAMESPACE=default
 # Set to false + use docker-compose.dev.yml for per-queue workers.
 TEMPORAL_ALL_QUEUES=true
 
-# Route voice/test executions through TestExecutionWorkflow directly instead
-# of the legacy poller-based path (simulate/services/test_executor.py). Must
-# be true for voice tests to actually execute.
-TEMPORAL_TEST_EXECUTION_ENABLED=true
-
 # Concurrency caps for the single all-queue worker
 TEMPORAL_MAX_CONCURRENT_ACTIVITIES=50
 TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS=50
 
 
 # ----------------------------------------------------------------------------
-# LLM gateway (agentcc) — shared secrets between backend and gateway.
-# Both values must match on both sides (backend env + gateway env_file).
-# Generate each: openssl rand -hex 32
+# LLM gateway (agentcc)
 # ----------------------------------------------------------------------------
 
+# Shared secret between backend and gateway. Generate: openssl rand -hex 32
 AGENTCC_INTERNAL_API_KEY=CHANGEME-gateway-shared-secret
-AGENTCC_ADMIN_TOKEN=CHANGEME-gateway-admin-token
 
 
 # ----------------------------------------------------------------------------
@@ -138,100 +131,3 @@ VITE_ENVIRONMENT=development
 
 FUTURE_AGI_CLOUD_API_KEY=
 FUTURE_AGI_CLOUD_API_URL=https://api.futureagi.com
-
-
-# ----------------------------------------------------------------------------
-# EE / deployment-mode toggles. Read at process start by tfc/ee_loader.py
-# and ee/usage/deployment.py — without these, the backend reports OSS even
-# when the ee/ package is on disk. CLOUD_DEPLOYMENT_SECRET is required
-# alongside CLOUD_DEPLOYMENT to enter cloud mode (sha-256 validated by
-# ee/usage/deployment.py:_validate_cloud_secret).
-# ----------------------------------------------------------------------------
-
-CLOUD_DEPLOYMENT=
-CLOUD_DEPLOYMENT_SECRET=
-
-# EE license key (any non-empty string enables EE features locally)
-EE_LICENSE_KEY=
-
-
-# ----------------------------------------------------------------------------
-# Stripe billing — read in tfc/settings/settings.py:562-589.
-# STRIPE_SECRET_KEY starting with sk_live_ flips STRIPE_LIVE=True.
-# STRIPE_REDIRECT_DOMAIN must include scheme (http:// or https://) and no
-# trailing slash, otherwise Stripe Checkout rejects success_url with
-# "Not a valid URL".
-# ----------------------------------------------------------------------------
-
-STRIPE_REDIRECT_DOMAIN=http://localhost:3000
-STRIPE_SECRET_KEY=
-STRIPE_PUBLIC_KEY=
-BASIC_MONTHLY_TEST_STRIPE_PRICE_ID=
-BASIC_MONTHLY_TEST_STRIPE_PRICE_IDS_ALL=
-BASIC_YEARLY_TEST_STRIPE_PRICE_ID=
-BASIC_YEARLY_TEST_STRIPE_PRICE_IDS_ALL=
-
-# Stripe webhook signing secret. Use whsec_test_* for sk_test_ keys,
-# whsec_live_* once you switch to live mode.
-WEBHOOK_SECRET=
-
-
-# ----------------------------------------------------------------------------
-# Voice provider config — fetch_assistant_from_provider, voice sim, etc.
-# Read in ee/voice/services/{vapi,retell}_service.py.
-# ----------------------------------------------------------------------------
-
-SYSTEM_VOICE_PROVIDER=vapi
-VAPI_API_KEY=
-VAPI_API_BASE_URL=https://api.vapi.ai
-VAPI_PHONE_NUMBER_ID=
-RETELL_API_KEY=
-RETELL_API_BASE_URL=https://api.retellai.com
-RETELL_PHONE_NUMBER_ID=
-RETELL_IP_ADDRESS=
-
-
-# ----------------------------------------------------------------------------
-# LiveKit + STT/TTS for voice simulation (ee/voice/services/livekit/*).
-# Required for any voice-sim flow that initiates an outbound call.
-# ----------------------------------------------------------------------------
-
-LIVEKIT_URL=
-LIVEKIT_API_KEY=
-LIVEKIT_API_SECRET=
-LIVEKIT_BACKEND_CALLBACK_URL=
-LIVEKIT_STT_RATE_PER_SECOND=0.000128
-LIVEKIT_TTS_RATE_PER_CHAR=0.000011
-LIVEKIT_STORAGE_RATE_PER_MB=0.000023
-SIP_INBOUND_TRUNK_ID=
-SIP_OUTBOUND_TRUNK_ID=
-SIP_CPS_BATCH_SIZE=1
-DEEPGRAM_API_KEY=
-CARTESIA_API_KEY=
-INTERNAL_API_SECRET=CHANGEME-internal-api-secret
-
-
-# ----------------------------------------------------------------------------
-# Google Cloud / Vertex AI — required by graph-scenario generation
-# (SyntheticDataAgent uses vertex_ai/gemini-2.5-pro). Place the service
-# account JSON at futureagi/<filename> and point this env var at it.
-# ----------------------------------------------------------------------------
-
-GOOGLE_APPLICATION_CREDENTIALS=Vertex_AI_creds.json
-GOOGLE_CLOUD_PROJECT=
-GOOGLE_CLOUD_LOCATION=us-central1
-GOOGLE_GENAI_USE_VERTEXAI=True
-
-
-# ----------------------------------------------------------------------------
-# Misc EE / runtime toggles
-# ----------------------------------------------------------------------------
-
-# 32-byte fernet key for encrypting integration credentials. Generate:
-#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-INTEGRATION_ENCRYPTION_KEY=CHANGEME-fernet-key
-
-DEFAULT_APP_LIMIT=100
-DEFAULT_ORG_LIMIT=20
-DEFAULT_PHONE_ORG_LIMIT=20
-BRAVE_SEARCH_API_KEY=


### PR DESCRIPTION
## Summary

- **TH-4577** — In `frontend/src/sections/annotations/queues/items/add-items-dialog.jsx`, the **Select all** branches for `dataset_row` and `observation_span` resolved `allIds` but never mapped them to `itemsToAdd`, so the downstream `itemsToAdd.length` threw `Cannot read properties of undefined (reading 'length')`. Now both branches build `itemsToAdd` like the `trace` branch does.
- Branch also carries other unrelated changes bundled in commit `08c458d "Fixing a couple of issues"` (dashboards, ClickHouse query builders, agentcc, evals, routes, .env / docker-compose). See `git log main..HEAD` and the file list in the diff for details.

## Test plan

- [ ] Annotation queue → Add items → dataset → **Select all** → submit; rows are added without a console error.
- [ ] Trace / span / session / call_execution selectAll paths still go through backend filter mode end-to-end.
- [ ] Reviewers please verify the non-TH-4577 changes against their respective tickets.

Closes TH-4577 (Linear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)