### PR TITLE
fix: charge AI credits for dataset eval reruns

### DIFF
--- a/futureagi/model_hub/tests/test_evaluation_api.py
+++ b/futureagi/model_hub/tests/test_evaluation_api.py
@@ -14,6 +14,7 @@ Run with: pytest model_hub/tests/test_evaluation_api.py -v
 """
 
 import uuid
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -921,6 +922,79 @@ class TestSingleRowEvaluationView:
             status.HTTP_401_UNAUTHORIZED,
             status.HTTP_403_FORBIDDEN,
         ]
+
+    def test_dataset_eval_rerun_checks_usage_and_sets_usage_source(
+        self, user_eval_metric, row
+    ):
+        """Dataset eval reruns should use the same AI-credit path metadata as initial runs."""
+        from model_hub.views.develop_dataset import run_evaluation_task
+
+        usage_check = SimpleNamespace(allowed=True)
+
+        with patch(
+            "ee.usage.services.metering.check_usage", return_value=usage_check
+        ) as mock_check_usage, patch(
+            "model_hub.views.develop_dataset.get_mixpanel_properties",
+            return_value={},
+        ), patch(
+            "model_hub.views.develop_dataset.track_mixpanel_event"
+        ), patch(
+            "model_hub.views.develop_dataset.EvaluationRunner"
+        ) as mock_runner_class:
+            mock_runner = MagicMock()
+            mock_runner_class.return_value = mock_runner
+
+            run_evaluation_task._original_func(
+                {
+                    "metric_ids": [str(user_eval_metric.id)],
+                    "row_ids": [str(row.id)],
+                }
+            )
+
+        mock_check_usage.assert_called_once()
+        mock_runner_class.assert_called_once()
+        _, kwargs = mock_runner_class.call_args
+        assert kwargs["source"] == "dataset_evaluation"
+        assert kwargs["source_id"] == user_eval_metric.template.id
+        assert kwargs["source_configs"]["dataset_id"] == str(user_eval_metric.dataset_id)
+        assert kwargs["source_configs"]["source"] == "dataset"
+        mock_runner.run_evaluation_for_row.assert_called_once_with(str(row.id))
+
+    def test_dataset_eval_rerun_stops_when_usage_limit_exceeded(
+        self, user_eval_metric, row
+    ):
+        """If AI credits are exhausted, reruns should not execute evaluator calls."""
+        from model_hub.models.choices import StatusType
+        from model_hub.views.develop_dataset import run_evaluation_task
+
+        usage_check = SimpleNamespace(
+            allowed=False,
+            reason="Usage limit exceeded",
+            error_code="USAGE_LIMIT_EXCEEDED",
+            dimension="ai_credits",
+            current_usage=10,
+            limit=10,
+            upgrade_cta=None,
+        )
+
+        with patch(
+            "ee.usage.services.metering.check_usage", return_value=usage_check
+        ), patch(
+            "model_hub.tasks.user_evaluation._mark_cells_usage_limit_error"
+        ) as mock_mark_limit, patch(
+            "model_hub.views.develop_dataset.EvaluationRunner"
+        ) as mock_runner_class:
+            run_evaluation_task._original_func(
+                {
+                    "metric_ids": [str(user_eval_metric.id)],
+                    "row_ids": [str(row.id)],
+                }
+            )
+
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.status == StatusType.FAILED.value
+        mock_mark_limit.assert_called_once()
+        mock_runner_class.assert_not_called()
 
 
 # ==================== Organization Isolation Tests ====================

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -169,6 +169,7 @@ from model_hub.views.utils.utils import (
     update_column_id,
     validate_file_url,
 )
+from sdk.utils.helpers import _get_api_call_type
 from tfc.settings.settings import BASE_URL, HUGGINGFACE_API_TOKEN
 
 # Define a Temporal activity for running the evaluation
@@ -10794,10 +10795,40 @@ def run_evaluation_task(evaluation_data):
             }
 
         futures = []
+        blocked_metric_ids = set()
         with ThreadPoolExecutor(max_workers=5) as executor:
             for metric_id in metric_ids:
                 metric = metric_map.get(metric_id)
                 if metric:
+                    try:
+                        from ee.usage.services.metering import check_usage
+                    except ImportError:
+                        check_usage = None
+
+                    if check_usage is not None:
+                        api_call_type = _get_api_call_type(
+                            metric.model or ModelChoices.TURING_LARGE.value
+                        )
+                        usage_check = check_usage(
+                            str(metric.organization.id), api_call_type
+                        )
+                        if not usage_check.allowed:
+                            from model_hub.tasks.user_evaluation import (
+                                _mark_cells_usage_limit_error,
+                            )
+
+                            UserEvalMetric.objects.filter(id=metric_id).update(
+                                status=StatusType.FAILED.value
+                            )
+                            blocked_metric_ids.add(str(metric_id))
+                            _mark_cells_usage_limit_error(metric, usage_check)
+                            logger.warning(
+                                "dataset_eval_rerun_usage_limit_exceeded",
+                                eval_id=str(metric_id),
+                                reason=usage_check.reason,
+                            )
+                            continue
+
                     properties = get_mixpanel_properties(
                         org=metric.organization,
                         eval=metric,
@@ -10813,9 +10844,24 @@ def run_evaluation_task(evaluation_data):
                     logger.info(
                         " ----- INSIDE run_evaluation_task | Initializing the EvaluationRunner for each metric -----"
                     )
+                    runner_args = dict(args)
+                    if not runner_args.get("source"):
+                        runner_args["source"] = "dataset_evaluation"
+                    if not runner_args.get("source_id"):
+                        runner_args["source_id"] = metric.template.id
+                    runner_source_configs = dict(
+                        runner_args.get("source_configs") or {}
+                    )
+                    if metric.dataset_id:
+                        runner_source_configs.setdefault(
+                            "dataset_id", str(metric.dataset_id)
+                        )
+                    runner_source_configs.setdefault("source", "dataset")
+                    runner_args["source_configs"] = runner_source_configs
+
                     evaluation_runner = EvaluationRunner(
                         user_eval_metric_id=metric_id,
-                        **args,
+                        **runner_args,
                     )
 
                     # Wrap function with OTel context propagation for thread safety
@@ -10860,9 +10906,15 @@ def run_evaluation_task(evaluation_data):
                 )
 
         # Update status to completed for successful metrics
-        UserEvalMetric.objects.filter(id__in=metric_ids).update(
-            status=StatusType.COMPLETED.value
-        )
+        completed_metric_ids = [
+            metric_id
+            for metric_id in metric_ids
+            if str(metric_id) not in blocked_metric_ids
+        ]
+        if completed_metric_ids:
+            UserEvalMetric.objects.filter(id__in=completed_metric_ids).update(
+                status=StatusType.COMPLETED.value
+            )
     except Exception as e:
         # Handle exceptions and log errors
         UserEvalMetric.objects.filter(id__in=metric_ids).update(


### PR DESCRIPTION
## Summary

Dataset eval reruns now run the same AI-credit usage preflight as normal dataset eval runs before evaluator execution. The rerun worker also sets the default `dataset_evaluation` source metadata so the existing eval usage emitter attributes AI-credit events correctly, and usage-limit failures now stop evaluator execution instead of later marking the metric completed.

## Linked issues

Closes TH-4711

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

`set -a && source .env.test && set +a && .venv/bin/pytest model_hub/tests/test_evaluation_api.py -q -k 'dataset_eval_rerun'`

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
