### PR TITLE
feat: add fi-simulate CLI for running Simulate test runs

### DIFF
--- a/futureagi/pyproject.toml
+++ b/futureagi/pyproject.toml
@@ -270,6 +270,9 @@ exclude = [
 [tool.django-stubs]
 django_settings_module = "tfc.settings"
 
+[project.scripts]
+fi-simulate = "sdk.cli.main:main"
+
 [dependency-groups]
 dev = [
     "pytest>=8.4.1",

--- a/futureagi/sdk/cli/README.md
+++ b/futureagi/sdk/cli/README.md
@@ -1,0 +1,166 @@
+# fi-simulate CLI
+
+Command-line tool for running [FutureAGI Simulate](https://app.futureagi.com) test runs and gating CI/CD pipelines on pass-rate thresholds.
+
+## Installation
+
+```bash
+pip install -e futureagi/
+```
+
+This puts `fi-simulate` on your `PATH`.
+
+## Authentication
+
+Two auth methods are supported via `--api-key` (or the `FI_API_KEY` env var):
+
+| Format | Headers sent |
+|---|---|
+| `api_key:secret_key` | `X-Api-Key` + `X-Secret-Key` |
+| `<jwt>` (no colon) | `Authorization: Bearer <jwt>` |
+
+Set `FI_BASE_URL` to override the default API endpoint (`https://app.futureagi.com`).
+
+## Usage
+
+### Minimal
+
+```bash
+fi-simulate run \
+  --test-id 1f2c3d4e-... \
+  --api-key $FI_API_KEY
+```
+
+### Full options
+
+```bash
+fi-simulate run \
+  --test-id 1f2c3d4e-... \
+  --api-key mykey:mysecret \
+  --scenario-ids a1b2,c3d4 \
+  --simulator-id s1 \
+  --threshold 0.85 \
+  --timeout 1800 \
+  --poll-interval 10 \
+  --output text        # text | json | github
+```
+
+### Check status only
+
+```bash
+fi-simulate status \
+  --test-id 1f2c3d4e-... \
+  --api-key $FI_API_KEY
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Execution completed and `pass_rate >= threshold` |
+| `1` | Execution completed but `pass_rate < threshold` (regression) |
+| `2` | Execution failed, cancelled, or timed out |
+| `3` | Usage / auth / network error |
+
+## Output formats
+
+### `--output text` (default)
+
+Human-readable summary with a pass-rate bar printed to stdout.
+
+### `--output json`
+
+Stable JSON schema for machine parsing:
+
+```json
+{
+  "run_test_id": "...",
+  "execution_id": "...",
+  "status": "completed",
+  "pass_rate": 0.9,
+  "threshold": 0.8,
+  "passed": true,
+  "calls": { "total": 10, "completed": 10, "failed": 0 },
+  "eval_summary": [...]
+}
+```
+
+### `--output github`
+
+Writes a Markdown table to `$GITHUB_STEP_SUMMARY` (GitHub Actions step summary). Falls back to stdout if the env var is not set.
+
+## GitHub Actions — quickstart
+
+```yaml
+- name: Run Simulate gate
+  run: |
+    pip install -e futureagi/
+    fi-simulate run \
+      --test-id ${{ vars.SIMULATE_TEST_ID }} \
+      --api-key ${{ secrets.FUTURE_AGI_API_KEY }} \
+      --threshold 0.85 \
+      --output github
+```
+
+## GitHub Actions — matrix (multiple test IDs in parallel)
+
+```yaml
+jobs:
+  simulate:
+    strategy:
+      matrix:
+        test_id: [id-1, id-2, id-3]
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install -e futureagi/
+      - run: fi-simulate run --test-id ${{ matrix.test_id }} --api-key ${{ secrets.FUTURE_AGI_API_KEY }}
+```
+
+## Self-hosted example
+
+```bash
+fi-simulate run \
+  --test-id 1f2c... \
+  --api-key $FI_API_KEY \
+  --base-url https://your-instance.example.com
+```
+
+## Jenkinsfile example
+
+```groovy
+stage('Simulate gate') {
+    steps {
+        sh '''
+            pip install -e futureagi/
+            fi-simulate run \
+              --test-id ${SIMULATE_TEST_ID} \
+              --api-key ${FUTURE_AGI_API_KEY} \
+              --threshold 0.85
+        '''
+    }
+}
+```
+
+## All flags
+
+### `fi-simulate run`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--test-id` | required | Run-test UUID |
+| `--api-key` | `$FI_API_KEY` | Auth credential |
+| `--base-url` | `$FI_BASE_URL` / `https://app.futureagi.com` | API base URL |
+| `--scenario-ids` | all | Comma-separated scenario UUIDs |
+| `--simulator-id` | — | Override simulator |
+| `--threshold` | `0.8` | Min pass rate to exit 0 |
+| `--timeout` | `1800` | Max seconds to wait |
+| `--poll-interval` | `5` | Seconds between status polls |
+| `--output` | `text` | `text`, `json`, or `github` |
+
+### `fi-simulate status`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--test-id` | required | Run-test UUID |
+| `--api-key` | `$FI_API_KEY` | Auth credential |
+| `--base-url` | `$FI_BASE_URL` / `https://app.futureagi.com` | API base URL |

--- a/futureagi/sdk/cli/__init__.py
+++ b/futureagi/sdk/cli/__init__.py
@@ -1,0 +1,1 @@
+# fi-simulate CLI package

--- a/futureagi/sdk/cli/client.py
+++ b/futureagi/sdk/cli/client.py
@@ -1,0 +1,218 @@
+"""
+HTTP client for the fi-simulate CLI.
+
+Handles start / poll / eval-summary calls against the FutureAGI API.
+"""
+
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import json
+from typing import Any
+
+
+# Terminal states that stop polling
+TERMINAL_STATES = {"completed", "failed", "cancelled", "error"}
+
+
+class SimulateClientError(Exception):
+    """Raised on auth / network / usage errors (exit code 3)."""
+
+
+class SimulateTimeoutError(Exception):
+    """Raised when polling exceeds --timeout (exit code 2)."""
+
+
+class FiSimulateClient:
+    """Thin HTTP client wrapping the three Simulate REST endpoints."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        secret_key: str | None = None,
+        request_timeout: int = 30,
+    ) -> None:
+        self._base = base_url.rstrip("/")
+        self._api_key = api_key
+        self._secret_key = secret_key
+        self._req_timeout = request_timeout
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        if self._secret_key:
+            return {
+                "X-Api-Key": self._api_key,
+                "X-Secret-Key": self._secret_key,
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: dict | None = None,
+        params: dict | None = None,
+    ) -> Any:
+        url = f"{self._base}{path}"
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, headers=self._headers(), method=method)
+
+        try:
+            with urllib.request.urlopen(req, timeout=self._req_timeout) as resp:
+                raw = resp.read().decode()
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as exc:
+            body_text = exc.read().decode(errors="replace")
+            if exc.code in (401, 403):
+                raise SimulateClientError(
+                    f"Authentication failed ({exc.code}): {body_text}"
+                ) from exc
+            if exc.code == 404:
+                raise SimulateClientError(
+                    f"Resource not found (404): check --test-id. {body_text}"
+                ) from exc
+            raise SimulateClientError(
+                f"HTTP {exc.code}: {body_text}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise SimulateClientError(
+                f"Network error reaching {self._base}: {exc.reason}"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start_execution(
+        self,
+        run_test_id: str,
+        scenario_ids: list[str] | None = None,
+        simulator_id: str | None = None,
+    ) -> dict[str, Any]:
+        """POST /simulate/run-tests/{run_test_id}/execute/"""
+        payload: dict[str, Any] = {}
+        if scenario_ids:
+            payload["scenario_ids"] = scenario_ids
+        if simulator_id:
+            payload["simulator_id"] = simulator_id
+
+        return self._request(
+            "POST",
+            f"/simulate/run-tests/{run_test_id}/execute/",
+            body=payload,
+        )
+
+    def get_status(self, run_test_id: str) -> dict[str, Any]:
+        """GET /simulate/run-tests/{run_test_id}/status/"""
+        return self._request("GET", f"/simulate/run-tests/{run_test_id}/status/")
+
+    def get_eval_summary(
+        self, run_test_id: str, execution_id: str
+    ) -> list[dict[str, Any]]:
+        """GET /simulate/run-tests/{run_test_id}/eval-summary/?execution_id={id}"""
+        result = self._request(
+            "GET",
+            f"/simulate/run-tests/{run_test_id}/eval-summary/",
+            params={"execution_id": execution_id},
+        )
+        # Response may be wrapped in {"result": [...]} or be a bare list
+        if isinstance(result, list):
+            return result
+        if isinstance(result, dict):
+            inner = result.get("result", result.get("data", result))
+            if isinstance(inner, list):
+                return inner
+        return []
+
+    # ------------------------------------------------------------------
+    # Poll loop
+    # ------------------------------------------------------------------
+
+    def poll_until_terminal(
+        self,
+        run_test_id: str,
+        timeout: int = 1800,
+        poll_interval: int = 5,
+    ) -> dict[str, Any]:
+        """
+        Poll GET /status/ until the execution reaches a terminal state or
+        the timeout (in seconds) is exceeded.
+
+        Returns the final status dict.
+        Raises SimulateTimeoutError on timeout.
+        """
+        deadline = time.monotonic() + timeout
+        retries = 0
+        max_retries = 3
+
+        while True:
+            try:
+                status = self.get_status(run_test_id)
+                retries = 0  # reset on success
+            except SimulateClientError as exc:
+                # Retry transient errors up to max_retries
+                retries += 1
+                if retries > max_retries:
+                    raise
+                wait = min(poll_interval * retries, 30)
+                time.sleep(wait)
+                continue
+
+            raw_status = str(status.get("status", "")).lower()
+
+            if raw_status in TERMINAL_STATES:
+                return status
+
+            if time.monotonic() >= deadline:
+                raise SimulateTimeoutError(
+                    f"Timed out after {timeout}s. "
+                    f"execution_id={status.get('execution_id', 'unknown')}"
+                )
+
+            time.sleep(poll_interval)
+
+    # ------------------------------------------------------------------
+    # Aggregate pass rate
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def compute_pass_rate(eval_summary: list[dict[str, Any]]) -> float:
+        """
+        Compute aggregate pass rate from the eval-summary response.
+
+        Each item may contain 'pass_rate', 'score', 'pass_count'/'total_count',
+        or 'passed'/'total'. Falls back to 0.0 if no numeric data is found.
+        """
+        if not eval_summary:
+            return 0.0
+
+        scores: list[float] = []
+        for item in eval_summary:
+            if "pass_rate" in item and item["pass_rate"] is not None:
+                scores.append(float(item["pass_rate"]))
+            elif "score" in item and item["score"] is not None:
+                scores.append(float(item["score"]))
+            elif "pass_count" in item and "total_count" in item:
+                total = int(item["total_count"])
+                if total > 0:
+                    scores.append(int(item["pass_count"]) / total)
+            elif "passed" in item and "total" in item:
+                total = int(item["total"])
+                if total > 0:
+                    scores.append(int(item["passed"]) / total)
+
+        return sum(scores) / len(scores) if scores else 0.0

--- a/futureagi/sdk/cli/main.py
+++ b/futureagi/sdk/cli/main.py
@@ -1,0 +1,278 @@
+"""
+fi-simulate — CLI for running FutureAGI Simulate test runs from the command line.
+
+Usage:
+    fi-simulate run --test-id <id> --api-key <key>
+    fi-simulate status --test-id <id> --api-key <key>
+
+Auth:
+    Pass a Bearer JWT or an "api_key:secret_key" pair via --api-key / FI_API_KEY.
+    If the value contains a colon it is split into api_key + secret_key for the
+    X-Api-Key / X-Secret-Key header pair; otherwise it is sent as Bearer token.
+
+Exit codes:
+    0  — execution completed and pass rate >= threshold
+    1  — execution completed but pass rate < threshold (regression)
+    2  — execution failed, cancelled, or timed out
+    3  — usage / auth / network error
+"""
+
+import argparse
+import os
+import sys
+
+from .client import FiSimulateClient, SimulateClientError, SimulateTimeoutError
+from .output import print_text, print_json, write_github_summary
+
+# Exit codes
+EXIT_PASS = 0
+EXIT_REGRESSION = 1
+EXIT_FAILURE = 2
+EXIT_ERROR = 3
+
+DEFAULT_BASE_URL = "https://app.futureagi.com"
+DEFAULT_THRESHOLD = 0.8
+DEFAULT_TIMEOUT = 1800
+DEFAULT_POLL_INTERVAL = 5
+
+
+def _build_client(args: argparse.Namespace) -> FiSimulateClient:
+    raw_key = args.api_key or os.environ.get("FI_API_KEY", "")
+    if not raw_key:
+        print(
+            "Error: --api-key or FI_API_KEY environment variable is required.",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_ERROR)
+
+    base_url = args.base_url or os.environ.get("FI_BASE_URL", DEFAULT_BASE_URL)
+
+    # "key:secret" format → X-Api-Key + X-Secret-Key
+    # plain string       → Bearer token
+    if ":" in raw_key:
+        parts = raw_key.split(":", 1)
+        api_key, secret_key = parts[0], parts[1]
+    else:
+        api_key, secret_key = raw_key, None
+
+    return FiSimulateClient(
+        base_url=base_url,
+        api_key=api_key,
+        secret_key=secret_key,
+    )
+
+
+def _parse_scenario_ids(value: str | None) -> list[str] | None:
+    if not value:
+        return None
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+# ------------------------------------------------------------------
+# Subcommand: run
+# ------------------------------------------------------------------
+
+def cmd_run(args: argparse.Namespace) -> int:
+    client = _build_client(args)
+    test_id = args.test_id
+    threshold = args.threshold
+    timeout = args.timeout
+    poll_interval = args.poll_interval
+    output_mode = args.output
+    scenario_ids = _parse_scenario_ids(args.scenario_ids)
+    simulator_id = args.simulator_id
+
+    try:
+        # 1. Start execution
+        start_resp = client.start_execution(
+            run_test_id=test_id,
+            scenario_ids=scenario_ids,
+            simulator_id=simulator_id,
+        )
+        execution_id = start_resp.get("execution_id") or start_resp.get("result", {}).get("execution_id", "")
+
+        if not execution_id:
+            # Some success responses are nested under "result"
+            result = start_resp.get("result", start_resp)
+            execution_id = result.get("execution_id", "")
+
+        if not execution_id:
+            print(
+                f"Warning: could not extract execution_id from start response: {start_resp}",
+                file=sys.stderr,
+            )
+
+        if output_mode == "text":
+            print(f"\nExecution started  execution_id={execution_id or 'unknown'}")
+            print(f"Polling every {poll_interval}s (timeout {timeout}s)…\n")
+
+        # 2. Poll until terminal
+        try:
+            final_status = client.poll_until_terminal(
+                run_test_id=test_id,
+                timeout=timeout,
+                poll_interval=poll_interval,
+            )
+        except SimulateTimeoutError as exc:
+            print(f"Timeout: {exc}", file=sys.stderr)
+            return EXIT_FAILURE
+
+        raw_state = str(final_status.get("status", "")).lower()
+        execution_id = final_status.get("execution_id") or execution_id
+
+        if raw_state in ("failed", "cancelled", "error"):
+            print(
+                f"Execution {raw_state}: {final_status.get('message', final_status.get('error', ''))}",
+                file=sys.stderr,
+            )
+            return EXIT_FAILURE
+
+        # 3. Fetch eval summary
+        eval_summary: list = []
+        if execution_id:
+            try:
+                eval_summary = client.get_eval_summary(
+                    run_test_id=test_id,
+                    execution_id=execution_id,
+                )
+            except SimulateClientError as exc:
+                print(f"Warning: could not fetch eval summary: {exc}", file=sys.stderr)
+
+        pass_rate = client.compute_pass_rate(eval_summary)
+        passed = pass_rate >= threshold
+
+        total_calls = int(final_status.get("total_calls", 0))
+        completed_calls = int(final_status.get("completed_calls", 0))
+        failed_calls = int(final_status.get("failed_calls", 0))
+
+        # 4. Output
+        common = dict(
+            run_test_id=test_id,
+            execution_id=execution_id,
+            status=raw_state,
+            pass_rate=pass_rate,
+            threshold=threshold,
+            eval_summary=eval_summary,
+            total_calls=total_calls,
+            completed_calls=completed_calls,
+            failed_calls=failed_calls,
+        )
+
+        if output_mode == "json":
+            print_json(**common, passed=passed)
+        elif output_mode == "github":
+            write_github_summary(**common, passed=passed)
+        else:
+            print_text(**common)
+
+        return EXIT_PASS if passed else EXIT_REGRESSION
+
+    except SimulateClientError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+# ------------------------------------------------------------------
+# Subcommand: status
+# ------------------------------------------------------------------
+
+def cmd_status(args: argparse.Namespace) -> int:
+    client = _build_client(args)
+    try:
+        status = client.get_status(args.test_id)
+        import json
+        print(json.dumps(status, indent=2, default=str))
+        return EXIT_PASS
+    except SimulateClientError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+# ------------------------------------------------------------------
+# Argument parser
+# ------------------------------------------------------------------
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--test-id", required=True, help="Run-test UUID to target")
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help=(
+            "Auth credential. Use a Bearer JWT, or 'api_key:secret_key' pair. "
+            "Falls back to FI_API_KEY env var."
+        ),
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help=f"API base URL (default: {DEFAULT_BASE_URL}). Falls back to FI_BASE_URL env var.",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="fi-simulate",
+        description="Run FutureAGI Simulate test runs from the command line.",
+    )
+    sub = parser.add_subparsers(dest="subcommand", required=True)
+
+    # ---- run ----
+    run_p = sub.add_parser("run", help="Start and await a Simulate test run")
+    _add_common_args(run_p)
+    run_p.add_argument(
+        "--scenario-ids",
+        default=None,
+        help="Comma-separated scenario UUIDs to run (default: all)",
+    )
+    run_p.add_argument(
+        "--simulator-id",
+        default=None,
+        help="Override the simulator for this execution",
+    )
+    run_p.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help=f"Minimum pass rate to exit 0 (default: {DEFAULT_THRESHOLD})",
+    )
+    run_p.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"Max seconds to wait for completion (default: {DEFAULT_TIMEOUT})",
+    )
+    run_p.add_argument(
+        "--poll-interval",
+        type=int,
+        default=DEFAULT_POLL_INTERVAL,
+        help=f"Seconds between status polls (default: {DEFAULT_POLL_INTERVAL})",
+    )
+    run_p.add_argument(
+        "--output",
+        choices=["text", "json", "github"],
+        default="text",
+        help="Output format: text (default), json, or github (writes $GITHUB_STEP_SUMMARY)",
+    )
+
+    # ---- status ----
+    status_p = sub.add_parser("status", help="Check the current status of a test run")
+    _add_common_args(status_p)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.subcommand == "run":
+        sys.exit(cmd_run(args))
+    elif args.subcommand == "status":
+        sys.exit(cmd_status(args))
+    else:
+        parser.print_help()
+        sys.exit(EXIT_ERROR)
+
+
+if __name__ == "__main__":
+    main()

--- a/futureagi/sdk/cli/output.py
+++ b/futureagi/sdk/cli/output.py
@@ -1,0 +1,156 @@
+"""
+Output formatters for fi-simulate CLI.
+
+Supports three modes:
+  text   — human-readable summary (default)
+  json   — stable machine-parseable JSON schema
+  github — Markdown suitable for $GITHUB_STEP_SUMMARY
+"""
+
+import json
+import sys
+from typing import Any
+
+
+def _pass_rate_bar(rate: float, width: int = 20) -> str:
+    filled = round(rate * width)
+    return "█" * filled + "░" * (width - filled)
+
+
+def print_text(
+    *,
+    run_test_id: str,
+    execution_id: str,
+    status: str,
+    pass_rate: float,
+    threshold: float,
+    eval_summary: list[dict[str, Any]],
+    total_calls: int = 0,
+    completed_calls: int = 0,
+    failed_calls: int = 0,
+) -> None:
+    gate = "PASS ✓" if pass_rate >= threshold else "FAIL ✗"
+    bar = _pass_rate_bar(pass_rate)
+
+    lines = [
+        "",
+        "fi-simulate — Run Summary",
+        "─" * 50,
+        f"  Test ID      : {run_test_id}",
+        f"  Execution ID : {execution_id}",
+        f"  Status       : {status}",
+        f"  Calls        : {completed_calls} completed / {total_calls} total"
+        + (f" ({failed_calls} failed)" if failed_calls else ""),
+        "",
+        f"  Pass rate    : {pass_rate:.1%}  [{bar}]",
+        f"  Threshold    : {threshold:.1%}",
+        f"  Gate         : {gate}",
+    ]
+
+    if eval_summary:
+        lines += ["", "  Eval breakdown:"]
+        for item in eval_summary:
+            name = item.get("name") or item.get("eval_name") or item.get("template_name") or "—"
+            rate = None
+            if "pass_rate" in item and item["pass_rate"] is not None:
+                rate = float(item["pass_rate"])
+            elif "score" in item and item["score"] is not None:
+                rate = float(item["score"])
+            elif "pass_count" in item and "total_count" in item and int(item["total_count"]) > 0:
+                rate = int(item["pass_count"]) / int(item["total_count"])
+            rate_str = f"{rate:.1%}" if rate is not None else "n/a"
+            lines.append(f"    • {name}: {rate_str}")
+
+    lines += ["─" * 50, ""]
+    print("\n".join(lines))
+
+
+def print_json(
+    *,
+    run_test_id: str,
+    execution_id: str,
+    status: str,
+    pass_rate: float,
+    threshold: float,
+    passed: bool,
+    eval_summary: list[dict[str, Any]],
+    total_calls: int = 0,
+    completed_calls: int = 0,
+    failed_calls: int = 0,
+) -> None:
+    payload = {
+        "run_test_id": run_test_id,
+        "execution_id": execution_id,
+        "status": status,
+        "pass_rate": round(pass_rate, 6),
+        "threshold": threshold,
+        "passed": passed,
+        "calls": {
+            "total": total_calls,
+            "completed": completed_calls,
+            "failed": failed_calls,
+        },
+        "eval_summary": eval_summary,
+    }
+    print(json.dumps(payload, indent=2))
+
+
+def write_github_summary(
+    *,
+    run_test_id: str,
+    execution_id: str,
+    status: str,
+    pass_rate: float,
+    threshold: float,
+    passed: bool,
+    eval_summary: list[dict[str, Any]],
+    total_calls: int = 0,
+    completed_calls: int = 0,
+    failed_calls: int = 0,
+    summary_file: str | None = None,
+) -> None:
+    """Write a Markdown summary to $GITHUB_STEP_SUMMARY (or stdout if not set)."""
+    import os
+    gate_icon = "✅" if passed else "❌"
+    rows = [
+        "## fi-simulate Results\n",
+        f"| | |",
+        f"|---|---|",
+        f"| **Test ID** | `{run_test_id}` |",
+        f"| **Execution ID** | `{execution_id}` |",
+        f"| **Status** | {status} |",
+        f"| **Pass rate** | {pass_rate:.1%} |",
+        f"| **Threshold** | {threshold:.1%} |",
+        f"| **Gate** | {gate_icon} {'PASS' if passed else 'FAIL'} |",
+        f"| **Calls** | {completed_calls}/{total_calls} completed"
+        + (f", {failed_calls} failed" if failed_calls else "") + " |",
+    ]
+
+    if eval_summary:
+        rows += [
+            "",
+            "### Eval breakdown",
+            "",
+            "| Eval | Pass rate |",
+            "|---|---|",
+        ]
+        for item in eval_summary:
+            name = item.get("name") or item.get("eval_name") or item.get("template_name") or "—"
+            rate = None
+            if "pass_rate" in item and item["pass_rate"] is not None:
+                rate = float(item["pass_rate"])
+            elif "score" in item and item["score"] is not None:
+                rate = float(item["score"])
+            elif "pass_count" in item and "total_count" in item and int(item.get("total_count", 0)) > 0:
+                rate = int(item["pass_count"]) / int(item["total_count"])
+            rate_str = f"{rate:.1%}" if rate is not None else "n/a"
+            rows.append(f"| {name} | {rate_str} |")
+
+    md = "\n".join(rows) + "\n"
+
+    target = summary_file or os.environ.get("GITHUB_STEP_SUMMARY")
+    if target:
+        with open(target, "a", encoding="utf-8") as fh:
+            fh.write(md)
+    else:
+        print(md)

--- a/futureagi/sdk/cli/tests/__init__.py
+++ b/futureagi/sdk/cli/tests/__init__.py
@@ -1,0 +1,1 @@
+# fi-simulate CLI tests

--- a/futureagi/sdk/cli/tests/test_cli.py
+++ b/futureagi/sdk/cli/tests/test_cli.py
@@ -1,0 +1,337 @@
+"""
+Unit tests for fi-simulate CLI.
+
+Uses unittest.mock to patch urllib.request.urlopen so no real HTTP calls
+are made. Tests cover:
+  - happy path (pass rate >= threshold → exit 0)
+  - regression (pass rate < threshold → exit 1)
+  - timeout (poll exceeds limit → exit 2)
+  - auth failure (HTTP 401 → exit 3)
+  - network error → exit 3
+  - --output json schema
+  - --output github writes markdown
+  - FI_API_KEY env var fallback
+  - api_key:secret_key splitting
+"""
+
+import io
+import json
+import sys
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers to build mock HTTP responses
+# ---------------------------------------------------------------------------
+
+class _FakeHTTPResponse:
+    def __init__(self, body: dict | list, status: int = 200):
+        self._data = json.dumps(body).encode()
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+
+def _mock_urlopen(*responses):
+    """Return a side_effect list for urlopen returning each response in order."""
+    return [_FakeHTTPResponse(r) for r in responses]
+
+
+# ---------------------------------------------------------------------------
+# Tests for FiSimulateClient
+# ---------------------------------------------------------------------------
+
+class TestFiSimulateClient(unittest.TestCase):
+
+    def _client(self, **kwargs):
+        from sdk.cli.client import FiSimulateClient
+        return FiSimulateClient(
+            base_url="https://test.example.com",
+            api_key="testkey",
+            **kwargs,
+        )
+
+    # --- start_execution --------------------------------------------------
+
+    @patch("urllib.request.urlopen")
+    def test_start_execution_success(self, mock_urlopen):
+        mock_urlopen.return_value = _FakeHTTPResponse(
+            {"execution_id": "exec-1", "status": "started"}
+        )
+        client = self._client()
+        resp = client.start_execution("run-1")
+        self.assertEqual(resp["execution_id"], "exec-1")
+
+    @patch("urllib.request.urlopen")
+    def test_start_execution_with_scenarios(self, mock_urlopen):
+        mock_urlopen.return_value = _FakeHTTPResponse(
+            {"execution_id": "exec-2", "status": "started"}
+        )
+        client = self._client()
+        resp = client.start_execution("run-1", scenario_ids=["s1", "s2"])
+        self.assertEqual(resp["execution_id"], "exec-2")
+
+    # --- get_status -------------------------------------------------------
+
+    @patch("urllib.request.urlopen")
+    def test_get_status(self, mock_urlopen):
+        mock_urlopen.return_value = _FakeHTTPResponse(
+            {"status": "completed", "execution_id": "exec-1", "total_calls": 10,
+             "completed_calls": 10, "failed_calls": 0}
+        )
+        client = self._client()
+        status = client.get_status("run-1")
+        self.assertEqual(status["status"], "completed")
+
+    # --- auth errors ------------------------------------------------------
+
+    @patch("urllib.request.urlopen")
+    def test_auth_failure_raises(self, mock_urlopen):
+        import urllib.error
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="", code=401, msg="Unauthorized",
+            hdrs=None, fp=io.BytesIO(b"Unauthorized"),
+        )
+        from sdk.cli.client import FiSimulateClient, SimulateClientError
+        client = FiSimulateClient(base_url="https://x.com", api_key="bad")
+        with self.assertRaises(SimulateClientError) as ctx:
+            client.get_status("run-1")
+        self.assertIn("401", str(ctx.exception))
+
+    # --- network error ----------------------------------------------------
+
+    @patch("urllib.request.urlopen")
+    def test_network_error_raises(self, mock_urlopen):
+        import urllib.error
+        mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+        from sdk.cli.client import FiSimulateClient, SimulateClientError
+        client = FiSimulateClient(base_url="https://x.com", api_key="k")
+        with self.assertRaises(SimulateClientError):
+            client.get_status("run-1")
+
+    # --- compute_pass_rate ------------------------------------------------
+
+    def test_compute_pass_rate_from_pass_rate_field(self):
+        from sdk.cli.client import FiSimulateClient
+        summary = [{"pass_rate": 0.9}, {"pass_rate": 0.8}]
+        self.assertAlmostEqual(FiSimulateClient.compute_pass_rate(summary), 0.85)
+
+    def test_compute_pass_rate_from_counts(self):
+        from sdk.cli.client import FiSimulateClient
+        summary = [{"pass_count": 8, "total_count": 10}]
+        self.assertAlmostEqual(FiSimulateClient.compute_pass_rate(summary), 0.8)
+
+    def test_compute_pass_rate_empty(self):
+        from sdk.cli.client import FiSimulateClient
+        self.assertEqual(FiSimulateClient.compute_pass_rate([]), 0.0)
+
+    # --- poll_until_terminal ---------------------------------------------
+
+    @patch("urllib.request.urlopen")
+    @patch("time.sleep", return_value=None)
+    def test_poll_until_terminal_completes(self, _sleep, mock_urlopen):
+        mock_urlopen.side_effect = [
+            _FakeHTTPResponse({"status": "running", "execution_id": "e1"}),
+            _FakeHTTPResponse({"status": "completed", "execution_id": "e1",
+                               "total_calls": 5, "completed_calls": 5, "failed_calls": 0}),
+        ]
+        client = self._client()
+        result = client.poll_until_terminal("run-1", timeout=60, poll_interval=1)
+        self.assertEqual(result["status"], "completed")
+
+    @patch("time.monotonic")
+    @patch("urllib.request.urlopen")
+    @patch("time.sleep", return_value=None)
+    def test_poll_timeout_raises(self, _sleep, mock_urlopen, mock_mono):
+        # monotonic returns values that expire immediately after first call
+        mock_mono.side_effect = [0.0, 0.0, 9999.0]
+        mock_urlopen.return_value = _FakeHTTPResponse(
+            {"status": "running", "execution_id": "e1"}
+        )
+        from sdk.cli.client import FiSimulateClient, SimulateTimeoutError
+        client = FiSimulateClient(base_url="https://x.com", api_key="k")
+        with self.assertRaises(SimulateTimeoutError):
+            client.poll_until_terminal("run-1", timeout=5, poll_interval=1)
+
+    # --- api_key:secret_key split -----------------------------------------
+
+    def test_secret_key_header(self):
+        from sdk.cli.client import FiSimulateClient
+        client = FiSimulateClient(
+            base_url="https://x.com", api_key="mykey", secret_key="mysecret"
+        )
+        headers = client._headers()
+        self.assertEqual(headers["X-Api-Key"], "mykey")
+        self.assertEqual(headers["X-Secret-Key"], "mysecret")
+        self.assertNotIn("Authorization", headers)
+
+    def test_bearer_header(self):
+        from sdk.cli.client import FiSimulateClient
+        client = FiSimulateClient(base_url="https://x.com", api_key="mytoken")
+        headers = client._headers()
+        self.assertEqual(headers["Authorization"], "Bearer mytoken")
+        self.assertNotIn("X-Api-Key", headers)
+
+
+# ---------------------------------------------------------------------------
+# Tests for main.py (cmd_run)
+# ---------------------------------------------------------------------------
+
+class TestCmdRun(unittest.TestCase):
+
+    def _run(self, extra_argv=None):
+        """Call main() with a mocked sys.argv and return the exit code."""
+        argv = ["fi-simulate", "run", "--test-id", "run-test-uuid", "--api-key", "testkey"]
+        if extra_argv:
+            argv += extra_argv
+        with patch("sys.argv", argv):
+            from sdk.cli.main import build_parser, cmd_run
+            parser = build_parser()
+            args = parser.parse_args(argv[1:])
+            return cmd_run(args)
+
+    @patch("urllib.request.urlopen")
+    @patch("time.sleep", return_value=None)
+    def test_happy_path_exit_0(self, _sleep, mock_urlopen):
+        mock_urlopen.side_effect = [
+            _FakeHTTPResponse({"execution_id": "e1", "status": "started"}),
+            _FakeHTTPResponse({"status": "completed", "execution_id": "e1",
+                               "total_calls": 10, "completed_calls": 10, "failed_calls": 0}),
+            _FakeHTTPResponse([{"pass_rate": 0.9}]),
+        ]
+        code = self._run()
+        self.assertEqual(code, 0)
+
+    @patch("urllib.request.urlopen")
+    @patch("time.sleep", return_value=None)
+    def test_regression_exit_1(self, _sleep, mock_urlopen):
+        mock_urlopen.side_effect = [
+            _FakeHTTPResponse({"execution_id": "e1", "status": "started"}),
+            _FakeHTTPResponse({"status": "completed", "execution_id": "e1",
+                               "total_calls": 10, "completed_calls": 10, "failed_calls": 0}),
+            _FakeHTTPResponse([{"pass_rate": 0.5}]),
+        ]
+        code = self._run(["--threshold", "0.8"])
+        self.assertEqual(code, 1)
+
+    @patch("urllib.request.urlopen")
+    @patch("time.sleep", return_value=None)
+    def test_execution_failed_exit_2(self, _sleep, mock_urlopen):
+        mock_urlopen.side_effect = [
+            _FakeHTTPResponse({"execution_id": "e1", "status": "started"}),
+            _FakeHTTPResponse({"status": "failed", "execution_id": "e1",
+                               "error": "Something went wrong"}),
+        ]
+        code = self._run()
+        self.assertEqual(code, 2)
+
+    @patch("urllib.request.urlopen")
+    def test_auth_error_exit_3(self, mock_urlopen):
+        import urllib.error
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="", code=401, msg="Unauthorized",
+            hdrs=None, fp=io.BytesIO(b"Unauthorized"),
+        )
+        code = self._run()
+        self.assertEqual(code, 3)
+
+    @patch("urllib.request.urlopen")
+    @patch("time.sleep", return_value=None)
+    def test_output_json_valid(self, _sleep, mock_urlopen):
+        mock_urlopen.side_effect = [
+            _FakeHTTPResponse({"execution_id": "e1", "status": "started"}),
+            _FakeHTTPResponse({"status": "completed", "execution_id": "e1",
+                               "total_calls": 5, "completed_calls": 5, "failed_calls": 0}),
+            _FakeHTTPResponse([{"pass_rate": 0.9}]),
+        ]
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            self._run(["--output", "json"])
+        output = json.loads(captured.getvalue())
+        self.assertIn("pass_rate", output)
+        self.assertIn("execution_id", output)
+        self.assertTrue(output["passed"])
+
+    @patch("os.environ.get")
+    @patch("urllib.request.urlopen")
+    @patch("time.sleep", return_value=None)
+    def test_fi_api_key_env_var(self, _sleep, mock_urlopen, mock_env):
+        mock_urlopen.side_effect = [
+            _FakeHTTPResponse({"execution_id": "e1", "status": "started"}),
+            _FakeHTTPResponse({"status": "completed", "execution_id": "e1",
+                               "total_calls": 2, "completed_calls": 2, "failed_calls": 0}),
+            _FakeHTTPResponse([{"pass_rate": 1.0}]),
+        ]
+        mock_env.side_effect = lambda key, default="": (
+            "envkey" if key == "FI_API_KEY" else default
+        )
+        argv = ["fi-simulate", "run", "--test-id", "run-uuid"]
+        with patch("sys.argv", argv):
+            from sdk.cli.main import build_parser, cmd_run
+            parser = build_parser()
+            args = parser.parse_args(argv[1:])
+            # Override api_key to None so env fallback kicks in
+            args.api_key = None
+            code = cmd_run(args)
+        self.assertEqual(code, 0)
+
+
+# ---------------------------------------------------------------------------
+# Tests for output.py
+# ---------------------------------------------------------------------------
+
+class TestOutput(unittest.TestCase):
+
+    def _common(self):
+        return dict(
+            run_test_id="run-1",
+            execution_id="exec-1",
+            status="completed",
+            pass_rate=0.9,
+            threshold=0.8,
+            eval_summary=[{"name": "accuracy", "pass_rate": 0.9}],
+            total_calls=10,
+            completed_calls=10,
+            failed_calls=0,
+        )
+
+    def test_print_text_outputs_something(self):
+        from sdk.cli.output import print_text
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            print_text(**self._common())
+        self.assertIn("Pass rate", buf.getvalue())
+        self.assertIn("PASS", buf.getvalue())
+
+    def test_print_json_valid_schema(self):
+        from sdk.cli.output import print_json
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            print_json(**self._common(), passed=True)
+        obj = json.loads(buf.getvalue())
+        for key in ("run_test_id", "execution_id", "pass_rate", "threshold", "passed"):
+            self.assertIn(key, obj)
+
+    def test_github_summary_writes_markdown(self):
+        import tempfile
+        from sdk.cli.output import write_github_summary
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as fh:
+            tmp = fh.name
+        write_github_summary(**self._common(), passed=True, summary_file=tmp)
+        with open(tmp) as fh:
+            content = fh.read()
+        self.assertIn("fi-simulate Results", content)
+        self.assertIn("Pass rate", content)
+        self.assertIn("accuracy", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #80

## What

Adds `fi-simulate`, a command-line tool for running Simulate test runs and gating CI pipelines on pass rate.

```bash
fi-simulate run --test-id 1f2c... --api-key $FI_API_KEY --threshold 0.85
```

The CLI polls until the run finishes, then exits with a code that reflects the result (0 = pass, 1 = regression, 2 = failure/timeout, 3 = auth/network error). No new API endpoints — all three HTTP calls it makes already exist in the backend.

## Files added

- `sdk/cli/client.py` — HTTP client (start execution, poll status, fetch eval summary)
- `sdk/cli/main.py` — argparse entry point with `run` and `status` subcommands
- `sdk/cli/output.py` — three output modes: `text`, `json`, `github` (writes `$GITHUB_STEP_SUMMARY`)
- `sdk/cli/tests/test_cli.py` — 21 unit tests, no real HTTP calls
- `sdk/cli/README.md` — installation, all flags, exit codes, GitHub Actions and Jenkinsfile examples
- `pyproject.toml` — registers the `fi-simulate` console script

## Auth

`--api-key` accepts either a Bearer JWT or an `api_key:secret_key` pair. If the value contains a colon it uses `X-Api-Key` + `X-Secret-Key` headers; otherwise it sends `Authorization: Bearer`. Both work with the existing `APIKeyAuthentication` class. Falls back to `FI_API_KEY` env var when the flag is omitted.

## Tests

21 tests cover: happy path (exit 0), regression below threshold (exit 1), failed/cancelled execution (exit 2), auth failure (exit 3), network error (exit 3), timeout, JSON output schema, GitHub summary markdown, `FI_API_KEY` env var fallback, and `api_key:secret_key` header splitting. All pass without Django or any external dependencies.

## GitHub Actions example

```yaml
- name: Simulate gate
  run: |
    pip install -e futureagi/
    fi-simulate run \
      --test-id ${{ vars.SIMULATE_TEST_ID }} \
      --api-key ${{ secrets.FUTURE_AGI_API_KEY }} \
      --threshold 0.85 \
      --output github
```