### PR TITLE
fix: handle null eval scores in trace list endpoint (TH-4716)

### DIFF
--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -3249,12 +3249,12 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 for config in eval_configs:
                     data = getattr(trace, f"metric_{config.id}")
                     if data and "score" in data:
-                        result[str(config.id)] = round(data["score"], 2)
+                        score = data["score"]
+                        result[str(config.id)] = round(score, 2) if score is not None else None
                     elif data:
                         for key, value in data.items():
-                            result[str(config.id) + "**" + key] = round(
-                                value["score"], 2
-                            )
+                            score = value["score"] if isinstance(value, dict) and "score" in value else None
+                            result[str(config.id) + "**" + key] = round(score, 2) if score is not None else None
                     reason = getattr(trace, f"metric_reason_{config.id}", None)
                     if reason:
                         result[f"{config.id}__reason"] = reason


### PR DESCRIPTION
## Summary

- Add null checks before `round()` in `list_traces_of_session` to prevent `TypeError` when eval metric scores are `None`
- Guard against non-dict values in nested metric data

## Problem

The trace list endpoint crashes with `type NoneType doesn't define __round__ method` when a trace has a null eval score, blocking trace selection in the eval playground.

## Test plan

- [ ] Select Trace row type in eval playground Tracing tab — should load traces without crashing
- [ ] Traces with null eval scores should display without error