### PR TITLE
fix: show code eval required keys in dataset edit

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -244,7 +244,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       [];
 
     if (evalType === "code") {
-      return [];
+      return [...new Set(requiredKeys)];
     }
 
     // System evals + Jinja mode: use static required_keys.


### PR DESCRIPTION
## Summary

This PR fixes the dataset eval edit flow for code evaluations that declare explicit `required_keys`. The eval picker was returning no mapping variables for code evals, so keys like `reference` and `hypothesis` never appeared in the dataset edit drawer even though the template detail API exposed them. This change makes the picker surface declared `required_keys` for code evals while still avoiding placeholder extraction from code bodies.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `yarn lint src/sections/common/EvalPicker/EvalPickerConfigFull.jsx` from `frontend/`
- Verified the code path against `EvalDetailPage.jsx`, which already treats code-eval `required_keys` as mapping variables

## Screenshots / recordings (if UI)

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
