### PR TITLE
chore(oss): per-service image versions, ECR→Docker Hub, amd64 backend release (main)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,13 @@
 # stack (~22 containers) so analytics views populate.
 # COMPOSE_PROFILES=full
 
-# Pin a specific release. Defaults to whatever docker-compose.yml pins to.
+# Each image has an independent version. Empty = use `:latest`. Pin per
+# service to lock a specific release.
 FUTURE_AGI_VERSION=
+FRONTEND_VERSION=
+AGENTCC_GATEWAY_VERSION=
+SERVING_VERSION=
+CODE_EXECUTOR_VERSION=
 
 # ---- BYO LLM provider keys ----
 OPENAI_API_KEY=

--- a/.github/workflows/release-backend.yml
+++ b/.github/workflows/release-backend.yml
@@ -1,5 +1,5 @@
 # Manual trigger only. Run from the Actions tab when ready to cut a backend release.
-# Publishes futureagi/future-agi:<version>, :<minor>, :latest.
+# Publishes futureagi/future-agi:<version>, :<minor>, :latest as a multi-arch manifest.
 # Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN.
 
 name: Release backend
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag to publish (e.g. v1.22.41)'
+        description: 'Version tag to publish (e.g. v1.22.43)'
         required: true
         type: string
       branch:
@@ -23,11 +23,26 @@ on:
 permissions:
   contents: read
 
+env:
+  IMAGE: futureagi/future-agi
+  CONTEXT: ./futureagi
+  DOCKERFILE: ./futureagi/Dockerfile.oss
+
 jobs:
-  release:
-    name: Build & push backend
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     environment: production
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout
@@ -36,6 +51,48 @@ jobs:
           ref: ${{ inputs.branch }}
           submodules: false
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ env.CONTEXT }}
+          file: ${{ env.DOCKERFILE }}
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=backend-${{ matrix.arch }}
+          cache-to: type=gha,scope=backend-${{ matrix.arch }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge multi-arch manifest
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
       - name: Resolve version & minor
         id: version
         run: |
@@ -50,8 +107,12 @@ jobs:
           { echo "version=$v"; echo "minor=$minor"; } >> "$GITHUB_OUTPUT"
           echo "Resolved: version=$v, minor=$minor"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -62,17 +123,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: ./futureagi
-          file: ./futureagi/Dockerfile.oss
-          platforms: linux/amd64,linux/arm64
-          push: true
-          provenance: false
-          tags: |
-            futureagi/future-agi:${{ steps.version.outputs.version }}
-            futureagi/future-agi:${{ steps.version.outputs.minor }}
-            futureagi/future-agi:latest
-          cache-from: type=registry,ref=futureagi/future-agi:buildcache
-          cache-to: type=registry,ref=futureagi/future-agi:buildcache,mode=max
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          set -eu
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE }}:${{ steps.version.outputs.version }} \
+            --tag ${{ env.IMAGE }}:${{ steps.version.outputs.minor }} \
+            --tag ${{ env.IMAGE }}:latest \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.version.outputs.version }}

--- a/.github/workflows/release-backend.yml
+++ b/.github/workflows/release-backend.yml
@@ -1,5 +1,5 @@
 # Manual trigger only. Run from the Actions tab when ready to cut a backend release.
-# Publishes futureagi/future-agi:<version>, :<minor>, :latest as a multi-arch manifest.
+# Publishes futureagi/future-agi:<version>, :<minor>, :latest (linux/amd64).
 # Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN.
 
 name: Release backend
@@ -29,20 +29,10 @@ env:
   DOCKERFILE: ./futureagi/Dockerfile.oss
 
 jobs:
-  build:
-    name: Build ${{ matrix.platform }}
-    runs-on: ${{ matrix.runner }}
+  release:
+    name: Build & push backend
+    runs-on: ubuntu-latest
     environment: production
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            arch: amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            arch: arm64
-            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout
@@ -51,48 +41,6 @@ jobs:
           ref: ${{ inputs.branch }}
           submodules: false
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          context: ${{ env.CONTEXT }}
-          file: ${{ env.DOCKERFILE }}
-          platforms: ${{ matrix.platform }}
-          provenance: false
-          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=backend-${{ matrix.arch }}
-          cache-to: type=gha,scope=backend-${{ matrix.arch }},mode=max
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ matrix.arch }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    name: Merge multi-arch manifest
-    needs: build
-    runs-on: ubuntu-latest
-    environment: production
-
-    steps:
       - name: Resolve version & minor
         id: version
         run: |
