### PR TITLE
[TH-4360] Render image/audio inline in trace Attributes table

### DIFF
--- a/frontend/src/components/multimodal/ImageCard.jsx
+++ b/frontend/src/components/multimodal/ImageCard.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Box } from "@mui/material";
+import Image from "src/components/image";
+import { useSingleImageViewContext } from "src/sections/develop-detail/Common/SingleImageViewer/SingleImageContext";
+
+const ImageCard = ({ image, width = 200 }) => {
+  const { setImageUrl } = useSingleImageViewContext();
+  return (
+    <Box
+      sx={{
+        borderRadius: (theme) => theme.spacing(1),
+        overflow: "hidden",
+        cursor: "pointer",
+      }}
+      onClick={() => setImageUrl(image)}
+    >
+      <Image key={image} src={image} alt="image" width={width} />
+    </Box>
+  );
+};
+
+ImageCard.propTypes = {
+  image: PropTypes.string,
+  width: PropTypes.number,
+};
+
+export default ImageCard;

--- a/frontend/src/components/multimodal/extractMediaSrc.js
+++ b/frontend/src/components/multimodal/extractMediaSrc.js
@@ -1,0 +1,12 @@
+// Match flat OTel media attribute paths. Source of truth:
+// `MessageContentAttributes` in core-backend/futureagi/tracer/utils/otel.py.
+
+export function isImageAttrPath(path) {
+  if (typeof path !== "string") return false;
+  return /\.(image|image_url\.url)$/i.test(path);
+}
+
+export function isAudioAttrPath(path) {
+  if (typeof path !== "string") return false;
+  return /\.(audio|audio_content\.url)$/i.test(path);
+}

