### PR TITLE
fix(labeler): switch to pull_request_target for fork PR support

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Label PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!
## Summary
- Labeler workflow was failing on fork PRs with `Resource not accessible by integration`.
- Root cause: `pull_request` events from forks get a read-only `GITHUB_TOKEN` by GitHub design — `permissions:` in the workflow can't override this. The labeler needs `pull-requests: write`.
- Switched the trigger to `pull_request_target`, which runs in the base repo's context and grants the declared write permissions. Safe here because the labeler only reads the PR's file list via API and never checks out or executes fork code.

## Test plan
- [ ] Open a PR from a fork and confirm labels are applied automatically.
- [ ] Push a new commit to the fork PR (`synchronize` event) and confirm labels update.
- [ ] Confirm labeler still works on PRs from branches in the base repo.
- [ ] Verify no other workflows regressed.


<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
