### PR TITLE
fix(model_hub): restructure annotation queue export columns

### DIFF
--- a/frontend/src/sections/annotations/queues/view/queue-analytics-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-analytics-tab.jsx
@@ -292,6 +292,14 @@ export default function QueueAnalyticsTab({ queueId }) {
         >
           Export CSV
         </Button>
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<Iconify icon="eva:download-fill" width={16} />}
+          onClick={() => handleExport("xlsx")}
+        >
+          Export Excel
+        </Button>
       </Stack>
 
       {/* Overview Cards */}

--- a/futureagi/model_hub/tests/test_annotation_queue_export.py
+++ b/futureagi/model_hub/tests/test_annotation_queue_export.py
@@ -1,0 +1,386 @@
+"""Tests for the annotation queue export helpers.
+
+Focuses on the pure helpers that the export composition relies on —
+``_flatten_score_value``, ``_resolve_recording_link``,
+``_slugify_for_header``, and the source-type dispatch in
+``_collect_evals_for_item`` / ``_collect_system_metrics_for_item``.
+These are the functions where the review found correctness regressions
+(falsy collapse, wrong recording field priority, slug collisions, N+1
+prefetch bypass).
+
+The HTTP-level shape (CSV/XLSX content type, header row, row count) is
+covered by lighter smoke tests that go through ``auth_client``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from model_hub.views.annotation_queues import AnnotationQueueViewSet
+
+
+# ---------------------------------------------------------------------------
+# _flatten_score_value
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenScoreValue:
+    flatten = staticmethod(AnnotationQueueViewSet._flatten_score_value)
+
+    def test_none_returns_empty_string(self):
+        assert self.flatten(None) == ""
+
+    def test_plain_scalars_pass_through(self):
+        assert self.flatten(42) == 42
+        assert self.flatten(4.5) == 4.5
+        assert self.flatten("yes") == "yes"
+        assert self.flatten(True) is True
+        assert self.flatten(False) is False
+
+    def test_plain_list_joined_with_comma(self):
+        assert self.flatten([1, 2, 3]) == "1, 2, 3"
+        assert self.flatten(["a", "b"]) == "a, b"
+
+    def test_unwraps_rating_wrapper(self):
+        assert self.flatten({"rating": 3}) == 3
+        # Falsy real values must NOT collapse to "".
+        assert self.flatten({"rating": 0}) == 0
+
+    def test_unwraps_value_wrapper(self):
+        assert self.flatten({"value": "yes"}) == "yes"
+        assert self.flatten({"value": False}) is False
+
+    def test_unwraps_text_wrapper(self):
+        assert self.flatten({"text": "free-form notes"}) == "free-form notes"
+        assert self.flatten({"text": ""}) == ""
+
+    def test_joins_selected_list_in_wrapper(self):
+        assert self.flatten({"selected": ["a", "b", "c"]}) == "a, b, c"
+
+    def test_wrapper_key_with_none_inner_falls_through(self):
+        # rating present-but-None should not short-circuit — the helper
+        # must keep looking so partial payloads still surface a value.
+        assert self.flatten({"rating": None, "value": "ok"}) == "ok"
+        assert self.flatten({"rating": None, "value": None, "text": "fb"}) == "fb"
+        assert self.flatten({"rating": None, "selected": ["x"]}) == "x"
+
+    def test_all_wrapper_inners_none_fall_through_to_json(self):
+        # No usable inner anywhere → JSON dump of the original payload.
+        assert self.flatten({"rating": None}) == '{"rating": null}'
+
+    def test_nested_dict_inner_is_jsonified(self):
+        # csv.writer / openpyxl would emit a Python repr otherwise.
+        assert self.flatten({"value": {"x": 1}}) == '{"x": 1}'
+
+    def test_unknown_shape_dumped_as_json(self):
+        assert self.flatten({"foo": "bar"}) == '{"foo": "bar"}'
+
+    def test_inner_list_in_wrapper_joined(self):
+        assert self.flatten({"value": ["a", "b"]}) == "a, b"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_recording_link
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRecordingLink:
+    @staticmethod
+    def _item(**call_attrs):
+        ce = MagicMock()
+        for k, v in call_attrs.items():
+            setattr(ce, k, v)
+        item = MagicMock()
+        item.call_execution = ce
+        return item
+
+    def test_returns_empty_when_no_call_execution(self):
+        item = MagicMock()
+        item.call_execution = None
+        assert AnnotationQueueViewSet._resolve_recording_link(item) == ""
+
+    def test_prefers_top_level_recording_url(self):
+        item = self._item(
+            recording_url="https://s3.example.com/rec.mp3",
+            stereo_recording_url="https://s3.example.com/stereo.mp3",
+            provider_call_data={
+                "vapi": {"recording_url": "https://vapi.example.com/x.mp3"}
+            },
+        )
+        assert (
+            AnnotationQueueViewSet._resolve_recording_link(item)
+            == "https://s3.example.com/rec.mp3"
+        )
+
+    def test_falls_back_to_stereo(self):
+        item = self._item(
+            recording_url="",
+            stereo_recording_url="https://s3.example.com/stereo.mp3",
+            provider_call_data={},
+        )
+        assert (
+            AnnotationQueueViewSet._resolve_recording_link(item)
+            == "https://s3.example.com/stereo.mp3"
+        )
+
+    def test_falls_back_to_vapi_artifact_camelcase(self):
+        item = self._item(
+            recording_url=None,
+            stereo_recording_url=None,
+            provider_call_data={
+                "vapi": {"artifact": {"recordingUrl": "https://v.example.com/r.mp3"}}
+            },
+        )
+        assert (
+            AnnotationQueueViewSet._resolve_recording_link(item)
+            == "https://v.example.com/r.mp3"
+        )
+
+    def test_falls_back_to_livekit_recording_url(self):
+        item = self._item(
+            recording_url=None,
+            stereo_recording_url=None,
+            provider_call_data={
+                "livekit": {"recording_url": "https://lk.example.com/r.mp3"}
+            },
+        )
+        assert (
+            AnnotationQueueViewSet._resolve_recording_link(item)
+            == "https://lk.example.com/r.mp3"
+        )
+
+    def test_returns_empty_when_no_url_anywhere(self):
+        item = self._item(
+            recording_url=None,
+            stereo_recording_url=None,
+            provider_call_data={},
+        )
+        assert AnnotationQueueViewSet._resolve_recording_link(item) == ""
+
+    def test_handles_non_dict_provider_call_data(self):
+        item = self._item(
+            recording_url=None,
+            stereo_recording_url=None,
+            provider_call_data="not-a-dict",
+        )
+        assert AnnotationQueueViewSet._resolve_recording_link(item) == ""
+
+
+# ---------------------------------------------------------------------------
+# _slugify_for_header
+# ---------------------------------------------------------------------------
+
+
+class TestSlugifyForHeader:
+    slug = staticmethod(AnnotationQueueViewSet._slugify_for_header)
+
+    def test_lowercases_and_keeps_simple_words(self):
+        assert self.slug("Latency") == "latency"
+        assert self.slug("OverallScore") == "overallscore"
+
+    def test_collapses_special_chars_to_single_underscore(self):
+        assert self.slug("Response Quality (5★)") == "response_quality_5"
+        assert self.slug("foo!!!bar") == "foo_bar"
+
+    def test_trims_leading_and_trailing_underscores(self):
+        assert self.slug("__hello__") == "hello"
+        assert self.slug("--world--") == "world"
+
+    def test_empty_or_none_input_falls_back_to_unknown(self):
+        assert self.slug("") == "unknown"
+        assert self.slug(None) == "unknown"
+        assert self.slug("!!!") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _collect_system_metrics_for_item
+# ---------------------------------------------------------------------------
+
+
+class TestCollectSystemMetrics:
+    def _item(self, source_type, source_obj):
+        item = MagicMock()
+        item.source_type = source_type
+        # _collect_system_metrics_for_item reads via getattr(item, source_type).
+        setattr(item, source_type, source_obj)
+        return item
+
+    def test_call_execution_pulls_declared_fields(self):
+        ce = MagicMock(
+            duration_seconds=42,
+            message_count=10,
+            overall_score=7.5,
+            talk_ratio=0.62,
+            avg_agent_latency_ms=350,
+            user_wpm=120.0,
+            bot_wpm=140.0,
+            user_interruption_count=2,
+            ai_interruption_count=1,
+        )
+        item = self._item("call_execution", ce)
+        out = AnnotationQueueViewSet._collect_system_metrics_for_item(item)
+        assert out["duration_seconds"] == 42
+        assert out["overall_score"] == 7.5
+        assert out["bot_wpm"] == 140.0
+
+    def test_null_fields_become_empty_string(self):
+        ce = MagicMock(
+            duration_seconds=None,
+            message_count=None,
+            overall_score=None,
+            talk_ratio=None,
+            avg_agent_latency_ms=None,
+            user_wpm=None,
+            bot_wpm=None,
+            user_interruption_count=None,
+            ai_interruption_count=None,
+        )
+        item = self._item("call_execution", ce)
+        out = AnnotationQueueViewSet._collect_system_metrics_for_item(item)
+        assert out["duration_seconds"] == ""
+        assert out["overall_score"] == ""
+
+    def test_unmapped_source_type_returns_empty_dict(self):
+        item = MagicMock()
+        item.source_type = "trace"  # no entry in _SYSTEM_METRICS_BY_SOURCE
+        assert AnnotationQueueViewSet._collect_system_metrics_for_item(item) == {}
+
+    def test_missing_source_object_returns_empty_dict(self):
+        item = MagicMock()
+        item.source_type = "call_execution"
+        item.call_execution = None
+        assert AnnotationQueueViewSet._collect_system_metrics_for_item(item) == {}
+
+
+# ---------------------------------------------------------------------------
+# _collect_evals_for_item — source dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestCollectEvals:
+    def test_call_execution_flattens_eval_outputs_payload(self):
+        ce = MagicMock()
+        ce.eval_outputs = {
+            "id-1": {"name": "helpfulness", "output": "Passed"},
+            "id-2": {"name": "coherence", "output": 0.87},
+            "id-3": {"name": "no-output", "output": None},
+            "id-4": "not-a-dict",
+        }
+        item = MagicMock()
+        item.source_type = "call_execution"
+        item.call_execution = ce
+        out = AnnotationQueueViewSet._collect_evals_for_item(item)
+        assert out == {
+            "helpfulness": "Passed",
+            "coherence": 0.87,
+            "no-output": "",
+        }
+
+    def test_call_execution_with_no_eval_outputs_returns_empty(self):
+        ce = MagicMock()
+        ce.eval_outputs = None
+        item = MagicMock()
+        item.source_type = "call_execution"
+        item.call_execution = ce
+        assert AnnotationQueueViewSet._collect_evals_for_item(item) == {}
+
+    def test_dataset_row_reads_prefetched_eval_cells(self):
+        col = MagicMock()
+        col.name = "ground_truth_match"
+        col.id = "col-uuid"
+        cell = MagicMock(value="Pass", column=col)
+        row = MagicMock()
+        row.eval_cells = [cell]
+        item = MagicMock()
+        item.source_type = "dataset_row"
+        item.dataset_row = row
+        out = AnnotationQueueViewSet._collect_evals_for_item(item)
+        assert out == {"ground_truth_match": "Pass"}
+
+    def test_dataset_row_with_no_prefetch_returns_empty(self):
+        row = MagicMock(spec=[])  # no eval_cells attribute attached
+        item = MagicMock()
+        item.source_type = "dataset_row"
+        item.dataset_row = row
+        assert AnnotationQueueViewSet._collect_evals_for_item(item) == {}
+
+    def test_trace_reads_prefetched_active_eval_logs(self):
+        cfg = MagicMock()
+        cfg.name = "is_good_summary"
+        log = MagicMock(
+            output_float=None,
+            output_bool=True,
+            output_str="",
+            output_str_list=[],
+            custom_eval_config=cfg,
+            eval_type_id=None,
+        )
+        trace = MagicMock()
+        trace.active_eval_logs = [log]
+        item = MagicMock()
+        item.source_type = "trace"
+        item.trace = trace
+        out = AnnotationQueueViewSet._collect_evals_for_item(item)
+        assert out == {"is_good_summary": True}
+
+    def test_observation_span_reads_prefetched_active_eval_logs(self):
+        log = MagicMock(
+            output_float=0.42,
+            output_bool=None,
+            output_str="",
+            output_str_list=[],
+            custom_eval_config=None,
+            eval_type_id="similarity",
+        )
+        span = MagicMock()
+        span.active_eval_logs = [log]
+        item = MagicMock()
+        item.source_type = "observation_span"
+        item.observation_span = span
+        out = AnnotationQueueViewSet._collect_evals_for_item(item)
+        assert out == {"similarity": 0.42}
+
+    def test_unsupported_source_type_returns_empty(self):
+        for src in ("trace_session", "prototype_run", "unknown"):
+            item = MagicMock()
+            item.source_type = src
+            assert AnnotationQueueViewSet._collect_evals_for_item(item) == {}
+
+
+# ---------------------------------------------------------------------------
+# _eval_logger_value — output-field priority
+# ---------------------------------------------------------------------------
+
+
+class TestEvalLoggerValue:
+    @staticmethod
+    def _log(**kw):
+        defaults = dict(
+            output_float=None,
+            output_bool=None,
+            output_str="",
+            output_str_list=[],
+        )
+        defaults.update(kw)
+        return MagicMock(**defaults)
+
+    def test_prefers_output_float(self):
+        log = self._log(output_float=0.91, output_bool=True, output_str="ignored")
+        assert AnnotationQueueViewSet._eval_logger_value(log) == 0.91
+
+    def test_falls_back_to_bool(self):
+        log = self._log(output_bool=False)
+        # False is a valid value — must not collapse to "".
+        assert AnnotationQueueViewSet._eval_logger_value(log) is False
+
+    def test_falls_back_to_str(self):
+        log = self._log(output_str="Passed")
+        assert AnnotationQueueViewSet._eval_logger_value(log) == "Passed"
+
+    def test_falls_back_to_str_list_joined(self):
+        log = self._log(output_str_list=["a", "b"])
+        assert AnnotationQueueViewSet._eval_logger_value(log) == "a, b"
+
+    def test_returns_empty_when_nothing_set(self):
+        log = self._log()
+        assert AnnotationQueueViewSet._eval_logger_value(log) == ""

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -517,6 +517,8 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         )
         if fmt == "csv":
             return self._build_csv_export(queue, items_qs, scores_by_item, pk)
+        if fmt == "xlsx":
+            return self._build_xlsx_export(queue, items_qs, scores_by_item, pk)
 
         return self._gm.success_response(result)
 
@@ -912,6 +914,210 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         safe_pk = quote(str(pk), safe="")
         response["Content-Disposition"] = (
             f'attachment; filename="queue_{safe_pk}_annotations.csv"'
+        )
+        return response
+
+    def _build_xlsx_export(self, queue, items_qs, scores_by_item, pk):
+        """XLSX export with merged two-row headers — row 1 is the group
+        title (Call details, Metrics, Evals, <label>, <label> Notes…),
+        row 2 is the column name under each group, data starts row 3.
+        """
+        import io
+        from urllib.parse import quote
+
+        from django.http import HttpResponse
+        from openpyxl import Workbook
+        from openpyxl.styles import Alignment, Font, PatternFill
+        from openpyxl.utils import get_column_letter
+
+        data = self._build_export_data(queue, items_qs, scores_by_item)
+        users = data["users"]
+        labels = data["labels"]
+        eval_names = data["eval_names"]
+        metric_columns = data["metric_columns"]
+        rows = data["rows"]
+
+        annotator_display = [
+            getattr(u, "name", None) or getattr(u, "email", None) or str(u.id)
+            for u in users
+        ]
+        n_users = len(users)
+        n_call_cols = len(self._CALL_DETAIL_COLUMNS)
+        n_metrics = len(metric_columns)
+        n_evals = len(eval_names)
+
+        wb = Workbook()
+        ws = wb.active
+        ws.title = "Annotations"
+
+        # ---- row 1: group headers ----
+        cursor = 1
+        ws.cell(row=1, column=cursor, value="Call details")
+        if n_call_cols > 1:
+            ws.merge_cells(
+                start_row=1,
+                start_column=cursor,
+                end_row=1,
+                end_column=cursor + n_call_cols - 1,
+            )
+        cursor += n_call_cols
+
+        if n_metrics > 0:
+            ws.cell(row=1, column=cursor, value="Metrics")
+            if n_metrics > 1:
+                ws.merge_cells(
+                    start_row=1,
+                    start_column=cursor,
+                    end_row=1,
+                    end_column=cursor + n_metrics - 1,
+                )
+            cursor += n_metrics
+
+        if n_evals > 0:
+            ws.cell(row=1, column=cursor, value="Evals")
+            if n_evals > 1:
+                ws.merge_cells(
+                    start_row=1,
+                    start_column=cursor,
+                    end_row=1,
+                    end_column=cursor + n_evals - 1,
+                )
+            cursor += n_evals
+
+        notes_group_starts = []
+        for label in labels:
+            type_label = (
+                str(label.type).replace("_", " ").title() if label.type else ""
+            )
+            group_title = (
+                f"{label.name} ({type_label})" if type_label else label.name
+            )
+            ws.cell(row=1, column=cursor, value=group_title)
+            if n_users > 1:
+                ws.merge_cells(
+                    start_row=1,
+                    start_column=cursor,
+                    end_row=1,
+                    end_column=cursor + n_users - 1,
+                )
+            cursor += n_users
+            notes_group_starts.append(cursor)
+            ws.cell(row=1, column=cursor, value=f"{label.name} Notes")
+            if n_users > 1:
+                ws.merge_cells(
+                    start_row=1,
+                    start_column=cursor,
+                    end_row=1,
+                    end_column=cursor + n_users - 1,
+                )
+            cursor += n_users
+
+        last_col = max(cursor - 1, n_call_cols)
+
+        # ---- row 2: column names ----
+        col2 = 1
+        for header, _ in self._CALL_DETAIL_COLUMNS:
+            ws.cell(row=2, column=col2, value=header)
+            col2 += 1
+        for metric in metric_columns:
+            ws.cell(row=2, column=col2, value=metric)
+            col2 += 1
+        for eval_name in eval_names:
+            ws.cell(row=2, column=col2, value=eval_name)
+            col2 += 1
+        for _ in labels:
+            for name in annotator_display:
+                ws.cell(row=2, column=col2, value=name)
+                col2 += 1
+            for name in annotator_display:
+                ws.cell(row=2, column=col2, value=name)
+                col2 += 1
+
+        # ---- header styling ----
+        header_font = Font(bold=True)
+        header_align = Alignment(
+            horizontal="center", vertical="center", wrap_text=True
+        )
+        group_fill = PatternFill(
+            fill_type="solid", start_color="E8EAF6", end_color="E8EAF6"
+        )
+        sub_fill = PatternFill(
+            fill_type="solid", start_color="F5F5F5", end_color="F5F5F5"
+        )
+        for col_idx in range(1, last_col + 1):
+            top = ws.cell(row=1, column=col_idx)
+            top.font = header_font
+            top.alignment = header_align
+            top.fill = group_fill
+            sub = ws.cell(row=2, column=col_idx)
+            sub.font = header_font
+            sub.alignment = header_align
+            sub.fill = sub_fill
+
+        # ---- data rows ----
+        user_ids = [u.id for u in users]
+        label_ids = [label.id for label in labels]
+        for ri, row in enumerate(rows, start=3):
+            ci = 1
+            for _, key in self._CALL_DETAIL_COLUMNS:
+                ws.cell(row=ri, column=ci, value=row[key])
+                ci += 1
+            for metric in metric_columns:
+                ws.cell(
+                    row=ri,
+                    column=ci,
+                    value=row["system_metrics"].get(metric, ""),
+                )
+                ci += 1
+            for eval_name in eval_names:
+                ws.cell(
+                    row=ri,
+                    column=ci,
+                    value=row["eval_values"].get(eval_name, ""),
+                )
+                ci += 1
+            for label_id in label_ids:
+                for user_id in user_ids:
+                    ws.cell(
+                        row=ri,
+                        column=ci,
+                        value=row["label_values"][label_id][user_id],
+                    )
+                    ci += 1
+                for user_id in user_ids:
+                    ws.cell(
+                        row=ri,
+                        column=ci,
+                        value=row["label_notes"][label_id][user_id],
+                    )
+                    ci += 1
+
+        # ---- column widths + freeze panes ----
+        for col_idx in range(1, last_col + 1):
+            ws.column_dimensions[get_column_letter(col_idx)].width = 18
+        # Recording Link is at column 3 in _CALL_DETAIL_COLUMNS — wider for URLs.
+        ws.column_dimensions[get_column_letter(3)].width = 48
+        # Per-label notes groups carry free-text — wider than value cells.
+        for start in notes_group_starts:
+            for offset in range(n_users):
+                ws.column_dimensions[
+                    get_column_letter(start + offset)
+                ].width = 40
+        ws.freeze_panes = "A3"
+
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+
+        response = HttpResponse(
+            buf.read(),
+            content_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        )
+        safe_pk = quote(str(pk), safe="")
+        response["Content-Disposition"] = (
+            f'attachment; filename="queue_{safe_pk}_annotations.xlsx"'
         )
         return response
 

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -1226,7 +1226,12 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
     @action(detail=True, methods=["post"], url_path="export-to-dataset")
     def export_to_dataset(self, request, pk=None):
-        """Export annotated items to a dataset with columns and cells."""
+        """Export annotated items to a dataset with columns and cells.
+
+        Column structure mirrors the CSV/XLSX export: source details,
+        system metrics, eval values, and per-(label, annotator) value +
+        notes columns — all flat, no merged headers.
+        """
         from model_hub.models.choices import (
             AnnotationTypeChoices,
             DataTypeChoices,
@@ -1271,15 +1276,8 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 user=request.user,
             )
 
-        # Filter items with select_related to avoid N+1 on source FK lookups
-        items_qs = QueueItem.objects.filter(queue=queue, deleted=False).select_related(
-            "trace",
-            "observation_span",
-            "dataset_row",
-            "prototype_run",
-            "call_execution",
-            "trace_session",
-        )
+        # Filter items
+        items_qs = QueueItem.objects.filter(queue=queue, deleted=False)
         if status_filter:
             items_qs = items_qs.filter(status=status_filter)
 
@@ -1301,17 +1299,50 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         for score in all_scores:
             scores_by_item.setdefault(score.queue_item_id, []).append(score)
 
-        # --- Collect unique annotation labels ---
-        label_map = {}  # label_name -> label_type
-        for scores in scores_by_item.values():
-            for score in scores:
-                label_name = score.label.name if score.label else str(score.label_id)
-                label_type = score.label.type if score.label else "text"
-                label_map[label_name] = label_type
+        # Build enriched export data — reuses all CSV/XLSX helpers
+        export_data = self._build_export_data(queue, items_qs, scores_by_item)
+        users = export_data["users"]
+        labels = export_data["labels"]
+        eval_names = export_data["eval_names"]
+        metric_columns = export_data["metric_columns"]
+        rows = export_data["rows"]
 
-        # --- Define and reuse/create columns ---
-        fixed_columns_def = [
+        # Slug maps: label_id -> slug, user_id -> slug  (mirrors CSV header logic)
+        label_slugs = {
+            label.id: self._slugify_for_header(label.name) for label in labels
+        }
+        user_slugs = {
+            u.id: self._slugify_for_header(
+                getattr(u, "name", None) or getattr(u, "email", None) or str(u.id)
+            )
+            for u in users
+        }
+
+        # --- Column definitions ---
+        # (col_name, data_type, source)
+        col_defs = [
+            # Source detail columns (parallel to CALL_DETAIL_COLUMNS)
+            ("source_id", "text", SourceChoices.OTHERS.value),
             ("source_type", "text", SourceChoices.OTHERS.value),
+            ("recording_link", "text", SourceChoices.OTHERS.value),
+            ("status", "text", SourceChoices.OTHERS.value),
+            ("created_at", "text", SourceChoices.OTHERS.value),
+            # System metric columns
+            *[(mc, "text", SourceChoices.OTHERS.value) for mc in metric_columns],
+            # Eval value columns
+            *[(f"eval_{self._slugify_for_header(name)}", "text", SourceChoices.OTHERS.value) for name in eval_names],
+            # Per-label per-annotator value + notes columns
+            *[
+                (f"{label_slugs[label.id]}_{user_slugs[u.id]}", "text", SourceChoices.ANNOTATION_LABEL.value)
+                for label in labels
+                for u in users
+            ],
+            *[
+                (f"{label_slugs[label.id]}_notes_{user_slugs[u.id]}", "text", SourceChoices.ANNOTATION_LABEL.value)
+                for label in labels
+                for u in users
+            ],
+            # Legacy input/output (preserved from original)
             ("input", "text", SourceChoices.OTHERS.value),
             ("output", "text", SourceChoices.OTHERS.value),
         ]
@@ -1323,8 +1354,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
         columns = {}  # name -> Column instance
         new_columns = []
-
-        for col_name, data_type, source in fixed_columns_def:
+        for col_name, data_type, source in col_defs:
             if col_name in existing_columns:
                 columns[col_name] = existing_columns[col_name]
             else:
@@ -1337,21 +1367,6 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 )
                 new_columns.append(col)
                 columns[col_name] = col
-
-        for label_name, label_type in label_map.items():
-            data_type = LABEL_TYPE_TO_DATA_TYPE.get(label_type, "text")
-            if label_name in existing_columns:
-                columns[label_name] = existing_columns[label_name]
-            else:
-                col = Column(
-                    name=label_name,
-                    data_type=data_type,
-                    source=SourceChoices.ANNOTATION_LABEL.value,
-                    dataset=dataset,
-                    status=StatusType.COMPLETED.value,
-                )
-                new_columns.append(col)
-                columns[label_name] = col
 
         if new_columns:
             Column.objects.bulk_create(new_columns)
@@ -1370,18 +1385,17 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
         # --- Create Rows (metadata preserved for auditability) ---
         items_list = list(items_qs.order_by("order"))
-        rows_to_create = []
-        for i, item in enumerate(items_list):
-            rows_to_create.append(
-                Row(
-                    dataset=dataset,
-                    order=max_order + i + 1,
-                    metadata={
-                        "queue_id": str(queue.id),
-                        "queue_item_id": str(item.id),
-                    },
-                )
+        rows_to_create = [
+            Row(
+                dataset=dataset,
+                order=max_order + i + 1,
+                metadata={
+                    "queue_id": str(queue.id),
+                    "queue_item_id": str(item.id),
+                },
             )
+            for i, item in enumerate(items_list)
+        ]
 
         if rows_to_create:
             Row.objects.bulk_create(rows_to_create, batch_size=500)
@@ -1394,73 +1408,83 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 return val
             return json.dumps(val, default=str)
 
-        def _extract_input_output(content):
+        def _extract_input_output(item):
+            content = resolve_source_content(item)
             source_type = content.get("type", "")
             if source_type == "dataset_row":
                 fields = content.get("fields", {})
-                return _to_cell_str(fields.get("input", "")), _to_cell_str(
-                    fields.get("output", "")
+                return (
+                    _to_cell_str(fields.get("input", "")),
+                    _to_cell_str(fields.get("output", "")),
                 )
             elif source_type == "prototype_run":
-                return _to_cell_str(content.get("prompt")), _to_cell_str(
-                    content.get("response")
+                return (
+                    _to_cell_str(content.get("prompt")),
+                    _to_cell_str(content.get("response")),
                 )
-            else:
-                return _to_cell_str(content.get("input")), _to_cell_str(
-                    content.get("output")
-                )
+            return (
+                _to_cell_str(content.get("input", "")),
+                _to_cell_str(content.get("output", "")),
+            )
 
         cells_to_create = []
-        for row, item in zip(rows_to_create, items_list):
-            # source_type cell
-            cells_to_create.append(
-                Cell(
-                    dataset=dataset,
-                    row=row,
-                    column=columns["source_type"],
-                    value=item.source_type or "",
-                )
-            )
+        for row, item, row_data in zip(rows_to_create, items_list, rows):
+            # Source detail cells
+            cells_to_create.extend([
+                Cell(dataset=dataset, row=row, column=columns["source_id"],
+                     value=row_data.get("source_id", "")),
+                Cell(dataset=dataset, row=row, column=columns["source_type"],
+                     value=row_data.get("source_type", "")),
+                Cell(dataset=dataset, row=row, column=columns["recording_link"],
+                     value=row_data.get("recording_link", "")),
+                Cell(dataset=dataset, row=row, column=columns["status"],
+                     value=row_data.get("status", "")),
+                Cell(dataset=dataset, row=row, column=columns["created_at"],
+                     value=row_data.get("created_at", "")),
+            ])
 
-            # input/output cells
-            content = resolve_source_content(item)
-            input_val, output_val = _extract_input_output(content)
-            cells_to_create.append(
-                Cell(
-                    dataset=dataset,
-                    row=row,
-                    column=columns["input"],
-                    value=input_val,
+            # System metric cells
+            for mc in metric_columns:
+                cells_to_create.append(
+                    Cell(dataset=dataset, row=row, column=columns[mc],
+                         value=row_data.get("system_metrics", {}).get(mc, ""))
                 )
-            )
-            cells_to_create.append(
-                Cell(
-                    dataset=dataset,
-                    row=row,
-                    column=columns["output"],
-                    value=output_val,
+
+            # Eval value cells
+            for name in eval_names:
+                col_name = f"eval_{self._slugify_for_header(name)}"
+                cells_to_create.append(
+                    Cell(dataset=dataset, row=row, column=columns[col_name],
+                         value=row_data.get("eval_values", {}).get(name, ""))
                 )
-            )
 
-            # Label cells — use first annotator's value
-            item_scores = scores_by_item.get(item.id, [])
-            label_first_value = {}
-            for score in item_scores:
-                label_name = score.label.name if score.label else str(score.label_id)
-                if label_name not in label_first_value:
-                    label_first_value[label_name] = score.value
-
-            for label_name in label_map:
-                if label_name in columns:
-                    value = label_first_value.get(label_name, "")
-                    cells_to_create.append(
+            # Per-label per-annotator value + notes cells
+            for label in labels:
+                label_id = label.id
+                lslug = label_slugs[label_id]
+                lv = row_data.get("label_values", {}).get(label_id, {})
+                ln = row_data.get("label_notes", {}).get(label_id, {})
+                for u in users:
+                    uslug = user_slugs[u.id]
+                    cells_to_create.extend([
                         Cell(
-                            dataset=dataset,
-                            row=row,
-                            column=columns[label_name],
-                            value=_to_cell_str(value),
-                        )
-                    )
+                            dataset=dataset, row=row,
+                            column=columns[f"{lslug}_{uslug}"],
+                            value=lv.get(u.id, ""),
+                        ),
+                        Cell(
+                            dataset=dataset, row=row,
+                            column=columns[f"{lslug}_notes_{uslug}"],
+                            value=ln.get(u.id, ""),
+                        ),
+                    ])
+
+            # input/output (legacy, from resolve_source_content)
+            input_val, output_val = _extract_input_output(item)
+            cells_to_create.extend([
+                Cell(dataset=dataset, row=row, column=columns["input"], value=input_val),
+                Cell(dataset=dataset, row=row, column=columns["output"], value=output_val),
+            ])
 
         if cells_to_create:
             Cell.objects.bulk_create(cells_to_create, batch_size=500)
@@ -1470,12 +1494,11 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             pre_existing_rows = Row.objects.filter(
                 dataset=dataset, deleted=False
             ).exclude(id__in=[r.id for r in rows_to_create])
-            backfill_cells = []
-            for row in pre_existing_rows:
-                for col in new_columns:
-                    backfill_cells.append(
-                        Cell(dataset=dataset, row=row, column=col, value="")
-                    )
+            backfill_cells = [
+                Cell(dataset=dataset, row=row, column=col, value="")
+                for row in pre_existing_rows
+                for col in new_columns
+            ]
             if backfill_cells:
                 Cell.objects.bulk_create(backfill_cells, batch_size=500)
 

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -534,14 +534,8 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
     @staticmethod
     def _flatten_score_value(value):
-        """Extract the display scalar from a Score.value JSON blob.
-
-        Score.value is a JSONField stored with a conventional wrapper:
-        ``{"rating": 3}`` for star/numeric, ``{"value": "yes"}`` for
-        bool/short-string, ``{"text": "..."}`` for free text,
-        ``{"selected": ["a", "b"]}`` for multi-select. Spreadsheet cells
-        should show the inner scalar (``3`` / ``"yes"`` / ``"a, b"``)
-        rather than the dict literal.
+        """Unwrap Score.value's conventional JSON wrapper to the inner
+        scalar (`rating` / `value` / `text` / joined `selected`).
         """
         if value is None:
             return ""
