### PR TITLE
[bugfix] disable per-row cluster_eval_results_task trigger

### DIFF
--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -972,15 +972,19 @@ def evaluate_observation_span_observe(
                 eval_task_id,
             )
 
-        # Cluster this project's unclustered eval results (idempotent —
-        # if another call already clustered everything, this is a no-op).
-        try:
-            from tracer.tasks.eval_clustering import cluster_eval_results_task
-
-            project_id = str(observation_span.project_id)
-            cluster_eval_results_task.delay(project_id)
-        except Exception:
-            logger.debug("eval_clustering_dispatch_skipped", exc_info=True)
+        # DISABLED 2026-04-30 — per-row enqueue caused Aurora CPU saturation
+        # under load (incident: cron-driven historical EvalTask × N×M fan-out
+        # → 60+ cluster_eval_results_task/sec → embedding service connection
+        # resets → workflow pile-up). Re-enable only after per-project debounce
+        # is implemented (Temporal workflow ID dedup or Redis lock).
+        #
+        # try:
+        #     from tracer.tasks.eval_clustering import cluster_eval_results_task
+        #
+        #     project_id = str(observation_span.project_id)
+        #     cluster_eval_results_task.delay(project_id)
+        # except Exception:
+        #     logger.debug("eval_clustering_dispatch_skipped", exc_info=True)
 
         return True
     except ValueError as e:


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
