### PR TITLE
fix(dashboards): correct rate metric scaling, simulation filters, and unit rendering

### DIFF
--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -189,6 +189,22 @@ const PERCENTILE_OPTIONS = [
 
 const ALL_AGGREGATIONS = [...AGGREGATION_OPTIONS, ...PERCENTILE_OPTIONS];
 
+// Curated list of unit presets shown in the widget editor's Unit
+// dropdown. Keep in sync with ``UNIT_RENDERING`` in ``widgetUtils.js``
+// (the formatter that places these as a prefix or suffix). "Custom" is
+// rendered separately by the editor and maps to an empty unit value.
+const UNIT_PRESETS = [
+  { label: "$", value: "$" },
+  { label: "%", value: "%" },
+  { label: "#", value: "#" },
+  { label: "ms", value: "ms" },
+  { label: "s", value: "s" },
+  { label: "tokens", value: "tokens" },
+  { label: "cents", value: "cents" },
+  { label: "wpm", value: "wpm" },
+  { label: "/min", value: "/min" },
+];
+
 const METRIC_CATEGORIES = [
   { key: "all", label: "All", icon: "mdi:view-grid-outline" },
   {
@@ -447,17 +463,24 @@ function AxisSection({ title, config, onChange, theme, showReset, onReset }) {
         <Typography variant="body2" color="text.secondary">
           Unit
         </Typography>
-        <ToggleButtons
-          options={[
-            { label: "$", value: "$" },
-            { label: "%", value: "%" },
-            { label: "#", value: "#" },
-            { label: "Custom", value: "custom" },
-          ]}
-          value={config.unit || "custom"}
-          onChange={(v) => onChange("unit", v === "custom" ? "" : v)}
-          theme={theme}
-        />
+        <TextField
+          select
+          size="small"
+          value={UNIT_PRESETS.some((u) => u.value === config.unit) ? config.unit : "custom"}
+          onChange={(e) =>
+            onChange("unit", e.target.value === "custom" ? "" : e.target.value)
+          }
+          sx={{ width: 180, "& .MuiOutlinedInput-root": { fontSize: "13px" } }}
+        >
+          {UNIT_PRESETS.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value} sx={{ fontSize: "13px" }}>
+              {opt.label}
+            </MenuItem>
+          ))}
+          <MenuItem value="custom" sx={{ fontSize: "13px" }}>
+            Custom
+          </MenuItem>
+        </TextField>
       </Stack>
 
       {/* Prefix / Suffix */}
@@ -617,7 +640,13 @@ function AxisSection({ title, config, onChange, theme, showReset, onReset }) {
   );
 }
 
