### PR TITLE
feat(entitlements): route synthetic data + agentic eval gates through unified check

### DIFF
--- a/futureagi/model_hub/views/datasets/create/synthetic.py
+++ b/futureagi/model_hub/views/datasets/create/synthetic.py
@@ -43,25 +43,12 @@ class CreateSyntheticDataset(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request, *args, **kwargs):
+        from tfc.ee_gating import EEFeature, check_ee_feature
+
+        org = getattr(request, "organization", None) or request.user.organization
+        check_ee_feature(EEFeature.SYNTHETIC_DATA, org_id=str(org.id))
+
         try:
-            # Entitlement check: synthetic data feature
-            try:
-                try:
-                    from ee.usage.services.entitlements import Entitlements
-                except ImportError:
-                    Entitlements = None
-
-                org = (
-                    getattr(request, "organization", None) or request.user.organization
-                )
-                feat_check = Entitlements.check_feature(
-                    str(org.id), "has_synthetic_data"
-                )
-                if not feat_check.allowed:
-                    return self._gm.forbidden_response(feat_check.reason)
-            except ImportError:
-                pass
-
             call_log_row_entry = log_and_deduct_cost_for_resource_request(
                 organization=getattr(request, "organization", None)
                 or request.user.organization,

--- a/futureagi/simulate/views/scenarios.py
+++ b/futureagi/simulate/views/scenarios.py
@@ -1058,22 +1058,12 @@ class AddScenarioColumnsView(APIView):
             ]
         }
         """
+        from tfc.ee_gating import EEFeature, check_ee_feature
+
+        org = getattr(request, "organization", None) or request.user.organization
+        check_ee_feature(EEFeature.AGENTIC_EVAL, org_id=str(org.id))
+
         try:
-            try:
-                try:
-                    from ee.usage.services.entitlements import Entitlements
-                except ImportError:
-                    Entitlements = None
-
-                org = (
-                    getattr(request, "organization", None) or request.user.organization
-                )
-                feat_check = Entitlements.check_feature(str(org.id), "has_agentic_eval")
-                if not feat_check.allowed:
-                    return self.gm.forbidden_response(feat_check.reason)
-            except ImportError:
-                pass
-
             # Get the scenario
             scenario = get_object_or_404(
                 Scenarios,


### PR DESCRIPTION
## Summary
- Replace `Entitlements.check_feature(...)` direct calls in `CreateSyntheticDataset.post` and `AddScenarioColumnsView.post` with `check_ee_feature(EEFeature.X, org_id=...)` from `tfc/ee_gating.py`.
- Matches the pattern already used by every other voice-sim / agentic-eval / synthetic-data entry point in this codebase (`simulate/views/scenarios.py:310, :918`, `simulate/views/agent_definition.py:439`, `ai_tools/tools/evaluations/evaluate_with_agent.py:79`).

## Why
The unified gate is deployment-mode aware:
- **OSS** (`mode == "oss"`): denies anything in `EE_FEATURES` via `has_feature_unified`. The two views previously bypassed this — they only consulted `PlanEntitlement` / `billing.yaml` fallback, which would erroneously allow access on EE deployments where the org's plan defaulted to "free".
- **EE self-hosted with license**: defers to `LicenseValidator.get_cached_license()`. License remains authoritative regardless of YAML.
- **Cloud**: reads `PlanEntitlement` (which the companion EE-repo PR flips on for the free plan).

Keeping OSS / EE-without-license blocked when the EE side opens up the free-tier `has_*` booleans is the whole point of this swap.

## Companion change
EE repo PR flips `has_*` booleans for free plan + adds the `PlanEntitlement` migration. Hard-cap on free credits is enforced by the existing `metering.check_usage` calls in `simulate/temporal/activities/small.py`, `simulate/services/chat_sim.py`, `tracer/utils/eval.py`, and the synthetic-data case generator — no new metering wired here.

## Test plan
- [ ] OSS deployment (`is_oss() == True`): both endpoints return HTTP 402 `FeatureUnavailable` (was: 500/AttributeError or pass-through depending on import state).
- [ ] EE self-hosted without `agentic_eval` / `synthetic_data` in license: both endpoints return HTTP 402.
- [ ] EE self-hosted with full license: both endpoints succeed.
- [ ] Cloud free plan (after EE PR merges): both endpoints succeed; usage metering trips `FREE_TIER_LIMIT` once `ai_credits` allowance is spent.
- [ ] Cloud paid plans: unchanged behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)