### PR TITLE
fix(simulate): chat sim eval variable mapping shows empty/voice-only columns

### DIFF
--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -544,20 +544,18 @@ const SimulationTestMode = React.forwardRef(
           }
 
           // -- Call-level runtime vocabulary — nested under `call.*`. --
-          const callType = callData.call_type || callData.simulation_call_type;
+          // simulation_call_type is the modality (text/voice); call_type is the direction (Inbound/Outbound).
+          const callType = callData.simulation_call_type || callData.call_type;
           const isTextCall =
             typeof callType === "string" &&
             ["text", "chat", "prompt"].includes(callType.toLowerCase());
 
           if (isTextCall) {
-            const rawTranscript =
-              typeof callData.transcript === "string"
-                ? callData.transcript
-                : "";
-            const { user, assistant } = splitChatTranscript(rawTranscript);
-            flat.call.transcript = rawTranscript;
-            flat.call.user_chat_transcript = user;
-            flat.call.assistant_chat_transcript = assistant;
+            flat.call.transcript = callData.transcript_text || "";
+            flat.call.user_chat_transcript =
+              callData.user_chat_transcript || "";
+            flat.call.assistant_chat_transcript =
+              callData.assistant_chat_transcript || "";
           } else {
             // Voice sim: pull recordings from the serializer's
             // `recordings` dict / `audio_url`, with provider_call_data

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -10,6 +10,7 @@ from simulate.models import (
     CallExecution,
     CallExecutionSnapshot,
     CallTranscript,
+    ChatMessageModel,
     TestExecution,
 )
 from simulate.serializers.chat_message import ChatMessageSerializer
@@ -139,6 +140,12 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
     duration = serializers.SerializerMethodField()
     start_time = serializers.SerializerMethodField()
     transcript = serializers.SerializerMethodField()
+    # Flat-string transcripts mirroring the eval-time resolver in
+    # simulate.temporal.activities.xl._build_transcript_data so the test/preview
+    # UI can render the same shape evals will see.
+    transcript_text = serializers.SerializerMethodField()
+    user_chat_transcript = serializers.SerializerMethodField()
+    assistant_chat_transcript = serializers.SerializerMethodField()
     scenario = serializers.CharField(source="scenario.name", read_only=True)
     overall_score = serializers.SerializerMethodField()
     response_time = serializers.SerializerMethodField()
@@ -218,6 +225,9 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
             "duration",
             "start_time",
             "transcript",
+            "transcript_text",
+            "user_chat_transcript",
+            "assistant_chat_transcript",
             "scenario",
             "overall_score",
             "response_time",
@@ -451,6 +461,68 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
                 context={"recording_offset_ms": offset},
             ).data
         return []
+
+    def _iter_chat_messages(self, obj):
+        if not hasattr(obj, "chat_messages"):
+            return []
+        return obj.chat_messages.order_by("created_at")
+
+    def _build_chat_transcripts(self, obj):
+        """Return (transcript, user, assistant) flat strings for a chat sim.
+
+        Mirrors simulate.temporal.activities.xl._build_transcript_data so the
+        test/preview UI sees the same shape the eval resolver will."""
+        full_lines = []
+        user_lines = []
+        assistant_lines = []
+        for cm in self._iter_chat_messages(obj):
+            messages = cm.messages or []
+            if not messages:
+                continue
+            for msg in messages:
+                if not isinstance(msg, str):
+                    msg = str(msg)
+                full_lines.append(f"{cm.role}: {msg}")
+                if cm.role == ChatMessageModel.RoleChoices.USER:
+                    user_lines.append(msg)
+                elif cm.role == ChatMessageModel.RoleChoices.ASSISTANT:
+                    assistant_lines.append(msg)
+        return (
+            "\n".join(full_lines),
+            "\n".join(user_lines),
+            "\n".join(assistant_lines),
+        )
+
+    def _build_voice_transcript_text(self, obj):
+        if not hasattr(obj, "transcripts"):
+            return ""
+        rows = obj.transcripts.exclude(
+            speaker_role=CallTranscript.SpeakerRole.UNKNOWN
+        ).order_by("start_time_ms")
+        lines = [f"{r.speaker_role}: {r.content}" for r in rows if (r.content or "").strip()]
+        return "\n".join(lines)
+
+    def get_transcript_text(self, obj):
+        if not self.context.get("detail_mode", True):
+            return ""
+        simulation_call_type = getattr(obj, "simulation_call_type", None)
+        if simulation_call_type == CallExecution.SimulationCallType.TEXT:
+            return self._build_chat_transcripts(obj)[0]
+        return self._build_voice_transcript_text(obj)
+
+    def get_user_chat_transcript(self, obj):
+        if not self.context.get("detail_mode", True):
+            return ""
+        if getattr(obj, "simulation_call_type", None) != CallExecution.SimulationCallType.TEXT:
+            return ""
+        return self._build_chat_transcripts(obj)[1]
+
+    def get_assistant_chat_transcript(self, obj):
+        if not self.context.get("detail_mode", True):
+            return ""
+        if getattr(obj, "simulation_call_type", None) != CallExecution.SimulationCallType.TEXT:
+            return ""
+        return self._build_chat_transcripts(obj)[2]
 
     def get_response_time(self, obj):
         """Convert response_time_ms to seconds"""

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -493,14 +493,35 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
             "\n".join(assistant_lines),
         )
 
-    def _build_voice_transcript_text(self, obj):
+    def _build_voice_transcripts(self, obj):
+        """Return (transcript, user, assistant) flat strings for a voice sim.
+
+        Mirrors the chat-sim split shape: combined dialogue plus per-role
+        joins keyed off the normalised speaker_role values written to
+        CallTranscript ("user" = simulator, "assistant" = tested agent).
+        """
         if not hasattr(obj, "transcripts"):
