### PR TITLE
fix: route composite eval test modes through execute endpoint

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -66,6 +66,7 @@ import { canonicalEntries } from "src/utils/utils";
 import { format } from "date-fns";
 import {
   buildEvalTemplateConfig,
+  buildCompositeSourceModeProps,
   hasNonEmptyPromptMessage,
 } from "./evalPickerConfigUtils";
 
@@ -278,6 +279,17 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       ([key]) => !variableSet.has(key),
     );
   }, [functionParamsSchema, variables]);
+
+  const compositeSourceModeProps = useMemo(
+    () =>
+      buildCompositeSourceModeProps({
+        isComposite,
+        fullEval,
+        compositeDetail,
+        compositeChildWeights,
+      }),
+    [isComposite, fullEval, compositeDetail, compositeChildWeights],
+  );
 
   const hasValidPromptMessages = useMemo(
     () => evalType !== "llm" || hasNonEmptyPromptMessage(messages),
@@ -1435,7 +1447,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     contextOptions={contextOptions}
                     errorLocalizerEnabled={errorLocalizerEnabled}
                     initialMapping={evalData?.mapping}
-                    isComposite={isComposite}
+                    {...compositeSourceModeProps}
                     sourceColumns={
                       source === "workbench" ? sourceColumns : null
                     }
@@ -1454,7 +1466,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     onReadyChange={handleSourceReadyChange}
                     errorLocalizerEnabled={errorLocalizerEnabled}
                     initialMapping={evalData?.mapping}
-                    isComposite={isComposite}
+                    {...compositeSourceModeProps}
                   />
                 )}
                 {(source === "simulation" || source === "test") && (
@@ -1470,7 +1482,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     errorLocalizerEnabled={errorLocalizerEnabled}
                     initialMapping={evalData?.mapping}
                     initialRunTestId={sourceId}
-                    isComposite={isComposite}
+                    {...compositeSourceModeProps}
                   />
                 )}
                 {source === "create-simulate" && (
@@ -1514,7 +1526,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     onReadyChange={handleSourceReadyChange}
                     contextOptions={contextOptions}
                     errorLocalizerEnabled={errorLocalizerEnabled}
-                    isComposite={isComposite}
+                    {...compositeSourceModeProps}
                   />
                 )}
                 {source === "composite" && (

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -67,6 +67,7 @@ import { format } from "date-fns";
 import {
   buildEvalTemplateConfig,
   buildCompositeSourceModeProps,
+  getSourceModeVariables,
   hasNonEmptyPromptMessage,
 } from "./evalPickerConfigUtils";
 
@@ -289,6 +290,16 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         compositeChildWeights,
       }),
     [isComposite, fullEval, compositeDetail, compositeChildWeights],
