### PR TITLE
Fix missing averages for reordered eval columns by sorting evaluation…

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -411,6 +411,18 @@ const getAverageColumnConfig = (columns, tableRows) => {
   }
 
   for (const [_, cols] of Object.entries(grouping)) {
+    // Ensure evaluation columns come before evaluation_reason so we
+    // pick the result column (which carries averageScore) as cols[0].
+    if (cols.length > 1) {
+      cols.sort((a, b) => {
+        const aType = a.originType || a.origin_type || "";
+        const bType = b.originType || b.origin_type || "";
+        if (aType === "evaluation" && bType !== "evaluation") return -1;
+        if (bType === "evaluation" && aType !== "evaluation") return 1;
+        return 0;
+      });
+    }
+
     if (cols.length === 1) {
       const eachCol = cols[0];
 


### PR DESCRIPTION
## Summary

When the backend returns `evaluation_reason` columns before `evaluation` columns in the `columnConfig` array, the `getAverageColumnConfig` function in `DevelopDataV2.jsx` picks the reason column as `cols[0]` for each grouped eval pair. Since reason columns have `averageScore: null` (the backend skips average calculation for `-reason` columns), the pinned bottom row ends up with no average displayed for those eval columns.

The `columnDefs` useMemo already had a sort to ensure `evaluation` comes before `evaluation_reason` within each group, but `getAverageColumnConfig` was missing the same sort.

This PR adds that sort so the result column (which carries `averageScore`) is always `cols[0]`, and its `id` correctly matches the rendered grid column.

## Linked issues

Closes #TH-4783

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How to test

1. Open a dataset that has eval columns with both result and reasoning (where the backend happens to return `evaluation_reason` before `evaluation` in the column config)
2. Verify the pinned bottom row now shows `Average : X%` (or `Average : X` for numeric evals) for those eval columns
3. Click "Show Reasoning" to expand the group — confirm averages still display correctly on the result column

## Screenshots / recordings (if UI)

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)