### PR TITLE
fix(annotations): harden filters and history refresh

### DIFF
--- a/frontend/src/api/annotation-queues/__tests__/annotation-queues.test.js
+++ b/frontend/src/api/annotation-queues/__tests__/annotation-queues.test.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -11,6 +12,8 @@ import {
   annotateKeys,
   automationRuleKeys,
   useCreateAutomationRule,
+  useCompleteItem,
+  useSubmitAnnotations,
 } from "../annotation-queues";
 
 vi.mock("src/utils/axios", () => ({
@@ -23,17 +26,29 @@ vi.mock("notistack", () => ({
   enqueueSnackbar: vi.fn(),
 }));
 
-function createQueryWrapper() {
-  const queryClient = new QueryClient({
+function createTestQueryClient() {
+  return new QueryClient({
     defaultOptions: {
       queries: { retry: false },
       mutations: { retry: false },
     },
   });
+}
 
-  return function QueryWrapper({ children }) {
-    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+function createQueryWrapper(queryClient = createTestQueryClient()) {
+  function QueryWrapper({ children }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  }
+
+  QueryWrapper.propTypes = {
+    children: PropTypes.node,
   };
+
+  return QueryWrapper;
 }
 
 describe("Annotation Queues API", () => {
@@ -145,6 +160,72 @@ describe("Annotation Queues API", () => {
         "q-1",
         "list",
       ]);
+    });
+  });
+
+  describe("useSubmitAnnotations", () => {
+    it("invalidates item annotation history after submit", async () => {
+      axios.post.mockResolvedValueOnce({ data: { result: { submitted: 3 } } });
+      const queryClient = createTestQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useSubmitAnnotations(), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+
+      result.current.mutate({
+        queueId: "queue-1",
+        itemId: "item-1",
+        annotations: [{ label_id: "label-1", value: 45 }],
+        notes: "checked",
+      });
+
+      await waitFor(() => {
+        expect(axios.post).toHaveBeenCalledWith(
+          "/model-hub/annotation-queues/queue-1/items/item-1/annotations/submit/",
+          {
+            annotations: [{ label_id: "label-1", value: 45 }],
+            notes: "checked",
+          },
+        );
+      });
+
+      await waitFor(() => {
+        expect(invalidateSpy).toHaveBeenCalledWith({
+          queryKey: annotateKeys.detail("queue-1", "item-1"),
+        });
+        expect(invalidateSpy).toHaveBeenCalledWith({
+          queryKey: annotateKeys.annotations("queue-1", "item-1"),
+        });
+      });
+    });
+  });
+
+  describe("useCompleteItem", () => {
+    it("invalidates annotate detail and annotation history after complete", async () => {
+      axios.post.mockResolvedValueOnce({
+        data: { result: { next_item: null } },
+      });
+      const queryClient = createTestQueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useCompleteItem(), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+
+      result.current.mutate({
+        queueId: "queue-1",
+        itemId: "item-1",
+      });
+
+      await waitFor(() => {
+        expect(invalidateSpy).toHaveBeenCalledWith({
+          queryKey: annotateKeys.detail("queue-1", "item-1"),
+        });
+        expect(invalidateSpy).toHaveBeenCalledWith({
+          queryKey: annotateKeys.annotations("queue-1", "item-1"),
+        });
+      });
     });
   });
 

--- a/frontend/src/api/annotation-queues/annotation-queues.js
+++ b/frontend/src/api/annotation-queues/annotation-queues.js
@@ -150,10 +150,9 @@ export const useHardDeleteAnnotationQueue = () => {
       queryClient.invalidateQueries({ queryKey: annotationQueueKeys.all });
     },
     onError: (error) => {
-      enqueueSnackbar(
-        extractErrorMessage(error, "Failed to delete queue"),
-        { variant: "error" },
-      );
+      enqueueSnackbar(extractErrorMessage(error, "Failed to delete queue"), {
+        variant: "error",
+      });
     },
   });
 };
@@ -394,6 +393,16 @@ export const annotateKeys = {
   annotations: (queueId, itemId) => ["item-annotations", queueId, itemId],
 };
 
+const invalidateAnnotateItem = (queryClient, queueId, itemId) => {
+  if (!queueId || !itemId) return;
+  queryClient.invalidateQueries({
+    queryKey: annotateKeys.detail(queueId, itemId),
+  });
+  queryClient.invalidateQueries({
+    queryKey: annotateKeys.annotations(queueId, itemId),
+  });
+};
+
 export const useAnnotateDetail = (queueId, itemId, options = {}) => {
   return useQuery({
     queryKey: annotateKeys.detail(queueId, itemId),
@@ -428,9 +437,7 @@ export const useSubmitAnnotations = () => {
         { annotations, notes },
       ),
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: annotateKeys.detail(variables.queueId, variables.itemId),
-      });
+      invalidateAnnotateItem(queryClient, variables.queueId, variables.itemId);
       queryClient.invalidateQueries({
         queryKey: queueItemKeys.all(variables.queueId),
       });
@@ -461,6 +468,7 @@ export const useCompleteItem = () => {
         exclude ? { exclude } : undefined,
       ),
     onSuccess: (_, variables) => {
+      invalidateAnnotateItem(queryClient, variables.queueId, variables.itemId);
       queryClient.invalidateQueries({
         queryKey: queueItemKeys.all(variables.queueId),
       });

--- a/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/items/add-items-dialog.jsx
@@ -62,41 +62,20 @@ import CallLogsGrid from "src/sections/agents/CallLogs/CallLogsGrid";
 import SelectAllBanner from "src/sections/projects/LLMTracing/SelectAllBanner";
 import { useGetProjectDetails } from "src/api/project/project-detail";
 import { PROJECT_SOURCE } from "src/utils/constants";
+import {
+  apiFilterHasValue,
+  apiOpToPanel,
+  isNumberFilterOp,
+  isRangeFilterOp,
+  normalizeApiFilterOp,
+  panelOperatorAndValueToApi,
+} from "src/sections/annotations/queues/utils/filter-operators";
 
 // ---------------------------------------------------------------------------
 // TraceFilterPanel ↔ API filter converters (mirror ObserveToolbar's inline
 // logic). Moved here so the dialog's Trace and Span selectors can mount the
 // same popover the main tracing page uses.
 // ---------------------------------------------------------------------------
-const PANEL_OP_TO_API = {
-  is: "equals",
-  is_not: "not_equals",
-  contains: "contains",
-  not_contains: "not_contains",
-  equals: "equals",
-  equal_to: "equal_to",
-  not_equal_to: "not_equal_to",
-  greater_than: "greater_than",
-  greater_than_or_equal: "greater_than_or_equal",
-  less_than: "less_than",
-  less_than_or_equal: "less_than_or_equal",
-  between: "between",
-  not_between: "not_between",
-};
-const API_OP_TO_PANEL = {
-  equals: "is",
-  not_equals: "is_not",
-  contains: "contains",
-  not_contains: "not_contains",
-  starts_with: "starts_with",
-  // `in` / `not_in` are the multi-value promotion of equals / not_equals
-  // that panelFilterToApi emits. Reverse back to `is` / `is_not` so the
-  // panel's operator Select finds a matching option (STRING_OPS and
-  // CATEGORICAL_OPS don't include `in` — without the reverse mapping the
-  // Operator dropdown goes blank on re-open).
-  in: "is",
-  not_in: "is_not",
-};
 const PANEL_TYPE_TO_API = {
   string: "text",
   number: "number",
@@ -116,31 +95,12 @@ const COL_TYPE_TO_PANEL_CAT = {
   EVAL_METRIC: "eval",
   ANNOTATION: "annotation",
 };
-const NUMBER_OPS = new Set([
-  "equal_to",
-  "not_equal_to",
-  "greater_than",
-  "greater_than_or_equal",
-  "less_than",
-  "less_than_or_equal",
-  "between",
-  "not_between",
-]);
-const RANGE_OPS = new Set(["between", "not_between"]);
 
 function panelFilterToApi(panel) {
-  const baseOp = PANEL_OP_TO_API[panel.operator] || panel.operator;
-  let filterOp = baseOp;
-  let filterValue = panel.value;
-  if (Array.isArray(filterValue)) {
-    if (filterValue.length === 1) {
-      filterValue = filterValue[0];
-    } else if (filterValue.length > 1) {
-      if (baseOp === "equals") filterOp = "in";
-      else if (baseOp === "not_equals") filterOp = "not_in";
-      else filterValue = filterValue.join(",");
-    }
-  }
+  const { filterOp, filterValue } = panelOperatorAndValueToApi(
+    panel.operator,
+    panel.value,
+  );
   const filterType = PANEL_TYPE_TO_API[panel.fieldType] || "text";
   const colType = PANEL_CAT_TO_COL_TYPE[panel.fieldCategory];
   return {
@@ -163,8 +123,9 @@ function panelFilterToApi(panel) {
 
 function apiFilterToPanel(api) {
   const rawOp = api?.filterConfig?.filterOp || "equals";
-  const isNumberOp = NUMBER_OPS.has(rawOp);
-  const isRange = RANGE_OPS.has(rawOp);
+  const canonicalOp = normalizeApiFilterOp(rawOp);
+  const isNumberOp = isNumberFilterOp(canonicalOp);
+  const isRange = isRangeFilterOp(canonicalOp);
   const rawVal = api?.filterConfig?.filterValue;
   let value;
   if (isRange && rawVal) {
@@ -191,20 +152,21 @@ function apiFilterToPanel(api) {
     api?.colType ||
     "SYSTEM_METRIC";
   const filterType = api?.filterConfig?.filterType;
+  const fieldType = isNumberOp
+    ? "number"
+    : filterType === "number"
+      ? "number"
+      : filterType === "categorical"
+        ? "categorical"
+        : filterType === "text" && rawColType === "ANNOTATION"
+          ? "text"
+          : "string";
   return {
     field: api.columnId,
     fieldName: api.displayName,
     fieldCategory: COL_TYPE_TO_PANEL_CAT[rawColType] || "system",
-    fieldType: isNumberOp
-      ? "number"
-      : filterType === "number"
-        ? "number"
-        : filterType === "categorical"
-          ? "categorical"
-          : filterType === "text" && rawColType === "ANNOTATION"
-            ? "text"
-            : "string",
-    operator: isNumberOp ? rawOp : API_OP_TO_PANEL[rawOp] || rawOp,
+    fieldType,
+    operator: apiOpToPanel(canonicalOp, fieldType),
     value,
   };
 }
@@ -334,10 +296,13 @@ const SPAN_ROWS_LIMIT = 20;
 // selectAll enumeration path when the backend filter-mode resolver isn't
 // available for a source type.
 // ---------------------------------------------------------------------------
-async function fetchAllTraceIds(projectId, excludedIds, filters, projectVersionId) {
-  const serializedFilters = JSON.stringify(
-    objectCamelToSnake(filters || []),
-  );
+async function fetchAllTraceIds(
+  projectId,
+  excludedIds,
+  filters,
+  projectVersionId,
+) {
+  const serializedFilters = JSON.stringify(objectCamelToSnake(filters || []));
   const allIds = [];
   const excluded = excludedIds || new Set();
   let page = 0;
@@ -369,10 +334,13 @@ async function fetchAllTraceIds(projectId, excludedIds, filters, projectVersionI
   return allIds;
 }
 
-async function fetchAllSpanIds(projectId, excludedIds, filters, projectVersionId) {
-  const serializedFilters = JSON.stringify(
-    objectCamelToSnake(filters || []),
-  );
+async function fetchAllSpanIds(
+  projectId,
+  excludedIds,
+  filters,
+  projectVersionId,
+) {
+  const serializedFilters = JSON.stringify(objectCamelToSnake(filters || []));
   const allIds = [];
   const excluded = excludedIds || new Set();
   let page = 0;
@@ -546,7 +514,6 @@ export default function AddItemsDialog({ open, onClose, queueId }) {
               source_id: id,
             }));
           }
-
         } finally {
           setIsResolving(false);
         }
@@ -1735,8 +1702,7 @@ function TraceSelector({ onSetSelection, onSelectAll, onVoiceProjectChange }) {
         const visibleRowIds = [];
         const rendered = event.api.getRenderedNodes?.() || [];
         rendered.forEach((node) => {
-          const rowId =
-            node?.data?.trace_id ?? node?.data?.traceId ?? node?.id;
+          const rowId = node?.data?.trace_id ?? node?.data?.traceId ?? node?.id;
           if (rowId && !excludedIds.has(rowId)) visibleRowIds.push(rowId);
         });
         onSetSelection(visibleRowIds);
@@ -1917,7 +1883,9 @@ function TraceSelector({ onSetSelection, onSelectAll, onVoiceProjectChange }) {
             .filter((f) => f?.columnId)
             .map(apiFilterToPanel)}
           onApply={(newPanelFilters) => {
-            const apiNext = (newPanelFilters || []).map(panelFilterToApi);
+            const apiNext = (newPanelFilters || [])
+              .map(panelFilterToApi)
+              .filter(apiFilterHasValue);
             setFilters(
               apiNext.length
                 ? apiNext.map((f) => ({ ...f, id: getRandomId() }))
@@ -2482,7 +2450,9 @@ function SpanSelector({ onSetSelection, onSelectAll }) {
             .filter((f) => f?.columnId)
             .map(apiFilterToPanel)}
           onApply={(newPanelFilters) => {
-            const apiNext = (newPanelFilters || []).map(panelFilterToApi);
+            const apiNext = (newPanelFilters || [])
+              .map(panelFilterToApi)
+              .filter(apiFilterHasValue);
             setFilters(
               apiNext.length
                 ? apiNext.map((f) => ({ ...f, id: getRandomId() }))

--- a/frontend/src/sections/annotations/queues/utils/__tests__/filter-operators.test.js
+++ b/frontend/src/sections/annotations/queues/utils/__tests__/filter-operators.test.js
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  apiFilterHasValue,
+  apiOpToPanel,
+  isNumberFilterOp,
+  isRangeFilterOp,
+  normalizeApiFilterOp,
+  panelOperatorAndValueToApi,
+  panelOpToApi,
+} from "../filter-operators";
+
+describe("annotation queue filter operator contract", () => {
+  it("serializes panel-only number operators to backend canonical operators", () => {
+    expect(panelOpToApi("equal_to")).toBe("equals");
+    expect(panelOpToApi("not_equal_to")).toBe("not_equals");
+    expect(panelOpToApi("not_between")).toBe("not_in_between");
+    expect(panelOpToApi("inBetween")).toBe("between");
+  });
+
+  it("serializes panel-only text operators to backend canonical operators", () => {
+    expect(panelOpToApi("is")).toBe("equals");
+    expect(panelOpToApi("is_not")).toBe("not_equals");
+    expect(panelOpToApi("contains")).toBe("contains");
+  });
+
+  it("keeps older saved operator aliases readable when hydrating the panel", () => {
+    expect(normalizeApiFilterOp("equal_to")).toBe("equals");
+    expect(normalizeApiFilterOp("not_equal_to")).toBe("not_equals");
+    expect(normalizeApiFilterOp("not_between")).toBe("not_in_between");
+  });
+
+  it("maps canonical backend number operators back to panel operators", () => {
+    expect(apiOpToPanel("equals", "number")).toBe("equal_to");
+    expect(apiOpToPanel("not_equals", "number")).toBe("not_equal_to");
+    expect(apiOpToPanel("not_in_between", "number")).toBe("not_between");
+  });
+
+  it("maps canonical backend text and date operators back to panel operators", () => {
+    expect(apiOpToPanel("equals", "text")).toBe("is");
+    expect(apiOpToPanel("not_equals", "text")).toBe("is_not");
+    expect(apiOpToPanel("equals", "date")).toBe("on");
+    expect(apiOpToPanel("less_than", "date")).toBe("before");
+  });
+
+  it("classifies canonical and legacy number/range operators", () => {
+    expect(isNumberFilterOp("not_equals")).toBe(true);
+    expect(isNumberFilterOp("not_equal_to")).toBe(true);
+    expect(isRangeFilterOp("not_in_between")).toBe(true);
+    expect(isRangeFilterOp("not_between")).toBe(true);
+  });
+
+  it("builds API operator/value pairs without leaking panel-only operators", () => {
+    expect(panelOperatorAndValueToApi("equal_to", "45")).toEqual({
+      filterOp: "equals",
+      filterValue: "45",
+    });
+    expect(panelOperatorAndValueToApi("not_equal_to", "45")).toEqual({
+      filterOp: "not_equals",
+      filterValue: "45",
+    });
+    expect(panelOperatorAndValueToApi("not_between", [10, 50])).toEqual({
+      filterOp: "not_in_between",
+      filterValue: ["10", "50"],
+    });
+  });
+
+  it("promotes multi-select equality to in/not_in while preserving ranges", () => {
+    expect(panelOperatorAndValueToApi("is", ["ok"])).toEqual({
+      filterOp: "in",
+      filterValue: ["ok"],
+    });
+    expect(panelOperatorAndValueToApi("is", ["ok", "warning"])).toEqual({
+      filterOp: "in",
+      filterValue: ["ok", "warning"],
+    });
+    expect(panelOperatorAndValueToApi("is_not", ["ok", "warning"])).toEqual({
+      filterOp: "not_in",
+      filterValue: ["ok", "warning"],
+    });
+    expect(panelOperatorAndValueToApi("between", [1, 5])).toEqual({
+      filterOp: "between",
+      filterValue: ["1", "5"],
+    });
+  });
+
+  it("drops empty value filters while keeping valueless null checks", () => {
+    expect(
+      apiFilterHasValue({
+        columnId: "status",
+        filterConfig: { filterOp: "in", filterValue: [] },
+      }),
+    ).toBe(false);
+    expect(
+      apiFilterHasValue({
+        columnId: "status",
+        filterConfig: { filterOp: "not_in", filterValue: [""] },
+      }),
+    ).toBe(false);
+    expect(
+      apiFilterHasValue({
+        columnId: "status",
+        filterConfig: { filterOp: "is_null" },
+      }),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/sections/annotations/queues/utils/filter-operators.js
+++ b/frontend/src/sections/annotations/queues/utils/filter-operators.js
@@ -1,0 +1,152 @@
+// TraceFilterPanel uses UI-facing operator names (`equal_to`, `is`,
+// `not_between`). The trace/filter APIs use canonical backend names
+// (`equals`, `not_equals`, `not_in_between`). Keep that contract in one place
+// so annotation queue flows do not leak panel-only operator names to the API.
+
+export const PANEL_OP_TO_API = {
+  is: "equals",
+  is_not: "not_equals",
+  contains: "contains",
+  not_contains: "not_contains",
+  starts_with: "starts_with",
+  ends_with: "ends_with",
+  equals: "equals",
+  not_equals: "not_equals",
+  equal_to: "equals",
+  not_equal_to: "not_equals",
+  greater_than: "greater_than",
+  greater_than_or_equal: "greater_than_or_equal",
+  less_than: "less_than",
+  less_than_or_equal: "less_than_or_equal",
+  between: "between",
+  not_between: "not_in_between",
+  not_in_between: "not_in_between",
+  inBetween: "between",
+  is_empty: "is_null",
+  is_not_empty: "is_not_null",
+  is_null: "is_null",
+  is_not_null: "is_not_null",
+  before: "less_than",
+  after: "greater_than",
+  on: "equals",
+  in: "in",
+  not_in: "not_in",
+};
+
+const API_OP_ALIASES = {
+  is: "equals",
+  is_not: "not_equals",
+  equal_to: "equals",
+  not_equal_to: "not_equals",
+  not_between: "not_in_between",
+  inBetween: "between",
+};
+
+const NUMBER_API_TO_PANEL = {
+  equals: "equal_to",
+  not_equals: "not_equal_to",
+  greater_than: "greater_than",
+  greater_than_or_equal: "greater_than_or_equal",
+  less_than: "less_than",
+  less_than_or_equal: "less_than_or_equal",
+  between: "between",
+  not_in_between: "not_between",
+};
+
+const DATE_API_TO_PANEL = {
+  equals: "on",
+  less_than: "before",
+  greater_than: "after",
+  between: "between",
+  not_in_between: "not_between",
+};
+
+const TEXT_API_TO_PANEL = {
+  equals: "is",
+  not_equals: "is_not",
+  contains: "contains",
+  not_contains: "not_contains",
+  starts_with: "starts_with",
+  ends_with: "ends_with",
+  in: "is",
+  not_in: "is_not",
+  is_null: "is_empty",
+  is_not_null: "is_not_empty",
+};
+
+export const NUMBER_FILTER_OPS = new Set(Object.keys(NUMBER_API_TO_PANEL));
+export const RANGE_FILTER_OPS = new Set(["between", "not_in_between"]);
+const VALUELESS_FILTER_OPS = new Set([
+  "is_null",
+  "is_not_null",
+  "is_empty",
+  "is_not_empty",
+]);
+
+export function normalizeApiFilterOp(op) {
+  if (!op) return op;
+  return API_OP_ALIASES[op] || op;
+}
+
+export function panelOpToApi(op) {
+  if (!op) return op;
+  return PANEL_OP_TO_API[op] || normalizeApiFilterOp(op);
+}
+
+export function panelOperatorAndValueToApi(operator, value) {
+  const baseOp = panelOpToApi(operator);
+  let filterOp = baseOp;
+  let filterValue = value;
+
+  if (Array.isArray(filterValue)) {
+    if (baseOp === "between" || baseOp === "not_in_between") {
+      filterValue = filterValue.map(String);
+    } else if (baseOp === "equals") {
+      filterOp = "in";
+      filterValue = filterValue.map(String);
+    } else if (baseOp === "not_equals") {
+      filterOp = "not_in";
+      filterValue = filterValue.map(String);
+    } else if (filterValue.length === 1) {
+      filterValue = filterValue[0];
+    } else if (filterValue.length > 1) {
+      filterValue = filterValue.join(",");
+    }
+  }
+
+  return { filterOp, filterValue };
+}
+
+export function apiFilterHasValue(filter) {
+  const op = normalizeApiFilterOp(filter?.filterConfig?.filterOp);
+  if (!filter?.columnId || !op) return false;
+  if (VALUELESS_FILTER_OPS.has(op)) return true;
+
+  const value = filter?.filterConfig?.filterValue;
+  if (Array.isArray(value)) {
+    return value.length > 0 && value.every((v) => v !== "" && v != null);
+  }
+  return value !== "" && value !== undefined && value !== null;
+}
+
+export function apiOpToPanel(op, fieldType) {
+  const canonicalOp = normalizeApiFilterOp(op);
+
+  if (fieldType === "number") {
+    return NUMBER_API_TO_PANEL[canonicalOp] || canonicalOp;
+  }
+
+  if (fieldType === "date" || fieldType === "datetime") {
+    return DATE_API_TO_PANEL[canonicalOp] || canonicalOp;
+  }
+
+  return TEXT_API_TO_PANEL[canonicalOp] || canonicalOp;
+}
+
+export function isNumberFilterOp(op) {
+  return NUMBER_FILTER_OPS.has(normalizeApiFilterOp(op));
+}
+
+export function isRangeFilterOp(op) {
+  return RANGE_FILTER_OPS.has(normalizeApiFilterOp(op));
+}

--- a/frontend/src/sections/annotations/queues/view/create-rule-dialog.jsx
+++ b/frontend/src/sections/annotations/queues/view/create-rule-dialog.jsx
@@ -42,6 +42,14 @@ import TraceFilterPanel from "src/sections/projects/LLMTracing/TraceFilterPanel"
 import { useGetProjectDetails } from "src/api/project/project-detail";
 import { PROJECT_SOURCE } from "src/utils/constants";
 import { getRandomId, objectCamelToSnake } from "src/utils/utils";
+import {
+  apiFilterHasValue,
+  apiOpToPanel,
+  isNumberFilterOp,
+  isRangeFilterOp,
+  normalizeApiFilterOp,
+  panelOperatorAndValueToApi,
+} from "src/sections/annotations/queues/utils/filter-operators";
 
 export const SOURCE_OPTIONS = [
   { value: "dataset_row", label: "Dataset Row" },
@@ -153,48 +161,6 @@ const SESSION_RULE_FILTER_FIELDS = [
   { id: "end_time", name: "End Time", category: "system", type: "date" },
 ];
 
-const PANEL_OP_TO_API = {
-  is: "equals",
-  is_not: "not_equals",
-  contains: "contains",
-  not_contains: "not_contains",
-  starts_with: "starts_with",
-  equals: "equals",
-  equal_to: "equal_to",
-  not_equal_to: "not_equal_to",
-  greater_than: "greater_than",
-  greater_than_or_equal: "greater_than_or_equal",
-  less_than: "less_than",
-  less_than_or_equal: "less_than_or_equal",
-  between: "between",
-  not_between: "not_between",
-  is_empty: "is_null",
-  is_not_empty: "is_not_null",
-  before: "less_than",
-  after: "greater_than",
-  on: "equals",
-};
-
-const API_OP_TO_PANEL = {
-  equals: "is",
-  not_equals: "is_not",
-  contains: "contains",
-  not_contains: "not_contains",
-  starts_with: "starts_with",
-  in: "is",
-  not_in: "is_not",
-  is_null: "is_empty",
-  is_not_null: "is_not_empty",
-};
-
-const API_DATE_OP_TO_PANEL = {
-  equals: "on",
-  less_than: "before",
-  greater_than: "after",
-  between: "between",
-  not_between: "not_between",
-};
-
 const PANEL_TYPE_TO_API = {
   string: "text",
   number: "number",
@@ -219,18 +185,6 @@ const COL_TYPE_TO_PANEL_CAT = {
   ANNOTATION: "annotation",
 };
 
-const NUMBER_OPS = new Set([
-  "equal_to",
-  "not_equal_to",
-  "greater_than",
-  "greater_than_or_equal",
-  "less_than",
-  "less_than_or_equal",
-  "between",
-  "not_between",
-]);
-
-const RANGE_OPS = new Set(["between", "not_between", "not_in_between"]);
 const MULTI_VALUE_OPS = new Set(["is", "is_not", "in", "not_in"]);
 
 function formatDateInputValue(value) {
@@ -268,22 +222,10 @@ export function defaultFiltersForSource(sourceType) {
 }
 
 function panelFilterToApi(panel) {
-  const baseOp = PANEL_OP_TO_API[panel.operator] || panel.operator;
-  let filterOp = baseOp;
-  let filterValue = panel.value;
-  if (Array.isArray(filterValue)) {
-    if (baseOp === "equals") {
-      filterOp = "in";
-      filterValue = filterValue.map(String);
-    } else if (baseOp === "not_equals") {
-      filterOp = "not_in";
-      filterValue = filterValue.map(String);
-    } else if (filterValue.length === 1) {
-      filterValue = filterValue[0];
-    } else if (filterValue.length > 1) {
-      filterValue = filterValue.join(",");
-    }
-  }
+  const { filterOp, filterValue } = panelOperatorAndValueToApi(
+    panel.operator,
+    panel.value,
+  );
   const filterType = PANEL_TYPE_TO_API[panel.fieldType] || "text";
   const colType = PANEL_CAT_TO_COL_TYPE[panel.fieldCategory];
   return {
@@ -300,10 +242,11 @@ function panelFilterToApi(panel) {
 
 function apiFilterToPanel(api) {
   const rawOp = api?.filterConfig?.filterOp || "equals";
+  const canonicalOp = normalizeApiFilterOp(rawOp);
   const rawVal = api?.filterConfig?.filterValue;
   const filterType = api?.filterConfig?.filterType;
-  const isNumberOp = NUMBER_OPS.has(rawOp);
-  const isRange = RANGE_OPS.has(rawOp);
+  const isNumberOp = isNumberFilterOp(canonicalOp);
+  const isRange = isRangeFilterOp(canonicalOp);
   const isDateType = filterType === "datetime" || filterType === "date";
   let value;
   if (isRange && rawVal) {
@@ -345,29 +288,13 @@ function apiFilterToPanel(api) {
     fieldName: api.displayName,
     fieldCategory: COL_TYPE_TO_PANEL_CAT[rawColType] || "system",
     fieldType,
-    operator: isNumberOp
-      ? rawOp
-      : isDateType
-        ? API_DATE_OP_TO_PANEL[rawOp] || rawOp
-        : API_OP_TO_PANEL[rawOp] || rawOp,
+    operator: apiOpToPanel(canonicalOp, fieldType),
     value,
   };
 }
 
 function filterWithValue(filter) {
-  const op = filter?.filterConfig?.filterOp;
-  if (!filter?.columnId || !op) return false;
-  if (
-    op === "is_null" ||
-    op === "is_not_null" ||
-    op === "is_empty" ||
-    op === "is_not_empty"
-  ) {
-    return true;
-  }
-  const value = filter?.filterConfig?.filterValue;
-  if (Array.isArray(value)) return value.length > 0 && value.every(Boolean);
-  return value !== "" && value !== undefined && value !== null;
+  return apiFilterHasValue(filter);
 }
 
 function toRuleRows(filters) {
@@ -892,7 +819,9 @@ function TraceRuleFilters({
         currentFilters={toApiFilters(filters).map(apiFilterToPanel)}
         onApply={(newPanelFilters) => {
           onInteraction?.();
-          const nextFilters = (newPanelFilters || []).map(panelFilterToApi);
+          const nextFilters = (newPanelFilters || [])
+            .map(panelFilterToApi)
+            .filter(apiFilterHasValue);
           setFilters(
             nextFilters.length
               ? nextFilters.map((filter) => ({ ...filter, id: getRandomId() }))
@@ -983,7 +912,9 @@ function SimulationRuleFilters({ filters, setFilters, onInteraction }) {
         currentFilters={panelCurrentFilters}
         onApply={(newPanelFilters) => {
           onInteraction?.();
-          const nextFilters = (newPanelFilters || []).map(panelFilterToApi);
+          const nextFilters = (newPanelFilters || [])
+            .map(panelFilterToApi)
+            .filter(apiFilterHasValue);
           setFilters(
             nextFilters.length
               ? nextFilters.map((filter) => ({ ...filter, id: getRandomId() }))

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -10,6 +10,8 @@ Django ORM querysets.
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
+from tracer.utils.filter_operators import normalize_filter_op
+
 _SAFE_ATTR_KEY_RE = re.compile(r"^[a-zA-Z0-9._\-]+$")
 
 
@@ -209,6 +211,13 @@ class ClickHouseFilterBuilder:
         self._param_counter += 1
         return f"{prefix}_{self._param_counter}"
 
+    @classmethod
+    def _sql_op(cls, filter_op: Optional[str]) -> Optional[str]:
+        """Return a SQL comparison operator for canonical filter ops only."""
+        if not filter_op:
+            return None
+        return cls.OP_MAP.get(filter_op)
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -243,6 +252,7 @@ class ClickHouseFilterBuilder:
 
             filter_type = config.get("filter_type") or config.get("filterType")
             filter_op = config.get("filter_op") or config.get("filterOp")
+            filter_op = normalize_filter_op(filter_op)
             filter_value = config.get("filter_value", config.get("filterValue"))
 
             # Skip date filters (handled by BaseQueryBuilder.parse_time_range)
@@ -391,7 +401,7 @@ class ClickHouseFilterBuilder:
             # by them. Other ops (``contains``, ``starts_with``, …) fall
             # back to equals-style membership, which matches how the
             # frontend ``userScopeFilter`` always sends ``equals``.
-            negate = filter_op in ("not_equals", "not_in", "!=", "is_not")
+            negate = filter_op in ("not_equals", "not_in", "!=")
             outer_op = "NOT IN" if negate else "IN"
             param = self._next_param("uid_s")
             self._params[param] = tuple(values)
@@ -575,7 +585,7 @@ class ClickHouseFilterBuilder:
         elif filter_op == "ends_with":
             self._params[param] = f"%{filter_value}"
             inner = f"{exists} AND {map_col}['{key}'] LIKE %({param})s"
-        elif filter_op in ("between", "inBetween") and isinstance(filter_value, list):
+        elif filter_op == "between" and isinstance(filter_value, list):
             p_lo = self._next_param("lo")
             p_hi = self._next_param("hi")
             self._params[p_lo] = filter_value[0]
@@ -588,15 +598,27 @@ class ClickHouseFilterBuilder:
             self._params[p_hi] = filter_value[1]
             inner = f"({exists} AND {map_col}['{key}'] NOT BETWEEN %({p_lo})s AND %({p_hi})s)"
         elif filter_op == "in" and isinstance(filter_value, list):
-            self._params[param] = tuple(filter_value)
-            inner = f"{exists} AND {map_col}['{key}'] IN %({param})s"
+            # ClickHouse rejects IN (). Keep empty-set semantics explicit:
+            # value IN [] matches nothing.
+            if not filter_value:
+                inner = "0 = 1"
+            else:
+                self._params[param] = tuple(filter_value)
+                inner = f"{exists} AND {map_col}['{key}'] IN %({param})s"
         elif filter_op == "not_in" and isinstance(filter_value, list):
-            self._params[param] = tuple(filter_value)
-            inner = f"(NOT {exists} OR {map_col}['{key}'] NOT IN %({param})s)"
+            # value NOT IN [] should not restrict results.
+            if not filter_value:
+                inner = "1 = 1"
+            else:
+                self._params[param] = tuple(filter_value)
+                inner = f"(NOT {exists} OR {map_col}['{key}'] NOT IN %({param})s)"
         else:
-            op = self.OP_MAP.get(filter_op, "=")
-            self._params[param] = filter_value
-            inner = f"{exists} AND {map_col}['{key}'] {op} %({param})s"
+            op = self._sql_op(filter_op)
+            if op is None:
+                inner = "0 = 1"
+            else:
+                self._params[param] = filter_value
+                inner = f"{exists} AND {map_col}['{key}'] {op} %({param})s"
 
         # In span-list mode the caller wants the filter to apply to
         # each span row directly — return the inner condition unwrapped.
@@ -646,7 +668,7 @@ class ClickHouseFilterBuilder:
         elif filter_op == "ends_with":
             self._params[param] = f"%{filter_value}"
             return f"{column} LIKE %({param})s"
-        elif filter_op in ("between", "inBetween") and isinstance(filter_value, list):
+        elif filter_op == "between" and isinstance(filter_value, list):
             p_lo = self._next_param("lo")
             p_hi = self._next_param("hi")
             self._params[p_lo] = filter_value[0]
@@ -662,6 +684,10 @@ class ClickHouseFilterBuilder:
             values = (
                 list(filter_value) if isinstance(filter_value, list) else [filter_value]
             )
+            # ClickHouse rejects IN (). Keep empty-set semantics explicit:
+            # value IN [] matches nothing.
+            if not values:
+                return "0 = 1"
             if ci:
                 values = [str(v).lower() for v in values]
                 self._params[param] = tuple(values)
@@ -672,6 +698,9 @@ class ClickHouseFilterBuilder:
             values = (
                 list(filter_value) if isinstance(filter_value, list) else [filter_value]
             )
+            # value NOT IN [] should not restrict results.
+            if not values:
+                return "1 = 1"
             if ci:
                 values = [str(v).lower() for v in values]
                 self._params[param] = tuple(values)
@@ -679,7 +708,9 @@ class ClickHouseFilterBuilder:
             self._params[param] = tuple(values)
             return f"{column} NOT IN %({param})s"
         else:
-            op = self.OP_MAP.get(filter_op, "=")
+            op = self._sql_op(filter_op)
+            if op is None:
+                return "0 = 1"
             if ci and op in ("=", "!=") and isinstance(filter_value, str):
                 self._params[param] = filter_value.lower()
                 return f"lower({column}) {op} %({param})s"
@@ -700,7 +731,7 @@ class ClickHouseFilterBuilder:
         """
         param = self._next_param("expr")
 
-        if filter_op in ("between", "inBetween") and isinstance(filter_value, list):
+        if filter_op == "between" and isinstance(filter_value, list):
             p_lo = self._next_param("lo")
             p_hi = self._next_param("hi")
             self._params[p_lo] = filter_value[0]
@@ -713,7 +744,9 @@ class ClickHouseFilterBuilder:
             self._params[p_hi] = filter_value[1]
             return f"({expr}) NOT BETWEEN %({p_lo})s AND %({p_hi})s"
         else:
-            op = self.OP_MAP.get(filter_op, "=")
+            op = self._sql_op(filter_op)
+            if op is None:
+                return "0 = 1"
             self._params[param] = filter_value
             return f"({expr}) {op} %({param})s"
 
@@ -771,7 +804,9 @@ class ClickHouseFilterBuilder:
         param_cfg = self._next_param("eval_cfg")
         self._params[param_cfg] = tuple(config_ids)
 
-        op = self.OP_MAP.get(filter_op, "=")
+        op = self._sql_op(filter_op)
+        if op is None:
+            return "0 = 1"
         _fv = filter_value
         if isinstance(_fv, (list, tuple)):
             _fv = _fv[0] if _fv and _fv[0] not in (None, "") else _fv
@@ -879,10 +914,9 @@ class ClickHouseFilterBuilder:
 
         if filter_type == "number":
             param = self._next_param("ann")
-            op = self.OP_MAP.get(filter_op, "=")
 
             if (
-                filter_op in ("between", "inBetween")
+                filter_op == "between"
                 and isinstance(filter_value, list)
                 and len(filter_value) == 2
             ):
@@ -912,6 +946,9 @@ class ClickHouseFilterBuilder:
                     f"JSONExtractFloat(value, 'value')) NOT BETWEEN %({p_lo})s AND %({p_hi})s)"
                 )
             else:
+                op = self._sql_op(filter_op)
+                if op is None:
+                    return "0 = 1"
                 self._params[param] = filter_value
                 return (
                     f"trace_id IN ({base_where} "
@@ -961,7 +998,7 @@ class ClickHouseFilterBuilder:
                 return None
             param = self._next_param("ann")
             self._params[param] = tuple(tokens)
-            negate = filter_op in ("not_in", "not_equals", "is_not")
+            negate = filter_op in ("not_in", "not_equals")
             sql_op = "NOT IN" if negate else "IN"
             return (
                 f"trace_id IN ({base_where} "
@@ -981,9 +1018,9 @@ class ClickHouseFilterBuilder:
             elif filter_op == "not_contains":
                 self._params[param] = f"%{filter_value}%"
                 return (
-                    f"trace_id NOT IN ({base_where} "
+                    f"trace_id IN ({base_where} "
                     f"AND {text_expr} != '' "
-                    f"AND {text_expr} ILIKE %({param})s)"
+                    f"AND {text_expr} NOT ILIKE %({param})s)"
                 )
             elif filter_op == "equals":
                 self._params[param] = filter_value
@@ -995,9 +1032,9 @@ class ClickHouseFilterBuilder:
             elif filter_op == "not_equals":
                 self._params[param] = filter_value
                 return (
-                    f"trace_id NOT IN ({base_where} "
+                    f"trace_id IN ({base_where} "
                     f"AND {text_expr} != '' "
-                    f"AND lower({text_expr}) = lower(%({param})s))"
+                    f"AND lower({text_expr}) != lower(%({param})s))"
                 )
             elif filter_op == "starts_with":
                 self._params[param] = f"{filter_value}%"
@@ -1014,8 +1051,10 @@ class ClickHouseFilterBuilder:
                     f"AND {text_expr} ILIKE %({param})s)"
                 )
             else:
+                op = self._sql_op(filter_op)
+                if op is None:
+                    return "0 = 1"
                 self._params[param] = filter_value
-                op = self.OP_MAP.get(filter_op, "=")
                 return (
                     f"trace_id IN ({base_where} " f"AND {text_expr} {op} %({param})s)"
                 )
@@ -1058,8 +1097,15 @@ class ClickHouseFilterBuilder:
                 return cond
 
             values = filter_value if isinstance(filter_value, list) else [filter_value]
+            # Empty categorical selections should not produce invalid IN () SQL.
+            if not values:
+                if filter_op in ("not_equals", "not_in", "not_contains"):
+                    return "1 = 1"
+                return "0 = 1"
             sub_conditions = [_build_one(v) for v in values]
             combined = " OR ".join(sub_conditions)
+            if filter_op in ("not_equals", "not_in", "not_contains"):
+                return f"trace_id IN ({base_where} AND NOT ({combined}))"
             return f"trace_id IN ({base_where} AND ({combined}))"
 
         elif filter_type == "annotator":

--- a/futureagi/tracer/services/clickhouse/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_list.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
+from tracer.utils.filter_operators import normalize_filter_op
 
 
 class SessionListQueryBuilder(BaseQueryBuilder):
@@ -384,8 +385,10 @@ class SessionListQueryBuilder(BaseQueryBuilder):
                 continue
 
             config = f.get("filter_config") or f.get("filterConfig", {})
-            filter_op = config.get("filter_op")
-            filter_value = config.get("filter_value")
+            filter_op = normalize_filter_op(
+                config.get("filter_op") or config.get("filterOp")
+            )
+            filter_value = config.get("filter_value", config.get("filterValue"))
             ch_col = self.SESSION_FILTER_MAP[col_id]
 
             op_map = {
@@ -396,7 +399,10 @@ class SessionListQueryBuilder(BaseQueryBuilder):
                 "greater_than_or_equal": ">=",
                 "less_than_or_equal": "<=",
             }
-            op = op_map.get(filter_op, "=")
+            op = op_map.get(filter_op)
+            if op is None:
+                conditions.append("0 = 1")
+                continue
 
             param_counter += 1
             param_name = f"having_{param_counter}"

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -1202,6 +1202,54 @@ class TestSessionListQueryBuilder:
         assert "GROUP BY trace_session_id" in query
         assert "HAVING" in query
 
+    def test_having_filter_normalizes_operator_alias(self):
+        """Session aggregate filters should accept saved UI operator aliases."""
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        builder = SessionListQueryBuilder(
+            project_id="test-project-id",
+            filters=[
+                {
+                    "column_id": "duration",
+                    "filter_config": {
+                        "filter_op": "equal_to",
+                        "filter_value": 60,
+                    },
+                }
+            ],
+            page_number=0,
+            page_size=10,
+        )
+        query, params = builder.build()
+
+        assert "HAVING" in query
+        assert "duration = %(having_" in query
+        assert 60 in params.values()
+
+    def test_having_filter_unknown_operator_does_not_fall_back_to_equals(self):
+        """Unsupported session aggregate operators should match no rows."""
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        builder = SessionListQueryBuilder(
+            project_id="test-project-id",
+            filters=[
+                {
+                    "column_id": "duration",
+                    "filter_config": {
+                        "filter_op": "definitely_not_supported",
+                        "filter_value": 60,
+                    },
+                }
+            ],
+            page_number=0,
+            page_size=10,
+        )
+        query, _params = builder.build()
+
+        assert "HAVING" in query
+        assert "0 = 1" in query
+        assert "duration = %(having_" not in query
+
     def test_build_with_user_id(self):
         """When user_id is provided, query should filter by end_user_id."""
         from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
@@ -3920,6 +3968,167 @@ class TestFilterBuilderEdgeCases:
         # The column on model_hub_score is simply label_id (not annotation_label_id).
         assert "label_id" in where
         assert "_peerdb_is_deleted = 0" in where
+
+    def test_annotation_number_not_equal_to_alias(self):
+        """Frontend number op not_equal_to should translate to SQL !=."""
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        builder = ClickHouseFilterBuilder()
+        filters = [
+            {
+                "column_id": "00000000-0000-0000-0000-000000000066",
+                "filter_config": {
+                    "filter_type": "number",
+                    "filter_op": "not_equal_to",
+                    "filter_value": 45,
+                    "col_type": "ANNOTATION",
+                },
+            }
+        ]
+        where, params = builder.translate(filters)
+
+        assert "model_hub_score FINAL" in where
+        assert ") != %(ann_" in where
+        assert "45" not in where
+        assert 45 in params.values()
+
+    def test_annotation_number_not_between_alias(self):
+        """Frontend number op not_between should translate to SQL NOT BETWEEN."""
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        builder = ClickHouseFilterBuilder()
+        filters = [
+            {
+                "column_id": "00000000-0000-0000-0000-000000000066",
+                "filter_config": {
+                    "filter_type": "number",
+                    "filter_op": "not_between",
+                    "filter_value": [10, 50],
+                    "col_type": "ANNOTATION",
+                },
+            }
+        ]
+        where, params = builder.translate(filters)
+
+        assert "model_hub_score FINAL" in where
+        assert "NOT BETWEEN" in where
+        assert 10 in params.values()
+        assert 50 in params.values()
+
+    def test_annotation_positive_operator_aliases(self):
+        """Frontend positive op aliases should translate to canonical SQL."""
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        label_id = "00000000-0000-0000-0000-000000000066"
+        cases = [
+            ("number", "equal_to", 45, ") = %(ann_", {45}),
+            ("number", "inBetween", [10, 50], " BETWEEN ", {10, 50}),
+            ("text", "is", "good", ") = lower(%(ann_", {"good"}),
+            ("text", "is_not", "bad", ") != lower(%(ann_", {"bad"}),
+        ]
+
+        for filter_type, filter_op, value, sql_fragment, expected_values in cases:
+            builder = ClickHouseFilterBuilder()
+            where, params = builder.translate(
+                [
+                    {
+                        "column_id": label_id,
+                        "filter_config": {
+                            "filter_type": filter_type,
+                            "filter_op": filter_op,
+                            "filter_value": value,
+                            "col_type": "ANNOTATION",
+                        },
+                    }
+                ]
+            )
+
+            assert "model_hub_score FINAL" in where
+            assert sql_fragment in where
+            assert expected_values.issubset(set(params.values()))
+
+    def test_unknown_operator_does_not_fall_back_to_equals(self):
+        """Unsupported operators should match nothing instead of becoming =."""
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        builder = ClickHouseFilterBuilder()
+        filters = [
+            {
+                "column_id": "model",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "definitely_not_supported",
+                    "filter_value": "gpt-4",
+                    "col_type": "SYSTEM_METRIC",
+                },
+            }
+        ]
+        where, params = builder.translate(filters)
+
+        assert "0 = 1" in where
+        assert "definitely_not_supported" not in where
+        assert " = %(col_" not in where
+        assert params == {}
+
+    def test_empty_in_filters_do_not_emit_invalid_clickhouse_sql(self):
+        """Empty IN arrays should not serialize to invalid IN () syntax."""
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        for filter_op, expected in (("in", "0 = 1"), ("not_in", "1 = 1")):
+            builder = ClickHouseFilterBuilder()
+            where, params = builder.translate(
+                [
+                    {
+                        "column_id": "status",
+                        "filter_config": {
+                            "filter_type": "text",
+                            "filter_op": filter_op,
+                            "filter_value": [],
+                            "col_type": "SYSTEM_METRIC",
+                        },
+                    }
+                ]
+            )
+
+            assert expected in where
+            assert "IN %(" not in where
+            assert "IN ()" not in where
+            assert params == {}
+
+    def test_annotation_text_not_equals_requires_existing_annotation(self):
+        """Text not-equals should not include rows with no annotation."""
+        from tracer.services.clickhouse.query_builders.filters import (
+            ClickHouseFilterBuilder,
+        )
+
+        builder = ClickHouseFilterBuilder()
+        filters = [
+            {
+                "column_id": "00000000-0000-0000-0000-000000000066",
+                "filter_config": {
+                    "filter_type": "text",
+                    "filter_op": "not_equals",
+                    "filter_value": "bad",
+                    "col_type": "ANNOTATION",
+                },
+            }
+        ]
+        where, params = builder.translate(filters)
+
+        assert "trace_id IN (" in where
+        assert "trace_id NOT IN" not in where
+        assert "!= lower" in where
+        assert "bad" in params.values()
 
     def test_is_null_system_metric(self):
         """IS NULL on system metric column."""

--- a/futureagi/tracer/tests/test_voice_call_annotation_filters.py
+++ b/futureagi/tracer/tests/test_voice_call_annotation_filters.py
@@ -116,6 +116,16 @@ class TestVoiceCallAnnotationNumberFilters:
         )
         assert result != Q()
 
+    def test_not_equal_to_alias_requires_existing_score(self):
+        uid = str(uuid.uuid4())
+        filters = [_make_annotation_filter(uid, "number", "not_equal_to", 4.0)]
+        result, _ = FilterEngine.get_filter_conditions_for_voice_call_annotations(
+            filters
+        )
+
+        assert result != Q()
+        assert f"('annotation_{uid}__score__isnull', False)" in repr(result)
+
     def test_greater_than_or_equal(self):
         uid = str(uuid.uuid4())
         filters = [_make_annotation_filter(uid, "number", "greater_than_or_equal", 3.0)]
@@ -147,6 +157,16 @@ class TestVoiceCallAnnotationNumberFilters:
             filters
         )
         assert result != Q()
+
+    def test_not_between_alias_requires_existing_score(self):
+        uid = str(uuid.uuid4())
+        filters = [_make_annotation_filter(uid, "number", "not_between", [2.0, 8.0])]
+        result, _ = FilterEngine.get_filter_conditions_for_voice_call_annotations(
+            filters
+        )
+
+        assert result != Q()
+        assert f"('annotation_{uid}__score__isnull', False)" in repr(result)
 
     def test_invalid_filter_value_is_skipped(self):
         uid = str(uuid.uuid4())
@@ -371,6 +391,21 @@ class TestVoiceCallAnnotationTextFilters:
         assert result != Q()
         assert extra == {}
 
+    def test_not_contains_requires_existing_text_annotation(self):
+        uid = str(uuid.uuid4())
+        filters = [_make_annotation_filter(uid, "text", "not_contains", "bad")]
+        result, extra = FilterEngine.get_filter_conditions_for_voice_call_annotations(
+            filters
+        )
+
+        exists_count = sum(
+            1
+            for node in result.flatten()
+            if node.__class__.__name__ == "Exists"
+        )
+        assert exists_count >= 2
+        assert extra == {}
+
     def test_equals(self):
         uid = str(uuid.uuid4())
         filters = [_make_annotation_filter(uid, "text", "equals", "exact match")]
@@ -387,6 +422,21 @@ class TestVoiceCallAnnotationTextFilters:
             filters
         )
         assert result != Q()
+        assert extra == {}
+
+    def test_not_equals_requires_existing_text_annotation(self):
+        uid = str(uuid.uuid4())
+        filters = [_make_annotation_filter(uid, "text", "not_equals", "bad value")]
+        result, extra = FilterEngine.get_filter_conditions_for_voice_call_annotations(
+            filters
+        )
+
+        exists_count = sum(
+            1
+            for node in result.flatten()
+            if node.__class__.__name__ == "Exists"
+        )
+        assert exists_count >= 2
         assert extra == {}
 
     def test_starts_with(self):

--- a/futureagi/tracer/utils/filter_operators.py
+++ b/futureagi/tracer/utils/filter_operators.py
@@ -1,0 +1,27 @@
+"""Shared filter operator helpers.
+
+Frontend panels have historically used display-oriented operator names such as
+``equal_to`` and ``not_between``. Backend filter builders should use the
+canonical API contract names below. The aliases remain only for saved filters
+and older clients.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+FILTER_OP_ALIASES = {
+    "is": "equals",
+    "is_not": "not_equals",
+    "equal_to": "equals",
+    "not_equal_to": "not_equals",
+    "not_between": "not_in_between",
+    "inBetween": "between",
+}
+
+
+def normalize_filter_op(filter_op: Optional[str]) -> str:
+    if not filter_op:
+        return ""
+    return FILTER_OP_ALIASES.get(filter_op, filter_op)

--- a/futureagi/tracer/utils/filters.py
+++ b/futureagi/tracer/utils/filters.py
@@ -10,6 +10,7 @@ from django.db.models.functions import Cast, Round
 from django.utils.dateparse import parse_datetime as django_parse_datetime
 
 from tracer.models.observability_provider import ProviderChoices
+from tracer.utils.filter_operators import normalize_filter_op
 from tracer.utils.helper import extract_date
 
 
@@ -66,7 +67,7 @@ def apply_created_at_filters(qs, filters):
         cfg = f.get("filter_config") or f.get("filterConfig") or {}
         if cfg.get("filter_type") != "datetime":
             continue
-        op = cfg.get("filter_op")
+        op = normalize_filter_op(cfg.get("filter_op"))
         val = cfg.get("filter_value")
         if val is None:
             continue
@@ -196,6 +197,7 @@ class FilterEngine:
         Returns:
             tuple: (is_valid, converted_value)
         """
+        filter_op = normalize_filter_op(filter_op)
         try:
             if filter_type == "number":
                 if filter_op in ["between", "not_in_between"]:
@@ -247,7 +249,7 @@ class FilterEngine:
                 continue
 
             filter_type = filter_config.get("filter_type")
-            filter_op = filter_config.get("filter_op")
+            filter_op = normalize_filter_op(filter_config.get("filter_op"))
             filter_value = filter_config.get("filter_value")
             if filter_type == "number":
                 filtered_objects = self._filter_number(
@@ -275,6 +277,7 @@ class FilterEngine:
         return filtered_objects
 
     def _filter_number(self, objects, column_id, filter_op, filter_value, col_type):
+        filter_op = normalize_filter_op(filter_op)
         operator_map = {
             "greater_than": lambda x, y: x > y,
             "less_than": lambda x, y: x < y,
@@ -318,6 +321,7 @@ class FilterEngine:
         return result
 
     def _filter_text(self, objects, column_id, filter_op, filter_value, col_type):
+        filter_op = normalize_filter_op(filter_op)
         filter_value = filter_value.lower()
         text_ops = {
             "contains": lambda x: filter_value in x.lower(),
@@ -363,6 +367,7 @@ class FilterEngine:
         ]
 
     def _filter_datetime(self, objects, column_id, filter_op, filter_value, col_type):
+        filter_op = normalize_filter_op(filter_op)
         if isinstance(filter_value, str):
             filter_value = datetime.strptime((filter_value), "%Y-%m-%dT%H:%M:%S.%fZ")
         elif isinstance(filter_value, list):
@@ -547,7 +552,7 @@ class FilterEngine:
             if not column_id or not filter_config:
                 continue
 
-            filter_op = str(filter_config.get("filter_op"))
+            filter_op = normalize_filter_op(filter_config.get("filter_op"))
             filter_value = filter_config.get("filter_value")
             filter_type = filter_config.get("filter_type")
 
@@ -723,8 +728,8 @@ class FilterEngine:
             if not defn:
                 continue
 
-            filter_op = str(
-                filter_config.get("filter_op") or filter_config.get("filterOp", "")
+            filter_op = normalize_filter_op(
+                filter_config.get("filter_op") or filter_config.get("filterOp")
             )
             filter_value = filter_config.get(
                 "filter_value", filter_config.get("filterValue")
@@ -837,7 +842,7 @@ class FilterEngine:
             if not column_id or not filter_config:
                 continue
 
-            filter_op = filter_config.get("filterOp")
+            filter_op = normalize_filter_op(filter_config.get("filterOp"))
             filter_value = filter_config.get("filterValue")
             filter_type = filter_config.get("filterType")
 
@@ -944,7 +949,7 @@ class FilterEngine:
             if column_id not in field_map:
                 continue
 
-            filter_op = filter_config.get("filter_op")
+            filter_op = normalize_filter_op(filter_config.get("filter_op"))
             filter_value = filter_config.get("filter_value")
             filter_type = filter_config.get("filter_type")
 
@@ -1055,7 +1060,7 @@ class FilterEngine:
             if column_id in FilterEngine.VOICE_SYSTEM_METRIC_IDS:
                 continue
 
-            filter_op = filter_config.get("filter_op")
+            filter_op = normalize_filter_op(filter_config.get("filter_op"))
             filter_value = filter_config.get("filter_value")
             filter_type = filter_config.get("filter_type")
 
@@ -1177,7 +1182,7 @@ class FilterEngine:
                 continue
 
             filter_type = filter_config.get("filterType")
-            filter_op = filter_config.get("filterOp")
+            filter_op = normalize_filter_op(filter_config.get("filterOp"))
             filter_value = filter_config.get("filterValue")
 
             if filter_type == "number":
@@ -1320,7 +1325,7 @@ class FilterEngine:
                 continue
 
             filter_type = filter_config.get("filter_type")
-            filter_op = filter_config.get("filter_op")
+            filter_op = normalize_filter_op(filter_config.get("filter_op"))
             filter_value = filter_config.get("filter_value")
 
             # Replace '*' with '_' in column_id
@@ -1636,7 +1641,7 @@ class FilterEngine:
                 continue
 
             filter_type = filter_config.get("filter_type")
-            filter_op = filter_config.get("filter_op")
+            filter_op = normalize_filter_op(filter_config.get("filter_op"))
             filter_value = filter_config.get("filter_value")
 
             # Parse column_id for sub-field separator
@@ -1664,6 +1669,7 @@ class FilterEngine:
                     score_field = f"{annotation_field}__{sub_field}"
                 else:
                     score_field = f"{annotation_field}__score"
+                has_score = Q(**{f"{score_field}__isnull": False})
                 score_condition = None
 
                 if filter_op == "greater_than":
@@ -1702,7 +1708,7 @@ class FilterEngine:
                     )
 
                 if score_condition:
-                    q_conditions &= score_condition
+                    q_conditions &= has_score & score_condition
 
             elif filter_type == "boolean":
                 # Thumbs up/down annotations: {"thumbs_up": N, "thumbs_down": M, ...}
@@ -1742,8 +1748,10 @@ class FilterEngine:
                     if t is not None and t not in tokens:
                         tokens.append(t)
                 if tokens:
-                    negate = filter_op in ("not_in", "not_equals", "is_not")
+                    negate = filter_op in ("not_in", "not_equals")
+                    has_annotation = Q(**{f"{annotation_field}__isnull": False})
                     if negate:
+                        q_conditions &= has_annotation
                         for t in tokens:
                             q_conditions &= ~Q(**{f"{annotation_field}__{t}__gt": 0})
                     else:
@@ -1761,6 +1769,7 @@ class FilterEngine:
                 _THUMBS_MAP = {"Thumbs Up": "thumbs_up", "Thumbs Down": "thumbs_down"}
                 raw_values = filter_value if isinstance(filter_value, list) else [filter_value]
                 values = [_THUMBS_MAP.get(v, v) for v in raw_values]
+                has_annotation = Q(**{f"{annotation_field}__isnull": False})
 
                 if filter_op in ("equals", "in", "contains"):
                     choice_q = Q()
@@ -1768,6 +1777,7 @@ class FilterEngine:
                         choice_q |= Q(**{f"{annotation_field}__{val}__gt": 0})
                     q_conditions &= choice_q
                 elif filter_op in ("not_equals", "not_in", "not_contains"):
+                    q_conditions &= has_annotation
                     for val in values:
                         q_conditions &= ~Q(**{f"{annotation_field}__{val}__gt": 0})
 
@@ -1776,17 +1786,18 @@ class FilterEngine:
                 # under the "text" key.  Use Exists subqueries against Score
                 # so that starts_with / ends_with operate on the actual text,
                 # not on a stringified JSON blob.
-                base_ann_filter = {
-                    "observation_span__trace_id": OuterRef("trace_id"),
-                    "label_id": (column_id if not sub_field else base_column_id),
-                    "value__text__isnull": False,
-                    "deleted": False,
-                }
+                label_id = column_id if not sub_field else base_column_id
+                base_text_qs = Score.objects.filter(
+                    source_q,
+                    label_id=label_id,
+                    value__text__isnull=False,
+                    deleted=False,
+                )
+                has_text_annotation = Q(Exists(base_text_qs))
                 if filter_op == "contains":
                     q_conditions &= Q(
                         Exists(
-                            Score.objects.filter(
-                                **base_ann_filter,
+                            base_text_qs.filter(
                                 value__text__icontains=filter_value,
                             )
                         )
@@ -1794,26 +1805,23 @@ class FilterEngine:
                 elif filter_op == "equals":
                     q_conditions &= Q(
                         Exists(
-                            Score.objects.filter(
-                                **base_ann_filter,
+                            base_text_qs.filter(
                                 value__text__iexact=filter_value,
                             )
                         )
                     )
                 elif filter_op == "not_contains":
-                    q_conditions &= ~Q(
+                    q_conditions &= has_text_annotation & ~Q(
                         Exists(
-                            Score.objects.filter(
-                                **base_ann_filter,
+                            base_text_qs.filter(
                                 value__text__icontains=filter_value,
                             )
                         )
                     )
                 elif filter_op == "not_equals":
-                    q_conditions &= ~Q(
+                    q_conditions &= has_text_annotation & ~Q(
                         Exists(
-                            Score.objects.filter(
-                                **base_ann_filter,
+                            base_text_qs.filter(
                                 value__text__iexact=filter_value,
                             )
                         )
@@ -1821,8 +1829,7 @@ class FilterEngine:
                 elif filter_op == "starts_with":
                     q_conditions &= Q(
                         Exists(
-                            Score.objects.filter(
-                                **base_ann_filter,
+                            base_text_qs.filter(
                                 value__text__istartswith=filter_value,
                             )
                         )
@@ -1830,8 +1837,7 @@ class FilterEngine:
                 elif filter_op == "ends_with":
                     q_conditions &= Q(
                         Exists(
-                            Score.objects.filter(
-                                **base_ann_filter,
+                            base_text_qs.filter(
                                 value__text__iendswith=filter_value,
                             )
                         )
@@ -2155,7 +2161,7 @@ class FilterEngine:
                 continue
 
             filter_type = filter_config.get("filter_type")
-            filter_op = filter_config.get("filter_op")
+            filter_op = normalize_filter_op(filter_config.get("filter_op"))
             filter_value = filter_config.get("filter_value", None)
 
             if filter_op not in ["is_null", "is_not_null"] and filter_value is None:


### PR DESCRIPTION
## Summary

Stacked on #192 (`feat/annotation-unified-score-hardening`).

Fixes the annotation hotfix set:
- TH-4443: numeric annotation `not_equal_to` now maps to the canonical backend `not_equals` behavior instead of falling back incorrectly.
- TH-3600: annotation submit/complete mutations invalidate item annotation history so counts refresh after saves.
- TH-4444: annotation filters now require the annotation key to exist, so non-annotated rows are excluded when a filter is applied.

Also centralizes the frontend/backend operator contract and adds regression coverage for unsafe operator aliases, unknown operators, empty `IN` values, and negative filters against missing annotations.

## Validation

- `cd frontend && yarn test:run src/api/annotation-queues/__tests__/annotation-queues.test.js src/sections/annotations/queues/utils/__tests__/filter-operators.test.js`
  - 2 files passed, 26 tests passed
- Backend focused pytest per `internal-docs/TESTING.md` Docker pattern:
  - `python -m pytest -m unit -v -k "operator_aliases or unknown_operator or empty_in_filters or not_equal_to_alias or not_between_alias or not_equals_requires_existing_annotation or having_filter or requires_existing_text_annotation" tracer/tests/test_clickhouse.py tracer/tests/test_voice_call_annotation_filters.py --tb=short`
  - 14 passed, 432 deselected
- `python -m py_compile` on touched backend files
- `git diff --cached --check`
- Pre-commit lint-staged ran ESLint/Prettier on staged frontend files during commit

## Notes

Browser verification on local `localhost:3031` was blocked by two-factor auth for the provided account, so no new working screenshot is attached. Existing Linear screenshots/videos remain on the tickets.