### PR TITLE
fix(ci): use real org-membership API to bucket Internal vs External

### DIFF
--- a/.github/scripts/pr-digest.mjs
+++ b/.github/scripts/pr-digest.mjs
@@ -6,6 +6,10 @@ const {
   GITHUB_TOKEN,
   SLACK_WEBHOOK_URL,
   GITHUB_REPOSITORY,
+  // Optional PAT with `read:org` scope. The default GITHUB_TOKEN cannot see
+  // private org membership, and most members keep their membership private,
+  // so without this token nearly everyone is misclassified as External.
+  ORG_READ_TOKEN,
 } = process.env;
 
 for (const [k, v] of Object.entries({
@@ -17,6 +21,14 @@ for (const [k, v] of Object.entries({
     console.error(`Missing required env var: ${k}`);
     process.exit(1);
   }
+}
+
+if (!ORG_READ_TOKEN) {
+  console.warn(
+    'ORG_READ_TOKEN is not set; falling back to author_association for Internal/External classification. ' +
+      'Members with private org membership will be miscounted as External. ' +
+      'Add a PAT with read:org scope as the ORG_READ_TOKEN secret to fix.',
+  );
 }
 
 const [OWNER, REPO] = GITHUB_REPOSITORY.split('/');
@@ -96,10 +108,33 @@ function reviewerInfo(pr, reviews) {
   return { attached: all.length > 0, names: all };
 }
 
-function bucket(pr) {
-  return pr.author_association === 'MEMBER' || pr.author_association === 'OWNER'
-    ? 'internal'
-    : 'external';
+const memberCache = new Map();
+
+async function isOrgMember(login) {
+  if (!login || !ORG_READ_TOKEN) return null;
+  if (memberCache.has(login)) return memberCache.get(login);
+  const res = await fetch(`${GH_API}/orgs/${OWNER}/members/${encodeURIComponent(login)}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${ORG_READ_TOKEN}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': `${OWNER}-${REPO}-pr-digest`,
+    },
+  });
+  // 204 = member; 302 = token can't see; 404 = not a member.
+  const isMember = res.status === 204;
+  memberCache.set(login, isMember);
+  return isMember;
+}
+
+async function bucket(pr) {
+  // Public org members surface as MEMBER on author_association — no API call needed.
+  if (pr.author_association === 'OWNER' || pr.author_association === 'MEMBER') {
+    return 'internal';
+  }
+  // Private members default to CONTRIBUTOR/NONE on author_association; query the org API.
+  const memberOf = await isOrgMember(pr.user?.login);
+  return memberOf === true ? 'internal' : 'external';
 }
 
 function truncate(s) {
@@ -160,16 +195,17 @@ function emptyStub() {
 }
 
 async function enrichPR(pr) {
-  const [files, reviews] = await Promise.all([
+  const [files, reviews, prBucket] = await Promise.all([
     ghAll(`/repos/${OWNER}/${REPO}/pulls/${pr.number}/files`),
     ghAll(`/repos/${OWNER}/${REPO}/pulls/${pr.number}/reviews`),
+    bucket(pr),
   ]);
   return {
     number: pr.number,
     title: pr.title,
     html_url: pr.html_url,
     user: { login: pr.user?.login || 'unknown' },
-    bucket: bucket(pr),
+    bucket: prBucket,
     area: classifyArea(files),
     review: classifyReviewState(pr, reviews),
     reviewers: reviewerInfo(pr, reviews),

--- a/.github/workflows/pr-digest.yml
+++ b/.github/workflows/pr-digest.yml
@@ -25,5 +25,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # PAT with read:org scope; needed to detect org members whose membership is private.
+          ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: node .github/scripts/pr-digest.mjs


### PR DESCRIPTION
## Summary

Mirrors #221 onto `dev`.

The PR digest was misclassifying virtually every PR as External because GitHub's `author_association` field only returns `MEMBER` for users with **public** org membership, and most members keep it private. Latest run reported **53 External, 0 Internal**.

This PR replaces the heuristic with a real `GET /orgs/{org}/members/{login}` lookup, which sees both public and private memberships. The endpoint requires a token with `read:org` scope (not granted to the built-in `GITHUB_TOKEN`), so a small new secret is needed.

### Behaviour

- `author_association == OWNER || MEMBER` → Internal (no API call).
- Everything else → check `GET /orgs/{org}/members/{login}` using the new `ORG_READ_TOKEN`. Per-author cached.
- If `ORG_READ_TOKEN` is missing, the script logs a warning and falls back to the old behaviour rather than failing the run.

## Linked issues

Mirrors #221 onto `dev`. Follow-up to #219.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `node --check` and YAML parse — both pass.
- Identical change to #221 (cherry-picked); same dry-run logic applies.

## Required configuration

Add **one new repo secret**:

| Name | Value |
| --- | --- |
| `ORG_READ_TOKEN` | PAT with `read:org` scope (fine-grained: resource owner = `future-agi`, `Organization permissions → Members: Read-only`). |

Existing `SLACK_WEBHOOK_URL` is unchanged.

## Screenshots / recordings (if UI)

N/A.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works — N/A; verification is via manual dispatch after merge
- [x] `make check-all` / `yarn check-all` passes locally — N/A for `.github/` changes; `node --check` passes
- [x] I've updated the documentation where relevant — none needed
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)