-function AggregationPicker({ value, onChange, theme, extraOptions }) {
+function AggregationPicker({
+  value,
+  onChange,
+  theme,
+  extraOptions,
+  allowedAggregations,
+}) {
   const [anchorEl, setAnchorEl] = useState(null);
   const [showPercentiles, setShowPercentiles] = useState(false);
 
@@ -639,7 +668,22 @@ function AggregationPicker({ value, onChange, theme, extraOptions }) {
   const allAggs = extraOptions
     ? [...ALL_AGGREGATIONS, ...extraOptions]
     : ALL_AGGREGATIONS;
-  const current = allAggs.find((a) => a.value === value);
+  const allowedSet = allowedAggregations?.length
+    ? new Set(allowedAggregations)
+    : null;
+  const primaryAggs = allowedSet
+    ? AGGREGATION_OPTIONS.filter((opt) => allowedSet.has(opt.value))
+    : AGGREGATION_OPTIONS;
+  const allowedExtraOptions = allowedSet
+    ? (extraOptions || []).filter((opt) => allowedSet.has(opt.value))
+    : extraOptions;
+  const percentileAggs = allowedSet
+    ? PERCENTILE_OPTIONS.filter((opt) => allowedSet.has(opt.value))
+    : PERCENTILE_OPTIONS;
+  const visibleAggs = allowedSet
+    ? [...primaryAggs, ...(allowedExtraOptions || []), ...percentileAggs]
+    : allAggs;
+  const current = visibleAggs.find((a) => a.value === value);
   const open = Boolean(anchorEl);
 
   return (
@@ -671,7 +715,7 @@ function AggregationPicker({ value, onChange, theme, extraOptions }) {
           >
             {!showPercentiles ? (
               <List dense disablePadding>
-                {AGGREGATION_OPTIONS.map((opt) => (
+                {primaryAggs.map((opt) => (
                   <ListItemButton
                     key={opt.value}
                     selected={value === opt.value}
@@ -687,10 +731,10 @@ function AggregationPicker({ value, onChange, theme, extraOptions }) {
                     />
                   </ListItemButton>
                 ))}
-                {extraOptions && extraOptions.length > 0 && (
+                {allowedExtraOptions && allowedExtraOptions.length > 0 && (
                   <>
                     <Divider />
-                    {extraOptions.map((opt) => (
+                    {allowedExtraOptions.map((opt) => (
                       <ListItemButton
                         key={opt.value}
                         selected={value === opt.value}
@@ -708,29 +752,33 @@ function AggregationPicker({ value, onChange, theme, extraOptions }) {
                     ))}
                   </>
                 )}
-                <Divider />
-                <ListItemButton
-                  onClick={() => setShowPercentiles(true)}
-                  sx={{ py: 0.75 }}
-                >
-                  <ListItemText
-                    primary="Percentile"
-                    primaryTypographyProps={{
-                      variant: "body2",
-                      fontSize: "13px",
-                      fontWeight: PERCENTILE_OPTIONS.some(
-                        (p) => p.value === value,
-                      )
-                        ? 600
-                        : 400,
-                    }}
-                  />
-                  <Iconify
-                    icon="mdi:chevron-right"
-                    width={16}
-                    sx={{ color: "text.secondary" }}
-                  />
-                </ListItemButton>
+                {percentileAggs.length > 0 && (
+                  <>
+                    <Divider />
+                    <ListItemButton
+                      onClick={() => setShowPercentiles(true)}
+                      sx={{ py: 0.75 }}
+                    >
+                      <ListItemText
+                        primary="Percentile"
+                        primaryTypographyProps={{
+                          variant: "body2",
+                          fontSize: "13px",
+                          fontWeight: percentileAggs.some(
+                            (p) => p.value === value,
+                          )
+                            ? 600
+                            : 400,
+                        }}
+                      />
+                      <Iconify
+                        icon="mdi:chevron-right"
+                        width={16}
+                        sx={{ color: "text.secondary" }}
+                      />
+                    </ListItemButton>
+                  </>
+                )}
               </List>
             ) : (
               <List dense disablePadding>
@@ -753,7 +801,7 @@ function AggregationPicker({ value, onChange, theme, extraOptions }) {
                   />
                 </ListItemButton>
                 <Divider />
-                {PERCENTILE_OPTIONS.map((opt) => (
+                {percentileAggs.map((opt) => (
                   <ListItemButton
                     key={opt.value}
                     selected={value === opt.value}
@@ -1236,8 +1284,14 @@ export default function WidgetEditorView() {
     xAxis: { visible: true, label: "" },
     seriesAxis: {}, // { [seriesIndex]: "left" | "right" }
   });
-  const [hasAutoAppliedLeftAxisUnit, setHasAutoAppliedLeftAxisUnit] =
-    useState(false);
+  // Tracks the unit value we last auto-applied to ``axisConfig.leftY``.
+  // Stored (rather than a single boolean) so we can tell the difference
+  // between "user picked this manually" and "we set it on their behalf
+  // when the metric set last changed". When the suggested unit changes
+  // — e.g. swapping a ``duration`` (s) metric for an annotation (no
+  // unit) — we reconcile the axis only if the current axis unit is the
+  // one we last auto-applied; user-chosen units are never overwritten.
+  const [autoAppliedLeftAxisUnit, setAutoAppliedLeftAxisUnit] = useState(null);
   const updateAxis = (axis, key, val) =>
     setAxisConfig((prev) => ({
       ...prev,
@@ -1409,6 +1463,7 @@ export default function WidgetEditorView() {
           columnDataType: m.dataType || m.data_type,
           configIds: m.configIds || m.config_ids,
           evalKey: m.evalKey || m.eval_key,
+          allowedAggregations: m.allowedAggregations || m.allowed_aggregations,
           unit: m.unit,
         };
       });
@@ -1426,6 +1481,7 @@ export default function WidgetEditorView() {
         type: "system",
         source: "traces",
         dataType: m.type || "string",
+        allowedAggregations: m.allowedAggregations || m.allowed_aggregations,
       });
     });
     (
@@ -1440,6 +1496,7 @@ export default function WidgetEditorView() {
         source: "datasets",
         dataType: "number",
         outputType: m.outputType || m.output_type,
+        allowedAggregations: m.allowedAggregations || m.allowed_aggregations,
       });
     });
     (
@@ -1454,6 +1511,7 @@ export default function WidgetEditorView() {
         source: "traces",
         dataType: "number",
         outputType: m.outputType || m.output_type,
+        allowedAggregations: m.allowedAggregations || m.allowed_aggregations,
       });
     });
     (
@@ -1467,6 +1525,7 @@ export default function WidgetEditorView() {
         type: "custom_attribute",
         source: "traces",
         dataType: m.type || "string",
+        allowedAggregations: m.allowedAggregations || m.allowed_aggregations,
       });
     });
     (
@@ -1481,6 +1540,7 @@ export default function WidgetEditorView() {
         source: "datasets",
         dataType: m.type || "number",
         columnDataType: m.dataType || m.data_type,
+        allowedAggregations: m.allowedAggregations || m.allowed_aggregations,
       });
     });
     return opts;
@@ -1512,13 +1572,18 @@ export default function WidgetEditorView() {
 
   const buildMetricPayload = (m, i) => {
     const backendType = toBackendType(m.type);
+    const aggregation =
+      m.allowedAggregations?.length &&
+      !m.allowedAggregations.includes(m.aggregation)
+        ? m.allowedAggregations[0]
+        : m.aggregation || "avg";
     const base = {
       id: m.id || `m${i}`,
       name: m.id,
       displayName: m.name || m.id,
       type: backendType,
       source: m.source || "traces",
-      aggregation: m.aggregation || "avg",
+      aggregation,
     };
     if (backendType === "eval_metric") {
       // m.id is eval_template_id from the metrics endpoint
@@ -1684,6 +1749,12 @@ export default function WidgetEditorView() {
         defaultAgg = "count";
       } else if (option.source === "simulation" && option.id === "call_count") {
         defaultAgg = "count";
+      }
+      if (
+        option.allowedAggregations?.length &&
+        !option.allowedAggregations.includes(defaultAgg)
+      ) {
+        [defaultAgg] = option.allowedAggregations;
       }
       const newMetric = {
         ...option,
@@ -2002,25 +2073,28 @@ export default function WidgetEditorView() {
   }, [axisConfig.leftY, suggestedLeftAxisUnit]);
 
   useEffect(() => {
-    if (
-      hasAutoAppliedLeftAxisUnit ||
-      axisConfig.leftY.unit ||
-      !suggestedLeftAxisUnit.unit
-    ) {
+    const currentUnit = axisConfig.leftY.unit;
+    const suggested = suggestedLeftAxisUnit.unit;
+    // Skip if the user picked something different from what we
+    // auto-applied — that's their choice and we leave it alone.
+    if (currentUnit && currentUnit !== autoAppliedLeftAxisUnit) {
       return;
     }
+    if (suggested === currentUnit) return;
     setAxisConfig((prev) => ({
       ...prev,
       leftY: {
         ...prev.leftY,
-        unit: suggestedLeftAxisUnit.unit,
-        prefixSuffix: suggestedLeftAxisUnit.prefixSuffix,
+        unit: suggested,
+        prefixSuffix: suggested
+          ? suggestedLeftAxisUnit.prefixSuffix
+          : prev.leftY.prefixSuffix || "prefix",
       },
     }));
-    setHasAutoAppliedLeftAxisUnit(true);
+    setAutoAppliedLeftAxisUnit(suggested || null);
   }, [
     axisConfig.leftY.unit,
-    hasAutoAppliedLeftAxisUnit,
+    autoAppliedLeftAxisUnit,
     suggestedLeftAxisUnit,
   ]);
 
@@ -4678,9 +4752,15 @@ export default function WidgetEditorView() {
                       </IconButton>
                     </Stack>
                     <AggregationPicker
-                      value={m.aggregation}
+                      value={
+                        m.allowedAggregations?.length &&
+                        !m.allowedAggregations.includes(m.aggregation)
+                          ? m.allowedAggregations[0]
+                          : m.aggregation
+                      }
                       onChange={(val) => handleUpdateMetricAggregation(i, val)}
                       theme={theme}
+                      allowedAggregations={m.allowedAggregations}
                       extraOptions={
                         m.source === "datasets" ||
                         m.source === "simulation" ||

--- a/frontend/src/sections/dashboards/widgetUtils.js
+++ b/frontend/src/sections/dashboards/widgetUtils.js
@@ -46,6 +46,24 @@ const UNIT_LESS_AGGREGATIONS = new Set([
   "fail_count",
 ]);
 
+// Units the backend may return on a metric. Anything listed as "suffix"
+// is rendered after the value (e.g. "120 ms", "5 /min"); "prefix" is for
+// currency-like indicators rendered before the value (e.g. "$3").
+// Without this mapping, non-percent units (ms, s, cents, /min, …) were
+// silently dropped, which is why latency metrics rendered with no unit
+// while percentage metrics misleadingly looked the same as latencies.
+const UNIT_RENDERING = {
+  $: { prefixSuffix: "prefix" },
+  "%": { prefixSuffix: "suffix" },
+  "#": { prefixSuffix: "prefix" },
+  ms: { prefixSuffix: "suffix", separator: " " },
+  s: { prefixSuffix: "suffix", separator: " " },
+  cents: { prefixSuffix: "suffix", separator: " " },
+  tokens: { prefixSuffix: "suffix", separator: " " },
+  wpm: { prefixSuffix: "suffix", separator: " " },
+  "/min": { prefixSuffix: "suffix" },
+};
+
 export const getSuggestedUnitConfig = (metricConfigs = []) => {
   if (
     metricConfigs.some((metric) =>
@@ -54,15 +72,19 @@ export const getSuggestedUnitConfig = (metricConfigs = []) => {
   ) {
     return { unit: "", prefixSuffix: "prefix" };
   }
-  const uniqueUnits = [
-    ...new Set(metricConfigs.map((metric) => metric?.unit).filter(Boolean)),
-  ];
-  if (uniqueUnits.length !== 1) {
+  // Don't filter empty strings here — a chart that mixes a unit-less
+  // metric (e.g. ``call_count`` with unit "") and a metric with a unit
+  // (e.g. ``duration`` with unit "s") should fall back to no suggested
+  // unit instead of inheriting the non-empty one. Otherwise call_count
+  // ends up rendered as ``35 s`` because it shares the axis suggestion.
+  const allUnits = metricConfigs.map((metric) => metric?.unit ?? "");
+  const uniqueUnits = [...new Set(allUnits)];
+  if (uniqueUnits.length !== 1 || !uniqueUnits[0]) {
     return { unit: "", prefixSuffix: "prefix" };
   }
   const [unit] = uniqueUnits;
-  if (unit === "$") return { unit, prefixSuffix: "prefix" };
-  if (unit === "%") return { unit, prefixSuffix: "suffix" };
+  const rendering = UNIT_RENDERING[unit];
+  if (rendering) return { unit, ...rendering };
   return { unit: "", prefixSuffix: "prefix" };
 };
 
@@ -85,5 +107,10 @@ export const formatValueWithConfig = (
   } else {
     str = num.toFixed(dec);
   }
-  return prefixSuffix === "suffix" ? `${str}${unit}` : `${unit}${str}`;
+  if (!unit) return str;
+  const rendering = UNIT_RENDERING[unit] || {};
+  const separator = rendering.separator ?? "";
+  return prefixSuffix === "suffix"
+    ? `${str}${separator}${unit}`
+    : `${unit}${separator}${str}`;
 };

--- a/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
@@ -140,12 +140,17 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
     def _build_float_query(self) -> Tuple[str, Dict[str, Any]]:
         """Average numeric/star annotation value per time bucket."""
         bucket_fn = self.time_bucket_expr(self.interval)
+        # Use the nullable extractor so rows whose JSON payload is missing
+        # the ``rating`` / ``value`` key return NULL and are skipped by
+        # ``avg()`` instead of silently contributing 0.0.
+        nullable_expr = annotation_numeric_value_expr(nullable=True)
         query = f"""
         SELECT
             {bucket_fn}(created_at) AS time_bucket,
-            avg({annotation_numeric_value_expr()}) AS value
+            avg({nullable_expr}) AS value
         FROM {self.TABLE} FINAL
         WHERE _peerdb_is_deleted = 0
+          AND deleted = 0
           AND label_id = toUUID(%(label_id)s)
           AND created_at >= %(start_date)s
           AND created_at < %(end_date)s
@@ -176,6 +181,7 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
             avg(CASE WHEN JSONExtractString(value, 'value') = %(bool_match)s THEN 100.0 ELSE 0.0 END) AS value
         FROM {self.TABLE} FINAL
         WHERE _peerdb_is_deleted = 0
+          AND deleted = 0
           AND label_id = toUUID(%(label_id)s)
           AND created_at >= %(start_date)s
           AND created_at < %(end_date)s
@@ -208,6 +214,7 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
             ) AS value
         FROM {self.TABLE} FINAL
         WHERE _peerdb_is_deleted = 0
+          AND deleted = 0
           AND label_id = toUUID(%(label_id)s)
           AND created_at >= %(start_date)s
           AND created_at < %(end_date)s
@@ -225,6 +232,7 @@ class AnnotationGraphQueryBuilder(BaseQueryBuilder):
             count() AS value
         FROM {self.TABLE} FINAL
         WHERE _peerdb_is_deleted = 0
+          AND deleted = 0
           AND label_id = toUUID(%(label_id)s)
           AND created_at >= %(start_date)s
           AND created_at < %(end_date)s

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -99,6 +99,11 @@ METRIC_UNITS: Dict[str, str] = {
     "tag": "",
 }
 
+# Metrics whose column expression emits a 0/1 indicator per row. The
+# averaging aggregations get rescaled to a percentage at query time via
+# ``rescale_rate_to_percent`` so the result matches the ``%`` unit.
+_RATE_INDICATOR_METRICS = frozenset({"error_rate"})
+
 # Metrics that are non-numeric identifiers — force count_distinct aggregation
 _COUNT_DISTINCT_METRICS = frozenset(
     {
@@ -121,6 +126,32 @@ _COUNT_DISTINCT_METRICS = frozenset(
         "tag",
     }
 )
+
+# Aggregations that produce an "average-like" result (mean, median, any
+# percentile). Rate metrics that store a 0/1 indicator per row need their
+# averaging result multiplied by 100 so the value matches the declared
+# ``%`` unit. sum/count/min/max are intentionally excluded — for a 0/1
+# indicator they keep their natural meaning (count of matching rows for
+# sum/count; bounded 0/1 for min/max).
+AVERAGING_AGGREGATIONS = frozenset(
+    {"avg", "median", "p25", "p50", "p75", "p90", "p95", "p99"}
+)
+
+
+def rescale_rate_to_percent(agg_expr: str, aggregation: str) -> str:
+    """Wrap *agg_expr* in ``(... ) * 100`` for averaging aggregations.
+
+    Used by metrics whose column expression emits a 0/1 indicator per
+    row (``error_rate``, ``cell_error_rate``, ``success_rate``,
+    ``failure_rate``) so widgets that render them with a ``%`` suffix
+    show ``42%`` rather than ``0.42%``. Non-averaging aggregations are
+    returned unchanged so e.g. ``sum(failure_rate)`` still reports a
+    failure count.
+    """
+    if aggregation in AVERAGING_AGGREGATIONS:
+        return f"({agg_expr}) * 100"
+    return agg_expr
+
 
 AGGREGATIONS: Dict[str, str] = {
     "avg": "avg({col})",
@@ -329,6 +360,10 @@ class DashboardQueryBuilder:
         ):
             aggregation = "count_distinct"
         agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
+
+        # 0/1 indicator metrics → rescale averaging aggs to percent.
+        if metric_name in _RATE_INDICATOR_METRICS:
+            agg_expr = rescale_rate_to_percent(agg_expr, aggregation)
 
         select_parts = [f"{bucket_fn}(start_time) AS time_bucket"]
         group_parts = ["time_bucket"]
@@ -777,19 +812,25 @@ class DashboardQueryBuilder:
                 pass
         if output_type in ("categorical", "choice"):
             # Categorical: count rows (each row = one annotation)
-            col_expr = "1"
             agg_expr = "count()"
-        elif output_type in ("thumbs_up_down", "pass_fail"):
-            # Boolean: percentage of "up" / "Passed"
-            col_expr = "JSONExtractString(a.value, 'value')"
-            agg_expr = f"countIf({col_expr} = 'up') * 100.0 / greatest(count(), 1)"
+        elif output_type == "thumbs_up_down":
+            # Stored as {"value": "up"|"down"} — percentage of "up".
+            # countIf already skips NULL/missing rows, but we still want
+            # the denominator to exclude rows where the key is absent.
+            col_expr = (
+                "JSONExtract(a.value, 'value', 'Nullable(String)')"
+            )
+            agg_expr = (
+                f"countIf({col_expr} = 'up') * 100.0 / "
+                f"greatest(countIf({col_expr} IS NOT NULL), 1)"
+            )
         elif output_type == "text":
             # Text: just count annotations
-            col_expr = "1"
             agg_expr = "count()"
         else:
-            # Numeric/star: average of the float value
-            col_expr = annotation_numeric_value_expr(alias="a")
+            # Numeric/star: aggregate the float value, skipping NULLs so
+            # missing/non-numeric payloads don't pull averages toward 0.
+            col_expr = annotation_numeric_value_expr(alias="a", nullable=True)
             agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
 
         select_parts = [f"{bucket_fn}(a.created_at) AS time_bucket"]
@@ -797,10 +838,28 @@ class DashboardQueryBuilder:
         order_parts = ["time_bucket"]
         select_parts.append(f"{agg_expr} AS value")
 
-        # model_hub_score has no project_id — resolve via trace_dict
+        # model_hub_score has no project_id of its own that maps to
+        # tracer.Project, so resolve via trace_dict for trace-attached
+        # scores and via the spans table for span-attached scores.
+        # Other source types (call_execution, dataset_row, …) are out of
+        # scope for trace dashboards.
         where_parts = [
-            "dictGet('trace_dict', 'project_id', a.trace_id) IN %(project_ids)s",
+            (
+                "("
+                "(a.trace_id IS NOT NULL "
+                "AND dictGet('trace_dict', 'project_id', a.trace_id) "
+                "IN %(project_ids)s)"
+                " OR "
+                "(a.observation_span_id IS NOT NULL "
+                "AND a.observation_span_id != '' "
+                "AND a.observation_span_id IN ("
+                "SELECT id FROM spans "
+                "WHERE project_id IN %(project_ids)s "
+                "AND _peerdb_is_deleted = 0))"
+                ")"
+            ),
             "a._peerdb_is_deleted = 0",
+            "a.deleted = 0",
             "a.created_at >= %(start_date)s",
             "a.created_at < %(end_date)s",
             "a.label_id = toUUID(%(annotation_label_id)s)",
@@ -1100,29 +1159,42 @@ class DashboardQueryBuilder:
                 params[param_key] = label_id
                 ann_idx += 1
 
-                # Value extraction based on type
+                # ``id IS NULL`` distinguishes "no annotation row matched
+                # the LEFT JOIN" from "row exists but value JSON is
+                # missing the key" (which would otherwise extract as 0
+                # / empty and silently bucket alongside real values).
+                missing_check = f"{alias}.id IS NULL"
                 if output_type in ("categorical", "choice"):
-                    val_expr = f"arrayJoin(if({alias}.trace_id IS NULL, ['(not set)'], JSONExtract({alias}.value, 'selected', 'Array(String)')))"
-                elif output_type in ("thumbs_up_down", "pass_fail"):
-                    val_expr = f"if({alias}.trace_id IS NULL, '(not set)', JSONExtractString({alias}.value, 'value'))"
-                elif output_type == "text":
-                    val_expr = f"if({alias}.trace_id IS NULL, '(not set)', JSONExtractString({alias}.value, 'text'))"
-                elif output_type in ("numeric", "star"):
                     val_expr = (
-                        f"if({alias}.trace_id IS NULL, '(not set)', "
-                        f"toString(round({annotation_numeric_value_expr(alias=alias)}, 1)))"
+                        f"arrayJoin(if({missing_check}, ['(not set)'], "
+                        f"JSONExtract({alias}.value, 'selected', 'Array(String)')))"
+                    )
+                elif output_type == "thumbs_up_down":
+                    val_expr = (
+                        f"if({missing_check}, '(not set)', "
+                        f"JSONExtractString({alias}.value, 'value'))"
+                    )
+                elif output_type == "text":
+                    val_expr = (
+                        f"if({missing_check}, '(not set)', "
+                        f"JSONExtractString({alias}.value, 'text'))"
                     )
                 else:
+                    nullable_num = annotation_numeric_value_expr(
+                        alias=alias, nullable=True
+                    )
+                    rounding = ", 1" if output_type in ("numeric", "star") else ""
                     val_expr = (
-                        f"if({alias}.trace_id IS NULL, '(not set)', "
-                        f"toString({annotation_numeric_value_expr(alias=alias)}))"
+                        f"if({missing_check} OR {nullable_num} IS NULL, "
+                        f"'(not set)', toString(round({nullable_num}{rounding})))"
                     )
 
                 join_clause = (
                     f"LEFT JOIN model_hub_score AS {alias} "
                     f"ON toString({alias}.trace_id) = s.trace_id "
                     f"AND {alias}.label_id = toUUID(%({param_key})s) "
-                    f"AND {alias}._peerdb_is_deleted = 0"
+                    f"AND {alias}._peerdb_is_deleted = 0 "
+                    f"AND {alias}.deleted = 0"
                 )
                 result.append(
                     {"type": "annotation", "expr": val_expr, "join": join_clause}
@@ -1396,14 +1468,21 @@ class DashboardQueryBuilder:
                 label_id = f.get("metric_name", "")
                 ann_org_key = f"{prefix}ann_org_id_{idx}"
 
+                # Use the nullable extractor so JSON payloads missing
+                # the numeric key compare as NULL (and are excluded by
+                # the filter) instead of evaluating as 0.
+                num_expr = annotation_numeric_value_expr(
+                    alias="model_hub_score", nullable=True
+                )
                 subquery = (
                     f"trace_id IN ("
                     f"SELECT toString(trace_id) FROM model_hub_score FINAL "
                     f"WHERE label_id = toUUID(%({label_id_key})s) "
                     f"AND organization_id = toUUID(%({ann_org_key})s) "
-                    f"AND {annotation_numeric_value_expr(alias='model_hub_score')} "
-                    f"{op_symbol} %({val_key})s "
-                    f"AND _peerdb_is_deleted = 0"
+                    f"AND {num_expr} IS NOT NULL "
+                    f"AND {num_expr} {op_symbol} %({val_key})s "
+                    f"AND _peerdb_is_deleted = 0 "
+                    f"AND deleted = 0"
                     f")"
                 )
                 clauses.append(subquery)

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard_base.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard_base.py
@@ -11,20 +11,27 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from tracer.services.clickhouse.query_builders.dashboard import (
     AGGREGATIONS,
+    AVERAGING_AGGREGATIONS,
     FILTER_OPERATORS,
     GRANULARITY_TO_CH,
     PRESET_RANGES,
     _coerce_filter_value,
     _generate_time_buckets,
     _parse_dt,
+    rescale_rate_to_percent,
 )
 
-# Re-export for convenience so subclasses can import from this module
+# Re-export for convenience so subclasses can import from this module.
+# ``rescale_rate_to_percent`` and ``AVERAGING_AGGREGATIONS`` live in
+# ``dashboard.py`` (the import root) to avoid the cycle that would
+# otherwise force inline imports here.
 __all__ = [
     "AGGREGATIONS",
+    "AVERAGING_AGGREGATIONS",
     "FILTER_OPERATORS",
     "GRANULARITY_TO_CH",
     "PRESET_RANGES",
+    "rescale_rate_to_percent",
     "_coerce_filter_value",
     "_generate_time_buckets",
     "_parse_dt",
@@ -163,7 +170,8 @@ class DashboardQueryBuilderBase:
             ``unit``, and ``series``.
         """
         metric_name = metric_info.get("name", "")
-        unit = unit_map.get(metric_name, "")
+        metric_key = metric_info.get("id") or metric_name
+        unit = unit_map.get(metric_key, unit_map.get(metric_name, ""))
 
         series_data = self._build_series_data(rows, name_map, name_map_breakdown)
 

--- a/futureagi/tracer/services/clickhouse/query_builders/dataset_dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dataset_dashboard.py
@@ -27,6 +27,7 @@ from tracer.services.clickhouse.query_builders.dashboard_base import (
     _coerce_filter_value,
     _generate_time_buckets,
     _parse_dt,
+    rescale_rate_to_percent,
 )
 
 # Allowed characters for safe string interpolation
@@ -58,6 +59,9 @@ DATASET_SYSTEM_METRICS: Dict[str, Tuple[str, str]] = {
     ),
 }
 
+# Metrics whose column expression emits a 0/1 indicator per row.
+_RATE_INDICATOR_METRICS = frozenset({"cell_error_rate"})
+
 DATASET_METRIC_UNITS: Dict[str, str] = {
     "row_count": "",
     "prompt_tokens": "tokens",
@@ -82,18 +86,22 @@ DATASET_AGGREGATIONS: Dict[str, str] = {
     "count": "count()",
     "count_distinct": "uniq({col})",
     "sum": "sum({col})",
-    # Dataset-specific aggregations for pass/fail and boolean
+    # Dataset-specific aggregations for pass/fail and boolean.
+    # Rate aggregations return 0–100 (percentage) so widgets that display
+    # them with a ``%`` suffix don't show 0.42% for a 42% pass rate.
     "pass_rate": (
-        "countIf(lower({col}) IN ('true', 'pass', 'passed', '1')) "
+        "countIf(lower({col}) IN ('true', 'pass', 'passed', '1')) * 100.0 "
         "/ nullIf(count(), 0)"
     ),
     "fail_rate": (
-        "countIf(lower({col}) IN ('false', 'fail', 'failed', '0')) "
+        "countIf(lower({col}) IN ('false', 'fail', 'failed', '0')) * 100.0 "
         "/ nullIf(count(), 0)"
     ),
     "pass_count": "countIf(lower({col}) IN ('true', 'pass', 'passed', '1'))",
     "fail_count": "countIf(lower({col}) IN ('false', 'fail', 'failed', '0'))",
-    "true_rate": ("countIf(lower({col}) IN ('true', '1')) / nullIf(count(), 0)"),
+    "true_rate": (
+        "countIf(lower({col}) IN ('true', '1')) * 100.0 / nullIf(count(), 0)"
+    ),
 }
 
 # Breakdown dimensions for dataset workflow
@@ -218,6 +226,9 @@ class DatasetQueryBuilder(DashboardQueryBuilderBase):
         agg_expr = DATASET_AGGREGATIONS.get(aggregation, "avg({col})").format(
             col=col_expr
         )
+
+        if metric_name in _RATE_INDICATOR_METRICS:
+            agg_expr = rescale_rate_to_percent(agg_expr, aggregation)
 
         select_parts = [f"{bucket_fn}(c.created_at) AS time_bucket"]
         group_parts = ["time_bucket"]

--- a/futureagi/tracer/services/clickhouse/query_builders/expressions.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/expressions.py
@@ -3,7 +3,9 @@
 from typing import Optional
 
 
-def annotation_numeric_value_expr(alias: Optional[str] = None) -> str:
+def annotation_numeric_value_expr(
+    alias: Optional[str] = None, nullable: bool = False
+) -> str:
     """Return the ClickHouse expression for a numeric annotation value.
 
     Annotations may store the numeric value under either ``rating`` (star
@@ -14,8 +16,18 @@ def annotation_numeric_value_expr(alias: Optional[str] = None) -> str:
         alias: Optional table alias. When provided, the column is
             referenced as ``{alias}.value``; otherwise it's a bare
             ``value`` reference.
+        nullable: When True, returns ``Nullable(Float64)`` so missing /
+            non-numeric values become SQL NULL instead of 0.0. Use this
+            for aggregations (avg, sum, …) so absent values are skipped
+            rather than dragging the result toward zero.
     """
     prefix = f"{alias}." if alias else ""
+    if nullable:
+        return (
+            f"if(JSONHas({prefix}value, 'rating'), "
+            f"JSONExtract({prefix}value, 'rating', 'Nullable(Float64)'), "
+            f"JSONExtract({prefix}value, 'value', 'Nullable(Float64)'))"
+        )
     return (
         f"if(JSONHas({prefix}value, 'rating'), "
         f"JSONExtractFloat({prefix}value, 'rating'), "

--- a/futureagi/tracer/services/clickhouse/query_builders/simulation_dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/simulation_dashboard.py
@@ -26,9 +26,36 @@ from tracer.services.clickhouse.query_builders.dashboard_base import (
     _coerce_filter_value,
     _generate_time_buckets,
     _parse_dt,
+    rescale_rate_to_percent,
 )
 
 _SAFE_KEY_RE = re.compile(r"^[a-zA-Z0-9._\-]+$")
+
+# Metrics whose column expression emits a 0/1 indicator per row.
+_RATE_INDICATOR_METRICS = frozenset({"success_rate", "failure_rate"})
+_STRING_DIMENSION_METRICS = frozenset(
+    {
+        "scenario",
+        "agent_definition",
+        "agent_version",
+        "persona",
+        "call_type",
+        "status",
+        "ended_reason",
+        "scenario_type",
+        "run_test",
+        "test_execution",
+        "persona_gender",
+        "persona_age_group",
+        "persona_location",
+        "persona_profession",
+        "persona_personality",
+        "persona_communication_style",
+        "persona_accent",
+        "persona_language",
+        "persona_conversation_speed",
+    }
+)
 
 
 def _sanitize_key(key: str) -> str:
@@ -56,10 +83,24 @@ _PERSONA_NAME_EXPR = (
 )
 
 _PERSONA_FIELD = lambda field: (f"JSONExtractString({_PERSONA_JSON_EXPR}, '{field}')")
+_CUSTOMER_LATENCY_FIELD = lambda field: (
+    f"JSONExtractFloat(c.customer_latency_metrics, 'systemMetrics', '{field}')"
+)
+# Nullable variant — returns NULL when the JSON key is absent so avg()
+# skips the row instead of folding a 0 into the average.
+_CUSTOMER_LATENCY_FIELD_NULLABLE = lambda field: (
+    "if(JSONHas(c.customer_latency_metrics, 'systemMetrics', "
+    f"'{field}'), JSONExtractFloat(c.customer_latency_metrics, "
+    f"'systemMetrics', '{field}'), CAST(NULL, 'Nullable(Float64)'))"
+)
 
 SIMULATION_SYSTEM_METRICS: Dict[str, Tuple[str, str]] = {
     # Call counts & entity counts
     "call_count": ("simulate_call_execution", "1"),
+    # Rate metrics emit a 0/1 indicator per row. ``avg`` is rescaled to a
+    # percentage in ``_build_system_metric_query`` so users see 42% rather
+    # than 0.42; ``sum`` / ``count`` keep their natural meaning (count of
+    # successful or failed calls).
     "success_rate": (
         "simulate_call_execution",
         "CASE WHEN status = 'completed' THEN 1.0 ELSE 0.0 END",
@@ -72,10 +113,22 @@ SIMULATION_SYSTEM_METRICS: Dict[str, Tuple[str, str]] = {
     "duration": ("simulate_call_execution", "duration_seconds"),
     "response_time": ("simulate_call_execution", "response_time_ms"),
     "agent_latency": ("simulate_call_execution", "avg_agent_latency_ms"),
-    # Component latencies (STT/TTS/LLM)
-    "stt_latency": ("simulate_call_execution", "stt_latency_ms"),
-    "tts_latency": ("simulate_call_execution", "tts_latency_ms"),
-    "llm_latency": ("simulate_call_execution", "llm_latency_ms"),
+    # Component latencies (STT/TTS/LLM). Use Nullable(Float64) so calls
+    # whose customer_latency_metrics JSON is empty / missing the key are
+    # skipped by avg() instead of being counted as 0 ms (which silently
+    # collapses real values toward zero and looks like "no data").
+    "stt_latency": (
+        "simulate_call_execution",
+        _CUSTOMER_LATENCY_FIELD_NULLABLE("transcriber"),
+    ),
+    "tts_latency": (
+        "simulate_call_execution",
+        _CUSTOMER_LATENCY_FIELD_NULLABLE("voice"),
+    ),
+    "llm_latency": (
+        "simulate_call_execution",
+        _CUSTOMER_LATENCY_FIELD_NULLABLE("model"),
+    ),
     # Cost breakdown
     "total_cost": ("simulate_call_execution", "cost_cents"),
     "stt_cost": ("simulate_call_execution", "stt_cost_cents"),
@@ -92,7 +145,17 @@ SIMULATION_SYSTEM_METRICS: Dict[str, Tuple[str, str]] = {
     "ai_interruption_rate": ("simulate_call_execution", "ai_interruption_rate"),
     "user_wpm": ("simulate_call_execution", "user_wpm"),
     "bot_wpm": ("simulate_call_execution", "bot_wpm"),
-    "talk_ratio": ("simulate_call_execution", "talk_ratio"),
+    # ``talk_ratio`` is stored as ``agent_talk_time / customer_talk_time``
+    # — an unbounded ratio that can exceed 1.0 (and therefore exceeded
+    # 100% when the frontend rendered it as a percentage). Convert it to
+    # the agent's share of total speaking time so the value is always
+    # within [0, 100]. Mirrors test_execution.agent_talk_percentage.
+    "talk_ratio": (
+        "simulate_call_execution",
+        "if(talk_ratio IS NULL OR talk_ratio <= 0, "
+        "CAST(NULL, 'Nullable(Float64)'), "
+        "(talk_ratio / (talk_ratio + 1)) * 100)",
+    ),
     "stop_time_after_interruption": (
         "simulate_call_execution",
         "avg_stop_time_after_interruption_ms",
@@ -125,6 +188,13 @@ SIMULATION_SYSTEM_METRICS: Dict[str, Tuple[str, str]] = {
         "simulate_call_execution",
         "dictGetOrDefault('simulate_scenario_dict', 'scenario_type', c.scenario_id, '')",
     ),
+    "run_test": (
+        "simulate_call_execution",
+        "dictGetOrDefault('simulate_run_test_dict', 'name', "
+        "dictGetOrDefault('simulate_test_execution_dict', 'run_test_id', "
+        "c.test_execution_id, toUUID('00000000-0000-0000-0000-000000000000')), '')",
+    ),
+    "test_execution": ("simulate_call_execution", "toString(c.test_execution_id)"),
     # Persona attributes
     "persona_gender": ("simulate_call_execution", _PERSONA_FIELD("gender")),
     "persona_age_group": ("simulate_call_execution", _PERSONA_FIELD("age_group")),
@@ -161,12 +231,12 @@ SIMULATION_METRIC_UNITS: Dict[str, str] = {
     "overall_score": "",
     "message_count": "",
     "user_interruptions": "",
-    "user_interruption_rate": "%",
+    "user_interruption_rate": "/min",
     "ai_interruptions": "",
-    "ai_interruption_rate": "%",
+    "ai_interruption_rate": "/min",
     "user_wpm": "wpm",
     "bot_wpm": "wpm",
-    "talk_ratio": "",
+    "talk_ratio": "%",
     "stop_time_after_interruption": "ms",
     # String dimension metrics (used with count/count_distinct)
     "scenario": "",
@@ -177,6 +247,8 @@ SIMULATION_METRIC_UNITS: Dict[str, str] = {
     "status": "",
     "ended_reason": "",
     "scenario_type": "",
+    "run_test": "",
+    "test_execution": "",
     "persona_gender": "",
     "persona_age_group": "",
     "persona_location": "",
@@ -224,6 +296,7 @@ SIMULATION_BREAKDOWN_COLUMNS: Dict[str, str] = {
     "call_type": "c.simulation_call_type",
     "status": "c.status",
     "ended_reason": "c.ended_reason",
+    "scenario_type": "dictGetOrDefault('simulate_scenario_dict', 'scenario_type', c.scenario_id, '')",
     "persona_gender": _PERSONA_FIELD("gender"),
     "persona_age_group": _PERSONA_FIELD("age_group"),
     "persona_location": _PERSONA_FIELD("location"),
@@ -279,6 +352,33 @@ SIMULATION_FILTER_COLUMNS: Dict[str, str] = {
         "c.test_execution_id, toUUID('00000000-0000-0000-0000-000000000000')), '')"
     ),
     "test_execution": "toString(c.test_execution_id)",
+    # Numeric columns — needed so range operators (>, <, between, …) on
+    # call.duration / latencies / costs actually filter instead of being
+    # silently dropped. JSON-derived latencies use the nullable extractor
+    # so missing keys don't compare against 0.
+    "duration": "c.duration_seconds",
+    "response_time": "c.response_time_ms",
+    "agent_latency": "c.avg_agent_latency_ms",
+    "stt_latency": _CUSTOMER_LATENCY_FIELD_NULLABLE("transcriber"),
+    "tts_latency": _CUSTOMER_LATENCY_FIELD_NULLABLE("voice"),
+    "llm_latency": _CUSTOMER_LATENCY_FIELD_NULLABLE("model"),
+    "total_cost": "c.cost_cents",
+    "stt_cost": "c.stt_cost_cents",
+    "llm_cost": "c.llm_cost_cents",
+    "tts_cost": "c.tts_cost_cents",
+    "customer_cost": "c.customer_cost_cents",
+    "overall_score": "c.overall_score",
+    "message_count": "c.message_count",
+    "user_interruptions": "c.user_interruption_count",
+    "user_interruption_rate": "c.user_interruption_rate",
+    "ai_interruptions": "c.ai_interruption_count",
+    "ai_interruption_rate": "c.ai_interruption_rate",
+    "user_wpm": "c.user_wpm",
+    "bot_wpm": "c.bot_wpm",
+    # Filter on the raw stored ratio (unbounded) — the SYSTEM_METRICS
+    # entry only converts to a percentage for display/aggregation.
+    "talk_ratio": "c.talk_ratio",
+    "stop_time_after_interruption": "c.avg_stop_time_after_interruption_ms",
 }
 
 
@@ -329,7 +429,7 @@ class SimulationQueryBuilder(DashboardQueryBuilderBase):
     def build_metric_query(self, metric: dict) -> Tuple[str, dict]:
         metric_type = metric.get("type", "system_metric")
         metric_name = metric.get("id") or metric.get("name", "")
-        aggregation = metric.get("aggregation", "avg")
+        aggregation = self._effective_aggregation(metric)
         per_metric_filters = metric.get("filters", [])
 
         start_date, end_date = self.parse_time_range()
@@ -356,6 +456,21 @@ class SimulationQueryBuilder(DashboardQueryBuilderBase):
         else:
             raise ValueError(f"Unknown simulation metric type: {metric_type}")
 
+    def build_all_queries(self) -> List[Tuple[str, dict, dict]]:
+        results = []
+        for metric in self.metrics:
+            sql, params = self.build_metric_query(metric)
+            metric_info = {
+                "id": metric.get("id", ""),
+                "name": metric.get("displayName")
+                or metric.get("display_name")
+                or metric.get("name", ""),
+                "type": metric.get("type", "system_metric"),
+                "aggregation": self._effective_aggregation(metric),
+            }
+            results.append((sql, params, metric_info))
+        return results
+
     # ------------------------------------------------------------------
     # System metric
     # ------------------------------------------------------------------
@@ -372,30 +487,19 @@ class SimulationQueryBuilder(DashboardQueryBuilderBase):
             raise ValueError(f"Unknown simulation system metric: {metric_name}")
         _, col_expr = SIMULATION_SYSTEM_METRICS[metric_name]
 
-        # call_count should default to count
-        if metric_name == "call_count" and aggregation not in ("count", "sum"):
-            aggregation = "count"
+        if metric_name in _STRING_DIMENSION_METRICS:
+            is_present = f"{col_expr} IS NOT NULL AND {col_expr} != ''"
+            if aggregation != "count":
+                agg_expr = f"uniqIf({col_expr}, {is_present})"
+            else:
+                agg_expr = f"countIf({is_present})"
+        else:
+            agg_expr = SIMULATION_AGGREGATIONS.get(aggregation, "avg({col})").format(
+                col=col_expr
+            )
 
-        # String dimension metrics — force count_distinct (can't avg/sum a string)
-        _STRING_DIMENSION_METRICS = {
-            "scenario",
-            "agent_definition",
-            "agent_version",
-            "persona",
-            "call_type",
-            "status",
-            "ended_reason",
-            "scenario_type",
-        }
-        if metric_name in _STRING_DIMENSION_METRICS and aggregation not in (
-            "count",
-            "count_distinct",
-        ):
-            aggregation = "count_distinct"
-
-        agg_expr = SIMULATION_AGGREGATIONS.get(aggregation, "avg({col})").format(
-            col=col_expr
-        )
+        if metric_name in _RATE_INDICATOR_METRICS:
+            agg_expr = rescale_rate_to_percent(agg_expr, aggregation)
 
         select_parts = [f"{bucket_fn}(c.created_at) AS time_bucket"]
         group_parts = ["time_bucket"]
@@ -490,17 +594,21 @@ class SimulationQueryBuilder(DashboardQueryBuilderBase):
                 aggregation = "count"
         else:
             # SCORE — numeric
-            col_expr = f"JSONExtractFloat(c.eval_outputs, '{eval_key}', 'score')"
+            col_expr = (
+                f"JSONExtract(c.eval_outputs, '{eval_key}', 'score', 'Nullable(Float64)')"
+            )
 
-        # Build aggregation with pass/fail support
+        # Build aggregation with pass/fail support. Rate aggregations
+        # are scaled to 0–100 so widgets that render them with a ``%``
+        # suffix don't show 0.42% for a 42% pass rate.
         EVAL_AGGREGATIONS = {
             **SIMULATION_AGGREGATIONS,
             "pass_rate": (
-                "countIf(lower({col}) IN ('true', 'pass', 'passed', '1')) "
+                "countIf(lower({col}) IN ('true', 'pass', 'passed', '1')) * 100.0 "
                 "/ nullIf(count(), 0)"
             ),
             "fail_rate": (
-                "countIf(lower({col}) IN ('false', 'fail', 'failed', '0')) "
+                "countIf(lower({col}) IN ('false', 'fail', 'failed', '0')) * 100.0 "
                 "/ nullIf(count(), 0)"
             ),
             "pass_count": "countIf(lower({col}) IN ('true', 'pass', 'passed', '1'))",
@@ -579,9 +687,32 @@ class SimulationQueryBuilder(DashboardQueryBuilderBase):
             return col
         return None
 
+    def _effective_aggregation(self, metric: dict) -> str:
+        metric_type = metric.get("type", "system_metric")
+        metric_name = metric.get("id") or metric.get("name", "")
+        aggregation = metric.get("aggregation", "avg")
+
+        if metric_type == "system_metric":
+            if metric_name == "call_count" and aggregation not in ("count", "sum"):
+                return "count"
+            if metric_name in _STRING_DIMENSION_METRICS:
+                return "count" if aggregation == "count" else "count_distinct"
+            return aggregation
+
+        if metric_type == "eval_metric":
+            output_type = metric.get("output_type", "SCORE")
+            if output_type == "PASS_FAIL":
+                pass_fail_aggs = {"pass_rate", "fail_rate", "pass_count", "fail_count"}
+                return aggregation if aggregation in (*pass_fail_aggs, "count") else "pass_rate"
+            if output_type == "CHOICE":
+                return aggregation if aggregation in ("count", "count_distinct") else "count"
+
+        return aggregation
+
     def _build_base_where(self, params: dict) -> List[str]:
         clauses = [
             "c._peerdb_is_deleted = 0",
+            "c.deleted = 0",
             "c.created_at >= %(start_date)s",
             "c.created_at < %(end_date)s",
         ]
@@ -607,6 +738,16 @@ class SimulationQueryBuilder(DashboardQueryBuilderBase):
     ) -> List[str]:
         idx = 0
         for f in filters:
+            # Skip filters scoped to other sources (trace / dataset). The
+            # frontend can mix filters from multiple sources on a single
+            # widget config; without this guard, a trace-scoped filter
+            # like ``model = 'gpt-4o'`` would be silently dropped here
+            # (no matching column) — but more importantly, simulation
+            # filters with an explicit ``source`` are picked up cleanly.
+            f_source = f.get("source")
+            if f_source and f_source != "simulation":
+                continue
+
             f_type = f.get("metric_type", "")
             f_name = f.get("metric_name", "")
             op = f.get("operator", "")

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -302,6 +302,35 @@ class TestMetricsEndpoint:
         assert "latency" in metric_names
         assert "cost" in metric_names
 
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=False)
+    @patch("tracer.views.dashboard.SQL_query_handler.get_span_attributes_for_project")
+    def test_metrics_suppresses_customer_attribute_aliases_when_canonical_metric_exists(
+        self,
+        mock_get_span_attrs,
+        _mock_clickhouse_enabled,
+        auth_client,
+        observe_project,
+    ):
+        mock_get_span_attrs.return_value = [
+            "call.bot_wpm",
+            "call.user_wpm",
+            "freeform.attr",
+        ]
+
+        response = auth_client.get(
+            f"/tracer/dashboard/metrics/?project_ids={observe_project.id}"
+        )
+
+        assert response.status_code == 200
+        metrics = response.json()["result"]["metrics"]
+        metric_names = [m["name"] for m in metrics]
+        assert "bot_wpm" in metric_names
+        assert "user_wpm" in metric_names
+        assert "call.bot_wpm" not in metric_names
+        assert "call.user_wpm" not in metric_names
+        assert "freeform.attr" in metric_names
+
 
 # ===========================================================================
 # DashboardQueryBuilder
@@ -1157,6 +1186,111 @@ class TestDashboardQueryExecution:
         sql = mock_service.execute_ch_query.call_args.args[0]
         assert "span_attr_num" in sql
         assert "simulate_call_execution" not in sql
+
+    def test_query_action_simulation_metric_failure_does_not_blank_other_metrics(
+        self,
+    ):
+        viewset = DashboardViewSet()
+        mock_service = MagicMock()
+        success_result = MagicMock()
+        success_result.data = [
+            {"time_bucket": "2025-01-01T00:00:00", "value": 1.0},
+        ]
+        mock_service.execute_ch_query.side_effect = [
+            Exception("Code: 47 unknown column"),
+            success_result,
+        ]
+
+        sim_config = {
+            "workflow": "simulation",
+            "workspace_id": str(uuid.uuid4()),
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "duration",
+                    "name": "duration",
+                    "type": "system_metric",
+                    "aggregation": "avg",
+                    "source": "simulation",
+                },
+                {
+                    "id": "success_rate",
+                    "name": "success_rate",
+                    "type": "system_metric",
+                    "aggregation": "avg",
+                    "source": "simulation",
+                },
+            ],
+        }
+
+        results = viewset._run_simulation_analytics_queries(
+            mock_service,
+            sim_config,
+        )
+
+        assert mock_service.execute_ch_query.call_count == 2
+        assert results[0][0]["name"] == "duration"
+        assert results[0][1] == []
+        assert results[1][0]["name"] == "success_rate"
+        assert results[1][1] == success_result.data
+
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.AnalyticsQueryService")
+    def test_query_action_simulation_metric_preserves_simulation_units(
+        self, mock_analytics_cls, auth_client
+    ):
+        mock_service = MagicMock()
+        mock_result = MagicMock()
+        mock_result.data = [{"time_bucket": "2025-01-01T00:00:00", "value": 12.5}]
+        mock_service.execute_ch_query.return_value = mock_result
+        mock_analytics_cls.return_value = mock_service
+
+        response = auth_client.post(
+            "/tracer/dashboard/query/",
+            {
+                "workflow": "simulation",
+                "granularity": "day",
+                "time_range": {"preset": "7D"},
+                "metrics": [
+                    {
+                        "id": "duration",
+                        "name": "duration",
+                        "displayName": "Duration",
+                        "type": "system_metric",
+                        "aggregation": "avg",
+                        "source": "simulation",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        metric = response.json()["result"]["metrics"][0]
+        assert metric["unit"] == "s"
+
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.AnalyticsQueryService")
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
+    def test_filter_values_simulation_excludes_deleted_rows_and_handles_numeric_columns(
+        self, _mock_enabled, mock_analytics_cls, auth_client
+    ):
+        mock_service = MagicMock()
+        mock_result = MagicMock()
+        mock_result.data = []
+        mock_service.execute_ch_query.return_value = mock_result
+        mock_analytics_cls.return_value = mock_service
+
+        response = auth_client.get(
+            "/tracer/dashboard/filter_values/?source=simulation&metric_name=duration&metric_type=system_metric"
+        )
+
+        assert response.status_code == 200
+        sql = mock_service.execute_ch_query.call_args.args[0]
+        assert "c.deleted = 0" in sql
+        assert "c.duration_seconds IS NOT NULL" in sql
+        assert "c.duration_seconds != ''" not in sql
 
 
 class TestDashboardTraceTimeoutSelection:
@@ -2377,3 +2511,17 @@ class TestDashboardQueryBuilderBase:
         )
         series_names = [s["name"] for s in result["series"]]
         assert "My Project" in series_names
+
+    def test_format_metric_result_uses_metric_id_for_unit_lookup(self):
+        config = {
+            "granularity": "day",
+            "metrics": [],
+            "breakdowns": [],
+        }
+        base = DashboardQueryBuilderBase(config)
+        all_buckets = [datetime(2025, 1, 1).isoformat()]
+        metric_info = {"id": "duration", "name": "Duration", "aggregation": "avg"}
+        rows = [{"time_bucket": datetime(2025, 1, 1), "value": 42.5}]
+        result = base._format_metric_result(metric_info, rows, all_buckets, {"duration": "s"})
+        assert result["name"] == "Duration"
+        assert result["unit"] == "s"

--- a/futureagi/tracer/tests/test_simulation_dashboard.py
+++ b/futureagi/tracer/tests/test_simulation_dashboard.py
@@ -140,6 +140,36 @@ class TestSimulationQueryBuilderSystemMetric(unittest.TestCase):
         sql, _, _ = queries[0]
         self.assertIn("count()", sql)
 
+    def test_base_query_excludes_soft_deleted_calls(self):
+        builder = SimulationQueryBuilder(self._make_config("ended_reason", "count"))
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        self.assertIn("c._peerdb_is_deleted = 0", sql)
+        self.assertIn("c.deleted = 0", sql)
+
+    def test_ended_reason_unsupported_aggregation_uses_distinct_non_empty_reasons(self):
+        builder = SimulationQueryBuilder(self._make_config("ended_reason", "avg"))
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        self.assertIn("uniqIf(c.ended_reason", sql)
+        self.assertIn("c.ended_reason IS NOT NULL AND c.ended_reason != ''", sql)
+        self.assertNotIn("uniq(c.ended_reason)", sql)
+
+    def test_ended_reason_count_counts_non_empty_reasons(self):
+        builder = SimulationQueryBuilder(self._make_config("ended_reason", "count"))
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        self.assertIn("countIf(c.ended_reason IS NOT NULL AND c.ended_reason != '')", sql)
+
+    def test_ended_reason_count_distinct_ignores_empty_reasons(self):
+        builder = SimulationQueryBuilder(
+            self._make_config("ended_reason", "count_distinct")
+        )
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        self.assertIn("uniqIf(c.ended_reason", sql)
+        self.assertIn("c.ended_reason IS NOT NULL AND c.ended_reason != ''", sql)
+
     def test_success_rate_metric(self):
         builder = SimulationQueryBuilder(self._make_config("success_rate", "avg"))
         queries = builder.build_all_queries()
@@ -159,6 +189,52 @@ class TestSimulationQueryBuilderSystemMetric(unittest.TestCase):
             sql, _, _ = queries[0]
             self.assertIn("avg(", sql)
             self.assertIn("simulate_call_execution", sql)
+
+    def test_component_latency_metrics_use_customer_latency_json(self):
+        expected_paths = {
+            "stt_latency": "transcriber",
+            "tts_latency": "voice",
+            "llm_latency": "model",
+        }
+        for metric, customer_key in expected_paths.items():
+            builder = SimulationQueryBuilder(self._make_config(metric, "avg"))
+            queries = builder.build_all_queries()
+            sql, _, _ = queries[0]
+            self.assertIn("customer_latency_metrics", sql)
+            self.assertIn(
+                f"JSONExtractFloat(c.customer_latency_metrics, 'systemMetrics', '{customer_key}')",
+                sql,
+            )
+
+    def test_run_test_and_test_execution_string_metrics_are_queryable(self):
+        expected_sql = {
+            "run_test": "simulate_run_test_dict",
+            "test_execution": "toString(c.test_execution_id)",
+        }
+        for metric, sql_snippet in expected_sql.items():
+            builder = SimulationQueryBuilder(self._make_config(metric, "avg"))
+            queries = builder.build_all_queries()
+            sql, _, _ = queries[0]
+            self.assertIn("uniqIf(", sql)
+            self.assertIn(sql_snippet, sql)
+
+    def test_persona_string_metrics_are_queryable(self):
+        expected_sql = {
+            "persona_gender": "gender",
+            "persona_language": "language",
+        }
+        for metric, field_snippet in expected_sql.items():
+            builder = SimulationQueryBuilder(self._make_config(metric, "avg"))
+            queries = builder.build_all_queries()
+            sql, _, _ = queries[0]
+            self.assertIn("uniqIf(", sql)
+            self.assertIn(field_snippet, sql)
+
+    def test_string_metric_reports_actual_aggregation(self):
+        builder = SimulationQueryBuilder(self._make_config("ended_reason", "avg"))
+        queries = builder.build_all_queries()
+        _, _, info = queries[0]
+        self.assertEqual(info["aggregation"], "count_distinct")
 
     def test_granularity_hour(self):
         config = self._make_config()
@@ -231,6 +307,13 @@ class TestSimulationQueryBuilderBreakdowns(unittest.TestCase):
         queries = builder.build_all_queries()
         sql, _, _ = queries[0]
         self.assertIn("c.status", sql)
+
+    def test_scenario_type_breakdown(self):
+        builder = SimulationQueryBuilder(self._make_config("scenario_type"))
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        self.assertIn("breakdown_value", sql)
+        self.assertIn("scenario_type", sql)
 
 
 class TestSimulationQueryBuilderFilters(unittest.TestCase):
@@ -356,7 +439,8 @@ class TestSimulationQueryBuilderEvalMetric(unittest.TestCase):
         builder = SimulationQueryBuilder(self._make_config())
         queries = builder.build_all_queries()
         sql, params, _ = queries[0]
-        self.assertIn("JSONExtractFloat", sql)
+        self.assertIn("Nullable(Float64)", sql)
+        self.assertNotIn("JSONExtractFloat(c.eval_outputs", sql)
         self.assertIn("eval-123", sql)
         self.assertIn("JSONHas", sql)
 

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -20,22 +20,54 @@ from tracer.services.clickhouse.client import (
     is_clickhouse_enabled,
 )
 from tracer.services.clickhouse.query_builders.dashboard import (
+    METRIC_UNITS,
     SYSTEM_METRICS,
     DashboardQueryBuilder,
 )
 from tracer.services.clickhouse.query_builders.dataset_dashboard import (
     DATASET_FILTER_COLUMNS,
+    DATASET_METRIC_UNITS,
     DatasetQueryBuilder,
 )
 from tracer.services.clickhouse.query_builders.simulation_dashboard import (
     SIMULATION_FILTER_COLUMNS,
+    SIMULATION_METRIC_UNITS,
     SIMULATION_SYSTEM_METRICS,
+    _STRING_DIMENSION_METRICS,
     SimulationQueryBuilder,
 )
 from tracer.services.clickhouse.query_service import AnalyticsQueryService
 from tracer.utils.sql_queries import SQL_query_handler
 
 logger = structlog.get_logger(__name__)
+
+
+def _customer_attribute_metric_aliases():
+    from tracer.utils.filters import FilterEngine
+
+    aliases = {}
+    for metric_id, definition in FilterEngine.VOICE_METRIC_DEFINITIONS.items():
+        json_keys = definition.get("json_keys") or []
+        if len(json_keys) == 1:
+            aliases[json_keys[0]] = metric_id
+    return aliases
+
+
+def _suppress_customer_attribute_metric_aliases(metric_entries):
+    aliases = _customer_attribute_metric_aliases()
+    exposed_metric_names = {
+        metric.get("name")
+        for metric in metric_entries
+        if metric.get("category") != "custom_attribute"
+    }
+    return [
+        metric
+        for metric in metric_entries
+        if not (
+            metric.get("category") == "custom_attribute"
+            and aliases.get(metric.get("name")) in exposed_metric_names
+        )
+    ]
 
 
 class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
@@ -65,6 +97,78 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
             if bd.get("source", "traces") in ("traces", "both", "all", "")
         )
         return 30000 if has_eval_metrics or has_project_breakdown else 10000
+
+    def _empty_simulation_metric_result(self, metric):
+        return (
+            {
+                "id": metric.get("id", ""),
+                "name": metric.get("displayName")
+                or metric.get("display_name")
+                or metric.get("name", ""),
+                "type": metric.get("type", "system_metric"),
+                "aggregation": metric.get("aggregation", "avg"),
+                "source": "simulation",
+            },
+            [],
+        )
+
+    def _format_merged_metric_results(self, query_config, all_metric_results):
+        formatter = DatasetQueryBuilder({**query_config, "metrics": query_config["metrics"]})
+        start_date, end_date = formatter.parse_time_range()
+        from tracer.services.clickhouse.query_builders.dashboard_base import (
+            _generate_time_buckets,
+        )
+
+        all_buckets = _generate_time_buckets(start_date, end_date, formatter.granularity)
+        unit_map = {**METRIC_UNITS, **DATASET_METRIC_UNITS, **SIMULATION_METRIC_UNITS}
+        formatted_metrics = []
+        for metric_info, rows in all_metric_results:
+            formatted_metrics.append(
+                formatter._format_metric_result(metric_info, rows, all_buckets, unit_map)
+            )
+
+        return {
+            "metrics": formatted_metrics,
+            "time_range": {
+                "start": start_date.isoformat(),
+                "end": end_date.isoformat(),
+            },
+            "granularity": formatter.granularity,
+        }
+
+    def _run_simulation_queries(self, simulation_config, fetch_rows):
+        results = []
+        for metric in simulation_config.get("metrics", []):
+            metric_config = {**simulation_config, "metrics": [metric]}
+            try:
+                builder = SimulationQueryBuilder(metric_config)
+                sql, params, metric_info = builder.build_all_queries()[0]
+                metric_info["source"] = "simulation"
+                results.append((metric_info, fetch_rows(sql, params)))
+            except Exception as e:
+                logger.warning(
+                    "Simulation query failed",
+                    metric_name=metric.get("id") or metric.get("name"),
+                    error=str(e),
+                )
+                results.append(self._empty_simulation_metric_result(metric))
+        return results
+
+    def _run_simulation_analytics_queries(self, analytics, simulation_config):
+        return self._run_simulation_queries(
+            simulation_config,
+            lambda sql, params: analytics.execute_ch_query(
+                sql, params, timeout_ms=10000
+            ).data,
+        )
+
+    def _run_simulation_clickhouse_queries(self, ch_client, simulation_config):
+        def _fetch_rows(sql, params):
+            rows, column_types, _ = ch_client.execute_read(sql, params)
+            col_names = [ct[0] for ct in column_types]
+            return [dict(zip(col_names, row)) for row in rows]
+
+        return self._run_simulation_queries(simulation_config, _fetch_rows)
 
     def _normalize_metric_sources(self, metrics):
         """Route simulation-scoped trace attributes through the trace builder.
@@ -301,33 +405,9 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
             if simulation_metrics:
                 sim_config = {**query_config, "metrics": simulation_metrics}
                 sim_config["workspace_id"] = str(request.workspace.id)
-
-                try:
-                    builder = SimulationQueryBuilder(sim_config)
-                    for sql, params, metric_info in builder.build_all_queries():
-                        metric_info["source"] = "simulation"
-                        result = analytics.execute_ch_query(
-                            sql, params, timeout_ms=10000
-                        )
-                        all_metric_results.append((metric_info, result.data))
-                except Exception as e:
-                    logger.warning(
-                        f"Simulation query failed (tables may not exist): {e}"
-                    )
-                    # Return empty series for each simulation metric
-                    for m in simulation_metrics:
-                        all_metric_results.append(
-                            (
-                                {
-                                    "id": m.get("id", ""),
-                                    "name": m.get("name", ""),
-                                    "type": m.get("type", "system_metric"),
-                                    "aggregation": m.get("aggregation", "avg"),
-                                    "source": "simulation",
-                                },
-                                [],
-                            )
-                        )
+                all_metric_results.extend(
+                    self._run_simulation_analytics_queries(analytics, sim_config)
+                )
 
             # --- Resolve project UUIDs to names in breakdown values ---
             has_project_breakdown = any(
@@ -386,8 +466,10 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
             merged_config = {**query_config, "metrics": query_config["metrics"]}
             if dataset_metrics:
                 merged_config["workspace_id"] = str(request.workspace.id)
-            formatter = DatasetQueryBuilder(merged_config)
-            response = formatter.format_results(all_metric_results)
+            response = self._format_merged_metric_results(
+                merged_config,
+                all_metric_results,
+            )
             return self._gm.success_response(response)
 
         except Exception as e:
@@ -1146,7 +1228,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                         "category": "system_metric",
                         "source": "simulation",
                         "type": "number",
-                        "unit": "%",
+                        "unit": "/min",
                     },
                     {
                         "name": "ai_interruptions",
@@ -1162,7 +1244,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                         "category": "system_metric",
                         "source": "simulation",
                         "type": "number",
-                        "unit": "%",
+                        "unit": "/min",
                     },
                     {
                         "name": "stop_time_after_interruption",
@@ -1194,7 +1276,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                         "category": "system_metric",
                         "source": "simulation",
                         "type": "number",
-                        "unit": "",
+                        "unit": "%",
                     },
                 ]
             )
@@ -1357,6 +1439,12 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     },
                 ]
             )
+
+            for metric in metrics:
+                if metric.get("source") == "simulation" and metric.get("type") == "string":
+                    metric["allowed_aggregations"] = ["count", "count_distinct"]
+
+            metrics = _suppress_customer_attribute_metric_aliases(metrics)
 
             # (Simulation eval metrics are now covered by the central
             #  EvalTemplate listing in section 3 above.)
@@ -2099,9 +2187,10 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     f"SELECT DISTINCT {col_expr} AS val "
                     f"FROM simulate_call_execution AS c FINAL "
                     f"WHERE c._peerdb_is_deleted = 0 "
+                    f"AND c.deleted = 0 "
                     f"AND dictGetOrDefault('simulate_scenario_dict', 'workspace_id', "
                     f"c.scenario_id, NULL) = toUUID(%(workspace_id)s) "
-                    f"AND {col_expr} != '' "
+                    f"AND {self._simulation_filter_value_presence_expr(metric_name, col_expr)} "
                     f"ORDER BY val "
                     f"LIMIT 500"
                 )
@@ -2120,6 +2209,11 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
             return self._gm.bad_request(
                 "Failed to fetch filter values. Please try again later."
             )
+
+    def _simulation_filter_value_presence_expr(self, metric_name, col_expr):
+        if metric_name in _STRING_DIMENSION_METRICS:
+            return f"{col_expr} IS NOT NULL AND {col_expr} != ''"
+        return f"{col_expr} IS NOT NULL"
 
     @action(detail=False, methods=["get"], url_path="simulation-agents")
     def simulation_agents(self, request):
@@ -2378,29 +2472,9 @@ class DashboardWidgetViewSet(BaseModelViewSetMixin, ModelViewSet):
         if simulation_metrics:
             sim_config = {**query_config, "metrics": simulation_metrics}
             sim_config["workspace_id"] = str(workspace.id)
-            try:
-                builder = SimulationQueryBuilder(sim_config)
-                for sql, params, metric_info in builder.build_all_queries():
-                    metric_info["source"] = "simulation"
-                    rows, column_types, _ = ch_client.execute_read(sql, params)
-                    col_names = [ct[0] for ct in column_types]
-                    row_dicts = [dict(zip(col_names, row)) for row in rows]
-                    metric_results.append((metric_info, row_dicts))
-            except Exception as e:
-                logger.warning(f"Simulation query failed (tables may not exist): {e}")
-                for m in simulation_metrics:
-                    metric_results.append(
-                        (
-                            {
-                                "id": m.get("id", ""),
-                                "name": m.get("name", ""),
-                                "type": m.get("type", "system_metric"),
-                                "aggregation": m.get("aggregation", "avg"),
-                                "source": "simulation",
-                            },
-                            [],
-                        )
-                    )
+            metric_results.extend(
+                self._run_simulation_clickhouse_queries(ch_client, sim_config)
+            )
 
         # Format using DatasetQueryBuilder (compatible format_results)
         formatter_config = {**query_config, "workspace_id": str(workspace.id)}


### PR DESCRIPTION
## Description

Fixes a cluster of dashboard correctness issues across annotation queries, simulation metrics, and frontend unit rendering.

**Backend — annotation queries (`tracer/services/clickhouse/query_builders/`)**
- Numeric/star annotations: switched to `Nullable(Float64)` extraction so missing JSON values are skipped by `avg()` instead of folding in as 0 and dragging averages toward zero.
- Resolve scores attached to spans (not just traces) via the `spans` table — previously these were silently dropped.
- Filter on `a.deleted = 0` (soft-deletes were being included).
- Tightened `thumbs_up_down` denominator (`countIf(IS NOT NULL)`) and the breakdown `(not set)` check (`alias.id IS NULL` instead of `trace_id IS NULL`).

**Backend — rate metrics (TH-4641)**
- New shared helper `rescale_rate_to_percent` in `dashboard.py`, re-exported through `dashboard_base.py`. Used by trace `error_rate`, dataset `cell_error_rate`, simulation `success_rate` / `failure_rate`. Stores 0/1 indicator per row; rescales **only averaging aggregations** (avg/median/percentiles) to 0–100 so `sum(failure_rate)` keeps reporting a count.
- `pass_rate` / `fail_rate` / `true_rate` aggregation templates in dataset & simulation eval queries now scale to 0–100 inline.

**Backend — `talk_ratio` (TH-4642)**
- Stored as agent/customer ratio (unbounded, can exceed 1.0). Column expression now converts to bounded 0–100 percentage `(ratio / (ratio + 1)) * 100`. Raw column kept for filtering. Unit advertised as `%`.

**Backend — simulation filters (TH-4645)**
- `SIMULATION_FILTER_COLUMNS` extended with all numeric columns (`duration`, latencies, costs, scores, interruption fields, WPM, `talk_ratio`, …). Range operators on `call.duration` etc. now actually filter instead of being silently dropped.
- `_apply_filters` ignores filters whose `source` is not `simulation` (mirrors the trace builder's existing guard).
- STT/TTS/LLM latencies use a nullable JSON extractor so calls with empty `customer_latency_metrics` aren't averaged in as 0.
- Corrected unit metadata: interruption rates → `/min` (per-minute, not %), `talk_ratio` → `%`.

**Frontend — unit rendering (`frontend/src/sections/dashboards/`)**
- `UNIT_RENDERING` extended with `ms`, `s`, `cents`, `tokens`, `wpm`, `/min`, `#`. `formatValueWithConfig` honors an optional separator so suffix units render as `120 ms`.
- `getSuggestedUnitConfig` no longer drops empty units before the uniqueness check — a chart mixing `call_count` (no unit) with `duration` (`s`) used to inherit `s` for both series; now it falls back to no auto-suggestion.
- `WidgetEditorView`: replaced the 4-button unit toggle with a Select dropdown of presets + Custom. The reconcile effect now tracks the unit it last auto-applied, so swapping a `duration` metric for an annotation drops the stale `s` suffix instead of leaving it stuck on the axis.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring

## Related Issues

- TH-4641 (Simulate-related attributes do not return any results)
- TH-4642 (Call.talk_ratio exceeds 100%)
- TH-4645 (Filtering on `call.duration` with range operators returns no results)

## Test plan

- [x] Verify trace dashboard with `error_rate` (avg) shows 0–100% percentages, and `sum(error_rate)` still reports an error count.
- [x] Verify simulation dashboard with `success_rate` / `failure_rate` (avg) shows 0–100%, and `sum(failure_rate)` returns count of failures.
- [x] Verify `talk_ratio` widget shows values bounded 0–100%.
- [ ] Verify `call.duration > 10` filter on a simulation widget actually filters and shows data.
- [ ] Verify STT / TTS / LLM / agent latency widgets render values with `ms` suffix and aren't dragged to zero by calls without `customer_latency_metrics`.
- [ ] Verify a chart mixing `call_count` and `duration` does not append `s` to the call_count series.
- [ ] Verify swapping a `duration` metric for an annotation in the widget editor clears the stale `s` axis unit.
- [ ] Verify annotation metrics (numeric/star) compute `avg` ignoring missing values, and span-attached annotation scores now appear in dashboards.