### PR TITLE
fix: reroute simulation dashboard trace attributes

### DIFF
--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -1121,6 +1121,43 @@ class TestDashboardQueryExecution:
         _, kwargs = mock_service.execute_ch_query.call_args
         assert kwargs["timeout_ms"] == 30000
 
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.AnalyticsQueryService")
+    def test_query_action_simulation_custom_attribute_routes_to_trace_builder(
+        self, mock_analytics_cls, auth_client, observe_project
+    ):
+        mock_service = MagicMock()
+        mock_result = MagicMock()
+        mock_result.data = [{"time_bucket": "2025-01-01T00:00:00", "value": 0.01}]
+        mock_service.execute_ch_query.return_value = mock_result
+        mock_analytics_cls.return_value = mock_service
+
+        response = auth_client.post(
+            "/tracer/dashboard/query/",
+            {
+                "project_ids": [str(observe_project.id)],
+                "granularity": "day",
+                "time_range": {"preset": "7D"},
+                "metrics": [
+                    {
+                        "id": "cost_breakdown.stt",
+                        "name": "cost_breakdown.stt",
+                        "type": "custom_attribute",
+                        "attribute_key": "cost_breakdown.stt",
+                        "attribute_type": "number",
+                        "aggregation": "avg",
+                        "source": "simulation",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        sql = mock_service.execute_ch_query.call_args.args[0]
+        assert "span_attr_num" in sql
+        assert "simulate_call_execution" not in sql
+
 
 class TestDashboardTraceTimeoutSelection:
     def test_default_trace_timeout_is_short(self):
@@ -1175,6 +1212,30 @@ class TestDashboardTraceTimeoutSelection:
         assert timeout == 30000
 
 
+class TestDashboardMetricSourceNormalization:
+    def test_simulation_custom_attribute_is_rerouted_to_traces(self):
+        viewset = DashboardViewSet()
+        normalized = viewset._normalize_metric_sources(
+            [
+                {
+                    "id": "cost_breakdown.stt",
+                    "type": "custom_attribute",
+                    "source": "simulation",
+                }
+            ]
+        )
+
+        assert normalized[0]["source"] == "traces"
+
+    def test_non_custom_simulation_metric_keeps_simulation_source(self):
+        viewset = DashboardViewSet()
+        normalized = viewset._normalize_metric_sources(
+            [{"id": "stt_cost", "type": "system_metric", "source": "simulation"}]
+        )
+
+        assert normalized[0]["source"] == "simulation"
+
+
 # ===========================================================================
 # Widget Query Execution (mocked ClickHouse)
 # ===========================================================================
@@ -1222,6 +1283,54 @@ class TestWidgetQueryExecution:
             f"/tracer/dashboard/{dashboard.id}/widgets/{dashboard_widget.id}/query/"
         )
         assert response.status_code == 400
+
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
+    @patch("tracer.views.dashboard.get_clickhouse_client")
+    def test_execute_query_simulation_custom_attribute_routes_to_trace_builder(
+        self,
+        mock_get_client,
+        mock_enabled,
+        auth_client,
+        dashboard,
+        dashboard_widget,
+        observe_project,
+    ):
+        dashboard_widget.query_config = {
+            "workflow": "simulation",
+            "project_ids": [str(observe_project.id)],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "cost_breakdown.stt",
+                    "name": "cost_breakdown.stt",
+                    "type": "custom_attribute",
+                    "attribute_key": "cost_breakdown.stt",
+                    "attribute_type": "number",
+                    "aggregation": "avg",
+                    "source": "simulation",
+                }
+            ],
+        }
+        dashboard_widget.save(update_fields=["query_config"])
+
+        mock_client = MagicMock()
+        mock_client.execute_read.return_value = (
+            [(datetime(2025, 1, 1), 0.01)],
+            [("time_bucket", "DateTime"), ("value", "Float64")],
+            5.0,
+        )
+        mock_get_client.return_value = mock_client
+
+        response = auth_client.post(
+            f"/tracer/dashboard/{dashboard.id}/widgets/{dashboard_widget.id}/query/"
+        )
+
+        assert response.status_code == 200
+        sql = mock_client.execute_read.call_args.args[0]
+        assert "span_attr_num" in sql
+        assert "simulate_call_execution" not in sql
 
     @pytest.mark.django_db
     @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -66,6 +66,24 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
         )
         return 30000 if has_eval_metrics or has_project_breakdown else 10000
 
+    def _normalize_metric_sources(self, metrics):
+        """Route simulation-scoped trace attributes through the trace builder.
+
+        The metric picker can save trace attributes with ``source=simulation``
+        for simulation workflow widgets. Those attributes still live on spans,
+        so sending them to ``SimulationQueryBuilder`` yields empty series.
+        """
+        normalized = []
+        for metric in metrics:
+            metric_copy = dict(metric)
+            if (
+                metric_copy.get("source") == "simulation"
+                and metric_copy.get("type") == "custom_attribute"
+            ):
+                metric_copy["source"] = "traces"
+            normalized.append(metric_copy)
+        return normalized
+
     def list(self, request, *args, **kwargs):
         try:
             queryset = self.get_queryset()
@@ -170,6 +188,8 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     m["source"] = "simulation"
                 else:
                     m["source"] = "traces"
+
+        query_config["metrics"] = self._normalize_metric_sources(query_config["metrics"])
 
         # Partition metrics by source
         # "both" source metrics (e.g. annotations) go to trace_metrics
@@ -2297,6 +2317,8 @@ class DashboardWidgetViewSet(BaseModelViewSetMixin, ModelViewSet):
         for m in query_config.get("metrics", []):
             if "source" not in m:
                 m["source"] = "datasets" if workflow == "dataset" else "traces"
+
+        query_config["metrics"] = self._normalize_metric_sources(query_config["metrics"])
 
         trace_metrics = [
             m for m in query_config["metrics"] if m.get("source") == "traces"


### PR DESCRIPTION
  ## Summary

  This fixes TH-4628 for dashboard widgets that use simulation data plus trace attributes such as `cost_breakdown.stt`. Those metrics could be saved with `source=simulation`,
  which sent them into the simulation query builder even though the underlying data lives on spans. This change reroutes simulation-scoped `custom_attribute` metrics through the
  trace dashboard builder so they return data correctly, while preserving existing simulation system metrics.

  ## Linked issues

  TH-4628

  ## Type of change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)

  ## How was this tested?

  - `set -a && source .env.test && set +a && .venv/bin/pytest tracer/tests/test_dashboard.py tracer/tests/test_simulation_dashboard.py -q -k
  'TestDashboardMetricSourceNormalization or TestSimulationQueryBuilder'`
  - Added regression tests for simulation-scoped custom attribute routing

  DB-backed dashboard endpoint tests were added but could not be executed in this environment because the local test Postgres on `localhost:15432` was not reachable.

  ## Screenshots / recordings (if UI)

  Not captured

  ## Checklist

  - [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
  - [x] I've added tests that prove my fix is effective or that my feature works
  - [ ] `make check-all` / `yarn check-all` passes locally
  - [ ] I've updated the documentation where relevant
  - [x] No hardcoded secrets, URLs, or PII
  - [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)