### PR TITLE
fix(annotations): TH-4576 source_type, reviewer view-only, envelope rendering

### DIFF
--- a/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
@@ -164,8 +164,9 @@ export default function AnnotateWorkspaceView() {
   const { mutate: skipItem, isPending: isSkipping } = useSkipItem();
   const { mutate: reviewItem, isPending: isReviewing } = useReviewItem();
 
+  const requiresReview = queueDetail?.requires_review === true;
   const isPendingReview = detail?.item?.review_status === "pending_review";
-  const isReviewMode = isPendingReview && canReview;
+  const isReviewMode = isPendingReview && canReview && requiresReview;
 
   // Item is explicitly assigned to someone else (only blocks in manual-assignment mode)
   const assignedUsers = detail?.item?.assigned_users || [];
@@ -181,7 +182,14 @@ export default function AnnotateWorkspaceView() {
           .filter(Boolean)
           .join(", ") || "other annotators"
       : null;
-  const isAssignedToOther = !isReviewMode && hasAssignments && !isAssignedToMe;
+  // User cannot edit annotations when the item is assigned to someone else.
+  const cannotAnnotate = hasAssignments && !isAssignedToMe;
+  // Reviewers/managers see assigned-to-other items in read-only mode (when
+  // not actively reviewing). Other members are fully blocked.
+  const isViewOnlyForReviewer = canReview && cannotAnnotate && !isReviewMode;
+  const isBlockedAssignedToOther = !canReview && cannotAnnotate;
+  // Backwards-compatible flag passed to header for disabling Skip.
+  const isAssignedToOther = cannotAnnotate && !isReviewMode;
 
   const isSubmittingRef = useRef(false);
 
@@ -344,8 +352,9 @@ export default function AnnotateWorkspaceView() {
   }, [historyIndex, itemHistory, queueId, isFetchingNext]);
 
   const handleKeyboardSubmit = useCallback(() => {
+    if (isViewOnlyForReviewer || isBlockedAssignedToOther) return;
     labelPanelRef.current?.submit();
-  }, []);
+  }, [isViewOnlyForReviewer, isBlockedAssignedToOther]);
 
   useKeyboardShortcuts({
     onSubmit: handleKeyboardSubmit,
@@ -526,7 +535,7 @@ export default function AnnotateWorkspaceView() {
               reviewStatus={detail?.item?.review_status}
               itemId={currentItemId}
             />
-          ) : isAssignedToOther ? (
+          ) : isBlockedAssignedToOther ? (
             <Stack
               alignItems="center"
               justifyContent="center"
@@ -565,6 +574,12 @@ export default function AnnotateWorkspaceView() {
               queueId={queueId}
               itemId={currentItemId}
               onDirtyChange={handleDirtyChange}
+              readOnly={isViewOnlyForReviewer}
+              readOnlyReason={
+                isViewOnlyForReviewer
+                  ? `Assigned to ${assignedToName || "another annotator"} — view only`
+                  : null
+              }
             />
           )}
         </Box>

--- a/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
@@ -153,6 +153,8 @@ const LabelPanel = forwardRef(function LabelPanel(
     queueId,
     itemId,
     onDirtyChange,
+    readOnly = false,
+    readOnlyReason = null,
   },
   ref,
 ) {
@@ -187,6 +189,7 @@ const LabelPanel = forwardRef(function LabelPanel(
 
   const handleChange = useCallback(
     (labelId, value) => {
+      if (readOnly) return;
       setValues((prev) => {
         const next = { ...prev, [labelId]: value };
         valuesRef.current = next;
@@ -200,10 +203,11 @@ const LabelPanel = forwardRef(function LabelPanel(
       });
       onDirtyChange?.(true);
     },
-    [onDirtyChange],
+    [onDirtyChange, readOnly],
   );
 
   const handleSubmit = useCallback(() => {
+    if (readOnly) return;
     // Flush any pending debounced text inputs so valuesRef is up-to-date
     Object.values(textFlushRefs.current).forEach((r) => r?.flush?.());
 
@@ -247,7 +251,7 @@ const LabelPanel = forwardRef(function LabelPanel(
       onDirtyChange?.(false);
       onSubmit({ annotations: annotationsList, notes });
     }
-  }, [notes, onSubmit, labels, onDirtyChange]);
+  }, [notes, onSubmit, labels, onDirtyChange, readOnly]);
 
   useImperativeHandle(ref, () => ({ submit: handleSubmit }), [handleSubmit]);
 
@@ -271,6 +275,9 @@ const LabelPanel = forwardRef(function LabelPanel(
         setShowShortcuts((p) => !p);
         return;
       }
+
+      // In read-only mode, only the help overlay shortcut is allowed.
+      if (readOnly) return;
 
       // Tab / Shift+Tab → navigate labels
       if (e.key === "Tab") {
@@ -340,7 +347,7 @@ const LabelPanel = forwardRef(function LabelPanel(
 
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [labels, focusedIndex, values, handleChange]);
+  }, [labels, focusedIndex, values, handleChange, readOnly]);
 
   return (
     <Box
@@ -355,6 +362,32 @@ const LabelPanel = forwardRef(function LabelPanel(
     >
       {showShortcuts && (
         <ShortcutsOverlay onClose={() => setShowShortcuts(false)} />
+      )}
+
+      {readOnly && readOnlyReason && (
+        <Box
+          sx={{
+            mb: 2,
+            px: 1.5,
+            py: 1,
+            borderRadius: 0.5,
+            bgcolor: "action.hover",
+            border: "1px solid",
+            borderColor: "divider",
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+          }}
+        >
+          <Iconify
+            icon="mingcute:lock-fill"
+            width={16}
+            sx={{ color: "text.secondary" }}
+          />
+          <Typography variant="caption" color="text.secondary">
+            {readOnlyReason}
+          </Typography>
+        </Box>
       )}
 
       {/* Shortcuts toggle + Instructions row */}
@@ -438,13 +471,22 @@ const LabelPanel = forwardRef(function LabelPanel(
       )}
 
       {/* Label inputs */}
-      <Stack spacing={2} sx={{ flex: 1 }}>
+      <Stack
+        spacing={2}
+        sx={{
+          flex: 1,
+          ...(readOnly && {
+            pointerEvents: "none",
+            opacity: 0.7,
+          }),
+        }}
+      >
         {labels.map((ql, i) => {
           const labelId = ql.label_id;
           return (
             <Box
               key={ql.id}
-              onClick={() => setFocusedIndex(i)}
+              onClick={() => !readOnly && setFocusedIndex(i)}
               sx={{ cursor: "default" }}
             >
               <LabelInput
@@ -484,9 +526,11 @@ const LabelPanel = forwardRef(function LabelPanel(
           placeholder="Notes (optional)"
           value={notes}
           onChange={(e) => {
+            if (readOnly) return;
             setNotes(e.target.value);
             onDirtyChange?.(true);
           }}
+          InputProps={{ readOnly }}
           sx={{ "& .MuiOutlinedInput-root": { borderRadius: 0.5 } }}
         />
       </Box>
@@ -494,24 +538,28 @@ const LabelPanel = forwardRef(function LabelPanel(
       {/* Annotation History */}
       <AnnotationHistory queueId={queueId} itemId={itemId} />
 
-      {/* Submit */}
-      <Tooltip title="Ctrl+Enter" placement="top">
-        <span>
-          <Button
-            variant="contained"
-            fullWidth
-            color="primary"
-            sx={{ mt: 2 }}
-            onClick={handleSubmit}
-            disabled={isPending || !hasValues}
-            startIcon={
-              isPending ? <CircularProgress size={16} color="inherit" /> : null
-            }
-          >
-            Submit & Next
-          </Button>
-        </span>
-      </Tooltip>
+      {/* Submit (hidden in read-only mode) */}
+      {!readOnly && (
+        <Tooltip title="Ctrl+Enter" placement="top">
+          <span>
+            <Button
+              variant="contained"
+              fullWidth
+              color="primary"
+              sx={{ mt: 2 }}
+              onClick={handleSubmit}
+              disabled={isPending || !hasValues}
+              startIcon={
+                isPending ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : null
+              }
+            >
+              Submit & Next
+            </Button>
+          </span>
+        </Tooltip>
+      )}
     </Box>
   );
 });
@@ -525,6 +573,8 @@ LabelPanel.propTypes = {
   queueId: PropTypes.string,
   itemId: PropTypes.string,
   onDirtyChange: PropTypes.func,
+  readOnly: PropTypes.bool,
+  readOnlyReason: PropTypes.string,
 };
 
 export default LabelPanel;

--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -535,25 +535,9 @@ export default function AddItemsDialog({ open, onClose, queueId }) {
           setIsResolving(false);
         }
       } else {
-        let ids = Array.from(selectedIds);
-        let effectiveSourceType = sourceType;
-
-        if (sourceType === "trace") {
-          const rootSpanMap = await fetchRootSpans(ids);
-          const originalCount = ids.length;
-          ids = ids.map((traceId) => rootSpanMap[traceId]).filter(Boolean);
-          effectiveSourceType = "observation_span";
-          const droppedCount = originalCount - ids.length;
-          if (droppedCount > 0) {
-            enqueueSnackbar(
-              `${droppedCount} trace${droppedCount !== 1 ? "s" : ""} skipped — no root span found yet`,
-              { variant: "warning" },
-            );
-          }
-        }
-
+        const ids = Array.from(selectedIds);
         itemsToAdd = ids.map((id) => ({
-          source_type: effectiveSourceType,
+          source_type: sourceType,
           source_id: id,
         }));
       }

--- a/frontend/src/sections/common/DatapointCard.jsx
+++ b/frontend/src/sections/common/DatapointCard.jsx
@@ -21,6 +21,10 @@ import GenerateDiffText from "./GenerateDiffText";
 import CustomJsonViewer from "src/components/custom-json-viewer/CustomJsonViewer";
 import CellMarkdown from "./CellMarkdown";
 import CustomTooltip from "src/components/tooltip";
+import {
+  parseAnnotationValue,
+  renderAnnotationValue,
+} from "./DevelopCellRenderer/AnnotationCellRenderer/renderAnnotationValue";
 const DatapointCard = ({
   value,
   column,
@@ -133,7 +137,30 @@ const DatapointCard = ({
     return null;
   }, [value?.valueInfos]);
 
+  const isAnnotationColumn = column?.originType === "annotation_label";
+
+  // Annotation cells store the typed envelope (e.g. {"selected":[...]},
+  // {"value":"up"}, {"rating":4}). Pull out the primitive once so the rest
+  // of the card (raw tab, copy, float-as-% formatting) sees the user-facing
+  // value rather than the envelope JSON.
+  const annotationUnwrapped = useMemo(() => {
+    if (!isAnnotationColumn) return undefined;
+    const parsed = parseAnnotationValue(value?.cellValue);
+    if (Array.isArray(parsed)) return JSON.stringify(parsed);
+    if (parsed && typeof parsed === "object") {
+      if (Array.isArray(parsed.selected))
+        return JSON.stringify(parsed.selected);
+      if (typeof parsed.rating === "number") return String(parsed.rating);
+      if (typeof parsed.value === "string" || typeof parsed.value === "number")
+        return String(parsed.value);
+      if (typeof parsed.text === "string") return parsed.text;
+      return value?.cellValue;
+    }
+    return parsed == null ? "" : String(parsed);
+  }, [isAnnotationColumn, value?.cellValue]);
+
   const formattedValue = useMemo(() => {
+    if (isAnnotationColumn) return annotationUnwrapped;
     if (dataType === "float") {
       return `${getScorePercentage(parseFloat(value?.cellValue) * 10)}%`;
     }
@@ -142,7 +169,12 @@ const DatapointCard = ({
       return isNaN(date.getTime()) ? value?.cellValue : date.toLocaleString();
     }
     return value?.cellValue;
-  }, [value?.cellValue, dataType]);
+  }, [value?.cellValue, dataType, isAnnotationColumn, annotationUnwrapped]);
+
+  const annotationContent = useMemo(
+    () => (isAnnotationColumn ? renderAnnotationValue(value?.cellValue, theme) : null),
+    [isAnnotationColumn, value?.cellValue, theme],
+  );
   const parsedJson = useMemo(() => {
     if (!isJsonValue(formattedValue)) return null;
     try {
@@ -412,6 +444,14 @@ const DatapointCard = ({
                       >
                         <ShowComponent
                           condition={
+                            isAnnotationColumn && annotationContent !== null
+                          }
+                        >
+                          {annotationContent}
+                        </ShowComponent>
+                        <ShowComponent
+                          condition={
+                            !isAnnotationColumn &&
                             column?.originType === "run_prompt" &&
                             isJsonValue(formattedValue) &&
                             parsedJson !== null
@@ -424,6 +464,7 @@ const DatapointCard = ({
                         </ShowComponent>
                         <ShowComponent
                           condition={
+                            !isAnnotationColumn &&
                             !(
                               column?.originType === "run_prompt" &&
                               isJsonValue(formattedValue) &&

--- a/frontend/src/sections/common/DevelopCellRenderer/AnnotationCellRenderer/AnnotationCellRenderer.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/AnnotationCellRenderer/AnnotationCellRenderer.jsx
@@ -1,17 +1,13 @@
-import { Box, Chip, useTheme } from "@mui/material";
-import React, { useMemo } from "react";
+import { Box, useTheme } from "@mui/material";
+import React from "react";
 import PropTypes from "prop-types";
 import RenderAnnotationInfo from "./RenderAnnotationInfo";
+import { renderAnnotationValue } from "./renderAnnotationValue";
 
 const AnnotationCellRenderer = ({ value, annotationData }) => {
   const theme = useTheme();
-  const finalArray = useMemo(() => {
-    try {
-      return JSON.parse(value?.replaceAll("'", '"'));
-    } catch (e) {
-      return [];
-    }
-  }, [value]);
+  const inner = renderAnnotationValue(value, theme);
+  if (inner === null) return null;
 
   return (
     <Box
@@ -30,22 +26,11 @@ const AnnotationCellRenderer = ({ value, annotationData }) => {
           display: "flex",
           gap: 1,
           flexWrap: "wrap",
+          alignItems: "center",
           overflow: "hidden",
         }}
       >
-        {finalArray?.map((item) => (
-          <Chip
-            key={item}
-            label={item}
-            size="small"
-            color="primary"
-            sx={{
-              backgroundColor: theme.palette.action.hover,
-              color: theme.palette.primary.main,
-              fontWeight: 400,
-            }}
-          />
-        ))}
+        {inner}
       </Box>
       <RenderAnnotationInfo annotationData={annotationData} />
     </Box>

--- a/frontend/src/sections/common/DevelopCellRenderer/AnnotationCellRenderer/renderAnnotationValue.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/AnnotationCellRenderer/renderAnnotationValue.jsx
@@ -1,0 +1,82 @@
+import { Chip, Stack } from "@mui/material";
+import React from "react";
+import Iconify from "src/components/iconify";
+
+const STAR_MAX = 5;
+
+export const parseAnnotationValue = (value) => {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "string" || !value) return value;
+  try {
+    return JSON.parse(value.replaceAll("'", '"'));
+  } catch {
+    return value;
+  }
+};
+
+const renderChips = (items, theme) =>
+  items.map((item) => (
+    <Chip
+      key={item}
+      label={item}
+      size="small"
+      color="primary"
+      sx={{
+        backgroundColor: theme.palette.action.hover,
+        color: theme.palette.primary.main,
+        fontWeight: 400,
+      }}
+    />
+  ));
+
+export const renderAnnotationValue = (value, theme) => {
+  const parsed = parseAnnotationValue(value);
+
+  if (Array.isArray(parsed)) return renderChips(parsed, theme);
+
+  if (parsed && typeof parsed === "object") {
+    if (Array.isArray(parsed.selected))
+      return renderChips(parsed.selected, theme);
+
+    if (typeof parsed.rating === "number") {
+      return (
+        <Stack direction="row" spacing={0.25} alignItems="center">
+          {Array.from({ length: STAR_MAX }, (_, i) => {
+            const filled = i + 1 <= parsed.rating;
+            return (
+              <Iconify
+                key={i}
+                icon={filled ? "solar:star-bold" : "solar:star-line-duotone"}
+                width={18}
+                sx={{ color: filled ? "#ef4444" : "text.disabled" }}
+              />
+            );
+          })}
+        </Stack>
+      );
+    }
+
+    if (parsed.value === "up" || parsed.value === "down") {
+      const isUp = parsed.value === "up";
+      return (
+        <Iconify
+          icon={isUp ? "solar:like-bold" : "solar:dislike-bold"}
+          width={20}
+          sx={{ color: isUp ? "#22c55e" : "#ef4444" }}
+        />
+      );
+    }
+
+    if (typeof parsed.value === "number" || typeof parsed.value === "string") {
+      return String(parsed.value);
+    }
+
+    if (typeof parsed.text === "string") return parsed.text;
+
+    return null;
+  }
+
+  if (parsed === null || parsed === undefined || parsed === "") return null;
+
+  return String(parsed);
+};

--- a/frontend/src/sections/common/DevelopCellRenderer/CustomCellRender.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CustomCellRender.jsx
@@ -335,11 +335,30 @@ const CustomCellRender = (props) => {
     );
   }
 
-  if (
-    originType === OriginTypes.ANNOTATION_LABEL &&
-    dataType === DataTypes.ARRAY
-  ) {
-    return <AnnotationArrayCellRenderer value={value} cellData={cellData} />;
+  if (originType === OriginTypes.ANNOTATION_LABEL) {
+    if (dataType === DataTypes.ARRAY) {
+      return <AnnotationArrayCellRenderer value={value} cellData={cellData} />;
+    }
+    if (typeof value === "string" && value.trim().startsWith("{")) {
+      let parsedEnvelope = null;
+      try {
+        parsedEnvelope = JSON.parse(value.replaceAll("'", '"'));
+      } catch {
+        parsedEnvelope = null;
+      }
+      if (
+        parsedEnvelope &&
+        typeof parsedEnvelope === "object" &&
+        ("selected" in parsedEnvelope ||
+          "rating" in parsedEnvelope ||
+          "value" in parsedEnvelope ||
+          "text" in parsedEnvelope)
+      ) {
+        return (
+          <AnnotationArrayCellRenderer value={value} cellData={cellData} />
+        );
+      }
+    }
   }
 
   switch (dataType) {

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -2157,27 +2157,23 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             .select_related("label")
             .order_by("order")
         )
-        # For items pending review, return all annotations so reviewers
-        # can see the annotator's submitted values. Only expose to users
-        # with reviewer or manager role to prevent information leaks.
+        # Reviewers and managers always see every annotator's scores —
+        # the role is the privacy boundary, and view-only mode would be
+        # useless without the values it's trying to display. Regular
+        # annotators only see their own scores.
         is_reviewer = AnnotationQueueAnnotator.objects.filter(
             queue_id=queue_id,
             user=request.user,
             role__in=[AnnotatorRole.REVIEWER.value, AnnotatorRole.MANAGER.value],
             deleted=False,
         ).exists()
-        review_status_pending = "pending_review"
-        if item.review_status == review_status_pending and is_reviewer:
-            annotations = Score.objects.filter(
-                queue_item=item,
-                deleted=False,
-            ).select_related("label")
-        else:
-            annotations = Score.objects.filter(
-                queue_item=item,
-                annotator=request.user,
-                deleted=False,
-            ).select_related("label")
+        annotations_qs = Score.objects.filter(
+            queue_item=item,
+            deleted=False,
+        ).select_related("label")
+        if not is_reviewer:
+            annotations_qs = annotations_qs.filter(annotator=request.user)
+        annotations = annotations_qs
 
         # Compute overall progress (all items in queue, unfiltered).
         progress_qs = QueueItem.objects.filter(queue_id=queue_id, deleted=False)
@@ -2209,14 +2205,21 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             ),
         )
 
-        # Adjacent items for prefetching — only items the user can annotate
-        # (assigned to them, or unassigned)
-        annotatable_qs = QueueItem.objects.filter(
-            queue_id=queue_id, deleted=False
-        ).filter(
-            Q(assignments__user=request.user, assignments__deleted=False)
-            | ~Q(assignments__deleted=False)
-        )
+        # Adjacent items for prefetching — items the user can annotate
+        # (assigned to them, or unassigned). Reviewers/managers also get
+        # items assigned to others, so they can navigate the full queue
+        # in view-only mode.
+        if is_reviewer:
+            annotatable_qs = QueueItem.objects.filter(
+                queue_id=queue_id, deleted=False
+            )
+        else:
+            annotatable_qs = QueueItem.objects.filter(
+                queue_id=queue_id, deleted=False
+            ).filter(
+                Q(assignments__user=request.user, assignments__deleted=False)
+                | ~Q(assignments__deleted=False)
+            )
         next_item = (
             annotatable_qs.filter(order__gt=item.order)
             .order_by("order", "created_at")


### PR DESCRIPTION
## Summary

- **TH-4576**: Stop converting trace queue items into their root span on add — items without a root span were silently dropped. Items now keep `source_type="trace"` and the backend handles them end-to-end.
- **Reviewer view-only mode** for the annotate workspace: reviewers/managers can now open items assigned to others and see the existing scores in a read-only label panel. Backend `annotate_detail` always returns every annotator's `Score` to reviewers (was gated on `review_status == "pending_review"`) and lets them navigate the full queue.
- **Envelope rendering** in the dataset grid + datapoint drawer: cells exported from annotation queues hold the typed `Score.value` envelope (`{"selected":[…]}`, `{"rating":N}`, `{"value":"up"/"down"}`, `{"value":N}`, `{"text":…}`). They now render as chips / stars / thumbs icons / unwrapped primitives instead of raw JSON, via a shared `renderAnnotationValue` helper.

## Test plan

- [ ] Add a queue item from a trace that has no root span yet → row appears in the queue (TH-4576).
- [ ] As a reviewer, open an item assigned to another annotator: label panel shows their submitted values in read-only mode with the lock banner; previous/next navigation works.
- [ ] Export an annotated queue to a dataset → grid renders chips for categorical, 5-star row for stars, like/dislike icons for thumbs, plain text/number for text and numeric labels.
- [ ] Open the datapoint drawer on the same row → Markdown tab shows the same widgets, Raw tab shows the unwrapped primitive (no `NaN%`).

Refs: TH-4576