### PR TITLE
fix(oss): replace None ee.usage fallbacks with no-op stubs

### DIFF
--- a/futureagi/_ee_stubs.py
+++ b/futureagi/_ee_stubs.py
@@ -1,0 +1,143 @@
+"""
+No-op fallbacks for symbols that live in the proprietary ``ee.usage`` package.
+
+On a fresh OSS install, ``from ee.usage.models.usage import APICallTypeChoices``
+raises ``ImportError``; many call sites previously fell back to ``None`` and
+then crashed on the first attribute access (``APICallTypeChoices.DATASET_ADD``).
+Use the stubs from this module as the fallback instead.
+
+Keep the value strings stable so logs and any downstream telemetry remain
+parseable when EE is later installed alongside an existing OSS database.
+"""
+
+from enum import Enum
+
+
+class APICallTypeChoices(str, Enum):
+    AUTO_ANNOTATION = "AUTO_ANNOTATION"
+    DATASET_ADD = "DATASET_ADD"
+    DATASET_EVALUATION = "DATASET_EVALUATION"
+    DATASET_OPTIMIZATION = "DATASET_OPTIMIZATION"
+    DATASET_RUN_PROMPT = "DATASET_RUN_PROMPT"
+    ERROR_LOCALIZER = "ERROR_LOCALIZER"
+    KNOWLEDGE_BASE = "KNOWLEDGE_BASE"
+    OBSERVE_ADD = "OBSERVE_ADD"
+    PROMPT_BENCH = "PROMPT_BENCH"
+    PROTECT_EVALUATOR = "PROTECT_EVALUATOR"
+    PROTECT_FLASH_EVALUATOR = "PROTECT_FLASH_EVALUATOR"
+    PROTOTYPE_ADD = "PROTOTYPE_ADD"
+    ROW_ADD = "ROW_ADD"
+    SYNTHETIC_DATA_GENERATION = "SYNTHETIC_DATA_GENERATION"
+    TRACE_ERROR_ANALYSIS = "TRACE_ERROR_ANALYSIS"
+    TURING_FLASH_EVALUATOR = "TURING_FLASH_EVALUATOR"
+    TURING_LARGE_EVALUATOR = "TURING_LARGE_EVALUATOR"
+    TURING_SMALL_EVALUATOR = "TURING_SMALL_EVALUATOR"
+    USER_ADD = "USER_ADD"
+
+
+class APICallStatusChoices(str, Enum):
+    ERROR = "ERROR"
+    PROCESSING = "PROCESSING"
+    RESOURCE_LIMIT = "RESOURCE_LIMIT"
+    SUCCESS = "SUCCESS"
+
+
+ROW_LIMIT_REACHED_MESSAGE = ""
+
+
+def log_and_deduct_cost_for_resource_request(*args, **kwargs):
+    """OSS no-op: usage tracking is an EE feature."""
+    return None
+
+
+class _StubManager:
+    """Mimic ``Model.objects`` / ``Model.no_workspace_objects`` enough that
+    OSS code paths which only check existence or call ``.filter(...).delete()``
+    keep working without an EE-only DB table."""
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return self
+
+    def first(self):
+        return None
+
+    def get(self, *args, **kwargs):
+        raise APICallLog.DoesNotExist
+
+    def delete(self):
+        return (0, {})
+
+    def count(self):
+        return 0
+
+    def exists(self):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+
+class _APICallLogDoesNotExist(Exception):
+    pass
+
+
+class APICallLog:
+    """OSS stub for the EE-only usage-tracking model. Behaves as an empty queryset
+    so existence checks return False and writes are no-ops."""
+
+    DoesNotExist = _APICallLogDoesNotExist
+    objects = _StubManager()
+    no_workspace_objects = _StubManager()
+
+    class config:
+        @staticmethod
+        def get(*args, **kwargs):
+            return None
+
+
+def log_and_deduct_cost_for_api_request(*args, **kwargs):
+    return None
+
+
+def refund_cost_for_api_call(*args, **kwargs):
+    return None
+
+
+def log_and_deduct_cost_for_dataset_creation(*args, **kwargs):
+    return None
+
+
+def count_text_tokens(*args, **kwargs):
+    return 0
+
+
+def count_tiktoken_tokens(*args, **kwargs):
+    return 0
+
+
+def deduct_cost_for_request(*args, **kwargs):
+    return None
+
+
+# OrganizationSubscription / SubscriptionTierChoices stubs (EE-only billing model)
+
+
+class _StubChoices(str, Enum):
+    FREE = "FREE"
+    PRO = "PRO"
+    ENTERPRISE = "ENTERPRISE"
+
+
+SubscriptionTierChoices = _StubChoices
+
+
+class OrganizationSubscription:
+    DoesNotExist = _APICallLogDoesNotExist
+    objects = _StubManager()
+
+    @classmethod
+    def is_active_for(cls, *args, **kwargs):
+        return False

