### PR TITLE
fix: disable data_type_default_nullable for ClickHouse table creation…

### DIFF
--- a/futureagi/agentic_eval/core/database/ch_vector.py
+++ b/futureagi/agentic_eval/core/database/ch_vector.py
@@ -130,7 +130,10 @@ class ClickHouseVectorDB:
         """
         start_time = datetime.now()
 
-        self.client.execute(create_table_query)
+        self.client.execute(
+            create_table_query,
+            settings={"data_type_default_nullable": 0},
+        )
         end_time = datetime.now()
         elapsed_time = (end_time - start_time).total_seconds()
         logger.info(f"create query took {elapsed_time:.2f} seconds to execute")


### PR DESCRIPTION
## Summary                                                                                                                                                   
                                                                                                                                                               
Disables `data_type_default_nullable` during ClickHouse table creation to prevent `Array(Float32)` columns from being wrapped in `Nullable`. ClickHouse does not support `Nullable` inside `Array` types — when `data_type_default_nullable` is enabled (the default), `Array(Float32)` silently becomes `Array(Nullable(Float32))`, which causes insertion failures for embedding/vector columns. This one-line settings override fixes the issue at the query level.
                                                                                                                                                             
  ## Linked issues                                                                                                                                             
  
  Closes #TH-4612                                                                                                                                               
                                                                                                                                                             
  ## Type of change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📖 Documentation only                                                                                                                                  
  - [ ] 🧹 Chore / refactor (no user-visible change)
  - [ ] 🚀 Performance improvement                                                                                                                             
  - [ ] 🧪 Test-only change                                                                                                                                    
  
  ## How was this tested?                                                                                                                                      
                                                                                                                                                             
  - Verified that `CREATE TABLE` with `Array(Float32)` columns no longer wraps them in `Nullable`                                                              
  - Confirmed embedding insertions succeed after the fix
  - Existing tables unaffected (setting only applies at table creation time)                                                                                   
                                                                                                                                                               
  ## Screenshots / recordings (if UI)                                                                                                                          
                                                                                                                                                               
  N/A — backend-only change.                                                                                                                                   
  
  ## Checklist                                                                                                                                                 
                                                                                                                                                             
  - [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
  - [ ] I've added tests that prove my fix is effective or that my feature works
  - [ ] `make check-all` / `yarn check-all` passes locally
  - [x] I've updated the documentation where relevant                                                                                                          
  - [x] No hardcoded secrets, URLs, or PII
  - [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)      