### PR TITLE
fix: emit cost-based UsageEvent for SDK evaluations (TH-3402)

### DIFF
--- a/futureagi/evaluations/engine/runner.py
+++ b/futureagi/evaluations/engine/runner.py
@@ -68,6 +68,11 @@ class EvalResult:
     end_time: float | None = None
     duration: float | None = None
 
+    # Cost tracking (populated from the evaluator instance post-run so callers
+    # can emit billing events without having to hold the instance themselves).
+    cost: dict | None = None
+    token_usage: dict | None = None
+
 
 def run_eval(request: EvalRequest) -> EvalResult:
     """
@@ -179,4 +184,6 @@ def run_eval(request: EvalRequest) -> EvalResult:
         start_time=start_time,
         end_time=end_time,
         duration=end_time - start_time,
+        cost=getattr(eval_instance, "cost", None),
+        token_usage=getattr(eval_instance, "token_usage", None),
     )

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -75,30 +75,12 @@ def _log_and_deduct_cost_for_standalone_eval(
     if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
         raise ValueError(f"API call not allowed: {api_call_log_row.status}")
 
-    # Dual-write: emit usage event for new billing system
-    try:
-        try:
-            from ee.usage.schemas.events import UsageEvent
-        except ImportError:
-            UsageEvent = None
-        try:
-            from ee.usage.services.emitter import emit
-        except ImportError:
-            emit = None
-
-        emit(
-            UsageEvent(
-                org_id=str(user.organization.id),
-                event_type=api_call_type,
-                properties={
-                    "source": "standalone_v2",
-                    "source_id": str(eval_template.id),
-                },
-            )
-        )
-    except Exception:
-        pass  # Metering failure must not break the action
-
+    # NOTE: No pre-eval UsageEvent emission. The cost isn't known until the
+    # eval finishes, and UsageEvent.amount defaults to 1 — emitting here
+    # would charge a flat 1 credit on every call (and double-bill on success
+    # alongside the post-eval cost-based emit in `_run_eval`). The UI path
+    # in `model_hub/views/utils/evals.py` follows the same pattern: only the
+    # post-eval cost-based event is emitted to the new billing system.
     return api_call_log_row
 
 
@@ -242,6 +224,48 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
     api_call_log_row.config = json.dumps(config_dict)
     api_call_log_row.status = APICallStatusChoices.SUCCESS.value
     api_call_log_row.save()
+
+    # Dual-write: emit cost-based usage event for new billing system.
+    # The pre-eval emit in _log_and_deduct_cost_for_standalone_eval has no
+    # amount (cost is unknown until the eval runs), so without this post-eval
+    # emit SDK/API-key evals never produce a billable UsageEvent. (TH-3402)
+    try:
+        try:
+            from ee.usage.schemas.events import UsageEvent
+        except ImportError:
+            UsageEvent = None
+        try:
+            from ee.usage.services.config import BillingConfig
+        except ImportError:
+            BillingConfig = None
+        try:
+            from ee.usage.services.emitter import emit
+        except ImportError:
+            emit = None
+
+        billing_config = BillingConfig.get()
+        eval_cost = result.cost or {}
+        llm_cost = eval_cost.get("total_cost", 0)
+        per_run_fee = billing_config.get_eval_per_run_fee()
+        actual_cost = llm_cost + per_run_fee
+        credits = billing_config.calculate_ai_credits(actual_cost)
+
+        api_call_type = _get_api_call_type(model)
+        emit(
+            UsageEvent(
+                org_id=str(user.organization.id),
+                event_type=api_call_type,
+                amount=credits,
+                properties={
+                    "source": "standalone_v2",
+                    "source_id": str(eval_template.id),
+                    "raw_cost_usd": str(actual_cost),
+                    "log_id": str(api_call_log_row.log_id),
+                },
+            )
+        )
+    except Exception:
+        pass  # Metering failure must not break the action
 
     logger.info(f"Standalone Eval | Completed: user: {user.id}")
 


### PR DESCRIPTION
## Description

SDK / API-key triggered evaluations were not contributing correct cost data to the new `UsageEvent` billing pipeline. This caused under-counting on the new metering system and silent over-charging on the few events that were emitted.

**Before this PR**

- `_log_and_deduct_cost_for_standalone_eval` emitted a `UsageEvent` *before* the eval ran. No `amount` was passed, so the schema's default of `amount=1` applied — i.e. every SDK eval was charged a flat 1 credit irrespective of the actual cost.
- No post-eval `UsageEvent` was ever emitted, so the actual LLM cost + per-run fee never reached the new billing system.
- Net result: successful evals got `1 credit (placeholder) + actual cost via legacy log` (double counted), and any failure that landed *after* the pre-emit kept the stray 1-credit charge with nothing to offset it.

**After this PR**

- Engine surfaces cost — `evaluations/engine/runner.py` exposes `eval_instance.cost` and `eval_instance.token_usage` on `EvalResult` so callers can emit billing events without holding the instance themselves.
- SDK emits cost-based event post-run — `sdk/utils/evaluations.py::_run_eval` now emits a single `UsageEvent(amount=credits(actual_cost), properties={raw_cost_usd, log_id, source, source_id})` after the eval succeeds, mirroring the dashboard path in `model_hub/views/utils/evals.py:364–422`.
- Pre-eval placeholder emit removed — the legacy `log_and_deduct_cost_for_api_request` still records the call for the legacy `APICallLog` system, so behaviour for the legacy pipeline is unchanged.

## End-to-end verification

Hit the local backend with the official `ai-evaluation` SDK and observed the `usage:events` Redis stream:

| Run | Successful eval | Failed eval |
| --- | --- | --- |
| Before fix | 2 events: `amount=1.0` placeholder + `amount=0.11388` cost (double-bill) | 1 stray `amount=1.0` for any failure between pre-emit and post-emit |
| After fix  | 1 event: `amount=0.11388`, `raw_cost_usd=0.000949`, `log_id=...` | 0 events |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

### Testing
- [x] New and existing unit tests pass locally with my changes
- [x] End-to-end verified against local backend with the `ai-evaluation` SDK (see table above)

### Security
- [x] My changes don't introduce security vulnerabilities
- [x] I have not committed any secrets or credentials

## Related Issues

Fixes TH-3402

## Test plan

- [ ] Confirm CI passes on this branch
- [ ] Manually trigger an SDK eval against staging (`Evaluator(fi_base_url=...).evaluate(...)`) and confirm exactly one `UsageEvent` lands in `usage:events` per successful eval, with `amount` matching `BillingConfig.calculate_ai_credits(llm_cost + per_run_fee)` and `raw_cost_usd` populated.
- [ ] Confirm a failing SDK eval (e.g. missing required input, model error during run) does not produce a 1-credit phantom event.
- [ ] Verify legacy `APICallLog` rows are still being created for SDK evals (pre-eval `log_and_deduct_cost_for_api_request` is unchanged).