@@ -558,9 +552,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         selected = value.get("selected")
         if isinstance(selected, list):
             return ", ".join(str(v) for v in selected)
-        # Unknown shape — fall back to a stable string so the cell isn't a
-        # raw dict (openpyxl can't store dicts), but flag it for the
-        # reader to investigate.
+        # Unknown shape — emit JSON so data isn't lost.
         import json
 
         try:
@@ -568,23 +560,9 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         except (TypeError, ValueError):
             return str(value)
 
-    # Layout: one row per QueueItem.
-    #   Call details (7 cols) | <label1> values | <label1> notes | … |
-    #   <labelN> values | <labelN> notes
-    # For each label, two adjacent groups: the values group (one column
-    # per annotator with their score) and the notes group (one column
-    # per annotator with that annotator's note for THIS label, since
-    # Score.notes is per-(annotator, label, item)). Values and notes for
-    # the same label sit next to each other so filters/comparisons stay
-    # local to the label.
-    # XLSX exposes this with merged group headers across row 1; CSV
-    # collapses each group into "<label>_<annotator>" /
-    # "<label>_notes_<annotator>" composite header names so both shapes
-    # describe the same data.
-    # Eval / system-metric columns (the "metrics" middle section of the
-    # UI mock) are deferred — they need cross-model traversal and
-    # column-set stability that's a separate pass.
-
+    # One row per QueueItem. Per label, the values group sits next to its
+    # notes group so filters stay local to the label. Score.notes is
+    # per-(annotator, label, item), so notes are keyed the same as values.
     _CALL_DETAIL_COLUMNS = [
         ("Source ID", "source_id"),
         ("Source Type", "source_type"),
@@ -593,12 +571,9 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         ("Created At", "created_at"),
     ]
 
