### PR TITLE
fix: update Falcon AI eval tools for revamped evals framework (TH-4666)

### DIFF
--- a/futureagi/ai_tools/tools/__init__.py
+++ b/futureagi/ai_tools/tools/__init__.py
@@ -80,31 +80,26 @@ from ai_tools.tools.docs import ask_docs  # noqa: F401
 from ai_tools.tools.docs import get_page  # noqa: F401
 from ai_tools.tools.docs import search_docs  # noqa: F401
 
-# Evaluation tools (25)
-from ai_tools.tools.evaluations import apply_eval_group_to_dataset  # noqa: F401
+# Evaluation tools
 from ai_tools.tools.evaluations import compare_evaluations  # noqa: F401
-from ai_tools.tools.evaluations import create_eval_group  # noqa: F401
+from ai_tools.tools.evaluations import create_composite_eval  # noqa: F401
 from ai_tools.tools.evaluations import create_eval_template  # noqa: F401
-from ai_tools.tools.evaluations import delete_eval_group  # noqa: F401
 from ai_tools.tools.evaluations import delete_eval_logs  # noqa: F401
 from ai_tools.tools.evaluations import delete_eval_template  # noqa: F401
 from ai_tools.tools.evaluations import duplicate_eval_template  # noqa: F401
-from ai_tools.tools.evaluations import edit_eval_group_templates  # noqa: F401
 from ai_tools.tools.evaluations import evaluate_with_agent  # noqa: F401
+from ai_tools.tools.evaluations import execute_composite_eval  # noqa: F401
 from ai_tools.tools.evaluations import get_eval_code_snippet  # noqa: F401
-from ai_tools.tools.evaluations import get_eval_group  # noqa: F401
 from ai_tools.tools.evaluations import get_eval_log_detail  # noqa: F401
 from ai_tools.tools.evaluations import get_eval_logs  # noqa: F401
 from ai_tools.tools.evaluations import get_eval_playground  # noqa: F401
 from ai_tools.tools.evaluations import get_eval_template  # noqa: F401
 from ai_tools.tools.evaluations import get_evaluation  # noqa: F401
-from ai_tools.tools.evaluations import list_eval_groups  # noqa: F401
 from ai_tools.tools.evaluations import list_eval_templates  # noqa: F401
 from ai_tools.tools.evaluations import list_evaluations  # noqa: F401
 from ai_tools.tools.evaluations import run_evaluation  # noqa: F401
 from ai_tools.tools.evaluations import submit_eval_feedback  # noqa: F401
 from ai_tools.tools.evaluations import test_eval_template  # noqa: F401
-from ai_tools.tools.evaluations import update_eval_group  # noqa: F401
 from ai_tools.tools.evaluations import update_eval_template  # noqa: F401
 
 # Experiment tools (11)

--- a/futureagi/ai_tools/tools/datasets/add_dataset_eval.py
+++ b/futureagi/ai_tools/tools/datasets/add_dataset_eval.py
@@ -124,7 +124,7 @@ class AddDatasetEvalTool(BaseTool):
         # Auto-detect mapping if not provided
         if not params.mapping:
             # Try to auto-map eval template keys to dataset columns by name similarity
-            required_keys = template.required_fields or []
+            required_keys = (template.config or {}).get("required_keys", [])
             auto_mapping = {}
             for key in required_keys:
                 key_lower = key.lower()

--- a/futureagi/ai_tools/tools/evaluations/create_composite_eval.py
+++ b/futureagi/ai_tools/tools/evaluations/create_composite_eval.py
@@ -1,0 +1,268 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import Field, field_validator
+
+from ai_tools.base import BaseTool, ToolContext, ToolResult
+from ai_tools.formatting import format_datetime, key_value_block, section
+from ai_tools.registry import register_tool
+
+
+class CreateCompositeEvalInput(PydanticBaseModel):
+    name: str = Field(
+        description=(
+            "Name for the composite evaluation. Must be lowercase alphanumeric "
+            "with hyphens or underscores only."
+        ),
+        min_length=1,
+        max_length=255,
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name_format(cls, v: str) -> str:
+        from model_hub.utils.eval_validators import validate_eval_name
+
+        return validate_eval_name(v)
+
+    description: Optional[str] = Field(
+        default=None,
+        description="Description of what this composite evaluation measures.",
+    )
+    child_template_ids: list[str] = Field(
+        description=(
+            "List of eval template UUIDs to include as children in this composite. "
+            "Use list_eval_templates to find template IDs. Minimum 1, maximum 50."
+        ),
+        min_length=1,
+        max_length=50,
+    )
+    aggregation_enabled: bool = Field(
+        default=True,
+        description="Whether to aggregate child scores into a single composite score.",
+    )
+    aggregation_function: Literal[
+        "weighted_avg", "avg", "min", "max", "pass_rate"
+    ] = Field(
+        default="weighted_avg",
+        description=(
+            "How to aggregate child scores: 'weighted_avg' (default, uses child_weights), "
+            "'avg' (simple average), 'min' (lowest score), 'max' (highest score), "
+            "'pass_rate' (percentage of children that passed)."
+        ),
+    )
+    child_weights: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Weight per child template for weighted_avg aggregation. "
+            "Keys are child template UUIDs, values are float weights. "
+            "Example: {'uuid1': 0.6, 'uuid2': 0.4}. "
+            "If not provided, equal weights are used."
+        ),
+    )
+    composite_child_axis: Optional[str] = Field(
+        default="",
+        description=(
+            "Enforce homogeneity: all children must have this output type. "
+            "Options: 'pass_fail', 'percentage', 'choices', 'code', or '' (no enforcement)."
+        ),
+    )
+    tags: Optional[list[str]] = Field(
+        default=None,
+        description="Tags to categorize this composite evaluation.",
+    )
+
+
+@register_tool
+class CreateCompositeEvalTool(BaseTool):
+    name = "create_composite_eval"
+    description = (
+        "Creates a composite evaluation that bundles multiple eval templates into one. "
+        "When run, each child eval executes independently on the same data, and their "
+        "scores are aggregated into a single result using the chosen function "
+        "(weighted_avg, avg, min, max, or pass_rate). "
+        "Use this to combine checks like toxicity + relevance + hallucination into one eval. "
+        "Use list_eval_templates to find child template IDs first. "
+        "All children must have compatible output types (enforced by composite_child_axis)."
+    )
+    category = "evaluations"
+    input_model = CreateCompositeEvalInput
+
+    def execute(
+        self, params: CreateCompositeEvalInput, context: ToolContext
+    ) -> ToolResult:
+        import re
+
+        from django.db.models import Q
+
+        from model_hub.models.choices import OwnerChoices
+        from model_hub.models.evals_metric import (
+            CompositeEvalChild,
+            EvalTemplate,
+            EvalTemplateVersion,
+        )
+
+        # ── 1. Validate name uniqueness ──
+        if EvalTemplate.objects.filter(
+            name=params.name,
+            organization=context.organization,
+            deleted=False,
+        ).exists():
+            return ToolResult.error(
+                f"An eval template named '{params.name}' already exists.",
+                error_code="VALIDATION_ERROR",
+            )
+        if EvalTemplate.no_workspace_objects.filter(
+            name=params.name,
+            owner=OwnerChoices.SYSTEM.value,
+            deleted=False,
+        ).exists():
+            return ToolResult.error(
+                f"A system eval template named '{params.name}' already exists.",
+                error_code="VALIDATION_ERROR",
+            )
+
+        # ── 2. Verify all child templates exist and are accessible ──
+        children = list(
+            EvalTemplate.no_workspace_objects.filter(
+                id__in=params.child_template_ids, deleted=False
+            ).filter(
+                Q(owner=OwnerChoices.SYSTEM.value)
+                | Q(owner=OwnerChoices.USER.value, organization=context.organization)
+            )
+        )
+
+        found_ids = {str(c.id) for c in children}
+        missing = [cid for cid in params.child_template_ids if cid not in found_ids]
+        if missing:
+            return ToolResult.error(
+                f"Child template(s) not found or not accessible: {', '.join(missing)}",
+                error_code="NOT_FOUND",
+            )
+
+        # ── 3. Reject nested composites ──
+        for child in children:
+            if child.template_type == "composite":
+                return ToolResult.error(
+                    f"Child '{child.name}' is itself a composite. Nested composites are not allowed.",
+                    error_code="VALIDATION_ERROR",
+                )
+
+        # ── 4. Enforce child axis homogeneity ──
+        if params.composite_child_axis:
+            axis_to_output = {
+                "pass_fail": "pass_fail",
+                "percentage": "percentage",
+                "choices": "deterministic",
+                "code": "code",
+            }
+            expected = axis_to_output.get(params.composite_child_axis)
+            if expected:
+                for child in children:
+                    child_output = child.output_type_normalized or "pass_fail"
+                    if child_output != expected:
+                        return ToolResult.error(
+                            f"Child '{child.name}' has output type '{child_output}' "
+                            f"but composite axis requires '{expected}'.",
+                            error_code="VALIDATION_ERROR",
+                        )
+
+        # ── 5. Create composite template ──
+        try:
+            # Infer eval_type from children
+            child_types = list({c.eval_type or "llm" for c in children})
+            composite_eval_type = child_types[0] if len(child_types) == 1 else "llm"
+
+            template = EvalTemplate.objects.create(
+                name=params.name,
+                organization=context.organization,
+                workspace=context.workspace,
+                owner=OwnerChoices.USER.value,
+                template_type="composite",
+                eval_type=composite_eval_type,
+                description=params.description or "",
+                eval_tags=list(params.tags) if params.tags else [],
+                aggregation_enabled=params.aggregation_enabled,
+                aggregation_function=params.aggregation_function,
+                composite_child_axis=params.composite_child_axis or "",
+                config={},
+                proxy_agi=True,
+                visible_ui=True,
+            )
+        except Exception as e:
+            from ai_tools.error_codes import code_from_exception
+
+            return ToolResult.error(
+                f"Failed to create composite eval: {str(e)}",
+                error_code=code_from_exception(e),
+            )
+
+        # ── 6. Create child links ──
+        weights = params.child_weights or {}
+        child_items = []
+        for order, child in enumerate(children):
+            cec = CompositeEvalChild.objects.create(
+                parent=template,
+                child=child,
+                order=order,
+                weight=weights.get(str(child.id), 1.0),
+            )
+            child_items.append({
+                "name": child.name,
+                "eval_type": child.eval_type or "llm",
+                "weight": cec.weight,
+            })
+
+        # ── 7. Create initial version ──
+        try:
+            EvalTemplateVersion.objects.create_version(
+                eval_template=template,
+                prompt_messages=[],
+                config_snapshot={
+                    "aggregation_enabled": params.aggregation_enabled,
+                    "aggregation_function": params.aggregation_function,
+                    "composite_child_axis": params.composite_child_axis or "",
+                    "children": [str(c.id) for c in children],
+                },
+                criteria="",
+                model="",
+                user=context.user,
+                organization=context.organization,
+                workspace=context.workspace,
+            )
+        except Exception:
+            pass  # Non-fatal
+
+        # ── 8. Build response ──
+        children_summary = "\n".join(
+            f"  - {c['name']} ({c['eval_type']}, weight: {c['weight']})"
+            for c in child_items
+        )
+
+        info = key_value_block(
+            [
+                ("ID", f"`{template.id}`"),
+                ("Name", template.name),
+                ("Type", "Composite"),
+                ("Children", str(len(child_items))),
+                ("Aggregation", params.aggregation_function),
+                ("Child Axis", params.composite_child_axis or "any"),
+                ("Tags", ", ".join(template.eval_tags) if template.eval_tags else "—"),
+                ("Created", format_datetime(template.created_at)),
+            ]
+        )
+
+        content = section("Composite Eval Created", info)
+        content += f"\n\n### Children\n\n{children_summary}"
+        content += "\n\n_Use `add_dataset_eval` to add this composite eval to a dataset, then `run_dataset_evals` to execute._"
+
+        return ToolResult(
+            content=content,
+            data={
+                "id": str(template.id),
+                "name": template.name,
+                "template_type": "composite",
+                "children": child_items,
+                "aggregation_function": params.aggregation_function,
+            },
+        )

