### PR TITLE
fix(annotation-queues): include annotator notes in queue export

### DIFF
--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -498,6 +498,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                             "label_name": ann.label.name if ann.label else None,
                             "value": ann.value,
                             "score_source": ann.score_source,
+                            "notes": ann.notes,
                             "annotator_name": (
                                 ann.annotator.name if ann.annotator else None
                             ),
@@ -531,6 +532,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                     "label_name",
                     "value",
                     "score_source",
+                    "notes",
                     "annotator_name",
                     "created_at",
                 ]
@@ -543,6 +545,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                             item_data["source_type"],
                             item_data["status"],
                             item_data["order"],
+                            "",
                             "",
                             "",
                             "",
@@ -566,6 +569,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                                 else str(ann["value"])
                             ),
                             ann["score_source"],
+                            ann["notes"] or "",
                             ann["annotator_name"],
                             ann["created_at"],
                         ]


### PR DESCRIPTION
The export endpoint was dropping the `notes` field from every Score row, so annotator-provided context never reached downstream consumers of the CSV/JSON export. Add it to both output shapes wired through the shared result dict (used by JSON), the CSV header, and the CSV data + empty-annotation rows so column counts stay aligned.

<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
