### PR TITLE
[Feature] add Jinja2 template format support across prompt editor and…

### DIFF
--- a/frontend/src/components/PromptCards/Blots/EditVariableBlot.jsx
+++ b/frontend/src/components/PromptCards/Blots/EditVariableBlot.jsx
@@ -9,13 +9,18 @@ class EditVariableBolt extends BlockEmbed {
   static create(value) {
     const node = super.create();
     node.setAttribute("contenteditable", false);
-    //node should take width of content not parent
-    //   node.style.width = "fit-content";
-    //   node.setAttribute("data-type", `generatePrompt-${value.id}`);
+    if (value.fromBlock) {
+      node.setAttribute("data-from-block", "true");
+    }
     // Render React component
     const root = createRoot(node);
 
-    root.render(<EditVariable openVariableEditor={value.openVariableEditor} />);
+    root.render(
+      <EditVariable
+        openVariableEditor={value.openVariableEditor}
+        fromBlock={!!value.fromBlock}
+      />,
+    );
 
     return node;
   }
@@ -24,6 +29,7 @@ class EditVariableBolt extends BlockEmbed {
   static value(node) {
     return {
       id: node.getAttribute("id"),
+      fromBlock: node.getAttribute("data-from-block") === "true",
     };
   }
 }

--- a/frontend/src/components/PromptCards/EmbedComponents/EditVariable.jsx
+++ b/frontend/src/components/PromptCards/EmbedComponents/EditVariable.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 // This component is embedded inside quill editor on run time and can't access theme easily
 // hence we need to hardcode the colors and other styles here.
-const EditVariable = ({ openVariableEditor }) => {
+const EditVariable = ({ openVariableEditor, fromBlock = false }) => {
   return (
     <span
       style={{
@@ -11,14 +11,16 @@ const EditVariable = ({ openVariableEditor }) => {
         alignItems: "center",
       }}
     >
-      <span
-        style={{
-          color: "var(--mention-invalid-color)",
-          fontWeight: "500",
-          fontSize: "15px",
-          backgroundColor: "var(--mention-invalid-bg)",
-        }}
-      >{`}`}</span>
+      {!fromBlock && (
+        <span
+          style={{
+            color: "var(--mention-invalid-color)",
+            fontWeight: "500",
+            fontSize: "15px",
+            backgroundColor: "var(--mention-invalid-bg)",
+          }}
+        >{`}`}</span>
+      )}
       <span className="edit-variable-button" onClick={openVariableEditor}>
         <SVGColor
           src="/assets/icons/components/ic_edit.svg"
@@ -31,6 +33,7 @@ const EditVariable = ({ openVariableEditor }) => {
 
 EditVariable.propTypes = {
   openVariableEditor: PropTypes.func,
+  fromBlock: PropTypes.bool,
 };
 
 export default EditVariable;

--- a/frontend/src/components/PromptCards/ExpandedPrompt.jsx
+++ b/frontend/src/components/PromptCards/ExpandedPrompt.jsx
@@ -60,6 +60,7 @@ export default function ExpandedPrompt({
   hideExpandedHeader,
   allVariablesValid = false,
   variableValidator,
+  jinjaMode = false,
 }) {
   const theme = useTheme();
   const quillRef = useRef(null);
@@ -275,6 +276,7 @@ export default function ExpandedPrompt({
           showEditEmbed,
           allVariablesValid,
           variableValidator,
+          jinjaMode,
         );
       }
     }
@@ -384,6 +386,7 @@ export default function ExpandedPrompt({
             allowVariables={allowVariables}
             allVariablesValid={allVariablesValid}
             variableValidator={variableValidator}
+            jinjaMode={jinjaMode}
             label={hideExpandedHeader ? role : ""}
           />
           <ShowComponent condition={isRecorderActive}>
@@ -466,4 +469,5 @@ ExpandedPrompt.propTypes = {
   hideExpandedHeader: PropTypes.bool,
   allVariablesValid: PropTypes.bool,
   variableValidator: PropTypes.func,
+  jinjaMode: PropTypes.bool,
 };

--- a/frontend/src/components/PromptCards/PromptCard.jsx
+++ b/frontend/src/components/PromptCards/PromptCard.jsx
@@ -55,6 +55,7 @@ const PromptCard = ({
   hideExpandedHeader,
   allVariablesValid = false,
   variableValidator,
+  jinjaMode = false,
 }) => {
   const {
     allowRoleChange,
@@ -153,6 +154,7 @@ const PromptCard = ({
           disabled={disabled}
           allVariablesValid={allVariablesValid}
           variableValidator={variableValidator}
+          jinjaMode={jinjaMode}
         />
         <ShowComponent condition={isRecorderActive}>
           <PromptRecorder
@@ -204,6 +206,7 @@ const PromptCard = ({
           openVariableEditor={openVariableEditor}
           allVariablesValid={allVariablesValid}
           variableValidator={variableValidator}
+          jinjaMode={jinjaMode}
         />
       )}
     </>
@@ -262,6 +265,7 @@ PromptCard.propTypes = {
   hideExpandedHeader: PropTypes.bool,
   allVariablesValid: PropTypes.bool,
   variableValidator: PropTypes.func,
+  jinjaMode: PropTypes.bool,
 };
 
 export default PromptCard;

--- a/frontend/src/components/PromptCards/PromptEditor.jsx
+++ b/frontend/src/components/PromptCards/PromptEditor.jsx
@@ -339,6 +339,23 @@ const PromptEditor = React.forwardRef(
       }
     }, [variableValidator]);
 
+    // Re-highlight when template format changes (mustache ↔ jinja)
+    useEffect(() => {
+      const quill = quillRef.current;
+      if (quill && allowVariables) {
+        placeEditBolt(
+          quill,
+          appliedVariableData,
+          theme,
+          openVariableEditor,
+          showEditEmbed,
+          allVariablesValid,
+          variableValidator,
+          jinjaMode,
+        );
+      }
+    }, [jinjaMode]);
+
     const onTextChange = (_, __, source) => {
       const quill = quillRef.current;
       if (source === "user" && allowVariables) {

--- a/frontend/src/components/PromptCards/common.js
+++ b/frontend/src/components/PromptCards/common.js
@@ -99,7 +99,7 @@ export const placeEditBolt = (
     jinjaInputVars = new Set(extractJinjaVariables(fullText));
 
     // Scan {% %} blocks for input variable references
-    const jinjaBlockRegex = /\{%-?(.*?)-?%\}/g;
+    const jinjaBlockRegex = /\{%-?([\s\S]*?)-?%\}/g;
     index = 0;
     newDelta.ops.forEach((op) => {
       if (typeof op.insert === "string") {

--- a/frontend/src/components/PromptCards/common.js
+++ b/frontend/src/components/PromptCards/common.js
@@ -1,6 +1,7 @@
 import logger from "src/utils/logger";
 import { getRandomId } from "src/utils/utils";
 import { normalizeForComparison } from "src/sections/workbench/createPrompt/Playground/common";
+import { extractJinjaVariables } from "src/utils/jinjaVariables";
 import { PromptRoles } from "src/utils/constants";
 import { alpha } from "@mui/material";
 
@@ -42,7 +43,7 @@ export const placeEditBolt = (
   let index = 0;
   const matches = [];
 
-  // First remove all existing EditVariable embeds and add back }
+  // First remove all existing EditVariable embeds and restore } for {{ }} embeds
   if (showEditEmbed) {
     delta.ops.forEach((op) => {
       if (
@@ -51,8 +52,11 @@ export const placeEditBolt = (
         op.insert.EditVariable
       ) {
         quill.deleteText(index, 1, "placeBlot");
-        quill.insertText(index, "}", "placeBlot");
-        index += 1;
+        // Only restore } for {{ }} embeds; block embeds were inserted without removing a char
+        if (!op.insert.EditVariable.fromBlock) {
+          quill.insertText(index, "}", "placeBlot");
+          index += 1;
+        }
       } else if (typeof op.insert === "string") {
         index += op.insert.length;
       } else {
@@ -83,26 +87,39 @@ export const placeEditBolt = (
     }
   });
 
-  // In Jinja mode, also find input variables inside {% %} blocks
-  // e.g. {% for example in examples %} → highlight "examples"
-  if (jinjaMode && typeof variableValidator === "function") {
-    const jinjaBlockRegex = /\{%-?\s*for\s+[\w\s,]+\s+in\s+(\w+)/g;
+  // In Jinja mode, compute input variables from the full text so we can:
+  // 1. Skip loop-scoped / set-scoped variables (e.g. "item" in {% for item in items %})
+  // 2. Highlight input variables referenced inside {% %} blocks (for, if, elif, etc.)
+  let jinjaInputVars = null;
+  if (jinjaMode) {
+    const fullText = newDelta.ops
+      .filter((op) => typeof op.insert === "string")
+      .map((op) => op.insert)
+      .join("");
+    jinjaInputVars = new Set(extractJinjaVariables(fullText));
+
+    // Scan {% %} blocks for input variable references
+    const jinjaBlockRegex = /\{%-?(.*?)-?%\}/g;
     index = 0;
     newDelta.ops.forEach((op) => {
       if (typeof op.insert === "string") {
-        let match;
-        while ((match = jinjaBlockRegex.exec(op.insert)) !== null) {
-          const varName = match[1];
-          const isValid = variableValidator(varName);
-          if (isValid === null) continue; // not an input variable
-          // Calculate position of just the variable name within the match
-          const varStart = index + match.index + match[0].indexOf(varName);
-          matches.push({
-            start: varStart,
-            length: varName.length,
-            text: varName,
-            word: varName,
-          });
+        let blockMatch;
+        while ((blockMatch = jinjaBlockRegex.exec(op.insert)) !== null) {
+          const blockStart = index + blockMatch.index;
+          for (const varName of jinjaInputVars) {
+            if (!/^\w+$/.test(varName)) continue;
+            const varRegex = new RegExp(`\\b${varName}\\b`, "g");
+            let varMatch;
+            while ((varMatch = varRegex.exec(blockMatch[0])) !== null) {
+              matches.push({
+                start: blockStart + varMatch.index,
+                length: varName.length,
+                text: varName,
+                word: varName,
+                fromBlock: true,
+              });
+            }
+          }
         }
         index += op.insert.length;
       } else {
@@ -111,8 +128,33 @@ export const placeEditBolt = (
     });
   }
 
-  // Process matches
-  matches.forEach(({ start, length, word }) => {
+  // For block matches, only highlight + embed the first occurrence of each
+  // variable name (by document position). Duplicate block references are skipped.
+  const firstBlockVars = new Set();
+  matches
+    .filter((m) => m.fromBlock)
+    .sort((a, b) => a.start - b.start)
+    .forEach((m) => {
+      if (!firstBlockVars.has(m.word)) {
+        firstBlockVars.add(m.word);
+        m.firstBlock = true;
+      }
+    });
+
+  // Process matches in reverse document order so embed insertions don't shift
+  // positions of matches that haven't been processed yet.
+  const sortedMatches = [...matches].sort((a, b) => b.start - a.start);
+  sortedMatches.forEach(({ start, length, word, fromBlock, firstBlock }) => {
+    // For block matches, skip duplicates — only process the first occurrence
+    if (fromBlock && !firstBlock) return;
+    // In Jinja mode, skip variables that are not real inputs (e.g. loop vars)
+    // Use root name for dotted access (e.g. "data.name" → check "data")
+    if (jinjaInputVars) {
+      const rootVar = word.trim().split(".")[0];
+      if (!jinjaInputVars.has(rootVar)) {
+        return;
+      }
+    }
     // When allVariablesValid is true, treat every variable as valid (green)
     if (allVariablesValid) {
       quill.formatText(
@@ -170,11 +212,10 @@ export const placeEditBolt = (
         return false;
       });
 
-    if (!variable) {
-      if (showEditEmbed) {
-        // Delete the last character (})
+    if (!variable && showEditEmbed) {
+      if (!fromBlock) {
+        // {{ }} match: replace the closing } with the embed
         quill.deleteText(start + length - 1, 1, "placeBlot");
-        // Insert the EditVariable embed
         quill.insertEmbed(
           start + length - 1,
           "EditVariable",
@@ -184,19 +225,29 @@ export const placeEditBolt = (
 
         const cursorPosition = getCursorPosition(quill);
         const isCursorAtPosition = cursorPosition === start + length - 1;
-        // If cursor was at the position, move it after the embed
         if (isCursorAtPosition) {
-          // Use setTimeout to ensure the embed is fully inserted before moving cursor
           setTimeout(() => {
             quill.setSelection(start + length + 100, 0, "placeBlot");
           }, 0);
         }
+      } else {
+        // {% %} block match: insert the embed after the first occurrence only
+        quill.insertEmbed(
+          start + length,
+          "EditVariable",
+          { openVariableEditor, fromBlock: true },
+          "placeBlot",
+        );
       }
     }
 
+    // Format the variable name text — for {{ }} embeds the } was replaced so use length - 1
+    const fmtLength =
+      !variable && showEditEmbed && !fromBlock ? length - 1 : length;
+
     quill.formatText(
       start,
-      variable ? length : showEditEmbed ? length - 1 : length,
+      fmtLength,
       {
         color: variable
           ? "var(--mention-valid-color)"
@@ -206,7 +257,7 @@ export const placeEditBolt = (
           : "var(--mention-invalid-bg)",
         bold: true,
       },
-      "placeBlot", // Use 'api' to prevent recursive triggers
+      "placeBlot",
     );
   });
 };
@@ -222,12 +273,14 @@ export const handleRemoveEditVariable = (quill) => {
 
   let index = 0;
 
-  // First remove all existing EditVariable embeds and add back }
+  // First remove all existing EditVariable embeds and restore } for {{ }} embeds
   delta.ops.forEach((op) => {
     if (op.insert && typeof op.insert === "object" && op.insert.EditVariable) {
       quill.deleteText(index, 1, "placeBlot");
-      quill.insertText(index, "}", "placeBlot");
-      index += 1;
+      if (!op.insert.EditVariable.fromBlock) {
+        quill.insertText(index, "}", "placeBlot");
+        index += 1;
+      }
     } else if (typeof op.insert === "string") {
       index += op.insert.length;
     } else {
@@ -464,7 +517,9 @@ export const getBlocks = (quill) => {
       op.insert.EditVariable
     ) {
       stringAbrupt = false;
-      lastString += "}";
+      if (!op.insert.EditVariable.fromBlock) {
+        lastString += "}";
+      }
     } else if (
       op.insert &&
       typeof op.insert === "object" &&

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/PromptNodeForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/PromptNodeForm.jsx
@@ -27,7 +27,8 @@ import { PORT_DIRECTION } from "../../../utils/constants";
 
 export default function PromptNodeForm({ nodeId }) {
   const queryClient = useQueryClient();
-  const { handleSubmit } = useFormContext();
+  const { handleSubmit, watch, setValue } = useFormContext();
+  const templateFormat = watch("templateFormat") || "mustache";
   const {
     control,
     modelConfig,
@@ -108,7 +109,7 @@ export default function PromptNodeForm({ nodeId }) {
         disabled={isUnsupportedOutputFormat}
       />
 
-      {/* Output Type and Tools Row */}
+      {/* Output Type, Tools, and Template Format Row */}
       <OutputToolsRow
         control={control}
         isModelSelected={isModelSelected}
@@ -117,6 +118,8 @@ export default function PromptNodeForm({ nodeId }) {
         modelConfig={modelConfig}
         onToolsApply={handleToolsApply}
         disabled={isUnsupportedOutputFormat}
+        templateFormat={templateFormat}
+        onTemplateFormatChange={(v) => setValue("templateFormat", v, { shouldDirty: true })}
       />
 
       {/* Model Parameters Popover */}
@@ -148,6 +151,7 @@ export default function PromptNodeForm({ nodeId }) {
           dropdownOptions={dropdownOptions}
           mentionEnabled
           variableValidator={validateVariable}
+          jinjaMode={templateFormat === "jinja"}
         />
       </Box>
 
@@ -198,6 +202,7 @@ export default function PromptNodeForm({ nodeId }) {
                 version: data.version,
                 prompt_version_id: data.prompt_version_id,
                 prompt_template_id: data.prompt_template_id,
+                templateFormat: data.templateFormat || "mustache",
                 modelConfig: data.modelConfig,
                 messages: data.messages,
                 payload,

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
@@ -92,6 +92,7 @@ export const getPromptNodeFormSchema = () =>
     prompt_version_id: z.string().nullable().optional().default(null),
     prompt_template_id: z.string().nullable().optional().default(null),
     outputFormat: z.string().optional().default("string"),
+    templateFormat: z.enum(["mustache", "jinja"]).optional().default("mustache"),
     modelConfig: modelConfigSchema,
     messages: z
       .array(getMessageValidationSchema())

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/promptNodeFormUtils.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/promptNodeFormUtils.js
@@ -5,14 +5,27 @@ import {
   KNOWN_FORMAT_VALUES,
 } from "../nodeFormUtils";
 
+import { extractJinjaVariables } from "src/utils/jinjaVariables";
+
 /**
  * Extract variables from content blocks
  * @param {Array} content - Array of content blocks
+ * @param {string} [templateFormat] - "jinja" for Jinja2 AST extraction, otherwise regex
  * @returns {Array} Array of variable names found in the content
  */
-export const extractVariablesFromContent = (content) => {
+export const extractVariablesFromContent = (content, templateFormat) => {
   if (!Array.isArray(content)) return [];
 
+  if (templateFormat === "jinja") {
+    // Collect all text, then use Jinja2 AST extraction
+    const allText = content
+      .filter((block) => block.type === "text" && block.text)
+      .map((block) => block.text)
+      .join("\n");
+    return extractJinjaVariables(allText);
+  }
+
+  // Default: mustache {{ }} regex
   const variables = new Set();
   const variablePattern = /{{\s*([^{}]+?)\s*}}/g;
 
@@ -95,6 +108,7 @@ export function buildPromptNodePayload(
     ...sliderValues,
     responseFormat: resolvedFormat,
     reasoning,
+    template_format: formData.templateFormat || "mustache",
   };
 
   // Build payload matching workbench format
@@ -169,6 +183,7 @@ export function buildPatchPayload(nodeUpdate, config) {
       tools: promptPayloadConfig?.tools || cfg.modelConfig?.tools || [],
       tool_choice:
         promptPayloadConfig?.tool_choice || cfg.modelConfig?.toolChoice || "",
+      template_format: promptPayloadConfig?.template_format || cfg.templateFormat || "mustache",
       save_prompt_version: false,
     };
   }
@@ -204,6 +219,7 @@ export function mapPatchResponseToStoreData(response) {
     storeData.config = {
       prompt_template_id: pt.prompt_template_id,
       prompt_version_id: pt.prompt_version_id,
+      templateFormat: pt.template_format || "mustache",
       modelConfig: {
         model: pt.model || "",
         modelDetail: pt.model_detail || {},
@@ -231,6 +247,7 @@ export function mapPatchResponseToStoreData(response) {
               presencePenalty: pt.presence_penalty,
               tools: pt.tools || [],
               toolChoice: pt.tool_choice || "auto",
+              template_format: pt.template_format || "mustache",
             },
           },
         ],

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/promptNodeFormUtils.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/promptNodeFormUtils.js
@@ -247,6 +247,8 @@ export function mapPatchResponseToStoreData(response) {
               presencePenalty: pt.presence_penalty,
               tools: pt.tools || [],
               toolChoice: pt.tool_choice || "auto",
+              // Intentionally snake_case — mirrors API contract shape;
+              // read by buildPatchPayload and getDefaultValues via configuration.template_format
               template_format: pt.template_format || "mustache",
             },
           },

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/nodeFormUtils.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/nodeFormUtils.js
@@ -96,6 +96,11 @@ export function getDefaultValues(nodeData) {
           mergedConfig.payload?.promptConfig?.[0]?.configuration
             ?.outputFormat ||
           "string",
+        templateFormat:
+          mergedConfig.templateFormat ||
+          mergedConfig.payload?.promptConfig?.[0]?.configuration
+            ?.template_format ||
+          "mustache",
         modelConfig: mergedConfig.modelConfig || PROMPT_DEFAULT_MODEL_CONFIG,
         messages: mergedConfig.messages || [
           {
@@ -117,6 +122,7 @@ export function getDefaultValues(nodeData) {
       prompt_version_id: null,
       prompt_template_id: null,
       outputFormat: "string",
+      templateFormat: "mustache",
       modelConfig: PROMPT_DEFAULT_MODEL_CONFIG,
       messages: [
         {
@@ -194,6 +200,7 @@ export function mapNodeDetailToNodeData(apiNode, existingNode) {
         prompt_template_id: pt.promptTemplateId,
         prompt_version_id: pt.promptVersionId,
         outputFormat: pt.outputFormat || "string",
+        templateFormat: pt.templateFormat || pt.template_format || "mustache",
         modelConfig: {
           model: pt.model || "",
           modelDetail:

--- a/frontend/src/sections/agent-playground/components/OutputToolsRow.jsx
+++ b/frontend/src/sections/agent-playground/components/OutputToolsRow.jsx
@@ -4,6 +4,7 @@ import { Stack } from "@mui/material";
 import CustomModelTools from "src/components/custom-model-tools";
 import CustomTooltip from "src/components/tooltip";
 import ResponseFormatDropdown from "./ResponseFormatDropdown";
+import TemplateFormatSelector from "src/sections/workbench/createPrompt/Playground/TemplateFormatSelector";
 
 export default function OutputToolsRow({
   control,
@@ -13,6 +14,8 @@ export default function OutputToolsRow({
   modelConfig,
   onToolsApply,
   disabled,
+  templateFormat = "mustache",
+  onTemplateFormatChange,
 }) {
   const tooltipProps = {
     show: !isModelSelected,
@@ -52,6 +55,11 @@ export default function OutputToolsRow({
           />
         </span>
       </CustomTooltip>
+      <TemplateFormatSelector
+        value={templateFormat}
+        onChange={onTemplateFormatChange}
+        disabled={disabled}
+      />
     </Stack>
   );
 }
@@ -64,4 +72,6 @@ OutputToolsRow.propTypes = {
   modelConfig: PropTypes.object,
   onToolsApply: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  templateFormat: PropTypes.string,
+  onTemplateFormatChange: PropTypes.func,
 };

--- a/frontend/src/sections/agent-playground/components/PromptMessageRow.jsx
+++ b/frontend/src/sections/agent-playground/components/PromptMessageRow.jsx
@@ -45,6 +45,7 @@ const SortablePromptCard = ({
   dropdownOptions,
   mentionEnabled,
   variableValidator,
+  jinjaMode = false,
 }) => {
   const {
     attributes,
@@ -110,6 +111,7 @@ const SortablePromptCard = ({
                 mentionEnabled={mentionEnabled}
                 variableValidator={variableValidator}
                 allVariablesValid={!variableValidator}
+                jinjaMode={jinjaMode}
               />
               {
                 // @ts-ignore
@@ -158,6 +160,7 @@ export default function PromptMessageRow({
   dropdownOptions = [],
   mentionEnabled = false,
   variableValidator,
+  jinjaMode = false,
 }) {
   const theme = useTheme();
   const { formState } = useFormContext();
@@ -356,6 +359,7 @@ export default function PromptMessageRow({
               dropdownOptions={dropdownOptions}
               mentionEnabled={mentionEnabled}
               variableValidator={variableValidator}
+              jinjaMode={jinjaMode}
             />
           ))}
         </SortableContext>

--- a/frontend/src/sections/agent-playground/components/PromptMessageRow.jsx
+++ b/frontend/src/sections/agent-playground/components/PromptMessageRow.jsx
@@ -150,6 +150,7 @@ SortablePromptCard.propTypes = {
   dropdownOptions: PropTypes.array,
   mentionEnabled: PropTypes.bool,
   variableValidator: PropTypes.func,
+  jinjaMode: PropTypes.bool,
 };
 
 export default function PromptMessageRow({
@@ -498,4 +499,5 @@ PromptMessageRow.propTypes = {
   dropdownOptions: PropTypes.array,
   mentionEnabled: PropTypes.bool,
   variableValidator: PropTypes.func,
+  jinjaMode: PropTypes.bool,
 };

--- a/frontend/src/sections/develop-detail/RunPrompt/PromptTemplatesSection.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/PromptTemplatesSection.jsx
@@ -12,6 +12,7 @@ import {
 } from "./common";
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
 import { useDevelopDetailContext } from "src/pages/dashboard/Develop/Context/DevelopDetailContext";
+import TemplateFormatSelector from "src/sections/workbench/createPrompt/Playground/TemplateFormatSelector";
 
 const PromptTemplatesSection = ({
   control,
@@ -65,9 +66,19 @@ const PromptTemplatesSection = ({
     clearErrors(`config.messages[${index}].content`);
   };
 
+  const templateFormat = watch("config.template_format") || "mustache";
+
   const existingRoles = messages.map((p) => p?.role);
   return (
     <Box sx={{ gap: "16px", display: "flex", flexDirection: "column" }}>
+      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+        <TemplateFormatSelector
+          value={templateFormat}
+          onChange={(v) =>
+            setValue("config.template_format", v, { shouldDirty: true })
+          }
+        />
+      </Box>
       {/* {fields.map(({ id }, index) => (
             <PromptSection
               key={id}
@@ -127,6 +138,7 @@ const PromptTemplatesSection = ({
               allowRoleChange: true,
             }}
             existingRoles={existingRoles}
+            jinjaMode={templateFormat === "jinja"}
           />
           {errors?.config?.messages?.[_idx]?.content?.message && (
             <Typography

--- a/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
@@ -13,6 +13,7 @@ import {
   Stack,
 } from "@mui/material";
 import CustomTooltip from "src/components/tooltip";
+import { extractJinjaVariables } from "src/utils/jinjaVariables";
 import PropTypes from "prop-types";
 import React, {
   useImperativeHandle,
@@ -443,24 +444,43 @@ export const RunPromptForm = React.forwardRef(
     const userChangedModelRef = useRef(false);
     // Track which model the current modelParameters state belongs to
     const modelParametersModelRef = useRef(watchedModel);
+    const watchedTemplateFormat = watch("config.template_format");
 
-    watchedMessages?.forEach((message) => {
-      if (!message) return;
-      const content = message.content;
-      if (Array.isArray(content)) {
-        content.forEach((part) => {
-          if (part.type === "text" && part.text) {
-            const invalids = findInvalidVariables(
-              part.text,
-              allColumns,
-              jsonSchemas,
-              derivedVariables,
-            );
-            allInvalidVariables.push(...invalids);
-          }
-        });
-      }
-    });
+    if (watchedTemplateFormat === "jinja") {
+      // Jinja mode: use AST extraction to find real input variables,
+      // then validate those against dataset columns.
+      const allText = (watchedMessages || [])
+        .flatMap((m) => m?.content || [])
+        .filter((c) => c?.type === "text" && c?.text)
+        .map((c) => c.text)
+        .join("\n");
+      const jinjaVars = extractJinjaVariables(allText);
+      const normalize = (s) => (s || "").toLowerCase();
+      jinjaVars.forEach((v) => {
+        const isValid = allColumns?.some(
+          (col) => normalize(col?.headerName) === normalize(v),
+        );
+        if (!isValid) allInvalidVariables.push(v);
+      });
+    } else {
+      watchedMessages?.forEach((message) => {
+        if (!message) return;
+        const content = message.content;
+        if (Array.isArray(content)) {
+          content.forEach((part) => {
+            if (part.type === "text" && part.text) {
+              const invalids = findInvalidVariables(
+                part.text,
+                allColumns,
+                jsonSchemas,
+                derivedVariables,
+              );
+              allInvalidVariables.push(...invalids);
+            }
+          });
+        }
+      });
+    }
 
     const validateForm = async () => {
       try {
@@ -843,6 +863,8 @@ export const RunPromptForm = React.forwardRef(
         ? originalResponseFormat
         : getResponseFormat(originalResponseFormat); // fallback
 
+      const isJinja = data?.config?.template_format === "jinja";
+
       buildRunPromptConfig(data, modelParameters, reasoningState, modelType);
 
       const configEntries = {
@@ -853,27 +875,38 @@ export const RunPromptForm = React.forwardRef(
           let content = rest.content;
 
           if (Array.isArray(content)) {
-            content = content.map((part) => {
-              if (part.type === "text" && part.text) {
-                let updatedText = sanitizeContent(part.text);
+            if (isJinja) {
+              // Jinja mode: sanitize text but skip per-{{ }} variable replacement.
+              // Variable validation is done below via extractJinjaVariables.
+              content = content.map((part) => {
+                if (part.type === "text" && part.text) {
+                  return { ...part, text: sanitizeContent(part.text) };
+                }
+                return part;
+              });
+            } else {
+              content = content.map((part) => {
+                if (part.type === "text" && part.text) {
+                  let updatedText = sanitizeContent(part.text);
 
-                // Extract all variables in the format {{ variable }}
-                const variablePattern = /{{\s*([^{}]+?)\s*}}/g;
-                const matches = [...updatedText.matchAll(variablePattern)];
+                  // Extract all variables in the format {{ variable }}
+                  const variablePattern = /{{\s*([^{}]+?)\s*}}/g;
+                  const matches = [...updatedText.matchAll(variablePattern)];
 
-                const result = replaceVariablesWithFields(
-                  updatedText,
-                  matches,
-                  allColumns,
-                  jsonSchemas,
-                );
-                updatedText = result.text;
-                inValidVariables.push(...result.invalidVariables);
+                  const result = replaceVariablesWithFields(
+                    updatedText,
+                    matches,
+                    allColumns,
+                    jsonSchemas,
+                  );
+                  updatedText = result.text;
+                  inValidVariables.push(...result.invalidVariables);
 
-                return { ...part, text: updatedText };
-              }
-              return part;
-            });
+                  return { ...part, text: updatedText };
+                }
+                return part;
+              });
+            }
           }
 
           return {
@@ -882,6 +915,24 @@ export const RunPromptForm = React.forwardRef(
           };
         }),
       };
+
+      // In Jinja mode, validate input variables (from AST) against dataset columns
+      if (isJinja) {
+        const allText = configEntries.messages
+          .flatMap((m) => m.content)
+          .filter((c) => c.type === "text" && c.text)
+          .map((c) => c.text)
+          .join("\n");
+        const jinjaVars = extractJinjaVariables(allText);
+        const columnNames = allColumns.map((c) =>
+          (c.headerName || "").toLowerCase(),
+        );
+        jinjaVars.forEach((v) => {
+          if (!columnNames.includes(v.toLowerCase())) {
+            inValidVariables.push(v);
+          }
+        });
+      }
 
       // Rename camelCase config keys to snake_case for the API
       const camelToSnakeMap = {

--- a/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/RunPrompt.jsx
@@ -924,7 +924,7 @@ export const RunPromptForm = React.forwardRef(
           .map((c) => c.text)
           .join("\n");
         const jinjaVars = extractJinjaVariables(allText);
-        const columnNames = allColumns.map((c) =>
+        const columnNames = (allColumns || []).map((c) =>
           (c.headerName || "").toLowerCase(),
         );
         jinjaVars.forEach((v) => {

--- a/frontend/src/sections/develop-detail/RunPrompt/common.js
+++ b/frontend/src/sections/develop-detail/RunPrompt/common.js
@@ -220,6 +220,7 @@ export const transformDefaultData = (editConfigData, allColumns) => {
       // maxTokens: editConfigData?.maxTokens,
       // presencePenalty: editConfigData?.presencePenalty,
       // frequencyPenalty: editConfigData?.frequencyPenalty,
+      template_format: runPromptConfig?.template_format || "mustache",
       prompt: "",
       promptVersion: "",
       // toolChoice: editConfigData?.toolChoice || "none",

--- a/frontend/src/sections/prompt/NewPrompt/AddNewPrompt.jsx
+++ b/frontend/src/sections/prompt/NewPrompt/AddNewPrompt.jsx
@@ -8,6 +8,7 @@ import { useLocation, useNavigate } from "react-router";
 import { useParams } from "src/routes/hooks";
 import { enqueueSnackbar } from "notistack";
 import { trackEvent, Events, PropertyName } from "src/utils/Mixpanel";
+import { extractJinjaVariables } from "src/utils/jinjaVariables";
 
 import Results from "./PromptGenerate/Results";
 import Workbench from "./PromptGenerate/Workbench";
@@ -22,6 +23,7 @@ const transformToPayload = (
   isRunTemplate,
   appliedVariableData,
   currentTitle,
+  templateFormat,
 ) => {
   const configuration = {
     temperature: modelData?.temperature || 0.7,
@@ -33,6 +35,7 @@ const transformToPayload = (
     response_format: modelData?.responseFormat || "text",
     tool_choice: modelData?.toolChoice === "none" ? "" : modelData?.toolChoice,
     tools: modelData?.tools || [],
+    template_format: templateFormat || "mustache",
   };
 
   const messages = checkVal.map((item) => {
@@ -74,6 +77,7 @@ const AddNewPromptView = () => {
   const location = useLocation();
   const [modelData, setModelData] = useState({});
   const [extractedVars, setExtractedVars] = useState([]);
+  const [templateFormat, setTemplateFormat] = useState("mustache");
   const debounceTimeout = useRef(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [titles, setTitles] = useState([]);
@@ -231,6 +235,7 @@ const AddNewPromptView = () => {
         isRun,
         appliedVariableData,
         currentTitle,
+        templateFormat,
       );
       trackEvent(Events.runPromptInitiated, {
         [PropertyName.formFields]: payload,
@@ -358,9 +363,13 @@ const AddNewPromptView = () => {
 
     for (const item of content) {
       if (item.type === "text") {
-        const match = item.text.match(/{{(.*?)}}/g);
-        if (match) {
-          variables.push(...match.map((v) => v.replace(/{{|}}/g, "").trim()));
+        if (templateFormat === "jinja") {
+          variables.push(...extractJinjaVariables(item.text));
+        } else {
+          const match = item.text.match(/{{(.*?)}}/g);
+          if (match) {
+            variables.push(...match.map((v) => v.replace(/{{|}}/g, "").trim()));
+          }
         }
       }
     }
@@ -393,6 +402,9 @@ const AddNewPromptView = () => {
       setCurrentTitle(currentResult?.name);
       setEvalsConfigs(currentResult?.evaluationConfigs ?? []);
       setModelData(currentResult?.promptConfig[0]?.configuration);
+      const savedFormat =
+        currentResult?.promptConfig[0]?.configuration?.template_format;
+      setTemplateFormat(savedFormat || "mustache");
       updateVersionList();
       if (
         JSON.stringify(appliedVariableData) !==
@@ -427,7 +439,7 @@ const AddNewPromptView = () => {
 
     return () => clearTimeout(debounceTimeout.current);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(checkVal)]);
+  }, [JSON.stringify(checkVal), templateFormat]);
 
   useEffect(() => {
     const newEvalsConfigs = versionList[versionIndex]?.evaluationConfigs;
@@ -518,6 +530,8 @@ const AddNewPromptView = () => {
             ? versions?.data?.data?.count + 1
             : versions?.data?.data?.count
         }
+        templateFormat={templateFormat}
+        setTemplateFormat={setTemplateFormat}
       />
       <Box sx={{ display: "flex", height: "calc(100% - 55px)", pb: "17px" }}>
         <Workbench

--- a/frontend/src/sections/prompt/NewPrompt/Menubar/RightMenu.jsx
+++ b/frontend/src/sections/prompt/NewPrompt/Menubar/RightMenu.jsx
@@ -17,6 +17,7 @@ import {
 import { useSnackbar } from "notistack";
 import React, { useMemo, useRef, useState } from "react";
 import Iconify from "src/components/iconify";
+import TemplateFormatSelector from "src/sections/workbench/createPrompt/Playground/TemplateFormatSelector";
 import RunEvaluation from "src/sections/develop-detail/Evaluation/RunEvaluation";
 import PropTypes from "prop-types";
 import { action } from "src/theme/palette";
@@ -43,6 +44,8 @@ const RightMenu = ({
   setVersionList,
   total,
   currentTitle,
+  templateFormat,
+  setTemplateFormat,
 }) => {
   const { enqueueSnackbar } = useSnackbar();
   const gridApiRef = useRef(null);
@@ -243,6 +246,11 @@ const RightMenu = ({
         flexItem
       />
 
+      <TemplateFormatSelector
+        value={templateFormat}
+        onChange={setTemplateFormat}
+      />
+
       <Box sx={{ display: "flex", alignItems: "center", gap: "4px" }}>
         {ICON_BTNS.map(({ label, icon, color }) => (
           <Tooltip key={label} title={label} placement="bottom" arrow>
@@ -424,4 +432,6 @@ RightMenu.propTypes = {
   setVersionIndex: PropTypes.func,
   total: PropTypes.number,
   currentTitle: PropTypes.string,
+  templateFormat: PropTypes.string,
+  setTemplateFormat: PropTypes.func,
 };

--- a/frontend/src/sections/prompt/NewPrompt/TopMenu.jsx
+++ b/frontend/src/sections/prompt/NewPrompt/TopMenu.jsx
@@ -31,6 +31,8 @@ const TopMenu = ({
   titles,
   setTitles,
   total,
+  templateFormat,
+  setTemplateFormat,
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   // const [titles, setTitles] = useState([]);
@@ -102,6 +104,8 @@ const TopMenu = ({
         setVersionList={setVersionList}
         total={total}
         currentTitle={currentTitle}
+        templateFormat={templateFormat}
+        setTemplateFormat={setTemplateFormat}
       />
     </Box>
   );
@@ -133,4 +137,6 @@ TopMenu.propTypes = {
   titles: PropTypes.array,
   setTitles: PropTypes.func,
   total: PropTypes.number,
+  templateFormat: PropTypes.string,
+  setTemplateFormat: PropTypes.func,
 };

--- a/frontend/src/sections/workbench/createPrompt/Compare/CompareContainer.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Compare/CompareContainer.jsx
@@ -21,6 +21,7 @@ const CompareContainer = () => {
     isImportDatasetDrawerOpen,
     setImportDatasetDrawerOpen,
     setVariableData,
+    templateFormat,
   } = usePromptWorkbenchContext();
 
   const handleOpenDrawer = () => {
@@ -33,7 +34,7 @@ const CompareContainer = () => {
     setVariableDrawerOpen(true);
   };
 
-  const variables = useExtractAllVariables(prompts);
+  const variables = useExtractAllVariables(prompts, templateFormat);
 
   return (
     <Box

--- a/frontend/src/sections/workbench/createPrompt/Compare/CompareInputSection.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Compare/CompareInputSection.jsx
@@ -69,6 +69,7 @@ const CompareInputSection = ({
     setStreamingIdForVersion,
     pushStoppedIds,
     closeSocketByIndex,
+    templateFormat,
   } = usePromptWorkbenchContext();
 
   const timeoutRef = useRef(null);
@@ -144,6 +145,7 @@ const CompareInputSection = ({
   const isVariablesDefined = useIsVariablesDefined(
     currentPrompts,
     variableData,
+    templateFormat,
   );
 
   let buttonTooltip = null;

--- a/frontend/src/sections/workbench/createPrompt/Playground.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Playground.jsx
@@ -30,6 +30,7 @@ const Playground = () => {
     setImportDatasetDrawerOpen,
     setVariableData,
     setPlaceholdersByIndex,
+    templateFormat,
   } = usePromptWorkbenchContext();
 
   const {
@@ -54,7 +55,7 @@ const Playground = () => {
     setVariableDrawerOpen(true);
   };
 
-  const variables = useExtractAllVariables(prompts);
+  const variables = useExtractAllVariables(prompts, templateFormat);
 
   return (
     <Box

--- a/frontend/src/sections/workbench/createPrompt/Playground/ModelContainer.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Playground/ModelContainer.jsx
@@ -24,6 +24,7 @@ import logger from "src/utils/logger";
 import { useModelParams } from "src/api/develop/prompt";
 import { useVoiceOptions } from "src/api/develop/develop-detail";
 import ResponseFormatSelector from "./ResponseFormatSelector";
+import TemplateFormatSelector from "./TemplateFormatSelector";
 import { ShowComponent } from "../../../../components/show";
 
 const modelTypeByValueType = {
@@ -48,7 +49,8 @@ const ModelContainer = ({
 }) => {
   const theme = useTheme();
   const { id } = useParams();
-  const { selectedVersions } = usePromptWorkbenchContext();
+  const { selectedVersions, templateFormat, setTemplateFormat } =
+    usePromptWorkbenchContext();
   const { role: userRole } = useAuthContext();
   const modelContainerRef = useRef(null);
   const { setSelectTemplateDrawerOpen, setSelectedPromptIndex } =
@@ -403,6 +405,11 @@ const ModelContainer = ({
             }
           />
         </ShowComponent>
+        <TemplateFormatSelector
+          value={templateFormat}
+          onChange={setTemplateFormat}
+          disabled={!RolePermission.PROMPTS[PERMISSIONS.DELETE][userRole]}
+        />
       </Box>
     </React.Fragment>
   );

--- a/frontend/src/sections/workbench/createPrompt/Playground/PromptSection.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Playground/PromptSection.jsx
@@ -54,6 +54,7 @@ const SortablePromptCard = ({
   onImprovePrompt,
   existingRoles,
   allowAttachment = false,
+  jinjaMode = false,
 }) => {
   const {
     attributes,
@@ -117,6 +118,7 @@ const SortablePromptCard = ({
         }}
         hideExpandedHeader
         showEditEmbed
+        jinjaMode={jinjaMode}
       />
     </Box>
   );
@@ -168,6 +170,7 @@ const PromptSection = ({
     loadingPrompt,
     openSelectModel,
     setOpenSelectModel,
+    templateFormat,
   } = usePromptWorkbenchContext();
 
   const [openGeneratePromptDrawer, setOpenGeneratePromptDrawer] = useState({
@@ -413,6 +416,7 @@ const PromptSection = ({
                     }
                     existingRoles={existingRoles}
                     allowAttachment={isChatModel}
+                    jinjaMode={templateFormat === "jinja"}
                   />
                 );
               })}

--- a/frontend/src/sections/workbench/createPrompt/Playground/PromptSection.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Playground/PromptSection.jsx
@@ -142,6 +142,7 @@ SortablePromptCard.propTypes = {
   onImprovePrompt: PropTypes.func,
   existingRoles: PropTypes.array,
   allowAttachment: PropTypes.bool,
+  jinjaMode: PropTypes.bool,
 };
 
 const PromptSection = ({
@@ -550,6 +551,7 @@ PromptSection.propTypes = {
   syncSystemPrompt: PropTypes.func,
   placeholders: PropTypes.array,
   setPlaceholders: PropTypes.func,
+  jinjaMode: PropTypes.bool,
 };
 
 export default PromptSection;

--- a/frontend/src/sections/workbench/createPrompt/Playground/TemplateFormatSelector.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Playground/TemplateFormatSelector.jsx
@@ -1,0 +1,139 @@
+import React, { useState } from "react";
+import { Box, MenuItem, Popover, Typography } from "@mui/material";
+import Iconify from "src/components/iconify";
+import PropTypes from "prop-types";
+
+const TEMPLATE_FORMATS = [
+  {
+    value: "mustache",
+    label: "Mustache",
+    icon: "{{x}}",
+    description: "{{variable}}, {{obj.key}}",
+  },
+  {
+    value: "jinja",
+    label: "Jinja",
+    icon: "{% %}",
+    description: "{{ variable }}, {% if %}, {% for %}",
+  },
+];
+
+const TemplateFormatSelector = ({ value, onChange, disabled }) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+  const selected = TEMPLATE_FORMATS.find((f) => f.value === value);
+
+  return (
+    <>
+      <Box
+        onClick={(e) => !disabled && setAnchorEl(e.currentTarget)}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 0.75,
+          padding: "4px 10px",
+          border: "1px solid",
+          borderColor: "border.default",
+          borderRadius: "4px",
+          cursor: disabled ? "not-allowed" : "pointer",
+          opacity: disabled ? 0.5 : 1,
+          bgcolor: open ? "action.hover" : "transparent",
+          flexShrink: 0,
+          "&:hover": {
+            bgcolor: disabled ? "transparent" : "action.hover",
+          },
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: "13px",
+            fontWeight: 700,
+            fontFamily: "monospace",
+            color: "text.secondary",
+            lineHeight: 1,
+          }}
+        >
+          {selected?.icon || "{{x}}"}
+        </Typography>
+        <Typography
+          variant="s2"
+          fontWeight="fontWeightMedium"
+          color="text.primary"
+          sx={{ whiteSpace: "nowrap" }}
+        >
+          {selected?.label || "Mustache"}
+        </Typography>
+        <Iconify
+          icon="eva:chevron-down-fill"
+          width={16}
+          height={16}
+          sx={{
+            color: "text.secondary",
+            transform: open ? "rotate(180deg)" : "none",
+            transition: "transform 0.2s",
+          }}
+        />
+      </Box>
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+        slotProps={{
+          paper: {
+            sx: { borderRadius: "8px", p: 0.5, minWidth: 220, mt: 0.5 },
+          },
+        }}
+      >
+        {TEMPLATE_FORMATS.map((fmt) => (
+          <MenuItem
+            key={fmt.value}
+            selected={value === fmt.value}
+            onClick={() => {
+              onChange(fmt.value);
+              setAnchorEl(null);
+            }}
+            sx={{ borderRadius: "6px", py: 1, gap: 1.5 }}
+          >
+            <Typography
+              sx={{
+                fontSize: "14px",
+                fontWeight: 700,
+                fontFamily: "monospace",
+                width: 40,
+                textAlign: "center",
+                color: value === fmt.value ? "primary.main" : "text.secondary",
+              }}
+            >
+              {fmt.icon}
+            </Typography>
+            <Box>
+              <Typography
+                variant="body2"
+                sx={{ fontSize: "13px", fontWeight: 600 }}
+              >
+                {fmt.label}
+              </Typography>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ fontSize: "11px" }}
+              >
+                {fmt.description}
+              </Typography>
+            </Box>
+          </MenuItem>
+        ))}
+      </Popover>
+    </>
+  );
+};
+
+TemplateFormatSelector.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+export default TemplateFormatSelector;

--- a/frontend/src/sections/workbench/createPrompt/Playground/TemplateFormatSelector.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Playground/TemplateFormatSelector.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Box, MenuItem, Popover, Typography } from "@mui/material";
+import { ButtonBase, MenuItem, Popover, Typography, Box } from "@mui/material";
 import Iconify from "src/components/iconify";
 import PropTypes from "prop-types";
 
@@ -25,8 +25,11 @@ const TemplateFormatSelector = ({ value, onChange, disabled }) => {
 
   return (
     <>
-      <Box
-        onClick={(e) => !disabled && setAnchorEl(e.currentTarget)}
+      <ButtonBase
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={(e) => setAnchorEl(e.currentTarget)}
         sx={{
           display: "flex",
           alignItems: "center",
@@ -73,7 +76,7 @@ const TemplateFormatSelector = ({ value, onChange, disabled }) => {
             transition: "transform 0.2s",
           }}
         />
-      </Box>
+      </ButtonBase>
       <Popover
         open={open}
         anchorEl={anchorEl}

--- a/frontend/src/sections/workbench/createPrompt/Playground/common.js
+++ b/frontend/src/sections/workbench/createPrompt/Playground/common.js
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import { getReasoningFormValues } from "src/sections/develop-detail/RunPrompt/common";
+import { extractJinjaVariables } from "src/utils/jinjaVariables";
 
 // Helper function to normalize for comparison only
 export const normalizeForComparison = (variable) => {
@@ -9,7 +10,7 @@ export const normalizeForComparison = (variable) => {
     .trim(); // Remove leading/trailing spaces
 };
 
-export const extractVariables = (content) => {
+export const extractVariables = (content, templateFormat) => {
   if (!Array.isArray(content) || content?.length === 0) {
     return [];
   }
@@ -19,20 +20,30 @@ export const extractVariables = (content) => {
 
   for (const item of content) {
     if (item.type === "text") {
-      const match = item.text.match(/{{(.*?)}}/g);
-      if (match) {
-        match
-          .map((v) => v.replace(/{{|}}/g, "").trim())
-          .filter((v) => v.length > 0)
-          .forEach((v) => {
-            const normalized = normalizeForComparison(v);
-            if (normalized.length > 0) {
-              // Store original value, but use normalized as key to avoid duplicates
-              if (!variableMap.has(normalized)) {
-                variableMap.set(normalized, v); // Store the first occurrence (original formatting)
+      if (templateFormat === "jinja") {
+        // Jinja2 AST-based extraction (excludes loop/set scoped vars)
+        extractJinjaVariables(item.text).forEach((v) => {
+          const normalized = normalizeForComparison(v);
+          if (normalized.length > 0 && !variableMap.has(normalized)) {
+            variableMap.set(normalized, v);
+          }
+        });
+      } else {
+        const match = item.text.match(/{{(.*?)}}/g);
+        if (match) {
+          match
+            .map((v) => v.replace(/{{|}}/g, "").trim())
+            .filter((v) => v.length > 0)
+            .forEach((v) => {
+              const normalized = normalizeForComparison(v);
+              if (normalized.length > 0) {
+                // Store original value, but use normalized as key to avoid duplicates
+                if (!variableMap.has(normalized)) {
+                  variableMap.set(normalized, v); // Store the first occurrence (original formatting)
+                }
               }
-            }
-          });
+            });
+        }
       }
     }
   }

--- a/frontend/src/sections/workbench/createPrompt/WorkbenchContext.js
+++ b/frontend/src/sections/workbench/createPrompt/WorkbenchContext.js
@@ -68,6 +68,8 @@ export const PromptWorkbenchContext = React.createContext({
   setPlaceholders: (value) => {},
   submitPlaceholders: () => {},
   setModelConfig: (_val) => {},
+  templateFormat: "mustache",
+  setTemplateFormat: (_val) => {},
 });
 
 export const usePromptWorkbenchContext = () => {

--- a/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
+++ b/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
@@ -1334,7 +1334,7 @@ const WorkbenchProvider = ({ children }) => {
 
       saveAndDraftAll(saveDraftIndexes);
     },
-    [saveAndDraftAll, setVariableData, prompts],
+    [saveAndDraftAll, setVariableData, prompts, templateFormat],
   );
 
   const setPlaceholdersDataModified = useCallback(

--- a/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
+++ b/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
@@ -557,9 +557,7 @@ const WorkbenchProvider = ({ children }) => {
         ...normalizeConfigurationForLoad(data?.prompt_config?.[0]?.configuration),
       });
       const savedFormat = data?.prompt_config?.[0]?.configuration?.template_format;
-      if (savedFormat) {
-        setTemplateFormat(savedFormat);
-      }
+      setTemplateFormat(savedFormat || "mustache");
     }
     if (data?.output?.length && !results?.[0]?.output?.length) {
       setResultsByIndex(0, {

--- a/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
+++ b/frontend/src/sections/workbench/createPrompt/WorkbenchProvider.jsx
@@ -84,6 +84,7 @@ const WorkbenchProvider = ({ children }) => {
   const [promptName, setPromptName] = useState("");
   const [openSelectModel, setOpenSelectModel] = useState(null);
   const [valuesChanged, setValuesChanged] = useState(false);
+  const [templateFormat, setTemplateFormat] = useState("mustache");
   const stoppedIds = useRef([]);
   const runningVersionIndexMapping = useRef({});
   const activeSocketsRef = useRef({});
@@ -555,6 +556,10 @@ const WorkbenchProvider = ({ children }) => {
         ...modelConfigDefault,
         ...normalizeConfigurationForLoad(data?.prompt_config?.[0]?.configuration),
       });
+      const savedFormat = data?.prompt_config?.[0]?.configuration?.template_format;
+      if (savedFormat) {
+        setTemplateFormat(savedFormat);
+      }
     }
     if (data?.output?.length && !results?.[0]?.output?.length) {
       setResultsByIndex(0, {
@@ -720,6 +725,7 @@ const WorkbenchProvider = ({ children }) => {
       const configuration = normalizeConfigurationForSave(currentConfig);
       configuration["tool_choice"] =
         currentConfig?.tools?.length > 0 ? "auto" : "";
+      configuration["template_format"] = templateFormat || "mustache";
 
       const selectedVersion = selectedVersions[index];
 
@@ -732,7 +738,7 @@ const WorkbenchProvider = ({ children }) => {
         return acc;
       }, {});
 
-      const finalVariables = getVariables(currentPrompts, variableData);
+      const finalVariables = getVariables(currentPrompts, variableData, templateFormat);
 
       const sanitizedMessages = currentPrompts?.map(({ id, ...rest }) => {
         return {
@@ -777,6 +783,7 @@ const WorkbenchProvider = ({ children }) => {
       variableData,
       placeholders,
       placeholderData,
+      templateFormat,
     ],
   );
 
@@ -1010,6 +1017,14 @@ const WorkbenchProvider = ({ children }) => {
       setSelectedVersions,
     ],
   );
+
+  // Auto-save when user changes template format (skip initial load from API).
+  const templateFormatUserChanged = useRef(false);
+  useEffect(() => {
+    if (!templateFormatUserChanged.current) return;
+    saveAndDraftAll();
+    templateFormatUserChanged.current = false;
+  }, [templateFormat]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onRestoreVersion = (version) => {
     setSelectedVersionByIndex(0, (prev) => {
@@ -1308,7 +1323,7 @@ const WorkbenchProvider = ({ children }) => {
       setVariableData(...v);
       const saveDraftIndexes = prompts.reduce(
         (acc, { prompts: currentPrompts }, i) => {
-          const finalVariables = getVariables(currentPrompts, v[0]);
+          const finalVariables = getVariables(currentPrompts, v[0], templateFormat);
           if (Object.keys(finalVariables).length) {
             acc.push(i);
           }
@@ -1416,6 +1431,11 @@ const WorkbenchProvider = ({ children }) => {
         pushStoppedIds,
         closeSocketByIndex,
         setModelConfig,
+        templateFormat,
+        setTemplateFormat: (v) => {
+          templateFormatUserChanged.current = true;
+          setTemplateFormat(v);
+        },
       }}
     >
       {children}

--- a/frontend/src/sections/workbench/createPrompt/common.js
+++ b/frontend/src/sections/workbench/createPrompt/common.js
@@ -7,14 +7,14 @@ export const dataTypeMapping = {
   choices: "array",
 };
 
-export const getVariables = (currentPrompts, variableData) => {
+export const getVariables = (currentPrompts, variableData, templateFormat) => {
   const extractedVariables = Array.from(
     new Set(
       currentPrompts.reduce((acc, { content, role }) => {
         if (role === PromptRoles.ASSISTANT) {
           return acc;
         }
-        return [...acc, ...extractVariables(content)];
+        return [...acc, ...extractVariables(content, templateFormat)];
       }, []),
     ),
   );

--- a/frontend/src/sections/workbench/createPrompt/hooks/use-extract-all-variables.jsx
+++ b/frontend/src/sections/workbench/createPrompt/hooks/use-extract-all-variables.jsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 
 import { extractVariables, normalizeForComparison } from "../Playground/common";
 
-export const useExtractAllVariables = (prompts) => {
+export const useExtractAllVariables = (prompts, templateFormat) => {
   // Use memoization to avoid re-running this expensive operation unless prompts change
   return useMemo(() => {
     // Use Map to store unique variables while preserving original formatting
@@ -19,7 +19,7 @@ export const useExtractAllVariables = (prompts) => {
         // }
         // Combine existing variables with newly extracted ones
         // extractVariables finds all text within {{ }} in the content
-        return [...acc, ...extractVariables(content)];
+        return [...acc, ...extractVariables(content, templateFormat)];
       }, []);
 
       // Process each extracted variable
@@ -36,5 +36,5 @@ export const useExtractAllVariables = (prompts) => {
 
     // Convert Map values to array, giving us deduplicated variables with original formatting
     return Array.from(variableMap.values());
-  }, [prompts]);
+  }, [prompts, templateFormat]);
 };

--- a/frontend/src/sections/workbench/createPrompt/hooks/use-is-variables-defined.jsx
+++ b/frontend/src/sections/workbench/createPrompt/hooks/use-is-variables-defined.jsx
@@ -3,8 +3,8 @@ import { useMemo } from "react";
 import { useExtractAllVariables } from "./use-extract-all-variables";
 import { normalizeForComparison } from "../Playground/common";
 
-export const useIsVariablesDefined = (prompts, variableData) => {
-  const variables = useExtractAllVariables(prompts);
+export const useIsVariablesDefined = (prompts, variableData, templateFormat) => {
+  const variables = useExtractAllVariables(prompts, templateFormat);
 
   return useMemo(() => {
     // Create a Set of normalized keys for fast lookup

--- a/frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx
+++ b/frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx
@@ -86,6 +86,7 @@ const PromptActions = () => {
     closeSocketByIndex,
     results,
     reset,
+    templateFormat,
     // placeholders,
     // placeholderData,
   } = usePromptWorkbenchContext();
@@ -139,7 +140,7 @@ const PromptActions = () => {
   //   filledPlaceholderLabels.includes(label),
   // );
 
-  const isVariablesDefined = useIsVariablesDefined(prompts, variableData);
+  const isVariablesDefined = useIsVariablesDefined(prompts, variableData, templateFormat);
 
   const isSingleVersion = selectedVersions.length === 1;
 

--- a/frontend/src/utils/jinjaVariables.js
+++ b/frontend/src/utils/jinjaVariables.js
@@ -5,7 +5,7 @@
  * variables are external inputs vs loop-scoped, set-scoped, or built-in.
  * This mirrors the backend's jinja2.meta.find_undeclared_variables().
  */
-import * as nunjucks from "nunjucks";
+import nunjucks from "nunjucks";
 
 /**
  * Extract top-level input variable names from a Jinja2 template string.

--- a/futureagi/agent_playground/serializers/node.py
+++ b/futureagi/agent_playground/serializers/node.py
@@ -95,6 +95,7 @@ class NodeReadSerializer(serializers.ModelSerializer):
             "tools": cfg.get("tools", snapshot.get("tools")),
             "tool_choice": cfg.get("tool_choice", snapshot.get("tool_choice")),
             "model_detail": cfg.get("model_detail", snapshot.get("model_detail")),
+            "template_format": cfg.get("template_format", "mustache"),
             "variable_names": pv.variable_names,
             "metadata": pv.metadata,
             "is_draft": pv.is_draft,
@@ -345,6 +346,10 @@ class PromptTemplateDataSerializer(serializers.Serializer):
     metadata = serializers.DictField(required=False, allow_null=True, default=None)
     commit_message = serializers.CharField(
         required=False, allow_null=True, allow_blank=True, default=None
+    )
+    template_format = serializers.CharField(
+        required=False, allow_null=True, allow_blank=True, default=None,
+        help_text="Template format: 'mustache' or 'jinja'",
     )
     save_prompt_version = serializers.BooleanField(required=False, default=False)
 

--- a/futureagi/agent_playground/services/engine/runners/llm_prompt.py
+++ b/futureagi/agent_playground/services/engine/runners/llm_prompt.py
@@ -215,20 +215,25 @@ class LLMPromptRunner(BaseNodeRunner):
             # Resolve all input variables, then render through Jinja2
             from model_hub.views.run_prompt import render_template, TEMPLATE_FORMAT_JINJA2
 
-            # Build context by resolving each input variable
+            # Build context by resolving each input variable.
+            # Dot-notation keys (e.g. "Node1.response") must be nested into
+            # dicts so Jinja2 attribute lookup ({{ Node1.response }}) works.
             context = {}
             for key, value in inputs.items():
                 resolved = value
                 if isinstance(resolved, str):
-                    # Try parsing JSON strings into native types for Jinja2 iteration
-                    import json as _json
                     try:
-                        parsed = _json.loads(resolved)
+                        parsed = json.loads(resolved)
                         if isinstance(parsed, (list, dict)):
                             resolved = parsed
                     except (ValueError, TypeError):
                         pass
-                context[key] = resolved
+                # Nest dot-notation keys: "Node1.response" -> context["Node1"]["response"]
+                parts = key.split(".")
+                target = context
+                for part in parts[:-1]:
+                    target = target.setdefault(part, {})
+                target[parts[-1]] = resolved
 
             return render_template(text, context, TEMPLATE_FORMAT_JINJA2)
 

--- a/futureagi/agent_playground/services/engine/runners/llm_prompt.py
+++ b/futureagi/agent_playground/services/engine/runners/llm_prompt.py
@@ -99,7 +99,8 @@ class LLMPromptRunner(BaseNodeRunner):
             raise ValueError("PromptVersion configuration missing 'model'")
 
         messages = prompt_config.get("messages", [])
-        rendered_messages = self._render_messages(messages, inputs, model)
+        template_format = configuration.get("template_format")
+        rendered_messages = self._render_messages(messages, inputs, model, template_format)
 
         # Extract tool configs
         tools = configuration.get("tools", [])
@@ -136,6 +137,7 @@ class LLMPromptRunner(BaseNodeRunner):
         messages: list[dict[str, Any]],
         inputs: dict[str, Any],
         model: str,
+        template_format: str | None = None,
     ) -> list[dict[str, Any]]:
         """
         Render messages by replacing {{variable}} placeholders and processing media.
@@ -147,6 +149,7 @@ class LLMPromptRunner(BaseNodeRunner):
             messages: Messages from prompt_config_snapshot
             inputs: Input port values for variable resolution
             model: Model name (needed for media capability checks)
+            template_format: "jinja" for Jinja2 rendering, otherwise regex replacement
 
         Returns:
             List of rendered messages ready for RunPrompt
@@ -168,7 +171,7 @@ class LLMPromptRunner(BaseNodeRunner):
 
                     if item["type"] == "text":
                         text = item.get("text", "")
-                        text = self._replace_placeholders(text, inputs)
+                        text = self._replace_placeholders(text, inputs, template_format)
                         processed_content.append({"type": "text", "text": text})
                     else:
                         # Non-text items (image_url, audio_url, pdf_url)
@@ -179,7 +182,7 @@ class LLMPromptRunner(BaseNodeRunner):
                             processed_content.append(item)
 
             elif isinstance(content, str):
-                text = self._replace_placeholders(content, inputs)
+                text = self._replace_placeholders(content, inputs, template_format)
                 processed_content.append({"type": "text", "text": text})
 
             rendered.append({"role": message["role"], "content": processed_content})
@@ -190,12 +193,17 @@ class LLMPromptRunner(BaseNodeRunner):
         self,
         text: str,
         inputs: dict[str, Any],
+        template_format: str | None = None,
     ) -> str:
         """Replace {{variable}} placeholders in text using resolve_variable.
 
+        For Jinja2 mode, resolves all variables first then renders through
+        the Jinja2 engine so {% if %}, {% for %}, filters, etc. work.
+
         Args:
-            text: Text containing {{variable}} placeholders
+            text: Text containing {{variable}} or Jinja2 placeholders
             inputs: Input port values for variable resolution
+            template_format: "jinja" for Jinja2 rendering, otherwise regex replacement
 
         Returns:
             Text with all resolvable placeholders replaced
@@ -203,6 +211,28 @@ class LLMPromptRunner(BaseNodeRunner):
         if not text:
             return text
 
+        if template_format in ("jinja", "jinja2"):
+            # Resolve all input variables, then render through Jinja2
+            from model_hub.views.run_prompt import render_template, TEMPLATE_FORMAT_JINJA2
+
+            # Build context by resolving each input variable
+            context = {}
+            for key, value in inputs.items():
+                resolved = value
+                if isinstance(resolved, str):
+                    # Try parsing JSON strings into native types for Jinja2 iteration
+                    import json as _json
+                    try:
+                        parsed = _json.loads(resolved)
+                        if isinstance(parsed, (list, dict)):
+                            resolved = parsed
+                    except (ValueError, TypeError):
+                        pass
+                context[key] = resolved
+
+            return render_template(text, context, TEMPLATE_FORMAT_JINJA2)
+
+        # Default: regex-based placeholder replacement
         def replacer(match: re.Match) -> str:
             variable_str = match.group("placeholder").strip()
             try:

--- a/futureagi/agent_playground/services/node_crud.py
+++ b/futureagi/agent_playground/services/node_crud.py
@@ -422,7 +422,8 @@ def _resolve_or_create_pt_ptv(
 
     # Build variable_names dict from messages (model_hub convention)
     messages = prompt_data.get("messages", [])
-    var_names = _extract_variables(messages)
+    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    var_names = _extract_variables(messages, template_format=_tf)
     var_names_dict = prompt_data.get("variable_names") or {v: [] for v in var_names}
     pv_metadata = prompt_data.get("metadata") or {}
 
@@ -515,7 +516,8 @@ def _handle_ptv_lifecycle_on_update(
 
     # Build variable_names and metadata from prompt_data
     messages = prompt_data.get("messages", [])
-    var_names = _extract_variables(messages)
+    _tf = snapshot.get("configuration", {}).get("template_format")
+    var_names = _extract_variables(messages, template_format=_tf)
     var_names_dict = prompt_data.get("variable_names") or {v: [] for v in var_names}
     pv_metadata = prompt_data.get("metadata") or {}
     commit_message = prompt_data.get("commit_message") or ""
@@ -616,7 +618,8 @@ def _reconcile_prompt_ports(node: Node, prompt_data: dict[str, Any]) -> None:
     """
     now = timezone.now()
     messages = prompt_data.get("messages", [])
-    new_vars = _extract_variables(messages)
+    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    new_vars = _extract_variables(messages, template_format=_tf)
 
     existing_input_ports = list(
         Port.no_workspace_objects.filter(node=node, direction=PortDirection.INPUT)
@@ -672,7 +675,8 @@ def _reconcile_prompt_ports(node: Node, prompt_data: dict[str, Any]) -> None:
 def _create_ports_from_prompt(node: Node, prompt_data: dict[str, Any]) -> None:
     """Create ports for an LLM prompt node from its messages."""
     messages = prompt_data.get("messages", [])
-    variables = _extract_variables(messages)
+    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    variables = _extract_variables(messages, template_format=_tf)
 
     # Input ports for each variable
     for var in variables:
@@ -697,9 +701,10 @@ def _create_ports_from_prompt(node: Node, prompt_data: dict[str, Any]) -> None:
 
 
 def _create_input_ports_from_prompt(node: Node, prompt_data: dict[str, Any]) -> None:
-    """Create input ports for an LLM prompt node from {{variables}} in messages."""
+    """Create input ports for an LLM prompt node from variables in messages."""
     messages = prompt_data.get("messages", [])
-    variables = _extract_variables(messages)
+    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    variables = _extract_variables(messages, template_format=_tf)
 
     for var in variables:
         Port(
@@ -1074,8 +1079,12 @@ def _replace_output_ports(node: Node, ports_data: list[dict]) -> None:
     _create_ports_from_fe_array(node, ports_data)
 
 
-def _extract_variables(messages: list[dict]) -> list[str]:
-    """Extract unique {{variable}} names from message contents, preserving order.
+def _extract_variables(messages: list[dict], template_format: str | None = None) -> list[str]:
+    """Extract unique variable names from message contents, preserving order.
+
+    When template_format is "jinja" or "jinja2", uses Jinja2 AST analysis to
+    correctly identify input variables (excluding loop/set scoped vars).
+    Otherwise falls back to {{variable}} regex matching.
 
     Handles new message format where content is an array of content items:
     [{
@@ -1086,6 +1095,24 @@ def _extract_variables(messages: list[dict]) -> list[str]:
         ]
     }]
     """
+    use_jinja = template_format in ("jinja", "jinja2")
+
+    if use_jinja:
+        from model_hub.utils.jinja_variables import extract_jinja_variables
+
+        # Collect all text from messages, then do a single AST parse
+        all_text = []
+        for msg in messages:
+            content = msg.get("content", [])
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        all_text.append(item.get("text", ""))
+            elif isinstance(content, str):
+                all_text.append(content)
+        return extract_jinja_variables("\n".join(all_text))
+
+    # Default: mustache {{ }} regex
     seen: set[str] = set()
     result: list[str] = []
     for msg in messages:
@@ -1165,6 +1192,7 @@ def _build_prompt_config_snapshot(prompt_data: dict[str, Any]) -> dict[str, Any]
         "tools",
         "tool_choice",
         "model_detail",
+        "template_format",
     )
     for key in _CONFIG_KEYS:
         value = prompt_data.get(key)
@@ -1176,7 +1204,8 @@ def _build_prompt_config_snapshot(prompt_data: dict[str, Any]) -> dict[str, Any]
 
     # Build variable_names dict for the snapshot (model_hub convention)
     messages = prompt_data.get("messages", [])
-    var_names = _extract_variables(messages)
+    _tf = configuration.get("template_format")
+    var_names = _extract_variables(messages, template_format=_tf)
     var_names_dict = prompt_data.get("variable_names") or {v: [] for v in var_names}
 
     return {

--- a/futureagi/ai_tools/tools/prompts/run_prompt.py
+++ b/futureagi/ai_tools/tools/prompts/run_prompt.py
@@ -175,7 +175,8 @@ class RunPromptTool(BaseTool):
         # as the WebSocket path (run_template_async)
         prompt_messages = config.get("messages", []).copy()
         messages_with_replacement = replace_variables(
-            prompt_messages, variable_combination, model
+            prompt_messages, variable_combination, model,
+            template_format=config.get("configuration", {}).get("template_format"),
         )
         messages_with_replacement = remove_empty_text_from_messages(
             messages_with_replacement

--- a/futureagi/model_hub/services/prompt_service.py
+++ b/futureagi/model_hub/services/prompt_service.py
@@ -114,21 +114,43 @@ def _normalize_prompt_config(prompt_config):
 
 
 def _extract_variables(prompt_config):
-    """Extract {{variable}} names from prompt config messages."""
+    """Extract {{variable}} names from prompt config messages.
+
+    When template_format is "jinja", delegates to the Jinja2 AST-based extractor
+    so that loop-scoped / set-scoped variables are correctly excluded.
+    """
     variables = set()
     if not prompt_config or not isinstance(prompt_config, list):
         return list(variables)
+
+    # Determine template_format from the first config entry
+    template_format = None
+    if prompt_config:
+        template_format = (
+            prompt_config[0].get("configuration", {}).get("template_format")
+        )
+
+    use_jinja = template_format in ("jinja", "jinja2")
+
     for cfg in prompt_config:
         messages = cfg.get("messages", [])
         for msg in messages:
             content = msg.get("content", "")
+            texts = []
             if isinstance(content, list):
                 for part in content:
                     if isinstance(part, dict) and part.get("type") == "text":
-                        content_text = part.get("text", "")
-                        variables.update(re.findall(r"\{\{(\w+)\}\}", content_text))
+                        texts.append(part.get("text", ""))
             elif isinstance(content, str):
-                variables.update(re.findall(r"\{\{(\w+)\}\}", content))
+                texts.append(content)
+
+            if use_jinja:
+                from model_hub.utils.jinja_variables import extract_jinja_variables
+            for text in texts:
+                if use_jinja:
+                    variables.update(extract_jinja_variables(text))
+                else:
+                    variables.update(re.findall(r"\{\{(\w+)\}\}", text))
     return sorted(variables)
 
 

--- a/futureagi/model_hub/utils/async_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_prompt_runner.py
@@ -87,6 +87,7 @@ async def run_template_async(
                     prompt_messages,
                     variable_combination,
                     config.get("configuration", {}).get("model"),
+                    template_format=config.get("configuration", {}).get("template_format"),
                 )
                 messages_with_replacement = remove_empty_text_from_messages(
                     messages_with_replacement

--- a/futureagi/model_hub/views/dynamic_columns.py
+++ b/futureagi/model_hub/views/dynamic_columns.py
@@ -1406,6 +1406,7 @@ class ConditionalColumnView(APIView):
                     row_id=row.id,
                     col_id=None,
                     model_name=config.get("model"),
+                    template_format=config.get("configuration", {}).get("template_format"),
                 )
                 messages = remove_empty_text_from_messages(messages)
                 executor = RunPrompt(

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -396,12 +396,14 @@ def _resolve_prompt_chain_from_run_prompter(runner, row):
             return None
 
         col_id = runner.column.id if runner.column else None
+        rp_config = getattr(runner.run_prompter, "run_prompt_config", {}) or {}
         populated_messages = populate_placeholders(
             messages,
             runner.dataset.id,
             row.id,
             col_id,
             model_name="",
+            template_format=rp_config.get("template_format"),
         )
 
         return _format_messages_to_prompt_chain(populated_messages)
@@ -498,12 +500,17 @@ def _resolve_special_value(value, row, runner):
             from model_hub.views.run_prompt import populate_placeholders
 
             col_id = runner.column.id if runner.column else None
+            # Extract template_format from experiment prompt config if available
+            tf = None
+            if epc and hasattr(epc, "configuration"):
+                tf = (epc.configuration or {}).get("template_format")
             populated_messages = populate_placeholders(
                 messages,
                 runner.dataset.id,
                 row.id,
                 col_id,
                 model_name="",
+                template_format=tf,
             )
 
             return _format_messages_to_prompt_chain(populated_messages)

--- a/futureagi/model_hub/views/experiment_runner.py
+++ b/futureagi/model_hub/views/experiment_runner.py
@@ -1290,7 +1290,8 @@ class ExperimentRunner:
 
             try:
                 messages = populate_placeholders(
-                    messages, self.dataset.id, row.id, column.id, model_name=model
+                    messages, self.dataset.id, row.id, column.id, model_name=model,
+                    template_format=model_config.get("template_format"),
                 )
                 if output_format != "audio":
                     messages = remove_empty_text_from_messages(messages)
@@ -1562,7 +1563,8 @@ def _process_row_impl(
 
         try:
             messages = populate_placeholders(
-                messages, dataset_id, row_id, column_id, model_name=model
+                messages, dataset_id, row_id, column_id, model_name=model,
+                template_format=model_config.get("template_format"),
             )
             if output_format != "audio":
                 messages = remove_empty_text_from_messages(messages)

--- a/futureagi/model_hub/views/prompt_template.py
+++ b/futureagi/model_hub/views/prompt_template.py
@@ -272,7 +272,7 @@ def handle_media(item: dict, model_name: str):
 
 
 def replace_variables(
-    messages: list[dict], variable_names: dict, model_name: str
+    messages: list[dict], variable_names: dict, model_name: str, template_format: str = None
 ) -> list[dict]:
     """
     Replace variables in message content with their corresponding values.
@@ -280,12 +280,45 @@ def replace_variables(
     Args:
         messages (List[dict]): List of message dictionaries with 'role' and 'content'
         variable_names (dict): Dictionary of variable names and their values
+        model_name (str): The model name (for media handling)
+        template_format (str): "jinja" to use Jinja2 engine, otherwise simple replacement.
 
     Returns:
         List[dict]: Messages with variables replaced in content
     """
-    # if not variable_names:
-    #     return messages
+    from model_hub.views.run_prompt import render_template, TEMPLATE_FORMAT_JINJA2
+
+    use_jinja = template_format in ("jinja", "jinja2")
+
+    if use_jinja:
+        # Parse JSON strings into native types so Jinja2 can iterate/access them.
+        # e.g. '["a","b"]' becomes a real list, '{"k":"v"}' becomes a real dict.
+        import json as _json
+
+        jinja_context = {}
+        for k, v in variable_names.items():
+            if isinstance(v, str):
+                try:
+                    parsed = _json.loads(v)
+                    if isinstance(parsed, (list, dict)):
+                        jinja_context[k] = parsed
+                    else:
+                        jinja_context[k] = v
+                except (ValueError, TypeError):
+                    jinja_context[k] = v
+            else:
+                jinja_context[k] = v
+    else:
+        jinja_context = None
+
+    def _render(text):
+        if use_jinja:
+            return render_template(text, jinja_context, TEMPLATE_FORMAT_JINJA2)
+        # Default: simple placeholder replacement (original behaviour)
+        for var_name, var_value in variable_names.items():
+            placeholder = f"{{{{{var_name}}}}}"
+            text = text.replace(placeholder, str(var_value))
+        return text
 
     processed_messages = []
     for message in messages:
@@ -301,27 +334,14 @@ def replace_variables(
                     )
 
                 if item["type"] == "text":
-                    text = item["text"]
-                    for var_name, var_value in variable_names.items():
-                        placeholder = f"{{{{{var_name}}}}}"
-
-                        text = text.replace(
-                            placeholder, str(var_value)
-                        )  # Replace placeholder
-
+                    text = _render(item["text"])
                     processed_content.append({"type": "text", "text": text})
 
                 else:
                     processed_content.append(handle_media(item, model_name))
 
         elif isinstance(content, str):
-            # Replace variables in string content
-            text = content
-            for var_name, var_value in variable_names.items():
-                placeholder = f"{{{{{var_name}}}}}"
-
-                text = text.replace(placeholder, str(var_value))  # Replace placeholder
-
+            text = _render(content)
             processed_content.append({"type": "text", "text": text})
 
         processed_messages.append(
@@ -641,82 +661,23 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
             serializer = self.get_serializer(instance)
             response = Response(serializer.data)
 
-            if (
-                PromptVersion.objects.filter(
-                    original_template=instance,
-                    original_template__organization=getattr(
-                        self.request, "organization", None
-                    )
-                    or self.request.user.organization,
-                    deleted=False,
-                    is_default=True,
-                )
-                .order_by("-is_default", "-created_at")
-                .exists()
-            ):
-                execution = (
-                    PromptVersion.objects.filter(
-                        original_template=instance,
-                        original_template__organization=getattr(
-                            self.request, "organization", None
-                        )
-                        or self.request.user.organization,
-                        deleted=False,
-                        is_default=True,
-                    )
-                    .order_by("-is_default", "-created_at")
-                    .first()
-                )
-            elif (
-                PromptVersion.objects.filter(
-                    original_template=instance,
-                    original_template__organization=getattr(
-                        self.request, "organization", None
-                    )
-                    or self.request.user.organization,
-                    deleted=False,
-                    is_draft=False,
-                )
-                .order_by("-is_default", "-created_at")
-                .exists()
-            ):
-                execution = (
-                    PromptVersion.objects.filter(
-                        original_template=instance,
-                        original_template__organization=getattr(
-                            self.request, "organization", None
-                        )
-                        or self.request.user.organization,
-                        deleted=False,
-                        is_draft=False,
-                    )
-                    .order_by("-is_default", "-created_at")
-                    .first()
-                )
-            elif (
-                PromptVersion.objects.filter(
-                    original_template=instance,
-                    original_template__organization=getattr(
-                        self.request, "organization", None
-                    )
-                    or self.request.user.organization,
-                    deleted=False,
-                )
-                .order_by("-is_default", "-created_at")
-                .exists()
-            ):
-                execution = (
-                    PromptVersion.objects.filter(
-                        original_template=instance,
-                        original_template__organization=getattr(
-                            self.request, "organization", None
-                        )
-                        or self.request.user.organization,
-                        deleted=False,
-                    )
-                    .order_by("-is_default", "-created_at")
-                    .first()
-                )
+            # Prioritize draft versions — they contain the latest unsaved edits
+            # (e.g. template_format changes) that haven't been committed yet.
+            org = getattr(self.request, "organization", None) or self.request.user.organization
+            base_qs = PromptVersion.objects.filter(
+                original_template=instance,
+                original_template__organization=org,
+                deleted=False,
+            )
+            draft_execution = base_qs.filter(is_draft=True).order_by("-created_at").first()
+            if draft_execution:
+                execution = draft_execution
+            elif base_qs.filter(is_default=True).exists():
+                execution = base_qs.filter(is_default=True).order_by("-is_default", "-created_at").first()
+            elif base_qs.filter(is_draft=False).exists():
+                execution = base_qs.filter(is_draft=False).order_by("-is_default", "-created_at").first()
+            elif base_qs.exists():
+                execution = base_qs.order_by("-is_default", "-created_at").first()
             else:
                 dummy_data = {
                     "name": "",
@@ -1892,6 +1853,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                         prompt_messages,
                         variable_combination,
                         config.get("configuration", {}).get("model"),
+                        template_format=config.get("configuration", {}).get("template_format"),
                     )
                     messages_with_replacement = remove_empty_text_from_messages(
                         messages_with_replacement
@@ -2905,6 +2867,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 config.get("messages"),
                 variable_combination,
                 model_name=config.get("configuration", {}).get("model"),
+                template_format=config.get("configuration", {}).get("template_format"),
             )
             response = (
                 execution.output[i]

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -321,7 +321,7 @@ class JsonStr(dict):
         return self._raw
 
 
-def populate_placeholders(messages: list[dict], dataset_id, row_id, col_id, model_name):
+def populate_placeholders(messages: list[dict], dataset_id, row_id, col_id, model_name, template_format=None):
     try:
         media_error = None
         # Debug: Log input messages to see what template we're processing
@@ -374,6 +374,10 @@ def populate_placeholders(messages: list[dict], dataset_id, row_id, col_id, mode
                         parsed_json, is_valid = parse_json_safely(cell_value)
                         if is_valid and isinstance(parsed_json, dict):
                             cell_value = JsonStr(parsed_json, cell_value)
+                        elif is_valid and isinstance(parsed_json, list) and template_format in ("jinja", "jinja2"):
+                            # Only parse lists for Jinja mode ({% for %} iteration).
+                            # Mustache/default mode keeps the raw JSON string.
+                            cell_value = parsed_json
 
                     # Create nested objects
                     for i, part in enumerate(parts):
@@ -425,6 +429,7 @@ def populate_placeholders(messages: list[dict], dataset_id, row_id, col_id, mode
                         context,
                         image_counter,
                         model_name,
+                        template_format=template_format,
                     )
                 elif isinstance(content, str):
                     processed_content = process_string_content(
@@ -433,6 +438,7 @@ def populate_placeholders(messages: list[dict], dataset_id, row_id, col_id, mode
                         context,
                         image_counter,
                         model_name,
+                        template_format=template_format,
                     )
 
                 # If no content was processed, keep original
@@ -461,7 +467,7 @@ def populate_placeholders(messages: list[dict], dataset_id, row_id, col_id, mode
             return messages
 
 
-def process_list_content(content, column_info, context, image_counter, model_name):
+def process_list_content(content, column_info, context, image_counter, model_name, template_format=None):
     """Process list-type content with proper media handling"""
     processed_content = []
 
@@ -474,6 +480,7 @@ def process_list_content(content, column_info, context, image_counter, model_nam
                 context,
                 image_counter,
                 model_name,
+                template_format=template_format,
             )
             processed_content.extend(text_segments)
         else:
@@ -488,14 +495,14 @@ def process_list_content(content, column_info, context, image_counter, model_nam
     return processed_content
 
 
-def process_string_content(content, column_info, context, image_counter, model_name):
+def process_string_content(content, column_info, context, image_counter, model_name, template_format=None):
     """Process string-type content with proper media handling"""
     return process_text_with_media(
-        content, column_info, context, image_counter, model_name
+        content, column_info, context, image_counter, model_name, template_format=template_format
     )
 
 
-def process_text_with_media(text, column_info, context, image_counter, model_name):
+def process_text_with_media(text, column_info, context, image_counter, model_name, template_format=None):
     """Process text content, handling both templates and media placeholders"""
     try:
         # Get the text and fix doubled-up quotes
@@ -605,9 +612,13 @@ def process_text_with_media(text, column_info, context, image_counter, model_nam
         text = sanitize_uuids_in_template(text)
         logger.debug(f"Template after UUID sanitization: {text[:500]}")
 
-        # Render template using multi-format renderer (default: jinja2)
+        # Render template using multi-format renderer
+        # Map frontend format names to backend constants
+        effective_format = template_format
+        if effective_format == "jinja":
+            effective_format = TEMPLATE_FORMAT_JINJA2
         try:
-            processed_text = render_template(text, context)
+            processed_text = render_template(text, context, template_format=effective_format)
         except Exception as render_error:
             logger.exception(
                 f"Template rendering failed: {render_error}. Template: {text[:200]}..."
@@ -1192,6 +1203,7 @@ class RunPrompts:
                     row_id=row.id,
                     col_id=column.id,
                     model_name=self.run_prompt_model.model,
+                    template_format=(self.run_prompt_model.run_prompt_config or {}).get("template_format"),
                 )
                 messages = remove_empty_text_from_messages(messages)
                 logger.info(


### PR DESCRIPTION
## Summary

  Adds Jinja2 template format support alongside the existing Mustache (`{{ }}`) syntax across the prompt editor, agent playground, run prompt, and backend
  rendering pipeline. Users can now toggle between Mustache and Jinja via a `TemplateFormatSelector` dropdown, enabling `{% if %}`, `{% for %}`, and other
  Jinja2 constructs. The backend uses `SandboxedEnvironment` for safe Jinja2 rendering and AST-based variable extraction (via nunjucks on frontend, jinja2 on
  backend). All paths default to `"mustache"` so existing prompts are unaffected.

  Also includes a query optimization in the `PromptTemplateViewSet.retrieve` endpoint — consolidates 6 redundant queries into a single `base_qs` with
  prioritized filtering (draft → default → committed → any).

  ## Linked issues

  Closes #TH-4656

  ## Type of change

  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [x] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📖 Documentation only
  - [ ] 🧹 Chore / refactor (no user-visible change)
  - [x] 🚀 Performance improvement
  - [ ] 🧪 Test-only change

  ## How was this tested?

  - Toggled between Mustache and Jinja in the workbench — variables extracted and highlighted correctly in both modes
  - Verified `{{ var }}` embeds still work identically in Mustache mode (no regression)
  - Verified `{% for item in items %}` / `{% if %}` blocks parse correctly and surface `items` as an input variable
  - Tested with malformed Jinja templates — graceful fallback (no crash, returns empty variable list)
  - Confirmed `template_format` persists across save/load/version-switch in workbench, new prompt, and agent playground
  - Confirmed backend renders Jinja templates with variable substitution (including JSON list/dict iteration)
  - Verified older prompts without `template_format` default to Mustache with no behavior change

  ## Screenshots / recordings (if UI)

  <!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

  ## Checklist

  - [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
  - [ ] I've added tests that prove my fix is effective or that my feature works
  - [ ] `make check-all` / `yarn check-all` passes locally
  - [ ] I've updated the documentation where relevant
  - [x] No hardcoded secrets, URLs, or PII
  - [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)