--- a/futureagi/ai_tools/tools/evaluations/create_eval_template.py
+++ b/futureagi/ai_tools/tools/evaluations/create_eval_template.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field, field_validator, model_validator
@@ -12,7 +12,7 @@ class CreateEvalTemplateInput(PydanticBaseModel):
     name: str = Field(
         description=(
             "Name for the evaluation template. Must be lowercase alphanumeric "
-            "with hyphens or underscores only (e.g. 'is_indian_name')."
+            "with hyphens or underscores only (e.g. 'toxicity-check', 'is_indian_name')."
         ),
         min_length=1,
         max_length=255,
@@ -28,85 +28,183 @@ class CreateEvalTemplateInput(PydanticBaseModel):
     description: Optional[str] = Field(
         default=None, description="Description of what this evaluation measures"
     )
-    template_type: Optional[str] = Field(
-        default="Futureagi",
+    eval_type: Literal["llm", "code", "agent"] = Field(
+        default="llm",
         description=(
-            "Type of evaluation: 'Futureagi' (deterministic, uses Future AGI's "
-            "own models — recommended), 'Llm' (uses external LLM like gpt-4o), "
-            "or 'Function' (custom function eval)."
+            "Type of evaluation: 'llm' (LLM-as-a-judge — uses an LLM to evaluate, "
+            "recommended default), 'code' (custom Python/JavaScript code), "
+            "or 'agent' (Falcon AI powered, uses agent loop with tools)."
         ),
     )
-    config: Optional[dict] = Field(
+    instructions: Optional[str] = Field(
         default=None,
         description=(
-            "Additional configuration dict. Can include 'model' for LLM evals, "
-            "'proxy_agi', 'visible_ui', etc."
+            "Evaluation prompt / criteria. MUST include template variables "
+            "using double curly braces (e.g. '{{input}}', '{{output}}'). "
+            "The variables map to dataset columns at runtime. "
+            "For agent evals, can also use auto-context variables like "
+            "{{row}}, {{span}}, {{trace}} which are resolved automatically."
         ),
     )
     model: Optional[str] = Field(
-        default=None,
+        default="turing_large",
         description=(
-            "Model to use for evaluation. For 'Futureagi' type: 'turing_small' "
-            "(recommended, fast), 'turing_large' (more capable). For 'Llm' type: "
-            "'gpt-4o', 'claude-3-5-sonnet', etc."
+            "Model for evaluation (not used for code evals). "
+            "Built-in: 'turing_large' (default), 'turing_small', 'turing_flash'. "
+            "External (needs configured API key): 'gpt-4o', 'claude-sonnet-4-6', 'gemini-2.5-pro', etc."
         ),
     )
-    criteria: Optional[str] = Field(
-        default=None,
+    output_type: Literal["pass_fail", "percentage", "deterministic"] = Field(
+        default="pass_fail",
         description=(
-            "Evaluation criteria / rule prompt. MUST include template variables "
-            "using double curly braces matching the required_keys. For example: "
-            "'Check if {{name}} from {{origin}} is Indian.' The variables will "
-            "be replaced with actual values from the dataset columns at runtime."
+            "Output type: 'pass_fail' (binary Pass/Fail), 'percentage' (0-100 score), "
+            "'deterministic' (custom choices with scores — requires choice_scores)."
         ),
     )
-    eval_tags: Optional[list[str]] = Field(
-        default=None,
-        description="Tags to categorize this evaluation template",
+    pass_threshold: Optional[float] = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Score threshold for pass/fail determination (0.0-1.0, default 0.5).",
     )
-    output_type: Optional[str] = Field(
-        default="Pass/Fail",
-        description="Output type: 'Pass/Fail' (binary), 'score' (numeric), 'choices' (custom choices)",
-    )
-    choices: Optional[dict] = Field(
+    choice_scores: Optional[dict] = Field(
         default=None,
         description=(
-            "Choices map for 'choices' output_type. Keys are choice labels, "
-            "values are descriptions (e.g. {'Indian': 'Name is of Indian origin', "
-            "'Not Indian': 'Name is not of Indian origin'})"
+            "Score per choice option. Required when output_type='deterministic'. "
+            "Keys are choice labels, values are float scores (e.g. "
+            "{'Excellent': 1.0, 'Good': 0.7, 'Poor': 0.3, 'Bad': 0.0})."
         ),
     )
-    multi_choice: Optional[bool] = Field(
+    tags: Optional[list[str]] = Field(
+        default=None,
+        description="Tags to categorize this evaluation template.",
+    )
+    check_internet: bool = Field(
         default=False,
-        description="Whether multiple choices can be selected (only for 'choices' output_type)",
+        description="Whether the eval can access the internet during execution.",
     )
-    required_keys: Optional[list[str]] = Field(
-        default=None,
+    template_format: Literal["mustache", "jinja"] = Field(
+        default="mustache",
         description=(
-            "Required input keys for the evaluation. These must match the "
-            "template variables used in the criteria (e.g. ['name', 'origin']). "
-            "When mapping to dataset columns, these keys map to column names."
+            "Template variable format: 'mustache' (default, {{var}}) or "
+            "'jinja' (supports {% for %}, {% if %}, filters)."
         ),
     )
+
+    # ── Code eval fields ──
+    code: Optional[str] = Field(
+        default=None,
+        description=(
+            "Custom evaluation code. Required when eval_type='code'. "
+            "Python or JavaScript code that receives inputs and returns a score."
+        ),
+    )
+    code_language: Optional[Literal["python", "javascript"]] = Field(
+        default=None,
+        description="Code language: 'python' or 'javascript'. Required when eval_type='code'.",
+    )
+
+    # ── LLM eval fields ──
+    messages: Optional[list[dict]] = Field(
+        default=None,
+        description=(
+            "Message chain for LLM evals. List of {role, content} dicts. "
+            "Example: [{'role': 'system', 'content': '...'}, {'role': 'user', 'content': '...'}]"
+        ),
+    )
+    few_shot_examples: Optional[list[dict]] = Field(
+        default=None,
+        description=(
+            "Reference datasets for few-shot calibration (LLM and agent evals). "
+            "Pass dataset references: [{'id': 'uuid', 'name': 'name'}]. "
+            "Use list_datasets to find IDs."
+        ),
+    )
+
+    # ── Agent eval fields ──
+    mode: Optional[Literal["auto", "agent", "quick"]] = Field(
+        default=None,
+        description=(
+            "Agent eval mode: 'agent' (default, multi-turn with tools), "
+            "'quick' (single-turn, fast), 'auto' (adapts to data complexity)."
+        ),
+    )
+    tools: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Tool configuration for agent evals. "
+            "Keys: 'internet' (bool, enable web search), "
+            "'connectors' (list of MCP connector IDs for external tools). "
+            "Example: {'internet': true, 'connectors': ['connector-uuid']}"
+        ),
+    )
+    knowledge_bases: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Knowledge base IDs for agent evals. The agent can search these KBs "
+            "during evaluation for fact-grounding. Pass a list of KB UUIDs."
+        ),
+    )
+    data_injection: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Context injection for agent evals. Flags: 'variables_only' (default), "
+            "'full_row', 'span_context', 'trace_context', 'session_context', 'call_context'. "
+            "Auto-detected from {{row}}/{{span}}/{{trace}} in instructions."
+        ),
+    )
+
+    summary: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Explanation style for agent evals: "
+            "{'type': 'concise'} (default), 'short', 'long', or "
+            "{'type': 'custom', 'custom_instructions': '...'}."
+        ),
+    )
+
+    # Aliases for alternate field names (excluded from schema sent to LLM).
+    criteria: Optional[str] = Field(default=None, exclude=True)
+    template_type: Optional[str] = Field(default=None, exclude=True)
+    required_keys: Optional[list[str]] = Field(default=None, exclude=True)
+    choices: Optional[dict] = Field(default=None, exclude=True)
 
     @model_validator(mode="after")
