### PR TITLE
fix(TH-4697): existing users fail to join new workspace

### DIFF
--- a/futureagi/accounts/models/user.py
+++ b/futureagi/accounts/models/user.py
@@ -167,7 +167,15 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     def has_global_workspace_access(self, organization=None):
         """Check if user's role in the given org grants global workspace access."""
-        role = self.get_organization_role(organization)
+        target_org = organization or self.organization
+        if target_org:
+            membership = self.get_membership(target_org)
+            if membership:
+                from tfc.constants.levels import Level
+
+                return membership.level_or_legacy >= Level.ADMIN
+
+        role = self.get_organization_role(target_org)
         if not role:
             return False
 

--- a/futureagi/accounts/models/user.py
+++ b/futureagi/accounts/models/user.py
@@ -168,13 +168,16 @@ class User(AbstractBaseUser, PermissionsMixin):
     def has_global_workspace_access(self, organization=None):
         """Check if user's role in the given org grants global workspace access."""
         target_org = organization or self.organization
-        if target_org:
-            membership = self.get_membership(target_org)
-            if membership:
-                from tfc.constants.levels import Level
+        if not target_org:
+            return False
 
-                return membership.level_or_legacy >= Level.ADMIN
+        membership = self.get_membership(target_org)
+        if membership:
+            from tfc.constants.levels import Level
 
+            return membership.level_or_legacy >= Level.ADMIN
+
+        # Legacy fallback: no membership record exists for this org
         role = self.get_organization_role(target_org)
         if not role:
             return False

--- a/futureagi/accounts/serializers/workspace.py
+++ b/futureagi/accounts/serializers/workspace.py
@@ -11,6 +11,8 @@ class WorkspaceListSerializer(serializers.ModelSerializer):
     admin_names = serializers.SerializerMethodField()
     start_data = serializers.SerializerMethodField()
     last_update_date = serializers.SerializerMethodField()
+    workspace_created_at = serializers.SerializerMethodField()
+    workspace_updated_at = serializers.SerializerMethodField()
     invite_link = serializers.SerializerMethodField()
 
     class Meta:
@@ -22,6 +24,8 @@ class WorkspaceListSerializer(serializers.ModelSerializer):
             "admin_names",
             "start_data",
             "last_update_date",
+            "workspace_created_at",
+            "workspace_updated_at",
             "invite_link",
         ]
 
@@ -49,6 +53,12 @@ class WorkspaceListSerializer(serializers.ModelSerializer):
     def get_last_update_date(self, obj):
         """Get last update date in required format"""
         return obj.updated_at.strftime("%Y-%m-%d") if obj.updated_at else ""
+
+    def get_workspace_created_at(self, obj):
+        return obj.created_at.isoformat() if obj.created_at else None
+
+    def get_workspace_updated_at(self, obj):
+        return obj.updated_at.isoformat() if obj.updated_at else None
 
     def get_invite_link(self, obj):
         """Get invite link (placeholder for v1)"""

--- a/futureagi/accounts/serializers/workspace.py
+++ b/futureagi/accounts/serializers/workspace.py
@@ -11,8 +11,6 @@ class WorkspaceListSerializer(serializers.ModelSerializer):
     admin_names = serializers.SerializerMethodField()
     start_data = serializers.SerializerMethodField()
     last_update_date = serializers.SerializerMethodField()
-    workspace_created_at = serializers.SerializerMethodField()
-    workspace_updated_at = serializers.SerializerMethodField()
     invite_link = serializers.SerializerMethodField()
 
     class Meta:
@@ -24,8 +22,6 @@ class WorkspaceListSerializer(serializers.ModelSerializer):
             "admin_names",
             "start_data",
             "last_update_date",
-            "workspace_created_at",
-            "workspace_updated_at",
             "invite_link",
         ]
 
@@ -53,12 +49,6 @@ class WorkspaceListSerializer(serializers.ModelSerializer):
     def get_last_update_date(self, obj):
         """Get last update date in required format"""
         return obj.updated_at.strftime("%Y-%m-%d") if obj.updated_at else ""
-
-    def get_workspace_created_at(self, obj):
-        return obj.created_at.isoformat() if obj.created_at else None
-
-    def get_workspace_updated_at(self, obj):
-        return obj.updated_at.isoformat() if obj.updated_at else None
 
     def get_invite_link(self, obj):
         """Get invite link (placeholder for v1)"""

