### PR TITLE
fix(observe): saved view filters / display / columns now persist correctly

### DIFF
--- a/frontend/src/api/project/saved-views.js
+++ b/frontend/src/api/project/saved-views.js
@@ -40,7 +40,32 @@ export const useCreateWorkspaceSavedView = (tabType) => {
   return useMutation({
     mutationFn: (data) =>
       axios.post(endpoints.savedViews.create, { ...data, tab_type: tabType }),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      const newView = response?.data?.result;
+      if (newView) {
+        queryClient.setQueryData(
+          [SAVED_VIEWS_KEY, "workspace", tabType],
+          (old) => {
+            if (!old) return old;
+            const currentResult = old.data?.result ?? {};
+            const currentList =
+              currentResult.custom_views ?? currentResult.customViews ?? [];
+            if (currentList.some((v) => v.id === newView.id)) return old;
+            const nextList = [...currentList, newView];
+            return {
+              ...old,
+              data: {
+                ...old.data,
+                result: {
+                  ...currentResult,
+                  custom_views: nextList,
+                  customViews: nextList,
+                },
+              },
+            };
+          },
+        );
+      }
       queryClient.invalidateQueries({
         queryKey: [SAVED_VIEWS_KEY, "workspace", tabType],
       });

--- a/frontend/src/api/project/saved-views.js
+++ b/frontend/src/api/project/saved-views.js
@@ -78,7 +78,33 @@ export const useUpdateWorkspaceSavedView = (tabType) => {
   return useMutation({
     mutationFn: ({ id, ...data }) =>
       axios.put(endpoints.savedViews.update(id), data),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      const updated = response?.data?.result;
+      if (updated?.id) {
+        queryClient.setQueryData(
+          [SAVED_VIEWS_KEY, "workspace", tabType],
+          (old) => {
+            if (!old) return old;
+            const currentResult = old.data?.result ?? {};
+            const currentList =
+              currentResult.custom_views ?? currentResult.customViews ?? [];
+            const nextList = currentList.map((v) =>
+              v.id === updated.id ? { ...v, ...updated } : v,
+            );
+            return {
+              ...old,
+              data: {
+                ...old.data,
+                result: {
+                  ...currentResult,
+                  custom_views: nextList,
+                  customViews: nextList,
+                },
+              },
+            };
+          },
+        );
+      }
       queryClient.invalidateQueries({
         queryKey: [SAVED_VIEWS_KEY, "workspace", tabType],
       });
@@ -146,7 +172,30 @@ export const useUpdateSavedView = (projectId) => {
       axios.put(endpoints.savedViews.update(id), data, {
         params: { project_id: projectId },
       }),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      const updated = response?.data?.result;
+      if (updated?.id) {
+        queryClient.setQueryData([SAVED_VIEWS_KEY, projectId], (old) => {
+          if (!old) return old;
+          const currentResult = old.data?.result ?? {};
+          const currentList =
+            currentResult.custom_views ?? currentResult.customViews ?? [];
+          const nextList = currentList.map((v) =>
+            v.id === updated.id ? { ...v, ...updated } : v,
+          );
+          return {
+            ...old,
+            data: {
+              ...old.data,
+              result: {
+                ...currentResult,
+                custom_views: nextList,
+                customViews: nextList,
+              },
+            },
+          };
+        });
+      }
       queryClient.invalidateQueries({
         queryKey: [SAVED_VIEWS_KEY, projectId],
       });

--- a/frontend/src/api/project/saved-views.js
+++ b/frontend/src/api/project/saved-views.js
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 
-const SAVED_VIEWS_KEY = "saved-views";
+export const SAVED_VIEWS_KEY = "saved-views";
 
 // ---------------------------------------------------------------------------
 // Queries
@@ -81,7 +81,32 @@ export const useCreateSavedView = (projectId) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data) => axios.post(endpoints.savedViews.create, data),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      const newView = response?.data?.result;
+      if (newView) {
+        queryClient.setQueryData(
+          [SAVED_VIEWS_KEY, projectId],
+          (old) => {
+            if (!old) return old;
+            const currentResult = old.data?.result ?? {};
+            const currentList =
+              currentResult.custom_views ?? currentResult.customViews ?? [];
+            if (currentList.some((v) => v.id === newView.id)) return old;
+            const nextList = [...currentList, newView];
+            return {
+              ...old,
+              data: {
+                ...old.data,
+                result: {
+                  ...currentResult,
+                  custom_views: nextList,
+                  customViews: nextList,
+                },
+              },
+            };
+          },
+        );
+      }
       queryClient.invalidateQueries({
         queryKey: [SAVED_VIEWS_KEY, projectId],
       });
@@ -93,7 +118,9 @@ export const useUpdateSavedView = (projectId) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ id, ...data }) =>
-      axios.put(endpoints.savedViews.update(id), data),
+      axios.put(endpoints.savedViews.update(id), data, {
+        params: { project_id: projectId },
+      }),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [SAVED_VIEWS_KEY, projectId],
@@ -121,7 +148,11 @@ export const useDuplicateSavedView = (projectId) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ id, name }) =>
-      axios.post(endpoints.savedViews.duplicate(id), { name }),
+      axios.post(
+        endpoints.savedViews.duplicate(id),
+        { name },
+        { params: { project_id: projectId } },
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [SAVED_VIEWS_KEY, projectId],

--- a/frontend/src/components/observe-tabs/ObserveTabBar.jsx
+++ b/frontend/src/components/observe-tabs/ObserveTabBar.jsx
@@ -122,17 +122,36 @@ const ObserveTabBar = ({
   const [saveViewAnchor, setSaveViewAnchor] = useState(null);
   const [isSavingView, setIsSavingView] = useState(false);
   const { mutate: createSavedView } = useCreateSavedView(projectId);
-  const { getViewConfig } = useObserveHeader();
+  const { getViewConfig, getTabType } = useObserveHeader();
+
+  // Derive tab_type for a new saved view. Priority:
+  //  - on a saved view tab, inherit the view's tab_type.
+  //  - on the Users fixed tab, save as "users".
+  //  - on the Sessions fixed tab, save as "sessions".
+  //  - on the Traces fixed tab, fall back to LLMTracingView's registered
+  //    callback (distinguishes trace vs span sub-tab).
+  const resolveTabType = useCallback(() => {
+    if (activeTab === "users") return "users";
+    if (activeTab === "sessions") return "sessions";
+    if (activeTab === "traces") return getTabType?.() ?? "traces";
+    if (activeTab?.startsWith("view-")) {
+      const currentId = activeTab.replace("view-", "");
+      const current = customViews.find((v) => v.id === currentId);
+      return current?.tab_type ?? current?.tabType ?? "traces";
+    }
+    return "traces";
+  }, [activeTab, customViews, getTabType]);
 
   const handleSaveViewConfirm = useCallback(
     (name) => {
       setIsSavingView(true);
       const snapshot = getViewConfig?.() ?? null;
+      const tabType = resolveTabType();
       createSavedView(
         {
           project_id: projectId,
           name,
-          tab_type: "traces",
+          tab_type: tabType,
           config: snapshot ?? {},
         },
         {
@@ -150,7 +169,7 @@ const ObserveTabBar = ({
         },
       );
     },
-    [projectId, createSavedView, onTabChange, getViewConfig],
+    [projectId, createSavedView, onTabChange, getViewConfig, resolveTabType],
   );
 
   // DnD sensors — require 5px of movement before starting drag

--- a/frontend/src/components/observe-tabs/ObserveTabBar.jsx
+++ b/frontend/src/components/observe-tabs/ObserveTabBar.jsx
@@ -23,6 +23,7 @@ import {
   useReorderSavedViews,
 } from "src/api/project/saved-views";
 import { useTabStoreShallow } from "src/sections/projects/LLMTracing/tabStore";
+import { useObserveHeader } from "src/sections/project/context/ObserveHeaderContext";
 
 import FixedTab from "./FixedTab";
 import CustomViewTab from "./CustomViewTab";
@@ -121,16 +122,18 @@ const ObserveTabBar = ({
   const [saveViewAnchor, setSaveViewAnchor] = useState(null);
   const [isSavingView, setIsSavingView] = useState(false);
   const { mutate: createSavedView } = useCreateSavedView(projectId);
+  const { getViewConfig } = useObserveHeader();
 
   const handleSaveViewConfirm = useCallback(
     (name) => {
       setIsSavingView(true);
+      const snapshot = getViewConfig?.() ?? null;
       createSavedView(
         {
           project_id: projectId,
           name,
           tab_type: "traces",
-          config: {},
+          config: snapshot ?? {},
         },
         {
           onSuccess: (res) => {
@@ -147,7 +150,7 @@ const ObserveTabBar = ({
         },
       );
     },
-    [projectId, createSavedView, onTabChange],
+    [projectId, createSavedView, onTabChange, getViewConfig],
   );
 
   // DnD sensors — require 5px of movement before starting drag

--- a/frontend/src/components/observe-tabs/ViewConfigModal.jsx
+++ b/frontend/src/components/observe-tabs/ViewConfigModal.jsx
@@ -22,6 +22,7 @@ import {
   useCreateSavedView,
   useUpdateSavedView,
 } from "src/api/project/saved-views";
+import { useObserveHeader } from "src/sections/project/context/ObserveHeaderContext";
 
 const TAB_TYPES = [
   { value: "traces", label: "Traces" },
@@ -45,6 +46,7 @@ const ViewConfigModal = ({
     useCreateSavedView(projectId);
   const { mutate: updateView, isPending: isUpdating } =
     useUpdateSavedView(projectId);
+  const { getViewConfig } = useObserveHeader();
 
   const isPending = isCreating || isUpdating;
 
@@ -60,11 +62,17 @@ const ViewConfigModal = ({
     e.preventDefault();
     if (!name.trim()) return;
 
+    const snapshot = getViewConfig?.() ?? null;
+    const config =
+      mode === "edit"
+        ? snapshot ?? initialValues?.config ?? {}
+        : snapshot ?? {};
+
     const payload = {
       name: name.trim(),
       tab_type: tabType,
       visibility,
-      config: initialValues?.config ?? {},
+      config,
     };
 
     if (mode === "edit" && initialValues?.id) {

--- a/frontend/src/components/observe-tabs/__tests__/ObserveTabBar.test.jsx
+++ b/frontend/src/components/observe-tabs/__tests__/ObserveTabBar.test.jsx
@@ -5,15 +5,20 @@ import ObserveTabBar from "../ObserveTabBar";
 import { ObserveHeaderContext } from "src/sections/project/context/ObserveHeaderContext";
 
 const mockCreateSavedView = vi.fn();
+let mockSavedViewsList = [];
 vi.mock("src/api/project/saved-views", () => ({
-  useGetSavedViews: () => ({ data: { customViews: [] } }),
+  useGetSavedViews: () => ({ data: { customViews: mockSavedViewsList } }),
   useCreateSavedView: () => ({ mutate: mockCreateSavedView }),
   useUpdateSavedView: () => ({ mutate: vi.fn() }),
   useDeleteSavedView: () => ({ mutate: vi.fn() }),
   useReorderSavedViews: () => ({ mutate: vi.fn() }),
 }));
 
-const renderWithCtx = (getViewConfig) =>
+const renderWithCtx = ({
+  getViewConfig = () => ({}),
+  getTabType = () => "traces",
+  activeTab = "traces",
+} = {}) =>
   render(
     <ObserveHeaderContext.Provider
       value={{
@@ -23,11 +28,13 @@ const renderWithCtx = (getViewConfig) =>
         setActiveViewConfig: () => {},
         registerGetViewConfig: () => {},
         getViewConfig,
+        registerGetTabType: () => {},
+        getTabType,
       }}
     >
       <ObserveTabBar
         projectId="p1"
-        activeTab="traces"
+        activeTab={activeTab}
         onTabChange={() => {}}
       />
     </ObserveHeaderContext.Provider>,
@@ -47,14 +54,17 @@ const typeAndSubmit = async (name) => {
 };
 
 describe("ObserveTabBar — Save View snapshots current filters", () => {
-  beforeEach(() => mockCreateSavedView.mockReset());
+  beforeEach(() => {
+    mockCreateSavedView.mockReset();
+    mockSavedViewsList = [];
+  });
 
   it("passes ctx.getViewConfig() output as config in createSavedView", async () => {
     const snapshot = {
       filters: [{ columnId: "status" }],
       display: { viewMode: "grid" },
     };
-    renderWithCtx(() => snapshot);
+    renderWithCtx({ getViewConfig: () => snapshot });
 
     clickCreateViewButton();
     await typeAndSubmit("t1");
@@ -68,12 +78,62 @@ describe("ObserveTabBar — Save View snapshots current filters", () => {
   });
 
   it("falls back to {} when getViewConfig returns null", async () => {
-    renderWithCtx(() => null);
+    renderWithCtx({ getViewConfig: () => null });
 
     clickCreateViewButton();
     await typeAndSubmit("t2");
 
     await waitFor(() => expect(mockCreateSavedView).toHaveBeenCalled());
     expect(mockCreateSavedView.mock.calls[0][0].config).toEqual({});
+  });
+});
+
+describe("ObserveTabBar — resolveTabType", () => {
+  beforeEach(() => {
+    mockCreateSavedView.mockReset();
+    mockSavedViewsList = [];
+  });
+
+  it("uses getTabType() when activeTab is 'traces' (returns 'traces' for trace sub-tab)", async () => {
+    renderWithCtx({ getTabType: () => "traces", activeTab: "traces" });
+    clickCreateViewButton();
+    await typeAndSubmit("t");
+    await waitFor(() => expect(mockCreateSavedView).toHaveBeenCalled());
+    expect(mockCreateSavedView.mock.calls[0][0].tab_type).toBe("traces");
+  });
+
+  it("uses getTabType() when activeTab is 'traces' (returns 'spans' for span sub-tab)", async () => {
+    renderWithCtx({ getTabType: () => "spans", activeTab: "traces" });
+    clickCreateViewButton();
+    await typeAndSubmit("s");
+    await waitFor(() => expect(mockCreateSavedView).toHaveBeenCalled());
+    expect(mockCreateSavedView.mock.calls[0][0].tab_type).toBe("spans");
+  });
+
+  it("forces tab_type to 'users' when activeTab is 'users'", async () => {
+    renderWithCtx({ getTabType: () => "traces", activeTab: "users" });
+    clickCreateViewButton();
+    await typeAndSubmit("u");
+    await waitFor(() => expect(mockCreateSavedView).toHaveBeenCalled());
+    expect(mockCreateSavedView.mock.calls[0][0].tab_type).toBe("users");
+  });
+
+  it("forces tab_type to 'sessions' when activeTab is 'sessions'", async () => {
+    renderWithCtx({ getTabType: () => "traces", activeTab: "sessions" });
+    clickCreateViewButton();
+    await typeAndSubmit("ss");
+    await waitFor(() => expect(mockCreateSavedView).toHaveBeenCalled());
+    expect(mockCreateSavedView.mock.calls[0][0].tab_type).toBe("sessions");
+  });
+
+  it("inherits the current view's tab_type when activeTab is 'view-<id>'", async () => {
+    mockSavedViewsList = [
+      { id: "abc", name: "my-spans-view", tab_type: "spans" },
+    ];
+    renderWithCtx({ getTabType: () => "traces", activeTab: "view-abc" });
+    clickCreateViewButton();
+    await typeAndSubmit("copy");
+    await waitFor(() => expect(mockCreateSavedView).toHaveBeenCalled());
+    expect(mockCreateSavedView.mock.calls[0][0].tab_type).toBe("spans");
   });
 });

--- a/frontend/src/components/observe-tabs/__tests__/ObserveTabBar.test.jsx
+++ b/frontend/src/components/observe-tabs/__tests__/ObserveTabBar.test.jsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "src/utils/test-utils";
+import React from "react";
+import ObserveTabBar from "../ObserveTabBar";
+import { ObserveHeaderContext } from "src/sections/project/context/ObserveHeaderContext";
+
+const mockCreateSavedView = vi.fn();
+vi.mock("src/api/project/saved-views", () => ({
+  useGetSavedViews: () => ({ data: { customViews: [] } }),
+  useCreateSavedView: () => ({ mutate: mockCreateSavedView }),
+  useUpdateSavedView: () => ({ mutate: vi.fn() }),
+  useDeleteSavedView: () => ({ mutate: vi.fn() }),
+  useReorderSavedViews: () => ({ mutate: vi.fn() }),
+}));
+
+const renderWithCtx = (getViewConfig) =>
+  render(
+    <ObserveHeaderContext.Provider
+      value={{
+        headerConfig: {},
+        setHeaderConfig: () => {},
+        activeViewConfig: null,
+        setActiveViewConfig: () => {},
+        registerGetViewConfig: () => {},
+        getViewConfig,
+      }}
+    >
+      <ObserveTabBar
+        projectId="p1"
+        activeTab="traces"
+        onTabChange={() => {}}
+      />
+    </ObserveHeaderContext.Provider>,
+  );
+
+const clickCreateViewButton = () => {
+  const btn = document.querySelector("[data-create-view-btn]");
+  if (!btn) throw new Error("data-create-view-btn not found");
+  fireEvent.click(btn);
+};
+
+const typeAndSubmit = async (name) => {
+  const input = await screen.findByRole("textbox");
+  fireEvent.change(input, { target: { value: name } });
+  const saveBtn = screen.getByRole("button", { name: /save|create/i });
+  fireEvent.click(saveBtn);
+};
+
+describe("ObserveTabBar — Save View snapshots current filters", () => {
+  beforeEach(() => mockCreateSavedView.mockReset());
+
+  it("passes ctx.getViewConfig() output as config in createSavedView", async () => {
+    const snapshot = {
+      filters: [{ columnId: "status" }],
+      display: { viewMode: "grid" },
+    };
+    renderWithCtx(() => snapshot);
+
+    clickCreateViewButton();
+    await typeAndSubmit("t1");
+
+    await waitFor(() => expect(mockCreateSavedView).toHaveBeenCalled());
+    const payload = mockCreateSavedView.mock.calls[0][0];
+    expect(payload.config).toEqual(snapshot);
+    expect(payload.tab_type).toBe("traces");
+    expect(payload.name).toBe("t1");
+    expect(payload.project_id).toBe("p1");
+  });
+
+  it("falls back to {} when getViewConfig returns null", async () => {
+    renderWithCtx(() => null);
+
+    clickCreateViewButton();
+    await typeAndSubmit("t2");
+
+    await waitFor(() => expect(mockCreateSavedView).toHaveBeenCalled());
+    expect(mockCreateSavedView.mock.calls[0][0].config).toEqual({});
+  });
+});

--- a/frontend/src/components/observe-tabs/__tests__/ViewConfigModal.test.jsx
+++ b/frontend/src/components/observe-tabs/__tests__/ViewConfigModal.test.jsx
@@ -1,11 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "src/utils/test-utils";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "src/utils/test-utils";
+import { ObserveHeaderContext } from "src/sections/project/context/ObserveHeaderContext";
 import ViewConfigModal from "../ViewConfigModal";
 
-// Mock the API hooks
+// Mock the API hooks — expose mockCreate/mockUpdate so tests can assert on payloads
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
 vi.mock("src/api/project/saved-views", () => ({
-  useCreateSavedView: () => ({ mutate: vi.fn(), isPending: false }),
-  useUpdateSavedView: () => ({ mutate: vi.fn(), isPending: false }),
+  useCreateSavedView: () => ({ mutate: mockCreate, isPending: false }),
+  useUpdateSavedView: () => ({ mutate: mockUpdate, isPending: false }),
 }));
 
 describe("ViewConfigModal", () => {
@@ -58,5 +61,79 @@ describe("ViewConfigModal", () => {
   it("does not render when open is false", () => {
     render(<ViewConfigModal {...defaultProps} open={false} />);
     expect(screen.queryByText("Create New View")).not.toBeInTheDocument();
+  });
+});
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  mode: "create",
+  projectId: "test-project-id",
+};
+
+const renderWithCtx = (getViewConfig, props) =>
+  render(
+    <ObserveHeaderContext.Provider
+      value={{
+        headerConfig: {},
+        setHeaderConfig: () => {},
+        activeViewConfig: null,
+        setActiveViewConfig: () => {},
+        registerGetViewConfig: () => {},
+        getViewConfig,
+      }}
+    >
+      <ViewConfigModal {...defaultProps} {...props} />
+    </ObserveHeaderContext.Provider>,
+  );
+
+describe("ViewConfigModal — config snapshot on save", () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+    mockUpdate.mockReset();
+  });
+
+  it("create mode sends getViewConfig() output as config", async () => {
+    const snapshot = { filters: [{ columnId: "status" }] };
+    renderWithCtx(() => snapshot);
+    fireEvent.change(screen.getByLabelText("Name *"), {
+      target: { value: "v1" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockCreate.mock.calls[0][0].config).toEqual(snapshot);
+  });
+
+  it("create mode falls back to {} when getViewConfig returns null", async () => {
+    renderWithCtx(() => null);
+    fireEvent.change(screen.getByLabelText("Name *"), {
+      target: { value: "v2" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockCreate.mock.calls[0][0].config).toEqual({});
+  });
+
+  it("edit mode re-captures live config on save", async () => {
+    const fresh = { filters: [{ columnId: "duration" }] };
+    const stale = { filters: [{ columnId: "status" }] };
+    renderWithCtx(() => fresh, {
+      mode: "edit",
+      initialValues: { id: "v9", name: "Old", tab_type: "traces", config: stale },
+    });
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    expect(mockUpdate.mock.calls[0][0].config).toEqual(fresh);
+  });
+
+  it("edit mode falls back to initialValues.config when getViewConfig returns null", async () => {
+    const stale = { filters: [{ columnId: "status" }] };
+    renderWithCtx(() => null, {
+      mode: "edit",
+      initialValues: { id: "v9", name: "Old", tab_type: "traces", config: stale },
+    });
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    expect(mockUpdate.mock.calls[0][0].config).toEqual(stale);
   });
 });

--- a/frontend/src/pages/dashboard/projects/UsersList.jsx
+++ b/frontend/src/pages/dashboard/projects/UsersList.jsx
@@ -1,9 +1,13 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import { Helmet } from "react-helmet-async";
 import { Box, Divider, Paper, Typography, useTheme } from "@mui/material";
 import Iconify from "src/components/iconify";
 import UsersView from "src/sections/projects/UsersView/UsersView";
 import UsersPageTabBar from "src/sections/projects/UsersView/UsersPageTabBar";
+import { useUrlState } from "src/routes/hooks/use-url-state";
+import { useGetWorkspaceSavedViews } from "src/api/project/saved-views";
+
+const USERS_TAB_TYPE = "users";
 
 // Top-level "Users" page at /dashboard/users.
 //
@@ -17,7 +21,23 @@ const UserList = () => {
 
   // Saved-view api ref populated by UsersView on mount. Drives the tab bar.
   const savedViewApiRef = useRef(null);
-  const [activeTab, setActiveTab] = useState("all");
+  // URL-synced so a refresh on `?usersTab=view-<id>` restores the saved view
+  // instead of resetting to the All Users default (which would clobber
+  // useUrlState-restored display state via UsersPageTabBar's applyConfig(null)
+  // path).
+  const [activeTab, setActiveTab] = useUrlState("usersTab", "all");
+
+  // Derive the active saved view's config so UsersView can compute
+  // canSaveView (Save view button visibility) against the right baseline.
+  // Same react-query subscription UsersPageTabBar uses — gets deduped.
+  const { data: savedViewsData } = useGetWorkspaceSavedViews(USERS_TAB_TYPE);
+  const activeViewConfig = useMemo(() => {
+    if (!activeTab?.startsWith?.("view-")) return null;
+    const id = activeTab.slice(5);
+    const list =
+      savedViewsData?.customViews ?? savedViewsData?.custom_views ?? [];
+    return list.find((v) => v.id === id)?.config ?? null;
+  }, [activeTab, savedViewsData]);
 
   // Stable handles — the ref indirection makes empty-deps safe.
   const getSavedViewConfig = useCallback(
@@ -162,7 +182,10 @@ const UserList = () => {
 
         {/* Content */}
         <Box sx={contentStyles}>
-          <UsersView savedViewApiRef={savedViewApiRef} />
+          <UsersView
+            savedViewApiRef={savedViewApiRef}
+            activeViewConfig={activeViewConfig}
+          />
         </Box>
       </Box>
     </>

--- a/frontend/src/routes/hooks/use-url-state.js
+++ b/frontend/src/routes/hooks/use-url-state.js
@@ -85,13 +85,7 @@ export function useUrlState(key, defaultValue) {
 
     const newValue = parseUrlValue(searchParams.get(key), defaultValue);
     setStateValue(newValue);
-    // Dep array intentionally excludes `value`: the effect should only fire on
-    // external URL changes. Including `value` causes spurious reruns on every
-    // state update, where the stringified comparison can register a false
-    // mismatch (e.g., when state carries a random id not in the URL payload)
-    // and reset the state back to the URL's default.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams, key, defaultValue]);
+  }, [searchParams, key, defaultValue, value]);
 
   return [value, setValue, removeValue];
 }

--- a/frontend/src/routes/hooks/use-url-state.js
+++ b/frontend/src/routes/hooks/use-url-state.js
@@ -29,7 +29,15 @@ export function useUrlState(key, defaultValue) {
   // Flag to track if the URL change was triggered internally
   const isInternalUpdate = useRef(false);
 
-  // Update both state and URL
+  // Update both state and URL.
+  // Reads from `window.location.search` rather than the functional
+  // setSearchParams form because react-router's prev arg in the functional
+  // form doesn't reflect intermediate navigate() calls within the same
+  // synchronous tick — when multiple useUrlState setters fire back-to-back
+  // (e.g. setActiveTab → applyConfig → setCellHeight/etc), the later writes
+  // clobber the earlier ones. window.location.search IS updated
+  // synchronously by react-router's underlying history.replaceState, so
+  // each setter merges with the latest URL state correctly.
   const setValue = useCallback(
     (newValue, options = { replace: true }) => {
       setStateValue((currentValue) => {
@@ -38,17 +46,9 @@ export function useUrlState(key, defaultValue) {
 
         isInternalUpdate.current = true;
 
-        // Functional form merges with the latest URL params so concurrent
-        // setValue calls from different useUrlState hooks don't clobber each
-        // other's writes in the same tick.
-        setSearchParams(
-          (prev) => {
-            const next = new URLSearchParams(prev);
-            next.set(key, stringifyUrlValue(nextValue));
-            return next;
-          },
-          { replace: options.replace },
-        );
+        const newSearchParams = new URLSearchParams(window.location.search);
+        newSearchParams.set(key, stringifyUrlValue(nextValue));
+        setSearchParams(newSearchParams, { replace: options.replace });
 
         return nextValue;
       });
@@ -60,14 +60,9 @@ export function useUrlState(key, defaultValue) {
     (options = { replace: true }) => {
       isInternalUpdate.current = true;
 
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          next.delete(key);
-          return next;
-        },
-        { replace: options.replace },
-      );
+      const newSearchParams = new URLSearchParams(window.location.search);
+      newSearchParams.delete(key);
+      setSearchParams(newSearchParams, { replace: options.replace });
 
       setStateValue(defaultValue);
     },

--- a/frontend/src/routes/hooks/use-url-state.js
+++ b/frontend/src/routes/hooks/use-url-state.js
@@ -32,41 +32,51 @@ export function useUrlState(key, defaultValue) {
   // Update both state and URL
   const setValue = useCallback(
     (newValue, options = { replace: true }) => {
-      // Update state using functional update to ensure latest value
       setStateValue((currentValue) => {
         const nextValue =
           typeof newValue === "function" ? newValue(currentValue) : newValue;
 
-        // Mark this as an internal update
         isInternalUpdate.current = true;
 
-        // Update URL
-        const newSearchParams = new URLSearchParams(window.location.search);
-        newSearchParams.set(key, stringifyUrlValue(nextValue));
-        setSearchParams(newSearchParams, { replace: options.replace });
+        // Functional form merges with the latest URL params so concurrent
+        // setValue calls from different useUrlState hooks don't clobber each
+        // other's writes in the same tick.
+        setSearchParams(
+          (prev) => {
+            const next = new URLSearchParams(prev);
+            next.set(key, stringifyUrlValue(nextValue));
+            return next;
+          },
+          { replace: options.replace },
+        );
 
         return nextValue;
       });
     },
-    [key, setSearchParams], // Removed value from dependencies since we use functional updates
+    [key, setSearchParams],
   );
+
   const removeValue = useCallback(
     (options = { replace: true }) => {
       isInternalUpdate.current = true;
 
-      const newSearchParams = new URLSearchParams(window.location.search);
-      newSearchParams.delete(key);
-      setSearchParams(newSearchParams, { replace: options.replace });
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete(key);
+          return next;
+        },
+        { replace: options.replace },
+      );
 
-      // Reset state (or set to undefined if you prefer).
       setStateValue(defaultValue);
     },
     [key, setSearchParams, defaultValue],
   );
+
   // Handle external URL changes (like browser back/forward)
   useEffect(() => {
     if (isInternalUpdate.current) {
-      // Reset the flag and skip the updateuseUrlState
       isInternalUpdate.current = false;
       return;
     }
@@ -78,10 +88,15 @@ export function useUrlState(key, defaultValue) {
       return;
     }
 
-    // Update state only if the change came from external source
     const newValue = parseUrlValue(searchParams.get(key), defaultValue);
     setStateValue(newValue);
-  }, [searchParams, key, defaultValue, value]);
+    // Dep array intentionally excludes `value`: the effect should only fire on
+    // external URL changes. Including `value` causes spurious reruns on every
+    // state update, where the stringified comparison can register a false
+    // mismatch (e.g., when state carries a random id not in the URL payload)
+    // and reset the state back to the URL's default.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, key, defaultValue]);
 
   return [value, setValue, removeValue];
 }

--- a/frontend/src/sections/project/context/ObserveHeaderContext.js
+++ b/frontend/src/sections/project/context/ObserveHeaderContext.js
@@ -20,6 +20,10 @@ export const ObserveHeaderContext = createContext({
   // Pass null to unregister.
   registerGetViewConfig: () => {},
   getViewConfig: () => null,
+  // Returns the current tab_type ("traces" | "spans") so save-view UIs know
+  // what to persist as the view's tab_type. Registered by LLMTracingView.
+  registerGetTabType: () => {},
+  getTabType: () => "traces",
 });
 
 export const useObserveHeader = () => {

--- a/frontend/src/sections/project/context/ObserveHeaderContext.js
+++ b/frontend/src/sections/project/context/ObserveHeaderContext.js
@@ -13,10 +13,13 @@ export const ObserveHeaderContext = createContext({
     toolbarElement: null,
   },
   setHeaderConfig: () => {},
-  // Active saved-view config (filters, columns, sort, display) — set when a
-  // custom view tab is selected, null for default fixed tabs.
   activeViewConfig: null,
   setActiveViewConfig: () => {},
+  // Callback registered by LLMTracingView so save-view UIs (ObserveTabBar,
+  // ViewConfigModal) can snapshot current filters/display at save time.
+  // Pass null to unregister.
+  registerGetViewConfig: () => {},
+  getViewConfig: () => null,
 });
 
 export const useObserveHeader = () => {

--- a/frontend/src/sections/project/context/ObserveHeaderContextProvider.jsx
+++ b/frontend/src/sections/project/context/ObserveHeaderContextProvider.jsx
@@ -28,6 +28,15 @@ const ObserveHeaderProvider = ({ children }) => {
     return typeof fn === "function" ? fn() : null;
   }, []);
 
+  const getTabTypeRef = useRef(null);
+  const registerGetTabType = useCallback((fn) => {
+    getTabTypeRef.current = typeof fn === "function" ? fn : null;
+  }, []);
+  const getTabType = useCallback(() => {
+    const fn = getTabTypeRef.current;
+    return typeof fn === "function" ? fn() : "traces";
+  }, []);
+
   return (
     <ObserveHeaderContext.Provider
       value={{
@@ -37,6 +46,8 @@ const ObserveHeaderProvider = ({ children }) => {
         setActiveViewConfig,
         registerGetViewConfig,
         getViewConfig,
+        registerGetTabType,
+        getTabType,
       }}
     >
       {children}

--- a/frontend/src/sections/project/context/ObserveHeaderContextProvider.jsx
+++ b/frontend/src/sections/project/context/ObserveHeaderContextProvider.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -16,8 +16,17 @@ const ObserveHeaderProvider = ({ children }) => {
     gridApi: null,
   });
 
-  // Config from the active saved-view tab (null for fixed default tabs)
   const [activeViewConfig, setActiveViewConfig] = useState(null);
+
+  // Ref (not state) so re-registering the callback doesn't re-render sibling consumers.
+  const getViewConfigRef = useRef(null);
+  const registerGetViewConfig = useCallback((fn) => {
+    getViewConfigRef.current = typeof fn === "function" ? fn : null;
+  }, []);
+  const getViewConfig = useCallback(() => {
+    const fn = getViewConfigRef.current;
+    return typeof fn === "function" ? fn() : null;
+  }, []);
 
   return (
     <ObserveHeaderContext.Provider
@@ -26,6 +35,8 @@ const ObserveHeaderProvider = ({ children }) => {
         setHeaderConfig,
         activeViewConfig,
         setActiveViewConfig,
+        registerGetViewConfig,
+        getViewConfig,
       }}
     >
       {children}

--- a/frontend/src/sections/project/context/__tests__/ObserveHeaderContext.test.jsx
+++ b/frontend/src/sections/project/context/__tests__/ObserveHeaderContext.test.jsx
@@ -41,3 +41,36 @@ describe("ObserveHeaderContext — getViewConfig register/read", () => {
     expect(second).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("ObserveHeaderContext — getTabType register/read", () => {
+  it("getTabType returns 'traces' default when nothing is registered", () => {
+    const { result } = renderHook(() => useObserveHeader(), { wrapper });
+    expect(result.current.getTabType()).toBe("traces");
+  });
+
+  it("getTabType returns the registered callback's result", () => {
+    const { result } = renderHook(() => useObserveHeader(), { wrapper });
+    const fake = vi.fn(() => "spans");
+    act(() => result.current.registerGetTabType(fake));
+    expect(result.current.getTabType()).toBe("spans");
+    expect(fake).toHaveBeenCalledTimes(1);
+  });
+
+  it("getTabType reverts to default after unregister", () => {
+    const { result } = renderHook(() => useObserveHeader(), { wrapper });
+    act(() => result.current.registerGetTabType(() => "spans"));
+    act(() => result.current.registerGetTabType(null));
+    expect(result.current.getTabType()).toBe("traces");
+  });
+
+  it("latest registration wins when re-registered", () => {
+    const { result } = renderHook(() => useObserveHeader(), { wrapper });
+    const first = vi.fn(() => "traces");
+    const second = vi.fn(() => "spans");
+    act(() => result.current.registerGetTabType(first));
+    act(() => result.current.registerGetTabType(second));
+    expect(result.current.getTabType()).toBe("spans");
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/sections/project/context/__tests__/ObserveHeaderContext.test.jsx
+++ b/frontend/src/sections/project/context/__tests__/ObserveHeaderContext.test.jsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import ObserveHeaderProvider from "../ObserveHeaderContextProvider";
+import { useObserveHeader } from "../ObserveHeaderContext";
+
+const wrapper = ({ children }) => (
+  <ObserveHeaderProvider>{children}</ObserveHeaderProvider>
+);
+
+describe("ObserveHeaderContext — getViewConfig register/read", () => {
+  it("getViewConfig returns null when nothing is registered", () => {
+    const { result } = renderHook(() => useObserveHeader(), { wrapper });
+    expect(result.current.getViewConfig()).toBeNull();
+  });
+
+  it("getViewConfig returns the registered callback's result", () => {
+    const { result } = renderHook(() => useObserveHeader(), { wrapper });
+    const fake = vi.fn(() => ({ filters: [{ columnId: "status" }] }));
+    act(() => result.current.registerGetViewConfig(fake));
+    expect(result.current.getViewConfig()).toEqual({
+      filters: [{ columnId: "status" }],
+    });
+    expect(fake).toHaveBeenCalledTimes(1);
+  });
+
+  it("getViewConfig returns null after unregister", () => {
+    const { result } = renderHook(() => useObserveHeader(), { wrapper });
+    act(() => result.current.registerGetViewConfig(() => ({ a: 1 })));
+    act(() => result.current.registerGetViewConfig(null));
+    expect(result.current.getViewConfig()).toBeNull();
+  });
+
+  it("latest registration wins when re-registered", () => {
+    const { result } = renderHook(() => useObserveHeader(), { wrapper });
+    const first = vi.fn(() => ({ v: 1 }));
+    const second = vi.fn(() => ({ v: 2 }));
+    act(() => result.current.registerGetViewConfig(first));
+    act(() => result.current.registerGetViewConfig(second));
+    expect(result.current.getViewConfig()).toEqual({ v: 2 });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -17,6 +17,7 @@ import React, {
   lazy,
   Suspense,
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -844,8 +845,12 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const compareCallLogsGridRef = useRef(null);
   const columnConfigureRef = useRef();
 
-  const { setHeaderConfig, activeViewConfig, registerGetViewConfig } =
-    useObserveHeader();
+  const {
+    setHeaderConfig,
+    activeViewConfig,
+    registerGetViewConfig,
+    registerGetTabType,
+  } = useObserveHeader();
 
   const { data: projectDetail } = useGetProjectDetails(observeId, !isUserMode);
   // In user mode the grid should behave like an OBSERVE project (no project
@@ -1832,6 +1837,12 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     return () => registerGetViewConfig(null);
   }, [registerGetViewConfig, buildViewConfig]);
 
+  useEffect(() => {
+    const getTabType = () => (selectedTab === "spans" ? "spans" : "traces");
+    registerGetTabType(getTabType);
+    return () => registerGetTabType(null);
+  }, [registerGetTabType, selectedTab]);
+
   // Auto-save display settings when they change
   const autoSaveTimerRef = useRef(null);
   useEffect(() => {
@@ -1974,35 +1985,88 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     [extraFilters],
   );
 
-  // Whether there's any non-default filter state worth saving. Drives the
-  // "Save view" button visibility. Broader than hasActiveFilter because
-  // date changes and column filters are also savable state.
+  // "Save view" button is a convenience affordance for a custom saved view
+  // that has been modified. On a default tab, the "+" button alone handles
+  // save-as-new — we don't want Save view cluttering the toolbar there.
   const canSaveView = useMemo(() => {
-    if (extraFilters?.length > 0) return true;
+    if (!activeViewConfig) return false;
+
+    const baselineDisplay = activeViewConfig.display || {};
+    const baselineExtraLen = activeViewConfig.extraFilters?.length ?? 0;
+    const baselineDateOption = baselineDisplay.dateFilter?.dateOption ?? null;
+    const baselineColumnHas = (activeViewConfig.filters ?? []).some(
+      (f) => f?.columnId,
+    );
+
+    if ((extraFilters?.length ?? 0) !== baselineExtraLen) return true;
 
     const currentDate =
       selectedTab === "trace" ? primaryTraceDateFilter : primarySpanDateFilter;
-    if (
-      currentDate?.dateOption &&
-      currentDate.dateOption !== defaultDateFilter?.dateOption
-    ) {
-      return true;
-    }
+    if ((currentDate?.dateOption ?? null) !== baselineDateOption) return true;
 
     const columnFilters =
       selectedTab === "trace" ? primaryTraceFilters : primarySpanFilters;
-    if (columnFilters?.some((f) => f?.columnId)) return true;
+    const currentColumnHas = !!columnFilters?.some((f) => f?.columnId);
+    if (currentColumnHas !== baselineColumnHas) return true;
 
+    if (
+      baselineDisplay.viewMode !== undefined &&
+      baselineDisplay.viewMode !== viewMode
+    ) {
+      return true;
+    }
+    if (
+      baselineDisplay.cellHeight !== undefined &&
+      baselineDisplay.cellHeight !== cellHeight
+    ) {
+      return true;
+    }
+    if (
+      baselineDisplay.showErrors !== undefined &&
+      baselineDisplay.showErrors !== showErrors
+    ) {
+      return true;
+    }
+    if (
+      baselineDisplay.showNonAnnotated !== undefined &&
+      baselineDisplay.showNonAnnotated !== showNonAnnotated
+    ) {
+      return true;
+    }
+    if (
+      baselineDisplay.showCompare !== undefined &&
+      baselineDisplay.showCompare !== showCompare
+    ) {
+      return true;
+    }
+    if (
+      baselineDisplay.hasEvalFilter !== undefined &&
+      baselineDisplay.hasEvalFilter !== hasEvalFilter
+    ) {
+      return true;
+    }
     return false;
   }, [
+    activeViewConfig,
     extraFilters,
     selectedTab,
     primaryTraceDateFilter,
     primarySpanDateFilter,
     primaryTraceFilters,
     primarySpanFilters,
-    defaultDateFilter,
+    viewMode,
+    cellHeight,
+    showErrors,
+    showNonAnnotated,
+    showCompare,
+    hasEvalFilter,
   ]);
+
+  // Defer the visibility signal so it catches up with activeViewConfig
+  // (which updates inside startTransition). Without this, canSaveView briefly
+  // returns true on view-switch because filter state updates urgently while
+  // the baseline update trails by a render, which makes the button flicker.
+  const canSaveViewDeferred = useDeferredValue(canSaveView);
 
   const currentGridRef = useMemo(() => {
     if (selectedGraph === "primary" && selectedTab === "trace") {
@@ -2868,7 +2932,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                   : setPrimarySpanDateFilter
               }
               hasActiveFilter={hasActiveFilter}
-              canSaveView={canSaveView}
+              canSaveView={canSaveViewDeferred}
               onFilterToggle={() => {
                 // Clear any chip/+ anchor so the popover re-anchors to the
                 // toolbar Filter button (avoids opening on a stale anchor).

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -844,6 +844,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const primaryCallLogsGridRef = useRef(null);
   const compareCallLogsGridRef = useRef(null);
   const columnConfigureRef = useRef();
+  // Saved-view columnState queued before the active sub-tab's primary grid
+  // mounted. Drained by onGridReady on the primary grid.
+  const pendingColumnStateRef = useRef(null);
 
   const {
     setHeaderConfig,
@@ -1616,6 +1619,23 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       pendingCustomColumnsRef.current = display.customColumns;
     }
 
+    // Apply column state (widths/order/sort) to the active sub-tab's primary
+    // grid. If the grid isn't mounted yet, queue for the onGridReady callback.
+    if (Array.isArray(display.columnState) && display.columnState.length > 0) {
+      const activeApi =
+        selectedTab === "trace"
+          ? primaryTraceGridRef.current?.api
+          : primarySpanGridRef.current?.api;
+      if (activeApi?.applyColumnState) {
+        activeApi.applyColumnState({
+          state: display.columnState,
+          applyOrder: true,
+        });
+      } else {
+        pendingColumnStateRef.current = display.columnState;
+      }
+    }
+
     // Primary date filter — stored inside display for backend-whitelist compatibility.
     // Only apply if the saved view has one; old views without it keep the current date.
     if (display.dateFilter) {
@@ -1665,6 +1685,39 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeViewConfig]);
+
+  // Drain the queued saved-view columnState once the active sub-tab's primary
+  // grid mounts. TraceGrid is lazy-loaded so the AG Grid api may not exist
+  // when applyConfig runs — retry a handful of times to catch it.
+  useEffect(() => {
+    if (!pendingColumnStateRef.current) return;
+    let attempts = 0;
+    let timer = null;
+    const tryApply = () => {
+      const api =
+        selectedTab === "trace"
+          ? primaryTraceGridRef.current?.api
+          : primarySpanGridRef.current?.api;
+      if (
+        api?.applyColumnState &&
+        Array.isArray(pendingColumnStateRef.current)
+      ) {
+        api.applyColumnState({
+          state: pendingColumnStateRef.current,
+          applyOrder: true,
+        });
+        pendingColumnStateRef.current = null;
+        return;
+      }
+      if (attempts++ < 20) {
+        timer = setTimeout(tryApply, 100);
+      }
+    };
+    tryApply();
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [activeViewConfig, selectedTab]);
 
   // ---------------------------------------------------------------------------
   // View persistence — auto-save display + reset/default
@@ -1772,6 +1825,15 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
 
   // Build the full saved view config payload
   const buildViewConfig = useCallback(() => {
+    // Capture current grid column state (widths/order/sort/visibility) of the
+    // active sub-tab's primary grid, so saved views restore the user's exact
+    // column layout. Stashed inside `display` because the backend serializer
+    // whitelists `display` for arbitrary subkeys.
+    const activeGridApi =
+      selectedTab === "trace"
+        ? primaryTraceGridRef.current?.api
+        : primarySpanGridRef.current?.api;
+    const columnState = activeGridApi?.getColumnState?.() ?? undefined;
     const currentDisplay = {
       viewMode,
       cellHeight,
@@ -1785,6 +1847,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         selectedTab === "trace"
           ? primaryTraceDateFilter
           : primarySpanDateFilter,
+      ...(columnState ? { columnState } : {}),
     };
     const mapFilters = (filters) =>
       (filters || []).map((f) => ({
@@ -2045,6 +2108,19 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     ) {
       return true;
     }
+    // Custom columns: did the user add/remove a custom column since the
+    // saved view? Compare by id, not deep shape.
+    const baselineCustom = Array.isArray(baselineDisplay.customColumns)
+      ? baselineDisplay.customColumns
+      : [];
+    const currentCustom = getCustomColumns() || [];
+    if (currentCustom.length !== baselineCustom.length) return true;
+    if (currentCustom.length > 0) {
+      const baselineIds = new Set(baselineCustom.map((c) => c?.id));
+      for (const col of currentCustom) {
+        if (!baselineIds.has(col?.id)) return true;
+      }
+    }
     return false;
   }, [
     activeViewConfig,
@@ -2060,6 +2136,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     showNonAnnotated,
     showCompare,
     hasEvalFilter,
+    getCustomColumns,
   ]);
 
   // Defer the visibility signal so it catches up with activeViewConfig

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -1687,10 +1687,6 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     }
     wasOnSavedViewRef.current = true;
 
-    if (import.meta.env.MODE !== "production") {
-      // eslint-disable-next-line no-console
-    }
-
     // Apply display settings
     const display = activeViewConfig.display || {};
     if (display.viewMode) setViewMode(display.viewMode);
@@ -1727,9 +1723,6 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     // Primary date filter — stored inside display for backend-whitelist compatibility.
     // Only apply if the saved view has one; old views without it keep the current date.
     if (display.dateFilter) {
-      if (import.meta.env.MODE !== "production") {
-        // eslint-disable-next-line no-console
-      }
       if (selectedTab === "trace") {
         setPrimaryTraceDateFilter(display.dateFilter);
       } else {

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -854,6 +854,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const {
     setHeaderConfig,
     activeViewConfig,
+    setActiveViewConfig,
     registerGetViewConfig,
     registerGetTabType,
   } = useObserveHeader();
@@ -1931,8 +1932,11 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     mutate(
       { id: activeViewTabId, config },
       {
-        onSuccess: () =>
-          enqueueSnackbar("View updated", { variant: "success" }),
+        onSuccess: (response) => {
+          // Refresh the baseline so canSaveView's diff resets to false.
+          setActiveViewConfig(response?.data?.result?.config ?? config);
+          enqueueSnackbar("View updated", { variant: "success" });
+        },
         onError: () =>
           enqueueSnackbar("Failed to update view", { variant: "error" }),
       },
@@ -1943,6 +1947,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     isUserMode,
     updateSavedView,
     updateWorkspaceSavedView,
+    setActiveViewConfig,
   ]);
 
   // Persist display settings to localStorage on the default tab so personal

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -187,6 +187,7 @@ import {
 } from "../SessionsView/ReplaySessions/store";
 import { REPLAY_MODULES } from "../SessionsView/ReplaySessions/configurations";
 import { REPLAY_TYPES } from "../SessionsView/ReplaySessions/constants";
+import { filtersContentEqual } from "../saved-view-utils";
 import { useCreateReplaySessions } from "src/api/project/replay-sessions";
 import { enqueueSnackbar } from "notistack";
 import {
@@ -674,29 +675,82 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   // grids/queries omit project_id so the backend scopes by org.
   const observeId = isUserMode ? null : routeObserveId;
 
+  // Pulled up out of the larger useObserveHeader() destructure below so
+  // handleGroupByChange (which clears activeViewConfig when navigating off
+  // a saved view) can reference it without a TDZ. Same context call ID,
+  // shape-stable from React.
+  const { setActiveViewConfig: setActiveViewConfigFromCtx } =
+    useObserveHeader();
+
   const handleGroupByChange = useCallback(
     (groupKey) => {
-      // In user mode we're not in a project context, so the cross-route
-      // navigation cases are no-ops.
+      // Group-by changes off a saved view land on the corresponding default
+      // tab — the saved view's filters/columns aren't meaningful for a
+      // different group key, so we drop activeViewConfig and rewrite the
+      // tab URL key. Detect saved view via the URL `tab` (`userTab` in
+      // user mode) — `view-<id>` means we're on a custom saved view.
+      const params = new URLSearchParams(window.location.search);
+      const tabKey = isUserMode ? "userTab" : "tab";
+      const onSavedView = params.get(tabKey)?.startsWith("view-");
+
       switch (groupKey) {
         case "none":
         case "trace":
-          setSelectedTab("trace");
+          if (onSavedView) {
+            setActiveViewConfigFromCtx(null);
+            if (isUserMode) {
+              navigate("?userTab=traces&selectedTab=trace", { replace: true });
+            } else {
+              navigate(
+                `/dashboard/observe/${observeId}/llm-tracing?tab=traces&selectedTab=trace`,
+                { replace: true },
+              );
+            }
+          } else {
+            setSelectedTab("trace");
+          }
           break;
         case "span":
-          setSelectedTab("spans");
+          if (onSavedView) {
+            setActiveViewConfigFromCtx(null);
+            if (isUserMode) {
+              // User Detail has a single "Trace" fixed tab that hosts the
+              // selectedTab toggle, so we land on userTab=traces with
+              // selectedTab=spans.
+              navigate("?userTab=traces&selectedTab=spans", { replace: true });
+            } else {
+              navigate(
+                `/dashboard/observe/${observeId}/llm-tracing?tab=spans&selectedTab=spans`,
+                { replace: true },
+              );
+            }
+          } else {
+            setSelectedTab("spans");
+          }
           break;
         case "users":
-          if (!isUserMode) navigate(`/dashboard/observe/${observeId}/users`);
+          if (!isUserMode) {
+            setActiveViewConfigFromCtx(null);
+            navigate(`/dashboard/observe/${observeId}/users`);
+          }
           break;
         case "sessions":
-          if (!isUserMode) navigate(`/dashboard/observe/${observeId}/sessions`);
+          if (!isUserMode) {
+            setActiveViewConfigFromCtx(null);
+            navigate(`/dashboard/observe/${observeId}/sessions`);
+          }
           break;
         default:
           break;
       }
     },
-    [observeId, navigate, setSelectedTab, isUserMode],
+    [
+      observeId,
+      navigate,
+      setSelectedTab,
+      setActiveViewConfigFromCtx,
+      isUserMode,
+    ],
   );
 
   const [_loading, setLoading] = useState(false);
@@ -1600,16 +1654,38 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   }, [selectedTab, primaryTraceDateFilter, primarySpanDateFilter]);
 
   // Load filters + display settings from saved view config when a custom view tab is selected
+  // Tracked separately so the null-branch reset only fires on a genuine
+  // saved-view → default transition, not on initial mount where
+  // activeViewConfig is null only because hydration hasn't landed yet.
+  // Without this guard, the destructive resets below clobber state that
+  // the localStorage rehydrate (line 1816) and the apply branch are
+  // about to set from the saved view itself.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const wasOnSavedViewRef = useRef(false);
   useEffect(() => {
     if (!activeViewConfig) {
+      const wasOnSavedView = wasOnSavedViewRef.current;
+      wasOnSavedViewRef.current = false;
+      if (!wasOnSavedView) return; // initial mount / already on default — nothing to clean up
       // Back to a default tab — clear local extraFilters so chips from a
-      // prior custom view don't linger. Intentionally do NOT touch
-      // pendingCustomColumnsRef — the localStorage hydration effect only
-      // queues into it once on mount and we'd erase a still-pending merge
-      // if the backend columns haven't arrived yet.
+      // prior custom view don't linger. URL-synced display state
+      // (cellHeight / showErrors / showNonAnnotated / hasEvalFilter /
+      // showCompare) is wiped via the parent's URL navigation; viewMode
+      // lives in the Zustand store (no URL key) so we reset it explicitly,
+      // and the active grid's columnState (widths/order/sort) is internal
+      // to AG Grid and likewise needs an imperative reset.
       setExtraFilters((prev) => (prev.length === 0 ? prev : []));
+      setViewMode(DEFAULT_DISPLAY_CONFIG.viewMode);
+      pendingColumnStateRef.current = null;
+      pendingCustomColumnsRef.current = [];
+      const activeApi =
+        selectedTab === "trace"
+          ? primaryTraceGridRef.current?.api
+          : primarySpanGridRef.current?.api;
+      if (activeApi?.resetColumnState) activeApi.resetColumnState();
       return;
     }
+    wasOnSavedViewRef.current = true;
 
     if (import.meta.env.MODE !== "production") {
       // eslint-disable-next-line no-console
@@ -2093,13 +2169,11 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     if (!activeViewConfig) return false;
 
     const baselineDisplay = activeViewConfig.display || {};
-    const baselineExtraLen = activeViewConfig.extraFilters?.length ?? 0;
+    const baselineExtraFilters = activeViewConfig.extraFilters || [];
     const baselineDateOption = baselineDisplay.dateFilter?.dateOption ?? null;
-    const baselineColumnHas = (activeViewConfig.filters ?? []).some(
-      (f) => f?.columnId,
-    );
+    const baselineColumnFilters = activeViewConfig.filters || [];
 
-    if ((extraFilters?.length ?? 0) !== baselineExtraLen) return true;
+    if (!filtersContentEqual(extraFilters, baselineExtraFilters)) return true;
 
     const currentDate =
       selectedTab === "trace" ? primaryTraceDateFilter : primarySpanDateFilter;
@@ -2107,8 +2181,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
 
     const columnFilters =
       selectedTab === "trace" ? primaryTraceFilters : primarySpanFilters;
-    const currentColumnHas = !!columnFilters?.some((f) => f?.columnId);
-    if (currentColumnHas !== baselineColumnHas) return true;
+    if (!filtersContentEqual(columnFilters, baselineColumnFilters)) return true;
 
     if (
       baselineDisplay.viewMode !== undefined &&

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -844,7 +844,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const compareCallLogsGridRef = useRef(null);
   const columnConfigureRef = useRef();
 
-  const { setHeaderConfig, activeViewConfig } = useObserveHeader();
+  const { setHeaderConfig, activeViewConfig, registerGetViewConfig } =
+    useObserveHeader();
 
   const { data: projectDetail } = useGetProjectDetails(observeId, !isUserMode);
   // In user mode the grid should behave like an OBSERVE project (no project
@@ -1590,6 +1591,10 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   useEffect(() => {
     if (!activeViewConfig) return;
 
+    if (import.meta.env.MODE !== "production") {
+      // eslint-disable-next-line no-console
+    }
+
     // Apply display settings
     const display = activeViewConfig.display || {};
     if (display.viewMode) setViewMode(display.viewMode);
@@ -1606,48 +1611,53 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       pendingCustomColumnsRef.current = display.customColumns;
     }
 
-    // Apply filters
-    if (activeViewConfig.filters?.length > 0) {
-      const filtersWithIds = activeViewConfig.filters.map((f) => ({
-        ...f,
-        id: f.id || getRandomId(),
-      }));
+    // Primary date filter — stored inside display for backend-whitelist compatibility.
+    // Only apply if the saved view has one; old views without it keep the current date.
+    if (display.dateFilter) {
+      if (import.meta.env.MODE !== "production") {
+        // eslint-disable-next-line no-console
+      }
       if (selectedTab === "trace") {
-        setPrimaryTraceFilters(filtersWithIds);
+        setPrimaryTraceDateFilter(display.dateFilter);
       } else {
-        setPrimarySpanFilters(filtersWithIds);
+        setPrimarySpanDateFilter(display.dateFilter);
       }
     }
 
-    // Restore compare state
-    if (display.showCompare) {
-      if (activeViewConfig.compareFilters?.length > 0) {
-        const compareFiltersWithIds = activeViewConfig.compareFilters.map(
-          (f) => ({
-            ...f,
-            id: f.id || getRandomId(),
-          }),
-        );
-        if (selectedTab === "trace") {
-          setCompareTraceFilters(compareFiltersWithIds);
-        } else {
-          setCompareSpansFilters(compareFiltersWithIds);
-        }
+    // Apply filters — replace unconditionally so switching views clears stale filters.
+    const nextFilters = (activeViewConfig.filters || []).map((f) => ({
+      ...f,
+      id: f.id || getRandomId(),
+    }));
+    if (selectedTab === "trace") {
+      setPrimaryTraceFilters(nextFilters);
+    } else {
+      setPrimarySpanFilters(nextFilters);
+    }
+
+    // Apply extraFilters unconditionally (independent of compare mode).
+    setExtraFilters(activeViewConfig.extraFilters || []);
+
+    // Compare state — always replace, regardless of current showCompare state.
+    const nextCompareFilters = (activeViewConfig.compareFilters || []).map(
+      (f) => ({
+        ...f,
+        id: f.id || getRandomId(),
+      }),
+    );
+    if (selectedTab === "trace") {
+      setCompareTraceFilters(nextCompareFilters);
+      if (activeViewConfig.compareDateFilter !== undefined) {
+        setCompareTraceDateFilter(activeViewConfig.compareDateFilter);
       }
-      if (activeViewConfig.compareDateFilter) {
-        if (selectedTab === "trace") {
-          setCompareTraceDateFilter(activeViewConfig.compareDateFilter);
-        } else {
-          setCompareSpansDateFilter(activeViewConfig.compareDateFilter);
-        }
-      }
-      if (activeViewConfig.extraFilters?.length > 0) {
-        setExtraFilters(activeViewConfig.extraFilters);
-      }
-      if (activeViewConfig.compareExtraFilters?.length > 0) {
-        setCompareExtraFilters(activeViewConfig.compareExtraFilters);
+    } else {
+      setCompareSpansFilters(nextCompareFilters);
+      if (activeViewConfig.compareDateFilter !== undefined) {
+        setCompareSpansDateFilter(activeViewConfig.compareDateFilter);
       }
     }
+    setCompareExtraFilters(activeViewConfig.compareExtraFilters || []);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeViewConfig]);
 
@@ -1765,6 +1775,11 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       showCompare,
       hasEvalFilter,
       customColumns: getCustomColumns(),
+      // Stash primary date filter inside display for backend-whitelist compatibility
+      dateFilter:
+        selectedTab === "trace"
+          ? primaryTraceDateFilter
+          : primarySpanDateFilter,
     };
     const mapFilters = (filters) =>
       (filters || []).map((f) => ({
@@ -1776,6 +1791,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       filters: mapFilters(
         selectedTab === "trace" ? primaryTraceFilters : primarySpanFilters,
       ),
+      // extraFilters is independent of compare mode — always persist
+      extraFilters: extraFilters || [],
     };
     // Include compare state when compare mode is on
     if (showCompare) {
@@ -1786,7 +1803,6 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         selectedTab === "trace"
           ? compareTraceDateFilter
           : compareSpansDateFilter;
-      config.extraFilters = extraFilters || [];
       config.compareExtraFilters = compareExtraFilters || [];
     }
     return config;
@@ -1801,6 +1817,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     selectedTab,
     primaryTraceFilters,
     primarySpanFilters,
+    primaryTraceDateFilter,
+    primarySpanDateFilter,
     compareTraceFilters,
     compareSpansFilters,
     compareTraceDateFilter,
@@ -1808,6 +1826,11 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     extraFilters,
     compareExtraFilters,
   ]);
+
+  useEffect(() => {
+    registerGetViewConfig(buildViewConfig);
+    return () => registerGetViewConfig(null);
+  }, [registerGetViewConfig, buildViewConfig]);
 
   // Auto-save display settings when they change
   const autoSaveTimerRef = useRef(null);
@@ -1943,10 +1966,43 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     createSavedView,
   ]);
 
+  // Eval filter chips — drives the Filter button's red "active" dot.
+  // Keep this scoped to extraFilters only; date/column changes should NOT
+  // light up the Filter button (those have their own affordances).
   const hasActiveFilter = useMemo(
     () => extraFilters?.length > 0,
     [extraFilters],
   );
+
+  // Whether there's any non-default filter state worth saving. Drives the
+  // "Save view" button visibility. Broader than hasActiveFilter because
+  // date changes and column filters are also savable state.
+  const canSaveView = useMemo(() => {
+    if (extraFilters?.length > 0) return true;
+
+    const currentDate =
+      selectedTab === "trace" ? primaryTraceDateFilter : primarySpanDateFilter;
+    if (
+      currentDate?.dateOption &&
+      currentDate.dateOption !== defaultDateFilter?.dateOption
+    ) {
+      return true;
+    }
+
+    const columnFilters =
+      selectedTab === "trace" ? primaryTraceFilters : primarySpanFilters;
+    if (columnFilters?.some((f) => f?.columnId)) return true;
+
+    return false;
+  }, [
+    extraFilters,
+    selectedTab,
+    primaryTraceDateFilter,
+    primarySpanDateFilter,
+    primaryTraceFilters,
+    primarySpanFilters,
+    defaultDateFilter,
+  ]);
 
   const currentGridRef = useMemo(() => {
     if (selectedGraph === "primary" && selectedTab === "trace") {
@@ -2812,6 +2868,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                   : setPrimarySpanDateFilter
               }
               hasActiveFilter={hasActiveFilter}
+              canSaveView={canSaveView}
               onFilterToggle={() => {
                 // Clear any chip/+ anchor so the popover re-anchors to the
                 // toolbar Filter button (avoids opening on a stale anchor).

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -1597,7 +1597,15 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
 
   // Load filters + display settings from saved view config when a custom view tab is selected
   useEffect(() => {
-    if (!activeViewConfig) return;
+    if (!activeViewConfig) {
+      // Back to a default tab — clear local extraFilters so chips from a
+      // prior custom view don't linger. Intentionally do NOT touch
+      // pendingCustomColumnsRef — the localStorage hydration effect only
+      // queues into it once on mount and we'd erase a still-pending merge
+      // if the backend columns haven't arrived yet.
+      setExtraFilters((prev) => (prev.length === 0 ? prev : []));
+      return;
+    }
 
     if (import.meta.env.MODE !== "production") {
       // eslint-disable-next-line no-console

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -192,7 +192,10 @@ import { enqueueSnackbar } from "notistack";
 import {
   useUpdateSavedView,
   useCreateSavedView,
+  useUpdateWorkspaceSavedView,
 } from "src/api/project/saved-views";
+
+const USER_DETAIL_TAB_TYPE = "user_detail";
 
 // Eagerly load the trace grid (always visible)
 import TraceGrid from "./TraceGrid";
@@ -1823,13 +1826,18 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
 
   const { mutate: updateSavedView } = useUpdateSavedView(observeId);
   const { mutate: createSavedView } = useCreateSavedView(observeId);
+  // Workspace-scoped update for user_detail mode (CrossProjectUserDetailPage).
+  // Always declared (hooks can't be conditional); only invoked when isUserMode.
+  const { mutate: updateWorkspaceSavedView } =
+    useUpdateWorkspaceSavedView(USER_DETAIL_TAB_TYPE);
 
-  // Get active view tab ID from URL
+  // Get active view tab ID from URL. The tab-key URL param differs per
+  // surface: "tab" on ObservePage, "userTab" on CrossProjectUserDetailPage.
   const activeViewTabId = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
-    const tab = params.get("tab");
+    const tab = isUserMode ? params.get("userTab") : params.get("tab");
     return tab?.startsWith("view-") ? tab.replace("view-", "") : null;
-  }, [activeViewConfig]); // re-derive when view config changes
+  }, [activeViewConfig, isUserMode]); // re-derive when view config changes
 
   // Build the full saved view config payload
   const buildViewConfig = useCallback(() => {
@@ -1914,9 +1922,40 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     return () => registerGetTabType(null);
   }, [registerGetTabType, selectedTab]);
 
-  // Auto-save display settings when they change
-  const autoSaveTimerRef = useRef(null);
+  // Explicit "Save view" — overwrite the active saved view's config with the
+  // current live state. Bound to ObserveToolbar's Save view button.
+  const handleSaveView = useCallback(() => {
+    if (!activeViewTabId) return;
+    const config = buildViewConfig();
+    const mutate = isUserMode ? updateWorkspaceSavedView : updateSavedView;
+    mutate(
+      { id: activeViewTabId, config },
+      {
+        onSuccess: () =>
+          enqueueSnackbar("View updated", { variant: "success" }),
+        onError: () =>
+          enqueueSnackbar("Failed to update view", { variant: "error" }),
+      },
+    );
+  }, [
+    activeViewTabId,
+    buildViewConfig,
+    isUserMode,
+    updateSavedView,
+    updateWorkspaceSavedView,
+  ]);
+
+  // Persist display settings to localStorage on the default tab so personal
+  // preferences (cellHeight, viewMode, …) survive across navigation. The
+  // backend-update branch that used to live here was removed: filter/date
+  // state was never in the dep array, so it silently missed those changes.
+  // Updates to a saved view are now triggered explicitly by handleSaveView
+  // (the Save view button in the toolbar).
   useEffect(() => {
+    // Default tab only — persist personal display preferences to localStorage
+    // so cellHeight / viewMode / etc. survive across navigation. Saved-view
+    // tabs go through the explicit Save view button (handleSaveView) instead.
+    if (activeViewTabId) return;
     const currentDisplay = {
       viewMode,
       cellHeight,
@@ -1926,25 +1965,11 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       hasEvalFilter,
       customColumns: getCustomColumns(),
     };
-
-    // For default tab (no custom view), persist to localStorage
-    if (!activeViewTabId) {
-      try {
-        localStorage.setItem(displayStorageKey, JSON.stringify(currentDisplay));
-      } catch {
-        /* quota exceeded */
-      }
-      return;
+    try {
+      localStorage.setItem(displayStorageKey, JSON.stringify(currentDisplay));
+    } catch {
+      /* quota exceeded */
     }
-
-    // For custom view tabs, debounced auto-save to backend
-    if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
-    autoSaveTimerRef.current = setTimeout(() => {
-      updateSavedView({ id: activeViewTabId, config: buildViewConfig() });
-    }, 1500);
-    return () => {
-      if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     viewMode,
@@ -3018,6 +3043,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
               }
               hasActiveFilter={hasActiveFilter}
               canSaveView={canSaveViewDeferred}
+              onSaveView={handleSaveView}
               onFilterToggle={() => {
                 // Clear any chip/+ anchor so the popover re-anchors to the
                 // toolbar Filter button (avoids opening on a stale anchor).

--- a/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
+++ b/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
@@ -468,8 +468,8 @@ const ObserveToolbar = ({
             }}
           />
 
-          {/* Save view — appears when there's any savable state (traces only) */}
-          {isTraces && canSaveView && (
+          {/* Save view — appears when there's any savable state */}
+          {canSaveView && (
             <Button
               variant="outlined"
               size="small"
@@ -487,8 +487,9 @@ const ObserveToolbar = ({
                 borderColor: "primary.main",
                 color: "primary.main",
                 "&:hover": {
-                  bgcolor: "primary.lighter",
+                  bgcolor: "action.hover",
                   borderColor: "primary.main",
+                  color: "primary.main",
                 },
               }}
             >

--- a/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
+++ b/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
@@ -50,6 +50,7 @@ const ObserveToolbar = ({
   // Filter
   hasActiveFilter,
   canSaveView,
+  onSaveView,
   isFilterOpen,
   onFilterToggle,
   filters,
@@ -468,14 +469,21 @@ const ObserveToolbar = ({
             }}
           />
 
-          {/* Save view — appears when there's any savable state */}
+          {/* Save view — updates the currently-active saved view in place
+              when its state has diverged from the saved baseline. The "+"
+              button in the tab bar handles save-as-new. */}
           {canSaveView && (
             <Button
               variant="outlined"
               size="small"
               startIcon={<Iconify icon="mdi:content-save-outline" width={16} />}
-              onClick={(e) => {
-                // Find the "+" button in the tab bar and click it to open the save view popover
+              onClick={() => {
+                if (typeof onSaveView === "function") {
+                  onSaveView();
+                  return;
+                }
+                // Fallback: open create-new popover via the "+" button if no
+                // explicit save handler was wired (e.g. an older mount path).
                 const createBtn = document.querySelector(
                   "[data-create-view-btn]",
                 );
@@ -575,6 +583,7 @@ ObserveToolbar.propTypes = {
   setDateFilter: PropTypes.func,
   hasActiveFilter: PropTypes.bool,
   canSaveView: PropTypes.bool,
+  onSaveView: PropTypes.func,
   isFilterOpen: PropTypes.bool,
   onFilterToggle: PropTypes.func,
   filters: PropTypes.array,

--- a/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
+++ b/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
@@ -49,6 +49,7 @@ const ObserveToolbar = ({
   setDateFilter,
   // Filter
   hasActiveFilter,
+  canSaveView,
   isFilterOpen,
   onFilterToggle,
   filters,
@@ -467,8 +468,8 @@ const ObserveToolbar = ({
             }}
           />
 
-          {/* Save view — appears when filters are active (traces only) */}
-          {isTraces && hasActiveFilter && (
+          {/* Save view — appears when there's any savable state (traces only) */}
+          {isTraces && canSaveView && (
             <Button
               variant="outlined"
               size="small"
@@ -572,6 +573,7 @@ ObserveToolbar.propTypes = {
   dateFilter: PropTypes.object,
   setDateFilter: PropTypes.func,
   hasActiveFilter: PropTypes.bool,
+  canSaveView: PropTypes.bool,
   isFilterOpen: PropTypes.bool,
   onFilterToggle: PropTypes.func,
   filters: PropTypes.array,

--- a/frontend/src/sections/projects/ObservePage.jsx
+++ b/frontend/src/sections/projects/ObservePage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useEffect, startTransition } from "react";
+import React, { useMemo, useCallback, useEffect, useRef, startTransition } from "react";
 import PropTypes from "prop-types";
 import { Box, Paper, useTheme, CircularProgress, Alert } from "@mui/material";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router";
@@ -126,6 +126,31 @@ const ObservePage = React.memo(() => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentRouteSegment]);
+
+  // Hydrate activeViewConfig on hard-refresh / direct URL load. handleTabChange
+  // sets it on click, but a page reload re-mounts with no in-memory state —
+  // children read activeViewConfig for extraFilters, visibleColumns, etc.,
+  // and without this all of those fall back to defaults until the user clicks
+  // the tab again. Re-runs only when the URL tab key or the saved-views list
+  // changes; the value for `tab=view-<id>` is stable across saved-views
+  // refetches so we don't churn the apply effect on every mutation invalidate.
+  const lastHydratedTabRef = useRef(null);
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const tab = params.get("tab");
+    if (!tab || !tab.startsWith("view-")) {
+      lastHydratedTabRef.current = null;
+      return;
+    }
+    if (lastHydratedTabRef.current === tab) return;
+    const customViews =
+      savedViewsData?.customViews ?? savedViewsData?.custom_views ?? [];
+    if (!customViews.length) return;
+    const view = customViews.find((v) => `view-${v.id}` === tab);
+    if (!view?.config) return;
+    lastHydratedTabRef.current = tab;
+    setActiveViewConfig(view.config);
+  }, [location.search, savedViewsData, setActiveViewConfig]);
 
   // Handle tab change from ObserveTabBar
   const handleTabChange = useCallback(

--- a/frontend/src/sections/projects/ObservePage.jsx
+++ b/frontend/src/sections/projects/ObservePage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useEffect } from "react";
+import React, { useMemo, useCallback, useEffect, startTransition } from "react";
 import PropTypes from "prop-types";
 import { Box, Paper, useTheme, CircularProgress, Alert } from "@mui/material";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router";
@@ -127,13 +127,16 @@ const ObservePage = React.memo(() => {
   // Handle tab change from ObserveTabBar
   const handleTabChange = useCallback(
     (tabKey) => {
-      setActiveTab(tabKey);
+      // setActiveTab is redundant here: navigate() below updates the URL and
+      // useUrlState's external-sync effect will update the state. Skipping
+      // the explicit call saves one setSearchParams round and the
+      // corresponding re-render cascade.
 
       // Set activeViewConfig from saved view data. Read from queryClient
       // directly rather than the `savedViewsData` closure, which can be stale
-      // immediately after an optimistic cache write (e.g., right after a new
-      // view is created — the closure hasn't re-rendered yet but the cache has).
+      // immediately after an optimistic cache write.
       let activeConfig = null;
+      let viewTabType = "traces";
       if (tabKey.startsWith("view-")) {
         const viewId = tabKey.replace("view-", "");
         const cached = queryClient.getQueryData([SAVED_VIEWS_KEY, observeId]);
@@ -142,44 +145,95 @@ const ObservePage = React.memo(() => {
           cachedResult?.customViews ?? cachedResult?.custom_views ?? [];
         const view = customViews.find((v) => v.id === viewId);
         activeConfig = view?.config || null;
-        setActiveViewConfig(activeConfig);
-      } else {
-        setActiveViewConfig(null);
+        viewTabType = view?.tab_type ?? view?.tabType ?? "traces";
       }
+
+      // Apply effects (activeViewConfig → apply effect → many setters) aren't
+      // urgent for tab responsiveness. Defer via startTransition so the
+      // navigation and URL update feel snappy while the filter apply runs as
+      // a non-blocking transition.
+      startTransition(() => {
+        setActiveViewConfig(activeConfig);
+      });
 
       // Navigate to the appropriate route
       if (tabKey.startsWith("view-")) {
-        const basePath = `/dashboard/observe/${observeId}/llm-tracing`;
-        // Inline all URL-synced state from the saved view so useUrlState hooks
-        // read the correct values on this navigation (avoids a race where the
-        // apply effect would try to re-write the URL and lose params).
+        const isUsersView =
+          viewTabType === "users" || viewTabType === "user_detail";
+        const isSessionsView = viewTabType === "sessions";
+        let routeSegment = "llm-tracing";
+        if (isUsersView) routeSegment = "users";
+        else if (isSessionsView) routeSegment = "sessions";
+        const basePath = `/dashboard/observe/${observeId}/${routeSegment}`;
+
         const params = new URLSearchParams();
         params.set("tab", tabKey);
-        params.set("selectedTab", "trace");
-        if (activeConfig?.filters) {
-          params.set(
-            "primaryTraceFilter",
-            JSON.stringify(activeConfig.filters),
-          );
+
+        if (isUsersView) {
+          // Users-typed views use a different config schema (config.filters is
+          // an object, not an array) and its own URL-state key pair.
+          if (activeConfig?.filters?.dateFilter) {
+            params.set(
+              "userDateFilter",
+              JSON.stringify(activeConfig.filters.dateFilter),
+            );
+          }
+        } else if (isSessionsView) {
+          // Sessions uses sessionFilter / sessionDateFilter URL keys.
+          if (activeConfig?.filters) {
+            params.set(
+              "sessionFilter",
+              JSON.stringify(activeConfig.filters),
+            );
+          }
+          if (activeConfig?.display?.dateFilter) {
+            params.set(
+              "sessionDateFilter",
+              JSON.stringify(activeConfig.display.dateFilter),
+            );
+          }
+        } else {
+          // Trace / Span views — pick URL keys that match LLMTracingView's
+          // useLLMTracingFilters registrations.
+          const isSpans = viewTabType === "spans";
+          const selectedTabValue = isSpans ? "spans" : "trace";
+          const primaryFilterKey = isSpans
+            ? "primarySpanFilter"
+            : "primaryTraceFilter";
+          const primaryDateKey = isSpans
+            ? "primarySpanDateFilter"
+            : "primaryTraceDateFilter";
+          const compareFilterKey = isSpans
+            ? "compareSpansFilter"
+            : "compareTraceFilter";
+          const compareDateKey = isSpans
+            ? "compareSpansDateFilter"
+            : "compareTraceDateFilter";
+
+          params.set("selectedTab", selectedTabValue);
+          if (activeConfig?.filters) {
+            params.set(primaryFilterKey, JSON.stringify(activeConfig.filters));
+          }
+          if (activeConfig?.display?.dateFilter) {
+            params.set(
+              primaryDateKey,
+              JSON.stringify(activeConfig.display.dateFilter),
+            );
+          }
+          if (activeConfig?.compareFilters) {
+            params.set(
+              compareFilterKey,
+              JSON.stringify(activeConfig.compareFilters),
+            );
+          }
+          if (activeConfig?.compareDateFilter) {
+            params.set(
+              compareDateKey,
+              JSON.stringify(activeConfig.compareDateFilter),
+            );
+          }
         }
-        if (activeConfig?.display?.dateFilter) {
-          params.set(
-            "primaryTraceDateFilter",
-            JSON.stringify(activeConfig.display.dateFilter),
-          );
-        }
-        if (activeConfig?.compareFilters) {
-          params.set(
-            "compareTraceFilter",
-            JSON.stringify(activeConfig.compareFilters),
-          );
-        }
-        if (activeConfig?.compareDateFilter) {
-          params.set(
-            "compareTraceDateFilter",
-            JSON.stringify(activeConfig.compareDateFilter),
-          );
-        }
+
         navigate(`${basePath}?${params.toString()}`, {
           replace: true,
         });
@@ -194,13 +248,7 @@ const ObservePage = React.memo(() => {
         }
       }
     },
-    [
-      observeId,
-      navigate,
-      setActiveTab,
-      queryClient,
-      setActiveViewConfig,
-    ],
+    [observeId, navigate, queryClient, setActiveViewConfig],
   );
 
   // Legacy tabs for non-tab-system routes (sessions, evals, charts, etc.)

--- a/frontend/src/sections/projects/ObservePage.jsx
+++ b/frontend/src/sections/projects/ObservePage.jsx
@@ -104,17 +104,20 @@ const ObservePage = React.memo(() => {
 
   // Derive active tab from URL on initial load / route changes
   useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const tab = params.get("tab");
+    // Saved-view tabs own the `tab` key — don't overwrite with the route
+    // default. Without this guard, a click on a sessions/users saved view
+    // would land on the route, this effect would fire, and `tab=view-<id>`
+    // would be replaced by `tab=sessions` (or `tab=users`), wiping the
+    // active-view-id needed by Save view.
+    if (tab && tab.startsWith("view-")) return;
     if (currentRouteSegment === "sessions") {
       setActiveTab("sessions");
     } else if (currentRouteSegment === "users") {
       setActiveTab("users");
     } else if (currentRouteSegment === "llm-tracing") {
-      const params = new URLSearchParams(location.search);
       const selectedTab = params.get("selectedTab");
-      const tab = params.get("tab");
-      // If it's a custom view tab, keep it
-      if (tab && tab.startsWith("view-")) return;
-      // Otherwise derive from selectedTab param
       if (selectedTab === "spans") {
         setActiveTab("spans");
       } else if (!tab || tab === "traces") {

--- a/frontend/src/sections/projects/ObservePage.jsx
+++ b/frontend/src/sections/projects/ObservePage.jsx
@@ -15,7 +15,11 @@ import {
 import ObserveTabs from "./ObserveTabs";
 import { useTabStoreShallow } from "./LLMTracing/tabStore";
 import { useGetProjectDetails } from "src/api/project/project-detail";
-import { useGetSavedViews } from "src/api/project/saved-views";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  useGetSavedViews,
+  SAVED_VIEWS_KEY,
+} from "src/api/project/saved-views";
 import ReplayDrawer from "./ReplayDrawer/ReplayDrawer";
 import {
   resetReplaySessionsStore,
@@ -68,6 +72,7 @@ const ObservePage = React.memo(() => {
   const { observeId } = useParams();
   const { data: projectDetail } = useGetProjectDetails(observeId);
   const { data: savedViewsData } = useGetSavedViews(observeId);
+  const queryClient = useQueryClient();
 
   // Tab store state for modals and context menu
   const {
@@ -124,13 +129,20 @@ const ObservePage = React.memo(() => {
     (tabKey) => {
       setActiveTab(tabKey);
 
-      // Set activeViewConfig from saved view data
+      // Set activeViewConfig from saved view data. Read from queryClient
+      // directly rather than the `savedViewsData` closure, which can be stale
+      // immediately after an optimistic cache write (e.g., right after a new
+      // view is created — the closure hasn't re-rendered yet but the cache has).
+      let activeConfig = null;
       if (tabKey.startsWith("view-")) {
         const viewId = tabKey.replace("view-", "");
-        const view = (
-          savedViewsData?.customViews ?? savedViewsData?.custom_views
-        )?.find((v) => v.id === viewId);
-        setActiveViewConfig(view?.config || null);
+        const cached = queryClient.getQueryData([SAVED_VIEWS_KEY, observeId]);
+        const cachedResult = cached?.data?.result;
+        const customViews =
+          cachedResult?.customViews ?? cachedResult?.custom_views ?? [];
+        const view = customViews.find((v) => v.id === viewId);
+        activeConfig = view?.config || null;
+        setActiveViewConfig(activeConfig);
       } else {
         setActiveViewConfig(null);
       }
@@ -138,7 +150,37 @@ const ObservePage = React.memo(() => {
       // Navigate to the appropriate route
       if (tabKey.startsWith("view-")) {
         const basePath = `/dashboard/observe/${observeId}/llm-tracing`;
-        navigate(`${basePath}?tab=${tabKey}&selectedTab=trace`, {
+        // Inline all URL-synced state from the saved view so useUrlState hooks
+        // read the correct values on this navigation (avoids a race where the
+        // apply effect would try to re-write the URL and lose params).
+        const params = new URLSearchParams();
+        params.set("tab", tabKey);
+        params.set("selectedTab", "trace");
+        if (activeConfig?.filters) {
+          params.set(
+            "primaryTraceFilter",
+            JSON.stringify(activeConfig.filters),
+          );
+        }
+        if (activeConfig?.display?.dateFilter) {
+          params.set(
+            "primaryTraceDateFilter",
+            JSON.stringify(activeConfig.display.dateFilter),
+          );
+        }
+        if (activeConfig?.compareFilters) {
+          params.set(
+            "compareTraceFilter",
+            JSON.stringify(activeConfig.compareFilters),
+          );
+        }
+        if (activeConfig?.compareDateFilter) {
+          params.set(
+            "compareTraceDateFilter",
+            JSON.stringify(activeConfig.compareDateFilter),
+          );
+        }
+        navigate(`${basePath}?${params.toString()}`, {
           replace: true,
         });
       } else {
@@ -156,7 +198,7 @@ const ObservePage = React.memo(() => {
       observeId,
       navigate,
       setActiveTab,
-      savedViewsData?.customViews ?? savedViewsData?.custom_views,
+      queryClient,
       setActiveViewConfig,
     ],
   );

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -61,6 +61,7 @@ const SessionGrid = React.forwardRef(
       className,
       onGridReady,
       pendingCustomColumnsRef,
+      isOnSavedView = false,
     },
     gridApiRef,
   ) => {
@@ -83,6 +84,23 @@ const SessionGrid = React.forwardRef(
     useEffect(() => {
       columnsRef.current = columns;
     }, [columns]);
+
+    // Same trick for updateObj + isOnSavedView — dataSource closes over them
+    // once when memoized, but getRows fires on every scroll/refetch and needs
+    // the latest values. On a saved view we filter columns by `updateObj`
+    // (the view's visibleColumns); on a default tab we fall through to
+    // `res.config.isVisible` (the backend's per-project saved visibility).
+    // Without this gate the data-fetch overwrites the saved view's columns
+    // with the project default on every page load.
+    const updateObjRef = useRef(updateObj);
+    useEffect(() => {
+      updateObjRef.current = updateObj;
+    }, [updateObj]);
+
+    const isOnSavedViewRef = useRef(isOnSavedView);
+    useEffect(() => {
+      isOnSavedViewRef.current = isOnSavedView;
+    }, [isOnSavedView]);
 
     const [dateInterval] = useUrlState("dateInterval", "day");
 
@@ -230,6 +248,14 @@ const SessionGrid = React.forwardRef(
                 // Grouped columns (e.g. Annotation Metrics) always visible
                 if (column.children) return true;
                 if (!column.field) return true;
+
+                // On a saved view, the view's visibleColumns (carried in
+                // updateObj) is the source of truth — ignore the backend's
+                // per-project default so view-specific hides don't get
+                // overwritten by the data-fetch response.
+                if (isOnSavedViewRef.current) {
+                  return updateObjRef.current?.[column.field] ?? true;
+                }
 
                 const columnConfig = (res?.config || []).find(
                   (config) => config.id === column.field,
@@ -438,6 +464,7 @@ SessionGrid.propTypes = {
   onSelectionChanged: PropTypes.func,
   className: PropTypes.string,
   pendingCustomColumnsRef: PropTypes.object,
+  isOnSavedView: PropTypes.bool,
 };
 
 export default SessionGrid;

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -102,6 +102,16 @@ const SessionGrid = React.forwardRef(
       isOnSavedViewRef.current = isOnSavedView;
     }, [isOnSavedView]);
 
+    // Mirror columnDefs into a ref so the dataSource's getRows always reads
+    // the latest. Without this, the dataSource memo (deps =
+    // [filters, projectId, dateInterval]) captures columnDefs ONCE — when
+    // columns is still []. That initial columnDefs uses the LoadingHeader
+    // skeleton branch (line 107-117), and every subsequent getRows call
+    // (page scroll, sort, etc.) writes those skeletons into filteredColumnDefs,
+    // causing the header skeletons to flash back in randomly even after
+    // proper headers had loaded.
+    const columnDefsRef = useRef([]);
+
     const [dateInterval] = useUrlState("dateInterval", "day");
 
     // Grid Options
@@ -175,6 +185,10 @@ const SessionGrid = React.forwardRef(
       };
     }, [columns, updateObj]);
 
+    useEffect(() => {
+      columnDefsRef.current = columnDefs;
+    }, [columnDefs]);
+
     const [filteredColumnDefs, setFilteredColumnDefs] = useState([]);
 
     // Prefetch cache: stores next page data so scroll feels instant
@@ -244,7 +258,13 @@ const SessionGrid = React.forwardRef(
                 }
               }
 
-              const filteredColumns = columnDefs.filter((column) => {
+              // Read columnDefs from the ref so this filter always sees the
+              // post-setColumns value, not the skeleton-headed default
+              // captured when dataSource was first memoized. Without the ref,
+              // every page-2+ scroll fetch wrote stale skeleton headers back
+              // into filteredColumnDefs.
+              const currentColumnDefs = columnDefsRef.current ?? columnDefs;
+              const filteredColumns = currentColumnDefs.filter((column) => {
                 // Grouped columns (e.g. Annotation Metrics) always visible
                 if (column.children) return true;
                 if (!column.field) return true;

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -4,6 +4,7 @@ import React, {
   lazy,
   Suspense,
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -167,7 +168,12 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const sessionGridApiRef = useRef(null);
-  const { setHeaderConfig } = useObserveHeader();
+  const {
+    setHeaderConfig,
+    activeViewConfig,
+    registerGetViewConfig,
+    registerGetTabType,
+  } = useObserveHeader();
 
   // --- Filter & date state (reuse trace filter hook) ---
   const defaultDateFilter = useMemo(() => getDefaultDateRange(), []);
@@ -190,6 +196,39 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   );
 
   const hasActiveFilter = extraFilters.length > 0;
+
+  // "Save view" only surfaces on a custom saved view when the user has
+  // modified its state. On a default tab the "+" button handles save-as-new,
+  // so we keep Save view out of the toolbar there.
+  const canSaveView = useMemo(() => {
+    if (!activeViewConfig) return false;
+
+    const baselineExtraLen = activeViewConfig.extraFilters?.length ?? 0;
+    const baselineDisplay = activeViewConfig.display || {};
+    const baselineDateOption =
+      baselineDisplay.dateFilter?.dateOption ?? null;
+
+    if ((extraFilters?.length ?? 0) !== baselineExtraLen) return true;
+    if ((dateFilter?.dateOption ?? null) !== baselineDateOption) return true;
+    if (
+      baselineDisplay.cellHeight !== undefined &&
+      baselineDisplay.cellHeight !== cellHeight
+    ) {
+      return true;
+    }
+    if (
+      baselineDisplay.showCompare !== undefined &&
+      baselineDisplay.showCompare !== showCompare
+    ) {
+      return true;
+    }
+    return false;
+  }, [activeViewConfig, extraFilters, dateFilter, cellHeight, showCompare]);
+
+  // Defer so the button doesn't flicker during the one-render gap between
+  // filter state updating urgently and activeViewConfig catching up from
+  // startTransition in the apply path.
+  const canSaveViewDeferred = useDeferredValue(canSaveView);
 
   const handleAddEvals = useCallback(() => {
     const url = buildAddEvalsDraft({
@@ -294,6 +333,57 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
 
   // --- Row height ---
   const [cellHeight, setCellHeight] = useUrlState("sessionCellHeight", "Short");
+
+  // --- Saved view capture + apply (TH-4578) ---
+  // Build a view-config snapshot that mirrors LLMTracingView's shape. dateFilter
+  // stays inside `display` because the backend's saved-view serializer only
+  // whitelists `display` for arbitrary sub-keys (no top-level `dateFilter`).
+  const buildViewConfig = useCallback(
+    () => ({
+      display: {
+        cellHeight,
+        showCompare,
+        dateFilter,
+      },
+      extraFilters: extraFilters || [],
+    }),
+    [cellHeight, showCompare, dateFilter, extraFilters],
+  );
+
+  useEffect(() => {
+    registerGetViewConfig(buildViewConfig);
+    return () => registerGetViewConfig(null);
+  }, [registerGetViewConfig, buildViewConfig]);
+
+  useEffect(() => {
+    registerGetTabType(() => "sessions");
+    return () => registerGetTabType(null);
+  }, [registerGetTabType]);
+
+  // Apply a saved view's config to LOCAL state only. URL-synced state
+  // (dateFilter / cellHeight / showCompare) is handled by seedUrlForView in
+  // UserDetailTabBar — the URL is populated synchronously at click time, and
+  // useUrlState reads it on first render. Writing those again from here
+  // would just trigger a second data refetch and the resulting header
+  // loading flash.
+  useEffect(() => {
+    if (!activeViewConfig) return;
+    const nextExtraFilters = activeViewConfig.extraFilters || [];
+    setExtraFilters((prev) => {
+      if (prev.length === 0 && nextExtraFilters.length === 0) return prev;
+      if (prev.length === nextExtraFilters.length) {
+        const allSame = prev.every(
+          (f, i) =>
+            f?.column_id === nextExtraFilters[i]?.column_id &&
+            JSON.stringify(f?.filter_config) ===
+              JSON.stringify(nextExtraFilters[i]?.filter_config),
+        );
+        if (allSame) return prev;
+      }
+      return nextExtraFilters;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeViewConfig]);
 
   // --- Replay sessions ---
   const {
@@ -516,6 +606,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         setDateFilter={setDateFilter}
         // Filter
         hasActiveFilter={hasActiveFilter}
+        canSaveView={canSaveViewDeferred}
         isFilterOpen={isFilterOpen}
         onFilterToggle={() => setIsFilterOpen(!isFilterOpen)}
         filterFields={sessionFilterFields}

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -469,11 +469,27 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   // for the ObservePage tab-bar path, which doesn't pre-seed display.
   useEffect(() => {
     if (!activeViewConfig) {
-      // Transitioning back to a default tab — clear local extraFilters so
-      // chips from a prior custom view don't linger. (URL-synced state is
-      // wiped by the parent's URL reset.)
+      // Transitioning back to a default tab — wipe everything that was
+      // applied by the saved view. URL-synced display state (cellHeight,
+      // showCompare, dateFilter) reverts via useUrlState as the parent's
+      // navigate() drops those URL keys; everything else has to be reset
+      // here because it lives in plain useState or inside AG Grid.
       setExtraFilters((prev) => (prev.length === 0 ? prev : []));
       viewLoadedUpdateObjRef.current = null;
+      setUpdateObj(initialVisibility);
+      const api = sessionGridApiRef.current?.api;
+      if (api?.setColumnsVisible) {
+        const showIds = Object.keys(initialVisibility).filter(
+          (id) => initialVisibility[id],
+        );
+        const hideIds = Object.keys(initialVisibility).filter(
+          (id) => !initialVisibility[id],
+        );
+        if (showIds.length) api.setColumnsVisible(showIds, true);
+        if (hideIds.length) api.setColumnsVisible(hideIds, false);
+      }
+      if (api?.resetColumnState) api.resetColumnState();
+      pendingColumnStateRef.current = null;
       return;
     }
     const display = activeViewConfig.display || {};
@@ -904,6 +920,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
           className={shouldDisable ? "ag-grid-disabled" : ""}
           onGridReady={onGridReady}
           pendingCustomColumnsRef={pendingCustomColumnsRef}
+          isOnSavedView={Boolean(activeViewConfig)}
         />
       </Box>
 

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -286,6 +286,12 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   const [updateObj, setUpdateObj] = useState(initialVisibility);
   const [autoSizeOn, setAutoSizeOn] = useState(false);
 
+  // Snapshot of updateObj at the moment a saved view becomes active, so
+  // canSaveView can compare against this snapshot for views whose stored
+  // config doesn't include `display.visibleColumns` (older views saved
+  // before that field was being captured).
+  const viewLoadedUpdateObjRef = useRef(null);
+
   const { mutate: updateSessionListColumnVisibility } = useMutation({
     mutationFn: (data) =>
       axios.post(endpoints.project.updateSessionListColumnVisibility(), {
@@ -300,9 +306,21 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       setSessionColumns((cols) =>
         cols.map((col) => ({ ...col, isVisible: newUpdateObj[col.id] })),
       );
-      updateSessionListColumnVisibility(newUpdateObj);
+      // Only persist project-wide default visibility when actually scoped to
+      // a project (not user mode — observeId is null there, and the request
+      // 400s with "Project not found") and not on a saved view tab. On a
+      // saved view, the per-view config owns its own visibleColumns and gets
+      // persisted via the explicit Save view button.
+      // Inline URL parse rather than closing over activeViewTabId (declared
+      // further down in the file) to avoid a TDZ on the deps array.
+      const params = new URLSearchParams(window.location.search);
+      const tabKey = isUserMode ? params.get("userTab") : params.get("tab");
+      const onSavedView = tabKey?.startsWith("view-");
+      if (!isUserMode && !onSavedView) {
+        updateSessionListColumnVisibility(newUpdateObj);
+      }
     },
-    [updateSessionListColumnVisibility],
+    [updateSessionListColumnVisibility, isUserMode],
   );
 
   // --- Row height ---
@@ -333,8 +351,31 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     ) {
       return true;
     }
+    // Column visibility — prefer the saved baseline (`display.visibleColumns`),
+    // fall back to the snapshot taken when the view was loaded so older views
+    // that never persisted visibleColumns still detect toggles.
+    const baseline =
+      baselineDisplay.visibleColumns &&
+      typeof baselineDisplay.visibleColumns === "object"
+        ? baselineDisplay.visibleColumns
+        : viewLoadedUpdateObjRef.current;
+    if (baseline && updateObj && typeof updateObj === "object") {
+      for (const colId of Object.keys(baseline)) {
+        const cur = updateObj[colId];
+        if (cur !== undefined && cur !== baseline[colId]) {
+          return true;
+        }
+      }
+    }
     return false;
-  }, [activeViewConfig, extraFilters, dateFilter, cellHeight, showCompare]);
+  }, [
+    activeViewConfig,
+    extraFilters,
+    dateFilter,
+    cellHeight,
+    showCompare,
+    updateObj,
+  ]);
 
   // Defer so the button doesn't flicker during the one-render gap between
   // filter state updating urgently and activeViewConfig catching up from
@@ -345,19 +386,29 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   // Build a view-config snapshot that mirrors LLMTracingView's shape. dateFilter
   // stays inside `display` because the backend's saved-view serializer only
   // whitelists `display` for arbitrary sub-keys (no top-level `dateFilter`).
+  // Note: in earlier versions this view skipped writing URL-synced state in
+  // the apply effect on the assumption that a click-time seedUrlForView
+  // would populate the URL. That's only true on UserDetailTabBar — the
+  // ObservePage tab-bar path doesn't seed sessionCellHeight / sessionShowCompare /
+  // sessionDateFilter, so display options never made it onto the page when
+  // selecting a sessions saved view from the project's tab bar. Now apply
+  // pushes them into URL state directly (matching UsersView / LLMTracingView).
   const buildViewConfig = useCallback(() => {
     const columnState =
       sessionGridApiRef.current?.api?.getColumnState?.() ?? undefined;
+    // updateObj is the authoritative {col.id: isVisible} source.
+    const hasVisibility = updateObj && Object.keys(updateObj).length > 0;
     return {
       display: {
         cellHeight,
         showCompare,
         dateFilter,
+        ...(hasVisibility ? { visibleColumns: updateObj } : {}),
         ...(columnState ? { columnState } : {}),
       },
       extraFilters: extraFilters || [],
     };
-  }, [cellHeight, showCompare, dateFilter, extraFilters]);
+  }, [cellHeight, showCompare, dateFilter, extraFilters, updateObj]);
 
   useEffect(() => {
     registerGetViewConfig(buildViewConfig);
@@ -411,21 +462,60 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   // below applies it once `sessionGridApiRef.current.api` shows up.
   const pendingColumnStateRef = useRef(null);
 
-  // Apply a saved view's config to LOCAL state only. URL-synced state
-  // (dateFilter / cellHeight / showCompare) is handled by seedUrlForView in
-  // UserDetailTabBar — the URL is populated synchronously at click time, and
-  // useUrlState reads it on first render. Writing those again from here
-  // would just trigger a second data refetch and the resulting header
-  // loading flash.
+  // Apply a saved view's config — push display options into URL-synced
+  // state (matches UsersView / LLMTracingView). UserDetailTabBar still
+  // pre-seeds the same URL keys at click time for snappiness; the writes
+  // here are idempotent for that path and are the only source of truth
+  // for the ObservePage tab-bar path, which doesn't pre-seed display.
   useEffect(() => {
     if (!activeViewConfig) {
       // Transitioning back to a default tab — clear local extraFilters so
       // chips from a prior custom view don't linger. (URL-synced state is
       // wiped by the parent's URL reset.)
       setExtraFilters((prev) => (prev.length === 0 ? prev : []));
+      viewLoadedUpdateObjRef.current = null;
       return;
     }
     const display = activeViewConfig.display || {};
+    if (display.cellHeight) setCellHeight(display.cellHeight);
+    if (typeof display.showCompare === "boolean") {
+      setShowCompare(display.showCompare);
+    }
+    if (display.dateFilter) {
+      setDateFilter(display.dateFilter);
+    }
+    // Apply visibleColumns dict — `updateObj` is the single source of truth
+    // for column visibility (drives the ColumnConfigure popover via
+    // displayColumns and is the authoritative {col.id: bool} dict). Push
+    // visibility into AG Grid directly when the api is available so the
+    // grid display matches without waiting for a re-render. Done before the
+    // snapshot below so canSaveView's baseline matches the just-applied state.
+    if (
+      display.visibleColumns &&
+      typeof display.visibleColumns === "object"
+    ) {
+      const next = { ...display.visibleColumns };
+      setUpdateObj(next);
+      const api = sessionGridApiRef.current?.api;
+      if (api?.setColumnsVisible) {
+        const toShow = [];
+        const toHide = [];
+        Object.entries(next).forEach(([colId, visible]) => {
+          (visible ? toShow : toHide).push(colId);
+        });
+        if (toShow.length) api.setColumnsVisible(toShow, true);
+        if (toHide.length) api.setColumnsVisible(toHide, false);
+      }
+    }
+    // Capture the visibility state at the moment this saved view is loaded,
+    // so canSaveView can compare any subsequent toggles against this
+    // snapshot — covers older views that didn't persist `visibleColumns`.
+    // Use the just-applied dict if it exists, otherwise current updateObj.
+    viewLoadedUpdateObjRef.current = display.visibleColumns
+      ? { ...display.visibleColumns }
+      : updateObj
+        ? { ...updateObj }
+        : null;
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
       const api = sessionGridApiRef.current?.api;
       if (api?.applyColumnState) {
@@ -822,7 +912,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         open={openColumnConfigure}
         onClose={() => setOpenColumnConfigure(false)}
         anchorEl={columnConfigureRef?.current}
-        columns={sessionColumns}
+        columns={displayColumns}
         onColumnVisibilityChange={onSessionVisibilityColumnChange}
         setColumns={setSessionColumns}
         defaultGrouping="Session Columns"

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -338,17 +338,19 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   // Build a view-config snapshot that mirrors LLMTracingView's shape. dateFilter
   // stays inside `display` because the backend's saved-view serializer only
   // whitelists `display` for arbitrary sub-keys (no top-level `dateFilter`).
-  const buildViewConfig = useCallback(
-    () => ({
+  const buildViewConfig = useCallback(() => {
+    const columnState =
+      sessionGridApiRef.current?.api?.getColumnState?.() ?? undefined;
+    return {
       display: {
         cellHeight,
         showCompare,
         dateFilter,
+        ...(columnState ? { columnState } : {}),
       },
       extraFilters: extraFilters || [],
-    }),
-    [cellHeight, showCompare, dateFilter, extraFilters],
-  );
+    };
+  }, [cellHeight, showCompare, dateFilter, extraFilters]);
 
   useEffect(() => {
     registerGetViewConfig(buildViewConfig);
@@ -360,6 +362,10 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     return () => registerGetTabType(null);
   }, [registerGetTabType]);
 
+  // Pending column state queued before the grid was ready. Drain effect
+  // below applies it once `sessionGridApiRef.current.api` shows up.
+  const pendingColumnStateRef = useRef(null);
+
   // Apply a saved view's config to LOCAL state only. URL-synced state
   // (dateFilter / cellHeight / showCompare) is handled by seedUrlForView in
   // UserDetailTabBar — the URL is populated synchronously at click time, and
@@ -368,6 +374,18 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   // loading flash.
   useEffect(() => {
     if (!activeViewConfig) return;
+    const display = activeViewConfig.display || {};
+    if (Array.isArray(display.columnState) && display.columnState.length > 0) {
+      const api = sessionGridApiRef.current?.api;
+      if (api?.applyColumnState) {
+        api.applyColumnState({
+          state: display.columnState,
+          applyOrder: true,
+        });
+      } else {
+        pendingColumnStateRef.current = display.columnState;
+      }
+    }
     const nextExtraFilters = activeViewConfig.extraFilters || [];
     setExtraFilters((prev) => {
       if (prev.length === 0 && nextExtraFilters.length === 0) return prev;
@@ -543,6 +561,14 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     (params) => {
       sessionGridApiRef.current = params;
       setHeaderConfig((prev) => ({ ...prev, gridApi: params.api }));
+      // Drain any saved-view columnState that arrived before the grid mounted.
+      if (pendingColumnStateRef.current && params.api?.applyColumnState) {
+        params.api.applyColumnState({
+          state: pendingColumnStateRef.current,
+          applyOrder: true,
+        });
+        pendingColumnStateRef.current = null;
+      }
     },
     [setHeaderConfig],
   );

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -70,6 +70,7 @@ import axios, { endpoints } from "src/utils/axios";
 import ColumnConfigureDropDown from "src/sections/project-detail/ColumnDropdown/ColumnConfigureDropDown";
 import useProjectFilterField from "../UsersView/useProjectFilterField";
 import CustomColumnDialog from "../LLMTracing/CustomColumnDialog";
+import { filtersContentEqual } from "../saved-view-utils";
 
 // ---------------------------------------------------------------------------
 // Base session filter fields (always available)
@@ -332,12 +333,12 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   const canSaveView = useMemo(() => {
     if (!activeViewConfig) return false;
 
-    const baselineExtraLen = activeViewConfig.extraFilters?.length ?? 0;
+    const baselineExtraFilters = activeViewConfig.extraFilters || [];
     const baselineDisplay = activeViewConfig.display || {};
     const baselineDateOption =
       baselineDisplay.dateFilter?.dateOption ?? null;
 
-    if ((extraFilters?.length ?? 0) !== baselineExtraLen) return true;
+    if (!filtersContentEqual(extraFilters, baselineExtraFilters)) return true;
     if ((dateFilter?.dateOption ?? null) !== baselineDateOption) return true;
     if (
       baselineDisplay.cellHeight !== undefined &&

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -1,5 +1,11 @@
 import { Box } from "@mui/material";
 import PropTypes from "prop-types";
+import {
+  useUpdateSavedView,
+  useUpdateWorkspaceSavedView,
+} from "src/api/project/saved-views";
+
+const USER_DETAIL_TAB_TYPE = "user_detail";
 import React, {
   lazy,
   Suspense,
@@ -362,6 +368,41 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     return () => registerGetTabType(null);
   }, [registerGetTabType]);
 
+  // Update mutations for the explicit Save view button. Project-scoped on
+  // ObservePage, workspace-scoped (user_detail) on CrossProjectUserDetailPage.
+  const { mutate: updateSavedView } = useUpdateSavedView(observeId);
+  const { mutate: updateWorkspaceSavedView } =
+    useUpdateWorkspaceSavedView(USER_DETAIL_TAB_TYPE);
+
+  // Active saved-view id from URL — "tab" key on ObservePage, "userTab" on
+  // CrossProjectUserDetailPage. Re-derived when activeViewConfig flips.
+  const activeViewTabId = useMemo(() => {
+    const params = new URLSearchParams(window.location.search);
+    const key = isUserMode ? params.get("userTab") : params.get("tab");
+    return key?.startsWith("view-") ? key.slice(5) : null;
+  }, [activeViewConfig, isUserMode]);
+
+  const handleSaveView = useCallback(() => {
+    if (!activeViewTabId) return;
+    const config = buildViewConfig();
+    const mutate = isUserMode ? updateWorkspaceSavedView : updateSavedView;
+    mutate(
+      { id: activeViewTabId, config },
+      {
+        onSuccess: () =>
+          enqueueSnackbar("View updated", { variant: "success" }),
+        onError: () =>
+          enqueueSnackbar("Failed to update view", { variant: "error" }),
+      },
+    );
+  }, [
+    activeViewTabId,
+    buildViewConfig,
+    isUserMode,
+    updateSavedView,
+    updateWorkspaceSavedView,
+  ]);
+
   // Pending column state queued before the grid was ready. Drain effect
   // below applies it once `sessionGridApiRef.current.api` shows up.
   const pendingColumnStateRef = useRef(null);
@@ -639,6 +680,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         // Filter
         hasActiveFilter={hasActiveFilter}
         canSaveView={canSaveViewDeferred}
+        onSaveView={handleSaveView}
         isFilterOpen={isFilterOpen}
         onFilterToggle={() => setIsFilterOpen(!isFilterOpen)}
         filterFields={sessionFilterFields}

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -373,7 +373,13 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   // would just trigger a second data refetch and the resulting header
   // loading flash.
   useEffect(() => {
-    if (!activeViewConfig) return;
+    if (!activeViewConfig) {
+      // Transitioning back to a default tab — clear local extraFilters so
+      // chips from a prior custom view don't linger. (URL-synced state is
+      // wiped by the parent's URL reset.)
+      setExtraFilters((prev) => (prev.length === 0 ? prev : []));
+      return;
+    }
     const display = activeViewConfig.display || {};
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
       const api = sessionGridApiRef.current?.api;

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -177,6 +177,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   const {
     setHeaderConfig,
     activeViewConfig,
+    setActiveViewConfig,
     registerGetViewConfig,
     registerGetTabType,
   } = useObserveHeader();
@@ -389,8 +390,10 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     mutate(
       { id: activeViewTabId, config },
       {
-        onSuccess: () =>
-          enqueueSnackbar("View updated", { variant: "success" }),
+        onSuccess: (response) => {
+          setActiveViewConfig(response?.data?.result?.config ?? config);
+          enqueueSnackbar("View updated", { variant: "success" });
+        },
         onError: () =>
           enqueueSnackbar("Failed to update view", { variant: "error" }),
       },
@@ -401,6 +404,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     isUserMode,
     updateSavedView,
     updateWorkspaceSavedView,
+    setActiveViewConfig,
   ]);
 
   // Pending column state queued before the grid was ready. Drain effect
@@ -681,6 +685,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         hasActiveFilter={hasActiveFilter}
         canSaveView={canSaveViewDeferred}
         onSaveView={handleSaveView}
+        graphFilters={extraFilters}
         isFilterOpen={isFilterOpen}
         onFilterToggle={() => setIsFilterOpen(!isFilterOpen)}
         filterFields={sessionFilterFields}

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -197,39 +197,6 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
 
   const hasActiveFilter = extraFilters.length > 0;
 
-  // "Save view" only surfaces on a custom saved view when the user has
-  // modified its state. On a default tab the "+" button handles save-as-new,
-  // so we keep Save view out of the toolbar there.
-  const canSaveView = useMemo(() => {
-    if (!activeViewConfig) return false;
-
-    const baselineExtraLen = activeViewConfig.extraFilters?.length ?? 0;
-    const baselineDisplay = activeViewConfig.display || {};
-    const baselineDateOption =
-      baselineDisplay.dateFilter?.dateOption ?? null;
-
-    if ((extraFilters?.length ?? 0) !== baselineExtraLen) return true;
-    if ((dateFilter?.dateOption ?? null) !== baselineDateOption) return true;
-    if (
-      baselineDisplay.cellHeight !== undefined &&
-      baselineDisplay.cellHeight !== cellHeight
-    ) {
-      return true;
-    }
-    if (
-      baselineDisplay.showCompare !== undefined &&
-      baselineDisplay.showCompare !== showCompare
-    ) {
-      return true;
-    }
-    return false;
-  }, [activeViewConfig, extraFilters, dateFilter, cellHeight, showCompare]);
-
-  // Defer so the button doesn't flicker during the one-render gap between
-  // filter state updating urgently and activeViewConfig catching up from
-  // startTransition in the apply path.
-  const canSaveViewDeferred = useDeferredValue(canSaveView);
-
   const handleAddEvals = useCallback(() => {
     const url = buildAddEvalsDraft({
       observeId,
@@ -333,6 +300,39 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
 
   // --- Row height ---
   const [cellHeight, setCellHeight] = useUrlState("sessionCellHeight", "Short");
+
+  // "Save view" only surfaces on a custom saved view when the user has
+  // modified its state. On a default tab the "+" button handles save-as-new,
+  // so we keep Save view out of the toolbar there.
+  const canSaveView = useMemo(() => {
+    if (!activeViewConfig) return false;
+
+    const baselineExtraLen = activeViewConfig.extraFilters?.length ?? 0;
+    const baselineDisplay = activeViewConfig.display || {};
+    const baselineDateOption =
+      baselineDisplay.dateFilter?.dateOption ?? null;
+
+    if ((extraFilters?.length ?? 0) !== baselineExtraLen) return true;
+    if ((dateFilter?.dateOption ?? null) !== baselineDateOption) return true;
+    if (
+      baselineDisplay.cellHeight !== undefined &&
+      baselineDisplay.cellHeight !== cellHeight
+    ) {
+      return true;
+    }
+    if (
+      baselineDisplay.showCompare !== undefined &&
+      baselineDisplay.showCompare !== showCompare
+    ) {
+      return true;
+    }
+    return false;
+  }, [activeViewConfig, extraFilters, dateFilter, cellHeight, showCompare]);
+
+  // Defer so the button doesn't flicker during the one-render gap between
+  // filter state updating urgently and activeViewConfig catching up from
+  // startTransition in the apply path.
+  const canSaveViewDeferred = useDeferredValue(canSaveView);
 
   // --- Saved view capture + apply (TH-4578) ---
   // Build a view-config snapshot that mirrors LLMTracingView's shape. dateFilter

--- a/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/CrossProjectUserDetailPage.jsx
+++ b/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/CrossProjectUserDetailPage.jsx
@@ -6,7 +6,6 @@ import Iconify from "src/components/iconify";
 import { useUrlState } from "src/routes/hooks/use-url-state";
 
 import ObserveHeaderProvider from "src/sections/project/context/ObserveHeaderContextProvider";
-import { useObserveHeader } from "src/sections/project/context/ObserveHeaderContext";
 
 import LLMTracingView from "../../LLMTracing/LLMTracingView";
 import SessionsView from "../../SessionsView/Sessions-view";
@@ -30,9 +29,6 @@ const CrossProjectUserDetailPage = () => (
   </ObserveHeaderProvider>
 );
 
-const TRACE_DISPLAY_KEY = (uid) => `user-display-${uid}`;
-const TRACE_FILTERS_KEY = (uid) => `user-filters-${uid}`;
-
 const UserDetailPageBody = () => {
   const theme = useTheme();
   const navigate = useNavigate();
@@ -44,56 +40,6 @@ const UserDetailPageBody = () => {
   const [activeTab, setActiveTab] = useUrlState("userTab", "sessions");
   const [subTab, setSubTab] = useState(
     activeTab === "traces" ? "traces" : "sessions",
-  );
-
-  const { setActiveViewConfig } = useObserveHeader();
-
-  // -------------------------------------------------------------------------
-  // Saved-view capture + apply
-  // -------------------------------------------------------------------------
-  // Capture reads the inner view's current state:
-  //   - traces: namespaced localStorage (LLMTracingView already persists there)
-  //   - sessions: v1 only stores {sub_tab} — Sessions-view has no config
-  //     restore path yet (driven by URL state, not context)
-  const getConfigFor = useCallback(
-    (which) => {
-      if (which !== "traces") return {};
-      try {
-        const rawDisplay = localStorage.getItem(TRACE_DISPLAY_KEY(userId));
-        const rawFilters = localStorage.getItem(TRACE_FILTERS_KEY(userId));
-        const display = rawDisplay ? JSON.parse(rawDisplay) : null;
-        const filtersBlob = rawFilters ? JSON.parse(rawFilters) : null;
-        // LLMTracingView consumes activeViewConfig with shape
-        // { display, filters, extraFilters, compareFilters, ... }. Pass
-        // through what exists; missing keys are ignored by the consumer.
-        return {
-          ...(display ? { display } : {}),
-          ...(filtersBlob?.filters ? { filters: filtersBlob.filters } : {}),
-          ...(filtersBlob?.extraFilters
-            ? { extraFilters: filtersBlob.extraFilters }
-            : {}),
-          ...(filtersBlob?.dateFilter
-            ? { dateFilter: filtersBlob.dateFilter }
-            : {}),
-        };
-      } catch {
-        return {};
-      }
-    },
-    [userId],
-  );
-
-  // Apply:
-  //   - traces: push config into the ObserveHeader context — LLMTracingView's
-  //     existing `activeViewConfig` effect will restore display + filters
-  //   - sessions: no-op in v1 (just flips the sub-tab via onTabChange)
-  const applyConfigFor = useCallback(
-    (which, cfg) => {
-      if (which === "traces") {
-        setActiveViewConfig(cfg || null);
-      }
-    },
-    [setActiveViewConfig],
   );
 
   const handleTabChange = useCallback(
@@ -248,8 +194,6 @@ const UserDetailPageBody = () => {
             <UserDetailTabBar
               activeTab={activeTab}
               onTabChange={handleTabChange}
-              getConfigFor={getConfigFor}
-              applyConfigFor={applyConfigFor}
             />
             <Box
               sx={{

--- a/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/CrossProjectUserDetailPage.jsx
+++ b/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/CrossProjectUserDetailPage.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Divider, Paper, Typography, useTheme } from "@mui/material";
 import { Helmet } from "react-helmet-async";
 import { useNavigate, useParams } from "react-router";
@@ -6,10 +6,14 @@ import Iconify from "src/components/iconify";
 import { useUrlState } from "src/routes/hooks/use-url-state";
 
 import ObserveHeaderProvider from "src/sections/project/context/ObserveHeaderContextProvider";
+import { useObserveHeader } from "src/sections/project/context/ObserveHeaderContext";
+import { useGetWorkspaceSavedViews } from "src/api/project/saved-views";
 
 import LLMTracingView from "../../LLMTracing/LLMTracingView";
 import SessionsView from "../../SessionsView/Sessions-view";
 import UserDetailTabBar from "./UserDetailTabBar";
+
+const USER_DETAIL_TAB_TYPE = "user_detail";
 
 // Cross-project user detail page.
 // ---------------------------------------------------------------------------
@@ -49,6 +53,39 @@ const UserDetailPageBody = () => {
     },
     [setActiveTab, subTab],
   );
+
+  // Hydrate activeViewConfig + the rendered subTab on hard-refresh / direct
+  // URL load. UserDetailTabBar already reacts to activeTab changes via click,
+  // but a page reload mounts the heavy sub-view (SessionsView / LLMTracingView)
+  // before the tab bar's effect lands — leaving filters / column visibility /
+  // extraFilters stuck at defaults until the user clicks the tab again.
+  // Mirrors ObservePage's hydration pattern. Re-runs only when the URL tab
+  // key or the saved-views list changes; the value for `userTab=view-<id>`
+  // is stable across saved-views refetches so the apply effect doesn't
+  // churn on every mutation invalidate.
+  const { setActiveViewConfig } = useObserveHeader();
+  const { data: workspaceSavedViewsData } =
+    useGetWorkspaceSavedViews(USER_DETAIL_TAB_TYPE);
+  const lastHydratedTabRef = useRef(null);
+  useEffect(() => {
+    if (!activeTab || !activeTab.startsWith("view-")) {
+      lastHydratedTabRef.current = null;
+      return;
+    }
+    if (lastHydratedTabRef.current === activeTab) return;
+    const customViews =
+      workspaceSavedViewsData?.customViews ??
+      workspaceSavedViewsData?.custom_views ??
+      [];
+    if (!customViews.length) return;
+    const viewId = activeTab.slice(5);
+    const view = customViews.find((v) => v.id === viewId);
+    if (!view?.config) return;
+    lastHydratedTabRef.current = activeTab;
+    setActiveViewConfig(view.config);
+    const targetSubTab = view.config.sub_tab || view.config.subTab;
+    if (targetSubTab && targetSubTab !== subTab) setSubTab(targetSubTab);
+  }, [activeTab, workspaceSavedViewsData, setActiveViewConfig, subTab]);
 
   // Styles — match ObservePage exactly
   const containerStyles = useMemo(

--- a/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/UserDetailTabBar.jsx
+++ b/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/UserDetailTabBar.jsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useEffect,
   useRef,
+  startTransition,
 } from "react";
 import PropTypes from "prop-types";
 import { Box, ButtonBase, Divider } from "@mui/material";
@@ -14,12 +15,16 @@ import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import FixedTab from "src/components/observe-tabs/FixedTab";
 import CustomViewTab from "src/components/observe-tabs/CustomViewTab";
 import SaveViewPopover from "src/components/traceDetail/SaveViewDialog";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   useGetWorkspaceSavedViews,
   useCreateWorkspaceSavedView,
   useUpdateWorkspaceSavedView,
   useDeleteWorkspaceSavedView,
+  SAVED_VIEWS_KEY,
 } from "src/api/project/saved-views";
+import { useObserveHeader } from "src/sections/project/context/ObserveHeaderContext";
+import { useSearchParams } from "react-router-dom";
 
 const USER_DETAIL_TAB_TYPE = "user_detail";
 
@@ -43,17 +48,61 @@ const FIXED_TABS = [
 // - Custom workspace-saved views (personal) whose config captures the active
 //   subTab + filter/display state so clicking one jumps to that subTab and
 //   restores its config via the parent's imperative api refs.
-const UserDetailTabBar = ({
-  activeTab,
-  onTabChange,
-  getConfigFor,
-  applyConfigFor,
-}) => {
+const UserDetailTabBar = ({ activeTab, onTabChange }) => {
   const { data: savedViewsData } =
     useGetWorkspaceSavedViews(USER_DETAIL_TAB_TYPE);
   const customViews = useMemo(
     () => savedViewsData?.customViews ?? savedViewsData?.custom_views ?? [],
     [savedViewsData],
+  );
+
+  const queryClient = useQueryClient();
+  const { getViewConfig, setActiveViewConfig } = useObserveHeader();
+  const [, setSearchParams] = useSearchParams();
+
+  // Pre-seed the URL-synced state keys for the target sub-tab from the saved
+  // view's config. Lets useUrlState read correct values on mount / refresh so
+  // the sub-view doesn't do a double-fetch (defaults then saved).
+  const seedUrlForView = useCallback(
+    (subTab, config) => {
+      if (!config) return;
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          const display = config.display || {};
+          if (subTab === "sessions") {
+            if (display.dateFilter) {
+              next.set(
+                "sessionDateFilter",
+                JSON.stringify(display.dateFilter),
+              );
+            }
+            if (display.cellHeight) {
+              next.set("sessionCellHeight", JSON.stringify(display.cellHeight));
+            }
+            if (display.showCompare !== undefined) {
+              next.set(
+                "sessionShowCompare",
+                JSON.stringify(display.showCompare),
+              );
+            }
+          } else if (subTab === "traces") {
+            if (display.dateFilter) {
+              next.set(
+                "primaryTraceDateFilter",
+                JSON.stringify(display.dateFilter),
+              );
+            }
+            if (config.filters) {
+              next.set("primaryTraceFilter", JSON.stringify(config.filters));
+            }
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
   );
 
   const { mutate: createSavedView } =
@@ -67,36 +116,59 @@ const UserDetailTabBar = ({
   const [isSavingView, setIsSavingView] = useState(false);
   const [renamingId, setRenamingId] = useState(null);
 
-  // Apply config only on real tab transitions — React Query refetches would
-  // otherwise stomp in-progress state.
+  // Apply config only on real tab transitions. Read from the React Query
+  // cache directly to avoid a stale-closure race right after create — the
+  // mutation's optimistic setQueryData has the new view before the
+  // `customViews` prop closure re-renders.
   const lastAppliedTabRef = useRef(null);
 
   useEffect(() => {
     if (lastAppliedTabRef.current === activeTab) return;
 
-    // Fixed tab (sessions/traces): reset that sub-tab's state to defaults
+    // Fixed tab (sessions/traces): clear activeViewConfig so sub-views
+    // fall back to their URL-driven state.
     if (FIXED_TABS.some((t) => t.key === activeTab)) {
       lastAppliedTabRef.current = activeTab;
-      applyConfigFor?.(activeTab, null);
+      startTransition(() => setActiveViewConfig(null));
       return;
     }
 
-    // Custom view
     const id = activeTab?.startsWith?.("view-") ? activeTab.slice(5) : null;
     if (!id) {
       lastAppliedTabRef.current = activeTab;
       return;
     }
-    const view = customViews.find((v) => v.id === id);
+    const cached = queryClient.getQueryData([
+      SAVED_VIEWS_KEY,
+      "workspace",
+      USER_DETAIL_TAB_TYPE,
+    ]);
+    const cachedResult = cached?.data?.result;
+    const cachedList =
+      cachedResult?.customViews ?? cachedResult?.custom_views ?? [];
+    const view = cachedList.find((v) => v.id === id) ??
+      customViews.find((v) => v.id === id);
     if (view?.config) {
       const subTab = view.config.sub_tab || view.config.subTab || "sessions";
-      // Push the sub-tab switch up to the parent
+      // Seed URL state first so the sub-view can read correct filter/date
+      // values on its first render, avoiding a default-then-saved double fetch
+      // (the flash). Apply via setActiveViewConfig still handles non-URL
+      // state (extraFilters, display.cellHeight, etc.).
+      seedUrlForView(subTab, view.config);
       onTabChange?.(activeTab, subTab);
-      applyConfigFor?.(subTab, view.config);
+      startTransition(() => setActiveViewConfig(view.config));
       lastAppliedTabRef.current = activeTab;
     }
-    // If not found yet — retry once customViews loads
-  }, [activeTab, applyConfigFor, onTabChange, customViews]);
+    // If not found yet — retry once customViews dep changes (React Query
+    // refetch will land and customViews will include the new view).
+  }, [
+    activeTab,
+    setActiveViewConfig,
+    onTabChange,
+    customViews,
+    queryClient,
+    seedUrlForView,
+  ]);
 
   const handleSaveViewConfirm = useCallback(
     (name) => {
@@ -112,7 +184,10 @@ const UserDetailTabBar = ({
         targetSubTab =
           view?.config?.sub_tab || view?.config?.subTab || "sessions";
       }
-      const inner = getConfigFor?.(targetSubTab) || {};
+      // Live snapshot of the currently-mounted sub-view (LLMTracingView /
+      // SessionsView register their buildViewConfig on the shared
+      // ObserveHeaderContext).
+      const inner = getViewConfig?.() ?? {};
       const config = { ...inner, sub_tab: targetSubTab };
       createSavedView(
         { name, config },
@@ -131,7 +206,7 @@ const UserDetailTabBar = ({
         },
       );
     },
-    [activeTab, customViews, createSavedView, getConfigFor, onTabChange],
+    [activeTab, customViews, createSavedView, getViewConfig, onTabChange],
   );
 
   const handleClose = useCallback(
@@ -223,6 +298,12 @@ const UserDetailTabBar = ({
             onClick={(key) => {
               const subTab =
                 view.config?.sub_tab || view.config?.subTab || "sessions";
+              // Seed URL synchronously in the same click tick so the tab
+              // switch, URL params, and sub-view mount all happen in one
+              // React commit. Without this the sub-view mounts first with
+              // defaults, fetches, then the apply-effect seeds the URL and
+              // triggers a second fetch (the flash).
+              seedUrlForView(subTab, view.config);
               onTabChange?.(key, subTab);
             }}
             onClose={handleClose}
@@ -242,6 +323,7 @@ const UserDetailTabBar = ({
         type="black"
       >
         <ButtonBase
+          data-create-view-btn
           onClick={(e) => setSaveViewAnchor(e.currentTarget)}
           sx={{
             display: "inline-flex",
@@ -275,8 +357,6 @@ const UserDetailTabBar = ({
 UserDetailTabBar.propTypes = {
   activeTab: PropTypes.string.isRequired,
   onTabChange: PropTypes.func.isRequired,
-  getConfigFor: PropTypes.func.isRequired,
-  applyConfigFor: PropTypes.func.isRequired,
 };
 
 export default UserDetailTabBar;

--- a/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/UserDetailTabBar.jsx
+++ b/frontend/src/sections/projects/UsersView/CrossProjectUserDetailPage/UserDetailTabBar.jsx
@@ -125,11 +125,25 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
   useEffect(() => {
     if (lastAppliedTabRef.current === activeTab) return;
 
-    // Fixed tab (sessions/traces): clear activeViewConfig so sub-views
-    // fall back to their URL-driven state.
+    // Fixed tab (sessions/traces): hard-reset the URL down to just `userTab`
+    // so any filter/date/display params left over from a previous saved view
+    // are wiped. useUrlState's external-sync then resets each sub-view's
+    // state to its default.
+    //
+    // The FixedTab onClick handler below already runs this reset
+    // synchronously in the click event tick — that's the primary path and
+    // is what guarantees `setActiveViewConfig(null)` lands in the same
+    // commit as the subTab swap (a `useEffect` reset would be one commit
+    // too late and the newly-mounted sub-view would read the stale custom
+    // config). This branch survives as a safety net for non-click activeTab
+    // transitions, e.g. handleClose at line ~230 calling
+    // `onTabChange("sessions","sessions")` after deleting an active view.
     if (FIXED_TABS.some((t) => t.key === activeTab)) {
+      setSearchParams(new URLSearchParams({ userTab: activeTab }), {
+        replace: true,
+      });
       lastAppliedTabRef.current = activeTab;
-      startTransition(() => setActiveViewConfig(null));
+      setActiveViewConfig(null);
       return;
     }
 
@@ -257,7 +271,20 @@ const UserDetailTabBar = ({ activeTab, onTabChange }) => {
             icon={tab.icon}
             shortcut={tab.shortcut}
             isActive={activeTab === tab.key}
-            onClick={(key) => onTabChange?.(key, key)}
+            onClick={(key) => {
+              // Reset context + URL synchronously in the click event so they
+              // batch with setActiveTab/setSubTab into one commit. Otherwise
+              // the newly-mounted sub-view (e.g. LLMTracingView remounting on
+              // sessions→traces) reads the stale custom-view config from
+              // context during its first render and re-writes the saved
+              // display state back into the URL before the apply useEffect
+              // gets a chance to clear it.
+              setActiveViewConfig(null);
+              setSearchParams(new URLSearchParams({ userTab: key }), {
+                replace: true,
+              });
+              onTabChange?.(key, key);
+            }}
           />
         ))}
       </Box>

--- a/frontend/src/sections/projects/UsersView/UsersPageTabBar.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersPageTabBar.jsx
@@ -203,6 +203,7 @@ const UsersPageTabBar = ({
           type="black"
         >
           <ButtonBase
+            data-create-view-btn
             onClick={(e) => setSaveViewAnchor(e.currentTarget)}
             sx={{
               display: "inline-flex",

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -2,6 +2,7 @@ import React, {
   lazy,
   Suspense,
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -180,7 +181,12 @@ const UsersView = ({ savedViewApiRef = null }) => {
   // Expose a refresh callback to the shared ObserveHeader so the refresh
   // button in the header triggers an ag-grid serverSide refresh on this
   // Users tab.
-  const { setHeaderConfig } = useObserveHeader();
+  const {
+    setHeaderConfig,
+    activeViewConfig,
+    registerGetViewConfig,
+    registerGetTabType,
+  } = useObserveHeader();
 
   const refreshUsers = useCallback(() => {
     if (gridApi) {
@@ -366,6 +372,83 @@ const UsersView = ({ savedViewApiRef = null }) => {
     }
   }, [savedViewApiRef, getConfig, applyConfig]);
 
+  // "Save view" surfaces only on a custom saved-view tab when the live state
+  // diverges from its saved baseline. UsersView's config nests dateFilter
+  // inside `filters` (not `display` like LLMTracingView/SessionsView).
+  const canSaveView = useMemo(() => {
+    if (!activeViewConfig) return false;
+
+    const baselineFilters = activeViewConfig.filters || {};
+    const baselineDisplay = activeViewConfig.display || {};
+    const baselineExtraLen = baselineFilters.extraFilters?.length ?? 0;
+    const baselineDateOption =
+      baselineFilters.dateFilter?.dateOption ?? null;
+
+    if ((extraFilters?.length ?? 0) !== baselineExtraLen) return true;
+    if ((dateFilter?.dateOption ?? null) !== baselineDateOption) return true;
+    if (
+      baselineDisplay.cellHeight !== undefined &&
+      baselineDisplay.cellHeight !== cellHeight
+    ) {
+      return true;
+    }
+    if (
+      baselineDisplay.showErrors !== undefined &&
+      baselineDisplay.showErrors !== showErrors
+    ) {
+      return true;
+    }
+    if (
+      baselineDisplay.showNonAnnotated !== undefined &&
+      baselineDisplay.showNonAnnotated !== showNonAnnotated
+    ) {
+      return true;
+    }
+    if (
+      baselineDisplay.hasEvalFilter !== undefined &&
+      baselineDisplay.hasEvalFilter !== hasEvalFilter
+    ) {
+      return true;
+    }
+    return false;
+  }, [
+    activeViewConfig,
+    extraFilters,
+    dateFilter,
+    cellHeight,
+    showErrors,
+    showNonAnnotated,
+    hasEvalFilter,
+  ]);
+
+  const canSaveViewDeferred = useDeferredValue(canSaveView);
+
+  // Register with ObserveHeaderContext so ObserveTabBar's "+" save flow can
+  // snapshot the current Users config when the user is on this fixed tab —
+  // without this, the save POSTs `config: {}` (TH-4578).
+  useEffect(() => {
+    registerGetViewConfig(getConfig);
+    return () => registerGetViewConfig(null);
+  }, [registerGetViewConfig, getConfig]);
+
+  useEffect(() => {
+    registerGetTabType(() => "users");
+    return () => registerGetTabType(null);
+  }, [registerGetTabType]);
+
+  // Apply a saved view's config when activeViewConfig changes. Reuses the
+  // existing applyConfig — handles extraFilters, dateFilter, display state,
+  // column visibility.
+  // Dep array intentionally only watches `activeViewConfig`. `applyConfig`'s
+  // identity changes whenever `columns` does, and `applyConfig` itself
+  // mutates `columns` via `updateColumnVisibility` — keeping it in deps
+  // creates an infinite re-apply loop.
+  useEffect(() => {
+    if (!activeViewConfig) return;
+    applyConfig(activeViewConfig);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeViewConfig]);
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
@@ -405,6 +488,7 @@ const UsersView = ({ savedViewApiRef = null }) => {
         setDateFilter={setDateFilter}
         // Filter
         hasActiveFilter={hasActiveFilter}
+        canSaveView={canSaveViewDeferred}
         isFilterOpen={isFilterOpen}
         onFilterToggle={() => setIsFilterOpen(!isFilterOpen)}
         filterFields={USER_FILTER_FIELDS}

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -33,6 +33,7 @@ const PrimaryGraph = lazy(
 
 // User-specific
 import useUsersStore from "./Store/usersStore";
+import { getUsersColumnConfig } from "./common";
 import UsersGrid from "./UsersGrid";
 import UsersEmptyScreen from "./UsersEmptyScreen";
 import { useShallow } from "zustand/react/shallow";
@@ -111,7 +112,13 @@ const getDateLabel = (dateFilter) => {
 
 const noopExtraProperties = () => ({});
 
-const UsersView = ({ savedViewApiRef = null }) => {
+const UsersView = ({
+  savedViewApiRef = null,
+  // Optional override for activeViewConfig — used by callers (e.g. UserList)
+  // that don't wrap UsersView in ObserveHeaderProvider but still want
+  // canSaveView to reflect divergence from a saved view's baseline.
+  activeViewConfig: activeViewConfigProp,
+}) => {
   const { observeId } = useParams();
   const location = useLocation();
   const isObservePath = location.pathname.includes("observe");
@@ -183,10 +190,13 @@ const UsersView = ({ savedViewApiRef = null }) => {
   // Users tab.
   const {
     setHeaderConfig,
-    activeViewConfig,
+    activeViewConfig: activeViewConfigCtx,
     registerGetViewConfig,
     registerGetTabType,
   } = useObserveHeader();
+  // Prefer prop (set by UserList for /dashboard/users) over context
+  // (set by ObservePage for the Users fixed tab).
+  const activeViewConfig = activeViewConfigProp ?? activeViewConfigCtx;
 
   const refreshUsers = useCallback(() => {
     if (gridApi) {
@@ -299,6 +309,11 @@ const UsersView = ({ savedViewApiRef = null }) => {
       acc[col.id] = col.isVisible !== false;
       return acc;
     }, {});
+    // Capture full grid column state (widths, order, sort) so saved views
+    // restore the user's exact column layout. Stash inside `display` since
+    // the backend serializer's allowed_keys whitelists `display` for
+    // arbitrary subkeys but does not whitelist a separate `columnState`.
+    const columnState = gridApi?.getColumnState?.() ?? undefined;
     return {
       display: {
         cellHeight,
@@ -306,6 +321,7 @@ const UsersView = ({ savedViewApiRef = null }) => {
         showNonAnnotated,
         hasEvalFilter,
         visibleColumns,
+        ...(columnState ? { columnState } : {}),
       },
       filters: {
         extraFilters,
@@ -320,7 +336,12 @@ const UsersView = ({ savedViewApiRef = null }) => {
     hasEvalFilter,
     extraFilters,
     dateFilter,
+    gridApi,
   ]);
+
+  // Pending column state from a saved view that arrived before the grid was
+  // ready. Drained by the effect below when gridApi becomes available.
+  const pendingColumnStateRef = useRef(null);
 
   const applyConfig = useCallback(
     (config) => {
@@ -332,6 +353,22 @@ const UsersView = ({ savedViewApiRef = null }) => {
         setShowNonAnnotated(false);
         setHasEvalFilter(false);
         setDateFilter(getDefaultDateRange());
+        pendingColumnStateRef.current = null;
+        // Reset column visibility to the column-config defaults so going back
+        // to All Users from a saved view with limited columns shows everything
+        // again.
+        const defaultsVisibility = (getUsersColumnConfig() || []).reduce(
+          (acc, col) => {
+            acc[col.field] = col.hide === undefined ? true : !col.hide;
+            return acc;
+          },
+          {},
+        );
+        if (Object.keys(defaultsVisibility).length > 0) {
+          updateColumnVisibility(defaultsVisibility);
+        }
+        // Reset AG Grid column state (widths/order/sort) to coldef defaults.
+        if (gridApi?.resetColumnState) gridApi.resetColumnState();
         return;
       }
       const display = config.display || {};
@@ -345,6 +382,16 @@ const UsersView = ({ savedViewApiRef = null }) => {
         setHasEvalFilter(display.hasEvalFilter);
       if (display.visibleColumns && columns?.length) {
         updateColumnVisibility(display.visibleColumns);
+      }
+      if (Array.isArray(display.columnState) && display.columnState.length > 0) {
+        if (gridApi?.applyColumnState) {
+          gridApi.applyColumnState({
+            state: display.columnState,
+            applyOrder: true,
+          });
+        } else {
+          pendingColumnStateRef.current = display.columnState;
+        }
       }
       if (Array.isArray(filtersCfg.extraFilters)) {
         setExtraFilters(filtersCfg.extraFilters);
@@ -362,8 +409,20 @@ const UsersView = ({ savedViewApiRef = null }) => {
       setExtraFilters,
       updateColumnVisibility,
       columns,
+      gridApi,
     ],
   );
+
+  // Drain any column state queued before the grid was ready.
+  useEffect(() => {
+    if (gridApi?.applyColumnState && pendingColumnStateRef.current) {
+      gridApi.applyColumnState({
+        state: pendingColumnStateRef.current,
+        applyOrder: true,
+      });
+      pendingColumnStateRef.current = null;
+    }
+  }, [gridApi]);
 
   // Keep the ref's handles in sync with the latest closures
   useEffect(() => {
@@ -410,6 +469,28 @@ const UsersView = ({ savedViewApiRef = null }) => {
     ) {
       return true;
     }
+    // Column visibility: compare baseline visibleColumns dict against current
+    // columns Zustand state. Only check columns the baseline knows about —
+    // newly-added columns from a backend schema bump shouldn't mark dirty.
+    if (
+      baselineDisplay.visibleColumns &&
+      typeof baselineDisplay.visibleColumns === "object"
+    ) {
+      const currentVisibility = (columns || []).reduce((acc, col) => {
+        acc[col.id] = col.isVisible !== false;
+        return acc;
+      }, {});
+      for (const colId of Object.keys(baselineDisplay.visibleColumns)) {
+        const baselineVisible = baselineDisplay.visibleColumns[colId];
+        const currentVisible = currentVisibility[colId];
+        if (
+          currentVisible !== undefined &&
+          currentVisible !== baselineVisible
+        ) {
+          return true;
+        }
+      }
+    }
     return false;
   }, [
     activeViewConfig,
@@ -419,6 +500,7 @@ const UsersView = ({ savedViewApiRef = null }) => {
     showErrors,
     showNonAnnotated,
     hasEvalFilter,
+    columns,
   ]);
 
   const canSaveViewDeferred = useDeferredValue(canSaveView);
@@ -641,6 +723,7 @@ const UsersView = ({ savedViewApiRef = null }) => {
 
 UsersView.propTypes = {
   savedViewApiRef: PropTypes.shape({ current: PropTypes.any }),
+  activeViewConfig: PropTypes.object,
 };
 
 export default UsersView;

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -44,6 +44,7 @@ import { getUsersColumnConfig } from "./common";
 import UsersGrid from "./UsersGrid";
 import UsersEmptyScreen from "./UsersEmptyScreen";
 import { useShallow } from "zustand/react/shallow";
+import { filtersContentEqual } from "../saved-view-utils";
 
 // ---------------------------------------------------------------------------
 // User filter fields for TraceFilterPanel
@@ -447,11 +448,11 @@ const UsersView = ({
 
     const baselineFilters = activeViewConfig.filters || {};
     const baselineDisplay = activeViewConfig.display || {};
-    const baselineExtraLen = baselineFilters.extraFilters?.length ?? 0;
+    const baselineExtraFilters = baselineFilters.extraFilters || [];
     const baselineDateOption =
       baselineFilters.dateFilter?.dateOption ?? null;
 
-    if ((extraFilters?.length ?? 0) !== baselineExtraLen) return true;
+    if (!filtersContentEqual(extraFilters, baselineExtraFilters)) return true;
     if ((dateFilter?.dateOption ?? null) !== baselineDateOption) return true;
     if (
       baselineDisplay.cellHeight !== undefined &&

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -18,6 +18,13 @@ import { useUrlState } from "src/routes/hooks/use-url-state";
 import axios, { endpoints } from "src/utils/axios";
 import { useQuery } from "@tanstack/react-query";
 import { useObserveHeader } from "src/sections/project/context/ObserveHeaderContext";
+import {
+  useUpdateSavedView,
+  useUpdateWorkspaceSavedView,
+} from "src/api/project/saved-views";
+import { enqueueSnackbar } from "notistack";
+
+const USERS_TAB_TYPE = "users";
 
 // Shared observe components
 import ObserveToolbar from "../LLMTracing/ObserveToolbar";
@@ -505,6 +512,44 @@ const UsersView = ({
 
   const canSaveViewDeferred = useDeferredValue(canSaveView);
 
+  // Update mutations for the explicit Save view button. Project-scoped on
+  // ObservePage's Users fixed tab; workspace-scoped (USERS_TAB_TYPE) on the
+  // top-level /dashboard/users page rendered by UserList.
+  const { mutate: updateSavedView } = useUpdateSavedView(observeId);
+  const { mutate: updateWorkspaceSavedView } =
+    useUpdateWorkspaceSavedView(USERS_TAB_TYPE);
+
+  // Active saved-view id from URL — "tab" key on ObservePage, "usersTab" on
+  // UserList. Re-derived when the active config flips.
+  const activeViewTabId = useMemo(() => {
+    const params = new URLSearchParams(window.location.search);
+    const key = isObservePath
+      ? params.get("tab")
+      : params.get("usersTab");
+    return key?.startsWith("view-") ? key.slice(5) : null;
+  }, [activeViewConfig, isObservePath]);
+
+  const handleSaveView = useCallback(() => {
+    if (!activeViewTabId) return;
+    const config = getConfig();
+    const mutate = isObservePath ? updateSavedView : updateWorkspaceSavedView;
+    mutate(
+      { id: activeViewTabId, config },
+      {
+        onSuccess: () =>
+          enqueueSnackbar("View updated", { variant: "success" }),
+        onError: () =>
+          enqueueSnackbar("Failed to update view", { variant: "error" }),
+      },
+    );
+  }, [
+    activeViewTabId,
+    getConfig,
+    isObservePath,
+    updateSavedView,
+    updateWorkspaceSavedView,
+  ]);
+
   // Register with ObserveHeaderContext so ObserveTabBar's "+" save flow can
   // snapshot the current Users config when the user is on this fixed tab —
   // without this, the save POSTs `config: {}` (TH-4578).
@@ -571,6 +616,7 @@ const UsersView = ({
         // Filter
         hasActiveFilter={hasActiveFilter}
         canSaveView={canSaveViewDeferred}
+        onSaveView={handleSaveView}
         isFilterOpen={isFilterOpen}
         onFilterToggle={() => setIsFilterOpen(!isFilterOpen)}
         filterFields={USER_FILTER_FIELDS}

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -198,6 +198,7 @@ const UsersView = ({
   const {
     setHeaderConfig,
     activeViewConfig: activeViewConfigCtx,
+    setActiveViewConfig,
     registerGetViewConfig,
     registerGetTabType,
   } = useObserveHeader();
@@ -536,8 +537,13 @@ const UsersView = ({
     mutate(
       { id: activeViewTabId, config },
       {
-        onSuccess: () =>
-          enqueueSnackbar("View updated", { variant: "success" }),
+        onSuccess: (response) => {
+          // Refresh context baseline (Observe path) — UserList path's
+          // activeViewConfig prop refreshes via the mutation's optimistic
+          // setQueryData on the workspace cache.
+          setActiveViewConfig(response?.data?.result?.config ?? config);
+          enqueueSnackbar("View updated", { variant: "success" });
+        },
         onError: () =>
           enqueueSnackbar("Failed to update view", { variant: "error" }),
       },
@@ -548,6 +554,7 @@ const UsersView = ({
     isObservePath,
     updateSavedView,
     updateWorkspaceSavedView,
+    setActiveViewConfig,
   ]);
 
   // Register with ObserveHeaderContext so ObserveTabBar's "+" save flow can
@@ -617,6 +624,7 @@ const UsersView = ({
         hasActiveFilter={hasActiveFilter}
         canSaveView={canSaveViewDeferred}
         onSaveView={handleSaveView}
+        graphFilters={extraFilters}
         isFilterOpen={isFilterOpen}
         onFilterToggle={() => setIsFilterOpen(!isFilterOpen)}
         filterFields={USER_FILTER_FIELDS}

--- a/frontend/src/sections/projects/saved-view-utils.js
+++ b/frontend/src/sections/projects/saved-view-utils.js
@@ -1,0 +1,28 @@
+// Helpers shared by canSaveView memos across LLMTracingView, SessionsView,
+// and UsersView. The naive length check used previously missed value-only
+// edits (same column, new filter value), so the Save view button stayed
+// hidden after legitimate changes.
+
+const readColumnId = (f) => f?.column_id ?? f?.columnId ?? null;
+const readFilterConfig = (f) => f?.filter_config ?? f?.filterConfig ?? null;
+
+// Deep equality for an extraFilters / structural-filter array. Tolerates the
+// snake_case ↔ camelCase split between the saved-view backend payload and the
+// live in-memory shape (Sessions normalizes on apply, but mixed inputs still
+// turn up via the popover and direct setExtraFilters callers).
+export const filtersContentEqual = (a, b) => {
+  const aArr = Array.isArray(a) ? a : [];
+  const bArr = Array.isArray(b) ? b : [];
+  if (aArr.length !== bArr.length) return false;
+  if (aArr.length === 0) return true;
+  for (let i = 0; i < aArr.length; i += 1) {
+    if (readColumnId(aArr[i]) !== readColumnId(bArr[i])) return false;
+    if (
+      JSON.stringify(readFilterConfig(aArr[i])) !==
+      JSON.stringify(readFilterConfig(bArr[i]))
+    ) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/futureagi/accounts/authentication.py
+++ b/futureagi/accounts/authentication.py
@@ -580,6 +580,12 @@ class AuthMonitoringMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        # Bypass rate limiting + IP blocking entirely in DEBUG (local dev) so
+        # repeated test logins / typo'd passwords don't lock the developer out.
+        # Production (DEBUG=False) keeps the full protection.
+        if settings.DEBUG:
+            return self.get_response(request)
+
         client_ip, _ = get_client_ip(request)
 
         if request.path.endswith("password-reset-initiate/"):

--- a/futureagi/accounts/authentication.py
+++ b/futureagi/accounts/authentication.py
@@ -580,12 +580,6 @@ class AuthMonitoringMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        # Bypass rate limiting + IP blocking entirely in DEBUG (local dev) so
-        # repeated test logins / typo'd passwords don't lock the developer out.
-        # Production (DEBUG=False) keeps the full protection.
-        if settings.DEBUG:
-            return self.get_response(request)
-
         client_ip, _ = get_client_ip(request)
 
         if request.path.endswith("password-reset-initiate/"):

--- a/futureagi/accounts/views/user.py
+++ b/futureagi/accounts/views/user.py
@@ -105,24 +105,22 @@ class CustomTokenObtainPairView(TokenObtainPairView):
             remember_me = request.data.get("remember_me", False)
             client_ip, _ = get_client_ip(request)
 
-            # Check if user is blocked. Skip the per-account block on local
-            # dev (DEBUG=True) so devs aren't locked out after a few typos.
+            # Check if user is blocked
             block_key = f"user_blocked_{email}"
-            if not settings.DEBUG:
-                block_data = cache.get(block_key)
-                if block_data:
-                    current_time = datetime.now().timestamp()
-                    block_expiry = block_data.get("expiry", 0)
+            block_data = cache.get(block_key)
+            if block_data:
+                current_time = datetime.now().timestamp()
+                block_expiry = block_data.get("expiry", 0)
 
-                    if current_time < block_expiry:
-                        minutes_left = int((block_expiry - current_time) / 60)
-                        return self._gm.bad_request(
-                            {
-                                "error": f"Account temporarily blocked. Please try again in {minutes_left} minutes.",
-                                "blocked": True,
-                                "block_time_remaining": int(block_expiry - current_time),
-                            }
-                        )
+                if current_time < block_expiry:
+                    minutes_left = int((block_expiry - current_time) / 60)
+                    return self._gm.bad_request(
+                        {
+                            "error": f"Account temporarily blocked. Please try again in {minutes_left} minutes.",
+                            "blocked": True,
+                            "block_time_remaining": int(block_expiry - current_time),
+                        }
+                    )
 
             # Get failed attempts
             attempts_key = f"login_attempts_{email}"

--- a/futureagi/accounts/views/user.py
+++ b/futureagi/accounts/views/user.py
@@ -105,22 +105,24 @@ class CustomTokenObtainPairView(TokenObtainPairView):
             remember_me = request.data.get("remember_me", False)
             client_ip, _ = get_client_ip(request)
 
-            # Check if user is blocked
+            # Check if user is blocked. Skip the per-account block on local
+            # dev (DEBUG=True) so devs aren't locked out after a few typos.
             block_key = f"user_blocked_{email}"
-            block_data = cache.get(block_key)
-            if block_data:
-                current_time = datetime.now().timestamp()
-                block_expiry = block_data.get("expiry", 0)
+            if not settings.DEBUG:
+                block_data = cache.get(block_key)
+                if block_data:
+                    current_time = datetime.now().timestamp()
+                    block_expiry = block_data.get("expiry", 0)
 
-                if current_time < block_expiry:
-                    minutes_left = int((block_expiry - current_time) / 60)
-                    return self._gm.bad_request(
-                        {
-                            "error": f"Account temporarily blocked. Please try again in {minutes_left} minutes.",
-                            "blocked": True,
-                            "block_time_remaining": int(block_expiry - current_time),
-                        }
-                    )
+                    if current_time < block_expiry:
+                        minutes_left = int((block_expiry - current_time) / 60)
+                        return self._gm.bad_request(
+                            {
+                                "error": f"Account temporarily blocked. Please try again in {minutes_left} minutes.",
+                                "blocked": True,
+                                "block_time_remaining": int(block_expiry - current_time),
+                            }
+                        )
 
             # Get failed attempts
             attempts_key = f"login_attempts_{email}"

--- a/futureagi/tracer/migrations/0072_saved_view_sessions_tab.py
+++ b/futureagi/tracer/migrations/0072_saved_view_sessions_tab.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tracer", "0071_observation_span_eval_attributes_gin"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="savedview",
+            name="tab_type",
+            field=models.CharField(
+                choices=[
+                    ("traces", "Traces"),
+                    ("spans", "Spans"),
+                    ("voice", "Voice"),
+                    ("imagine", "Imagine"),
+                    ("users", "Users"),
+                    ("user_detail", "User Detail"),
+                    ("sessions", "Sessions"),
+                ],
+                max_length=20,
+            ),
+        ),
+    ]

--- a/futureagi/tracer/models/saved_view.py
+++ b/futureagi/tracer/models/saved_view.py
@@ -16,6 +16,7 @@ class SavedView(BaseModel):
         ("imagine", "Imagine"),
         ("users", "Users"),
         ("user_detail", "User Detail"),
+        ("sessions", "Sessions"),
     )
 
     VISIBILITY_CHOICES = (

--- a/futureagi/tracer/serializers/saved_view.py
+++ b/futureagi/tracer/serializers/saved_view.py
@@ -70,7 +70,15 @@ class SavedViewCreateSerializer(serializers.Serializer):
     project_id = serializers.UUIDField(required=False, allow_null=True)
     name = serializers.CharField(max_length=255)
     tab_type = serializers.ChoiceField(
-        choices=["traces", "spans", "voice", "imagine", "users", "user_detail"]
+        choices=[
+            "traces",
+            "spans",
+            "voice",
+            "imagine",
+            "users",
+            "user_detail",
+            "sessions",
+        ]
     )
     visibility = serializers.ChoiceField(
         choices=["personal", "project"], default="personal"
@@ -156,7 +164,15 @@ class ReorderItemSerializer(serializers.Serializer):
 class SavedViewReorderSerializer(serializers.Serializer):
     project_id = serializers.UUIDField(required=False, allow_null=True)
     tab_type = serializers.ChoiceField(
-        choices=["traces", "spans", "voice", "imagine", "users", "user_detail"],
+        choices=[
+            "traces",
+            "spans",
+            "voice",
+            "imagine",
+            "users",
+            "user_detail",
+            "sessions",
+        ],
         required=False,
     )
     order = ReorderItemSerializer(many=True)


### PR DESCRIPTION
**Linear:** [TH-4578 — Saved view filters are not persisting](https://linear.app/future-agi/issue/TH-4578/saved-view-filters-are-not-persisting)

## Summary

Saved views across Trace / Sessions / Users / User Detail / `/dashboard/users` now round-trip filter, date, display options, column visibility, and AG Grid column state. The half-broken auto-save was replaced with an explicit Save view button, and refresh / tab-switch / group-by paths no longer leak or drop saved-view state.

## What changed

**Round-trip** — `buildViewConfig` + apply effect in each of LLMTracingView / Sessions-view / UsersView now capture and apply: filter chips (extraFilters), `display.dateFilter`, `cellHeight`, `showCompare` / `showErrors` / `showNonAnnotated` / `hasEvalFilter`, `viewMode`, `visibleColumns` dict, and AG Grid `columnState` (widths / order / sort).

**Save view UX** — split the toolbar `+` (always create new) from a new `Save view` button (only appears when on a saved view AND state diverges, only updates in place). `canSaveView` baseline is reset via the mutation's `onSuccess` + an optimistic `setQueryData` cache write so the button clears immediately. Removed the broken backend auto-save that silently dropped fields.

**Content-aware canSaveView** — replaced length-only (`extraFilters?.length`) and boolean-only (`some(f => f?.columnId)`) checks with a new `filtersContentEqual` helper that deep-equals `column_id`/`filter_config`. Editing a filter's value with the same column now surfaces the Save view button.

**ObservePage routing** — pulled the `tab=view-<id>` short-circuit above the route-derived `setActiveTab` so a sessions/users saved view click no longer clobbers the URL with `tab=sessions`/`tab=users` (which had silently broken Save view via `activeViewTabId === null`).

**Hard-refresh hydration** — ObservePage and CrossProjectUserDetailPage now read `tab=view-<id>` (or `userTab=view-<id>`) on mount and seed `activeViewConfig` from the saved-views React Query cache (workspace-scoped on User Detail). Guarded by a `lastHydratedTabRef` so saved-views invalidates after Save don't re-fire the apply effect and trample URL-driven state mid-session.

**Sessions column persistence** — `Session-grid.getRows` was overwriting per-row-fetch column visibility from `res.config` (backend per-project default). Added `isOnSavedView` prop fed from `Boolean(activeViewConfig)`; on a saved view the data-fetch respects `updateObj` (the saved view's `visibleColumns`) instead. Also fixed a stale-closure bug where `columnDefs` captured at first mount left skeleton headers flashing back on page-2 scroll / sort / filter changes — `columnDefs` now read via a ref.

**Saved-view → default reset** — apply effect's null branch now wipes the right state on a real saved-view → default transition (and *only* on a real transition, guarded by `wasOnSavedViewRef`):
- Sessions: `updateObj` → `initialVisibility` + imperative `setColumnsVisible` + `gridApi.resetColumnState()` + clear `pendingColumnStateRef`.
- LLMTracing: `viewMode` → default, drain `pendingColumnStateRef` + `pendingCustomColumnsRef`, `activeApi.resetColumnState()`. Without the wasOnSavedViewRef guard, hard-refresh on a saved view fired the resets during the brief activeViewConfig=null window and clobbered the values the apply branch was about to load.

**Group-by from a custom Trace view** — `handleGroupByChange` now detects saved-view URL and navigates to the corresponding default route (clearing `tab=view-<id>` and `activeViewConfig`) instead of just setting `selectedTab`, which used to leave the page on the saved-view chips.

**Cross-project `/dashboard/users`** — `UsersList.activeTab` switched from `useState` to `useUrlState("usersTab")` so the saved view survives a refresh.

**User Detail page** — fixed-tab click from a custom view now wipes URL-synced state synchronously in the click event tick (not a deferred `useEffect`), so the sub-view that mounts next doesn't read stale custom-view config.

**Backend (futureagi/)** — added `sessions` to `SavedView.tab_type` choices (model + Create / Update / Reorder serializers + migration `0072_saved_view_sessions_tab.py`) so SessionsView can persist saved views via the existing `/saved-views/` endpoints.

## Test plan

Manual checklist tracked in Obsidian: `TH-4578 — Saved View Filter Persistence — Test Checklist.md`.

- [ ] Trace saved view round-trip + hard refresh
- [ ] Sessions saved view URL stays `view-<id>` (no `tab=sessions` clobber)
- [ ] Sessions display / visibleColumns / columnState round-trip
- [ ] Save view button clears after click (no flicker)
- [ ] Custom view → fixed tab fully resets state
- [ ] `+` always creates new, Save view always updates in place
- [ ] `/dashboard/users` saved view survives refresh
- [ ] User Detail fixed-tab click wipes custom-view URL keys
- [ ] Filter value edit surfaces Save view button
- [ ] Group By → Spans on a custom Trace view navigates to All Spans
- [ ] Backend `POST /saved-views/` accepts `tab_type=sessions`