-    def validate_template_type_constraints(self):
-        from model_hub.utils.eval_validators import (
-            validate_choices_for_output_type,
-            validate_criteria_has_variables,
-            validate_length_between_config,
-        )
+    def normalize_and_validate(self):
+        # Normalize alternate field names
+        _type_map = {"Futureagi": "agent", "Llm": "llm", "Function": "code"}
+        if self.template_type and not self.eval_type:
+            mapped = _type_map.get(self.template_type)
+            if mapped:
+                self.eval_type = mapped
+        if self.criteria and not self.instructions:
+            self.instructions = self.criteria
+        if self.choices and not self.choice_scores and self.output_type == "deterministic":
+            keys = list(self.choices.keys())
+            n = len(keys)
+            self.choice_scores = {k: round(1.0 - i / max(n - 1, 1), 2) for i, k in enumerate(keys)}
 
-        template_type = self.template_type or "Futureagi"
+        # Validate
+        if self.eval_type == "code" and not self.code:
+            raise ValueError("'code' field is required when eval_type='code'.")
 
-        # Criteria must have variables for non-Function types
-        validate_criteria_has_variables(self.criteria or "", template_type)
+        # Validate: non-code evals need instructions (unless data_injection)
+        if self.eval_type != "code" and not self.instructions:
+            has_injection = (
+                self.data_injection
+                and (
+                    self.data_injection.get("full_row")
+                    or not self.data_injection.get("variables_only", True)
+                )
+            ) if self.data_injection else False
+            if not has_injection:
+                raise ValueError(
+                    "Instructions are required. Include template variables like {{input}}, {{output}}."
+                )
 
-        # Choices required when output_type is 'choices'
-        validate_choices_for_output_type(self.output_type or "Pass/Fail", self.choices)
-
-        # LengthBetween config validation
-        validate_length_between_config(self.config)
+        # Validate: deterministic needs choice_scores
+        if self.output_type == "deterministic" and not self.choice_scores:
+            raise ValueError("choice_scores is required when output_type='deterministic'.")
 
         return self
 
@@ -115,12 +213,19 @@ class CreateEvalTemplateInput(PydanticBaseModel):
 class CreateEvalTemplateTool(BaseTool):
     name = "create_eval_template"
     description = (
-        "Creates a new custom (user-owned) evaluation template. "
-        "The template can be used to run evaluations on datasets, prompts, or traces. "
-        "Use list_eval_templates to see existing templates first. "
-        "Recommended: use template_type='Futureagi' with model='turing_small' "
-        "Criteria is necessary and make sure a variable like {{variable_name}} is present in the criteria."
-        "(Future AGI's own fast, accurate models) for best results."
+        "Creates an evaluation template that can be run on datasets, prompts, or traces. "
+        "Three eval types are supported:\n"
+        "- **llm** (LLM-as-a-Judge): Provide instructions with {{variable}} placeholders. "
+        "An LLM evaluates each row by substituting variables with column values. "
+        "Best for subjective quality, relevance, safety, and semantic checks. "
+        "Supports few_shot_examples and messages for multi-turn prompting.\n"
+        "- **code**: Provide Python or JavaScript code with an evaluate() function that "
+        "receives kwargs and returns True/False, a 0-1 score, or {result, reason}. "
+        "Runs in a sandbox. Best for deterministic, rule-based checks (regex, format, exact match).\n"
+        "- **agent**: Uses an AI agent that can call tools, search knowledge bases, and "
+        "reason over multiple turns. Best for complex evaluations needing internet, "
+        "knowledge base grounding, or multi-step analysis of traces/spans.\n\n"
+        "Use list_eval_templates to see existing templates first."
     )
     category = "evaluations"
     input_model = CreateEvalTemplateInput
@@ -128,24 +233,22 @@ class CreateEvalTemplateTool(BaseTool):
     def execute(
         self, params: CreateEvalTemplateInput, context: ToolContext
     ) -> ToolResult:
+        import re
+        import traceback
 
         from model_hub.models.choices import OwnerChoices
-        from model_hub.models.evals_metric import EvalTemplate
-        from model_hub.serializers.eval_runner import CustomEvalTemplateCreateSerializer
+        from model_hub.models.evals_metric import EvalTemplate, EvalTemplateVersion
 
-        # Check name uniqueness within organization for user-owned templates
+        # ── 1. Check name uniqueness ──
         if EvalTemplate.objects.filter(
             name=params.name,
             organization=context.organization,
-            owner=OwnerChoices.USER.value,
             deleted=False,
         ).exists():
             return ToolResult.error(
                 f"An eval template named '{params.name}' already exists in this organization.",
                 error_code="VALIDATION_ERROR",
             )
-
-        # Also check against system templates
         if EvalTemplate.no_workspace_objects.filter(
             name=params.name,
             owner=OwnerChoices.SYSTEM.value,
@@ -157,68 +260,172 @@ class CreateEvalTemplateTool(BaseTool):
                 error_code="VALIDATION_ERROR",
             )
 
-        # Build data dict matching what the serializer expects
-        serializer_data = {
-            "name": params.name,
-            "description": params.description or "",
-            "criteria": params.criteria or "",
-            "tags": params.eval_tags or [],
-            "config": params.config or {},
-            "template_type": params.template_type or "Futureagi",
-            "output_type": params.output_type or "Pass/Fail",
-            "multi_choice": params.multi_choice or False,
-            "required_keys": params.required_keys or [],
-            "choices": params.choices or {},
+        # ── 2. Extract variables from instructions ──
+        instructions = params.instructions or ""
+        template_format = params.template_format or "mustache"
+
+        _AUTO_CTX_ROOTS = {"row", "span", "trace", "session", "call"}
+        _AUTO_CTX_ROOT_TO_FLAG = {
+            "row": "full_row",
+            "span": "span_context",
+            "trace": "trace_context",
+            "session": "session_context",
+            "call": "call_context",
         }
-        if params.model:
-            serializer_data.setdefault("config", {})["model"] = params.model
 
-        # Validate through the same serializer the view uses
-        serializer = CustomEvalTemplateCreateSerializer(data=serializer_data)
-        if not serializer.is_valid():
-            from tfc.utils.parse_errors import parse_serialized_errors
+        # Collect text from instructions + messages
+        all_text = [instructions]
+        if params.messages:
+            for msg in params.messages:
+                all_text.append(msg.get("content", ""))
+        combined_text = "\n".join(t for t in all_text if t)
 
-            error_msg = parse_serialized_errors(serializer)
-            return ToolResult.error(
-                f"Validation failed: {error_msg}",
-                error_code="VALIDATION_ERROR",
+        if template_format == "jinja":
+            try:
+                from model_hub.utils.jinja_variables import extract_jinja_variables
+
+                variables = []
+                for t in all_text:
+                    if t.strip():
+                        variables.extend(extract_jinja_variables(t))
+                variables = list(set(variables))
+            except Exception:
+                variables = re.findall(r"\{\{\s*([^{}]+?)\s*\}\}", combined_text)
+                variables = [v.strip() for v in variables]
+        else:
+            variables = re.findall(r"\{\{\s*([^{}]+?)\s*\}\}", combined_text)
+            variables = [v.strip() for v in variables]
+
+        # Filter auto-context roots and detect data injection flags
+        auto_flags: dict = {}
+        filtered_vars = []
+        for v in variables:
+            head = v.split(".", 1)[0].strip()
+            if head in _AUTO_CTX_ROOTS:
+                auto_flags[_AUTO_CTX_ROOT_TO_FLAG[head]] = True
+            else:
+                filtered_vars.append(v)
+        required_keys = list(set(filtered_vars))
+
+        # ── 3. Build output values ──
+        output_map = {
+            "pass_fail": "Pass/Fail",
+            "percentage": "score",
+            "deterministic": "choices",
+        }
+        output_value = output_map.get(params.output_type, "Pass/Fail")
+
+        # Build choices list
+        if params.choice_scores:
+            choices_list = list(params.choice_scores.keys())
+            choices_map = {
+                k: "pass" if v >= 0.7 else ("neutral" if v >= 0.3 else "fail")
+                for k, v in params.choice_scores.items()
+            }
+        elif params.output_type == "pass_fail":
+            choices_list = ["Passed", "Failed"]
+            choices_map = {}
+        else:
+            choices_list = []
+            choices_map = {}
+
+        # ── 4. Build config per eval_type ──
+        if params.eval_type == "code":
+            config = {
+                "output": output_value,
+                "eval_type_id": "CustomCodeEval",
+                "code": params.code,
+                "language": params.code_language or "python",
+                "required_keys": [],
+                "custom_eval": True,
+            }
+            criteria = params.code or ""
+
+        elif params.eval_type == "agent":
+            # Merge auto-detected context flags with explicit data_injection
+            merged_injection = dict(
+                params.data_injection or {"variables_only": True}
             )
+            if auto_flags:
+                merged_injection.update(auto_flags)
+                merged_injection.pop("variables_only", None)
+                merged_injection.pop("variablesOnly", None)
 
-        validated_data = serializer.validated_data
+            config = {
+                "output": output_value,
+                "eval_type_id": "AgentEvaluator",
+                "required_keys": required_keys,
+                "rule_prompt": instructions,
+                "custom_eval": True,
+                "check_internet": params.check_internet,
+                "agent_mode": params.mode or "agent",
+                "model": params.model,
+                "tools": params.tools or {},
+                "knowledge_bases": params.knowledge_bases or [],
+                "data_injection": merged_injection,
+                "summary": params.summary or {"type": "concise"},
+                "instructions": instructions,
+            }
+            if choices_map:
+                config["choices"] = choices_list
+                config["choices_map"] = choices_map
+                config["multi_choice"] = False
+            if params.few_shot_examples:
+                config["few_shot_examples"] = params.few_shot_examples
+            criteria = instructions
 
-        # Process config through the same pipeline as the view
-        try:
-            from model_hub.utils.evals import prepare_user_eval_config
+        else:
+            # LLM-as-a-judge (default)
+            system_prompt = None
+            if params.messages:
+                sys_msgs = [m for m in params.messages if m.get("role") == "system"]
+                if sys_msgs:
+                    system_prompt = sys_msgs[0].get("content", "")
 
-            validated_data = prepare_user_eval_config(validated_data, bypass=False)
-        except Exception as e:
-            return ToolResult.error(
-                f"Failed to prepare eval config: {str(e)}",
-                error_code="VALIDATION_ERROR",
-            )
+            config = {
+                "output": output_value,
+                "eval_type_id": "CustomPromptEvaluator",
+                "required_keys": required_keys,
+                "rule_prompt": instructions,
+                "system_prompt": system_prompt,
+                "custom_eval": True,
+                "check_internet": params.check_internet,
+            }
+            if params.messages and len(params.messages) > 1:
+                config["messages"] = params.messages
+            if params.few_shot_examples:
+                config["few_shot_examples"] = params.few_shot_examples
+            if choices_map:
+                config["choices"] = choices_list
+                config["choices_map"] = choices_map
+                config["multi_choice"] = False
+            criteria = instructions
 
-        # Create the template using the same pattern as CustomEvalTemplateCreateView
+        # Store template_format in config
+        config["template_format"] = template_format
+
+        eval_tags = list(params.tags) if params.tags else []
+
+        # ── 5. Create EvalTemplate ──
         try:
             template = EvalTemplate.objects.create(
-                name=validated_data.get("name", params.name),
-                description=validated_data.get("description", ""),
+                name=params.name,
                 organization=context.organization,
                 workspace=context.workspace,
                 owner=OwnerChoices.USER.value,
-                config=(
-                    validated_data.get("configuration")
-                    if validated_data.get("configuration")
-                    else validated_data.get("config", {})
-                ),
-                criteria=validated_data.get("criteria", ""),
-                choices=validated_data.get("choices"),
-                multi_choice=validated_data.get("multi_choice") or False,
-                model=validated_data.get("config", {}).get(
-                    "model", params.model or "turing_small"
-                ),
-                eval_tags=validated_data.get("eval_tags", params.eval_tags or []),
-                proxy_agi=validated_data.get("config", {}).get("proxy_agi", True),
-                visible_ui=validated_data.get("config", {}).get("visible_ui", True),
+                eval_type=params.eval_type,
+                eval_tags=eval_tags,
+                config=config,
+                choices=choices_list,
+                description=params.description or "",
+                criteria=criteria,
+                multi_choice=False,
+                proxy_agi=True,
+                visible_ui=True,
+                model=params.model,
+                output_type_normalized=params.output_type,
+                pass_threshold=params.pass_threshold,
+                choice_scores=params.choice_scores,
             )
         except Exception as e:
             from ai_tools.error_codes import code_from_exception
@@ -228,22 +435,46 @@ class CreateEvalTemplateTool(BaseTool):
                 error_code=code_from_exception(e),
             )
 
+        # ── 6. Create initial version (V1) ──
+        try:
+            EvalTemplateVersion.objects.create_version(
+                eval_template=template,
+                prompt_messages=[],
+                config_snapshot=config,
+                criteria=criteria,
+                model=params.model,
+                user=context.user,
+                organization=context.organization,
+                workspace=context.workspace,
+            )
+        except Exception:
+            pass  # Non-fatal — version creation is best-effort
+
+        # ── 7. Build response ──
+        eval_type_labels = {"llm": "LLM-as-a-Judge", "code": "Code", "agent": "Agent"}
+
         info = key_value_block(
             [
                 ("ID", f"`{template.id}`"),
                 ("Name", template.name),
-                ("Owner", template.owner),
+                ("Type", eval_type_labels.get(params.eval_type, params.eval_type)),
                 ("Model", template.model or "—"),
-                ("Output Type", params.output_type or "Pass/Fail"),
-                ("Tags", ", ".join(template.eval_tags) if template.eval_tags else "—"),
+                ("Output Type", params.output_type),
+                ("Pass Threshold", str(params.pass_threshold)),
+                ("Tags", ", ".join(eval_tags) if eval_tags else "—"),
                 ("Created", format_datetime(template.created_at)),
             ]
         )
 
         content = section("Eval Template Created", info)
 
-        if template.criteria:
-            content += f"\n\n### Criteria\n\n{template.criteria[:500]}"
+        if criteria:
+            preview = criteria[:500] + ("..." if len(criteria) > 500 else "")
+            label = "Code" if params.eval_type == "code" else "Instructions"
+            content += f"\n\n### {label}\n\n{preview}"
+
+        if required_keys:
+            content += f"\n\n**Variables:** {', '.join(f'`{k}`' for k in required_keys)}"
 
         content += "\n\n_Use `test_eval_template` to validate the template before running evaluations._"
 
@@ -252,10 +483,13 @@ class CreateEvalTemplateTool(BaseTool):
             data={
                 "id": str(template.id),
                 "name": template.name,
+                "eval_type": params.eval_type,
                 "owner": template.owner,
                 "config": template.config,
                 "model": template.model,
-                "criteria": template.criteria,
-                "eval_tags": template.eval_tags,
+                "output_type": params.output_type,
+                "criteria": criteria,
+                "eval_tags": eval_tags,
+                "required_keys": required_keys,
             },
         )