--- a/futureagi/accounts/tests/test_invite_login_workspace_e2e.py
+++ b/futureagi/accounts/tests/test_invite_login_workspace_e2e.py
@@ -340,6 +340,97 @@ class TestSingleWorkspaceInvite:
 
 
 # ===========================================================================
+# Existing Active Member Re-invite
+# ===========================================================================
+
+
+@pytest.mark.django_db
+class TestExistingActiveMemberReinvite:
+    def test_existing_active_member_gets_email_when_workspace_access_is_added(
+        self, monkeypatch, owner_client, org, owner, ws_default, ws_second
+    ):
+        existing_user = _create_invited_user(
+            org,
+            "existing-active@futureagi.com",
+            Level.MEMBER,
+            [{"workspace": ws_default, "level": Level.WORKSPACE_MEMBER}],
+            owner,
+        )
+        sent_emails = []
+
+        def fake_send_invite_email(email, organization, invited_by):
+            sent_emails.append((email, organization.id, invited_by.id))
+
+        monkeypatch.setattr(
+            "accounts.views.rbac_views.send_invite_email", fake_send_invite_email
+        )
+
+        response = owner_client.post(
+            INVITE_URL,
+            {
+                "emails": [existing_user.email],
+                "org_level": Level.MEMBER,
+                "workspace_access": [
+                    {
+                        "workspace_id": str(ws_second.id),
+                        "level": Level.WORKSPACE_MEMBER,
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["result"] == {
+            "invited": [],
+            "already_members": [existing_user.email],
+        }
+        assert sent_emails == [(existing_user.email, org.id, owner.id)]
+        assert WorkspaceMembership.no_workspace_objects.filter(
+            user=existing_user,
+            workspace=ws_second,
+            is_active=True,
+            level=Level.WORKSPACE_MEMBER,
+        ).exists()
+
+    def test_existing_active_member_does_not_get_email_when_access_is_unchanged(
+        self, monkeypatch, owner_client, org, owner, ws_default
+    ):
+        existing_user = _create_invited_user(
+            org,
+            "existing-unchanged@futureagi.com",
+            Level.MEMBER,
+            [{"workspace": ws_default, "level": Level.WORKSPACE_MEMBER}],
+            owner,
+        )
+        sent_emails = []
+
+        monkeypatch.setattr(
+            "accounts.views.rbac_views.send_invite_email",
+            lambda email, organization, invited_by: sent_emails.append(email),
+        )
+
+        response = owner_client.post(
+            INVITE_URL,
+            {
+                "emails": [existing_user.email],
+                "org_level": Level.MEMBER,
+                "workspace_access": [
+                    {
+                        "workspace_id": str(ws_default.id),
+                        "level": Level.WORKSPACE_MEMBER,
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["result"]["already_members"] == [existing_user.email]
+        assert sent_emails == []
+
+
+# ===========================================================================
 # B. Multiple Workspace Invite
 # ===========================================================================
 

--- a/futureagi/accounts/tests/test_rbac_regressions.py
+++ b/futureagi/accounts/tests/test_rbac_regressions.py
@@ -1,0 +1,6 @@
+from tfc.constants.levels import Level
+
+
+def test_owner_level_maps_to_workspace_admin_label():
+    assert Level.to_ws_string(Level.OWNER) == "Workspace Admin"
+    assert Level.to_ws_role(Level.OWNER) == "workspace_admin"

--- a/futureagi/accounts/tests/test_workspace_org_access_enforcement.py
+++ b/futureagi/accounts/tests/test_workspace_org_access_enforcement.py
@@ -235,6 +235,37 @@ class TestWorkspaceAccessEnforcement:
             resp.status_code == status.HTTP_200_OK
         ), f"Admin should access any workspace in their org, got {resp.status_code}"
 
+    def test_level_admin_with_legacy_member_role_can_list_all_org_workspaces(
+        self, org_a, ws_alpha, ws_beta
+    ):
+        user = _create_user(org_a, "drift-admin@futureagi.com", "Member", Level.ADMIN)
+        _add_workspace_membership(user, ws_alpha, Level.WORKSPACE_ADMIN)
+
+        token = _get_access_token(user)
+        client = APIClient()
+        response = client.get(
+            "/accounts/workspace/list/",
+            **_auth_header(token),
+            HTTP_X_ORGANIZATION_ID=str(org_a.id),
+            HTTP_X_WORKSPACE_ID=str(ws_alpha.id),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        workspace_names = {workspace["name"] for workspace in response.data["results"]}
+        assert workspace_names == {"Alpha", "Beta"}
+        assert all(
+            workspace["user_ws_level"] == Level.WORKSPACE_ADMIN
+            for workspace in response.data["results"]
+        )
+        beta_row = next(
+            workspace
+            for workspace in response.data["results"]
+            if workspace["name"] == "Beta"
+        )
+        assert beta_row["org_joined_at"]
+        assert beta_row["workspace_member_since"] is None
+        assert beta_row["workspace_created_at"]
+
     def test_viewer_can_access_authorized_workspace(self, viewer_user, ws_alpha):
         """Viewer CAN access ws_alpha (they have membership)."""
         token = _get_access_token(viewer_user)

--- a/futureagi/accounts/tests/test_workspace_org_access_enforcement.py
+++ b/futureagi/accounts/tests/test_workspace_org_access_enforcement.py
@@ -262,9 +262,7 @@ class TestWorkspaceAccessEnforcement:
             for workspace in response.data["results"]
             if workspace["name"] == "Beta"
         )
-        assert beta_row["org_joined_at"]
-        assert beta_row["workspace_member_since"] is None
-        assert beta_row["workspace_created_at"]
+        assert "user_ws_level" in beta_row
 
     def test_viewer_can_access_authorized_workspace(self, viewer_user, ws_alpha):
         """Viewer CAN access ws_alpha (they have membership)."""

--- a/futureagi/accounts/utils.py
+++ b/futureagi/accounts/utils.py
@@ -498,6 +498,39 @@ def _run_post_registration(user_id, generated_password):
             create_demo_traces_and_spans(str(org.id))
 
 
+def existing_member_access_will_change(existing_user, organization, org_level, workspace_access):
+    """Check if re-inviting an existing active member would actually grant new access."""
+    from accounts.models.workspace import WorkspaceMembership
+    from tfc.constants.levels import Level
+
+    existing_membership = OrganizationMembership.no_workspace_objects.filter(
+        user=existing_user,
+        organization=organization,
+        is_active=True,
+    ).first()
+    if not existing_membership:
+        return True
+
+    if org_level > existing_membership.level_or_legacy:
+        return True
+
+    for ws_entry in workspace_access:
+        ws_id = ws_entry.get("workspace_id")
+        ws_level = ws_entry.get("level", Level.WORKSPACE_VIEWER)
+        workspace_membership = WorkspaceMembership.no_workspace_objects.filter(
+            user=existing_user,
+            workspace_id=ws_id,
+            workspace__organization=organization,
+            is_active=True,
+        ).first()
+        if not workspace_membership:
+            return True
+        if workspace_membership.level_or_legacy < ws_level:
+            return True
+
+    return False
+
+
 # TODO: use async views to replace this code. its wrong
 def process_post_registration(user_id, generated_password):
     """Process post-registration steps using Temporal"""

--- a/futureagi/accounts/views/rbac_views.py
+++ b/futureagi/accounts/views/rbac_views.py
@@ -28,7 +28,12 @@ from accounts.serializers.rbac import (
     WorkspaceMemberRemoveSerializer,
     WorkspaceMemberRoleUpdateSerializer,
 )
-from accounts.utils import generate_password, resolve_org, send_invite_email
+from accounts.utils import (
+    existing_member_access_will_change,
+    generate_password,
+    resolve_org,
+    send_invite_email,
+)
 from tfc.constants.levels import Level
 from tfc.constants.roles import OrganizationRoles
 from tfc.permissions.rbac import (
@@ -153,7 +158,7 @@ class InviteCreateAPIView(APIView):
                         is_active=True,
                         deleted=False,
                     ).exists():
-                        access_will_change = self._existing_member_access_will_change(
+                        access_will_change = existing_member_access_will_change(
                             existing_user,
                             organization,
                             target_org_level,
@@ -344,36 +349,6 @@ class InviteCreateAPIView(APIView):
                 )
             except Workspace.DoesNotExist:
                 continue
-
-    def _existing_member_access_will_change(
-        self, existing_user, organization, org_level, workspace_access
-    ):
-        existing_membership = OrganizationMembership.no_workspace_objects.filter(
-            user=existing_user,
-            organization=organization,
-            is_active=True,
-        ).first()
-        if not existing_membership:
-            return True
-
-        if org_level > existing_membership.level_or_legacy:
-            return True
-
-        for ws_entry in workspace_access:
-            ws_id = ws_entry.get("workspace_id")
-            ws_level = ws_entry.get("level", Level.WORKSPACE_VIEWER)
-            workspace_membership = WorkspaceMembership.no_workspace_objects.filter(
-                user=existing_user,
-                workspace_id=ws_id,
-                workspace__organization=organization,
-                is_active=True,
-            ).first()
-            if not workspace_membership:
-                return True
-            if workspace_membership.level_or_legacy < ws_level:
-                return True
-
-        return False
 
 
 class InviteResendAPIView(APIView):
@@ -723,9 +698,6 @@ class MemberListAPIView(APIView):
                         or ws_mem.workspace.name,
                         "ws_level": ws_mem.level_or_legacy,
                         "ws_role": Level.to_ws_string(ws_mem.level_or_legacy),
-                        "workspace_member_since": (
-                            ws_mem.created_at.isoformat() if ws_mem.created_at else None
-                        ),
                     }
                     for ws_mem in ws_memberships
                 ]
@@ -746,12 +718,6 @@ class MemberListAPIView(APIView):
                                     "workspace_name": ws.display_name or ws.name,
                                     "ws_level": Level.WORKSPACE_ADMIN,
                                     "ws_role": "Workspace Admin",
-                                    "workspace_member_since": None,
-                                    "org_joined_at": (
-                                        mem.joined_at.isoformat()
-                                        if mem.joined_at
-                                        else None
-                                    ),
                                     "auto_access": True,
                                 }
                             )
@@ -1362,14 +1328,6 @@ class WorkspaceMemberListAPIView(APIView):
                         if hasattr(ws_mem, "created_at") and ws_mem.created_at
                         else ""
                     ),
-                    "workspace_member_since": (
-                        ws_mem.created_at.isoformat() if ws_mem.created_at else None
-                    ),
-                    "org_joined_at": (
-                        org_mem.joined_at.isoformat()
-                        if org_mem and org_mem.joined_at
-                        else None
-                    ),
                     "type": "member",
                 }
             )
@@ -1403,10 +1361,6 @@ class WorkspaceMemberListAPIView(APIView):
                         "status": "Active",
                         "created_at": (
                             org_mem.joined_at.isoformat() if org_mem.joined_at else ""
-                        ),
-                        "workspace_member_since": None,
-                        "org_joined_at": (
-                            org_mem.joined_at.isoformat() if org_mem.joined_at else None
                         ),
                         "type": "member",
                         "auto_access": True,
@@ -1520,11 +1474,6 @@ class WorkspaceMemberListAPIView(APIView):
                     "status": inv.effective_status,  # "Pending" or "Expired"
                     "created_at": (
                         inv.created_at.isoformat() if inv.created_at else ""
-                    ),
-                    "workspace_member_since": None,
-                    "org_joined_at": None,
-                    "invite_created_at": (
-                        inv.created_at.isoformat() if inv.created_at else None
                     ),
                     "type": "invite",
                 }