--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -66,14 +66,11 @@ from tfc.utils.parse_errors import parse_serialized_errors
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices, OrganizationSubscription, SubscriptionTierChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
-    OrganizationSubscription = None
-    SubscriptionTierChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices, OrganizationSubscription, SubscriptionTierChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_resource_request
 except ImportError:
-    log_and_deduct_cost_for_resource_request = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_resource_request
 
 
 def clear_user_redis_cache(user_id):

--- a/futureagi/ai_tools/tools/prompts/run_prompt.py
+++ b/futureagi/ai_tools/tools/prompts/run_prompt.py
@@ -63,8 +63,7 @@ class RunPromptTool(BaseTool):
         try:
             from ee.usage.utils.usage_entries import APICallTypeChoices, log_and_deduct_cost_for_api_request
         except ImportError:
-            APICallTypeChoices = None
-            log_and_deduct_cost_for_api_request = None
+            from futureagi._ee_stubs import APICallTypeChoices, log_and_deduct_cost_for_api_request
 
         template_obj, err = resolve_prompt_template(
             params.template_id, context.organization, context.workspace

--- a/futureagi/model_hub/services/dataset_service.py
+++ b/futureagi/model_hub/services/dataset_service.py
@@ -30,12 +30,11 @@ def _check_resource_limit(organization, workspace, api_call_type, config=None):
         try:
             from ee.usage.models import APICallStatusChoices, APICallTypeChoices
         except ImportError:
-            APICallStatusChoices = None
-            APICallTypeChoices = None
+            from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
         try:
             from ee.usage.utils import log_and_deduct_cost_for_resource_request
         except ImportError:
-            log_and_deduct_cost_for_resource_request = None
+            from futureagi._ee_stubs import log_and_deduct_cost_for_resource_request
 
         call_log = log_and_deduct_cost_for_resource_request(
             organization,

--- a/futureagi/model_hub/tasks/develop_dataset.py
+++ b/futureagi/model_hub/tasks/develop_dataset.py
@@ -54,13 +54,11 @@ from tfc.utils.storage import (
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    count_text_tokens = None
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import count_text_tokens, log_and_deduct_cost_for_api_request
 
 
 def run_generate_new_rows_test(
@@ -367,7 +365,7 @@ def create_synthetic_dataset(
         try:
             from ee.usage.models.usage import APICallTypeChoices
         except ImportError:
-            APICallTypeChoices = None
+            from futureagi._ee_stubs import APICallTypeChoices
         try:
             from ee.usage.schemas.event_types import BillingEventType
         except ImportError:

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -45,14 +45,11 @@ from tracer.models.observation_span import EvalLogger
 try:
     from ee.usage.models.usage import APICallLog, APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallLog = None
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallLog, APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 except ImportError:
-    log_and_deduct_cost_for_api_request = None
-    refund_cost_for_api_call = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 
 
 def _mark_cells_usage_limit_error(user_eval_metric, usage_check):

--- a/futureagi/model_hub/utils/async_generate_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_generate_prompt_runner.py
@@ -19,9 +19,7 @@ except ImportError:
 try:
     from ee.usage.utils.usage_entries import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallTypeChoices = None
-    count_text_tokens = None
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
 
 
 async def generate_prompt_async(

--- a/futureagi/model_hub/utils/async_improve_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_improve_prompt_runner.py
@@ -19,9 +19,7 @@ except ImportError:
 try:
     from ee.usage.utils.usage_entries import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallTypeChoices = None
-    count_text_tokens = None
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
 
 
 async def improve_prompt_async(

--- a/futureagi/model_hub/utils/async_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_prompt_runner.py
@@ -14,8 +14,7 @@ from model_hub.utils.column_utils import is_json_response_format
 try:
     from ee.usage.utils.usage_entries import APICallTypeChoices, log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallTypeChoices = None
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import APICallTypeChoices, log_and_deduct_cost_for_api_request
 
 
 async def run_template_async(

--- a/futureagi/model_hub/utils/auto_annotate.py
+++ b/futureagi/model_hub/utils/auto_annotate.py
@@ -34,12 +34,11 @@ from tfc.utils.error_codes import get_error_message
 try:
     from ee.usage.models.usage import APICallTypeChoices
 except ImportError:
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_tiktoken_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    count_tiktoken_tokens = None
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import count_tiktoken_tokens, log_and_deduct_cost_for_api_request
 
 # from ee.agenthub.feedback_agent_updated.utils import delete_table
 

--- a/futureagi/model_hub/views/datasets/add_rows/existing_dataset.py
+++ b/futureagi/model_hub/views/datasets/add_rows/existing_dataset.py
@@ -15,13 +15,11 @@ from tfc.utils.general_methods import GeneralMethods
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
-    ROW_LIMIT_REACHED_MESSAGE = None
-    log_and_deduct_cost_for_resource_request = None
+    from futureagi._ee_stubs import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 
 
 class AddRowsFromExistingView(APIView):

--- a/futureagi/model_hub/views/datasets/add_rows/huggingface.py
+++ b/futureagi/model_hub/views/datasets/add_rows/huggingface.py
@@ -22,13 +22,11 @@ from tfc.utils.general_methods import GeneralMethods
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
-    ROW_LIMIT_REACHED_MESSAGE = None
-    log_and_deduct_cost_for_resource_request = None
+    from futureagi._ee_stubs import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 
 
 class AddRowsFromHuggingFaceView(APIView):

--- a/futureagi/model_hub/views/datasets/create/dataset_from_experiment.py
+++ b/futureagi/model_hub/views/datasets/create/dataset_from_experiment.py
@@ -24,12 +24,11 @@ from tfc.utils.parse_errors import parse_serialized_errors
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_resource_request
 except ImportError:
-    log_and_deduct_cost_for_resource_request = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_resource_request
 
 
 class CreateDatasetFromExpView(APIView):

--- a/futureagi/model_hub/views/datasets/create/empty_dataset.py
+++ b/futureagi/model_hub/views/datasets/create/empty_dataset.py
@@ -24,12 +24,11 @@ from tfc.utils.parse_errors import parse_serialized_errors
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_resource_request
 except ImportError:
-    log_and_deduct_cost_for_resource_request = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_resource_request
 
 
 class CreateEmptyDatasetView(APIView):

--- a/futureagi/model_hub/views/datasets/create/file_upload.py
+++ b/futureagi/model_hub/views/datasets/create/file_upload.py
@@ -51,13 +51,11 @@ from tfc.utils.storage_client import (
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
-    ROW_LIMIT_REACHED_MESSAGE = None
-    log_and_deduct_cost_for_resource_request = None
+    from futureagi._ee_stubs import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 
 
 def normalize_cell_value(value):

--- a/futureagi/model_hub/views/datasets/create/huggingface.py
+++ b/futureagi/model_hub/views/datasets/create/huggingface.py
@@ -39,13 +39,11 @@ from tfc.utils.parse_errors import parse_serialized_errors
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
-    ROW_LIMIT_REACHED_MESSAGE = None
-    log_and_deduct_cost_for_resource_request = None
+    from futureagi._ee_stubs import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 
 
 class GetHuggingFaceDatasetConfigView(APIView):

--- a/futureagi/model_hub/views/datasets/create/synthetic.py
+++ b/futureagi/model_hub/views/datasets/create/synthetic.py
@@ -29,13 +29,11 @@ from tfc.utils.parse_errors import parse_serialized_errors
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
-    ROW_LIMIT_REACHED_MESSAGE = None
-    log_and_deduct_cost_for_resource_request = None
+    from futureagi._ee_stubs import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 
 
 class CreateSyntheticDataset(APIView):

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -193,13 +193,11 @@ from tfc.utils.storage import (
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
-    ROW_LIMIT_REACHED_MESSAGE = None
-    log_and_deduct_cost_for_resource_request = None
+    from futureagi._ee_stubs import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 
 # =============================================================================
 # Standalone helper functions for Temporal activities

--- a/futureagi/model_hub/views/develop_optimiser.py
+++ b/futureagi/model_hub/views/develop_optimiser.py
@@ -48,12 +48,11 @@ from model_hub.views.prompt_template import replace_ids_with_column_name
 try:
     from ee.usage.models.usage import APICallTypeChoices
 except ImportError:
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_tiktoken_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    count_tiktoken_tokens = None
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import count_tiktoken_tokens, log_and_deduct_cost_for_api_request
 
 
 class DevelopOptimizer:

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -73,14 +73,11 @@ from tfc.utils.parse_errors import parse_serialized_errors
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_tiktoken_tokens, log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 except ImportError:
-    count_tiktoken_tokens = None
-    log_and_deduct_cost_for_api_request = None
-    refund_cost_for_api_call = None
+    from futureagi._ee_stubs import count_tiktoken_tokens, log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 
 
 def _format_messages_to_prompt_chain(messages):

--- a/futureagi/model_hub/views/prompt_template.py
+++ b/futureagi/model_hub/views/prompt_template.py
@@ -166,9 +166,7 @@ except ImportError:
 try:
     from ee.usage.utils.usage_entries import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallTypeChoices = None
-    count_text_tokens = None
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
 
 MIME_TO_EXT = {
     # Documents

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -85,12 +85,11 @@ from tfc.utils.storage import (
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_api_request
 
 PROVIDERS_WITH_JSON = ["vertex_ai", "azure", "bedrock", "sagemaker"]
 

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -30,7 +30,7 @@ except ImportError:
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_api_request
 
 
 def run_eval_func(

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -17,7 +17,7 @@ except ImportError:
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_api_request
 
 
 class StandaloneEvaluationError(Exception):

--- a/futureagi/sdk/utils/helpers.py
+++ b/futureagi/sdk/utils/helpers.py
@@ -5,7 +5,7 @@ from model_hub.models.choices import ModelChoices
 try:
     from ee.usage.models.usage import APICallTypeChoices
 except ImportError:
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallTypeChoices
 
 if APICallTypeChoices is not None:
     model_to_api_call_type = {

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -111,8 +111,7 @@ except ImportError:
 try:
     from ee.usage.utils.usage_entries import deduct_cost_for_request, log_and_deduct_cost_for_api_request
 except ImportError:
-    deduct_cost_for_request = None
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import deduct_cost_for_request, log_and_deduct_cost_for_api_request
 
 
 class TestExecutor:

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -1216,7 +1216,7 @@ def _run_tool_evaluation_standalone(call_execution, test_execution):
     try:
         from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
     except ImportError:
-        log_and_deduct_cost_for_api_request = None
+        from futureagi._ee_stubs import log_and_deduct_cost_for_api_request
 
     try:
         # Skip if no service_provider_call_id for VOICE agents

--- a/futureagi/sockets/prompt_stream_consumer.py
+++ b/futureagi/sockets/prompt_stream_consumer.py
@@ -33,13 +33,11 @@ from model_hub.views.prompt_template import (
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    count_text_tokens = None
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import count_text_tokens, log_and_deduct_cost_for_api_request
 
 
 class PromptStreamConsumer(AsyncJsonWebsocketConsumer):

--- a/futureagi/tracer/tasks.py
+++ b/futureagi/tracer/tasks.py
@@ -61,13 +61,11 @@ from tracer.utils.otel import SpanAttributes, convert_otel_span_to_observation_s
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 except ImportError:
-    log_and_deduct_cost_for_api_request = None
-    refund_cost_for_api_call = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 
 
 def _convert_attributes(attributes):

--- a/futureagi/tracer/tasks/error_analysis.py
+++ b/futureagi/tracer/tasks/error_analysis.py
@@ -49,13 +49,11 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
     try:
         from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
     except ImportError:
-        APICallStatusChoices = None
-        APICallTypeChoices = None
+        from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
     try:
         from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
     except ImportError:
-        log_and_deduct_cost_for_api_request = None
-        refund_cost_for_api_call = None
+        from futureagi._ee_stubs import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 
     api_call_log_row = None
     organization = None

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -28,7 +28,7 @@ except ImportError:
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_api_request
 
 custom_prompt_eval_types = ["CustomPrompt"]
 EXPERIMENT = "experiment"

--- a/futureagi/tracer/utils/external_eval.py
+++ b/futureagi/tracer/utils/external_eval.py
@@ -19,7 +19,7 @@ except ImportError:
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
-    log_and_deduct_cost_for_api_request = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_api_request
 
 
 def _run_external_platform_evaluation(

--- a/futureagi/tracer/utils/otel.py
+++ b/futureagi/tracer/utils/otel.py
@@ -38,12 +38,11 @@ from tracer.utils.semantic_conventions import (
 try:
     from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+    from futureagi._ee_stubs import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_resource_request
 except ImportError:
-    log_and_deduct_cost_for_resource_request = None
+    from futureagi._ee_stubs import log_and_deduct_cost_for_resource_request
 
 
 class OtelSpan:


### PR DESCRIPTION
Fixes #180.

OSS installs don't ship the proprietary `ee.usage` package. ~30 files used `try/except ImportError` blocks that fell back to `APICallTypeChoices = None` and `log_and_deduct_cost_for_resource_request = None`, then immediately dereferenced those Nones (`APICallTypeChoices.DATASET_ADD.value`) and crashed with `AttributeError: 'NoneType' object has no attribute 'DATASET_ADD'`. The dataset-creation path described in the bug is the most visible victim, but the same pattern crashes prompt running, eval execution, file upload, and several other endpoints.

This PR adds `futureagi/_ee_stubs.py` with no-op stubs (an `Enum` with all the existing values, a fake Django `objects` manager, no-op cost-deduction helpers) and rewrites every fallback to import from it. The existing `try` block still wins when EE is installed; OSS just gets functional stubs instead of `None`.

No behavior change when EE is present. On OSS, dataset creation, file upload, prompt running, eval runs, etc. now succeed.

The stub enum values match the strings used in EE so logs stay parseable across installs.