### PR TITLE
fix(dashboard): correct average calculation and show --- for empty periods

### DIFF
--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -153,9 +153,20 @@ export default function WidgetChart({ widget, globalDateRange }) {
     setVisibleSeries(topIndices);
   }, [series]);
 
+  // Null y-values are replaced with 0 so the chart renders continuous lines;
+  // the original series retains nulls for correct average and table display.
   const chartSeries = useMemo(() => {
-    if (visibleSeries === null) return series;
-    return series.filter((_, i) => visibleSeries.has(i));
+    const filtered =
+      visibleSeries === null
+        ? series
+        : series.filter((_, i) => visibleSeries.has(i));
+    return filtered.map((s) => ({
+      ...s,
+      data: s.data.map((point) => ({
+        ...point,
+        y: point.y ?? 0,
+      })),
+    }));
   }, [series, visibleSeries]);
 
   const pieValues = useMemo(

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -2049,10 +2049,21 @@ export default function WidgetEditorView() {
   const isTable = chartType === "table";
   const isMetricCard = chartType === "metric";
 
-  // Filtered series for chart — respects checkbox visibility, preserving original colors
+  // Filtered series for chart — respects checkbox visibility, preserving original colors.
+  // Null y-values are replaced with 0 so the chart renders continuous lines;
+  // previewSeries retains nulls for correct average calculation and table display.
   const chartSeries = useMemo(() => {
-    if (visibleSeries === null) return previewSeries;
-    return previewSeries.filter((_, i) => visibleSeries.has(i));
+    const filtered =
+      visibleSeries === null
+        ? previewSeries
+        : previewSeries.filter((_, i) => visibleSeries.has(i));
+    return filtered.map((series) => ({
+      ...series,
+      data: series.data.map((point) => ({
+        ...point,
+        y: point.y ?? 0,
+      })),
+    }));
   }, [previewSeries, visibleSeries]);
 
   const autoDecimals = useMemo(() => getAutoDecimals(chartSeries), [chartSeries]);
@@ -4381,7 +4392,7 @@ export default function WidgetEditorView() {
                                           : pt.y % 1 === 0
                                             ? pt.y
                                             : pt.y.toFixed(2)
-                                        : "-"}
+                                        : "---"}
                                     </td>
                                   );
                                 })}


### PR DESCRIPTION
## Summary
- `chartSeries` memo now maps null y-values to 0 so chart lines render continuously, while the original `series` / `previewSeries` retain nulls for correct average and table display
- Data table shows `---` (was `-`) for periods with no data; genuine zeros still show `0`
- Average only counts periods with actual data (excludes null/empty periods) — already handled by the existing `getSeriesAverage()` helper in `widgetUtils.js`

## Notes for reviewers
- Ported from old core-frontend [#2611](https://github.com/future-agi/core-frontend/pull/2611) + core-backend [#2535](https://github.com/future-agi/core-backend/pull/2535) into the monorepo
- **Backend hunks already in `main`** — `dashboard.py:format_results()` and `dashboard_base.py:_format_metric_result()` already return `None` for missing buckets (different syntax — `data_map[k] if k in data_map else None` vs old `.get(k, None)` — but semantically identical). Skipped.
- **Most FE hunks were no-ops** — the monorepo extracted the average-computation pattern into `getSeriesAverage()` (in `widgetUtils.js`), which already does `if (pt?.y == null) continue`. So 7 of the 8 average-computation hunks from the original PR are already correct here. Only the 2 `chartSeries` memos and 1 table-cell display string needed porting.

## Test plan
- [ ] Create a chart with a metric that has sparse data (data in only some periods)
- [ ] Verify average only counts periods with data
- [ ] Verify table shows `---` for empty periods and `0` for real zeros
- [ ] Verify chart still renders lines continuously through gaps

Fixes TH-3558