--- a/futureagi/accounts/views/rbac_views.py
+++ b/futureagi/accounts/views/rbac_views.py
@@ -153,6 +153,12 @@ class InviteCreateAPIView(APIView):
                         is_active=True,
                         deleted=False,
                     ).exists():
+                        access_will_change = self._existing_member_access_will_change(
+                            existing_user,
+                            organization,
+                            target_org_level,
+                            workspace_access,
+                        )
                         with transaction.atomic():
                             self._dual_write_legacy(
                                 email,
@@ -161,6 +167,8 @@ class InviteCreateAPIView(APIView):
                                 target_org_level,
                                 workspace_access,
                             )
+                        if access_will_change:
+                            send_invite_email(email, organization, user)
                         already_members.append(email)
                         continue
 
@@ -320,12 +328,7 @@ class InviteCreateAPIView(APIView):
             ws_level = ws_entry.get("level", Level.WORKSPACE_VIEWER)
             try:
                 workspace = Workspace.objects.get(id=ws_id, organization=organization)
-                # Map level to OrganizationRoles value (DB value, not display label)
-                ws_role = {
-                    Level.WORKSPACE_ADMIN: OrganizationRoles.WORKSPACE_ADMIN,
-                    Level.WORKSPACE_MEMBER: OrganizationRoles.WORKSPACE_MEMBER,
-                    Level.WORKSPACE_VIEWER: OrganizationRoles.WORKSPACE_VIEWER,
-                }.get(ws_level, OrganizationRoles.WORKSPACE_MEMBER)
+                ws_role = Level.to_ws_role(ws_level)
                 unfiltered_ws_qs.update_or_create(
                     workspace=workspace,
                     user=target_user,
@@ -341,6 +344,36 @@ class InviteCreateAPIView(APIView):
                 )
             except Workspace.DoesNotExist:
                 continue
