### PR TITLE
[TH-4760] Fix Save Eval button + variable mapping missing on Task page

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -242,7 +242,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       [];
 
     if (evalType === "code") {
-      const savedMapping = evalData?.mapping || {};
+      const savedMapping = normalizedEvalData?.mapping || {};
       const savedStdvars = ["input", "output", "expected"].filter(
         (v) => v in savedMapping,
       );

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -228,8 +228,6 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   //      these on `CompositeDetailResponse.children[].required_keys`).
   //   2. required_keys on the template (authoritative for system evals)
   //   3. `{{var}}` patterns in the user-edited instructions
-  // Note: code eval stdvars (input, output, expected) are always available
-  // as positional args — they don't need explicit column mapping.
   const variables = useMemo(() => {
     if (isComposite) {
       const union = new Set();
@@ -244,7 +242,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       [];
 
     if (evalType === "code") {
-      return [...new Set(requiredKeys)];
+      const savedMapping = evalData?.mapping || {};
+      const savedStdvars = ["input", "output", "expected"].filter(
+        (v) => v in savedMapping,
+      );
+      return [...new Set([...savedStdvars, ...requiredKeys])];
     }
 
     // System evals + Jinja mode: use static required_keys.

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -726,10 +726,13 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                   compositeChildAxis={compositeChildAxis}
                   childWeights={childWeights}
                   children={selectedChildren}
-                  // Forward the dataset context so the inner child
+                  // Forward the source context so the inner child
                   // picker shows the variable-mapping screen for each
-                  // child instead of directly appending it.
+                  // child against the same source the parent composite
+                  // was opened from (task, dataset, tracing, ...).
+                  pickerSource={source}
                   pickerSourceId={sourceId}
+                  pickerSourceRowType={sourceRowType}
                   pickerSourceColumns={sourceColumns}
                   onNameChange={setName}
                   onDescriptionChange={setDescription}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -75,8 +75,14 @@ const SOURCE_LABELS = {
 };
 
 const EvalPickerCreateNew = ({ onBack, onSave }) => {
-  const { source, sourceId, sourceColumns, setSelectedEval, setStep } =
-    useEvalPickerContext();
+  const {
+    source,
+    sourceId,
+    sourceRowType,
+    sourceColumns,
+    setSelectedEval,
+    setStep,
+  } = useEvalPickerContext();
   const { enqueueSnackbar } = useSnackbar();
   const { isOSS } = useDeploymentMode();
   const createEval = useCreateEval();
@@ -964,7 +970,6 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
               <Box sx={{ flex: 1, overflow: "auto" }}>
                 {(source === "dataset" ||
                   source === "workbench" ||
-                  source === "task" ||
                   source === "custom" ||
                   source === "run-experiment" ||
                   source === "run-optimization") && (
@@ -982,6 +987,20 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     sourceColumns={
                       source === "workbench" ? sourceColumns : null
                     }
+                  />
+                )}
+                {source === "task" && (
+                  <TracingTestMode
+                    ref={sourceRef}
+                    templateId={draftId}
+                    variables={isComposite ? compositeUnionKeys : variables}
+                    onTestResult={handleTestResult}
+                    onColumnsLoaded={handleColumnsLoaded}
+                    onReadyChange={handleSourceReadyChange}
+                    initialProjectId={sourceId}
+                    initialRowType={sourceRowType}
+                    isComposite={isComposite}
+                    compositeAdhocConfig={compositeAdhocConfig}
                   />
                 )}
                 {source === "tracing" && (

--- a/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
+++ b/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
@@ -62,11 +62,16 @@ const CompositeDetailPanel = ({
   // overrides without exposing the full composite edit surface
   // (add/remove children, switch axis, rename, etc.).
   weightEditable = false,
-  // Forward dataset context to the inner child picker so the EvalPicker
+  // Forward source context to the inner child picker so the EvalPicker
   // can show its mapping screen for each child. When omitted (e.g. when
-  // editing a composite from /evals/create with no dataset bound), the
+  // editing a composite from /evals/create with no source bound), the
   // child picker falls back to the original direct-add behaviour.
+  // pickerSource carries the parent's source type ("dataset", "task",
+  // "tracing", ...) so children re-use the same test mode instead of
+  // getting forced into DatasetTestMode.
+  pickerSource = "",
   pickerSourceId = "",
+  pickerSourceRowType = null,
   pickerSourceColumns = [],
   onNameChange,
   onDescriptionChange,
@@ -463,8 +468,9 @@ const CompositeDetailPanel = ({
           // skipConfig=true bypassed all of that and added the child
           // straight to the list with template defaults.
           skipConfig={false}
-          source={pickerSourceId ? "dataset" : "composite"}
+          source={pickerSource || (pickerSourceId ? "dataset" : "composite")}
           sourceId={pickerSourceId || ""}
+          sourceRowType={pickerSourceRowType}
           sourceColumns={pickerSourceColumns || []}
           lockedFilters={axisToLockedFilters(compositeChildAxis)}
         />
@@ -520,7 +526,9 @@ CompositeDetailPanel.propTypes = {
   editable: PropTypes.bool,
   disabled: PropTypes.bool,
   weightEditable: PropTypes.bool,
+  pickerSource: PropTypes.string,
   pickerSourceId: PropTypes.string,
+  pickerSourceRowType: PropTypes.string,
   pickerSourceColumns: PropTypes.array,
   onNameChange: PropTypes.func,
   onDescriptionChange: PropTypes.func,

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -381,6 +381,12 @@ function ColumnTreeSelect({ columnNames, value, onChange, isUnmapped }) {
           onChange(e.target.value);
           if (!open) setOpen(true);
         }}
+        autoComplete="off"
+        inputProps={{
+          autoComplete: "off",
+          autoCorrect: "off",
+          spellCheck: false,
+        }}
         InputProps={{
           sx: { fontSize: "12px", fontFamily: "monospace", height: 30, py: 0 },
           endAdornment: (


### PR DESCRIPTION
## Summary

The new "Create New Evaluation" eval picker on the Task page (`/dashboard/tasks/{id}`) was failing to populate the Variable Mapping column dropdown — Save & Add Evaluation stayed disabled. Root cause was the picker rendering `<DatasetTestMode>` for `source === "task"` with `sourceId` (a project ID) as `initialDatasetId`, producing 400s on `get-dataset-table` and `json-schema`.

This PR aligns the new eval flow with the existing prebuilt eval flow's source handling, and fixes two related issues surfaced by the change.

## What changed

- **`EvalPickerCreateNew.jsx`** — added a dedicated `source === "task"` branch that renders `<TracingTestMode>` with `initialProjectId={sourceId}` and `initialRowType={sourceRowType}`, mirroring `EvalPickerConfigFull.jsx:1510-1526`. Real span rows now show in the right panel; the column dropdown populates correctly.
- **`CompositeDetailPanel.jsx`** + parent wiring in `EvalPickerCreateNew.jsx` — accept `pickerSource` / `pickerSourceRowType` and forward them to the inner child picker. Previously hardcoded `source="dataset"` re-broke the same flow when adding a child eval inside a composite created from a Task page.
- **`EvalPickerConfigFull.jsx`** — code-eval `variables` derivation now surfaces stdvars (`input`, `output`, `expected`) only when the saved eval already has a mapping for them. Backend stores `required_keys: []` for code evals (`separate_evals.py:1801`), so saved overrides like `expected → custom_column` were invisible/uneditable on edit. Prebuilt code evals with no stdvar mapping are unchanged — no regression.
- **`DatasetTestMode.jsx`** — `autoComplete="off"` on the column dropdown TextField; browser autofill was rendering on top of the dropdown.

Closes TH-4760

## Linear Ticket

[TH-4760](https://linear.app/future-agi/issue/TH-4760/save-eval-button-missing-when-creating-new-evaluation)

## Files Changed

- `frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx`
- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx`
- `frontend/src/sections/evals/components/CompositeDetailPanel.jsx`
- `frontend/src/sections/evals/components/DatasetTestMode.jsx`

## Test plan

- [ ] On a Task page, click "Add Evaluation" → "Create New" → confirm the right panel shows real span rows and the Variable Mapping dropdown populates.
- [ ] Save & Add Evaluation enables once variables are mapped.
- [ ] Create a Composite eval from a Task page → add a child → confirm the child picker also shows the same span rows and dropdown.
- [ ] Create a Code eval with `expected → custom_column` override → save → re-open in edit mode → confirm the saved override is visible and editable.
- [ ] Open an existing prebuilt code eval (e.g. `word_info_preserved`) → confirm no new mapping rows appear (no regression).
- [ ] Type into the column dropdown — browser autofill should not overlay.
