### PR TITLE
feat: add fi-simulate composite GitHub Action

### DIFF
--- a/.github/actions/fi-simulate/README.md
+++ b/.github/actions/fi-simulate/README.md
@@ -1,0 +1,123 @@
+# fi-simulate GitHub Action
+
+Composite action that runs a [FutureAGI Simulate](https://app.futureagi.com) test run and gates your CI pipeline on the pass-rate result.
+
+## Quickstart
+
+```yaml
+- uses: future-agi/future-agi/.github/actions/fi-simulate@main
+  with:
+    test-id: ${{ vars.SIMULATE_TEST_ID }}
+    api-key: ${{ secrets.FUTURE_AGI_API_KEY }}
+    threshold: "0.85"
+```
+
+The step fails if the aggregate pass rate falls below `threshold`.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `test-id` | ✅ | — | Run-test UUID to execute |
+| `api-key` | ✅ | — | API credential — Bearer JWT or `api_key:secret_key` pair. Use a repo/org secret. |
+| `scenario-ids` | | (all) | Comma-separated scenario UUIDs |
+| `simulator-id` | | — | Override the simulator |
+| `threshold` | | `0.8` | Min pass rate to pass the step (0.0–1.0) |
+| `timeout` | | `1800` | Max seconds to wait for completion |
+| `poll-interval` | | `5` | Seconds between status polls |
+| `base-url` | | `https://app.futureagi.com` | Override for self-hosted deployments |
+| `python-version` | | `3.11` | Python version on the runner |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `execution-id` | The execution ID (use for downstream steps) |
+| `pass-rate` | Aggregate pass rate (0.0–1.0) |
+| `summary-json` | Full eval summary as a JSON string |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Pass rate ≥ threshold |
+| `1` | Pass rate < threshold (regression) |
+| `2` | Execution failed, cancelled, or timed out |
+| `3` | Auth / network / usage error |
+
+## Examples
+
+### Gate a PR on simulation results
+
+```yaml
+name: Simulate gate
+
+on:
+  pull_request:
+
+jobs:
+  simulate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run FutureAGI Simulate
+        uses: future-agi/future-agi/.github/actions/fi-simulate@main
+        with:
+          test-id: ${{ vars.SIMULATE_TEST_ID }}
+          api-key: ${{ secrets.FUTURE_AGI_API_KEY }}
+          threshold: "0.85"
+```
+
+### Use outputs in subsequent steps
+
+```yaml
+- name: Run Simulate
+  id: simulate
+  uses: future-agi/future-agi/.github/actions/fi-simulate@main
+  with:
+    test-id: ${{ vars.SIMULATE_TEST_ID }}
+    api-key: ${{ secrets.FUTURE_AGI_API_KEY }}
+
+- name: Print results
+  run: |
+    echo "Execution: ${{ steps.simulate.outputs.execution-id }}"
+    echo "Pass rate: ${{ steps.simulate.outputs.pass-rate }}"
+```
+
+### Run multiple tests in parallel (matrix)
+
+```yaml
+jobs:
+  simulate:
+    strategy:
+      matrix:
+        test_id: [id-1, id-2, id-3]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: future-agi/future-agi/.github/actions/fi-simulate@main
+        with:
+          test-id: ${{ matrix.test_id }}
+          api-key: ${{ secrets.FUTURE_AGI_API_KEY }}
+          threshold: "0.8"
+```
+
+### Self-hosted deployment
+
+```yaml
+- uses: future-agi/future-agi/.github/actions/fi-simulate@main
+  with:
+    test-id: ${{ vars.SIMULATE_TEST_ID }}
+    api-key: ${{ secrets.FUTURE_AGI_API_KEY }}
+    base-url: "https://your-instance.example.com"
+```
+
+## How it works
+
+1. Sets up Python on the runner via `actions/setup-python@v5`
+2. Installs `fi-simulate` via `pip`
+3. Runs `fi-simulate run` with the provided inputs
+4. Writes a Markdown summary table to `$GITHUB_STEP_SUMMARY`
+5. Sets `execution-id`, `pass-rate`, and `summary-json` outputs
+6. Exits with the CLI exit code — GitHub marks the step failed on exit code > 0

--- a/.github/actions/fi-simulate/action.yml
+++ b/.github/actions/fi-simulate/action.yml
@@ -1,0 +1,160 @@
+name: "fi-simulate"
+description: "Run a FutureAGI Simulate test and gate your pipeline on the pass-rate result."
+author: "FutureAGI"
+
+branding:
+  icon: "check-circle"
+  color: "purple"
+
+inputs:
+  test-id:
+    description: "Run-test UUID to execute"
+    required: true
+  api-key:
+    description: >
+      FutureAGI API credential. Use a repo or org secret.
+      Accepts a Bearer JWT or an 'api_key:secret_key' pair.
+    required: true
+  scenario-ids:
+    description: "Comma-separated scenario UUIDs to run. Defaults to all scenarios in the test."
+    required: false
+    default: ""
+  simulator-id:
+    description: "Override the simulator for this execution."
+    required: false
+    default: ""
+  threshold:
+    description: "Minimum pass rate (0.0–1.0) required to pass the step. Defaults to 0.8."
+    required: false
+    default: "0.8"
+  timeout:
+    description: "Maximum seconds to wait for the run to finish. Defaults to 1800."
+    required: false
+    default: "1800"
+  poll-interval:
+    description: "Seconds between status polls. Defaults to 5."
+    required: false
+    default: "5"
+  base-url:
+    description: "API base URL. Override for self-hosted deployments."
+    required: false
+    default: "https://app.futureagi.com"
+  python-version:
+    description: "Python version to use on the runner. Defaults to 3.11."
+    required: false
+    default: "3.11"
+
+outputs:
+  execution-id:
+    description: "The execution ID returned by the Simulate run."
+    value: ${{ steps.fi-simulate.outputs.execution-id }}
+  pass-rate:
+    description: "Aggregate pass rate (0.0–1.0) from the eval summary."
+    value: ${{ steps.fi-simulate.outputs.pass-rate }}
+  summary-json:
+    description: "Full eval summary as a JSON string."
+    value: ${{ steps.fi-simulate.outputs.summary-json }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install fi-simulate
+      shell: bash
+      run: pip install --quiet fi-simulate
+
+    - name: Run fi-simulate
+      id: fi-simulate
+      shell: bash
+      env:
+        FI_API_KEY: ${{ inputs.api-key }}
+        FI_BASE_URL: ${{ inputs.base-url }}
+      run: |
+        # Build argument list
+        ARGS=(
+          run
+          --test-id "${{ inputs.test-id }}"
+          --threshold "${{ inputs.threshold }}"
+          --timeout "${{ inputs.timeout }}"
+          --poll-interval "${{ inputs.poll-interval }}"
+          --output json
+        )
+        if [ -n "${{ inputs.scenario-ids }}" ]; then
+          ARGS+=(--scenario-ids "${{ inputs.scenario-ids }}")
+        fi
+        if [ -n "${{ inputs.simulator-id }}" ]; then
+          ARGS+=(--simulator-id "${{ inputs.simulator-id }}")
+        fi
+
+        # Run and capture JSON output; preserve the exit code
+        JSON_FILE="$(mktemp)"
+        fi-simulate "${ARGS[@]}" | tee "$JSON_FILE"
+        EXIT_CODE=${PIPESTATUS[0]}
+
+        # Write GitHub step summary from the JSON result
+        python3 - "$JSON_FILE" << 'PYEOF'
+        import json, os, sys
+
+        path = sys.argv[1]
+        try:
+            with open(path) as f:
+                d = json.load(f)
+        except Exception:
+            sys.exit(0)
+
+        passed     = d.get("passed", False)
+        pass_rate  = d.get("pass_rate", 0)
+        threshold  = d.get("threshold", 0)
+        exec_id    = d.get("execution_id", "")
+        run_id     = d.get("run_test_id", "")
+        status     = d.get("status", "")
+        calls      = d.get("calls", {})
+        evals      = d.get("eval_summary", [])
+
+        gate  = "✅ PASS" if passed else "❌ FAIL"
+        lines = [
+            "## fi-simulate Results\n",
+            "| | |",
+            "|---|---|",
+            f"| **Test ID** | `{run_id}` |",
+            f"| **Execution ID** | `{exec_id}` |",
+            f"| **Status** | {status} |",
+            f"| **Pass rate** | {pass_rate:.1%} |",
+            f"| **Threshold** | {threshold:.1%} |",
+            f"| **Gate** | {gate} |",
+        ]
+        if calls:
+            lines.append(
+                f"| **Calls** | {calls.get('completed',0)}/{calls.get('total',0)} completed |"
+            )
+        if evals:
+            lines += ["", "### Eval breakdown", "", "| Eval | Pass rate |", "|---|---|"]
+            for e in evals:
+                name = e.get("name") or e.get("eval_name") or "—"
+                rate = e.get("pass_rate") or e.get("score")
+                rate_str = f"{float(rate):.1%}" if rate is not None else "n/a"
+                lines.append(f"| {name} | {rate_str} |")
+
+        md = "\n".join(lines) + "\n"
+        summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_file:
+            with open(summary_file, "a") as f:
+                f.write(md)
+        else:
+            print(md)
+
+        # Write outputs
+        output_file = os.environ.get("GITHUB_OUTPUT")
+        if output_file:
+            with open(output_file, "a") as f:
+                f.write(f"execution-id={exec_id}\n")
+                f.write(f"pass-rate={pass_rate}\n")
+                f.write(f"summary-json={json.dumps(evals)}\n")
+        PYEOF
+
+        rm -f "$JSON_FILE"
+        exit $EXIT_CODE


### PR DESCRIPTION
Closes #81
Depends on #80

## What

Adds a composite GitHub Action at `.github/actions/fi-simulate/` that wraps the `fi-simulate` CLI. Teams can gate PRs on Simulate test results with a single `uses:` line:

```yaml
- uses: future-agi/future-agi/.github/actions/fi-simulate@main
  with:
    test-id: ${{ vars.SIMULATE_TEST_ID }}
    api-key: ${{ secrets.FUTURE_AGI_API_KEY }}
    threshold: "0.85"
```

## Files

- `action.yml` — composite action (Python setup → pip install fi-simulate → run → step summary + outputs)
- `README.md` — all inputs/outputs, exit codes, PR gate example, matrix example, self-hosted example

## How it works

1. Sets up Python on the runner via `actions/setup-python@v5`
2. Installs `fi-simulate` via pip
3. Runs `fi-simulate run` with all inputs mapped to CLI flags, capturing JSON output
4. Writes a Markdown table to `$GITHUB_STEP_SUMMARY`
5. Sets `execution-id`, `pass-rate`, and `summary-json` outputs via `$GITHUB_OUTPUT`
6. Exit code flows through directly — step fails on regression (exit 1), timeout/failure (exit 2), or auth error (exit 3)