### PR TITLE
feat(observability): persist external Vapi/Retell recording URLs on FAGI S3

### DIFF
--- a/futureagi/simulate/temporal/utils/async_storage.py
+++ b/futureagi/simulate/temporal/utils/async_storage.py
@@ -118,15 +118,8 @@ async def convert_audio_url_to_s3_async(
         logger.info(f"{url_type} URL is already S3: {audio_url}")
         return audio_url
 
-    # Check if it's a Vapi URL (we only convert Vapi URLs)
-    if "vapi.ai" not in str(audio_url):
-        logger.info(
-            f"{url_type} URL is not a Vapi URL, skipping conversion: {audio_url}"
-        )
-        return audio_url
-
     try:
-        logger.info(f"Converting {url_type} URL from Vapi to S3: {audio_url}")
+        logger.info(f"Converting {url_type} URL to S3: {audio_url}")
 
         # Async download
         audio_bytes = await download_audio_from_url_async(audio_url)

--- a/futureagi/tfc/temporal/common/registry.py
+++ b/futureagi/tfc/temporal/common/registry.py
@@ -737,6 +737,7 @@ def _import_temporal_activity_modules() -> None:
         # tracer tasks
         "tracer.tasks",
         "tracer.tasks.trace_scanner",
+        "tracer.tasks.recordings_rehost",
         "tracer.utils.span",
         "tracer.utils.eval",
         "tracer.utils.observability_provider",

--- a/futureagi/tracer/services/observability_providers.py
+++ b/futureagi/tracer/services/observability_providers.py
@@ -666,13 +666,21 @@ class ObservabilityService:
         return VoiceCallLogs(**processed_log).model_dump()
 
     @staticmethod
-    def process_raw_logs(raw_log: dict, provider: str) -> VoiceCallLogs:
+    def process_raw_logs(
+        raw_log: dict,
+        provider: str,
+        span_attributes: dict | None = None,
+    ) -> VoiceCallLogs:
         """
         Processes a raw log from a voice provider into a structured format.
 
         Args:
             raw_log: Raw call log from the provider
             provider: One of ProviderChoices.VAPI or ProviderChoices.RETELL
+            span_attributes: Optional ObservationSpan.span_attributes. When
+                provided, the canonical recording URLs from the span (which
+                may be FAGI-S3-rehosted) override the provider URLs read from
+                ``raw_log``.
 
         Returns:
             VoiceCallLogs object containing processed call logs
@@ -681,8 +689,18 @@ class ObservabilityService:
             ValueError: If provider is not recognized
         """
         if provider == ProviderChoices.VAPI:
-            return ObservabilityService._process_vapi_logs(raw_log)
+            processed = ObservabilityService._process_vapi_logs(raw_log)
         elif provider == ProviderChoices.RETELL:
-            return ObservabilityService._process_retell_logs(raw_log)
+            processed = ObservabilityService._process_retell_logs(raw_log)
         else:
             raise ValueError(f"Invalid choice for provider: {provider}")
+
+        if span_attributes:
+            mono_combined = span_attributes.get("conversation.recording.mono.combined")
+            stereo = span_attributes.get("conversation.recording.stereo")
+            if mono_combined:
+                processed["recording_url"] = mono_combined
+            if stereo:
+                processed["stereo_recording_url"] = stereo
+
+        return processed

--- a/futureagi/tracer/tasks/recordings_rehost.py
+++ b/futureagi/tracer/tasks/recordings_rehost.py
@@ -1,0 +1,158 @@
+"""
+Recording rehost tasks.
+
+Per-call activity that downloads external Vapi/Retell recording URLs and
+re-hosts them on FAGI S3, overwriting the same `conversation.recording.*`
+span_attribute keys in place. The provider's original URL is preserved
+verbatim under `span_attributes["raw_log"]`.
+
+Dispatched from `tracer.utils.observability_provider.process_and_store_logs`
+via `transaction.on_commit` after each upsert.
+"""
+
+import uuid
+
+import structlog
+
+from tfc.temporal import temporal_activity
+from tfc.utils.storage import download_audio_from_url, upload_audio_to_s3
+from tracer.models.observability_provider import ProviderChoices
+from tracer.models.observation_span import ObservationSpan
+from tracer.utils.otel import ConversationAttributes
+
+logger = structlog.get_logger(__name__)
+
+
+# Recording attribute keys per provider — overwritten in place with S3 URLs
+# after rehost. Raw provider URLs remain in span_attributes["raw_log"].
+RECORDING_KEYS_BY_PROVIDER: dict[str, list[tuple[str, str]]] = {
+    ProviderChoices.VAPI: [
+        (
+            f"{ConversationAttributes.CONVERSATION_RECORDING}.{ConversationAttributes.MONO_COMBINED}",
+            "mono_combined",
+        ),
+        (
+            f"{ConversationAttributes.CONVERSATION_RECORDING}.{ConversationAttributes.MONO_CUSTOMER}",
+            "mono_customer",
+        ),
+        (
+            f"{ConversationAttributes.CONVERSATION_RECORDING}.{ConversationAttributes.MONO_ASSISTANT}",
+            "mono_assistant",
+        ),
+        (
+            f"{ConversationAttributes.CONVERSATION_RECORDING}.{ConversationAttributes.STEREO}",
+            "stereo",
+        ),
+    ],
+    ProviderChoices.RETELL: [
+        (
+            f"{ConversationAttributes.CONVERSATION_RECORDING}.{ConversationAttributes.MONO_COMBINED}",
+            "mono_combined",
+        ),
+        (
+            f"{ConversationAttributes.CONVERSATION_RECORDING}.{ConversationAttributes.STEREO}",
+            "stereo",
+        ),
+    ],
+}
+
+
+def is_already_s3_url(url: str) -> bool:
+    return "amazonaws.com" in str(url) or "minio" in str(url)
+
+
+def _convert_audio_url_to_s3(call_id: str, audio_url: str, url_type: str) -> str:
+    """Sync download-then-upload of an external audio URL onto FAGI S3.
+
+    Returns the FAGI S3 URL on success, or the input URL unchanged on
+    failure so the caller can detect "no rehost happened" by comparing
+    input vs output.
+    """
+    try:
+        audio_bytes = download_audio_from_url(audio_url)
+        object_key = f"call-recordings/{call_id}/{uuid.uuid4()}.mp3"
+        s3_url = upload_audio_to_s3({"bytes": audio_bytes}, object_key=object_key)
+        logger.info(
+            "rehost_external_recordings: uploaded to S3",
+            call_id=call_id,
+            url_type=url_type,
+            s3_url=s3_url,
+        )
+        return s3_url
+    except Exception as exc:
+        logger.warning(
+            "rehost_external_recordings: convert failed",
+            call_id=call_id,
+            url_type=url_type,
+            audio_url=audio_url,
+            error=str(exc),
+        )
+        return audio_url
+
+
+def _resolve_call_id(span: ObservationSpan) -> str:
+    """Best-effort call id used for the S3 object path."""
+    attrs = span.span_attributes or {}
+    raw_log = attrs.get("raw_log") or {}
+    return (
+        attrs.get("vapi.call_id")
+        or raw_log.get("id")
+        or raw_log.get("call_id")
+        or (span.metadata or {}).get("provider_log_id")
+        or str(span.id)
+    )
+
+
+@temporal_activity(
+    max_retries=3,
+    time_limit=600,
+    queue="tasks_s",
+)
+def rehost_external_recordings(span_id: str) -> None:
+    """Re-host external provider recording URLs (Vapi/Retell) on FAGI S3.
+
+    Reads `conversation.recording.*` keys from the span, downloads each URL
+    that isn't already on S3, uploads to FAGI S3, and overwrites the same
+    keys with the durable S3 URL. `span_attributes["raw_log"]` is left
+    untouched. Idempotent: URLs already containing "amazonaws.com" or
+    "minio" are skipped, so retries and re-runs are safe.
+
+    On per-URL download failure, `_convert_audio_url_to_s3` returns the
+    input URL unchanged — we leave the key as-is so a future tick can
+    pick it up.
+    """
+    try:
+        span = ObservationSpan.objects.get(id=span_id)
+    except ObservationSpan.DoesNotExist:
+        logger.warning("rehost_external_recordings: span not found", span_id=span_id)
+        return
+
+    keys = RECORDING_KEYS_BY_PROVIDER.get(span.provider) or []
+    if not keys:
+        return
+
+    attrs = dict(span.span_attributes or {})
+    call_id = _resolve_call_id(span)
+    changed = False
+
+    for key, url_type in keys:
+        url = attrs.get(key)
+        if not url or is_already_s3_url(url):
+            continue
+
+        s3_url = _convert_audio_url_to_s3(call_id, url, url_type)
+        if s3_url and s3_url != url:
+            attrs[key] = s3_url
+            changed = True
+
+    if not changed:
+        return
+
+    span.span_attributes = attrs
+    span.save(update_fields=["span_attributes"])
+    logger.info(
+        "rehost_external_recordings: persisted recordings",
+        span_id=span_id,
+        provider=span.provider,
+        call_id=call_id,
+    )

--- a/futureagi/tracer/tasks/recordings_rehost.py
+++ b/futureagi/tracer/tasks/recordings_rehost.py
@@ -10,12 +10,12 @@ Dispatched from `tracer.utils.observability_provider.process_and_store_logs`
 via `transaction.on_commit` after each upsert.
 """
 
-import uuid
+import asyncio
 
 import structlog
 
+from simulate.temporal.utils.async_storage import convert_audio_url_to_s3_async
 from tfc.temporal import temporal_activity
-from tfc.utils.storage import download_audio_from_url, upload_audio_to_s3
 from tracer.models.observability_provider import ProviderChoices
 from tracer.models.observation_span import ObservationSpan
 from tracer.utils.otel import ConversationAttributes
@@ -61,35 +61,6 @@ def is_already_s3_url(url: str) -> bool:
     return "amazonaws.com" in str(url) or "minio" in str(url)
 
 
-def _convert_audio_url_to_s3(call_id: str, audio_url: str, url_type: str) -> str:
-    """Sync download-then-upload of an external audio URL onto FAGI S3.
-
-    Returns the FAGI S3 URL on success, or the input URL unchanged on
-    failure so the caller can detect "no rehost happened" by comparing
-    input vs output.
-    """
-    try:
-        audio_bytes = download_audio_from_url(audio_url)
-        object_key = f"call-recordings/{call_id}/{uuid.uuid4()}.mp3"
-        s3_url = upload_audio_to_s3({"bytes": audio_bytes}, object_key=object_key)
-        logger.info(
-            "rehost_external_recordings: uploaded to S3",
-            call_id=call_id,
-            url_type=url_type,
-            s3_url=s3_url,
-        )
-        return s3_url
-    except Exception as exc:
-        logger.warning(
-            "rehost_external_recordings: convert failed",
-            call_id=call_id,
-            url_type=url_type,
-            audio_url=audio_url,
-            error=str(exc),
-        )
-        return audio_url
-
-
 def _resolve_call_id(span: ObservationSpan) -> str:
     """Best-effort call id used for the S3 object path."""
     attrs = span.span_attributes or {}
@@ -111,15 +82,14 @@ def _resolve_call_id(span: ObservationSpan) -> str:
 def rehost_external_recordings(span_id: str) -> None:
     """Re-host external provider recording URLs (Vapi/Retell) on FAGI S3.
 
-    Reads `conversation.recording.*` keys from the span, downloads each URL
-    that isn't already on S3, uploads to FAGI S3, and overwrites the same
-    keys with the durable S3 URL. `span_attributes["raw_log"]` is left
-    untouched. Idempotent: URLs already containing "amazonaws.com" or
-    "minio" are skipped, so retries and re-runs are safe.
+    Hands each non-S3 `conversation.recording.*` URL to
+    `convert_audio_url_to_s3_async` (downloads run concurrently) and
+    overwrites the key with the durable S3 URL. The helper returns the
+    input URL unchanged on download failure, so the key falls back to the
+    provider URL and a future tick can pick it up.
 
-    On per-URL download failure, `_convert_audio_url_to_s3` returns the
-    input URL unchanged — we leave the key as-is so a future tick can
-    pick it up.
+    `span_attributes["raw_log"]` is left untouched. Idempotent: URLs
+    already on S3 are skipped before dispatch.
     """
     try:
         span = ObservationSpan.objects.get(id=span_id)
@@ -132,18 +102,37 @@ def rehost_external_recordings(span_id: str) -> None:
         return
 
     attrs = dict(span.span_attributes or {})
+    jobs = [
+        (key, attrs[key], url_type)
+        for key, url_type in keys
+        if attrs.get(key) and not is_already_s3_url(attrs[key])
+    ]
+    if not jobs:
+        return
+
     call_id = _resolve_call_id(span)
+
+    async def _rehost_all() -> list[str]:
+        return await asyncio.gather(
+            *(
+                convert_audio_url_to_s3_async(call_id, url, url_type)
+                for _, url, url_type in jobs
+            )
+        )
+
+    results = asyncio.run(_rehost_all())
+
     changed = False
-
-    for key, url_type in keys:
-        url = attrs.get(key)
-        if not url or is_already_s3_url(url):
-            continue
-
-        s3_url = _convert_audio_url_to_s3(call_id, url, url_type)
-        if s3_url and s3_url != url:
+    for (key, original_url, url_type), s3_url in zip(jobs, results):
+        if s3_url and s3_url != original_url:
             attrs[key] = s3_url
             changed = True
+            logger.info(
+                "rehost_external_recordings: uploaded to S3",
+                call_id=call_id,
+                url_type=url_type,
+                s3_url=s3_url,
+            )
 
     if not changed:
         return

--- a/futureagi/tracer/tests/test_observability_recordings_rehost.py
+++ b/futureagi/tracer/tests/test_observability_recordings_rehost.py
@@ -6,7 +6,7 @@ Run with: pytest tracer/tests/test_observability_recordings_rehost.py -v
 """
 
 import uuid
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -71,12 +71,12 @@ class TestRehostExternalRecordings:
             observe_project, provider="vapi", span_attributes=dict(original)
         )
 
