### PR TITLE
fix: treat backend created_at as UTC in dataset list to show correct …

### DIFF
--- a/frontend/src/sections/develop/DevelopView.jsx
+++ b/frontend/src/sections/develop/DevelopView.jsx
@@ -308,7 +308,10 @@ const DevelopView = () => {
           try {
             return (
               <Typography variant="body2" noWrap sx={{ fontSize: "13px" }}>
-                {formatDistanceToNow(new Date(val), { addSuffix: true })}
+                {formatDistanceToNow(
+                  new Date(/[Z+-]/.test(val.slice(-6)) ? val : val + "Z"),
+                  { addSuffix: true },
+                )}
               </Typography>
             );
           } catch {


### PR DESCRIPTION
## Summary
The dataset list "Created" column was showing incorrect relative timestamps (e.g. "6 hours ago" for a just-duplicated dataset). The backend returns `created_at` as `"%Y-%m-%d %H:%M"` (no timezone indicator), so `new Date("2026-05-04 10:30")` in the frontend treats it as local time instead of UTC — causing an offset equal to the user's timezone difference from UTC.

Fixed by appending `"Z"` to the timestamp string on the frontend before parsing, so JavaScript correctly interprets it as UTC and `formatDistanceToNow` calculates the right relative time.

## Linked issues
Closes #TH-4696

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
- Duplicated a dataset from UTC+5:30 timezone → verified "Created" column shows "less than a minute ago" instead of "6 hours ago"
- Verified existing datasets still show correct relative timestamps

## Screenshots / recordings (if UI)

## Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)