### PR TITLE
fix: hide lifetime free-tier countdown copy in usage page

### DIFF
--- a/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
@@ -628,6 +628,7 @@ export default function UsageSummaryV2() {
   }, [overview]);
 
   const daysRemaining = useMemo(() => {
+    if (overview?.plan === "free") return null;
     if (!overview?.billing_period_end) return null;
     const end = new Date(overview.billing_period_end);
     const now = new Date();

--- a/frontend/src/sections/settings/UsageSummaryV2/__tests__/UsageSummaryV2.test.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/__tests__/UsageSummaryV2.test.jsx
@@ -1,7 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockGet = vi.fn();
 
 vi.mock("src/utils/axios", () => ({
-  default: { get: vi.fn() },
+  default: { get: (...args) => mockGet(...args) },
   endpoints: {
     settings: {
       v2: {
@@ -22,10 +26,53 @@ vi.mock("react-apexcharts", () => ({
   default: () => null,
 }));
 
+vi.mock("../UsageChart", () => ({
+  default: () => null,
+}));
+
+vi.mock("../WorkspaceBreakdown", () => ({
+  default: () => null,
+}));
+
+function renderWithQuery(ui) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+const BASE_OVERVIEW = {
+  plan: "free",
+  billing_period_start: "2026-05-01",
+  billing_period_end: "2099-05-31",
+  total_with_platform: 0,
+  total_estimated_cost: 0,
+  dimensions: [],
+};
+
 describe("UsageSummaryV2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockImplementation((url) => {
+      if (url === "/usage/v2/usage-overview/") {
+        return Promise.resolve({ data: { result: BASE_OVERVIEW } });
+      }
+      if (url === "/usage/v2/notifications/") {
+        return Promise.resolve({ data: { result: { banners: [] } } });
+      }
+      return Promise.resolve({ data: { result: {} } });
+    });
+  });
+
   it("should be importable", async () => {
     const module = await import("../UsageSummaryV2");
     expect(module.default).toBeDefined();
+  });
+
+  it("does not show countdown chip for lifetime free plan", async () => {
+    const { default: UsageSummaryV2 } = await import("../UsageSummaryV2");
+    renderWithQuery(<UsageSummaryV2 />);
+
+    expect(await screen.findByText("Usage & Billing")).toBeInTheDocument();
+    expect(screen.queryByText(/days left/i)).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

This fixes incorrect lifetime free-tier messaging in Usage & Billing.  
Free-tier users were seeing a countdown chip (`X days left`) based on `billing_period_end`, which implies a time-limited trial.  
The UI now hides that countdown when the active plan is `free`, while preserving existing countdown behavior for non-free plans.  
A regression test was added to ensure free-tier payloads do not render the countdown copy.

## Linked issues

TH-4495

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `yarn vitest run src/sections/settings/UsageSummaryV2/__tests__/UsageSummaryV2.test.jsx`

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