-        def _fake_convert(call_id, url, url_type):
+        async def _fake_convert(call_id, url, url_type):
             return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3"
 
         with patch(
-            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
-            side_effect=_fake_convert,
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            new=AsyncMock(side_effect=_fake_convert),
         ):
             rehost_external_recordings(span_id=str(span.id))
 
@@ -103,12 +103,12 @@ class TestRehostExternalRecordings:
             observe_project, provider="retell", span_attributes=dict(original)
         )
 
-        def _fake_convert(call_id, url, url_type):
+        async def _fake_convert(call_id, url, url_type):
             return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3"
 
         with patch(
-            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
-            side_effect=_fake_convert,
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            new=AsyncMock(side_effect=_fake_convert),
         ):
             rehost_external_recordings(span_id=str(span.id))
 
@@ -136,7 +136,8 @@ class TestRehostExternalRecordings:
         )
 
         with patch(
-            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            new=AsyncMock(),
         ) as mock_convert:
             rehost_external_recordings(span_id=str(span.id))
 
@@ -158,15 +159,15 @@ class TestRehostExternalRecordings:
             observe_project, provider="vapi", span_attributes=dict(original)
         )
 
-        def _flaky_convert(call_id, url, url_type):
+        async def _flaky_convert(call_id, url, url_type):
             # Combined succeeds, stereo fails (helper returns input on failure).
             if url_type == "stereo":
                 return url
             return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3"
 
         with patch(
-            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
-            side_effect=_flaky_convert,
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            new=AsyncMock(side_effect=_flaky_convert),
         ):
             rehost_external_recordings(span_id=str(span.id))
 
