### PR TITLE
fix: show org name for legacy eval creators

### DIFF
--- a/futureagi/model_hub/tests/test_eval_list.py
+++ b/futureagi/model_hub/tests/test_eval_list.py
@@ -194,9 +194,9 @@ class TestGetCreatedByName:
         """System-owned template should return 'System'."""
         assert get_created_by_name(system_eval_template) == "System"
 
-    def test_user_owner_without_evaluator(self, user_eval_template):
-        """User-owned template without evaluator should return 'User'."""
-        assert get_created_by_name(user_eval_template) == "User"
+    def test_user_owner_without_evaluator(self, user_eval_template, organization):
+        """User-owned template without creator metadata falls back to org name."""
+        assert get_created_by_name(user_eval_template) == organization.display_name
 
 
 # =============================================================================
@@ -338,6 +338,33 @@ class TestEvalTemplateListAPI:
             assert items_by_name["user_custom_eval"]["eval_type"] == "code"
         if "agent_quality_eval" in items_by_name:
             assert items_by_name["agent_quality_eval"]["eval_type"] == "agent"
+
+    def test_list_creator_fallback_uses_org_name(
+        self, auth_client, user_eval_template, organization
+    ):
+        response = auth_client.post(
+            self.url, {"search": user_eval_template.name}, format="json"
+        )
+        assert response.status_code == 200
+        items = response.data["result"]["items"]
+        assert len(items) == 1
+        assert items[0]["created_by_name"] == organization.display_name
+
+    def test_list_created_by_filter_matches_org_name(
+        self, auth_client, user_eval_template, organization
+    ):
+        response = auth_client.post(
+            self.url,
+            {
+                "owner_filter": "user",
+                "filters": {"created_by": [organization.display_name]},
+                "page_size": 100,
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+        item_names = {item["name"] for item in response.data["result"]["items"]}
+        assert user_eval_template.name in item_names
 
     def test_list_version_defaults_no_versions(self, auth_client, user_eval_template):
         """Templates without any version rows fall back to V1 / count=1."""

--- a/futureagi/model_hub/utils/eval_list.py
+++ b/futureagi/model_hub/utils/eval_list.py
@@ -162,12 +162,26 @@ def derive_output_type(template: "EvalTemplate") -> str:
     return _OUTPUT_TYPE_MAP.get(output, "percentage")
 
 
+def get_organization_display_name(template: "EvalTemplate") -> str:
+    organization = getattr(template, "organization", None)
+    if not organization:
+        return "User"
+
+    display_name = (
+        getattr(organization, "display_name", "")
+        or getattr(organization, "name", "")
+        or ""
+    ).strip()
+    return display_name or "User"
+
+
 def get_created_by_name(template: "EvalTemplate") -> str:
     """
     Get display name for the template creator.
 
     Returns "System" for system-owned templates, or the user's name/email
-    for user-owned templates. Falls back to checking EvalTemplateVersion.created_by.
+    for user-owned templates. Falls back to EvalTemplateVersion.created_by,
+    then to the organization display name for legacy rows without creator metadata.
     """
     if template.owner == OwnerChoices.SYSTEM.value:
         return "System"
@@ -212,7 +226,7 @@ def get_created_by_name(template: "EvalTemplate") -> str:
     except Exception:
         pass
 
-    return "User"
+    return get_organization_display_name(template)
 
 
 def build_user_eval_list_items(
@@ -395,16 +409,21 @@ def build_eval_list_queryset(
                 deleted=False,
                 created_by__email__in=created_by_list,
             ).values_list("eval_template_id", flat=True)
+            org_q = Q(organization__display_name__in=created_by_list) | Q(
+                organization__name__in=created_by_list
+            )
             if "System" in created_by_list:
                 qs = qs.filter(
                     Q(id__in=version_template_ids)
                     | Q(id__in=version_template_ids_email)
+                    | org_q
                     | Q(owner="system")
                 )
             else:
                 qs = qs.filter(
                     Q(id__in=version_template_ids)
                     | Q(id__in=version_template_ids_email)
+                    | org_q
                 )
 
         # Note: eval_type filter is applied in-memory after fetching because

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -1273,11 +1273,10 @@ class EvalTemplateListView(APIView):
         from model_hub.types import EvalListItem, EvalListResponse
         from model_hub.utils.eval_list import (
             build_eval_list_queryset,
-            compute_thirty_day_data,
             derive_eval_type,
             derive_output_type,
             fetch_version_metadata,
-            get_created_by_name,
+            get_organization_display_name,
         )
 
         try:
@@ -1313,7 +1312,7 @@ class EvalTemplateListView(APIView):
                     )[:1],
                     to_attr="_prefetched_evaluators",
                 ),
-            )
+            ).select_related("organization")
 
             # 3. Sort
             order_field = req.get("sort_by", "updated_at")
@@ -1378,7 +1377,9 @@ class EvalTemplateListView(APIView):
                         u = prefetched[0].user
                         created_by = (getattr(u, "name", "") or "").strip() or u.email
                     else:
-                        created_by = version_creators.get(tid, "User")
+                        created_by = version_creators.get(tid) or (
+                            get_organization_display_name(template)
+                        )
 
                 vcount = version_counts.get(tid, 0)
                 default_vnum = default_version_numbers.get(tid)


### PR DESCRIPTION
## Summary

Fixes inconsistent "Created By" display for legacy user-owned evals that do not have creator metadata. These evals now fall back to the organization display name instead of "User", and created-by filtering also matches the organization name.

## Linked issues

TH-4361

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `.venv/bin/pytest model_hub/tests/test_eval_list.py::TestGetCreatedByName::test_user_owner_without_evaluator -v`
- `.venv/bin/pytest model_hub/tests/test_eval_list.py::TestEvalTemplateListAPI::test_list_creator_fallback_uses_org_name model_hub/tests/test_eval_list.py::TestEvalTemplateListAPI::test_list_created_by_filter_matches_org_name -m e2e -v`
- `.venv/bin/python -m py_compile model_hub/utils/eval_list.py model_hub/views/separate_evals.py model_hub/tests/test_eval_list.py`

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
