### PR TITLE
fix(auth): track OAuth signup ad conversions via is_new_user URL signal

### DIFF
--- a/frontend/src/auth/guard/auth-guard.jsx
+++ b/frontend/src/auth/guard/auth-guard.jsx
@@ -54,6 +54,7 @@ function Container({ children }) {
     const sso_token =
       queryParams.get("sso_token") || queryParams.get("access_token");
     const refreshToken = queryParams.get("refresh_token");
+    const isNewOAuthUser = queryParams.get("is_new_user") === "true";
     const returnTo = localStorage.getItem("redirectUrl");
 
     if (!authenticated) {
@@ -62,6 +63,11 @@ function Container({ children }) {
           localStorage.setItem("refreshToken", refreshToken);
         }
         localStorage.setItem("accessToken", sso_token);
+    
+        if (isNewOAuthUser) {
+          localStorage.setItem("isNewOAuthSignup", "1");
+          localStorage.setItem("isNewOAuthSignupAt", String(Date.now()));
+        }
         // if (newOrg) {
         //   // redirect to onboarding page
         //   window.location.href = "/auth/jwt/setup-org";
@@ -105,6 +111,37 @@ function Container({ children }) {
     // Skip redirect logic for standalone pages (e.g. MCP OAuth consent)
     if (window.location.pathname.startsWith("/mcp/")) return;
     if (!user) return;
+    const isNewOAuthSignup =
+      localStorage.getItem("isNewOAuthSignup") === "1";
+    if (isNewOAuthSignup) {
+      const stampedAt = Number(
+        localStorage.getItem("isNewOAuthSignupAt") || 0,
+      );
+      const fresh = Date.now() - stampedAt < 10 * 60 * 1000;
+      const provider = localStorage.getItem("signupProvider") || "oauth";
+      if (fresh && user?.email && user?.id && provider !== "email") {
+        if (typeof window.gtag === "function") {
+          trackSignupConversion({
+            email: user.email,
+            method: provider,
+            userId: String(user.id),
+          });
+        }
+        if (typeof window.rdt === "function") {
+          trackRedditSignup({
+            email: user.email,
+            userId: String(user.id),
+          });
+        }
+        trackTwitterSignup({
+          email: user.email,
+          method: provider,
+          userId: String(user.id),
+        });
+      }
+      localStorage.removeItem("isNewOAuthSignup");
+      localStorage.removeItem("isNewOAuthSignupAt");
+    }
 
     // New user to platform (requires_org_setup) — redirect to org-setup
     // flow and, for OAuth/SSO paths, fire ad-platform signup conversions.

--- a/futureagi/saml2_auth/views.py
+++ b/futureagi/saml2_auth/views.py
@@ -657,7 +657,10 @@ class Auth0CallbackView(APIView):
                     timeout=AUTH_TOKEN_EXPIRATION_TIME_IN_MINUTES * 60,
                 )
 
-                next_url += f"?sso_token={str(access_token_encrypted)}"
+                next_url += (
+                    f"?sso_token={str(access_token_encrypted)}"
+                    f"&is_new_user={new_org}"
+                )
                 login_next_url = request.session.get("login_next_url", None)
                 if login_next_url:
                     next_url += f"&next={login_next_url}"
@@ -792,7 +795,10 @@ class GithubCallbackView(APIView):
                 timeout=AUTH_TOKEN_EXPIRATION_TIME_IN_MINUTES * 60,
             )
 
-            next_url += f"?sso_token={str(access_token_encrypted)}"
+            next_url += (
+                f"?sso_token={str(access_token_encrypted)}"
+                f"&is_new_user={new_org}"
+            )
             login_next_url = request.session.get("login_next_url", None)
             if login_next_url:
                 next_url += f"&next={login_next_url}"
@@ -912,7 +918,10 @@ class MicrosoftCallbackView(APIView):
                 timeout=AUTH_TOKEN_EXPIRATION_TIME_IN_MINUTES * 60,
             )
 
-            next_url += f"?sso_token={str(access_token_encrypted)}"
+            next_url += (
+                f"?sso_token={str(access_token_encrypted)}"
+                f"&is_new_user={new_org}"
+            )
             login_next_url = request.session.get("login_next_url", None)
             if login_next_url:
                 next_url += f"&next={login_next_url}"


### PR DESCRIPTION
## Summary
- OAuth callbacks (Auth0, GitHub, Microsoft) now append `&is_new_user=true|false`
  to the post-login redirect URL. Previously this signal lived on a 302
  response header that browsers drop, so the frontend never received it.
- `auth-guard.jsx` reads the param in `check()` and stamps it (with timestamp)
  to localStorage so it survives the post-callback `window.location.href` reload.
- Once `/me` resolves, fires `trackSignupConversion` / `trackRedditSignup` /
  `trackTwitterSignup` exactly once off the localStorage flag, then drains it.
  Stale flags (>10 min) are cleared without firing.
- Existing `requires_org_setup`-gated tracking is left untouched as a fallback.


<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
