### PR TITLE
feat: wire agent template entry point in EmptyView

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/EmptyView.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/EmptyView.jsx
@@ -1,4 +1,4 @@
-import { Box, Stack, Typography } from "@mui/material";
+import { Box, Link, Stack, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState, useRef } from "react";
 import SvgColor from "src/components/svg-color";
@@ -67,10 +67,10 @@ export default function EmptyView() {
     setOpen(false);
   };
 
-  // const handleOpenTemplateDrawer = (e) => {
-  //   e.stopPropagation();
-  //   setTemplateDrawerOpen(true);
-  // };
+  const handleOpenTemplateDrawer = (e) => {
+    e.stopPropagation();
+    setTemplateDrawerOpen(true);
+  };
 
   const handleCloseTemplateDrawer = () => {
     setTemplateDrawerOpen(false);
@@ -114,14 +114,14 @@ export default function EmptyView() {
               >
                 Add first node
               </Typography>
-              {/* <Link
+              <Link
                 typography={"s2_1"}
                 fontWeight={"fontWeightMedium"}
                 onClick={handleOpenTemplateDrawer}
                 sx={{ cursor: "pointer" }}
               >
-                or start from the template
-              </Link> */}
+                or start from a template
+              </Link>
             </Stack>
           }
         />


### PR DESCRIPTION
Closes #32

## What

The agent template system was already fully built — `ChooseAgentTemplateDrawer`, `SelectedAgentTemplateDrawer`, `TemplateLoadingOverlay`, `StopTemplateLoadingDialog`, the Zustand store, and template data are all in place. The only missing piece was the entry point in `EmptyView.jsx`, which had been commented out.

This PR uncomments it.

## Changes

- Import `Link` from `@mui/material` in `EmptyView.jsx`
- Uncomment `handleOpenTemplateDrawer` handler
- Uncomment the 'or start from a template' link that opens the template gallery drawer

## Result

Users on an empty canvas now see 'or start from a template' below the 'Add first node' button. Clicking it opens `ChooseAgentTemplateDrawer`, where they can browse templates by category, preview details, and load one into the builder.