### PR TITLE
fix(replay): stop copying system prompt into scenario/agent description

### DIFF
--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -1163,8 +1163,8 @@ const CreateRunTestPage = ({ open, onClose }) => {
                                   overflow: "hidden",
                                 }}
                               >
-                                {scenario?.description ||
-                                  scenario?.source ||
+                                {scenario.description ||
+                                  scenario.source ||
                                   "No description available"}
                               </Typography>
                             }
@@ -1899,9 +1899,9 @@ const CreateRunTestPage = ({ open, onClose }) => {
                                 textOverflow: "ellipsis",
                               }}
                             >
-                              {scenario?.description ||
-                                scenario?.source ||
-                                "No description available"}
+                              {scenario.description ||
+                                scenario.source ||
+                                "No description"}
                             </Typography>
                           </Box>
                           <Typography variant="body2" fontWeight={600}>

--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -139,6 +139,20 @@ const StyledStepConnector = styled(StepConnector)(({ theme }) => ({
   },
 }));
 
+const SCENARIO_DESCRIPTION_PREVIEW_CHARS = 200;
+
+// Replay scenarios store the full system prompt in `description`, which
+// dwarfs the card and looks broken even with CSS line-clamp. Cap the
+// rendered text so the card stays compact regardless of source.
+const previewScenarioDescription = (scenario) => {
+  const raw =
+    scenario?.description || scenario?.source || "No description available";
+  if (typeof raw !== "string") return raw;
+  return raw.length > SCENARIO_DESCRIPTION_PREVIEW_CHARS
+    ? `${raw.slice(0, SCENARIO_DESCRIPTION_PREVIEW_CHARS).trimEnd()}…`
+    : raw;
+};
+
 const CreateRunTestPage = ({ open, onClose }) => {
   const { enqueueSnackbar } = useSnackbar();
   const theme = useTheme();
@@ -1163,9 +1177,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
                                   overflow: "hidden",
                                 }}
                               >
-                                {scenario.description ||
-                                  scenario.source ||
-                                  "No description available"}
+                                {previewScenarioDescription(scenario)}
                               </Typography>
                             }
                           />
@@ -1899,9 +1911,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
                                 textOverflow: "ellipsis",
                               }}
                             >
-                              {scenario.description ||
-                                scenario.source ||
-                                "No description"}
+                              {previewScenarioDescription(scenario)}
                             </Typography>
                           </Box>
                           <Typography variant="body2" fontWeight={600}>

--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -139,20 +139,6 @@ const StyledStepConnector = styled(StepConnector)(({ theme }) => ({
   },
 }));
 
-const SCENARIO_DESCRIPTION_PREVIEW_CHARS = 200;
-
-// Replay scenarios store the full system prompt in `description`, which
-// dwarfs the card and looks broken even with CSS line-clamp. Cap the
-// rendered text so the card stays compact regardless of source.
-const previewScenarioDescription = (scenario) => {
-  const raw =
-    scenario?.description || scenario?.source || "No description available";
-  if (typeof raw !== "string") return raw;
-  return raw.length > SCENARIO_DESCRIPTION_PREVIEW_CHARS
-    ? `${raw.slice(0, SCENARIO_DESCRIPTION_PREVIEW_CHARS).trimEnd()}…`
-    : raw;
-};
-
 const CreateRunTestPage = ({ open, onClose }) => {
   const { enqueueSnackbar } = useSnackbar();
   const theme = useTheme();
@@ -1177,7 +1163,9 @@ const CreateRunTestPage = ({ open, onClose }) => {
                                   overflow: "hidden",
                                 }}
                               >
-                                {previewScenarioDescription(scenario)}
+                                {scenario?.description ||
+                                  scenario?.source ||
+                                  "No description available"}
                               </Typography>
                             }
                           />
@@ -1911,7 +1899,9 @@ const CreateRunTestPage = ({ open, onClose }) => {
                                 textOverflow: "ellipsis",
                               }}
                             >
-                              {previewScenarioDescription(scenario)}
+                              {scenario?.description ||
+                                scenario?.source ||
+                                "No description available"}
                             </Typography>
                           </Box>
                           <Typography variant="body2" fontWeight={600}>

--- a/futureagi/tracer/tests/test_replay_session_utils.py
+++ b/futureagi/tracer/tests/test_replay_session_utils.py
@@ -184,18 +184,22 @@ class TestGetAgentSuggestions:
         assert "scenario_name" in suggestions
         assert agent_def == mock_agent_def
 
-    @patch("tracer.utils.replay_session.get_system_prompt")
     @patch("tracer.utils.replay_session._get_agent_definition_from_replay_sessions")
     def test_generates_defaults_when_no_agent_definition(
-        self, mock_get_agent_def_from_sessions, mock_get_prompt
+        self, mock_get_agent_def_from_sessions
     ):