--- a/frontend/src/components/traceDetail/SmartPreview.jsx
+++ b/frontend/src/components/traceDetail/SmartPreview.jsx
@@ -26,6 +26,7 @@ const SmartPreview = ({
   ContentCard,
   AttributesCard,
   JsonPreviewBlock,
+  drawerOpen = true,
 }) => {
   const type = (span?.observation_type || "").toLowerCase();
   const model = span?.model;
@@ -108,6 +109,9 @@ const SmartPreview = ({
           attributes={attributes}
           searchQuery={searchQuery}
           hideInlineSearch
+          spanId={span?.id}
+          traceId={span?.trace}
+          drawerOpen={drawerOpen}
         />
       </Stack>
     );
@@ -255,6 +259,9 @@ const SmartPreview = ({
         attributes={attributes}
         searchQuery={searchQuery}
         hideInlineSearch
+        spanId={span?.id}
+        traceId={span?.trace}
+        drawerOpen={drawerOpen}
       />
     </Stack>
   );
@@ -908,6 +915,7 @@ SmartPreview.propTypes = {
   ContentCard: PropTypes.elementType.isRequired,
   AttributesCard: PropTypes.elementType.isRequired,
   JsonPreviewBlock: PropTypes.elementType.isRequired,
+  drawerOpen: PropTypes.bool,
 };
 
 export default React.memo(SmartPreview);

--- a/frontend/src/components/traceDetail/SpanDetailPane.jsx
+++ b/frontend/src/components/traceDetail/SpanDetailPane.jsx
@@ -2,6 +2,7 @@ import React, {
   useState,
   useCallback,
   useDeferredValue,
+  useEffect,
   useMemo,
   useRef,
 } from "react";
@@ -40,6 +41,15 @@ import TagChip from "./TagChip";
 import TagInput from "./TagInput";
 import EvalsTabView, { collectAllEvalsFromEntry } from "./EvalsTabView";
 import { openFixWithFalcon } from "src/sections/falcon-ai/helpers/openFixWithFalcon";
+import ImageCard from "src/components/multimodal/ImageCard";
+import AudioCellRenderer from "src/sections/common/DevelopCellRenderer/CellRenderers/AudioCellRenderer";
+import useWavesurferCache from "src/hooks/use-wavesurfer-cache";
+import {
+  isImageAttrPath,
+  isAudioAttrPath,
+} from "src/components/multimodal/extractMediaSrc";
+import { AudioPlaybackProvider } from "src/components/custom-audio/context-provider/AudioPlaybackContext";
+import SingleImageViewerProvider from "src/sections/develop-detail/Common/SingleImageViewer/SingleImageViewerProvider";
 
 /* ── helpers ──────────────────────────────────────────── */
 
@@ -589,6 +599,7 @@ const LogViewRow = ({
   isExpanded,
   onToggle,
   viewMode = "markdown",
+  drawerOpen = true,
 }) => {
   const { span, depth, entry } = item;
   const type = (span.observation_type || "unknown").toLowerCase();
@@ -822,7 +833,12 @@ const LogViewRow = ({
                 viewMode={viewMode}
               />
               {Object.keys(attributes).length > 0 && (
-                <AttributesCard attributes={attributes} />
+                <AttributesCard
+                  attributes={attributes}
+                  spanId={span?.id}
+                  traceId={span?.trace}
+                  drawerOpen={drawerOpen}
+                />
               )}
             </Stack>
           ) : (
@@ -849,6 +865,7 @@ LogViewRow.propTypes = {
   isExpanded: PropTypes.bool,
   onToggle: PropTypes.func,
   viewMode: PropTypes.string,
+  drawerOpen: PropTypes.bool,
 };
 
 const LOG_COLUMNS = [
@@ -860,7 +877,7 @@ const LOG_COLUMNS = [
   { key: "annotations", label: "Ann.", width: 36 },
 ];
 
-const LogViewTable = ({ allSpans, traceStartTime }) => {
+const LogViewTable = ({ allSpans, traceStartTime, drawerOpen = true }) => {
   const [logSearch, setLogSearch] = useState("");
   const [expandedRows, setExpandedRows] = useState(new Set());
   const [logViewMode, setLogViewMode] = useState("markdown"); // "markdown" | "json"
@@ -1184,6 +1201,7 @@ const LogViewTable = ({ allSpans, traceStartTime }) => {
               isExpanded={expandedRows.has(item.span.id)}
               onToggle={() => handleToggle(item.span.id)}
               viewMode={logViewMode}
+              drawerOpen={drawerOpen}
             />
           ))
         )}
@@ -1195,6 +1213,7 @@ const LogViewTable = ({ allSpans, traceStartTime }) => {
 LogViewTable.propTypes = {
   allSpans: PropTypes.array,
   traceStartTime: PropTypes.any,
+  drawerOpen: PropTypes.bool,
 };
 
 /* ── InlineTagsRow — always-visible tag chips with add/remove ── */
@@ -1719,6 +1738,7 @@ const SpanDetailPane = ({
   onClose,
   onAction,
   onSelectSpan,
+  drawerOpen = true,
 }) => {
   const [activeTab, setActiveTab] = useState("preview");
   const [searchQuery, setSearchQuery] = useState("");
@@ -2107,6 +2127,7 @@ const SpanDetailPane = ({
                 ContentCard={ContentCard}
                 AttributesCard={AttributesCard}
                 JsonPreviewBlock={JsonPreviewBlock}
+                drawerOpen={drawerOpen}
               />
             </Box>
           </Box>
@@ -2114,7 +2135,11 @@ const SpanDetailPane = ({
 
         {/* Log View Tab — only for root span */}
         {activeTab === "log" && (
-          <LogViewTable allSpans={allSpans} traceStartTime={traceStartTime} />
+          <LogViewTable
+            allSpans={allSpans}
+            traceStartTime={traceStartTime}
+            drawerOpen={drawerOpen}
+          />
         )}
 
         {/* Evals Tab — this span + child span evals. Rendered via the
@@ -2226,13 +2251,40 @@ function deepMatch(val, q) {
 
 /* ── AttrValueCell — renders a value with expand/collapse ── */
 
-const AttrValueCell = ({ value, expanded, onToggle, searchQuery: _sq }) => {
+const AttrValueCell = ({
+  value,
+  expanded,
+  onToggle,
+  searchQuery: _sq,
+  path,
+  spanId,
+  traceId,
+  audioCache,
+}) => {
   if (value === null || value === undefined) {
     return (
       <Typography variant="caption" color="text.disabled" sx={{ fontSize: 11 }}>
         null
       </Typography>
     );
+  }
+
+  if (typeof value === "string" && value && path) {
+    if (isImageAttrPath(path)) {
+      return <ImageCard image={value} />;
+    }
+    if (isAudioAttrPath(path)) {
+      return (
+        <AudioCellRenderer
+          value={value}
+          cacheKey={`${traceId}-${spanId}::${path}`}
+          getWaveSurferInstance={audioCache?.getWaveSurferInstance}
+          storeWaveSurferInstance={audioCache?.storeWaveSurferInstance}
+          updateWaveSurferInstance={audioCache?.updateWaveSurferInstance}
+          editable={false}
+        />
+      );
+    }
   }
 
   const isObj = typeof value === "object" && !Array.isArray(value);
@@ -2290,7 +2342,14 @@ const AttrValueCell = ({ value, expanded, onToggle, searchQuery: _sq }) => {
               ? value.map((v, i) => [String(i), v])
               : Object.entries(value)
             ).map(([k, v]) => (
-              <AttrNestedRow key={k} path={k} value={v} />
+              <AttrNestedRow
+                key={k}
+                path={k}
+                value={v}
+                spanId={spanId}
+                traceId={traceId}
+                audioCache={audioCache}
+              />
             ))}
           </Box>
         )}
@@ -2322,11 +2381,15 @@ AttrValueCell.propTypes = {
   expanded: PropTypes.bool,
   onToggle: PropTypes.func,
   searchQuery: PropTypes.string,
+  path: PropTypes.string,
+  spanId: PropTypes.string,
+  traceId: PropTypes.string,
+  audioCache: PropTypes.object,
 };
 
 /* ── AttrNestedRow — recursive nested row ── */
 
-const AttrNestedRow = ({ path, value }) => {
+const AttrNestedRow = ({ path, value, spanId, traceId, audioCache }) => {
   const [open, setOpen] = useState(false);
   const isComplex = value !== null && typeof value === "object";
 
@@ -2363,6 +2426,10 @@ const AttrNestedRow = ({ path, value }) => {
             value={value}
             expanded={open}
             onToggle={() => setOpen(!open)}
+            path={path}
+            spanId={spanId}
+            traceId={traceId}
+            audioCache={audioCache}
           />
         </Box>
       </Box>
@@ -2370,7 +2437,13 @@ const AttrNestedRow = ({ path, value }) => {
   );
 };
 
-AttrNestedRow.propTypes = { path: PropTypes.string, value: PropTypes.any };
+AttrNestedRow.propTypes = {
+  path: PropTypes.string,
+  value: PropTypes.any,
+  spanId: PropTypes.string,
+  traceId: PropTypes.string,
+  audioCache: PropTypes.object,
+};
 
 /* ── AttributesCard — searchable Path | Value table ───── */
 
@@ -2378,10 +2451,38 @@ const AttributesCard = ({
   attributes,
   searchQuery,
   hideInlineSearch = false,
+  spanId,
+  traceId,
+  drawerOpen = true,
 }) => {
   const [expanded, setExpanded] = useState(true);
   const [attrSearch, setAttrSearch] = useState("");
   const [expandedKeys, setExpandedKeys] = useState({});
+
+  const {
+    getWaveSurferInstance,
+    storeWaveSurferInstance,
+    updateWaveSurferInstance,
+    clearWaveSurferCache,
+  } = useWavesurferCache();
+
+  // Drawer uses variant="persistent" and the card is reused across span/trace
+  // navigation, so unmount cleanup never fires — re-run on each dep change to
+  // destroy stale wavesurfer instances.
+  useEffect(() => {
+    return () => {
+      clearWaveSurferCache();
+    };
+  }, [drawerOpen, traceId, spanId, clearWaveSurferCache]);
+
+  const audioCache = useMemo(
+    () => ({
+      getWaveSurferInstance,
+      storeWaveSurferInstance,
+      updateWaveSurferInstance,
+    }),
+    [getWaveSurferInstance, storeWaveSurferInstance, updateWaveSurferInstance],
+  );
 
   // Parse attributes if string
   const parsed = useMemo(() => {
@@ -2417,6 +2518,8 @@ const AttributesCard = ({
   }, []);
 
   return (
+    <SingleImageViewerProvider>
+      <AudioPlaybackProvider>
     <Box
       sx={{
         border: "1px solid",
@@ -2615,6 +2718,10 @@ const AttributesCard = ({
                           expanded={expandedKeys[key]}
                           onToggle={() => toggleKey(key)}
                           searchQuery={query}
+                          path={key}
+                          spanId={spanId}
+                          traceId={traceId}
+                          audioCache={audioCache}
                         />
                       )}
                     </Box>
@@ -2626,6 +2733,8 @@ const AttributesCard = ({
         </Box>
       </Collapse>
     </Box>
+      </AudioPlaybackProvider>
+    </SingleImageViewerProvider>
   );
 };
 
@@ -2633,6 +2742,9 @@ AttributesCard.propTypes = {
   attributes: PropTypes.object,
   searchQuery: PropTypes.string,
   hideInlineSearch: PropTypes.bool,
+  spanId: PropTypes.string,
+  traceId: PropTypes.string,
+  drawerOpen: PropTypes.bool,
 };
 
 SpanDetailPane.propTypes = {
@@ -2651,6 +2763,7 @@ SpanDetailPane.propTypes = {
   onClose: PropTypes.func.isRequired,
   onAction: PropTypes.func,
   onSelectSpan: PropTypes.func,
+  drawerOpen: PropTypes.bool,
 };
 
 export default React.memo(SpanDetailPane);

--- a/frontend/src/components/traceDetail/TraceDetailDrawerV2.jsx
+++ b/frontend/src/components/traceDetail/TraceDetailDrawerV2.jsx
@@ -1255,6 +1255,7 @@ const TraceDetailDrawerV2 = ({
                   onClose={() => setSelectedSpanId(null)}
                   onAction={handleAction}
                   onSelectSpan={handleSelectSpan}
+                  drawerOpen={open}
                 />
               </Box>
             )}
@@ -1337,6 +1338,7 @@ const TraceDetailDrawerV2 = ({
                   onClose={() => setSelectedSpanId(null)}
                   onAction={handleAction}
                   onSelectSpan={handleSelectSpan}
+                  drawerOpen={open}
                 />
               ) : (
                 /* Summary when no span selected */

--- a/frontend/src/components/traceDetailDrawer/DrawerRightRenderer/CustomDataPointCard.jsx
+++ b/frontend/src/components/traceDetailDrawer/DrawerRightRenderer/CustomDataPointCard.jsx
@@ -14,36 +14,13 @@ import { transformSafeJson } from "src/utils/utils";
 import Iconify from "src/components/iconify";
 import { copyToClipboard } from "src/utils/utils";
 import { enqueueSnackbar } from "notistack";
-import Image from "src/components/image";
 import CustomJsonViewer from "src/components/custom-json-viewer/CustomJsonViewer";
 import { AudioPlaybackProvider } from "src/components/custom-audio/context-provider/AudioPlaybackContext";
 import SingleImageViewerProvider from "src/sections/develop-detail/Common/SingleImageViewer/SingleImageViewerProvider";
-import { useSingleImageViewContext } from "src/sections/develop-detail/Common/SingleImageViewer/SingleImageContext";
 import CellMarkdown from "src/sections/common/CellMarkdown";
 import CustomVideoPlayer from "src/components/VideoPlayer/CustomVideoPlayer";
 import TestAudioPlayer from "../../custom-audio/TestAudioPlayer";
-
-const ImageCard = ({ image }) => {
-  const { setImageUrl } = useSingleImageViewContext();
-  return (
-    <Box
-      sx={{
-        borderRadius: (theme) => theme.spacing(1),
-        overflow: "hidden",
-        cursor: "pointer",
-      }}
-      onClick={() => {
-        setImageUrl(image);
-      }}
-    >
-      <Image key={image} src={image} alt="image" width={200} />
-    </Box>
-  );
-};
-
-ImageCard.propTypes = {
-  image: PropTypes.string,
-};
+import ImageCard from "src/components/multimodal/ImageCard";
 
 const CustomDataPointCard = ({ value, label, allowCopy = false }) => {
   const [tabValue, setTabValue] = useState("raw");


### PR DESCRIPTION
## Summary
- Multimodal LLM message attributes (image/audio) were rendered as raw URLs in the trace detail Attributes section. Now dispatch on the canonical OTel key suffix (`.image`, `.image_url.url`, `.audio`, `.audio_content.url`) and render inline using existing `ImageCard` / `AudioCellRenderer`.
- The drawer uses MUI `variant="persistent"` and reuses the same `AttributesCard` across span/trace navigation, so unmount cleanup never fires. Added a `useEffect` that re-runs on `drawerOpen` / `traceId` / `spanId` and clears the wavesurfer cache on each transition — fixes audio that kept playing after closing the drawer or switching traces.
- `cacheKey` is namespaced as `${traceId}-${spanId}::${path}` so per-path audio instances stay isolated when the same URL appears at multiple paths within a span.

Closes TH-4360

## Linear Ticket
[TH-4360](https://linear.app/future-agi/issue/TH-4360)

## Files Changed
- `src/components/multimodal/extractMediaSrc.js` _(new)_ — `isImageAttrPath` / `isAudioAttrPath` regex helpers matching the canonical OTel suffixes.
- `src/components/multimodal/ImageCard.jsx` _(new)_ — extracted from `CustomDataPointCard` so both the trace Attributes table and the existing renderer can share it.
- `src/components/traceDetail/SpanDetailPane.jsx` — `AttrValueCell` dispatches on path; `AttributesCard` hooks `useWavesurferCache`, plumbs `spanId` / `traceId` / `audioCache` through to `AudioCellRenderer`. New `drawerOpen` prop drives the cleanup effect.
- `src/components/traceDetail/SmartPreview.jsx` — forwards `drawerOpen` + `spanId` + `traceId` to both `<AttributesCard>` call sites.
- `src/components/traceDetail/TraceDetailDrawerV2.jsx` — passes `drawerOpen={open}` to both `<SpanDetailPane>` instances.
- `src/components/traceDetailDrawer/DrawerRightRenderer/CustomDataPointCard.jsx` — drops the inline `ImageCard` definition in favour of the shared one.

## Test plan
- [ ] Open a trace with multimodal LLM input → expand a span → image and audio attributes render inline in the Attributes table (no raw URLs).
- [ ] Multiple audio rows in the same span (different paths, same URL) get separate players and play independently.
- [ ] Play audio → close drawer → audio stops.
- [ ] Play audio → click prev/next trace → audio from previous trace stops, new trace's audio is fresh.
- [ ] Play audio → expand a different span (same trace) → audio stops.
- [ ] Existing `AudioCellRenderer` consumers (`ScenarioCellRenderer`, `CustomCellRender`) continue to behave unchanged.
- [ ] `CustomDataPointCard` image rendering (now using the shared `ImageCard`) continues to work in both tracker variants.