### PR TITLE
[TH-4762] Make nested attribute values expandable + add sibling dividers

### DIFF
--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -147,7 +147,7 @@ function JsonEntries({ data, depth = 0 }) {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column" }}>
-      {entries.map(([key, val]) => {
+      {entries.map(([key, val], idx) => {
         const isObj = val !== null && typeof val === "object";
         return (
           <JsonEntryRow
@@ -156,6 +156,7 @@ function JsonEntries({ data, depth = 0 }) {
             entryValue={val}
             isObject={isObj}
             depth={depth}
+            isLast={idx === entries.length - 1}
           />
         );
       })}
@@ -163,8 +164,9 @@ function JsonEntries({ data, depth = 0 }) {
   );
 }
 
-function JsonEntryRow({ entryKey, entryValue, isObject, depth }) {
+function JsonEntryRow({ entryKey, entryValue, isObject, depth, isLast }) {
   const [open, setOpen] = useState(false);
+  const [valueExpanded, setValueExpanded] = useState(false);
 
   return (
     <Box sx={{ py: 0.25 }}>
@@ -180,7 +182,11 @@ function JsonEntryRow({ entryKey, entryValue, isObject, depth }) {
           px: 0.5,
           py: 0.15,
         }}
-        onClick={() => isObject && setOpen(!open)}
+        onClick={(e) => {
+          if (!isObject) return;
+          e.stopPropagation();
+          setOpen(!open);
+        }}
       >
         {isObject && (
           <Iconify
@@ -190,52 +196,71 @@ function JsonEntryRow({ entryKey, entryValue, isObject, depth }) {
           />
         )}
         {!isObject && <Box sx={{ width: 12, flexShrink: 0 }} />}
-        <Typography
-          variant="caption"
-          fontWeight={600}
+        <Box
           sx={{
-            fontSize: "11px",
-            minWidth: 60,
-            flexShrink: 0,
-            color: "text.secondary",
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 0.5,
+            flex: 1,
+            minWidth: 0,
+            ...(isLast || (isObject && open)
+              ? {}
+              : { borderBottom: "1px solid", borderColor: "divider" }),
           }}
         >
-          {entryKey}
-        </Typography>
-        {!isObject && (
           <Typography
             variant="caption"
+            fontWeight={600}
             sx={{
               fontSize: "11px",
-              color: "primary.main",
-              wordBreak: "break-all",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
+              minWidth: 60,
+              flexShrink: 0,
+              color: "text.secondary",
             }}
           >
-            {entryValue === null
-              ? "null"
-              : entryValue === true
-                ? "true"
-                : entryValue === false
-                  ? "false"
-                  : String(entryValue)}
+            {entryKey}
           </Typography>
-        )}
-        {isObject && !open && (
-          <Typography
-            variant="caption"
-            color="text.disabled"
-            sx={{ fontSize: "10px" }}
-          >
-            {Array.isArray(entryValue)
-              ? `[${entryValue.length}]`
-              : `{${Object.keys(entryValue).length}}`}
-          </Typography>
-        )}
+          {!isObject && (
+            <Typography
+              variant="caption"
+              onClick={(e) => {
+                e.stopPropagation();
+                setValueExpanded((v) => !v);
+              }}
+              sx={{
+                fontSize: "11px",
+                color: "primary.main",
+                wordBreak: "break-all",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                display: "-webkit-box",
+                WebkitLineClamp: valueExpanded ? 9999 : 2,
+                WebkitBoxOrient: "vertical",
+                cursor: "pointer",
+                "&:hover": { opacity: 0.85 },
+              }}
+            >
+              {entryValue === null
+                ? "null"
+                : entryValue === true
+                  ? "true"
+                  : entryValue === false
+                    ? "false"
+                    : String(entryValue)}
+            </Typography>
+          )}
+          {isObject && !open && (
+            <Typography
+              variant="caption"
+              color="text.disabled"
+              sx={{ fontSize: "10px" }}
+            >
+              {Array.isArray(entryValue)
+                ? `[${entryValue.length}]`
+                : `{${Object.keys(entryValue).length}}`}
+            </Typography>
+          )}
+        </Box>
       </Box>
       {isObject && open && (
         <Box


### PR DESCRIPTION
## Summary

In `TaskLivePreview`'s right panel (and other surfaces that render span attributes through `JsonValueTree`), long string values were getting clipped to 2 lines with no way to see the full content — no click-to-expand, no tooltip. Nested rows also lacked horizontal separators, making it hard to scan where one row ended and the next began.

## What changed

`frontend/src/sections/evals/components/DatasetTestMode.jsx` — `JsonEntries` and `JsonEntryRow`:

- **Click to expand truncated values.** Primitive value `Typography` now has a click handler that toggles `WebkitLineClamp` between `2` and `9999`. Clicking once expands; clicking again collapses. Cursor stays `pointer` and uses the codebase's existing 9999 idiom (matches `TaskLivePreview.jsx:923`).
- **Horizontal dividers between sibling rows in the nested tree**, inset to start at the label column (chevron stays in its own column outside the divider). The label + value live in a flex sub-container that owns the `borderBottom`.
- **Skip the divider when:** the row is the last sibling in its group (avoids hanging line at the bottom of a group), AND when the row is an expanded object (the indented children container with its left-border already provides visual grouping; sandwiching a divider above the children was confusing).
- **`stopPropagation` on the outer object-row `onClick`** so a click on a deeply nested chevron doesn't bubble to ancestor object rows and toggle their `open` state. Defensive, same pattern as the TH-4745 fix in `SpanDetailPane.jsx`.

Closes TH-4762

## Linear Ticket

[TH-4762](https://linear.app/future-agi/issue/TH-4762/mapping-data-is-hard-to-read-in-attributes-drawer)

## Files Changed

- `frontend/src/sections/evals/components/DatasetTestMode.jsx`

## Test plan

- [ ] Open Tasks → Create Task with a project that has spans/traces. The Live Preview right panel loads a sample row.
- [ ] Expand a top-level row whose value is a deeply nested object (e.g. `output`).
- [ ] Click a long string value (e.g. a markdown content blob): expands fully, click again to collapse to 2 lines.
- [ ] Multi-child groups (e.g. `output → content / token_consumed / tokenConsumed`) show dividers between the first N-1 siblings, none after the last.
- [ ] Single-child chains (e.g. `level1 → level2 → level3`) show no internal dividers.
- [ ] Expanded parent rows have no divider directly under them — the children container's left-border is the only visual grouping.
- [ ] Clicking the chevron of a deeply nested row only toggles that row's expansion; ancestor rows stay expanded.
