### PR TITLE
docs(simulate): contract spec + 5 ADRs for simulation platform

### DIFF
--- a/docs/adr/014-temporal-vs-celery-dual-execution-path.md
+++ b/docs/adr/014-temporal-vs-celery-dual-execution-path.md
@@ -1,0 +1,39 @@
+---
+status: Problematic — filed as issue #310
+date: 2026-05-08
+---
+
+# ADR 014 — Dual execution path: Temporal workflow vs. legacy TestExecutor
+
+## Evidence
+
+`futureagi/simulate/services/test_executor.py` — comment: "DEPRECATED".
+`futureagi/simulate/views/` — `RunTestExecutionView._execute_with_temporal()` vs.
+`_execute_with_legacy()`, gated on `TEMPORAL_TEST_EXECUTION_ENABLED` feature flag.
+
+## Context
+
+The simulate app originally executed tests with a polling-based Celery task
+(`TestExecutor.execute_test()`). This was replaced by a durable Temporal workflow
+(`TestExecutionWorkflow`) that handles retries, signals, and continue-as-new.
+
+## Decision
+
+The `TestExecutor` (Celery path) was kept alive as a fallback behind the
+`TEMPORAL_TEST_EXECUTION_ENABLED` flag rather than being removed after Temporal
+was validated in production.
+
+## Why
+
+Operational caution: Temporal was a new dependency. Keeping the Celery fallback allowed
+rolling back without a code deploy if Temporal had reliability issues.
+
+## Consequences
+
+- Two execution paths must be kept in sync. Features added to `TestExecutionWorkflow`
+  are silently absent in the Celery path.
+- `TestExecutor` is 256 KB of tightly-coupled logic with balance checking, call monitoring,
+  and metric calculation — it cannot be easily removed without refactoring callers.
+- The divergence is already happening: `continue_as_new`, `eval_only` reruns, and merge
+  signals exist only in the Temporal path.
+- Filed as issue #310.

--- a/docs/adr/015-agent-version-snapshot-as-config-source.md
+++ b/docs/adr/015-agent-version-snapshot-as-config-source.md
@@ -1,0 +1,38 @@
+---
+status: Accepted
+date: 2026-05-08
+---
+
+# ADR 015 — `agent_version.configuration_snapshot` is the source of truth for call config
+
+## Evidence
+
+`futureagi/simulate/temporal/activities/test_execution.py` — `setup_test_execution()`:
+loads `agent_version.configuration_snapshot`, not `agent_definition.*` fields.
+
+## Context
+
+An `AgentDefinition` can be edited between when a test is created and when it executes.
+If a simulation used the live definition, changes made after the test was queued would
+silently alter its config — making it impossible to reproduce a specific test run.
+
+## Decision
+
+`AgentVersion` stores a `configuration_snapshot` (JSONField) capturing the full agent
+config at the time the version was created. `setup_test_execution()` uses this snapshot
+exclusively. The live `agent_definition` fields are ignored during execution.
+
+## Why
+
+Reproducibility: a test must use the same agent config each time it runs, regardless of
+subsequent definition edits. Versioning provides an explicit "this is the config that
+was tested" contract.
+
+## Consequences
+
+- If `run_test.agent_version` is `None`, the activity silently falls back to the latest
+  `ACTIVE` version. If the agent was modified since the test was created, the fallback
+  version may not match the intended config. Filed as issue #309.
+- Callers that want deterministic execution must always pin an `agent_version`.
+- The snapshot can become stale if the underlying provider API changes what fields mean,
+  but the version record holds the old values.

--- a/docs/adr/016-persona-attributes-as-json-arrays.md
+++ b/docs/adr/016-persona-attributes-as-json-arrays.md
@@ -1,0 +1,38 @@
+---
+status: Problematic — filed as issue #311
+date: 2026-05-08
+---
+
+# ADR 016 — Persona attributes stored as JSON arrays, only first element used
+
+## Evidence
+
+`futureagi/simulate/models/` — `Persona` model: `gender`, `age_group`, `personality`,
+`accent`, etc. are all `JSONField` storing lists.
+`futureagi/simulate/services/` — `Persona.to_voice_mapper_dict()`:
+`"gender": persona.gender[0] if persona.gender else "male"`.
+
+## Context
+
+The persona UI allows users to select multiple values per attribute (e.g., two personality
+traits, two accent options). Storing as JSON arrays made the model flexible for multi-select
+without a schema migration.
+
+## Decision
+
+Attributes are stored as arrays to support multi-select in the UI. At runtime, only
+`field[0]` (the first element) is passed to the voice or chat provider.
+
+## Why
+
+The UI multi-select capability was built before the execution layer needed to handle
+more than one value per attribute. Combining multiple values (e.g., two accents) into
+a single VAPI voice call requires provider-specific logic that was not implemented.
+
+## Consequences
+
+- Users who select multiple values for a persona attribute observe only the first one
+  having any effect. The selection appears to be honoured but is silently truncated.
+- The data model supports N values; the execution layer supports 1. Any future multi-value
+  support requires updating every provider adapter, not the model.
+- Filed as issue #311.

