### PR TITLE
test(tracer): Z3 + Hypothesis formal verification for ID transform pure functions

### DIFF
--- a/.github/workflows/tracer-formal-tests.yml
+++ b/.github/workflows/tracer-formal-tests.yml
@@ -1,0 +1,29 @@
+name: Tracer — Formal Verification Tests
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "futureagi/tracer/**"
+      - ".github/workflows/tracer-formal-tests.yml"
+
+jobs:
+  formal-tests:
+    name: Tracer pure-function formal tests (no Docker)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install test dependencies
+        run: pip install z3-solver hypothesis pytest pytest-mock structlog
+
+      - name: Run tracer formal tests
+        working-directory: futureagi
+        run: |
+          python -m pytest tracer/formal_tests/ -m unit -v --tb=short --no-header -p no:django

--- a/futureagi/tracer/formal_tests/conftest.py
+++ b/futureagi/tracer/formal_tests/conftest.py
@@ -1,0 +1,101 @@
+"""
+Lightweight stub layer for tracer formal tests.
+
+Stubs out all Django, model, and celery imports so that the pure-function
+tests in this directory can run without a database or Django settings.
+"""
+import sys
+import types
+
+
+def _make_module(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+# ── structlog ─────────────────────────────────────────────────────────────────
+
+structlog = _make_module("structlog")
+
+
+class _NullLogger:
+    def info(self, *a, **k): pass
+    def warning(self, *a, **k): pass
+    def error(self, *a, **k): pass
+    def exception(self, *a, **k): pass
+    def debug(self, *a, **k): pass
+
+
+structlog.get_logger = lambda *a, **k: _NullLogger()
+
+# ── django ────────────────────────────────────────────────────────────────────
+
+django = _make_module("django")
+django_db = _make_module("django.db")
+django_db_models = _make_module("django.db.models")
+django_utils = _make_module("django.utils")
+django_utils_timezone = _make_module("django.utils.timezone")
+
+django_db_models.Model = object
+django_db_models.Manager = object
+
+
+class _FakeField:
+    def __init__(self, *a, **k): pass
+
+
+for _fname in ("CharField", "TextField", "IntegerField", "FloatField",
+               "BooleanField", "DateTimeField", "UUIDField", "JSONField",
+               "ForeignKey", "ManyToManyField", "OneToOneField",
+               "ArrayField", "GenericIPAddressField"):
+    setattr(django_db_models, _fname, _FakeField)
+
+django_db.models = django_db_models
+django_db.connection = None
+django_db.transaction = types.SimpleNamespace(atomic=lambda: None)
+
+django.db = django_db
+django.utils = django_utils
+django_utils.timezone = django_utils_timezone
+
+# ── model_hub stubs ───────────────────────────────────────────────────────────
+
+for _mod in (
+    "model_hub", "model_hub.models", "model_hub.models.prompt_label",
+    "model_hub.models.run_prompt",
+):
+    m = _make_module(_mod)
+    m.PromptLabel = object
+    m.PromptVersion = object
+
+# ── tfc stubs ─────────────────────────────────────────────────────────────────
+
+for _mod in ("tfc", "tfc.temporal", "tfc.utils", "tfc.utils.payload_storage"):
+    m = _make_module(_mod)
+    m.temporal_activity = lambda f: f
+    m.payload_storage = types.SimpleNamespace(get=lambda *a, **k: None)
+
+# ── tracer model stubs ────────────────────────────────────────────────────────
+
+for _mod in (
+    "tracer", "tracer.models", "tracer.models.observation_span",
+    "tracer.models.project", "tracer.models.trace_session",
+    "tracer.tasks", "tracer.tasks.trace_scanner",
+    "tracer.utils", "tracer.utils.adapters", "tracer.utils.otel",
+    "tracer.utils.parsers", "tracer.utils.pii_scrubber",
+    "tracer.utils.pii_settings",
+):
+    m = _make_module(_mod)
+    # Populate stub attributes tests might reference
+    m.ObservationSpan = object
+    m.Trace = object
+    m.EndUser = object
+    m.Project = object
+    m.TraceSession = object
+    m.scan_traces_task = lambda *a, **k: None
+    m.normalize_span_attributes = lambda x: x
+    m.bulk_convert_otel_spans_to_observation_spans = lambda *a, **k: []
+    m.deserialize_trace_payload = lambda x: x
+    m.scrub_pii_in_span_batch = lambda *a, **k: None
+    m.get_pii_settings_for_projects = lambda *a, **k: {}

--- a/futureagi/tracer/formal_tests/pytest.ini
+++ b/futureagi/tracer/formal_tests/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = -p no:django --tb=short
+markers =
+    unit: fast, no external services
+# pytest.ini here sets rootdir = tracer/formal_tests/, which prevents pytest from
+# collecting conftest.py files in parent directories (futureagi/conftest.py
+# imports rest_framework/Django which aren't installed in lightweight CI).

--- a/futureagi/tracer/formal_tests/test_id_transforms_hypothesis.py
+++ b/futureagi/tracer/formal_tests/test_id_transforms_hypothesis.py
@@ -1,0 +1,226 @@
+"""
+Hypothesis property-based tests for tracer ID transformation pure functions.
+
+Tests the actual implementations inline (without importing the Django-coupled
+trace_ingestion module) to verify properties across random inputs.
+
+Implementations sourced from tracer/utils/trace_ingestion.py — any changes
+there must be mirrored here or the tests become stale.
+
+Run with: pytest tracer/formal_tests/ -v -m unit
+"""
+import base64
+import json
+import re
+
+import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+pytestmark = pytest.mark.unit
+
+
+# ── Implementations under test (inlined from trace_ingestion.py) ──────────────
+
+def _is_hex(s: str) -> bool:
+    return re.fullmatch(r"^[0-9a-fA-F]+$", s or "") is not None
+
+
+def _format_id(id_str: str) -> str | None:
+    if not id_str:
+        return None
+    return base64.b64decode(id_str).hex()
+
+
+def _format_if_needed(raw: str) -> str | None:
+    if not raw:
+        return None
+    return raw if _is_hex(raw) else _format_id(raw)
+
+
+def _serialize_json_field_value(val) -> str | None:
+    if val is None:
+        return None
+    if isinstance(val, str):
+        try:
+            json.loads(val)
+            return val
+        except (json.JSONDecodeError, TypeError):
+            return json.dumps(val)
+    return json.dumps(val)
+
+
+def _convert_attributes(attributes: list[dict]) -> dict:
+    if not attributes:
+        return {}
+    return {
+        item["key"]: item["value"].get(list(item["value"].keys())[0])
+        for item in attributes
+        if "key" in item and "value" in item and item["value"]
+    }
+
+
+# ── _is_hex ────────────────────────────────────────────────────────────────────
+
+@given(st.text(alphabet="0123456789abcdefABCDEF", min_size=1))
+def test_is_hex_true_for_hex_strings(s):
+    assert _is_hex(s) is True
+
+
+@given(st.text(alphabet="ghijklmnopqrstuvwxyz!@#$%^&*()", min_size=1))
+def test_is_hex_false_for_non_hex_strings(s):
+    # Only test strings with at least one definitely-non-hex character
+    assume(any(c not in "0123456789abcdefABCDEF" for c in s))
+    assert _is_hex(s) is False
+
+
+def test_is_hex_empty_string():
+    assert _is_hex("") is False
+
+
+def test_is_hex_none_coerced():
+    # _is_hex uses `s or ""` so None is coerced to ""
+    assert _is_hex(None) is False
+
+
+# ── _format_if_needed idempotency ─────────────────────────────────────────────
+
+@given(st.text(alphabet="0123456789abcdefABCDEF", min_size=1))
+def test_format_if_needed_is_identity_for_hex(s):
+    """Hex strings are returned unchanged — no base64 decode attempted."""
+    assert _format_if_needed(s) == s
+
+
+@given(st.none() | st.just("") | st.just(False))
+def test_format_if_needed_falsy_returns_none(raw):
+    assert _format_if_needed(raw) is None
+
+
+@given(
+    st.binary(min_size=1, max_size=32).map(
+        lambda b: base64.b64encode(b).decode("ascii")
+    )
+)
+def test_format_if_needed_result_of_format_id_is_hex(b64_str):
+    """
+    The output of _format_id is always hex, so applying _format_if_needed to
+    that output should always return it unchanged (idempotency of hex path).
+    """
+    formatted = _format_id(b64_str)
+    assert formatted is not None
+    assert _is_hex(formatted), f"_format_id output is not hex: {formatted!r}"
+    assert _format_if_needed(formatted) == formatted
+
+
+# ── _serialize_json_field_value ───────────────────────────────────────────────
+
+def test_serialize_none_returns_none():
+    assert _serialize_json_field_value(None) is None
+
+
+@given(st.none())
+def test_serialize_none_is_always_none(v):
+    assert _serialize_json_field_value(v) is None
+
+
+@given(st.one_of(
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.booleans(),
+    st.lists(st.text()),
+    st.dictionaries(st.text(min_size=1), st.text()),
+))
+def test_serialize_non_string_returns_valid_json(val):
+    result = _serialize_json_field_value(val)
+    assert isinstance(result, str)
+    # Round-trip must succeed
+    json.loads(result)
+
+
+@given(st.text())
+@settings(max_examples=500)
+def test_serialize_string_result_is_always_valid_json(s):
+    result = _serialize_json_field_value(s)
+    assert isinstance(result, str)
+    json.loads(result)  # must not raise
+
+
+@given(
+    st.one_of(
+        st.just("{}"),
+        st.just("[]"),
+        st.just('"hello"'),
+        st.just("42"),
+        st.just("null"),
+        st.just("true"),
+    )
+)
+def test_serialize_valid_json_string_is_identity(json_str):
+    """Valid JSON strings are returned unchanged, not double-encoded."""
+    assert _serialize_json_field_value(json_str) == json_str
+
+
+# ── _convert_attributes ───────────────────────────────────────────────────────
+
+def test_convert_attributes_empty_list():
+    assert _convert_attributes([]) == {}
+
+
+def test_convert_attributes_none_like():
+    assert _convert_attributes(None) == {}
+
+
+@given(st.lists(
+    st.fixed_dictionaries({
+        "key": st.text(min_size=1, max_size=20),
+        "value": st.fixed_dictionaries({
+            "stringValue": st.text(max_size=50),
+        }),
+    }),
+    min_size=1,
+    max_size=10,
+))
+def test_convert_attributes_all_keys_preserved(items):
+    """Every key in the input list appears in the output dict."""
+    result = _convert_attributes(items)
+    for item in items:
+        assert item["key"] in result
+
+
+@given(st.lists(
+    st.fixed_dictionaries({
+        "key": st.text(min_size=1, max_size=20),
+        "value": st.fixed_dictionaries({
+            "intValue": st.integers(min_value=0, max_value=1000),
+        }),
+    }),
+    min_size=1,
+    max_size=10,
+    unique_by=lambda x: x["key"],
+))
+def test_convert_attributes_values_extracted_from_value_dict(items):
+    """Values are taken from the first key of the 'value' sub-dict."""
+    result = _convert_attributes(items)
+    for item in items:
+        expected = item["value"]["intValue"]
+        assert result[item["key"]] == expected
+
+
+def test_convert_attributes_skips_items_without_key():
+    items = [
+        {"value": {"stringValue": "no key here"}},
+        {"key": "valid", "value": {"stringValue": "present"}},
+    ]
+    result = _convert_attributes(items)
+    assert "valid" in result
+    assert len(result) == 1
+
+
+def test_convert_attributes_skips_items_with_empty_value():
+    items = [
+        {"key": "empty_val", "value": {}},
+        {"key": "valid", "value": {"stringValue": "ok"}},
+    ]
+    result = _convert_attributes(items)
+    assert "empty_val" not in result
+    assert "valid" in result

--- a/futureagi/tracer/formal_tests/test_id_transforms_z3.py
+++ b/futureagi/tracer/formal_tests/test_id_transforms_z3.py
@@ -1,0 +1,147 @@
+"""
+Z3 symbolic verification of tracer ID transformation invariants.
+
+Models the decision trees of `_format_if_needed` and
+`_serialize_json_field_value` from tracer/utils/trace_ingestion.py.
+
+Each test encodes a property as a Z3 formula and asserts UNSAT on its
+negation — if Z3 cannot find a counterexample, the property is proven.
+
+Run with: pytest tracer/formal_tests/ -v -m unit
+"""
+
+import pytest
+
+pytest.importorskip("z3", reason="z3-solver required")
+import z3
+
+pytestmark = pytest.mark.unit
+
+
+# ── Module-level Z3 sorts (declared once — Z3 forbids re-declaration) ─────────
+
+# Output categories for _format_if_needed decision tree:
+#   IS_NONE             — empty/falsy input
+#   IS_HEX_PASSTHROUGH  — hex input returned unchanged
+#   IS_FORMATTED        — non-hex input sent through base64 decode
+FormatCat, (IS_NONE, IS_HEX_PASSTHROUGH, IS_FORMATTED) = z3.EnumSort(
+    "FormatCat", ["is_none", "is_hex_passthrough", "is_formatted"]
+)
+
+# Output categories for _serialize_json_field_value decision tree:
+#   OUT_NONE        — None input
+#   OUT_PASSTHROUGH — string input that is already valid JSON
+#   OUT_WRAPPED     — everything else (json.dumps applied)
+SerializeCat, (OUT_NONE, OUT_PASSTHROUGH, OUT_WRAPPED) = z3.EnumSort(
+    "SerializeCat", ["out_none", "out_passthrough", "out_wrapped"]
+)
+
+
+def _fmt(is_hex_in: z3.BoolRef, is_empty: z3.BoolRef) -> z3.ExprRef:
+    """Z3 model of the _format_if_needed decision tree."""
+    return z3.If(is_empty, IS_NONE,
+           z3.If(is_hex_in, IS_HEX_PASSTHROUGH, IS_FORMATTED))
+
+
+def _ser(is_none: z3.BoolRef, is_str: z3.BoolRef, is_valid_json_str: z3.BoolRef) -> z3.ExprRef:
+    """Z3 model of the _serialize_json_field_value decision tree."""
+    return z3.If(is_none, OUT_NONE,
+           z3.If(z3.And(is_str, is_valid_json_str), OUT_PASSTHROUGH, OUT_WRAPPED))
+
+
+# ── _format_if_needed properties ──────────────────────────────────────────────
+
+def test_empty_input_always_returns_none():
+    """PROPERTY: _format_if_needed(empty) is None regardless of hex status."""
+    s = z3.Solver()
+    is_hex_in, is_empty = z3.Bools("is_hex_in is_empty")
+    s.add(z3.And(is_empty, _fmt(is_hex_in, is_empty) != IS_NONE))
+    assert s.check() == z3.unsat, "Empty input must always produce None"
+
+
+def test_hex_input_returned_unchanged():
+    """PROPERTY: hex, non-empty input always takes the passthrough path."""
+    s = z3.Solver()
+    is_hex_in, is_empty = z3.Bools("is_hex_in2 is_empty2")
+    s.add(z3.And(z3.Not(is_empty), is_hex_in, _fmt(is_hex_in, is_empty) != IS_HEX_PASSTHROUGH))
+    assert s.check() == z3.unsat, "Hex input must be returned unchanged"
+
+
+def test_non_empty_non_hex_always_formatted():
+    """PROPERTY: non-empty non-hex input always goes through format_id."""
+    s = z3.Solver()
+    is_hex_in, is_empty = z3.Bools("is_hex_in3 is_empty3")
+    s.add(z3.And(
+        z3.Not(is_empty),
+        z3.Not(is_hex_in),
+        _fmt(is_hex_in, is_empty) != IS_FORMATTED,
+    ))
+    assert s.check() == z3.unsat, "Non-hex input must always be formatted"
+
+
+def test_passthrough_and_format_paths_are_exclusive():
+    """PROPERTY: IS_HEX_PASSTHROUGH and IS_FORMATTED cannot hold simultaneously."""
+    s = z3.Solver()
+    is_hex_in, is_empty = z3.Bools("is_hex_in4 is_empty4")
+    out = _fmt(is_hex_in, is_empty)
+    s.add(z3.And(out == IS_HEX_PASSTHROUGH, out == IS_FORMATTED))
+    assert s.check() == z3.unsat, "Passthrough and format paths must be exclusive"
+
+
+def test_all_inputs_produce_exactly_one_output_category():
+    """PROPERTY: every input produces exactly one of the three output categories."""
+    s = z3.Solver()
+    is_hex_in, is_empty = z3.Bools("is_hex_in5 is_empty5")
+    out = _fmt(is_hex_in, is_empty)
+    # Negation: output is none of the three
+    s.add(z3.And(out != IS_NONE, out != IS_HEX_PASSTHROUGH, out != IS_FORMATTED))
+    assert s.check() == z3.unsat, "Output must be one of the three defined categories"
+
+
+# ── _serialize_json_field_value properties ────────────────────────────────────
+
+def test_none_input_returns_none():
+    """PROPERTY: None input always produces OUT_NONE."""
+    s = z3.Solver()
+    is_none, is_str, is_valid = z3.Bools("sn1 ss1 sv1")
+    s.add(z3.And(is_none, _ser(is_none, is_str, is_valid) != OUT_NONE))
+    assert s.check() == z3.unsat, "None input must return None"
+
+
+def test_non_none_input_never_returns_none():
+    """PROPERTY: non-None input never produces OUT_NONE."""
+    s = z3.Solver()
+    is_none, is_str, is_valid = z3.Bools("sn2 ss2 sv2")
+    s.add(z3.And(z3.Not(is_none), _ser(is_none, is_str, is_valid) == OUT_NONE))
+    assert s.check() == z3.unsat, "Non-None input must never produce None output"
+
+
+def test_valid_json_string_passes_through():
+    """PROPERTY: non-None str that is already valid JSON always takes passthrough path."""
+    s = z3.Solver()
+    is_none, is_str, is_valid = z3.Bools("sn3 ss3 sv3")
+    s.add(z3.And(
+        z3.Not(is_none),
+        is_str,
+        is_valid,
+        _ser(is_none, is_str, is_valid) != OUT_PASSTHROUGH,
+    ))
+    assert s.check() == z3.unsat, "Valid JSON string must be passed through unchanged"
+
+
+def test_passthrough_and_wrapped_are_exclusive():
+    """PROPERTY: OUT_PASSTHROUGH and OUT_WRAPPED cannot hold simultaneously."""
+    s = z3.Solver()
+    is_none, is_str, is_valid = z3.Bools("sn4 ss4 sv4")
+    out = _ser(is_none, is_str, is_valid)
+    s.add(z3.And(out == OUT_PASSTHROUGH, out == OUT_WRAPPED))
+    assert s.check() == z3.unsat, "Passthrough and wrapped paths must be exclusive"
+
+
+def test_all_serialize_inputs_produce_exactly_one_output_category():
+    """PROPERTY: every input produces exactly one of the three output categories."""
+    s = z3.Solver()
+    is_none, is_str, is_valid = z3.Bools("sn5 ss5 sv5")
+    out = _ser(is_none, is_str, is_valid)
+    s.add(z3.And(out != OUT_NONE, out != OUT_PASSTHROUGH, out != OUT_WRAPPED))
+    assert s.check() == z3.unsat, "Output must be one of the three defined categories"


### PR DESCRIPTION
## Summary

- 10 Z3 symbolic proofs for `_format_if_needed` and `_serialize_json_field_value` decision trees
- 18 Hypothesis property tests covering `_is_hex`, `_format_if_needed`, `_format_id`, `_serialize_json_field_value`, `_convert_attributes`
- CI workflow (`tracer-formal-tests.yml`) runs the suite on every PR touching `futureagi/tracer/`
- Lightweight: no Docker, no database, no Django settings — runs in ~1s

## Design

Same pattern as evaluations formal tests (PR #303): Z3 models the decision tree symbolically; Hypothesis tests inline the pure function implementations. The stub conftest isolates the test directory from Django-coupled imports in the rest of the tracer module.

## Test results

```
28 passed in 1.22s
```

## Bugs discovered in writing these tests

None in the pure functions themselves. The `_convert_attributes` function has a subtle last-write-wins behaviour when duplicate keys exist in the OTLP attribute list — not a bug but worth noting in the SPEC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)