### PR TITLE
[TH-4567] Remove dead search box from trace detail drawer

### DIFF
--- a/frontend/src/components/traceDetail/TraceDetailDrawerV2.jsx
+++ b/frontend/src/components/traceDetail/TraceDetailDrawerV2.jsx
@@ -286,7 +286,6 @@ const TraceDetailDrawerV2 = ({
     }
   });
   const [leftPanelWidth, setLeftPanelWidth] = useState(40); // percentage
-  const [searchQuery, setSearchQuery] = useState("");
   const [actionsAnchorEl, setActionsAnchorEl] = useState(null);
   const [isFullscreen, setIsFullscreen] = useState(initialFullscreen);
   const [drawerWidth, setDrawerWidth] = useState(60); // percentage of viewport
@@ -1116,50 +1115,6 @@ const TraceDetailDrawerV2 = ({
             >
               Save
             </Typography>
-          </Box>
-        </Box>
-      )}
-
-      {/* Search bar — hidden on Imagine tab */}
-      {!isImagineActive && (
-        <Box
-          sx={{
-            px: 2,
-            py: 0.75,
-            borderBottom: "1px solid",
-            borderColor: "divider",
-            flexShrink: 0,
-          }}
-        >
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 1,
-              px: 1.5,
-              py: 0.5,
-              border: "1px solid",
-              borderColor: "divider",
-              borderRadius: 1,
-            }}
-          >
-            <Iconify icon="mdi:magnify" width={16} color="text.disabled" />
-            <Box
-              component="input"
-              placeholder="Search"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              sx={{
-                border: "none",
-                outline: "none",
-                flex: 1,
-                fontSize: 13,
-                color: "text.primary",
-                bgcolor: "transparent",
-                fontFamily: "inherit",
-                "&::placeholder": { color: "text.disabled" },
-              }}
-            />
           </Box>
         </Box>
       )}


### PR DESCRIPTION
## Summary
- The top search box on the Trace tab of the trace detail drawer was dead UI: its `searchQuery` state was set on input change but never read anywhere — not passed down, not consumed by any child, no effect.
- Removed the input block and its `useState` from `TraceDetailDrawerV2.jsx`. The functional `TRACE TREE` search inside `TraceTreeV2.jsx` (which filters span names) is unaffected.

Closes TH-4567

## Linear Ticket
[TH-4567](https://linear.app/future-agi/issue/TH-4567/clarify-purpose-of-the-first-search-box-functionality)

## Files Changed
- `frontend/src/components/traceDetail/TraceDetailDrawerV2.jsx`

## Test plan
- [ ] Open a trace in LLM Tracing — only one search box (under `TRACE TREE`) is visible
- [ ] That search still filters span names in the tree
- [ ] No regression on the Imagine tab (search bar was already hidden there)