### PR TITLE
fix(accounts): decouple invite-email from user-add transaction (#159)

### DIFF
--- a/futureagi/accounts/tests/test_invite_email_failure.py
+++ b/futureagi/accounts/tests/test_invite_email_failure.py
@@ -1,0 +1,66 @@
+"""Test: a transient invite-email failure must NOT block the member add
+(PR #332, issue #159) in accounts.views.workspace_management.ManageTeamView.
+
+Pre-fix: email_helper() ran in-line and uncaught; the exception propagated, so the
+member add failed (and under ATOMIC_REQUESTS rolled the new user back too).
+Post-fix: user + membership are committed in an inner transaction BEFORE the email,
+and email_helper is wrapped in try/except that logs `invite_email_failed`.
+
+Payload mirrors ManageTeamView.post: members=[{email,name,role}] where role must be a
+valid OrganizationRoles value ("Member" == OrganizationRoles.MEMBER). The acting user
+must be an org Owner (the endpoint is Owner-gated), so we ensure that membership like
+the e2e suite does.
+
+Run:  cd futureagi && pytest accounts/tests/test_invite_email_failure.py
+"""
+from unittest.mock import patch
+
+import pytest
+from rest_framework import status
+
+from accounts.models.organization_membership import OrganizationMembership
+from accounts.models.user import User
+from tfc.constants.levels import Level
+
+ADD_TEAM_USER_URL = "/accounts/team/users/"
+NEW_EMAIL = "newhire-emailfail@futureagi.com"
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestInviteEmailFailureDecoupled:
+    @patch("accounts.views.workspace_management.logger")
+    @patch(
+        "accounts.views.workspace_management.email_helper",
+        side_effect=RuntimeError("smtp down"),
+    )
+    def test_member_add_succeeds_when_invite_email_fails(
+        self, mock_email, mock_logger, auth_client, user, organization, workspace
+    ):
+        # ManageTeamView is Owner-gated -- mirror the e2e suite's owner-membership setup.
+        OrganizationMembership.objects.get_or_create(
+            user=user,
+            organization=organization,
+            defaults={"role": "Owner", "level": Level.OWNER, "is_active": True},
+        )
+
+        resp = auth_client.post(
+            ADD_TEAM_USER_URL,
+            {
+                "workspace": {"name": workspace.name},
+                "members": [
+                    {"email": NEW_EMAIL, "name": "New Hire", "role": "Member"}
+                ],
+            },
+            format="json",
+        )
+
+        # Post-fix: mail outage no longer fails the request. Pre-fix: exception propagated.
+        assert resp.status_code in (status.HTTP_200_OK, status.HTTP_201_CREATED)
+        # The new member persisted despite the mail failure (the core guarantee of #159).
+        assert User.objects.filter(email=NEW_EMAIL).exists()
+        # email_helper was actually hit, and the failure was logged, not swallowed.
+        assert mock_email.called
+        warned = [c.args[0] for c in mock_logger.warning.call_args_list if c.args]
+        assert "invite_email_failed" in warned

--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -2235,44 +2235,56 @@ class ManageTeamView(APIView):
                             #     )
                             #     continue
 
-                        # Create new user for this organization
-                        new_member = User.objects.create(
-                            email=member_data["email"],
-                            name=member_data["name"],
-                            organization=organization,
-                            organization_role=org_role,  # None for workspace-level roles
-                            is_active=False,
-                            invited_by=request.user,
-                        )
-                        password = generate_password()
-                        new_member.set_password(password)
-                        new_member.save()
+                        # Create new user and workspace membership atomically.
+                        # Email is sent AFTER the commit so a transient mail
+                        # failure never prevents the user from being added.
+                        with transaction.atomic():
+                            new_member = User.objects.create(
+                                email=member_data["email"],
+                                name=member_data["name"],
+                                organization=organization,
+                                organization_role=org_role,  # None for workspace-level roles
+                                is_active=False,
+                                invited_by=request.user,
+                            )
+                            password = generate_password()
+                            new_member.set_password(password)
+                            new_member.save()
 
-                        # Add user to workspace with determined workspace role
-                        self._add_user_to_workspace(
-                            new_member,
-                            workspace,
-                            workspace_role,
-                            request.user,
-                        )
+                            # Add user to workspace with determined workspace role
+                            self._add_user_to_workspace(
+                                new_member,
+                                workspace,
+                                workspace_role,
+                                request.user,
+                            )
+
+                        created_members.append(UserSerializer(new_member).data)
 
                         token = default_token_generator.make_token(new_member)
                         uidb64 = urlsafe_base64_encode(force_bytes(new_member.pk))
-                        email_helper(
-                            f"You are invited by {organization.display_name if organization.display_name else organization.name} - Future AGI",
-                            "member_invite.html",
-                            {
-                                "password": password,
-                                "email": member_data["email"],
-                                "uid": str(uidb64),
-                                "token": token,
-                                "workspace_name": workspace.name,
-                                "app_url": settings.APP_URL,
-                                "ssl": ssl,
-                            },
-                            [member_data["email"]],
-                        )
-                        created_members.append(UserSerializer(new_member).data)
+                        try:
+                            email_helper(
+                                f"You are invited by {organization.display_name if organization.display_name else organization.name} - Future AGI",
+                                "member_invite.html",
+                                {
+                                    "password": password,
+                                    "email": member_data["email"],
+                                    "uid": str(uidb64),
+                                    "token": token,
+                                    "workspace_name": workspace.name,
+                                    "app_url": settings.APP_URL,
+                                    "ssl": ssl,
+                                },
+                                [member_data["email"]],
+                            )
+                        except Exception as email_exc:
+                            logger.warning(
+                                "invite_email_failed",
+                                user_id=str(new_member.id),
+                                email=member_data["email"],
+                                error=str(email_exc),
+                            )
 
                     except IntegrityError:
                         errors.append(


### PR DESCRIPTION
## Summary

- Fixes #159: `POST /accounts/team/users/` could leave an orphaned user row in the DB while returning a 400 to the caller when `email_helper()` raised
- Wrap `User.objects.create()` + `_add_user_to_workspace()` in `transaction.atomic()` so the two DB writes are all-or-nothing
- Move `email_helper()` **after** the atomic commit, in its own `try/except` — a transient mail failure is logged as a warning and does not fail the request

## Root cause

`email_helper()` was called inline between the user creation and `created_members.append()`. Any mail exception (SMTP error, Mailgun outage, missing API key) propagated past `except IntegrityError` and was caught by the outer `except Exception` at line 2313, which returned `400 "Error in managing users"`. In Django's default auto-commit mode the `User` row and `WorkspaceMembership` were already committed — the caller got a 400 but the user was in the DB.

## Design decision (why email outside the transaction)

Email delivery is inherently non-transactional — SMTP has no rollback. The atomicity guarantee that matters is "user row and workspace membership are created together". Whether the welcome email arrives is best-effort: a failed email should trigger a retry/resend path, not undo account creation. The `invite_email_failed` warning log gives operators visibility to resend manually or wire up a retry task.

## Test plan

- [ ] Add member via `POST /accounts/team/users/` with email backend configured to raise → user is added, 201 returned, warning logged
- [ ] Add member with working email backend → user added, email sent, 201 returned
- [ ] `IntegrityError` (duplicate email) still returns the existing error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)