### PR TITLE
[TH-4653] Fix Talk Ratio rendering and hide column by default

### DIFF
--- a/frontend/src/sections/agents/CallLogs/TalkRatioCell.jsx
+++ b/frontend/src/sections/agents/CallLogs/TalkRatioCell.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Box, Tooltip, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
 
 const TalkRatioCell = (params) => {
   const data = params?.data;
@@ -16,9 +17,8 @@ const TalkRatioCell = (params) => {
     );
   }
 
-  // Backend may return talk_ratio as a scalar (bot_time / user_time) from
-  // trace.py:480 or as an object {user, bot, user_pct, bot_pct} from
-  // observability_providers.py. Normalize both to userPct/botPct.
+  // talk_ratio may arrive as a scalar (bot_time / user_time) or as an object
+  // ({user, bot, user_pct, bot_pct}). Normalize both shapes to userPct/botPct.
   let userPct;
   let botPct;
   let userSec;
@@ -39,7 +39,7 @@ const TalkRatioCell = (params) => {
       : `User: ${userPct}% | Bot: ${botPct}%`;
 
   return (
-    <Tooltip title={tooltip} arrow placement="bottom">
+    <CustomTooltip title={tooltip} arrow placement="bottom" show>
       <Box
         sx={{
           display: "flex",
@@ -82,7 +82,7 @@ const TalkRatioCell = (params) => {
           {userPct}:{botPct}
         </Typography>
       </Box>
-    </Tooltip>
+    </CustomTooltip>
   );
 };
 

--- a/frontend/src/sections/agents/CallLogs/TalkRatioCell.jsx
+++ b/frontend/src/sections/agents/CallLogs/TalkRatioCell.jsx
@@ -5,7 +5,7 @@ import { Box, Tooltip, Typography } from "@mui/material";
 const TalkRatioCell = (params) => {
   const data = params?.data;
   const ratio = data?.talk_ratio;
-  if (!ratio) {
+  if (ratio == null) {
     return (
       <Typography
         variant="body2"
@@ -16,15 +16,30 @@ const TalkRatioCell = (params) => {
     );
   }
 
-  const userPct = ratio.user_pct ?? 0;
-  const botPct = ratio.bot_pct ?? 0;
+  // Backend may return talk_ratio as a scalar (bot_time / user_time) from
+  // trace.py:480 or as an object {user, bot, user_pct, bot_pct} from
+  // observability_providers.py. Normalize both to userPct/botPct.
+  let userPct;
+  let botPct;
+  let userSec;
+  let botSec;
+  if (typeof ratio === "number") {
+    botPct = Math.round((ratio / (ratio + 1)) * 100);
+    userPct = 100 - botPct;
+  } else {
+    userPct = ratio.user_pct ?? 0;
+    botPct = ratio.bot_pct ?? 0;
+    userSec = ratio.user;
+    botSec = ratio.bot;
+  }
+
+  const tooltip =
+    userSec != null || botSec != null
+      ? `User: ${userSec ?? 0}s (${userPct}%) | Bot: ${botSec ?? 0}s (${botPct}%)`
+      : `User: ${userPct}% | Bot: ${botPct}%`;
 
   return (
-    <Tooltip
-      title={`User: ${ratio.user ?? 0}s (${userPct}%) | Bot: ${ratio.bot ?? 0}s (${botPct}%)`}
-      arrow
-      placement="bottom"
-    >
+    <Tooltip title={tooltip} arrow placement="bottom">
       <Box
         sx={{
           display: "flex",

--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -640,6 +640,7 @@ export const getCallLogsColumnDefs = (
       flex: 0,
       minWidth: 120,
       cellRenderer: TalkRatioCell,
+      hide: true,
     },
 
     // ── Resources ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix `TalkRatioCell` to render correctly when the API returns `talk_ratio` as a scalar (`bot_time / user_time`). The cell only handled the legacy object shape `{user, bot, user_pct, bot_pct}`, so every row showed `0:0`. Derive `userPct`/`botPct` from the scalar via `R / (R + 1) * 100` (matches the backend's own derivation in `trace.py`). Object branch kept as a fallback for any path still emitting the old shape.
- Hide `Talk Ratio` column by default. It's mathematically equivalent to `Agent Talk %` (same metric, different units). Showing both side by side is redundant. Users can toggle it back on via the display panel.

Fixes TH-4653

## Linear Ticket
[TH-4653](https://linear.app/future-agi/issue/TH-4653/fix-overlapping-talk-ratio-and-agent-talk-percent-ui)

## Files Changed
- `frontend/src/sections/agents/CallLogs/TalkRatioCell.jsx`
- `frontend/src/sections/agents/helper.jsx`

## Test plan
- [ ] Talk Ratio column is hidden by default in agent call logs grid
- [ ] Toggle Talk Ratio on via display panel — bar renders user/bot split correctly
- [ ] Tooltip math reconciles with Agent Talk %: e.g. `talk_ratio: 2.033` → bar `33:67` → tooltip `User: 33% | Bot: 67%` → matches Agent Talk % column showing `67.0%`
- [ ] Rows with `talk_ratio: null` still render `-`
- [ ] No regression in Agent Talk % or other adjacent columns