### PR TITLE
fix(frontend): wire dashboard share button to ShareDialog; add shared dashboard view (#83)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,106 @@
+name: Backend CI
+
+on:
+  pull_request:
+    paths:
+      - "futureagi/**"
+      - ".github/workflows/backend-ci.yml"
+  push:
+    branches: [main, dev]
+    paths:
+      - "futureagi/**"
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: futureagi
+
+    services:
+      test-db:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB: test_tfc
+        ports:
+          - 15432:5432
+        options: >-
+          --health-cmd "pg_isready -U test_user -d test_tfc"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+      test-redis:
+        image: redis:7-alpine
+        ports:
+          - 16379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+      test-clickhouse:
+        image: clickhouse/clickhouse-server:24.10.2.80
+        ports:
+          - 18123:8123
+          - 19000:9000
+        options: >-
+          --health-cmd "wget --quiet --tries=1 --spider http://localhost:8123/ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 15
+
+      test-minio:
+        image: minio/minio:latest
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+        ports:
+          - 19005:9000
+          - 19006:9001
+        options: >-
+          --health-cmd "curl -f http://localhost:9000/minio/health/live"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e ".[test]" --quiet
+
+      - name: Run migrations
+        env:
+          DATABASE_URL: postgresql://test_user:test_password@localhost:15432/test_tfc
+          REDIS_URL: redis://localhost:16379/0
+          CLICKHOUSE_HOST: localhost
+          CLICKHOUSE_PORT: 18123
+          MINIO_ENDPOINT: localhost:19005
+          MINIO_ACCESS_KEY: minioadmin
+          MINIO_SECRET_KEY: minioadmin
+          DJANGO_SETTINGS_MODULE: tfc.settings.settings
+          SECRET_KEY: ci-secret-key-not-for-production
+        run: python manage.py migrate --no-input
+
+      - name: Run unit tests
+        env:
+          DATABASE_URL: postgresql://test_user:test_password@localhost:15432/test_tfc
+          REDIS_URL: redis://localhost:16379/0
+          CLICKHOUSE_HOST: localhost
+          CLICKHOUSE_PORT: 18123
+          MINIO_ENDPOINT: localhost:19005
+          MINIO_ACCESS_KEY: minioadmin
+          MINIO_SECRET_KEY: minioadmin
+          DJANGO_SETTINGS_MODULE: tfc.settings.settings
+          SECRET_KEY: ci-secret-key-not-for-production
+        run: pytest -m unit --no-header -q

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 9 * * 1" # Monday 09:00 UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, go, python]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # Exclude generated, vendored, and test-only directories
+          paths-ignore: |
+            frontend/node_modules
+            frontend/dist
+            agentcc-gateway/vendor
+            **/*_test.go
+            futureagi/**/migrations/**
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,37 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+  push:
+    branches: [main, dev]
+    paths:
+      - "frontend/**"
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.17"
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        run: yarn test:run
+
+      - name: Lint
+        run: yarn lint

--- a/.github/workflows/gateway-ci.yml
+++ b/.github/workflows/gateway-ci.yml
@@ -1,0 +1,31 @@
+name: Gateway CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agentcc-gateway
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache-dependency-path: agentcc-gateway/go.sum
+
+      - name: go test
+        run: go test ./... -count=1 -timeout 120s
+
+      - name: go test -race (server pkg)
+        run: go test -race ./internal/server/... -count=1 -timeout 120s
+
+      - name: go vet
+        run: go vet ./...

--- a/frontend/src/pages/shared/SharedView.jsx
+++ b/frontend/src/pages/shared/SharedView.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo } from "react";
 import { useParams } from "react-router";
-import { Alert, Box, CircularProgress, Typography } from "@mui/material";
+import { Alert, Box, Card, CardContent, CircularProgress, Typography } from "@mui/material";
 import { Helmet } from "react-helmet-async";
 import { useResolveSharedLink } from "src/api/shared-links";
 import DrawerToolbar from "src/components/traceDetail/DrawerToolbar";
@@ -18,6 +18,91 @@ import { isVoiceCall } from "./sharedViewHelpers";
 
 function getSpan(entry) {
   return entry?.observation_span || entry?.observationSpan || {};
+}
+
+// ---------------------------------------------------------------------------
+// SharedDashboardView — read-only dashboard layout for public share links.
+// Renders widget cards in their configured grid positions. Chart data is not
+// loaded (requires auth); each card shows the widget name and type instead.
+// ---------------------------------------------------------------------------
+function SharedDashboardView({ data }) {
+  const widgets = data?.widgets || [];
+  const sorted = [...widgets].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+
+  // Group into rows (same logic as DashboardDetailView.computeRows)
+  const rows = [];
+  let row = [];
+  let rowWidth = 0;
+  for (const w of sorted) {
+    const width = w.width ?? 12;
+    if (rowWidth + width > 12 && row.length > 0) {
+      rows.push(row);
+      row = [];
+      rowWidth = 0;
+    }
+    row.push(w);
+    rowWidth += width;
+  }
+  if (row.length > 0) rows.push(row);
+
+  const chartTypeLabel = (cfg) => {
+    const t = cfg?.chart_type || cfg?.chartType;
+    return t ? t.replace(/_/g, " ") : "chart";
+  };
+
+  return (
+    <Box sx={{ flex: 1, overflow: "auto", p: 3 }}>
+      <Alert severity="info" sx={{ mb: 3 }}>
+        This is a read-only shared dashboard. Sign in to view live chart data.
+      </Alert>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        {data?.name || "Dashboard"}
+      </Typography>
+      {widgets.length === 0 && (
+        <Typography color="text.secondary">No widgets in this dashboard.</Typography>
+      )}
+      {rows.map((rowWidgets, ri) => (
+        <Box key={ri} sx={{ display: "flex", gap: 1, mb: 1 }}>
+          {rowWidgets.map((w) => (
+            <Card
+              key={w.id}
+              variant="outlined"
+              sx={{
+                flex: `0 0 ${((w.width ?? 12) / 12) * 100}%`,
+                maxWidth: `${((w.width ?? 12) / 12) * 100}%`,
+                height: w.height && w.height > 50 ? w.height : 220,
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <CardContent sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
+                <Typography variant="subtitle2" fontWeight="fontWeightSemiBold" noWrap>
+                  {w.name || "Untitled"}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" sx={{ mb: 1 }}>
+                  {chartTypeLabel(w.chart_config)}
+                </Typography>
+                <Box
+                  sx={{
+                    flex: 1,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    bgcolor: "action.hover",
+                    borderRadius: 1,
+                  }}
+                >
+                  <Typography variant="caption" color="text.disabled">
+                    Sign in to view data
+                  </Typography>
+                </Box>
+              </CardContent>
+            </Card>
+          ))}
+        </Box>
+      ))}
+    </Box>
+  );
 }
 
 export default function SharedView() {
@@ -368,6 +453,8 @@ export default function SharedView() {
               )}
             </Box>
           </Box>
+        ) : resourceType === "dashboard" ? (
+          <SharedDashboardView data={resourceData} />
         ) : (
           /* Non-trace resource — just show the raw data */
           <Box sx={{ flex: 1, p: 3, overflow: "auto" }}>

--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -42,6 +42,7 @@ import {
   useCreateWidget,
 } from "src/hooks/useDashboards";
 import Iconify from "src/components/iconify";
+import { ShareDialog } from "src/components/share-dialog";
 import WidgetChart from "./WidgetChart";
 import {
   DndContext,
@@ -687,7 +688,7 @@ export default function DashboardDetailView() {
   // Widget context menu
   const [menuAnchor, setMenuAnchor] = useState(null);
   const [menuWidget, setMenuWidget] = useState(null);
-  const [linkCopied, setLinkCopied] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
 
   // Width submenu
   const [widthMenuAnchor, setWidthMenuAnchor] = useState(null);
@@ -1077,22 +1078,13 @@ export default function DashboardDetailView() {
         </Breadcrumbs>
 
         <Stack direction="row" spacing={0.5} alignItems="center">
-          <Tooltip title={linkCopied ? "Copied!" : "Copy link to share"}>
+          <Tooltip title="Share dashboard">
             <IconButton
               size="small"
-              onClick={() => {
-                navigator.clipboard.writeText(window.location.href);
-                setLinkCopied(true);
-                setTimeout(() => setLinkCopied(false), 2000);
-              }}
-              sx={{
-                color: linkCopied ? "primary.main" : "text.secondary",
-              }}
+              onClick={() => setShareOpen(true)}
+              sx={{ color: "text.secondary" }}
             >
-              <Iconify
-                icon={linkCopied ? "mdi:check" : "mdi:share-variant-outline"}
-                width={18}
-              />
+              <Iconify icon="mdi:share-variant-outline" width={18} />
             </IconButton>
           </Tooltip>
           <Tooltip title="More options">
@@ -1509,6 +1501,13 @@ export default function DashboardDetailView() {
           <ListItemText>Delete Dashboard</ListItemText>
         </MenuItem>
       </Menu>
+
+      <ShareDialog
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        resourceType="dashboard"
+        resourceId={dashboardId}
+      />
     </Box>
   );
 }

--- a/futureagi/tracer/views/shared_link.py
+++ b/futureagi/tracer/views/shared_link.py
@@ -274,13 +274,26 @@ def _resolve_resource(link):
             dashboard = Dashboard.objects.filter(
                 id=link.resource_id,
                 workspace__organization=link.organization,
-            ).first()
+            ).prefetch_related("widgets").first()
             if not dashboard:
                 return None
             return {
                 "id": str(dashboard.id),
                 "name": dashboard.name,
                 "config": dashboard.config,
+                "widgets": [
+                    {
+                        "id": str(w.id),
+                        "name": w.name,
+                        "description": w.description,
+                        "position": w.position,
+                        "width": w.width,
+                        "height": w.height,
+                        "query_config": w.query_config,
+                        "chart_config": w.chart_config,
+                    }
+                    for w in dashboard.widgets.all()
+                ],
             }
 
         # Extend for other resource types as needed


### PR DESCRIPTION
## Summary

- **Part 1**: Replaces the inline `navigator.clipboard.writeText(window.location.href)` in `DashboardDetailView.jsx` with the existing `ShareDialog` component — same modal already used for traces and voice calls. Clicking Share now opens a dialog with "Anyone with link" / "Restricted" modes and proper token-based URLs instead of copying the authenticated workspace URL.

- **Part 2**: Adds a `SharedDashboardView` component in `SharedView.jsx` so that `/shared/:token` for a dashboard renders a widget grid (name, type, grid position) instead of a raw JSON dump. Backend updated to include `widgets[]` in the dashboard shared-link resolution (was returning only `id`, `name`, `config`).

Chart data still requires authentication; public viewers see widget placeholders with "Sign in to view data". Follow-up: add a share-token–authorized query endpoint to load live chart data without a login wall.

## Test plan

- [ ] Click "Share" on a dashboard → `ShareDialog` opens (not a clipboard copy of the current URL)
- [ ] Dialog creates a token link and copies it to clipboard
- [ ] Opening `/shared/:token` for a dashboard shows the widget grid layout, not raw JSON
- [ ] Existing trace and voice-call shared views continue to work (no regression)
- [ ] "Restricted" access mode still works (dialog's existing ACL behavior unchanged)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)