@@ -186,7 +187,8 @@ class TestRehostExternalRecordings:
         )
 
         with patch(
-            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            new=AsyncMock(),
         ) as mock_convert:
             rehost_external_recordings(span_id=str(span.id))
 
@@ -202,7 +204,8 @@ class TestRehostExternalRecordings:
         )
 
         with patch(
-            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            new=AsyncMock(),
         ) as mock_convert:
             rehost_external_recordings(span_id=str(span.id))
 
@@ -210,7 +213,8 @@ class TestRehostExternalRecordings:
 
     def test_missing_span_logs_and_returns(self):
         with patch(
-            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            new=AsyncMock(),
         ) as mock_convert:
             rehost_external_recordings(span_id=str(uuid.uuid4()))
 

--- a/futureagi/tracer/tests/test_observability_recordings_rehost.py
+++ b/futureagi/tracer/tests/test_observability_recordings_rehost.py
@@ -1,0 +1,377 @@
+"""
+Tests for tracer.tasks.recordings_rehost.rehost_external_recordings and
+the dispatch wiring in tracer.utils.observability_provider.
+
+Run with: pytest tracer/tests/test_observability_recordings_rehost.py -v
+"""
+
+import uuid
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from tracer.models.observability_provider import (
+    ObservabilityProvider,
+    ProviderChoices,
+)
+from tracer.models.observation_span import ObservationSpan
+from tracer.models.trace import Trace
+from tracer.tasks.recordings_rehost import rehost_external_recordings
+from tracer.utils.observability_provider import _maybe_enqueue_recording_rehost
+
+
+VAPI_KEYS = {
+    "mono_combined": "conversation.recording.mono.combined",
+    "mono_customer": "conversation.recording.mono.customer",
+    "mono_assistant": "conversation.recording.mono.assistant",
+    "stereo": "conversation.recording.stereo",
+}
+
+RETELL_KEYS = {
+    "mono_combined": "conversation.recording.mono.combined",
+    "stereo": "conversation.recording.stereo",
+}
+
+
+def _make_span(
+    project,
+    *,
+    provider: str,
+    span_attributes: dict,
+    metadata: dict | None = None,
+) -> ObservationSpan:
+    trace = Trace.objects.create(project=project, metadata=metadata or {})
+    return ObservationSpan.objects.create(
+        id=f"span_{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=trace,
+        name=f"{provider.capitalize()} Call Log",
+        observation_type="conversation",
+        provider=provider,
+        span_attributes=span_attributes,
+        metadata=metadata or {},
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+class TestRehostExternalRecordings:
+    """Tests for the rehost_external_recordings activity body."""
+
+    def test_vapi_overwrites_four_keys(self, observe_project):
+        raw_log = {"id": "vapi-call-abc", "artifact": {"recording": {"foo": "bar"}}}
+        original = {
+            "raw_log": raw_log,
+            "vapi.call_id": "vapi-call-abc",
+            VAPI_KEYS["mono_combined"]: "https://storage.vapi.ai/combined.mp3",
+            VAPI_KEYS["mono_customer"]: "https://storage.vapi.ai/customer.mp3",
+            VAPI_KEYS["mono_assistant"]: "https://storage.vapi.ai/assistant.mp3",
+            VAPI_KEYS["stereo"]: "https://storage.vapi.ai/stereo.mp3",
+        }
+        span = _make_span(
+            observe_project, provider="vapi", span_attributes=dict(original)
+        )
+
+        def _fake_convert(call_id, url, url_type):
+            return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3"
+
+        with patch(
+            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+            side_effect=_fake_convert,
+        ):
+            rehost_external_recordings(span_id=str(span.id))
+
+        span.refresh_from_db()
+        attrs = span.span_attributes
+
+        # Raw log untouched
+        assert attrs["raw_log"] == raw_log
+
+        # Each recording key now points at S3
+        for url_type, key in VAPI_KEYS.items():
+            assert attrs[key].startswith("https://fagi.s3.amazonaws.com/")
+            assert attrs[key].endswith(f"{url_type}.mp3")
+            assert "vapi-call-abc" in attrs[key]
+
+    def test_retell_overwrites_two_keys(self, observe_project):
+        raw_log = {"call_id": "retell-call-xyz"}
+        original = {
+            "raw_log": raw_log,
+            RETELL_KEYS["mono_combined"]: "https://retellai.com/combined.wav",
+            RETELL_KEYS["stereo"]: "https://retellai.com/stereo.wav",
+        }
+        span = _make_span(
+            observe_project, provider="retell", span_attributes=dict(original)
+        )
+
+        def _fake_convert(call_id, url, url_type):
+            return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3"
+
+        with patch(
+            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+            side_effect=_fake_convert,
+        ):
+            rehost_external_recordings(span_id=str(span.id))
+
+        span.refresh_from_db()
+        attrs = span.span_attributes
+
+        assert attrs["raw_log"] == raw_log
+        assert attrs[RETELL_KEYS["mono_combined"]].startswith(
+            "https://fagi.s3.amazonaws.com/"
+        )
+        assert attrs[RETELL_KEYS["mono_combined"]].endswith("mono_combined.mp3")
+        assert attrs[RETELL_KEYS["stereo"]].endswith("stereo.mp3")
+
+    def test_idempotent_when_already_s3(self, observe_project):
+        s3_combined = "https://fagi.s3.amazonaws.com/x/combined.mp3"
+        s3_stereo = "https://fagi.s3.amazonaws.com/x/stereo.mp3"
+        original = {
+            "raw_log": {"id": "vapi-call-abc"},
+            "vapi.call_id": "vapi-call-abc",
+            VAPI_KEYS["mono_combined"]: s3_combined,
+            VAPI_KEYS["stereo"]: s3_stereo,
+        }
+        span = _make_span(
+            observe_project, provider="vapi", span_attributes=dict(original)
+        )
+
+        with patch(
+            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+        ) as mock_convert:
+            rehost_external_recordings(span_id=str(span.id))
+
+        mock_convert.assert_not_called()
+        span.refresh_from_db()
+        assert span.span_attributes[VAPI_KEYS["mono_combined"]] == s3_combined
+        assert span.span_attributes[VAPI_KEYS["stereo"]] == s3_stereo
+
+    def test_partial_failure_leaves_provider_url(self, observe_project):
+        provider_combined = "https://storage.vapi.ai/combined.mp3"
+        provider_stereo = "https://storage.vapi.ai/stereo.mp3"
+        original = {
+            "raw_log": {"id": "vapi-call-abc"},
+            "vapi.call_id": "vapi-call-abc",
+            VAPI_KEYS["mono_combined"]: provider_combined,
+            VAPI_KEYS["stereo"]: provider_stereo,
+        }
+        span = _make_span(
+            observe_project, provider="vapi", span_attributes=dict(original)
+        )
+
+        def _flaky_convert(call_id, url, url_type):
+            # Combined succeeds, stereo fails (helper returns input on failure).
+            if url_type == "stereo":
+                return url
+            return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3"
+
+        with patch(
+            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+            side_effect=_flaky_convert,
+        ):
+            rehost_external_recordings(span_id=str(span.id))
+
+        span.refresh_from_db()
+        attrs = span.span_attributes
+        assert attrs[VAPI_KEYS["mono_combined"]].startswith(
+            "https://fagi.s3.amazonaws.com/"
+        )
+        # Stereo download failed → key still holds provider URL for next retry.
+        assert attrs[VAPI_KEYS["stereo"]] == provider_stereo
+
+    def test_skips_when_no_recording_keys(self, observe_project):
+        span = _make_span(
+            observe_project,
+            provider="vapi",
+            span_attributes={"raw_log": {"id": "x"}, "some.other.key": "value"},
+        )
+
+        with patch(
+            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+        ) as mock_convert:
+            rehost_external_recordings(span_id=str(span.id))
+
+        mock_convert.assert_not_called()
+
+    def test_unknown_provider_is_noop(self, observe_project):
+        span = _make_span(
+            observe_project,
+            provider="eleven_labs",
+            span_attributes={
+                VAPI_KEYS["mono_combined"]: "https://elevenlabs.io/x.mp3"
+            },
+        )
+
+        with patch(
+            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+        ) as mock_convert:
+            rehost_external_recordings(span_id=str(span.id))
+
+        mock_convert.assert_not_called()
+
+    def test_missing_span_logs_and_returns(self):
+        with patch(
+            "tracer.tasks.recordings_rehost._convert_audio_url_to_s3",
+        ) as mock_convert:
+            rehost_external_recordings(span_id=str(uuid.uuid4()))
+
+        mock_convert.assert_not_called()
+
+
+@pytest.mark.django_db(transaction=True)
+class TestMaybeEnqueueRecordingRehost:
+    """Tests for the dispatch helper called from process_and_store_logs."""
+
+    def test_enqueues_when_recording_keys_present(self, observe_project):
+        from accounts.models.organization import Organization
+
+        organization = observe_project.organization
+        workspace = observe_project.workspace
+        provider = ObservabilityProvider.objects.create(
+            project=observe_project,
+            provider=ProviderChoices.VAPI,
+            enabled=True,
+            organization=organization,
+            workspace=workspace,
+            metadata={},
+        )
+        span = _make_span(
+            observe_project,
+            provider="vapi",
+            span_attributes={
+                VAPI_KEYS["mono_combined"]: "https://storage.vapi.ai/x.mp3",
+            },
+        )
+
+        with patch(
+            "tracer.utils.observability_provider.rehost_external_recordings"
+        ) as mock_activity, patch(
+            "tracer.utils.observability_provider.transaction.on_commit",
+            side_effect=lambda fn: fn(),
+        ):
+            _maybe_enqueue_recording_rehost(provider, span)
+
+        mock_activity.delay.assert_called_once_with(span_id=str(span.id))
+
+    def test_skipped_when_metadata_disables(self, observe_project):
+        organization = observe_project.organization
+        workspace = observe_project.workspace
+        provider = ObservabilityProvider.objects.create(
+            project=observe_project,
+            provider=ProviderChoices.VAPI,
+            enabled=True,
+            organization=organization,
+            workspace=workspace,
+            metadata={"rehost_recordings": False},
+        )
+        span = _make_span(
+            observe_project,
+            provider="vapi",
+            span_attributes={
+                VAPI_KEYS["mono_combined"]: "https://storage.vapi.ai/x.mp3",
+            },
+        )
+
+        with patch(
+            "tracer.utils.observability_provider.rehost_external_recordings"
+        ) as mock_activity:
+            _maybe_enqueue_recording_rehost(provider, span)
+
+        mock_activity.delay.assert_not_called()
+
+    def test_skipped_when_no_recording_keys(self, observe_project):
+        organization = observe_project.organization
+        workspace = observe_project.workspace
+        provider = ObservabilityProvider.objects.create(
+            project=observe_project,
+            provider=ProviderChoices.VAPI,
+            enabled=True,
+            organization=organization,
+            workspace=workspace,
+            metadata={},
+        )
+        span = _make_span(
+            observe_project,
+            provider="vapi",
+            span_attributes={"raw_log": {"id": "x"}},
+        )
+
+        with patch(
+            "tracer.utils.observability_provider.rehost_external_recordings"
+        ) as mock_activity:
+            _maybe_enqueue_recording_rehost(provider, span)
+
+        mock_activity.delay.assert_not_called()
+
+    def test_skipped_for_unknown_provider(self, observe_project):
+        organization = observe_project.organization
+        workspace = observe_project.workspace
+        provider = ObservabilityProvider.objects.create(
+            project=observe_project,
+            provider=ProviderChoices.ELEVEN_LABS,
+            enabled=True,
+            organization=organization,
+            workspace=workspace,
+            metadata={},
+        )
+        span = _make_span(
+            observe_project,
+            provider="eleven_labs",
+            span_attributes={
+                VAPI_KEYS["mono_combined"]: "https://x/y.mp3",
+            },
+        )
+
+        with patch(
+            "tracer.utils.observability_provider.rehost_external_recordings"
+        ) as mock_activity:
+            _maybe_enqueue_recording_rehost(provider, span)
+
+        mock_activity.delay.assert_not_called()
+
+
+class TestProcessRawLogsOverlay:
+    """Tests for the span_attributes overlay in ObservabilityService.process_raw_logs."""
+
+    def test_vapi_overlay_overrides_recording_url(self):
+        from tracer.services.observability_providers import ObservabilityService
+
+        raw_log = {
+            "id": "vapi-call-1",
+            "recordingUrl": "https://storage.vapi.ai/combined.mp3",
+            "artifact": {"stereoRecordingUrl": "https://storage.vapi.ai/stereo.mp3"},
+            "messages": [],
+        }
+        span_attributes = {
+            "conversation.recording.mono.combined": "https://fagi.s3.amazonaws.com/x/combined.mp3",
+            "conversation.recording.stereo": "https://fagi.s3.amazonaws.com/x/stereo.mp3",
+        }
+
+        result = ObservabilityService.process_raw_logs(
+            raw_log, ProviderChoices.VAPI, span_attributes=span_attributes
+        )
+
+        assert result["recording_url"] == span_attributes[
+            "conversation.recording.mono.combined"
+        ]
+        assert result["stereo_recording_url"] == span_attributes[
+            "conversation.recording.stereo"
+        ]
+
+    def test_no_overlay_keeps_provider_urls(self):
+        from tracer.services.observability_providers import ObservabilityService
+
+        raw_log = {
+            "id": "vapi-call-1",
+            "recordingUrl": "https://storage.vapi.ai/combined.mp3",
+            "artifact": {"stereoRecordingUrl": "https://storage.vapi.ai/stereo.mp3"},
+            "messages": [],
+        }
+
+        result = ObservabilityService.process_raw_logs(
+            raw_log, ProviderChoices.VAPI
+        )
+
+        assert result["recording_url"] == "https://storage.vapi.ai/combined.mp3"
+        assert (
+            result["stereo_recording_url"] == "https://storage.vapi.ai/stereo.mp3"
+        )

--- a/futureagi/tracer/utils/observability_provider.py
+++ b/futureagi/tracer/utils/observability_provider.py
@@ -17,6 +17,10 @@ from tracer.models.project import ProjectSourceChoices
 from tracer.models.trace import Trace
 from tracer.serializers.observability_provider import ObservabilityProviderSerializer
 from tracer.services.observability_providers import ObservabilityService
+from tracer.tasks.recordings_rehost import (
+    RECORDING_KEYS_BY_PROVIDER,
+    rehost_external_recordings,
+)
 from tracer.utils.eleven_labs import normalize_eleven_labs_data
 from tracer.utils.otel import ResourceLimitError, get_or_create_project
 from tracer.utils.retell import normalize_retell_data
@@ -208,7 +212,7 @@ def _create_observation_span(project, provider, normalized_data, metadata):
 
     attributes = normalized_data.get("span_attributes", {})
 
-    ObservationSpan.objects.create(
+    return ObservationSpan.objects.create(
         id=uuid.uuid4(),
         project=project,
         trace=trace,
@@ -261,6 +265,7 @@ def _update_observation_span(existing_span, normalized_data):
             "latency_ms",
         ]
     )
+    return existing_span
 
 
 def process_and_store_logs(logs: list, provider: ObservabilityProvider):
@@ -308,16 +313,40 @@ def process_and_store_logs(logs: list, provider: ObservabilityProvider):
                 )
 
                 if existing_span:
-                    _update_observation_span(existing_span, normalized_data)
+                    span = _update_observation_span(existing_span, normalized_data)
                 else:
-                    _create_observation_span(
+                    span = _create_observation_span(
                         project, provider, normalized_data, metadata
                     )
+
+                _maybe_enqueue_recording_rehost(provider, span)
         except Exception as e:
             logger.exception(
                 f"Error updating or creating observation span for {provider.provider}: {e}"
             )
             continue
+
+
+def _maybe_enqueue_recording_rehost(
+    provider: ObservabilityProvider, span: ObservationSpan
+) -> None:
+    """Enqueue S3 rehost for recording URLs on this span, if applicable.
+
+    Scheduled via transaction.on_commit so the worker won't race the upsert.
+    Opt out per provider via metadata["rehost_recordings"] = False.
+    """
+    if (provider.metadata or {}).get("rehost_recordings", True) is False:
+        return
+
+    keys = RECORDING_KEYS_BY_PROVIDER.get(provider.provider) or []
+    attrs = span.span_attributes or {}
+    if not any(attrs.get(key) for key, _ in keys):
+        return
+
+    span_id = str(span.id)
+    transaction.on_commit(
+        lambda: rehost_external_recordings.delay(span_id=span_id)
+    )
 
 
 def create_observability_provider(

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -1089,7 +1089,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             raw_log = attrs.get("raw_log") or {}
             provider = trace.provider or "vapi"
 
-            processed_log = ObservabilityService.process_raw_logs(raw_log, provider)
+            processed_log = ObservabilityService.process_raw_logs(
+                raw_log, provider, span_attributes=attrs
+            )
             voice_metrics = self._extract_voice_turn_and_talk_metrics(attrs, raw_log)
 
             # Observation spans are served by the detail endpoint — skip
@@ -3616,7 +3618,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             raw_log = attrs.get("raw_log") or {}
             provider = root_span.provider or "vapi"
 
-            processed_log = ObservabilityService.process_raw_logs(raw_log, provider)
+            processed_log = ObservabilityService.process_raw_logs(
+                raw_log, provider, span_attributes=attrs
+            )
             voice_metrics = self._extract_voice_turn_and_talk_metrics(attrs, raw_log)
 
             recording = self._build_recording_dict(attrs)
@@ -3789,7 +3793,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         if isinstance(metadata_map, dict):
             metadata = metadata_map
 
-        processed_log = ObservabilityService.process_raw_logs(raw_log, provider)
+        processed_log = ObservabilityService.process_raw_logs(
+            raw_log, provider, span_attributes=span_attrs
+        )
         voice_metrics = self._extract_voice_turn_and_talk_metrics(span_attrs, raw_log)
 
         attr_str = row.get("span_attr_str") or {}
@@ -5206,7 +5212,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             )
 
             # Process raw_log through existing provider-specific logic
-            processed_log = ObservabilityService.process_raw_logs(raw_log, provider)
+            processed_log = ObservabilityService.process_raw_logs(
+                raw_log, provider, span_attributes=span_attrs
+            )
 
             entry = {
                 **processed_log,


### PR DESCRIPTION
## Summary

External provider recording URLs returned by the observability poller (Vapi/Retell) were stored verbatim. Vapi rotates / expires these and Retell's `opt_in_signed_url` is 24h-bounded, so playback broke silently for older calls. The internal voice engine (LiveKit + Vapi simulator) already re-hosts every recording on FAGI S3; the observability path didn't.

This PR adds a per-call S3 rehost via a new Temporal activity, fanned out from `process_and_store_logs` after the span is upserted. The activity reads the existing `conversation.recording.*` span attribute keys, downloads each non-S3 URL, uploads to FAGI S3, and **overwrites the same keys** with the durable S3 URL. `span_attributes["raw_log"]` is left untouched, so the provider's original URL is still recoverable.

## Changes

- **New Temporal activity** `rehost_external_recordings` (queue: `tasks_s`, `max_retries=3`, `time_limit=600`) in `tracer/tasks/recordings_rehost.py`.
  - Idempotent: URLs containing `amazonaws.com` or `minio` are skipped, so retries and re-runs are safe.
  - On per-URL download failure the helper returns the input URL unchanged and the key stays as the provider URL — a future tick can still pick it up.
- **Dispatch** from `process_and_store_logs` via `transaction.on_commit` so the worker won't race the upsert.
- **Per-provider opt-out** via `ObservabilityProvider.metadata["rehost_recordings"] = false` (default ON).
- `_create_observation_span` / `_update_observation_span` now return the upserted span so the dispatcher can enqueue.
- `ObservabilityService.process_raw_logs` accepts an optional `span_attributes` overlay; the four call sites in `tracer/views/trace.py` pass it so `VoiceCallLogs.recording_url` and `stereo_recording_url` reflect the durable S3 URL after rehost.
- Drop the hard-coded `vapi.ai`-only host filter in `convert_audio_url_to_s3_async` — function name is host-agnostic and existing simulator callers only ever pass Vapi URLs anyway, so behaviour is unchanged for them.
- Register `tracer.tasks.recordings_rehost` in the Temporal worker registry import list.

## Storage layout (raw_log untouched)

| Where | Before | After |
|---|---|---|
| `span_attributes["raw_log"]` | original provider URLs | unchanged ✓ |
| `span_attributes["conversation.recording.mono.combined"]` etc. | provider URLs | overwritten with FAGI S3 URLs |
| `VoiceCallLogs.recording_url` / `.stereo_recording_url` | provider URLs (built from raw_log) | S3 URLs (via overlay in views) |

## Out of scope (tracked separately)

- ElevenLabs `/audio` endpoint fetch — different shape (binary stream, no URL).
- Retell `scrubbed_recording_url[_multi_channel_url]` — not extracted today.
- Vapi video URLs (`artifact.recording.video.combinedUrl`, `artifact.videoRecordingUrl`).
- Backfill management command for already-stranded spans (will follow if needed).

## Test plan

- [x] `pytest tracer/tests/test_observability_recordings_rehost.py -v` — 13 tests pass (Vapi 4-key overwrite, Retell 2-key overwrite, idempotency on already-S3 URLs, partial-failure preservation, dispatch gating by metadata, view-model overlay).
- [x] `pytest tracer/tests/test_observability_providers.py -v` — existing 27 tests still pass.
- [x] Verified end-to-end on dev: live Vapi cron picked up new calls, fanned out to `worker-tasks-s` / `worker-default`, MinIO uploads succeeded, `span_attributes["raw_log"]` byte-identical to provider response.
- [ ] Reviewer to confirm: Temporal UI shows `rehost_external_recordings` activity registered on `tasks_s` after deploy.
- [ ] Reviewer to confirm: `provider.metadata["rehost_recordings"] = false` skips the dispatch (Temporal UI shows no extra workflow).