### PR TITLE
fix: clear Falcon chat state on logout to prevent cross-account leak

### DIFF
--- a/frontend/src/auth/context/jwt/auth-provider.jsx
+++ b/frontend/src/auth/context/jwt/auth-provider.jsx
@@ -18,6 +18,7 @@ import { identifyPostHogUser, resetPostHogUser } from "src/utils/PostHog";
 import { useQueryClient } from "@tanstack/react-query";
 import { setUser } from "@sentry/react";
 import logger from "src/utils/logger";
+import useFalconStore from "src/sections/falcon-ai/store/useFalconStore";
 
 // Session storage key for per-tab user tracking
 const SESSION_USER_ID_KEY = "currentUserId";
@@ -308,6 +309,7 @@ export function AuthProvider({ children }) {
       sessionStorage.removeItem("2fa_challenge");
       sessionStorage.removeItem(SESSION_USER_ID_KEY);
       localStorage.removeItem("initial-render"); // Clear flag so next login triggers redirect logic
+      useFalconStore.getState().resetAll();
       dispatch({
         type: "LOGOUT",
       });


### PR DESCRIPTION
## Summary

`useFalconStore` is plain in-memory Zustand. It isn't cleared by `clearTokens()`, `queryClient.clear()`, or the `LOGOUT` reducer dispatch — and the SPA doesn't hard-refresh on in-app logout. So Falcon chat state (conversations, current conversation id, message content) survived across logout/login on the same tab, briefly exposing the previous account's chat history to the next user.

Adding a `useFalconStore.getState().resetAll()` call into the existing `logout` callback so in-memory chat state is dropped alongside tokens / react-query cache / analytics identities.

## Linked issues

Closes # *(paste Linear ticket — title: "Falcon AI chat history visible to next user after same-tab logout/login")*

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Steps to reproduce (before fix)

1. Log in as user A → open Falcon (sidebar or `/dashboard/falcon-ai`) → send a message or two.
2. Click profile → Logout (in-app, *not* a hard reload).
3. Log in as user B on the same tab.
4. Open Falcon → user A's messages render in the chat list / message panel for a brief window.

**After fix:** step 4 starts with empty Falcon state regardless of how recently another user signed out on this tab.

## Root cause

The `logout` callback ([auth-provider.jsx:301](frontend/src/auth/context/jwt/auth-provider.jsx#L301)) handles tokens, sessionStorage, the auth reducer, the react-query cache, and analytics identities — but not Zustand stores. `useFalconStore` is plain in-memory state with no `persist` middleware; it survives any state change that isn't a full page reload. The cross-tab logout path at line 200 already triggers `window.location.href = "/auth/jwt/login"` (full reload), so it implicitly clears the store; only the same-tab in-app logout was affected.

## Fix

```js
import useFalconStore from "src/sections/falcon-ai/store/useFalconStore";
...
const logout = useCallback(async () => {
  ...
  useFalconStore.getState().resetAll();   // ← added
  dispatch({ type: "LOGOUT" });
  ...
});