+  );
+
+  const sourceModeVariables = useMemo(
+    () =>
+      getSourceModeVariables({
+        isComposite,
+        variables,
+        compositeUnionKeys,
+      }),
+    [isComposite, variables, compositeUnionKeys],
   );
 
   const hasValidPromptMessages = useMemo(
@@ -1458,7 +1469,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   <TracingTestMode
                     ref={sourceRef}
                     templateId={templateId}
-                    variables={isComposite ? compositeUnionKeys : variables}
+                    variables={sourceModeVariables}
                     codeParams={codeParams}
                     onTestResult={handleTestResult}
                     onClearResult={handleClearTestResult}
@@ -1473,7 +1484,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   <SimulationTestMode
                     ref={sourceRef}
                     templateId={templateId}
-                    variables={isComposite ? compositeUnionKeys : variables}
+                    variables={sourceModeVariables}
                     codeParams={codeParams}
                     onTestResult={handleTestResult}
                     onClearResult={handleClearTestResult}
@@ -1500,7 +1511,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   <TracingTestMode
                     ref={sourceRef}
                     templateId={templateId}
-                    variables={variables}
+                    variables={sourceModeVariables}
                     codeParams={codeParams}
                     onTestResult={handleTestResult}
                     onClearResult={handleClearTestResult}
@@ -1510,6 +1521,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     initialRowType={sourceRowType}
                     initialMapping={evalData?.mapping}
                     errorLocalizerEnabled={errorLocalizerEnabled}
+                    {...compositeSourceModeProps}
                   />
                 )}
                 {source === "custom" && (

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -44,6 +44,7 @@ import OutputTypeConfig from "src/sections/evals/components/OutputTypeConfig";
 import FewShotExamples from "src/sections/evals/components/FewShotExamples";
 import CompositeDetailPanel from "src/sections/evals/components/CompositeDetailPanel";
 import { useCompositeDetail } from "src/sections/evals/hooks/useCompositeEval";
+import { useCompositeChildrenUnionKeys } from "src/sections/evals/hooks/useCompositeChildrenKeys";
 import DatasetTestMode from "src/sections/evals/components/DatasetTestMode";
 import TracingTestMode from "src/sections/evals/components/TracingTestMode";
 import SimulationTestMode from "src/sections/evals/components/SimulationTestMode";
@@ -187,6 +188,9 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   // single-eval picks don't pay the round-trip cost. `compositeChildWeights`
   // is the state that flows into `composite_weight_overrides` on save.
   const { data: compositeDetail } = useCompositeDetail(templateId, isComposite);
+  const compositeUnionKeys = useCompositeChildrenUnionKeys(
+    compositeDetail?.children || [],
+  );
   const [compositeChildWeights, setCompositeChildWeights] = useState({});
   const compositePopulatedRef = useRef(false);
   useEffect(() => {
@@ -1442,20 +1446,22 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   <TracingTestMode
                     ref={sourceRef}
                     templateId={templateId}
-                    variables={variables}
+                    variables={isComposite ? compositeUnionKeys : variables}
                     codeParams={codeParams}
                     onTestResult={handleTestResult}
                     onClearResult={handleClearTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
                     onReadyChange={handleSourceReadyChange}
                     errorLocalizerEnabled={errorLocalizerEnabled}
+                    initialMapping={evalData?.mapping}
+                    isComposite={isComposite}
                   />
                 )}
                 {(source === "simulation" || source === "test") && (
                   <SimulationTestMode
                     ref={sourceRef}
                     templateId={templateId}
-                    variables={variables}
+                    variables={isComposite ? compositeUnionKeys : variables}
                     codeParams={codeParams}
                     onTestResult={handleTestResult}
                     onClearResult={handleClearTestResult}
@@ -1464,6 +1470,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     errorLocalizerEnabled={errorLocalizerEnabled}
                     initialMapping={evalData?.mapping}
                     initialRunTestId={sourceId}
+                    isComposite={isComposite}
                   />
                 )}
                 {source === "create-simulate" && (

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -967,6 +967,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     variables={isComposite ? compositeUnionKeys : variables}
                     onTestResult={handleTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
+                    isComposite={isComposite}
                   />
                 )}
                 {(source === "simulation" ||
@@ -978,6 +979,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     variables={isComposite ? compositeUnionKeys : variables}
                     onTestResult={handleTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
+                    isComposite={isComposite}
                   />
                 )}
                 {/* Fallback: no source context (standalone composite create page) */}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -112,6 +112,29 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   // Union of every child template's required_keys — drives the top
   // TestPlayground so the user sees inputs for all child variables.
   const compositeUnionKeys = useCompositeChildrenUnionKeys(selectedChildren);
+  const compositeAdhocConfig = useMemo(
+    () =>
+      mode !== "composite"
+        ? null
+        : {
+            child_template_ids: selectedChildren.map((c) => c.child_id),
+            aggregation_enabled: aggregationEnabled,
+            aggregation_function: aggregationFunction,
+            composite_child_axis: compositeChildAxis || "",
+            child_weights:
+              Object.keys(childWeights || {}).length > 0 ? childWeights : null,
+            pass_threshold: passThreshold ?? 0.5,
+          },
+    [
+      mode,
+      selectedChildren,
+      aggregationEnabled,
+      aggregationFunction,
+      compositeChildAxis,
+      childWeights,
+      passThreshold,
+    ],
+  );
 
   // Draft management
   const [draftId, setDraftId] = useState(null);
@@ -955,6 +978,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     initialDatasetId={sourceId}
                     onReadyChange={handleSourceReadyChange}
                     isComposite={isComposite}
+                    compositeAdhocConfig={compositeAdhocConfig}
                     sourceColumns={
                       source === "workbench" ? sourceColumns : null
                     }
@@ -968,6 +992,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     onTestResult={handleTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
                     isComposite={isComposite}
+                    compositeAdhocConfig={compositeAdhocConfig}
                   />
                 )}
                 {(source === "simulation" ||
@@ -980,6 +1005,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     onTestResult={handleTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
                     isComposite={isComposite}
+                    compositeAdhocConfig={compositeAdhocConfig}
                   />
                 )}
                 {/* Fallback: no source context (standalone composite create page) */}
@@ -1004,6 +1030,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                       evalType="llm"
                       requiredKeys={compositeUnionKeys}
                       isComposite
+                      compositeAdhocConfig={compositeAdhocConfig}
                       showVersions={false}
                       onTestResult={handleTestResult}
                       onColumnsLoaded={handleColumnsLoaded}

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
@@ -60,3 +60,53 @@ export const buildEvalTemplateConfig = ({
 
   return nextConfig;
 };
+
+export const buildCompositeSourceModeProps = ({
+  isComposite,
+  fullEval,
+  compositeDetail,
+  compositeChildWeights = {},
+}) => {
+  if (!isComposite) {
+    return { isComposite: false };
+  }
+
+  const children = Array.isArray(compositeDetail?.children)
+    ? compositeDetail.children
+    : [];
+
+  if (children.length === 0) {
+    return { isComposite: true };
+  }
+
+  const baseWeights = children.reduce((acc, child) => {
+    if (child?.child_id) {
+      acc[child.child_id] = child.weight ?? 1;
+    }
+    return acc;
+  }, {});
+
+  const mergedWeights = {
+    ...baseWeights,
+    ...(compositeChildWeights || {}),
+  };
+
+  return {
+    isComposite: true,
+    compositeAdhocConfig: {
+      child_template_ids: children.map((child) => child.child_id),
+      aggregation_enabled:
+        compositeDetail?.aggregation_enabled ?? fullEval?.aggregation_enabled ?? true,
+      aggregation_function:
+        compositeDetail?.aggregation_function
+        || fullEval?.aggregation_function
+        || "weighted_avg",
+      composite_child_axis:
+        compositeDetail?.composite_child_axis || fullEval?.composite_child_axis || "",
+      child_weights:
+        Object.keys(mergedWeights).length > 0 ? mergedWeights : null,
+      pass_threshold:
+        compositeDetail?.pass_threshold ?? fullEval?.pass_threshold ?? 0.5,
+    },
+  };
+};

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
@@ -110,3 +110,9 @@ export const buildCompositeSourceModeProps = ({
     },
   };
 };
+
+export const getSourceModeVariables = ({
+  isComposite,
+  variables = [],
+  compositeUnionKeys = [],
+}) => (isComposite ? compositeUnionKeys : variables);

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCompositeSourceModeProps } from "./evalPickerConfigUtils";
+
+describe("buildCompositeSourceModeProps", () => {
+  it("does not expose adhoc config for non-composite evals", () => {
+    expect(
+      buildCompositeSourceModeProps({
+        isComposite: false,
+      }),
+    ).toEqual({ isComposite: false });
+  });
+
+  it("builds and forwards composite adhoc config from current composite detail and weights", () => {
+    expect(
+      buildCompositeSourceModeProps({
+        isComposite: true,
+        fullEval: {
+          aggregation_enabled: true,
+          aggregation_function: "weighted_avg",
+          composite_child_axis: "pass_fail",
+          pass_threshold: 0.5,
+        },
+        compositeDetail: {
+          aggregation_enabled: false,
+          aggregation_function: "min",
+          composite_child_axis: "percentage",
+          pass_threshold: 0.7,
+          children: [
+            { child_id: "child-a", weight: 1.5 },
+            { child_id: "child-b", weight: 2 },
+          ],
+        },
+        compositeChildWeights: {
+          "child-a": 3,
+        },
+      }),
+    ).toEqual({
+      isComposite: true,
+      compositeAdhocConfig: {
+        child_template_ids: ["child-a", "child-b"],
+        aggregation_enabled: false,
+        aggregation_function: "min",
+        composite_child_axis: "percentage",
+        child_weights: {
+          "child-a": 3,
+          "child-b": 2,
+        },
+        pass_threshold: 0.7,
+      },
+    });
+  });
+});

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildCompositeSourceModeProps } from "./evalPickerConfigUtils";
+import {
+  buildCompositeSourceModeProps,
+  getSourceModeVariables,
+} from "./evalPickerConfigUtils";
 
 describe("buildCompositeSourceModeProps", () => {
   it("does not expose adhoc config for non-composite evals", () => {
@@ -49,5 +52,27 @@ describe("buildCompositeSourceModeProps", () => {
         pass_threshold: 0.7,
       },
     });
+  });
+});
+
+describe("getSourceModeVariables", () => {
+  it("returns base variables for non-composite evals", () => {
+    expect(
+      getSourceModeVariables({
+        isComposite: false,
+        variables: ["input"],
+        compositeUnionKeys: ["child_input"],
+      }),
+    ).toEqual(["input"]);
+  });
+
+  it("returns composite union keys for composite evals", () => {
+    expect(
+      getSourceModeVariables({
+        isComposite: true,
+        variables: ["input"],
+        compositeUnionKeys: ["child_input", "child_output"],
+      }),
+    ).toEqual(["child_input", "child_output"]);
   });
 });

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -654,7 +654,7 @@ const EvaluationDrawerChild = ({
               // Dataset adds are also save-only now: the user runs evals
               // manually from the dataset grid rather than auto-running on
               // add, which would otherwise queue work the user didn't ask for.
-              run: module !== "run-optimization" && (module !== "dataset" || isComposite),
+              run: module !== "run-optimization" && module !== "dataset",
               // Mirror the workbench path: surface error_localizer at the top
               // level so EditAndRunUserEvalView can update eval_metric.error_localizer.
               error_localizer: runConfig.error_localizer_enabled ?? false,

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -654,7 +654,7 @@ const EvaluationDrawerChild = ({
               // Dataset adds are also save-only now: the user runs evals
               // manually from the dataset grid rather than auto-running on
               // add, which would otherwise queue work the user didn't ask for.
-              run: module !== "run-optimization" && module !== "dataset",
+              run: module !== "run-optimization" && (module !== "dataset" || isComposite),
               // Mirror the workbench path: surface error_localizer at the top
               // level so EditAndRunUserEvalView can update eval_metric.error_localizer.
               error_localizer: runConfig.error_localizer_enabled ?? false,

--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -297,7 +297,7 @@ export default function WidgetChart({ widget, globalDateRange }) {
         }}
       >
         <Typography variant="body2" color="text.disabled">
-          No data available
+          No output for the selected inputs.
         </Typography>
       </Box>
     );

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -48,6 +48,7 @@ import AnnotationSidebarContent from "src/components/traceDetailDrawer/Annotatio
 import ScoresListSection from "src/components/ScoresListSection/ScoresListSection";
 import AddLabelDrawer from "src/components/traceDetailDrawer/AddLabelDrawer";
 import { useEvalsList } from "src/sections/common/EvaluationDrawer/getEvalsList";
+import CompositeResultView from "src/sections/evals/components/CompositeResultView";
 
 const SkeletonLoader = () => (
   <Box
@@ -855,10 +856,41 @@ const DatapointDrawerChild = () => {
                       borderRadius: "4px",
                     }}
                   >
-                    {evalOpen?.valueInfos?.reason?.trim() ? (
+                    {Array.isArray(evalOpen?.valueInfos?.children) &&
+                    evalOpen.valueInfos.children.length > 0 ? (
+                      (() => {
+                        /** @type {any[]} */
+                        const compositeChildren =
+                          evalOpen.valueInfos.children || [];
+                        return (
+                          <CompositeResultView
+                            compositeResult={{
+                              ...evalOpen.valueInfos,
+                              total_children:
+                                evalOpen.valueInfos.total_children ??
+                                compositeChildren.length,
+                              completed_children:
+                                evalOpen.valueInfos.completed_children ??
+                                compositeChildren.filter(
+                                  (child) => child.status === "completed",
+                                ).length,
+                              failed_children:
+                                evalOpen.valueInfos.failed_children ??
+                                compositeChildren.filter(
+                                  (child) => child.status === "failed",
+                                ).length,
+                            }}
+                          />
+                        );
+                      })()
+                    ) : evalOpen?.valueInfos?.reason?.trim() ||
+                      evalOpen?.valueInfos?.summary ? (
                       <CellMarkdown
                         spacing={0}
-                        text={evalOpen?.valueInfos?.reason}
+                        text={
+                          evalOpen?.valueInfos?.reason ||
+                          evalOpen?.valueInfos?.summary
+                        }
                       />
                     ) : (
                       "Unable to fetch Explanation"

--- a/frontend/src/sections/evals/Helpers/compositeRuntimeConfig.js
+++ b/frontend/src/sections/evals/Helpers/compositeRuntimeConfig.js
@@ -1,0 +1,22 @@
+export function buildCompositeRuntimeConfig({ config = {}, codeParams = {} } = {}) {
+  const runtimeConfig = config && typeof config === "object" ? { ...config } : {};
+  const existingParams =
+    runtimeConfig.params && typeof runtimeConfig.params === "object"
+      ? runtimeConfig.params
+      : {};
+  const explicitParams =
+    codeParams && typeof codeParams === "object" ? codeParams : {};
+
+  const mergedParams = {
+    ...existingParams,
+    ...explicitParams,
+  };
+
+  if (Object.keys(mergedParams).length > 0) {
+    runtimeConfig.params = mergedParams;
+  } else {
+    delete runtimeConfig.params;
+  }
+
+  return runtimeConfig;
+}

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -30,6 +30,7 @@ import { useDebounce } from "src/hooks/use-debounce";
 import CellMarkdown from "src/sections/common/CellMarkdown";
 import EvalResultDisplay from "./EvalResultDisplay";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
+import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
 
 const DATASET_PAGE_SIZE = 25;
 
@@ -502,6 +503,7 @@ const DatasetTestMode = React.forwardRef(
       errorLocalizerEnabled = false,
       initialMapping = null,
       isComposite = false,
+      compositeAdhocConfig = null,
       sourceColumns,
       extraColumns,
     },
@@ -558,6 +560,7 @@ const DatasetTestMode = React.forwardRef(
     // resulting error_details into `result` for EvalResultDisplay.
     const { state: errorLocalizerState, start: startErrorLocalizerPoll } =
       useErrorLocalizerPoll();
+    const executeCompositeAdhoc = useExecuteCompositeEvalAdhoc();
 
     // 1. Fetch dataset list — paginated + searchable
     const fetchDatasets = useCallback(async (page, search, append) => {
@@ -998,18 +1001,37 @@ const DatasetTestMode = React.forwardRef(
 
         // Composite evals use the composite execute endpoint
         const { data } = isComposite
-          ? await axios.post(endpoints.develop.eval.executeCompositeEval(tid), {
-              mapping: evalMapping,
-              model,
-              config: {
-                ...(Object.keys(codeParams || {}).length > 0
-                  ? { params: codeParams }
-                  : {}),
-              },
-              error_localizer: errorLocalizerEnabled,
-              input_data_types: inputDataTypes,
-              row_context: rowContext,
-            })
+          ? compositeAdhocConfig
+            ? {
+                data: {
+                  status: true,
+                  result: await executeCompositeAdhoc.mutateAsync({
+                    ...compositeAdhocConfig,
+                    mapping: evalMapping,
+                    model,
+                    config: {
+                      ...(Object.keys(codeParams || {}).length > 0
+                        ? { params: codeParams }
+                        : {}),
+                    },
+                    error_localizer: errorLocalizerEnabled,
+                    input_data_types: inputDataTypes,
+                    row_context: rowContext,
+                  }),
+                },
+              }
+            : await axios.post(endpoints.develop.eval.executeCompositeEval(tid), {
+                mapping: evalMapping,
+                model,
+                config: {
+                  ...(Object.keys(codeParams || {}).length > 0
+                    ? { params: codeParams }
+                    : {}),
+                },
+                error_localizer: errorLocalizerEnabled,
+                input_data_types: inputDataTypes,
+                row_context: rowContext,
+              })
           : await axios.post(endpoints.develop.eval.evalPlayground, {
               template_id: tid,
               model,
@@ -1071,7 +1093,9 @@ const DatasetTestMode = React.forwardRef(
       sourceNameToField,
       codeParams,
       isComposite,
+      compositeAdhocConfig,
       model,
+      executeCompositeAdhoc,
     ]);
 
     // Readiness: dataset selected + (all variables mapped OR a non-template
@@ -1658,6 +1682,7 @@ DatasetTestMode.propTypes = {
   sourceColumns: PropTypes.array,
   extraColumns: PropTypes.array,
   isComposite: PropTypes.bool,
+  compositeAdhocConfig: PropTypes.object,
 };
 
 export default DatasetTestMode;

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -1000,6 +1000,12 @@ const DatasetTestMode = React.forwardRef(
         const { data } = isComposite
           ? await axios.post(endpoints.develop.eval.executeCompositeEval(tid), {
               mapping: evalMapping,
+              model,
+              config: {
+                ...(Object.keys(codeParams || {}).length > 0
+                  ? { params: codeParams }
+                  : {}),
+              },
               error_localizer: errorLocalizerEnabled,
               input_data_types: inputDataTypes,
               row_context: rowContext,
@@ -1020,9 +1026,20 @@ const DatasetTestMode = React.forwardRef(
             });
 
         if (data?.status) {
-          setResult(data.result);
-          onTestResult?.(true, data.result);
-          if (errorLocalizerEnabled && data.result?.log_id) {
+          const nextResult = isComposite
+            ? {
+                output:
+                  data.result?.aggregation_enabled &&
+                  data.result?.aggregate_score != null
+                    ? data.result.aggregate_score
+                    : null,
+                reason: data.result?.summary || "",
+                compositeResult: data.result,
+              }
+            : data.result;
+          setResult(nextResult);
+          onTestResult?.(true, nextResult);
+          if (!isComposite && errorLocalizerEnabled && data.result?.log_id) {
             startErrorLocalizerPoll(data.result.log_id);
           }
         } else {
@@ -1053,6 +1070,8 @@ const DatasetTestMode = React.forwardRef(
       isWorkbenchMode,
       sourceNameToField,
       codeParams,
+      isComposite,
+      model,
     ]);
 
     // Readiness: dataset selected + (all variables mapped OR a non-template
@@ -1638,6 +1657,7 @@ DatasetTestMode.propTypes = {
   initialMapping: PropTypes.object,
   sourceColumns: PropTypes.array,
   extraColumns: PropTypes.array,
+  isComposite: PropTypes.bool,
 };
 
 export default DatasetTestMode;

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -29,6 +29,7 @@ import axios, { endpoints } from "src/utils/axios";
 import { useDebounce } from "src/hooks/use-debounce";
 import CellMarkdown from "src/sections/common/CellMarkdown";
 import EvalResultDisplay from "./EvalResultDisplay";
+import { buildCompositeRuntimeConfig } from "../Helpers/compositeRuntimeConfig";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
 
@@ -921,6 +922,9 @@ const DatasetTestMode = React.forwardRef(
         const inputDataTypes = {};
         const rowContext = {};
         const imageUrls = [];
+        const compositeConfig = buildCompositeRuntimeConfig({
+          codeParams,
+        });
 
         if (isWorkbenchMode) {
           // Workbench mode: mapping sends variable → field name (e.g. input_prompt)
@@ -1009,11 +1013,7 @@ const DatasetTestMode = React.forwardRef(
                     ...compositeAdhocConfig,
                     mapping: evalMapping,
                     model,
-                    config: {
-                      ...(Object.keys(codeParams || {}).length > 0
-                        ? { params: codeParams }
-                        : {}),
-                    },
+                    config: compositeConfig,
                     error_localizer: errorLocalizerEnabled,
                     input_data_types: inputDataTypes,
                     row_context: rowContext,
@@ -1023,11 +1023,7 @@ const DatasetTestMode = React.forwardRef(
             : await axios.post(endpoints.develop.eval.executeCompositeEval(tid), {
                 mapping: evalMapping,
                 model,
-                config: {
-                  ...(Object.keys(codeParams || {}).length > 0
-                    ? { params: codeParams }
-                    : {}),
-                },
+                config: compositeConfig,
                 error_localizer: errorLocalizerEnabled,
                 input_data_types: inputDataTypes,
                 row_context: rowContext,

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -28,6 +28,7 @@ import CustomAudioPlayer from "src/components/custom-audio/CustomAudioPlayer";
 import { AudioPlaybackProvider } from "src/components/custom-audio/context-provider/AudioPlaybackContext";
 import DraggableColResizer from "src/components/draggable-col-resizer";
 import { JsonValueTree } from "./DatasetTestMode";
+import { buildCompositeRuntimeConfig } from "../Helpers/compositeRuntimeConfig";
 import EvalResultDisplay from "./EvalResultDisplay";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import {
@@ -852,15 +853,14 @@ const SimulationTestMode = React.forwardRef(
         // Auto-context: single-eval playground resolves call_id server-side.
         // Composite execution expects the concrete call context directly.
         const _callId = currentCall?.id;
+        const compositeConfig = buildCompositeRuntimeConfig({
+          codeParams,
+        });
         const compositePayload = {
           mapping: evalMapping,
           model,
           error_localizer: errorLocalizerEnabled,
-          config: {
-            ...(Object.keys(codeParams || {}).length > 0
-              ? { params: codeParams }
-              : {}),
-          },
+          config: compositeConfig,
           ...(callDetail ? { call_context: callDetail } : {}),
         };
 

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -30,7 +30,10 @@ import DraggableColResizer from "src/components/draggable-col-resizer";
 import { JsonValueTree } from "./DatasetTestMode";
 import EvalResultDisplay from "./EvalResultDisplay";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
-import { useExecuteCompositeEval } from "../hooks/useCompositeEval";
+import {
+  useExecuteCompositeEval,
+  useExecuteCompositeEvalAdhoc,
+} from "../hooks/useCompositeEval";
 
 // Hover-tooltip content for the Columns / Value table. Stringifies
 // primitives and JSON-encodes objects, then caps length so a 50k-char
@@ -178,6 +181,7 @@ const SimulationTestMode = React.forwardRef(
       initialMapping = null,
       initialRunTestId = "",
       isComposite = false,
+      compositeAdhocConfig = null,
     },
     ref,
   ) => {
@@ -265,6 +269,7 @@ const SimulationTestMode = React.forwardRef(
     const { state: errorLocalizerState, start: startErrorLocalizerPoll } =
       useErrorLocalizerPoll();
     const executeComposite = useExecuteCompositeEval();
+    const executeCompositeAdhoc = useExecuteCompositeEvalAdhoc();
 
     // 1. Fetch run tests (simulations) — infinite-scroll pagination.
     // Page 1 loads on mount; subsequent pages fetch via onScroll on the
@@ -860,15 +865,25 @@ const SimulationTestMode = React.forwardRef(
         };
 
         const { data } = isComposite
-          ? {
-              data: {
-                status: true,
-                result: await executeComposite.mutateAsync({
-                  templateId: tid,
-                  payload: compositePayload,
-                }),
-              },
-            }
+          ? compositeAdhocConfig
+            ? {
+                data: {
+                  status: true,
+                  result: await executeCompositeAdhoc.mutateAsync({
+                    ...compositeAdhocConfig,
+                    ...compositePayload,
+                  }),
+                },
+              }
+            : {
+                data: {
+                  status: true,
+                  result: await executeComposite.mutateAsync({
+                    templateId: tid,
+                    payload: compositePayload,
+                  }),
+                },
+              }
           : await axios.post(endpoints.develop.eval.evalPlayground, {
               template_id: tid,
               model,
@@ -923,10 +938,12 @@ const SimulationTestMode = React.forwardRef(
       onTestResult,
       errorLocalizerEnabled,
       isComposite,
+      compositeAdhocConfig,
       startErrorLocalizerPoll,
       codeParams,
       model,
       executeComposite,
+      executeCompositeAdhoc,
     ]);
 
     useImperativeHandle(
@@ -1726,6 +1743,7 @@ SimulationTestMode.propTypes = {
   initialMapping: PropTypes.object,
   initialRunTestId: PropTypes.string,
   isComposite: PropTypes.bool,
+  compositeAdhocConfig: PropTypes.object,
 };
 
 export default SimulationTestMode;

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -30,6 +30,7 @@ import DraggableColResizer from "src/components/draggable-col-resizer";
 import { JsonValueTree } from "./DatasetTestMode";
 import EvalResultDisplay from "./EvalResultDisplay";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
+import { useExecuteCompositeEval } from "../hooks/useCompositeEval";
 
 // Hover-tooltip content for the Columns / Value table. Stringifies
 // primitives and JSON-encodes objects, then caps length so a 50k-char
@@ -176,6 +177,7 @@ const SimulationTestMode = React.forwardRef(
       errorLocalizerEnabled = false,
       initialMapping = null,
       initialRunTestId = "",
+      isComposite = false,
     },
     ref,
   ) => {
@@ -262,6 +264,7 @@ const SimulationTestMode = React.forwardRef(
     // Async error localization poll — see DatasetTestMode for rationale.
     const { state: errorLocalizerState, start: startErrorLocalizerPoll } =
       useErrorLocalizerPoll();
+    const executeComposite = useExecuteCompositeEval();
 
     // 1. Fetch run tests (simulations) — infinite-scroll pagination.
     // Page 1 loads on mount; subsequent pages fetch via onScroll on the
@@ -841,29 +844,58 @@ const SimulationTestMode = React.forwardRef(
             }
           }
         }
-        // Auto-context: send the call ID so the evaluator resolves
-        // {{call}}, {{call.transcript}}, {{call.recording_url}} etc.
-        // against the CallExecution fetched server-side.
+        // Auto-context: single-eval playground resolves call_id server-side.
+        // Composite execution expects the concrete call context directly.
         const _callId = currentCall?.id;
-        const { data } = await axios.post(
-          endpoints.develop.eval.evalPlayground,
-          {
-            template_id: tid,
-            model,
-            error_localizer: errorLocalizerEnabled,
-            config: {
-              mapping: evalMapping,
-              ...(Object.keys(codeParams || {}).length > 0
-                ? { params: codeParams }
-                : {}),
-            },
-            ...(_callId ? { call_id: _callId } : {}),
+        const compositePayload = {
+          mapping: evalMapping,
+          model,
+          error_localizer: errorLocalizerEnabled,
+          config: {
+            ...(Object.keys(codeParams || {}).length > 0
+              ? { params: codeParams }
+              : {}),
           },
-        );
+          ...(callDetail ? { call_context: callDetail } : {}),
+        };
+
+        const { data } = isComposite
+          ? {
+              data: {
+                status: true,
+                result: await executeComposite.mutateAsync({
+                  templateId: tid,
+                  payload: compositePayload,
+                }),
+              },
+            }
+          : await axios.post(endpoints.develop.eval.evalPlayground, {
+              template_id: tid,
+              model,
+              error_localizer: errorLocalizerEnabled,
+              config: {
+                mapping: evalMapping,
+                ...(Object.keys(codeParams || {}).length > 0
+                  ? { params: codeParams }
+                  : {}),
+              },
+              ...(_callId ? { call_id: _callId } : {}),
+            });
         if (data?.status) {
-          setResult(data.result);
-          onTestResult?.(true, data.result);
-          if (errorLocalizerEnabled && data.result?.log_id) {
+          const nextResult = isComposite
+            ? {
+                output:
+                  data.result?.aggregation_enabled &&
+                  data.result?.aggregate_score != null
+                    ? data.result.aggregate_score
+                    : null,
+                reason: data.result?.summary || "",
+                compositeResult: data.result,
+              }
+            : data.result;
+          setResult(nextResult);
+          onTestResult?.(true, nextResult);
+          if (!isComposite && errorLocalizerEnabled && data.result?.log_id) {
             startErrorLocalizerPoll(data.result.log_id);
           }
         } else {
@@ -890,8 +922,11 @@ const SimulationTestMode = React.forwardRef(
       currentCall,
       onTestResult,
       errorLocalizerEnabled,
+      isComposite,
       startErrorLocalizerPoll,
       codeParams,
+      model,
+      executeComposite,
     ]);
 
     useImperativeHandle(
@@ -1690,6 +1725,7 @@ SimulationTestMode.propTypes = {
   onClearResult: PropTypes.func,
   initialMapping: PropTypes.object,
   initialRunTestId: PropTypes.string,
+  isComposite: PropTypes.bool,
 };
 
 export default SimulationTestMode;

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -1342,6 +1342,7 @@ const TestPlayground = React.forwardRef(
                   errorLocalizerEnabled={errorLocalizerEnabled}
                   onReadyChange={handleDatasetReady}
                   isComposite={isComposite}
+                  compositeAdhocConfig={compositeAdhocConfig}
                 />
               )}
 
@@ -1358,6 +1359,7 @@ const TestPlayground = React.forwardRef(
                   errorLocalizerEnabled={errorLocalizerEnabled}
                   onReadyChange={handleTracingReady}
                   isComposite={isComposite}
+                  compositeAdhocConfig={compositeAdhocConfig}
                 />
               )}
 
@@ -1374,6 +1376,7 @@ const TestPlayground = React.forwardRef(
                   errorLocalizerEnabled={errorLocalizerEnabled}
                   onReadyChange={handleSimulationReady}
                   isComposite={isComposite}
+                  compositeAdhocConfig={compositeAdhocConfig}
                 />
               )}
 

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -39,6 +39,7 @@ import {
 } from "../hooks/useEvalVersions";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import EvalResultDisplay from "./EvalResultDisplay";
+import { buildCompositeRuntimeConfig } from "../Helpers/compositeRuntimeConfig";
 import VersionBadge from "./VersionBadge";
 import {
   useExecuteCompositeEval,
@@ -856,11 +857,15 @@ const TestPlayground = React.forwardRef(
             mapping[k] = v == null ? "" : String(v);
           });
 
+          const compositeConfig = buildCompositeRuntimeConfig({
+            codeParams: evalType === "code" ? codeParamsRef.current : {},
+          });
+
           const compositeResult = compositeAdhocConfig
             ? await executeCompositeAdhoc.mutateAsync({
                 ...compositeAdhocConfig,
                 mapping,
-                config: { params: {} },
+                config: compositeConfig,
                 error_localizer: errorLocalizerEnabled,
                 input_data_types: {},
               })
@@ -868,7 +873,7 @@ const TestPlayground = React.forwardRef(
                 templateId: tid,
                 payload: {
                   mapping,
-                  config: { params: {} },
+                  config: compositeConfig,
                   error_localizer: errorLocalizerEnabled,
                   input_data_types: {},
                 },

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -1341,6 +1341,7 @@ const TestPlayground = React.forwardRef(
                   onClearResult={onClearResult}
                   errorLocalizerEnabled={errorLocalizerEnabled}
                   onReadyChange={handleDatasetReady}
+                  isComposite={isComposite}
                 />
               )}
 
@@ -1356,6 +1357,7 @@ const TestPlayground = React.forwardRef(
                   onClearResult={onClearResult}
                   errorLocalizerEnabled={errorLocalizerEnabled}
                   onReadyChange={handleTracingReady}
+                  isComposite={isComposite}
                 />
               )}
 
@@ -1371,6 +1373,7 @@ const TestPlayground = React.forwardRef(
                   onClearResult={onClearResult}
                   errorLocalizerEnabled={errorLocalizerEnabled}
                   onReadyChange={handleSimulationReady}
+                  isComposite={isComposite}
                 />
               )}
 

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -215,6 +215,7 @@ const TracingTestMode = React.forwardRef(
       // already-configured eval so the user's previous mapping is preserved).
       initialMapping = null,
       errorLocalizerEnabled = false,
+      isComposite = false,
     },
     ref,
   ) => {
@@ -862,10 +863,9 @@ const TracingTestMode = React.forwardRef(
           }
         }
 
-        // Auto-context IDs — the evaluator resolves {{span}}, {{trace}},
-        // {{session}} references against data fetched server-side by ID.
-        // The backend runs voice-span enrichment (recording, transcript,
-        // metrics) when the span is a Vapi conversation.
+        // Single-eval playground resolves {{span}} / {{trace}} /
+        // {{session}} server-side from IDs. Composite execution expects
+        // the concrete context objects directly.
         const autoCtx = {};
         const _spanId = currentRow?.span_id || currentRow?.spanId;
         const _traceId = currentRow?.trace_id || currentRow?.traceId;
@@ -877,26 +877,55 @@ const TracingTestMode = React.forwardRef(
           autoCtx.session_id = _sessionId;
         if (rowType === "VoiceCall" && _traceId) autoCtx.trace_id = _traceId;
 
-        const { data } = await axios.post(
-          endpoints.develop.eval.evalPlayground,
-          {
-            template_id: tid,
-            model,
-            error_localizer: errorLocalizerEnabled,
-            config: {
+        const compositeCtx = {};
+        if (rowType === "Span" && spanDetail) compositeCtx.span_context = spanDetail;
+        if (rowType === "Trace" && currentRow)
+          compositeCtx.trace_context = currentRow;
+        if (rowType === "Session" && currentRow)
+          compositeCtx.session_context = currentRow;
+        if (rowType === "VoiceCall" && currentRow)
+          compositeCtx.trace_context = currentRow;
+
+        const { data } = isComposite
+          ? await axios.post(endpoints.develop.eval.executeCompositeEval(tid), {
               mapping: evalMapping,
-              ...(Object.keys(codeParams || {}).length > 0
-                ? { params: codeParams }
-                : {}),
-            },
-            ...autoCtx,
-          },
-        );
+              model,
+              error_localizer: errorLocalizerEnabled,
+              config: {
+                ...(Object.keys(codeParams || {}).length > 0
+                  ? { params: codeParams }
+                  : {}),
+              },
+              ...compositeCtx,
+            })
+          : await axios.post(endpoints.develop.eval.evalPlayground, {
+              template_id: tid,
+              model,
+              error_localizer: errorLocalizerEnabled,
+              config: {
+                mapping: evalMapping,
+                ...(Object.keys(codeParams || {}).length > 0
+                  ? { params: codeParams }
+                  : {}),
+              },
+              ...autoCtx,
+            });
 
         if (data?.status) {
-          setResult(data.result);
-          onTestResult?.(true, data.result);
-          if (errorLocalizerEnabled && data.result?.log_id) {
+          const nextResult = isComposite
+            ? {
+                output:
+                  data.result?.aggregation_enabled &&
+                  data.result?.aggregate_score != null
+                    ? data.result.aggregate_score
+                    : null,
+                reason: data.result?.summary || "",
+                compositeResult: data.result,
+              }
+            : data.result;
+          setResult(nextResult);
+          onTestResult?.(true, nextResult);
+          if (!isComposite && errorLocalizerEnabled && data.result?.log_id) {
             startErrorLocalizerPoll(data.result.log_id);
           }
         } else {
@@ -925,6 +954,7 @@ const TracingTestMode = React.forwardRef(
       rowType,
       onTestResult,
       errorLocalizerEnabled,
+      isComposite,
       startErrorLocalizerPoll,
       codeParams,
       model,
@@ -1895,6 +1925,7 @@ TracingTestMode.propTypes = {
   initialProjectId: PropTypes.string,
   initialRowType: PropTypes.string,
   initialMapping: PropTypes.object,
+  isComposite: PropTypes.bool,
 };
 
 export default TracingTestMode;

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -44,6 +44,7 @@ import {
 import { JsonValueTree } from "./DatasetTestMode";
 import EvalResultDisplay from "./EvalResultDisplay";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
+import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
 
 const ROW_TYPES = ["Span", "Trace", "Session"];
 
@@ -216,6 +217,7 @@ const TracingTestMode = React.forwardRef(
       initialMapping = null,
       errorLocalizerEnabled = false,
       isComposite = false,
+      compositeAdhocConfig = null,
     },
     ref,
   ) => {
@@ -331,6 +333,7 @@ const TracingTestMode = React.forwardRef(
     // Async error localization poll — see DatasetTestMode for rationale.
     const { state: errorLocalizerState, start: startErrorLocalizerPoll } =
       useErrorLocalizerPoll();
+    const executeCompositeAdhoc = useExecuteCompositeEvalAdhoc();
 
     // ── Fetch project list (skip when project is pre-selected/locked) ──
     useEffect(() => {
@@ -887,17 +890,35 @@ const TracingTestMode = React.forwardRef(
           compositeCtx.trace_context = currentRow;
 
         const { data } = isComposite
-          ? await axios.post(endpoints.develop.eval.executeCompositeEval(tid), {
-              mapping: evalMapping,
-              model,
-              error_localizer: errorLocalizerEnabled,
-              config: {
-                ...(Object.keys(codeParams || {}).length > 0
-                  ? { params: codeParams }
-                  : {}),
-              },
-              ...compositeCtx,
-            })
+          ? compositeAdhocConfig
+            ? {
+                data: {
+                  status: true,
+                  result: await executeCompositeAdhoc.mutateAsync({
+                    ...compositeAdhocConfig,
+                    mapping: evalMapping,
+                    model,
+                    error_localizer: errorLocalizerEnabled,
+                    config: {
+                      ...(Object.keys(codeParams || {}).length > 0
+                        ? { params: codeParams }
+                        : {}),
+                    },
+                    ...compositeCtx,
+                  }),
+                },
+              }
+            : await axios.post(endpoints.develop.eval.executeCompositeEval(tid), {
+                mapping: evalMapping,
+                model,
+                error_localizer: errorLocalizerEnabled,
+                config: {
+                  ...(Object.keys(codeParams || {}).length > 0
+                    ? { params: codeParams }
+                    : {}),
+                },
+                ...compositeCtx,
+              })
           : await axios.post(endpoints.develop.eval.evalPlayground, {
               template_id: tid,
               model,
@@ -955,9 +976,11 @@ const TracingTestMode = React.forwardRef(
       onTestResult,
       errorLocalizerEnabled,
       isComposite,
+      compositeAdhocConfig,
       startErrorLocalizerPoll,
       codeParams,
       model,
+      executeCompositeAdhoc,
     ]);
 
     useImperativeHandle(
@@ -1926,6 +1949,7 @@ TracingTestMode.propTypes = {
   initialRowType: PropTypes.string,
   initialMapping: PropTypes.object,
   isComposite: PropTypes.bool,
+  compositeAdhocConfig: PropTypes.object,
 };
 
 export default TracingTestMode;

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -42,6 +42,7 @@ import {
   isRecordingObjectKey,
 } from "src/components/inline-audio/audio-detection";
 import { JsonValueTree } from "./DatasetTestMode";
+import { buildCompositeRuntimeConfig } from "../Helpers/compositeRuntimeConfig";
 import EvalResultDisplay from "./EvalResultDisplay";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
@@ -889,6 +890,10 @@ const TracingTestMode = React.forwardRef(
         if (rowType === "VoiceCall" && currentRow)
           compositeCtx.trace_context = currentRow;
 
+        const compositeConfig = buildCompositeRuntimeConfig({
+          codeParams,
+        });
+
         const { data } = isComposite
           ? compositeAdhocConfig
             ? {
@@ -899,11 +904,7 @@ const TracingTestMode = React.forwardRef(
                     mapping: evalMapping,
                     model,
                     error_localizer: errorLocalizerEnabled,
-                    config: {
-                      ...(Object.keys(codeParams || {}).length > 0
-                        ? { params: codeParams }
-                        : {}),
-                    },
+                    config: compositeConfig,
                     ...compositeCtx,
                   }),
                 },
@@ -912,11 +913,7 @@ const TracingTestMode = React.forwardRef(
                 mapping: evalMapping,
                 model,
                 error_localizer: errorLocalizerEnabled,
-                config: {
-                  ...(Object.keys(codeParams || {}).length > 0
-                    ? { params: codeParams }
-                    : {}),
-                },
+                config: compositeConfig,
                 ...compositeCtx,
               })
           : await axios.post(endpoints.develop.eval.evalPlayground, {

--- a/frontend/src/sections/evals/components/__tests__/compositeRuntimeConfig.test.js
+++ b/frontend/src/sections/evals/components/__tests__/compositeRuntimeConfig.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCompositeRuntimeConfig } from "../../Helpers/compositeRuntimeConfig";
+
+describe("buildCompositeRuntimeConfig", () => {
+  it("returns an empty object when no config or params are provided", () => {
+    expect(buildCompositeRuntimeConfig()).toEqual({});
+  });
+
+  it("adds function params to the runtime config", () => {
+    expect(
+      buildCompositeRuntimeConfig({
+        codeParams: { min_words: 100, max_words: 200 },
+      }),
+    ).toEqual({
+      params: { min_words: 100, max_words: 200 },
+    });
+  });
+
+  it("preserves unrelated config fields while merging params", () => {
+    expect(
+      buildCompositeRuntimeConfig({
+        config: { provider: "openai", threshold: 0.5 },
+        codeParams: { min_words: 100 },
+      }),
+    ).toEqual({
+      provider: "openai",
+      threshold: 0.5,
+      params: { min_words: 100 },
+    });
+  });
+
+  it("merges existing params with function params and prefers explicit function params", () => {
+    expect(
+      buildCompositeRuntimeConfig({
+        config: { params: { model_name: "gpt-4", min_words: 10 } },
+        codeParams: { min_words: 100, max_words: 200 },
+      }),
+    ).toEqual({
+      params: {
+        model_name: "gpt-4",
+        min_words: 100,
+        max_words: 200,
+      },
+    });
+  });
+});

--- a/futureagi/ai_tools/tools/datasets/add_dataset_eval.py
+++ b/futureagi/ai_tools/tools/datasets/add_dataset_eval.py
@@ -64,6 +64,7 @@ class AddDatasetEvalTool(BaseTool):
         from ai_tools.resolvers import resolve_dataset, resolve_eval_template
         from model_hub.models.develop_dataset import Column
         from model_hub.models.evals_metric import EvalTemplate, UserEvalMetric
+        from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
         from model_hub.utils.eval_validators import validate_eval_template_org_access
 
         # Resolve dataset by name or UUID
@@ -255,18 +256,7 @@ class AddDatasetEvalTool(BaseTool):
 
                 dataset = Dataset.objects.get(id=dataset.id)
 
-                # Determine output data type from template
-                output_type = "boolean"
-                if template.config and isinstance(template.config, dict):
-                    output_map = {
-                        "reason": "text",
-                        "score": "float",
-                        "choices": "array",
-                        "Pass/Fail": "boolean",
-                    }
-                    output_type = output_map.get(
-                        template.config.get("output", ""), "boolean"
-                    )
+                output_type = infer_eval_result_column_data_type(template)
 
                 col = Column(
                     name=eval_name,

--- a/futureagi/ai_tools/tools/datasets/run_dataset_evals.py
+++ b/futureagi/ai_tools/tools/datasets/run_dataset_evals.py
@@ -43,6 +43,7 @@ class RunDatasetEvalsTool(BaseTool):
         )
         from model_hub.models.develop_dataset import Cell, Column
         from model_hub.models.evals_metric import UserEvalMetric
+        from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
 
         dataset, error = resolve_dataset(
             params.dataset_id, context.organization, context.workspace
@@ -112,17 +113,7 @@ class RunDatasetEvalsTool(BaseTool):
             column = existing_columns.get(source_id)
 
             if not column:
-                output_type = "boolean"
-                if em.template and em.template.config:
-                    output_map = {
-                        "reason": "text",
-                        "score": "float",
-                        "choices": "array",
-                        "Pass/Fail": "boolean",
-                    }
-                    output_type = output_map.get(
-                        em.template.config.get("output", ""), "boolean"
-                    )
+                output_type = infer_eval_result_column_data_type(em.template)
 
                 column = Column.objects.create(
                     source_id=source_id,

--- a/futureagi/model_hub/tasks/composite_runner.py
+++ b/futureagi/model_hub/tasks/composite_runner.py
@@ -49,6 +49,7 @@ from model_hub.utils.composite_execution import (
     CompositeRunOutcome,
     execute_composite_children_sync,
 )
+from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +160,7 @@ class CompositeEvaluationRunner:
             source_id = f"{optimize.id}-sourceid-{user_eval_metric.id}"
             name = f"{user_eval_metric.name}-{column.name}"
 
-        data_type = "float" if template.aggregation_enabled else "text"
+        data_type = infer_eval_result_column_data_type(template)
 
         return {
             "name": name,

--- a/futureagi/model_hub/tests/test_eval_result_column_types.py
+++ b/futureagi/model_hub/tests/test_eval_result_column_types.py
@@ -1,0 +1,39 @@
+import pytest
+
+from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
+
+
+class _TemplateStub:
+    def __init__(
+        self,
+        *,
+        template_type="single",
+        aggregation_enabled=True,
+        output=None,
+    ):
+        self.template_type = template_type
+        self.aggregation_enabled = aggregation_enabled
+        self.config = {"output": output} if output is not None else {}
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        (_TemplateStub(output="reason"), "text"),
+        (_TemplateStub(output="score"), "float"),
+        (_TemplateStub(output="numeric"), "float"),
+        (_TemplateStub(output="choices"), "array"),
+        (_TemplateStub(output="Pass/Fail"), "boolean"),
+        (_TemplateStub(output=None), "boolean"),
+        (
+            _TemplateStub(template_type="composite", aggregation_enabled=True),
+            "float",
+        ),
+        (
+            _TemplateStub(template_type="composite", aggregation_enabled=False),
+            "text",
+        ),
+    ],
+)
+def test_infer_eval_result_column_data_type(template, expected):
+    assert infer_eval_result_column_data_type(template) == expected

--- a/futureagi/model_hub/utils/eval_result_columns.py
+++ b/futureagi/model_hub/utils/eval_result_columns.py
@@ -1,0 +1,28 @@
+from model_hub.models.develop_dataset import DataTypeChoices
+
+
+def infer_eval_result_column_data_type(eval_template) -> str:
+    """Return the column data type for an eval result.
+
+    This is the shared source of truth used by add-time creation, runtime
+    runners, and display helpers so output-type support cannot drift between
+    code paths.
+    """
+
+    if getattr(eval_template, "template_type", "single") == "composite":
+        return (
+            DataTypeChoices.FLOAT.value
+            if getattr(eval_template, "aggregation_enabled", False)
+            else DataTypeChoices.TEXT.value
+        )
+
+    output_type = ((getattr(eval_template, "config", None) or {}).get("output") or "")
+
+    return {
+        "reason": DataTypeChoices.TEXT.value,
+        "score": DataTypeChoices.FLOAT.value,
+        "numeric": DataTypeChoices.FLOAT.value,
+        "choices": DataTypeChoices.ARRAY.value,
+        "Pass/Fail": DataTypeChoices.BOOLEAN.value,
+        "datetime": DataTypeChoices.DATETIME.value,
+    }.get(output_type, DataTypeChoices.BOOLEAN.value)

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -141,6 +141,7 @@ from model_hub.utils.eval_reasons import (
     MIN_ROWS_FOR_CRITICAL_ISSUES,
     get_explanation_summary,
 )
+from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
 from model_hub.utils.evals import (
     FUNCTION_CONFIG_EVALS,
     NOT_UI_EVALS,
@@ -7092,11 +7093,7 @@ class StartEvalsProcess(APIView):
             column_order_changed = False
 
             for user_eval_metric in eval_metrics:
-                data_type = {
-                    "reason": "text",
-                    "score": "float",
-                    "choices": "array",
-                }.get(user_eval_metric.template.config.get("output"), "boolean")
+                data_type = infer_eval_result_column_data_type(user_eval_metric.template)
 
                 source_id = str(user_eval_metric.id)
                 column = existing_columns.get(str(source_id))
@@ -7775,17 +7772,7 @@ class AddUserEvalView(CreateAPIView):
                     dataset = Dataset.no_workspace_objects.select_for_update().get(
                         id=id1
                     )
-                    # Composite evals: aggregation-on → float, off → text.
-                    # Single evals: derive from config.output.
-                    if template.template_type == "composite":
-                        data_type = "float" if template.aggregation_enabled else "text"
-                    else:
-                        output_type = user_eval_metric.template.config.get("output")
-                        data_type = {
-                            "reason": "text",
-                            "score": "float",
-                            "choices": "array",
-                        }.get(output_type, "boolean")
+                    data_type = infer_eval_result_column_data_type(template)
 
                     column = Column.objects.create(
                         name=validated_data.get("name"),
@@ -13249,12 +13236,9 @@ class AddCompareExperimentEvalView(APIView):
                         dataset = Dataset.no_workspace_objects.select_for_update().get(
                             id=dataset_id
                         )
-                        output_type = user_eval_metric.template.config.get("output")
-                        data_type = {
-                            "reason": "text",
-                            "score": "float",
-                            "choices": "array",
-                        }.get(output_type, "boolean")
+                        data_type = infer_eval_result_column_data_type(
+                            user_eval_metric.template
+                        )
 
                         column = Column.objects.create(
                             name=validated_data.get("name"),
@@ -13341,11 +13325,7 @@ class CompareDatasetsStartEvalsProcess(APIView):
 
             # Process each metric for column creation
             for metric in user_eval_metrics:
-                data_type = {
-                    "reason": "text",
-                    "score": "float",
-                    "choices": "array",
-                }.get(metric.template.config.get("output"), "boolean")
+                data_type = infer_eval_result_column_data_type(metric.template)
 
                 # Get or create evaluation column
                 column, created = Column.objects.get_or_create(

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -56,6 +56,7 @@ from model_hub.serializers.eval_runner import (
     EvalTemplateSerializer,
     EvalUserTemplateSerializer,
 )
+from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
 from model_hub.utils.evals import prepare_user_eval_config  # noqa: E402
 from model_hub.utils.json_path_resolver import (  # noqa: E402
     parse_json_safely,
@@ -848,13 +849,7 @@ class EvaluationRunner:
         logger.info(
             " ----- INSIDE EvaluationRunner : function _get_column_config -----"
         )
-        output_type = self.eval_template.config.get("output")
-        output_type = {
-            "reason": "text",
-            "score": "float",
-            "numeric": "float",
-            "choices": "array",
-        }.get(output_type, "boolean")
+        output_type = infer_eval_result_column_data_type(self.eval_template)
 
         source = SourceChoices.EVALUATION.value
         source_id = self.user_eval_metric_id

--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -56,6 +56,7 @@ from model_hub.serializers.experiments import (
 )
 from model_hub.services.dataset_snapshot import create_dataset_snapshot
 from model_hub.tasks.experiment_runner import process_experiments
+from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
 from model_hub.utils.function_eval_params import (
     has_function_params_schema,
     normalize_eval_runtime_config,
@@ -1149,13 +1150,9 @@ class DatasetExperimentsView(APIView):
                             em = eval_metric_map.get(eval_id) if eval_id else None
                             if em:
                                 col_status = em.status
-                                output_type = em.template.config.get("output")
-                                data_type = {
-                                    "reason": "text",
-                                    "score": "float",
-                                    "numeric": "float",
-                                    "choices": "array",
-                                }.get(output_type, "boolean")
+                                data_type = infer_eval_result_column_data_type(
+                                    em.template
+                                )
                                 choices_map = em.template.config.get("choices_map", {})
                                 group = {
                                     "id": str(eval_id),

--- a/futureagi/tfc/temporal/experiments/activities.py
+++ b/futureagi/tfc/temporal/experiments/activities.py
@@ -830,12 +830,10 @@ def _create_skipped_eval_cells(
 
     from model_hub.models.choices import CellStatus, SourceChoices
     from model_hub.models.develop_dataset import Column, Row
+    from model_hub.utils.eval_result_columns import infer_eval_result_column_data_type
     from model_hub.views.eval_runner import bulk_update_or_create_cells
 
-    output_type = user_eval_metric.template.config.get("output", "boolean")
-    data_type = {"reason": "text", "score": "float", "choices": "array"}.get(
-        output_type, "boolean"
-    )
+    data_type = infer_eval_result_column_data_type(user_eval_metric.template)
 
     eval_column, _ = Column.objects.get_or_create(
         name=user_eval_metric.name,


### PR DESCRIPTION
## Summary

This PR routes composite eval runs in tracing, simulation, and dataset test modes through the composite execute endpoint instead of the single-eval playground endpoint. It also passes composite union keys into the affected picker flows and normalizes composite responses into the shape the existing result display expects, so composite test results render consistently outside custom mode. Single-eval execution and error-localizer polling remain unchanged.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Manual validation in the local UI for composite eval execution outside custom mode
- `./node_modules/.bin/eslint src/sections/evals/components/SimulationTestMode.jsx src/sections/evals/components/TracingTestMode.jsx src/sections/evals/components/TestPlayground.jsx src/sections/common/EvalPicker/EvalPickerConfigFull.jsx src/sections/common/EvalPicker/EvalPickerCreateNew.jsx`
- `./node_modules/.bin/eslint src/sections/evals/components/DatasetTestMode.jsx`

## Screenshots / recordings (if UI)

Not included.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