--- a/docs/adr/017-chat-session-id-backward-compat.md
+++ b/docs/adr/017-chat-session-id-backward-compat.md
@@ -1,0 +1,37 @@
+---
+status: Accepted — cleanup pending
+date: 2026-05-08
+---
+
+# ADR 017 — `vapi_chat_session_id` / `chat_session_id` backward-compat fallback
+
+## Evidence
+
+`futureagi/simulate/services/chat_sim.py` — `initiate_chat()` and message routing:
+`metadata.get("chat_session_id") or metadata.get("vapi_chat_session_id")`
+
+## Context
+
+The chat simulation was originally built exclusively on VAPI. `call_metadata` stored the
+session ID under the key `"vapi_chat_session_id"`. When provider-agnostic routing was
+added (`ChatServiceManager`), the key was renamed to `"chat_session_id"`.
+
+## Decision
+
+Rather than migrating existing `CallExecution` rows, a fallback was added:
+`get("chat_session_id") or get("vapi_chat_session_id")`. New sessions are written under
+`"chat_session_id"`.
+
+## Why
+
+A migration of live `CallExecution.call_metadata` JSONField values across all orgs was
+risky and unnecessary once the fallback made both old and new records work correctly.
+
+## Consequences
+
+- If a row somehow has both keys set to different values, `or` semantics return the first
+  non-falsy value — which is `"chat_session_id"`. The old VAPI key is silently ignored.
+  This is the correct behaviour but is not enforced by any invariant.
+- `"vapi_chat_session_id"` as a key is a leaked implementation detail visible in all
+  `CallExecution.call_metadata` JSON blobs for historical records.
+- The old key should be cleaned up once all active records have been migrated.

