### PR TITLE
[TH-4371] Fix prompt workbench eval delete hitting wrong endpoint

### DIFF
--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -364,17 +364,26 @@ const EvaluationDrawerChild = ({
                     disableDeleteReason="An experiment must have at least one evaluation"
                     onDeleteEvalClick={async (evalItem) => {
                       try {
-                        await axios.delete(
-                          endpoints.develop.eval.deleteEval(id, evalItem.id),
-                          {
-                            data: {
-                              delete_column: true,
-                              ...(module === "experiment" && experimentId
-                                ? { experiment_id: experimentId }
-                                : {}),
+                        if (module === "workbench") {
+                          await axios.delete(
+                            endpoints.develop.runPrompt.deleteEvalConfig(
+                              id,
+                              evalItem.id,
+                            ),
+                          );
+                        } else {
+                          await axios.delete(
+                            endpoints.develop.eval.deleteEval(id, evalItem.id),
+                            {
+                              data: {
+                                delete_column: true,
+                                ...(module === "experiment" && experimentId
+                                  ? { experiment_id: experimentId }
+                                  : {}),
+                              },
                             },
-                          },
-                        );
+                          );
+                        }
                         enqueueSnackbar(`${evalItem.name} deleted`, {
                           variant: "success",
                         });


### PR DESCRIPTION
## Summary
- Prompt workbench eval delete returned 404 "Eval not found" because `SavedEvalsList.onDeleteEvalClick` in `EvaluationDrawer.jsx` always called `DELETE /model-hub/develops/{id}/delete_user_eval/{evalId}/`, which queries the `UserEvalMetric` table (dataset/develop flow) — but workbench evals live in `PromptEvalConfig`, the same table the `evaluation-configs` GET reads from.
- Branched the handler on `module === "workbench"` to use `endpoints.develop.runPrompt.deleteEvalConfig` → `DELETE /model-hub/prompt-templates/{templateId}/delete-evaluation-config/?id={evalId}`, matching the module-aware pattern already in the sibling `DeleteEval.jsx`.
- Develop and experiment paths are unchanged: same `delete_column: true` body and conditional `experiment_id` passthrough.

Closes TH-4371

## Linear Ticket
[TH-4371](https://linear.app/future-agi/issue/TH-4371/unable-to-delete-evals-in-prompt-workbench)

## Files Changed
- `frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx`

## Test plan
- [ ] In prompt workbench, open Evaluations drawer on a saved eval and confirm delete succeeds (no 404, snackbar shows success, eval disappears from list).
- [ ] In develop/dataset detail, delete an eval column and confirm existing behavior is preserved (column removed, `delete_column: true` still sent).
- [ ] In an experiment, delete an eval and confirm `experiment_id` is still included in the request body.