### PR TITLE
fix(test-runs): gate Run New Simulation on scenario readiness

### DIFF
--- a/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
+++ b/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
@@ -23,6 +23,7 @@ import { useTestRunsSelectedCount } from "../common";
 import { useTestRunSdkStoreShallow } from "./state";
 import { AGENT_TYPES } from "src/sections/agents/constants";
 import { SIMULATION_TYPE } from "src/components/run-tests/common";
+import { SCENARIO_STATUS } from "src/pages/dashboard/scenarios/common";
 
 const ScenarioPopover = lazy(() => import("./ScenarioPopover"));
 const TestRunsSelection = lazy(() => import("./TestRunsSelection"));
@@ -88,6 +89,16 @@ const TestRunHeader = () => {
   const isAgentDefinitionDeleted =
     !isPromptSimulation &&
     !(testData?.agent_definition ?? testData?.agentDefinition);
+
+  const selectedScenarioIds = new Set(
+    (selectedScenarios || []).map((s) => (typeof s === "string" ? s : s?.id)),
+  );
+  const scenarioDetails =
+    testData?.scenarios_detail ?? testData?.scenariosDetail ?? [];
+  const hasUnreadyScenario = scenarioDetails.some(
+    (s) =>
+      selectedScenarioIds.has(s.id) && s.status !== SCENARIO_STATUS.COMPLETED,
+  );
   const agentType = isPromptSimulation
     ? AGENT_TYPES.CHAT
     : testData?.agent_version?.configuration_snapshot?.agent_type ??
@@ -261,7 +272,8 @@ const TestRunHeader = () => {
                     PERMISSIONS.RUN_SIMULATION_TEST
                   ][role] ||
                   selectedScenarios.length === 0 ||
-                  isAgentDefinitionDeleted
+                  isAgentDefinitionDeleted ||
+                  hasUnreadyScenario
                 }
               >
                 Run New Simulation

