### PR TITLE
fix: align page_size with cacheBlockSize in annotation queue dataset …

### DIFF
--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -307,7 +307,7 @@ async function fetchAllDatasetRowIds(
       validFilters,
       [],
       search || "",
-      { enabled: true, staleTime: 30000 },
+      { enabled: true, staleTime: 30000, pageSize: DATASET_ROWS_LIMIT },
     );
     const data = await queryClient.fetchQuery(queryOptions);
     const rows = data?.data?.result?.table ?? [];
@@ -987,7 +987,7 @@ function createDataSource(queryClient, datasetId, filtersRef, searchRef) {
           validFilters,
           sort,
           search,
-          { enabled: true, staleTime: 0 },
+          { enabled: true, staleTime: 0, pageSize: DATASET_ROWS_LIMIT },
         );
         const data = await queryClient.fetchQuery({ ...queryOptions });
         const rows = data?.data?.result?.table ?? [];


### PR DESCRIPTION
## Summary
When adding dataset rows to an annotation queue, the dataset preview grid was stuck in a permanent loading state despite the backend returning data successfully. The root cause was a mismatch between AG Grid's `cacheBlockSize` (10) and the `page_size` sent to the backend (defaulting to 30). This caused the server-side row model to receive 30 rows per block when it expected 10, leading to data misalignment — block 1 would fetch page 1 (rows 30–59) instead of rows 10–19, skipping chunks of data entirely and leaving the grid unable to render.

Fixed by passing `pageSize: DATASET_ROWS_LIMIT` to `getDatasetQueryOptions` in both the server-side datasource and the `fetchAllDatasetRowIds` pagination helper, matching the pattern already used in `DevelopDataV2.jsx`.

## Linked issues
Closes #

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
- Opened annotation queue → Add Items → Choose from dataset
- Selected a dataset with 50+ rows
- Verified rows now load and render in the grid instead of showing infinite loading
- Scrolled down to confirm subsequent pages load correctly with no gaps
- Tested "Select All" flow to verify `fetchAllDatasetRowIds` paginates correctly

## Screenshots / recordings (if UI)
N/A

## Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)