### PR TITLE
fix(ci): cap PR digest blocks under Slack 50-block limit

### DIFF
--- a/.github/scripts/pr-digest.mjs
+++ b/.github/scripts/pr-digest.mjs
@@ -22,6 +22,10 @@ for (const [k, v] of Object.entries({
 const [OWNER, REPO] = GITHUB_REPOSITORY.split('/');
 const GH_API = 'https://api.github.com';
 const DESC_MAX = 140;
+// Slack hard-caps a single message at 50 blocks. We render fixed scaffolding
+// (header + context + 2 dividers + 2 sub-headers + up to 2 "+N more" notes) =
+// up to 8 blocks, so per-bucket cap of 20 keeps us safely under the limit.
+const MAX_PRS_PER_BUCKET = 20;
 
 const ghHeaders = {
   Accept: 'application/vnd.github+json',
@@ -198,8 +202,26 @@ async function postSlack(blocks, fallbackText) {
     }),
   });
   if (!res.ok) {
-    throw new Error(`Slack webhook failed: ${res.status} ${await res.text()}`);
+    const body = await res.text();
+    throw new Error(
+      `Slack webhook failed: ${res.status} ${body} (block count: ${blocks.length})`,
+    );
   }
+}
+
+function renderBucket(bucketHeader, prs) {
+  const out = [bucketHeader];
+  if (prs.length === 0) {
+    out.push(emptyStub());
+    return out;
+  }
+  const shown = prs.slice(0, MAX_PRS_PER_BUCKET);
+  const hidden = prs.length - shown.length;
+  out.push(...shown.map(prSection));
+  if (hidden > 0) {
+    out.push(context(`_+${hidden} older PR${hidden === 1 ? '' : 's'} not shown_`));
+  }
+  return out;
 }
 
 async function main() {
@@ -216,11 +238,9 @@ async function main() {
       `${enriched.length} open  •  ${external.length} External  •  ${internal.length} Internal`,
     ),
     { type: 'divider' },
-    header(`📤 External PRs (${external.length})`),
-    ...(external.length ? external.map(prSection) : [emptyStub()]),
+    ...renderBucket(header(`📤 External PRs (${external.length})`), external),
     { type: 'divider' },
-    header(`🏢 Internal PRs (${internal.length})`),
-    ...(internal.length ? internal.map(prSection) : [emptyStub()]),
+    ...renderBucket(header(`🏢 Internal PRs (${internal.length})`), internal),
   ];
 
   const fallback = `PR Digest — ${enriched.length} open (${external.length} external, ${internal.length} internal)`;


### PR DESCRIPTION
## Summary

The PR digest workflow added in #215 fails with `400 invalid_blocks` against Slack because one section block is emitted per open PR, and this repo currently has **55+ open PRs**. Slack's incoming-webhook hard limit is **50 blocks per message**.

This PR caps each bucket (External / Internal) at **20 PRs** and renders a context line `_+N older PRs not shown_` underneath when truncated. PRs are already sorted by `updated_at` desc, so oldest-stale fall off first — the most recently active ones always make it into the digest.

Block budget after the fix: 6 fixed scaffold blocks + up to 40 PR sections + up to 2 "+N more" notes = **48 blocks max**, comfortably under 50.

Also annotates the Slack-error message with the block count, so any future limit-related failure is obvious from the workflow log.

## Linked issues

N/A — follow-up to #215.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `node --check .github/scripts/pr-digest.mjs` — passes.
- Reproduced the failure: pre-fix run posted `block count: 61` (logged after the post-fix error annotation patch), exceeded the 50-block limit, returned `invalid_blocks`.
- Post-fix block count locally: 6 fixed + 40 PR sections + 2 "+N more" notes = 48 blocks. Within limit.
- After merge, re-trigger the workflow manually from **Actions → PR Digest to Slack → Run workflow** to confirm the digest posts cleanly.

## Required configuration

No new secrets. The existing `SLACK_WEBHOOK_URL` from #215 is unchanged.

## Screenshots / recordings (if UI)

N/A.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works — N/A; verification is via manual dispatch after merge
- [x] `make check-all` / `yarn check-all` passes locally — N/A for `.github/` changes; `node --check` passes
- [x] I've updated the documentation where relevant — none needed
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)