### PR TITLE
chore: replace expired Discord invite in agentcc-gateway README

### DIFF
--- a/agentcc-gateway/README.md
+++ b/agentcc-gateway/README.md
@@ -19,7 +19,7 @@ Route · cache · govern · guard · observe. Single Go binary. Drop-in OpenAI A
   <a href="https://github.com/future-agi/future-agi/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0"></a>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/built%20with-Go%201.23-00ADD8?style=flat-square&logo=go" alt="Go 1.23"></a>
   <a href="https://docs.futureagi.com/docs/prism"><img src="https://img.shields.io/badge/docs-docs.futureagi.com-fafafa?style=flat-square" alt="Docs"></a>
-  <a href="https://discord.gg/UjZ2gRT5p"><img src="https://img.shields.io/badge/community-Discord-5865F2?style=flat-square" alt="Discord"></a>
+  <a href="https://discord.com/invite/n2tCUKBkAw"><img src="https://img.shields.io/badge/community-Discord-5865F2?style=flat-square" alt="Discord"></a>
 </p>
 
 <p>
@@ -1046,6 +1046,6 @@ Apache License 2.0 — see [LICENSE](../../LICENSE) and [NOTICE](../../NOTICE).
 
 **Built with ❤️ in Go by the [Future AGI](https://futureagi.com) team and contributors.**
 
-[🌐 futureagi.com](https://futureagi.com) · [📖 docs](https://docs.futureagi.com/docs/prism) · [💬 Discord](https://discord.gg/UjZ2gRT5p) · [🐦 Twitter](https://twitter.com/futureagi)
+[🌐 futureagi.com](https://futureagi.com) · [📖 docs](https://docs.futureagi.com/docs/prism) · [💬 Discord](https://discord.com/invite/n2tCUKBkAw) · [🐦 Twitter](https://twitter.com/futureagi)
 
 </div>


### PR DESCRIPTION
## Summary

Follow-up to #273. That PR replaced the dead `discord.gg/UjZ2gRT5p` invite with `discord.com/invite/n2tCUKBkAw` in the root `README.md` (4 occurrences), but the same expired link still survived in two places in `futureagi/agentcc-gateway/README.md` — the header Discord badge and the community footer. Both replaced here with the team-blessed invite the team picked in #273.

## Linked issues

Closes #264

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

(Both `chore:` and `docs:` apply — followed the precedent of #273 which used `chore:` for the same change shape.)

## How was this tested?

```bash
# After applying the patch, the invariant holds:
$ git grep -l UjZ2gRT5p
(no output)
```

Click-tested the two new links on the rendered diff:

- Header badge → `https://discord.com/invite/n2tCUKBkAw` resolves to the active Future AGI Discord server.
- Footer link → same.

No code paths affected; no `make check-all` / `yarn check-all` pass needed for this README-only change.

## Screenshots / recordings (if UI)

N/A — link substitution only.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (n/a — README-only; invariant `git grep -l UjZ2gRT5p` returns empty)
- [x] `make check-all` / `yarn check-all` passes locally (n/a — no code paths touched)
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) — first-time contribution, will sign when the bot prompts.
