### PR TITLE
feat(eval): route protect and protect_flash calls through DeterministicEvaluator

### DIFF
--- a/futureagi/evaluations/engine/runner.py
+++ b/futureagi/evaluations/engine/runner.py
@@ -95,6 +95,14 @@ def run_eval(request: EvalRequest) -> EvalResult:
             f"eval_type_id not found in EvalTemplate config for '{eval_template.name}'"
         )
 
+    call_type = request.inputs.get("call_type", "")
+    if call_type in ("protect", "protect_flash") and eval_type_id != "DeterministicEvaluator":
+        eval_type_id = "DeterministicEvaluator"
+        # Patch template config so format_eval_value uses DeterministicEvaluator branch
+        eval_template.config = {**eval_template.config, "eval_type_id": "DeterministicEvaluator"}
+        if not request.model:
+            request.model = "protect_flash" if call_type == "protect_flash" else "protect"
+
     is_futureagi = eval_type_id in FUTUREAGI_EVAL_TYPES
 
     # 1. Look up evaluator class

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -396,7 +396,7 @@ def _run_protect(
         for rk in template_required_keys:
             if rk not in protect_inputs:
                 protect_inputs[rk] = input_text
-        protect_inputs["call_type"] = "protect"
+        protect_inputs["call_type"] = "protect_flash" if protect_flash else "protect"
 
         api_call_log_row = _log_and_deduct_cost_for_standalone_eval(
             user, eval_template, True, protect_inputs, workspace=workspace
@@ -408,6 +408,7 @@ def _run_protect(
                     eval_template=eval_template,
                     inputs=protect_inputs,
                     config_overrides=config or {},
+                    model="protect_flash" if protect_flash else None,
                     organization_id=str(user.organization.id),
                     workspace_id=str(workspace.id) if workspace else None,
                 )


### PR DESCRIPTION
## Summary

- Route `protect` and `protect_flash` evaluation calls through the `DeterministicEvaluator` pipeline, improving latency and accuracy for content moderation checks.
- Patch template config during routing override so result formatting reads the evaluator output correctly.
- Fix `call_type` and model name for `protect_flash` SDK path.

## Changes

- **`evaluations/engine/runner.py`** - Add call_type-based routing override to direct protect calls to DeterministicEvaluator regardless of template config. Patch template config so `format_eval_value` uses the correct result extraction branch.
- **`sdk/utils/evaluations.py`** - Set correct `call_type` (`protect` vs `protect_flash`) and model name in protect SDK path.

## Test plan

- [x] Verify protect SDK calls route through DeterministicEvaluator
- [x] Verify protect_flash SDK calls route correctly with correct model name
- [x] Verify all 4 protect metrics correctly flag harmful text and pass safe text
- [x] Verify protect_flash correctly classifies harmful and safe text
- [x] Verify no impact on other eval types (routing override only triggers for protect call_type)