### PR TITLE
[Fix #309] Warn on agent_version silent fallback in setup_test_execution

### DIFF
--- a/futureagi/simulate/formal_tests/test_agent_version_fallback_hypothesis.py
+++ b/futureagi/simulate/formal_tests/test_agent_version_fallback_hypothesis.py
@@ -1,0 +1,186 @@
+"""
+Hypothesis property tests for the agent_version fallback selection logic (issue #309).
+
+Tests a pure-Python reference implementation of the selection + warning state
+machine to ensure that:
+  - Pinned path never logs
+  - Active fallback always logs with correct payload keys
+  - Latest fallback always logs with correct payload keys
+  - No-version path never logs
+  - Warning payload always contains non-empty resolved_version_id
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+
+# ── Reference implementation ──────────────────────────────────────────────────
+
+@dataclass
+class FakeVersion:
+    id: str
+    version_number: int
+    status: str = "active"
+
+
+@dataclass
+class SelectionLog:
+    event: str
+    extra: dict = field(default_factory=dict)
+
+
+def resolve_agent_version(
+    pinned: Optional[FakeVersion],
+    definition_id: Optional[str],
+    active_version: Optional[FakeVersion],
+    latest_version: Optional[FakeVersion],
+) -> tuple[Optional[FakeVersion], list[SelectionLog]]:
+    """
+    Reference implementation of the fallback logic from test_execution.py.
+    Returns (resolved_version, warnings_emitted).
+    """
+    logs: list[SelectionLog] = []
+
+    if pinned:
+        return pinned, logs
+
+    if not definition_id:
+        return None, logs
+
+    agent_version = active_version
+    if agent_version:
+        logs.append(SelectionLog(
+            event="simulate_agent_version_fallback_to_active",
+            extra={
+                "run_test_id": "run-1",
+                "agent_definition_id": definition_id,
+                "resolved_version_id": str(agent_version.id),
+                "resolved_version_number": agent_version.version_number,
+            },
+        ))
+    else:
+        agent_version = latest_version
+        if agent_version:
+            logs.append(SelectionLog(
+                event="simulate_agent_version_fallback_to_latest",
+                extra={
+                    "run_test_id": "run-1",
+                    "agent_definition_id": definition_id,
+                    "resolved_version_id": str(agent_version.id),
+                    "resolved_version_number": agent_version.version_number,
+                    "resolved_version_status": agent_version.status,
+                },
+            ))
+
+    return agent_version, logs
+
+
+# ── Strategies ────────────────────────────────────────────────────────────────
+
+_version_id = st.text(min_size=1, max_size=36).filter(str.strip)
+
+@st.composite
+def fake_version(draw, statuses=None):
+    statuses = statuses or ["active", "inactive", "draft"]
+    return FakeVersion(
+        id=draw(_version_id),
+        version_number=draw(st.integers(min_value=1, max_value=999)),
+        status=draw(st.sampled_from(statuses)),
+    )
+
+opt_version = st.one_of(st.none(), fake_version())
+opt_str = st.one_of(st.none(), st.text(min_size=1, max_size=36).filter(str.strip))
+
+
+# ── Properties ────────────────────────────────────────────────────────────────
+
+@given(pinned=fake_version(), definition_id=opt_str, active=opt_version, latest=opt_version)
+def test_pinned_path_never_logs(pinned, definition_id, active, latest):
+    """Pinned version bypasses fallback — zero warnings regardless of DB state."""
+    _, logs = resolve_agent_version(pinned, definition_id, active, latest)
+    assert logs == []
+
+
+@given(definition_id=opt_str, active=opt_version, latest=opt_version)
+def test_no_pinned_no_definition_never_logs(definition_id, active, latest):
+    """Without an agent_definition_id, the fallback block is never entered."""
+    _, logs = resolve_agent_version(None, None, active, latest)
+    assert logs == []
+
+
+@given(definition_id=_version_id, active=fake_version(), latest=opt_version)
+@settings(max_examples=100)
+def test_active_fallback_emits_exactly_one_warning(definition_id, active, latest):
+    """When ACTIVE version exists, exactly one 'active' warning is emitted."""
+    _, logs = resolve_agent_version(None, definition_id, active, latest)
+    assert len(logs) == 1
+    assert logs[0].event == "simulate_agent_version_fallback_to_active"
+
+
+@given(definition_id=_version_id, latest=fake_version())
+@settings(max_examples=100)
+def test_latest_fallback_emits_exactly_one_warning(definition_id, latest):
+    """When no ACTIVE version but latest exists, exactly one 'latest' warning is emitted."""
+    _, logs = resolve_agent_version(None, definition_id, None, latest)
+    assert len(logs) == 1
+    assert logs[0].event == "simulate_agent_version_fallback_to_latest"
+
+
+@given(definition_id=_version_id)
+def test_no_version_no_warning(definition_id):
+    """No versions available → no warnings, no resolved version."""
+    resolved, logs = resolve_agent_version(None, definition_id, None, None)
+    assert logs == []
+    assert resolved is None
+
+
+@given(definition_id=_version_id, active=fake_version())
+@settings(max_examples=100)
+def test_active_warning_payload_has_required_keys(definition_id, active):
+    """Active fallback warning payload contains all required diagnostic keys."""
+    _, logs = resolve_agent_version(None, definition_id, active, None)
+    extra = logs[0].extra
+    assert "run_test_id" in extra
+    assert "agent_definition_id" in extra
+    assert "resolved_version_id" in extra
+    assert "resolved_version_number" in extra
+    assert extra["resolved_version_id"]  # non-empty
+
+
+@given(definition_id=_version_id, latest=fake_version())
+@settings(max_examples=100)
+def test_latest_warning_payload_has_required_keys(definition_id, latest):
+    """Latest fallback warning payload contains all required diagnostic keys including status."""
+    _, logs = resolve_agent_version(None, definition_id, None, latest)
+    extra = logs[0].extra
+    assert "run_test_id" in extra
+    assert "agent_definition_id" in extra
+    assert "resolved_version_id" in extra
+    assert "resolved_version_number" in extra
+    assert "resolved_version_status" in extra
+    assert extra["resolved_version_id"]  # non-empty
+
+
+@given(definition_id=_version_id, active=fake_version(), latest=opt_version)
+@settings(max_examples=100)
+def test_active_takes_priority_over_latest(definition_id, active, latest):
+    """When both active and latest are present, only the active warning fires."""
+    _, logs = resolve_agent_version(None, definition_id, active, latest)
+    events = [log.event for log in logs]
+    assert "simulate_agent_version_fallback_to_latest" not in events
+
+
+@given(
+    definition_id=_version_id,
+    active=opt_version,
+    latest=opt_version,
+)
+@settings(max_examples=200)
+def test_at_most_one_warning_ever(definition_id, active, latest):
+    """The fallback logic emits at most one warning under all inputs."""
+    _, logs = resolve_agent_version(None, definition_id, active, latest)
+    assert len(logs) <= 1

--- a/futureagi/simulate/formal_tests/test_agent_version_fallback_z3.py
+++ b/futureagi/simulate/formal_tests/test_agent_version_fallback_z3.py
@@ -1,0 +1,144 @@
+"""
+Z3 formal proofs for the agent_version fallback selection logic (issue #309).
+
+The state machine:
+  - If test_execution has a pinned agent_version → use it directly, no warning
+  - If no pinned version but agent_definition_id present → query ACTIVE, warn if found
+  - If no ACTIVE version → query any latest, warn if found
+  - If no version found at all → agent_version_data stays None, no warning
+
+Invariants proved:
+  1. Pinned version is used directly (no fallback path entered)
+  2. Active fallback emits warning iff ACTIVE version exists
+  3. Latest fallback emits warning iff no ACTIVE but latest exists
+  4. No version found → no warning emitted
+  5. Warning includes resolved_version_id (non-empty)
+  6. At most one fallback path is taken (mutual exclusion)
+  7. Fallback paths are disjoint (warning_active AND warning_latest ⊢ False)
+"""
+
+import pytest
+from z3 import (
+    And,
+    Bool,
+    BoolSort,
+    Function,
+    Implies,
+    Not,
+    Or,
+    Solver,
+    StringSort,
+    sat,
+    unsat,
+)
+
+
+def _solver_with_model():
+    """Return a fresh solver pre-loaded with the fallback state machine model."""
+    s = Solver()
+
+    # Inputs
+    has_pinned = Bool("has_pinned")
+    has_definition = Bool("has_definition")
+    active_exists = Bool("active_exists")
+    latest_exists = Bool("latest_exists")
+
+    # Outputs
+    warning_active = Bool("warning_active")
+    warning_latest = Bool("warning_latest")
+    version_resolved = Bool("version_resolved")
+
+    # Fallback is entered only when no pinned version and definition is known
+    in_fallback = And(Not(has_pinned), has_definition)
+
+    # Active warning fires iff in fallback AND active exists
+    s.add(warning_active == And(in_fallback, active_exists))
+
+    # Latest-fallback fires iff in fallback AND no active AND latest exists
+    s.add(warning_latest == And(in_fallback, Not(active_exists), latest_exists))
+
+    # Version is resolved iff pinned OR active found OR latest found
+    s.add(version_resolved == Or(has_pinned, And(in_fallback, Or(active_exists, latest_exists))))
+
+    return s, has_pinned, has_definition, active_exists, latest_exists, warning_active, warning_latest, version_resolved
+
+
+# ── Proof 1: pinned version skips fallback ────────────────────────────────────
+
+def test_pinned_skips_fallback():
+    s, has_pinned, has_definition, active_exists, latest_exists, warning_active, warning_latest, version_resolved = _solver_with_model()
+    s.add(has_pinned)
+    s.add(Or(warning_active, warning_latest))
+    # Pinned version → warnings are impossible
+    assert s.check() == unsat
+
+
+# ── Proof 2: active fallback emits warning iff ACTIVE version exists ──────────
+
+def test_active_fallback_iff_active_exists():
+    s, has_pinned, has_definition, active_exists, latest_exists, warning_active, warning_latest, version_resolved = _solver_with_model()
+    s.add(Not(has_pinned), has_definition)
+
+    # active_exists → warning_active
+    s2 = Solver()
+    s2.add(s.assertions())
+    s2.add(active_exists, Not(warning_active))
+    assert s2.check() == unsat
+
+    # not active_exists → not warning_active
+    s3 = Solver()
+    s3.add(s.assertions())
+    s3.add(Not(active_exists), warning_active)
+    assert s3.check() == unsat
+
+
+# ── Proof 3: latest fallback only fires when no ACTIVE version ────────────────
+
+def test_latest_fallback_requires_no_active():
+    s, has_pinned, has_definition, active_exists, latest_exists, warning_active, warning_latest, version_resolved = _solver_with_model()
+    s.add(Not(has_pinned), has_definition, active_exists)
+    s.add(warning_latest)
+    # If ACTIVE exists, latest-fallback warning is impossible
+    assert s.check() == unsat
+
+
+# ── Proof 4: no version → no warning ─────────────────────────────────────────
+
+def test_no_version_no_warning():
+    s, has_pinned, has_definition, active_exists, latest_exists, warning_active, warning_latest, version_resolved = _solver_with_model()
+    s.add(Not(has_pinned), Not(active_exists), Not(latest_exists))
+    s.add(Or(warning_active, warning_latest))
+    assert s.check() == unsat
+
+
+# ── Proof 5: warnings are mutually exclusive ──────────────────────────────────
+
+def test_warnings_mutually_exclusive():
+    s, has_pinned, has_definition, active_exists, latest_exists, warning_active, warning_latest, version_resolved = _solver_with_model()
+    s.add(warning_active, warning_latest)
+    # Both warnings simultaneously is impossible
+    assert s.check() == unsat
+
+
+# ── Proof 6: no_definition → no fallback entered ─────────────────────────────
+
+def test_no_definition_no_fallback():
+    s, has_pinned, has_definition, active_exists, latest_exists, warning_active, warning_latest, version_resolved = _solver_with_model()
+    s.add(Not(has_definition), Not(has_pinned))
+    s.add(Or(warning_active, warning_latest))
+    assert s.check() == unsat
+
+
+# ── Proof 7: version_resolved iff warning or pinned ──────────────────────────
+
+def test_version_resolved_consistent():
+    s, has_pinned, has_definition, active_exists, latest_exists, warning_active, warning_latest, version_resolved = _solver_with_model()
+
+    # version_resolved → (has_pinned OR warning_active OR warning_latest OR (in fallback and latest_exists))
+    # Specifically: if resolved and not pinned → at least one warning fired
+    s2 = Solver()
+    s2.add(s.assertions())
+    s2.add(version_resolved, Not(has_pinned), Not(warning_active), Not(warning_latest))
+    # This is possible if latest_exists but active_exists is False (latest fallback)
+    # Actually warning_latest covers this case, so this should be unsat
+    assert s2.check() == unsat

--- a/futureagi/simulate/temporal/activities/test_execution.py
+++ b/futureagi/simulate/temporal/activities/test_execution.py
@@ -127,7 +127,17 @@ async def setup_test_execution(input: SetupTestInput) -> SetupTestOutput:
                 .order_by("-version_number")
                 .afirst()
             )
-            if not agent_version:
+            if agent_version:
+                activity.logger.warning(
+                    "simulate_agent_version_fallback_to_active",
+                    extra={
+                        "run_test_id": str(test_execution.run_test_id),
+                        "agent_definition_id": str(test_execution.agent_definition_id),
+                        "resolved_version_id": str(agent_version.id),
+                        "resolved_version_number": agent_version.version_number,
+                    },
+                )
+            else:
                 agent_version = (
                     await AgentVersion.objects.filter(
                         agent_definition_id=test_execution.agent_definition_id,
@@ -135,6 +145,17 @@ async def setup_test_execution(input: SetupTestInput) -> SetupTestOutput:
                     .order_by("-version_number")
                     .afirst()
                 )
+                if agent_version:
+                    activity.logger.warning(
+                        "simulate_agent_version_fallback_to_latest",
+                        extra={
+                            "run_test_id": str(test_execution.run_test_id),
+                            "agent_definition_id": str(test_execution.agent_definition_id),
+                            "resolved_version_id": str(agent_version.id),
+                            "resolved_version_number": agent_version.version_number,
+                            "resolved_version_status": str(agent_version.status),
+                        },
+                    )
 
             # Save the resolved agent_version back to TestExecution so
             # create_call_execution_records can read it from DB

--- a/futureagi/simulate/temporal/activities/test_execution.py
+++ b/futureagi/simulate/temporal/activities/test_execution.py
@@ -128,7 +128,17 @@ async def setup_test_execution(input: SetupTestInput) -> SetupTestOutput:
                 .order_by("-version_number")
                 .afirst()
             )
-            if not agent_version:
+            if agent_version:
+                activity.logger.warning(
+                    "simulate_agent_version_fallback_to_active",
+                    extra={
+                        "run_test_id": str(test_execution.run_test_id),
+                        "agent_definition_id": str(test_execution.agent_definition_id),
+                        "resolved_version_id": str(agent_version.id),
+                        "resolved_version_number": agent_version.version_number,
+                    },
+                )
+            else:
                 agent_version = (
                     await AgentVersion.objects.filter(
                         agent_definition_id=test_execution.agent_definition_id,
@@ -136,6 +146,17 @@ async def setup_test_execution(input: SetupTestInput) -> SetupTestOutput:
                     .order_by("-version_number")
                     .afirst()
                 )
+                if agent_version:
+                    activity.logger.warning(
+                        "simulate_agent_version_fallback_to_latest",
+                        extra={
+                            "run_test_id": str(test_execution.run_test_id),
+                            "agent_definition_id": str(test_execution.agent_definition_id),
+                            "resolved_version_id": str(agent_version.id),
+                            "resolved_version_number": agent_version.version_number,
+                            "resolved_version_status": str(agent_version.status),
+                        },
+                    )
 
             # Save the resolved agent_version back to TestExecution so
             # create_call_execution_records can read it from DB

--- a/futureagi/simulate/tests/test_agent_version_fallback_warning.py
+++ b/futureagi/simulate/tests/test_agent_version_fallback_warning.py
@@ -1,0 +1,233 @@
+"""Behavioral regression test for #309 / PR #345.
+
+setup_test_execution silently resolved a missing agent_version pin by falling back to the
+agent_definition's ACTIVE version (or, failing that, the LATEST by version_number) with no
+signal that the pin was absent -- runs could execute against a version nobody chose. The
+fix warns on both fallback rungs (simulate_agent_version_fallback_to_active /
+_to_latest) with the resolved version identified in the payload.
+
+Exercises the REAL setup_test_execution activity against the real ORM (fixtures mirror
+simulate/tests/test_temporal_activities.py, minus the agent_version pin). Asserts the
+warning fires on each fallback rung with the resolved version in the payload, the resolved
+version is persisted back onto the TestExecution, and -- the near-miss -- the pinned path
+emits no fallback warning at all. All three fail if the fix's warnings are removed.
+"""
+import os
+from unittest.mock import patch
+
+import pytest
+
+from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from simulate.models import AgentDefinition, Scenarios
+from simulate.models.agent_version import AgentVersion
+from simulate.models.run_test import RunTest
+from simulate.models.simulator_agent import SimulatorAgent
+from simulate.models.test_execution import TestExecution
+
+VAPI_API_KEY = os.environ.get("VAPI_API_KEY", "test-api-key-for-testing")
+
+
+@pytest.fixture
+def agent_definition(db, organization, workspace):
+    return AgentDefinition.objects.create(
+        agent_name="Fallback Warn Agent",
+        agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+        contact_number="+1234567890",
+        inbound=True,
+        description="Agent for #309 fallback-warning regression test",
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+@pytest.fixture
+def simulator_agent(db, organization, workspace):
+    return SimulatorAgent.objects.create(
+        name="Fallback Warn Simulator",
+        prompt="You are a test simulator agent.",
+        voice_provider="elevenlabs",
+        voice_name="marissa",
+        model="gpt-4",
+        organization=organization,
+        workspace=workspace,
+        conversation_speed=1.0,
+        interrupt_sensitivity=0.5,
+        finished_speaking_sensitivity=0.5,
+        max_call_duration_in_minutes=15,
+        initial_message_delay=0,
+        initial_message="Hello",
+    )
+
+
+def _make_version(agent_definition, organization, workspace, number, status):
+    return AgentVersion.objects.create(
+        agent_definition=agent_definition,
+        organization=organization,
+        workspace=workspace,
+        version_number=number,
+        version_name="v%d" % number,
+        status=status,
+        configuration_snapshot={
+            "contact_number": "+15551234567",
+            "assistant_id": "test-assistant-id",
+            "api_key": VAPI_API_KEY,
+            "workspace_id": str(agent_definition.workspace_id),
+        },
+    )
+
+
+@pytest.fixture
+def dataset_for_scenario(db, organization, user, workspace):
+    dataset = Dataset.no_workspace_objects.create(
+        name="Fallback Warn Dataset",
+        organization=organization,
+        workspace=workspace,
+        user=user,
+        source=DatasetSourceChoices.SCENARIO.value,
+    )
+    col = Column.objects.create(
+        dataset=dataset,
+        name="situation",
+        data_type="text",
+        source=SourceChoices.OTHERS.value,
+    )
+    dataset.column_order = [str(col.id)]
+    dataset.save()
+    row = Row.objects.create(dataset=dataset, order=0)
+    Cell.objects.create(dataset=dataset, column=col, row=row, value="Test situation")
+    return dataset
+
+
+@pytest.fixture
+def scenario(
+    db, organization, workspace, dataset_for_scenario, agent_definition, simulator_agent
+):
+    return Scenarios.objects.create(
+        name="Fallback Warn Scenario",
+        description="Scenario for #309 regression test",
+        source="Test source",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=organization,
+        workspace=workspace,
+        dataset=dataset_for_scenario,
+        agent_definition=agent_definition,
+        simulator_agent=simulator_agent,
+        status=StatusType.COMPLETED.value,
+    )
+
+
+@pytest.fixture
+def unpinned_test_execution(
+    db, organization, workspace, agent_definition, simulator_agent, scenario
+):
+    """A TestExecution WITHOUT an agent_version pin -- the fallback path's precondition."""
+    run_test = RunTest.objects.create(
+        name="Fallback Warn Run",
+        agent_definition=agent_definition,
+        simulator_agent=simulator_agent,
+        organization=organization,
+        workspace=workspace,
+    )
+    run_test.scenarios.add(scenario)
+    return TestExecution.objects.create(
+        run_test=run_test,
+        status=TestExecution.ExecutionStatus.PENDING,
+        total_scenarios=1,
+        total_calls=1,
+        simulator_agent=simulator_agent,
+        agent_definition=agent_definition,
+        agent_version=None,
+    )
+
+
+async def _run_setup(test_execution, scenario):
+    from simulate.temporal.activities.test_execution import setup_test_execution
+    from simulate.temporal.types.activities import SetupTestInput
+
+    with patch("temporalio.activity.info"), patch(
+        "temporalio.activity.logger"
+    ) as mock_logger:
+        result = await setup_test_execution(
+            SetupTestInput(
+                test_execution_id=str(test_execution.id),
+                run_test_id=str(test_execution.run_test_id),
+                scenario_ids=[str(scenario.id)],
+            )
+        )
+    warn_events = [c.args[0] for c in mock_logger.warning.call_args_list]
+    warn_extras = {
+        c.args[0]: c.kwargs.get("extra", {}) for c in mock_logger.warning.call_args_list
+    }
+    return result, warn_events, warn_extras
+
+
+@pytest.mark.unit
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_fallback_to_active_version_warns_and_persists(
+    unpinned_test_execution, scenario, organization, workspace, agent_definition
+):
+    from asgiref.sync import sync_to_async
+
+    active = await sync_to_async(_make_version)(
+        agent_definition, organization, workspace, 2, AgentVersion.StatusChoices.ACTIVE
+    )
+
+    result, warn_events, warn_extras = await _run_setup(
+        unpinned_test_execution, scenario
+    )
+
+    assert "simulate_agent_version_fallback_to_active" in warn_events
+    extra = warn_extras["simulate_agent_version_fallback_to_active"]
+    assert extra["resolved_version_id"] == str(active.id)
+    assert extra["resolved_version_number"] == active.version_number
+    # The silent half of the bug: the resolved version must be persisted back.
+    await sync_to_async(unpinned_test_execution.refresh_from_db)()
+    assert unpinned_test_execution.agent_version_id == active.id
+
+
+@pytest.mark.unit
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_fallback_to_latest_version_warns_with_status(
+    unpinned_test_execution, scenario, organization, workspace, agent_definition
+):
+    from asgiref.sync import sync_to_async
+
+    # No ACTIVE version exists -- only a draft -- so the second rung must fire.
+    draft = await sync_to_async(_make_version)(
+        agent_definition, organization, workspace, 3, AgentVersion.StatusChoices.DRAFT
+    )
+
+    result, warn_events, warn_extras = await _run_setup(
+        unpinned_test_execution, scenario
+    )
+
+    assert "simulate_agent_version_fallback_to_latest" in warn_events
+    extra = warn_extras["simulate_agent_version_fallback_to_latest"]
+    assert extra["resolved_version_id"] == str(draft.id)
+    assert extra["resolved_version_status"] == str(draft.status)
+
+
+@pytest.mark.unit
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_pinned_version_does_not_warn(
+    unpinned_test_execution, scenario, organization, workspace, agent_definition
+):
+    from asgiref.sync import sync_to_async
+
+    pinned = await sync_to_async(_make_version)(
+        agent_definition, organization, workspace, 4, AgentVersion.StatusChoices.ACTIVE
+    )
+    unpinned_test_execution.agent_version = pinned
+    await sync_to_async(unpinned_test_execution.save)(update_fields=["agent_version"])
+
+    result, warn_events, warn_extras = await _run_setup(
+        unpinned_test_execution, scenario
+    )
+
+    # Near-miss: a pinned execution is NOT a fallback -- no fallback warning may fire.
+    assert not any(e.startswith("simulate_agent_version_fallback") for e in warn_events)


### PR DESCRIPTION
## Problem

When a `TestExecution` has no pinned `agent_version`, `setup_test_execution()` silently queries for the latest ACTIVE version (or any latest version if none active) and proceeds. There is no observable signal that a fallback occurred, making it impossible for on-call to detect misconfigured test runs.

## Fix

Two structured `activity.logger.warning` calls added to the fallback block:

- `simulate_agent_version_fallback_to_active` — fires when the ACTIVE query succeeds. Payload: `run_test_id`, `agent_definition_id`, `resolved_version_id`, `resolved_version_number`.
- `simulate_agent_version_fallback_to_latest` — fires when no ACTIVE version is found and the any-status fallback is used. Payload adds `resolved_version_status` to distinguish non-ACTIVE picks.

No behaviour change; warnings are purely diagnostic.

## Formal tests

- **7 Z3 proofs** (`test_agent_version_fallback_z3.py`): state-machine invariants — pinned bypasses fallback, warnings mutually exclusive, no-version → no warning, etc.
- **9 Hypothesis properties** (`test_agent_version_fallback_hypothesis.py`): all 16 pass against the reference implementation.

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)