+
+    def _existing_member_access_will_change(
+        self, existing_user, organization, org_level, workspace_access
+    ):
+        existing_membership = OrganizationMembership.no_workspace_objects.filter(
+            user=existing_user,
+            organization=organization,
+            is_active=True,
+        ).first()
+        if not existing_membership:
+            return True
+
+        if org_level > existing_membership.level_or_legacy:
+            return True
+
+        for ws_entry in workspace_access:
+            ws_id = ws_entry.get("workspace_id")
+            ws_level = ws_entry.get("level", Level.WORKSPACE_VIEWER)
+            workspace_membership = WorkspaceMembership.no_workspace_objects.filter(
+                user=existing_user,
+                workspace_id=ws_id,
+                workspace__organization=organization,
+                is_active=True,
+            ).first()
+            if not workspace_membership:
+                return True
+            if workspace_membership.level_or_legacy < ws_level:
+                return True
+
+        return False
 
 
 class InviteResendAPIView(APIView):
@@ -690,6 +723,9 @@ class MemberListAPIView(APIView):
                         or ws_mem.workspace.name,
                         "ws_level": ws_mem.level_or_legacy,
                         "ws_role": Level.to_ws_string(ws_mem.level_or_legacy),
+                        "workspace_member_since": (
+                            ws_mem.created_at.isoformat() if ws_mem.created_at else None
+                        ),
                     }
                     for ws_mem in ws_memberships
                 ]
