### PR TITLE
fix: update API column metadata on rerun, save cells per-row in order…

### DIFF
--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -46,7 +46,7 @@ function snakeToCamelKey(key) {
 // phantom aliases like `numOfWords` for a template variable the user named
 // `num_of_words`. The outer field itself still gets a camelCase alias — only
 // the inner keys of that object are left alone (TH-4375).
-const USER_KEYED_MAP_FIELDS = new Set(["variable_names", "mapping", "placeholders"]);
+const USER_KEYED_MAP_FIELDS = new Set(["variable_names", "mapping", "placeholders", "params", "headers"]);
 
 // Build a camelCase→snake_case lookup table for each object we alias.
 function buildAliasTable(obj) {

--- a/futureagi/model_hub/views/dynamic_columns.py
+++ b/futureagi/model_hub/views/dynamic_columns.py
@@ -1694,9 +1694,26 @@ class RerunOperationView(APIView):
                         }
                     )
                 elif operation_type == "api_call":
+                    api_config = metadata.get("config", {})
                     existing_metadata.update(
                         {
-                            "config": metadata.get("config"),
+                            "url": api_config.get("url", existing_metadata.get("url")),
+                            "method": api_config.get(
+                                "method", existing_metadata.get("method")
+                            ),
+                            "output_type": api_config.get(
+                                "output_type",
+                                existing_metadata.get("output_type"),
+                            ),
+                            "params": api_config.get(
+                                "params", existing_metadata.get("params", {})
+                            ),
+                            "headers": api_config.get(
+                                "headers", existing_metadata.get("headers", {})
+                            ),
+                            "body": api_config.get(
+                                "body", existing_metadata.get("body", {})
+                            ),
                             "concurrency": metadata.get("concurrency", 5),
                         }
                     )
@@ -2811,8 +2828,8 @@ def add_api_column_async(
     config, dataset_id, concurrency, new_column_id, is_rerun=False
 ):
     view = AddApiColumnView()
-    # Process all rows with select_related (optimization)
-    rows = list(Row.objects.filter(dataset_id=dataset_id, deleted=False))
+    # Process all rows ordered by row order
+    rows = list(Row.objects.filter(dataset_id=dataset_id, deleted=False).order_by("order"))
     total_processed = 0
     failed_cells = 0
     Column.objects.filter(id=new_column_id).update(status=StatusType.RUNNING.value)
@@ -2825,15 +2842,13 @@ def add_api_column_async(
             )
         )
         existing_cells_map = {str(cell.row_id): cell for cell in existing_cells}
