### PR TITLE
fix(run_test): temporarily disable trace details addition due to index issue

### DIFF
--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -2989,7 +2989,15 @@ class CallExecutionDetailView(APIView):
             # without an extra ObservationSpan query per instance, so we
             # add it here in the detail view where a one-row lookup is cheap.
             response_data = dict(serializer.data)
-            add_trace_details_to_call_executions([response_data])
+            # temporarily disabled while
+            # tracer_obse_eval_attr_gin is being rebuilt on prod (the index is
+            # currently INVALID, causing this JSONB containment lookup to
+            # seq-scan ~7.6M rows and hit statement_timeout). Re-enable as
+            # soon as the index is valid. Knock-on effect while disabled:
+            # Logs tab is empty for all simulate calls; Attributes tab is
+            # empty for chat/LiveKit (VAPI/Retell still work via the
+            # provider_call_data fallback below).
+            # add_trace_details_to_call_executions([response_data])
 
             # Shape parity with the observe drawer: when a trace is linked,
             # also return the full serialized observation spans array. The

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -2989,14 +2989,6 @@ class CallExecutionDetailView(APIView):
             # without an extra ObservationSpan query per instance, so we
             # add it here in the detail view where a one-row lookup is cheap.
             response_data = dict(serializer.data)
-            # temporarily disabled while
-            # tracer_obse_eval_attr_gin is being rebuilt on prod (the index is
-            # currently INVALID, causing this JSONB containment lookup to
-            # seq-scan ~7.6M rows and hit statement_timeout). Re-enable as
-            # soon as the index is valid. Knock-on effect while disabled:
-            # Logs tab is empty for all simulate calls; Attributes tab is
-            # empty for chat/LiveKit (VAPI/Retell still work via the
-            # provider_call_data fallback below).
             # add_trace_details_to_call_executions([response_data])
 
             # Shape parity with the observe drawer: when a trace is linked,


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

tracer_obse_eval_attr_gin is being rebuilt on prod (the index is
currently INVALID, causing this JSONB containment lookup to
seq-scan ~7.6M rows and hit statement_timeout). Re-enable as
soon as the index is valid. Knock-on effect while disabled:
Logs tab is empty for all simulate calls; Attributes tab is
empty for chat/LiveKit (VAPI/Retell still work via the
provider_call_data fallback).

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
