### PR TITLE
fix(billing): deterministic monthly-closing period via workflow.now()

### DIFF
--- a/futureagi/tfc/temporal/billing/__init__.py
+++ b/futureagi/tfc/temporal/billing/__init__.py
@@ -5,6 +5,7 @@ def get_activities():
     """Lazy-load billing activities (imports Django)."""
     from tfc.temporal.billing.activities import (
         generate_monthly_invoices_activity,
+        monthly_closing_activity,
         report_stripe_usage_activity,
         run_dunning_checks_activity,
     )
@@ -13,4 +14,5 @@ def get_activities():
         report_stripe_usage_activity,
         run_dunning_checks_activity,
         generate_monthly_invoices_activity,
+        monthly_closing_activity,
     ]

--- a/futureagi/tfc/temporal/billing/activities.py
+++ b/futureagi/tfc/temporal/billing/activities.py
@@ -15,6 +15,8 @@ from temporalio import activity
 from tfc.temporal.billing.types import (
     DunningCheckInput,
     DunningCheckOutput,
+    MonthlyClosingInput,
+    MonthlyClosingOutput,
     MonthlyInvoiceInput,
     MonthlyInvoiceOutput,
     StripeUsageReportInput,
@@ -185,5 +187,62 @@ def _generate_monthly_invoices_sync(
             stdout=lambda msg: activity.logger.info(msg),
         )
         return result.created, result.skipped, result.errors
+    finally:
+        close_old_connections()
+
+
+# ── Monthly Closing (reset + invoice gen, chained) ─────────────────────────
+
+
+def _run_monthly_reset_sync(period: str) -> None:
+    close_old_connections()
+    try:
+        from ee.usage.tasks.monthly_reset import run_monthly_reset
+
+        run_monthly_reset(period=period)
+    finally:
+        close_old_connections()
+
+
+@activity.defn(name="monthly_closing_activity")
+async def monthly_closing_activity(
+    input: MonthlyClosingInput,
+) -> MonthlyClosingOutput:
+    """Flush Redis usage to DB, then generate invoices for the same period.
+
+    Reset must precede invoice generation: the invoice-gen idempotency gate
+    skips orgs that already have an Invoice row for the period, so a retry
+    can't recover events still buffered in Redis at fire time.
+
+    ``input.period`` MUST be a non-empty ``YYYY-MM`` string, derived from
+    ``workflow.now()`` in ``MonthlyClosingWorkflow``. No wall-clock
+    fallback — see the workflow docstring for why.
+    """
+    close_old_connections()
+    try:
+        period = input.period
+        if not period or len(period) != 7 or period[4] != "-":
+            raise ValueError(
+                f"monthly_closing_activity requires YYYY-MM period, got {period!r}"
+            )
+        activity.logger.info(f"monthly_closing_start period={period}")
+
+        await sync_to_async(_run_monthly_reset_sync, thread_sensitive=False)(period)
+
+        created, skipped, errors = await sync_to_async(
+            _generate_monthly_invoices_sync, thread_sensitive=False
+        )(period, "")
+        activity.logger.info(
+            f"monthly_closing_done period={period} "
+            f"created={created} skipped={skipped} errors={errors}"
+        )
+
+        return MonthlyClosingOutput(
+            period=period,
+            invoices_created=created,
+            invoices_skipped=skipped,
+            errors=errors,
+            status="COMPLETED",
+        )
     finally:
         close_old_connections()

--- a/futureagi/tfc/temporal/billing/types.py
+++ b/futureagi/tfc/temporal/billing/types.py
@@ -54,3 +54,17 @@ class MonthlyInvoiceOutput:
     invoices_skipped: int = 0
     errors: int = 0
     status: str = "COMPLETED"
+
+
+@dataclass
+class MonthlyClosingInput:
+    period: str = ""  # YYYY-MM. Empty = previous month from now.
+
+
+@dataclass
+class MonthlyClosingOutput:
+    period: str = ""
+    invoices_created: int = 0
+    invoices_skipped: int = 0
+    errors: int = 0
+    status: str = "COMPLETED"

--- a/futureagi/tfc/temporal/billing/workflows.py
+++ b/futureagi/tfc/temporal/billing/workflows.py
@@ -45,7 +45,6 @@ class MonthlyClosingWorkflow:
             "monthly_closing_activity",
             MonthlyClosingInput(period=period),
             start_to_close_timeout=timedelta(hours=2),
-            heartbeat_timeout=timedelta(minutes=5),
             retry_policy=CLOSING_RETRY_POLICY,
         )
 

