### PR TITLE
fix: sort eval column groups so result renders before reason by default

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -722,6 +722,21 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
       }
     }
 
+    // Ensure evaluation columns come before evaluation_reason in each
+    // group so the result renders by default (not the reason).
+    for (const key of Object.keys(grouping)) {
+      const grp = grouping[key];
+      if (grp.length > 1) {
+        grp.sort((a, b) => {
+          const aType = a.originType || a.origin_type || "";
+          const bType = b.originType || b.origin_type || "";
+          if (aType === "evaluation" && bType !== "evaluation") return -1;
+          if (bType === "evaluation" && aType !== "evaluation") return 1;
+          return 0;
+        });
+      }
+    }
+
     const columnMap = [];
 
     for (const [_, cols] of Object.entries(grouping)) {


### PR DESCRIPTION
## Summary

When certain evaluations were created, the backend inserted the `evaluation_reason` column into `column_order` before the `evaluation` column. The frontend groups eval+reason columns by `sourceId` and renders `cols[0]` as the default visible column. For affected evals, `cols[0]` was the reason column — so users saw reasoning text instead of the eval result (pass/fail/score). Clicking "Show Reasoning" then revealed the eval result, which is the opposite of expected behavior.

The fix adds a sort after grouping in `DevelopDataV2.jsx` to ensure `evaluation` columns always come before `evaluation_reason` within each group, regardless of backend ordering.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

1. Opened dataset `e99d66c9-13c2-4dd0-8840-56622ccc392b` which has 6 evals — 4 render correctly, 2 show reasoning instead of result
2. Verified the API response has `evaluation_reason` columns at lower `order_index` than their paired `evaluation` columns for the 2 affected evals
3. After fix: all 6 evals render the result column by default
4. Toggling "Show Reasoning" correctly expands to show both result + reason as grouped children
5. "Hide Reasoning" collapses back to result-only — no regression on working evals

## Screenshots / recordings (if UI)

**Before:** Last 2 eval columns show reasoning text by default. Clicking "Show Reasoning" reveals the actual eval result.

**After:** All eval columns show pass/fail/score by default. "Show Reasoning" expands to show the explanation.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)