-    # System-metric columns per source type — only metrics the annotator
-    # UI actually surfaces. For call_execution that's the
-    # VoiceRightPanel ``apiMetrics`` set plus the duration / score /
-    # message_count from the call details bar. For other source types
-    # the annotator UI doesn't show a flat metrics panel, so they
-    # contribute no system-metric columns to the export.
+    # Mirrors what the annotator UI actually shows — VoiceRightPanel
+    # apiMetrics plus the call detail bar. Other source types render a
+    # different UI (no flat metrics panel) so they contribute nothing.
     _SYSTEM_METRICS_BY_SOURCE = {
         "call_execution": [
             "duration_seconds",
@@ -765,17 +740,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         return out
 
     def _build_export_data(self, queue, items_qs, scores_by_item):
-        """Shared shape for CSV + XLSX exports.
-
-        Returns ``{users, labels, eval_names, rows}``:
-          - users: stable annotator list (sorted by name, then email)
-          - labels: queue labels in queue-defined order
-          - eval_names: union of eval names that appear on any item
-            (sorted alphabetically) — drives the Evals column block
-          - rows: per-item dict with call-detail fields,
-            ``label_values`` / ``label_notes`` (label_id → user_id → cell)
-            and ``eval_values`` (eval_name → cell).
-        """
+        """Materialise the rows + column metadata the CSV writer iterates."""
         annotator_qs = (
             queue.queue_annotators.filter(deleted=False)
             .select_related("user")
@@ -871,10 +836,8 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
         eval_names_ordered.sort(key=lambda n: n.lower())
 
-        # Stable ordered list of system-metric columns: every metric across
-        # every known source type, in the order they're declared in
-        # _SYSTEM_METRICS_BY_SOURCE. Cells are populated only for items
-        # whose source_type matches; otherwise empty.
+        # Union of all source-type metrics in declaration order — populated
+        # only on rows whose source_type matches.
         metric_columns = []
         for fields in self._SYSTEM_METRICS_BY_SOURCE.values():
             metric_columns.extend(fields)
@@ -888,10 +851,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         }
 
     def _build_csv_export(self, queue, items_qs, scores_by_item, pk):
-        """Flat CSV mirroring the XLSX layout: label-first nesting, separate
-        Notes group at the end. CSV cannot express merged-cell header groups,
-        so column names use ``<label>_<annotator>`` / ``notes_<annotator>``.
-        """
+        """Flat CSV: composite header names per (label, annotator)."""
         import csv
         import io
         from urllib.parse import quote
@@ -921,8 +881,6 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         ]
 
         headers = [field for _, field in self._CALL_DETAIL_COLUMNS]
-        # System metrics block (one column per metric across all source
-        # types — empty when an item's source_type doesn't carry it).
         for metric in metric_columns:
             headers.append(metric)
         for _, e_slug in eval_slugs:

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -1,5 +1,4 @@
 import json
-import uuid
 from datetime import timedelta
 
 import structlog
@@ -2707,19 +2706,7 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             queue_item=item,
             deleted=False,
         ).select_related("label")