@@ -107,13 +55,6 @@ jobs:
           { echo "version=$v"; echo "minor=$minor"; } >> "$GITHUB_OUTPUT"
           echo "Resolved: version=$v, minor=$minor"
 
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -123,16 +64,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Create multi-arch manifest
-        working-directory: /tmp/digests
-        run: |
-          set -eu
-          docker buildx imagetools create \
-            --tag ${{ env.IMAGE }}:${{ steps.version.outputs.version }} \
-            --tag ${{ env.IMAGE }}:${{ steps.version.outputs.minor }} \
-            --tag ${{ env.IMAGE }}:latest \
-            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
-
-      - name: Inspect
-        run: |
-          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.version.outputs.version }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ env.CONTEXT }}
+          file: ${{ env.DOCKERFILE }}
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.version.outputs.version }}
+            ${{ env.IMAGE }}:${{ steps.version.outputs.minor }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,scope=backend,mode=max

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -329,14 +329,14 @@ docker compose up
 
 ## Upgrading
 
-Bump `FUTURE_AGI_VERSION` in `.env` to a newer release tag, then:
+Each image is independently versioned. Bump the relevant variable(s) in `.env` (`FUTURE_AGI_VERSION` for backend + worker, `FRONTEND_VERSION`, `AGENTCC_GATEWAY_VERSION`, `SERVING_VERSION`, `CODE_EXECUTOR_VERSION`), then:
 
 ```bash
 docker compose pull
 docker compose up -d
 ```
 
-Backend migrations run automatically on startup. Downtime is ~30 seconds for the backend restart. Workers restart independently. To roll back, set `FUTURE_AGI_VERSION` to the previous tag and re-run the same two commands.
+Backend migrations run automatically on startup. Downtime is ~30 seconds for the backend restart. Workers restart independently. To roll back, set the bumped variable(s) to the previous tag and re-run the same two commands.
 
 ## Backups
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -106,8 +106,13 @@ docker compose up
 | Disk | 20 GB free | Image pulls are ~3 GB; data grows from there |
 | CPU | 4 cores | — |
 | Platform | `privileged: true` supported | `code-executor` needs it — won't run on Fargate, Cloud Run, or some PaaS |
+| Architecture | `linux/amd64` | Prebuilt images ship amd64 only; see Apple Silicon note below |
 
 On Docker Desktop for Mac, give Docker at least **8 GB RAM** and **64 GB disk** under Settings → Resources. The defaults are often too small.
+
+**Apple Silicon (M-series) Macs:** prebuilt images are `linux/amd64`, so Docker Desktop will pull with an arch warning and run them under **Rosetta 2** emulation (auto-enabled on Docker Desktop 4.16+). Functional for evaluation and most local development; expect a 20–50% performance hit vs. native. For native arm64, build locally with `docker compose build` instead of `docker compose pull`.
+
+**Linux arm64 hosts (e.g. Graviton):** install `qemu-user-static` (most distros include it) for amd64 emulation, or build locally.
 
 ---
 

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -15,8 +15,13 @@ AGENTCC_ADMIN_TOKEN=
 PG_PASSWORD=
 MINIO_ROOT_PASSWORD=
 
-# ---- REQUIRED — pin to a specific release ----
-FUTURE_AGI_VERSION=v1.22.41
+# ---- REQUIRED — pin a specific release per image ----
+# Each service has an independent version. Don't run `:latest` in prod.
+FUTURE_AGI_VERSION=v1.22.43
+FRONTEND_VERSION=v1.0.0
+AGENTCC_GATEWAY_VERSION=v0.1.0
+SERVING_VERSION=v1.0.0
+CODE_EXECUTOR_VERSION=v1.0.0
 
 # ---- REQUIRED — public URLs ----
 # FRONTEND_URL drives backend's email/OAuth links.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -44,7 +44,17 @@ Paste each into `deploy/.env.production`.
 
 ## 2. Pin a release
 
-Set `FUTURE_AGI_VERSION` in `.env.production` to a specific tag (e.g. `v1.22.41`). Mutable tags (`v1.22`, `latest`) are discouraged in production — they shift under you on the next release.
+Each image is independently versioned. Pin all five in `.env.production`:
+
+| Variable | Image |
+|---|---|
+| `FUTURE_AGI_VERSION` | `futureagi/future-agi` (backend + worker) |
+| `FRONTEND_VERSION` | `futureagi/frontend` |
+| `AGENTCC_GATEWAY_VERSION` | `futureagi/agentcc-gateway` |
+| `SERVING_VERSION` | `futureagi/serving` |
+| `CODE_EXECUTOR_VERSION` | `futureagi/code-executor` |
+
+Use immutable `vX.Y.Z` tags. Mutable tags (`vX.Y`, `latest`) are discouraged in production — they shift under you on the next release.
 
 ## 3. Boot
 
@@ -155,14 +165,16 @@ For internal MinIO, configure `mc mirror` to an off-host bucket, or replace the 
 ## Upgrades
 
 ```bash
-# bump FUTURE_AGI_VERSION in deploy/.env.production
+# bump the relevant version variable(s) in deploy/.env.production
+# (FUTURE_AGI_VERSION / FRONTEND_VERSION / AGENTCC_GATEWAY_VERSION /
+#  SERVING_VERSION / CODE_EXECUTOR_VERSION)
 docker compose --env-file deploy/.env.production \
   -f docker-compose.yml -f deploy/docker-compose.production.yml pull
 docker compose --env-file deploy/.env.production \
   -f docker-compose.yml -f deploy/docker-compose.production.yml up -d
 ```
 
-Roll back by setting `FUTURE_AGI_VERSION` to the previous tag and re-running the same two commands.
+Roll back by setting the bumped variable(s) to the previous tag and re-running the same two commands.
 
 ## Resource sizing
 
@@ -184,7 +196,7 @@ Roll back by setting `FUTURE_AGI_VERSION` to the previous tag and re-running the
 
 - [ ] `SECRET_KEY`, `AGENTCC_INTERNAL_API_KEY`, `AGENTCC_ADMIN_TOKEN` are 32+ random bytes
 - [ ] `PG_PASSWORD`, `MINIO_ROOT_PASSWORD`, `RABBITMQ_PASSWORD` set to non-default values
-- [ ] `FUTURE_AGI_VERSION` pinned to an immutable `vX.Y.Z` tag (not `latest` / `vX.Y`)
+- [ ] `FUTURE_AGI_VERSION`, `FRONTEND_VERSION`, `AGENTCC_GATEWAY_VERSION`, `SERVING_VERSION`, `CODE_EXECUTOR_VERSION` all pinned to immutable `vX.Y.Z` tags (not `latest` / `vX.Y`)
 - [ ] `FRONTEND_URL` matches the public URL behind your reverse proxy
 - [ ] `VITE_HOST_API` matches the public backend URL (or `/api` if route-split at the proxy)
 - [ ] Backend CORS allows the frontend origin (split-domain only)

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -81,9 +81,13 @@ if [[ ! -f "$ENV_FILE" || "${ans:-}" == "y" || "${ans:-}" == "Y" || "${ans:-}" =
   VITE_HOST_API=$(prompt_required "Backend URL (e.g. https://api.example.com)")
 
   say ""
-  say "${BOLD}== Release pin ==${RESET}"
-  default_version=$(grep -E '^FUTURE_AGI_VERSION=' "$EXAMPLE_FILE" | cut -d= -f2- || echo "")
-  FUTURE_AGI_VERSION=$(prompt "Image version tag" "${default_version:-v1.22.41}")
+  say "${BOLD}== Release pins (one per image) ==${RESET}"
+  read_default() { grep -E "^$1=" "$EXAMPLE_FILE" | cut -d= -f2- || echo ""; }
+  FUTURE_AGI_VERSION=$(prompt        "Backend tag (futureagi/future-agi)"        "$(read_default FUTURE_AGI_VERSION)")
+  FRONTEND_VERSION=$(prompt          "Frontend tag (futureagi/frontend)"         "$(read_default FRONTEND_VERSION)")
+  AGENTCC_GATEWAY_VERSION=$(prompt   "Gateway tag (futureagi/agentcc-gateway)"   "$(read_default AGENTCC_GATEWAY_VERSION)")
+  SERVING_VERSION=$(prompt           "Serving tag (futureagi/serving)"           "$(read_default SERVING_VERSION)")
+  CODE_EXECUTOR_VERSION=$(prompt     "Code-executor tag (futureagi/code-executor)" "$(read_default CODE_EXECUTOR_VERSION)")
 
   say ""
   say "${BOLD}== Generating secrets ==${RESET}"
@@ -118,6 +122,10 @@ RABBITMQ_USER=futureagi
 RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}
 
 FUTURE_AGI_VERSION=${FUTURE_AGI_VERSION}
+FRONTEND_VERSION=${FRONTEND_VERSION}
+AGENTCC_GATEWAY_VERSION=${AGENTCC_GATEWAY_VERSION}
+SERVING_VERSION=${SERVING_VERSION}
+CODE_EXECUTOR_VERSION=${CODE_EXECUTOR_VERSION}
 
 FRONTEND_URL=${FRONTEND_URL}
 VITE_HOST_API=${VITE_HOST_API}

--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -9,7 +9,7 @@
 
 services:
   frontend:
-    image: futureagi/frontend:${FUTURE_AGI_VERSION:-v1.22.41}
+    image: futureagi/frontend:${FRONTEND_VERSION:-latest}
     ports:
       - "${FRONTEND_PORT:-3000}:80"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,10 @@
 # Open http://localhost:3000 once the frontend logs "ready".
 # First boot pulls images from Docker Hub (~30s). No source builds.
 #
-# Pin a specific release (recommended for production): set FUTURE_AGI_VERSION
-# in .env (defaults to whatever this file's defaults pin to — currently
-# v1.22.41).
+# Each image is independently versioned. Defaults to `:latest`. Pin per
+# service in .env for production: FUTURE_AGI_VERSION (backend + worker),
+# FRONTEND_VERSION, AGENTCC_GATEWAY_VERSION, SERVING_VERSION,
+# CODE_EXECUTOR_VERSION.
 #
 # For hot-reload development (build from source, volume mounts, per-queue
 # workers, exposed DB ports, Temporal UI), layer the dev overlay:
@@ -150,7 +151,7 @@ services:
   # ==========================================================================
 
   frontend:
-    image: futureagi/frontend:${FUTURE_AGI_VERSION:-v1.22.41}
+    image: futureagi/frontend:${FRONTEND_VERSION:-latest}
     ports:
       - "${FRONTEND_PORT:-3000}:80"
     environment:
@@ -163,7 +164,7 @@ services:
     restart: unless-stopped
 
   backend:
-    image: futureagi/future-agi:${FUTURE_AGI_VERSION:-v1.22.41}
+    image: futureagi/future-agi:${FUTURE_AGI_VERSION:-latest}
     ports:
       - "${BACKEND_PORT:-8000}:80"
     env_file:
@@ -192,7 +193,7 @@ services:
     restart: unless-stopped
 
   worker:
-    image: futureagi/future-agi:${FUTURE_AGI_VERSION:-v1.22.41}
+    image: futureagi/future-agi:${FUTURE_AGI_VERSION:-latest}
     env_file:
       - path: .env
         required: false
@@ -216,7 +217,7 @@ services:
   # LLM gateway. Provider creds live in agentcc-gateway/config.yaml (override
   # the shipped example via AGENTCC_CONFIG_PATH).
   agentcc-gateway:
-    image: futureagi/agentcc-gateway:${FUTURE_AGI_VERSION:-v1.22.41}
+    image: futureagi/agentcc-gateway:${AGENTCC_GATEWAY_VERSION:-latest}
     ports:
       - "${AGENTCC_GATEWAY_PORT:-8090}:8080"
     env_file:
@@ -235,7 +236,7 @@ services:
     restart: unless-stopped
 
   serving:
-    image: futureagi/serving:${FUTURE_AGI_VERSION:-v1.22.41}
+    image: futureagi/serving:${SERVING_VERSION:-latest}
     ports:
       - "${SERVING_PORT:-8080}:8080"
     env_file:
@@ -250,7 +251,7 @@ services:
   # Requires privileged: true for nsjail namespaces — won't run on Fargate /
   # managed platforms that disallow privileged containers.
   code-executor:
-    image: futureagi/code-executor:${FUTURE_AGI_VERSION:-v1.22.41}
+    image: futureagi/code-executor:${CODE_EXECUTOR_VERSION:-latest}
     ports:
       - "${CODE_EXECUTOR_PORT:-8060}:8060"
     privileged: true

--- a/futureagi/Dockerfile
+++ b/futureagi/Dockerfile
@@ -1,4 +1,4 @@
-FROM 375763256607.dkr.ecr.us-east-2.amazonaws.com/core-backend:v1.8.19_base
+FROM futureagi/future-agi:v1.8.19_base
 
 COPY . .
 


### PR DESCRIPTION
Cherry-picks the 5 commits from [#354](https://github.com/future-agi/future-agi/pull/354) onto `main` so the `Run workflow` button sees the new `release-backend.yml` shape. See #354 for the full rationale

## Commits

- `121b225` — per-service version vars in compose (`FRONTEND_VERSION`, `AGENTCC_GATEWAY_VERSION`, `SERVING_VERSION`, `CODE_EXECUTOR_VERSION` alongside `FUTURE_AGI_VERSION`, all default to `latest`)
- `d5fa67f` — backend SaaS Dockerfile `FROM` swapped from ECR to `futureagi/future-agi:v1.8.19_base`
- `484a985` + `590a6fc` — `release-backend.yml` is now a single amd64 job on `ubuntu-latest` with `type=gha` cache. ~5–8 min cold, ~2 min warm
- `deaf730` — `INSTALLATION.md` notes amd64-only prebuilt images + Apple Silicon Rosetta 2 fallback

## Test plan

- [ ] Dispatch `release-backend.yml` from `main` with `version=v1.22.44`
- [ ] Re-dispatch `v1.22.45` — confirm warm build hits the GHA cache
- [ ] Manually delete orphan `futureagi/future-agi:buildcache` on Docker Hub