### PR TITLE
fix(tracer): include LiveKit raw trace attributes in dashboard

### DIFF
--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -1570,6 +1570,9 @@ export default function WidgetEditorView() {
     return map[type] || type;
   };
 
+  const toAttributeType = (dataType) =>
+    dataType === "number" ? "number" : "string";
+
   const buildMetricPayload = (m, i) => {
     const backendType = toBackendType(m.type);
     const aggregation =
@@ -1595,6 +1598,7 @@ export default function WidgetEditorView() {
       if (m.outputType) base.output_type = m.outputType;
     } else if (backendType === "custom_attribute") {
       base.attribute_key = m.id;
+      base.attribute_type = toAttributeType(m.dataType);
     } else if (backendType === "custom_column") {
       base.column_id = m.id;
       if (m.columnDataType) base.data_type = m.columnDataType;
@@ -1627,7 +1631,7 @@ export default function WidgetEditorView() {
       source: f.source || "traces",
     };
     if (backendType === "custom_attribute") {
-      base.attribute_type = "string";
+      base.attribute_type = toAttributeType(f.dataType);
     }
     if (backendType === "eval_metric" && f.outputType) {
       base.output_type = f.outputType;
@@ -1645,7 +1649,7 @@ export default function WidgetEditorView() {
       source: b.source || "traces",
     };
     if (backendType === "custom_attribute") {
-      base.attribute_type = "string";
+      base.attribute_type = toAttributeType(b.dataType);
     }
     if (backendType === "annotation_metric") {
       base.label_id = b.id;
@@ -1841,6 +1845,7 @@ export default function WidgetEditorView() {
         id: option.id,
         name: option.name,
         type: option.type,
+        dataType: option.dataType || "string",
         source: option.source || "traces",
         outputType: option.outputType,
       };

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -10,7 +10,7 @@ Supports four metric types:
 - **system_metric** -- columns on the ``spans`` table (latency, tokens, cost, etc.)
 - **eval_metric** -- aggregates from ``tracer_eval_logger FINAL``
 - **annotation_metric** -- aggregates from ``model_hub_score FINAL``
-- **custom_attribute** -- ``span_attr_num`` / ``span_attr_str`` map columns on ``spans``
+- **custom_attribute** -- typed maps on ``spans`` with raw JSON fallback
 """
 
 import logging
@@ -33,6 +33,40 @@ def _sanitize_attr_key(key: str) -> str:
     if not key or not _SAFE_ATTR_KEY_RE.match(key):
         raise ValueError(f"Invalid attribute key: {key!r}")
     return key
+
+
+def _span_col(column: str, table_alias: Optional[str] = None) -> str:
+    return f"{table_alias}.{column}" if table_alias else column
+
+
+def _custom_attr_value_expr(
+    attr_key: str,
+    attr_type: str = "string",
+    table_alias: Optional[str] = None,
+    raw_attrs_expr: Optional[str] = None,
+) -> str:
+    if raw_attrs_expr:
+        raw_expr = raw_attrs_expr
+    else:
+        raw_attrs = _span_col("span_attributes_raw", table_alias)
+        raw_expr = (
+            f"if({raw_attrs} != '{{}}' AND {raw_attrs} != '', {raw_attrs}, '{{}}')"
+        )
+
+    if attr_type == "number":
+        typed_map = _span_col("span_attr_num", table_alias)
+        return (
+            f"if(mapContains({typed_map}, '{attr_key}'), "
+            f"{typed_map}['{attr_key}'], "
+            f"JSONExtractFloat({raw_expr}, '{attr_key}'))"
+        )
+
+    typed_map = _span_col("span_attr_str", table_alias)
+    return (
+        f"if(mapContains({typed_map}, '{attr_key}'), "
+        f"{typed_map}['{attr_key}'], "
+        f"JSONExtractString({raw_expr}, '{attr_key}'))"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -671,7 +705,8 @@ class DashboardQueryBuilder:
             elif bd_type == "custom_attribute":
                 need_spans_join = True
                 attr_key = _sanitize_attr_key(bd_name)
-                bd_expr = f"if(s.span_attr_str['{attr_key}'] != '', s.span_attr_str['{attr_key}'], '(not set)')"
+                attr_expr = _custom_attr_value_expr(attr_key, "string", "s")
+                bd_expr = f"if({attr_expr} != '', {attr_expr}, '(not set)')"
 
             else:
                 bd_expr = "'(not set)'"
@@ -734,9 +769,9 @@ class DashboardQueryBuilder:
             elif f_type == "custom_attribute":
                 need_spans_join = True
                 attr_key = _sanitize_attr_key(f_name)
-                where_parts.append(
-                    f"s.span_attr_str['{attr_key}'] {op_symbol} %({val_key})s"
-                )
+                attr_type = f.get("attribute_type", "string")
+                col = _custom_attr_value_expr(attr_key, attr_type, "s")
+                where_parts.append(f"{col} {op_symbol} %({val_key})s")
                 params[val_key] = _coerce_filter_value(val, op)
 
         # --- Build JOINs ---
@@ -893,18 +928,9 @@ class DashboardQueryBuilder:
             "if(span_attributes_raw != '{}' AND span_attributes_raw != '', "
             "span_attributes_raw, ifNull(os.span_attributes, '{}'))"
         )
-        if attr_type == "number":
-            col_expr = (
-                f"if(mapContains(span_attr_num, '{attr_key}'), "
-                f"span_attr_num['{attr_key}'], "
-                f"JSONExtractFloat({raw_attr_expr}, '{attr_key}'))"
-            )
-        else:
-            col_expr = (
-                f"if(mapContains(span_attr_str, '{attr_key}'), "
-                f"span_attr_str['{attr_key}'], "
-                f"JSONExtractString({raw_attr_expr}, '{attr_key}'))"
-            )
+        col_expr = _custom_attr_value_expr(
+            attr_key, attr_type, raw_attrs_expr=raw_attr_expr
+        )
 
         agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
 
@@ -1149,11 +1175,7 @@ class DashboardQueryBuilder:
             elif bd_type == "custom_attribute":
                 safe_name = _sanitize_attr_key(bd_name)
                 attr_type = bd.get("attribute_type", "string")
-                expr = (
-                    f"span_attr_num['{safe_name}']"
-                    if attr_type == "number"
-                    else f"span_attr_str['{safe_name}']"
-                )
+                expr = _custom_attr_value_expr(safe_name, attr_type)
                 result.append({"type": "column", "expr": expr, "join": None})
 
             elif bd_type == "annotation_metric":
@@ -1386,10 +1408,7 @@ class DashboardQueryBuilder:
                 op = f.get("operator", "")
                 val = f.get("value")
                 attr_type = f.get("attribute_type", "string")
-                if attr_type == "number":
-                    col = f"span_attr_num['{f_name}']"
-                else:
-                    col = f"span_attr_str['{f_name}']"
+                col = _custom_attr_value_expr(f_name, attr_type)
 
                 if op in ("is_set", "is_not_set", "is_numeric", "is_not_numeric"):
                     op_tpl = FILTER_OPERATORS.get(op)

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -889,10 +889,22 @@ class DashboardQueryBuilder:
         attr_key = _sanitize_attr_key(metric.get("attribute_key", ""))
         attr_type = metric.get("attribute_type", "number")
 
+        raw_attr_expr = (
+            "if(span_attributes_raw != '{}' AND span_attributes_raw != '', "
+            "span_attributes_raw, ifNull(os.span_attributes, '{}'))"
+        )
         if attr_type == "number":
-            col_expr = f"span_attr_num['{attr_key}']"
+            col_expr = (
+                f"if(mapContains(span_attr_num, '{attr_key}'), "
+                f"span_attr_num['{attr_key}'], "
+                f"JSONExtractFloat({raw_attr_expr}, '{attr_key}'))"
+            )
         else:
-            col_expr = f"span_attr_str['{attr_key}']"
+            col_expr = (
+                f"if(mapContains(span_attr_str, '{attr_key}'), "
+                f"span_attr_str['{attr_key}'], "
+                f"JSONExtractString({raw_attr_expr}, '{attr_key}'))"
+            )
 
         agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
 
@@ -924,6 +936,17 @@ class DashboardQueryBuilder:
         query = (
             f"SELECT {', '.join(select_parts)}\n"
             f"FROM spans\n"
+            f"LEFT JOIN (\n"
+            f"    SELECT id, span_attributes\n"
+            f"    FROM tracer_observation_span FINAL\n"
+            f"    PREWHERE project_id IN %(project_ids)s\n"
+            f"    WHERE _peerdb_is_deleted = 0\n"
+            f"      AND start_time >= %(start_date)s\n"
+            f"      AND start_time < %(end_date)s\n"
+            f"      AND span_attributes != '{{}}'\n"
+            f"      AND span_attributes != ''\n"
+            f"      AND JSONHas(span_attributes, '{attr_key}')\n"
+            f") AS os ON os.id = spans.id\n"
             f"WHERE {' AND '.join(all_where)}\n"
             f"GROUP BY {', '.join(group_parts)}\n"
             f"ORDER BY {', '.join(order_parts)}"

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -69,6 +69,15 @@ def _custom_attr_value_expr(
     )
 
 
+def _normalize_attr_type(attr_type: Optional[str]) -> str:
+    normalized = (attr_type or "string").lower()
+    if normalized in ("number", "numeric", "float", "integer", "int"):
+        return "number"
+    if normalized in ("bool", "boolean"):
+        return "boolean"
+    return "string"
+
+
 # ---------------------------------------------------------------------------
 # Metric resolution tables
 # ---------------------------------------------------------------------------
@@ -769,7 +778,7 @@ class DashboardQueryBuilder:
             elif f_type == "custom_attribute":
                 need_spans_join = True
                 attr_key = _sanitize_attr_key(f_name)
-                attr_type = f.get("attribute_type", "string")
+                attr_type = _normalize_attr_type(f.get("attribute_type", "string"))
                 col = _custom_attr_value_expr(attr_key, attr_type, "s")
                 where_parts.append(f"{col} {op_symbol} %({val_key})s")
                 params[val_key] = _coerce_filter_value(val, op)
@@ -922,7 +931,11 @@ class DashboardQueryBuilder:
         params: dict,
     ) -> Tuple[str, dict]:
         attr_key = _sanitize_attr_key(metric.get("attribute_key", ""))
-        attr_type = metric.get("attribute_type", "number")
+        attr_type = _normalize_attr_type(
+            metric.get("attribute_type")
+            or metric.get("data_type")
+            or metric.get("dataType")
+        )
 
         raw_attr_expr = (
             "if(span_attributes_raw != '{}' AND span_attributes_raw != '', "
@@ -932,7 +945,12 @@ class DashboardQueryBuilder:
             attr_key, attr_type, raw_attrs_expr=raw_attr_expr
         )
 
-        agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
+        if attr_type == "number":
+            agg_expr = AGGREGATIONS.get(aggregation, "avg({col})").format(col=col_expr)
+        elif aggregation == "count_distinct":
+            agg_expr = f"uniqIf({col_expr}, {col_expr} != '')"
+        else:
+            agg_expr = f"countIf({col_expr} != '')"
 
         select_parts = [f"{bucket_fn}(start_time) AS time_bucket"]
         group_parts = ["time_bucket"]
@@ -1174,7 +1192,7 @@ class DashboardQueryBuilder:
 
             elif bd_type == "custom_attribute":
                 safe_name = _sanitize_attr_key(bd_name)
-                attr_type = bd.get("attribute_type", "string")
+                attr_type = _normalize_attr_type(bd.get("attribute_type", "string"))
                 expr = _custom_attr_value_expr(safe_name, attr_type)
                 result.append({"type": "column", "expr": expr, "join": None})
 
@@ -1407,7 +1425,7 @@ class DashboardQueryBuilder:
                 f_name = _sanitize_attr_key(f.get("metric_name", ""))
                 op = f.get("operator", "")
                 val = f.get("value")
-                attr_type = f.get("attribute_type", "string")
+                attr_type = _normalize_attr_type(f.get("attribute_type", "string"))
                 col = _custom_attr_value_expr(f_name, attr_type)
 
                 if op in ("is_set", "is_not_set", "is_numeric", "is_not_numeric"):

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -800,6 +800,29 @@ class TestDashboardQueryBuilder:
         assert "PREWHERE project_id IN %(project_ids)s" in sql
         assert "JSONHas(span_attributes, 'customer.tier')" in sql
 
+    def test_custom_attribute_text_metric_without_type_counts_values(self):
+        config = {
+            "project_ids": ["proj1"],
+            "granularity": "month",
+            "time_range": {"preset": "6M"},
+            "metrics": [
+                {
+                    "id": "error.message",
+                    "name": "error.message",
+                    "type": "custom_attribute",
+                    "attribute_key": "error.message",
+                    "aggregation": "sum",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "countIf(" in sql
+        assert "JSONExtractString" in sql
+        assert "JSONExtractFloat" not in sql
+        assert "sum(" not in sql
+
     def test_multiple_metrics(self, sample_query_config):
         sample_query_config["metrics"].append(
             {

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -634,6 +634,74 @@ class TestDashboardQueryBuilder:
         assert "countIf(" in sql
         assert "AS value" in sql
 
+    def test_eval_metric_custom_attribute_breakdown_uses_raw_fallback(self):
+        config = {
+            "project_ids": ["proj1"],
+            "organization_id": str(uuid.uuid4()),
+            "workspace_id": str(uuid.uuid4()),
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "e_score",
+                    "name": "quality",
+                    "type": "eval_metric",
+                    "config_id": str(uuid.uuid4()),
+                    "output_type": "SCORE",
+                    "aggregation": "avg",
+                }
+            ],
+            "breakdowns": [
+                {
+                    "type": "custom_attribute",
+                    "name": "livekit.room",
+                    "attribute_type": "string",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "s.span_attr_str" in sql
+        assert "s.span_attributes_raw" in sql
+        assert "JSONExtractString" in sql
+        assert "breakdown_value" in sql
+
+    def test_eval_metric_custom_attribute_filter_uses_raw_fallback(self):
+        config = {
+            "project_ids": ["proj1"],
+            "organization_id": str(uuid.uuid4()),
+            "workspace_id": str(uuid.uuid4()),
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "e_score",
+                    "name": "quality",
+                    "type": "eval_metric",
+                    "config_id": str(uuid.uuid4()),
+                    "output_type": "SCORE",
+                    "aggregation": "avg",
+                }
+            ],
+            "filters": [
+                {
+                    "metric_type": "custom_attribute",
+                    "metric_name": "livekit.score",
+                    "operator": "greater_than",
+                    "value": "0.75",
+                    "attribute_type": "number",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, params, _ = queries[0]
+        assert "s.span_attr_num" in sql
+        assert "s.span_attributes_raw" in sql
+        assert "JSONExtractFloat" in sql
+        assert params["_evf_0_val"] == 0.75
+
     def test_annotation_metric_query(self):
         config = {
             "project_ids": ["proj1"],
@@ -787,6 +855,8 @@ class TestDashboardQueryBuilder:
         queries = builder.build_all_queries()
         sql, _, _ = queries[0]
         assert "span_attr_str" in sql
+        assert "span_attributes_raw" in sql
+        assert "JSONExtractString" in sql
         assert "breakdown_value" in sql
 
 
@@ -1951,6 +2021,8 @@ class TestFrontendPayloadSimulation:
         queries = builder.build_all_queries()
         sql, params, _ = queries[0]
         assert "span_attr_str" in sql
+        assert "span_attributes_raw" in sql
+        assert "JSONExtractString" in sql
         assert "llm.model" in sql
 
     def test_eval_filter_frontend_payload(self):
@@ -2032,6 +2104,8 @@ class TestFrontendPayloadSimulation:
         queries = builder.build_all_queries()
         sql, _, _ = queries[0]
         assert "span_attr_str" in sql
+        assert "span_attributes_raw" in sql
+        assert "JSONExtractString" in sql
         assert "breakdown_value" in sql
 
     # --- Time ranges ---

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -337,7 +337,11 @@ class TestMetricsEndpoint:
         mock_ch.execute_read.side_effect = [
             (
                 [
-                    {"key": "typed.attr", "type": "text"},
+                    {
+                        "span_attr_str": {"typed.attr": "value"},
+                        "span_attr_num": {"typed.score": 1.0},
+                        "span_attr_bool": {"typed.enabled": True},
+                    },
                 ],
                 [],
                 1.0,
@@ -367,8 +371,11 @@ class TestMetricsEndpoint:
         typed_sql = mock_ch.execute_read.call_args_list[0].args[0]
         spans_raw_sql = mock_ch.execute_read.call_args_list[1].args[0]
         cdc_raw_sql = mock_ch.execute_read.call_args_list[2].args[0]
-        assert "mapKeys(span_attr_str)" in typed_sql
+        assert "SELECT span_attr_str, span_attr_num, span_attr_bool" in typed_sql
+        assert "ARRAY JOIN" not in typed_sql
+        assert "mapKeys" not in typed_sql
         assert "JSONExtractKeys" not in typed_sql
+        assert "LIMIT 500" in typed_sql
         assert "span_attributes_raw AS attrs" in spans_raw_sql
         assert "span_attributes AS attrs" in cdc_raw_sql
         assert "PREWHERE project_id IN %(project_ids)s" in spans_raw_sql
@@ -381,6 +388,8 @@ class TestMetricsEndpoint:
             {"key": "livekit.customer_id", "type": "text"},
             {"key": "livekit.score", "type": "number"},
             {"key": "typed.attr", "type": "text"},
+            {"key": "typed.enabled", "type": "boolean"},
+            {"key": "typed.score", "type": "number"},
         ]
 
 

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -331,6 +331,58 @@ class TestMetricsEndpoint:
         assert "call.user_wpm" not in metric_names
         assert "freeform.attr" in metric_names
 
+    def test_clickhouse_custom_attribute_discovery_includes_raw_attribute_sources(self):
+        viewset = DashboardViewSet()
+        mock_ch = MagicMock()
+        mock_ch.execute_read.side_effect = [
+            (
+                [
+                    {"key": "typed.attr", "type": "text"},
+                ],
+                [],
+                1.0,
+            ),
+            (
+                [
+                    {
+                        "attrs": '{"livekit.customer_id": "cust-1", "livekit.score": 0.95}'
+                    },
+                ],
+                [],
+                1.0,
+            ),
+            (
+                [
+                    {
+                        "attrs": '{"livekit.connected": true, "nested": {"ignored": true}}'
+                    },
+                ],
+                [],
+                1.0,
+            ),
+        ]
+
+        attrs = viewset._fetch_clickhouse_custom_attributes(mock_ch, ["project-1"])
+
+        typed_sql = mock_ch.execute_read.call_args_list[0].args[0]
+        spans_raw_sql = mock_ch.execute_read.call_args_list[1].args[0]
+        cdc_raw_sql = mock_ch.execute_read.call_args_list[2].args[0]
+        assert "mapKeys(span_attr_str)" in typed_sql
+        assert "JSONExtractKeys" not in typed_sql
+        assert "span_attributes_raw AS attrs" in spans_raw_sql
+        assert "span_attributes AS attrs" in cdc_raw_sql
+        assert "PREWHERE project_id IN %(project_ids)s" in spans_raw_sql
+        assert "LIMIT 200" in spans_raw_sql
+        assert mock_ch.execute_read.call_args_list[0].args[1]["project_ids"] == [
+            "project-1"
+        ]
+        assert attrs == [
+            {"key": "livekit.connected", "type": "boolean"},
+            {"key": "livekit.customer_id", "type": "text"},
+            {"key": "livekit.score", "type": "number"},
+            {"key": "typed.attr", "type": "text"},
+        ]
+
 
 # ===========================================================================
 # DashboardQueryBuilder
@@ -638,6 +690,38 @@ class TestDashboardQueryBuilder:
         sql, _, _ = queries[0]
         assert "span_attr_num" in sql
         assert "custom.score" in sql
+        assert "tracer_observation_span" in sql
+        assert "span_attributes_raw" in sql
+        assert "JSONExtractFloat" in sql
+        assert "PREWHERE project_id IN %(project_ids)s" in sql
+        assert "JSONHas(span_attributes, 'custom.score')" in sql
+
+    def test_custom_attribute_query_falls_back_to_raw_string_attributes(self):
+        config = {
+            "project_ids": ["proj1"],
+            "granularity": "day",
+            "time_range": {"preset": "7D"},
+            "metrics": [
+                {
+                    "id": "customer_tier",
+                    "name": "customer_tier",
+                    "type": "custom_attribute",
+                    "attribute_key": "customer.tier",
+                    "attribute_type": "string",
+                    "aggregation": "count_distinct",
+                }
+            ],
+        }
+        builder = DashboardQueryBuilder(config)
+        queries = builder.build_all_queries()
+        sql, _, _ = queries[0]
+        assert "span_attr_str" in sql
+        assert "customer.tier" in sql
+        assert "tracer_observation_span" in sql
+        assert "span_attributes_raw" in sql
+        assert "JSONExtractString" in sql
+        assert "PREWHERE project_id IN %(project_ids)s" in sql
+        assert "JSONHas(span_attributes, 'customer.tier')" in sql
 
     def test_multiple_metrics(self, sample_query_config):
         sample_query_config["metrics"].append(

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -188,6 +188,91 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
             normalized.append(metric_copy)
         return normalized
 
+    def _fetch_clickhouse_custom_attributes(self, ch, project_ids):
+        def _infer_raw_attr_type(value):
+            if isinstance(value, bool):
+                return "boolean"
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return "number"
+            return "text"
+
+        def _add_raw_attrs(raw_rows, attrs_by_key):
+            import json
+
+            for row in raw_rows:
+                raw = row.get("attrs") if isinstance(row, dict) else row[0]
+                try:
+                    attrs = json.loads(raw) if isinstance(raw, str) else (raw or {})
+                except (TypeError, ValueError):
+                    continue
+                if not isinstance(attrs, dict):
+                    continue
+                for key, value in attrs.items():
+                    if key not in attrs_by_key and isinstance(
+                        value, (str, int, float, bool)
+                    ):
+                        attrs_by_key[key] = _infer_raw_attr_type(value)
+
+        rows, _cols, _ = ch.execute_read(
+            """
+            SELECT key, argMax(type, cnt) AS type
+            FROM (
+                SELECT key, 'text' AS type, count() AS cnt
+                FROM spans ARRAY JOIN mapKeys(span_attr_str) AS key
+                WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
+                GROUP BY key
+                UNION ALL
+                SELECT key, 'number' AS type, count() AS cnt
+                FROM spans ARRAY JOIN mapKeys(span_attr_num) AS key
+                WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
+                GROUP BY key
+                UNION ALL
+                SELECT key, 'boolean' AS type, count() AS cnt
+                FROM spans ARRAY JOIN mapKeys(span_attr_bool) AS key
+                WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
+                GROUP BY key
+            )
+            GROUP BY key ORDER BY key LIMIT 2000
+            """,
+            {"project_ids": project_ids},
+            timeout_ms=15000,
+        )
+        attrs_by_key = {}
+        for row in rows:
+            if isinstance(row, dict):
+                key, attr_type = row.get("key", ""), row.get("type", "string")
+            elif isinstance(row, (list, tuple)) and len(row) >= 2:
+                key, attr_type = row[0], row[1]
+            else:
+                continue
+            if key:
+                attrs_by_key[key] = attr_type
+
+        for table, column in (
+            ("spans", "span_attributes_raw"),
+            ("tracer_observation_span", "span_attributes"),
+        ):
+            raw_rows, _cols, _ = ch.execute_read(
+                f"""
+                SELECT {column} AS attrs
+                FROM {table}
+                PREWHERE project_id IN %(project_ids)s
+                WHERE _peerdb_is_deleted = 0
+                    AND {column} != '{{}}'
+                    AND {column} != ''
+                ORDER BY created_at DESC
+                LIMIT 200
+                """,
+                {"project_ids": project_ids},
+                timeout_ms=5000,
+            )
+            _add_raw_attrs(raw_rows, attrs_by_key)
+
+        return [
+            {"key": key, "type": attr_type}
+            for key, attr_type in sorted(attrs_by_key.items())
+        ][:2000]
+
     def list(self, request, *args, **kwargs):
         try:
             queryset = self.get_queryset()
@@ -991,39 +1076,9 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     from tracer.services.clickhouse.client import get_clickhouse_client
 
                     ch = get_clickhouse_client()
-                    # Single batch query with type inference across all projects
-                    rows, cols, _ = ch.execute_read(
-                        """
-                        SELECT key, argMax(type, cnt) AS type FROM (
-                            SELECT key, 'text' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_str) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'number' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_num) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                            UNION ALL
-                            SELECT key, 'boolean' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_bool) AS key
-                            WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                            GROUP BY key
-                        )
-                        GROUP BY key ORDER BY key LIMIT 2000
-                        """,
-                        {"project_ids": project_ids},
-                        timeout_ms=15000,
+                    custom_attributes.extend(
+                        self._fetch_clickhouse_custom_attributes(ch, project_ids)
                     )
-                    for r in rows:
-                        if isinstance(r, dict):
-                            k, t = r.get("key", ""), r.get("type", "string")
-                        elif isinstance(r, (list, tuple)) and len(r) >= 2:
-                            k, t = r[0], r[1]
-                        else:
-                            continue
-                        if k:
-                            custom_attributes.append({"key": k, "type": t})
                 elif project_ids:
                     for pid in project_ids:
                         keys = SQL_query_handler.get_span_attributes_for_project(pid)

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -213,40 +213,40 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     ):
                         attrs_by_key[key] = _infer_raw_attr_type(value)
 
-        rows, _cols, _ = ch.execute_read(
-            """
-            SELECT key, argMax(type, cnt) AS type
-            FROM (
-                SELECT key, 'text' AS type, count() AS cnt
-                FROM spans ARRAY JOIN mapKeys(span_attr_str) AS key
-                WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                GROUP BY key
-                UNION ALL
-                SELECT key, 'number' AS type, count() AS cnt
-                FROM spans ARRAY JOIN mapKeys(span_attr_num) AS key
-                WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                GROUP BY key
-                UNION ALL
-                SELECT key, 'boolean' AS type, count() AS cnt
-                FROM spans ARRAY JOIN mapKeys(span_attr_bool) AS key
-                WHERE project_id IN %(project_ids)s AND _peerdb_is_deleted = 0
-                GROUP BY key
+        def _add_typed_map_attrs(rows, attrs_by_key):
+            map_columns = (
+                ("span_attr_str", "text"),
+                ("span_attr_num", "number"),
+                ("span_attr_bool", "boolean"),
             )
-            GROUP BY key ORDER BY key LIMIT 2000
+            for row in rows:
+                for index, (column, attr_type) in enumerate(map_columns):
+                    values = row.get(column, {}) if isinstance(row, dict) else row[index]
+                    if not isinstance(values, dict):
+                        continue
+                    for key in values:
+                        if key and key not in attrs_by_key:
+                            attrs_by_key[key] = attr_type
+
+        typed_rows, _cols, _ = ch.execute_read(
+            """
+            SELECT span_attr_str, span_attr_num, span_attr_bool
+            FROM spans
+            PREWHERE project_id IN %(project_ids)s
+            WHERE _peerdb_is_deleted = 0
+                AND (
+                    notEmpty(span_attr_str)
+                    OR notEmpty(span_attr_num)
+                    OR notEmpty(span_attr_bool)
+                )
+            ORDER BY created_at DESC
+            LIMIT 500
             """,
             {"project_ids": project_ids},
-            timeout_ms=15000,
+            timeout_ms=5000,
         )
         attrs_by_key = {}
-        for row in rows:
-            if isinstance(row, dict):
-                key, attr_type = row.get("key", ""), row.get("type", "string")
-            elif isinstance(row, (list, tuple)) and len(row) >= 2:
-                key, attr_type = row[0], row[1]
-            else:
-                continue
-            if key:
-                attrs_by_key[key] = attr_type
+        _add_typed_map_attrs(typed_rows, attrs_by_key)
 
         for table, column in (
             ("spans", "span_attributes_raw"),

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1095,6 +1095,25 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
             for attr in custom_attributes:
                 k = attr["key"] if isinstance(attr, dict) else attr
                 t = attr.get("type", "string") if isinstance(attr, dict) else "string"
+                allowed_aggregations = (
+                    [
+                        "avg",
+                        "median",
+                        "max",
+                        "min",
+                        "p25",
+                        "p50",
+                        "p75",
+                        "p90",
+                        "p95",
+                        "p99",
+                        "sum",
+                        "count",
+                        "count_distinct",
+                    ]
+                    if t == "number"
+                    else ["count", "count_distinct"]
+                )
                 metrics.append(
                     {
                         "name": k,
@@ -1102,6 +1121,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                         "category": "custom_attribute",
                         "source": "traces",
                         "type": t,
+                        "allowed_aggregations": allowed_aggregations,
                     }
                 )
 


### PR DESCRIPTION
## Description

This PR fixes dashboard attribute discovery and custom-attribute querying so LiveKit (and other raw-span) attributes visible in tracing are also available on dashboard metrics.

It also keeps the discovery/query path performant for large datasets by avoiding expensive full-table JSON key expansion.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Configuration change

## Checklist

### Code Quality

- [ ] I have run `make pre-commit-all` and fixed all issues
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run `make test` successfully

### Django-Specific (if applicable)

- [x] I have created/updated migrations if model changes were made
- [ ] I have run `python manage.py check` without errors
- [x] Database migrations are reversible

### Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have added/updated docstrings for new/modified functions
- [ ] I have updated the CHANGELOG (if applicable)

### Security

- [x] My changes don't introduce security vulnerabilities
- [x] I have not committed any secrets or credentials
- [ ] I have run `make check-secrets` and addressed any issues

## Pre-commit Hooks

- [ ] ✅ Pre-commit hooks are installed (`make pre-commit-install`)
- [ ] ✅ All pre-commit checks pass (`make pre-commit-all`)

## Related Issues

- Fixes TH-4660
- Related to TH-4641

## Screenshots (if applicable)

N/A

## Additional Notes

- Discovery now combines typed-map keys with bounded raw JSON sampling (200 rows from spans + 200 rows from tracer_observation_span) parsed in Python to avoid ClickHouse OOM risk from `JSONExtractKeys` expansion.
- Custom attribute metric queries now fallback to raw JSON values and use a scoped join to `tracer_observation_span` with project/time/key filters.
- Targeted tests for this change pass. Running the full `tracer/tests/test_dashboard.py` in this environment still has unrelated DB connectivity failures (`localhost:15432` not reachable in sandbox).
