### PR TITLE
fix: add reflexion retry to guard() with feedback propagation

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/base_evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/base_evaluator.py
@@ -149,15 +149,52 @@ class BaseEvaluator(ABC):
             eval_results=[eval_result],
         )
 
-    def guard(self, **kwargs):
+    def guard(self, max_retries: int = 1, **kwargs):
         """
-        Guard
+        Evaluate the input and return a GuardResult.
+
+        When *max_retries* > 1 a reflexion loop is used: if the evaluation
+        fails the specific failure *reason* is fed back to the next attempt
+        as ``kwargs["feedback"]``, giving the underlying evaluator a chance
+        to correct borderline outputs before a hard block is issued.
+
+        Args:
+            max_retries: Maximum number of evaluation attempts (default 1,
+                         i.e. no retry — original behaviour is preserved).
+                         Values above 3 are clamped to 3 to avoid runaway
+                         costs on persistent failures.
+            **kwargs:    Arguments forwarded to ``_evaluate``.
+
+        Returns:
+            GuardResult with *passed*, *reason*, *runtime*, and *attempts*.
         """
-        eval_result = self._evaluate(**kwargs)
-        passed = not eval_result["failure"]
-        reason = eval_result["reason"]
-        runtime = eval_result["runtime"]
-        return GuardResult(passed=passed, reason=reason, runtime=runtime)
+        max_retries = max(1, min(max_retries, 3))
+        total_runtime = 0
+
+        for attempt in range(1, max_retries + 1):
+            eval_result = self._evaluate(**kwargs)
+            passed = not eval_result["failure"]
+            reason = eval_result["reason"]
+            total_runtime += eval_result["runtime"]
+
+            if passed:
+                return GuardResult(
+                    passed=True,
+                    reason=reason,
+                    runtime=total_runtime,
+                    attempts=attempt,
+                )
+
+            # Feed the failure reason back so the next attempt has context
+            if attempt < max_retries:
+                kwargs["feedback"] = reason
+
+        return GuardResult(
+            passed=False,
+            reason=reason,
+            runtime=total_runtime,
+            attempts=max_retries,
+        )
 
     def _run_batch_generator_async(
         self, data: list[DataPoint], max_parallel_evals: int

--- a/futureagi/agentic_eval/core_evals/fi_utils/evals_result.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/evals_result.py
@@ -124,3 +124,4 @@ class GuardResult(BaseModel):
     passed: bool
     reason: str
     runtime: int
+    attempts: int = 1


### PR DESCRIPTION
Closes #42

## Problem

When `guard()` evaluates to `False`, it hard-blocks immediately. The failure `reason` field contains the exact description of what went wrong but it's only returned to the caller, never used for recovery. False positives silently break the agent.

## Fix

`guard()` now accepts an optional `max_retries` parameter (default `1`, clamped to max `3`). On each failed attempt the failure reason is fed back as `kwargs["feedback"]` so the evaluator can use it to correct borderline outputs before a hard block is issued.

Default behaviour (`max_retries=1`) is unchanged — no retry, no extra cost.

## Files changed

- `base_evaluator.py` — reflexion loop in `guard()`
- `evals_result.py` — `GuardResult.attempts` field added (default `1`, backward compatible)

## Usage

```python
# Original behaviour — no change
result = evaluator.guard(input=text)

# With reflexion retry (up to 3 attempts)
result = evaluator.guard(max_retries=3, input=text)
print(result.attempts)  # how many rounds were needed
```