### PR TITLE
fix: support longer eval usage periods

### DIFF
--- a/frontend/src/sections/evals/components/EvalUsageTab.jsx
+++ b/frontend/src/sections/evals/components/EvalUsageTab.jsx
@@ -54,6 +54,8 @@ const DATE_OPTION_TO_PERIOD = {
   "7D": "7d",
   "30D": "30d",
   "3M": "90d",
+  "6M": "180d",
+  "12M": "365d",
   Custom: "30d",
 };
 

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -4175,7 +4175,7 @@ class EvalUsageStatsView(APIView):
     GET /model-hub/eval-templates/<id>/usage/
 
     Returns usage stats, chart data, and paginated eval logs.
-    Query params: page (0-based), page_size, period (30m|6h|1d|7d|30d|90d)
+    Query params: page (0-based), page_size, period (30m|6h|1d|7d|30d|90d|180d|365d)
     """
 
     _gm = GeneralMethods()
@@ -4188,6 +4188,8 @@ class EvalUsageStatsView(APIView):
         "7d": timedelta(days=7),
         "30d": timedelta(days=30),
         "90d": timedelta(days=90),
+        "180d": timedelta(days=180),
+        "365d": timedelta(days=365),
     }
 
     def get(self, request, template_id, *args, **kwargs):


### PR DESCRIPTION
## Summary

Fixes eval usage filters for 6M and 12M ranges. The frontend now sends `180d` and `365d` period values for those date options, and the backend usage endpoint accepts those periods instead of silently falling back to the default 30-day range.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `npm exec eslint src/sections/evals/components/EvalUsageTab.jsx`
- `uv run python -m py_compile model_hub/views/separate_evals.py`
- `git diff --check -- frontend/src/sections/evals/components/EvalUsageTab.jsx futureagi/model_hub/views/separate_evals.py`
- Verified in the running backend container that the affected template has usage rows across 90d, 180d, and 365d ranges.
- Exercised `EvalUsageStatsView` directly in the backend container and confirmed `period=180d` and `period=365d` return usage rows instead of falling back to the empty 30d window.

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