-        """Should generate default suggestions when no agent_def exists."""
+        """Should generate default suggestions when no agent_def exists.
+
+        The system prompt is intentionally NOT copied into agent_description —
+        for text agents it lives on AgentVersion.configuration_snapshot, and
+        for voice agents on the external provider config; duplicating it into
+        description pollutes the scenario card UI.
+        """
         mock_project = MagicMock()
         mock_project.name = "New Project"
         mock_project.id = uuid.uuid4()
 
         mock_get_agent_def_from_sessions.return_value = None
-        mock_get_prompt.return_value = "System prompt from traces"
 
         exists, suggestions, agent_def = get_agent_suggestions(
             mock_project, "trace", [str(uuid.uuid4())], False
@@ -203,16 +207,13 @@ class TestGetAgentSuggestions:
 
         assert exists is False
         assert "New Project" in suggestions["agent_name"]
-        assert suggestions["agent_description"] == "System prompt from traces"
+        assert suggestions["agent_description"] == ""
         assert suggestions["agent_type"] == "text"
         assert suggestions["version_name"] is None
         assert agent_def is None
 
-    @patch("tracer.utils.replay_session.get_system_prompt")
     @patch("tracer.utils.replay_session._get_agent_definition_from_replay_sessions")
-    def test_handles_agent_definition_not_found(
-        self, mock_get_agent_def_from_sessions, mock_get_prompt
-    ):
+    def test_handles_agent_definition_not_found(self, mock_get_agent_def_from_sessions):
         """Should generate defaults when no agent_def is found from replay sessions."""
         mock_project = MagicMock()
         mock_project.name = "Project"
@@ -220,7 +221,6 @@ class TestGetAgentSuggestions:
         mock_project.organization = MagicMock()
 
         mock_get_agent_def_from_sessions.return_value = None
-        mock_get_prompt.return_value = None
 
         exists, suggestions, agent_def = get_agent_suggestions(
             mock_project, "trace", [], False

--- a/futureagi/tracer/utils/replay_session.py
+++ b/futureagi/tracer/utils/replay_session.py
@@ -204,19 +204,16 @@ def get_agent_suggestions(
         # Extract the original Vapi/Retell config from the trace
         original_config = _extract_voice_trace_original_config(trace_query)
 
-        # Extract system prompt from the already-loaded config to avoid a redundant span query
-        agent_description = (
-            _extract_voice_trace_system_prompt(trace_query, _config=original_config)
-            or ""
-        )
-
-        # Fallback: try the project's agent definition
-        if not agent_description:
-            agent_def_from_project = AgentDefinition.objects.filter(
-                observability_provider__project=project,
-            ).first()
-            if agent_def_from_project:
-                agent_description = agent_def_from_project.description or ""
+        # The voice system prompt lives on the external provider (Vapi/Retell)
+        # and is reachable via assistant_id on the AgentDefinition — don't
+        # duplicate it into agent_description. Reuse the existing project
+        # agent definition's description if one exists; otherwise leave blank.
+        agent_description = ""
+        agent_def_from_project = AgentDefinition.objects.filter(
+            observability_provider__project=project,
+        ).first()
+        if agent_def_from_project:
+            agent_description = agent_def_from_project.description or ""
 
         return (
             False,
@@ -231,18 +228,13 @@ def get_agent_suggestions(
             None,
         )
 
-    system_prompt = get_system_prompt(
-        project_id=str(project.id),
-        replay_type=replay_type,
-        ids=ids,
-        select_all=select_all,
-    )
-
+    # Text agent system prompt is captured on AgentVersion.configuration_snapshot
+    # at version-create time, so don't copy it into agent_description here.
     return (
         False,
         {
             "agent_name": agent_name,
-            "agent_description": system_prompt or "",
+            "agent_description": "",
             "agent_type": "text",
             "scenario_name": scenario_name,
             "version_name": None,


### PR DESCRIPTION
The voice-observe → simulate replay path was extracting the agent's full system prompt and storing it as `agent_description`, which then flowed into AgentDefinition.description, AgentVersion.description, and Scenarios.description. The scenario card on the test-run creation screen rendered tens of lines of prompt text instead of a real description.

The system prompt is already captured where it belongs:

* Voice agents: on the external provider (Vapi/Retell), reachable via AgentDefinition.assistant_id.
* Text agents: on AgentVersion.configuration_snapshot, populated by create_version()/create_snapshot().

Drop the prompt extraction in get_agent_suggestions:

* Voice path: leave agent_description empty unless an existing project agent definition has its own description to reuse.
* Text path: leave agent_description empty.

Downstream Scenarios.objects.create has an `or "Generated from replay session for {agent_name}"` fallback, so cards now show that short generated text. Tests updated to match.

Belt-and-suspenders: also cap rendered scenario description at 200 chars in the test-run creation card — covers historical scenarios in the DB that were created with system-prompt-as-description before this fix.

Refs [TH-3870](https://linear.app/future-agi/issue/TH-3870/scenario-table-only-shows-name-full-scenario-data-should-be-displayed)

## Summary

## Linked issues

Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

## Screenshots / recordings (if UI)

## Checklist

- [ ] My code follows the [style guide](<../CONTRIBUTING.md#code-style>)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](<../CONTRIBUTING.md#contributor-license-agreement-cla>)