### PR TITLE
fix: prevent dynamic API column params/headers from being lost on edit

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
@@ -1,6 +1,6 @@
 import { Box, Drawer, IconButton, Typography } from "@mui/material";
 import PropTypes from "prop-types";
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import Iconify from "src/components/iconify";
 import {
@@ -12,7 +12,7 @@ import AddFieldInput from "./AddFieldInput";
 import RequestBody from "./RequestBody";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { getAddColumnApiCallValidation } from "./validation";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import { useParams } from "react-router";
 import { enqueueSnackbar } from "src/components/snackbar";
@@ -66,6 +66,7 @@ export const AddColumnApiCallChild = ({
   const { dataset } = useParams();
 
   const { refreshGrid } = useDevelopDetailContext();
+  const queryClient = useQueryClient();
 
   const allColumns = useDatasetColumnConfig(dataset);
 
@@ -76,12 +77,19 @@ export const AddColumnApiCallChild = ({
     ),
   });
 
+  // Track which editId we've already loaded data for so that background
+  // re-renders (e.g. React Query refetches on window-focus) don't silently
+  // overwrite the user's in-progress edits via reset().
+  const loadedEditIdRef = useRef(null);
+
   useEffect(() => {
-    if (initialData) {
+    if (initialData && loadedEditIdRef.current !== editId) {
       reset(initialData);
+      loadedEditIdRef.current = editId;
     } else if (!editId) {
       // Reset to default values when opening for new column (no editId)
       reset(getDefaultValue());
+      loadedEditIdRef.current = null;
     }
   }, [initialData, reset, editId]);
 
@@ -107,8 +115,17 @@ export const AddColumnApiCallChild = ({
       enqueueSnackbar("API Call column updated successfully", {
         variant: "success",
       });
+      queryClient.invalidateQueries({
+        queryKey: ["dynamic-column-config", editId],
+      });
+      loadedEditIdRef.current = null;
       refreshGrid();
       onClose();
+    },
+    onError: () => {
+      enqueueSnackbar("Failed to update API Call column", {
+        variant: "error",
+      });
     },
   });
 
@@ -360,6 +377,14 @@ const AddColumnApiCall = ({ initialData, onFormSubmit }) => {
 
   const allColumns = useDatasetColumnConfig(dataset, true);
 
+  // Memoize so the child receives a stable reference and its useEffect
+  // does not fire on every parent re-render.
+  const memoizedInitialData = useMemo(() => {
+    return columnConfig
+      ? transformDynamicColumnConfig("api_call", columnConfig, allColumns)
+      : initialData;
+  }, [columnConfig, allColumns, initialData]);
+
   return (
     <Drawer
       anchor="right"
@@ -389,15 +414,7 @@ const AddColumnApiCall = ({ initialData, onFormSubmit }) => {
       )}
       <ShowComponent condition={!isLoadingColumnConfig}>
         <AddColumnApiCallChild
-          initialData={
-            columnConfig
-              ? transformDynamicColumnConfig(
-                  "api_call",
-                  columnConfig,
-                  allColumns,
-                )
-              : initialData
-          }
+          initialData={memoizedInitialData}
           onFormSubmit={onFormSubmit}
           onClose={onClose}
           editId={editId}


### PR DESCRIPTION
## Summary
When editing a dynamic API call column, newly added parameters or headers were intermittently lost. The root cause was the `useEffect` in `AddColumnApiCallChild` calling `reset(initialData)` on every parent re-render — because `transformDynamicColumnConfig` produces a new object reference (with fresh random IDs) each time. Background React Query refetches (e.g. triggered by window focus) would re-render the parent, silently wiping the user's in-progress edits before they could submit.

This PR guards the `useEffect` with a ref so the form is only populated once per edit session, memoizes the `initialData` computation in the parent, invalidates the `["dynamic-column-config"]` query cache after a successful save, and adds an `onError` handler so mutation failures are surfaced to the user.

## Linked issues
Closes #TH-4748

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
1. Open an existing API call dynamic column for editing
2. Add new params and/or headers
3. Alt-tab away and back (triggers React Query window-focus refetch)
4. Verify the newly added fields are still present in the form
5. Click "Update Column" — confirm success snackbar appears
6. Re-open the same column's configure drawer — verify new params/headers persist
7. Simulate a backend error (e.g. network disconnect) — verify error snackbar appears

## Screenshots / recordings (if UI)
<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)