### PR TITLE
feat(annotate): add annotator selector to queue annotation workspace

### DIFF
--- a/frontend/src/api/annotation-queues/annotation-queues.js
+++ b/frontend/src/api/annotation-queues/annotation-queues.js
@@ -341,17 +341,25 @@ export const useUpdateQueueItemStatus = () => {
 // ---------------------------------------------------------------------------
 
 export const annotateKeys = {
-  detail: (queueId, itemId) => ["annotate-detail", queueId, itemId],
+  detail: (queueId, itemId, annotatorId) =>
+    annotatorId
+      ? ["annotate-detail", queueId, itemId, annotatorId]
+      : ["annotate-detail", queueId, itemId],
   nextItem: (queueId) => ["annotate-next-item", queueId],
   annotations: (queueId, itemId) => ["item-annotations", queueId, itemId],
 };
 
-export const useAnnotateDetail = (queueId, itemId, options = {}) => {
+export const useAnnotateDetail = (
+  queueId,
+  itemId,
+  { annotatorId, ...options } = {},
+) => {
   return useQuery({
-    queryKey: annotateKeys.detail(queueId, itemId),
+    queryKey: annotateKeys.detail(queueId, itemId, annotatorId),
     queryFn: () =>
       axios.get(
         `/model-hub/annotation-queues/${queueId}/items/${itemId}/annotate-detail/`,
+        annotatorId ? { params: { annotator_id: annotatorId } } : undefined,
       ),
     select: (d) => extractData(d),
     enabled: !!queueId && !!itemId,

--- a/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
@@ -104,15 +104,10 @@ export default function AnnotateWorkspaceView() {
     }
   }, [nextItemData, currentItemId]);
 
-  // Fetch annotate detail for current item
-  const {
-    data: detail,
-    isLoading: detailLoading,
-    error: detailError,
-  } = useAnnotateDetail(queueId, currentItemId);
-
   const { data: progress } = useQueueProgress(queueId);
   const { data: queueDetail } = useAnnotationQueueDetail(queueId);
+
+  const currentUserId = String(user?.id || user?.pk || "");
 
   const myQueueRole = useMemo(() => {
     if (!queueDetail?.annotators || !user) return null;
@@ -125,32 +120,96 @@ export default function AnnotateWorkspaceView() {
   const canReview =
     myQueueRole === QUEUE_ROLES.REVIEWER || myQueueRole === QUEUE_ROLES.MANAGER;
 
+  // Reviewers/managers can switch which annotator's annotations they are
+  // viewing. Default to self; null means "use the caller's identity" (the
+  // backend default).
+  const [viewingAnnotatorId, setViewingAnnotatorId] = useState(null);
+  useEffect(() => {
+    if (canReview && currentUserId && viewingAnnotatorId === null) {
+      setViewingAnnotatorId(currentUserId);
+    }
+  }, [canReview, currentUserId, viewingAnnotatorId]);
+
+  const isViewingOtherAnnotator =
+    canReview &&
+    !!viewingAnnotatorId &&
+    String(viewingAnnotatorId) !== currentUserId;
+
+  const {
+    data: detail,
+    isLoading: detailLoading,
+    isFetching: detailFetching,
+    error: detailError,
+  } = useAnnotateDetail(queueId, currentItemId, {
+    annotatorId: isViewingOtherAnnotator ? viewingAnnotatorId : undefined,
+  });
+
+  // Track which annotator the displayed detail belongs to so we can flag
+  // a real cross-annotator swap (placeholderData keeps the prior payload
+  // visible during the refetch).
+  const lastLoadedAnnotatorIdRef = useRef(null);
+  useEffect(() => {
+    if (detail && !detailFetching) {
+      lastLoadedAnnotatorIdRef.current = isViewingOtherAnnotator
+        ? viewingAnnotatorId
+        : currentUserId;
+    }
+  }, [
+    detail,
+    detailFetching,
+    isViewingOtherAnnotator,
+    viewingAnnotatorId,
+    currentUserId,
+  ]);
+  const requestedAnnotatorId = isViewingOtherAnnotator
+    ? viewingAnnotatorId
+    : currentUserId;
+  const isAnnotatorSwitchPending =
+    detailFetching &&
+    !!detail &&
+    lastLoadedAnnotatorIdRef.current !== null &&
+    String(lastLoadedAnnotatorIdRef.current) !== String(requestedAnnotatorId);
+
   // Prefetch adjacent items for instant navigation
   useEffect(() => {
     if (!detail || !queueId) return;
     const nextId = detail.next_item_id;
     const prevId = detail.prev_item_id;
+    const params = isViewingOtherAnnotator
+      ? { annotator_id: viewingAnnotatorId }
+      : undefined;
+    const cacheAnnotatorId = isViewingOtherAnnotator
+      ? viewingAnnotatorId
+      : undefined;
     if (nextId) {
       queryClient.prefetchQuery({
-        queryKey: annotateKeys.detail(queueId, nextId),
+        queryKey: annotateKeys.detail(queueId, nextId, cacheAnnotatorId),
         queryFn: () =>
           axios.get(
             `/model-hub/annotation-queues/${queueId}/items/${nextId}/annotate-detail/`,
+            params ? { params } : undefined,
           ),
         staleTime: 1000 * 60 * 2,
       });
     }
     if (prevId) {
       queryClient.prefetchQuery({
-        queryKey: annotateKeys.detail(queueId, prevId),
+        queryKey: annotateKeys.detail(queueId, prevId, cacheAnnotatorId),
         queryFn: () =>
           axios.get(
             `/model-hub/annotation-queues/${queueId}/items/${prevId}/annotate-detail/`,
+            params ? { params } : undefined,
           ),
         staleTime: 1000 * 60 * 2,
       });
     }
-  }, [detail, queueId, queryClient]);
+  }, [
+    detail,
+    queueId,
+    queryClient,
+    isViewingOtherAnnotator,
+    viewingAnnotatorId,
+  ]);
 
   const labelPanelRef = useRef(null);
   const isDirtyRef = useRef(false);
@@ -170,7 +229,6 @@ export default function AnnotateWorkspaceView() {
 
   // Item is explicitly assigned to someone else (only blocks in manual-assignment mode)
   const assignedUsers = detail?.item?.assigned_users || [];
-  const currentUserId = String(user?.id || user?.pk || "");
   const hasAssignments = assignedUsers.length > 0;
   const isAssignedToMe = assignedUsers.some(
     (a) => String(a.id) === currentUserId,
@@ -579,12 +637,33 @@ export default function AnnotateWorkspaceView() {
               queueId={queueId}
               itemId={currentItemId}
               onDirtyChange={handleDirtyChange}
-              readOnly={isViewOnlyForReviewer}
+              readOnly={isViewOnlyForReviewer || isViewingOtherAnnotator}
               readOnlyReason={
-                isViewOnlyForReviewer
-                  ? `Assigned to ${assignedToName || "another annotator"} — view only`
-                  : null
+                isViewingOtherAnnotator
+                  ? "Viewing another annotator's submissions (read only)"
+                  : isViewOnlyForReviewer
+                    ? `Assigned to ${assignedToName || "another annotator"} — view only`
+                    : null
               }
+              annotators={canReview ? queueDetail?.annotators || [] : null}
+              viewingAnnotatorId={viewingAnnotatorId}
+              currentUserId={currentUserId}
+              isAnnotatorSwitchPending={isAnnotatorSwitchPending}
+              onViewingAnnotatorChange={(id) => {
+                // Confirm before discarding unsaved annotations on the
+                // user's own (editable) view. A view of another annotator
+                // is always read-only, so it can't be dirty.
+                if (!isViewingOtherAnnotator && isDirtyRef.current) {
+                  if (
+                    !window.confirm(
+                      "You have unsaved annotations. Switch annotator anyway?",
+                    )
+                  ) {
+                    return;
+                  }
+                }
+                setViewingAnnotatorId(id || currentUserId);
+              }}
             />
           )}
         </Box>

--- a/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
@@ -14,6 +14,8 @@ import {
   Collapse,
   Divider,
   IconButton,
+  MenuItem,
+  Select,
   Stack,
   TextField,
   Tooltip,
@@ -155,6 +157,11 @@ const LabelPanel = forwardRef(function LabelPanel(
     onDirtyChange,
     readOnly = false,
     readOnlyReason = null,
+    annotators = null,
+    viewingAnnotatorId = null,
+    currentUserId = null,
+    onViewingAnnotatorChange,
+    isAnnotatorSwitchPending = false,
   },
   ref,
 ) {
@@ -470,6 +477,75 @@ const LabelPanel = forwardRef(function LabelPanel(
         </Box>
       )}
 
+      {/* Annotator picker for reviewers/managers when the queue has more
+          than one annotator. Switches whose annotations are displayed. */}
+      {Array.isArray(annotators) && annotators.length > 1 && (
+        <Box sx={{ mb: 2 }}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            spacing={1}
+            sx={{ mb: 0.75 }}
+          >
+            <Iconify
+              icon="solar:user-id-bold"
+              width={16}
+              sx={{ color: "text.secondary" }}
+            />
+            <Typography variant="subtitle2" color="text.secondary">
+              Viewing annotator
+            </Typography>
+            {isAnnotatorSwitchPending && (
+              <CircularProgress size={12} thickness={5} sx={{ ml: 0.5 }} />
+            )}
+          </Stack>
+          <Select
+            fullWidth
+            size="small"
+            value={viewingAnnotatorId || ""}
+            onChange={(e) => onViewingAnnotatorChange?.(e.target.value || null)}
+            displayEmpty
+            sx={{
+              borderRadius: 0.5,
+              "& .MuiSelect-select": { py: 1 },
+            }}
+          >
+            {annotators.map((a) => {
+              const isSelf =
+                currentUserId && String(a.user_id) === String(currentUserId);
+              return (
+                <MenuItem key={a.user_id} value={a.user_id}>
+                  {a.name || a.email || "Unknown"}
+                  {isSelf ? " (you)" : ""}
+                </MenuItem>
+              );
+            })}
+          </Select>
+          {viewingAnnotatorId &&
+            (() => {
+              const selected = annotators.find(
+                (a) => String(a.user_id) === String(viewingAnnotatorId),
+              );
+              const isSelf =
+                currentUserId &&
+                String(viewingAnnotatorId) === String(currentUserId);
+              const name = selected?.name || selected?.email || "this annotator";
+              return (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block", mt: 0.75, fontStyle: "italic" }}
+                >
+                  {isSelf
+                    ? "You are viewing your own annotations"
+                    : `You are viewing annotations of ${name}`}
+                </Typography>
+              );
+            })()}
+          <Divider sx={{ mt: 2 }} />
+        </Box>
+      )}
+
       {/* Label inputs */}
       <Stack
         spacing={2}
@@ -478,6 +554,11 @@ const LabelPanel = forwardRef(function LabelPanel(
           ...(readOnly && {
             pointerEvents: "none",
             opacity: 0.7,
+          }),
+          ...(isAnnotatorSwitchPending && {
+            pointerEvents: "none",
+            opacity: 0.4,
+            transition: "opacity 120ms ease-out",
           }),
         }}
       >
@@ -575,6 +656,11 @@ LabelPanel.propTypes = {
   onDirtyChange: PropTypes.func,
   readOnly: PropTypes.bool,
   readOnlyReason: PropTypes.string,
+  annotators: PropTypes.array,
+  viewingAnnotatorId: PropTypes.string,
+  currentUserId: PropTypes.string,
+  onViewingAnnotatorChange: PropTypes.func,
+  isAnnotatorSwitchPending: PropTypes.bool,
 };
 
 export default LabelPanel;

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -2167,7 +2167,7 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             try:
                 viewing_annotator_id = uuid.UUID(raw_annotator_id)
             except (ValueError, TypeError):
-                return self._gm.bad_request("annotator_id must be a valid UUID.")
+                return self._gm.bad_request("Invalid annotator selection.")
         if viewing_annotator_id:
             annotations_qs = annotations_qs.filter(annotator_id=viewing_annotator_id)
         elif not is_reviewer:

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from datetime import timedelta
 
 import structlog
@@ -2157,7 +2158,19 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             queue_item=item,
             deleted=False,
         ).select_related("label")
-        if not is_reviewer:
+        # Reviewers/managers can scope to a specific annotator via
+        # ?annotator_id=<uuid> so the workspace shows whose annotations are
+        # being viewed. Ignored for non-reviewers (they only see their own).
+        raw_annotator_id = request.query_params.get("annotator_id") or None
+        viewing_annotator_id = None
+        if raw_annotator_id and is_reviewer:
+            try:
+                viewing_annotator_id = uuid.UUID(raw_annotator_id)
+            except (ValueError, TypeError):
+                return self._gm.bad_request("annotator_id must be a valid UUID.")
+        if viewing_annotator_id:
+            annotations_qs = annotations_qs.filter(annotator_id=viewing_annotator_id)
+        elif not is_reviewer:
             annotations_qs = annotations_qs.filter(annotator=request.user)
         annotations = annotations_qs
 


### PR DESCRIPTION
## Summary
- Managers and reviewers viewing a queue item with multiple annotators had no way to tell whose annotations were displayed, and no way to switch between them.
- Adds an annotator picker below the instructions in the annotation workspace, with a "You are viewing annotations of <name>" caption. The picker is hidden for regular annotators and for queues with a single annotator.
- Forces the labels panel into read-only mode when someone other than the caller is selected, so a manager cannot accidentally overwrite another annotator's labels. Confirms before discarding unsaved annotations on switch, and dims the panel during the cross-annotator refetch so stale values are not actionable.
- Backend: `GET /annotation-queues/{queueId}/items/{itemId}/annotate-detail/` accepts an optional `?annotator_id=<uuid>` query param. Gated to REVIEWER/MANAGER roles; validated as a UUID and 400s on bad input.

## Test plan
- [ ] As a manager on a queue with two or more annotators, open an item: picker appears below instructions, defaults to self, no caption text reads as "viewing your own annotations".
- [ ] Select another annotator: panel dims briefly, refetches, displays their labels with read-only banner. Submit button is hidden.
- [ ] With unsaved edits on your own view, change the picker: a confirm dialog appears; cancelling leaves the dropdown on the previous selection.
- [ ] As a regular (non-reviewer) annotator: picker is not rendered.
- [ ] On a queue with exactly one annotator: picker is not rendered.
- [ ] `curl ".../annotate-detail/?annotator_id=not-a-uuid"` as a reviewer returns 400 with a clear message; passing it as a non-reviewer is silently ignored (existing self-only scoping applies).