### PR TITLE
[Fix] Older UI briefly appears after refreshing call details

### DIFF
--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
@@ -311,10 +311,6 @@ const TestDetailSideDrawerChild = ({
                 transformedData = { ...metricDetails, evalMetrics };
               }
 
-              // Reset isFetching before populating the store so the parent's
-              // open-gate flips with `isFetching === null` already in effect —
-              // otherwise the drawer slides in while the wide-skeleton branch
-              // is still active for one frame.
               setIsFetching(null);
               setTestDetailDrawerOpen({
                 ...transformedData,

--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
@@ -311,9 +311,15 @@ const TestDetailSideDrawerChild = ({
                 transformedData = { ...metricDetails, evalMetrics };
               }
 
+              // Reset isFetching before populating the store so the parent's
+              // open-gate flips with `isFetching === null` already in effect —
+              // otherwise the drawer slides in while the wide-skeleton branch
+              // is still active for one frame.
+              setIsFetching(null);
               setTestDetailDrawerOpen({
                 ...transformedData,
               });
+              return;
             }
           }
         } catch (error) {
@@ -424,6 +430,11 @@ const TestDetailSideDrawerChild = ({
       null
     );
   }, [mergedData?.observation_span]);
+
+
+  if (!data || isFetching === "initial") {
+    return null;
+  }
 
   return (
     <Box sx={{ display: "flex", minHeight: "100vh" }}>
@@ -724,8 +735,10 @@ const TestDetailSideDrawer = ({
     removeRowIndex();
   };
 
-  const isDrawerOpen =
+
+  const hasUrlRowIndex =
     updatedRowIndex !== undefined && updatedRowIndex !== null;
+  const isDrawerOpen = hasUrlRowIndex && !!testDetailDrawerOpen;
 
   const effectiveOrigin = urlOrigin || origin;
   const effectiveModule = module || "simulate";
@@ -733,6 +746,7 @@ const TestDetailSideDrawer = ({
   return (
     <Drawer
       open={isDrawerOpen}
+      keepMounted={hasUrlRowIndex}
       onClose={handleClose}
       anchor="right"
       SlideProps={{


### PR DESCRIPTION

## Summary

Problem: Reloading with the test detail drawer open flashed a 90vw skeleton, then collapsed to the 50vw voice drawer with real content.

Cause: Drawer visibility was URL-driven (?rowIndex=… persists across reload), but row data lived in a non-persisted Zustand store. On reload, the URL reopened the drawer immediately while data was still null — isVoiceCall evaluated false, so the wide 90vw skeleton rendered until the fetch completed and flipped the layout to 50vw.

Fix in [TestDetailSideDrawer.jsx](vscode-webview://06u6rlolmr403a4sqsdu9fj0ddrf2562s8spse4h21s0pobmdr7r/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx) — four layers:

Gate open on store data, not URL — drawer only slides in once testDetailDrawerOpen is populated.
keepMounted={hasUrlRowIndex} — child stays mounted while drawer is hidden so its existing restore effect can fetch and populate the store.
Reorder the effect — setIsFetching(null) runs before setTestDetailDrawerOpen(data), eliminating the interim frame.
Child early-returns null when !data || isFetching === "initial" — defense-in-depth against async re-renders.
Result: drawer stays hidden, child silently restores the row, then drawer slides in directly at the correct width with real content. In-session cell clicks are unaffected.

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues
TH-4345

<!-- "Closes #123" links and auto-closes on merge. -->
Closes TH-4345

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
