### PR TITLE
feat: data injection runtime config + gateway parallel tool_use fix (TH-4720)

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -317,7 +317,12 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       // Merge template config with any saved runtime overrides from the
       // user eval (run_config). Edit mode: evalData.run_config holds the
       // previously saved model, agentMode, passThreshold, etc.
-      const rawRunConfig = evalData?.run_config || evalData?.runConfig || {};
+      const rawRunConfig =
+        evalData?.run_config ||
+        evalData?.runConfig ||
+        evalData?.config?.run_config ||
+        evalData?.config?.runConfig ||
+        {};
       const normalizedRunConfig = {
         ...rawRunConfig,
         agent_mode: rawRunConfig.agent_mode ?? rawRunConfig.agentMode,
@@ -418,8 +423,19 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       if (Array.isArray(config.knowledge_bases)) {
         setKnowledgeBaseIds(config.knowledge_bases);
       }
-      const di = config.data_injection;
-      if (di?.full_row || di?.fullRow) setContextOptions(["full_row"]);
+      const di = config.data_injection || config.run_config?.data_injection;
+      if (di && typeof di === "object") {
+        const opts = [];
+        if (di.full_row || di.fullRow) opts.push("dataset_row");
+        if (di.span_context || di.spanContext) opts.push("span_context");
+        if (di.trace_context || di.traceContext) opts.push("trace_context");
+        if (di.session_context || di.sessionContext) opts.push("session_context");
+        if (opts.length > 0) {
+          setContextOptions(opts);
+        } else if (di.variables_only || di.variablesOnly) {
+          setContextOptions(["variables_only"]);
+        }
+      }
       setErrorLocalizerEnabled(
         config.error_localizer_enabled ??
           fullEval.error_localizer_enabled ??
@@ -723,13 +739,23 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     }
   }
 
-    // Build a data_injection config from context options. "variables_only"
-    // means only use template variables; any other option enables full_row.
-    const dataInjection =
-      contextOptions.length === 0 ||
-      (contextOptions.length === 1 && contextOptions[0] === "variables_only")
-        ? { variables_only: true }
-        : { full_row: true };
+    // Build a data_injection config from context options.
+    const dataInjection = (() => {
+      if (
+        contextOptions.length === 0 ||
+        (contextOptions.length === 1 && contextOptions[0] === "variables_only")
+      ) {
+        return { variables_only: true };
+      }
+      const flags = {};
+      if (contextOptions.includes("dataset_row")) flags.full_row = true;
+      if (contextOptions.includes("span_variables")) flags.span_context = true;
+      if (contextOptions.includes("span_context")) flags.span_context = true;
+      if (contextOptions.includes("trace_context")) flags.trace_context = true;
+      if (contextOptions.includes("session_context")) flags.session_context = true;
+      if (contextOptions.includes("full_row")) flags.full_row = true;
+      return Object.keys(flags).length > 0 ? flags : { full_row: true };
+    })();
     const tools = build_tools_payload(connectorIds);
 
     const templateType =

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -323,19 +323,47 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         evalData?.config?.run_config ||
         evalData?.config?.runConfig ||
         {};
-      const normalizedRunConfig = {
+        
+     const normalizedRunConfig = {
         ...rawRunConfig,
-        agent_mode: rawRunConfig.agent_mode ?? rawRunConfig.agentMode,
+        agent_mode:
+          rawRunConfig.agent_mode ??
+          rawRunConfig.agentMode ??
+          evalData?.agent_mode ??
+          evalData?.agentMode,
         check_internet:
-          rawRunConfig.check_internet ?? rawRunConfig.checkInternet,
+          rawRunConfig.check_internet ??
+          rawRunConfig.checkInternet ??
+          evalData?.check_internet ??
+          evalData?.checkInternet,
         knowledge_bases:
-          rawRunConfig.knowledge_bases ?? rawRunConfig.knowledgeBases,
+          rawRunConfig.knowledge_bases ??
+          rawRunConfig.knowledgeBases ??
+          evalData?.knowledge_bases ??
+          evalData?.knowledgeBases,
         data_injection:
-          rawRunConfig.data_injection ?? rawRunConfig.dataInjection,
+          rawRunConfig.data_injection ??
+          rawRunConfig.dataInjection ??
+          evalData?.data_injection ??
+          evalData?.dataInjection,
         template_format:
           rawRunConfig.template_format ?? rawRunConfig.templateFormat,
         few_shot_examples:
           rawRunConfig.few_shot_examples ?? rawRunConfig.fewShotExamples,
+        summary: rawRunConfig.summary ?? evalData?.summary,
+        tools: rawRunConfig.tools ?? evalData?.tools,
+        pass_threshold:
+          rawRunConfig.pass_threshold ??
+          rawRunConfig.passThreshold ??
+          evalData?.pass_threshold ??
+          evalData?.passThreshold,
+        choice_scores:
+          rawRunConfig.choice_scores ??
+          rawRunConfig.choiceScores ??
+          evalData?.choice_scores ??
+          evalData?.choiceScores,
+        params: rawRunConfig.params ?? evalData?.params,
+        messages: rawRunConfig.messages ?? evalData?.messages,
       };
       const config = {
         ...(fullEval.config || {}),

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -430,6 +430,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         if (di.span_context || di.spanContext) opts.push("span_context");
         if (di.trace_context || di.traceContext) opts.push("trace_context");
         if (di.session_context || di.sessionContext) opts.push("session_context");
+        if (di.call_context || di.callContext) opts.push("call_context");
         if (opts.length > 0) {
           setContextOptions(opts);
         } else if (di.variables_only || di.variablesOnly) {
@@ -749,10 +750,10 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       }
       const flags = {};
       if (contextOptions.includes("dataset_row")) flags.full_row = true;
-      if (contextOptions.includes("span_variables")) flags.span_context = true;
       if (contextOptions.includes("span_context")) flags.span_context = true;
       if (contextOptions.includes("trace_context")) flags.trace_context = true;
       if (contextOptions.includes("session_context")) flags.session_context = true;
+      if (contextOptions.includes("call_context")) flags.call_context = true;
       if (contextOptions.includes("full_row")) flags.full_row = true;
       return Object.keys(flags).length > 0 ? flags : { full_row: true };
     })();

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -1038,6 +1038,19 @@ const DatasetTestMode = React.forwardRef(
                   ? { params: codeParams }
                   : {}),
                 image_urls: imageUrls.length > 0 ? imageUrls : undefined,
