### PR TITLE
fix(eval): resolve voice-span mappings via dotted-path walk + FE prefix strip

### DIFF
--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -29,7 +29,11 @@ import DraggableColResizer from "src/components/draggable-col-resizer";
 import Iconify from "src/components/iconify";
 import axios, { endpoints } from "src/utils/axios";
 import { PROJECT_SOURCE } from "src/utils/constants";
-import { canonicalEntries, canonicalKeys } from "src/utils/utils";
+import {
+  canonicalEntries,
+  canonicalKeys,
+  stripAttributePathPrefix,
+} from "src/utils/utils";
 
 import {
   InlineAudio,
@@ -659,13 +663,11 @@ const TracingTestMode = React.forwardRef(
         }
       };
       walk(source, "");
-      // Strip `span_attributes.` prefix and dedupe against top-level keys.
+      // Strip wrapper/span_attributes prefix and dedupe against top-level keys.
       const seen = new Set();
       const flattened = [];
       keys.forEach((k) => {
-        const short = k.startsWith("span_attributes.")
-          ? k.slice("span_attributes.".length)
-          : k;
+        const short = stripAttributePathPrefix(k);
         if (seen.has(short)) return;
         seen.add(short);
         flattened.push(short);

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -21,7 +21,7 @@ import { alpha } from "@mui/material/styles";
 import { useWatch } from "react-hook-form";
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
-import { canonicalEntries } from "src/utils/utils";
+import { canonicalEntries, stripAttributePathPrefix } from "src/utils/utils";
 import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 
@@ -379,13 +379,11 @@ const TaskLivePreview = forwardRef(function TaskLivePreview(
       }
     };
     walk(spanDetail, "");
-    // Strip `span_attributes.` prefix and dedupe against existing top-level keys.
+    // Strip wrapper/span_attributes prefix and dedupe against top-level keys.
     const seen = new Set();
     const flattened = [];
     keys.forEach((k) => {
-      const short = k.startsWith("span_attributes.")
-        ? k.slice("span_attributes.".length)
-        : k;
+      const short = stripAttributePathPrefix(k);
       if (seen.has(short)) return;
       seen.add(short);
       flattened.push(short);

--- a/frontend/src/utils/__tests__/stripAttributePathPrefix.test.js
+++ b/frontend/src/utils/__tests__/stripAttributePathPrefix.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { stripAttributePathPrefix } from "../utils";
+
+describe("stripAttributePathPrefix", () => {
+  it("strips a bare span_attributes prefix", () => {
+    expect(stripAttributePathPrefix("span_attributes.input.value")).toBe(
+      "input.value",
+    );
+  });
+
+  it("strips the voice-detail observation_span.<n>.span_attributes wrapper", () => {
+    expect(
+      stripAttributePathPrefix(
+        "observation_span.0.span_attributes.conversation.recording.mono.combined",
+      ),
+    ).toBe("conversation.recording.mono.combined");
+  });
+
+  it("strips the wrapper for multi-digit indices", () => {
+    expect(
+      stripAttributePathPrefix("observation_span.42.span_attributes.transcript"),
+    ).toBe("transcript");
+  });
+
+  it("strips the wrapper for top-level span fields (no span_attributes segment)", () => {
+    expect(stripAttributePathPrefix("observation_span.0.model")).toBe("model");
+    expect(stripAttributePathPrefix("observation_span.0.latency_ms")).toBe(
+      "latency_ms",
+    );
+    expect(stripAttributePathPrefix("observation_span.7.prompt_tokens")).toBe(
+      "prompt_tokens",
+    );
+  });
+
+  it("returns the input unchanged when no prefix matches", () => {
+    expect(stripAttributePathPrefix("input.value")).toBe("input.value");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(stripAttributePathPrefix("")).toBe("");
+  });
+
+  it("only strips an actual prefix, not a mid-string occurrence", () => {
+    expect(stripAttributePathPrefix("metadata.span_attributes.input")).toBe(
+      "metadata.span_attributes.input",
+    );
+  });
+});

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -1368,3 +1368,10 @@ export const tokenMatchesLeaf = (tok, pathLower, valueLower, words) => {
   }
   return false;
 };
+
+// Strip the voice-detail wrapper (`observation_span.<n>.[span_attributes.]`)
+// and bare `span_attributes.` so the saved mapping uses bare attribute paths.
+export const stripAttributePathPrefix = (key) =>
+  String(key ?? "")
+    .replace(/^observation_span\.\d+\.(?:span_attributes\.)?/, "")
+    .replace(/^span_attributes\./, "");

--- a/futureagi/tracer/tests/test_process_mapping.py
+++ b/futureagi/tracer/tests/test_process_mapping.py
@@ -1,0 +1,74 @@
+"""Tests for `_process_mapping`: literal lookup → dotted-path walk fallback."""
+
+import pytest
+
+from tracer.utils.eval import _process_mapping
+
+
+@pytest.fixture
+def _span_with_attrs(observation_span):
+    """Helper to set `span_attributes` on the shared fixture and return it."""
+
+    def _set(attrs):
+        observation_span.span_attributes = attrs
+        observation_span.save(update_fields=["span_attributes"])
+        return observation_span
+
+    return _set
+
+
+def test_literal_key_resolves(_span_with_attrs):
+    span = _span_with_attrs({"input": "hello"})
+    out = _process_mapping({"prompt": "input"}, span, eval_template_id=-1)
+    assert out == {"prompt": "hello"}
+
+
+def test_dot_value_fallback_resolves(_span_with_attrs):
+    span = _span_with_attrs({"input.value": "hello"})
+    out = _process_mapping({"prompt": "input"}, span, eval_template_id=-1)
+    assert out == {"prompt": "hello"}
+
+
+def test_alias_literal_resolves(_span_with_attrs):
+    # `recording_url` shorthand → resolves via alias entry `stereo_recording_url`.
+    span = _span_with_attrs({"stereo_recording_url": "https://x/y.wav"})
+    out = _process_mapping({"audio": "recording_url"}, span, eval_template_id=-1)
+    assert out == {"audio": "https://x/y.wav"}
+
+
+def test_dotted_nested_path_resolves_through_walk(_span_with_attrs):
+    # Repro of the prod voice-eval bug: nested JSON only resolves via the walker.
+    span = _span_with_attrs(
+        {
+            "conversation": {
+                "recording": {"mono": {"combined": "https://x/combined.wav"}}
+            }
+        }
+    )
+    out = _process_mapping(
+        {"audio": "conversation.recording.mono.combined"},
+        span,
+        eval_template_id=-1,
+    )
+    assert out == {"audio": "https://x/combined.wav"}
+
+
+def test_alias_with_dotted_path_resolves_against_nested(_span_with_attrs):
+    # `transcript` shorthand → alias `conversation.transcript` walks nested JSON.
+    transcript = [{"role": "user", "text": "hello"}]
+    span = _span_with_attrs({"conversation": {"transcript": transcript}})
+    out = _process_mapping({"text": "transcript"}, span, eval_template_id=-1)
+    # Non-string values are JSON-serialised by the resolver.
+    assert out == {"text": '[{"role": "user", "text": "hello"}]'}
+
+
+def test_provider_transcript_alias_resolves(_span_with_attrs):
+    span = _span_with_attrs({"provider_transcript": "hello world"})
+    out = _process_mapping({"text": "transcript"}, span, eval_template_id=-1)
+    assert out == {"text": "hello world"}
+
+
+def test_missing_attribute_raises(_span_with_attrs):
+    span = _span_with_attrs({"unrelated": "value"})
+    with pytest.raises(ValueError, match="Required attribute 'input'"):
+        _process_mapping({"prompt": "input"}, span, eval_template_id=-1)

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -47,6 +47,40 @@ from tracer.utils.eval_helpers import resolve_eval_config_id  # noqa: F401, E402
 # here each provider would require a hand-written mapping per span.
 # When the exact attribute isn't present we probe these fallbacks in
 # order — first match wins.
+def _walk_dotted_path(root, path):
+    """Walk a dotted path through nested dicts/lists; return None on miss."""
+    if not isinstance(path, str) or not path:
+        return None
+    current = root
+    for part in path.split("."):
+        if current is None:
+            return None
+        if isinstance(current, dict):
+            current = current.get(part)
+        elif isinstance(current, list):
+            try:
+                current = current[int(part)]
+            except (ValueError, IndexError):
+                return None
+        else:
+            return None
+    return current
+
+
+# Sentinel: ``None`` is a legitimate stored value, so we can't use it for "miss".
+_MISSING = object()
+
+
+def _resolve_attr(span_attrs: dict, candidate: str):
+    """Literal lookup, then dotted-path walk. Returns ``_MISSING`` on miss."""
+    if candidate in span_attrs:
+        return span_attrs[candidate]
+    walked = _walk_dotted_path(span_attrs, candidate)
+    if walked is not None:
+        return walked
+    return _MISSING
+
+
 _ATTRIBUTE_ALIASES: dict[str, list[str]] = {
     "recording_url": [
         # Vapi ingestion (``tracer.utils.vapi._extract_recording_urls``)
@@ -78,6 +112,7 @@ _ATTRIBUTE_ALIASES: dict[str, list[str]] = {
         "gen_ai.voice.transcript",
         "voice_transcript",
         "call.transcript",
+        "provider_transcript",
     ],
     "call_summary": [
         "conversation.summary",
@@ -131,22 +166,23 @@ def _process_mapping(
         # shorthands (``recording_url``, ``transcript``, …) resolve to
         # one of several provider-specific attribute names via the
         # ``_ATTRIBUTE_ALIASES`` table above — first hit wins.
-        resolved_attr = None
         candidates = [attribute, f"{attribute}.value"]
         for alias in _ATTRIBUTE_ALIASES.get(attribute, []):
             candidates.append(alias)
             candidates.append(f"{alias}.value")
+
+        resolved_value = _MISSING
         for candidate in candidates:
-            if candidate in span_attrs:
-                resolved_attr = candidate
+            value = _resolve_attr(span_attrs, candidate)
+            if value is not _MISSING:
+                resolved_value = value
                 break
 
-        if resolved_attr is not None:
-            value = span_attrs.get(resolved_attr, "")
-            if isinstance(value, str):
-                parsed_mapping[key] = value
+        if resolved_value is not _MISSING:
+            if isinstance(resolved_value, str):
+                parsed_mapping[key] = resolved_value
             else:
-                parsed_mapping[key] = json.dumps(value)
+                parsed_mapping[key] = json.dumps(resolved_value)
         else:
             logger.error(
                 f"Required attribute '{attribute}' for key '{key}' not found for span {span.id}"

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -34,32 +34,8 @@ class _RegexpReplace(Func):
     output_field = models.TextField()
 
 
-def _walk_dotted_path(root, path):
-    """
-    Walk a dotted path through nested dicts/lists. Returns None if any
-    segment misses.
-
-    Used by `get_usage` to resolve an eval template's variable mapping
-    (e.g. `{"prompt": "input.value", "expected": "output.0.text"}`)
-    against a span's attributes so the side panel can show the actual
-    values that were fed into the eval, not just the field paths.
-    """
-    if not isinstance(path, str) or not path:
-        return None
-    current = root
-    for part in path.split("."):
-        if current is None:
-            return None
-        if isinstance(current, dict):
-            current = current.get(part)
-        elif isinstance(current, list):
-            try:
-                current = current[int(part)]
-            except (ValueError, IndexError):
-                return None
-        else:
-            return None
-    return current
+# Re-exported for back-compat; canonical definition lives in `tracer.utils.eval`.
+from tracer.utils.eval import _walk_dotted_path  # noqa: E402, F401
 
 
 # Per-variable size cap to keep the panel payload bounded — a single


### PR DESCRIPTION
## Summary

- **BE** — `_process_mapping` falls back to a dotted-path walk through nested dicts/lists when literal lookup misses. Voice spans store `span_attributes` as nested JSON (e.g. `{conversation: {transcript: ...}}`), so aliases like `conversation.transcript` only resolve via the walker. Adds `provider_transcript` to the `transcript` alias list and dedupes `_walk_dotted_path` (canonical in `tracer/utils/eval.py`, re-exported from `tracer/views/eval_task.py`).
- **FE** — extracts `stripAttributePathPrefix` utility that strips the `observation_span.<n>.[span_attributes.]` voice-detail wrapper plus bare `span_attributes.`. Reused in both `TaskLivePreview` and `TracingTestMode` walkers so saved mappings use bare attribute paths instead of the wrapper-leaked form.

## Why

Audit of prod eval-logger rows for tasks `f7e36930` and `798139be` on 2026-04-30: **8,228 errored rows in one day**. Of those, **~89.6%** are alias-miss / dotted-path-miss errors (`Required attribute 'transcript' for key '…' not found`, `Required attribute 'conversation.recording.mono.combined' for key '…' not found`) — every one of those is a direct hit for this fix. After deploy, the next cron tick auto-resolves them without a backfill.

The remaining ~10% are FE-prefix-bleed (`observation_span.0.span_attributes.raw_log`) where the saved mapping itself is wrong; once the FE strip ships, re-saving the mapping produces a clean shape that the BE walker handles. (Some pre-existing rows will need the user to re-pick the mapping.)

## Test plan

- [ ] `cd futureagi && pytest tracer/tests/test_process_mapping.py -v` — 7 cases pass
- [ ] `cd frontend && yarn test stripAttributePathPrefix` — 7 cases pass
- [ ] Open eval-task creation drawer for a voice project; confirm dropdown shows bare paths (no `observation_span.0.…` prefixes)
- [ ] Run an eval task on a voice project against a saved mapping using the `transcript` alias; confirm `tracer_eval_logger` rows succeed (not "Required attribute … not found")