### PR TITLE
fix(dashboard): support str_contains/str_not_contains filters on eval/annotation metrics

### DIFF
--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -1386,7 +1386,9 @@ export default function WidgetEditorView() {
                     ? "datasets"
                     : "traces"),
               operator: f.operator || "contains",
-              value: f.value ?? [],
+              value: ["str_contains", "str_not_contains"].includes(f.operator)
+                ? (typeof f.value === "string" ? f.value : "")
+                : (f.value ?? []),
             };
           });
           return {
@@ -4951,7 +4953,7 @@ export default function WidgetEditorView() {
                                 type={
                                   mf.dataType === "number" ? "number" : "text"
                                 }
-                                value={mf.value || ""}
+                                value={Array.isArray(mf.value) ? "" : (mf.value || "")}
                                 onChange={(e) =>
                                   handleUpdateMetricFilter(i, fi, {
                                     value: e.target.value,
@@ -5425,7 +5427,7 @@ export default function WidgetEditorView() {
                                 type={
                                   f.dataType === "number" ? "number" : "text"
                                 }
-                                value={f.value || ""}
+                                value={Array.isArray(f.value) ? "" : (f.value || "")}
                                 onChange={(e) => {
                                   const updated = [...filters];
                                   updated[i] = {

--- a/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/dashboard.py
@@ -707,29 +707,27 @@ class DashboardQueryBuilder:
                 f_out_type = (f.get("output_type") or "SCORE").upper()
 
                 # Same eval as the metric → filter on main table directly
+                is_string_op = op in ("str_contains", "str_not_contains")
                 if ev_tid == eval_template_id:
-                    if f_out_type in ("PASS_FAIL", "CHOICE", "CHOICES"):
+                    if f_out_type in ("PASS_FAIL", "CHOICE", "CHOICES") or is_string_op:
                         where_parts.append(
                             f"e.eval_output_str {op_symbol} %({val_key})s"
                         )
-                        params[val_key] = val
                     else:
                         where_parts.append(f"e.eval_score {op_symbol} %({val_key})s")
-                        params[val_key] = _coerce_filter_value(val, op)
+                    params[val_key] = _coerce_filter_value(val, op)
                 else:
                     # Different eval → cross-eval JOIN
                     ev_alias = f"ev_f{i}"
                     fkey = f"_evf_{i}_tid"
                     params[fkey] = ev_tid
                     need_eval_join[ev_alias] = fkey
-                    if f_out_type in ("PASS_FAIL", "CHOICE", "CHOICES"):
+                    if f_out_type in ("PASS_FAIL", "CHOICE", "CHOICES") or is_string_op:
                         ev_col = f"{ev_alias}.eval_output_str"
-                        where_parts.append(f"{ev_col} {op_symbol} %({val_key})s")
-                        params[val_key] = val
                     else:
                         ev_col = f"{ev_alias}.eval_score"
-                        where_parts.append(f"{ev_col} {op_symbol} %({val_key})s")
-                        params[val_key] = _coerce_filter_value(val, op)
+                    where_parts.append(f"{ev_col} {op_symbol} %({val_key})s")
+                    params[val_key] = _coerce_filter_value(val, op)
 
             elif f_type == "custom_attribute":
                 need_spans_join = True
@@ -1433,9 +1431,9 @@ class DashboardQueryBuilder:
                 )
 
                 output_type = (f.get("output_type") or "SCORE").upper()
-                # config is double-encoded
-                if output_type == "PASS_FAIL":
-                    eval_col = "if(eval_output_str = 'Passed', 1.0, 0.0)"
+                is_string_op = op in ("str_contains", "str_not_contains")
+                if output_type in ("PASS_FAIL", "CHOICE", "CHOICES") or is_string_op:
+                    eval_col = "eval_output_str"
                 else:
                     eval_col = "eval_score"
 
@@ -1470,17 +1468,24 @@ class DashboardQueryBuilder:
 
                 # Use the nullable extractor so JSON payloads missing
                 # the numeric key compare as NULL (and are excluded by
-                # the filter) instead of evaluating as 0.
-                num_expr = annotation_numeric_value_expr(
-                    alias="model_hub_score", nullable=True
-                )
+                # the filter) instead of evaluating as 0. For string-op
+                # filters (contains/not contains) extract as a string.
+                is_string_op = op in ("str_contains", "str_not_contains")
+                if is_string_op:
+                    val_expr = "JSONExtractString(value, 'value')"
+                    null_check = ""
+                else:
+                    val_expr = annotation_numeric_value_expr(
+                        alias="model_hub_score", nullable=True
+                    )
+                    null_check = f"AND {val_expr} IS NOT NULL "
                 subquery = (
                     f"trace_id IN ("
                     f"SELECT toString(trace_id) FROM model_hub_score FINAL "
                     f"WHERE label_id = toUUID(%({label_id_key})s) "
                     f"AND organization_id = toUUID(%({ann_org_key})s) "
-                    f"AND {num_expr} IS NOT NULL "
-                    f"AND {num_expr} {op_symbol} %({val_key})s "
+                    f"{null_check}"
+                    f"AND {val_expr} {op_symbol} %({val_key})s "
                     f"AND _peerdb_is_deleted = 0 "
                     f"AND deleted = 0"
                     f")"


### PR DESCRIPTION
## Summary
**Backend:**
- Use `eval_output_str` instead of `eval_score` (Float64) when the filter operator is `str_contains`/`str_not_contains`, preventing ClickHouse LIKE-on-Float64 errors. Applied in both `_build_eval_metric_query` and `_build_subquery_filters`.
- Extract annotation values with `JSONExtractString` instead of the numeric extractor when the operator is a string op
- Always coerce PASS_FAIL filter values through `_coerce_filter_value` for consistent `%..%` wrapping

**Frontend:**
- Ensure TextFields for `str_contains`/`str_not_contains` operators always receive a string value, even if the filter value is an array from saved state
- Normalize per-metric filter values on config restore based on operator type

## Notes for reviewers
- Ported from old core-frontend [#2613](https://github.com/future-agi/core-frontend/pull/2613) + core-backend [#2536](https://github.com/future-agi/core-backend/pull/2536) into the monorepo
- BE adapted to monorepo's annotation_metric branch which now uses `annotation_numeric_value_expr()` helper + nullable extraction. String-op branch skips the IS NOT NULL guard (JSONExtractString returns "" for missing keys, which LIKE excludes naturally).
- The `_build_subquery_filters` PASS_FAIL block also touched by **TH-3542 PR #203** — same line, this PR's change is a superset. Trivial conflict if both merge; whichever lands second is a no-op for that block.

## Test plan
- [ ] Add a system metric filter (e.g., Model), select "Contains" operator, type a value — no error
- [ ] Add a PASS_FAIL eval metric filter, select "Contains", type a value — no error
- [ ] Add an annotation metric filter, select "Contains" — no error
- [ ] Save a widget with a "Contains" filter, reload — filter value restores correctly
- [ ] Switch operator from "Is" to "Contains" — text input renders without error
- [ ] Verify "Is" (multi-select) and "Between" (range) operators still work

Fixes TH-3569