### PR TITLE
hotfix(error-feed): loading skeletons + Traces grid lag (cherry-pick of #61)

### DIFF
--- a/frontend/src/pages/dashboard/error-feed/ErrorFeedDetailView.jsx
+++ b/frontend/src/pages/dashboard/error-feed/ErrorFeedDetailView.jsx
@@ -280,6 +280,7 @@ export default function ErrorFeedDetailView() {
                 variant="contained"
                 color="primary"
                 startIcon={<Iconify icon="mdi:check" width={13} />}
+                disabled={updateIssue.isPending}
                 onClick={() =>
                   updateIssue.mutate({
                     clusterId: currentError.clusterId,
@@ -301,6 +302,7 @@ export default function ErrorFeedDetailView() {
                 startIcon={
                   <Iconify icon="mdi:check-circle-outline" width={13} />
                 }
+                disabled={updateIssue.isPending}
                 onClick={() =>
                   updateIssue.mutate({
                     clusterId: currentError.clusterId,
@@ -322,6 +324,7 @@ export default function ErrorFeedDetailView() {
                 size="small"
                 variant="outlined"
                 startIcon={<Iconify icon="mdi:eye-off-outline" width={13} />}
+                disabled={updateIssue.isPending}
                 onClick={() =>
                   updateIssue.mutate({
                     clusterId: currentError.clusterId,

--- a/frontend/src/pages/dashboard/error-feed/components/ErrorFeedTable.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorFeedTable.jsx
@@ -376,7 +376,9 @@ export default function ErrorFeedTable({ selected, onSelect, onSelectAll }) {
           {/* ── body ── */}
           <TableBody>
             {isLoading ? (
-              Array.from({ length: 8 }).map((_, i) => <SkeletonRow key={i} />)
+              Array.from({ length: pageSize }).map((_, i) => (
+                <SkeletonRow key={i} />
+              ))
             ) : rows.length === 0 ? (
               <EmptyState filtered={isFiltered} />
             ) : (

--- a/frontend/src/pages/dashboard/error-feed/components/ErrorTrendSparkline.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorTrendSparkline.jsx
@@ -28,7 +28,7 @@ function padToRange(data, days = 14) {
   return Array.from(buckets.values());
 }
 
-export default function ErrorTrendSparkline({ data }) {
+function ErrorTrendSparkline({ data }) {
   const chartRef = useRef(null);
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
@@ -164,3 +164,5 @@ export default function ErrorTrendSparkline({ data }) {
 ErrorTrendSparkline.propTypes = {
   data: PropTypes.array,
 };
+
+export default React.memo(ErrorTrendSparkline);

--- a/frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx
@@ -6,6 +6,7 @@ import {
   Button,
   Chip,
   IconButton,
+  Skeleton,
   Stack,
   Tooltip,
   Typography,
@@ -1552,7 +1553,8 @@ export default function OverviewTab({ _error: currentError }) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const clusterId = currentError?.clusterId;
-  const { data: overview } = useErrorFeedOverview(clusterId);
+  const { data: overview, isLoading: isOverviewLoading } =
+    useErrorFeedOverview(clusterId);
   const traces = useMemo(
     () => overview?.representativeTraces ?? [],
     [overview],
@@ -1758,7 +1760,30 @@ export default function OverviewTab({ _error: currentError }) {
 
       {/* ── RIGHT PANEL: trace detail ── */}
       <Box sx={{ flex: 1, minWidth: 0, overflow: "auto" }}>
-        {!trace ? (
+        {isOverviewLoading && !trace ? (
+          <Stack gap={1.5} sx={{ p: 1.75 }}>
+            <Skeleton
+              variant="rectangular"
+              height={56}
+              sx={{ borderRadius: "6px" }}
+            />
+            <Skeleton
+              variant="rectangular"
+              height={140}
+              sx={{ borderRadius: "8px" }}
+            />
+            <Skeleton
+              variant="rectangular"
+              height={260}
+              sx={{ borderRadius: "8px" }}
+            />
+            <Skeleton
+              variant="rectangular"
+              height={200}
+              sx={{ borderRadius: "8px" }}
+            />
+          </Stack>
+        ) : !trace ? (
           <Stack
             alignItems="center"
             justifyContent="center"

--- a/frontend/src/pages/dashboard/error-feed/components/StateGraphTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/StateGraphTab.jsx
@@ -410,10 +410,11 @@ export default function StateGraphTab({ error }) {
     useGetTraceDetail(failTraceId);
   const { data: successData, isLoading: isSuccessLoading } =
     useGetTraceDetail(successTraceId);
-  const isLoading =
+  const isLoading = Boolean(
     isDetailLoading ||
-    (failTraceId && isFailLoading && !failData) ||
-    (successTraceId && isSuccessLoading && !successData);
+      (failTraceId && isFailLoading && !failData) ||
+      (successTraceId && isSuccessLoading && !successData),
+  );
   const failSteps = useMemo(
     () =>
       extractSteps(failData?.observation_spans || failData?.observationSpans),

--- a/frontend/src/pages/dashboard/error-feed/components/StateGraphTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/StateGraphTab.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { Box, Stack, Typography, alpha, useTheme } from "@mui/material";
+import { Box, Skeleton, Stack, Typography, alpha, useTheme } from "@mui/material";
 import PropTypes from "prop-types";
 import Iconify from "src/components/iconify";
 import { useGetTraceDetail } from "src/api/project/trace-detail";
@@ -402,11 +402,18 @@ DivergenceDiagram.propTypes = {
 
 export default function StateGraphTab({ error }) {
   const clusterId = error?.clusterId;
-  const { data: detail } = useErrorFeedDetail(clusterId);
+  const { data: detail, isLoading: isDetailLoading } =
+    useErrorFeedDetail(clusterId);
   const failTraceId = detail?.representativeTrace?.traceId;
   const successTraceId = detail?.successTrace?.traceId;
-  const { data: failData } = useGetTraceDetail(failTraceId);
-  const { data: successData } = useGetTraceDetail(successTraceId);
+  const { data: failData, isLoading: isFailLoading } =
+    useGetTraceDetail(failTraceId);
+  const { data: successData, isLoading: isSuccessLoading } =
+    useGetTraceDetail(successTraceId);
+  const isLoading =
+    isDetailLoading ||
+    (failTraceId && isFailLoading && !failData) ||
+    (successTraceId && isSuccessLoading && !successData);
   const failSteps = useMemo(
     () =>
       extractSteps(failData?.observation_spans || failData?.observationSpans),
@@ -419,6 +426,18 @@ export default function StateGraphTab({ error }) {
       ),
     [successData],
   );
+
+  if (isLoading) {
+    return (
+      <Stack gap={2}>
+        <Skeleton
+          variant="rectangular"
+          height={420}
+          sx={{ borderRadius: "8px" }}
+        />
+      </Stack>
+    );
+  }
 
   if (!failTraceId && !successTraceId) {
     return (

--- a/frontend/src/pages/dashboard/error-feed/components/TracesTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/TracesTab.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { Box, Stack, Typography, alpha, useTheme } from "@mui/material";
+import { Box, Skeleton, Stack, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import { AgGridReact } from "ag-grid-react";
 import { useAgTheme } from "src/hooks/use-ag-theme";
@@ -195,11 +195,11 @@ function TracesGrid({ rows, onRowClick }) {
     <Box
       sx={{
         width: "100%",
+        height: 600,
         borderRadius: "8px",
         overflow: "hidden",
         border: "1px solid",
         borderColor: "divider",
-        // autoHeight lets the grid grow to fit all rows; outer tab area scrolls
         "& .ag-root-wrapper": { borderRadius: "8px" },
       }}
     >
@@ -210,7 +210,7 @@ function TracesGrid({ rows, onRowClick }) {
         defaultColDef={defaultColDef}
         rowHeight={40}
         headerHeight={38}
-        domLayout="autoHeight"
+        rowBuffer={10}
         suppressCellFocus
         suppressRowClickSelection
         onRowClicked={(e) => onRowClick?.(e.data?.id)}
@@ -236,7 +236,7 @@ export default function TracesTab({ error }) {
   const [drawerTraceId, setDrawerTraceId] = useState(null);
 
   const agg = data?.aggregates ?? EMPTY_AGG;
-  const rows = data?.traces ?? [];
+  const rows = useMemo(() => data?.traces ?? [], [data]);
   const total = data?.total ?? 0;
 
   const traceIndex = rows.findIndex((r) => r.id === drawerTraceId);
@@ -246,6 +246,35 @@ export default function TracesTab({ error }) {
   const handleNext = useCallback(() => {
     if (traceIndex < rows.length - 1) setDrawerTraceId(rows[traceIndex + 1].id);
   }, [traceIndex, rows]);
+
+  if (isLoading && !data) {
+    return (
+      <Stack gap={2}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "repeat(5, 1fr)",
+            gap: 1,
+            mb: 1.5,
+          }}
+        >
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton
+              key={i}
+              variant="rectangular"
+              height={62}
+              sx={{ borderRadius: "6px" }}
+            />
+          ))}
+        </Box>
+        <Skeleton
+          variant="rectangular"
+          height={600}
+          sx={{ borderRadius: "8px" }}
+        />
+      </Stack>
+    );
+  }
 
   return (
     <Stack gap={2}>


### PR DESCRIPTION
## Summary

Hotfix to `main` — cherry-pick of the same two FE commits already in PR #61 (which targets `dev`). Same code, different base.

Picks:
- 9eb414a — `fix(error-feed): add loading skeletons and lift Traces grid lag`
- 00a78a6 — `fix(error-feed): coerce StateGraphTab isLoading to a boolean`

### What's in it
- `ErrorFeedTable` skeleton row count matches `pageSize` (was hardcoded 8)
- `ErrorFeedDetailView` Resolve / Acknowledge / Ignore buttons disabled during the update mutation
- `TracesTab` dropped `domLayout="autoHeight"` with `limit=200` — replaced with fixed-height grid + `rowBuffer` so AG Grid's row virtualization actually kicks in. Skeleton for AggregateBar + grid. Memoized rows.
- `OverviewTab` shows skeleton in the right panel during overview fetch instead of "No trace evidence available" empty state
- `StateGraphTab` shows skeleton until both fail and success traces resolve. `isLoading` coerced to a real boolean via `Boolean(...)` (review fix from cdileep23 on #61).
- `ErrorTrendSparkline` wrapped in `React.memo` so the per-row ApexCharts instance isn't recreated on every list re-render

## Why hotfix
Demo for an enterprise prospect tonight — needs the loading-state UX live on `main`. PR #61 will continue through the normal `dev` flow.

## Test plan
- [ ] Open `/dashboard/error-feed` on a project with data — list skeletons match the pageSize selector
- [ ] Heavy cluster (~200 traces) on Traces tab — grid scrolls smoothly, no freeze
- [ ] Resolve / Acknowledge / Ignore on an issue — buttons disable until mutation resolves
- [ ] Issue detail with cold cache — Overview right panel shows skeletons, not empty state
- [ ] State Graph tab on cold cache — skeleton, then diagram (not empty diagram → diagram)
- [ ] Light + dark mode pass on all skeletons