### PR TITLE
docs(agentic_eval): contract spec + 3 ADRs for evaluator implementation layer

### DIFF
--- a/docs/adr/019-custom-prompt-evaluator-inherits-llm-not-base.md
+++ b/docs/adr/019-custom-prompt-evaluator-inherits-llm-not-base.md
@@ -1,0 +1,40 @@
+---
+status: Problematic — filed as issue #314
+date: 2026-05-08
+---
+
+# ADR 019 — `CustomPromptEvaluator` inherits from `LLM`, not `BaseEvaluator`
+
+## Evidence
+
+`futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py`:
+`class CustomPromptEvaluator(LLM):` — not `BaseEvaluator`.
+
+Missing: `metric_ids` property, `required_args` property, `is_failure()` method.
+
+## Context
+
+`CustomPromptEvaluator` was implemented early as part of the `LLM` class hierarchy. When
+`BaseEvaluator` was formalised as the abstract protocol, `CustomPromptEvaluator` was not
+migrated.
+
+## Decision
+
+`CustomPromptEvaluator` shares the `run()` and `run_batch()` implementations from `LLM`
+via inheritance. It works because `LLM.run()` calls `_evaluate()`, and
+`CustomPromptEvaluator` implements `_evaluate()`. The registry accepts it because
+`get_eval_class()` looks up by `cls.name`, not by `isinstance(cls, BaseEvaluator)`.
+
+## Why
+
+Migration cost: `CustomPromptEvaluator` is the most-used evaluator class. Refactoring
+it to inherit from `BaseEvaluator` risked changing its runtime behaviour through
+`super()` resolution order changes.
+
+## Consequences
+
+- Code that calls `isinstance(evaluator, BaseEvaluator)` will return `False` for
+  `CustomPromptEvaluator` — violating the Liskov Substitution Principle.
+- `metric_ids` and `required_args` are absent, causing `AttributeError` in any caller
+  that assumes all evaluators conform to the full protocol.
+- Filed as issue #314.

--- a/docs/adr/020-batch-run-result-none-on-error.md
+++ b/docs/adr/020-batch-run-result-none-on-error.md
@@ -1,0 +1,40 @@
+---
+status: Accepted — caller contract documented
+date: 2026-05-08
+---
+
+# ADR 020 — `run_batch()` returns `None` entries for per-item errors
+
+## Evidence
+
+`futureagi/agentic_eval/core_evals/fi_evals/base_evaluator.py` — `_run_batch_generator_async()`:
+thread exceptions are caught and yield `None` into `eval_results`.
+
+`BatchRunResult.eval_results: list[EvalResult | None]`
+
+## Context
+
+`run_batch()` uses a `ThreadPoolExecutor` to evaluate multiple items in parallel.
+Individual item failures should not abort the entire batch — other items should still
+produce results.
+
+## Decision
+
+Per-item exceptions are caught inside the thread, logged, and replaced with `None` in
+`eval_results`. The batch always completes; callers inspect the list and handle `None`.
+
+## Why
+
+Batch evaluation is used for dataset evaluation where partial results are valuable.
+Failing the whole batch because one row had a malformed input would discard all valid
+results. `None` as a sentinel is cheap to check and doesn't conflate "eval ran and
+failed" (which produces `EvalResult(failure=True)`) with "eval raised an exception".
+
+## Consequences
+
+- Callers must distinguish `None` (exception swallowed) from `EvalResult(failure=True)`
+  (evaluator ran successfully but judged a failure). These have different meanings.
+- The exception is logged but the caller has no programmatic access to the error.
+- `evaluations/engine/formatting.extract_raw_result()` reads `eval_results[0]` — if
+  that entry is `None`, it returns `{}` and the error appears as an empty result, not a
+  raised exception. The failure is silent at the engine level.

