### PR TITLE
fix(evals): retry gateway calls in LLM class for transient failures

### DIFF
--- a/futureagi/agentic_eval/core/llm/llm.py
+++ b/futureagi/agentic_eval/core/llm/llm.py
@@ -635,6 +635,11 @@ class LLM:
                         content = gw_response.choices[0].message.content
                         return content if content is not None else ""
 
+                    if self.provider == "turing":
+                        _resolved = os.environ.get(f"{payload['model'].upper()}_MODEL")
+                        if _resolved:
+                            payload["model"] = _resolved
+
                     if streaming:
                         payload["stream"] = True
                         payload["stream_options"] = {"include_usage": True}
@@ -796,6 +801,11 @@ class LLM:
                     if not gw_response.choices:
                         raise ValueError("Empty response from gateway")
                     return gw_response
+
+                if self.provider == "turing":
+                    _resolved = os.environ.get(f"{payload['model'].upper()}_MODEL")
+                    if _resolved:
+                        payload["model"] = _resolved
 
                 response = litellm.completion(
                     **payload,

--- a/futureagi/agentic_eval/core/llm/llm.py
+++ b/futureagi/agentic_eval/core/llm/llm.py
@@ -414,6 +414,9 @@ class LLM:
         except (ImportError, Exception):
             pass
 
+    GATEWAY_MAX_ATTEMPTS = 3
+    GATEWAY_RETRY_BACKOFF = (0.5, 1.0, 2.0)
+
     def _try_gateway_completion(
         self, payload: dict, tools: Optional[list] = None
     ) -> Optional[Any]:
@@ -422,24 +425,31 @@ class LLM:
             return None
         if getattr(self, "api_key", None):
             return None
-        try:
-            extra_headers = {}
-            if getattr(self, "org_id", None):
-                extra_headers["X-Org-Id"] = self.org_id
-            kwargs = self._build_gateway_request_kwargs(
-                payload=payload,
-                extra_headers=extra_headers or None,
-            )
-            if tools:
-                kwargs["tools"] = tools
-            return self._gateway_client.chat.completions.create(**kwargs)
-        except Exception as gw_err:
-            logger.debug(
-                "gateway_call_failed_falling_back_to_litellm",
-                error=str(gw_err),
-                model=payload.get("model", self.model_name),
-            )
-            return None
+
+        extra_headers = {}
+        if getattr(self, "org_id", None):
+            extra_headers["X-Org-Id"] = self.org_id
+        kwargs = self._build_gateway_request_kwargs(
+            payload=payload,
+            extra_headers=extra_headers or None,
+        )
+        if tools:
+            kwargs["tools"] = tools
+
+        for attempt in range(self.GATEWAY_MAX_ATTEMPTS):
+            try:
+                return self._gateway_client.chat.completions.create(**kwargs)
+            except Exception as gw_err:
+                logger.warning(
+                    "gateway_attempt_failed",
+                    error=str(gw_err),
+                    model=payload.get("model", self.model_name),
+                    attempt=attempt + 1,
+                    max_attempts=self.GATEWAY_MAX_ATTEMPTS,
+                )
+                if attempt < self.GATEWAY_MAX_ATTEMPTS - 1:
+                    time.sleep(self.GATEWAY_RETRY_BACKOFF[attempt])
+        return None
 
     def _build_gateway_request_kwargs(
         self,
@@ -468,24 +478,31 @@ class LLM:
             return None
         if getattr(self, "api_key", None):
             return None
-        try:
-            extra_headers = {}
-            if getattr(self, "org_id", None):
-                extra_headers["X-Org-Id"] = self.org_id
-            kwargs = self._build_gateway_request_kwargs(
-                payload=payload,
-                extra_headers=extra_headers or None,
-            )
-            if tools:
-                kwargs["tools"] = tools
-            return await self._async_gateway_client.chat.completions.create(**kwargs)
-        except Exception as gw_err:
-            logger.debug(
-                "async_gateway_call_failed_falling_back_to_litellm",
-                error=str(gw_err),
-                model=payload.get("model", self.model_name),
-            )
-            return None
+
+        extra_headers = {}
+        if getattr(self, "org_id", None):
+            extra_headers["X-Org-Id"] = self.org_id
+        kwargs = self._build_gateway_request_kwargs(
+            payload=payload,
+            extra_headers=extra_headers or None,
+        )
+        if tools:
+            kwargs["tools"] = tools
+
+        for attempt in range(self.GATEWAY_MAX_ATTEMPTS):
+            try:
+                return await self._async_gateway_client.chat.completions.create(**kwargs)
+            except Exception as gw_err:
+                logger.warning(
+                    "async_gateway_attempt_failed",
+                    error=str(gw_err),
+                    model=payload.get("model", self.model_name),
+                    attempt=attempt + 1,
+                    max_attempts=self.GATEWAY_MAX_ATTEMPTS,
+                )
+                if attempt < self.GATEWAY_MAX_ATTEMPTS - 1:
+                    await asyncio.sleep(self.GATEWAY_RETRY_BACKOFF[attempt])
+        return None
 
     def _update_token_usage(self, response: Any) -> None:
         """

--- a/futureagi/agentic_eval/core/llm/llm.py
+++ b/futureagi/agentic_eval/core/llm/llm.py
@@ -16,11 +16,6 @@ import requests
 import structlog
 from agentic_eval.core.utils.functions import download_image_to_base64
 from agentic_eval.core.utils.model_config import ModelConfigs
-
-
-def _turing_aliases():
-    from model_hub.models.choices import ModelChoices
-    return {m.value for m in ModelChoices if m.name.startswith("TURING_")} | {"turing_large_xl"}
 from agentic_eval.core_evals.fi_utils.token_count_helper import calculate_total_cost
 from anthropic import AnthropicBedrock, AsyncAnthropic, AsyncAnthropicBedrock
 from botocore.exceptions import ClientError
@@ -657,11 +652,6 @@ class LLM:
                         content = gw_response.choices[0].message.content
                         return content if content is not None else ""
 
-                    if payload["model"] in _turing_aliases():
-                        _resolved = os.environ.get(f"{payload['model'].upper()}_MODEL")
-                        if _resolved:
-                            payload["model"] = _resolved
-
                     if streaming:
                         payload["stream"] = True
                         payload["stream_options"] = {"include_usage": True}
@@ -823,11 +813,6 @@ class LLM:
                     if not gw_response.choices:
                         raise ValueError("Empty response from gateway")
                     return gw_response
-
-                if payload["model"] in _turing_aliases():
-                    _resolved = os.environ.get(f"{payload['model'].upper()}_MODEL")
-                    if _resolved:
-                        payload["model"] = _resolved
 
                 response = litellm.completion(
                     **payload,

--- a/futureagi/agentic_eval/core/llm/llm.py
+++ b/futureagi/agentic_eval/core/llm/llm.py
@@ -16,6 +16,11 @@ import requests
 import structlog
 from agentic_eval.core.utils.functions import download_image_to_base64
 from agentic_eval.core.utils.model_config import ModelConfigs
+
+
+def _turing_aliases():
+    from model_hub.models.choices import ModelChoices
+    return {m.value for m in ModelChoices if m.name.startswith("TURING_")} | {"turing_large_xl"}
 from agentic_eval.core_evals.fi_utils.token_count_helper import calculate_total_cost
 from anthropic import AnthropicBedrock, AsyncAnthropic, AsyncAnthropicBedrock
 from botocore.exceptions import ClientError
@@ -652,7 +657,7 @@ class LLM:
                         content = gw_response.choices[0].message.content
                         return content if content is not None else ""
 
-                    if self.provider == "turing":
+                    if payload["model"] in _turing_aliases():
                         _resolved = os.environ.get(f"{payload['model'].upper()}_MODEL")
                         if _resolved:
                             payload["model"] = _resolved
@@ -819,7 +824,7 @@ class LLM:
                         raise ValueError("Empty response from gateway")
                     return gw_response
 
-                if self.provider == "turing":
+                if payload["model"] in _turing_aliases():
                     _resolved = os.environ.get(f"{payload['model'].upper()}_MODEL")
                     if _resolved:
                         payload["model"] = _resolved


### PR DESCRIPTION
## Summary
- `agentic_eval/core/llm/llm.py` (`LLM` class — used by `CustomPromptEvaluator`, `TuringClient`, run_prompt handlers) doesn't have a `stream_with_retry` equivalent. The outer `MAX_RETRIES` loop retries on `Exception`, but `_try_gateway_completion` *returns None silently* on failure — so the gateway only gets retried by accident, when the subsequent `litellm.completion` call raises (which it does for turing aliases since litellm doesn't know them).
- Now: `_try_gateway_completion` and `_try_gateway_completion_async` retry the gateway call 3× (0.5s/1s/2s backoff) before returning None. Logs `gateway_attempt_failed` per attempt for observability.

This is the LLM-class side only. 

Linear: TH-4774

## Test plan
- [x] `docker stop core-backend-gateway-1` → `TuringClient.chat_completion(model="turing_flash", ...)` logs 3× `gateway_attempt_failed` per outer attempt (the existing outer `MAX_RETRIES` loop also fires)
- [x] Gateway up: hits gateway on first attempt, no retry overhead