### PR TITLE
fix(frontend): only require reCAPTCHA when site key is configured

### DIFF
--- a/frontend/src/sections/auth/jwt/jwt-login-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-login-view.jsx
@@ -20,7 +20,7 @@ import { useRouter } from "src/routes/hooks";
 import { useBoolean } from "src/hooks/use-boolean";
 import { useAuthContext } from "src/auth/hooks";
 import { setSession, setRefreshToken } from "src/auth/context/jwt/utils";
-import { PATH_AFTER_LOGIN } from "src/config-global";
+import { PATH_AFTER_LOGIN, GOOGLE_SITE_KEY } from "src/config-global";
 
 import Iconify from "src/components/iconify";
 import FormProvider, { RHFTextField } from "src/components/hook-form";
@@ -182,14 +182,14 @@ export default function JwtLoginView() {
   } = methods;
 
   const onSubmit = handleSubmit(async (data) => {
-    if (!executeRecaptcha) {
+    if (GOOGLE_SITE_KEY && !executeRecaptcha) {
       enqueueSnackbar({
         message: "reCAPTCHA not ready. Please try again",
         variant: "error",
       });
       return;
     }
-    const token = await executeRecaptcha("login");
+    const token = GOOGLE_SITE_KEY ? await executeRecaptcha("login") : "";
 
     trackEvent(Events.loginClicked, {
       [PropertyName.status]: true,

--- a/frontend/src/sections/auth/jwt/jwt-register-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-register-view.jsx
@@ -28,6 +28,7 @@ import logger from "src/utils/logger";
 import SvgColor from "src/components/svg-color";
 import { RouterLink } from "src/routes/components";
 import RegionSelect from "src/components/RegionSelect";
+import { GOOGLE_SITE_KEY } from "src/config-global";
 import RightSectionAuth from "./RightSectionAuth";
 
 export default function JwtRegisterView() {
@@ -110,7 +111,7 @@ export default function JwtRegisterView() {
   const email = watch("email");
 
   const handleSignup = async (data) => {
-    const token = await executeRecaptcha("signup");
+    const token = GOOGLE_SITE_KEY ? await executeRecaptcha("signup") : "";
     setErrorMsg("");
     try {
       setLoading(true);
@@ -180,7 +181,7 @@ export default function JwtRegisterView() {
   };
 
   const handleLogin = async (data) => {
-    const token = await executeRecaptcha("login");
+    const token = GOOGLE_SITE_KEY ? await executeRecaptcha("login") : "";
 
     trackEvent(Events.loginClicked, {
       [PropertyName.status]: true,
@@ -225,7 +226,7 @@ export default function JwtRegisterView() {
   };
 
   const onSubmit = handleSubmit(async (data) => {
-    if (!executeRecaptcha) {
+    if (GOOGLE_SITE_KEY && !executeRecaptcha) {
       enqueueSnackbar({
         message: "reCAPTCHA not ready. Please try again",
         variant: "error",


### PR DESCRIPTION
#Closes #155

## Summary
- Self-hosted installs ship with `RECAPTCHA_ENABLED=false` and an empty `VITE_GOOGLE_SITE_KEY` in `.env.example`. The backend honors the flag (`accounts/views/signup.py:verify_recaptcha` returns `True` when disabled), but the frontend gates every login and signup on `executeRecaptcha`, which is undefined when no site key is configured. Result: a fresh `docker compose up -d` install cannot create the first account — every submit shows `reCAPTCHA not ready. Please try again`.
- This PR mirrors the backend's semantics on the frontend: when `VITE_GOOGLE_SITE_KEY` is unset, skip the reCAPTCHA readiness check and pass an empty `recaptcha-response` (which the backend already accepts).
- Behavior with a real site key is unchanged: the readiness gate still fires and a real token is still requested.

## Files
- `frontend/src/sections/auth/jwt/jwt-login-view.jsx` — gate `if (!executeRecaptcha)` on `GOOGLE_SITE_KEY`; only call `executeRecaptcha("login")` when it's set.
- `frontend/src/sections/auth/jwt/jwt-register-view.jsx` — same treatment for both `handleSignup` and `handleLogin`, plus the `onSubmit` readiness gate.

## Repro
1. `cp .env.example .env` and fill the four `CHANGEME` values. Leave `VITE_GOOGLE_SITE_KEY` blank (the default).
2. `docker compose up -d`
3. Open http://localhost:3000 → Sign Up → submit the form.
4. **Before**: snackbar shows `reCAPTCHA not ready. Please try again`; account is never created.
5. **After**: signup proceeds normally; account is created and email is sent.

## Test plan
- [ ] `docker compose up -d` on a fresh checkout with default `.env` → sign up succeeds.
- [ ] Set `VITE_GOOGLE_SITE_KEY` to a real reCAPTCHA v3 site key, rebuild frontend → reCAPTCHA still fires on signup and login (no regression in production-like config).
- [ ] Login flow exercised on both `jwt-login-view` (the standalone login route) and `jwt-register-view`'s post-registration login path.

## Related
- The migration-conflict bug that also blocks first boot is being addressed separately (see `chore/merge-migrations` / PR #121 on `dev`). With both landed on `main`, `docker compose up -d` becomes a clean first-boot experience for self-hosted users.