### PR TITLE
fix: render zero eval scores

### DIFF
--- a/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateCell.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateCell.jsx
@@ -22,6 +22,9 @@ const getScorePercentage = (s, decimalPlaces = 0) => {
   return Number(score.toFixed(decimalPlaces));
 };
 
+const hasRenderableValue = (value) =>
+  value !== undefined && value !== null && value !== "";
+
 // Normalise the `value_infos` blob into an object regardless of whether
 // the caller passed camelCase, snake_case, or a JSON string. The cell
 // layer upstream is inconsistent across grids (the backend returns a
@@ -142,7 +145,7 @@ const EvaluateCell = ({
   }
   if (output === OutputTypes.SCORE) {
     const result = parsedValueInfos?.data?.result;
-    if (!result) return null;
+    if (!hasRenderableValue(result)) return null;
     return (
       <Box sx={{ display: "inline-flex", p: 1, maxWidth: "100%" }}>
         <Chip
@@ -194,8 +197,8 @@ const EvaluateCell = ({
     );
   }
   if (dataType === "float") {
-    // console.log("float", cellData.cellValue, value);
-    const bgColor = cellData?.cellValue
+    const hasValue = hasRenderableValue(cellData?.cellValue);
+    const bgColor = hasValue
       ? interpolateColorBasedOnScore(value, 1)
       : "";
     return (
@@ -210,7 +213,7 @@ const EvaluateCell = ({
             alignItems: "center",
           }}
         >
-          {cellData?.cellValue ? `${getScorePercentage(value)}%` : ""}
+          {hasValue ? `${getScorePercentage(value)}%` : ""}
           {compositeBadge}
           <RenderMeta
             originType={originType}

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawer/DatapointDrawer.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawer/DatapointDrawer.jsx
@@ -43,6 +43,10 @@ const SkeletonLoader = () => (
     <Skeleton sx={{ width: "100%", height: "10px" }} variant="rounded" />
   </Box>
 );
+
+const hasRenderableCellValue = (value) =>
+  value !== undefined && value !== null && value !== "";
+
 const StatusCellRenderer = (data) => {
   const theme = useTheme();
 
@@ -68,7 +72,7 @@ const StatusCellRenderer = (data) => {
   if (cellValue?.startsWith("[") && cellValue?.endsWith("]")) {
     cellValue = JSON.parse(cellValue.replace(/'/g, '"'));
   }
-  if (!cellValue || cellValue === undefined || cellValue === "") return;
+  if (!hasRenderableCellValue(cellValue)) return;
 
   return (
     <>
@@ -571,8 +575,7 @@ const DatapointDrawerChild = ({
                     Error
                   </Box>
                 ) : (
-                  runEval?.cellValue &&
-                  runEval?.cellValue !== "" && (
+                  hasRenderableCellValue(runEval?.cellValue) && (
                     <>
                       <ShowComponent condition={!Array.isArray(finalArray)}>
                         <Chip

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -63,6 +63,9 @@ const SkeletonLoader = () => (
   </Box>
 );
 
+const hasRenderableCellValue = (value) =>
+  value !== undefined && value !== null && value !== "";
+
 const ViewDetailsCellRenderer = (props) => {
   const { data = {}, node, setRunEval, disabled } = props;
   const theme = useTheme();
@@ -762,8 +765,7 @@ const DatapointDrawerChild = () => {
                         Error
                       </Box>
                     ) : (
-                      evalOpen?.cellValue &&
-                      evalOpen?.cellValue !== "" && (
+                      hasRenderableCellValue(evalOpen?.cellValue) && (
                         <>
                           <ShowComponent condition={!Array.isArray(finalArray)}>
                             <Chip

--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/CellRenderingData.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/CellRenderingData.jsx
@@ -58,6 +58,8 @@ export const EvaluateCell = ({ value, dataType, cellData }) => {
     const score = s * 100;
     return Number(score.toFixed(decimalPlaces));
   };
+  const hasRenderableValue = (cellValue) =>
+    cellValue !== undefined && cellValue !== null && cellValue !== "";
 
   if (Array.isArray(value?.output)) {
     return <EvaluateArrayCellRenderer value={value?.output} />;
@@ -96,7 +98,8 @@ export const EvaluateCell = ({ value, dataType, cellData }) => {
     );
   }
   if (dataType === "float" || cellData?.output_type == "score") {
-    const bgColor = cellData?.cell_value
+    const hasValue = hasRenderableValue(cellData?.cell_value);
+    const bgColor = hasValue
       ? interpolateColorBasedOnScore(value?.output, 1)
       : "";
     return (
@@ -108,7 +111,7 @@ export const EvaluateCell = ({ value, dataType, cellData }) => {
           height: "100%",
         }}
       >
-        {cellData?.cell_value ? `${getScorePercentage(value?.output)}%` : ""}
+        {hasValue ? `${getScorePercentage(value?.output)}%` : ""}
       </Box>
     );
   }


### PR DESCRIPTION
## Summary

Fixes eval score rendering paths that treated numeric 0 as an empty value. Dataset grids, eval logs, and datapoint drawers now render zero scores instead of showing blank cells.

## Linked issues

Closes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only
- [ ] Chore / refactor (no user-visible change)
- [ ] Performance improvement
- [ ] Test-only change

## How was this tested?

- npx eslint src/sections/common/DevelopCellRenderer/EvaluateCellRenderer/EvaluateCell.jsx src/sections/evals/EvalDetails/EvalsLog/CellRenderingData.jsx src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx src/sections/develop-detail/DataTab/DatapointDrawer/DatapointDrawer.jsx

## Screenshots / recordings (if UI)

Not captured.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] make check-all / yarn check-all passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