+                // Send data_injection flags from contextOptions — same pattern
+                // as EvalPickerConfigFull (tracing tab) so the BE knows which
+                // context toggles are enabled.
+                ...(() => {
+                  const flags = {};
+                  if (contextOptions.includes("dataset_row")) flags.full_row = true;
+                  if (contextOptions.includes("full_row")) flags.full_row = true;
+                  if (contextOptions.includes("span_context")) flags.span_context = true;
+                  if (contextOptions.includes("trace_context")) flags.trace_context = true;
+                  if (contextOptions.includes("session_context")) flags.session_context = true;
+                  if (contextOptions.includes("call_context")) flags.call_context = true;
+                  return Object.keys(flags).length > 0 ? { data_injection: flags } : {};
+                })(),
               },
               input_data_types: inputDataTypes,
               row_context: rowContext,

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -115,12 +115,13 @@ const resolveContextOptions = (dataInjection) => {
   if (!dataInjection || typeof dataInjection !== "object") {
     return ["variables_only"];
   }
-  if (
-    dataInjection.full_row ||
-    dataInjection.fullRow ||
-    dataInjection.variables_only === false ||
-    dataInjection.variablesOnly === false
-  ) {
+  const opts = [];
+  if (dataInjection.full_row || dataInjection.fullRow) opts.push("dataset_row");
+  if (dataInjection.span_context || dataInjection.spanContext) opts.push("span_context");
+  if (dataInjection.trace_context || dataInjection.traceContext) opts.push("trace_context");
+  if (dataInjection.session_context || dataInjection.sessionContext) opts.push("session_context");
+  if (opts.length > 0) return opts;
+  if (dataInjection.variables_only === false || dataInjection.variablesOnly === false) {
     return ["full_row"];
   }
   return ["variables_only"];
@@ -311,11 +312,23 @@ const EvalCreatePage = () => {
   const autoSaveTimer = useRef(null);
   const autoSaveSkipFirst = useRef(!!urlDraftId); // skip first trigger when loading existing draft
   const buildUpdatePayload = useCallback(() => {
-    const dataInjection =
-      contextOptions.length === 0 ||
-      (contextOptions.length === 1 && contextOptions[0] === "variables_only")
-        ? { variables_only: true }
-        : { full_row: true };
+    const dataInjection = (() => {
+      if (
+        contextOptions.length === 0 ||
+        (contextOptions.length === 1 && contextOptions[0] === "variables_only")
+      ) {
+        return { variables_only: true };
+      }
+      // Send individual flags so the backend can enable the right tools
+      const flags = {};
+      if (contextOptions.includes("dataset_row")) flags.full_row = true;
+      if (contextOptions.includes("span_variables")) flags.span_context = true;
+      if (contextOptions.includes("span_context")) flags.span_context = true;
+      if (contextOptions.includes("trace_context")) flags.trace_context = true;
+      if (contextOptions.includes("session_context")) flags.session_context = true;
+      // If nothing specific matched, default to full_row for backward compat
+      return Object.keys(flags).length > 0 ? flags : { full_row: true };
+    })();
 
     const summary =
       summaryType === "custom"

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -120,6 +120,7 @@ const resolveContextOptions = (dataInjection) => {
   if (dataInjection.span_context || dataInjection.spanContext) opts.push("span_context");
   if (dataInjection.trace_context || dataInjection.traceContext) opts.push("trace_context");
   if (dataInjection.session_context || dataInjection.sessionContext) opts.push("session_context");
+  if (dataInjection.call_context || dataInjection.callContext) opts.push("call_context");
   if (opts.length > 0) return opts;
   if (dataInjection.variables_only === false || dataInjection.variablesOnly === false) {
     return ["full_row"];
@@ -322,10 +323,10 @@ const EvalCreatePage = () => {
       // Send individual flags so the backend can enable the right tools
       const flags = {};
       if (contextOptions.includes("dataset_row")) flags.full_row = true;
-      if (contextOptions.includes("span_variables")) flags.span_context = true;
       if (contextOptions.includes("span_context")) flags.span_context = true;
       if (contextOptions.includes("trace_context")) flags.trace_context = true;
       if (contextOptions.includes("session_context")) flags.session_context = true;
+      if (contextOptions.includes("call_context")) flags.call_context = true;
       // If nothing specific matched, default to full_row for backward compat
       return Object.keys(flags).length > 0 ? flags : { full_row: true };
     })();

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -89,6 +89,7 @@ const resolve_context_options = (data_injection) => {
   if (data_injection.span_context || data_injection.spanContext) opts.push("span_context");
   if (data_injection.trace_context || data_injection.traceContext) opts.push("trace_context");
   if (data_injection.session_context || data_injection.sessionContext) opts.push("session_context");
+  if (data_injection.call_context || data_injection.callContext) opts.push("call_context");
   if (opts.length > 0) return opts;
   if (data_injection.variables_only === false || data_injection.variablesOnly === false) {
     return ["full_row"];

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -84,12 +84,13 @@ const resolve_context_options = (data_injection) => {
   if (!data_injection || typeof data_injection !== "object") {
     return ["variables_only"];
   }
-  if (
-    data_injection.full_row ||
-    data_injection.fullRow ||
-    data_injection.variables_only === false ||
-    data_injection.variablesOnly === false
-  ) {
+  const opts = [];
+  if (data_injection.full_row || data_injection.fullRow) opts.push("dataset_row");
+  if (data_injection.span_context || data_injection.spanContext) opts.push("span_context");
+  if (data_injection.trace_context || data_injection.traceContext) opts.push("trace_context");
+  if (data_injection.session_context || data_injection.sessionContext) opts.push("session_context");
+  if (opts.length > 0) return opts;
+  if (data_injection.variables_only === false || data_injection.variablesOnly === false) {
     return ["full_row"];
   }
   return ["variables_only"];

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -59,9 +59,9 @@ const CONTEXT_OPTIONS = [
   {
     value: "variables_only",
     label: "Template variables",
-    desc: "Only mapped {{variables}}",
+    desc: "Only mapped {{variables}} (default)",
     icon: "mdi:code-braces",
-    always: true,
+    isDefault: true,
   },
   {
     value: "dataset_row",
@@ -1627,25 +1627,29 @@ const ModelSelector = ({
             {plusSubmenu === "injection" && (
               <Box>
                 {CONTEXT_OPTIONS.map((opt) => {
-                  const isActive =
-                    opt.always || activeContextOptions.includes(opt.value);
+                  const isActive = activeContextOptions.includes(opt.value);
                   return (
                     <MenuItem
                       key={opt.value}
                       onClick={() => {
-                        if (opt.always) return;
-                        setActiveContextOptions((prev) =>
-                          prev.includes(opt.value)
+                        setActiveContextOptions((prev) => {
+                          if (opt.isDefault) {
+                            // Clicking "variables_only" deselects everything else
+                            return ["variables_only"];
+                          }
+                          // Toggle the clicked option
+                          let next = prev.includes(opt.value)
                             ? prev.filter((x) => x !== opt.value)
-                            : [...prev, opt.value],
-                        );
+                            : [...prev.filter((x) => x !== "variables_only"), opt.value];
+                          // If nothing left, revert to variables_only
+                          if (next.length === 0) next = ["variables_only"];
+                          return next;
+                        });
                       }}
                       sx={{
                         borderRadius: "6px",
                         py: 0.6,
                         gap: 1,
-                        opacity: opt.always ? 0.7 : 1,
-                        cursor: opt.always ? "default" : "pointer",
                       }}
                     >
                       <Iconify
@@ -1688,11 +1692,11 @@ const ModelSelector = ({
                             ? "primary.main"
                             : (theme) =>
                                 theme.palette.mode === "dark"
-                                  ? "rgba(255,255,255,0.12)"
+                                  ? "rgba(255,255,255,0.25)"
                                   : "rgba(0,0,0,0.12)",
                           transition: "all 0.2s",
                           flexShrink: 0,
-                          cursor: opt.always ? "default" : "pointer",
+                          cursor: "pointer",
                         }}
                       >
                         <Box
@@ -1700,7 +1704,12 @@ const ModelSelector = ({
                             width: 12,
                             height: 12,
                             borderRadius: "50%",
-                            backgroundColor: "#fff",
+                            backgroundColor: isActive
+                              ? "#fff"
+                              : (theme) =>
+                                  theme.palette.mode === "dark"
+                                    ? "rgba(255,255,255,0.7)"
+                                    : "#fff",
                             position: "absolute",
                             top: 2,
                             left: isActive ? 18 : 2,

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -70,10 +70,10 @@ const CONTEXT_OPTIONS = [
     icon: "mdi:table-row",
   },
   {
-    value: "span_variables",
-    label: "Span variables",
-    desc: "Variables from matched spans",
-    icon: "mdi:code-tags",
+    value: "call_context",
+    label: "Call context",
+    desc: "Call transcript, recording, scenario",
+    icon: "mdi:phone-outline",
   },
   {
     value: "span_context",

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -380,7 +380,13 @@ const TaskConfigPanel = ({
               name: evalConfig.name,
               model: evalConfig.model || null,
               mapping: evalConfig.mapping,
-              config: { ...(evalConfig.config || {}), mapping: evalConfig.mapping },
+              config: {
+                ...(evalConfig.config || {}),
+                mapping: evalConfig.mapping,
+                ...(evalConfig.data_injection
+                  ? { run_config: { data_injection: evalConfig.data_injection } }
+                  : {}),
+              },
               error_localizer: evalConfig.errorLocalizerEnabled || false,
             },
           );
@@ -399,7 +405,13 @@ const TaskConfigPanel = ({
               name: evalConfig.name,
               model: evalConfig.model || null,
               mapping: evalConfig.mapping,
-              config: { ...(evalConfig.config || {}), mapping: evalConfig.mapping },
+              config: {
+                ...(evalConfig.config || {}),
+                mapping: evalConfig.mapping,
+                ...(evalConfig.data_injection
+                  ? { run_config: { data_injection: evalConfig.data_injection } }
+                  : {}),
+              },
               error_localizer: evalConfig.errorLocalizerEnabled || false,
             },
           );

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -496,12 +496,25 @@ const TaskLivePreview = forwardRef(function TaskLivePreview(
             }));
             return;
           }
+          // Build data_injection flags from the eval's saved config
+          // so the BE enables the correct context toggles (same as
+          // EvalPickerConfigFull does for tracing tab).
+          const diFlags =
+            evalItem?.data_injection ||
+            evalItem?.config?.run_config?.data_injection ||
+            evalItem?.config?.data_injection ||
+            {};
           const { data } = await axios.post(
             endpoints.develop.eval.evalPlayground,
             {
               template_id: templateId,
               model: evalItem?.model || "turing_large",
-              config: { mapping: resolveMapping(evalItem?.mapping) },
+              config: {
+                mapping: resolveMapping(evalItem?.mapping),
+                ...(Object.keys(diFlags).length > 0
+                  ? { data_injection: diFlags }
+                  : {}),
+              },
               ...autoCtx,
             },
           );

--- a/frontend/src/sections/test-detail/TestDetailConfigureEval.jsx
+++ b/frontend/src/sections/test-detail/TestDetailConfigureEval.jsx
@@ -97,8 +97,13 @@ const TestDetailConfigureEval = () => {
         name: evalConfig.name,
         model: evalConfig.model,
         mapping: evalConfig.mapping || {},
-        config: evalConfig.config || {},
-        error_localizer: false,
+        config: {
+          ...(evalConfig.config || {}),
+          ...(evalConfig.data_injection
+            ? { run_config: { data_injection: evalConfig.data_injection } }
+            : {}),
+        },
+        error_localizer: evalConfig.error_localizer_enabled || false,
         filters: {},
       };
       try {
@@ -130,6 +135,8 @@ const TestDetailConfigureEval = () => {
       template_id: templateId,
       name: editingEvalItem.name,
       mapping: editingEvalItem.mapping || {},
+      config: editingEvalItem.config || {},
+      run_config: editingEvalItem.config?.run_config || {},
     };
   }, [editingEvalItem]);
 

--- a/frontend/src/sections/test/TestEvaluationDrawer.jsx
+++ b/frontend/src/sections/test/TestEvaluationDrawer.jsx
@@ -196,6 +196,8 @@ const TestEvaluationDrawer = ({ executionIds, onSuccessOfAdditionOfEvals }) => {
                   editingEvalItem.template_id || editingEvalItem.templateId,
                 name: editingEvalItem.name,
                 mapping: editingEvalItem.mapping || {},
+                config: editingEvalItem.config || {},
+                run_config: editingEvalItem.config?.run_config || {},
               }
             : null
         }

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationDrawer.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationDrawer.jsx
@@ -187,6 +187,8 @@ const SimulationEvaluationDrawer = ({ open, onClose, onSuccess }) => {
                   editingEvalItem.template_id || editingEvalItem.templateId,
                 name: editingEvalItem.name,
                 mapping: editingEvalItem.mapping || {},
+                config: editingEvalItem.config || {},
+                run_config: editingEvalItem.config?.run_config || {},
               }
             : null
         }

--- a/futureagi/agentcc-gateway/internal/providers/bedrock/converse.go
+++ b/futureagi/agentcc-gateway/internal/providers/bedrock/converse.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -132,24 +131,6 @@ func buildConverseRequest(req *models.ChatCompletionRequest) (*converseRequest, 
 	modelID := resolveModelName(req.Model)
 	cr := &converseRequest{}
 
-	// Debug: log incoming message structure for tool_use debugging
-	slog.Debug("bedrock_converse_build_request",
-		"model", req.Model,
-		"resolved_model", modelID,
-		"message_count", len(req.Messages),
-		"tools_count", len(req.Tools),
-	)
-	for i, msg := range req.Messages {
-		contentLen := len(msg.Content)
-		slog.Debug("bedrock_converse_message",
-			"index", i,
-			"role", msg.Role,
-			"content_bytes", contentLen,
-			"tool_calls_count", len(msg.ToolCalls),
-			"tool_call_id", msg.ToolCallID,
-		)
-	}
-
 	cfg := converseInference{Temperature: req.Temperature, TopP: req.TopP}
 	switch {
 	case req.MaxTokens != nil:
@@ -257,10 +238,6 @@ func buildConverseMessage(msg models.Message) converseMessage {
 			Content:   buildConverseContentParts(msg.Content),
 		}
 		if len(toolResult.Content) == 0 {
-			slog.Debug("bedrock_converse_tool_result_empty_content",
-				"tool_call_id", msg.ToolCallID,
-				"raw_content_bytes", len(msg.Content),
-			)
 			empty := ""
 			toolResult.Content = []converseContentPart{{Text: &empty}}
 		}
@@ -274,11 +251,6 @@ func buildConverseMessage(msg models.Message) converseMessage {
 
 	if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
 		for _, tc := range msg.ToolCalls {
-			slog.Debug("bedrock_converse_tool_use_block",
-				"tool_call_id", tc.ID,
-				"name", tc.Function.Name,
-				"arguments_len", len(tc.Function.Arguments),
-			)
 			cm.Content = append(cm.Content, converseContentPart{ToolUse: &converseToolUse{
 				ToolUseID: tc.ID,
 				Name:      tc.Function.Name,
@@ -288,10 +260,6 @@ func buildConverseMessage(msg models.Message) converseMessage {
 	}
 
 	if len(cm.Content) == 0 {
-		slog.Debug("bedrock_converse_empty_message_content",
-			"role", msg.Role,
-			"raw_content_bytes", len(msg.Content),
-		)
 		empty := ""
 		cm.Content = []converseContentPart{{Text: &empty}}
 	}
@@ -438,14 +406,6 @@ func (p *Provider) chatCompletionConverse(ctx context.Context, req *models.ChatC
 		return nil, models.ErrInternal(fmt.Sprintf("bedrock converse: marshaling request: %v", err))
 	}
 
-	slog.Info("bedrock_converse_request",
-		"model", modelID,
-		"body_bytes", len(body),
-		"message_count", len(cr.Messages),
-		"has_tools", cr.ToolConfig != nil,
-		"has_system", len(cr.System) > 0,
-	)
-
 	reqURL := fmt.Sprintf("%s/model/%s/converse", p.baseURL, url.PathEscape(modelID))
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", reqURL, bytes.NewReader(body))
@@ -473,16 +433,7 @@ func (p *Provider) chatCompletionConverse(ctx context.Context, req *models.ChatC
 		return nil, models.ErrUpstreamProvider(resp.StatusCode, fmt.Sprintf("bedrock converse: reading response: %v", err))
 	}
 
-	slog.Info("bedrock_converse_response",
-		"status", resp.StatusCode,
-		"body_bytes", len(respBody),
-	)
-
 	if resp.StatusCode != http.StatusOK {
-		slog.Error("bedrock_converse_error",
-			"status", resp.StatusCode,
-			"body", string(respBody[:min(len(respBody), 500)]),
-		)
 		return nil, parseBedrockError(resp.StatusCode, respBody)
 	}
 
@@ -490,13 +441,6 @@ func (p *Provider) chatCompletionConverse(ctx context.Context, req *models.ChatC
 	if err := json.Unmarshal(respBody, &cr2); err != nil {
 		return nil, models.ErrUpstreamProvider(resp.StatusCode, fmt.Sprintf("bedrock converse: parsing response: %v", err))
 	}
-
-	slog.Info("bedrock_converse_parsed",
-		"stop_reason", cr2.StopReason,
-		"content_blocks", len(cr2.Output.Message.Content),
-		"input_tokens", cr2.Usage.InputTokens,
-		"output_tokens", cr2.Usage.OutputTokens,
-	)
 
 	return translateConverseResponse(&cr2, modelID), nil
 }
@@ -516,37 +460,6 @@ func (p *Provider) streamChatCompletionConverse(ctx context.Context, req *models
 			errs <- models.ErrInternal(fmt.Sprintf("bedrock converse stream: %v", err))
 			return
 		}
-
-		// Debug: log converse message structure
-		for i, msg := range cr.Messages {
-			var parts []string
-			for _, p := range msg.Content {
-				if p.Text != nil {
-					parts = append(parts, fmt.Sprintf("text(%d)", len(*p.Text)))
-				}
-				if p.ToolUse != nil {
-					parts = append(parts, fmt.Sprintf("tool_use(%s)", p.ToolUse.Name))
-				}
-				if p.ToolResult != nil {
-					parts = append(parts, fmt.Sprintf("tool_result(%s)", p.ToolResult.ToolUseID))
-				}
-				if p.Image != nil {
-					parts = append(parts, "image")
-				}
-			}
-			slog.Info("bedrock_converse_stream_message",
-				"index", i,
-				"role", msg.Role,
-				"parts", parts,
-			)
-		}
-
-		slog.Info("bedrock_converse_stream_request",
-			"model", modelID,
-			"body_bytes", len(body),
-			"message_count", len(cr.Messages),
-			"has_tools", cr.ToolConfig != nil,
-		)
 
 		reqURL := fmt.Sprintf("%s/model/%s/converse-stream", p.baseURL, url.PathEscape(modelID))
 
@@ -574,22 +487,13 @@ func (p *Provider) streamChatCompletionConverse(ctx context.Context, req *models
 		}
 		defer resp.Body.Close()
 
-		slog.Info("bedrock_converse_stream_http_status",
-			"status", resp.StatusCode,
-		)
-
 		if resp.StatusCode != http.StatusOK {
 			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
-			slog.Error("bedrock_converse_stream_error",
-				"status", resp.StatusCode,
-				"body", string(respBody[:min(len(respBody), 500)]),
-			)
 			errs <- parseBedrockError(resp.StatusCode, respBody)
 			return
 		}
 
 		state := newConverseStreamState(modelID)
-		eventCount := 0
 		for {
 			select {
 			case <-ctx.Done():
@@ -599,39 +503,17 @@ func (p *Provider) streamChatCompletionConverse(ctx context.Context, req *models
 
 			msg, err := readEventStreamMessage(resp.Body)
 			if err != nil {
-				slog.Error("bedrock_converse_stream_read_error",
-					"error", err.Error(),
-					"events_so_far", eventCount,
-				)
 				if ctx.Err() == nil {
 					errs <- models.ErrUpstreamProvider(0, fmt.Sprintf("bedrock converse stream: %v", err))
 				}
 				return
 			}
 			if msg == nil {
-				slog.Info("bedrock_converse_stream_eof",
-					"total_events", eventCount,
-				)
 				return
 			}
 
-			eventCount++
-			eventType := msg.Headers[":event-type"]
-			msgType := msg.Headers[":message-type"]
-			slog.Debug("bedrock_converse_stream_event",
-				"event_num", eventCount,
-				"event_type", eventType,
-				"message_type", msgType,
-				"payload_bytes", len(msg.Payload),
-			)
-
 			chunk, done, err := state.parseConverseEvent(msg)
 			if err != nil {
-				slog.Error("bedrock_converse_stream_parse_error",
-					"event_type", eventType,
-					"error", err.Error(),
-					"payload", string(msg.Payload[:min(len(msg.Payload), 200)]),
-				)
 				if msg.Headers[":message-type"] == "exception" {
 					errs <- models.ErrUpstreamProvider(0, err.Error())
 					return
@@ -647,10 +529,6 @@ func (p *Provider) streamChatCompletionConverse(ctx context.Context, req *models
 				}
 			}
 			if done {
-				slog.Info("bedrock_converse_stream_done",
-					"total_events", eventCount,
-					"input_tokens", state.inputTokens,
-				)
 				return
 			}
 		}

--- a/futureagi/agentcc-gateway/internal/providers/bedrock/converse.go
+++ b/futureagi/agentcc-gateway/internal/providers/bedrock/converse.go
@@ -66,6 +66,19 @@ type converseMessage struct {
 	Content []converseContentPart `json:"content"`
 }
 
+// messageHasToolResult reports whether any content part in the message is a
+// tool_result. Used to scope same-role merging to tool-result sequences only,
+// so we don't silently bundle independent user/user or assistant/assistant
+// turns.
+func messageHasToolResult(m converseMessage) bool {
+	for _, p := range m.Content {
+		if p.ToolResult != nil {
+			return true
+		}
+	}
+	return false
+}
+
 type converseContentPart struct {
 	Text       *string             `json:"text,omitempty"`
 	Image      *converseImagePart  `json:"image,omitempty"`
@@ -163,9 +176,19 @@ func buildConverseRequest(req *models.ChatCompletionRequest) (*converseRequest, 
 		cm := buildConverseMessage(msg)
 
 		// Bedrock Converse API requires alternating user/assistant roles.
-		// Multiple OpenAI "tool" messages map to role:"user" with ToolResult
-		// content. Merge consecutive user messages (tool results) into one.
-		if len(cr.Messages) > 0 && cm.Role == cr.Messages[len(cr.Messages)-1].Role {
+		// We merge consecutive same-role messages ONLY when BOTH sides are
+		// tool results — that's the only case the API forces us to collapse
+		// (multiple OpenAI "tool" messages all become role:"user" with
+		// ToolResult blocks). Don't bundle independent user/user or
+		// assistant/assistant turns, and don't bundle a real user follow-up
+		// into a prior tool result: those silently rewrite caller intent.
+		// If those occur the request goes through as-is and Bedrock returns
+		// a clear alternation error.
+		shouldMerge := len(cr.Messages) > 0 &&
+			cm.Role == cr.Messages[len(cr.Messages)-1].Role &&
+			msg.Role == "tool" &&
+			messageHasToolResult(cr.Messages[len(cr.Messages)-1])
+		if shouldMerge {
 			cr.Messages[len(cr.Messages)-1].Content = append(
 				cr.Messages[len(cr.Messages)-1].Content, cm.Content...,
 			)

--- a/futureagi/agentcc-gateway/internal/providers/bedrock/converse.go
+++ b/futureagi/agentcc-gateway/internal/providers/bedrock/converse.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -131,6 +132,24 @@ func buildConverseRequest(req *models.ChatCompletionRequest) (*converseRequest, 
 	modelID := resolveModelName(req.Model)
 	cr := &converseRequest{}
 
+	// Debug: log incoming message structure for tool_use debugging
+	slog.Debug("bedrock_converse_build_request",
+		"model", req.Model,
+		"resolved_model", modelID,
+		"message_count", len(req.Messages),
+		"tools_count", len(req.Tools),
+	)
+	for i, msg := range req.Messages {
+		contentLen := len(msg.Content)
+		slog.Debug("bedrock_converse_message",
+			"index", i,
+			"role", msg.Role,
+			"content_bytes", contentLen,
+			"tool_calls_count", len(msg.ToolCalls),
+			"tool_call_id", msg.ToolCallID,
+		)
+	}
+
 	cfg := converseInference{Temperature: req.Temperature, TopP: req.TopP}
 	switch {
 	case req.MaxTokens != nil:
@@ -160,7 +179,18 @@ func buildConverseRequest(req *models.ChatCompletionRequest) (*converseRequest, 
 			}
 			continue
 		}
-		cr.Messages = append(cr.Messages, buildConverseMessage(msg))
+		cm := buildConverseMessage(msg)
+
+		// Bedrock Converse API requires alternating user/assistant roles.
+		// Multiple OpenAI "tool" messages map to role:"user" with ToolResult
+		// content. Merge consecutive user messages (tool results) into one.
+		if len(cr.Messages) > 0 && cm.Role == cr.Messages[len(cr.Messages)-1].Role {
+			cr.Messages[len(cr.Messages)-1].Content = append(
+				cr.Messages[len(cr.Messages)-1].Content, cm.Content...,
+			)
+		} else {
+			cr.Messages = append(cr.Messages, cm)
+		}
 	}
 
 	if len(req.Tools) > 0 {
@@ -227,6 +257,10 @@ func buildConverseMessage(msg models.Message) converseMessage {
 			Content:   buildConverseContentParts(msg.Content),
 		}
 		if len(toolResult.Content) == 0 {
+			slog.Debug("bedrock_converse_tool_result_empty_content",
+				"tool_call_id", msg.ToolCallID,
+				"raw_content_bytes", len(msg.Content),
+			)
 			empty := ""
 			toolResult.Content = []converseContentPart{{Text: &empty}}
 		}
@@ -240,6 +274,11 @@ func buildConverseMessage(msg models.Message) converseMessage {
 
 	if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
 		for _, tc := range msg.ToolCalls {
+			slog.Debug("bedrock_converse_tool_use_block",
+				"tool_call_id", tc.ID,
+				"name", tc.Function.Name,
+				"arguments_len", len(tc.Function.Arguments),
+			)
 			cm.Content = append(cm.Content, converseContentPart{ToolUse: &converseToolUse{
 				ToolUseID: tc.ID,
 				Name:      tc.Function.Name,
@@ -249,6 +288,10 @@ func buildConverseMessage(msg models.Message) converseMessage {
 	}
 
 	if len(cm.Content) == 0 {
+		slog.Debug("bedrock_converse_empty_message_content",
+			"role", msg.Role,
+			"raw_content_bytes", len(msg.Content),
+		)
 		empty := ""
 		cm.Content = []converseContentPart{{Text: &empty}}
 	}
@@ -395,6 +438,14 @@ func (p *Provider) chatCompletionConverse(ctx context.Context, req *models.ChatC
 		return nil, models.ErrInternal(fmt.Sprintf("bedrock converse: marshaling request: %v", err))
 	}
 
+	slog.Info("bedrock_converse_request",
+		"model", modelID,
+		"body_bytes", len(body),
+		"message_count", len(cr.Messages),
+		"has_tools", cr.ToolConfig != nil,
+		"has_system", len(cr.System) > 0,
+	)
+
 	reqURL := fmt.Sprintf("%s/model/%s/converse", p.baseURL, url.PathEscape(modelID))
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", reqURL, bytes.NewReader(body))
@@ -421,7 +472,17 @@ func (p *Provider) chatCompletionConverse(ctx context.Context, req *models.ChatC
 	if err != nil {
 		return nil, models.ErrUpstreamProvider(resp.StatusCode, fmt.Sprintf("bedrock converse: reading response: %v", err))
 	}
+
+	slog.Info("bedrock_converse_response",
+		"status", resp.StatusCode,
+		"body_bytes", len(respBody),
+	)
+
 	if resp.StatusCode != http.StatusOK {
+		slog.Error("bedrock_converse_error",
+			"status", resp.StatusCode,
+			"body", string(respBody[:min(len(respBody), 500)]),
+		)
 		return nil, parseBedrockError(resp.StatusCode, respBody)
 	}
 
@@ -429,6 +490,13 @@ func (p *Provider) chatCompletionConverse(ctx context.Context, req *models.ChatC
 	if err := json.Unmarshal(respBody, &cr2); err != nil {
 		return nil, models.ErrUpstreamProvider(resp.StatusCode, fmt.Sprintf("bedrock converse: parsing response: %v", err))
 	}
+
+	slog.Info("bedrock_converse_parsed",
+		"stop_reason", cr2.StopReason,
+		"content_blocks", len(cr2.Output.Message.Content),
+		"input_tokens", cr2.Usage.InputTokens,
+		"output_tokens", cr2.Usage.OutputTokens,
+	)
 
 	return translateConverseResponse(&cr2, modelID), nil
 }
@@ -448,6 +516,37 @@ func (p *Provider) streamChatCompletionConverse(ctx context.Context, req *models
 			errs <- models.ErrInternal(fmt.Sprintf("bedrock converse stream: %v", err))
 			return
 		}
+
+		// Debug: log converse message structure
+		for i, msg := range cr.Messages {
+			var parts []string
+			for _, p := range msg.Content {
+				if p.Text != nil {
+					parts = append(parts, fmt.Sprintf("text(%d)", len(*p.Text)))
+				}
+				if p.ToolUse != nil {
+					parts = append(parts, fmt.Sprintf("tool_use(%s)", p.ToolUse.Name))
+				}
+				if p.ToolResult != nil {
+					parts = append(parts, fmt.Sprintf("tool_result(%s)", p.ToolResult.ToolUseID))
+				}
+				if p.Image != nil {
+					parts = append(parts, "image")
+				}
+			}
+			slog.Info("bedrock_converse_stream_message",
+				"index", i,
+				"role", msg.Role,
+				"parts", parts,
+			)
+		}
+
+		slog.Info("bedrock_converse_stream_request",
+			"model", modelID,
+			"body_bytes", len(body),
+			"message_count", len(cr.Messages),
+			"has_tools", cr.ToolConfig != nil,
+		)
 
 		reqURL := fmt.Sprintf("%s/model/%s/converse-stream", p.baseURL, url.PathEscape(modelID))
 
@@ -475,13 +574,22 @@ func (p *Provider) streamChatCompletionConverse(ctx context.Context, req *models
 		}
 		defer resp.Body.Close()
 
+		slog.Info("bedrock_converse_stream_http_status",
+			"status", resp.StatusCode,
+		)
+
 		if resp.StatusCode != http.StatusOK {
 			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+			slog.Error("bedrock_converse_stream_error",
+				"status", resp.StatusCode,
+				"body", string(respBody[:min(len(respBody), 500)]),
+			)
 			errs <- parseBedrockError(resp.StatusCode, respBody)
 			return
 		}
 
 		state := newConverseStreamState(modelID)
+		eventCount := 0
 		for {
 			select {
 			case <-ctx.Done():
@@ -491,17 +599,39 @@ func (p *Provider) streamChatCompletionConverse(ctx context.Context, req *models
 
 			msg, err := readEventStreamMessage(resp.Body)
 			if err != nil {
+				slog.Error("bedrock_converse_stream_read_error",
+					"error", err.Error(),
+					"events_so_far", eventCount,
+				)
 				if ctx.Err() == nil {
 					errs <- models.ErrUpstreamProvider(0, fmt.Sprintf("bedrock converse stream: %v", err))
 				}
 				return
 			}
 			if msg == nil {
+				slog.Info("bedrock_converse_stream_eof",
+					"total_events", eventCount,
+				)
 				return
 			}
 
+			eventCount++
+			eventType := msg.Headers[":event-type"]
+			msgType := msg.Headers[":message-type"]
+			slog.Debug("bedrock_converse_stream_event",
+				"event_num", eventCount,
+				"event_type", eventType,
+				"message_type", msgType,
+				"payload_bytes", len(msg.Payload),
+			)
+
 			chunk, done, err := state.parseConverseEvent(msg)
 			if err != nil {
+				slog.Error("bedrock_converse_stream_parse_error",
+					"event_type", eventType,
+					"error", err.Error(),
+					"payload", string(msg.Payload[:min(len(msg.Payload), 200)]),
+				)
 				if msg.Headers[":message-type"] == "exception" {
 					errs <- models.ErrUpstreamProvider(0, err.Error())
 					return
@@ -517,6 +647,10 @@ func (p *Provider) streamChatCompletionConverse(ctx context.Context, req *models
 				}
 			}
 			if done {
+				slog.Info("bedrock_converse_stream_done",
+					"total_events", eventCount,
+					"input_tokens", state.inputTokens,
+				)
 				return
 			}
 		}

--- a/futureagi/agentcc-gateway/internal/providers/bedrock/translate.go
+++ b/futureagi/agentcc-gateway/internal/providers/bedrock/translate.go
@@ -176,7 +176,21 @@ func translateRequest(req *models.ChatCompletionRequest) (*bedrockRequest, strin
 		}
 
 		bm := translateMessage(msg)
-		br.Messages = append(br.Messages, bm)
+		// Bedrock requires alternating user/assistant roles.
+		// Multiple OpenAI "tool" messages become "user" role with
+		// tool_result content — merge consecutive same-role messages.
+		if len(br.Messages) > 0 && bm.Role == br.Messages[len(br.Messages)-1].Role {
+			// Merge content arrays.
+			var existing []bedrockContentBlock
+			json.Unmarshal(br.Messages[len(br.Messages)-1].Content, &existing)
+			var additional []bedrockContentBlock
+			json.Unmarshal(bm.Content, &additional)
+			existing = append(existing, additional...)
+			merged, _ := json.Marshal(existing)
+			br.Messages[len(br.Messages)-1].Content = merged
+		} else {
+			br.Messages = append(br.Messages, bm)
+		}
 	}
 
 	if len(systemParts) > 0 {

--- a/futureagi/agentcc-gateway/internal/providers/bedrock/translate.go
+++ b/futureagi/agentcc-gateway/internal/providers/bedrock/translate.go
@@ -86,6 +86,25 @@ type bedrockMessage struct {
 	Content json.RawMessage `json:"content"`
 }
 
+// messageContentHasToolResult reports whether the Content RawMessage decodes
+// to a block array containing at least one tool_result block. Used to scope
+// same-role merging to tool-result sequences only.
+func messageContentHasToolResult(content json.RawMessage) bool {
+	if len(content) == 0 {
+		return false
+	}
+	var blocks []bedrockContentBlock
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return false
+	}
+	for _, b := range blocks {
+		if b.Type == "tool_result" {
+			return true
+		}
+	}
+	return false
+}
+
 type bedrockContentBlock struct {
 	Type      string          `json:"type"`
 	Text      string          `json:"text,omitempty"`
@@ -176,21 +195,47 @@ func translateRequest(req *models.ChatCompletionRequest) (*bedrockRequest, strin
 		}
 
 		bm := translateMessage(msg)
-		// Bedrock requires alternating user/assistant roles.
-		// Multiple OpenAI "tool" messages become "user" role with
-		// tool_result content — merge consecutive same-role messages.
-		if len(br.Messages) > 0 && bm.Role == br.Messages[len(br.Messages)-1].Role {
-			// Merge content arrays.
-			var existing []bedrockContentBlock
-			json.Unmarshal(br.Messages[len(br.Messages)-1].Content, &existing)
-			var additional []bedrockContentBlock
-			json.Unmarshal(bm.Content, &additional)
-			existing = append(existing, additional...)
-			merged, _ := json.Marshal(existing)
-			br.Messages[len(br.Messages)-1].Content = merged
-		} else {
+		// Bedrock requires alternating user/assistant roles. Merge consecutive
+		// same-role messages ONLY when BOTH sides are tool results — that's
+		// the only case the API forces us to collapse (multiple OpenAI "tool"
+		// messages all map to the same role with tool_result blocks). We
+		// deliberately don't bundle plain user/user or assistant/assistant
+		// turns, nor a real user follow-up into a prior tool result: those
+		// silently rewrite caller intent. Bedrock will surface a clear
+		// alternation error in those cases.
+		shouldMerge := len(br.Messages) > 0 &&
+			bm.Role == br.Messages[len(br.Messages)-1].Role &&
+			msg.Role == "tool" &&
+			messageContentHasToolResult(br.Messages[len(br.Messages)-1].Content)
+		if !shouldMerge {
 			br.Messages = append(br.Messages, bm)
+			continue
 		}
+		prev := &br.Messages[len(br.Messages)-1]
+		var existing, additional []bedrockContentBlock
+		errExisting := json.Unmarshal(prev.Content, &existing)
+		errAdditional := json.Unmarshal(bm.Content, &additional)
+		if errExisting != nil || errAdditional != nil {
+			// If either side's Content can't be parsed as a content-block
+			// array (e.g. legacy pass-through where Content is a JSON
+			// string), fall back to appending separately. A clear Bedrock
+			// alternation error beats silently dropping content via a
+			// botched merge.
+			slog.Warn("bedrock: same-role merge skipped — content not a block array",
+				"role", bm.Role,
+				"existing_err", errExisting,
+				"additional_err", errAdditional)
+			br.Messages = append(br.Messages, bm)
+			continue
+		}
+		merged, err := json.Marshal(append(existing, additional...))
+		if err != nil {
+			slog.Warn("bedrock: same-role merge failed to marshal — appending separately",
+				"role", bm.Role, "err", err)
+			br.Messages = append(br.Messages, bm)
+			continue
+		}
+		prev.Content = merged
 	}
 
 	if len(systemParts) > 0 {

--- a/futureagi/agentcc-gateway/internal/providers/bedrock/translate_test.go
+++ b/futureagi/agentcc-gateway/internal/providers/bedrock/translate_test.go
@@ -1695,3 +1695,209 @@ func TestExtractTextContent(t *testing.T) {
 		})
 	}
 }
+
+// ===========================================================================
+// Same-role merge tests — Bedrock requires alternating user/assistant.
+// Multiple OpenAI "tool" messages all become role:"user" (tool_result blocks)
+// and must be merged into a single message; otherwise Bedrock returns empty.
+// ===========================================================================
+
+func TestTranslateRequest_MergesConsecutiveToolMessages(t *testing.T) {
+	// translate.go merges by role only; it does not rewrite "tool" to "user"
+	// (that's a separate concern owned by the Messages API path, which is
+	// defensive — Converse is the primary). What we assert here is that the
+	// two consecutive same-role messages collapse into one, with both
+	// tool_result blocks preserved.
+	req := &models.ChatCompletionRequest{
+		Model: "claude-3-sonnet",
+		Messages: []models.Message{
+			{Role: "user", Content: json.RawMessage(`"hi"`)},
+			{Role: "assistant", ToolCalls: []models.ToolCall{
+				{ID: "call_1", Type: "function", Function: models.FunctionCall{Name: "f1", Arguments: `{}`}},
+				{ID: "call_2", Type: "function", Function: models.FunctionCall{Name: "f2", Arguments: `{}`}},
+			}},
+			{Role: "tool", ToolCallID: "call_1", Content: json.RawMessage(`"result1"`)},
+			{Role: "tool", ToolCallID: "call_2", Content: json.RawMessage(`"result2"`)},
+		},
+	}
+
+	br, _ := translateRequest(req)
+
+	// Expect: user, assistant, tool (merged) — 3 messages.
+	if len(br.Messages) != 3 {
+		t.Fatalf("expected 3 messages after merge, got %d", len(br.Messages))
+	}
+
+	var blocks []bedrockContentBlock
+	if err := json.Unmarshal(br.Messages[2].Content, &blocks); err != nil {
+		t.Fatalf("merged content not a block array: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 tool_result blocks in merged message, got %d", len(blocks))
+	}
+	for i, b := range blocks {
+		if b.Type != "tool_result" {
+			t.Errorf("block[%d] type = %q, want tool_result", i, b.Type)
+		}
+	}
+	if blocks[0].ToolUseID != "call_1" || blocks[1].ToolUseID != "call_2" {
+		t.Errorf("merged tool_use_ids = %q,%q; want call_1,call_2",
+			blocks[0].ToolUseID, blocks[1].ToolUseID)
+	}
+}
+
+func TestTranslateRequest_MergeDoesNotDropContentOnPassThrough(t *testing.T) {
+	// Simulate the pass-through path: a message whose Content can't be parsed
+	// as a content-block array. The previous implementation would silently
+	// drop the existing content and produce a malformed merged body. The fix
+	// is to log and append separately rather than corrupt the merge.
+	req := &models.ChatCompletionRequest{
+		Model: "claude-3-sonnet",
+		Messages: []models.Message{
+			// Content here is a JSON string ("foo"); translateMessage will
+			// take the text path and produce a proper block array.
+			{Role: "user", Content: json.RawMessage(`"foo"`)},
+			// Content here is a JSON null — neither vision, text, nor block
+			// array. translateMessage falls through and bm.Content = `null`.
+			{Role: "user", Content: json.RawMessage(`null`)},
+		},
+	}
+
+	br, _ := translateRequest(req)
+
+	// Either the merge succeeds and content is preserved, or the function
+	// falls back to two separate messages — in neither case should the
+	// first message's content be silently replaced with `null`.
+	if len(br.Messages) == 0 {
+		t.Fatalf("expected at least one message")
+	}
+	first := br.Messages[0]
+	if string(first.Content) == "null" {
+		t.Fatalf("first message content was overwritten with null — original content dropped")
+	}
+}
+
+func TestTranslateRequest_DoesNotMergePlainSameRoleMessages(t *testing.T) {
+	// Two consecutive "user" messages with no tool_result on either side
+	// should be left as separate messages. The merge is scoped to tool
+	// result sequences so we don't silently bundle independent user turns.
+	req := &models.ChatCompletionRequest{
+		Model: "claude-3-sonnet",
+		Messages: []models.Message{
+			{Role: "user", Content: json.RawMessage(`"first"`)},
+			{Role: "user", Content: json.RawMessage(`"second"`)},
+		},
+	}
+
+	br, _ := translateRequest(req)
+
+	if len(br.Messages) != 2 {
+		t.Fatalf("expected 2 separate user messages, got %d (merge over-eagerly bundled plain user turns)", len(br.Messages))
+	}
+}
+
+func TestTranslateRequest_DoesNotMergeUserFollowingToolResult(t *testing.T) {
+	// tool result followed by a real user message must NOT be bundled —
+	// they are semantically distinct turns even though both end up as
+	// role:"tool"/role:"user" in this provider's representation.
+	req := &models.ChatCompletionRequest{
+		Model: "claude-3-sonnet",
+		Messages: []models.Message{
+			{Role: "user", Content: json.RawMessage(`"do X"`)},
+			{Role: "assistant", ToolCalls: []models.ToolCall{
+				{ID: "call_1", Type: "function", Function: models.FunctionCall{Name: "f", Arguments: `{}`}},
+			}},
+			{Role: "tool", ToolCallID: "call_1", Content: json.RawMessage(`"result"`)},
+			{Role: "user", Content: json.RawMessage(`"and now Y"`)},
+		},
+	}
+
+	br, _ := translateRequest(req)
+
+	// Expect: user(do X), assistant(tool_use), tool(tool_result), user(and now Y)
+	// Note: translate.go does not rewrite "tool" to "user", so tool stays
+	// distinct. The key invariant is that the trailing user turn is NOT
+	// merged into the tool message.
+	if len(br.Messages) != 4 {
+		t.Fatalf("expected 4 messages (no bundling of trailing user turn), got %d", len(br.Messages))
+	}
+	if br.Messages[3].Role != "user" {
+		t.Errorf("last message role = %q, want user (separate turn)", br.Messages[3].Role)
+	}
+}
+
+func TestBuildConverseRequest_DoesNotMergePlainSameRoleMessages(t *testing.T) {
+	// Same scoping check on the Converse path.
+	req := &models.ChatCompletionRequest{
+		Model: "claude-3-sonnet",
+		Messages: []models.Message{
+			{Role: "user", Content: json.RawMessage(`"first"`)},
+			{Role: "user", Content: json.RawMessage(`"second"`)},
+		},
+	}
+
+	cr, _ := buildConverseRequest(req)
+
+	if len(cr.Messages) != 2 {
+		t.Fatalf("expected 2 separate user messages, got %d", len(cr.Messages))
+	}
+}
+
+func TestBuildConverseRequest_DoesNotMergeUserFollowingToolResult(t *testing.T) {
+	// In the Converse path, tool messages are rewritten to role:"user".
+	// A subsequent real user message must NOT be merged into the tool
+	// result's user message — they are separate turns.
+	req := &models.ChatCompletionRequest{
+		Model: "claude-3-sonnet",
+		Messages: []models.Message{
+			{Role: "user", Content: json.RawMessage(`"do X"`)},
+			{Role: "assistant", ToolCalls: []models.ToolCall{
+				{ID: "call_1", Type: "function", Function: models.FunctionCall{Name: "f", Arguments: `{}`}},
+			}},
+			{Role: "tool", ToolCallID: "call_1", Content: json.RawMessage(`"result"`)},
+			{Role: "user", Content: json.RawMessage(`"and now Y"`)},
+		},
+	}
+
+	cr, _ := buildConverseRequest(req)
+
+	// Expect: user(do X), assistant(tool_use), user(tool_result), user(and now Y)
+	// — 4 messages, with the last two NOT merged.
+	if len(cr.Messages) != 4 {
+		t.Fatalf("expected 4 messages (no bundling of trailing user turn), got %d", len(cr.Messages))
+	}
+	// Sanity: the third message must contain a ToolResult, the fourth must not.
+	if !messageHasToolResult(cr.Messages[2]) {
+		t.Errorf("message[2] should be the tool_result message")
+	}
+	if messageHasToolResult(cr.Messages[3]) {
+		t.Errorf("message[3] (real user follow-up) should not contain tool_result blocks")
+	}
+}
+
+func TestBuildConverseRequest_MergesConsecutiveToolMessages(t *testing.T) {
+	req := &models.ChatCompletionRequest{
+		Model: "claude-3-sonnet",
+		Messages: []models.Message{
+			{Role: "user", Content: json.RawMessage(`"hi"`)},
+			{Role: "assistant", ToolCalls: []models.ToolCall{
+				{ID: "call_1", Type: "function", Function: models.FunctionCall{Name: "f1", Arguments: `{}`}},
+				{ID: "call_2", Type: "function", Function: models.FunctionCall{Name: "f2", Arguments: `{}`}},
+			}},
+			{Role: "tool", ToolCallID: "call_1", Content: json.RawMessage(`"r1"`)},
+			{Role: "tool", ToolCallID: "call_2", Content: json.RawMessage(`"r2"`)},
+		},
+	}
+
+	cr, _ := buildConverseRequest(req)
+
+	if len(cr.Messages) != 3 {
+		t.Fatalf("expected 3 converse messages after merge, got %d", len(cr.Messages))
+	}
+	if cr.Messages[2].Role != "user" {
+		t.Errorf("merged message role = %q, want user", cr.Messages[2].Role)
+	}
+	if len(cr.Messages[2].Content) != 2 {
+		t.Errorf("merged content blocks = %d, want 2", len(cr.Messages[2].Content))
+	}
+}

--- a/futureagi/ai_tools/tools/web/trace_explorer.py
+++ b/futureagi/ai_tools/tools/web/trace_explorer.py
@@ -382,10 +382,11 @@ class TraceExplorerTool(BaseTool):
             if m:
                 models.add(m)
 
+        _status = "error" if error_count > 0 else "ok"
         lines = [
             f"## Trace Summary",
             f"**Name:** {data.get('trace_name', data.get('name', 'unnamed'))}",
-            f"**Status:** {data.get('status', '?')}",
+            f"**Status:** {_status}",
             f"**Total spans:** {total_spans}",
             f"**Errors:** {error_count}",
             f"**Total latency:** {total_latency}ms",

--- a/futureagi/ai_tools/tools/web/trace_explorer.py
+++ b/futureagi/ai_tools/tools/web/trace_explorer.py
@@ -74,17 +74,16 @@ class TraceExploreInput(PydanticBaseModel):
     )
     action: str = Field(
         description=(
-            "Action to perform:\n"
-            "- 'summary' — overview with span counts, errors, latency\n"
-            "- 'filter_spans' — filter by field=value (e.g. query='observation_type=llm')\n"
-            "- 'span_detail' — full span input/output (query=span_id)\n"
-            "- 'span_tree' — hierarchical view of all spans\n"
-            "- 'errors' — list error spans\n"
-            "- 'slow_spans' — list slowest spans\n"
-            "- 'list_trace_spans' — fetch spans for a trace (query=trace_id)\n"
-            "- 'keys' — list top-level data keys\n"
-            "- 'get' — read a specific path (query=field.path)\n"
-            "- 'search' — substring search (query=text)"
+            "Action to perform. Works on any root: "
+            "'keys' (list fields), 'get' (read path, query=field.path), "
+            "'search' (find text, query=substring). "
+            "Trace-only (root=trace): "
+            "'summary' (overview), 'span_tree' (hierarchy), "
+            "'filter_spans' (query=field=value, e.g. observation_type=llm), "
+            "'span_detail' (query=span_id, fetches full input/output), "
+            "'errors', 'slow_spans'. "
+            "Session-only (root=session): "
+            "'list_trace_spans' (query=trace_id, fetches spans for a trace)."
         )
     )
     query: Optional[str] = Field(
@@ -102,13 +101,15 @@ class TraceExploreInput(PydanticBaseModel):
 class TraceExplorerTool(BaseTool):
     name = "explore_trace"
     description = (
-        "Navigate eval context data (trace / session / span / row / call). "
-        "Workflow: 1) action='summary' to understand what's there, "
-        "2) action='filter_spans' query='observation_type=llm' to find specific spans, "
-        "3) action='span_detail' query='<span_id>' to see full input/output. "
-        "Other actions: 'keys', 'get' query='path', 'search' query='text', "
-        "'span_tree', 'errors', 'slow_spans', "
-        "'list_trace_spans' query='<trace_id>' (for session drill-down)."
+        "Explore eval context data. Use the `root` parameter to select which "
+        "context to explore (trace/session/span/call/row). "
+        "See the 'Additional Context Available' or 'Eval Context' section in "
+        "your prompt for which roots are loaded and recommended actions. "
+        "Common workflows:\n"
+        "- Trace: summary → filter_spans query='observation_type=llm' → span_detail query='<id>'\n"
+        "- Session: keys → get query='traces[0]' → list_trace_spans query='<trace_id>' → span_detail\n"
+        "- Span/Call: keys → get query='input' or get query='transcript'\n"
+        "- Row: keys → get query='<column_name>'"
     )
     category = "web"  # Same category as web_search so it loads together
     input_model = TraceExploreInput

--- a/futureagi/ai_tools/tools/web/trace_explorer.py
+++ b/futureagi/ai_tools/tools/web/trace_explorer.py
@@ -74,13 +74,17 @@ class TraceExploreInput(PydanticBaseModel):
     )
     action: str = Field(
         description=(
-            "Action to perform. Generic (work on any data): "
-            "'keys' (list top-level keys with type+size), "
-            "'get' (drill into a dot-path — pass path in `query`), "
-            "'search' (substring search across the blob), "
-            "'summary' (shape-aware overview). "
-            "Trace-specific (only work when the data has spans): "
-            "'span_detail', 'errors', 'slow_spans', 'span_tree'."
+            "Action to perform:\n"
+            "- 'summary' — overview with span counts, errors, latency\n"
+            "- 'filter_spans' — filter by field=value (e.g. query='observation_type=llm')\n"
+            "- 'span_detail' — full span input/output (query=span_id)\n"
+            "- 'span_tree' — hierarchical view of all spans\n"
+            "- 'errors' — list error spans\n"
+            "- 'slow_spans' — list slowest spans\n"
+            "- 'list_trace_spans' — fetch spans for a trace (query=trace_id)\n"
+            "- 'keys' — list top-level data keys\n"
+            "- 'get' — read a specific path (query=field.path)\n"
+            "- 'search' — substring search (query=text)"
         )
     )
     query: Optional[str] = Field(
@@ -98,12 +102,13 @@ class TraceExploreInput(PydanticBaseModel):
 class TraceExplorerTool(BaseTool):
     name = "explore_trace"
     description = (
-        "Navigate and search through eval context data (row / span / trace / "
-        "session / call) that is too large to inline. Start with action='keys' "
-        "to see what's available, then action='get' query='path.to.field' to "
-        "read specific values, or action='search' query='...' to find patterns. "
-        "For trace-shaped data, action='summary' / 'span_tree' / 'errors' / "
-        "'slow_spans' are also available."
+        "Navigate eval context data (trace / session / span / row / call). "
+        "Workflow: 1) action='summary' to understand what's there, "
+        "2) action='filter_spans' query='observation_type=llm' to find specific spans, "
+        "3) action='span_detail' query='<span_id>' to see full input/output. "
+        "Other actions: 'keys', 'get' query='path', 'search' query='text', "
+        "'span_tree', 'errors', 'slow_spans', "
+        "'list_trace_spans' query='<trace_id>' (for session drill-down)."
     )
     category = "web"  # Same category as web_search so it loads together
     input_model = TraceExploreInput
@@ -148,6 +153,18 @@ class TraceExplorerTool(BaseTool):
             if spans:
                 return self._summary(data, spans)
             return self._generic_summary(data, params.root)
+
+        # Live DB actions — work without pre-loaded spans
+        if params.action == "list_trace_spans":
+            return self._list_trace_spans(params.query, params.limit)
+
+        # Filter action — works on loaded spans
+        if params.action == "filter_spans":
+            if not spans:
+                return ToolResult.error(
+                    "No spans available to filter. Use action='keys' to see data."
+                )
+            return self._filter_spans(spans, params.query, params.limit)
 
         # Trace-specific actions — require span-shaped data
         if not spans:
@@ -352,10 +369,10 @@ class TraceExplorerTool(BaseTool):
         total_spans = len(spans)
         error_count = sum(1 for s in spans if s.get("status") == "ERROR")
         total_latency = data.get(
-            "total_latency_ms", sum(s.get("latency_ms", 0) for s in spans)
+            "total_latency_ms", sum(s.get("latency_ms") or 0 for s in spans)
         )
-        total_tokens = sum(s.get("total_tokens", 0) for s in spans)
-        total_cost = sum(s.get("cost", 0) for s in spans)
+        total_tokens = sum(s.get("total_tokens") or 0 for s in spans)
+        total_cost = sum(s.get("cost") or 0 for s in spans)
         types = {}
         models = set()
         for s in spans:
@@ -381,9 +398,12 @@ class TraceExplorerTool(BaseTool):
         ]
         for i, s in enumerate(spans):
             status_icon = "❌" if s.get("status") == "ERROR" else "✓"
+            model_str = f" model={s['model']}" if s.get("model") else ""
+            tokens_str = f" {s['total_tokens']}tok" if s.get("total_tokens") else ""
             lines.append(
                 f"  {i+1}. {status_icon} [{s.get('observation_type','?')}] {s.get('name','?')} "
-                f"({s.get('latency_ms',0)}ms)"
+                f"({s.get('latency_ms') or 0}ms{model_str}{tokens_str}) "
+                f"id=`{s.get('id', '?')}`"
             )
 
         return ToolResult(
@@ -407,7 +427,10 @@ class TraceExplorerTool(BaseTool):
 
         if not matches:
             return ToolResult(
-                content=f"No spans matching '{query}'", data={"matches": 0}
+                content=f"No spans matching '{query}' in span names/types/models. "
+                f"Note: search only checks span summary fields (name, type, model, status), "
+                f"not full input/output. Use `span_detail` to see the full content of a specific span.",
+                data={"matches": 0},
             )
 
         lines = [f"## Search Results for '{query}' ({len(matches)} matches)\n"]
@@ -417,7 +440,12 @@ class TraceExplorerTool(BaseTool):
         return ToolResult(content="\n".join(lines), data={"matches": len(matches)})
 
     def _span_detail(self, spans, span_id):
-        """Get full details of a specific span."""
+        """Get full details of a specific span.
+
+        If the span data in the store is a lightweight summary (from enriched
+        trace/session context), fetches the full span from the database to
+        provide input, output, span_attributes, etc.
+        """
         if not span_id:
             return ToolResult.error("Provide a span ID or span name")
 
@@ -437,6 +465,16 @@ class TraceExplorerTool(BaseTool):
 
         if not target:
             return ToolResult.error(f"Span '{span_id}' not found")
+
+        # If the span is a lightweight summary (no input/output), fetch
+        # the full span from DB for detailed inspection.
+        if target.get("id") and "input" not in target and "output" not in target:
+            try:
+                full_span = _fetch_full_span(target["id"])
+                if full_span:
+                    target = full_span
+            except Exception as e:
+                logger.warning(f"Failed to fetch full span {target.get('id')}: {e}")
 
         lines = [f"## Span Detail: {target.get('name', '?')}\n"]
         for key, val in target.items():
@@ -473,7 +511,7 @@ class TraceExplorerTool(BaseTool):
 
     def _slow_spans(self, spans, limit):
         """Find the slowest spans."""
-        sorted_spans = sorted(spans, key=lambda s: s.get("latency_ms", 0), reverse=True)
+        sorted_spans = sorted(spans, key=lambda s: s.get("latency_ms") or 0, reverse=True)
 
         lines = [f"## Slowest Spans (top {limit})\n"]
         for s in sorted_spans[:limit]:
@@ -503,7 +541,7 @@ class TraceExplorerTool(BaseTool):
             status = "❌" if span.get("status") == "ERROR" else "✓"
             lines.append(
                 f"{indent}{status} [{span.get('observation_type','?')}] {span.get('name','?')} "
-                f"({span.get('latency_ms',0)}ms)"
+                f"({span.get('latency_ms') or 0}ms) id=`{span.get('id', '?')}`"
             )
             for child in children.get(span.get("id"), []):
                 _render(child, depth + 1)
@@ -513,16 +551,161 @@ class TraceExplorerTool(BaseTool):
 
         return ToolResult(content="\n".join(lines))
 
+    def _filter_spans(self, spans, query, limit):
+        """Filter spans by field=value criteria.
+
+        Examples:
+          observation_type=llm
+          status=ERROR
+          model=gpt-4o
+          observation_type=guardrail
+        """
+        if not query or "=" not in query:
+            return ToolResult.error(
+                "Provide filter as field=value. Examples:\n"
+                "- observation_type=llm (LLM calls)\n"
+                "- observation_type=guardrail (guardrail checks)\n"
+                "- observation_type=agent (agent spans)\n"
+                "- observation_type=retriever (RAG retrieval)\n"
+                "- status=ERROR (failed spans)\n"
+                "- model=gpt-4o (specific model)"
+            )
+
+        field, value = query.split("=", 1)
+        field = field.strip()
+        value = value.strip().lower()
+
+        matches = [
+            s for s in spans
+            if str(s.get(field, "")).lower() == value
+        ]
+
+        if not matches:
+            # Show available values for that field to help the agent
+            available = sorted(set(
+                str(s.get(field, "")) for s in spans if s.get(field)
+            ))
+            return ToolResult(
+                content=f"No spans match `{field}={value}`. "
+                f"Available values for `{field}`: {', '.join(available[:15])}",
+                data={"matches": 0, "available_values": available[:15]},
+            )
+
+        lines = [f"## Filtered: {field}={value} ({len(matches)} spans)\n"]
+        for s in matches[:limit]:
+            lines.append(self._format_span_summary(s))
+            if s.get("status_message"):
+                lines.append(f"  → {s['status_message'][:100]}")
+
+        if len(matches) > limit:
+            lines.append(f"\n... and {len(matches) - limit} more. Increase `limit` to see more.")
+
+        lines.append(
+            f"\nUse action='span_detail' query='<span_id>' to see "
+            f"full input/output of a specific span."
+        )
+
+        return ToolResult(
+            content="\n".join(lines),
+            data={"matches": len(matches), "field": field, "value": value},
+        )
+
+    def _list_trace_spans(self, trace_id, limit):
+        """Fetch spans for a specific trace from DB on demand.
+
+        Useful when exploring session context — the agent sees trace
+        summaries and drills into a specific trace to see its spans.
+
+        Data isolation: scoped by project → organization via request context.
+        """
+        if not trace_id:
+            return ToolResult.error(
+                "Provide a trace_id in `query` to list its spans."
+            )
+        try:
+            from tracer.models.observation_span import ObservationSpan
+            from tfc.middleware.workspace_context import get_current_organization
+
+            qs = ObservationSpan.objects.filter(
+                trace_id=trace_id, deleted=False
+            )
+            org = get_current_organization()
+            if org:
+                qs = qs.filter(project__organization=org)
+
+            spans = list(
+                qs
+                .order_by("start_time")
+                .values(
+                    "id", "name", "observation_type", "status",
+                    "status_message", "latency_ms", "model",
+                    "total_tokens", "cost", "parent_span_id",
+                )[:limit * 10]  # Allow more for tree view
+            )
+            if not spans:
+                return ToolResult(
+                    content=f"No spans found for trace `{trace_id}`.",
+                    data={"span_count": 0},
+                )
+
+            # Build a tree view
+            children = {}
+            roots = []
+            for s in spans:
+                parent = s.get("parent_span_id")
+                if parent:
+                    children.setdefault(parent, []).append(s)
+                else:
+                    roots.append(s)
+            if not roots:
+                roots = spans
+
+            error_count = sum(1 for s in spans if s.get("status") == "ERROR")
+            lines = [
+                f"## Spans for trace `{trace_id}` "
+                f"({len(spans)} spans, {error_count} errors)\n",
+            ]
+
+            def _render(span, depth=0):
+                indent = "  " * depth
+                status = "ERR" if span.get("status") == "ERROR" else "OK"
+                lines.append(
+                    f"{indent}- [{status}] [{span.get('observation_type', '?')}] "
+                    f"**{span.get('name', '?')}** "
+                    f"({span.get('latency_ms', 0)}ms"
+                    f"{', ' + span['model'] if span.get('model') else ''}) "
+                    f"id=`{span.get('id', '?')}`"
+                )
+                for child in children.get(span.get("id"), []):
+                    _render(child, depth + 1)
+
+            for root in roots:
+                _render(root)
+
+            lines.append(
+                f"\nUse action='span_detail' query='<span_id>' to see "
+                f"full input/output of a specific span."
+            )
+
+            return ToolResult(
+                content="\n".join(lines),
+                data={"span_count": len(spans), "trace_id": trace_id},
+            )
+        except Exception as e:
+            logger.warning(f"_list_trace_spans failed for {trace_id}: {e}")
+            return ToolResult.error(f"Failed to fetch spans for trace: {e}")
+
     def _format_span_summary(self, s):
-        """Format a single span as a summary line."""
+        """Format a single span as a summary line with ID for drill-down."""
         parts = [f"- **{s.get('name','?')}** [{s.get('observation_type','?')}]"]
         if s.get("model"):
             parts.append(f"model={s['model']}")
-        parts.append(f"{s.get('latency_ms',0)}ms")
+        parts.append(f"{s.get('latency_ms') or 0}ms")
         if s.get("total_tokens"):
             parts.append(f"{s['total_tokens']} tokens")
         if s.get("status") and s["status"] != "OK":
             parts.append(f"status={s['status']}")
+        parts.append(f"id=`{s.get('id', '?')}`")
         return " | ".join(parts)
 
 
@@ -609,3 +792,56 @@ def _snippet_around(blob: str, needle: str, width: int = 120) -> str:
     start = max(0, idx - width // 2)
     end = min(len(blob), idx + len(needle) + width // 2)
     return blob[start:end]
+
+
+def _fetch_full_span(span_id: str) -> dict | None:
+    """Fetch full span details from DB for on-demand drill-down.
+
+    Called when the agent requests span_detail on a lightweight summary
+    (from enriched trace/session context that only has id/name/status/latency).
+    Returns a rich dict matching the format of _build_span_context().
+
+    Data isolation: scoped by project → organization via the request context.
+    The span_id itself comes from the pre-loaded trace/session context which
+    was already scoped during the playground view.
+    """
+    try:
+        from tracer.models.observation_span import ObservationSpan
+        from tfc.middleware.workspace_context import get_current_organization
+
+        qs = ObservationSpan.objects.filter(id=str(span_id), deleted=False)
+        # Scope by organization if available in request context
+        org = get_current_organization()
+        if org:
+            qs = qs.filter(project__organization=org)
+        span = qs.first()
+        if not span:
+            return None
+
+        result = {
+            "id": span.id,
+            "trace_id": str(span.trace_id) if span.trace_id else None,
+            "name": span.name,
+            "observation_type": span.observation_type,
+            "input": span.input,
+            "output": span.output,
+            "status": span.status,
+            "status_message": span.status_message,
+            "model": span.model,
+            "provider": span.provider,
+            "start_time": str(span.start_time) if span.start_time else None,
+            "end_time": str(span.end_time) if span.end_time else None,
+            "latency_ms": span.latency_ms,
+            "cost": float(span.cost) if span.cost is not None else None,
+            "prompt_tokens": span.prompt_tokens,
+            "completion_tokens": span.completion_tokens,
+            "total_tokens": span.total_tokens,
+            "metadata": span.metadata or {},
+            "tags": span.tags or [],
+            "parent_span_id": span.parent_span_id,
+            "span_attributes": span.span_attributes or {},
+        }
+        return result
+    except Exception as e:
+        logger.warning(f"_fetch_full_span failed for {span_id}: {e}")
+        return None

--- a/futureagi/ai_tools/tools/web/trace_explorer.py
+++ b/futureagi/ai_tools/tools/web/trace_explorer.py
@@ -628,12 +628,21 @@ class TraceExplorerTool(BaseTool):
             from tracer.models.observation_span import ObservationSpan
             from tfc.middleware.workspace_context import get_current_organization
 
-            qs = ObservationSpan.objects.filter(
-                trace_id=trace_id, deleted=False
-            )
+            # Org scoping is the only authorization check between an
+            # agent-supplied trace_id and the DB. If we don't have an org
+            # context, refuse rather than running an unscoped query.
             org = get_current_organization()
-            if org:
-                qs = qs.filter(project__organization=org)
+            if not org:
+                logger.warning(
+                    "_list_trace_spans called without organization context; refusing"
+                )
+                return ToolResult.error(
+                    "Cannot list spans without an authenticated organization context."
+                )
+
+            qs = ObservationSpan.objects.filter(
+                trace_id=trace_id, deleted=False, project__organization=org
+            )
 
             spans = list(
                 qs
@@ -804,19 +813,24 @@ def _fetch_full_span(span_id: str) -> dict | None:
     Returns a rich dict matching the format of _build_span_context().
 
     Data isolation: scoped by project → organization via the request context.
-    The span_id itself comes from the pre-loaded trace/session context which
-    was already scoped during the playground view.
+    Org scoping is mandatory — if no org is in context (e.g. background worker
+    without the workspace middleware), the call refuses rather than running
+    an unscoped query against an LLM-supplied span_id.
     """
     try:
         from tracer.models.observation_span import ObservationSpan
         from tfc.middleware.workspace_context import get_current_organization
 
-        qs = ObservationSpan.objects.filter(id=str(span_id), deleted=False)
-        # Scope by organization if available in request context
         org = get_current_organization()
-        if org:
-            qs = qs.filter(project__organization=org)
-        span = qs.first()
+        if not org:
+            logger.warning(
+                "_fetch_full_span called without organization context; refusing"
+            )
+            return None
+
+        span = ObservationSpan.objects.filter(
+            id=str(span_id), deleted=False, project__organization=org
+        ).first()
         if not span:
             return None
 

--- a/futureagi/common/utils/data_injection.py
+++ b/futureagi/common/utils/data_injection.py
@@ -1,0 +1,55 @@
+"""Helpers for normalizing eval `data_injection` config across surfaces.
+
+The frontend has settled on snake_case keys (full_row, span_context,
+trace_context, session_context, call_context, variables_only) but older
+saved configs and a few code paths used camelCase (fullRow, spanContext,
+...) or the alias `dataset_row` for full_row. This module is the single
+place that bridges those.
+"""
+
+from typing import Any, Dict, Mapping, Optional
+
+CANONICAL_FLAGS = (
+    "full_row",
+    "span_context",
+    "trace_context",
+    "session_context",
+    "call_context",
+    "variables_only",
+)
+
+# snake_case canonical name → set of legacy aliases.
+_ALIASES: Dict[str, tuple] = {
+    "full_row": ("fullRow", "dataset_row", "datasetRow"),
+    "span_context": ("spanContext",),
+    "trace_context": ("traceContext",),
+    "session_context": ("sessionContext",),
+    "call_context": ("callContext",),
+    "variables_only": ("variablesOnly",),
+}
+
+
+def normalize(data_injection: Optional[Mapping[str, Any]]) -> Dict[str, bool]:
+    """Return a dict keyed by canonical snake_case flag names with bool values.
+
+    Unknown keys are dropped. Missing flags default to False.
+    """
+    if not isinstance(data_injection, Mapping):
+        return {flag: False for flag in CANONICAL_FLAGS}
+    out = {}
+    for flag in CANONICAL_FLAGS:
+        value = data_injection.get(flag)
+        if not value:
+            for alias in _ALIASES.get(flag, ()):
+                if data_injection.get(alias):
+                    value = data_injection[alias]
+                    break
+        out[flag] = bool(value)
+    return out
+
+
+def is_enabled(data_injection: Optional[Mapping[str, Any]], flag: str) -> bool:
+    """Return True if the given canonical flag is enabled in data_injection."""
+    if flag not in CANONICAL_FLAGS:
+        raise ValueError(f"Unknown data_injection flag: {flag!r}")
+    return normalize(data_injection).get(flag, False)

--- a/futureagi/model_hub/utils/eval_list.py
+++ b/futureagi/model_hub/utils/eval_list.py
@@ -279,6 +279,9 @@ def build_user_eval_list_items(
                 "summary": summary,
                 "pass_threshold": run_config.get("pass_threshold", 0.5),
                 "error_localizer_enabled": user_eval.error_localizer,
+                "data_injection": run_config.get("data_injection", {}),
+                "knowledge_bases": run_config.get("knowledge_bases", []),
+                "tools": run_config.get("tools", {}),
             },
             "output_type": template.output_type_normalized or "pass_fail",
         }

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -7500,19 +7500,27 @@ class EditAndRunUserEvalView(APIView):
                             "Failed to rebuild column_order after edit-eval"
                         )
                 else:
-                    column = Column.objects.get(source_id=eval_metric.id)
-                    reason_column, created = Column.objects.get_or_create(
-                        name=f"{eval_metric.name}-reason",
-                        data_type=DataTypeChoices.TEXT.value,
-                        source=SourceChoices.EVALUATION_REASON.value,
-                        dataset=eval_metric.dataset,
-                        source_id=f"{column.id}-sourceid-{eval_metric.id}",
-                    )
-                    if created:
-                        column_order = eval_metric.dataset.column_order
-                        column_order.append(str(reason_column.id))
-                        eval_metric.dataset.column_order = column_order
-                        eval_metric.dataset.save()
+                    column = Column.objects.filter(
+                        source_id=eval_metric.id, deleted=False
+                    ).first()
+                    if not column:
+                        # Column doesn't exist yet (eval was added with run=false
+                        # and never run). Skip reason-column creation — it will
+                        # be created when the eval actually runs for the first time.
+                        pass
+                    else:
+                        reason_column, created = Column.objects.get_or_create(
+                            name=f"{eval_metric.name}-reason",
+                            data_type=DataTypeChoices.TEXT.value,
+                            source=SourceChoices.EVALUATION_REASON.value,
+                            dataset=eval_metric.dataset,
+                            source_id=f"{column.id}-sourceid-{eval_metric.id}",
+                        )
+                        if created:
+                            column_order = eval_metric.dataset.column_order
+                            column_order.append(str(reason_column.id))
+                            eval_metric.dataset.column_order = column_order
+                            eval_metric.dataset.save()
 
             # Eval columns live under different source types depending on scope:
             # dataset evals → SourceChoices.EVALUATION

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -6995,6 +6995,7 @@ class GetEvalStructureView(APIView):
             "template_id": str(template.id),
             "name": eval.name,
             "eval_type_id": eval_type_id,
+            "eval_type": template.eval_type,
             "reason_column": eval.config.get("reason_column", False),
             "eval_tags": template.eval_tags,
             "description": template.description,
@@ -7014,6 +7015,7 @@ class GetEvalStructureView(APIView):
             "output": template.config.get("output", ""),
             "config_params_desc": template.config.get("config_params_desc", {}),
             "config_params_option": template.config.get("config_params_option", {}),
+            "run_config": eval.config.get("run_config", {}),
         }
 
         return self._gm.success_response({"eval": eval_data})

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -26,6 +26,7 @@ from accounts.utils import get_request_organization
 from agentic_eval.core_evals.fi_evals import *  # noqa: F403
 from agentic_eval.core_evals.fi_evals.grounded.similarity import *  # noqa: F403
 from agentic_eval.core_evals.run_prompt.litellm_models import LiteLLMModelManager
+from common.utils.data_injection import normalize as _di_normalize
 from analytics.utils import (
     MixpanelEvents,
     MixpanelSources,
@@ -2018,20 +2019,21 @@ class EvaluationRunner:
 
             _mapped = preprocess_inputs(self.eval_template.name, _mapped)
 
-        # Inject row_context when dataset_row data injection is enabled.
+        # Inject row_context when full_row data injection is enabled.
         # data_injection lives in the user's eval metric config (run_config)
         # or the eval template config — check both.
-        _di = {}
+        _di_raw = {}
         if self.user_eval_metric and self.user_eval_metric.config:
             _uem_cfg = self.user_eval_metric.config
-            _di = (
+            _di_raw = (
                 _uem_cfg.get("run_config", {}).get("data_injection", {})
                 or _uem_cfg.get("data_injection", {})
             )
-        if not _di and self.eval_template:
-            _di = self.eval_template.config.get("data_injection", {})
+        if not _di_raw and self.eval_template:
+            _di_raw = self.eval_template.config.get("data_injection", {})
+        _di = _di_normalize(_di_raw)
 
-        if (_di.get("dataset_row") or _di.get("full_row") or _di.get("fullRow")) and "row_context" not in _mapped:
+        if _di["full_row"] and "row_context" not in _mapped:
             try:
                 row_dict = {}
                 cells = Cell.objects.filter(
@@ -2381,15 +2383,16 @@ class EvaluationRunner:
                 "knowledge_bases", []
             )
             # data_injection: prefer user's eval metric config (run_config),
-            # fall back to the base template config.
+            # fall back to the base template config. Normalize to canonical
+            # snake_case flags so downstream code never has to re-handle aliases.
             _uem_di = {}
             if self.user_eval_metric and self.user_eval_metric.config:
                 _uem_di = (
                     self.user_eval_metric.config.get("run_config", {}).get("data_injection", {})
                     or self.user_eval_metric.config.get("data_injection", {})
                 )
-            config["data_injection"] = _uem_di or self.eval_template.config.get(
-                "data_injection", {}
+            config["data_injection"] = _di_normalize(
+                _uem_di or self.eval_template.config.get("data_injection", {})
             )
             config["summary"] = self.eval_template.config.get(
                 "summary", {"type": "concise"}

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -2018,6 +2018,41 @@ class EvaluationRunner:
 
             _mapped = preprocess_inputs(self.eval_template.name, _mapped)
 
+        # Inject row_context when dataset_row data injection is enabled.
+        # data_injection lives in the user's eval metric config (run_config)
+        # or the eval template config — check both.
+        _di = {}
+        if self.user_eval_metric and self.user_eval_metric.config:
+            _uem_cfg = self.user_eval_metric.config
+            _di = (
+                _uem_cfg.get("run_config", {}).get("data_injection", {})
+                or _uem_cfg.get("data_injection", {})
+            )
+        if not _di and self.eval_template:
+            _di = self.eval_template.config.get("data_injection", {})
+
+        if (_di.get("dataset_row") or _di.get("full_row") or _di.get("fullRow")) and "row_context" not in _mapped:
+            try:
+                row_dict = {}
+                cells = Cell.objects.filter(
+                    row=row, deleted=False
+                ).select_related("column")
+                for cell in cells:
+                    col_name = cell.column.name if cell.column else None
+                    if not col_name:
+                        continue
+                    val = cell.value
+                    if isinstance(val, str):
+                        try:
+                            val = json.loads(val)
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+                    row_dict[col_name] = val
+                if row_dict:
+                    _mapped["row_context"] = row_dict
+            except Exception as e:
+                logger.warning("eval_runner_row_context_build_failed", error=str(e))
+
         return (
             eval_instance.run(**_mapped),
             required_field_error,
@@ -2345,7 +2380,15 @@ class EvaluationRunner:
             config["knowledge_bases"] = self.eval_template.config.get(
                 "knowledge_bases", []
             )
-            config["data_injection"] = self.eval_template.config.get(
+            # data_injection: prefer user's eval metric config (run_config),
+            # fall back to the base template config.
+            _uem_di = {}
+            if self.user_eval_metric and self.user_eval_metric.config:
+                _uem_di = (
+                    self.user_eval_metric.config.get("run_config", {}).get("data_injection", {})
+                    or self.user_eval_metric.config.get("data_injection", {})
+                )
+            config["data_injection"] = _uem_di or self.eval_template.config.get(
                 "data_injection", {}
             )
             config["summary"] = self.eval_template.config.get(

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -5105,7 +5105,7 @@ class EvalPlayGroundAPIView(APIView):
                                 "error_count": _span_agg["error_count"] or 0,
                                 "total_tokens": _span_agg["total_tokens"] or 0,
                                 "total_cost": (
-                                    round(_span_agg["total_cost"], 6)
+                                    float(round(_span_agg["total_cost"], 6))
                                     if _span_agg["total_cost"]
                                     else 0
                                 ),
@@ -5151,17 +5151,32 @@ class EvalPlayGroundAPIView(APIView):
                             )
 
                             # Lightweight trace summaries for the agent to
-                            # browse and decide which to drill into.
-                            _trace_summaries = []
-                            for _tr in _trace_qs.order_by("created_at")[:100]:
-                                _tr_span_agg = ObservationSpan.objects.filter(
-                                    trace=_tr, deleted=False
-                                ).aggregate(
-                                    span_count=Count("id"),
-                                    error_count=Count("id", filter=Q(status="ERROR")),
-                                    total_tokens=Sum("total_tokens"),
-                                    total_latency=Sum("latency_ms"),
+                            # browse and decide which to drill into. Use one
+                            # grouped aggregate instead of N+1 per-trace queries.
+                            _traces_page = list(
+                                _trace_qs.order_by("created_at")[:100]
+                            )
+                            _trace_ids = [_tr.id for _tr in _traces_page]
+                            _per_trace = {
+                                _row["trace_id"]: _row
+                                for _row in (
+                                    ObservationSpan.objects
+                                    .filter(trace_id__in=_trace_ids, deleted=False)
+                                    .values("trace_id")
+                                    .annotate(
+                                        span_count=Count("id"),
+                                        error_count=Count(
+                                            "id", filter=Q(status="ERROR")
+                                        ),
+                                        total_tokens=Sum("total_tokens"),
+                                        total_latency=Sum("latency_ms"),
+                                    )
                                 )
+                            }
+                            _trace_summaries = []
+                            for _tr in _traces_page:
+                                _agg = _per_trace.get(_tr.id, {})
+                                _err_count = _agg.get("error_count") or 0
                                 _trace_summaries.append({
                                     "id": str(_tr.id),
                                     "name": _tr.name,
@@ -5170,14 +5185,11 @@ class EvalPlayGroundAPIView(APIView):
                                         if _tr.created_at
                                         else None
                                     ),
-                                    "span_count": _tr_span_agg["span_count"] or 0,
-                                    "error_count": _tr_span_agg["error_count"] or 0,
-                                    "total_tokens": _tr_span_agg["total_tokens"] or 0,
-                                    "total_latency_ms": _tr_span_agg["total_latency"] or 0,
-                                    "has_error": bool(
-                                        _tr.error
-                                        or (_tr_span_agg["error_count"] or 0) > 0
-                                    ),
+                                    "span_count": _agg.get("span_count") or 0,
+                                    "error_count": _err_count,
+                                    "total_tokens": _agg.get("total_tokens") or 0,
+                                    "total_latency_ms": _agg.get("total_latency") or 0,
+                                    "has_error": bool(_tr.error or _err_count > 0),
                                 })
 
                             _start = _sess_agg["start_time"]
@@ -5205,7 +5217,7 @@ class EvalPlayGroundAPIView(APIView):
                                 "error_count": _sess_agg["error_count"] or 0,
                                 "total_tokens": _sess_agg["total_tokens"] or 0,
                                 "total_cost": (
-                                    round(_sess_agg["total_cost"], 6)
+                                    float(round(_sess_agg["total_cost"], 6))
                                     if _sess_agg["total_cost"]
                                     else 0
                                 ),

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -5036,10 +5036,40 @@ class EvalPlayGroundAPIView(APIView):
                         logger.warning(f"Failed to fetch span {_span_id}: {_e}")
                 if trace_context is None and _trace_id:
                     try:
+                        from django.db.models import Count, Sum, Min, Max, Q
                         from tracer.models.trace import Trace
+                        from tracer.models.observation_span import ObservationSpan
 
                         _t = Trace.objects.filter(id=_trace_id).first()
                         if _t:
+                            # Aggregate stats from child spans (single query)
+                            _span_agg = ObservationSpan.objects.filter(
+                                trace=_t, deleted=False
+                            ).aggregate(
+                                span_count=Count("id"),
+                                error_count=Count("id", filter=Q(status="ERROR")),
+                                total_tokens=Sum("total_tokens"),
+                                total_cost=Sum("cost"),
+                                start_time=Min("start_time"),
+                                end_time=Max("end_time"),
+                                total_latency=Sum("latency_ms"),
+                            )
+
+                            # Lightweight span summaries for the agent to
+                            # browse and decide which to drill into.
+                            # Only fetch essential fields, cap at 200 spans.
+                            _span_summaries = list(
+                                ObservationSpan.objects.filter(
+                                    trace=_t, deleted=False
+                                )
+                                .order_by("start_time")
+                                .values(
+                                    "id", "name", "observation_type", "status",
+                                    "status_message", "latency_ms", "model",
+                                    "total_tokens", "cost", "parent_span_id",
+                                )[:200]
+                            )
+
                             trace_context = {
                                 "id": str(_t.id),
                                 "project_id": (
@@ -5051,26 +5081,128 @@ class EvalPlayGroundAPIView(APIView):
                                 ),
                                 "metadata": _t.metadata or {},
                                 "tags": _t.tags or [],
+                                "input": _t.input,
+                                "output": _t.output,
+                                "error": _t.error,
+                                "created_at": (
+                                    _t.created_at.isoformat() if _t.created_at else None
+                                ),
+                                "span_count": _span_agg["span_count"] or 0,
+                                "error_count": _span_agg["error_count"] or 0,
+                                "total_tokens": _span_agg["total_tokens"] or 0,
+                                "total_cost": (
+                                    round(_span_agg["total_cost"], 6)
+                                    if _span_agg["total_cost"]
+                                    else 0
+                                ),
+                                "total_latency_ms": _span_agg["total_latency"] or 0,
+                                "start_time": (
+                                    str(_span_agg["start_time"])
+                                    if _span_agg["start_time"]
+                                    else None
+                                ),
+                                "end_time": (
+                                    str(_span_agg["end_time"])
+                                    if _span_agg["end_time"]
+                                    else None
+                                ),
+                                "spans": _span_summaries,
                             }
                     except Exception as _e:
                         logger.warning(f"Failed to fetch trace {_trace_id}: {_e}")
                 if session_context is None and _session_id:
                     try:
+                        from django.db.models import Count, Sum, Min, Max, Q
+                        from tracer.models.trace import Trace
                         from tracer.models.trace_session import TraceSession
+                        from tracer.models.observation_span import ObservationSpan
 
                         _ss = TraceSession.objects.filter(id=_session_id).first()
                         if _ss:
+                            # Get trace IDs for this session
+                            _trace_qs = Trace.objects.filter(
+                                session=_ss, deleted=False
+                            )
+
+                            # Aggregate stats across all spans in session
+                            _sess_agg = ObservationSpan.objects.filter(
+                                trace__in=_trace_qs, deleted=False
+                            ).aggregate(
+                                total_spans=Count("id"),
+                                error_count=Count("id", filter=Q(status="ERROR")),
+                                total_tokens=Sum("total_tokens"),
+                                total_cost=Sum("cost"),
+                                start_time=Min("start_time"),
+                                end_time=Max("end_time"),
+                            )
+
+                            # Lightweight trace summaries for the agent to
+                            # browse and decide which to drill into.
+                            _trace_summaries = []
+                            for _tr in _trace_qs.order_by("created_at")[:100]:
+                                _tr_span_agg = ObservationSpan.objects.filter(
+                                    trace=_tr, deleted=False
+                                ).aggregate(
+                                    span_count=Count("id"),
+                                    error_count=Count("id", filter=Q(status="ERROR")),
+                                    total_tokens=Sum("total_tokens"),
+                                    total_latency=Sum("latency_ms"),
+                                )
+                                _trace_summaries.append({
+                                    "id": str(_tr.id),
+                                    "name": _tr.name,
+                                    "created_at": (
+                                        _tr.created_at.isoformat()
+                                        if _tr.created_at
+                                        else None
+                                    ),
+                                    "span_count": _tr_span_agg["span_count"] or 0,
+                                    "error_count": _tr_span_agg["error_count"] or 0,
+                                    "total_tokens": _tr_span_agg["total_tokens"] or 0,
+                                    "total_latency_ms": _tr_span_agg["total_latency"] or 0,
+                                    "has_error": bool(
+                                        _tr.error
+                                        or (_tr_span_agg["error_count"] or 0) > 0
+                                    ),
+                                })
+
+                            _start = _sess_agg["start_time"]
+                            _end = _sess_agg["end_time"]
+                            _duration = None
+                            if _start and _end:
+                                _duration = (
+                                    _end - _start
+                                ).total_seconds()
+
                             session_context = {
                                 "id": str(_ss.id),
                                 "name": _ss.name,
                                 "project_id": (
                                     str(_ss.project_id) if _ss.project_id else None
                                 ),
-                                "status": _ss.status,
-                                "start_time": (
-                                    str(_ss.start_time) if _ss.start_time else None
+                                "bookmarked": _ss.bookmarked,
+                                "created_at": (
+                                    _ss.created_at.isoformat()
+                                    if _ss.created_at
+                                    else None
                                 ),
-                                "end_time": str(_ss.end_time) if _ss.end_time else None,
+                                "trace_count": _trace_qs.count(),
+                                "total_spans": _sess_agg["total_spans"] or 0,
+                                "error_count": _sess_agg["error_count"] or 0,
+                                "total_tokens": _sess_agg["total_tokens"] or 0,
+                                "total_cost": (
+                                    round(_sess_agg["total_cost"], 6)
+                                    if _sess_agg["total_cost"]
+                                    else 0
+                                ),
+                                "start_time": (
+                                    str(_start) if _start else None
+                                ),
+                                "end_time": (
+                                    str(_end) if _end else None
+                                ),
+                                "duration_seconds": _duration,
+                                "traces": _trace_summaries,
                             }
                     except Exception as _e:
                         logger.warning(f"Failed to fetch session {_session_id}: {_e}")

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -134,6 +134,7 @@ def run_eval_func(
         runner.eval_template = template
         if "mapping" in data_config:
             data_config.pop("mapping")
+
         eval_instance = runner._create_eval_instance(
             config=data_config,
             eval_class=eval_class,

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -720,22 +720,34 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
 
         # Build call_context for data_injection support — gives the eval
         # agent access to the full call data via explore_trace tool.
-        _call_context = {
-            "id": str(call_execution.id),
-            "status": call_execution.status,
-            "call_type": call_execution.call_type,
-            "simulation_call_type": call_execution.simulation_call_type,
-            "phone_number": call_execution.phone_number,
-            "started_at": str(call_execution.started_at) if call_execution.started_at else None,
-            "ended_at": str(call_execution.ended_at) if call_execution.ended_at else None,
-            "duration_seconds": call_execution.duration_seconds,
-            "recording_url": call_execution.recording_url,
-            "call_summary": call_execution.call_summary,
-            "ended_reason": call_execution.ended_reason,
-            "error_message": call_execution.error_message,
-            "message_count": call_execution.message_count,
-            "overall_score": float(call_execution.overall_score) if call_execution.overall_score is not None else None,
-        }
+        # Only built when the eval's data_injection.call_context flag is on,
+        # because the payload contains PII (phone_number, recording_url) and
+        # we shouldn't ship it into the LLM prompt unless explicitly enabled.
+        from common.utils.data_injection import is_enabled as _di_enabled
+
+        _di_cfg = (
+            (config or {}).get("run_config", {}).get("data_injection")
+            or (config or {}).get("data_injection")
+            or {}
+        )
+        _call_context = None
+        if _di_enabled(_di_cfg, "call_context"):
+            _call_context = {
+                "id": str(call_execution.id),
+                "status": call_execution.status,
+                "call_type": call_execution.call_type,
+                "simulation_call_type": call_execution.simulation_call_type,
+                "phone_number": call_execution.phone_number,
+                "started_at": str(call_execution.started_at) if call_execution.started_at else None,
+                "ended_at": str(call_execution.ended_at) if call_execution.ended_at else None,
+                "duration_seconds": call_execution.duration_seconds,
+                "recording_url": call_execution.recording_url,
+                "call_summary": call_execution.call_summary,
+                "ended_reason": call_execution.ended_reason,
+                "error_message": call_execution.error_message,
+                "message_count": call_execution.message_count,
+                "overall_score": float(call_execution.overall_score) if call_execution.overall_score is not None else None,
+            }
 
         eval_result = run_eval_func(
             config=config,

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -718,6 +718,25 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
         config = eval_config.config.copy() if eval_config.config else {}
         organization = call_execution.test_execution.run_test.organization
 
+        # Build call_context for data_injection support — gives the eval
+        # agent access to the full call data via explore_trace tool.
+        _call_context = {
+            "id": str(call_execution.id),
+            "status": call_execution.status,
+            "call_type": call_execution.call_type,
+            "simulation_call_type": call_execution.simulation_call_type,
+            "phone_number": call_execution.phone_number,
+            "started_at": str(call_execution.started_at) if call_execution.started_at else None,
+            "ended_at": str(call_execution.ended_at) if call_execution.ended_at else None,
+            "duration_seconds": call_execution.duration_seconds,
+            "recording_url": call_execution.recording_url,
+            "call_summary": call_execution.call_summary,
+            "ended_reason": call_execution.ended_reason,
+            "error_message": call_execution.error_message,
+            "message_count": call_execution.message_count,
+            "overall_score": float(call_execution.overall_score) if call_execution.overall_score is not None else None,
+        }
+
         eval_result = run_eval_func(
             config=config,
             mappings=updated_mapping,
@@ -728,6 +747,7 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
             error_localizer=eval_config.error_localizer,
             workspace=call_execution.test_execution.run_test.workspace,
             source="simulate",
+            call_context=_call_context,
         )
 
         if isinstance(eval_result, str):

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from accounts.models.workspace import Workspace
+from common.utils.data_injection import normalize as _di_normalize
 
 logger = structlog.get_logger(__name__)
 from agentic_eval.core_evals.fi_evals import *
@@ -602,8 +603,10 @@ def _execute_evaluation(
 
     # --- Build context for data_injection support ---
     _eval_inputs = dict(run_params or {})
-    _di = (custom_eval_config.config or {}).get("run_config", {}).get("data_injection", {})
-    if _di.get("span_context") or _di.get("spanContext"):
+    _di = _di_normalize(
+        (custom_eval_config.config or {}).get("run_config", {}).get("data_injection", {})
+    )
+    if _di["span_context"]:
         _eval_inputs["span_context"] = {
             "id": str(observation_span.id),
             "name": observation_span.name,
@@ -615,7 +618,7 @@ def _execute_evaluation(
             "total_tokens": observation_span.total_tokens,
             "cost": float(observation_span.cost) if observation_span.cost else None,
         }
-    if _di.get("trace_context") or _di.get("traceContext"):
+    if _di["trace_context"]:
         _eval_inputs["trace_context"] = {
             "id": str(observation_span.trace_id),
             "span_id": str(observation_span.id),

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -600,12 +600,33 @@ def _execute_evaluation(
     if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
         raise ValueError("API call not allowed : ", api_call_log_row.status)
 
+    # --- Build context for data_injection support ---
+    _eval_inputs = dict(run_params or {})
+    _di = (custom_eval_config.config or {}).get("run_config", {}).get("data_injection", {})
+    if _di.get("span_context") or _di.get("spanContext"):
+        _eval_inputs["span_context"] = {
+            "id": str(observation_span.id),
+            "name": observation_span.name,
+            "observation_type": observation_span.observation_type,
+            "status": observation_span.status,
+            "status_message": observation_span.status_message,
+            "model": observation_span.model,
+            "latency_ms": observation_span.latency_ms,
+            "total_tokens": observation_span.total_tokens,
+            "cost": float(observation_span.cost) if observation_span.cost else None,
+        }
+    if _di.get("trace_context") or _di.get("traceContext"):
+        _eval_inputs["trace_context"] = {
+            "id": str(observation_span.trace_id),
+            "span_id": str(observation_span.id),
+        }
+
     # --- Run eval via unified engine ---
     try:
         result = run_eval(
             EvalRequest(
                 eval_template=eval_model,
-                inputs=run_params or {},
+                inputs=_eval_inputs,
                 model=custom_eval_config.model,
                 kb_id=(
                     getattr(custom_eval_config.kb_id, "id", custom_eval_config.kb_id)


### PR DESCRIPTION
## Summary

Fixes gateway empty response on parallel tool calls (Bedrock Converse API), wires data injection toggles end-to-end across all eval surfaces, and enriches trace/session context for agent exploration.

## Critical Fixes

### Gateway: empty response on parallel tool calls

When an LLM returns multiple tool calls (parallel execution), each OpenAI `role: "tool"` message was converted to a separate Converse `role: "user"` message. Bedrock silently rejects consecutive same-role messages with an empty response. Fix: merge consecutive same-role messages into one.

### MCP connectors not loading in eval agent (TH-4754)

Fixed in the ee repo (PR #14). When `tools_config` had connector UUIDs, `tool_registry.get()` returned None. Added fallback to `MCPConnector` model. Only tested with custom evals.

## Changes

### Gateway (2 files)
- `converse.go` — merge consecutive same-role messages in `buildConverseRequest` (streaming + non-streaming)
- `translate.go` — same merge for Messages API path (defensive)

### Backend (4 files)
- `eval_runner.py` — read `data_injection` from UserEvalMetric config; build `row_context` from row cells when `full_row` enabled
- `develop_dataset.py` — return `run_config` in get_eval_structure for edit pre-population
- `separate_evals.py` — enriched trace context (span summaries, aggregates) + session context
- `trace_explorer.py` — `filter_spans`, `list_trace_spans` actions; live DB span_detail; span IDs in outputs

### Frontend (10 files)
- `EvalPickerConfigFull.jsx` — load + send all 6 data_injection flags individually
- `EvalCreatePage.jsx` / `EvalDetailPage.jsx` — resolve all flags on load/save
- `ModelSelector.jsx` — replaced `span_variables` with `call_context`; fixed toggle interaction
- `DatasetTestMode.jsx` — send `data_injection` flags in playground request
- `TaskLivePreview.jsx` — send `data_injection` flags in test eval request
- `TaskConfigPanel.jsx` — send `data_injection` in `run_config` on save
- `TestDetailConfigureEval.jsx` / `TestEvaluationDrawer.jsx` / `SimulationEvaluationDrawer.jsx` — pass config for edit

## Test plan

- [x] Gateway: parallel tool calls (2+) return proper response (streaming test verified)
- [x] Eval playground (tracing tab): trace_context, span_context, session_context toggles work
- [x] Eval playground (simulation tab): call_context toggle works
- [x] Dataset batch run (Temporal worker): data_injection loaded from UserEvalMetric config
- [x] Tasks tab: test eval with session context works
- [x] Agent uses explore_trace tool when context is loaded
- [x] MCP connector (URL Checker) loads and agent uses it (custom evals only)