--- a/futureagi/ai_tools/tools/evaluations/execute_composite_eval.py
+++ b/futureagi/ai_tools/tools/evaluations/execute_composite_eval.py
@@ -1,0 +1,172 @@
+from typing import Any, Optional
+
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import Field
+
+from ai_tools.base import BaseTool, ToolContext, ToolResult
+from ai_tools.formatting import key_value_block, section, truncate
+from ai_tools.registry import register_tool
+
+
+class ExecuteCompositeEvalInput(PydanticBaseModel):
+    composite_eval_id: str = Field(
+        description="UUID of the composite eval template to execute."
+    )
+    mapping: dict[str, Any] = Field(
+        description=(
+            "Variable mapping: keys are template variable names, values are the "
+            "data to evaluate. Example: {'input': 'user query text', 'output': 'model response'}"
+        )
+    )
+    model: Optional[str] = Field(
+        default=None,
+        description="Override the model for all child evals (optional).",
+    )
+    row_context: Optional[dict] = Field(
+        default=None,
+        description="Full row context as key-value dict (for data injection).",
+    )
+    span_context: Optional[dict] = Field(
+        default=None,
+        description="Span context for trace-aware evals.",
+    )
+    trace_context: Optional[dict] = Field(
+        default=None,
+        description="Trace context for trace-aware evals.",
+    )
+
+
+@register_tool
+class ExecuteCompositeEvalTool(BaseTool):
+    name = "execute_composite_eval"
+    description = (
+        "Executes a composite evaluation: runs all child evals on the provided data "
+        "and aggregates their scores. Returns per-child results plus the aggregate score. "
+        "Use create_composite_eval to create one first, or list_eval_templates to find existing ones."
+    )
+    category = "evaluations"
+    input_model = ExecuteCompositeEvalInput
+
+    def execute(
+        self, params: ExecuteCompositeEvalInput, context: ToolContext
+    ) -> ToolResult:
+        from model_hub.models.evals_metric import CompositeEvalChild, EvalTemplate
+        from model_hub.utils.composite_execution import (
+            execute_composite_children_sync,
+        )
+
+        # ── 1. Load composite template ──
+        try:
+            parent = EvalTemplate.no_workspace_objects.get(
+                id=params.composite_eval_id,
+                deleted=False,
+                template_type="composite",
+            )
+        except EvalTemplate.DoesNotExist:
+            return ToolResult.not_found(
+                "Composite eval template", params.composite_eval_id
+            )
+
+        # ── 2. Load children ──
+        child_links = list(
+            CompositeEvalChild.objects.filter(parent=parent, deleted=False)
+            .select_related("child", "pinned_version")
+            .order_by("order")
+        )
+        if not child_links:
+            return ToolResult.error(
+                "Composite eval has no children.",
+                error_code="VALIDATION_ERROR",
+            )
+
+        org = context.organization
+        workspace = context.workspace
+
+        # ── 3. Execute ──
+        try:
+            outcome = execute_composite_children_sync(
+                parent=parent,
+                child_links=child_links,
+                mapping=params.mapping,
+                config={},
+                org=org,
+                workspace=workspace,
+                model=params.model,
+                input_data_types={},
+                row_context=params.row_context,
+                span_context=params.span_context,
+                trace_context=params.trace_context,
+                session_context=None,
+                call_context=None,
+                error_localizer=False,
+                source="falcon_tool",
+            )
+        except Exception as e:
+            from ai_tools.error_codes import code_from_exception
+
+            return ToolResult.error(
+                f"Composite execution failed: {str(e)}",
+                error_code=code_from_exception(e),
+            )
+
+        # ── 4. Build response ──
+        completed = sum(1 for cr in outcome.child_results if cr.status == "completed")
+        failed = sum(1 for cr in outcome.child_results if cr.status == "failed")
+
+        children_lines = []
+        for cr in outcome.child_results:
+            status_icon = "Pass" if cr.status == "completed" and cr.score and cr.score >= 0.5 else "Fail"
+            if cr.status == "failed":
+                status_icon = "Error"
+            score_str = f"{cr.score:.2f}" if cr.score is not None else "—"
+            reason_preview = truncate(cr.reason or "", 120) if cr.reason else ""
+            children_lines.append(
+                f"  - **{cr.child_name}**: {status_icon} (score: {score_str})"
+                + (f"\n    {reason_preview}" if reason_preview else "")
+            )
+
+        agg_str = "—"
+        if outcome.aggregate_score is not None:
+            agg_str = f"{outcome.aggregate_score:.2f}"
+        agg_pass = "—"
+        if outcome.aggregate_pass is not None:
+            agg_pass = "Pass" if outcome.aggregate_pass else "Fail"
+
+        info = key_value_block(
+            [
+                ("Composite", f"{parent.name} (`{parent.id}`)"),
+                ("Aggregate Score", agg_str),
+                ("Aggregate Result", agg_pass),
+                ("Aggregation", parent.aggregation_function if parent.aggregation_enabled else "disabled"),
+                ("Children", f"{completed} completed, {failed} failed out of {len(outcome.child_results)}"),
+            ]
+        )
+
+        content = section("Composite Eval Result", info)
+        content += "\n\n### Per-Child Results\n\n" + "\n".join(children_lines)
+
+        if outcome.summary:
+            content += f"\n\n### Summary\n\n{truncate(outcome.summary, 500)}"
+
+        return ToolResult(
+            content=content,
+            data={
+                "composite_id": str(parent.id),
+                "composite_name": parent.name,
+                "aggregate_score": outcome.aggregate_score,
+                "aggregate_pass": outcome.aggregate_pass,
+                "total_children": len(outcome.child_results),
+                "completed_children": completed,
+                "failed_children": failed,
+                "children": [
+                    {
+                        "name": cr.child_name,
+                        "score": cr.score,
+                        "output": cr.output,
+                        "status": cr.status,
+                        "reason": truncate(cr.reason or "", 300) if cr.reason else None,
+                    }
+                    for cr in outcome.child_results
+                ],
+            },
+        )

