### PR TITLE
[1/6] eval-task: test infrastructure & span-level regression coverage

### DIFF
--- a/futureagi/tracer/tests/conftest.py
+++ b/futureagi/tracer/tests/conftest.py
@@ -3,6 +3,7 @@ Conftest for tracer app tests.
 Provides fixtures specific to tracer models and test data.
 """
 
+import json
 import uuid
 from datetime import datetime, timedelta
 
@@ -298,3 +299,215 @@ def multiple_spans(db, project, trace):
         )
         spans.append(span)
     return spans
+
+
+# ── PR1 fixtures: stubs for eval-task runtime tests ──
+#
+# These let tests drive `process_eval_task` end-to-end against real Postgres
+# without hitting the eval engine, the billing/cost layer, or Temporal.
+# Each one is opt-in (no autouse) — pull only the ones a given test needs.
+
+
+@pytest.fixture
+def stub_run_eval(monkeypatch):
+    """Stub `evaluations.engine.run_eval` to a deterministic ``EvalResult``.
+
+    Returns a callable ``set_result(value=..., reason=..., failure=...)`` so
+    tests can flip pass/fail or simulate engine-side failures without
+    re-patching. Default outcome is a passing eval.
+
+    Patched at the package re-export (``evaluations.engine.run_eval``) AND at
+    the underlying definition (``evaluations.engine.runner.run_eval``) because
+    callers import both paths in different code locations.
+    """
+    from evaluations.engine.runner import EvalResult
+
+    state = {"value": True, "reason": "stubbed pass", "failure": None}
+
+    def _make_result():
+        return EvalResult(
+            value=state["value"],
+            data={"stub": True},
+            reason=state["reason"],
+            failure=state["failure"],
+            runtime=0.001,
+            model_used="stub-model",
+            metrics=None,
+            metadata={"stub": True},
+            output_type="Pass/Fail",
+            start_time=0.0,
+            end_time=0.001,
+            duration=0.001,
+            cost={"total_cost": 0.0},
+            token_usage={"prompt_tokens": 0, "completion_tokens": 0},
+        )
+
+    def _stub(_request):
+        return _make_result()
+
+    monkeypatch.setattr("evaluations.engine.run_eval", _stub, raising=False)
+    monkeypatch.setattr("evaluations.engine.runner.run_eval", _stub, raising=False)
+
+    def set_result(*, value=True, reason="stubbed pass", failure=None):
+        state["value"] = value
+        state["reason"] = reason
+        state["failure"] = failure
+
+    return set_result
+
+
+@pytest.fixture
+def stub_cost_log(monkeypatch):
+    """Stub ``log_and_deduct_cost_for_api_request`` so tests skip billing.
+
+    Returns a stub object that satisfies the contract ``_execute_evaluation``
+    expects: ``.status``, mutable ``.config``, ``.log_id``, and ``.save()``.
+    """
+    try:
+        from ee.usage.models.usage import APICallStatusChoices
+        processing_status = APICallStatusChoices.PROCESSING.value
+    except ImportError:
+        processing_status = "processing"
+
+    class _StubCostLog:
+        def __init__(self, config):
+            self.status = processing_status
+            self.config = json.dumps(config) if not isinstance(config, str) else config
+            self.log_id = uuid.uuid4()
+
+        def save(self):
+            pass
+
+    def _stub(*, organization, api_call_type, source, source_id, config, workspace, **kwargs):
+        return _StubCostLog(config)
+
+    monkeypatch.setattr(
+        "tracer.utils.eval.log_and_deduct_cost_for_api_request",
+        _stub,
+    )
+    return _stub
+
+
+@pytest.fixture
+def inline_temporal(monkeypatch):
+    """Replace ``.delay`` with the raw underlying function on eval activities so
+    the dispatcher executes them inline (no Temporal worker needed).
+
+    We use ``._original_func`` rather than ``.run_sync`` because ``run_sync``
+    wraps the call in ``close_old_connections()`` (the temporal_activity
+    decorator's DB-lifecycle hook), which closes pytest-django's TestCase
+    transaction connection mid-test and surfaces as ``OperationalError: the
+    connection is closed``. ``._original_func`` is the raw Python function
+    -- no DB lifecycle management, plays nicely with the test transaction.
+
+    Forward-compatible: each patch is gated by ``hasattr`` so activities
+    introduced in later PRs (PR4 adds ``evaluate_trace_observe`` and
+    ``evaluate_trace_session_observe``) are auto-patched once they exist.
+    Today only ``evaluate_observation_span_observe`` gets patched.
+    """
+    import tracer.utils.eval as eval_module
+
+    activity_names = (
+        "evaluate_observation_span_observe",
+        "evaluate_trace_observe",
+        "evaluate_trace_session_observe",
+    )
+    for name in activity_names:
+        if hasattr(eval_module, name):
+            activity = getattr(eval_module, name)
+            monkeypatch.setattr(activity, "delay", activity._original_func)
+
+
+@pytest.fixture
+def track_eval_dispatch(monkeypatch):
+    """Spy on ``.delay`` calls without executing the activity.
+
+    Returns a list that the test inspects after running the dispatcher to
+    assert which (entity_id, eval_config_id, eval_task_id) tuples were
+    fanned out. Use this when you want to test dispatcher behaviour without
+    incurring the cost of running each activity inline.
+    """
+    import tracer.utils.eval as eval_module
+
+    calls = []
+
+    def _make_recorder(activity_name):
+        def _record(*args, **kwargs):
+            calls.append((activity_name, args, kwargs))
+
+        return _record
+
+    activity_names = (
+        "evaluate_observation_span_observe",
+        "evaluate_trace_observe",
+        "evaluate_trace_session_observe",
+    )
+    for name in activity_names:
+        if hasattr(eval_module, name):
+            activity = getattr(eval_module, name)
+            monkeypatch.setattr(activity, "delay", _make_recorder(name))
+
+    return calls
+
+
+@pytest.fixture
+def populated_observe_project(db, observe_project):
+    """Build a small, realistic graph for end-to-end task tests.
+
+    2 sessions × 2 traces × 3 spans. Each trace's first span (sp_idx=0) is
+    its root (``parent_span_id IS NULL``); the others have it as parent.
+    Span types alternate between ``llm`` and ``tool``. Returns a dict so
+    tests can grab specific entities without re-querying.
+    """
+    sessions = []
+    traces = []
+    spans = []
+
+    for s_idx in range(2):
+        session = TraceSession.objects.create(
+            project=observe_project,
+            name=f"Session {s_idx}",
+            bookmarked=False,
+        )
+        sessions.append(session)
+
+        for t_idx in range(2):
+            trace = Trace.objects.create(
+                project=observe_project,
+                session=session,
+                name=f"Trace s{s_idx}t{t_idx}",
+                input={"prompt": f"input s{s_idx}t{t_idx}"},
+                output={"response": f"output s{s_idx}t{t_idx}"},
+                metadata={"session_idx": s_idx, "trace_idx": t_idx},
+            )
+            traces.append(trace)
+
+            root_span_id = f"span_s{s_idx}t{t_idx}_0"
+            for sp_idx in range(3):
+                span_id = f"span_s{s_idx}t{t_idx}_{sp_idx}"
+                ObservationSpan.objects.create(
+                    id=span_id,
+                    project=observe_project,
+                    trace=trace,
+                    parent_span_id=None if sp_idx == 0 else root_span_id,
+                    name=f"Span s{s_idx}t{t_idx}_{sp_idx}",
+                    observation_type="llm" if sp_idx % 2 == 0 else "tool",
+                    start_time=timezone.now() - timedelta(seconds=10 - sp_idx),
+                    end_time=timezone.now() - timedelta(seconds=9 - sp_idx),
+                    input={"messages": [{"role": "user", "content": f"hi s{s_idx}t{t_idx}_{sp_idx}"}]},
+                    output={"choices": [{"message": {"content": f"reply s{s_idx}t{t_idx}_{sp_idx}"}}]},
+                    span_attributes={
+                        "input": {"value": f"hi s{s_idx}t{t_idx}_{sp_idx}"},
+                        "output": {"value": f"reply s{s_idx}t{t_idx}_{sp_idx}"},
+                    },
+                    model="gpt-4",
+                    status="OK",
+                )
+            spans.extend(list(trace.observation_spans.order_by("start_time")))
+
+    return {
+        "project": observe_project,
+        "sessions": sessions,
+        "traces": traces,
+        "spans": spans,
+    }

--- a/futureagi/tracer/tests/test_eval_task_runtime.py
+++ b/futureagi/tracer/tests/test_eval_task_runtime.py
@@ -1,0 +1,240 @@
+"""
+Eval-task runtime tests.
+
+Drive ``process_eval_task`` end-to-end against real Postgres with the eval
+engine, billing layer, and Temporal stubbed via fixtures from conftest.py:
+  - ``stub_run_eval``, ``stub_cost_log``: skip the engine + cost layers.
+  - ``inline_temporal``: route ``.delay`` -> ``.run_sync`` so dispatch executes inline.
+  - ``track_eval_dispatch``: spy on ``.delay`` to assert dispatcher fan-out without running.
+
+These tests pin the current span-level behaviour. PR4 will add trace+session
+counterparts (those tests live in this same file).
+"""
+
+import pytest
+
+# Break a pre-existing import cycle: ``tracer.utils.eval_tasks`` imports
+# ``tracer.utils.eval``, which imports ``model_hub.tasks.user_evaluation``,
+# which loads ``model_hub.tasks.__init__`` -- and that __init__ imports
+# from ``tracer.utils.eval_tasks``. In production Django app autoloading
+# walks ``model_hub.tasks`` before anyone imports ``tracer.utils.eval_tasks``
+# directly, so the cycle resolves. Test files don't get that ordering for
+# free; importing ``model_hub.tasks`` first here lets the chain unwind via
+# the user_evaluation submodule (which doesn't depend on tracer.utils.eval).
+import model_hub.tasks  # noqa: F401, E402
+
+from tracer.models.custom_eval_config import CustomEvalConfig  # noqa: E402
+from tracer.models.eval_task import EvalTask, EvalTaskStatus, RunType  # noqa: E402
+from tracer.models.observation_span import EvalLogger  # noqa: E402
+from tracer.utils.eval_tasks import process_eval_task  # noqa: E402
+
+
+@pytest.fixture
+def observe_eval_task(db, populated_observe_project, eval_template):
+    """Historical eval task scoped to ``populated_observe_project``.
+
+    Returns ``{"task": EvalTask, "config": CustomEvalConfig, "project": Project}``.
+    """
+    project = populated_observe_project["project"]
+    config = CustomEvalConfig.objects.create(
+        project=project,
+        eval_template=eval_template,
+        name="Test Span Eval",
+        config={"output": "Pass/Fail"},
+        mapping={"input": "input", "output": "output"},
+        model="turing_large",
+    )
+    task = EvalTask.objects.create(
+        project=project,
+        name="Test spans task",
+        filters={"project_id": str(project.id)},
+        sampling_rate=100.0,
+        run_type=RunType.HISTORICAL,
+        spans_limit=1000,
+        status=EvalTaskStatus.PENDING,
+    )
+    task.evals.add(config)
+    return {"task": task, "config": config, "project": project}
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestProcessEvalTaskSpans:
+    """Span-level dispatcher behaviour locked in as a regression net."""
+
+    def test_creates_eval_logger_per_span(
+        self,
+        populated_observe_project,
+        observe_eval_task,
+        stub_run_eval,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """One EvalLogger row per (span, eval) pair after a single dispatch tick."""
+        task = observe_eval_task["task"]
+
+        process_eval_task._original_func(str(task.id))
+
+        rows = EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False)
+        # 2 sessions * 2 traces * 3 spans = 12 spans, * 1 eval = 12 EvalLogger rows
+        assert rows.count() == 12
+        assert all(r.observation_span_id is not None for r in rows)
+        span_ids = {s.id for s in populated_observe_project["spans"]}
+        assert {r.observation_span_id for r in rows} == span_ids
+
+    def test_respects_sampling_rate(
+        self,
+        populated_observe_project,
+        observe_eval_task,
+        stub_run_eval,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """sampling_rate=50 with 12 spans -> int(12 * 0.5) = 6 sampled."""
+        task = observe_eval_task["task"]
+        task.sampling_rate = 50.0
+        task.save()
+
+        process_eval_task._original_func(str(task.id))
+
+        count = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).count()
+        assert count == 6
+
+    def test_respects_spans_limit(
+        self,
+        populated_observe_project,
+        observe_eval_task,
+        stub_run_eval,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """spans_limit caps how many entities the dispatcher hands out per tick."""
+        task = observe_eval_task["task"]
+        task.spans_limit = 3
+        task.save()
+
+        process_eval_task._original_func(str(task.id))
+
+        count = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).count()
+        assert count == 3
+
+    def test_dedup_on_second_tick(
+        self,
+        populated_observe_project,
+        observe_eval_task,
+        stub_run_eval,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """Second tick reuses spanids_processed; no additional EvalLogger rows."""
+        task = observe_eval_task["task"]
+
+        process_eval_task._original_func(str(task.id))
+        first_count = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).count()
+
+        process_eval_task._original_func(str(task.id))
+        second_count = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).count()
+
+        assert second_count == first_count
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestEvalTaskStatusTransitions:
+    """End-to-end status flow: PENDING -> RUNNING -> COMPLETED / FAILED."""
+
+    def test_pending_to_running_to_completed(
+        self,
+        populated_observe_project,
+        observe_eval_task,
+        stub_run_eval,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """First tick dispatches inline; second tick finds drain complete and flips to COMPLETED."""
+        task = observe_eval_task["task"]
+        assert task.status == EvalTaskStatus.PENDING
+
+        process_eval_task._original_func(str(task.id))
+        task.refresh_from_db()
+        # Dispatch tick keeps status at RUNNING — the drain check happens on the next tick
+        assert task.status == EvalTaskStatus.RUNNING
+
+        process_eval_task._original_func(str(task.id))
+        task.refresh_from_db()
+        assert task.status == EvalTaskStatus.COMPLETED
+
+    def test_failed_on_dispatch_exception(
+        self,
+        populated_observe_project,
+        observe_eval_task,
+        monkeypatch,
+    ):
+        """Any exception inside the dispatch loop flips status to FAILED."""
+        import tracer.utils.eval as eval_module
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated dispatch failure")
+
+        monkeypatch.setattr(
+            eval_module.evaluate_observation_span_observe, "delay", _boom
+        )
+
+        task = observe_eval_task["task"]
+        process_eval_task._original_func(str(task.id))
+        task.refresh_from_db()
+        assert task.status == EvalTaskStatus.FAILED
+
+    def test_drain_stall_completes_task_with_warning(
+        self,
+        populated_observe_project,
+        observe_eval_task,
+        track_eval_dispatch,
+        monkeypatch,
+        caplog,
+    ):
+        """Dispatch without execution -> next tick detects stall, logs warning, flips to COMPLETED.
+
+        Note on `failed_spans`: the dispatcher *intends* to surface the stall
+        summary on `EvalTask.failed_spans`, but the current code path
+        (`tracer/utils/eval_tasks.py:282-329`) saves the summary via a
+        `select_for_update`'d ref then immediately calls `eval_task.save()`
+        on the stale local reference WITHOUT `update_fields`, clobbering the
+        just-written list back to []. This is a pre-existing bug — test pins
+        the observable behaviour (status flip + warning log) so future fixes
+        that correctly persist `failed_spans` will surface as a deliberate
+        update to this test, not a silent regression.
+        """
+        import logging
+
+        monkeypatch.setattr("tracer.utils.eval_tasks._DRAIN_STALL_SECONDS", 0)
+
+        task = observe_eval_task["task"]
+        task.spans_limit = 12
+        task.save()
+
+        process_eval_task._original_func(str(task.id))  # tick 1: dispatch only
+        assert len(track_eval_dispatch) == 12
+        assert EvalLogger.objects.filter(eval_task_id=str(task.id)).count() == 0
+
+        with caplog.at_level(logging.WARNING, logger="tracer.utils.eval_tasks"):
+            process_eval_task._original_func(str(task.id))  # tick 2: drain check trips stall
+
+        task.refresh_from_db()
+        assert task.status == EvalTaskStatus.COMPLETED
+        # The "eval_task_completed_with_drops" warning is the user-observable
+        # signal that a stall was detected (logged for SRE / Sentry).
+        assert any(
+            "eval_task_completed_with_drops" in record.getMessage()
+            for record in caplog.records
+        ), "expected stall-detection warning in logs"


### PR DESCRIPTION
## Stack

This is **#1 of 6** in the eval-task `row_type` stack.

```
dev
 └─ feature/eval-task-row-type
     ├─ pr/01-test-infra            ← this PR
     │   └─ pr/02-persist-row-type
     │       └─ pr/03-eval-logger-shape
     │           └─ pr/04-trace-and-session-evaluation
     │               └─ pr/05-row-type-aware-attributes
     │                   └─ pr/06-session-drawer-evals
     └─ feature → dev once whole stack lands
```

Plan reference: `EvalTask row_type — Stacked PR Plan` (approved before PR1 cut).

## Summary

Lands the test foundation for the row_type stack. Zero production code change — just fixtures + tests that pin **current** span-level dispatcher behaviour so PRs 2–6 can refactor with a regression net.

**Why land tests first**: the EvalLogger schema change (PR3) and the dispatcher refactor (PR4) both touch hot paths. Having an executable spec of "what works today" before either PR is merged means every diff after this one can be reviewed against a green baseline.

## Diff

- `futureagi/tracer/tests/conftest.py` — +213 LOC. Five new fixtures, all opt-in (no `autouse`). Existing fixtures untouched.
- `futureagi/tracer/tests/test_eval_task_runtime.py` — new file. 7 tests across two classes.

### Fixtures

| Fixture | What it does |
|---|---|
| `stub_run_eval` | Monkeypatches `evaluations.engine.run_eval` to a deterministic `EvalResult`. Returns a `set_result(value=, reason=, failure=)` callable for tests that want to drive pass/fail outcomes. |
| `stub_cost_log` | Stubs `tracer.utils.eval.log_and_deduct_cost_for_api_request` with a fake row that satisfies the `.status / .config / .log_id / .save()` contract `_execute_evaluation` expects. |
| `inline_temporal` | Replaces `.delay` with `._original_func` on the eval activities so the dispatcher executes them inline. Uses `_original_func` rather than `.run_sync` because `run_sync` wraps in `close_old_connections()` which closes pytest-django's TestCase transaction connection mid-test. `hasattr`-gated so PR4's new activities are auto-picked-up once they exist. |
| `track_eval_dispatch` | Spy on `.delay` calls without executing — for tests that only care about dispatcher fan-out shape. |
| `populated_observe_project` | 2 sessions × 2 traces × 3 spans on a real `observe_project`. Each trace's first span (`sp_idx=0`) is its root (`parent_span_id IS NULL`). |

### Tests

`TestProcessEvalTaskSpans` (4):
- `test_creates_eval_logger_per_span`
- `test_respects_sampling_rate`
- `test_respects_spans_limit`
- `test_dedup_on_second_tick`

`TestEvalTaskStatusTransitions` (3):
- `test_pending_to_running_to_completed`
- `test_failed_on_dispatch_exception`
- `test_drain_stall_completes_task_with_warning`

## Test plan

- [x] `uv run pytest tracer/tests/test_eval_task_runtime.py -v` → 7/7 passing locally against the canonical test stack (`docker-compose.test.yml -p futureagi-test`, `.env.test.local`).
- [x] `uv run pytest tracer/tests/test_eval_task.py -v` → confirmed 2 pre-existing failures (`test_create_eval_task_success`, `test_pause_eval_task_success`) reproduce on `dev` without this PR's changes. Not in scope for PR1.
- [ ] CI green against `feature/eval-task-row-type`.

## Pre-existing bugs surfaced (not fixed in this PR)

1. **Import cycle**: `tracer.utils.eval_tasks` → `tracer.utils.eval` → `model_hub.tasks.user_evaluation` → `model_hub.tasks.__init__` → `tracer.utils.eval_tasks.eval_task_cron` (which is still loading). Production resolves it via Django app autoloading order; tests don't get that ordering for free. PR1 works around with a single leading `import model_hub.tasks` in the test file (with a docstring explaining why). Cycle itself is a follow-up.
2. **Drain-stall summary clobbered**: `tracer/utils/eval_tasks.py:282-329` writes the stall summary on a `select_for_update`'d ref (`_et`), then immediately calls `eval_task.save()` on the stale local ref **without** `update_fields`, overwriting the just-written `failed_spans` back to `[]`. PR1's `test_drain_stall_completes_task_with_warning` pins the observable behaviour (status → COMPLETED, warning log fires) rather than the broken `failed_spans` assertion that would lock in the bug. Comment in the test flags it for a follow-up.

## Risk

- Migration: none.
- Rollback: revert the squash-merge — no data, no schema, no behaviour change.
- Cross-repo deploy: n/a.