### PR TITLE
[TH-4785] Hide reason cols by default and render reason text in voice grid

### DIFF
--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -10,7 +10,7 @@ import EvalCellRenderer from "../test-detail/CellRenderers/EvalCellRenderer";
 import CallLogsHeaderCellRenderer from "./CallLogs/CallLogsHeaderCellRenderer";
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
-import { Skeleton } from "@mui/material";
+import { Box, Skeleton } from "@mui/material";
 import { AGENT_TYPES, isLiveKitProvider } from "./constants";
 import AnnotationHeaderCellRenderer from "./CallLogs/AnnotationHeaderCellRenderer";
 import headerComponentLabels from "./headerComponetLabels";
@@ -381,16 +381,36 @@ export const generateEvalColumnsFromConfig = (items = []) => {
   return items.map((item) => {
     const evalId = item.id;
     const displayName = item.name?.replace(/_/g, " ") || evalId;
+    const isReason = item.source_field === "reason";
+    const dataKey = isReason ? item.parent_eval_id : evalId;
     return {
       headerName: displayName,
       field: `eval_outputs.${evalId}`,
       flex: 1,
-      minWidth: 140,
+      minWidth: isReason ? 240 : 140,
+      hide: item.is_visible === false,
       headerComponent: CallLogsHeaderCellRenderer,
       headerComponentParams: { displayName },
-      valueGetter: (params) => params.data?.eval_outputs?.[evalId] || {},
+      valueGetter: (params) => params.data?.eval_outputs?.[dataKey] || {},
       cellRenderer: (params) => {
-        const evalData = params?.data?.eval_outputs?.[evalId] || {};
+        const evalData = params?.data?.eval_outputs?.[dataKey] || {};
+        if (isReason) {
+          const reason = evalData?.reason;
+          return (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                height: "100%",
+                width: "100%",
+                padding: "4px 8px",
+                color: "text.primary",
+              }}
+            >
+              {reason || "-"}
+            </Box>
+          );
+        }
         return (
           <EvalCellRenderer
             value={{


### PR DESCRIPTION
## Summary
- Voice/CallLogs grid was rendering eval `_reason` columns by default and showing them blank.
- `generateEvalColumnsFromConfig` now honors `is_visible` from the backend config so `_reason` cols default to hidden (matches trace/span behavior).
- Reason data is read from `eval_outputs[parent_eval_id].reason` (voice API shape) instead of the nonexistent `eval_outputs[<id>__reason]` key, and rendered with the same padding/style as eval cells.
- Trace/span paths were already correct via `getTraceListColumnDefs` (`hide: !col?.isVisible`); only the voice path needed the fix.

Closes TH-4785

## Linear Ticket
[TH-4785](https://linear.app/future-agi/issue/TH-4785/reason-and-explanation-columns-show-blank-by-default)

## Files Changed
- `frontend/src/sections/agents/helper.jsx`

## Test plan
- [ ] Voice project: open LLM Tracing → eval `_reason` cols are hidden by default.
- [ ] Toggle reason col on via column picker → reason text renders with proper padding (matches eval cell style); empty reason shows `-`.
- [ ] Trace + span grids on a non-voice project: behavior unchanged (reason cols still hidden by default, score cells render normally).