### PR TITLE
fix: raise error when audio recording URL is inaccessible (TH-4734)

### DIFF
--- a/futureagi/agentic_eval/core/utils/llm_payloads.py
+++ b/futureagi/agentic_eval/core/utils/llm_payloads.py
@@ -565,6 +565,14 @@ def detect_and_build_media_blocks(
         for key, media_type in detected.items():
             if isinstance(media_type, str) and media_type in _SUPPORTED_MEDIA:
                 key_media_types[key] = media_type
+            elif str(media_type).lower() == "file":
+                val = remaining.get(key, "") if isinstance(remaining, dict) else ""
+                if isinstance(val, str) and val.startswith(("http://", "https://")):
+                    raise ValueError(
+                        f"Media file is not accessible for '{key}'. "
+                        f"The file could not be downloaded — please ensure "
+                        f"the URL is valid and accessible."
+                    )
 
     # Build content blocks from detected types
     media_blocks: List[ContentBlock] = []


### PR DESCRIPTION
When detect_input_type returns 'file' for an HTTP URL, raise a user-facing error instead of silently passing URL as text.