### PR TITLE
fix: use resolve_eval_template for consistent name/UUID handling in eval tools

### DIFF
--- a/futureagi/ai_tools/resolvers.py
+++ b/futureagi/ai_tools/resolvers.py
@@ -118,10 +118,16 @@ def resolve_project(identifier: str, organization, workspace=None):
 
 
 def resolve_eval_template(identifier: str, organization, workspace=None):
-    """Resolve an eval template by name or UUID."""
+    """Resolve an eval template by name or UUID.
+
+    Looks up user-owned templates within the org (workspace-filtered via
+    the default manager), then falls back to system templates (global,
+    organization=NULL) which are accessible to all orgs.
+    """
     if not identifier:
         return None, "Eval template identifier is required."
 
+    # 1. Try org-scoped lookup (respects workspace filtering)
     if is_uuid(identifier):
         try:
             return (
@@ -131,8 +137,20 @@ def resolve_eval_template(identifier: str, organization, workspace=None):
                 None,
             )
         except EvalTemplate.DoesNotExist:
+            pass
+
+        # 2. Fall back to system templates (org=NULL, no workspace)
+        try:
+            return (
+                EvalTemplate.no_workspace_objects.get(
+                    id=identifier, owner="system", deleted=False
+                ),
+                None,
+            )
+        except EvalTemplate.DoesNotExist:
             return None, f"Eval template with ID `{identifier}` not found."
 
