### PR TITLE
chore(frontend): enable Vite HMR in docker-compose dev overlay

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,8 @@
 # Dev overlay — for Future AGI engineers, not external OSS users.
 #
 # Adds to docker-compose.yml:
-#   - volume mounts for hot reload (backend + worker)
+#   - volume mounts for hot reload (frontend + backend + worker)
+#   - frontend runs Vite dev server (HMR) instead of the nginx prod bundle
 #   - per-queue workers (tasks_s / tasks_l / tasks_xl / trace_ingestion /
 #     agent_compass) so queue-specific behavior can be tested
 #   - Temporal UI + admin tools
@@ -39,6 +40,28 @@ services:
   # --------------------------------------------------------------------------
   # Hot reload — replace the built-in code with live-mounted source
   # --------------------------------------------------------------------------
+
+  frontend:
+    build:
+      # Use the dev stage from frontend/Dockerfile (node + deps, no nginx).
+      target: dev
+    # Bind-mount source for HMR; anonymous volume preserves the image's
+    # node_modules so we don't need a host-side `yarn install`. If you change
+    # package.json, rebuild: `docker compose build frontend`.
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    ports: !override
+      - "${FRONTEND_PORT:-3000}:3000"
+    environment:
+      # Required on macOS/Windows: Docker bind mounts don't propagate FS
+      # events into the container, so Vite's chokidar watcher needs polling
+      # to see edits. Costs a bit of CPU; remove if you're on Linux.
+      VITE_USE_POLLING: "true"
+      # Vite reads VITE_* from process.env at startup in dev mode.
+      VITE_HOST_API: ${VITE_HOST_API:-http://localhost:8000}
+      VITE_ENVIRONMENT: ${VITE_ENVIRONMENT:-development}
+      VITE_GOOGLE_SITE_KEY: ${VITE_GOOGLE_SITE_KEY:-}
 
   backend:
     volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,6 +18,17 @@ RUN yarn install
 COPY . ./
 RUN yarn build
 
+# Stage 1b (dev only): live Vite dev server for hot reload. Selected via
+# `target: dev` in docker-compose.dev.yml. Source is bind-mounted at runtime;
+# this stage just provides node + a baked-in node_modules so HMR works without
+# a host-side `yarn install`.
+FROM node:20.17 AS dev
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install
+EXPOSE 3000
+CMD ["yarn", "dev", "--host", "--port", "3000"]
+
 # Stage 2: Serve the React app with Nginx
 FROM nginx:alpine
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -81,6 +81,13 @@ export default defineConfig({
     hmr: {
       overlay: false,
     },
+    // Polling watcher — Docker bind mounts on macOS/Windows don't deliver
+    // inotify events to the container, so chokidar's default (FS events)
+    // misses host edits. Enabled only when VITE_USE_POLLING is set so
+    // host-native dev keeps the cheap event-based watcher.
+    watch: process.env.VITE_USE_POLLING
+      ? { usePolling: true, interval: 100 }
+      : undefined,
     headers: {
       // Prevent Clickjacking
       "X-Frame-Options": "DENY",


### PR DESCRIPTION
## Summary

- Adds a `dev` stage to `frontend/Dockerfile` that runs `yarn dev --host --port 3000` instead of the nginx prod bundle, with `node_modules` baked in so contributors don't need a host-side `yarn install`.
- Wires the new stage into `docker-compose.dev.yml` via `target: dev`, bind-mounts `./frontend` for live source, and uses an anonymous volume for `/app/node_modules` so the image's deps win over the host's. Forwards `VITE_HOST_API`, `VITE_ENVIRONMENT`, and `VITE_GOOGLE_SITE_KEY` so the dev server matches the prod build's env contract.
- Opts Vite's chokidar watcher into polling when `VITE_USE_POLLING=true` (set by the dev overlay). Docker bind mounts on macOS/Windows don't propagate inotify events into the container, so the default FS-event watcher silently misses host edits — polling is the standard workaround. Host-native dev keeps the cheap event-based watcher because the env var is unset.

## Why

Until now `docker-compose.dev.yml` rebuilt the prod nginx bundle for the frontend, so any UI change required a full image rebuild. Backend/worker already had hot reload via volume mounts; this brings the frontend in line so the full dev loop is edit → save → see-it-in-browser.

## Test plan

- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml up frontend` boots the Vite dev server on `http://localhost:3000`
- [x] Editing a file under `frontend/src/` triggers HMR in the browser within ~1s (verified on macOS, where polling is required)
- [x] `package.json` change → `docker compose build frontend` picks up new deps
- [x] Prod path unaffected: `docker compose build frontend` without the dev overlay still produces the nginx image (default target)
- [x] `VITE_HOST_API` / `VITE_ENVIRONMENT` are readable from the running app