-        # Reviewers/managers can scope the response to a specific annotator
-        # via ?annotator_id=<uuid> so the workspace shows whose annotations
-        # they are currently viewing. Ignored for non-reviewers.
-        raw_annotator_id = request.query_params.get("annotator_id") or None
-        viewing_annotator_id = None
-        if raw_annotator_id and is_reviewer:
-            try:
-                viewing_annotator_id = uuid.UUID(raw_annotator_id)
-            except (ValueError, TypeError):
-                return self._gm.bad_request("Invalid annotator selection.")
-        if viewing_annotator_id:
-            annotations_qs = annotations_qs.filter(annotator_id=viewing_annotator_id)
-        elif not is_reviewer:
+        if not is_reviewer:
             annotations_qs = annotations_qs.filter(annotator=request.user)
         annotations = annotations_qs
 

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -522,9 +522,7 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
         return self._gm.success_response(result)
 
-    # ------------------------------------------------------------------
-    # Export helpers
-    # ------------------------------------------------------------------
+    # ── Export helpers ────────────────────────────────────────────────
 
     @staticmethod
     def _slugify_for_header(text: str) -> str:
@@ -536,13 +534,9 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
     @staticmethod
     def _flatten_score_value(value):
-        """Unwrap Score.value's conventional JSON wrapper to the inner
-        scalar (`rating` / `value` / `text` / joined `selected`). A
-        wrapper key that's present but None doesn't short-circuit — we
-        keep looking so a partially-populated payload still surfaces a
-        useful value. Nested dicts inside a wrapper key are JSONified
-        rather than passed through raw (csv.writer would otherwise emit
-        a Python repr).
+        """Unwrap Score.value's wrapper to a scalar. Skips None inners so
+        a partial payload falls through to the next candidate; nested
+        dicts get JSONified instead of leaking a Python repr into a cell.
         """
         import json
 
@@ -609,9 +603,8 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
     @staticmethod
     def _resolve_recording_link(item) -> str:
-        """Best-effort recording URL — only meaningful for call_execution
-        items. Prefers the canonical top-level fields, then falls back
-        to provider-specific paths in provider_call_data.
+        """Recording URL for call_execution items — top-level fields first,
+        then provider-specific paths inside provider_call_data.
         """
         ce = getattr(item, "call_execution", None)
         if ce is None:
@@ -664,17 +657,8 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
     @classmethod
     def _collect_evals_for_item(cls, item) -> dict:
-        """Return ``{eval_name: scalar_value}`` for a queue item.
-
-        Per source type:
-          - ``call_execution``: flatten ``CallExecution.eval_outputs`` JSON.
-          - ``trace``: ``Trace.eval_logs`` (EvalLogger via FK).
-          - ``observation_span``: ``ObservationSpan.eval_logs``.
-          - ``dataset_row``: per-row Cells where ``column.source`` is
-            ``"evaluation"`` or ``"experiment_evaluation"`` — those columns
-            hold eval results and the cell value is the per-row output.
-          - ``trace_session`` / ``prototype_run``: empty for now — would
-            need cross-trace aggregation or a separate eval mechanism.
+        """Return ``{eval_name: value}`` for a queue item — source-type
+        aware. trace_session / prototype_run are not yet wired up.
         """
         src = item.source_type
         if src == "call_execution":
@@ -688,7 +672,6 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                     continue
                 name = payload.get("name") or str(eval_id)
                 value = payload.get("output")
-                # Last-write-wins if multiple outputs share a name.
                 out[name] = "" if value is None else value
             return out
 
@@ -696,19 +679,20 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             row = getattr(item, "dataset_row", None)
             if row is None:
                 return {}
-            # `eval_cells` is attached by _build_export_data's Prefetch.
+            # eval_cells / active_eval_logs are attached by the Prefetches
+            # in _build_export_data; reading them avoids re-firing the query.
             eval_cells = getattr(row, "eval_cells", None) or []
             out = {}
             for cell in eval_cells:
                 col = cell.column
                 if col is None:
                     continue
-                name = col.name or str(col.id)
-                # Last-write-wins if multiple cells share a column name.
-                out[name] = "" if cell.value is None else cell.value
+                # Last-write-wins on duplicate column names.
+                out[col.name or str(col.id)] = (
+                    "" if cell.value is None else cell.value
+                )
             return out
 
-        # `active_eval_logs` is attached by _build_export_data's Prefetch.
         eval_logs = None
         if src == "trace":
             trace = getattr(item, "trace", None)
@@ -728,14 +712,13 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
 
     @classmethod
     def _collect_system_metrics_for_item(cls, item) -> dict:
-        """Return ``{field_name: value}`` for system metrics that live on
-        the item's linked source object. Empty dict when the item's
-        source_type has no metric mapping or its FK target is missing.
+        """Return ``{field: value}`` from the item's linked source object,
+        or ``{}`` if its source_type has no metric mapping.
         """
         fields = cls._SYSTEM_METRICS_BY_SOURCE.get(item.source_type, [])
         if not fields:
             return {}
-        # source_type matches the attribute name on QueueItem.
+        # source_type matches the QueueItem attribute holding the FK.
         source_obj = getattr(item, item.source_type, None)
         if source_obj is None:
             return {}
@@ -768,12 +751,9 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         )
         labels = [ql.label for ql in queue_labels if ql.label is not None]
 
-        # Pre-fetch FK-linked source objects and their eval children so the
-        # per-item loop below doesn't fan out into N+1 queries. The Prefetch
-        # objects with to_attr= matter: _collect_evals_for_item reads the
-        # cached attributes directly (active_eval_logs / eval_cells) — using
-        # the default related-manager would re-issue the filter and waste
-        # the prefetch.
+        # to_attr matters: _collect_evals_for_item reads the cached
+        # attributes directly. Without it, accessing the related manager
+        # re-issues the filter and discards the prefetch.
         from django.db.models import Prefetch
 
         from model_hub.models.develop_dataset import Cell
@@ -955,9 +935,8 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         return response
 
     def _build_xlsx_export(self, queue, items_qs, scores_by_item, pk):
