### PR TITLE
chore(ci): add twice-daily PR digest Slack workflow

### DIFF
--- a/.github/scripts/pr-digest.mjs
+++ b/.github/scripts/pr-digest.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+// Posts a digest of open PRs (External vs Internal) to Slack.
+// Invoked by .github/workflows/pr-digest.yml on a cron + workflow_dispatch.
+
+const {
+  GITHUB_TOKEN,
+  SLACK_WEBHOOK_URL,
+  GITHUB_REPOSITORY,
+} = process.env;
+
+for (const [k, v] of Object.entries({
+  GITHUB_TOKEN,
+  SLACK_WEBHOOK_URL,
+  GITHUB_REPOSITORY,
+})) {
+  if (!v) {
+    console.error(`Missing required env var: ${k}`);
+    process.exit(1);
+  }
+}
+
+const [OWNER, REPO] = GITHUB_REPOSITORY.split('/');
+const GH_API = 'https://api.github.com';
+const DESC_MAX = 140;
+
+const ghHeaders = {
+  Accept: 'application/vnd.github+json',
+  Authorization: `Bearer ${GITHUB_TOKEN}`,
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': `${OWNER}-${REPO}-pr-digest`,
+};
+
+async function gh(path) {
+  const res = await fetch(`${GH_API}${path}`, { headers: ghHeaders });
+  if (!res.ok) {
+    throw new Error(`GitHub ${path} → ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function ghAll(path) {
+  const out = [];
+  let page = 1;
+  while (true) {
+    const sep = path.includes('?') ? '&' : '?';
+    const batch = await gh(`${path}${sep}per_page=100&page=${page}`);
+    out.push(...batch);
+    if (batch.length < 100) break;
+    page += 1;
+  }
+  return out;
+}
+
+function classifyArea(files) {
+  let fe = false;
+  let be = false;
+  for (const f of files) {
+    if (f.filename.startsWith('frontend/')) fe = true;
+    else if (f.filename.startsWith('futureagi/')) be = true;
+    if (fe && be) break;
+  }
+  if (fe && be) return { label: 'FE+BE', emoji: '🧩' };
+  if (fe) return { label: 'FE', emoji: '🎨' };
+  if (be) return { label: 'BE', emoji: '⚙️' };
+  return { label: 'Other', emoji: '📦' };
+}
+
+function classifyReviewState(pr, reviews) {
+  if (pr.draft) return { label: 'Draft', emoji: '📝' };
+  // Use latest non-PENDING review per reviewer to determine state.
+  const latestByUser = new Map();
+  for (const r of reviews) {
+    if (!r.user || r.state === 'PENDING') continue;
+    const prev = latestByUser.get(r.user.login);
+    if (!prev || new Date(r.submitted_at) > new Date(prev.submitted_at)) {
+      latestByUser.set(r.user.login, r);
+    }
+  }
+  const states = [...latestByUser.values()].map((r) => r.state);
+  if (states.includes('CHANGES_REQUESTED')) return { label: 'Changes requested', emoji: '🟡' };
+  if (states.includes('APPROVED')) return { label: 'Approved', emoji: '🟢' };
+  if (states.includes('COMMENTED')) return { label: 'Commented', emoji: '💬' };
+  return { label: 'Awaiting review', emoji: '⏳' };
+}
+
+function reviewerInfo(pr, reviews) {
+  const requestedUsers = (pr.requested_reviewers || []).map((u) => u.login);
+  const requestedTeams = (pr.requested_teams || []).map((t) => `@${t.slug}`);
+  const reviewedUsers = [
+    ...new Set(reviews.filter((r) => r.user).map((r) => r.user.login)),
+  ];
+  const all = [...new Set([...requestedUsers, ...requestedTeams, ...reviewedUsers])];
+  return { attached: all.length > 0, names: all };
+}
+
+function bucket(pr) {
+  return pr.author_association === 'MEMBER' || pr.author_association === 'OWNER'
+    ? 'internal'
+    : 'external';
+}
+
+function truncate(s) {
+  if (!s) return '';
+  // Collapse newlines & HTML comments (PR templates often include them).
+  const cleaned = s
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (cleaned.length <= DESC_MAX) return cleaned;
+  return cleaned.slice(0, DESC_MAX - 1).trimEnd() + '…';
+}
+
+function escapeMrkdwn(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function prSection(pr) {
+  const lines = [];
+  lines.push(`*<${pr.html_url}|${escapeMrkdwn(pr.title)}>* \`#${pr.number}\``);
+  lines.push(
+    `👤 ${pr.user.login}  •  ${pr.area.emoji} ${pr.area.label}  •  ${pr.review.emoji} ${pr.review.label}`,
+  );
+  if (pr.reviewers.attached) {
+    lines.push(`👀 Reviewers: ${pr.reviewers.names.join(', ')}`);
+  } else {
+    lines.push('🚨 *No reviewer assigned*');
+  }
+  if (pr.tags.length) {
+    lines.push(`🏷 ${pr.tags.join(', ')}`);
+  }
+  if (pr.snippet) {
+    lines.push(`> ${escapeMrkdwn(pr.snippet)}`);
+  }
+  return {
+    type: 'section',
+    text: { type: 'mrkdwn', text: lines.join('\n') },
+  };
+}
+
+function header(text) {
+  return { type: 'header', text: { type: 'plain_text', text, emoji: true } };
+}
+
+function context(text) {
+  return {
+    type: 'context',
+    elements: [{ type: 'mrkdwn', text }],
+  };
+}
+
+function emptyStub() {
+  return {
+    type: 'section',
+    text: { type: 'mrkdwn', text: '_No open PRs in this bucket._' },
+  };
+}
+
+async function enrichPR(pr) {
+  const [files, reviews] = await Promise.all([
+    ghAll(`/repos/${OWNER}/${REPO}/pulls/${pr.number}/files`),
+    ghAll(`/repos/${OWNER}/${REPO}/pulls/${pr.number}/reviews`),
+  ]);
+  return {
+    number: pr.number,
+    title: pr.title,
+    html_url: pr.html_url,
+    user: { login: pr.user?.login || 'unknown' },
+    bucket: bucket(pr),
+    area: classifyArea(files),
+    review: classifyReviewState(pr, reviews),
+    reviewers: reviewerInfo(pr, reviews),
+    tags: (pr.labels || []).map((l) => l.name),
+    snippet: truncate(pr.body),
+    updated_at: pr.updated_at,
+  };
+}
+
+function istDateString(now = new Date()) {
+  return now.toLocaleDateString('en-IN', {
+    timeZone: 'Asia/Kolkata',
+    weekday: 'short',
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+async function postSlack(blocks, fallbackText) {
+  const res = await fetch(SLACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify({
+      text: fallbackText,
+      blocks,
+      unfurl_links: false,
+      unfurl_media: false,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Slack webhook failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+async function main() {
+  const openPRs = await ghAll(`/repos/${OWNER}/${REPO}/pulls?state=open`);
+  const enriched = await Promise.all(openPRs.map(enrichPR));
+  enriched.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
+
+  const external = enriched.filter((p) => p.bucket === 'external');
+  const internal = enriched.filter((p) => p.bucket === 'internal');
+
+  const blocks = [
+    header(`🚀 PR Digest — ${istDateString()}`),
+    context(
+      `${enriched.length} open  •  ${external.length} External  •  ${internal.length} Internal`,
+    ),
+    { type: 'divider' },
+    header(`📤 External PRs (${external.length})`),
+    ...(external.length ? external.map(prSection) : [emptyStub()]),
+    { type: 'divider' },
+    header(`🏢 Internal PRs (${internal.length})`),
+    ...(internal.length ? internal.map(prSection) : [emptyStub()]),
+  ];
+
+  const fallback = `PR Digest — ${enriched.length} open (${external.length} external, ${internal.length} internal)`;
+  await postSlack(blocks, fallback);
+  console.log(`Posted digest: ${fallback}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/workflows/pr-digest.yml
+++ b/.github/workflows/pr-digest.yml
@@ -1,0 +1,31 @@
+name: PR Digest to Slack
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 10:00 IST (UTC+5:30) → 04:30 UTC
+    - cron: '30 4 * * *'
+    # 18:00 IST (UTC+5:30) → 12:30 UTC
+    - cron: '30 12 * * *'
+
+jobs:
+  digest:
+    # Skip on forks — secrets aren't available there and the run would just spam Actions logs.
+    if: github.repository == 'future-agi/future-agi'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build and post PR digest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node .github/scripts/pr-digest.mjs


### PR DESCRIPTION
## Summary

Promotes the PR digest workflow (already merged to `dev` in #211) to `main`, plus a small fork-safety addition. Once this lands, the workflow will be **registered** on the default branch — making the Actions UI dropdown visible, enabling manual `workflow_dispatch`, and activating the 10:00 / 18:00 IST cron.

The workflow posts a single dense Slack message twice a day listing every open PR, split into **External** vs **Internal** authors. For each PR it surfaces: clickable title, author, FE/BE/Both classification (by changed file paths under `frontend/` vs `futureagi/`), review state, reviewer-attached check (with a warning when none is set), labels, and a truncated description.

### What's different vs the dev merge (#211)

A single line on the job:

```yaml
if: github.repository == 'future-agi/future-agi'
```

This skips the job entirely on forks — important because this is a public repo. Without the guard, a fork owner who enables Actions would see the cron fail every 12 hours on the missing `SLACK_WEBHOOK_URL` secret. With the guard, forks see a clean "Skipped" instead.

## Linked issues

N/A — internal automation.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [x] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `node --check .github/scripts/pr-digest.mjs` — passes.
- Workflow YAML parsed with `python -c "import yaml; yaml.safe_load(...)"` — passes.
- Local dry-run path (posts a real Slack message against the actual repo state):
  ```bash
  GITHUB_TOKEN=$(gh auth token) \
  SLACK_WEBHOOK_URL=<https://hooks.slack.com/services/...> \
  GITHUB_REPOSITORY=future-agi/future-agi \
  node .github/scripts/pr-digest.mjs
  ```
- Workflow dispatch attempted while the file was only on `dev` returned `404 — workflow pr-digest.yml not found on the default branch`, confirming the registration must happen on `main`. After this PR merges, the dispatch button + cron go live.

## Required configuration before first run

| Name | Value |
| --- | --- |
| `SLACK_WEBHOOK_URL` | Slack incoming webhook URL (`https://hooks.slack.com/services/T…/B…/…`). The target channel is bound to the webhook at creation. |

`GITHUB_TOKEN` is provided automatically; the workflow declares only `pull-requests: read` and `contents: read` permissions.

## Screenshots / recordings (if UI)

N/A — no UI change.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works — N/A, this is a CI workflow; verification is via manual dispatch after merging
- [x] `make check-all` / `yarn check-all` passes locally — N/A for `.github/` changes; `node --check` and YAML parse both pass
- [x] I've updated the documentation where relevant — none needed (workflow is self-documenting; required secret is listed above)
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)