### PR TITLE
feat: Add API Call / HTTP Request Node

### DIFF
--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/apiCallNodeDrawer.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/apiCallNodeDrawer.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { Box, Button, Typography, Chip, Stack, Alert } from '@mui/material';
+
+const METHOD_COLORS = {
+  GET: '#4CAF50',
+  POST: '#2196F3',
+  PUT: '#FF9800',
+  PATCH: '#9C27B0',
+  DELETE: '#F44336',
+};
+
+const truncateUrl = (url, maxLength = 40) => {
+  if (!url || url.length <= maxLength) return url;
+  const protocolEnd = url.indexOf('://') + 3;
+  const pathStart = url.indexOf('/', protocolEnd);
+  const domain = url.substring(protocolEnd, pathStart !== -1 ? pathStart : undefined);
+  const path = pathStart !== -1 ? url.substring(pathStart) : '';
+  if (domain.length <= maxLength - path.length - 3) return url;
+  return `${url.substring(0, protocolEnd + Math.floor((maxLength - path.length - 3) / 2))}...${path}`;
+};
+
+export const ApiCallNodeDrawer = ({ config, onChange }) => {
+  const [testResult, setTestResult] = useState(null);
+  const [testing, setTesting] = useState(false);
+
+  const handleTestRequest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const response = await fetch('/api/agent-playground/test-http-request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      });
+      const data = await response.json();
+      setTestResult(data);
+    } catch (_err) {
+      setTestResult({ success: false, error: 'Could not load data. Please refresh.' });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Stack spacing={2}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Chip
+            label={config.method || 'GET'}
+            sx={{
+              backgroundColor: METHOD_COLORS[config.method] || '#757575',
+              color: '#fff',
+              fontWeight: 'bold',
+            }}
+          />
+          <Typography variant="body2" noWrap title={config.url}>
+            {truncateUrl(config.url)}
+          </Typography>
+        </Box>
+
+        <Button
+          variant="contained"
+          onClick={handleTestRequest}
+          disabled={testing || !config.url}
+          fullWidth
+        >
+          {testing ? 'Testing...' : 'Test Request'}
+        </Button>
+
+        {testResult && (
+          <Alert severity={testResult.success ? 'success' : 'error'}>
+            Status: {testResult.status}
+            {testResult.error && <Typography variant="caption" display="block">{testResult.error}</Typography>}
+          </Alert>
+        )}
+      </Stack>
+    </Box>
+  );
+};

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
@@ -145,8 +145,35 @@ export const evalNodeFormSchema = z.object({
 });
 
 /**
+ * Schema for API Call Node Form
+ */
+export const apiCallNodeFormSchema = z.object({
+  nodeType: z.literal("api_call").optional(),
+  nodeId: z.string().optional(),
+  name: z
+    .string()
+    .min(1, "Node name is required")
+    .regex(
+      /^[a-z][a-z0-9_]*$/,
+      "Name must be lowercase letters, numbers, and underscores only",
+    )
+    .trim(),
+  method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]).default("GET"),
+  url: z.string().min(1, "URL is required"),
+  headers: z.array(z.object({ key: z.string(), value: z.string() })).optional().default([]),
+  bodyType: z.enum(["json", "form", "raw"]).optional().default("json"),
+  body: z.string().optional().default(""),
+  authType: z.enum(["none", "bearer", "basic", "api_key"]).optional().default("none"),
+  authToken: z.string().optional(),
+  apiKeyName: z.string().optional(),
+  apiKeyValue: z.string().optional(),
+  timeout: z.number().min(1).max(300).optional().default(30),
+  retries: z.number().min(0).max(5).optional().default(0),
+});
+
+/**
  * Get the appropriate schema based on node type
- * @param {string} nodeType - The type of node ('prompt', 'agent', 'eval')
+ * @param {string} nodeType - The type of node ('prompt', 'agent', 'eval', 'api_call')
  * @returns {z.ZodSchema} The Zod schema for the node type
  */
 export function getNodeFormSchema(nodeType) {
@@ -157,6 +184,8 @@ export function getNodeFormSchema(nodeType) {
       return agentNodeFormSchema;
     case "eval":
       return evalNodeFormSchema;
+    case "api_call":
+      return apiCallNodeFormSchema;
     default:
       // Return a basic schema for unknown types
       return z.object({

--- a/futureagi/agent_playground/services/engine/runners/__init__.py
+++ b/futureagi/agent_playground/services/engine/runners/__init__.py
@@ -17,3 +17,4 @@ Adding a new runner:
 # Import runner modules to trigger self-registration.
 # Add new runners here as they are created.
 import agent_playground.services.engine.runners.llm_prompt  # noqa: F401
+import agent_playground.services.engine.runners.http_request  # noqa: F401

--- a/futureagi/agent_playground/services/engine/runners/http_request.py
+++ b/futureagi/agent_playground/services/engine/runners/http_request.py
@@ -1,0 +1,173 @@
+"""
+HTTP Request Runner for Graph Execution Engine.
+
+This runner executes HTTP requests (GET, POST, PUT, PATCH, DELETE) with
+configurable method, URL, headers, body, authentication, timeout, and retry
+support. Includes SSRF protection to block requests to internal/private
+network addresses.
+
+Variable resolution:
+    - ${variable} patterns in URL and headers are replaced with values from
+      the inputs dict (workflow context).
+
+Output:
+    - status: int - HTTP status code (0 on failure)
+    - headers: dict - Response headers
+    - body: str - Response body text
+    - success: bool - Whether the request succeeded
+    - error: str | None - Error message if failed
+"""
+
+import base64
+import ipaddress
+import json
+import re
+import socket
+import time
+from urllib.parse import urlparse
+
+import requests
+from agent_playground.services.engine.node_runner import BaseNodeRunner, register_runner
+
+
+def _is_safe_url(url: str) -> bool:
+    """Check if the URL points to an external, non-private address."""
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname or ""
+        if not re.match(r"^https?://", url, re.IGNORECASE):
+            return False
+        if not hostname:
+            return False
+
+        # Resolve hostname to IP addresses to prevent DNS rebinding/SSRF
+        addr_infos = socket.getaddrinfo(hostname, None)
+        for info in addr_infos:
+            ip_str = info[4][0]
+            try:
+                addr = ipaddress.ip_address(ip_str)
+                if addr.is_private or addr.is_loopback or addr.is_reserved:
+                    return False
+            except ValueError:
+                # If IP parsing fails, treat as unsafe to be conservative
+                return False
+        return True
+    except (socket.gaierror, socket.herror):
+        # DNS resolution failed, treat as unsafe
+        return False
+
+
+def interpolate_variables(text: str, inputs: dict) -> str:
+    """Replace ${variable} patterns with values from the workflow context."""
+    if not text:
+        return ""
+
+    def replacer(match):
+        var_name = match.group(1)
+        return str(inputs.get(var_name, match.group(0)))
+
+    return re.sub(r"\$\{([^}]+)\}", replacer, str(text))
+
+
+class HttpRequestRunner(BaseNodeRunner):
+    """Executes HTTP requests with configurable method, headers, body, auth, and timeout."""
+
+    def run(self, config: dict, inputs: dict, execution_context: dict) -> dict:
+        method = config.get("method", "GET").upper()
+        url = config.get("url", "")
+        headers_config = config.get("headers") or []
+        body = config.get("body", "")
+        body_type = config.get("bodyType", "json")
+        timeout = config.get("timeout", 30)
+        retries = config.get("retries", 0)
+
+        # Variable interpolation for URL and headers
+        interpolated_url = interpolate_variables(url, inputs)
+        interpolated_headers = {
+            interpolate_variables(h["key"], inputs): interpolate_variables(h["value"], inputs)
+            for h in headers_config
+        }
+
+        # SSRF Protection
+        if not _is_safe_url(interpolated_url):
+            return {
+                "status": 0,
+                "headers": {},
+                "body": "",
+                "success": False,
+                "error": "Request blocked: Access to internal or private network addresses is not allowed.",
+            }
+
+        # Authentication handling
+        auth_type = config.get("authType", "none")
+        final_headers = dict(interpolated_headers)
+
+        if auth_type == "bearer":
+            token = interpolate_variables(config.get("authToken", ""), inputs)
+            final_headers["Authorization"] = f"Bearer {token}"
+        elif auth_type == "basic":
+            token = interpolate_variables(config.get("authToken", ""), inputs)
+            if ":" in token:
+                username, password = token.split(":", 1)
+            else:
+                username = token
+                password = ""
+            creds = base64.b64encode(f"{username}:{password}".encode()).decode()
+            final_headers["Authorization"] = f"Basic {creds}"
+        elif auth_type == "api_key":
+            key_name = interpolate_variables(config.get("apiKeyName", ""), inputs)
+            key_value = interpolate_variables(config.get("apiKeyValue", ""), inputs)
+            final_headers[key_name] = key_value
+
+        # Execute request with retry logic
+        last_exception = None
+        for attempt in range(retries + 1):
+            try:
+                prepared_data = None
+                prepared_json = None
+                if body:
+                    if body_type == "json":
+                        try:
+                            prepared_json = json.loads(body)
+                        except json.JSONDecodeError:
+                            prepared_data = body
+                    elif body_type == "form":
+                        prepared_data = dict(
+                            pair.split("=", 1) for pair in body.split("&") if "=" in pair
+                        )
+                    else:  # raw
+                        prepared_data = body
+
+                response = requests.request(
+                    method=method,
+                    url=interpolated_url,
+                    headers=final_headers,
+                    data=prepared_data,
+                    json=prepared_json,
+                    timeout=timeout,
+                    allow_redirects=False,
+                )
+                return {
+                    "status": response.status_code,
+                    "headers": dict(response.headers),
+                    "body": response.text,
+                    "success": True,
+                }
+            except requests.exceptions.RequestException as e:
+                last_exception = str(e)
+                if attempt < retries:
+                    time.sleep(2 ** attempt)
+                    continue
+                break
+
+        return {
+            "status": 0,
+            "headers": {},
+            "body": "",
+            "success": False,
+            "error": "Could not complete the request. Please check configuration and try again.",
+        }
+
+
+# Self-register on module import
+register_runner("http_request", HttpRequestRunner())


### PR DESCRIPTION
  ---                                                                                                                                                                                                          
  Closes #29           
                                                                                                                                                                                                               
  ## Summary                                                                                                                                                                                                   
                                                                                                                                                                                                               
  Adds an API Call node to the workflow engine, enabling HTTP requests (GET, POST, PUT, PATCH, DELETE) with SSRF protection, variable interpolation, and auth support. Allows pipelines to integrate directly  
  with external services without leaving the builder.                                                                                                                                                          
                                                            
  ## Linked issues                                                                                                                                                                                             
                                                            
  Closes #29
            
  ## Type of change
                   
  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [x] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📖 Docs                                                                                                                                                                                                
  - [x] Backwards compatible
                                                                                                                                                                                                               
  ## Special notes                                                                                                                                                                                             
                  
  - `runners/http_request.py` (new) — `HttpRequestRunner` with SSRF protection (DNS + IP blocking), variable interpolation via `${var}`, auth (bearer/basic/api_key), body type routing (json/form/raw), retry 
  with exponential backoff                                                                                                                                                                                     
  - `runners/__init__.py` — import to trigger self-registration
  - `NodeDrawer/apiCallNodeDrawer.js` (new) — colored method badges, truncated URL display, "Test Request" button                                                                                              
  - `NodeDrawer/forms/nodeFormSchemas.js` — `api_call` schema registered in `getNodeFormSchema()`                
                                                                                                                                                                                                               
  ---