-        """XLSX export with merged two-row headers — row 1 is the group
-        title (Call details, Metrics, Evals, <label>, <label> Notes…),
-        row 2 is the column name under each group, data starts row 3.
+        """Same data as CSV, with merged group titles in row 1 above the
+        sub-column names in row 2. Data starts row 3.
         """
         import io
         from urllib.parse import quote
@@ -1129,12 +1108,10 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                     )
                     ci += 1
 
-        # ---- column widths + freeze panes ----
+        # column widths + freeze panes — wider for URL and notes cells
         for col_idx in range(1, last_col + 1):
             ws.column_dimensions[get_column_letter(col_idx)].width = 18
-        # Recording Link is at column 3 in _CALL_DETAIL_COLUMNS — wider for URLs.
-        ws.column_dimensions[get_column_letter(3)].width = 48
-        # Per-label notes groups carry free-text — wider than value cells.
+        ws.column_dimensions[get_column_letter(3)].width = 48  # Recording Link
         for start in notes_group_starts:
             for offset in range(n_users):
                 ws.column_dimensions[

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from datetime import timedelta
 
 import structlog
@@ -515,75 +516,446 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             "export_format", request.query_params.get("format", "json")
         )
         if fmt == "csv":
-            import csv
-            import io
-
-            from django.http import HttpResponse
-
-            output = io.StringIO()
-            writer = csv.writer(output)
-            writer.writerow(
-                [
-                    "item_id",
-                    "source_type",
-                    "status",
-                    "order",
-                    "label_id",
-                    "label_name",
-                    "value",
-                    "score_source",
-                    "notes",
-                    "annotator_name",
-                    "created_at",
-                ]
-            )
-            for item_data in result:
-                if not item_data["annotations"]:
-                    writer.writerow(
-                        [
-                            item_data["item_id"],
-                            item_data["source_type"],
-                            item_data["status"],
-                            item_data["order"],
-                            "",
-                            "",
-                            "",
-                            "",
-                            "",
-                            "",
-                            "",
-                        ]
-                    )
-                for ann in item_data["annotations"]:
-                    writer.writerow(
-                        [
-                            item_data["item_id"],
-                            item_data["source_type"],
-                            item_data["status"],
-                            item_data["order"],
-                            ann["label_id"],
-                            ann["label_name"],
-                            (
-                                ann["value"]
-                                if not isinstance(ann["value"], dict)
-                                else str(ann["value"])
-                            ),
-                            ann["score_source"],
-                            ann["notes"] or "",
-                            ann["annotator_name"],
-                            ann["created_at"],
-                        ]
-                    )
-            from urllib.parse import quote
-
-            response = HttpResponse(output.getvalue(), content_type="text/csv")
-            safe_pk = quote(str(pk), safe="")
-            response["Content-Disposition"] = (
-                f'attachment; filename="queue_{safe_pk}_annotations.csv"'
-            )
-            return response
+            return self._build_csv_export(queue, items_qs, scores_by_item, pk)
 
         return self._gm.success_response(result)
+
+    # ------------------------------------------------------------------
+    # Export helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _slugify_for_header(text: str) -> str:
+        """Produce a snake_case-safe header fragment from a free-text name."""
+        import re
+
+        s = re.sub(r"[^a-z0-9]+", "_", str(text or "").lower()).strip("_")
+        return s or "unknown"
+
+    @staticmethod
+    def _flatten_score_value(value):
+        """Extract the display scalar from a Score.value JSON blob.
+
+        Score.value is a JSONField stored with a conventional wrapper:
+        ``{"rating": 3}`` for star/numeric, ``{"value": "yes"}`` for
+        bool/short-string, ``{"text": "..."}`` for free text,
+        ``{"selected": ["a", "b"]}`` for multi-select. Spreadsheet cells
+        should show the inner scalar (``3`` / ``"yes"`` / ``"a, b"``)
+        rather than the dict literal.
+        """
+        if value is None:
+            return ""
+        if not isinstance(value, dict):
+            if isinstance(value, list):
+                return ", ".join(str(v) for v in value)
+            return value
+        for key in ("rating", "value", "text"):
+            if key in value:
+                inner = value[key]
+                if isinstance(inner, list):
+                    return ", ".join(str(v) for v in inner)
+                return "" if inner is None else inner
+        selected = value.get("selected")
+        if isinstance(selected, list):
+            return ", ".join(str(v) for v in selected)
+        # Unknown shape — fall back to a stable string so the cell isn't a
+        # raw dict (openpyxl can't store dicts), but flag it for the
+        # reader to investigate.
+        import json
+
+        try:
+            return json.dumps(value, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(value)
+
+    # Layout: one row per QueueItem.
+    #   Call details (7 cols) | <label1> values | <label1> notes | … |
+    #   <labelN> values | <labelN> notes
+    # For each label, two adjacent groups: the values group (one column
+    # per annotator with their score) and the notes group (one column
+    # per annotator with that annotator's note for THIS label, since
+    # Score.notes is per-(annotator, label, item)). Values and notes for
+    # the same label sit next to each other so filters/comparisons stay
+    # local to the label.
+    # XLSX exposes this with merged group headers across row 1; CSV
+    # collapses each group into "<label>_<annotator>" /
+    # "<label>_notes_<annotator>" composite header names so both shapes
+    # describe the same data.
+    # Eval / system-metric columns (the "metrics" middle section of the
+    # UI mock) are deferred — they need cross-model traversal and
+    # column-set stability that's a separate pass.
+
+    _CALL_DETAIL_COLUMNS = [
+        ("Source ID", "source_id"),
+        ("Source Type", "source_type"),
+        ("Recording Link", "recording_link"),
+        ("Status", "status"),
+        ("Created At", "created_at"),
+    ]
+
+    # System-metric columns per source type — only metrics the annotator
+    # UI actually surfaces. For call_execution that's the
+    # VoiceRightPanel ``apiMetrics`` set plus the duration / score /
+    # message_count from the call details bar. For other source types
+    # the annotator UI doesn't show a flat metrics panel, so they
+    # contribute no system-metric columns to the export.
+    _SYSTEM_METRICS_BY_SOURCE = {
+        "call_execution": [
+            "duration_seconds",
+            "message_count",
+            "overall_score",
+            "talk_ratio",
+            "avg_agent_latency_ms",
+            "user_wpm",
+            "bot_wpm",
+            "user_interruption_count",
+            "ai_interruption_count",
+        ],
+    }
+
+    # ── Source-aware helpers ──────────────────────────────────────────
+
+    @staticmethod
+    def _resolve_recording_link(item) -> str:
+        """Best-effort recording URL — only meaningful for call_execution
+        items. Tries known provider paths inside provider_call_data and
+        falls back to customer_log_url.
+        """
+        ce = getattr(item, "call_execution", None)
+        if ce is None:
+            return ""
+        log_url = getattr(ce, "customer_log_url", None)
+        if isinstance(log_url, str) and log_url:
+            return log_url
+        pcd = getattr(ce, "provider_call_data", None) or {}
+        if not isinstance(pcd, dict):
+            return ""
+        candidate_paths = (
+            ("vapi", "artifact", "recordingUrl"),
+            ("vapi", "artifact", "recording_url"),
+            ("vapi", "recording_url"),
+            ("livekit", "recording_url"),
+            ("retell", "recording_url"),
+        )
+        for path in candidate_paths:
+            node = pcd
+            for key in path:
+                if not isinstance(node, dict):
+                    node = None
+                    break
+                node = node.get(key)
+            if isinstance(node, str) and node:
+                return node
+        return ""
+
+    @staticmethod
+    def _eval_logger_value(el):
+        """Pick the populated output field from an EvalLogger row."""
+        if el.output_float is not None:
+            return el.output_float
+        if el.output_bool is not None:
+            return el.output_bool
+        if el.output_str:
+            return el.output_str
+        if el.output_str_list:
+            return ", ".join(str(x) for x in el.output_str_list)
+        return ""
+
+    @classmethod
+    def _eval_logger_name(cls, el) -> str:
+        """Display name for an EvalLogger row — prefers custom config name."""
+        cfg = getattr(el, "custom_eval_config", None)
+        if cfg is not None and getattr(cfg, "name", None):
+            return cfg.name
+        return el.eval_type_id or "<unnamed eval>"
+
+    @classmethod
+    def _collect_evals_for_item(cls, item) -> dict:
+        """Return ``{eval_name: scalar_value}`` for a queue item.
+
+        Per source type:
+          - ``call_execution``: flatten ``CallExecution.eval_outputs`` JSON.
+          - ``trace``: ``Trace.eval_logs`` (EvalLogger via FK).
+          - ``observation_span``: ``ObservationSpan.eval_logs``.
+          - ``dataset_row``: per-row Cells where ``column.source`` is
+            ``"evaluation"`` or ``"experiment_evaluation"`` — those columns
+            hold eval results and the cell value is the per-row output.
+          - ``trace_session`` / ``prototype_run``: empty for now — would
+            need cross-trace aggregation or a separate eval mechanism.
+        """
+        src = item.source_type
+        if src == "call_execution":
+            ce = getattr(item, "call_execution", None)
+            outputs = getattr(ce, "eval_outputs", None) if ce is not None else None
+            if not isinstance(outputs, dict):
+                return {}
+            out = {}
+            for eval_id, payload in outputs.items():
+                if not isinstance(payload, dict):
+                    continue
+                name = payload.get("name") or str(eval_id)
+                value = payload.get("output")
+                # Last-write-wins if multiple outputs share a name.
+                out[name] = "" if value is None else value
+            return out
+
+        if src == "dataset_row":
+            row = getattr(item, "dataset_row", None)
+            if row is None:
+                return {}
+            from model_hub.models.develop_dataset import Cell
+
+            eval_cells = (
+                Cell.objects.filter(
+                    row=row,
+                    column__source__in=("evaluation", "experiment_evaluation"),
+                    deleted=False,
+                )
+                .select_related("column")
+                .order_by("column__name", "created_at")
+            )
+            out = {}
+            for cell in eval_cells:
+                col = cell.column
+                if col is None:
+                    continue
+                name = col.name or str(col.id)
+                # Last-write-wins if multiple cells share a column name.
+                out[name] = "" if cell.value is None else cell.value
+            return out
+
+        eval_logs = None
+        if src == "trace":
+            trace = getattr(item, "trace", None)
+            if trace is not None:
+                eval_logs = trace.eval_logs.filter(deleted=False).select_related(
+                    "custom_eval_config"
+                )
+        elif src == "observation_span":
+            span = getattr(item, "observation_span", None)
+            if span is not None:
+                eval_logs = span.eval_logs.filter(deleted=False).select_related(
+                    "custom_eval_config"
+                )
+        if eval_logs is None:
+            return {}
+
+        out = {}
+        for el in eval_logs:
+            out[cls._eval_logger_name(el)] = cls._eval_logger_value(el)
+        return out
+
+    @classmethod
+    def _collect_system_metrics_for_item(cls, item) -> dict:
+        """Return ``{field_name: value}`` for system metrics that live on
+        the item's linked source object. Empty dict when the item's
+        source_type has no metric mapping or its FK target is missing.
+        """
+        fields = cls._SYSTEM_METRICS_BY_SOURCE.get(item.source_type, [])
+        if not fields:
+            return {}
+        # source_type matches the attribute name on QueueItem.
+        source_obj = getattr(item, item.source_type, None)
+        if source_obj is None:
+            return {}
+        out = {}
+        for field in fields:
+            value = getattr(source_obj, field, None)
+            out[field] = "" if value is None else value
+        return out
+
+    def _build_export_data(self, queue, items_qs, scores_by_item):
+        """Shared shape for CSV + XLSX exports.
+
+        Returns ``{users, labels, eval_names, rows}``:
+          - users: stable annotator list (sorted by name, then email)
+          - labels: queue labels in queue-defined order
+          - eval_names: union of eval names that appear on any item
+            (sorted alphabetically) — drives the Evals column block
+          - rows: per-item dict with call-detail fields,
+            ``label_values`` / ``label_notes`` (label_id → user_id → cell)
+            and ``eval_values`` (eval_name → cell).
+        """
+        annotator_qs = (
+            queue.queue_annotators.filter(deleted=False)
+            .select_related("user")
+            .order_by("user__name", "user__email", "user_id")
+        )
+        seen_user_ids = set()
+        users = []
+        for qa in annotator_qs:
+            user = qa.user
+            if user is None or user.id in seen_user_ids:
+                continue
+            seen_user_ids.add(user.id)
+            users.append(user)
+
+        queue_labels = list(
+            queue.queue_labels.filter(deleted=False)
+            .select_related("label")
+            .order_by("order", "id")
+        )
+        labels = [ql.label for ql in queue_labels if ql.label is not None]
+
+        # Pre-fetch FK-linked source objects and their eval children so the
+        # per-item loop below doesn't fan out into N+1 queries.
+        items_qs = items_qs.select_related(
+            "trace",
+            "trace__project",
+            "observation_span",
+            "trace_session",
+            "call_execution",
+            "dataset_row",
+            "prototype_run",
+        ).prefetch_related(
+            "trace__eval_logs__custom_eval_config",
+            "observation_span__eval_logs__custom_eval_config",
+        )
+
+        rows = []
+        eval_names_seen = set()
+        eval_names_ordered = []
+
+        for item in items_qs:
+            source_id = (
+                getattr(item, "trace_id", None)
+                or getattr(item, "call_execution_id", None)
+                or getattr(item, "dataset_row_id", None)
+                or getattr(item, "trace_session_id", None)
+                or getattr(item, "observation_span_id", None)
+                or getattr(item, "prototype_run_id", None)
+            )
+
+            score_map = {}
+            for s in scores_by_item.get(item.id, []):
+                score_map[(s.annotator_id, s.label_id)] = s
+
+            label_values = {label.id: {} for label in labels}
+            label_notes = {label.id: {} for label in labels}
+
+            for label in labels:
+                for u in users:
+                    s = score_map.get((u.id, label.id))
+                    if s is None:
+                        label_values[label.id][u.id] = ""
+                        label_notes[label.id][u.id] = ""
+                        continue
+                    label_values[label.id][u.id] = self._flatten_score_value(
+                        s.value
+                    )
+                    label_notes[label.id][u.id] = s.notes or ""
+
+            eval_values = self._collect_evals_for_item(item)
+            for name in eval_values:
+                if name not in eval_names_seen:
+                    eval_names_seen.add(name)
+                    eval_names_ordered.append(name)
+
+            metric_values = self._collect_system_metrics_for_item(item)
+
+            rows.append(
+                {
+                    "source_id": str(source_id) if source_id else "",
+                    "source_type": item.source_type,
+                    "recording_link": self._resolve_recording_link(item),
+                    "status": item.status,
+                    "created_at": (
+                        item.created_at.isoformat() if item.created_at else ""
+                    ),
+                    "label_values": label_values,
+                    "label_notes": label_notes,
+                    "eval_values": eval_values,
+                    "system_metrics": metric_values,
+                }
+            )
+
+        eval_names_ordered.sort(key=lambda n: n.lower())
+
+        # Stable ordered list of system-metric columns: every metric across
+        # every known source type, in the order they're declared in
+        # _SYSTEM_METRICS_BY_SOURCE. Cells are populated only for items
+        # whose source_type matches; otherwise empty.
+        metric_columns = []
+        for fields in self._SYSTEM_METRICS_BY_SOURCE.values():
+            metric_columns.extend(fields)
+
+        return {
+            "users": users,
+            "labels": labels,
+            "eval_names": eval_names_ordered,
+            "metric_columns": metric_columns,
+            "rows": rows,
+        }
+
+    def _build_csv_export(self, queue, items_qs, scores_by_item, pk):
+        """Flat CSV mirroring the XLSX layout: label-first nesting, separate
+        Notes group at the end. CSV cannot express merged-cell header groups,
+        so column names use ``<label>_<annotator>`` / ``notes_<annotator>``.
+        """
+        import csv
+        import io
+        from urllib.parse import quote
+
+        from django.http import HttpResponse
+
+        data = self._build_export_data(queue, items_qs, scores_by_item)
+        users = data["users"]
+        labels = data["labels"]
+        eval_names = data["eval_names"]
+        metric_columns = data["metric_columns"]
+        rows = data["rows"]
+
+        user_slugs = []
+        for u in users:
+            display = (
+                getattr(u, "name", None)
+                or getattr(u, "email", None)
+                or str(u.id)
+            )
+            user_slugs.append((u.id, self._slugify_for_header(display)))
+        label_slugs = [
+            (label.id, self._slugify_for_header(label.name)) for label in labels
+        ]
+        eval_slugs = [
+            (name, self._slugify_for_header(name)) for name in eval_names
+        ]
+
+        headers = [field for _, field in self._CALL_DETAIL_COLUMNS]
+        # System metrics block (one column per metric across all source
+        # types — empty when an item's source_type doesn't carry it).
+        for metric in metric_columns:
+            headers.append(metric)
+        for _, e_slug in eval_slugs:
+            headers.append(f"eval_{e_slug}")
+        for _, l_slug in label_slugs:
+            for _, u_slug in user_slugs:
+                headers.append(f"{l_slug}_{u_slug}")
+            for _, u_slug in user_slugs:
+                headers.append(f"{l_slug}_notes_{u_slug}")
+
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(headers)
+
+        for row in rows:
+            line = [row[field] for _, field in self._CALL_DETAIL_COLUMNS]
+            for metric in metric_columns:
+                line.append(row["system_metrics"].get(metric, ""))
+            for name, _ in eval_slugs:
+                line.append(row["eval_values"].get(name, ""))
+            for label_id, _ in label_slugs:
+                for user_id, _ in user_slugs:
+                    line.append(row["label_values"][label_id][user_id])
+                for user_id, _ in user_slugs:
+                    line.append(row["label_notes"][label_id][user_id])
+            writer.writerow(line)
+
+        response = HttpResponse(output.getvalue(), content_type="text/csv")
+        safe_pk = quote(str(pk), safe="")
+        response["Content-Disposition"] = (
+            f'attachment; filename="queue_{safe_pk}_annotations.csv"'
+        )
+        return response
 
     @action(detail=True, methods=["get"], url_path="analytics")
     def analytics(self, request, pk=None):
@@ -2157,7 +2529,19 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             queue_item=item,
             deleted=False,
         ).select_related("label")
-        if not is_reviewer:
+        # Reviewers/managers can scope the response to a specific annotator
+        # via ?annotator_id=<uuid> so the workspace shows whose annotations
+        # they are currently viewing. Ignored for non-reviewers.
+        raw_annotator_id = request.query_params.get("annotator_id") or None
+        viewing_annotator_id = None
+        if raw_annotator_id and is_reviewer:
+            try:
+                viewing_annotator_id = uuid.UUID(raw_annotator_id)
+            except (ValueError, TypeError):
+                return self._gm.bad_request("Invalid annotator selection.")
+        if viewing_annotator_id:
+            annotations_qs = annotations_qs.filter(annotator_id=viewing_annotator_id)
+        elif not is_reviewer:
             annotations_qs = annotations_qs.filter(annotator=request.user)
         annotations = annotations_qs
 

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -537,8 +537,23 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
     @staticmethod
     def _flatten_score_value(value):
         """Unwrap Score.value's conventional JSON wrapper to the inner
