### PR TITLE
feat: Add GitHub Action wrapper for fi-simulate

### DIFF
--- a/.github/actions/simulate/LICENSE
+++ b/.github/actions/simulate/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Future AGI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.github/actions/simulate/README.md
+++ b/.github/actions/simulate/README.md
@@ -1,0 +1,70 @@
+# Future AGI Simulate Action
+
+A GitHub Action to run simulation and evaluation tests via Future AGI.
+
+## Usage
+
+### Minimal Example
+
+```yaml
+steps:
+  - name: Run Future AGI tests
+    uses: future-agi/future-agi/.github/actions/simulate@main
+    with:
+      test-id: 'your-test-id'
+      api-key: ${{ secrets.FI_API_KEY }}
+```
+
+### Self-Hosted Example
+
+```yaml
+steps:
+  - name: Run Future AGI tests
+    uses: future-agi/future-agi/.github/actions/simulate@main
+    with:
+      test-id: 'your-test-id'
+      base-url: 'https://your-internal-futureagi.com'
+      api-key: ${{ secrets.FI_API_KEY }}
+```
+
+### Matrix Example
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-id: ['test-id-1', 'test-id-2']
+    steps:
+      - name: Run Future AGI tests
+        uses: future-agi/future-agi/.github/actions/simulate@main
+        with:
+          test-id: ${{ matrix.test-id }}
+          api-key: ${{ secrets.FI_API_KEY }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `test-id` | Yes | - | Run-test ID to execute |
+| `api-key` | Yes | - | API key |
+| `scenario-ids` | No | (all) | Comma-separated scenario IDs |
+| `simulator-id` | No | - | Override simulator |
+| `threshold` | No | 0.8 | Pass-rate gate (0.0-1.0) |
+| `timeout` | No | 1800 | Seconds to wait |
+| `base-url` | No | `https://app.futureagi.com` | API base URL |
+| `python-version` | No | 3.11 | Python version |
+
+## Outputs
+
+- `execution-id`: The execution ID.
+- `pass-rate`: Aggregate pass rate.
+- `summary-json`: The full eval summary as JSON.
+
+## Exit Codes
+- 0: Pass rate >= threshold
+- 1: Pass rate < threshold (regression)
+- 2: Timeout or execution failure
+- 3: Usage / Auth error

--- a/.github/actions/simulate/action.yml
+++ b/.github/actions/simulate/action.yml
@@ -1,0 +1,78 @@
+name: 'Future AGI Simulate'
+description: 'Run Future AGI simulation and evaluation tests'
+author: 'Future AGI'
+inputs:
+  test-id:
+    description: 'Run-test ID to execute'
+    required: true
+  scenario-ids:
+    description: 'Comma-separated scenario IDs'
+    required: false
+  simulator-id:
+    description: 'Override simulator ID'
+    required: false
+  threshold:
+    description: 'Pass-rate gate (0.0-1.0)'
+    required: false
+    default: '0.8'
+  timeout:
+    description: 'Seconds to wait'
+    required: false
+    default: '1800'
+  base-url:
+    description: 'API base URL (set for self-hosted)'
+    required: false
+    default: 'https://app.futureagi.com'
+  api-key:
+    description: 'API key (use a repo/org secret)'
+    required: true
+  python-version:
+    description: 'Python version for the runner'
+    required: false
+    default: '3.11'
+
+outputs:
+  execution-id:
+    description: 'The execution ID'
+    value: ${{ steps.simulate.outputs.execution-id }}
+  pass-rate:
+    description: 'Aggregate pass rate (0.0-1.0)'
+    value: ${{ steps.simulate.outputs.pass-rate }}
+  summary-json:
+    description: 'The full eval summary as JSON'
+    value: ${{ steps.simulate.outputs.summary-json }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install fi-simulate
+      shell: bash
+      run: pip install fi-simulate
+
+    - name: Run fi-simulate
+      id: simulate
+      shell: bash
+      env:
+        FI_API_KEY: ${{ inputs.api-key }}
+        FI_BASE_URL: ${{ inputs.base-url }}
+      run: |
+        ARGS="--test-id ${{ inputs.test-id }} --output github"
+        if [ -n "${{ inputs.scenario-ids }}" ]; then
+          ARGS="$ARGS --scenario-ids ${{ inputs.scenario-ids }}"
+        fi
+        if [ -n "${{ inputs.simulator-id }}" ]; then
+          ARGS="$ARGS --simulator-id ${{ inputs.simulator-id }}"
+        fi
+        if [ -n "${{ inputs.threshold }}" ]; then
+          ARGS="$ARGS --threshold ${{ inputs.threshold }}"
+        fi
+        if [ -n "${{ inputs.timeout }}" ]; then
+          ARGS="$ARGS --timeout ${{ inputs.timeout }}"
+        fi
+        
+        fi-simulate run $ARGS


### PR DESCRIPTION
Closes #81

This adds a GitHub Action composite wrapper for the `fi-simulate` CLI as requested.