### PR TITLE
fix(ci): unify branch name validation regex across CI, hook, and docs

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -19,7 +19,7 @@ jobs:
           fi
 
           # Enforce type/short-description pattern
-          PATTERN="^(feat|fix|chore|docs|refactor|test|perf)/[a-z0-9][a-z0-9._-]+$"
+          PATTERN="^(feat|fix|chore|docs|refactor|test|perf)/[a-zA-Z0-9]+([a-zA-Z0-9-]*[a-zA-Z0-9])?$"
 
           if [[ "$BRANCH" =~ $PATTERN ]]; then
             echo "✅ Branch name '$BRANCH' follows convention"

--- a/.github/workflows/frontend-feature.yml
+++ b/.github/workflows/frontend-feature.yml
@@ -85,14 +85,13 @@ jobs:
             const [type, description] = branchName.split('/');
 
             const typeEmojis = {
-              'feature': '✨',
-              'bugfix': '🐛',
-              'hotfix': '🚨',
-              'refactor': '♻️',
-              'docs': '📚',
-              'test': '🧪',
+              'feat': '✨',
+              'fix': '🐛',
               'chore': '🔧',
-              'release': '🚀'
+              'docs': '📚',
+              'refactor': '♻️',
+              'test': '🧪',
+              'perf': '⚡'
             };
 
             const emoji = typeEmojis[type] || '📝';


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

The branch-name-check workflow used a stricter lowercase-only regex
than the pre-push hook and BRANCH_NAMING_CONVENTION.md, so branches
with uppercase ticket IDs (e.g. fix/TH-4481-foo) passed locally but
failed CI on the PR — making validation appear flaky.

Align all three on the documented pattern:
  ^(feat|fix|chore|docs|refactor|test|perf)/[a-zA-Z0-9]+([a-zA-Z0-9-]*[a-zA-Z0-9])?$

Also fix the typeEmojis map in frontend-feature.yml, which keyed on
invalid prefixes (feature, bugfix, hotfix, release) instead of the
actual allowed types (feat, fix, chore, docs, refactor, test, perf).

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
