### PR TITLE
fix(frontend): treat 404 on /usage/v2/deployment-info/ as OSS mode

### DIFF
--- a/frontend/src/hooks/useDeploymentMode.js
+++ b/frontend/src/hooks/useDeploymentMode.js
@@ -14,10 +14,23 @@ import axios, { endpoints } from "src/utils/axios";
 export function useDeploymentMode() {
   const { data, isLoading } = useQuery({
     queryKey: ["deployment-info"],
-    queryFn: () => axios.get(endpoints.settings.v2.deploymentInfo),
+    queryFn: async () => {
+      try {
+        return await axios.get(endpoints.settings.v2.deploymentInfo);
+      } catch (err) {
+        // OSS builds without the ee/usage module don't register
+        // /usage/v2/deployment-info/. Treat 404 as "we're on OSS" instead
+        // of letting the error bubble — every consumer of this hook would
+        // otherwise re-mount in a tight loop, causing visible UI flicker.
+        if (err?.response?.status === 404) {
+          return { data: { result: { mode: "oss" } } };
+        }
+        throw err;
+      }
+    },
     select: (res) => res.data?.result?.mode || "oss",
     staleTime: Infinity,
-    retry: 1,
+    retry: false,
   });
 
   const mode = data || "oss";


### PR DESCRIPTION
Closes #165

## Summary
- \`useDeploymentMode\` calls \`/usage/v2/deployment-info/\` to detect OSS / EE / Cloud mode. The endpoint is owned by \`ee.usage\`, only loaded when \`ee/\` is present (\`tfc/settings.py\`'s \`has_ee(\"ee.usage\")\` guard). On OSS builds the URL is unregistered, every call 404s, the hook never resolves, and every consumer (\`config-navigation\`, \`CreditExhaustionBanner\`, every \`EvalCreatePage\` / \`AgentBasicInfoStep\` / etc.) sees \`isLoading: true\` indefinitely. Conditional renders flip, components remount, the dashboard flickers visibly, and the network panel shows \`/usage/v2/deployment-info/\` firing ~50×/min.
- This patch makes the hook tolerant of the missing endpoint: 404 → return a synthetic \`{ result: { mode: \"oss\" } }\` payload (a missing endpoint *is* the OSS signal), and \`retry: false\` so the query resolves once and stays stable. Other error shapes (5xx, network) continue to propagate so real outages remain visible.
- A more architecturally complete fix is to register a stub \`/usage/v2/deployment-info/\` route in OSS that returns the same payload — recommended as a follow-up; the issue (#165) describes that path. This frontend patch is a defensive contract that holds either way.

## Files
- \`frontend/src/hooks/useDeploymentMode.js\` — wrap \`queryFn\` with try/catch; swallow 404 and return the OSS shape; flip \`retry\` from \`1\` to \`false\`.

## Repro
1. Fresh \`git clone\`, \`cp .env.example .env\`, fill the four CHANGEME values, \`docker compose up -d\`.
2. Sign up, log in, navigate around any dashboard page.
3. **Before**: DevTools network shows \`/usage/v2/deployment-info/\` returning 404 ~50×/min while the page visibly flickers as components remount.
4. **After**: the request fires once, the 404 is swallowed, the hook resolves to \`mode: \"oss\"\`, and the UI is stable.

## Test plan
- [ ] OSS smoke (default \`.env\`) — page loads stable, no flicker, no repeated 404 on \`/usage/v2/deployment-info/\`.
- [ ] Mock the endpoint to return 500 (or unplug the backend) — verify the hook still surfaces the error to consumers (no regression on real-outage detection).
- [ ] EE smoke (with \`ee/\` present) — endpoint returns 200 \`{result: {mode: \"ee\"}}\`, hook returns \"ee\", EE-only menu items visible. No regression.
- [ ] React Query devtools — confirm exactly one fetch per query key invalidation, no retry storms.

## Related
Fifth first-boot bug for self-hosted OSS, alongside:
- #121 — \`tracer\` migration conflict (already on \`dev\`).
- #155 / #152 — frontend reCAPTCHA gate ignores \`RECAPTCHA_ENABLED=false\`.
- #156 / #157 — \`EMAIL_BACKEND\` hardcoded to Mailgun.
- #159 — workspace-add fails when invite-email send fails (transactional coupling).