### PR TITLE
fix(error-feed): skeletons for events chart, trace list, and sidebar

### DIFF
--- a/frontend/src/pages/dashboard/error-feed/components/ErrorMetadataPanel.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorMetadataPanel.jsx
@@ -9,6 +9,7 @@ import {
   Divider,
   Menu,
   MenuItem,
+  Skeleton,
   Stack,
   Tooltip,
   Typography,
@@ -1341,10 +1342,11 @@ export default function ErrorMetadataPanel({ error }) {
   const selectedTraceId = useErrorFeedStore(
     (s) => s.selectedTraceIdByCluster[error?.clusterId] ?? null,
   );
-  const { data: sidebar } = useErrorFeedSidebar(
+  const { data: sidebar, isLoading: isSidebarLoading } = useErrorFeedSidebar(
     error?.clusterId,
     selectedTraceId,
   );
+  const sidebarPending = isSidebarLoading && !sidebar;
   // Effective trace id (what the backend actually used) — hand to the
   // deep-analysis button so Re-run hits the same trace.
   const effectiveTraceId = sidebar?.aiMetadata?.traceId ?? null;
@@ -1562,28 +1564,66 @@ export default function ErrorMetadataPanel({ error }) {
         </Section>
 
         {/* ── Evaluations ── */}
-        {qualityScores.length > 0 && (
+        {sidebarPending ? (
           <Section title="Evaluations">
-            <Stack gap={0.5}>
-              {qualityScores.map((qs) => (
-                <EvalRow
-                  key={qs.label}
-                  label={qs.label}
-                  type={qs.type}
-                  result={qs.result}
-                  score={qs.score}
-                  value={qs.value}
-                />
+            <Stack gap={0.75}>
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Stack
+                  key={i}
+                  direction="row"
+                  alignItems="center"
+                  gap={0.75}
+                >
+                  <Skeleton width={90} height={12} sx={{ borderRadius: "3px" }} />
+                  <Box sx={{ flex: 1 }} />
+                  <Skeleton width={36} height={12} sx={{ borderRadius: "3px" }} />
+                </Stack>
               ))}
             </Stack>
           </Section>
+        ) : (
+          qualityScores.length > 0 && (
+            <Section title="Evaluations">
+              <Stack gap={0.5}>
+                {qualityScores.map((qs) => (
+                  <EvalRow
+                    key={qs.label}
+                    label={qs.label}
+                    type={qs.type}
+                    result={qs.result}
+                    score={qs.score}
+                    value={qs.value}
+                  />
+                ))}
+              </Stack>
+            </Section>
+          )
         )}
 
         {/* ── Co-occurring Issues ── */}
-        {coOccurringIssues.length > 0 && (
+        {sidebarPending ? (
           <Section title="Co-occurring Issues">
-            <CoOccurringList issues={coOccurringIssues} />
+            <Stack gap={0.75}>
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Stack
+                  key={i}
+                  direction="row"
+                  alignItems="center"
+                  gap={0.75}
+                >
+                  <Skeleton width="65%" height={12} sx={{ borderRadius: "3px" }} />
+                  <Box sx={{ flex: 1 }} />
+                  <Skeleton width={28} height={12} sx={{ borderRadius: "3px" }} />
+                </Stack>
+              ))}
+            </Stack>
           </Section>
+        ) : (
+          coOccurringIssues.length > 0 && (
+            <Section title="Co-occurring Issues">
+              <CoOccurringList issues={coOccurringIssues} />
+            </Section>
+          )
         )}
 
         {/* ── Activity ── */}

--- a/frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx
@@ -398,6 +398,7 @@ function EventsUsersChart({
   flat = false,
   data = null,
   deployMarkers: deployMarkersProp = null,
+  loading = false,
 }) {
   const chartRef = useRef(null);
   const theme = useTheme();
@@ -589,21 +590,33 @@ function EventsUsersChart({
                 {item.label}
               </Typography>
             </Stack>
-            <Typography
-              fontSize="13px"
-              fontWeight={700}
-              color="text.primary"
-              sx={{ fontFeatureSettings: "'tnum'", lineHeight: 1 }}
-            >
-              {item.total.toLocaleString()}
-            </Typography>
+            {loading ? (
+              <Skeleton width={28} height={14} sx={{ borderRadius: "3px" }} />
+            ) : (
+              <Typography
+                fontSize="13px"
+                fontWeight={700}
+                color="text.primary"
+                sx={{ fontFeatureSettings: "'tnum'", lineHeight: 1 }}
+              >
+                {item.total.toLocaleString()}
+              </Typography>
+            )}
           </Stack>
         ))}
       </Stack>
 
       {/* Chart — full width */}
       <Box sx={{ flex: 1, minWidth: 0, px: 0.5 }}>
-        <div ref={chartRef} style={{ width: "100%" }} />
+        {loading ? (
+          <Skeleton
+            variant="rectangular"
+            height={64}
+            sx={{ mx: 0.5, my: 1, borderRadius: "4px" }}
+          />
+        ) : (
+          <div ref={chartRef} style={{ width: "100%" }} />
+        )}
       </Box>
     </Box>
   );
@@ -629,12 +642,43 @@ EventsUsersChart.propTypes = {
   flat: PropTypes.bool,
   data: PropTypes.array,
   deployMarkers: PropTypes.array,
+  loading: PropTypes.bool,
 };
 
 // ── Trace list (left panel) ───────────────────────────────────────────────────
-function TraceList({ traces, selectedIndex, onSelect }) {
+function TraceList({ traces, selectedIndex, onSelect, loading = false }) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
+
+  if (loading) {
+    return (
+      <Stack gap={0}>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Box
+            key={i}
+            sx={{
+              px: 1.5,
+              py: 1.1,
+              borderBottom: "1px solid",
+              borderColor: "divider",
+              borderLeft: "3px solid transparent",
+            }}
+          >
+            <Stack direction="row" alignItems="center" gap={0.75} mb={0.4}>
+              <Skeleton width="55%" height={11} sx={{ borderRadius: "3px" }} />
+              <Box sx={{ flex: 1 }} />
+              <Skeleton width={36} height={10} sx={{ borderRadius: "3px" }} />
+            </Stack>
+            <Stack direction="row" gap={1.5}>
+              <Skeleton width={50} height={10} sx={{ borderRadius: "3px" }} />
+              <Skeleton width={42} height={10} sx={{ borderRadius: "3px" }} />
+              <Skeleton width={34} height={10} sx={{ borderRadius: "3px" }} />
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    );
+  }
 
   return (
     <Stack gap={0}>
@@ -748,6 +792,7 @@ function TraceList({ traces, selectedIndex, onSelect }) {
   );
 }
 TraceList.propTypes = {
+  loading: PropTypes.bool,
   traces: PropTypes.array.isRequired,
   selectedIndex: PropTypes.number.isRequired,
   onSelect: PropTypes.func.isRequired,
@@ -1662,7 +1707,12 @@ export default function OverviewTab({ _error: currentError }) {
             borderColor: "divider",
           }}
         >
-          <EventsUsersChart flat data={eventsOverTime} deployMarkers={[]} />
+          <EventsUsersChart
+            flat
+            data={eventsOverTime}
+            deployMarkers={[]}
+            loading={isOverviewLoading && !overview}
+          />
         </Box>
 
         {/* Traces heading */}
@@ -1681,19 +1731,30 @@ export default function OverviewTab({ _error: currentError }) {
           <Typography fontSize="11px" fontWeight={600} color="text.secondary">
             Traces affected
           </Typography>
-          <Typography
-            fontSize="11px"
-            fontWeight={600}
-            sx={{
-              color: "text.disabled",
-              bgcolor: isDark ? alpha("#fff", 0.06) : alpha("#000", 0.05),
-              px: 0.75,
-              py: 0.1,
-              borderRadius: "4px",
-            }}
-          >
-            {traces.length.toLocaleString()}
-          </Typography>
+          {isOverviewLoading && !overview ? (
+            <Skeleton
+              width={28}
+              height={14}
+              sx={{
+                borderRadius: "4px",
+                bgcolor: isDark ? alpha("#fff", 0.06) : alpha("#000", 0.05),
+              }}
+            />
+          ) : (
+            <Typography
+              fontSize="11px"
+              fontWeight={600}
+              sx={{
+                color: "text.disabled",
+                bgcolor: isDark ? alpha("#fff", 0.06) : alpha("#000", 0.05),
+                px: 0.75,
+                py: 0.1,
+                borderRadius: "4px",
+              }}
+            >
+              {traces.length.toLocaleString()}
+            </Typography>
+          )}
         </Stack>
 
         {/* Scrollable trace list */}
@@ -1702,6 +1763,7 @@ export default function OverviewTab({ _error: currentError }) {
             traces={traces}
             selectedIndex={traceIndex}
             onSelect={selectTrace}
+            loading={isOverviewLoading && !overview}
           />
         </Box>
       </Stack>


### PR DESCRIPTION
## Summary

Follow-up to #61 (already merged). On the issue detail page three more surfaces were rendering 0 / empty during the overview + sidebar fetch instead of indicating "still loading" — caught against a real cluster on dev where the metadata panel said "56 traces" but the left panel showed "EVENTS 0 USERS 0 Traces affected 0" with no spinner.

### What's in it

- **`EventsUsersChart`** takes a new `loading` prop. While the overview query is in flight, the EVENTS / USERS totals render as small skeleton bars and the chart area shows a flat placeholder instead of "0 0".
- **`TraceList`** renders 6 skeleton rows when loading instead of nothing.
- **"Traces affected"** count shows a skeleton chip instead of "0" while loading.
- **`ErrorMetadataPanel`** reads `isLoading` from `useErrorFeedSidebar` and, while pending, renders skeleton rows inside the **Evaluations** and **Co-occurring Issues** sections instead of hiding them entirely (the prior behavior — `length > 0 &&` — made the panel look broken when those sections were the only sidebar data the user was waiting on).

### Test plan

- [ ] Open an issue detail page on a project with cold cache — left panel shows skeleton totals + chart placeholder + skeleton trace rows + skeleton "Traces affected" chip until overview returns
- [ ] Same page with cold cache — right metadata panel renders skeleton rows in Evaluations + Co-occurring Issues until sidebar returns, then swaps to real data (or hides if genuinely empty)
- [ ] Light + dark mode pass on all skeletons
- [ ] Sanity check: clusters that genuinely have no evals / no co-occurring issues should hide those sections after load (no permanent skeletons)