--- a/futureagi/ai_tools/tools/evaluations/get_eval_playground.py
+++ b/futureagi/ai_tools/tools/evaluations/get_eval_playground.py
@@ -52,23 +52,19 @@ class GetEvalPlaygroundTool(BaseTool):
         optional_keys = (
             config.get("optional_keys", []) if isinstance(config, dict) else []
         )
-        template_type = (
-            config.get("template_type", "—") if isinstance(config, dict) else "—"
-        )
-        eval_type_id = (
-            config.get("eval_type_id", "—") if isinstance(config, dict) else "—"
-        )
+        eval_type_labels = {"llm": "LLM", "code": "Code", "agent": "Agent"}
+        eval_type = eval_type_labels.get(template.eval_type or "", template.eval_type or "—")
+        template_type = template.template_type or "single"
 
         info = key_value_block(
             [
                 ("ID", f"`{template.id}`"),
                 ("Name", template.name),
                 ("Owner", template.owner or "—"),
+                ("Eval Type", eval_type),
                 ("Template Type", template_type),
-                ("Eval Type ID", eval_type_id),
                 ("Output Type", output_type),
                 ("Model", template.model or "—"),
-                ("Multi-Choice", "Yes" if template.multi_choice else "No"),
             ]
         )
 

--- a/futureagi/ai_tools/tools/evaluations/get_eval_template.py
+++ b/futureagi/ai_tools/tools/evaluations/get_eval_template.py
@@ -22,8 +22,9 @@ class GetEvalTemplateTool(BaseTool):
     name = "get_eval_template"
     description = (
         "Returns detailed information about an evaluation template including "
-        "its criteria, choices, configuration schema, required/optional keys, "
-        "and output type. Use this to understand how to configure an evaluation."
+        "its type (LLM/code/agent), instructions, configuration, required variables, "
+        "output type, scoring, and version history. "
+        "For composite evals, also shows children and aggregation config."
     )
     category = "evaluations"
     input_model = GetEvalTemplateInput
@@ -31,8 +32,11 @@ class GetEvalTemplateTool(BaseTool):
     def execute(self, params: GetEvalTemplateInput, context: ToolContext) -> ToolResult:
 
         from ai_tools.resolvers import resolve_eval_template
-        from model_hub.models.evals_metric import EvalTemplate
-        from model_hub.utils.eval_validators import validate_eval_template_org_access
+        from model_hub.models.evals_metric import (
+            CompositeEvalChild,
+            EvalTemplate,
+            EvalTemplateVersion,
+        )
 
         template_obj, err = resolve_eval_template(
             params.eval_template_id, context.organization
@@ -46,7 +50,6 @@ class GetEvalTemplateTool(BaseTool):
             return ToolResult.not_found("Eval Template", str(template_obj.id))
 
         config = template.config or {}
-        output_type = config.get("output", "—") if isinstance(config, dict) else "—"
         required_keys = (
             config.get("required_keys", []) if isinstance(config, dict) else []
         )
@@ -56,61 +59,120 @@ class GetEvalTemplateTool(BaseTool):
 
         tags = ", ".join(template.eval_tags) if template.eval_tags else "—"
 
-        info = key_value_block(
-            [
-                ("ID", f"`{template.id}`"),
-                ("Name", template.name),
-                ("Owner", template.owner or "—"),
-                ("Output Type", output_type),
-                ("Tags", tags),
-                ("Multi-Choice", "Yes" if template.multi_choice else "No"),
-                ("Model", template.model or "—"),
-                ("Created", format_datetime(template.created_at)),
-            ]
-        )
+        eval_type_labels = {"llm": "LLM-as-a-Judge", "code": "Code", "agent": "Agent"}
+        eval_type = eval_type_labels.get(template.eval_type or "", template.eval_type or "—")
+        template_type = template.template_type or "single"
+        output_type = template.output_type_normalized or config.get("output", "—")
 
+        # Version count
+        version_count = EvalTemplateVersion.objects.filter(
+            eval_template=template
+        ).count()
+
+        info_pairs = [
+            ("ID", f"`{template.id}`"),
+            ("Name", template.name),
+            ("Owner", template.owner or "—"),
+            ("Eval Type", eval_type),
+            ("Template Type", template_type),
+            ("Output Type", output_type),
+            ("Pass Threshold", str(template.pass_threshold) if template.pass_threshold is not None else "0.5"),
+            ("Model", template.model or "—"),
+            ("Tags", tags),
+            ("Versions", str(version_count)),
+            ("Created", format_datetime(template.created_at)),
+        ]
+
+        # Add type-specific fields
+        if template.eval_type == "agent":
+            agent_mode = config.get("agent_mode", "—")
+            info_pairs.append(("Agent Mode", agent_mode))
+            kbs = config.get("knowledge_bases", [])
+            if kbs:
+                info_pairs.append(("Knowledge Bases", str(len(kbs))))
+
+        if template.eval_type == "code":
+            lang = config.get("language", "python")
+            info_pairs.append(("Code Language", lang))
+
+        template_format = config.get("template_format", "mustache")
+        info_pairs.append(("Template Format", template_format))
+
+        info = key_value_block(info_pairs)
         content = section(f"Eval Template: {template.name}", info)
 
         if template.description:
             content += f"\n\n### Description\n\n{truncate(template.description, 500)}"
 
         if template.criteria:
-            content += f"\n\n### Criteria\n\n{truncate(template.criteria, 1000)}"
+            label = "Code" if template.eval_type == "code" else "Instructions"
+            content += f"\n\n### {label}\n\n{truncate(template.criteria, 1000)}"
 
         if template.choices:
             content += "\n\n### Choices\n\n"
             if isinstance(template.choices, list):
                 for choice in template.choices:
-                    content += f"- {choice}\n"
+                    score = ""
+                    if template.choice_scores and choice in template.choice_scores:
+                        score = f" (score: {template.choice_scores[choice]})"
+                    content += f"- {choice}{score}\n"
             else:
                 content += f"```json\n{truncate(str(template.choices), 500)}\n```"
 
         if required_keys:
-            content += f"\n\n### Required Parameters\n\n{', '.join(f'`{k}`' for k in required_keys)}"
+            content += f"\n\n### Required Variables\n\n{', '.join(f'`{k}`' for k in required_keys)}"
 
         if optional_keys:
-            content += f"\n\n### Optional Parameters\n\n{', '.join(f'`{k}`' for k in optional_keys)}"
+            content += f"\n\n### Optional Variables\n\n{', '.join(f'`{k}`' for k in optional_keys)}"
 
-        # Config params descriptions
-        config_params = config.get("config", {}) if isinstance(config, dict) else {}
-        if config_params and isinstance(config_params, dict):
-            content += "\n\n### Parameter Details\n\n"
-            for param_name, param_info in list(config_params.items())[:10]:
-                desc = param_info if isinstance(param_info, str) else str(param_info)
-                content += f"- **{param_name}**: {truncate(desc, 200)}\n"
+        # Composite children
+        if template_type == "composite":
+            children = (
+                CompositeEvalChild.objects.filter(parent=template, deleted=False)
+                .select_related("child")
+                .order_by("order")
+            )
+            if children.exists():
+                content += "\n\n### Composite Children\n\n"
+                content += f"**Aggregation:** {template.aggregation_function if template.aggregation_enabled else 'disabled'}\n"
+                if template.composite_child_axis:
+                    content += f"**Child Axis:** {template.composite_child_axis}\n"
+                content += "\n"
+                for link in children:
+                    child = link.child
+                    et = eval_type_labels.get(child.eval_type or "", child.eval_type or "—")
+                    content += f"- {child.name} ({et}, weight: {link.weight})\n"
+
+        # Version summary
+        if version_count > 0:
+            versions = (
+                EvalTemplateVersion.objects.filter(eval_template=template)
+                .order_by("-version_number")[:3]
+            )
+            content += "\n\n### Recent Versions\n\n"
+            for v in versions:
+                default_marker = " **(default)**" if v.is_default else ""
+                content += f"- V{v.version_number}{default_marker} — {format_datetime(v.created_at)}\n"
+            if version_count > 3:
+                content += f"\n_{version_count - 3} more versions available._"
 
         data = {
             "id": str(template.id),
             "name": template.name,
             "owner": template.owner,
+            "eval_type": template.eval_type,
+            "template_type": template_type,
             "description": template.description,
             "output_type": output_type,
+            "pass_threshold": template.pass_threshold,
+            "choice_scores": template.choice_scores,
             "required_keys": required_keys,
             "optional_keys": optional_keys,
             "tags": template.eval_tags,
             "criteria": template.criteria,
             "choices": template.choices,
-            "multi_choice": template.multi_choice,
+            "model": template.model,
+            "version_count": version_count,
         }
 
         return ToolResult(content=content, data=data)

--- a/futureagi/ai_tools/tools/evaluations/list_eval_templates.py
+++ b/futureagi/ai_tools/tools/evaluations/list_eval_templates.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field
@@ -24,16 +24,31 @@ class ListEvalTemplatesInput(PydanticBaseModel):
         default=None,
         description="Search eval templates by name (case-insensitive)",
     )
