### PR TITLE
fix(model_hub): gate experiment status cascade on optimistic lock success (#320)

### DIFF
--- a/futureagi/model_hub/tests/test_experiment_status_cascade.py
+++ b/futureagi/model_hub/tests/test_experiment_status_cascade.py
@@ -1,0 +1,64 @@
+"""Unit test for the optimistic-lock cascade gate (PR #331, issue #320) in
+experiment_runner.check_and_update_experiment_dataset_status.
+
+Pre-fix: in the no-columns branch the experiment-level cascade
+(check_and_update_experiment_status) fired UNCONDITIONALLY, so a worker that LOST the
+optimistic update (.update() -> 0, because a concurrent worker already transitioned the
+dataset) still cascaded -> duplicate experiment-status work.
+Post-fix: cascade fires only when this worker performed the transition
+(dataset_updated > 0) or the dataset was already COMPLETED.
+
+We drive the REAL function body and control the optimistic-update result by patching
+the ExperimentDatasetTable / Column managers, spying the cascade. No DB required.
+Pre-fix this asserts a cascade that DID happen -> fails; post-fix -> passes.
+
+Run:  cd futureagi && pytest model_hub/tests/test_experiment_status_cascade.py
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from unittest.mock import MagicMock, patch
+
+from model_hub.views import experiment_runner
+from model_hub.views.experiment_runner import (
+    check_and_update_experiment_dataset_status,
+)
+
+NOT_COMPLETED = "in_progress"  # any status != StatusType.COMPLETED.value
+
+
+def _no_columns_dataset():
+    ed = MagicMock()
+    ed.id = "ed-1"
+    ed.status = NOT_COMPLETED
+    ed.experiment.id = "exp-1"
+    return ed
+
+
+@patch.object(experiment_runner, "check_and_update_experiment_status")
+@patch.object(experiment_runner, "Column")
+@patch.object(experiment_runner, "ExperimentDatasetTable")
+def test_no_cascade_when_optimistic_update_loses(mock_edt, mock_column, mock_cascade):
+    mock_edt.objects.filter.return_value.first.return_value = _no_columns_dataset()
+    mock_column.objects.filter.return_value.values_list.return_value = []
+    # Losing worker: concurrent worker already transitioned -> update affects 0 rows.
+    mock_edt.objects.filter.return_value.update.return_value = 0
+
+    check_and_update_experiment_dataset_status("ed-1")
+
+    mock_cascade.assert_not_called()
+
+
+@patch.object(experiment_runner, "check_and_update_experiment_status")
+@patch.object(experiment_runner, "Column")
+@patch.object(experiment_runner, "ExperimentDatasetTable")
+def test_cascade_when_optimistic_update_wins(mock_edt, mock_column, mock_cascade):
+    mock_edt.objects.filter.return_value.first.return_value = _no_columns_dataset()
+    mock_column.objects.filter.return_value.values_list.return_value = []
+    mock_edt.objects.filter.return_value.update.return_value = 1  # we won the race
+
+    check_and_update_experiment_dataset_status("ed-1")
+
+    mock_cascade.assert_called_once_with("exp-1")

--- a/futureagi/model_hub/views/experiment_runner.py
+++ b/futureagi/model_hub/views/experiment_runner.py
@@ -351,20 +351,23 @@ def check_and_update_experiment_dataset_status(experiment_dataset_id: uuid.UUID)
 
         if not all_column_ids:
             # No columns means dataset is complete - use optimistic update
+            dataset_updated = 0
             if current_status != StatusType.COMPLETED.value:
-                ExperimentDatasetTable.objects.filter(
+                dataset_updated = ExperimentDatasetTable.objects.filter(
                     id=experiment_dataset_id,
                     status=current_status,  # Optimistic lock
                 ).update(status=StatusType.COMPLETED.value)
 
-            # CRITICAL FIX: Always check experiment status when dataset is complete
-            experiment = experiment_dataset.experiment
-            if experiment:
-                logger.info(
-                    f"No columns for experiment_dataset {experiment_dataset_id}, "
-                    f"checking experiment {experiment.id} status"
-                )
-                check_and_update_experiment_status(experiment.id)
+            # Only cascade to experiment-level check if we performed the transition.
+            # If updated == 0, a concurrent worker already transitioned and cascaded.
+            if dataset_updated > 0 or current_status == StatusType.COMPLETED.value:
+                experiment = experiment_dataset.experiment
+                if experiment:
+                    logger.info(
+                        f"No columns for experiment_dataset {experiment_dataset_id}, "
+                        f"checking experiment {experiment.id} status"
+                    )
+                    check_and_update_experiment_status(experiment.id)
             return True
 
         # CRITICAL FIX: Before checking column statuses, update any columns that have


### PR DESCRIPTION
## Summary

- Fixes #320: `check_and_update_experiment_dataset_status()` cascaded to `check_and_update_experiment_status()` unconditionally, even when the optimistic `UPDATE` returned 0 rows (meaning a concurrent worker already performed the transition)
- Capture the update row count (`dataset_updated`) and only cascade if `> 0`
- Preserve the recovery path: if the dataset was already `COMPLETED` on read, still cascade so the experiment-level check fires for datasets that were completed without triggering the cascade (e.g. after a worker crash)

## Root cause

Two concurrent workers both entering `check_and_update_experiment_dataset_status()` with `current_status != COMPLETED`:
1. Both pass the `running_count == 0` check
2. Only one wins the `filter(status=current_status).update(...)` — the other gets `updated = 0`
3. **Before this fix**: both called `check_and_update_experiment_status()`, creating duplicate cascades and risking a premature experiment `COMPLETED` transition
4. **After this fix**: only the worker that performed the DB transition cascades; the loser returns early

## Test plan

- [ ] Verify `check_and_update_experiment_dataset_status` is called concurrently from two workers in integration tests
- [ ] Confirm experiment status does not advance prematurely under concurrent column completion
- [ ] Regression: single-worker path (no concurrency) still cascades correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)