--- a/futureagi/tfc/temporal/billing/workflows.py
+++ b/futureagi/tfc/temporal/billing/workflows.py
@@ -1,0 +1,53 @@
+"""Workflows for billing operations.
+
+``MonthlyClosingWorkflow`` runs once per month, started by the
+``monthly-closing`` Temporal schedule (cron ``0 0 1 * *``). It locks the
+closing period to ``workflow.now()`` — the deterministic, replay-safe
+clock fixed at workflow start — and passes that period explicitly to
+``monthly_closing_activity``. Wall-clock derivation inside the activity
+would otherwise depend on the worker pod's local clock at execution
+time, which is fragile across worker clock skew and across activity
+retries that span midnight UTC of the 1st.
+"""
+
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from tfc.temporal.billing.types import (
+        MonthlyClosingInput,
+        MonthlyClosingOutput,
+    )
+
+
+CLOSING_RETRY_POLICY = RetryPolicy(
+    initial_interval=timedelta(seconds=30),
+    maximum_interval=timedelta(minutes=10),
+    maximum_attempts=5,
+    backoff_coefficient=2.0,
+)
+
+
+def _previous_period(fire) -> str:
+    if fire.month == 1:
+        return f"{fire.year - 1}-12"
+    return f"{fire.year}-{fire.month - 1:02d}"
+
+
+@workflow.defn
+class MonthlyClosingWorkflow:
+    @workflow.run
+    async def run(self) -> MonthlyClosingOutput:
+        period = _previous_period(workflow.now())
+        return await workflow.execute_activity(
+            "monthly_closing_activity",
+            MonthlyClosingInput(period=period),
+            start_to_close_timeout=timedelta(hours=2),
+            heartbeat_timeout=timedelta(minutes=5),
+            retry_policy=CLOSING_RETRY_POLICY,
+        )
+
+
+__all__ = ["MonthlyClosingWorkflow"]

--- a/futureagi/tfc/temporal/common/registry.py
+++ b/futureagi/tfc/temporal/common/registry.py
@@ -298,6 +298,20 @@ def _ensure_workflows_registered() -> None:
 
         get_logger(__name__).warning("could_not_load_billing_workflows", error=str(e))
 
+    try:
+        from tfc.temporal.billing.workflows import MonthlyClosingWorkflow
+
+        register_for_queues(
+            queues=["tasks_s"],
+            workflows=[MonthlyClosingWorkflow],
+        )
+    except ImportError as e:
+        from tfc.logging.temporal import get_logger
+
+        get_logger(__name__).warning(
+            "could_not_load_monthly_closing_workflow", error=str(e)
+        )
+
     _workflows_registered = True
 
 
@@ -656,7 +670,7 @@ def _ensure_activities_registered() -> None:
 
         billing_activities = get_billing_activities()
         register_for_queues(
-            queues=["default", "tasks_l"],
+            queues=["default", "tasks_l", "tasks_s"],
             activities=billing_activities,
         )
         log.info("registered_billing_activities", count=len(billing_activities))

--- a/futureagi/tfc/temporal/schedules/billing.py
+++ b/futureagi/tfc/temporal/schedules/billing.py
@@ -6,7 +6,7 @@ Hourly Stripe usage reporting + daily dunning checks. The consumer workflow runs
 """
 
 from datetime import datetime, timezone
-from typing import List
+from typing import Any, List
 
 import structlog
 
@@ -14,6 +14,13 @@ from tfc.temporal.drop_in import temporal_activity
 from tfc.temporal.schedules.config import ScheduleConfig
 
 logger = structlog.get_logger(__name__)
+
+
+def _monthly_closing_workflow() -> Any:
+    """Lazy import — workflow module pulls in temporalio's sandbox guards."""
+    from tfc.temporal.billing.workflows import MonthlyClosingWorkflow
+
+    return MonthlyClosingWorkflow
 
 
 @temporal_activity(time_limit=300, queue="default")
