### PR TITLE
fix(ci): chunk PR digest across multiple Slack messages

### DIFF
--- a/.github/scripts/pr-digest.mjs
+++ b/.github/scripts/pr-digest.mjs
@@ -22,6 +22,9 @@ for (const [k, v] of Object.entries({
 const [OWNER, REPO] = GITHUB_REPOSITORY.split('/');
 const GH_API = 'https://api.github.com';
 const DESC_MAX = 140;
+// Slack caps a single message at 50 blocks. We use 1 header + N PR sections
+// per message; 35 keeps us well clear of the limit even with edge-case sections.
+const PRS_PER_MESSAGE = 35;
 
 const ghHeaders = {
   Accept: 'application/vnd.github+json',
@@ -198,8 +201,32 @@ async function postSlack(blocks, fallbackText) {
     }),
   });
   if (!res.ok) {
-    throw new Error(`Slack webhook failed: ${res.status} ${await res.text()}`);
+    const body = await res.text();
+    throw new Error(
+      `Slack webhook failed: ${res.status} ${body} (block count: ${blocks.length})`,
+    );
   }
+}
+
+async function postBucket(bucketEmoji, bucketLabel, prs) {
+  if (prs.length === 0) {
+    await postSlack(
+      [header(`${bucketEmoji} ${bucketLabel} (0)`), emptyStub()],
+      `${bucketLabel}: none`,
+    );
+    return 1;
+  }
+  const totalParts = Math.ceil(prs.length / PRS_PER_MESSAGE);
+  for (let i = 0; i < totalParts; i++) {
+    const chunk = prs.slice(i * PRS_PER_MESSAGE, (i + 1) * PRS_PER_MESSAGE);
+    const partSuffix = totalParts > 1 ? ` — part ${i + 1}/${totalParts}` : '';
+    const blocks = [
+      header(`${bucketEmoji} ${bucketLabel} (${prs.length})${partSuffix}`),
+      ...chunk.map(prSection),
+    ];
+    await postSlack(blocks, `${bucketLabel}${partSuffix}`);
+  }
+  return totalParts;
 }
 
 async function main() {
@@ -210,22 +237,21 @@ async function main() {
   const external = enriched.filter((p) => p.bucket === 'external');
   const internal = enriched.filter((p) => p.bucket === 'internal');
 
-  const blocks = [
+  // Message 1: digest summary. Subsequent messages: each bucket, chunked if needed.
+  const summaryBlocks = [
     header(`🚀 PR Digest — ${istDateString()}`),
     context(
       `${enriched.length} open  •  ${external.length} External  •  ${internal.length} Internal`,
     ),
-    { type: 'divider' },
-    header(`📤 External PRs (${external.length})`),
-    ...(external.length ? external.map(prSection) : [emptyStub()]),
-    { type: 'divider' },
-    header(`🏢 Internal PRs (${internal.length})`),
-    ...(internal.length ? internal.map(prSection) : [emptyStub()]),
   ];
-
   const fallback = `PR Digest — ${enriched.length} open (${external.length} external, ${internal.length} internal)`;
-  await postSlack(blocks, fallback);
-  console.log(`Posted digest: ${fallback}`);
+  await postSlack(summaryBlocks, fallback);
+
+  const externalParts = await postBucket('📤', 'External PRs', external);
+  const internalParts = await postBucket('🏢', 'Internal PRs', internal);
+
+  const totalMessages = 1 + externalParts + internalParts;
+  console.log(`Posted digest in ${totalMessages} message(s): ${fallback}`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Mirrors the chunking fix opened against `main` in #218 onto `dev`, so the two branches stay in sync.

The PR digest workflow (#211) hits Slack's 50-block-per-message limit because one block is rendered per open PR (currently 55+ open). Replace the single-message render with a chunked approach so every PR is included:

1. **Message 1** — digest header + summary counts.
2. **Messages 2..N** — External PRs in chunks of up to 35 per message, with a `— part X/Y` suffix on the bucket header when split.
3. **Messages N+1..M** — Internal PRs, same chunking rule.

Per-message block count tops out at ~36, comfortably under the 50-block limit. Sequential `await`s serialize the posts within Slack's webhook rate limits.

The Slack-error message also now annotates the offending block count, so any future limit-related failure is obvious from the workflow log.

## Linked issues

Mirrors #218 onto `dev`. Follow-up to #211.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `node --check .github/scripts/pr-digest.mjs` — passes.
- Identical change to #218 (cherry-picked); the same dry-run logic applies. End-to-end verification needs the workflow to be on `main` first (done via #218) — once that lands, manual dispatch from `dev` will exercise this path.

## Required configuration

No new secrets — `SLACK_WEBHOOK_URL` from #215 is unchanged.

## Screenshots / recordings (if UI)

N/A.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works — N/A; verification is via manual dispatch after merge
- [x] `make check-all` / `yarn check-all` passes locally — N/A for `.github/` changes; `node --check` passes
- [x] I've updated the documentation where relevant — none needed
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)