@@ -710,6 +746,12 @@ class MemberListAPIView(APIView):
                                     "workspace_name": ws.display_name or ws.name,
                                     "ws_level": Level.WORKSPACE_ADMIN,
                                     "ws_role": "Workspace Admin",
+                                    "workspace_member_since": None,
+                                    "org_joined_at": (
+                                        mem.joined_at.isoformat()
+                                        if mem.joined_at
+                                        else None
+                                    ),
                                     "auto_access": True,
                                 }
                             )
@@ -1320,6 +1362,14 @@ class WorkspaceMemberListAPIView(APIView):
                         if hasattr(ws_mem, "created_at") and ws_mem.created_at
                         else ""
                     ),
+                    "workspace_member_since": (
+                        ws_mem.created_at.isoformat() if ws_mem.created_at else None
+                    ),
+                    "org_joined_at": (
+                        org_mem.joined_at.isoformat()
+                        if org_mem and org_mem.joined_at
+                        else None
+                    ),
                     "type": "member",
                 }
             )
@@ -1353,6 +1403,10 @@ class WorkspaceMemberListAPIView(APIView):
                         "status": "Active",
                         "created_at": (
                             org_mem.joined_at.isoformat() if org_mem.joined_at else ""
+                        ),
+                        "workspace_member_since": None,
+                        "org_joined_at": (
+                            org_mem.joined_at.isoformat() if org_mem.joined_at else None
                         ),
                         "type": "member",
                         "auto_access": True,
@@ -1466,6 +1520,11 @@ class WorkspaceMemberListAPIView(APIView):
                     "status": inv.effective_status,  # "Pending" or "Expired"
                     "created_at": (
                         inv.created_at.isoformat() if inv.created_at else ""
+                    ),
+                    "workspace_member_since": None,
+                    "org_joined_at": None,
+                    "invite_created_at": (
+                        inv.created_at.isoformat() if inv.created_at else None
                     ),
                     "type": "invite",
                 }

--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -63,8 +63,14 @@ from tfc.utils.error_codes import get_error_message
 from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.pagination import ExtendedPageNumberPagination
 from tfc.utils.parse_errors import parse_serialized_errors
+
 try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices, OrganizationSubscription, SubscriptionTierChoices
+    from ee.usage.models.usage import (
+        APICallStatusChoices,
+        APICallTypeChoices,
+        OrganizationSubscription,
+        SubscriptionTierChoices,
+    )
 except ImportError:
     APICallStatusChoices = None
     APICallTypeChoices = None
@@ -201,6 +207,26 @@ class WorkspaceListAPIView(APIView):
                 user=user, organization=organization, is_active=True
             ).first()
             org_level = org_membership.level_or_legacy if org_membership else 0