-        scalar (`rating` / `value` / `text` / joined `selected`).
+        scalar (`rating` / `value` / `text` / joined `selected`). A
+        wrapper key that's present but None doesn't short-circuit — we
+        keep looking so a partially-populated payload still surfaces a
+        useful value. Nested dicts inside a wrapper key are JSONified
+        rather than passed through raw (csv.writer would otherwise emit
+        a Python repr).
         """
+        import json
+
+        def _coerce(v):
+            if isinstance(v, dict):
+                try:
+                    return json.dumps(v, ensure_ascii=False)
+                except (TypeError, ValueError):
+                    return str(v)
+            return v
+
         if value is None:
             return ""
         if not isinstance(value, dict):
@@ -546,17 +561,17 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 return ", ".join(str(v) for v in value)
             return value
         for key in ("rating", "value", "text"):
-            if key in value:
-                inner = value[key]
-                if isinstance(inner, list):
-                    return ", ".join(str(v) for v in inner)
-                return "" if inner is None else inner
+            if key not in value:
+                continue
+            inner = value[key]
+            if inner is None:
+                continue
+            if isinstance(inner, list):
+                return ", ".join(str(v) for v in inner)
+            return _coerce(inner)
         selected = value.get("selected")
         if isinstance(selected, list):
             return ", ".join(str(v) for v in selected)
-        # Unknown shape — emit JSON so data isn't lost.
-        import json
-
         try:
             return json.dumps(value, ensure_ascii=False)
         except (TypeError, ValueError):
@@ -595,15 +610,16 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
     @staticmethod
     def _resolve_recording_link(item) -> str:
         """Best-effort recording URL — only meaningful for call_execution