--- a/docs/adr/018-temporal-continue-as-new-at-500-events.md
+++ b/docs/adr/018-temporal-continue-as-new-at-500-events.md
@@ -1,0 +1,43 @@
+---
+status: Accepted
+date: 2026-05-08
+---
+
+# ADR 018 — `TestExecutionWorkflow` uses continue-as-new at 500 history events
+
+## Evidence
+
+`futureagi/simulate/temporal/workflows/test_execution_workflow.py`:
+`MAX_EVENTS_BEFORE_CONTINUE_AS_NEW = 500`; checkpoint logic with `_event_count`.
+
+## Context
+
+Temporal persists every workflow event (activity schedule, activity complete, signal
+received, timer fired, etc.) in an immutable history log. History size is bounded by
+Temporal Server configuration (default ~2 MB). A test execution with 1000 calls
+generates O(calls × activities × signals) events, easily exceeding the limit.
+
+## Decision
+
+`TestExecutionWorkflow` tracks `_event_count` (incremented per iteration of the main
+loop) and calls `continue_as_new()` when it hits 500. The checkpoint payload includes
+the current state (`_completed_calls`, `_failed_calls`, `_launched_call_ids`) so the
+new workflow instance resumes correctly.
+
+## Why
+
+`continue_as_new` is the idiomatic Temporal pattern for long-running workflows. It
+creates a new workflow execution with the same ID, passing state as input, and the old
+history is closed. The workflow appears continuous from the outside.
+
+## Consequences
+
+- `_event_count` tracks parent workflow iterations, not actual Temporal event count.
+  The mapping is not 1:1 (each iteration may produce multiple events), so the
+  checkpoint may fire earlier or later than the actual limit.
+- Signals arriving during `continue_as_new` can be lost if Temporal delivers them to
+  the old (closing) workflow instance. Child workflows must handle the case where
+  their parent has reset.
+- After continue-as-new, `get_unlaunched_call_ids()` queries the DB for remaining
+  PENDING calls — this re-establishes ground truth from Postgres rather than relying
+  on in-memory state that was carried across.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,37 @@
+# Architecture Decision Records
+
+Each ADR documents a non-obvious design decision: why it was made, what the alternatives
+were, and what the consequences are.
+
+## Evaluations Engine (001–008)
+
+| # | Title |
+|---|-------|
+| [001](001-evaluations-engine-extraction.md) | Why the engine was extracted from `EvaluationRunner` |
+| [002](002-few-shots-futureagi-only.md) | Why few-shot RAG is FutureAGI-eval-only |
+| [003](003-result-failure-string.md) | Why `EvalResult.failure` is a string, not a bool |
+| [004](004-cost-none-not-empty-dict.md) | Why `cost`/`token_usage` are `None` when absent |
+| [005](005-registry-lazy-singleton.md) | Why the evaluator registry is a lazy singleton |
+| [006](006-protect-shortcut-in-runner.md) | Why the protect shortcut reads runtime inputs |
+| [007](007-preprocessing-keyed-on-template-name.md) | Why preprocessing was keyed on template name (fragility → #301, fixed in #304) |
+| [008](008-oss-stubs-not-none-fallbacks.md) | Why OSS billing stubs replace `None` fallbacks |
+
+## Tracer App (009–013)
+
+| # | Title |
+|---|-------|
+| [009](009-eval-status-denormalized-on-span.md) | Why `eval_status` on `ObservationSpan` is stale (→ #305) |
+| [010](010-root-span-input-output-last-writer-wins.md) | Why root span `input`/`output` is last-writer-wins |
+| [011](011-scanner-unconditional-10s-delay.md) | Why the scanner waits 10s unconditionally |
+| [012](012-clickhouse-consistency-window-undefined.md) | Why ClickHouse dual-write has no consistency SLA |
+| [013](013-ingest-redis-staging-before-temporal.md) | Why OTLP payloads stage in Redis before Temporal |
+
+## Simulate App (014–018)
+
+| # | Title |
+|---|-------|
+| [014](014-temporal-vs-celery-dual-execution-path.md) | Why the Celery fallback was kept alongside Temporal (→ #310) |
+| [015](015-agent-version-snapshot-as-config-source.md) | Why `configuration_snapshot` is the source of truth for call config (→ #309) |
+| [016](016-persona-attributes-as-json-arrays.md) | Why persona attributes are JSON arrays but only first element is used (→ #311) |
+| [017](017-chat-session-id-backward-compat.md) | Why `vapi_chat_session_id` / `chat_session_id` fallback exists |
+| [018](018-temporal-continue-as-new-at-500-events.md) | Why `TestExecutionWorkflow` uses continue-as-new at 500 events |

--- a/futureagi/simulate/SPEC.md
+++ b/futureagi/simulate/SPEC.md
@@ -1,0 +1,296 @@
+# Simulate App — Specification
+
+The simulate app is the **AI agent testing and simulation platform**. It lets users run
+scripted or persona-driven conversations against live agent endpoints, capturing transcripts,
+metrics, and evaluation results. Supports both text (chat) and voice (phone) simulations.
+
+---
+
+## Architecture
+
+```
+POST /run_tests/{id}/execute/
+    → RunTestExecutionView
+    → TestExecution.create(status=PENDING)
+    → start_test_execution_workflow() [Temporal]
+    → TestExecutionWorkflow
+        ├─ setup_test_execution() [activity]
+        ├─ create_call_execution_records() [activity]
+        ├─ CallExecutionWorkflow × N [child workflows]
+        │   ├─ TEXT: ChatServiceManager → FutureAGIChatService / VapiChatService
+        │   └─ VOICE: VAPI phone call via ee/voice/
+        └─ finalize_test_execution() [activity]
+```
+
+---
+
+## Core Models
+
+### `RunTest`
+
+The user-created test definition. Not an execution — a template that can be run multiple times.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name`, `description` | str | |
+| `agent_definition` | FK → `AgentDefinition` | The agent under test |
+| `agent_version` | FK → `AgentVersion`, nullable | Pinned version; `None` = latest active |
+| `scenarios` | M2M → `Scenarios` | Which scenarios to run |
+| `dataset_row_ids` | ArrayField(UUID) | Specific rows if dataset-based |
+| `evaluations_config` | JSONField | Inline eval config |
+
+### `TestExecution`
+
+One run of a `RunTest`. Created when the user clicks "Execute".
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `run_test` | FK | |
+| `status` | enum | `PENDING / RUNNING / EVALUATING / COMPLETED / FAILED / CANCELLED` |
+| `scenario_ids` | JSONField | List of scenario UUIDs for this execution |
+| `total_scenarios`, `completed_calls`, `failed_calls`, `analyzing_calls` | int | Progress counters |
+| `agent_version` | FK, nullable | Pinned at execution time from `run_test.agent_version` |
+| `eval_explanation_summary_status` | enum | `PENDING / RUNNING / COMPLETED / FAILED` — independent of main status |
+| `picked_up_by_executor` | bool | Prevents double-execution if two workers see the same record |
+
+### `CallExecution`
+
+One simulated conversation (voice call or chat session). One row per (scenario, dataset_row).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `test_execution` | FK | |
+| `scenario` | FK → `Scenarios` | |
+| `status` | enum | `PENDING / REGISTERED / ONGOING / COMPLETED / FAILED / ANALYSING / CANCELLED` |
+| `simulation_call_type` | enum | `VOICE / TEXT` |
+| `call_metadata` | JSONField | `{system_prompt, initial_message, chat_session_id, persona, …}` |
+| `provider_call_data` | JSONField | `{provider_name: data}` — raw provider response |
+| `eval_outputs` | JSONField | Final evaluation results |
+| `row_id` | UUID, nullable | Dataset row this call was instantiated from |
+| `agent_version` | FK, nullable | Version config used for this specific call |
+
+**`call_metadata` keys:**
+- `system_prompt` / `dynamic_prompt` / `base_prompt` — resolved in priority order (first non-null wins)
+- `initial_message` — customer's opening line
+- `chat_session_id` / `vapi_chat_session_id` — backward-compat fallback (see ADR 017)
+- `persona` — persona dict if persona-based simulation
+
+### `Scenarios`
+
+A reusable test configuration. Three types, two source types.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `scenario_type` | enum | `GRAPH / SCRIPT / DATASET` |
+| `source_type` | enum | `AGENT_DEFINITION / PROMPT` |
+| `agent_definition` | FK, nullable | |
+| `simulator_agent` | FK → `SimulatorAgent` | The simulated customer |
+| `dataset` | FK, nullable | For DATASET scenarios |
+
+### `Persona`
+
+Defines how the simulated customer behaves. All demographic/behavioral attributes are
+**JSON arrays** — multiple values can be stored, but only the first element is used at
+runtime (see ADR 016 and issue #311).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `persona_type` | enum | `SYSTEM / WORKSPACE` |
+| `persona_id` | int | Stable ID for system personas (1–8) |
+| `simulation_type` | enum | `VOICE / TEXT` |
+| Voice attributes | JSONField arrays | `accent`, `conversation_speed`, `background_sound`, `finished_speaking_sensitivity`, `interrupt_sensitivity` |
+| Text attributes | JSONField arrays | `punctuation`, `emoji_usage`, `slang_usage`, `typos_frequency`, `tone`, `verbosity` |
+
+**System personas** (8 hardcoded, created at boot via `insert_system_personas()`):
+Impatient Driver, Lost Newbie, Stressed Accountant, Frustrated Subscriber,
+Confused First-Time User, Curious Evaluator, No-Nonsense Executive, Frustrated Everyday User.
+
+### `AgentVersion`
+
+A point-in-time snapshot of an agent's configuration.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `agent_definition` | FK | |
+| `version_number` | int | |
+| `configuration_snapshot` | JSONField | **Source of truth for call execution config** (see ADR 015) |
+| `status` | enum | `ACTIVE / DRAFT / DEPRECATED` |
+
+**Invariant:** `setup_test_execution()` loads `configuration_snapshot`, not the live
+`agent_definition`. If no `agent_version` is pinned, it falls back to the latest ACTIVE
+version silently (see issue #309).
+
+### `SimulatorAgent`
+
+The LLM-powered simulated customer.
+
+| Field | Notes |
+|-------|-------|
+| `prompt` | System prompt for the simulated customer persona |
+| `model`, `llm_temperature`, `max_tokens` | LLM config |
+| `voice_provider`, `voice_name` | For voice simulations |
+| `max_call_duration_in_minutes` | Hard stop |
+
+---
+
+## Execution Flow
+
+### 1. Create RunTest
+
+`POST /simulate/api/run_tests/`
+
+Creates `RunTest` + `SimulateEvalConfig` rows. No execution starts.
+
+### 2. Start Execution
+
+`POST /simulate/api/run_tests/{run_test_id}/execute/`
+
+**Request:** `{scenario_ids: [...], simulator_id: uuid | null}`
+
+**Actions:**
+1. Creates `TestExecution(status=PENDING, picked_up_by_executor=False)`
+2. Calls `start_test_execution_workflow()` → starts `TestExecutionWorkflow` in Temporal
+3. Returns `{execution_id, workflow_id, status: "started"}`
+
+**Fallback:** If `TEMPORAL_TEST_EXECUTION_ENABLED=False`, falls through to deprecated
+`TestExecutor.execute_test()` (Celery-based).
+
+### 3. TestExecutionWorkflow (Temporal)
+
+Lifecycle: `INITIALIZING → LAUNCHING → RUNNING → FINALIZING → COMPLETED | FAILED`
+
+**INITIALIZING:**
+- `setup_test_execution()` — loads scenarios, resolves `agent_version.configuration_snapshot`,
+  enumerates dataset rows. Returns `SetupTestOutput`.
+- `create_call_execution_records()` — creates one `CallExecution(status=PENDING)` per
+  (scenario, row) pair. Substitutes dataset row values into system prompt.
+
+**LAUNCHING:**
+- Spawns `CallExecutionWorkflow` child workflows in batches of 50, sub-batches of 10
+  with 5-second pauses to avoid overwhelming the agent.
+
+**RUNNING:**
+- Waits for `SIGNAL_CALL_COMPLETED` and `SIGNAL_CALL_ANALYZING` signals from children.
+- Tracks `_completed_calls`, `_failed_calls`, `_analyzing_calls`.
+- At 500 Temporal history events: checkpoints state via `continue_as_new()` (see ADR 018).
+
+**FINALIZING:**
+- `finalize_test_execution()` — writes final counts, sets `status=COMPLETED`,
+  triggers async eval summary Celery task.
+
+### 4. CallExecutionWorkflow (Child)
+
+Per-call lifecycle: `PENDING → REGISTERED → ONGOING → ANALYSING → COMPLETED | FAILED`
+
+**TEXT path:**
+1. `ChatSimService.initiate_chat()` — creates simulator assistant + session, returns
+   initial customer message.
+2. Exchange messages until termination condition (max turns, goodbye phrase, timeout).
+3. Mark `status=ANALYSING`, run evaluations.
+4. Signal parent: `SIGNAL_CALL_COMPLETED`.
+
+**VOICE path (EE):**
+1. Acquire phone number slot.
+2. Initiate VAPI call with persona voice settings.
+3. Poll for call completion via webhook.
+4. Mark `status=ANALYSING`, run evaluations.
+5. Signal parent: `SIGNAL_CALL_COMPLETED`.
+
+### 5. Rerun
+
+`POST /simulate/api/test_executions/{id}/rerun/`
+
+`{call_ids: [...], eval_only: bool}`
+
+Launches `RerunCoordinatorWorkflow`. Supports merge: concurrent rerun requests for the
+same `test_execution_id` are merged into one workflow via `MergeCallsSignal`.
+
+`eval_only=True`: skips call execution, re-runs evaluations on existing transcripts.
+`eval_only=False`: full re-execution of the call.
+
+---
+
+## Services
+
+### `ChatServiceManager`
+
+Provider-agnostic router. Delegates to `VapiChatService` or `FutureAGIChatService`.
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `create_assistant(name, system_prompt, voice_settings, model, temperature, max_tokens)` | `CreateAssistantResult` | |
+| `delete_assistant(assistant_id)` | `DeleteAssistantResult` | |
+| `create_session(assistant_id, name, initial_message)` | `CreateSessionResult` | |
+| `send_message(session_id, messages)` | `SendMessageResult` | |
+
+### `FutureAGIChatService`
+
+Implements `ChatEngineBlueprint` using Django ORM + internal LLM client. State persisted
+to `ChatSimulatorAssistant` / `ChatSimulatorSession` — recoverable across pod restarts.
+
+### `ChatSimService.initiate_chat(call_execution, organization, workspace) → List[ChatMessage] | None`
+
+**Contract:**
+1. Check balance via `TestExecutor._check_call_balance()`. On failure: sets
+   `call_execution.status=FAILED`, raises `ValueError`. Never returns `None` for balance failure.
+2. Resolve system prompt: `call_metadata["system_prompt"]` → `"dynamic_prompt"` →
+   `"base_prompt"` → `generate_simulator_agent_prompt()`.
+3. Create assistant + session via `ChatServiceManager`.
+4. Write `chat_session_id` to `call_metadata`, save.
+5. Return initial messages from AI customer.
+
+**Invariants:**
+- `call_execution.status` is not advanced to `ONGOING` here — that happens in `CallExecutionWorkflow`.
+- Side effect: `call_execution.call_metadata` is mutated and saved.
+
+---
+
+## Persona Resolution
+
+At `CallExecution` creation time, persona data is copied into `call_metadata["persona"]`.
+
+For **voice**: `Persona.to_voice_mapper_dict()` takes `field[0]` (first element of each
+JSON array) and maps to VAPI voice settings.
+
+For **text**: Persona attributes are injected into the simulator system prompt as
+behavioural instructions (e.g., "use frequent typos", "speak in casual tone").
+
+**Invariant:** Only the first element of each JSON array attribute is used at runtime,
+even if multiple values are stored in the model. See issue #311.
+
+---
+
+## Dataset Row Substitution
+
+When `Scenarios.scenario_type == DATASET`, `create_call_execution_records()` substitutes
+dataset row values into the system prompt before storing in `call_metadata["system_prompt"]`.
+
+**Known gap:** No validation that all placeholder tokens (e.g., `${email}`) were
+replaced. Calls execute with literal placeholder text if the dataset row is missing a
+column. See issue #312.
+
+---
+
+## Evaluation Pipeline
+
+After each call reaches `ANALYSING` status:
+1. `SimulateEvalConfig` rows for the `RunTest` are loaded.
+2. Each eval is run via the evaluations engine (`run_eval()`).
+3. Results written to `CallExecution.eval_outputs`.
+4. After all calls complete, `finalize_test_execution()` triggers an async Celery task
+   for eval explanation summary generation.
+
+**`eval_explanation_summary_status`** tracks this separately from main execution status.
+No timeout or retry if the Celery task silently fails. See issue #313.
+
+---
+
+## Known Design Issues
+
+- **Agent version silent fallback** — ADR 015, issue #309
+- **Legacy `TestExecutor` dual execution path** — ADR 014, issue #310
+- **Persona multi-valued fields, only first used** — ADR 016, issue #311
+- **No dataset row placeholder validation** — issue #312
+- **Eval summary has no timeout/retry** — issue #313
+- **Call status transitions not enforced** — any code can set any status; no state machine
+- **`chat_session_id` / `vapi_chat_session_id` non-determinism** — ADR 017


### PR DESCRIPTION
## Summary

- `futureagi/simulate/SPEC.md` — contract documentation for the simulate app: core models, full Temporal workflow execution flow, ChatServiceManager contract, persona resolution, dataset substitution, eval pipeline, and rerun flow.
- `docs/adr/014–018` — 5 ADRs capturing non-obvious design decisions.
- `docs/adr/README.md` — updated index covering all 18 ADRs (evaluations + tracer + simulate).

## Bugs filed

| Issue | Title |
|-------|-------|
| #309 | `agent_version=None` silently falls back to latest active version |
| #310 | Legacy `TestExecutor` (Celery) diverges from Temporal workflow features |
| #311 | Persona multi-valued attributes silently truncated to first element |
| #312 | Dataset row placeholder substitution has no validation |
| #313 | `eval_explanation_summary_status` has no timeout or retry |

## ADRs

| # | Decision | Status |
|---|---------|--------|
| 014 | Temporal vs. Celery dual execution path | Problematic → #310 |
| 015 | `configuration_snapshot` as source of truth | Accepted (→ #309 for fallback risk) |
| 016 | Persona attributes as JSON arrays | Problematic → #311 |
| 017 | `vapi_chat_session_id` / `chat_session_id` backward-compat | Accepted, cleanup pending |
| 018 | `continue_as_new` at 500 Temporal history events | Accepted |

🤖 Generated with [Claude Code](https://claude.com/claude-code)