### PR TITLE
fix: dot-notation eval variables + nested JSON keys in dataset mapping (TH-4629)

### DIFF
--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -722,23 +722,88 @@ const DatasetTestMode = React.forwardRef(
             }
           }
         } else {
-          // Dataset mode: mapping sends variable → actual cell values
-          // Map template variables to dataset columns
-          for (const variable of variables) {
-            const mappedColName = mapping[variable];
-            if (mappedColName && currentRow) {
-              const col = columns.find((c) => c.name === mappedColName);
-              if (col) {
-                const cell = currentRow[col.id];
-                evalMapping[variable] = cell?.cell_value ?? cell ?? "";
-                const dt = col.data_type || "text";
-                if (["image", "images"].includes(dt)) {
-                  inputDataTypes[variable] = "image";
-                } else if (dt === "audio") {
-                  inputDataTypes[variable] = "audio";
-                } else {
-                  inputDataTypes[variable] = "text";
+          // Dataset mode: mapping sends variable → actual cell values.
+          // Build a valueMap of all dotted paths from row cells — same
+          // walkValues + resolveMapping pattern as TaskLivePreview.
+          const ARRAY_PEEK_R = 500;
+          const DICT_LIMIT_R = 5000;
+          const valueMap = {};
+          const walkValues = (node, prefix) => {
+            if (Array.isArray(node)) {
+              node.slice(0, ARRAY_PEEK_R).forEach((item, idx) => {
+                const path = prefix ? `${prefix}.${idx}` : String(idx);
+                valueMap[path] = item;
+                if (item && typeof item === "object") {
+                  walkValues(item, path);
                 }
+              });
+              return;
+            }
+            for (const [k, v] of canonicalEntries(node)) {
+              if (k.startsWith("_")) continue;
+              const path = prefix ? `${prefix}.${k}` : k;
+              valueMap[path] = v;
+              if (v && typeof v === "object") {
+                if (Array.isArray(v) || Object.keys(v).length < DICT_LIMIT_R) {
+                  walkValues(v, path);
+                }
+              }
+            }
+          };
+
+          // Walk each column's cell value into the valueMap
+          const colDataTypes = {};
+          columns
+            .filter(
+              (c) => c.id && c.name && !["id", "orgId"].includes(c.name),
+            )
+            .forEach((col) => {
+              const cell = currentRow[col.id];
+              let cellValue = cell?.cell_value ?? cell ?? "";
+              valueMap[col.name] = cellValue;
+              colDataTypes[col.name] = col.data_type || "text";
+
+              // Parse JSON strings and walk nested keys
+              if (typeof cellValue === "string") {
+                const trimmed = cellValue.trim();
+                if (
+                  (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+                  (trimmed.startsWith("[") && trimmed.endsWith("]"))
+                ) {
+                  try {
+                    const parsed = JSON.parse(trimmed);
+                    if (parsed && typeof parsed === "object") {
+                      walkValues(parsed, col.name);
+                    }
+                  } catch {
+                    // not valid JSON
+                  }
+                }
+              } else if (cellValue && typeof cellValue === "object") {
+                walkValues(cellValue, col.name);
+              }
+            });
+
+          // Resolve mapping using the valueMap — same as TaskLivePreview
+          for (const variable of variables) {
+            const field = mapping[variable];
+            if (!field) continue;
+            const val = valueMap[field];
+            if (val !== undefined && val !== null) {
+              evalMapping[variable] =
+                typeof val === "object" ? JSON.stringify(val) : String(val);
+
+              // Find the root column for data type detection
+              const rootCol = field.includes(".")
+                ? field.slice(0, field.indexOf("."))
+                : field;
+              const dt = colDataTypes[rootCol] || "text";
+              if (["image", "images"].includes(dt)) {
+                inputDataTypes[variable] = "image";
+              } else if (dt === "audio") {
+                inputDataTypes[variable] = "audio";
+              } else {
+                inputDataTypes[variable] = "text";
               }
             }
           }

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -22,6 +22,7 @@ import React, {
 } from "react";
 import Iconify from "src/components/iconify";
 import axios, { endpoints } from "src/utils/axios";
+import { canonicalEntries } from "src/utils/utils";
 import { useDebounce } from "src/hooks/use-debounce";
 import CellMarkdown from "src/sections/common/CellMarkdown";
 import EvalResultDisplay from "./EvalResultDisplay";
@@ -525,7 +526,63 @@ const DatasetTestMode = React.forwardRef(
       const base = columns
         .filter((c) => c.id && c.name && !["id", "orgId"].includes(c.name))
         .map((c) => c.name);
-      if (!extraColumns?.length) return base;
+
+      // Expand JSON columns with nested sub-key paths (e.g. "EXPECTED OUTPUT.where_conditions")
+      // by introspecting the first row's cell values — same recursive walk as TaskLivePreview.
+      const ARRAY_PEEK = 500;
+      const DICT_LIMIT = 5000;
+      const walk = (node, prefix, keys) => {
+        if (Array.isArray(node)) {
+          node.slice(0, ARRAY_PEEK).forEach((item, idx) => {
+            const path = prefix ? `${prefix}.${idx}` : String(idx);
+            keys.push(path);
+            if (item && typeof item === "object") {
+              walk(item, path, keys);
+            }
+          });
+          return;
+        }
+        for (const [k, v] of canonicalEntries(node)) {
+          if (k.startsWith("_")) continue;
+          const path = prefix ? `${prefix}.${k}` : k;
+          keys.push(path);
+          if (v && typeof v === "object") {
+            if (Array.isArray(v) || Object.keys(v).length < DICT_LIMIT) {
+              walk(v, path, keys);
+            }
+          }
+        }
+      };
+
+      const expanded = [];
+      base.forEach((colName) => {
+        expanded.push(colName);
+        const cell = rowCells.find((rc) => rc.name === colName);
+        if (!cell) return;
+        let parsed = cell.value;
+        if (typeof parsed === "string") {
+          const trimmed = parsed.trim();
+          if (
+            (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+            (trimmed.startsWith("[") && trimmed.endsWith("]"))
+          ) {
+            try {
+              parsed = JSON.parse(trimmed);
+            } catch {
+              return;
+            }
+          } else {
+            return;
+          }
+        }
+        if (parsed && typeof parsed === "object") {
+          const subKeys = [];
+          walk(parsed, colName, subKeys);
+          expanded.push(...subKeys);
+        }
+      });
+
+      if (!extraColumns?.length) return expanded;
       // Virtual columns ("Output", "Prompt Chain" for experiments) render
       // first so they're prominent in the dropdown AND win auto-mapping
       // ties — auto-map iterates columnNames in order and takes the first
@@ -539,9 +596,9 @@ const DatasetTestMode = React.forwardRef(
         )
         .filter(Boolean);
       const extraSet = new Set(extras);
-      const baseWithoutExtras = base.filter((n) => !extraSet.has(n));
+      const baseWithoutExtras = expanded.filter((n) => !extraSet.has(n));
       return [...extras, ...baseWithoutExtras];
-    }, [columns, sourceColumns, extraColumns, isWorkbenchMode]);
+    }, [columns, sourceColumns, extraColumns, isWorkbenchMode, rowCells]);
 
     // Workbench mode: map display name → field identifier (e.g. "model_output" → "output_prompt")
     const sourceNameToField = useMemo(() => {

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -930,8 +930,21 @@ const DatasetTestMode = React.forwardRef(
         Object.entries(mapping).forEach(([variable, colName]) => {
           // Extras resolve to their own field (e.g. "Output" → "output") and
           // bypass the dataset UUID lookup since they don't exist in columns.
-          m[variable] =
-            extraNameToField[colName] || nameToId[colName] || colName;
+          if (extraNameToField[colName]) {
+            m[variable] = extraNameToField[colName];
+          } else if (nameToId[colName]) {
+            m[variable] = nameToId[colName];
+          } else if (colName.includes(".")) {
+            // Dotted sub-key path (e.g. "EXPECTED OUTPUT.where_conditions"):
+            // convert root column name to UUID, keep the sub-key path.
+            const dotIdx = colName.indexOf(".");
+            const rootName = colName.slice(0, dotIdx);
+            const subPath = colName.slice(dotIdx + 1);
+            const rootId = nameToId[rootName];
+            m[variable] = rootId ? `${rootId}.${subPath}` : colName;
+          } else {
+            m[variable] = colName;
+          }
         });
       }
       return m;

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -212,8 +212,8 @@ class CustomPromptEvaluator(LLM):
                     )
                 elif "." in stripped and stripped in safe_context:
                     # Dotted variable names (e.g., {{expected.where_conditions}})
-                    # are flat keys in template_context but Jinja2 interprets dots
-                    # as nested object access. Pre-replace before Jinja2 parsing.
+                    # Jinja2 interprets dots as attribute access, but these are
+                    # flat keys — pre-replace them, same approach as spaces above.
                     prompt_to_render = prompt_to_render.replace(
                         "{{" + var_name + "}}", str(safe_context.pop(stripped))
                     )

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -210,6 +210,13 @@ class CustomPromptEvaluator(LLM):
                     prompt_to_render = prompt_to_render.replace(
                         "{{ " + stripped + " }}", str(template_context.get(stripped, ""))
                     )
+                elif "." in stripped and stripped in safe_context:
+                    # Dotted variable names (e.g., {{expected.where_conditions}})
+                    # are flat keys in template_context but Jinja2 interprets dots
+                    # as nested object access. Pre-replace before Jinja2 parsing.
+                    prompt_to_render = prompt_to_render.replace(
+                        "{{" + var_name + "}}", str(safe_context.pop(stripped))
+                    )
 
             # In Jinja mode, parse JSON strings to native objects right
             # before rendering so {% for %} loops work correctly.

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import structlog
 
 # from ee.agenthub.feedback_agent_updated.utils import RAG
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import close_old_connections, models, transaction
 from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import IsAuthenticated
@@ -303,7 +303,7 @@ def _resolve_column_reference(column_ref, dataset_id):
     # Try as UUID first
     try:
         return Column.objects.get(id=column_ref)
-    except (Column.DoesNotExist, ValueError):
+    except (Column.DoesNotExist, ValueError, ValidationError):
         pass
 
     # Try as column name within the dataset


### PR DESCRIPTION
## Summary (TH-4629)

**Backend (evaluator):** Pre-replace dotted variable names (e.g. `{{expected.where_conditions}}`) before Jinja2 parsing — same pattern as the existing spaces-in-variable-names handling.

**Backend (eval_runner):** Catch `ValidationError` in `_resolve_column_reference` — Django raises `ValidationError` (not `ValueError`) when a non-UUID string is passed to a UUID field, preventing the column-name fallback from running.

**Frontend (dropdown):** Expand dataset eval mapping dropdown to show nested JSON sub-keys (e.g. `EXPECTED OUTPUT.where_conditions`). Uses the same recursive `walk` + `canonicalEntries` pattern from `TaskLivePreview.jsx`.

**Frontend (value resolution):** Resolve dotted mapping paths to actual sub-key values using `walkValues` + `valueMap` lookup — same pattern as `TaskLivePreview.jsx`. Previously, selecting a dotted path sent an empty mapping `{}`.

**Frontend (UUID conversion):** Extend existing `nameToId` → `idMapping` conversion to handle dotted sub-key paths. Splits on first dot, converts root column name to UUID, rejoins with sub-path (e.g. `"EXPECTED OUTPUT.where_conditions"` → `"UUID.where_conditions"`). This ensures the backend eval_runner receives UUID-based mappings it expects.

## Test plan
- [ ] Create a custom eval with dotted variables like `{{expected.where_conditions}}` — verify it renders correctly in eval playground
- [ ] Open dataset eval mapping dropdown — verify nested JSON keys appear at all depths
- [ ] Map a variable to a dotted path — verify mapping payload contains UUID-based path, not column name
- [ ] Add eval to dataset and run — verify eval completes without UUID validation errors
- [ ] Verify tasks/simulate/traces eval mapping still works as before