### PR TITLE
fix(tracer): tolerate span PK collisions during bulk COPY

### DIFF
--- a/futureagi/tracer/utils/trace_ingestion.py
+++ b/futureagi/tracer/utils/trace_ingestion.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 import structlog
-from django.db import connection, models, transaction
+from django.db import IntegrityError, connection, models, transaction
 from django.utils import timezone
 
 logger = structlog.get_logger(__name__)
@@ -91,6 +91,25 @@ def _serialize_json_field_value(val: Any) -> str | None:
             return json.dumps(val)
 
     return json.dumps(val)
+
+
+def _is_pk_unique_violation(exc: BaseException, table_name: str) -> bool:
+    """True iff exc represents a unique violation on ``{table_name}_pkey``.
+
+    Handles both Django-wrapped IntegrityError (psycopg cause on __cause__)
+    and the raw psycopg UniqueViolation that escapes from ``cursor.copy()``
+    contexts (which bypass Django's exception translation).
+    """
+    from psycopg.errors import UniqueViolation as PgUniqueViolation
+
+    pg_exc: Any = exc if isinstance(exc, PgUniqueViolation) else getattr(
+        exc, "__cause__", None
+    )
+    if not isinstance(pg_exc, PgUniqueViolation):
+        return False
+    diag = getattr(pg_exc, "diag", None)
+    constraint = getattr(diag, "constraint_name", None) if diag else None
+    return constraint == f"{table_name}_pkey"
 
 
 def _bulk_create_with_copy(model: models.Model, objects: list[models.Model]):
@@ -580,7 +599,13 @@ def _prepare_observation_spans_and_trace_updates(
 
 
 def _bulk_insert_observation_spans(spans_to_create: list[ObservationSpan]):
-    """Sets timestamps and bulk inserts observation spans using the COPY command."""
+    """Sets timestamps and bulk inserts observation spans.
+
+    Fast path: PostgreSQL COPY (all-or-nothing). On unique-key collision (e.g.
+    a client double-submitting an OTLP batch), the savepoint rolls back and we
+    re-insert via bulk_create(ignore_conflicts=True), which emits
+    INSERT ... ON CONFLICT DO NOTHING and skips only the duplicate rows.
+    """
     if not spans_to_create:
         return
 
@@ -592,7 +617,23 @@ def _bulk_insert_observation_spans(spans_to_create: list[ObservationSpan]):
         if not span.updated_at:
             span.updated_at = now
 
-    _bulk_create_with_copy(ObservationSpan, spans_to_create)
+    from psycopg.errors import UniqueViolation as PgUniqueViolation
+
+    try:
+        with transaction.atomic():
+            _bulk_create_with_copy(ObservationSpan, spans_to_create)
+    except (IntegrityError, PgUniqueViolation) as e:
+        if not _is_pk_unique_violation(e, "tracer_observation_span"):
+            raise
+        logger.warning(
+            "observation_span_copy_pk_violation_falling_back",
+            batch_size=len(spans_to_create),
+        )
+        ObservationSpan.objects.bulk_create(
+            spans_to_create,
+            ignore_conflicts=True,
+            batch_size=500,
+        )
 
 
 def _bulk_update_traces(


### PR DESCRIPTION
## Summary

`_bulk_insert_observation_spans` ingests OTLP spans via PostgreSQL `COPY` for speed, but `COPY` is all-or-nothing — a single duplicate primary key on `tracer_observation_span_pkey` aborted the entire batch and the raw `psycopg.errors.UniqueViolation` propagated out of the activity, killing the workflow and dropping every span (not just the duplicate).

The previous code path didn't catch this because (a) `cursor.copy()` raises the *raw* psycopg `UniqueViolation` directly, bypassing Django's exception translation, and (b) without `transaction.atomic()` the connection was left in `aborted-transaction` state, so any recovery query would itself fail.

This PR wraps the COPY in `transaction.atomic()`, catches both `IntegrityError` and the raw `psycopg.errors.UniqueViolation`, and only swallows the error when the violated constraint is exactly `tracer_observation_span_pkey`. On match, it falls back to `bulk_create(ignore_conflicts=True)` (`INSERT … ON CONFLICT DO NOTHING`) which keeps the good rows and skips only the duplicates. FK / NOT NULL / non-PK unique violations still fail loudly. New helper `_is_pk_unique_violation(exc, table_name)` does the constraint-name match against `pg_exc.diag.constraint_name`.

Pairs with #277 — that PR removes the retry-driven collisions; this one is the safety net for concurrent-worker races and any in-flight workflows still on the old retry policy.

## Linked issues

Linear: [TH-4778](https://linear.app/future-agi/issue/TH-4778/tracer-span-bulk-copy-crashes-on-duplicate-primary-key-drops-entire)

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Manual scenarios to be exercised against the dev compose stack:

1. Send the same OTLP batch twice in quick succession — both ingest cleanly, no workflow failure, no duplicate rows in \`tracer_observation_span\`.
2. Submit a batch with a NOT NULL or FK violation in one row — activity still fails loudly (verifies the narrow PK-only fallback).
3. Run the worker against the existing in-flight backlog of failing workflows — they succeed on the next attempt instead of dropping the entire batch.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] \`make check-all\` / \`yarn check-all\` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)