### PR TITLE
fix: Fall back to console email backend when Mailgun keys are unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,10 @@ VITE_GOOGLE_SITE_KEY=
 # Mailgun (email delivery)
 MAILGUN_API_KEY=
 MAILGUN_SENDER_DOMAIN=
+
+# By default, EMAIL_BACKEND falls back to console output if MAILGUN_API_KEY is unset.
+# Override this if using a different ESP.
+EMAIL_BACKEND=
 DEFAULT_FROM_EMAIL=
 SERVER_EMAIL=
 

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -413,8 +413,11 @@ ANYMAIL = {
         "MAILGUN_SENDER_DOMAIN"
     ),  # your Mailgun domain, if needed
 }
-EMAIL_BACKEND = (
-    "anymail.backends.mailgun.EmailBackend"  # or sendgrid.EmailBackend, or...
+EMAIL_BACKEND = os.getenv(
+    "EMAIL_BACKEND",
+    "anymail.backends.mailgun.EmailBackend"
+    if os.getenv("MAILGUN_API_KEY")
+    else "django.core.mail.backends.console.EmailBackend",
 )
 DEFAULT_FROM_EMAIL = os.getenv(
     "DEFAULT_FROM_EMAIL"


### PR DESCRIPTION
Closes #156

This prevents self-hosted environments from silently failing to deliver transactional emails like password resets and signup confirmations when no ESP is configured. It falls back to the console backend so emails can be retrieved via `docker compose logs`.