### PR TITLE
fix(model_hub): warn on unresolved {{tokens}} in populate_placeholders

### DIFF
--- a/futureagi/model_hub/tests/test_run_prompt_unresolved_placeholders.py
+++ b/futureagi/model_hub/tests/test_run_prompt_unresolved_placeholders.py
@@ -1,0 +1,52 @@
+"""Unit tests for the unresolved-{{token}} warning in run_prompt (PR #329, issue #321).
+
+Pre-fix: populate_placeholders did not warn when a {{token}} survived substitution.
+Post-fix: `_warn_unresolved_placeholders` logs the structured structlog event
+`populate_placeholders_unresolved_tokens` listing the surviving tokens, on both the
+normal and the exception-fallback path.
+
+These import the production helper directly and assert against the (patched) module
+logger, so they exercise the real warning logic with no DB. Pre-fix the symbol does
+not exist -> ImportError -> fails; post-fix -> passes.
+
+Run:  cd futureagi && make test-unit   (or: pytest model_hub/tests/test_run_prompt_unresolved_placeholders.py)
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from unittest.mock import patch
+
+from model_hub.views.run_prompt import _warn_unresolved_placeholders
+
+
+@patch("model_hub.views.run_prompt.logger")
+def test_warns_on_unresolved_string_token(mock_logger):
+    _warn_unresolved_placeholders(
+        [{"role": "user", "content": "Hello {{missing_column}}, welcome"}]
+    )
+    mock_logger.warning.assert_called_once()
+    args, kwargs = mock_logger.warning.call_args
+    assert args[0] == "populate_placeholders_unresolved_tokens"
+    assert kwargs["unresolved"] == ["{{missing_column}}"]
+    assert kwargs["role"] == "user"
+
+
+@patch("model_hub.views.run_prompt.logger")
+def test_warns_on_unresolved_tokens_in_list_content(mock_logger):
+    _warn_unresolved_placeholders(
+        [{"role": "system", "content": [{"type": "text", "text": "x {{a}} and {{b}}"}]}]
+    )
+    mock_logger.warning.assert_called_once()
+    _, kwargs = mock_logger.warning.call_args
+    assert kwargs["unresolved"] == ["{{a}}", "{{b}}"]
+    assert kwargs["role"] == "system"
+
+
+@patch("model_hub.views.run_prompt.logger")
+def test_no_warning_when_all_tokens_resolved(mock_logger):
+    _warn_unresolved_placeholders(
+        [{"role": "user", "content": "Fully resolved content, no tokens here"}]
+    )
+    mock_logger.warning.assert_not_called()

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -211,6 +211,33 @@ class ApiKeyViewSet(viewsets.ModelViewSet):
         return self._gm.success_response("success")
 
 
+_UNRESOLVED_TOKEN_RE = re.compile(r"\{\{[^}]+\}\}")
+
+
+def _warn_unresolved_placeholders(messages: list[dict]) -> None:
+    """Log a warning for any {{token}} that survived template substitution."""
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, str):
+            tokens = _UNRESOLVED_TOKEN_RE.findall(content)
+            if tokens:
+                logger.warning(
+                    "populate_placeholders_unresolved_tokens",
+                    unresolved=tokens,
+                    role=msg.get("role"),
+                )
+        elif isinstance(content, list):
+            for item in content:
+                text = item.get("text", "") if isinstance(item, dict) else ""
+                tokens = _UNRESOLVED_TOKEN_RE.findall(text)
+                if tokens:
+                    logger.warning(
+                        "populate_placeholders_unresolved_tokens",
+                        unresolved=tokens,
+                        role=msg.get("role"),
+                    )
+
+
 def create_placeholder(variable_name):
     """Create a Jinja2/Mustache placeholder like {{variable_name}}"""
     return "{{" + str(variable_name) + "}}"
@@ -451,6 +478,7 @@ def populate_placeholders(messages: list[dict], dataset_id, row_id, col_id, mode
                 # Preserve all message keys (name, tool_calls, tool_call_id, etc.)
                 processed_messages.append({**message, "content": processed_content})
 
+            _warn_unresolved_placeholders(processed_messages)
             return processed_messages
 
         except ValueError as e:
@@ -463,7 +491,8 @@ def populate_placeholders(messages: list[dict], dataset_id, row_id, col_id, mode
         else:
             traceback.print_exc()
             logger.exception(f"Fatal error processing messages: {e}")
-            # Return original messages as fallback
+            # Return original messages as fallback — warn if they contain unresolved tokens
+            _warn_unresolved_placeholders(messages)
             return messages
 
 


### PR DESCRIPTION
## Summary

Fixes issue #321: adds structured warning logging when `{{token}}` placeholders survive template substitution in `populate_placeholders`.

**What changed:**
- Added `_UNRESOLVED_TOKEN_RE` regex and `_warn_unresolved_placeholders()` at module level in `run_prompt.py`
- Called on the **success path** (before `return processed_messages`) — catches tokens that weren't in the dataset context
- Called on the **fallback path** (before `return messages` in the outer except) — catches the case where the entire substitution failed and the original unresolved messages are returned

**Why not raise:**
`populate_placeholders` has 6 callers across `experiment_runner`, `eval_runner`, `dynamic_columns`, and `run_prompt`. Changing the return type or raising a new exception would require updating all callers. The structured log gives operators immediate observability via `populate_placeholders_unresolved_tokens` events with `unresolved` and `role` fields, which can be alerted on without breaking existing call sites.

**Structured log fields:**
```
event: populate_placeholders_unresolved_tokens
unresolved: ["{{column_name}}", ...]
role: "user" | "system" | ...
```

## Test plan
- [x] `_warn_unresolved_placeholders` covers both `str` content and `list` content (multi-modal messages)
- [x] Called on both return paths
- [x] Does not change return type — zero caller impact

Closes #321.

🤖 Generated with [Claude Code](https://claude.com/code)