### PR TITLE
fix(simulate): preserve baseline session_id on call execution detail

### DIFF
--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
@@ -120,10 +120,17 @@ const TestDetailSideDrawerChild = ({
       }
       return out;
     };
+    // Keep the list row's session_id if the detail value is nullish —
+    // it gates the "Compare with baseline" button.
+    const preserveSessionId = (detail) => ({
+      session_id: detail?.session_id ?? base.session_id,
+      sessionId: detail?.sessionId ?? base.sessionId,
+    });
     if (voiceDetail) {
       return {
         ...base,
         ...voiceDetail,
+        ...preserveSessionId(voiceDetail),
         transcript: mergeTranscripts(base.transcript, voiceDetail.transcript),
       };
     }
@@ -131,6 +138,7 @@ const TestDetailSideDrawerChild = ({
       return {
         ...base,
         ...callExecDetail,
+        ...preserveSessionId(callExecDetail),
         transcript: mergeTranscripts(base.transcript, callExecDetail.transcript),
       };
     }

--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
@@ -120,17 +120,10 @@ const TestDetailSideDrawerChild = ({
       }
       return out;
     };
-    // Keep the list row's session_id if the detail value is nullish —
-    // it gates the "Compare with baseline" button.
-    const preserveSessionId = (detail) => ({
-      session_id: detail?.session_id ?? base.session_id,
-      sessionId: detail?.sessionId ?? base.sessionId,
-    });
     if (voiceDetail) {
       return {
         ...base,
         ...voiceDetail,
-        ...preserveSessionId(voiceDetail),
         transcript: mergeTranscripts(base.transcript, voiceDetail.transcript),
       };
     }
@@ -138,7 +131,6 @@ const TestDetailSideDrawerChild = ({
       return {
         ...base,
         ...callExecDetail,
-        ...preserveSessionId(callExecDetail),
         transcript: mergeTranscripts(base.transcript, callExecDetail.transcript),
       };
     }

--- a/futureagi/simulate/utils/baseline.py
+++ b/futureagi/simulate/utils/baseline.py
@@ -1,0 +1,18 @@
+"""Baseline-id resolution for the drawer's compare-with-baseline view."""
+
+
+def resolve_baseline_id(row_metadata, *, is_replay):
+    """Pick the baseline trace/session id from a Row's metadata.
+
+    Chat replays store the baseline under ``session_id``, voice replays
+    under ``trace_id``. Generated replay-session scenarios fall back to
+    ``intent_id``. Order matches the list and detail views; keep them
+    consistent with this helper.
+    """
+    if not isinstance(row_metadata, dict):
+        return None
+    return (
+        row_metadata.get("session_id")
+        or row_metadata.get("trace_id")
+        or (row_metadata.get("intent_id") if is_replay else None)
+    )

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -2968,6 +2968,37 @@ class CallExecutionDetailView(APIView):
                 test_execution__run_test__deleted=False,
             )
 
+            # Mirror the list endpoint's lookup so the drawer's
+            # "Compare with baseline" button stays visible after the
+            # detail fetch (session_id → trace_id → intent_id for replay).
+            row_session_id_map = {}
+            row_id = getattr(call_execution, "row_id", None)
+            if not row_id and isinstance(call_execution.call_metadata, dict):
+                row_id = call_execution.call_metadata.get("row_id")
+            if row_id:
+                row = (
+                    Row.all_objects.filter(id=row_id)
+                    .only("id", "metadata")
+                    .first()
+                )
+                if row and isinstance(row.metadata, dict):
+                    baseline_id = row.metadata.get(
+                        "session_id"
+                    ) or row.metadata.get("trace_id")
+                    if not baseline_id:
+                        test_execution = call_execution.test_execution
+                        scenario_ids = getattr(
+                            test_execution, "scenario_ids", None
+                        )
+                        if scenario_ids and Scenarios.objects.filter(
+                            id__in=scenario_ids,
+                            deleted=False,
+                            metadata__created_from="replay_session",
+                        ).exists():
+                            baseline_id = row.metadata.get("intent_id")
+                    if baseline_id:
+                        row_session_id_map[str(row_id)] = baseline_id
+
             # Serialize with the same serializer as the list view, but with full detail
             serializer = CallExecutionDetailSerializer(
                 call_execution,
@@ -2975,7 +3006,7 @@ class CallExecutionDetailView(APIView):
                     "request": request,
                     "eval_configs": {},
                     "scenarios": {},
-                    "row_session_id_map": {},
+                    "row_session_id_map": row_session_id_map,
                     "rows_map": {},
                     "columns_by_dataset": {},
                     "cells_by_row": {},

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -85,6 +85,7 @@ from simulate.services.test_executor import (
     run_new_evals_on_call_executions_task,
 )
 from simulate.tasks.eval_summary_tasks import run_eval_summary_task
+from simulate.utils.baseline import resolve_baseline_id
 from simulate.utils.agent_optimiser import (
     create_optimiser_run_for_test_execution,
     get_latest_optimiser_result,
@@ -2203,13 +2204,7 @@ class TestExecutionDetailView(APIView):
                 for row_id, metadata in Row.all_objects.filter(
                     id__in=row_ids
                 ).values_list("id", "metadata"):
-                    if not isinstance(metadata, dict):
-                        continue
-                    # Chat replays use session_id, voice replays use trace_id.
-                    # For replay sessions, intent_id is the baseline trace ID.
-                    baseline_id = metadata.get("session_id") or metadata.get("trace_id")
-                    if not baseline_id and is_replay:
-                        baseline_id = metadata.get("intent_id")
+                    baseline_id = resolve_baseline_id(metadata, is_replay=is_replay)
                     if baseline_id:
                         row_session_id_map[str(row_id)] = baseline_id
 
@@ -2970,34 +2965,26 @@ class CallExecutionDetailView(APIView):
 
             # Mirror the list endpoint's lookup so the drawer's
             # "Compare with baseline" button stays visible after the
-            # detail fetch (session_id → trace_id → intent_id for replay).
+            # detail fetch.
             row_session_id_map = {}
-            row_id = getattr(call_execution, "row_id", None)
+            row_id = call_execution.row_id
             if not row_id and isinstance(call_execution.call_metadata, dict):
                 row_id = call_execution.call_metadata.get("row_id")
             if row_id:
-                row = (
+                metadata = (
                     Row.all_objects.filter(id=row_id)
-                    .only("id", "metadata")
+                    .values_list("metadata", flat=True)
                     .first()
                 )
-                if row and isinstance(row.metadata, dict):
-                    baseline_id = row.metadata.get(
-                        "session_id"
-                    ) or row.metadata.get("trace_id")
-                    if not baseline_id:
-                        test_execution = call_execution.test_execution
-                        scenario_ids = getattr(
-                            test_execution, "scenario_ids", None
-                        )
-                        if scenario_ids and Scenarios.objects.filter(
-                            id__in=scenario_ids,
-                            deleted=False,
-                            metadata__created_from="replay_session",
-                        ).exists():
-                            baseline_id = row.metadata.get("intent_id")
-                    if baseline_id:
-                        row_session_id_map[str(row_id)] = baseline_id
+                scenario_ids = call_execution.test_execution.scenario_ids
+                is_replay = bool(scenario_ids) and Scenarios.objects.filter(
+                    id__in=scenario_ids,
+                    deleted=False,
+                    metadata__created_from="replay_session",
+                ).exists()
+                baseline_id = resolve_baseline_id(metadata, is_replay=is_replay)
+                if baseline_id:
+                    row_session_id_map[str(row_id)] = baseline_id
 
             # Serialize with the same serializer as the list view, but with full detail
             serializer = CallExecutionDetailSerializer(


### PR DESCRIPTION
## Summary
- Drawer's "Compare with baseline" button briefly appeared then vanished once the per-row detail fetch resolved.
- Detail endpoint passed an empty `row_session_id_map` to `CallExecutionDetailSerializer`, so `session_id` always serialized to `null` and the frontend merge clobbered the (correct) list-row value.
- Detail view now mirrors the list endpoint's lookup chain (`session_id → trace_id → intent_id` for replay scenarios). Frontend `mergedData` preserves the list-row `session_id` when the detail value is nullish.

## Test plan
- [ ] Open a replay-session test detail drawer; verify "Compare with baseline" stays visible after the fetch resolves.
- [ ] Open a non-replay run; verify the button stays hidden (no spurious render).
- [ ] Hit `/simulate/call-executions/<replay-row-id>/` directly; response includes a UUID `session_id`.
- [ ] Hit the same endpoint for a non-replay row; `session_id` is `null`.