### PR TITLE
fix(voice-analytics): show Latency, Silence, TTFW in pure ms

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/CallAnalyticsView.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/CallAnalyticsView.jsx
@@ -10,11 +10,7 @@ import {
   useTheme,
 } from "@mui/material";
 import Iconify from "src/components/iconify";
-import {
-  computeCallMetrics,
-  enrichTurns,
-  formatClock,
-} from "./transcriptUtils";
+import { computeCallMetrics, enrichTurns } from "./transcriptUtils";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Formatting helpers
@@ -28,9 +24,9 @@ const fmtDuration = (seconds) => {
   return `${m}:${String(s).padStart(2, "0")}`;
 };
 
-const fmtMs = (ms) => {
+const fmtMs = (ms, { forceMs = false } = {}) => {
   if (ms == null || !Number.isFinite(ms)) return "—";
-  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  if (!forceMs && ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
   return `${Math.round(ms)}ms`;
 };
 
@@ -184,7 +180,7 @@ const KpiStrip = ({ metrics, apiMetrics }) => {
     { label: "Turns", value: fmtNumber(turnCount), hint: "Speech turns" },
     {
       label: "Latency",
-      value: avgLatency != null ? fmtMs(avgLatency) : "—",
+      value: avgLatency != null ? fmtMs(avgLatency, { forceMs: true }) : "—",
       hint: "Avg agent response latency",
     },
     { label: "User / AI", value: talkRatioValue, hint: "Talk time split (%)" },
@@ -195,13 +191,17 @@ const KpiStrip = ({ metrics, apiMetrics }) => {
     },
     {
       label: "Silence",
-      value: silenceTotal > 0 ? `${silenceTotal.toFixed(1)}s` : "0s",
+      value:
+        silenceTotal > 0 ? fmtMs(silenceTotal * 1000, { forceMs: true }) : "0ms",
       hint: "Dead air (> 0.3s gaps)",
       tone: silenceTotal > 10 ? "warn" : "default",
     },
     {
       label: "TTFW",
-      value: timeToFirstWord != null ? formatClock(timeToFirstWord) : "—",
+      value:
+        timeToFirstWord != null
+          ? fmtMs(timeToFirstWord * 1000, { forceMs: true })
+          : "—",
       hint: "Time to first word",
     },
   ];

--- a/frontend/src/components/VoiceDetailDrawerV2/CallAnalyticsView.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/CallAnalyticsView.jsx
@@ -10,6 +10,7 @@ import {
   useTheme,
 } from "@mui/material";
 import Iconify from "src/components/iconify";
+import { fmtMs } from "src/utils/utils";
 import { computeCallMetrics, enrichTurns } from "./transcriptUtils";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -22,12 +23,6 @@ const fmtDuration = (seconds) => {
   const m = Math.floor(seconds / 60);
   const s = Math.round(seconds % 60);
   return `${m}:${String(s).padStart(2, "0")}`;
-};
-
-const fmtMs = (ms, { forceMs = false } = {}) => {
-  if (ms == null || !Number.isFinite(ms)) return "—";
-  if (!forceMs && ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
-  return `${Math.round(ms)}ms`;
 };
 
 const fmtMoney = (n) => {
@@ -192,7 +187,7 @@ const KpiStrip = ({ metrics, apiMetrics }) => {
     {
       label: "Silence",
       value:
-        silenceTotal > 0 ? fmtMs(silenceTotal * 1000, { forceMs: true }) : "0ms",
+        silenceTotal > 0 ? fmtMs(silenceTotal * 1000, { forceMs: false }) : "0ms",
       hint: "Dead air (> 0.3s gaps)",
       tone: silenceTotal > 10 ? "warn" : "default",
     },

--- a/frontend/src/sections/agents/CallLogs/VoiceLatencyCell.jsx
+++ b/frontend/src/sections/agents/CallLogs/VoiceLatencyCell.jsx
@@ -3,9 +3,9 @@ import PropTypes from "prop-types";
 import { Box, Tooltip, Typography } from "@mui/material";
 import Iconify from "src/components/iconify";
 
-function fmtMs(v) {
+function fmtMs(v, { forceMs = false } = {}) {
   if (v == null || !Number.isFinite(v)) return "-";
-  if (v >= 1000) return `${(v / 1000).toFixed(2)}s`;
+  if (!forceMs && v >= 1000) return `${(v / 1000).toFixed(2)}s`;
   return `${Math.round(v)}ms`;
 }
 
@@ -122,7 +122,7 @@ const VoiceLatencyCell = (params) => {
           whiteSpace: "nowrap",
         }}
       >
-        {fmtMs(totalMs)}
+        {fmtMs(totalMs, { forceMs: true })}
       </Typography>
       {hasStages && (
         <Tooltip

--- a/frontend/src/sections/agents/CallLogs/VoiceLatencyCell.jsx
+++ b/frontend/src/sections/agents/CallLogs/VoiceLatencyCell.jsx
@@ -2,12 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Box, Tooltip, Typography } from "@mui/material";
 import Iconify from "src/components/iconify";
-
-function fmtMs(v, { forceMs = false } = {}) {
-  if (v == null || !Number.isFinite(v)) return "-";
-  if (!forceMs && v >= 1000) return `${(v / 1000).toFixed(2)}s`;
-  return `${Math.round(v)}ms`;
-}
+import { fmtMs } from "src/utils/utils";
 
 const PIPELINE_STAGES = [
   { key: "endpointingLatencyAverage", label: "Endpointing" },

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -911,6 +911,32 @@ export function formatMs(ms) {
   return `${(ms / 86_400_000).toFixed(1)}d`;
 }
 
+/**
+ * Lightweight ms ↔ s formatter used by voice analytics surfaces.
+ *
+ * Differs from formatMs:
+ *   - Tops out at seconds (no minutes/hours/days)
+ *   - Optional forceMs flag to keep the unit in milliseconds at all
+ *     magnitudes (so a 4060ms latency reads as "4060ms", not "4.06s")
+ *   - Configurable empty placeholder so callers that want a dash, an
+ *     em-dash, or null can all share the helper
+ *
+ * @param {number|null|undefined} ms
+ * @param {Object}  [opts]
+ * @param {boolean} [opts.forceMs=false]      Always render in milliseconds.
+ * @param {number}  [opts.secondsDecimals=2]  Decimal places when switching to seconds.
+ * @param {string|null} [opts.emptyText="—"]  Returned for null/NaN/Infinity input.
+ * @returns {string|null}
+ */
+export const fmtMs = (
+  ms,
+  { forceMs = false, secondsDecimals = 2, emptyText = "—" } = {},
+) => {
+  if (ms == null || !Number.isFinite(ms)) return emptyText;
+  if (!forceMs && ms >= 1000) return `${(ms / 1000).toFixed(secondsDecimals)}s`;
+  return `${Math.round(ms)}ms`;
+};
+
 export const formatPercentage = (value) => {
   if (value == null || isNaN(value)) return "-";
   return value % 1 === 0 ? `${value}%` : `${value?.toFixed(2)}%`;


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

The Latency / Silence / TTFW KPI cells in the call analytics drawer
auto-switched to seconds for any value ≥1s (e.g. "4.06s", "15.5s",
"0:01"), losing sub-second precision and making it hard to compare
calls at a glance. The call-logs table's Latency column had the same
inconsistency.

Add an optional { forceMs: true } flag to the local fmtMs helpers in
both CallAnalyticsView and VoiceLatencyCell. The three KPI cells and
the call-logs Latency column opt in (always render "1657ms"), while
the LatencyPipeline section and the tooltip pipeline breakdown keep
the default smart format ("131ms" for short stages, "4.06s" for the
total) where readability matters more than uniformity.

Also switch TTFW off formatClock — its whole-seconds floor was
collapsing every sub-2s value to "0:01"

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
