### PR TITLE
[TH-4481] Enable Save & Add in composite child eval picker

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -282,8 +282,11 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         "Instructions must contain at least one template variable (e.g. {{input}})";
     }
 
-    // Mapping
-    if (!sourceReady) next.mapping = "Map all variables before saving";
+    // Mapping — no dataset to map against in the composite child-picker flow,
+    // so skip this check. Matches the canSave bypass below.
+    if (!sourceReady && source !== "composite") {
+      next.mapping = "Map all variables before saving";
+    }
 
     // pass_threshold must be 0–1
     if (passThreshold < 0 || passThreshold > 1) {
@@ -313,6 +316,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     code,
     instructions,
     sourceReady,
+    source,
     passThreshold,
     outputType,
     choiceScores,
@@ -494,11 +498,14 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   ]);
 
   const isComposite = mode === "composite";
+  // `source === "composite"` means this drawer was opened from a composite's
+  // child picker with no dataset bound — there's no variable mapping to
+  // complete here, so don't gate saving on `sourceReady`.
   const canSave = isComposite
     ? !!name.trim() && selectedChildren.length > 0
     : name.trim() &&
       (evalType === "code" ? code.trim() : instructions.trim()) &&
-      sourceReady;
+      (source === "composite" || sourceReady);
 
   // Variables from instructions
   const variables = useMemo(() => {


### PR DESCRIPTION
## Summary
- Opening **Create New Eval** from a composite's **Add evaluation** button left **Save & Add** permanently disabled because no dataset is bound in that flow, so `sourceReady` never flips to `true`.
- Bypass the `sourceReady` gate in `canSave` and `validate()` when `source === "composite"` — there is nothing to map in this flow, so it shouldn't block saving.

Fixes TH-4481

(Replaces #125, which was opened on a `bugfix/...` branch that fails the branch-name-check workflow.)

## Linear Ticket
[TH-4481](https://linear.app/future-agi/issue/TH-4481)

## Files Changed
- `frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx`

## Test plan
- [x] From a composite eval, click **Add evaluation** → **Create New Eval**, fill name + instructions with a `{{var}}`, confirm **Save & Add** enables and the child eval is added to the composite.
- [x] Standalone `/evaluations/create` and the dataset / experiment / task / simulation / tracing / workbench eval picker flows still gate **Save & Add** on variable mapping (no regression — the bypass only triggers when `source === "composite"`).