-        items. Tries known provider paths inside provider_call_data and
-        falls back to customer_log_url.
+        items. Prefers the canonical top-level fields, then falls back
+        to provider-specific paths in provider_call_data.
         """
         ce = getattr(item, "call_execution", None)
         if ce is None:
             return ""
-        log_url = getattr(ce, "customer_log_url", None)
-        if isinstance(log_url, str) and log_url:
-            return log_url
+        for attr in ("recording_url", "stereo_recording_url"):
+            url = getattr(ce, attr, None)
+            if isinstance(url, str) and url:
+                return url
         pcd = getattr(ce, "provider_call_data", None) or {}
         if not isinstance(pcd, dict):
             return ""
@@ -680,17 +696,8 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             row = getattr(item, "dataset_row", None)
             if row is None:
                 return {}
-            from model_hub.models.develop_dataset import Cell
-
-            eval_cells = (
-                Cell.objects.filter(
-                    row=row,
-                    column__source__in=("evaluation", "experiment_evaluation"),
-                    deleted=False,
-                )
-                .select_related("column")
-                .order_by("column__name", "created_at")
-            )
+            # `eval_cells` is attached by _build_export_data's Prefetch.
+            eval_cells = getattr(row, "eval_cells", None) or []
             out = {}
             for cell in eval_cells:
                 col = cell.column
@@ -701,20 +708,17 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
                 out[name] = "" if cell.value is None else cell.value
             return out
 
+        # `active_eval_logs` is attached by _build_export_data's Prefetch.
         eval_logs = None
         if src == "trace":
             trace = getattr(item, "trace", None)
             if trace is not None:
-                eval_logs = trace.eval_logs.filter(deleted=False).select_related(
-                    "custom_eval_config"
-                )
+                eval_logs = getattr(trace, "active_eval_logs", None)
         elif src == "observation_span":
             span = getattr(item, "observation_span", None)
             if span is not None:
-                eval_logs = span.eval_logs.filter(deleted=False).select_related(
-                    "custom_eval_config"
-                )
-        if eval_logs is None:
+                eval_logs = getattr(span, "active_eval_logs", None)
+        if not eval_logs:
             return {}
 
         out = {}
@@ -765,7 +769,27 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         labels = [ql.label for ql in queue_labels if ql.label is not None]
 
         # Pre-fetch FK-linked source objects and their eval children so the
-        # per-item loop below doesn't fan out into N+1 queries.
+        # per-item loop below doesn't fan out into N+1 queries. The Prefetch
+        # objects with to_attr= matter: _collect_evals_for_item reads the
+        # cached attributes directly (active_eval_logs / eval_cells) — using
+        # the default related-manager would re-issue the filter and waste
+        # the prefetch.
+        from django.db.models import Prefetch
+
+        from model_hub.models.develop_dataset import Cell
+        from tracer.models.observation_span import EvalLogger
+
+        active_eval_logs_qs = EvalLogger.objects.filter(
+            deleted=False
+        ).select_related("custom_eval_config")
+        eval_cells_qs = (
+            Cell.objects.filter(
+                column__source__in=("evaluation", "experiment_evaluation"),
+                deleted=False,
+            )
+            .select_related("column")
+            .order_by("column__name", "created_at")
+        )
         items_qs = items_qs.select_related(
             "trace",
             "trace__project",
@@ -775,8 +799,21 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
             "dataset_row",
             "prototype_run",
         ).prefetch_related(
-            "trace__eval_logs__custom_eval_config",
-            "observation_span__eval_logs__custom_eval_config",
+            Prefetch(
+                "trace__eval_logs",
+                queryset=active_eval_logs_qs,
+                to_attr="active_eval_logs",
+            ),
+            Prefetch(
+                "observation_span__eval_logs",
+                queryset=active_eval_logs_qs,
+                to_attr="active_eval_logs",
+            ),
+            Prefetch(
+                "dataset_row__cell_set",
+                queryset=eval_cells_qs,
+                to_attr="eval_cells",
+            ),
         )
 
         rows = []


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

The CSV export of an annotation queue was missing most of the context that makes the file useful — call/source identity, the system metrics shown to annotators, automated eval scores, and per-annotator notes alongside their values. Reviewers had to re-join the file against other tables to interpret each row.

This reshapes the export so one flat row per `QueueItem` carries everything visible to an annotator in the workspace:

- **Call details** — `source_id`, `source_type`, `recording_link` (best-effort across Vapi / LiveKit / Retell), `status`, `created_at`.
- **System metrics** — only the metrics actually rendered in the call detail bar / `VoiceRightPanel` (`duration_seconds`, `message_count`, `overall_score`, `talk_ratio`, `avg_agent_latency_ms`, `user_wpm`, `bot_wpm`, `user_interruption_count`, `ai_interruption_count`). Empty cells for non-call source types so column count stays stable.
- **Evals** — pulled per source type: `CallExecution.eval_outputs` for calls, `EvalLogger` for traces and observation spans, evaluation `Cell`s (where `column.source` is `evaluation` / `experiment_evaluation`) for dataset rows. Eval names form their own column block; only names that actually appear get columns.
- **Per-label values + notes** — for each queue label, one column per annotator with the score, immediately followed by a matching column per annotator with that annotator's note for the same label, so attribution is preserved.

Headers are flat single-row composite names (`latency_kenny`, `latency_notes_kenny`, `eval_helpfulness`, …) — works as-is in both spreadsheet tools and downstream pipelines without schema munging.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `python3 -c "import ast; ast.parse(...)"` clean.
- Hit `GET /model-hub/annotation-queues/<id>/export/?export_format=csv` against a local queue with mixed call_execution + dataset_row items and verified:
  - Source-aware metric / eval columns populate only on rows whose source carries them
  - Per-annotator value + notes columns sit adjacent per label
  - Score values are unwrapped from their JSON shape (`{"rating": 3}` → `3`, `{"selected": ["a","b"]}` → `"a, b"`, `{"text": "..."}` → text)
  - JSON output (`?export_format=json`) is unchanged
- N+1 protection: added `select_related` on the FK source links and `prefetch_related` on `eval_logs__custom_eval_config` so the per-item loop holds at constant query count regardless of queue size.

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