+    eval_type: Optional[Literal["llm", "code", "agent"]] = Field(
+        default=None,
+        description="Filter by eval type: 'llm', 'code', or 'agent'.",
+    )
+    template_type: Optional[Literal["single", "composite"]] = Field(
+        default=None,
+        description="Filter by template type: 'single' or 'composite'.",
+    )
+    output_type: Optional[Literal["pass_fail", "percentage", "deterministic"]] = Field(
+        default=None,
+        description="Filter by output type: 'pass_fail', 'percentage', or 'deterministic'.",
+    )
+    tags: Optional[list[str]] = Field(
+        default=None,
+        description="Filter by tags (returns templates with any of the given tags).",
+    )
 
 
 @register_tool
 class ListEvalTemplatesTool(BaseTool):
     name = "list_eval_templates"
     description = (
-        "Lists available evaluation templates (metrics). "
-        "Returns template name, owner type (system/user), output type, "
-        "tags, and description. Use this to discover what evaluation metrics "
-        "are available before running evaluations."
+        "Lists available evaluation templates. Returns name, type (LLM/code/agent), "
+        "template type (single/composite), output type, tags, and description. "
+        "Use this to discover what evaluations are available before running them."
     )
     category = "evaluations"
     input_model = ListEvalTemplatesInput
@@ -47,16 +62,27 @@ class ListEvalTemplatesTool(BaseTool):
         from model_hub.models.evals_metric import EvalTemplate
 
         qs = EvalTemplate.no_workspace_objects.filter(
-            Q(organization=context.organization) | Q(organization__isnull=True)
+            Q(organization=context.organization) | Q(organization__isnull=True),
+            deleted=False,
         ).order_by("-created_at")
 
         if params.owner:
             qs = qs.filter(owner=params.owner.lower())
         if params.search:
             qs = qs.filter(name__icontains=params.search)
+        if params.eval_type:
+            qs = qs.filter(eval_type=params.eval_type)
+        if params.template_type:
+            qs = qs.filter(template_type=params.template_type)
+        if params.output_type:
+            qs = qs.filter(output_type_normalized=params.output_type)
+        if params.tags:
+            qs = qs.filter(eval_tags__overlap=params.tags)
 
         total = qs.count()
         templates = qs[params.offset : params.offset + params.limit]
+
+        eval_type_labels = {"llm": "LLM", "code": "Code", "agent": "Agent"}
 
         rows = []
         data_list = []
@@ -65,17 +91,19 @@ class ListEvalTemplatesTool(BaseTool):
             if t.eval_tags and len(t.eval_tags) > 3:
                 tags += f" (+{len(t.eval_tags) - 3})"
 
-            config = t.config or {}
-            output_type = config.get("output", "—") if isinstance(config, dict) else "—"
+            et = eval_type_labels.get(t.eval_type or "", t.eval_type or "—")
+            tt = t.template_type or "single"
+            ot = t.output_type_normalized or "—"
 
             rows.append(
                 [
                     f"`{t.id}`",
-                    truncate(t.name, 40),
+                    truncate(t.name, 35),
                     t.owner or "—",
-                    output_type,
+                    et,
+                    tt,
+                    ot,
                     tags,
-                    format_datetime(t.created_at),
                 ]
             )
             data_list.append(
@@ -83,21 +111,34 @@ class ListEvalTemplatesTool(BaseTool):
                     "id": str(t.id),
                     "name": t.name,
                     "owner": t.owner,
-                    "output_type": output_type,
+                    "eval_type": t.eval_type,
+                    "template_type": t.template_type or "single",
+                    "output_type": t.output_type_normalized,
                     "tags": t.eval_tags,
                     "description": t.description,
+                    "model": t.model,
                 }
             )
 
         table = markdown_table(
-            ["ID", "Name", "Owner", "Output", "Tags", "Created"], rows
+            ["ID", "Name", "Owner", "Eval Type", "Template", "Output", "Tags"], rows
         )
 
-        showing = f"Showing {len(rows)} of {total}"
+        filters_desc = []
         if params.owner:
-            showing += f" (owner: {params.owner})"
+            filters_desc.append(f"owner: {params.owner}")
         if params.search:
-            showing += f" (search: '{params.search}')"
+            filters_desc.append(f"search: '{params.search}'")
+        if params.eval_type:
+            filters_desc.append(f"eval_type: {params.eval_type}")
+        if params.template_type:
+            filters_desc.append(f"template_type: {params.template_type}")
+        if params.output_type:
+            filters_desc.append(f"output_type: {params.output_type}")
+
+        showing = f"Showing {len(rows)} of {total}"
+        if filters_desc:
+            showing += f" ({', '.join(filters_desc)})"
 
         content = section(f"Eval Templates ({total})", f"{showing}\n\n{table}")
 

--- a/futureagi/ai_tools/tools/evaluations/test_eval_template.py
+++ b/futureagi/ai_tools/tools/evaluations/test_eval_template.py
@@ -13,13 +13,13 @@ class TestEvalTemplateInput(PydanticBaseModel):
     eval_template_id: UUID = Field(description="The UUID of the eval template to test")
     mapping: dict = Field(
         description=(
-            "Mapping of template keys to test values. "
-            'Example: {"response": "The capital of France is Paris.", "query": "What is the capital of France?"}'
+            "Mapping of template variable names to test values. "
+            'Example: {"input": "What is the capital of France?", "output": "Paris is the capital."}'
         )
     )
     model: Optional[str] = Field(
         default=None,
-        description="Override model for the test run",
+        description="Override model for the test run (optional).",
     )
 
 
@@ -29,6 +29,7 @@ class TestEvalTemplateTool(BaseTool):
     description = (
         "Runs a dry-run test of an evaluation template with provided input data. "
         "Returns the evaluation result without persisting anything. "
+        "Works with LLM, code, and agent eval types. "
         "Use this to validate template configuration before applying to datasets."
     )
     category = "evaluations"
@@ -41,17 +42,16 @@ class TestEvalTemplateTool(BaseTool):
 
         from model_hub.models.evals_metric import EvalTemplate
 
-        # Look up the user template
+        # Look up the template (user-owned or system)
         try:
-            user_template = EvalTemplate.no_workspace_objects.get(
+            template = EvalTemplate.no_workspace_objects.get(
                 Q(organization=context.organization) | Q(organization__isnull=True),
                 id=params.eval_template_id,
             )
         except EvalTemplate.DoesNotExist:
             return ToolResult.not_found("Eval Template", str(params.eval_template_id))
 
-        config = user_template.config or {}
-        template_type = config.get("template_type", "")
+        config = template.config or {}
         required_keys = config.get("required_keys", [])
 
         # Validate required keys are present in mapping
@@ -70,14 +70,13 @@ class TestEvalTemplateTool(BaseTool):
             "output": config.get("output", "Pass/Fail"),
         }
 
-        if user_template.criteria:
-            eval_config["criteria"] = user_template.criteria
-        if user_template.choices:
-            eval_config["choices"] = user_template.choices
+        if template.criteria:
+            eval_config["criteria"] = template.criteria
+        if template.choices:
+            eval_config["choices"] = template.choices
 
-        model = params.model or user_template.model
+        model = params.model or template.model
 
-        # Try to run the evaluation
         try:
             from model_hub.models.evals_metric import EvalTemplate as ET
             from model_hub.views.separate_evals import (
@@ -85,7 +84,7 @@ class TestEvalTemplateTool(BaseTool):
                 run_eval_func,
             )
 
-            # Get the deterministic_evals base template
+            # Get the base template for eval execution
             try:
                 base_template = ET.no_workspace_objects.get(name="deterministic_evals")
             except ET.DoesNotExist:
@@ -94,9 +93,19 @@ class TestEvalTemplateTool(BaseTool):
                     error_code="CONFIGURATION_ERROR",
                 )
 