+    # Name-based lookup: try org-scoped first
     matches = EvalTemplate.objects.filter(
         name__iexact=identifier.strip(),
         organization=organization,
@@ -144,10 +162,24 @@ def resolve_eval_template(identifier: str, organization, workspace=None):
         names = [f"`{t.name}` (ID: {t.id})" for t in matches[:5]]
         return None, f"Multiple templates match '{identifier}': {', '.join(names)}."
 
-    # Try fuzzy
-    fuzzy = EvalTemplate.objects.filter(
+    # Fall back to system templates by name
+    sys_matches = EvalTemplate.no_workspace_objects.filter(
+        name__iexact=identifier.strip(),
+        owner="system",
+        deleted=False,
+    )
+    if sys_matches.count() == 1:
+        return sys_matches.first(), None
+    elif sys_matches.count() > 1:
+        names = [f"`{t.name}` (ID: {t.id})" for t in sys_matches[:5]]
+        return None, f"Multiple system templates match '{identifier}': {', '.join(names)}."
+
+    # Try fuzzy across both org + system
+    from django.db.models import Q
+
+    fuzzy = EvalTemplate.no_workspace_objects.filter(
+        Q(organization=organization) | Q(owner="system"),
         name__icontains=identifier.strip(),
-        organization=organization,
         deleted=False,
     )[:5]
     if fuzzy.exists():

--- a/futureagi/ai_tools/tests/test_resolvers.py
+++ b/futureagi/ai_tools/tests/test_resolvers.py
@@ -288,7 +288,8 @@ class TestResolveProject:
 
 class TestResolveEvalTemplate:
     @patch("ai_tools.resolvers.EvalTemplate")
-    def test_resolve_by_uuid_found(self, MockTemplate):
+    def test_resolve_by_uuid_found_in_org(self, MockTemplate):
+        """UUID found in org-scoped lookup (first try)."""
         org = _make_mock_org()
         tmpl = _make_mock_obj("Faithfulness", obj_id=VALID_UUID)
         MockTemplate.objects.get.return_value = tmpl
@@ -298,17 +299,34 @@ class TestResolveEvalTemplate:
         assert err is None
 
     @patch("ai_tools.resolvers.EvalTemplate")
-    def test_resolve_by_uuid_not_found(self, MockTemplate):
+    def test_resolve_by_uuid_found_as_system(self, MockTemplate):
+        """UUID not in org but found as system template (fallback)."""
         org = _make_mock_org()
         MockTemplate.DoesNotExist = type("DoesNotExist", (Exception,), {})
         MockTemplate.objects.get.side_effect = MockTemplate.DoesNotExist
+
+        sys_tmpl = _make_mock_obj("toxicity", obj_id=VALID_UUID)
+        MockTemplate.no_workspace_objects.get.return_value = sys_tmpl
+
+        result, err = resolve_eval_template(VALID_UUID, org)
+        assert result is sys_tmpl
+        assert err is None
+
+    @patch("ai_tools.resolvers.EvalTemplate")
+    def test_resolve_by_uuid_not_found_anywhere(self, MockTemplate):
+        """UUID not in org and not a system template — error."""
+        org = _make_mock_org()
+        MockTemplate.DoesNotExist = type("DoesNotExist", (Exception,), {})
+        MockTemplate.objects.get.side_effect = MockTemplate.DoesNotExist
+        MockTemplate.no_workspace_objects.get.side_effect = MockTemplate.DoesNotExist
 
         result, err = resolve_eval_template(VALID_UUID, org)
         assert result is None
         assert "not found" in err.lower()
 
     @patch("ai_tools.resolvers.EvalTemplate")
-    def test_resolve_by_name(self, MockTemplate):
+    def test_resolve_by_name_in_org(self, MockTemplate):
+        """Name found in org-scoped lookup."""
         org = _make_mock_org()
         tmpl = _make_mock_obj("Hallucination")
 
@@ -323,6 +341,7 @@ class TestResolveEvalTemplate:
 
     @patch("ai_tools.resolvers.EvalTemplate")
     def test_resolve_by_name_multiple_matches(self, MockTemplate):
+        """Multiple org templates with same name — error."""
         org = _make_mock_org()
         t1 = _make_mock_obj("Custom Eval", obj_id=uuid.uuid4())
         t2 = _make_mock_obj("Custom Eval", obj_id=uuid.uuid4())
@@ -337,20 +356,48 @@ class TestResolveEvalTemplate:
         assert "Multiple templates" in err
 
     @patch("ai_tools.resolvers.EvalTemplate")
+    def test_resolve_by_name_system_fallback(self, MockTemplate):
+        """Name not in org but found as system template."""
+        org = _make_mock_org()
+
+        # Org lookup returns nothing
+        org_qs = MagicMock()
+        org_qs.count.return_value = 0
+        MockTemplate.objects.filter.return_value = org_qs
+
+        # System fallback finds it
+        sys_tmpl = _make_mock_obj("toxicity")
+        sys_qs = MagicMock()
+        sys_qs.count.return_value = 1
+        sys_qs.first.return_value = sys_tmpl
+        MockTemplate.no_workspace_objects.filter.return_value = sys_qs
+
+        result, err = resolve_eval_template("toxicity", org)
+        assert result is sys_tmpl
+        assert err is None
+
+    @patch("ai_tools.resolvers.EvalTemplate")
     def test_resolve_fuzzy_suggestions(self, MockTemplate):
+        """No exact match — fuzzy suggestions returned."""
         org = _make_mock_org()
         tmpl = _make_mock_obj("hallucination_detection")
 
-        exact_qs = MagicMock()
-        exact_qs.count.return_value = 0
-        # Resolver does `EvalTemplate.objects.filter(...)[:5]` — make __getitem__
-        # return the same mock so configured exists/__iter__ stay applied.
+        # Org exact match — nothing
+        org_exact_qs = MagicMock()
+        org_exact_qs.count.return_value = 0
+        MockTemplate.objects.filter.return_value = org_exact_qs
+
+        # System exact match — nothing
+        sys_exact_qs = MagicMock()
+        sys_exact_qs.count.return_value = 0
+
+        # Fuzzy — found suggestion
         fuzzy_qs = MagicMock()
         fuzzy_qs.exists.return_value = True
         fuzzy_qs.__iter__ = MagicMock(return_value=iter([tmpl]))
         fuzzy_qs.__getitem__ = MagicMock(return_value=fuzzy_qs)
 
-        MockTemplate.objects.filter.side_effect = [exact_qs, fuzzy_qs]
+        MockTemplate.no_workspace_objects.filter.side_effect = [sys_exact_qs, fuzzy_qs]
 
         result, err = resolve_eval_template("hallucination", org)
         assert result is None
@@ -359,15 +406,24 @@ class TestResolveEvalTemplate:
 
     @patch("ai_tools.resolvers.EvalTemplate")
     def test_resolve_no_match(self, MockTemplate):
+        """No match anywhere — returns error."""
         org = _make_mock_org()
 
-        exact_qs = MagicMock()
-        exact_qs.count.return_value = 0
+        # Org exact — nothing
+        org_exact_qs = MagicMock()
+        org_exact_qs.count.return_value = 0
+        MockTemplate.objects.filter.return_value = org_exact_qs
+
+        # System exact — nothing
+        sys_exact_qs = MagicMock()
+        sys_exact_qs.count.return_value = 0
+
+        # Fuzzy — nothing
         fuzzy_qs = MagicMock()
         fuzzy_qs.exists.return_value = False
         fuzzy_qs.__getitem__ = MagicMock(return_value=fuzzy_qs)
 
-        MockTemplate.objects.filter.side_effect = [exact_qs, fuzzy_qs]
+        MockTemplate.no_workspace_objects.filter.side_effect = [sys_exact_qs, fuzzy_qs]
 
         result, err = resolve_eval_template("nonexistent", org)
         assert result is None

--- a/futureagi/ai_tools/tools/evaluations/create_composite_eval.py
+++ b/futureagi/ai_tools/tools/evaluations/create_composite_eval.py
@@ -123,22 +123,17 @@ class CreateCompositeEvalTool(BaseTool):
             )
 
         # ── 2. Verify all child templates exist and are accessible ──
-        children = list(
-            EvalTemplate.no_workspace_objects.filter(
-                id__in=params.child_template_ids, deleted=False
-            ).filter(
-                Q(owner=OwnerChoices.SYSTEM.value)
-                | Q(owner=OwnerChoices.USER.value, organization=context.organization)
-            )
-        )
+        from ai_tools.resolvers import resolve_eval_template
 
-        found_ids = {str(c.id) for c in children}
-        missing = [cid for cid in params.child_template_ids if cid not in found_ids]
-        if missing:
-            return ToolResult.error(
-                f"Child template(s) not found or not accessible: {', '.join(missing)}",
-                error_code="NOT_FOUND",
-            )
+        children = []
+        for cid in params.child_template_ids:
+            child, err = resolve_eval_template(cid, context.organization)
+            if err:
+                return ToolResult.error(
+                    f"Child template '{cid}': {err}",
+                    error_code="NOT_FOUND",
+                )
+            children.append(child)
 
         # ── 3. Reject nested composites ──
         for child in children:

--- a/futureagi/ai_tools/tools/evaluations/execute_composite_eval.py
+++ b/futureagi/ai_tools/tools/evaluations/execute_composite_eval.py
@@ -55,16 +55,18 @@ class ExecuteCompositeEvalTool(BaseTool):
             execute_composite_children_sync,
         )
 
