### PR TITLE
fix(error-feed): tighten cluster embedding for issue briefs

### DIFF
--- a/futureagi/tracer/tests/test_scan_types.py
+++ b/futureagi/tracer/tests/test_scan_types.py
@@ -1,0 +1,47 @@
+"""
+Embedding-input contract for ClusterableIssue.
+
+The clustering pipeline embeds `embedding_text` per issue and assigns to
+clusters by cosine distance. Key moments are trace-specific verbatim
+quotes that dominated the embedding and fragmented same-issue findings
+across many singleton clusters. We embed the brief alone — the issue
+described, not the surrounding trace text.
+"""
+
+from tracer.types.scan_types import ClusterableIssue
+
+
+def _issue(brief: str, key_moments: list[str] | None = None) -> ClusterableIssue:
+    return ClusterableIssue(
+        issue_id="i1",
+        trace_id="t1",
+        project_id="p1",
+        category="reasoning",
+        group="g1",
+        fix_layer="prompt",
+        brief=brief,
+        confidence="high",
+        key_moments_text=key_moments or [],
+    )
+
+
+def test_embedding_text_is_brief_only():
+    issue = _issue(
+        brief="Agent ignored the user's stated currency preference.",
+        key_moments=["user said USD", "agent replied in EUR"],
+    )
+    assert issue.embedding_text == "Agent ignored the user's stated currency preference."
+
+
+def test_embedding_text_ignores_empty_key_moments():
+    issue = _issue(brief="Tool output contradicted the final answer.")
+    assert issue.embedding_text == "Tool output contradicted the final answer."
+
+
+def test_embedding_text_same_brief_clusters_across_traces():
+    """Two issues with identical briefs but different per-trace key moments
+    must produce identical embedding inputs — that's the whole point."""
+    brief = "Agent hallucinated a non-existent API endpoint."
+    a = _issue(brief, key_moments=["called /v1/foo", "got 404"])
+    b = _issue(brief, key_moments=["called /v2/bar", "got 404"])
+    assert a.embedding_text == b.embedding_text

--- a/futureagi/tracer/types/scan_types.py
+++ b/futureagi/tracer/types/scan_types.py
@@ -85,10 +85,8 @@ class ClusterableIssue:
 
     @property
     def embedding_text(self) -> str:
-        """brief + key moments → single string for embedding."""
-        parts = [self.brief]
-        parts.extend(self.key_moments_text)
-        return " | ".join(parts)
+        """Embed only the issue brief."""
+        return self.brief
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Adjusts the embedding input used by issue clustering. We now embed the issue brief alone instead of the brief joined with per-trace key-moment text. Brief is the description of the issue; key-moment text is trace-specific verbatim content. Mixing them made the embedding sensitive to surrounding trace text rather than the issue described, so near-identical issues across different traces wouldn't merge into the same cluster (producing singleton clusters and fragmenting same-issue findings across many duplicate cards).

## Test plan

- [x] Unit test (`tracer/tests/test_scan_types.py`):
  - `embedding_text` returns the brief verbatim.
  - Identical briefs with different per-trace key moments produce identical embedding inputs.
- [ ] Post-deploy: issues with the same brief and category cluster together more reliably (drop in singleton-cluster rate per project).
- [ ] Post-deploy: cluster cardinality tracks underlying issue diversity, not surrounding trace text variance.

## Refs
- TH-4671 (Linear)
