### PR TITLE
[Hotfix] Fix Score eval type rendering in datasets

### DIFF
--- a/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper.js
+++ b/frontend/src/sections/common/DevelopCellRenderer/CellRenderers/cellRendererHelper.js
@@ -68,6 +68,7 @@ export const DataTypes = {
 
 export const OutputTypes = {
   NUMERIC: "numeric",
+  SCORE: "score",
 };
 
 export const StatusTypes = {

--- a/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateArrayCellRenderer.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateArrayCellRenderer.jsx
@@ -27,13 +27,25 @@ const EvaluateArrayCellRenderer = ({
       if (typeof value !== "string") return [];
       const trimmed = value.trim();
       if (!trimmed) return [];
-      
-      if (!(trimmed.startsWith("[") && trimmed.endsWith("]"))) {
-        return [trimmed];
+
+      if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+        const parsed = JSON.parse(trimmed.replaceAll("'", '"'));
+        return Array.isArray(parsed) ? parsed : [];
       }
 
-      const parsed = JSON.parse(trimmed.replaceAll("'", '"'));
-      return Array.isArray(parsed) ? parsed : [];
+      if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+        const parsed = JSON.parse(trimmed.replaceAll("'", '"'));
+        if (parsed && typeof parsed === "object") {
+          if (Array.isArray(parsed.choices)) {
+            return parsed.choices.map((c) => String(c));
+          }
+          if (parsed.choices != null) return [String(parsed.choices)];
+          if (parsed.choice != null) return [String(parsed.choice)];
+        }
+        return [];
+      }
+
+      return [trimmed];
     } catch (e) {
       return typeof value === "string" && value.trim() ? [value.trim()] : [];
     }

--- a/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateCell.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateCell.jsx
@@ -150,8 +150,8 @@ const EvaluateCell = ({
           size="small"
           variant="outlined"
           sx={{
-            borderColor: "#7c3aed",
-            color: "#7c3aed",
+            borderColor: "purple.500",
+            color: "purple.500",
             fontWeight: 500,
             maxWidth: 240,
             "& .MuiChip-label": {

--- a/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateCell.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateCell.jsx
@@ -51,6 +51,7 @@ const EvaluateCell = ({
 }) => {
   const output = cellData?.valueInfos?.output || outputType;
 
+
   // Detect composite eval cells. The Phase B runner writes a `composite_id`
   // key and a `children` array into `value_infos` alongside the aggregate
   // score. Use either as a liveness signal so both newer (composite_id)
@@ -59,11 +60,12 @@ const EvaluateCell = ({
     () => parseValueInfos(cellData),
     [cellData],
   );
+
   const isComposite = Boolean(
     parsedValueInfos?.composite_id ||
-      (Array.isArray(parsedValueInfos?.children) &&
-        parsedValueInfos.children.length > 0 &&
-        parsedValueInfos.children[0]?.child_id),
+    (Array.isArray(parsedValueInfos?.children) &&
+      parsedValueInfos.children.length > 0 &&
+      parsedValueInfos.children[0]?.child_id),
   );
   const [compositeDialogOpen, setCompositeDialogOpen] = useState(false);
 
@@ -137,6 +139,29 @@ const EvaluateCell = ({
 
   if (output === OutputTypes.NUMERIC) {
     return <NumericCell value={value} />;
+  }
+  if (output === OutputTypes.SCORE) {
+    const result = parsedValueInfos?.data?.result;
+    if (!result) return null;
+    return (
+      <Box sx={{ display: "inline-flex", p: 1, maxWidth: "100%" }}>
+        <Chip
+          label={result}
+          size="small"
+          variant="outlined"
+          sx={{
+            borderColor: "#7c3aed",
+            color: "#7c3aed",
+            fontWeight: 500,
+            maxWidth: 240,
+            "& .MuiChip-label": {
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            },
+          }}
+        />
+      </Box>
+    );
   }
   if (dataType === "boolean") {
     const bgColor = value


### PR DESCRIPTION
<!--
Added a new branch for output === OutputTypes.SCORE rendering the result as a violet outlined Chip, capped at maxWidth: 240 with ellipsis on overflow. Wrapped in an inline-flex Box so it shrinks to content.


## Summary

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
