### PR TITLE
fix: allow adding traces from null-workspace projects to annotation q…

### DIFF
--- a/futureagi/model_hub/utils/annotation_queue_helpers.py
+++ b/futureagi/model_hub/utils/annotation_queue_helpers.py
@@ -84,7 +84,11 @@ def resolve_source_object(source_type, source_id, organization=None, workspace=N
 
     if workspace is not None:
         obj_ws = _get_source_workspace(obj)
-        if obj_ws is None or obj_ws != workspace:
+        ws_match = (
+            obj_ws == workspace
+            or (obj_ws is None and getattr(workspace, "is_default", False))
+        )
+        if not ws_match:
             logger.warning(
                 "source_workspace_mismatch",
                 source_type=source_type,


### PR DESCRIPTION
## Summary

Fix annotation queue source resolution failing for traces belonging to projects with `workspace = NULL`.

Observe projects created via SDK/OTLP ingestion can have a null workspace because the ingestion flow does not always populate `project.workspace`. While these traces were still visible to users in the default workspace (via existing `BaseModelManager` null-workspace handling), annotation queue source resolution applied a stricter workspace check and rejected them as "Not found".

This caused users to see traces in the UI grid but fail when attempting to add them to annotation queues.

This PR updates the workspace matching logic in `annotation_queue_helpers.py` to allow null-workspace objects when the requesting user belongs to the default workspace, aligning annotation queue behavior with existing visibility rules used elsewhere in the application.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Created / used traces belonging to projects with `workspace = NULL`
- Verified traces remain visible in the Observe traces grid
- Verified traces can now successfully be added to annotation queues from the default workspace
- Verified non-default workspace isolation behavior remains unchanged
- Confirmed existing workspace-matching flows continue to work correctly

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)