### PR TITLE
fix(dashboard): show custom eval metrics in widget metric selector

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -1629,9 +1629,12 @@ class DashboardQueryBuilder:
                 )
 
                 output_type = (f.get("output_type") or "SCORE").upper()
-                # config is double-encoded
-                if output_type == "PASS_FAIL":
-                    eval_col = "if(eval_output_str = 'Passed', 1.0, 0.0)"
+                # For PASS_FAIL/CHOICES evals, compare against the raw string
+                # column directly. The old numeric cast
+                # (if(eval_output_str='Passed',1.0,0.0)) caused a type mismatch
+                # when the filter value is a string list like ['Passed'].
+                if output_type in ("PASS_FAIL", "CHOICE", "CHOICES"):
+                    eval_col = "eval_output_str"
                 else:
                     eval_col = "eval_score"
 

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1125,13 +1125,24 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                         ).values_list("eval_template_id", flat=True)
                     )
 
+                # Always include org-owned templates (user-created custom evals)
+                # alongside any templates discovered via ClickHouse usage data,
+                # so custom evals appear even before first use.
+                from django.db.models import Q
+
                 if used_template_ids:
                     # Use no_workspace_objects since system eval templates
                     # may have no workspace (workspace=None).
-                    eval_templates = EvalTemplate.no_workspace_objects.filter(
-                        id__in=used_template_ids,
-                        deleted=False,
-                    ).values("id", "name", "config", "choices")
+                    template_filter = Q(id__in=used_template_ids, deleted=False)
+                    if not filter_by_project:
+                        template_filter |= Q(
+                            organization=workspace.organization, deleted=False
+                        )
+                    eval_templates = (
+                        EvalTemplate.no_workspace_objects.filter(template_filter)
+                        .values("id", "name", "config", "choices")
+                        .distinct()
+                    )
                 elif filter_by_project:
                     # Project-scoped but no evals found — return empty
                     eval_templates = EvalTemplate.objects.none().values(
@@ -1139,10 +1150,14 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     )
                 else:
                     # Fallback: list all templates for the org
-                    eval_templates = EvalTemplate.objects.filter(
-                        organization=workspace.organization,
-                        deleted=False,
-                    ).values("id", "name", "config", "choices")
+                    eval_templates = (
+                        EvalTemplate.objects.filter(
+                            organization=workspace.organization,
+                            deleted=False,
+                        )
+                        .values("id", "name", "config", "choices")
+                        .distinct()
+                    )
 
                 per_eval_config = request.query_params.get("per_eval_config") == "true"
                 metrics.extend(


### PR DESCRIPTION
## Summary
- Custom eval metrics now appear in the dashboard widget metric selection list alongside predefined metrics
- The backend metrics endpoint previously only showed eval templates discovered via ClickHouse usage data — user-created templates that hadn't been executed yet were excluded
- Now always includes org-owned templates alongside usage-discovered ones (with `.distinct()` to prevent duplicates) when not project-scoped
- Fixed ClickHouse type mismatch crash when filtering PASS_FAIL/CHOICES evals — was casting to Float64 then comparing against string values like `['Passed']`

## Notes for reviewers
- Ported from old core-backend PR [#2523](https://github.com/future-agi/core-backend/pull/2523) into the monorepo
- Adapted to monorepo's `metrics()` view which now has a `filter_by_project` branch (not present in old repo). Org-template inclusion only applies when `not filter_by_project`, preserving project-scoped behavior

## Test plan
- [ ] Create a custom eval metric
- [ ] Open Dashboards > Add Widget > Query > Metric — verify custom eval appears in the Evals section even before first use
- [ ] Apply a PASS_FAIL eval filter with value "Passed" — verify no ClickHouse error
- [ ] Project-scoped widget still shows only relevant evals

Fixes TH-3542