### PR TITLE
feat: route protect evaluations through AgentEvaluator and gateway

### DIFF
--- a/futureagi/agentcc/services/config_push.py
+++ b/futureagi/agentcc/services/config_push.py
@@ -3,6 +3,8 @@ Config Push Service — pushes per-org configs from Django to the Go gateway.
 Called when org configs are created, activated, or deleted.
 """
 
+import os
+
 import structlog
 from django.conf import settings as django_settings
 
@@ -262,7 +264,7 @@ def _inject_fi_credentials(checks, org_id):
         if org_key:
             cfg.setdefault("api_key", org_key.api_key)
             cfg.setdefault("secret_key", org_key.secret_key)
-            cfg.setdefault("base_url", django_settings.BASE_URL)
+            cfg.setdefault("base_url", os.getenv("FI_BASE_URL") or django_settings.BASE_URL)
             cfg.setdefault("call_type", "protect")
             fi_check["config"] = cfg
             logger.info(

--- a/futureagi/agentcc/views/gateway.py
+++ b/futureagi/agentcc/views/gateway.py
@@ -605,20 +605,21 @@ class AgentccGatewayViewSet(ViewSet):
         try:
             from model_hub.models.evals_metric import EvalTemplate
 
-            # Protect-compatible metric names (from DeterministicEvaluator._resolve_protect_metric)
+            # Protect-compatible eval templates.
             protect_metrics = [
                 "toxicity",
                 "bias_detection",
                 "prompt_injection",
                 "data_privacy_compliance",
-                "pii",
-                "content_moderation",
+                "protect_flash",
             ]
 
-            templates = EvalTemplate.objects.filter(
+            # System eval templates have organization_id=None, workspace_id=None,
+            # so WorkspaceContextMiddleware filters them out. Use no_workspace_objects
+            # to bypass workspace filtering.
+            templates = EvalTemplate.no_workspace_objects.filter(
                 owner="system",
                 deleted=False,
-                config__eval_type_id="DeterministicEvaluator",
                 name__in=protect_metrics,
             ).values("eval_id", "name", "description")
 

--- a/futureagi/agentic_eval/core/utils/model_config.py
+++ b/futureagi/agentic_eval/core/utils/model_config.py
@@ -147,6 +147,34 @@ class ModelConfigs:
         max_tokens=150,
     )
 
+    PROTECT_TOXICITY: Final[ModelConfig] = ModelConfig(
+        provider=LiteLlmProvider.PROTECT.value,
+        model_name="protect_toxicity",
+        temperature=0.0,
+        max_tokens=150,
+    )
+
+    PROTECT_BIAS: Final[ModelConfig] = ModelConfig(
+        provider=LiteLlmProvider.PROTECT.value,
+        model_name="protect_bias",
+        temperature=0.0,
+        max_tokens=150,
+    )
+
+    PROTECT_PRIVACY: Final[ModelConfig] = ModelConfig(
+        provider=LiteLlmProvider.PROTECT.value,
+        model_name="protect_privacy",
+        temperature=0.0,
+        max_tokens=150,
+    )
+
+    PROTECT_PROMPT_INJECTION: Final[ModelConfig] = ModelConfig(
+        provider=LiteLlmProvider.PROTECT.value,
+        model_name="protect_prompt_injection",
+        temperature=0.0,
+        max_tokens=150,
+    )
+
     OPUS_4_5_BEDROCK_ARN: Final[ModelConfig] = ModelConfig(
         provider=LiteLlmProvider.AWS_BEDROCK_ANTHROPIC.value,
         model_name=os.environ.get("BEDROCK_OPUS_ARN", ""),
@@ -218,6 +246,16 @@ class ModelConfigs:
         """Check if the model is a turing model."""
         cfg = cls.get_config(model_name)
         return bool(cfg and cfg.provider == LiteLlmProvider.TURING.value)
+
+    @classmethod
+    def is_protect(cls, model_name: str) -> bool:
+        """Check if the model is a protect or protect_flash model."""
+        cfg = cls.get_config(model_name)
+        return bool(
+            cfg
+            and cfg.provider
+            in (LiteLlmProvider.PROTECT.value, LiteLlmProvider.PROTECT_FLASH.value)
+        )
 
     @classmethod
     def supports_audio(cls, model_name: str) -> bool:

--- a/futureagi/evaluations/engine/runner.py
+++ b/futureagi/evaluations/engine/runner.py
@@ -96,12 +96,9 @@ def run_eval(request: EvalRequest) -> EvalResult:
         )
 
     call_type = request.inputs.get("call_type", "")
-    if call_type in ("protect", "protect_flash") and eval_type_id != "DeterministicEvaluator":
-        eval_type_id = "DeterministicEvaluator"
-        # Patch template config so format_eval_value uses DeterministicEvaluator branch
-        eval_template.config = {**eval_template.config, "eval_type_id": "DeterministicEvaluator"}
-        if not request.model:
-            request.model = "protect_flash" if call_type == "protect_flash" else "protect"
+    # Set a default model for protect calls if not provided.
+    if call_type in ("protect", "protect_flash") and not request.model:
+        request.model = "protect_flash" if call_type == "protect_flash" else "protect"
 
     is_futureagi = eval_type_id in FUTUREAGI_EVAL_TYPES
 
@@ -139,6 +136,10 @@ def run_eval(request: EvalRequest) -> EvalResult:
             organization_id=request.organization_id,
             workspace_id=request.workspace_id,
         )
+
+    # Ensure eval_name is available for protect calls.
+    if call_type in ("protect", "protect_flash"):
+        run_params.setdefault("eval_name", eval_template.name)
 
     # 3.5. Preprocess inputs (e.g., compute embeddings for CLIP/FID)
     from evaluations.engine.preprocessing import preprocess_inputs

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -75,29 +75,35 @@ def _log_and_deduct_cost_for_standalone_eval(
     if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
         raise ValueError(f"API call not allowed: {api_call_log_row.status}")
 
-    # Dual-write: emit usage event for new billing system
-    try:
+    # Dual-write: emit usage event for new billing system.
+    # Protect evals emit a separate cost-based event after completion.
+    _protect_call_types = (
+        _get_api_call_type("protect"),
+        _get_api_call_type("protect_flash"),
+    )
+    if api_call_type not in _protect_call_types:
         try:
-            from ee.usage.schemas.events import UsageEvent
-        except ImportError:
-            UsageEvent = None
-        try:
-            from ee.usage.services.emitter import emit
-        except ImportError:
-            emit = None
+            try:
+                from ee.usage.schemas.events import UsageEvent
+            except ImportError:
+                UsageEvent = None
+            try:
+                from ee.usage.services.emitter import emit
+            except ImportError:
+                emit = None
 
-        emit(
-            UsageEvent(
-                org_id=str(user.organization.id),
-                event_type=api_call_type,
-                properties={
-                    "source": "standalone_v2",
-                    "source_id": str(eval_template.id),
-                },
+            emit(
+                UsageEvent(
+                    org_id=str(user.organization.id),
+                    event_type=api_call_type,
+                    properties={
+                        "source": "standalone_v2",
+                        "source_id": str(eval_template.id),
+                    },
+                )
             )
-        )
-    except Exception:
-        pass  # Metering failure must not break the action
+        except Exception:
+            pass  # Metering failure must not break the action
 
     return api_call_log_row
 
@@ -399,7 +405,9 @@ def _run_protect(
         protect_inputs["call_type"] = "protect_flash" if protect_flash else "protect"
 
         api_call_log_row = _log_and_deduct_cost_for_standalone_eval(
-            user, eval_template, True, protect_inputs, workspace=workspace
+            user, eval_template, True, protect_inputs,
+            model="protect_flash" if protect_flash else "protect",
+            workspace=workspace,
         )
 
         try:
@@ -450,6 +458,55 @@ def _run_protect(
         api_call_log_row.config = json.dumps(config_dict)
         api_call_log_row.status = APICallStatusChoices.SUCCESS.value
         api_call_log_row.save()
+
+        # Emit usage event with actual cost after eval completion
+        try:
+            try:
+                from ee.usage.schemas.events import UsageEvent
+            except ImportError:
+                UsageEvent = None
+            try:
+                from ee.usage.services.config import BillingConfig
+            except ImportError:
+                BillingConfig = None
+            try:
+                from ee.usage.services.emitter import emit
+            except ImportError:
+                emit = None
+
+            billing_config = BillingConfig.get()
+            token_usage = (result.metadata or {}).get("token_usage", {})
+            from agentic_eval.core_evals.fi_utils.token_count_helper import (
+                calculate_total_cost,
+            )
+            # Resolve model alias for pricing lookup
+            if protect_flash:
+                protect_model = "protect_flash"
+            else:
+                from ee.protect.helper import ProtectHelper
+                protect_model = ProtectHelper.resolve_alias(eval_template.name, is_flash=False)
+            cost_info = calculate_total_cost(protect_model, token_usage)
+            llm_cost = cost_info.get("total_cost", 0)
+            per_run_fee = billing_config.get_eval_per_run_fee()
+            actual_cost = llm_cost + per_run_fee
+            credits = billing_config.calculate_ai_credits(actual_cost)
+
+            emit(
+                UsageEvent(
+                    org_id=str(user.organization.id),
+                    event_type=_get_api_call_type(
+                        "protect_flash" if protect_flash else "protect"
+                    ),
+                    amount=credits,
+                    properties={
+                        "source": "standalone_v2",
+                        "source_id": str(eval_template.id),
+                        "raw_cost_usd": str(actual_cost),
+                    },
+                )
+            )
+        except Exception:
+            pass
 
         logger.info(f"Protect Eval | Completed: user: {user.id}")
         return formatted


### PR DESCRIPTION
## Summary

Route Protect and Protect Flash evaluations through the AgentEvaluator.

- Add per-metric protect model configs and `is_protect()` helper in ModelConfigs
- Remove DeterministicEvaluator force-routing for protect calls in eval runner
- Fix protect SDK billing: emit correct event type (`protect_evaluator` / `protect_flash_evaluator`)
- Fix `protect_templates` endpoint: return correct templates

## Test plan
- [ ] SDK: `fi.evals.Protect` for all 4 metrics — verify pass/fail
- [ ] SDK: `fi.evals.Protect` with `use_flash=True`
- [ ] FE: protect templates dropdown shows correct templates