@@ -71,13 +78,6 @@ def evaluate_budgets_catchup_activity():
 BILLING_SCHEDULES: List[ScheduleConfig] = [
     # sync-usage-to-db: REMOVED — now runs inside UsageConsumerWorkflow (every 60s)
     ScheduleConfig(
-        schedule_id="monthly-usage-reset",
-        activity_name="monthly_reset_activity",
-        interval_seconds=86400,  # Daily — activity is idempotent, only acts on 1st of month
-        queue="default",
-        description="Monthly usage reset: snapshot counters, clear Redis, update billing periods",
-    ),
-    ScheduleConfig(
         schedule_id="budget-catchup",
         activity_name="evaluate_budgets_catchup_activity",
         interval_seconds=900,
@@ -99,10 +99,15 @@ BILLING_SCHEDULES: List[ScheduleConfig] = [
         description="Process dunning steps for past_due orgs (daily)",
     ),
     ScheduleConfig(
-        schedule_id="monthly-invoice-generation",
-        activity_name="generate_monthly_invoices_activity",
-        interval_seconds=86400,  # Daily — activity is idempotent, only generates once per period
-        queue="tasks_l",
-        description="Generate monthly invoices for all paid orgs (runs daily, acts on 1st of month)",
+        schedule_id="monthly-closing",
+        activity_name="monthly_closing_activity",
+        cron_expression="0 0 1 * *",
+        catchup_window_seconds=7 * 86400,
+        queue="tasks_s",
+        description=(
+            "Flush closing-period Redis usage to UsageSummary, then generate "
+            "invoices for all paid orgs."
+        ),
+        workflow_class=_monthly_closing_workflow(),
     ),
 ]

--- a/futureagi/tfc/temporal/schedules/config.py
+++ b/futureagi/tfc/temporal/schedules/config.py
@@ -7,42 +7,54 @@ Temporal schedules across all domains (model_hub, tracer, simulate, etc.).
 
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Optional
+from typing import Any, Optional
 
 from temporalio.client import ScheduleOverlapPolicy
 
 
 @dataclass
 class ScheduleConfig:
-    """
-    Configuration for a Temporal schedule.
+    """Configuration for a Temporal schedule.
 
-    This is a general-purpose configuration that can be used by any domain
-    to define recurring scheduled tasks.
+    Set exactly one of ``interval_seconds`` (epoch-aligned interval firing)
+    or ``cron_expression`` (calendar-aligned firing). For schedules that
+    fire less than once per Temporal's default catchup window (~1 min),
+    set ``catchup_window_seconds`` so a missed firing is retried when the
+    worker comes back instead of being silently dropped.
 
-    Attributes:
-        schedule_id: Unique identifier for the schedule
-        activity_name: Name of the activity to execute
-        interval_seconds: How often to run (in seconds)
-        queue: Task queue to run on (default: "default")
-        description: Human-readable description
-        overlap_policy: What to do if previous run is still running:
-            - SKIP: Skip this trigger if previous is running (default, prevents overlap)
-            - BUFFER_ONE: Buffer one pending run
-            - ALLOW_ALL: Allow concurrent runs
+    Set ``workflow_class`` to start a dedicated workflow class instead of
+    the generic ``TaskRunnerWorkflow``. Use this when the workflow needs
+    deterministic state at fire time (e.g. a closing period derived from
+    ``workflow.now()``) that the activity cannot reconstruct reliably
+    from its own wall clock.
     """
 
     schedule_id: str
     activity_name: str
-    interval_seconds: int
+    interval_seconds: int = 0
+    cron_expression: Optional[str] = None
+    catchup_window_seconds: int = 0
     queue: str = "default"
     description: Optional[str] = None
     overlap_policy: ScheduleOverlapPolicy = field(default=ScheduleOverlapPolicy.SKIP)
+    workflow_class: Optional[Any] = None
+
+    def __post_init__(self) -> None:
+        if not self.cron_expression and self.interval_seconds <= 0:
+            raise ValueError(
+                f"ScheduleConfig {self.schedule_id!r} must set either "
+                f"interval_seconds (>0) or cron_expression."
+            )
 
     @property
     def interval(self) -> timedelta:
-        """Get interval as timedelta."""
         return timedelta(seconds=self.interval_seconds)
+
+    @property
+    def catchup_window(self) -> Optional[timedelta]:
+        if self.catchup_window_seconds <= 0:
+            return None
+        return timedelta(seconds=self.catchup_window_seconds)
 
 
 __all__ = ["ScheduleConfig"]

--- a/futureagi/tfc/temporal/schedules/manager.py
+++ b/futureagi/tfc/temporal/schedules/manager.py
@@ -232,8 +232,23 @@ async def list_schedules(client: Client) -> List[str]:
 
 def _build_schedule_for_config(config: ScheduleConfig) -> Schedule:
     """Build a Temporal Schedule from a ScheduleConfig."""
-    return Schedule(
-        action=ScheduleActionStartWorkflow(
+    if config.cron_expression:
+        spec = ScheduleSpec(cron_expressions=[config.cron_expression])
+    else:
+        spec = ScheduleSpec(intervals=[ScheduleIntervalSpec(every=config.interval)])
+
+    policy_kwargs: dict = {"overlap": config.overlap_policy}
+    if config.catchup_window is not None:
+        policy_kwargs["catchup_window"] = config.catchup_window
+
+    if config.workflow_class is not None:
+        action = ScheduleActionStartWorkflow(
+            config.workflow_class.run,
+            id=f"scheduled-{config.schedule_id}",
+            task_queue=config.queue,
+        )
+    else:
+        action = ScheduleActionStartWorkflow(
             TaskRunnerWorkflow.run,
             TaskRunnerInput(
                 activity_name=config.activity_name,
@@ -243,11 +258,12 @@ def _build_schedule_for_config(config: ScheduleConfig) -> Schedule:
             ),
             id=f"scheduled-{config.schedule_id}",
             task_queue=config.queue,
-        ),
-        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=config.interval)]),
-        policy=SchedulePolicy(
-            overlap=config.overlap_policy,  # Default: SKIP (prevents overlapping runs)
-        ),
+        )
+
+    return Schedule(
+        action=action,
+        spec=spec,
+        policy=SchedulePolicy(**policy_kwargs),
         state=ScheduleState(
             note=config.description or f"Schedule for {config.activity_name}"
         ),


### PR DESCRIPTION
## Summary

The `monthly-closing` schedule was firing a generic `TaskRunnerWorkflow` with empty args, leaving `monthly_closing_activity` to derive the closing period from `datetime.now(timezone.utc)`. Worker clock skew or a retry that crosses midnight UTC of the 1st could compute the wrong month, after which `delete_redis_keys(period)` wipes events that were never billed → silent revenue leakage. This PR adds a dedicated `MonthlyClosingWorkflow` that locks the closing period to `workflow.now()` (deterministic, replay-safe, fixed at workflow start) and passes it explicitly to the activity. `ScheduleConfig` gains an optional `workflow_class` so a schedule can target a custom workflow instead of `TaskRunnerWorkflow`; all other schedules are unaffected. The schedule moves off the overloaded `tasks_l` queue onto `tasks_s`, and `monthly_closing_activity` is now strict — empty/malformed `period` raises `ValueError` instead of falling back to wall clock. Companion EE-tree changes (gitignored here, separate PR) make `sync_usage_to_db(period)` a required parameter.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `cd futureagi && pytest ee/usage/tests/test_temporal_billing.py -x` with EE companion changes applied
- Local Temporal dev cluster: `temporal schedule describe -s scheduled-monthly-closing` shows workflow type `MonthlyClosingWorkflow`, task queue `tasks_s`, cron `0 0 1 * *`, catchup window 7d
- `temporal schedule trigger -s scheduled-monthly-closing` → activity logs show `monthly_closing_start period=YYYY-MM` matching the previous month, regardless of worker wall clock
- Negative test: start `monthly_closing_activity` directly with `MonthlyClosingInput(period="")` and confirm it fails with `ValueError`, not a silent run
- Post-deploy (US first, then EU): assert `scheduled-monthly-usage-reset`, `scheduled-monthly-invoice-generation`, `scheduled-sync-usage-to-db` are absent and `scheduled-monthly-closing` is present via `temporal schedule list`

## Screenshots / recordings (if UI)

N/A — backend + Temporal change.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)