### PR TITLE
fix(scenarios): surface 402 plan-gate error on scenario create

### DIFF
--- a/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -467,13 +467,9 @@ const CreateScenarioView = () => {
     // @ts-ignore
     try {
       const data = await mutateAsync(payload);
-      navigate(`/dashboard/simulate/scenarios/${data?.data?.scenario?.id}`, {
-        replace: true,
-      });
+      navigate(`/dashboard/simulate/scenarios/${data?.data?.scenario?.id}`);
     } catch (error) {
-      const message =
-        error?.error || error?.message || "Failed to create scenario";
-      enqueueSnackbar(message, { variant: "error" });
+      enqueueSnackbar(error?.message, { variant: "error" });
       return;
     }
   };

--- a/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -467,9 +467,13 @@ const CreateScenarioView = () => {
     // @ts-ignore
     try {
       const data = await mutateAsync(payload);
-      navigate(`/dashboard/simulate/scenarios/${data?.data?.scenario?.id}`);
+      navigate(`/dashboard/simulate/scenarios/${data?.data?.scenario?.id}`, {
+        replace: true,
+      });
     } catch (error) {
-      enqueueSnackbar(error?.message, { variant: "error" });
+      const message =
+        error?.error || error?.message || "Failed to create scenario";
+      enqueueSnackbar(message, { variant: "error" });
       return;
     }
   };

--- a/futureagi/simulate/views/scenarios.py
+++ b/futureagi/simulate/views/scenarios.py
@@ -304,12 +304,12 @@ class CreateScenarioView(APIView):
         """
         Create a new scenario by copying the specified dataset
         """
+        from tfc.ee_gating import EEFeature, check_ee_feature
+
+        org = getattr(request, "organization", None) or request.user.organization
+        check_ee_feature(EEFeature.SYNTHETIC_DATA, org_id=str(org.id))
+
         try:
-            from tfc.ee_gating import EEFeature, check_ee_feature
-
-            org = getattr(request, "organization", None) or request.user.organization
-            check_ee_feature(EEFeature.SYNTHETIC_DATA, org_id=str(org.id))
-
             serializer = CreateScenarioSerializer(
                 data=request.data, context={"request": request}
             )

--- a/futureagi/simulate/views/scenarios.py
+++ b/futureagi/simulate/views/scenarios.py
@@ -418,9 +418,8 @@ class CreateScenarioView(APIView):
 
         except Exception as e:
             traceback.print_exc()
-            return Response(
-                {"error": f"Failed to create scenario: {str(e)}"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            return self.gm.internal_server_error_response(
+                f"Failed to create scenario: {str(e)}"
             )
 
     def _create_temp_scenario(self, request, validated_data):


### PR DESCRIPTION
The plan gate (`check_ee_feature(EEFeature.SYNTHETIC_DATA, …)`) was inside the `post()` try/except, so `FeatureUnavailable` (a DRF `APIException`, HTTP 402) was caught and re-wrapped as a generic 500 with body `{"error": "Failed to create scenario: …"}`. That bypassed the dedicated 402 handler in `custom_exception_handler` which emits `{"upgrade_required": true, "upgrade_cta": …}`, and the frontend's global upgrade-toast in `axios.js` (which keys off status===402 + upgrade_required) never fired. Result: free-plan users got a silent failure with no UI hint.

Move the gate above the try block so `FeatureUnavailable` bubbles to DRF unchanged. The except now only catches genuine 500-level failures.

Frontend: read `error?.error || error?.message || …` in the create-scenario catch block so any backend error shape surfaces in the snackbar instead of rendering an empty toast (the 500 body used the `error` key, not `message`). Also pass `replace: true` to the post-create navigate so the create-form URL isn't stranded in browser history.

<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
