### PR TITLE
fix(annotations): block manual-assignment queue items unless user is …

### DIFF
--- a/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
@@ -175,6 +175,7 @@ export default function AnnotateWorkspaceView() {
   const isAssignedToMe = assignedUsers.some(
     (a) => String(a.id) === currentUserId,
   );
+  const isManualAssignment = queueDetail?.auto_assign === false;
   const assignedToName =
     hasAssignments && !isAssignedToMe
       ? assignedUsers
@@ -182,8 +183,9 @@ export default function AnnotateWorkspaceView() {
           .filter(Boolean)
           .join(", ") || "other annotators"
       : null;
-  // User cannot edit annotations when the item is assigned to someone else.
-  const cannotAnnotate = hasAssignments && !isAssignedToMe;
+  // In manual-assignment queues, only explicitly assigned users may annotate.
+  // Auto-assign queues implicitly assign everyone, so they never block.
+  const cannotAnnotate = isManualAssignment && !isAssignedToMe;
   // Reviewers/managers see assigned-to-other items in read-only mode (when
   // not actively reviewing). Other members are fully blocked.
   const isViewOnlyForReviewer = canReview && cannotAnnotate && !isReviewMode;


### PR DESCRIPTION
…explicitly assigned
Closes TH-3881

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
