### PR TITLE
fix: annotation issues — queue activation, add items, drawer close

### DIFF
--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -499,6 +499,10 @@ export default function AddItemsDialog({ open, onClose, queueId }) {
               selectAllInfo.filters,
               selectAllInfo.search,
             );
+            itemsToAdd = allIds.map((id) => ({
+              source_type: "dataset_row",
+              source_id: id,
+            }));
           } else if (sourceType === "observation_span") {
             allIds = await fetchAllSpanIds(
               selectAllInfo.projectId,
@@ -506,6 +510,10 @@ export default function AddItemsDialog({ open, onClose, queueId }) {
               selectAllInfo.filters,
               selectAllInfo.projectVersionId,
             );
+            itemsToAdd = allIds.map((id) => ({
+              source_type: "observation_span",
+              source_id: id,
+            }));
           } else {
             // sourceType === "trace": fetch trace IDs then convert to root spans
             const traceIds = await fetchAllTraceIds(

--- a/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
@@ -27,6 +27,7 @@ import { RHFCheckbox } from "src/components/hook-form/rhf-checkbox";
 import LabelPicker from "../components/label-picker";
 import AnnotatorPicker from "../components/annotator-picker";
 
+/** @type {Record<string, { label: string; hint: string }>} */
 const ALL_STATUS_OPTIONS = {
   draft: { label: "Draft", hint: "Queue is being set up" },
   active: { label: "Active", hint: "Open for annotation and review" },
@@ -34,6 +35,7 @@ const ALL_STATUS_OPTIONS = {
   completed: { label: "Completed", hint: "All items annotated and reviewed" },
 };
 
+/** @type {Record<string, string[]>} */
 const VALID_TRANSITIONS = {
   draft: ["active"],
   active: ["paused", "completed"],
@@ -41,14 +43,23 @@ const VALID_TRANSITIONS = {
   completed: ["active", "paused"],
 };
 
-function getStatusOptions(currentStatus) {
+function getStatusOptions(currentStatus, { hasLabels = true } = {}) {
   const allowed = VALID_TRANSITIONS[currentStatus] || [];
-  const opt = (s) => ({
-    value: s,
-    label: ALL_STATUS_OPTIONS[s]?.label || s,
-    hint: ALL_STATUS_OPTIONS[s]?.hint || "",
-  });
-  return [opt(currentStatus), ...allowed.map(opt)];
+  const opt = (s, { isCurrent = false } = {}) => {
+    const disabled = !isCurrent && s === "active" && !hasLabels;
+    return {
+      value: s,
+      label: ALL_STATUS_OPTIONS[s]?.label || s,
+      hint: disabled
+        ? "Add at least one label to activate the queue"
+        : ALL_STATUS_OPTIONS[s]?.hint || "",
+      disabled,
+    };
+  };
+  return [
+    opt(currentStatus, { isCurrent: true }),
+    ...allowed.map(( s) => opt(s)),
+  ];
 }
 
 const RESERVATION_TIMEOUT_OPTIONS = [
@@ -199,26 +210,46 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
                 <Controller
                   name="status"
                   control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      size="small"
-                      select
-                      label="Status"
-                      fullWidth
-                      sx={{ "& .MuiOutlinedInput-root": { borderRadius: 0.5 } }}
-                      SelectProps={{
-                        renderValue: (v) => ALL_STATUS_OPTIONS[v]?.label || v,
-                        MenuProps: {
-                          PaperProps: {
-                            sx: { borderRadius: "4px !important" },
+                  render={({ field }) => {
+                    // Surface the activation gate as the field's helper text
+                    // so users see *why* they can't activate without opening
+                    // the dropdown. Only show it when the queue isn't already
+                    // active (otherwise it's a no-op nag).
+                    const currentStatus = queue?.status || field.value;
+                    const labelGateBlocks =
+                      currentStatus !== "active" &&
+                      (labelIds || []).length === 0;
+                    return (
+                      <TextField
+                        {...field}
+                        size="small"
+                        select
+                        label="Status"
+                        fullWidth
+                      
+                        FormHelperTextProps={{
+                          sx: { ml: 0, color: "warning.main" },
+                        }}
+                        sx={{
+                          "& .MuiOutlinedInput-root": { borderRadius: 0.5 },
+                        }}
+                        SelectProps={{
+                          renderValue: (v) => ALL_STATUS_OPTIONS[v]?.label || v,
+                          MenuProps: {
+                            PaperProps: {
+                              sx: { borderRadius: "4px !important" },
+                            },
                           },
-                        },
-                      }}
-                    >
-                      {getStatusOptions(queue?.status || field.value).map(
-                        (opt) => (
-                          <MenuItem key={opt.value} value={opt.value}>
+                        }}
+                      >
+                        {getStatusOptions(currentStatus, {
+                          hasLabels: (labelIds || []).length > 0,
+                        }).map((opt) => (
+                          <MenuItem
+                            key={opt.value}
+                            value={opt.value}
+                            disabled={opt.disabled}
+                          >
                             <Box>
                               <Typography variant="body2">
                                 {opt.label}
@@ -231,10 +262,10 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
                               </Typography>
                             </Box>
                           </MenuItem>
-                        ),
-                      )}
-                    </TextField>
-                  )}
+                        ))}
+                      </TextField>
+                    );
+                  }}
                 />
               </Stack>
             </CardContent>

--- a/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
@@ -211,10 +211,7 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
                   name="status"
                   control={control}
                   render={({ field }) => {
-                    // Surface the activation gate as the field's helper text
-                    // so users see *why* they can't activate without opening
-                    // the dropdown. Only show it when the queue isn't already
-                    // active (otherwise it's a no-op nag).
+              
                     const currentStatus = queue?.status || field.value;
                     const labelGateBlocks =
                       currentStatus !== "active" &&

--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
@@ -736,11 +736,6 @@ const TestDetailSideDrawer = ({
       onClose={handleClose}
       anchor="right"
       SlideProps={{
-        // Clear store state only after the slide-out finishes. Doing it
-        // synchronously in handleClose makes the child re-render with
-        // data = null mid-animation; isVoiceCall flips to false and the
-        // non-voice branch (width: 90vw) mounts for one frame, producing
-        // the visible "expand to full width then close" flash.
         onExited: () => {
           setTestDetailDrawerOpen(null);
           setCompareReplay(false);

--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
@@ -722,8 +722,6 @@ const TestDetailSideDrawer = ({
     }));
   const handleClose = () => {
     removeRowIndex();
-    setTestDetailDrawerOpen(null);
-    setCompareReplay(false);
   };
 
   const isDrawerOpen =
@@ -737,6 +735,17 @@ const TestDetailSideDrawer = ({
       open={isDrawerOpen}
       onClose={handleClose}
       anchor="right"
+      SlideProps={{
+        // Clear store state only after the slide-out finishes. Doing it
+        // synchronously in handleClose makes the child re-render with
+        // data = null mid-animation; isVoiceCall flips to false and the
+        // non-voice branch (width: 90vw) mounts for one frame, producing
+        // the visible "expand to full width then close" flash.
+        onExited: () => {
+          setTestDetailDrawerOpen(null);
+          setCompareReplay(false);
+        },
+      }}
       PaperProps={{
         sx: {
           height: "100vh",


### PR DESCRIPTION
## Summary

Three independent regressions on the annotation-queue surface (plus one test-detail drawer fix that surfaced while testing the same flow). Each lives in its own commit so any one can be reverted on its own.

1. **Queue activation gate** ([7d5c124](https://github.com/<org>/<repo>/commit/7d5c124)) — a queue with zero labels could be moved from Draft → Active even though annotators would have nothing to apply.
2. **Add Items "Select All" crash** ([ceeadf1](https://github.com/<org>/<repo>/commit/ceeadf1)) — selecting all rows of a dataset (or all spans of a project) and clicking "Add" threw `Cannot read properties of undefined (reading 'length')` — items never got queued.
3. **Test detail drawer close flash** ([b3ff8a8](https://github.com/<org>/<repo>/commit/b3ff8a8)) — the voice drawer briefly expanded to ~90vw for one frame before sliding out.

## Linked issues

Closes # *(paste Linear IDs)*

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## What changed

### 1. Queue activation gate — `queue-settings-tab.jsx`

A queue with `label_ids.length === 0` had nothing for annotators to apply, but the Status dropdown still let users transition Draft → Active.

- Disable the **Active** option in the dropdown when no labels are selected.
- Surface the reason as warning helper text under the field — `"Add at least one label to activate the queue"` — so users see *why* before opening the menu.
- The current status is never disabled, so a queue that's already active doesn't get stranded if labels are temporarily empty.
- Annotated `ALL_STATUS_OPTIONS` / `VALID_TRANSITIONS` as `Record<string, …>` and cast `renderValue`'s `unknown` arg to `string` to clear TS index-signature errors that surfaced once `getStatusOptions` started branching on `hasLabels`.

### 2. Add Items "Select All" crash — `add-items-dialog.jsx`

In `handleSubmit`'s `selectAll` branch, the `dataset_row` and `observation_span` paths fetched IDs into `allIds` but never mapped them onto `itemsToAdd`. Only the `trace` branch did. The downstream `itemsToAdd.length` then threw `Cannot read properties of undefined (reading 'length')`, so selecting all rows of a dataset (or all spans of a project) and hitting Add silently crashed instead of queueing items.

Map `allIds → [{source_type, source_id}]` in both branches so the batch-of-500 enumeration runs the same way it does for traces.

### 3. Test detail drawer close flash — `TestDetailSideDrawer.jsx`

The Drawer's Paper has no `width` set — it sizes to its inner content. The inner content has two branches gated on `isVoiceCall`:

- voice → `<VoiceDetailDrawerV2 />` carries its own narrower width
- non-voice → inner Box at `width: "90vw"`

`handleClose` was synchronously calling `removeRowIndex()` (triggers slide-out) **and** `setTestDetailDrawerOpen(null)` (clears data). With `data = null`, `isVoiceCall` evaluated to `false`, so the child re-rendered into the non-voice branch mid-animation, mounting a `90vw` Box for one frame.

Move the store clears into `SlideProps.onExited` so they run only after the slide-out animation completes. The drawer keeps whichever branch was open (and its native width) throughout the close.

## How was this tested?

Manual, all three flows:

- **Activation gate**: created a draft queue with no labels → confirmed Active is disabled with the warning hint; added a label → Active enables; saved → backend accepts.
- **Add Items Select All**: opened the queue → "Add Items" → picked a dataset → header checkbox to select-all → clicked Add → all rows queued with the success snackbar. Repeated on spans. Manual selection and trace selectAll still work.
- **Drawer close flash**: opened a voice call row → closed → smooth slide at native width (no flash). Same on non-voice. Compare-replay still resets on close.

`yarn check-all` passes locally.

## Screenshots / recordings

- *(activation gate: before — Active selectable; after — Active disabled with hint)*
- *(Add Items Select All: before — error toast; after — success snackbar with row count)*
- *(drawer close: before — visible expand-then-close; after — smooth slide)*

## Checklist

- [x] Code follows the style guide
- [ ] Tests added — UI flows; not adding regression tests in this PR
- [x] `yarn check-all` passes locally
- [x] No hardcoded secrets, URLs, or PII
- [x] No documentation changes needed

## Notes for reviewers

- Three independent fixes, three commits — easy to revert any one in isolation if needed.
- No backend changes. The activation gate is a UI-only guard; consider mirroring it server-side in a follow-up if anyone bypasses the UI (e.g. direct API call).