--- a/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
+++ b/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
@@ -232,11 +232,17 @@ const TestRunHeader = () => {
             </Box>
           </CustomTooltip>
           <CustomTooltip
-            show={isAgentDefinitionDeleted || selectedScenarios.length === 0}
+            show={
+              isAgentDefinitionDeleted ||
+              selectedScenarios.length === 0 ||
+              hasIncompleteScenario
+            }
             title={
               isAgentDefinitionDeleted
                 ? "Agent definition has been deleted. Please select a new agent definition to run simulation."
-                : "Select atleast one scenario to run test"
+                : selectedScenarios.length === 0
+                  ? "Select atleast one scenario to run test"
+                  : "Some selected scenarios are still being generated. Wait for them to complete before running a simulation."
             }
             size="small"
             arrow

--- a/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
+++ b/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
@@ -242,7 +242,7 @@ const TestRunHeader = () => {
                 ? "Agent definition has been deleted. Please select a new agent definition to run simulation."
                 : selectedScenarios.length === 0
                   ? "Select atleast one scenario to run test"
-                  : "Some selected scenarios are still being generated. Wait for them to complete before running a simulation."
+                  : "Some selected scenarios are not completed. Wait for them to finish or remove them from the selection."
             }
             size="small"
             arrow

--- a/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
+++ b/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
@@ -90,12 +90,9 @@ const TestRunHeader = () => {
     !isPromptSimulation &&
     !(testData?.agent_definition ?? testData?.agentDefinition);
 
-  const selectedScenarioIds = new Set(
-    (selectedScenarios || []).map((s) => (typeof s === "string" ? s : s?.id)),
-  );
-  const scenarioDetails =
-    testData?.scenarios_detail ?? testData?.scenariosDetail ?? [];
-  const hasUnreadyScenario = scenarioDetails.some(
+  const selectedScenarioIds = new Set(selectedScenarios || []);
+  const scenarioDetails = testData?.scenarios_detail ?? [];
+  const hasIncompleteScenario = scenarioDetails.some(
     (s) =>
       selectedScenarioIds.has(s.id) && s.status !== SCENARIO_STATUS.COMPLETED,
   );
@@ -273,7 +270,7 @@ const TestRunHeader = () => {
                   ][role] ||
                   selectedScenarios.length === 0 ||
                   isAgentDefinitionDeleted ||
-                  hasUnreadyScenario
+                  hasIncompleteScenario
                 }
               >
                 Run New Simulation

--- a/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
+++ b/frontend/src/sections/test/TestRuns/TestRunHeader.jsx
@@ -98,8 +98,9 @@ const TestRunHeader = () => {
   );
   const agentType = isPromptSimulation
     ? AGENT_TYPES.CHAT
-    : testData?.agent_version?.configuration_snapshot?.agent_type ??
-      testData?.agentVersion?.configurationSnapshot?.agentType;
+    : (testData?.agent_definition_detail?.agent_type ??
+      testData?.agent_version?.configuration_snapshot?.agent_type ??
+      testData?.agentVersion?.configurationSnapshot?.agentType);
 
   return (
     <Box

--- a/futureagi/simulate/tests/test_scenario_completeness.py
+++ b/futureagi/simulate/tests/test_scenario_completeness.py
@@ -130,13 +130,17 @@ def test_failed_scenarios_also_block(
 
 
 def test_cross_org_scenarios_are_not_leaked(
-    db, run_test, organization, workspace, agent_definition, simulator_agent
+    db, run_test, user, organization, workspace, agent_definition, simulator_agent
 ):
     """A scenario belonging to another org must NOT appear in the gate's
     response, even if its UUID is passed in."""
     other_org = Organization.objects.create(name="Other Org")
     other_ws = Workspace.objects.create(
-        name="Other WS", organization=other_org, is_default=True, is_active=True,
+        name="Other WS",
+        organization=other_org,
+        is_default=True,
+        is_active=True,
+        created_by=user,
     )
     other_agent = AgentDefinition.objects.create(
         agent_name="Other Agent",

--- a/futureagi/simulate/tests/test_scenario_completeness.py
+++ b/futureagi/simulate/tests/test_scenario_completeness.py
@@ -42,7 +42,9 @@ def simulator_agent(db, organization, workspace):
     )
 
 
-def _scenario(organization, workspace, agent_definition, simulator_agent, *, name, status_):
+def _scenario(
+    organization, workspace, agent_definition, simulator_agent, *, name, status_
+):
     return Scenarios.objects.create(
         name=name,
         description="",
@@ -68,21 +70,35 @@ def run_test(db, organization, workspace, agent_definition, simulator_agent):
     return rt
 
 
-def test_returns_none_for_empty_scenario_ids(run_test):
-    assert check_scenarios_incomplete([], run_test) is None
-    assert check_scenarios_incomplete(None, run_test) is None
+@pytest.mark.parametrize("scenario_ids", [[], None])
+def test_returns_400_when_no_scenario_ids(run_test, scenario_ids):
+    response = check_scenarios_incomplete(scenario_ids, run_test)
+
+    assert response is not None
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    payload = response.data["result"]
+    assert payload["error"] == "No scenarios"
+    assert payload["scenarios"] == []
 
 
 def test_returns_none_when_all_scenarios_completed(
     db, run_test, organization, workspace, agent_definition, simulator_agent
 ):
     s1 = _scenario(
-        organization, workspace, agent_definition, simulator_agent,
-        name="A", status_=StatusType.COMPLETED.value,
+        organization,
+        workspace,
+        agent_definition,
+        simulator_agent,
+        name="A",
+        status_=StatusType.COMPLETED.value,
     )
     s2 = _scenario(
-        organization, workspace, agent_definition, simulator_agent,
-        name="B", status_=StatusType.COMPLETED.value,
+        organization,
+        workspace,
+        agent_definition,
+        simulator_agent,
+        name="B",
+        status_=StatusType.COMPLETED.value,
     )
     run_test.scenarios.add(s1, s2)
 
@@ -93,12 +109,20 @@ def test_returns_400_when_any_scenario_running(
     db, run_test, organization, workspace, agent_definition, simulator_agent
 ):
     s1 = _scenario(
-        organization, workspace, agent_definition, simulator_agent,
-        name="Done", status_=StatusType.COMPLETED.value,
+        organization,
+        workspace,
+        agent_definition,
+        simulator_agent,
+        name="Done",
+        status_=StatusType.COMPLETED.value,
     )
     s2 = _scenario(
-        organization, workspace, agent_definition, simulator_agent,
-        name="StillRunning", status_=StatusType.RUNNING.value,
+        organization,
+        workspace,
+        agent_definition,
+        simulator_agent,
+        name="StillRunning",
+        status_=StatusType.RUNNING.value,
     )
     run_test.scenarios.add(s1, s2)
 
@@ -117,8 +141,12 @@ def test_failed_scenarios_also_block(
     db, run_test, organization, workspace, agent_definition, simulator_agent
 ):
     s = _scenario(
-        organization, workspace, agent_definition, simulator_agent,
-        name="Broken", status_=StatusType.FAILED.value,
+        organization,
+        workspace,
+        agent_definition,
+        simulator_agent,
+        name="Broken",
+        status_=StatusType.FAILED.value,
     )
     run_test.scenarios.add(s)
 
@@ -186,8 +214,12 @@ def test_unattached_scenarios_silently_ignored(
     """Scenario in the same org but NOT attached to this run_test should not
     affect the gate."""
     unattached = _scenario(
-        organization, workspace, agent_definition, simulator_agent,
-        name="Unattached", status_=StatusType.RUNNING.value,
+        organization,
+        workspace,
+        agent_definition,
+        simulator_agent,
+        name="Unattached",
+        status_=StatusType.RUNNING.value,
     )
 
     response = check_scenarios_incomplete([unattached.id], run_test)
@@ -199,8 +231,12 @@ def test_soft_deleted_scenarios_excluded(
     db, run_test, organization, workspace, agent_definition, simulator_agent
 ):
     s = _scenario(
-        organization, workspace, agent_definition, simulator_agent,
-        name="DeletedRunning", status_=StatusType.RUNNING.value,
+        organization,
+        workspace,
+        agent_definition,
+        simulator_agent,
+        name="DeletedRunning",
+        status_=StatusType.RUNNING.value,
     )
     run_test.scenarios.add(s)
     s.deleted = True

--- a/futureagi/simulate/tests/test_scenario_completeness.py
+++ b/futureagi/simulate/tests/test_scenario_completeness.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for the scenario-completeness gate used by execute endpoints.
+"""
+
+import uuid
+
+import pytest
+from rest_framework import status
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.choices import StatusType
+from simulate.models import AgentDefinition, Scenarios
+from simulate.models.run_test import RunTest
+from simulate.models.simulator_agent import SimulatorAgent
+from simulate.utils.scenario_completeness import check_scenarios_incomplete
+
+
+@pytest.fixture
+def agent_definition(db, organization, workspace):
+    return AgentDefinition.objects.create(
+        agent_name="Agent",
+        agent_type=AgentDefinition.AgentTypeChoices.TEXT,
+        contact_number="+1234567890",
+        inbound=True,
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+@pytest.fixture
+def simulator_agent(db, organization, workspace):
+    return SimulatorAgent.objects.create(
+        name="Sim Agent",
+        prompt="Test simulator",
+        organization=organization,
+        workspace=workspace,
+        voice_provider="openai",
+        voice_name="alloy",
+        model="gpt-4-turbo",
+    )
+
+
+def _scenario(organization, workspace, agent_definition, simulator_agent, *, name, status_):
+    return Scenarios.objects.create(
+        name=name,
+        description="",
+        source="test",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=organization,
+        workspace=workspace,
+        agent_definition=agent_definition,
+        simulator_agent=simulator_agent,
+        status=status_,
+    )
+
+
+@pytest.fixture
+def run_test(db, organization, workspace, agent_definition, simulator_agent):
+    rt = RunTest.objects.create(
+        name="Test Run",
+        agent_definition=agent_definition,
+        simulator_agent=simulator_agent,
+        organization=organization,
+        workspace=workspace,
+    )
+    return rt
+
+
+def test_returns_none_for_empty_scenario_ids(run_test):
+    assert check_scenarios_incomplete([], run_test) is None
+    assert check_scenarios_incomplete(None, run_test) is None
+
+
+def test_returns_none_when_all_scenarios_completed(
+    db, run_test, organization, workspace, agent_definition, simulator_agent
+):
+    s1 = _scenario(
+        organization, workspace, agent_definition, simulator_agent,
+        name="A", status_=StatusType.COMPLETED.value,
+    )
+    s2 = _scenario(
+        organization, workspace, agent_definition, simulator_agent,
+        name="B", status_=StatusType.COMPLETED.value,
+    )
+    run_test.scenarios.add(s1, s2)
+
+    assert check_scenarios_incomplete([s1.id, s2.id], run_test) is None
+
+
+def test_returns_400_when_any_scenario_running(
+    db, run_test, organization, workspace, agent_definition, simulator_agent
+):
+    s1 = _scenario(
+        organization, workspace, agent_definition, simulator_agent,
+        name="Done", status_=StatusType.COMPLETED.value,
+    )
+    s2 = _scenario(
+        organization, workspace, agent_definition, simulator_agent,
+        name="StillRunning", status_=StatusType.RUNNING.value,
+    )
+    run_test.scenarios.add(s1, s2)
+
+    response = check_scenarios_incomplete([s1.id, s2.id], run_test)
+
+    assert response is not None
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    payload = response.data["result"]
+    assert payload["error"] == "Scenarios incomplete"
+    names = [s["name"] for s in payload["scenarios"]]
+    assert names == ["StillRunning"]
+    assert payload["scenarios"][0]["status"] == StatusType.RUNNING.value
+
+
+def test_failed_scenarios_also_block(
+    db, run_test, organization, workspace, agent_definition, simulator_agent
+):
+    s = _scenario(
+        organization, workspace, agent_definition, simulator_agent,
+        name="Broken", status_=StatusType.FAILED.value,
+    )
+    run_test.scenarios.add(s)
+
+    response = check_scenarios_incomplete([s.id], run_test)
+
+    assert response is not None
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["result"]["scenarios"][0]["status"] == StatusType.FAILED.value
+
+
+def test_cross_org_scenarios_are_not_leaked(
+    db, run_test, organization, workspace, agent_definition, simulator_agent
+):
+    """A scenario belonging to another org must NOT appear in the gate's
+    response, even if its UUID is passed in."""
+    other_org = Organization.objects.create(name="Other Org")
+    other_ws = Workspace.objects.create(
+        name="Other WS", organization=other_org, is_default=True, is_active=True,
+    )
+    other_agent = AgentDefinition.objects.create(
+        agent_name="Other Agent",
+        agent_type=AgentDefinition.AgentTypeChoices.TEXT,
+        contact_number="+0987654321",
+        inbound=True,
+        organization=other_org,
+        workspace=other_ws,
+        languages=["en"],
+    )
+    other_sim = SimulatorAgent.objects.create(
+        name="Other Sim",
+        prompt="x",
+        organization=other_org,
+        workspace=other_ws,
+        voice_provider="openai",
+        voice_name="alloy",
+        model="gpt-4-turbo",
+    )
+    foreign = Scenarios.objects.create(
+        name="ForeignSecret",
+        description="",
+        source="test",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=other_org,
+        workspace=other_ws,
+        agent_definition=other_agent,
+        simulator_agent=other_sim,
+        status=StatusType.RUNNING.value,
+    )
+
+    # Caller passes the foreign UUID as if it were one of theirs.
+    response = check_scenarios_incomplete([foreign.id], run_test)
+
+    # Gate scopes through run_test.scenarios → foreign UUID is not attached,
+    # so it's silently filtered. No leak, no false 400.
+    assert response is None
+
+
+def test_unattached_scenarios_silently_ignored(
+    db, run_test, organization, workspace, agent_definition, simulator_agent
+):
+    """Scenario in the same org but NOT attached to this run_test should not
+    affect the gate."""
+    unattached = _scenario(
+        organization, workspace, agent_definition, simulator_agent,
+        name="Unattached", status_=StatusType.RUNNING.value,
+    )
+
+    response = check_scenarios_incomplete([unattached.id], run_test)
+
+    assert response is None
+
+
+def test_soft_deleted_scenarios_excluded(
+    db, run_test, organization, workspace, agent_definition, simulator_agent
+):
+    s = _scenario(
+        organization, workspace, agent_definition, simulator_agent,
+        name="DeletedRunning", status_=StatusType.RUNNING.value,
+    )
+    run_test.scenarios.add(s)
+    s.deleted = True
+    s.save()
+
+    response = check_scenarios_incomplete([s.id], run_test)
+
+    # Deleted scenario is filtered out; gate doesn't catch it. The executor
+    # downstream is responsible for rejecting deleted scenarios.
+    assert response is None
+
+
+def test_nonexistent_uuids_silently_ignored(run_test):
+    response = check_scenarios_incomplete([uuid.uuid4()], run_test)
+    assert response is None

--- a/futureagi/simulate/utils/scenario_completeness.py
+++ b/futureagi/simulate/utils/scenario_completeness.py
@@ -5,11 +5,9 @@ endpoints — chat, voice / agent_definition, and prompt simulation — so direc
 API/SDK callers get the same 400 the UI button now blocks.
 """
 
-from rest_framework import status
-from rest_framework.response import Response
-
 from model_hub.models.choices import StatusType
 from simulate.models.scenarios import Scenarios
+from tfc.utils.general_methods import GeneralMethods
 
 
 def check_scenarios_incomplete(scenario_ids):
@@ -32,18 +30,16 @@ def check_scenarios_incomplete(scenario_ids):
     if not incomplete:
         return None
 
-    return Response(
+    return GeneralMethods().bad_request(
         {
             "error": "Scenarios incomplete",
             "detail": (
-                f"{len(incomplete)} scenario(s) are still being generated or "
-                "failed generation. Wait for them to complete before running "
-                "a simulation."
+                f"{len(incomplete)} scenario(s) are not completed. Wait for "
+                "them to finish or remove them from the selection."
             ),
             "scenarios": [
                 {"id": str(s["id"]), "name": s["name"], "status": s["status"]}
                 for s in incomplete
             ],
-        },
-        status=status.HTTP_400_BAD_REQUEST,
+        }
     )

--- a/futureagi/simulate/utils/scenario_completeness.py
+++ b/futureagi/simulate/utils/scenario_completeness.py
@@ -1,12 +1,16 @@
 """
-Gate that prevents test execution when any selected scenario is incomplete
-(still being generated, or generation failed). Used by all three execute
+Gate that prevents test execution unless every selected scenario is attached
+to the run-test and has status == "Completed". Used by all three execute
 endpoints — chat, voice / agent_definition, and prompt simulation — so direct
 API/SDK callers get the same 400 the UI button now blocks.
 
-The check scopes through `run_test.scenarios`, so cross-organization UUIDs and
-scenarios not attached to the run-test are silently ignored by the gate
-(they're handled — or rejected — downstream by the executor).
+Empty / None `scenario_ids` is itself a 400: a run requires at least one
+scenario.
+
+The completeness check scopes through `run_test.scenarios`, so
+cross-organization UUIDs and scenarios not attached to the run-test are
+silently ignored by the gate (they're handled — or rejected — downstream by
+the executor).
 """
 
 from model_hub.models.choices import StatusType
@@ -15,16 +19,21 @@ from tfc.utils.general_methods import GeneralMethods
 
 def check_scenarios_incomplete(scenario_ids, run_test):
     """
-    Return None if every scenario in `scenario_ids` that's attached to
-    `run_test` has status == "Completed". Otherwise return a 400 Response
-    listing the offenders.
+    Return None when every scenario in `scenario_ids` is attached to
+    `run_test` and has status == "Completed". Otherwise return a 400
+    Response.
 
-    `scenario_ids` may be a list of UUIDs or strings; empty/None is treated
-    as complete (the caller is responsible for the "at least one scenario"
-    check).
+    `scenario_ids` may be a list of UUIDs or strings. Empty / None is itself
+    a 400 — a run needs at least one scenario.
     """
     if not scenario_ids:
-        return None
+        return GeneralMethods().bad_request(
+            {
+                "error": "No scenarios",
+                "detail": "At least one scenario is required to execute the test.",
+                "scenarios": [],
+            }
+        )
 
     incomplete = list(
         run_test.scenarios.filter(id__in=scenario_ids, deleted=False)

--- a/futureagi/simulate/utils/scenario_completeness.py
+++ b/futureagi/simulate/utils/scenario_completeness.py
@@ -1,0 +1,49 @@
+"""
+Gate that prevents test execution when any selected scenario is incomplete
+(still being generated, or generation failed). Used by all three execute
+endpoints — chat, voice / agent_definition, and prompt simulation — so direct
+API/SDK callers get the same 400 the UI button now blocks.
+"""
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from model_hub.models.choices import StatusType
+from simulate.models.scenarios import Scenarios
+
+
+def check_scenarios_incomplete(scenario_ids):
+    """
+    Return None if every scenario in `scenario_ids` has status == "Completed".
+    Otherwise return a 400 Response listing the incomplete scenarios.
+
+    `scenario_ids` may be a list of UUIDs or strings; empty/None is treated as
+    complete (the caller is responsible for the "at least one scenario" check).
+    """
+    if not scenario_ids:
+        return None
+
+    incomplete = list(
+        Scenarios.objects.filter(id__in=scenario_ids, deleted=False)
+        .exclude(status=StatusType.COMPLETED.value)
+        .values("id", "name", "status")
+    )
+
+    if not incomplete:
+        return None
+
+    return Response(
+        {
+            "error": "Scenarios incomplete",
+            "detail": (
+                f"{len(incomplete)} scenario(s) are still being generated or "
+                "failed generation. Wait for them to complete before running "
+                "a simulation."
+            ),
+            "scenarios": [
+                {"id": str(s["id"]), "name": s["name"], "status": s["status"]}
+                for s in incomplete
+            ],
+        },
+        status=status.HTTP_400_BAD_REQUEST,
+    )

--- a/futureagi/simulate/utils/scenario_completeness.py
+++ b/futureagi/simulate/utils/scenario_completeness.py
@@ -3,26 +3,31 @@ Gate that prevents test execution when any selected scenario is incomplete
 (still being generated, or generation failed). Used by all three execute
 endpoints — chat, voice / agent_definition, and prompt simulation — so direct
 API/SDK callers get the same 400 the UI button now blocks.
+
+The check scopes through `run_test.scenarios`, so cross-organization UUIDs and
+scenarios not attached to the run-test are silently ignored by the gate
+(they're handled — or rejected — downstream by the executor).
 """
 
 from model_hub.models.choices import StatusType
-from simulate.models.scenarios import Scenarios
 from tfc.utils.general_methods import GeneralMethods
 
 
-def check_scenarios_incomplete(scenario_ids):
+def check_scenarios_incomplete(scenario_ids, run_test):
     """
-    Return None if every scenario in `scenario_ids` has status == "Completed".
-    Otherwise return a 400 Response listing the incomplete scenarios.
+    Return None if every scenario in `scenario_ids` that's attached to
+    `run_test` has status == "Completed". Otherwise return a 400 Response
+    listing the offenders.
 
-    `scenario_ids` may be a list of UUIDs or strings; empty/None is treated as
-    complete (the caller is responsible for the "at least one scenario" check).
+    `scenario_ids` may be a list of UUIDs or strings; empty/None is treated
+    as complete (the caller is responsible for the "at least one scenario"
+    check).
     """
     if not scenario_ids:
         return None
 
     incomplete = list(
-        Scenarios.objects.filter(id__in=scenario_ids, deleted=False)
+        run_test.scenarios.filter(id__in=scenario_ids, deleted=False)
         .exclude(status=StatusType.COMPLETED.value)
         .values("id", "name", "status")
     )

--- a/futureagi/simulate/views/chat_simulation.py
+++ b/futureagi/simulate/views/chat_simulation.py
@@ -106,9 +106,9 @@ class RunTestChatExecutionView(APIView):
                 run_test.scenarios.filter(deleted=False).values_list("id", flat=True)
             )
 
-            incomplete = check_scenarios_incomplete(scenarios)
-            if incomplete is not None:
-                return incomplete
+            gate_response = check_scenarios_incomplete(scenarios, run_test)
+            if gate_response is not None:
+                return gate_response
 
             logger.info(f"Run test used here is.... {run_test_id}")
 

--- a/futureagi/simulate/views/chat_simulation.py
+++ b/futureagi/simulate/views/chat_simulation.py
@@ -19,6 +19,7 @@ from simulate.models import (
 from simulate.pydantic_schemas.chat import ChatSendMessageViewResponse, SendChatRequest
 from simulate.services.chat_sim import initiate_chat, send_message_to_chat
 from simulate.services.test_executor import TestExecutor
+from simulate.utils.scenario_completeness import check_scenarios_incomplete
 from simulate.utils.test_execution_utils import generate_simulator_agent_prompt
 from tfc.utils.general_methods import GeneralMethods
 
@@ -104,6 +105,10 @@ class RunTestChatExecutionView(APIView):
             scenarios = list(
                 run_test.scenarios.filter(deleted=False).values_list("id", flat=True)
             )
+
+            incomplete = check_scenarios_incomplete(scenarios)
+            if incomplete is not None:
+                return incomplete
 
             logger.info(f"Run test used here is.... {run_test_id}")
 

--- a/futureagi/simulate/views/prompt_simulation.py
+++ b/futureagi/simulate/views/prompt_simulation.py
@@ -495,9 +495,9 @@ class ExecutePromptSimulationView(APIView):
                         str(scenario_id) for scenario_id in all_scenario_ids
                     ]
 
-            incomplete = check_scenarios_incomplete(final_scenario_ids)
-            if incomplete is not None:
-                return incomplete
+            gate_response = check_scenarios_incomplete(final_scenario_ids, run_test)
+            if gate_response is not None:
+                return gate_response
 
             # Use the existing TestExecutor
             test_executor = TestExecutor()

--- a/futureagi/simulate/views/prompt_simulation.py
+++ b/futureagi/simulate/views/prompt_simulation.py
@@ -22,6 +22,7 @@ from simulate.serializers.run_test import (
     RunTestSerializer,
 )
 from simulate.services.test_executor import TestExecutor
+from simulate.utils.scenario_completeness import check_scenarios_incomplete
 from tfc.utils.general_methods import GeneralMethods
 
 logger = structlog.get_logger(__name__)
@@ -493,6 +494,10 @@ class ExecutePromptSimulationView(APIView):
                     final_scenario_ids = [
                         str(scenario_id) for scenario_id in all_scenario_ids
                     ]
+
+            incomplete = check_scenarios_incomplete(final_scenario_ids)
+            if incomplete is not None:
+                return incomplete
 
             # Use the existing TestExecutor
             test_executor = TestExecutor()

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -96,6 +96,7 @@ from simulate.utils.eval_summary import (
     _get_completed_call_executions,
     _get_eval_configs_with_template,
 )
+from simulate.utils.scenario_completeness import check_scenarios_incomplete
 from simulate.utils.sql_query import (
     get_combined_call_executions_and_snapshots_count_query,
     get_combined_call_executions_and_snapshots_query,
@@ -626,6 +627,10 @@ class RunTestExecutionView(APIView):
                     {"error": "At least one scenario is required to execute the test."},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+
+            incomplete = check_scenarios_incomplete(final_scenario_ids)
+            if incomplete is not None:
+                return incomplete
 
             # Check if Temporal test execution is enabled
             if getattr(app_settings, "TEMPORAL_TEST_EXECUTION_ENABLED", False):

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -628,9 +628,9 @@ class RunTestExecutionView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            incomplete = check_scenarios_incomplete(final_scenario_ids)
-            if incomplete is not None:
-                return incomplete
+            gate_response = check_scenarios_incomplete(final_scenario_ids, run_test)
+            if gate_response is not None:
+                return gate_response
 
             # Check if Temporal test execution is enabled
             if getattr(app_settings, "TEMPORAL_TEST_EXECUTION_ENABLED", False):


### PR DESCRIPTION
The Run New Simulation button on the test-run detail page is enabled the moment a scenario is created, even while its generation is still in progress. Submitting the run dispatches a call execution against a scenario with no usable data, so it never connects (0 calls connected, "Pending" forever).

Disable the button when any selected scenario has status !== "Completed". Reads from `scenarios_detail` (full scenario objects with status) rather than `scenarios` (just UUIDs); tolerant to either camelCase or snake_case shape from the response.

<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
