### PR TITLE
Fix/scenarios cell scroll and back nav

### DIFF
--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/TextArrayJsonCellRenderer.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/TextArrayJsonCellRenderer.jsx
@@ -115,6 +115,7 @@ const TextArrayJsonCellRenderer = ({
           display: "flex",
           flexDirection: "column",
           height: "100%",
+          minHeight: 0,
           justifyContent: metadata?.responseTimeMs ? "space-between" : "start",
           padding: "4px 8px",
         }}
@@ -124,10 +125,9 @@ const TextArrayJsonCellRenderer = ({
             sx={{
               whiteSpace: "pre-wrap",
               lineHeight: "1.5",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              WebkitLineClamp: metadata?.responseTimeMs ? "5" : "6",
-              WebkitBoxOrient: "vertical",
+              flex: 1,
+              minHeight: 0,
+              overflowY: "auto",
             }}
           >
             {isValueArray ? (

--- a/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -467,7 +467,9 @@ const CreateScenarioView = () => {
     // @ts-ignore
     try {
       const data = await mutateAsync(payload);
-      navigate(`/dashboard/simulate/scenarios/${data?.data?.scenario?.id}`);
+      navigate(`/dashboard/simulate/scenarios/${data?.data?.scenario?.id}`, {
+        replace: true,
+      });
     } catch (error) {
       enqueueSnackbar(error?.message, { variant: "error" });
       return;


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

- After creating a scenario, browser back returned to the
generation page; switched the post-create `navigate(...)` to                    
`{ replace: true }` so back goes to the scenario list instead.                  
-  Scenario-grid text cells (situation / outcome / etc.) clamped          
long text at 6 lines with no scrollbar; replaced the                            
`-webkit-line-clamp` with an `overflow-y: auto` flex-column scroll              
container so users can scroll within the cell.     

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