-            return ""
+            return "", "", ""
         rows = obj.transcripts.exclude(
             speaker_role=CallTranscript.SpeakerRole.UNKNOWN
         ).order_by("start_time_ms")
-        lines = [f"{r.speaker_role}: {r.content}" for r in rows if (r.content or "").strip()]
-        return "\n".join(lines)
+        full_lines = []
+        user_lines = []
+        assistant_lines = []
+        for r in rows:
+            content = (r.content or "").strip()
+            if not content:
+                continue
+            full_lines.append(f"{r.speaker_role}: {content}")
+            if r.speaker_role == CallTranscript.SpeakerRole.USER:
+                user_lines.append(content)
+            elif r.speaker_role == CallTranscript.SpeakerRole.ASSISTANT:
+                assistant_lines.append(content)
+        return (
+            "\n".join(full_lines),
+            "\n".join(user_lines),
+            "\n".join(assistant_lines),
+        )
 
     def get_transcript_text(self, obj):
         if not self.context.get("detail_mode", True):
@@ -508,21 +529,23 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
         simulation_call_type = getattr(obj, "simulation_call_type", None)
         if simulation_call_type == CallExecution.SimulationCallType.TEXT:
             return self._build_chat_transcripts(obj)[0]
-        return self._build_voice_transcript_text(obj)
+        return self._build_voice_transcripts(obj)[0]
 
     def get_user_chat_transcript(self, obj):
         if not self.context.get("detail_mode", True):
             return ""
-        if getattr(obj, "simulation_call_type", None) != CallExecution.SimulationCallType.TEXT:
-            return ""
-        return self._build_chat_transcripts(obj)[1]
+        simulation_call_type = getattr(obj, "simulation_call_type", None)
+        if simulation_call_type == CallExecution.SimulationCallType.TEXT:
+            return self._build_chat_transcripts(obj)[1]
+        return self._build_voice_transcripts(obj)[1]
 
     def get_assistant_chat_transcript(self, obj):
         if not self.context.get("detail_mode", True):
             return ""
-        if getattr(obj, "simulation_call_type", None) != CallExecution.SimulationCallType.TEXT:
-            return ""
-        return self._build_chat_transcripts(obj)[2]
+        simulation_call_type = getattr(obj, "simulation_call_type", None)
+        if simulation_call_type == CallExecution.SimulationCallType.TEXT:
+            return self._build_chat_transcripts(obj)[2]
+        return self._build_voice_transcripts(obj)[2]
 
     def get_response_time(self, obj):
         """Convert response_time_ms to seconds"""

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -280,13 +280,22 @@ def _build_transcript_data(call_execution):
                 is_outbound = str(call_dir).strip().lower() == "outbound"
 
                 for transcript in transcripts:
-                    if transcript.content.strip():
-                        eval_role = SpeakerRoleResolver.get_eval_role_label(
-                            transcript.speaker_role,
-                            provider=provider,
-                            is_outbound=is_outbound,
-                        )
-                        transcript_text.append(f"{eval_role}: {transcript.content}")
+                    content = (transcript.content or "").strip()
+                    if not content:
+                        continue
+                    eval_role = SpeakerRoleResolver.get_eval_role_label(
+                        transcript.speaker_role,
+                        provider=provider,
+                        is_outbound=is_outbound,
+                    )
+                    transcript_text.append(f"{eval_role}: {content}")
+                    # Per-role splits, keyed off the raw CallTranscript role
+                    # ("user" = simulator, "assistant" = tested agent — see
+                    # SpeakerRoleResolver._VAPI_INBOUND for the convention).
+                    if transcript.speaker_role == CallTranscript.SpeakerRole.USER:
+                        user_chat_transcript_text.append(content)
+                    elif transcript.speaker_role == CallTranscript.SpeakerRole.ASSISTANT:
+                        assistant_chat_transcript_text.append(content)
 
             transcript_data["transcript"] = "\n".join(transcript_text)
             transcript_data["user_chat_transcript"] = "\n".join(


### PR DESCRIPTION
Two issues caused the eval Variable Mapping picker to be unusable for chat simulations:

1. simulate/serializers/test_execution.py.CallExecutionDetailSerializer exposed `transcript` as an array of ChatMessage objects for chat sims, but the test/preview UI in SimulationTestMode.jsx still parsed it as the legacy "user: …\nassistant: …" string. Result: empty call.transcript / call.user_chat_transcript / call.assistant_chat_transcript.

2. SimulationTestMode.jsx read `callData.call_type` first when deciding text-vs-voice, but `call_type` is the direction (Inbound/Outbound) while `simulation_call_type` is the modality (text/voice). For chat sims `callType` resolved to "Inbound", isTextCall was always false, and the voice branch fired — populating empty call.voice_recording / stereo_recording / assistant_recording / customer_recording rows.

Backend: add three flat-string fields on CallExecutionDetailSerializer (`transcript_text`, `user_chat_transcript`, `assistant_chat_transcript`) that mirror the eval-time resolver in xl._build_transcript_data — same "role: msg" line format, same per-role split. This is the single source of truth the frontend now reads, instead of duplicating walker logic.

Frontend: prefer simulation_call_type for the modality check; in the text branch, read the new flat-string fields directly instead of reparsing the array shape.

Test plan
- Chat sim → variable mapping picker shows populated call.transcript, call.user_chat_transcript, call.assistant_chat_transcript; no empty call.voice_recording / stereo_recording / etc.
- Voice sim → unchanged behaviour: call.voice_recording etc. populate as before.

<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
