### PR TITLE
fix(evals): import Autocomplete in DatasetTestMode

### DIFF
--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import {
+  Autocomplete,
   Box,
   Chip,
   ClickAwayListener,


### PR DESCRIPTION
## Summary
- `DatasetTestMode.jsx` renders `<Autocomplete>` (line 1128) but the symbol was missing from the `@mui/material` import block.
- This adds `Autocomplete` to the existing import.

## Test plan
- [x] `npx eslint src/sections/evals/components/DatasetTestMode.jsx` reports 0 errors
- [ ] CI `build-check` job turns green on this branch