### PR TITLE
[bugfix] eval list default version + eval-task reason truncation

### DIFF
--- a/futureagi/model_hub/tests/test_eval_list.py
+++ b/futureagi/model_hub/tests/test_eval_list.py
@@ -339,13 +339,59 @@ class TestEvalTemplateListAPI:
         if "agent_quality_eval" in items_by_name:
             assert items_by_name["agent_quality_eval"]["eval_type"] == "agent"
 
-    def test_list_version_defaults(self, auth_client, user_eval_template):
-        """All templates should show V1 and version_count=1 until Phase 5."""
+    def test_list_version_defaults_no_versions(self, auth_client, user_eval_template):
+        """Templates without any version rows fall back to V1 / count=1."""
         response = auth_client.post(self.url, {}, format="json")
         assert response.status_code == 200
         for item in response.data["result"]["items"]:
             assert item["current_version"] == "V1"
             assert item["version_count"] == 1
+
+    def test_list_reflects_default_version(
+        self, auth_client, organization, workspace, user
+    ):
+        """List should reflect the version flagged is_default, not always V1."""
+        from model_hub.models.evals_metric import EvalTemplate, EvalTemplateVersion
+
+        template = EvalTemplate.no_workspace_objects.create(
+            name="multi_version_eval",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+            config={"output": "score"},
+            eval_tags=["llm"],
+            visible_ui=True,
+        )
+        EvalTemplateVersion.objects.create(
+            eval_template=template,
+            version_number=1,
+            is_default=False,
+            organization=organization,
+            workspace=workspace,
+        )
+        EvalTemplateVersion.objects.create(
+            eval_template=template,
+            version_number=2,
+            is_default=True,
+            organization=organization,
+            workspace=workspace,
+        )
+        EvalTemplateVersion.objects.create(
+            eval_template=template,
+            version_number=3,
+            is_default=False,
+            organization=organization,
+            workspace=workspace,
+        )
+
+        response = auth_client.post(
+            self.url, {"search": "multi_version_eval"}, format="json"
+        )
+        assert response.status_code == 200
+        items = response.data["result"]["items"]
+        assert len(items) == 1
+        assert items[0]["current_version"] == "V2"
+        assert items[0]["version_count"] == 3
 
     def test_list_template_type_single(self, auth_client, user_eval_template):
         """All templates should show 'single' until Phase 7."""

--- a/futureagi/model_hub/utils/eval_list.py
+++ b/futureagi/model_hub/utils/eval_list.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from datetime import timedelta
 from typing import TYPE_CHECKING, Iterable
 
-from django.db.models import Q, QuerySet
+from django.db.models import Count, Q, QuerySet
 from django.utils import timezone
 
 from agentic_eval.core_evals.fi_evals.eval_type import (
@@ -413,6 +413,40 @@ def build_eval_list_queryset(
         # a denormalized eval_type field to EvalTemplate in a future phase.
 
     return qs
+
+
+def fetch_version_metadata(
+    template_ids: Iterable[str],
+) -> tuple[dict[str, int], dict[str, int]]:
+    """
+    Bulk-fetch version count and default version_number for a set of templates.
+
+    Returns:
+        (counts_by_template_id, default_version_number_by_template_id)
+        Templates with no versions are absent from both maps; callers should
+        fall back to count=1 / "V1" for display.
+    """
+    from model_hub.models.evals_metric import EvalTemplateVersion
+
+    tids = [str(t) for t in template_ids]
+    if not tids:
+        return {}, {}
+
+    counts: dict[str, int] = {}
+    for row in (
+        EvalTemplateVersion.objects.filter(eval_template_id__in=tids)
+        .values("eval_template_id")
+        .annotate(c=Count("id"))
+    ):
+        counts[str(row["eval_template_id"])] = row["c"]
+
+    defaults: dict[str, int] = {}
+    for v in EvalTemplateVersion.objects.filter(
+        eval_template_id__in=tids, is_default=True
+    ).only("eval_template_id", "version_number"):
+        defaults[str(v.eval_template_id)] = v.version_number
+
+    return counts, defaults
 
 
 def compute_thirty_day_data(

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -1276,6 +1276,7 @@ class EvalTemplateListView(APIView):
             compute_thirty_day_data,
             derive_eval_type,
             derive_output_type,
+            fetch_version_metadata,
             get_created_by_name,
         )
 
@@ -1356,6 +1357,10 @@ class EvalTemplateListView(APIView):
                         name.strip() if name.strip() else v.created_by.email
                     )
 
+            version_counts, default_version_numbers = fetch_version_metadata(
+                str(t.id) for t in templates
+            )
+
             # 8. Build response items
             items = []
             for template in templates:
@@ -1375,6 +1380,8 @@ class EvalTemplateListView(APIView):
                     else:
                         created_by = version_creators.get(tid, "User")
 
+                vcount = version_counts.get(tid, 0)
+                default_vnum = default_version_numbers.get(tid)
                 items.append(
                     EvalListItem(
                         id=tid,
@@ -1388,8 +1395,10 @@ class EvalTemplateListView(APIView):
                             else "user"
                         ),
                         created_by_name=created_by,
-                        version_count=1,
-                        current_version="V1",
+                        version_count=max(vcount, 1),
+                        current_version=(
+                            f"V{default_vnum}" if default_vnum else "V1"
+                        ),
                         last_updated=template.updated_at.isoformat(),
                         thirty_day_chart=[],
                         thirty_day_error_rate=[],

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -632,9 +632,7 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                         "input": input_str,
                         "result": result_label,
                         "score": score,
-                        "reason": (
-                            (reason[:200] + "...") if len(reason) > 200 else reason
-                        ),
+                        "reason": reason,
                         "status": status,
                         "source": "eval_task",
                         "created_at": (


### PR DESCRIPTION
## Summary

Two backend fixes bundled on this branch:

- **TH-4488 — eval list default version**: `EvalTemplateListView` was hardcoding `version_count=1` / `current_version="V1"` for every template, so changing the default version never reflected in the outer evals list. Added `fetch_version_metadata()` helper in `model_hub/utils/eval_list.py` (bulk count + default `version_number` per page, no N+1) and wired it into the view. Falls back to `V1`/`1` when a template has no version rows.
- **eval-task usage reason truncation**: `tracer/eval-task/get_usage/` was capping the per-log `eval_explanation` at 200 chars and appending `"..."` in the row payload, so the full reason was unrecoverable client-side. Now sends the full explanation; the table can handle visual truncation. The sibling `detail.results_explanation` was already untruncated.

## Test plan

- [ ] `pytest futureagi/model_hub/tests/test_eval_list.py -k version -v` — covers the new `test_list_reflects_default_version` case (V1, V2 default, V3) and the no-versions fallback
- [ ] Hit `/model-hub/eval-templates/list/` after promoting a non-V1 version to default → list should now show the new default version
- [ ] Hit `/tracer/eval-task/get_usage/` for a task with long eval explanations → `logs.items[].reason` should be the full string, no trailing `...`