### PR TITLE
fix(error-feed): match Title-case fix_layer values from backend

### DIFF
--- a/frontend/src/pages/dashboard/error-feed/components/ErrorFeedFilters.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorFeedFilters.jsx
@@ -47,10 +47,10 @@ const TIME_RANGE_OPTIONS = [
 
 const FIX_LAYER_OPTIONS = [
   { value: "", label: "All Fix Layers" },
-  { value: "prompt", label: "Prompt" },
-  { value: "tools", label: "Tools" },
-  { value: "orchestration", label: "Orchestration" },
-  { value: "guardrails", label: "Guardrails" },
+  { value: "Prompt", label: "Prompt" },
+  { value: "Tools", label: "Tools" },
+  { value: "Orchestration", label: "Orchestration" },
+  { value: "Guardrails", label: "Guardrails" },
 ];
 
 // ── compact select ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix Layer filter dropdown sent lowercase values (`prompt`/`tools`/...) but the scanner persists Title-case (`Prompt`/`Tools`/...).
- Backend filter is exact-match (`qs.filter(fix_layer=...)`), so every layer silently returned 0 results.
- Updated the dropdown to send the canonical Title-case values.

## Test plan
- [ ] Open Error Feed list page
- [ ] Pick "Prompt" from the Fix Layer filter → should show issues with `fix_layer = Prompt`
- [ ] Repeat for Tools / Orchestration / Guardrails
- [ ] "All Fix Layers" still returns everything