### PR TITLE
fix: sync gateway docker-compose with inner compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
     build:
       context: ./futureagi/agentcc-gateway
     ports:
-      - "${GATEWAY_PORT:-8090}:8080"
+      - "${GATEWAY_PORT:-8090}:8090"
     env_file:
       - .env
     environment:
@@ -190,10 +190,10 @@ services:
       GEMINI_API_KEY: ${GOOGLE_API_KEY:-}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      GOOGLE_APPLICATION_CREDENTIALS: /app/Vertex_AI_Creds.json
     volumes:
-      # Default to the shipped example config. Override by creating
-      # `futureagi/agentcc-gateway/config.yaml`.
-      - ./futureagi/agentcc-gateway/config.example.yaml:/app/config.yaml:ro
+      - ./futureagi/${AGENTCC_CONFIG_PATH:-agentcc-gateway/config.example.yaml}:/app/config.yaml:ro
+      - ./futureagi/Vertex_AI_Creds.json:/app/Vertex_AI_Creds.json:ro
     restart: unless-stopped
 
   # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Sync the parent-level `docker-compose.yml` gateway service with the inner `futureagi/docker-compose.yml`.

- Fix port mapping: `8090:8090` (gateway listens on 8090, was incorrectly mapped to 8080)
- Use `AGENTCC_CONFIG_PATH` env var for config file override (matches inner compose)
- Add Vertex AI credentials volume mount and env var (missing from outer compose)

## Test plan
- [ ] `docker compose up gateway` — verify gateway starts and listens on 8090
- [ ] Verify config file mounts correctly from `AGENTCC_CONFIG_PATH`