### PR TITLE
fix(tasks): relabel Pass Rate pill to Task Completion Rate (TH-4573) [dev]

### DIFF
--- a/frontend/src/sections/tasks/components/TaskUsageTab.jsx
+++ b/frontend/src/sections/tasks/components/TaskUsageTab.jsx
@@ -975,7 +975,7 @@ const TaskUsageTab = ({ taskId }) => {
                 sx={{ width: "1px", height: 14, backgroundColor: "divider" }}
               />
               <StatPill
-                label="Pass Rate"
+                label="Task Completion Rate"
                 value={`${stats.pass_rate ?? 0}%`}
                 color="info.main"
               />


### PR DESCRIPTION
Cherry-pick of #18 onto `dev`. Original PR went to `main` only — porting the same one-line copy fix here so `dev` doesn't drift.

Linear: [TH-4573](https://linear.app/futureagi/issue/TH-4573)

## Summary

On the task usage view, the top-right stat pill was labeled **"Pass Rate"** but the backend field it reads (`stats.pass_rate` from `GET /tracer/eval-task/get_usage/`) is actually computing **task completion rate** — the variable is just misnamed. This PR relabels the pill only. No metric or backend change.

Per the ticket:
> For tasks, the top-right copy should say `task completion rate` and the metric should calculate task completion rate instead of pass rate. Evals tasks can include many kinds of evals, not just boolean evals.

## Changes

- `frontend/src/sections/tasks/components/TaskUsageTab.jsx` — pill label `"Pass Rate"` → `"Task Completion Rate"` (1-line change, still reads the same `stats.pass_rate` field).

## Test plan

- [ ] Navigate to any task detail page → Usage tab → confirm top-right pill now reads **"Task Completion Rate: XX%"**
- [ ] Confirm the numeric value matches what was shown before the change (same backing field).
- [ ] Confirm chart legend / right-axis still read **"Pass Rate"** for pass/fail-typed evals (intentional — chart math is different, see #18 for full context).
- [ ] Confirm pill row does not overflow at ~1280px viewport.

---

Cherry-pick of commit `fad6627a` from #18 (merged to `main` 2026-04-29). See #18 for the full pill-vs-chart analysis and rationale for not renaming the backend field.