-            # Build the validated_data structure that prepare_user_eval_config expects
+            # Resolve eval_type_id from the template's eval_type or config
+            eval_type_id = config.get("eval_type_id", "")
+            if not eval_type_id:
+                _type_map = {
+                    "agent": "AgentEvaluator",
+                    "llm": "CustomPromptEvaluator",
+                    "code": "CustomCodeEval",
+                }
+                eval_type_id = _type_map.get(template.eval_type or "llm", "CustomPromptEvaluator")
+
+            # Build validated_data for prepare_user_eval_config
             validated_data = {
-                "template_type": template_type or "futureagi",
+                "template_type": "futureagi" if eval_type_id == "AgentEvaluator" else "llm",
                 "config": eval_config,
                 "model": model,
                 "input_data_types": {},
@@ -105,13 +114,10 @@ class TestEvalTemplateTool(BaseTool):
             prepared_config = prepare_user_eval_config(validated_data, True)
             prepared_config["output"] = config.get("output", "Pass/Fail")
 
-            if template_type == "llm":
+            if eval_type_id in ("CustomPromptEvaluator", "AgentEvaluator"):
                 data_config = prepared_config.get("config", {})
                 data_config["organization_id"] = str(context.organization.id)
                 prepared_config["config"] = data_config
-                eval_id = "CustomPromptEvaluator"
-            else:
-                eval_id = "DeterministicEvaluator"
 
             response = run_eval_func(
                 prepared_config,
@@ -121,7 +127,7 @@ class TestEvalTemplateTool(BaseTool):
                 input_data_types={},
                 type="user_built",
                 model=model,
-                eval_id=eval_id,
+                eval_id=eval_type_id,
                 test=True,
                 source="mcp_tool_test",
                 workspace=context.workspace,
@@ -135,20 +141,19 @@ class TestEvalTemplateTool(BaseTool):
             else:
                 result_info.append(("Result", truncate(str(response), 500)))
 
+            eval_type_labels = {"llm": "LLM", "code": "Code", "agent": "Agent"}
             info = key_value_block(
                 [
-                    (
-                        "Template",
-                        f"{user_template.name} (`{str(user_template.id)}`)",
-                    ),
+                    ("Template", f"{template.name} (`{str(template.id)}`)"),
+                    ("Type", eval_type_labels.get(template.eval_type or "llm", template.eval_type or "—")),
                     ("Model", model or "default"),
                 ]
                 + result_info
             )
 
             return ToolResult(
-                content=section("Eval Template Test Result", info),
-                data={"template_id": str(user_template.id), "result": response},
+                content=section("Eval Test Result", info),
+                data={"template_id": str(template.id), "result": response},
             )
 
         except Exception as e:

--- a/futureagi/ai_tools/tools/evaluations/update_eval_template.py
+++ b/futureagi/ai_tools/tools/evaluations/update_eval_template.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel as PydanticBaseModel
@@ -13,33 +13,149 @@ class UpdateEvalTemplateInput(PydanticBaseModel):
     eval_template_id: UUID = Field(
         description="The UUID of the eval template to update"
     )
-    name: Optional[str] = Field(default=None, description="New name for the template")
-    description: Optional[str] = Field(default=None, description="New description")
-    criteria: Optional[str] = Field(
-        default=None, description="New evaluation criteria/prompt"
+
+    # ── Core fields ──
+    name: Optional[str] = Field(default=None, description="Name for the template")
+    description: Optional[str] = Field(default=None, description="Description")
+    eval_type: Optional[Literal["llm", "code", "agent"]] = Field(
+        default=None,
+        description="Change eval type: 'llm', 'code', or 'agent'.",
+    )
+    instructions: Optional[str] = Field(
+        default=None,
+        description=(
+            "Evaluation instructions/criteria. Must include {{variable}} "
+            "placeholders for non-code evals."
+        ),
     )
     model: Optional[str] = Field(
-        default=None, description="New model to use for evaluation"
-    )
-    eval_tags: Optional[list[str]] = Field(
-        default=None, description="New tags for the template"
-    )
-    choices_map: Optional[dict] = Field(
         default=None,
-        description="New choices map (key=choice label, value=description)",
+        description=(
+            "Model for evaluation. Prefer turing models (no extra setup): "
+            "'turing_large' (recommended), 'turing_small', 'turing_flash'. "
+            "External models require configured API key: "
+            "'gpt-4o', 'claude-sonnet-4-6', 'gemini-2.5-pro', etc."
+        ),
     )
-    function_eval: Optional[bool] = Field(
-        default=None, description="New function eval flag"
+    output_type: Optional[Literal["pass_fail", "percentage", "deterministic"]] = Field(
+        default=None,
+        description=(
+            "Output type: 'pass_fail' (binary Pass/Fail), "
+            "'percentage' (0-1 numeric score), "
+            "'deterministic' (custom choices with scores — requires choice_scores)."
+        ),
     )
+    pass_threshold: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Score threshold for pass/fail (0.0-1.0, default 0.5). "
+            "For percentage output: score >= threshold = Pass. "
+            "For deterministic: choice_score >= threshold = Pass."
+        ),
+    )
+    choice_scores: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Choice scores. Required when output_type='deterministic'. "
+            "Keys are choice labels, values are float scores."
+        ),
+    )
+    tags: Optional[list[str]] = Field(
+        default=None, description="tags for the template"
+    )
+    check_internet: Optional[bool] = Field(
+        default=None,
+        description="Whether the eval can access the internet.",
+    )
+    template_format: Optional[Literal["mustache", "jinja"]] = Field(
+        default=None,
+        description="Template variable format: 'mustache' or 'jinja'.",
+    )
+    error_localizer_enabled: Optional[bool] = Field(
+        default=None,
+        description="Enable/disable error localizer for this eval.",
+    )
+    publish: Optional[bool] = Field(
+        default=None,
+        description="Set to true to publish a draft eval (make it visible in listings).",
+    )
+
+    # ── Code eval fields ──
+    code: Optional[str] = Field(
+        default=None,
+        description="evaluation code (for code-type evals).",
+    )
+    code_language: Optional[Literal["python", "javascript"]] = Field(
+        default=None,
+        description="Code language: 'python' or 'javascript'.",
+    )
+
+    # ── LLM eval fields ──
+    messages: Optional[list[dict]] = Field(
+        default=None,
+        description="message chain for LLM evals: [{role, content}].",
+    )
+    few_shot_examples: Optional[list[dict]] = Field(
+        default=None,
+        description="few-shot examples: [{input, output, score}].",
+    )
+
+    # ── Agent eval fields ──
+    mode: Optional[Literal["auto", "agent", "quick"]] = Field(
+        default=None,
+        description=(
+            "Agent evaluation mode: "
+            "'agent' (multi-turn reasoning, up to 15 iterations, full tool access), "
+            "'quick' (single-turn, fast), "
+            "'auto' (auto-selects based on data complexity)."
+        ),
+    )
+    tools: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Tool configuration for agent evals: "
+            "{'internet': bool, 'connectors': ['connector-uuid']}."
+        ),
+    )
+    knowledge_bases: Optional[list[str]] = Field(
+        default=None,
+        description="Knowledge base UUIDs for agent evals to search during evaluation.",
+    )
+    data_injection: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Context injection for agent evals. Flags: "
+            "'variables_only' (default true), 'full_row', 'span_context', "
+            "'trace_context', 'session_context', 'call_context'."
+        ),
+    )
+    summary: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Explanation style for agent evals: "
+            "{'type': 'concise'} (default), 'short', 'long', or "
+            "{'type': 'custom', 'custom_instructions': '...'}."
+        ),
+    )
+
+    # Aliases for alternate field names (excluded from schema sent to LLM).
+    criteria: Optional[str] = Field(default=None, exclude=True)
+    eval_tags: Optional[list[str]] = Field(default=None, exclude=True)
+    choices_map: Optional[dict] = Field(default=None, exclude=True)
 
 
 @register_tool
 class UpdateEvalTemplateTool(BaseTool):
     name = "update_eval_template"
     description = (
-        "Updates a user-owned evaluation template's fields. "
-        "Only USER-owned templates can be updated (not SYSTEM templates). "
-        "Provide only the fields you want to change."
+        "Updates a user-owned evaluation template. "
+        "Only USER-owned templates can be updated (system templates are read-only). "
+        "Provide only the fields you want to change. "
+        "Can update instructions, model, output type, scoring thresholds, "
+        "code (for code evals), agent config (mode, tools, knowledge bases), "
+        "LLM config (messages, few-shot examples), and template format."
     )
     category = "evaluations"
     input_model = UpdateEvalTemplateInput
@@ -47,10 +163,18 @@ class UpdateEvalTemplateTool(BaseTool):
     def execute(
         self, params: UpdateEvalTemplateInput, context: ToolContext
     ) -> ToolResult:
+        import re
+
         from django.utils import timezone
 
         from model_hub.models.choices import OwnerChoices
-        from model_hub.models.evals_metric import EvalTemplate
+        from model_hub.models.evals_metric import EvalTemplate, EvalTemplateVersion
+
+        # Normalize alternate field names
+        if params.criteria and not params.instructions:
+            params.instructions = params.criteria
+        if params.eval_tags and not params.tags:
+            params.tags = params.eval_tags
 
         try:
             template = EvalTemplate.objects.get(
@@ -64,119 +188,288 @@ class UpdateEvalTemplateTool(BaseTool):
                 "User-owned Eval Template", str(params.eval_template_id)
             )
 
-        update_fields = ["updated_at"]
+        changed_fields = []
 
-        # Validate name pattern and uniqueness
+        # ── Name ──
         if params.name is not None:
-            import re
-
             clean_name = params.name.strip()
-            if not re.match(r"^[0-9a-z_-]+$", clean_name):
+            if not re.match(r"^[a-z0-9_-]+$", clean_name):
                 return ToolResult.error(
-                    "Name can only contain lowercase alphabets, numbers, hyphens (-), or underscores (_).",
+                    "Name can only contain lowercase letters, numbers, hyphens, or underscores.",
                     error_code="VALIDATION_ERROR",
                 )
             if clean_name[0] in "-_" or clean_name[-1] in "-_":
                 return ToolResult.error(
-                    "Name cannot start or end with hyphens (-) or underscores (_).",
+                    "Name cannot start or end with hyphens or underscores.",
                     error_code="VALIDATION_ERROR",
                 )
             if "_-" in clean_name or "-_" in clean_name:
                 return ToolResult.error(
-                    "Name cannot contain consecutive mixed separators (_- or -_).",
+                    "Name cannot contain consecutive mixed separators.",
                     error_code="VALIDATION_ERROR",
                 )
-
-        if params.name is not None:
             if (
                 EvalTemplate.objects.filter(
-                    name=params.name,
+                    name=clean_name,
                     organization=context.organization,
-                    owner=OwnerChoices.USER.value,
                     deleted=False,
                 )
                 .exclude(id=params.eval_template_id)
                 .exists()
             ):
                 return ToolResult.error(
-                    f"An eval template named '{params.name}' already exists.",
+                    f"An eval template named '{clean_name}' already exists.",
                     error_code="VALIDATION_ERROR",
                 )
-            template.name = params.name
-            update_fields.append("name")
+            template.name = clean_name
+            changed_fields.append("name")
 
+        # ── Description ──
         if params.description is not None:
             template.description = params.description
-            update_fields.append("description")
+            changed_fields.append("description")
 
-        if params.criteria is not None:
-            # Validate that criteria contains at least one template variable
-            # (skip if data injection is enabled — eval runs on injected data)
-            import re
+        # ── Tags ──
+        if params.tags is not None:
+            template.eval_tags = params.tags
+            changed_fields.append("tags")
 
