### PR TITLE
fix(evals): explain why output type is locked for system evals

### DIFF
--- a/frontend/src/sections/evals/components/OutputTypeConfig.jsx
+++ b/frontend/src/sections/evals/components/OutputTypeConfig.jsx
@@ -94,6 +94,27 @@ const OutputTypeConfig = ({
         >
           Select your preferred evaluation output format.
         </Typography>
+        {radioDisabled && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.75,
+              mb: 1,
+            }}
+          >
+            <Iconify
+              icon="solar:info-circle-bold"
+              width={14}
+              height={14}
+              sx={{ color: "text.disabled", flexShrink: 0 }}
+            />
+            <Typography variant="caption" color="text.secondary">
+              Output type is fixed for system-level evaluations and can&apos;t
+              be changed.
+            </Typography>
+          </Box>
+        )}
         <RadioGroup
           row
           value={outputType}


### PR DESCRIPTION
## Summary
- The Output Type radio group disables itself for system-level evaluations, but the UI gave no reason — users couldn't tell whether it was an intentional restriction or a broken control.
- Adds a small inline note under the field caption when the group is disabled, making the lock read as a deliberate system constraint.

## Test plan
- [ ] Open an eval config where the output type is system-fixed; verify the explainer line appears under the caption with an info icon.
- [ ] Open an eval config where the output type is editable; verify no explainer line shows and the radio group remains interactive.