### PR TITLE
[hotfix] fix(observe): guard against non-array filters shape in saved-view apply

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -1731,10 +1731,17 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     }
 
     // Apply filters — replace unconditionally so switching views clears stale filters.
-    const nextFilters = (activeViewConfig.filters || []).map((f) => ({
-      ...f,
-      id: f.id || getRandomId(),
-    }));
+    // Guard with Array.isArray: UsersView writes `filters` as an object
+    // ({extraFilters, dateFilter}), and that config can briefly leak into this
+    // view's apply effect during cross-tab transitions (the route change is
+    // queued in startTransition while activeViewConfig updates synchronously).
+    const rawFilters = activeViewConfig.filters;
+    const nextFilters = (Array.isArray(rawFilters) ? rawFilters : []).map(
+      (f) => ({
+        ...f,
+        id: f.id || getRandomId(),
+      }),
+    );
     if (selectedTab === "trace") {
       setPrimaryTraceFilters(nextFilters);
     } else {
@@ -1742,15 +1749,20 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     }
 
     // Apply extraFilters unconditionally (independent of compare mode).
-    setExtraFilters(activeViewConfig.extraFilters || []);
+    setExtraFilters(
+      Array.isArray(activeViewConfig.extraFilters)
+        ? activeViewConfig.extraFilters
+        : [],
+    );
 
     // Compare state — always replace, regardless of current showCompare state.
-    const nextCompareFilters = (activeViewConfig.compareFilters || []).map(
-      (f) => ({
-        ...f,
-        id: f.id || getRandomId(),
-      }),
-    );
+    const rawCompareFilters = activeViewConfig.compareFilters;
+    const nextCompareFilters = (
+      Array.isArray(rawCompareFilters) ? rawCompareFilters : []
+    ).map((f) => ({
+      ...f,
+      id: f.id || getRandomId(),
+    }));
     if (selectedTab === "trace") {
       setCompareTraceFilters(nextCompareFilters);
       if (activeViewConfig.compareDateFilter !== undefined) {


### PR DESCRIPTION
## Summary

**Hotfix to prod.** Sister PR to dev: #115. Branched directly off `main` so the diff is the single-file fix, no incidental dev commits.

```
TypeError: (activeViewConfig.filters || []).map is not a function
  at LLMTracingView.jsx:1734:58
```

Reproduces in local and prod when navigating from a Users-tab saved view to a Trace tab.

## Root cause

Two views write saved-view `config.filters` under the same key in incompatible shapes:

- `LLMTracingView.jsx:1945` — array of `{columnId, filterConfig}`
- `UsersView.jsx:335` — object `{extraFilters, dateFilter}`

`ObservePage.jsx:184` calls `setActiveViewConfig(activeConfig)` synchronously while the route navigation is queued in `startTransition`. During cross-tab transitions, LLMTracingView re-renders with the foreign Users-shape config still active and its apply effect (`:1666-1768`) crashes on `.map()` because `||` doesn't fall back when `filters` is a truthy non-array.

## Fix

Defensive `Array.isArray` guard at the apply effect for `filters`, `compareFilters`, and `extraFilters`. Falls back to `[]` when the shape doesn't match. Stops the crash; the foreign-shape config is effectively ignored, which is correct behavior (LLMTracing shouldn't try to interpret a Users view's filters anyway).

## Follow-up (not in this PR)

Harmonize the saved-view schema. UsersView should stop writing `filters: {extraFilters, dateFilter}` — move those to top-level keys (or rename) so they can't collide with LLMTracingView's array shape. Existing Users views may need a read-time normalizer.

## Files Changed

- `frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx`

## Test plan

- [ ] Navigate to `/users`, open a Users saved view, click any Trace tab → no crash, Trace view loads with empty filters
- [ ] Open a Trace-tab saved view directly → filters still apply normally (regression check)
- [ ] Toggle compare mode and switch tabs → no crash