-            variable_pattern = r"\{\{[a-zA-Z0-9_]+\}\}"
-            data_injection = (template.config or {}).get("data_injection", {})
-            has_data_injection = bool(
-                data_injection
-                and (
-                    data_injection.get("full_row")
-                    or data_injection.get("fullRow")
-                    or not data_injection.get("variables_only", True)
-                    or not data_injection.get("variablesOnly", True)
-                )
+        # ── Template format ──
+        template_format = params.template_format or (template.config or {}).get(
+            "template_format", "mustache"
+        )
+
+        # ── Instructions ──
+        if params.instructions is not None:
+            if template.config is None:
+                template.config = {}
+
+            # Don't overwrite code with instructions for code evals
+            if template.config.get("eval_type_id") != "CustomCodeEval":
+                template.criteria = params.instructions
+
+            # Extract variables and auto-context roots
+            _AUTO_CTX_ROOTS = {"row", "span", "trace", "session", "call"}
+            _AUTO_CTX_ROOT_TO_FLAG = {
+                "row": "full_row",
+                "span": "span_context",
+                "trace": "trace_context",
+                "session": "session_context",
+                "call": "call_context",
+            }
+
+            all_text = [params.instructions or ""]
+            msgs = (
+                params.messages
+                if params.messages
+                else (template.config or {}).get("messages", [])
             )
-            if (
-                not re.search(variable_pattern, params.criteria)
-                and not has_data_injection
-            ):
-                return ToolResult.error(
-                    "Criteria must contain at least one template variable "
-                    "using double curly braces (e.g. {{variable_name}}), or "
-                    "enable data injection to evaluate without mapping.",
-                    error_code="VALIDATION_ERROR",
-                )
-            template.criteria = params.criteria
-            update_fields.append("criteria")
+            if msgs:
+                for msg in msgs:
+                    all_text.append(msg.get("content", "") if isinstance(msg, dict) else "")
+            combined = "\n".join(t for t in all_text if t)
 
-        if params.eval_tags is not None:
-            template.eval_tags = params.eval_tags
-            update_fields.append("eval_tags")
+            if template_format == "jinja":
+                try:
+                    from model_hub.utils.jinja_variables import extract_jinja_variables
 
-        config = template.config
+                    raw_vars = []
+                    for t in all_text:
+                        if t.strip():
+                            raw_vars.extend(extract_jinja_variables(t))
+                    raw_vars = list(set(raw_vars))
+                except Exception:
+                    raw_vars = re.findall(r"\{\{\s*([^{}]+?)\s*\}\}", combined)
+                    raw_vars = [v.strip() for v in raw_vars]
+            else:
+                raw_vars = re.findall(r"\{\{\s*([^{}]+?)\s*\}\}", combined)
+                raw_vars = [v.strip() for v in raw_vars]
 
+            auto_flags = {}
+            filtered = []
+            for v in raw_vars:
+                head = v.split(".", 1)[0].strip()
+                if head in _AUTO_CTX_ROOTS:
+                    auto_flags[_AUTO_CTX_ROOT_TO_FLAG[head]] = True
+                else:
+                    filtered.append(v)
+
+            template.config["required_keys"] = list(set(filtered))
+            template.config["rule_prompt"] = params.instructions
+            if auto_flags:
+                di = template.config.get("data_injection") or {}
+                di.update(auto_flags)
+                di.pop("variables_only", None)
+                di.pop("variablesOnly", None)
+                template.config["data_injection"] = di
+
+            changed_fields.append("instructions")
+
+        # ── Model ──
         if params.model is not None:
-            config["model"] = params.model
             template.model = params.model
-            update_fields.append("model")
+            changed_fields.append("model")
 
-        if params.choices_map is not None and len(params.choices_map) > 0:
-            config["choices_map"] = params.choices_map
-            template.choices = list(params.choices_map.keys())
-            update_fields.append("choices")
+        # ── Output type ──
+        if params.output_type is not None:
+            template.output_type_normalized = params.output_type
+            output_map = {
+                "pass_fail": "Pass/Fail",
+                "percentage": "score",
+                "deterministic": "choices",
+            }
+            if template.config is None:
+                template.config = {}
+            template.config["output"] = output_map.get(params.output_type, "Pass/Fail")
+            changed_fields.append("output_type")
 
-        if params.function_eval is not None:
-            config["function_eval"] = params.function_eval
-            update_fields.append("function_eval")
+        # ── Pass threshold ──
+        if params.pass_threshold is not None:
+            template.pass_threshold = params.pass_threshold
+            changed_fields.append("pass_threshold")
 
-        template.config = config
-        if "config" not in update_fields:
-            update_fields.append("config")
+        # ── Choice scores ──
+        if params.choice_scores is not None:
+            template.choice_scores = params.choice_scores
+            template.choices = list(params.choice_scores.keys())
+            if template.config is None:
+                template.config = {}
+            template.config["choices"] = list(params.choice_scores.keys())
+            template.config["choices_map"] = {
+                k: "pass" if v >= 0.7 else ("neutral" if v >= 0.3 else "fail")
+                for k, v in params.choice_scores.items()
+            }
+            changed_fields.append("choice_scores")
 
+        # ── Check internet ──
+        if params.check_internet is not None:
+            if template.config is None:
+                template.config = {}
+            template.config["check_internet"] = params.check_internet
+            changed_fields.append("check_internet")
+
+        # ── Code eval fields ──
+        if params.code is not None:
+            if template.config is None:
+                template.config = {}
+            template.config["code"] = params.code
+            template.config["eval_type_id"] = "CustomCodeEval"
+            template.eval_type = "code"
+            template.criteria = params.code
+            changed_fields.append("code")
+
+        if params.code_language is not None:
+            if template.config is None:
+                template.config = {}
+            template.config["language"] = params.code_language
+            changed_fields.append("code_language")
+
+        # ── LLM eval fields ──
+        if params.messages is not None:
+            if template.config is None:
+                template.config = {}
+            template.config["messages"] = params.messages
+            changed_fields.append("messages")
+
+        if params.few_shot_examples is not None:
+            if template.config is None:
+                template.config = {}
+            template.config["few_shot_examples"] = params.few_shot_examples
+            changed_fields.append("few_shot_examples")
+
+        # ── Agent eval fields ──
+        if params.mode is not None:
+            if template.config is None:
+                template.config = {}
+            template.config["agent_mode"] = params.mode
+            changed_fields.append("mode")
+
+        if params.tools is not None:
+            if template.config is None:
+                template.config = {}
+            template.config["tools"] = params.tools
+            changed_fields.append("tools")
+
+        if params.knowledge_bases is not None:
+            if template.config is None:
+                template.config = {}
+            template.config["knowledge_bases"] = params.knowledge_bases
+            changed_fields.append("knowledge_bases")
+
+        if params.data_injection is not None:
+            if template.config is None:
+                template.config = {}
+            template.config["data_injection"] = params.data_injection
+            changed_fields.append("data_injection")
+
+        if params.summary is not None:
+            if template.config is None:
+                template.config = {}
+            template.config["summary"] = params.summary
+            changed_fields.append("summary")
+
+        # ── Eval type change ──
+        if params.eval_type is not None:
+            _EVAL_TYPE_ID_MAP = {
+                "agent": "AgentEvaluator",
+                "llm": "CustomPromptEvaluator",
+                "code": "CustomCodeEval",
+            }
+            template.eval_type = params.eval_type
+            if template.config is None:
+                template.config = {}
+            template.config["eval_type_id"] = _EVAL_TYPE_ID_MAP[params.eval_type]
+            changed_fields.append("eval_type")
+
+        # ── Error localizer ──
+        if params.error_localizer_enabled is not None:
+            template.error_localizer_enabled = params.error_localizer_enabled
+            changed_fields.append("error_localizer_enabled")
+
+        # ── Template format ──
+        if template.config is None:
+            template.config = {}
+        template.config["template_format"] = template_format
+
+        # ── Publish draft ──
+        if params.publish:
+            template.visible_ui = True
+            changed_fields.append("published")
+
+        if not changed_fields:
+            return ToolResult.error(
+                "No fields to update. Provide at least one field to change.",
+                error_code="VALIDATION_ERROR",
+            )
+
+        # ── Save ──
         template.updated_at = timezone.now()
-        template.save(update_fields=update_fields)
+        template.save()
+
+        # ── Create new version on update ──
+        try:
+            EvalTemplateVersion.objects.create_version(
+                eval_template=template,
+                prompt_messages=[],
+                config_snapshot=template.config,
+                criteria=template.criteria,
+                model=template.model,
+                user=context.user,
+                organization=context.organization,
+                workspace=context.workspace,
+            )
+        except Exception:
+            pass  # Non-fatal
 
         info = key_value_block(
             [
                 ("ID", f"`{template.id}`"),
                 ("Name", template.name),
-                (
-                    "Updated Fields",
-                    ", ".join(f for f in update_fields if f != "updated_at"),
-                ),
+                ("Updated Fields", ", ".join(changed_fields)),
             ]
         )
 
         return ToolResult(
             content=section("Eval Template Updated", info),
-            data={"id": str(template.id), "name": template.name},
+            data={"id": str(template.id), "name": template.name, "updated_fields": changed_fields},
         )


### PR DESCRIPTION
## Summary

Updates evaluation tool definitions to align with the revamped evals framework.

**Tools rewritten:**
- `create_eval_template` — supports eval_type (llm/code/agent), proper config building per type, version creation, scoring fields (pass_threshold, choice_scores), template format (mustache/jinja)
- `update_eval_template` — 22 parameters covering all eval type configs, version creation on update
- `test_eval_template` — correct eval_type routing for all types
- `list_eval_templates` — eval_type, template_type, output_type, tags filters
- `get_eval_template` — shows eval type, versions, composite children, scoring config

**Tools added:**
- `create_composite_eval` — bundle multiple evals with aggregation (weighted_avg, avg, min, max, pass_rate)
- `execute_composite_eval` — run composite and return per-child + aggregate results

**Tools removed from registration:**
- 7 eval group tools — replaced by composite evals

## Test plan
- [ ] Create LLM eval — verify eval_type is set correctly, eval runs without errors
- [ ] Create code eval — verify code and language are stored
- [ ] Create agent eval — verify mode, tools, knowledge_bases in config
- [ ] Create composite eval — verify children linked, aggregation configured
- [ ] Execute composite eval — verify per-child results and aggregate score
- [ ] List evals with filters (eval_type, template_type) — verify filtering works
- [ ] Get eval detail — verify version count, composite children shown
- [ ] Verify eval group tools are not accessible