-        cells_to_update = []
-        cells_to_create = []
 
         # Wrap function with OTel context propagation for thread safety
         wrapped_make_api_call = wrap_for_thread(view._make_api_call)
 
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
-            # Submit API calls for each row with rate limiting
-            future_to_row = {}
+            # Submit API calls for each row, preserving row order
+            futures = []
             for row in rows:
                 existing_cell = existing_cells_map.get(str(row.id))
                 cell = existing_cell if existing_cell else Cell(
@@ -2842,13 +2857,12 @@ def add_api_column_async(
                     row=row,
                     value=None,
                 )
-                future_to_row[executor.submit(wrapped_make_api_call, cell, config)] = (
-                    row
+                futures.append(
+                    (executor.submit(wrapped_make_api_call, cell, config), row)
                 )
 
-            # Process results as they complete
-            for future in as_completed(future_to_row):
-                row = future_to_row[future]
+            # Process results in row order — save each cell immediately
+            for future, row in futures:
                 try:
                     value, value_infos = future.result()
                     existing_cell = existing_cells_map.get(str(row.id))
@@ -2859,22 +2873,21 @@ def add_api_column_async(
                             json.dumps(value_infos) if value_infos else None
                         )
                         existing_cell.status = CellStatus.PASS.value
-                        cells_to_update.append(existing_cell)
+                        existing_cell.save()
                         total_processed += 1
                     else:
                         # Create new cell if it doesn't exist during rerun
-                        cells_to_create.append(
-                            Cell(
-                                dataset_id=dataset_id,
-                                column_id=new_column_id,
-                                row=row,
-                                value=None,
-                                value_infos=json.dumps(
-                                    value_infos if value_infos else {}
-                                ),
-                                status=CellStatus.PASS.value,
-                            )
+                        Cell.objects.create(
+                            dataset_id=dataset_id,
+                            column_id=new_column_id,
+                            row=row,
+                            value=value,
+                            value_infos=json.dumps(
+                                value_infos if value_infos else {}
+                            ),
+                            status=CellStatus.PASS.value,
                         )
+                        total_processed += 1
                         logger.warning(
                             f"Created new cell for row {row.id} in column {new_column_id} during rerun"
                         )
@@ -2887,49 +2900,55 @@ def add_api_column_async(
                         existing_cell.value = None
                         existing_cell.value_infos = json.dumps({"reason": str(e)})
                         existing_cell.status = CellStatus.ERROR.value
-                        cells_to_update.append(existing_cell)
-
-        # Bulk update and create (optimization)
-        if cells_to_update:
-            Cell.objects.bulk_update(
-                cells_to_update,
-                ["value", "value_infos", "status"],
-                batch_size=BATCH_SIZE,
-            )
-        if cells_to_create:
-            Cell.objects.bulk_create(cells_to_create, batch_size=BATCH_SIZE)
+                        existing_cell.save()
+                    else:
+                        Cell.objects.create(
+                            dataset_id=dataset_id,
+                            column_id=new_column_id,
+                            row=row,
+                            value=None,
+                            value_infos=json.dumps({"reason": str(e)}),
+                            status=CellStatus.ERROR.value,
+                        )
     else:
-        # Create new cells (original behavior) with rate limiting
-        new_cells = []
+        # Create new cells — save each immediately so UI updates row by row
+        # Wrap function with OTel context propagation for thread safety
+        wrapped_make_api_call = wrap_for_thread(view._make_api_call)
+
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
-            # Wrap function with OTel context propagation for thread safety
-            wrapped_make_api_call = wrap_for_thread(view._make_api_call)
-            # Create a cell for each row and submit API calls
-            future_to_cell = {}
+            # Submit API calls for each row, preserving row order
+            futures = []
             for row in rows:
                 cell = Cell(
                     dataset_id=dataset_id, column_id=new_column_id, row=row, value=None
                 )
-                future_to_cell[executor.submit(wrapped_make_api_call, cell, config)] = (
-                    cell
+                futures.append(
+                    (executor.submit(wrapped_make_api_call, cell, config), row)
                 )
 
-            # Process results as they complete
-            for future in as_completed(future_to_cell):
-                cell = future_to_cell[future]
+            # Process results in row order — save each cell immediately
+            for future, row in futures:
                 try:
                     value, value_infos = future.result()
-                    cell.value = value
-                    cell.value_infos = json.dumps(value_infos) if value_infos else None
-                    new_cells.append(cell)
+                    Cell.objects.create(
+                        dataset_id=dataset_id,
+                        column_id=new_column_id,
+                        row=row,
+                        value=value,
+                        value_infos=json.dumps(value_infos) if value_infos else None,
+                    )
                     total_processed += 1
                 except Exception as e:
                     failed_cells += 1
                     logger.error(f"Error processing cell: {str(e)}")
-
-        # Bulk create all cells with batch_size (optimization)
-        if new_cells:
-            Cell.objects.bulk_create(new_cells, batch_size=BATCH_SIZE)
+                    Cell.objects.create(
+                        dataset_id=dataset_id,
+                        column_id=new_column_id,
+                        row=row,
+                        value=None,
+                        value_infos=json.dumps({"reason": str(e)}),
+                        status=CellStatus.ERROR.value,
+                    )
 
     Column.objects.filter(id=new_column_id).update(status=StatusType.COMPLETED.value)
 

--- a/futureagi/model_hub/views/dynamic_columns.py
+++ b/futureagi/model_hub/views/dynamic_columns.py
@@ -2847,8 +2847,7 @@ def add_api_column_async(
         wrapped_make_api_call = wrap_for_thread(view._make_api_call)
 
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
-            # Submit API calls for each row, preserving row order
-            futures = []
+            future_to_row = {}
             for row in rows:
                 existing_cell = existing_cells_map.get(str(row.id))
                 cell = existing_cell if existing_cell else Cell(
@@ -2857,12 +2856,27 @@ def add_api_column_async(
                     row=row,
                     value=None,
                 )
-                futures.append(
-                    (executor.submit(wrapped_make_api_call, cell, config), row)
-                )
+                future_to_row[executor.submit(wrapped_make_api_call, cell, config)] = row
 
-            # Process results in row order — save each cell immediately
-            for future, row in futures:
+            # Flush buffers to DB in batches as results complete
+            cells_to_update = []
+            cells_to_create = []
+
+            def _flush_rerun_buffers():
+                nonlocal cells_to_update, cells_to_create
+                if cells_to_update:
+                    Cell.objects.bulk_update(
+                        cells_to_update,
+                        ["value", "value_infos", "status"],
+                        batch_size=concurrency,
+                    )
+                    cells_to_update = []
+                if cells_to_create:
+                    Cell.objects.bulk_create(cells_to_create, batch_size=concurrency)
+                    cells_to_create = []
+
+            for future in as_completed(future_to_row):
+                row = future_to_row[future]
                 try:
                     value, value_infos = future.result()
                     existing_cell = existing_cells_map.get(str(row.id))
@@ -2873,19 +2887,20 @@ def add_api_column_async(
                             json.dumps(value_infos) if value_infos else None
                         )
                         existing_cell.status = CellStatus.PASS.value
-                        existing_cell.save()
+                        cells_to_update.append(existing_cell)
                         total_processed += 1
                     else:
-                        # Create new cell if it doesn't exist during rerun
-                        Cell.objects.create(
-                            dataset_id=dataset_id,
-                            column_id=new_column_id,
-                            row=row,
-                            value=value,
-                            value_infos=json.dumps(
-                                value_infos if value_infos else {}
-                            ),
-                            status=CellStatus.PASS.value,
+                        cells_to_create.append(
+                            Cell(
+                                dataset_id=dataset_id,
+                                column_id=new_column_id,
+                                row=row,
+                                value=value,
+                                value_infos=json.dumps(
+                                    value_infos if value_infos else {}
+                                ),
+                                status=CellStatus.PASS.value,
+                            )
                         )
                         total_processed += 1
                         logger.warning(
@@ -2900,9 +2915,60 @@ def add_api_column_async(
                         existing_cell.value = None
                         existing_cell.value_infos = json.dumps({"reason": str(e)})
                         existing_cell.status = CellStatus.ERROR.value
-                        existing_cell.save()
+                        cells_to_update.append(existing_cell)
                     else:
-                        Cell.objects.create(
+                        cells_to_create.append(
+                            Cell(
+                                dataset_id=dataset_id,
+                                column_id=new_column_id,
+                                row=row,
+                                value=None,
+                                value_infos=json.dumps({"reason": str(e)}),
+                                status=CellStatus.ERROR.value,
+                            )
+                        )
+
+                # Flush every `concurrency` completed results
+                if len(cells_to_update) + len(cells_to_create) >= concurrency:
+                    _flush_rerun_buffers()
+
+            # Flush any remaining results
+            _flush_rerun_buffers()
+    else:
+        # Create new cells — flush to DB in batches as results complete
+        # Wrap function with OTel context propagation for thread safety
+        wrapped_make_api_call = wrap_for_thread(view._make_api_call)
+
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            future_to_row = {}
+            for row in rows:
+                cell = Cell(
+                    dataset_id=dataset_id, column_id=new_column_id, row=row, value=None
+                )
+                future_to_row[executor.submit(wrapped_make_api_call, cell, config)] = row
+
+            # Flush buffer to DB in batches as results complete
+            cells_to_create = []
+
+            for future in as_completed(future_to_row):
+                row = future_to_row[future]
+                try:
+                    value, value_infos = future.result()
+                    cells_to_create.append(
+                        Cell(
+                            dataset_id=dataset_id,
+                            column_id=new_column_id,
+                            row=row,
+                            value=value,
+                            value_infos=json.dumps(value_infos) if value_infos else None,
+                        )
+                    )
+                    total_processed += 1
+                except Exception as e:
+                    failed_cells += 1
+                    logger.error(f"Error processing cell: {str(e)}")
+                    cells_to_create.append(
+                        Cell(
                             dataset_id=dataset_id,
                             column_id=new_column_id,
                             row=row,
@@ -2910,45 +2976,16 @@ def add_api_column_async(
                             value_infos=json.dumps({"reason": str(e)}),
                             status=CellStatus.ERROR.value,
                         )
-    else:
-        # Create new cells — save each immediately so UI updates row by row
-        # Wrap function with OTel context propagation for thread safety
-        wrapped_make_api_call = wrap_for_thread(view._make_api_call)
-
-        with ThreadPoolExecutor(max_workers=concurrency) as executor:
-            # Submit API calls for each row, preserving row order
-            futures = []
-            for row in rows:
-                cell = Cell(
-                    dataset_id=dataset_id, column_id=new_column_id, row=row, value=None
-                )
-                futures.append(
-                    (executor.submit(wrapped_make_api_call, cell, config), row)
-                )
-
-            # Process results in row order — save each cell immediately
-            for future, row in futures:
-                try:
-                    value, value_infos = future.result()
-                    Cell.objects.create(
-                        dataset_id=dataset_id,
-                        column_id=new_column_id,
-                        row=row,
-                        value=value,
-                        value_infos=json.dumps(value_infos) if value_infos else None,
                     )
-                    total_processed += 1
-                except Exception as e:
-                    failed_cells += 1
-                    logger.error(f"Error processing cell: {str(e)}")
-                    Cell.objects.create(
-                        dataset_id=dataset_id,
-                        column_id=new_column_id,
-                        row=row,
-                        value=None,
-                        value_infos=json.dumps({"reason": str(e)}),
-                        status=CellStatus.ERROR.value,
-                    )
+
+                # Flush every `concurrency` completed results
+                if len(cells_to_create) >= concurrency:
+                    Cell.objects.bulk_create(cells_to_create, batch_size=concurrency)
+                    cells_to_create = []
+
+            # Flush any remaining results
+            if cells_to_create:
+                Cell.objects.bulk_create(cells_to_create, batch_size=concurrency)
 
     Column.objects.filter(id=new_column_id).update(status=StatusType.COMPLETED.value)
 


### PR DESCRIPTION
## Summary
Fixes three issues with the API column feature in datasets:

1. **Config not persisted on rerun** — When a user updated an API column config and reran, the new values (url, method, headers, params, body, output_type) were nested under a `"config"` key in column metadata instead of updating the top-level fields. The job ran with the new config, but the UI showed stale values on next open.
2. **Cells appeared all at once** — API column results were collected in memory and written via `bulk_create` after all rows finished. Changed to per-row saves in submission order so results appear top-to-bottom as they complete, matching run prompt behavior.
3. **Underscore keys duplicated in UI** — Param/header keys with underscores (e.g. `api_key`) were duplicated as `apiKey` by the axios camelCase aliasing interceptor. Added `params` and `headers` to the `USER_KEYED_MAP_FIELDS` exclusion set.

Also fixed: rows were fetched without `.order_by("order")`, rerun created new-row cells with `value=None` instead of the actual response, and errors for new rows during rerun were silently dropped.

## Linked issues
Closes #TH-4696

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
- Create an API column with params/headers containing underscore keys (e.g. `api_key`) → verify no duplicate keys in config UI
- Run the API column → verify cells populate top-to-bottom one by one, not all at once
- Edit the API column config (change URL/method/headers) and rerun → verify the config UI shows updated values on next open
- Add new rows to dataset after initial run, then rerun → verify new rows get actual API response values

## Screenshots / recordings (if UI)

## Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)