### PR TITLE
fix(voice): correct talk-time split and hide redundant Annotations tab in annotate workspace

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceDetailDrawerV2.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceDetailDrawerV2.jsx
@@ -69,6 +69,7 @@ const VoiceDetailDrawerV2 = ({
   // the VoiceDrawerHeader (close/nav/fullscreen bar) — and just render
   // the call body so it fits the host's layout.
   embedded = false,
+  hideAnnotationTab=false
 }) => {
   const queryClient = useQueryClient();
   const { observeId } = useParams();
@@ -498,6 +499,7 @@ const VoiceDetailDrawerV2 = ({
                 data={data}
                 onCompareBaseline={onCompareBaseline}
                 onAction={handleVoiceAction}
+                hideAnnotationTab={hideAnnotationTab}
               />
             </Box>
           </>
@@ -620,6 +622,7 @@ VoiceDetailDrawerV2.propTypes = {
   isLoading: PropTypes.bool,
   initialFullscreen: PropTypes.bool,
   embedded: PropTypes.bool,
+  hideAnnotationTab: PropTypes.bool,
 };
 
 export default VoiceDetailDrawerV2;

--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -37,7 +37,7 @@ const TABS = {
   SCENARIO: "scenario",
 };
 
-const VoiceRightPanel = ({ data, onCompareBaseline, onAction }) => {
+const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab }) => {
   const [currentTab, setCurrentTab] = useState(TABS.ANALYTICS);
   const isSimulate = data?.module === "simulate";
   // Prefer the conversation root span (where voice-call attributes/raw_log
@@ -119,11 +119,14 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction }) => {
       value: TABS.ATTRIBUTES,
       icon: "mdi:code-json",
     });
-    t.push({
-      label: "Annotations",
-      value: TABS.ANNOTATIONS,
-      icon: "mdi:pencil-outline",
-    });
+    if (!hideAnnotationTab) {
+      t.push({
+        label: "Annotations",
+        value: TABS.ANNOTATIONS,
+        icon: "mdi:pencil-outline",
+      });
+    }
+
     if (hasScenarioData) {
       t.push({
         label: "Scenario",
@@ -489,6 +492,7 @@ VoiceRightPanel.propTypes = {
   data: PropTypes.object.isRequired,
   onCompareBaseline: PropTypes.func,
   onAction: PropTypes.func,
+  hideAnnotationTab: PropTypes.bool
 };
 
 export default VoiceRightPanel;

--- a/frontend/src/components/VoiceDetailDrawerV2/transcriptUtils.js
+++ b/frontend/src/components/VoiceDetailDrawerV2/transcriptUtils.js
@@ -166,12 +166,16 @@ export const enrichTurns = (transcript) => {
     });
   }
 
-  // Step 5: back-fill `end` from start + duration. Observe rows don't
-  // ship an explicit end — without this, silence/overlap pass skips
-  // every pair.
+  // Step 5: back-fill `end` from start + duration, and `duration` from
+  // end - start. Observe rows don't ship an explicit end (without this,
+  // silence/overlap pass skips every pair). Simulate rows ship start +
+  // end but no duration (without this, computeTotals skips every turn
+  // → talk-time split renders as "—").
   raw.forEach((t) => {
     if (t.end == null && t.start != null && t.duration != null) {
       t.end = t.start + t.duration;
+    } else if (t.duration == null && t.start != null && t.end != null) {
+      t.duration = t.end - t.start;
     }
   });
 
@@ -287,6 +291,7 @@ export const computeCallMetrics = (turns) => {
       }
     }
   }