+            org_joined_at = (
+                org_membership.joined_at.isoformat()
+                if org_membership and org_membership.joined_at
+                else None
+            )
+            ws_memberships = {
+                str(wm.workspace_id): wm
+                for wm in WorkspaceMembership.no_workspace_objects.filter(
+                    user=user,
+                    workspace__in=[w["id"] for w in data],
+                    is_active=True,
+                )
+            }
+
+            for ws_data in data:
+                wm = ws_memberships.get(str(ws_data["id"]))
+                ws_data["org_joined_at"] = org_joined_at
+                ws_data["workspace_member_since"] = (
+                    wm.created_at.isoformat() if wm and wm.created_at else None
+                )
 
             if org_level and org_level >= Level.ADMIN:
                 # Org Admin+ auto-have WS Admin in all workspaces
@@ -209,14 +235,6 @@ class WorkspaceListAPIView(APIView):
                     ws_data["user_ws_role"] = "Workspace Admin"
             else:
                 # Look up actual workspace memberships
-                ws_memberships = {
-                    str(wm.workspace_id): wm
-                    for wm in WorkspaceMembership.no_workspace_objects.filter(
-                        user=user,
-                        workspace__in=[w["id"] for w in data],
-                        is_active=True,
-                    )
-                }
                 for ws_data in data:
                     wm = ws_memberships.get(str(ws_data["id"]))
                     if wm:
@@ -2058,12 +2076,9 @@ class ManageTeamView(APIView):
                 )
             else:
                 call_log_row = None
-            if (
-                log_and_deduct_cost_for_resource_request is not None
-                and (
-                    call_log_row is None
-                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-                )
+            if log_and_deduct_cost_for_resource_request is not None and (
+                call_log_row is None
+                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
             ):
                 config = json.loads(call_log_row.config)
                 return self._gm.too_many_requests(

--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -207,11 +207,6 @@ class WorkspaceListAPIView(APIView):
                 user=user, organization=organization, is_active=True
             ).first()
             org_level = org_membership.level_or_legacy if org_membership else 0
-            org_joined_at = (
-                org_membership.joined_at.isoformat()
-                if org_membership and org_membership.joined_at
-                else None
-            )
             ws_memberships = {
                 str(wm.workspace_id): wm
                 for wm in WorkspaceMembership.no_workspace_objects.filter(
@@ -220,13 +215,6 @@ class WorkspaceListAPIView(APIView):
                     is_active=True,
                 )
             }
-
-            for ws_data in data:
-                wm = ws_memberships.get(str(ws_data["id"]))
-                ws_data["org_joined_at"] = org_joined_at
-                ws_data["workspace_member_since"] = (
-                    wm.created_at.isoformat() if wm and wm.created_at else None
-                )
 
             if org_level and org_level >= Level.ADMIN:
                 # Org Admin+ auto-have WS Admin in all workspaces

--- a/futureagi/tfc/constants/levels.py
+++ b/futureagi/tfc/constants/levels.py
@@ -60,6 +60,7 @@ class Level:
     }
 
     LEVEL_TO_WS_STRING = {
+        OWNER: "Workspace Admin",
         WORKSPACE_ADMIN: "Workspace Admin",
         WORKSPACE_MEMBER: "Workspace Member",
         WORKSPACE_VIEWER: "Workspace Viewer",
@@ -67,6 +68,7 @@ class Level:
 
     # DB-safe values matching OrganizationRoles choices for CharField storage
     LEVEL_TO_WS_ROLE = {
+        OWNER: "workspace_admin",
         WORKSPACE_ADMIN: "workspace_admin",
         WORKSPACE_MEMBER: "workspace_member",
         WORKSPACE_VIEWER: "workspace_viewer",


### PR DESCRIPTION
## Summary

Existing active org members invited to a new workspace received no email, couldn't see the workspace in their workspace list, and re-inviting showed "already added." Root causes: the `already_members` branch skipped email entirely, `has_global_workspace_access()` checked stale legacy `role` string instead of `level_or_legacy`, and workspace level 15 mapped to "Unknown."

## Linked issues

Closes TH-4697

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- Reproduced end-to-end locally with real Mailgun delivery using `azain+th4697` aliases
- Verified invite email delivery via Mailgun events API
- Verified DB state (User, OrganizationMembership, WorkspaceMembership, OrganizationInvite)
- 45 targeted regression tests pass against Docker Postgres (invite E2E, workspace access enforcement, RBAC regressions)
- 16 member removal regression tests pass (no deletion/deactivation side effects)
- Black formatting verified
- No migrations required

## Screenshots / recordings (if UI)

N/A — backend-only change. Frontend already renders `ws_role` from API response.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA