### PR TITLE
feat: add array index suggestions and tree select for dataset variabl…

### DIFF
--- a/frontend/src/sections/develop-detail/RunPrompt/common.js
+++ b/frontend/src/sections/develop-detail/RunPrompt/common.js
@@ -276,6 +276,18 @@ export const extractVariableFromAllCols = (
           }
         }
       }
+
+      // For json/text columns with top-level array data, add indexed access
+      const colSchema = jsonSchemas?.[col?.field];
+      if (col?.dataType !== "images" && colSchema?.maxArrayCount) {
+        const count = Math.min(colSchema.maxArrayCount, 2);
+        for (let idx = 0; idx < count; idx++) {
+          const indexedPath = `${col.headerName}[${idx}]`;
+          if (!res[indexedPath]) {
+            res[indexedPath] = ["1"];
+          }
+        }
+      }
     }
   }
 
@@ -345,6 +357,24 @@ export const getDropdownOptionsFromCols = (
           value: `${col?.headerName}[${idx}]`,
           dataType: "images_index",
           isImagesIndex: true,
+          parentColumn: col?.headerName,
+        });
+      }
+    }
+
+    // If this is a json/text column with top-level array data, add indexed options
+    const colSchema = jsonSchemas?.[col?.field];
+    if (
+      col?.dataType !== "images" &&
+      colSchema?.maxArrayCount
+    ) {
+      const count = Math.min(colSchema.maxArrayCount, 2);
+      for (let idx = 0; idx < count; idx++) {
+        options.push({
+          id: `${col?.field}[${idx}]`,
+          value: `${col?.headerName}[${idx}]`,
+          dataType: "array_index",
+          isJsonPath: true,
           parentColumn: col?.headerName,
         });
       }
@@ -453,7 +483,7 @@ export function findInvalidVariables(
       }
     }
 
-    // Check if it's a valid images indexed access (columnName[index])
+    // Check if it's a valid indexed access (columnName[index])
     const bracketMatch = rawVar.match(/^(.+?)\[(\d+)\]$/);
     if (bracketMatch) {
       const baseColumn = bracketMatch[1];
@@ -474,6 +504,11 @@ export function findInvalidVariables(
           return;
         }
         // Even if index exceeds maxImagesCount, allow it (will resolve to empty at runtime)
+        return;
+      }
+
+      // Allow indexed access for json/text columns with top-level array data
+      if (column && jsonSchemas?.[column.field]?.maxArrayCount) {
         return;
       }
     }
@@ -651,25 +686,29 @@ export const replaceVariablesWithFields = (text, matches, allColumns, jsonSchema
       return;
     }
 
-    // Check for images indexed access (e.g., images[0])
+    // Check for indexed access (e.g., images[0], myarray[1])
     const bracketMatch = rawVar.match(/^(.+?)\[(\d+)\]$/);
     if (bracketMatch) {
       const baseColumn = bracketMatch[1];
       const index = bracketMatch[2];
-      const imagesColumn = allColumns.find(
+      const matchedColumn = allColumns.find(
         ({ headerName }) =>
           normalizeForComparison(headerName).toLowerCase() ===
           normalizeForComparison(baseColumn).toLowerCase(),
       );
 
-      if (imagesColumn?.dataType === "images") {
+      // Allow indexed access for images columns and json/text columns with top-level arrays
+      if (
+        matchedColumn?.dataType === "images" ||
+        (matchedColumn && jsonSchemas?.[matchedColumn.field]?.maxArrayCount)
+      ) {
         const replacePattern = new RegExp(
           `{{\\s*${rawVar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*}}`,
           "g",
         );
         updatedText = updatedText.replace(
           replacePattern,
-          `{{${imagesColumn.field}[${index}]}}`,
+          `{{${matchedColumn.field}[${index}]}}`,
         );
         return;
       }

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -1,16 +1,19 @@
 /* eslint-disable react/prop-types */
 import {
-  Autocomplete,
   Box,
   Chip,
+  ClickAwayListener,
   CircularProgress,
   IconButton,
   InputAdornment,
+  Paper,
+  Popper,
   Tab,
   Tabs,
   TextField,
   Typography,
 } from "@mui/material";
+import { TreeView, TreeItem } from "@mui/lab";
 import PropTypes from "prop-types";
 import React, {
   useCallback,
@@ -247,6 +250,191 @@ function JsonEntryRow({ entryKey, entryValue, isObject, depth }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// ColumnTreeSelect — dropdown with tree view for column + nested path selection
+// ---------------------------------------------------------------------------
+function buildTree(columnNames) {
+  const roots = [];
+  const nodeMap = {}; // path → node
+
+  const getOrCreate = (path, label, parentList) => {
+    if (nodeMap[path]) return nodeMap[path];
+    const node = { id: path, label, path, children: [] };
+    nodeMap[path] = node;
+    parentList.push(node);
+    return node;
+  };
+
+  columnNames.forEach((fullPath) => {
+    // Split into segments: "col.a.b" → ["col","a","b"], "col[0].x" → ["col","[0]","x"]
+    const segments = [];
+    let current = "";
+    for (let i = 0; i < fullPath.length; i++) {
+      const ch = fullPath[i];
+      if (ch === ".") {
+        if (current) segments.push(current);
+        current = "";
+      } else if (ch === "[") {
+        if (current) segments.push(current);
+        current = "[";
+      } else if (ch === "]") {
+        current += "]";
+        segments.push(current);
+        current = "";
+      } else {
+        current += ch;
+      }
+    }
+    if (current) segments.push(current);
+
+    if (segments.length === 1) {
+      getOrCreate(fullPath, segments[0], roots);
+    } else {
+      // Walk segments, creating intermediate nodes
+      let parentList = roots;
+      let builtPath = "";
+      for (let i = 0; i < segments.length; i++) {
+        const sep = i === 0 ? "" : segments[i].startsWith("[") ? "" : ".";
+        builtPath += sep + segments[i];
+        const node = getOrCreate(builtPath, segments[i], parentList);
+        parentList = node.children;
+      }
+    }
+  });
+  return roots;
+}
+
+function renderTreeNode(node, onSelect) {
+  const hasKids = node.children.length > 0;
+  return (
+    <TreeItem
+      key={node.id}
+      nodeId={node.id}
+      label={
+        <Typography
+          sx={{
+            fontSize: "12px",
+            fontFamily: "monospace",
+            fontWeight: hasKids ? 600 : 400,
+            color: hasKids ? "text.primary" : "text.secondary",
+            py: 0.15,
+          }}
+          onClick={(e) => { e.stopPropagation(); onSelect(node.path); }}
+        >
+          {node.label}
+        </Typography>
+      }
+    >
+      {hasKids && node.children.map((child) => renderTreeNode(child, onSelect))}
+    </TreeItem>
+  );
+}
+
+function ColumnTreeSelect({ columnNames, value, onChange, isUnmapped }) {
+  const [open, setOpen] = useState(false);
+  const [typing, setTyping] = useState(false);
+  const anchorRef = useRef(null);
+  const tree = useMemo(() => buildTree(columnNames), [columnNames]);
+
+  // Only filter when user is actively typing, not when re-opening with a selected value
+  const filtered = useMemo(() => {
+    if (!typing || !value) return tree;
+    const q = value.toLowerCase();
+    const filterNodes = (nodes) =>
+      nodes.map((node) => {
+        if (node.path.toLowerCase().startsWith(q)) return node;
+        const kids = filterNodes(node.children);
+        if (kids.length) return { ...node, children: kids };
+        return null;
+      }).filter(Boolean);
+    return filterNodes(tree);
+  }, [tree, value, typing]);
+
+  // Collect all node IDs for default expansion
+  const allIds = useMemo(() => {
+    const ids = [];
+    const walk = (nodes) => nodes.forEach((n) => { ids.push(n.id); walk(n.children); });
+    walk(filtered);
+    return ids;
+  }, [filtered]);
+
+  const handleSelect = (path) => {
+    onChange(path);
+    setOpen(false);
+    setTyping(false);
+  };
+
+  return (
+    <Box sx={{ flex: 1 }}>
+      <TextField
+        ref={anchorRef}
+        size="small"
+        fullWidth
+        value={value}
+        placeholder="Select column"
+        onFocus={() => setOpen(true)}
+        onChange={(e) => {
+          setTyping(true);
+          onChange(e.target.value);
+          if (!open) setOpen(true);
+        }}
+        InputProps={{
+          sx: { fontSize: "12px", fontFamily: "monospace", height: 30, py: 0 },
+          endAdornment: (
+            <InputAdornment position="end">
+              <Iconify
+                icon={open ? "mdi:chevron-up" : "mdi:chevron-down"}
+                width={16}
+                sx={{ color: "text.disabled", cursor: "pointer" }}
+                onClick={() => { setOpen((p) => !p); setTyping(false); }}
+              />
+            </InputAdornment>
+          ),
+        }}
+        sx={{
+          ...(isUnmapped && {
+            "& .MuiOutlinedInput-notchedOutline": { borderColor: "warning.main" },
+          }),
+        }}
+      />
+      {open && filtered.length > 0 && (
+        <Popper
+          open
+          anchorEl={anchorRef.current}
+          placement="bottom-start"
+          style={{ zIndex: 1301, width: anchorRef.current?.offsetWidth || 240 }}
+        >
+          <ClickAwayListener onClickAway={(e) => {
+            // Don't close if clicking the input field itself
+            if (anchorRef.current?.contains(e.target)) return;
+            setOpen(false);
+            setTyping(false);
+          }}>
+            <Paper
+              elevation={8}
+              sx={{ mt: 0.5, borderRadius: "8px", border: "1px solid", borderColor: "divider" }}
+            >
+              <Box sx={{ maxHeight: 260, overflow: "auto", py: 0.5 }}>
+                <TreeView
+                  defaultExpanded={allIds}
+                  defaultCollapseIcon={<Iconify icon="mdi:chevron-down" width={14} sx={{ color: "text.disabled" }} />}
+                  defaultExpandIcon={<Iconify icon="mdi:chevron-right" width={14} sx={{ color: "text.disabled" }} />}
+                  sx={{
+                    "& .MuiTreeItem-content": { py: 0.1, borderRadius: "4px" },
+                    "& .MuiTreeItem-content:hover": { bgcolor: "action.hover" },
+                  }}
+                >
+                  {filtered.map((node) => renderTreeNode(node, handleSelect))}
+                </TreeView>
+              </Box>
+            </Paper>
+          </ClickAwayListener>
+        </Popper>
+      )}
+    </Box>
+  );
+}
+
 // Walk a JSON value and extract dot-notation keys (max 3 levels deep).
 function extractKeysFromValue(raw) {
   let parsed = null;
@@ -259,11 +447,13 @@ function extractKeysFromValue(raw) {
   const walk = (obj, prefix, depth) => {
     if (depth > 3 || !obj || typeof obj !== "object") return;
     if (Array.isArray(obj)) {
-      keys.push(`${prefix}[0]`);
-      // Walk first element to discover object keys inside arrays
-      if (obj.length && obj[0] && typeof obj[0] === "object" && !Array.isArray(obj[0])) {
-        for (const k of Object.keys(obj[0])) {
-          keys.push(`${prefix}[0].${k}`);
+      // Show first 3 indices (or less if array is shorter)
+      const count = Math.min(obj.length, 3);
+      for (let i = 0; i < count; i++) {
+        keys.push(`${prefix}[${i}]`);
+        // Recurse into each element to discover nested object keys
+        if (obj[i] && typeof obj[i] === "object") {
+          walk(obj[i], `${prefix}[${i}]`, depth + 1);
         }
       }
       return;
@@ -1344,85 +1534,16 @@ const DatasetTestMode = React.forwardRef(
                     width={14}
                     sx={{ color: "text.disabled" }}
                   />
-                  <Autocomplete
-                    size="small"
-                    freeSolo
-                    options={
-                      mapping[variable] &&
-                      !columnNames.includes(mapping[variable])
-                        ? [mapping[variable], ...columnNames]
-                        : columnNames
-                    }
-                    value={mapping[variable] || null}
-                    onChange={(_, val) =>
+                  <ColumnTreeSelect
+                    columnNames={columnNames}
+                    value={mapping[variable] || ""}
+                    onChange={(val) =>
                       setMapping((prev) => ({
                         ...prev,
                         [variable]: val || "",
                       }))
                     }
-                    onBlur={(e) => {
-                      const val = e.target.value?.trim();
-                      if (val) setMapping((prev) => ({ ...prev, [variable]: val }));
-                    }}
-                    filterOptions={(opts, { inputValue }) => {
-                      const q = inputValue.toLowerCase();
-                      if (!q) return opts.filter((o) => !o.includes(".") && !o.includes("["));
-                      const showNested = q.includes(".") || q.includes("[");
-                      return opts.filter((o) => {
-                        const lower = o.toLowerCase();
-                        if (!showNested && (lower.includes(".") || lower.includes("["))) return false;
-                        return lower.startsWith(q);
-                      });
-                    }}
-                    openOnFocus
-                    autoHighlight
-                    selectOnFocus
-                    handleHomeEndKeys
-                    isOptionEqualToValue={(opt, val) => opt === val}
-                    sx={{
-                      flex: 1,
-                      ...(isUnmapped && {
-                        "& .MuiOutlinedInput-notchedOutline": {
-                          borderColor: "warning.main",
-                        },
-                      }),
-                    }}
-                    renderInput={(params) => (
-                      <TextField
-                        {...params}
-                        placeholder="Select column (required)"
-                        InputProps={{
-                          ...params.InputProps,
-                          sx: {
-                            ...params.InputProps.sx,
-                            fontSize: "12px",
-                            fontFamily: "monospace",
-                            height: 30,
-                            py: 0,
-                          },
-                        }}
-                      />
-                    )}
-                    renderOption={(props, col) => {
-                      const { key, ...rest } = props;
-                      const isNested = col.includes(".") || col.includes("[");
-                      return (
-                        <Box
-                          component="li"
-                          key={key}
-                          {...rest}
-                          sx={{
-                            ...rest.sx,
-                            fontSize: "12px",
-                            fontFamily: "monospace",
-                            ...(isNested && { pl: 3, color: "text.secondary" }),
-                          }}
-                        >
-                          {col}
-                        </Box>
-                      );
-                    }}
-                    ListboxProps={{ style: { maxHeight: 260 } }}
+                    isUnmapped={isUnmapped}
                   />
                 </Box>
               );

--- a/frontend/src/sections/evals/components/InstructionEditor.jsx
+++ b/frontend/src/sections/evals/components/InstructionEditor.jsx
@@ -83,6 +83,21 @@ function buildDropdownOptions(datasetColumns, jsonSchemas = {}) {
         });
       }
     }
+
+    // Expand json/text columns with top-level array data
+    const colSchema = jsonSchemas?.[colId];
+    if (col.data_type !== "images" && colSchema?.max_array_count) {
+      const count = Math.min(colSchema.max_array_count, 2);
+      for (let idx = 0; idx < count; idx++) {
+        options.push({
+          id: `${colId}[${idx}]`,
+          value: `${col.name}[${idx}]`,
+          dataType: "array_index",
+          isJsonPath: true,
+          parentColumn: col.name,
+        });
+      }
+    }
   });
 
   return options;
@@ -112,6 +127,15 @@ function buildValidVariableSet(datasetColumns, jsonSchemas = {}) {
     const imagesSchema = jsonSchemas?.[colId];
     if (col.data_type === "images" && imagesSchema?.max_images_count) {
       for (let idx = 0; idx < imagesSchema.max_images_count; idx++) {
+        validSet.add(`${col.name}[${idx}]`.toLowerCase());
+      }
+    }
+
+    // Add array indexed access for json/text columns with top-level arrays
+    const colSchema = jsonSchemas?.[colId];
+    if (col.data_type !== "images" && colSchema?.max_array_count) {
+      const count = Math.min(colSchema.max_array_count, 2);
+      for (let idx = 0; idx < count; idx++) {
         validSet.add(`${col.name}[${idx}]`.toLowerCase());
       }
     }

--- a/futureagi/model_hub/utils/json_path_resolver.py
+++ b/futureagi/model_hub/utils/json_path_resolver.py
@@ -175,7 +175,27 @@ def extract_json_keys(
 
     paths = []
 
-    if isinstance(json_data, dict):
+    if isinstance(json_data, list) and json_data and prefix:
+        # Handle arrays with a known prefix (nested arrays inside objects).
+        # Top-level arrays (no prefix) are handled via max_array_count in the
+        # schema response; the frontend generates indexed options from that
+        # count so we don't emit bare "[0]" keys which would produce
+        # malformed "col.[0]" paths in the dot-join expansion loops.
+        count = min(len(json_data), 2)
+        for i in range(count):
+            if max_paths is not None and len(paths) >= max_paths:
+                break
+            array_path = f"{prefix}[{i}]"
+            paths.append(array_path)
+
+            if isinstance(json_data[i], dict):
+                remaining = max_paths - len(paths) if max_paths else None
+                sub_paths = extract_json_keys(
+                    json_data[i], array_path, max_depth - 1, remaining
+                )
+                paths.extend(sub_paths)
+
+    elif isinstance(json_data, dict):
         for key, value in json_data.items():
             # Check if we've reached the limit
             if max_paths is not None and len(paths) >= max_paths:
@@ -305,12 +325,16 @@ def extract_json_schema_for_column(sample_values: List[str]) -> dict:
     """
     all_keys = set()
     first_sample = None
+    max_array_count = 0
 
     for value in sample_values:
         parsed, is_valid = parse_json_safely(value)
         if is_valid:
             if first_sample is None:
                 first_sample = parsed
+            # Track top-level array lengths
+            if isinstance(parsed, list):
+                max_array_count = max(max_array_count, len(parsed))
             keys = extract_json_keys(parsed, max_depth=5)
             all_keys.update(keys)
 
@@ -324,7 +348,13 @@ def extract_json_schema_for_column(sample_values: List[str]) -> dict:
         if len(sample_str) < 1000:
             sample_for_storage = first_sample
 
-    return {
+    result = {
         "keys": sorted_keys,
         "sample": sample_for_storage,
     }
+
+    # Include max_array_count when column contains top-level arrays
+    if max_array_count > 0:
+        result["max_array_count"] = max_array_count
+
+    return result

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -14787,13 +14787,16 @@ def get_json_column_schemas(dataset):
         metadata = column.metadata or {}
         json_schema = metadata.get("json_schema")
 
-        if json_schema and json_schema.get("keys"):
+        if json_schema and (json_schema.get("keys") or json_schema.get("max_array_count")):
             # Use cached schema
-            result[str(column.id)] = {
+            entry = {
                 "name": column.name,
                 "keys": json_schema.get("keys", []),
                 "sample": json_schema.get("sample"),
             }
+            if json_schema.get("max_array_count"):
+                entry["max_array_count"] = json_schema["max_array_count"]
+            result[str(column.id)] = entry
         else:
             # Extract schema from cells. For text columns, check a small
             # sample first to avoid wasting time on non-JSON content.
@@ -14818,17 +14821,20 @@ def get_json_column_schemas(dataset):
             if sample_cells:
                 schema = extract_json_schema_for_column(list(sample_cells))
 
-                if schema.get("keys"):
+                if schema.get("keys") or schema.get("max_array_count"):
                     # Store schema in column metadata
                     metadata["json_schema"] = schema
                     column.metadata = metadata
                     column.save(update_fields=["metadata"])
 
-                    result[str(column.id)] = {
+                    entry = {
                         "name": column.name,
                         "keys": schema.get("keys", []),
                         "sample": schema.get("sample"),
                     }
+                    if schema.get("max_array_count"):
+                        entry["max_array_count"] = schema["max_array_count"]
+                    result[str(column.id)] = entry
 
     # Get images-type columns and calculate max_images_count
     images_columns = Column.objects.filter(


### PR DESCRIPTION
## Summary
When users type `{{` in eval or run prompt editors and their dataset column contains a top-level array (e.g. `["a", "b", "c"]` or `[{...}, {...}]`), we now suggest `col[0]`, `col[1]` so they know indexed access is available — previously this only worked for `images`-type columns. Also replaces the flat Autocomplete dropdown in the DatasetTestMode variable mapping sidebar with a hierarchical TreeView, making nested JSON paths and array indices much easier to discover and select.

### Backend
- `extract_json_keys` now handles top-level list inputs (with prefix guard to avoid malformed `col.[0]` paths in dot-join loops)
- `extract_json_schema_for_column` tracks `max_array_count` across sampled rows
- `get_json_column_schemas` passes `max_array_count` through to the API response and accepts schemas where `keys` is empty but `max_array_count` exists (plain arrays like `["a","b","c"]`)

### Frontend — RunPrompt path (`common.js`)
- `getDropdownOptionsFromCols` generates `col[0]`, `col[1]` suggestions for array columns
- `extractVariableFromAllCols` registers indexed paths for validation/coloring
- `findInvalidVariables` accepts bracket access for json/text array columns
- `replaceVariablesWithFields` maps `{{colName[0]}}` → `{{fieldId[0]}}` for array columns (collapsed with existing images logic, no duplication)

### Frontend — Evals path (`InstructionEditor.jsx`)
- `buildDropdownOptions` and `buildValidVariableSet` mirror the same array index expansion

### Frontend — DatasetTestMode sidebar (`DatasetTestMode.jsx`)
- New `ColumnTreeSelect` component with `TreeView` replaces flat `Autocomplete` for variable mapping
- `extractKeysFromValue` now discovers up to 3 array indices and recurses into each element

## Linked issues
Closes #

## Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
- Verified `extract_json_keys` returns empty keys for top-level arrays (no malformed `col.[0]` paths) and correct nested paths for dicts with arrays
- Verified `resolve_json_path` resolves `[0]`, `[1]` on top-level arrays correctly
- Verified `extract_json_schema_for_column` returns `max_array_count` for both plain arrays and arrays of objects
- Verified the `get_json_column_schemas` gate passes for plain array columns where `keys=[]` but `max_array_count>0`
- Frontend: typing `{{` in prompt editor shows `col[0]`, `col[1]` for array columns; selected variables are colored green; variable replacement maps to field IDs correctly

## Screenshots / recordings (if UI)
<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)