### PR TITLE
[TH-4745] Fix nested attribute row collapsing ancestors on click

### DIFF
--- a/frontend/src/components/traceDetail/SpanDetailPane.jsx
+++ b/frontend/src/components/traceDetail/SpanDetailPane.jsx
@@ -2344,7 +2344,11 @@ const AttrNestedRow = ({ path, value }) => {
           px: 0.25,
           py: 0.1,
         }}
-        onClick={() => isComplex && setOpen(!open)}
+        onClick={(e) => {
+          if (!isComplex) return;
+          e.stopPropagation();
+          setOpen(!open);
+        }}
       >
         <Typography
           variant="caption"


### PR DESCRIPTION
## Summary

In the trace span attributes drawer, clicking a deeply-nested expandable row was collapsing all of its ancestors instead of just expanding the clicked level. The collapse unmounted descendant rows and reset their state, so the user couldn't drill down past the second or third level.

### Root cause

`AttrNestedRow` (`SpanDetailPane.jsx:2329`) renders an outer `Box` with `onClick={() => isComplex && setOpen(!open)}` to make the whole row clickable. Inside, `AttrValueCell` renders more nested `AttrNestedRow`s as descendants — so every nested row is a DOM descendant of every ancestor's outer `Box`.

When the user clicked a deep chevron, the click bubbled up through every ancestor's outer `Box` and each one toggled its own `open` state, collapsing the rows above the click. The descendants then unmounted and lost their local state — so to the user, the click looked like a reset.

No errors logged because nothing throws — it's just unintended state changes from event bubbling.

### Fix

Stop propagation on the outer click handler so a click inside a nested row never reaches an ancestor row's handler:

```jsx
onClick={(e) => {
  if (!isComplex) return;
  e.stopPropagation();
  setOpen(!open);
}}
```

The originating click on the chevron still fires (it's a descendant), bubbles to its own outer Box where it's handled and stopped. Ancestor outer Boxes never see it.

Closes TH-4745

## Linear Ticket

[TH-4745](https://linear.app/future-agi/issue/TH-4745/tooltip-text-is-unreadable-in-attributes-drawer-dark-mode)

## Files Changed

- `frontend/src/components/traceDetail/SpanDetailPane.jsx`

## Test plan

- [ ] Open any trace with deeply nested attributes (3+ levels deep) in the span detail drawer.
- [ ] Expand level 1 → level 2 → level 3.
- [ ] Click a chevron at level 3 — only level 3 expands; levels 1 and 2 remain expanded.
- [ ] Click a primitive (non-object) row — no toggle happens, no errors.
- [ ] Click a top-level expandable row in the Attributes table — still expands as before (top-level is unaffected since it lives in `AttributesCard`, not `AttrNestedRow`).
