### PR TITLE
fix(oss): stub deployment-info endpoint and gate Falcon AI on dashboard

### DIFF
--- a/frontend/src/layouts/dashboard/index.jsx
+++ b/frontend/src/layouts/dashboard/index.jsx
@@ -17,6 +17,7 @@ import NavGatewayPanel from "./NavGatewayPanel";
 import FalconAISidebar from "src/sections/falcon-ai/FalconAISidebar";
 import FalconAIFab from "src/sections/falcon-ai/components/FalconAIFab";
 import useFalconStore from "src/sections/falcon-ai/store/useFalconStore";
+import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 import CreateWorkspaceModal from "./WorkspaceSwitcher/CreateWorkspaceModal";
 import TwoFactorBanner from "src/components/two-factor-enforcement/TwoFactorBanner";
 import { Typography } from "@mui/material";
@@ -28,6 +29,7 @@ export default function DashboardLayout({ children }) {
   const settings = useSettingsContext();
   const isSOSMode = localStorage.getItem("sosMode");
   const router = useRouter();
+  const { isOSS } = useDeploymentMode();
   const pendingNavigation = useFalconStore((s) => s.pendingNavigation);
   const clearPendingNavigation = useFalconStore(
     (s) => s.clearPendingNavigation,
@@ -107,9 +109,9 @@ export default function DashboardLayout({ children }) {
         {navComponent}
         <NavGatewayPanel />
         <Main>{children}</Main>
-        <FalconAISidebar />
+        {!isOSS && <FalconAISidebar />}
       </Box>
-      <FalconAIFab />
+      {!isOSS && <FalconAIFab />}
     </>
   );
 }

--- a/futureagi/tfc/urls.py
+++ b/futureagi/tfc/urls.py
@@ -133,6 +133,20 @@ urlpatterns = [
 
 if has_ee("ee.usage"):
     urlpatterns += [path("usage/", include("ee.usage.urls"))]
+else:
+    # OSS-only stub for the deployment-info endpoint that ee.usage normally
+    # provides. The frontend's useDeploymentMode hook (and several layouts /
+    # eval components built on top of it) calls this on every dashboard page.
+    # Without this stub the hook stays in error state, downstream components
+    # remount in a tight loop, and the dashboard flickers heavily on OSS.
+    from django.http import JsonResponse  # noqa: E402
+    urlpatterns += [
+        path(
+            "usage/v2/deployment-info/",
+            lambda request: JsonResponse({"result": {"mode": "oss"}}),
+            name="deployment-info-oss-stub",
+        ),
+    ]
 
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 


### PR DESCRIPTION
Refs #165

## Summary
Two paired changes that together make the OSS dashboard usable. Issue #165 documents the cascade in detail; PR #166 (frontend hook 404 tolerance) is useful as a defensive layer but is **not sufficient on its own** because downstream EE-only features still try to mount on OSS. This is the architectural complement #165 explicitly recommended.

- **Backend stub for \`/usage/v2/deployment-info/\`** when \`ee.usage\` is not installed (\`tfc/urls.py\`). The endpoint is owned by the EE module; on OSS the URL goes unregistered, returns 404, and \`useDeploymentMode\` never resolves. The stub returns the same payload shape \`ee.usage\` would emit for the OSS case (\`{\"result\": {\"mode\": \"oss\"}}\`). Gated on \`not has_ee(\"ee.usage\")\` so EE installs continue to use the real endpoint with no behavior change.
- **Conditionally render \`<FalconAISidebar />\` and \`<FalconAIFab />\`** in the dashboard layout (\`layouts/dashboard/index.jsx\`). Falcon AI is an EE-only feature whose components unconditionally fetch \`/falcon-ai/skills/\`, \`/falcon-ai/conversations/\`, and \`/falcon-ai/mcp-connectors/\` on every dashboard page mount. On OSS each of those returns HTTP 402 Payment Required, the global axios interceptor enqueues an \"upgrade required\" snackbar per response, and on a stable page the storm hits ~70 calls/30s — visible UI flicker, dozens of red toasts. Gating both components on \`!isOSS\` (read via \`useDeploymentMode\`) stops the polling at the source. EE / Cloud installs keep mounting them as before.

## Files
- \`futureagi/tfc/urls.py\` — add OSS-only stub URL inside the existing \`if has_ee(\"ee.usage\")\` else-branch.
- \`frontend/src/layouts/dashboard/index.jsx\` — import \`useDeploymentMode\`; wrap \`<FalconAISidebar />\` and \`<FalconAIFab />\` in \`{!isOSS && ...}\`.

## Repro
1. \`cp .env.example .env\`, fill the four CHANGEME values, \`docker compose up -d\`.
2. Sign up, log in, land on \`/dashboard\`.

**Before**: Network panel shows \`/usage/v2/deployment-info/\` at 12+/sec returning 404, \`/falcon-ai/{skills,conversations,mcp-connectors}/\` at 2–10/sec returning 402, screen flickers, snackbar storms with red \"upgrade required\" errors.

**After**: \`/usage/v2/deployment-info/\` returns 200 on the first fetch and is cached forever; no \`/falcon-ai/*\` requests at all on OSS; dashboard renders stable.

## Test plan
- [ ] Fresh OSS install (no \`ee/\` directory). Sign up → land on dashboard → verify single 200 on \`/usage/v2/deployment-info/\`, zero \`/falcon-ai/*\` requests, no flicker, no snackbar errors.
- [ ] EE smoke (with \`ee.usage\` installed). Verify the stub does NOT shadow the real \`ee.usage\` URLs (the \`else\` branch keeps the existing \`if has_ee\` behavior intact). Verify Falcon AI sidebar and FAB still mount.
- [ ] Curl the new stub directly: \`curl http://localhost:8000/usage/v2/deployment-info/\` → \`{\"result\": {\"mode\": \"oss\"}}\` HTTP 200.
- [ ] React Query devtools — confirm a single \`deployment-info\` fetch per page load, then cache hit forever.

## Relationship to other open work
This is the **fifth + sixth** first-boot bug for self-hosted OSS, addressed together. Full story:

- #121 — \`tracer\` migration conflict (already on \`dev\`).
- #155 / #152 — frontend reCAPTCHA gate ignores \`RECAPTCHA_ENABLED=false\`.
- #156 / #157 — \`EMAIL_BACKEND\` hardcoded to Mailgun.
- #159 — workspace-add fails when invite-email send fails (transactional coupling, no PR yet — needs maintainer call between three approaches).
- #165 / #166 — frontend hook 404 tolerance (defensive layer).
- **This PR** — backend stub + Falcon AI gating (architectural complement to #166).

With these landed, \`docker compose up -d\` is a clean first-boot for self-hosted OSS users.