### PR TITLE
fix(email): make EMAIL_BACKEND env-driven with console fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,17 @@ RECAPTCHA_ENABLED=false
 RECAPTCHA_SECRET_KEY=
 VITE_GOOGLE_SITE_KEY=
 
-# Mailgun (email delivery)
+# Email delivery
+#
+# EMAIL_BACKEND defaults to:
+#   - anymail.backends.mailgun.EmailBackend  (when MAILGUN_API_KEY is set)
+#   - django.core.mail.backends.console.EmailBackend  (otherwise)
+#
+# The console backend prints outbound emails to the backend container's
+# stdout — view with `docker compose logs backend`. Use it for local /
+# self-host installs without an ESP so signup, password reset, and invite
+# flows still work end-to-end.
+# EMAIL_BACKEND=
 MAILGUN_API_KEY=
 MAILGUN_SENDER_DOMAIN=
 DEFAULT_FROM_EMAIL=

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -413,8 +413,17 @@ ANYMAIL = {
         "MAILGUN_SENDER_DOMAIN"
     ),  # your Mailgun domain, if needed
 }
-EMAIL_BACKEND = (
-    "anymail.backends.mailgun.EmailBackend"  # or sendgrid.EmailBackend, or...
+# Email backend — env-overridable. When self-hosting without an ESP, set
+# EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend so password,
+# reset, and invite emails print to stdout (`docker compose logs backend`)
+# instead of silently failing through anymail. The default below auto-falls-
+# back to the console backend when MAILGUN_API_KEY is unset, so a fresh
+# self-host install can complete its first signup without any extra config.
+EMAIL_BACKEND = os.getenv(
+    "EMAIL_BACKEND",
+    "anymail.backends.mailgun.EmailBackend"
+    if os.getenv("MAILGUN_API_KEY")
+    else "django.core.mail.backends.console.EmailBackend",
 )
 DEFAULT_FROM_EMAIL = os.getenv(
     "DEFAULT_FROM_EMAIL"


### PR DESCRIPTION
Closes #156

## Summary
- `EMAIL_BACKEND` was hardcoded to `anymail.backends.mailgun.EmailBackend` in `tfc/settings/settings.py:416`. The shipped `.env.example` leaves `MAILGUN_API_KEY` blank, so a default self-host install has the anymail Mailgun backend wired up to a missing API key, and every transactional email — temporary-password mail on signup, password resets, workspace invites, deactivation notices, autorecharge failures — fails to deliver. First-boot signup is effectively gated on having a Mailgun account.
- This PR makes `EMAIL_BACKEND` env-overridable and picks a sensible default: keep Mailgun when `MAILGUN_API_KEY` is set (preserves existing production behavior), otherwise fall back to Django's console backend so outbound emails print to backend stdout. Operators with another ESP can override explicitly via `EMAIL_BACKEND=<dotted.import.path>` in `.env`.
- `.env.example` is updated alongside to document the new behavior next to the existing Mailgun knobs.

## Files
- `futureagi/tfc/settings/settings.py` — replace the hardcoded literal with `os.getenv(\"EMAIL_BACKEND\", ...)` and a smart default.
- `.env.example` — document the env knob and the new console-fallback behavior.

## Repro
1. `cp .env.example .env`, fill the four `CHANGEME` values, leave the Mailgun keys blank (default).
2. `docker compose up -d` and wait for all services healthy.
3. Sign up at http://localhost:3000.

**Before**: backend says \"we sent you a password\" but no email arrives and `docker compose logs backend` shows no email content. The only way to get a password is `docker exec backend python manage.py shell` and `set_password()` manually.

**After**: the same flow prints the full HTML password email — recipient, subject, body — to the backend logs, ready to copy out.

## Test plan
- [ ] Fresh checkout, default `.env` (Mailgun blank) → signup → password email visible in `docker compose logs backend`.
- [ ] Set `MAILGUN_API_KEY` to a real value → restart backend → email goes through Mailgun (no regression on the production path).
- [ ] Set `EMAIL_BACKEND=django.core.mail.backends.locmem.EmailBackend` explicitly → verify the override is honored over the smart default.

## Related
This is the third of three first-boot bugs in self-host. The other two:
- Migration conflict in the `tracer` app — already on `dev` via #121, awaiting promotion to `main`.
- Frontend reCAPTCHA gate ignores `RECAPTCHA_ENABLED=false` — issue #155, PR #152.

With all three landed, \`docker compose up -d\` becomes a clean first-boot experience for self-hosted users.