### PR TITLE
fix(annotations): forward arrow stuck in view-only annotation workspace

### DIFF
--- a/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
@@ -325,7 +325,12 @@ export default function AnnotateWorkspaceView() {
       return;
     }
 
-    // Otherwise, fetch the next pending item from the API
+    // detail.next_item_id is status-agnostic — works for view-only managers.
+    if (detail?.next_item_id) {
+      dispatch({ type: "push", id: detail.next_item_id });
+      return;
+    }
+
     if (isFetchingNext) return;
     setIsFetchingNext(true);
     nextAbortRef.current?.abort();
@@ -349,7 +354,7 @@ export default function AnnotateWorkspaceView() {
     } finally {
       setIsFetchingNext(false);
     }
-  }, [historyIndex, itemHistory, queueId, isFetchingNext]);
+  }, [historyIndex, itemHistory, queueId, isFetchingNext, detail]);
 
   const handleKeyboardSubmit = useCallback(() => {
     if (isViewOnlyForReviewer || isBlockedAssignedToOther) return;


### PR DESCRIPTION
For users with view-only access (manager role) browsing a queue whose items are all completed, the forward button silently no-ops while the back button works. Root cause: handleNext hits the next-item API with ?exclude=, which filters by status PENDING/IN_PROGRESS — completed items don't match, the endpoint returns null, and the click does nothing.

Use detail.next_item_id instead. The annotate-detail response already exposes it, computed status-agnostically (only filtered by user assignability), which is the same shape the back arrow uses via ?before=. The pending-only API call is kept as a fallback when detail isn't loaded.

<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
