### PR TITLE
fix(deployment): serve /api/deployment-info/ from OSS code (TH-4771)

### DIFF
--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -678,7 +678,7 @@ export const endpoints = {
       paymentMethodDefault: (pmId) =>
         `/usage/v2/payment-methods/${pmId}/default/`,
       paymentMethodDelete: (pmId) => `/usage/v2/payment-methods/${pmId}/`,
-      deploymentInfo: `/usage/v2/deployment-info/`,
+      deploymentInfo: `/api/deployment-info/`,
     },
   },
   tools: {

--- a/futureagi/tfc/urls.py
+++ b/futureagi/tfc/urls.py
@@ -25,6 +25,7 @@ from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 
 from tfc.ee_loader import ee_feature_enabled, has_ee
+from tfc.views.deployment import DeploymentInfoView
 from tfc.views.health import (
     AuthenticatedHealthView,
     HealthCheckView,
@@ -128,6 +129,11 @@ urlpatterns = [
         "api/traces/span-attribute-detail/",
         SpanAttributeDetailView.as_view(),
         name="span-attribute-detail",
+    ),
+    path(
+        "api/deployment-info/",
+        DeploymentInfoView.as_view(),
+        name="deployment-info",
     ),
 ]
 

--- a/futureagi/tfc/views/deployment.py
+++ b/futureagi/tfc/views/deployment.py
@@ -1,0 +1,25 @@
+import os
+
+from rest_framework.views import APIView
+
+from tfc.utils.general_methods import GeneralMethods
+
+
+class DeploymentInfoView(APIView):
+    """Public deployment-mode probe used by the frontend to gate UI.
+
+    Returns ``{"mode": "oss"|"ee"|"cloud"}``. No auth — public config.
+    """
+
+    authentication_classes = []
+    permission_classes = []
+
+    def get(self, request, *args, **kwargs):
+        if os.environ.get("CLOUD_DEPLOYMENT", "") in ("US", "EU", "DEV"):
+            mode = "cloud"
+        elif os.environ.get("EE_LICENSE_KEY", ""):
+            mode = "ee"
+        else:
+            mode = "oss"
+        gm = GeneralMethods(request)
+        return gm.success_response({"mode": mode})


### PR DESCRIPTION
## Summary
- Frontend gates UI on `GET /usage/v2/deployment-info/`, but that endpoint lived only in `futureagi/ee/usage/` — which is `.gitignore`d in this monorepo. A fresh `docker compose up` had no `ee/` on disk, so `/usage/` was never mounted (`tfc/urls.py:has_ee` gate) and the request 404'd, hanging the deployment-mode resolver.
- Moves the public, no-auth deployment-mode probe into `futureagi/tfc/views/deployment.py` and wires it unconditionally at `/api/deployment-info/`.
- Updates the frontend axios constant to match.

## Why a new path
- `/usage/...` is gated on `ee.usage` being importable, which is exactly what's missing in OSS. `/api/...` sits next to other public probes (`/api/health/...`, `/api/traces/...`) and ships unconditionally.

## Test plan
- [ ] `docker compose up` from a fresh clone — frontend loads past the deployment-mode gate
- [ ] `curl localhost:8000/api/deployment-info/` returns `{"status": true, "result": {"mode": "oss"}}`
- [ ] With `EE_LICENSE_KEY=...` set, returns `{"mode": "ee"}`
- [ ] With `CLOUD_DEPLOYMENT=DEV` set, returns `{"mode": "cloud"}`

Refs: [TH-4771](https://linear.app/future-agi/issue/TH-4771/local-setup-fails-because-deployment-info-api-returns-404)