-        # ── 1. Load composite template ──
-        try:
-            parent = EvalTemplate.no_workspace_objects.get(
-                id=params.composite_eval_id,
-                deleted=False,
-                template_type="composite",
-            )
-        except EvalTemplate.DoesNotExist:
-            return ToolResult.not_found(
-                "Composite eval template", params.composite_eval_id
+        # ── 1. Load composite template (by name or UUID) ──
+        from ai_tools.resolvers import resolve_eval_template
+
+        parent, err = resolve_eval_template(
+            params.composite_eval_id, context.organization
+        )
+        if err:
+            return ToolResult.error(err, error_code="NOT_FOUND")
+        if getattr(parent, "template_type", "single") != "composite":
+            return ToolResult.error(
+                f"'{parent.name}' is not a composite eval.",
+                error_code="VALIDATION_ERROR",
             )
 
         # ── 2. Load children ──

--- a/futureagi/ai_tools/tools/evaluations/test_eval_template.py
+++ b/futureagi/ai_tools/tools/evaluations/test_eval_template.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from uuid import UUID
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field
@@ -10,7 +9,7 @@ from ai_tools.registry import register_tool
 
 
 class TestEvalTemplateInput(PydanticBaseModel):
-    eval_template_id: UUID = Field(description="The UUID of the eval template to test")
+    eval_template_id: str = Field(description="Name or UUID of the eval template to test")
     mapping: dict = Field(
         description=(
             "Mapping of template variable names to test values. "
@@ -38,18 +37,15 @@ class TestEvalTemplateTool(BaseTool):
     def execute(
         self, params: TestEvalTemplateInput, context: ToolContext
     ) -> ToolResult:
-        from django.db.models import Q
-
+        from ai_tools.resolvers import resolve_eval_template
         from model_hub.models.evals_metric import EvalTemplate
 
-        # Look up the template (user-owned or system)
-        try:
-            template = EvalTemplate.no_workspace_objects.get(
-                Q(organization=context.organization) | Q(organization__isnull=True),
-                id=params.eval_template_id,
-            )
-        except EvalTemplate.DoesNotExist:
-            return ToolResult.not_found("Eval Template", str(params.eval_template_id))
+        # Look up the template (by name or UUID)
+        template, err = resolve_eval_template(
+            params.eval_template_id, context.organization
+        )
+        if err:
+            return ToolResult.error(err, error_code="NOT_FOUND")
 
         config = template.config or {}
         required_keys = config.get("required_keys", [])

--- a/futureagi/ai_tools/tools/evaluations/update_eval_template.py
+++ b/futureagi/ai_tools/tools/evaluations/update_eval_template.py
@@ -1,5 +1,4 @@
 from typing import Literal, Optional
-from uuid import UUID
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field
@@ -10,8 +9,8 @@ from ai_tools.registry import register_tool
 
 
 class UpdateEvalTemplateInput(PydanticBaseModel):
-    eval_template_id: UUID = Field(
-        description="The UUID of the eval template to update"
+    eval_template_id: str = Field(
+        description="Name or UUID of the eval template to update"
     )
 
     # ── Core fields ──
@@ -176,16 +175,17 @@ class UpdateEvalTemplateTool(BaseTool):
         if params.eval_tags and not params.tags:
             params.tags = params.eval_tags
 
-        try:
-            template = EvalTemplate.objects.get(
-                id=params.eval_template_id,
-                organization=context.organization,
-                owner=OwnerChoices.USER.value,
-                deleted=False,
-            )
-        except EvalTemplate.DoesNotExist:
-            return ToolResult.not_found(
-                "User-owned Eval Template", str(params.eval_template_id)
+        from ai_tools.resolvers import resolve_eval_template
+
+        template, err = resolve_eval_template(
+            params.eval_template_id, context.organization
+        )
+        if err:
+            return ToolResult.error(err, error_code="NOT_FOUND")
+        if template.owner != OwnerChoices.USER.value:
+            return ToolResult.error(
+                "Only user-owned templates can be updated.",
+                error_code="VALIDATION_ERROR",
             )
 
         changed_fields = []


### PR DESCRIPTION
## Summary

Fixes eval tools crashing when template names are passed instead of UUIDs, and updates the shared resolver to find system eval templates.

**Resolver fix (`resolvers.py`):**
- `resolve_eval_template` only searched within the user's org — system templates (org=NULL) like `toxicity`, `hallucination`, etc. were not resolvable
- Now uses tiered fallback: org-scoped first → system templates (`owner="system"`) fallback
- Multi-tenancy preserved — system fallback only matches `owner="system"`, never another org's templates

**Tool fixes (4 files):**
- `create_composite_eval` — use shared resolver for child template resolution (handles both names and UUIDs)
- `execute_composite_eval` — use shared resolver with composite type validation
- `test_eval_template` — accept both names and UUIDs
- `update_eval_template` — accept both names and UUIDs with owner check

Fixes CORE-BACKEND-114Q

## Test plan
- [x] Create composite eval with child template names (not UUIDs) — should resolve
- [x] Create composite eval with system template children (toxicity, hallucination) — should resolve
- [x] Update/test eval template by name — should work
- [x] Verify org isolation — user cannot resolve another org's user templates