### PR TITLE
fix(ai_tools): guard json.loads() on LLM output, log silent exceptions

### DIFF
--- a/futureagi/ai_tools/tools/datasets/add_run_prompt_column.py
+++ b/futureagi/ai_tools/tools/datasets/add_run_prompt_column.py
@@ -320,7 +320,12 @@ class AddRunPromptColumnTool(BaseTool):
                     args=({"type": "not_started", "prompt_id": str(run_prompter.id)},)
                 )
                 workflow_started = True
-            except Exception:
+            except Exception as e:
+                logger.warning(
+                    "run_prompt_celery_dispatch_failed",
+                    run_prompter_id=str(run_prompter.id),
+                    error=str(e),
+                )
                 # Fallback: mark as not_started, will be picked up by polling
                 run_prompter.status = StatusType.NOT_STARTED.value
                 run_prompter.save(update_fields=["status"])

--- a/futureagi/ai_tools/tools/evaluations/create_composite_eval.py
+++ b/futureagi/ai_tools/tools/evaluations/create_composite_eval.py
@@ -1,11 +1,14 @@
 from typing import Literal, Optional
 
+import structlog
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field, field_validator
 
 from ai_tools.base import BaseTool, ToolContext, ToolResult
 from ai_tools.formatting import format_datetime, key_value_block, section
 from ai_tools.registry import register_tool
+
+logger = structlog.get_logger(__name__)
 
 
 class CreateCompositeEvalInput(PydanticBaseModel):
@@ -230,8 +233,8 @@ class CreateCompositeEvalTool(BaseTool):
                 organization=context.organization,
                 workspace=context.workspace,
             )
-        except Exception:
-            pass  # Non-fatal
+        except Exception as e:
+            logger.warning("composite_eval_version_create_failed", error=str(e))
 
         # ── 8. Build response ──
         children_summary = "\n".join(

--- a/futureagi/ai_tools/tools/evaluations/trigger_error_localization.py
+++ b/futureagi/ai_tools/tools/evaluations/trigger_error_localization.py
@@ -167,7 +167,13 @@ class TriggerErrorLocalizationTool(BaseTool):
         # Parse config to get eval data
         config = log.config
         if isinstance(config, str):
-            config = json.loads(config)
+            try:
+                config = json.loads(config)
+            except (json.JSONDecodeError, ValueError):
+                return ToolResult.error(
+                    "Malformed config on log entry — expected JSON.",
+                    error_code="VALIDATION_ERROR",
+                )
 
         reference_id = config.get("reference_id") or log.reference_id
         if not reference_id:

--- a/futureagi/ai_tools/tools/tracing/explore_trace.py
+++ b/futureagi/ai_tools/tools/tracing/explore_trace.py
@@ -381,16 +381,25 @@ class ExploreTraceTool(BaseTool):
             if "```json" in raw:
                 match = re.search(r"```json\s*(.*?)\s*```", raw, re.DOTALL)
                 if match:
-                    parsed = json.loads(match.group(1))
+                    try:
+                        parsed = json.loads(match.group(1))
+                    except (json.JSONDecodeError, ValueError):
+                        pass
             elif "```" in raw:
                 match = re.search(r"```\s*(.*?)\s*```", raw, re.DOTALL)
                 if match:
-                    parsed = json.loads(match.group(1))
+                    try:
+                        parsed = json.loads(match.group(1))
+                    except (json.JSONDecodeError, ValueError):
+                        pass
 
             if not parsed:
                 match = re.search(r"\{.*\}", raw, re.DOTALL)
                 if match:
-                    parsed = json.loads(match.group(0))
+                    try:
+                        parsed = json.loads(match.group(0))
+                    except (json.JSONDecodeError, ValueError):
+                        pass
 
             if not parsed:
                 return {"sub_flows": [], "trace_overview": ""}


### PR DESCRIPTION
## Problem

Four bugs in `ai_tools/` that cause either silent failures or unhandled 500 errors:

1. **`explore_trace.py`** — three consecutive `json.loads()` calls parsing LLM code-fence output had no error handling. If the LLM emits malformed JSON inside a code fence (common during degraded model responses), the tool raises an unhandled `JSONDecodeError` instead of falling through to the empty-result branch.

2. **`trigger_error_localization.py`** — `json.loads(config)` is called when `config` is a database-stored string, with no guard. Corrupt or legacy records raise a 500.

3. **`create_composite_eval.py`** — `except Exception: pass` silently swallows version-creation failures. Operators have no way to know the step failed.

4. **`add_run_prompt_column.py`** — bare `except Exception` catches Celery dispatch failures without logging anything, then resets status to `NOT_STARTED`. The failure is invisible in logs.

## Fix

- Wrap each `json.loads()` in `try/except (json.JSONDecodeError, ValueError)` and fall through to the next parse strategy (explore_trace) or return a structured `VALIDATION_ERROR` (trigger_error_localization).
- Replace `except Exception: pass` with `logger.warning("composite_eval_version_create_failed", error=str(e))`.
- Add `logger.warning("run_prompt_celery_dispatch_failed", run_prompter_id=..., error=str(e))` before the NOT_STARTED fallback.

## Test plan

- [ ] `explore_trace`: confirm LLM returning `\`\`\`json\nbad{\`\`\`` returns `{"sub_flows": [], "trace_overview": ""}` instead of crashing
- [ ] `trigger_error_localization`: confirm a log entry with `config='not-json'` returns `VALIDATION_ERROR` response
- [ ] `create_composite_eval`: confirm version-create failure is now visible in structured logs
- [ ] `add_run_prompt_column`: confirm Celery dispatch failure logs `run_prompt_celery_dispatch_failed` before fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)