+
 
   return {
     duration: lastEnd > 0 ? lastEnd : null,

--- a/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
@@ -132,7 +132,7 @@ export default function ContentPanel({ item }) {
   if (sourceType === "call_execution") {
     return (
       <Box sx={{ p: 3, overflow: "auto", height: "100%" }}>
-        <SimulationContent content={content} />
+        <SimulationContent hideAnnotationTab={true} content={content} />
       </Box>
     );
   }
@@ -669,6 +669,7 @@ function VoiceCallContent({ traceId }) {
         data={drawerData}
         onClose={() => {}}
         hasPrev={false}
+        hideAnnotationTab={true}
         hasNext={false}
         scenarioId={drawerData.scenarioId}
         embedded
@@ -1181,7 +1182,7 @@ PrototypeContent.propTypes = {
 // ---------------------------------------------------------------------------
 // Simulation Content — reuses the same components as the Call Log Details drawer
 // ---------------------------------------------------------------------------
-function SimulationContent({ content }) {
+function SimulationContent({ content, hideAnnotationTab=false }) {
   const callId = content?.call_id;
 
   const { data: callData, isLoading } = useQuery({
@@ -1469,6 +1470,7 @@ function SimulationContent({ content }) {
               status={drawerData.status}
               simulationCallType={drawerData.simulationCallType}
               sessionId={drawerData.sessionId}
+              hideAnnotationTab={hideAnnotationTab}
             />
           </Box>
         </Grid>
@@ -1479,6 +1481,7 @@ function SimulationContent({ content }) {
 
 SimulationContent.propTypes = {
   content: PropTypes.object,
+    hideAnnotationTab: PropTypes.bool,
 };
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailDrawerRightSection.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailDrawerRightSection.jsx
@@ -46,6 +46,7 @@ const TestDetailDrawerRightSection = ({
   simulationCallType,
   sessionId,
   provider,
+  hideAnnotationTab=false,
 }) => {
   const [currentRightTab, setCurrentRightTab] = useState(
     simulationCallType === AGENT_TYPES.CHAT ? "evaluations" : "callAnalytics",
@@ -98,14 +99,15 @@ const TestDetailDrawerRightSection = ({
         value: TEST_DETAIL_RIGHT_TABS.FLOW_ANALYSIS,
       });
     }
-
-    t.push({
-      label: "Annotations",
-      value: TEST_DETAIL_RIGHT_TABS.ANNOTATIONS,
-    });
+    if (!hideAnnotationTab) {
+      t.push({
+        label: "Annotations",
+        value: TEST_DETAIL_RIGHT_TABS.ANNOTATIONS,
+      });
+    }
 
     return t;
-  }, [scenarioGraph]);
+  }, [scenarioGraph, hideAnnotationTab, simulationCallType]);
 
   const { nodes, edges } = useMemo(() => {
     const currentPath = flowAnalysis?.analysis?.currentPath;
@@ -418,6 +420,7 @@ TestDetailDrawerRightSection.propTypes = {
   simulationCallType: PropTypes.string,
   sessionId: PropTypes.string,
   provider: PropTypes.string,
+  hideAnnotationTab: PropTypes.bool,
 };
 
 export default TestDetailDrawerRightSection;


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

Summary
Three fixes for the voice call drawer when used inside the annotation queue:

Talk-time split rendered "—" for every call. enrichTurns only backfilled end from start + duration, so simulate transcripts (which ship start_time_seconds + end_time_seconds without a duration field) left every turn with duration: null. computeTotals skips turns missing duration, so the per-role talk seconds came out empty and both userTalkPct / assistantTalkPct were null. Added the reverse backfill (duration = end - start).

Annotations tab still showed in the V2 voice drawer when embedded in the annotate workspace. The drawer is mounted inside an annotation panel, so its own Annotations tab is redundant. Threaded a hideAnnotationTab prop through VoiceDetailDrawerV2 → VoiceRightPanel and passed it from VoiceCallContent.

Annotations tab still showed (and duplicated) in TestDetailDrawerRightSection. The tab list had a guarded push followed by an unconditional push of the same Annotations tab, so the flag was effectively ignored and the tab was duplicated when the flag was off. Removed the duplicate, fixed the useMemo deps to include hideAnnotationTab / simulationCallType, and threaded the flag from SimulationContent.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes  TH-4646,4684

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