--- a/docs/adr/021-eval-result-metadata-is-json-string.md
+++ b/docs/adr/021-eval-result-metadata-is-json-string.md
@@ -1,0 +1,46 @@
+---
+status: Problematic — filed as issue #315
+date: 2026-05-08
+---
+
+# ADR 021 — `EvalResult.metadata` is always a JSON string, typed as `str | None`
+
+## Evidence
+
+`futureagi/agentic_eval/core_evals/fi_evals/base_evaluator.py` — `EvalResult` TypedDict:
+`"metadata": str | None`.
+
+`futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py`:
+`metadata = json.dumps({"usage": ..., "cost": ..., "response_time": ..., "explanation": ...})`
+
+`futureagi/agentic_eval/core_evals/fi_evals/function/function_evaluator.py`:
+`metadata = None`
+
+## Context
+
+`metadata` was added to carry ancillary data (token usage, cost, explanation) out of
+the evaluator without changing the `EvalResult` TypedDict structure. JSON-serialising
+it was the path of least resistance.
+
+## Decision
+
+LLM-based evaluators always serialise a metadata dict to a JSON string.
+Function-based evaluators always return `None`. The type hint `str | None` accurately
+reflects the actual range but does not convey that the string is always valid JSON.
+
+## Why
+
+Adding structured fields to `EvalResult` TypedDict (e.g., `token_usage: dict | None`,
+`cost: float | None`) would require updating all evaluator implementations at once.
+The JSON string approach let each evaluator carry arbitrary ancillary data with no
+schema change.
+
+## Consequences
+
+- Callers wanting `usage` or `cost` must `json.loads(result["metadata"])` and handle the
+  `None` case. No caller can tell from the type hint whether the string is JSON.
+- Function evaluators always produce `metadata=None`, so callers can't assume metadata
+  is always present even for successful evals.
+- The actual cost data lives in `eval_instance.cost` (post-run attribute), not in
+  `EvalResult.metadata`. These are two separate paths for the same information. Filed as
+  issue #315.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,45 @@
+# Architecture Decision Records
+
+Each ADR documents a non-obvious design decision: why it was made, what the alternatives
+were, and what the consequences are.
+
+## Evaluations Engine (001–008)
+
+| # | Title |
+|---|-------|
+| [001](001-evaluations-engine-extraction.md) | Why the engine was extracted from `EvaluationRunner` |
+| [002](002-few-shots-futureagi-only.md) | Why few-shot RAG is FutureAGI-eval-only |
+| [003](003-result-failure-string.md) | Why `EvalResult.failure` is a string, not a bool |
+| [004](004-cost-none-not-empty-dict.md) | Why `cost`/`token_usage` are `None` when absent |
+| [005](005-registry-lazy-singleton.md) | Why the evaluator registry is a lazy singleton |
+| [006](006-protect-shortcut-in-runner.md) | Why the protect shortcut reads runtime inputs |
+| [007](007-preprocessing-keyed-on-template-name.md) | Why preprocessing was keyed on template name (fragility → #301, fixed in #304) |
+| [008](008-oss-stubs-not-none-fallbacks.md) | Why OSS billing stubs replace `None` fallbacks |
+
+## Tracer App (009–013)
+
+| # | Title |
+|---|-------|
+| [009](009-eval-status-denormalized-on-span.md) | Why `eval_status` on `ObservationSpan` is stale (→ #305) |
+| [010](010-root-span-input-output-last-writer-wins.md) | Why root span `input`/`output` is last-writer-wins |
+| [011](011-scanner-unconditional-10s-delay.md) | Why the scanner waits 10s unconditionally |
+| [012](012-clickhouse-consistency-window-undefined.md) | Why ClickHouse dual-write has no consistency SLA |
+| [013](013-ingest-redis-staging-before-temporal.md) | Why OTLP payloads stage in Redis before Temporal |
+
+## Simulate App (014–018)
+
+| # | Title |
+|---|-------|
+| [014](014-temporal-vs-celery-dual-execution-path.md) | Why the Celery fallback was kept alongside Temporal (→ #310) |
+| [015](015-agent-version-snapshot-as-config-source.md) | Why `configuration_snapshot` is the source of truth (→ #309) |
+| [016](016-persona-attributes-as-json-arrays.md) | Why persona attributes are JSON arrays but only first used (→ #311) |
+| [017](017-chat-session-id-backward-compat.md) | Why `vapi_chat_session_id` / `chat_session_id` fallback exists |
+| [018](018-temporal-continue-as-new-at-500-events.md) | Why `TestExecutionWorkflow` uses continue-as-new at 500 events |
+
+## agentic_eval (019–021)
+
+| # | Title |
+|---|-------|
+| [019](019-custom-prompt-evaluator-inherits-llm-not-base.md) | Why `CustomPromptEvaluator` inherits `LLM` not `BaseEvaluator` (→ #314) |
+| [020](020-batch-run-result-none-on-error.md) | Why `run_batch()` returns `None` for per-item errors |
+| [021](021-eval-result-metadata-is-json-string.md) | Why `EvalResult.metadata` is a JSON string, not a typed dict (→ #315) |

--- a/futureagi/agentic_eval/SPEC.md
+++ b/futureagi/agentic_eval/SPEC.md
@@ -1,0 +1,201 @@
+# agentic_eval — Specification
+
+`agentic_eval` is the **evaluator implementation layer**. It hosts all 95+ evaluator
+class implementations. The `evaluations/engine/` orchestration layer imports from here —
+`agentic_eval` has no knowledge of Django ORM, templates, or the eval runner.
+
+```
+evaluations/engine/registry.py
+    → imports agentic_eval.core_evals.fi_evals.__all__
+    → registers each class by its .name property
+
+evaluations/engine/runner.run_eval()
+    → registry.get_eval_class(eval_type_id)
+    → instance.create_eval_instance(eval_class, ...)
+    → eval_instance.run(**params)          # Returns BatchRunResult
+    → formatting.extract_raw_result(...)   # Extracts EvalResult from eval_results[0]
+```
+
+---
+
+## The Evaluator Protocol
+
+All evaluators must satisfy this interface, defined in `base_evaluator.py`:
+
+### Abstract properties
+
+| Property | Type | Contract |
+|----------|------|---------|
+| `name` | `str` | Stable identifier, matches `eval_type_id` in the registry |
+| `display_name` | `str` | Human-readable label |
+| `metric_ids` | `list[str]` | Names of metrics this evaluator computes |
+| `required_args` | `list[str]` | Keys that must be present in `run()` kwargs |
+| `examples` | any | Sample inputs (may be `None`) |
+
+### Methods
+
+**`run(**kwargs) → BatchRunResult`** — single evaluation. Calls `_evaluate(**kwargs)` and
+wraps the result.
+
+**`run_batch(data: list[DataPoint], max_parallel_evals=5, upload_to_fi=True) → BatchRunResult`**
+— parallel evaluation via `ThreadPoolExecutor`. Errors per item produce `None` in
+`eval_results`, not exceptions.
+
+**`_evaluate(**kwargs) → EvalResult`** — abstract, implemented by each subclass.
+
+**`guard(**kwargs) → GuardResult`** — guard mode: returns `GuardResult(passed, reason, runtime)`.
+
+**`is_failure(*args) → bool | None`** — abstract. Whether a given raw result counts as failure.
+
+### `EvalResult` (TypedDict)
+
+```python
+{
+    "name":       str,                         # evaluator.name
+    "display_name": str,
+    "data":       dict,                        # echo of inputs
+    "failure":    bool | None,                 # True = failed, None = inconclusive
+    "reason":     str,                         # explanation or error message
+    "runtime":    int,                         # milliseconds
+    "model":      str | None,
+    "metadata":   str | None,                  # JSON-serialised dict (see ADR 021)
+    "metrics":    list[{"id": str, "value": float}],
+    "datapoint_field_annotations": list | None,
+}
+```
+
+### `BatchRunResult` (dataclass)
+
+```python
+@dataclass
+class BatchRunResult:
+    eval_results: list[EvalResult | None]  # None means an exception was swallowed
+    eval_request_id: str | None = None
+```
+
+**Invariant:** `evaluations/engine/formatting.extract_raw_result()` reads
+`raw_result.eval_results[0]`. If the list is empty, it returns an empty dict and the
+eval is treated as failed with no reason.
+
+---
+
+## Evaluator Categories
+
+### LLM-Based
+
+**`CustomPromptEvaluator`** (open-source)
+
+The most-used evaluator. Runs an LLM with a Jinja2/Mustache template prompt.
+
+Constructor key params:
+- `rule_prompt` — template string with `{{variable}}` placeholders
+- `output_type` — `"Pass/Fail"` / `"score"` / `"choices"` / `"numeric"`
+- `model` — required LLM model name
+- `choices` — list of valid choice strings (for `output_type="choices"`)
+
+`_evaluate()` pipeline:
+1. Validate required keys exist in inputs.
+2. Truncate values >15KB via `fit_to_context()` — **silent truncation, no feedback** (see issue #316).
+3. Render template: Jinja2 with `PreserveUndefined` (missing vars render as `{{var}}`, not error — see issue #317).
+4. Detect multimodal content (images, audio, PDFs) and build media blocks.
+5. Build message chain: system prompt → few-shot examples → optional `messages` turns → main eval message.
+6. Route LLM call: Turing models → `TuringClient`; external models → `call_llm()` via provider.
+7. Parse JSON response: extract `"result"` and `"explanation"` fields.
+8. Return `EvalResult` with `metadata` = JSON-serialised `{usage, cost, response_time, explanation}`.
+
+**Note:** `CustomPromptEvaluator` inherits from `LLM`, not `BaseEvaluator` — see ADR 019.
+
+**`AgentEvaluator`** (EE stub in OSS)
+
+Multi-turn reasoning evaluator. Uses an agent with tool access to evaluate complex
+responses. Config supports whitelisted runtime overrides: `model`, `agent_mode`,
+`check_internet`, `knowledge_base_id`, `tools`, etc.
+
+**`LlmEvaluator`, `Groundedness`** (EE stubs in OSS)
+
+EE-only evaluators. OSS builds get stub classes that raise `FeatureUnavailable`.
+
+### Function-Based
+
+**`FunctionEvaluator`** — wraps 92 deterministic functions from `functions.py`.
+
+Constructor: `FunctionEvaluator(function_name, function_arguments=None)`
+
+`_evaluate()`: looks up function in `operations` dict by `function_name`, calls
+`operator(**inputs, **function_arguments)`. Functions return `{"result": bool|float, "reason": str}`.
+
+**All 92 functions follow this contract:** `(reference, actual, **kwargs) → {"result": bool|float, "reason": str}`
+
+**`CustomCodeEval`** — runs arbitrary Python in a sandboxed subprocess.
+
+**`ApiCall`** — calls an external HTTP endpoint with the eval inputs.
+
+### Grounded
+
+**`GroundedEvaluator`** — computes string similarity via a configurable comparator.
+
+Comparators: `JaccardSimilarity`, `NormalisedLevenshteinSimilarity`, `JaroWincklerSimilarity`,
+`SorensenDiceSimilarity`, `CosineSimilarity`.
+
+Failure condition: `score < failure_threshold` (default 0.5).
+
+### FutureAGI Internal
+
+**`DeterministicEvaluator`** (EE) — constraint-based, multimodal-capable. Uses Turing models.
+**`RankingEvaluator`** (EE) — preference learning. Uses Turing models.
+**`FormalConstraintEvaluator`** — Z3 SMT solver. See `evaluations/SPEC.md` for contract.
+
+---
+
+## LLM Provider Integration (`core_evals/run_prompt/`)
+
+Unified provider gateway for all LLM-calling evaluators.
+
+**`available_models.py`** (386 KB) — comprehensive model registry with pricing metadata.
+
+**Provider routing:**
+- Turing models (`turing_large`, `turing_small`, `turing_flash`) → `TuringClient` (internal)
+- Protect models (`protect`, `protect_flash`) → `DeterministicEvaluator` shortcut
+- External models → LiteLLM with provider-resolved API key
+
+**Cost calculation:** `model_pricing.py` maps `(model, prompt_tokens, completion_tokens)` → cost.
+Stored on `eval_instance.cost` and `eval_instance.token_usage` post-run.
+
+---
+
+## Registry Structure
+
+`core_evals/fi_evals/__init__.py` exports `__all__` — a list of ~95 class names.
+`evaluations/engine/registry.py` imports this module and registers each class by
+`cls.name` on first call (lazy singleton). See evaluations `SPEC.md` for full registry contract.
+
+**Invariant:** Every class in `__all__` must have a `.name` property that returns its
+stable `eval_type_id` string. The registry uses `cls.name` — not `cls.__name__` — as
+the lookup key.
+
+---
+
+## Batch Execution
+
+**Async / Temporal path** (`model_hub/tasks/user_evaluation.py`):
+
+- `process_single_evaluation()` — Temporal activity for dataset row evaluation
+- `process_experiment_evaluation()` — multi-prompt experiment evaluation
+- Distributed state tracking via `evaluation_tracker`
+- Cancellation via `should_cancel()` callback checked between evals
+
+**Thread-pool path** (`BaseEvaluator.run_batch()`):
+- `ThreadPoolExecutor(max_workers=max_parallel_evals)`
+- Per-item errors caught → `None` in `eval_results` (never raises from batch)
+- Callers must distinguish `None` (eval error) from `EvalResult(failure=True)` (eval ran, failed)
+
+---
+
+## Known Design Issues
+
+- **`CustomPromptEvaluator` violates the evaluator protocol** — ADR 019, issue #314
+- **`EvalResult.metadata` is always a JSON string, not `str | None`** — ADR 021, issue #315
+- **Silent template context truncation** — issue #316
+- **`PreserveUndefined` hides prompt typos** — issue #317
+- **`required_args` is abstract but FunctionEvaluator returns `[]`** — no enforced validation contract
+- **`_log_evaluation_request/results()` swallows all exceptions** — silent Fi logging failures


### PR DESCRIPTION
## Summary

- `futureagi/agentic_eval/SPEC.md` — contract documentation: BaseEvaluator protocol, EvalResult/BatchRunResult shapes, all evaluator categories, LLM provider routing, batch execution paths.
- `docs/adr/019–021` — 3 ADRs for non-obvious decisions.
- `docs/adr/README.md` — updated index covering all 21 ADRs across 4 modules.

## Bugs filed

| Issue | Title |
|-------|-------|
| #314 | `CustomPromptEvaluator` inherits `LLM` not `BaseEvaluator` (LSP violation) |
| #315 | `EvalResult.metadata` dual-path (JSON string vs `eval_instance.cost`) |
| #316 | Silent input truncation with no feedback to caller |
| #317 | `PreserveUndefined` hides prompt template typos |

## ADRs

| # | Decision | Status |
|---|---------|--------|
| 019 | `CustomPromptEvaluator` inherits `LLM` not `BaseEvaluator` | Problematic → #314 |
| 020 | `run_batch()` returns `None` for per-item errors | Accepted |
| 021 | `EvalResult.metadata` is always a JSON string | Problematic → #315 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)