### PR TITLE
chore(ci): allow uppercase letters in branch names

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -19,7 +19,7 @@ jobs:
           fi
 
           # Enforce type/short-description pattern
-          PATTERN="^(feat|fix|chore|docs|refactor|test|perf)/[a-z0-9][a-z0-9._-]+$"
+          PATTERN="^(feat|fix|chore|docs|refactor|test|perf)/[A-Za-z0-9][A-Za-z0-9._-]+$"
 
           if [[ "$BRANCH" =~ $PATTERN ]]; then
             echo "✅ Branch name '$BRANCH' follows convention"


### PR DESCRIPTION
## Summary
- Updates the branch-name validation regex in `.github/workflows/branch-name-check.yml` from `[a-z0-9]` to `[A-Za-z0-9]` so branches containing ticket IDs like `TH-####` are accepted.
- Branch cut from `origin/main`.

## Test plan
- [ ] Verify the branch-name-check workflow passes for this PR.
- [ ] After merge, confirm a branch with uppercase ticket prefix (e.g. `fix/TH-1234-foo`) passes validation.