### PR TITLE
fix: use request.organization for multi-org support in experiment views

### DIFF
--- a/futureagi/model_hub/views/experiments.py
+++ b/futureagi/model_hub/views/experiments.py
@@ -1457,7 +1457,7 @@ class GetRowDiffV2View(APIView):
                 ExperimentsTable, id=experiment_id, deleted=False
             )
 
-            organization = request.user.organization
+            organization = getattr(request, "organization", None) or request.user.organization
             if experiment.dataset.organization_id != organization.id:
                 return self._gm.bad_request("Experiment not found.")
 
@@ -3385,7 +3385,7 @@ class ExperimentsTableV2View(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, experiment_id):
-        organization = request.user.organization
+        organization = getattr(request, "organization", None) or request.user.organization
 
         try:
             experiment = (
@@ -3425,7 +3425,7 @@ class ExperimentsTableV2View(APIView):
             return self._gm.bad_request(parse_serialized_errors(serializer))
 
         data = serializer.validated_data
-        organization = request.user.organization
+        organization = getattr(request, "organization", None) or request.user.organization
 
         try:
             # Validate dataset belongs to org
@@ -3745,7 +3745,7 @@ class ExperimentsTableV2View(APIView):
             return self._gm.bad_request(parse_serialized_errors(serializer))
 
         data = serializer.validated_data
-        organization = request.user.organization
+        organization = getattr(request, "organization", None) or request.user.organization
 
         try:
             experiment = ExperimentsTable.objects.get(
@@ -4774,7 +4774,7 @@ class ExperimentJsonSchemaView(APIView):
         try:
             from model_hub.views.develop_dataset import get_json_column_schemas
 
-            organization = request.user.organization
+            organization = getattr(request, "organization", None) or request.user.organization
             experiment = ExperimentsTable.objects.select_related(
                 "dataset", "snapshot_dataset"
             ).get(
@@ -4812,7 +4812,7 @@ class ExperimentDerivedVariablesView(APIView):
                 get_dataset_derived_variables,
             )
 
-            organization = request.user.organization
+            organization = getattr(request, "organization", None) or request.user.organization
             experiment = ExperimentsTable.objects.select_related(
                 "dataset", "snapshot_dataset"
             ).get(
@@ -4852,7 +4852,7 @@ class ExperimentDeleteV2View(APIView):
             if not experiment_ids:
                 return self._gm.bad_request(get_error_message("MISSING_EXP_IDS"))
 
-            organization = request.user.organization
+            organization = getattr(request, "organization", None) or request.user.organization
             experiments = ExperimentsTable.objects.filter(
                 id__in=experiment_ids,
                 dataset__organization=organization,
@@ -4927,7 +4927,7 @@ class ExperimentRerunV2View(APIView):
 
             experiment_ids = serializer.validated_data["experiment_ids"]
             max_concurrent_rows = request.data.get("max_concurrent_rows", 10)
-            organization = request.user.organization
+            organization = getattr(request, "organization", None) or request.user.organization
 
             experiments = ExperimentsTable.objects.filter(
                 id__in=experiment_ids,
@@ -4977,7 +4977,7 @@ class ExperimentRerunCellsV2View(APIView):
             if not serializer.is_valid():
                 return self._gm.bad_request(parse_serialized_errors(serializer))
 
-            organization = request.user.organization
+            organization = getattr(request, "organization", None) or request.user.organization
             experiment = ExperimentsTable.objects.filter(
                 id=experiment_id,
                 dataset__organization=organization,
@@ -5510,7 +5510,7 @@ class ExperimentStopV2View(APIView):
 
     def post(self, request, experiment_id):
         try:
-            organization = request.user.organization
+            organization = getattr(request, "organization", None) or request.user.organization
             experiment = ExperimentsTable.objects.filter(
                 id=experiment_id,
                 dataset__organization=organization,
@@ -5586,7 +5586,7 @@ class ExperimentNameSuggestionView(APIView):
 
     def get(self, request, dataset_id):
         try:
-            organization = request.user.organization
+            organization = getattr(request, "organization", None) or request.user.organization
             dataset = Dataset.objects.filter(
                 id=dataset_id,
                 organization=organization,
@@ -5643,7 +5643,7 @@ class ExperimentNameValidationView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        organization = request.user.organization
+        organization = getattr(request, "organization", None) or request.user.organization
         dataset_id = request.query_params.get("dataset_id")
         name = request.query_params.get("name", "").strip()
 


### PR DESCRIPTION
## Summary
Fixed a multi-org bug in all experiment views where `request.user.organization` (a static FK on the User model) was used instead of `request.organization` (set by the auth middleware based on the user's currently active org). This caused 404 "Dataset not found" errors when users switched to a different org, created a dataset there, and then tried to interact with experiments — because the query was always filtering against the user's original/default org.

All 13 occurrences in `experiments.py` have been updated to use the standard pattern: `getattr(request, "organization", None) or request.user.organization`, which is already used correctly in the rest of the codebase.

## Linked issues
Closes #

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
- Switched to a newly created org, created a dataset, and verified the `suggest-name` endpoint no longer returns 404
- Confirmed existing experiment flows (create, update, rerun, stop, JSON schema, derived variables, name validation) still resolve the correct org

## Screenshots / recordings (if UI)
N/A — backend-only change.

## Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)