### PR TITLE
fix(annotations): add label notes and annotator selector

### DIFF
--- a/frontend/src/api/annotation-queues/__tests__/annotation-queues.test.js
+++ b/frontend/src/api/annotation-queues/__tests__/annotation-queues.test.js
@@ -12,12 +12,14 @@ import {
   annotateKeys,
   automationRuleKeys,
   useCreateAutomationRule,
+  useAnnotateDetail,
   useCompleteItem,
   useSubmitAnnotations,
 } from "../annotation-queues";
 
 vi.mock("src/utils/axios", () => ({
   default: {
+    get: vi.fn(),
     post: vi.fn(),
   },
 }));
@@ -130,6 +132,15 @@ describe("Annotation Queues API", () => {
       ]);
     });
 
+    it("generates annotator-scoped detail key", () => {
+      expect(annotateKeys.detail("q-1", "item-1", "user-1")).toEqual([
+        "annotate-detail",
+        "q-1",
+        "item-1",
+        "user-1",
+      ]);
+    });
+
     it("generates nextItem key", () => {
       expect(annotateKeys.nextItem("q-1")).toEqual([
         "annotate-next-item",
@@ -160,6 +171,33 @@ describe("Annotation Queues API", () => {
         "q-1",
         "list",
       ]);
+    });
+  });
+
+  describe("useAnnotateDetail", () => {
+    it("passes annotator_id when an annotator is selected", async () => {
+      axios.get.mockResolvedValueOnce({
+        data: { result: { annotations: [] } },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useAnnotateDetail("queue-1", "item-1", {
+            annotatorId: "user-2",
+          }),
+        {
+          wrapper: createQueryWrapper(),
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(axios.get).toHaveBeenCalledWith(
+        "/model-hub/annotation-queues/queue-1/items/item-1/annotate-detail/",
+        { params: { annotator_id: "user-2" } },
+      );
     });
   });
 

--- a/frontend/src/api/annotation-queues/annotation-queues.js
+++ b/frontend/src/api/annotation-queues/annotation-queues.js
@@ -388,7 +388,10 @@ export const useUpdateQueueItemStatus = () => {
 // ---------------------------------------------------------------------------
 
 export const annotateKeys = {
-  detail: (queueId, itemId) => ["annotate-detail", queueId, itemId],
+  detail: (queueId, itemId, annotatorId) =>
+    annotatorId
+      ? ["annotate-detail", queueId, itemId, annotatorId]
+      : ["annotate-detail", queueId, itemId],
   nextItem: (queueId) => ["annotate-next-item", queueId],
   annotations: (queueId, itemId) => ["item-annotations", queueId, itemId],
 };
@@ -403,12 +406,17 @@ const invalidateAnnotateItem = (queryClient, queueId, itemId) => {
   });
 };
 
-export const useAnnotateDetail = (queueId, itemId, options = {}) => {
+export const useAnnotateDetail = (
+  queueId,
+  itemId,
+  { annotatorId, ...options } = {},
+) => {
   return useQuery({
-    queryKey: annotateKeys.detail(queueId, itemId),
+    queryKey: annotateKeys.detail(queueId, itemId, annotatorId),
     queryFn: () =>
       axios.get(
         `/model-hub/annotation-queues/${queueId}/items/${itemId}/annotate-detail/`,
+        annotatorId ? { params: { annotator_id: annotatorId } } : undefined,
       ),
     select: (d) => extractData(d),
     enabled: !!queueId && !!itemId,
@@ -431,11 +439,14 @@ export const useNextItem = (queueId, options = {}) => {
 export const useSubmitAnnotations = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ queueId, itemId, annotations, notes }) =>
-      axios.post(
+    mutationFn: ({ queueId, itemId, annotations, notes }) => {
+      const payload = { annotations };
+      if (notes !== undefined) payload.notes = notes;
+      return axios.post(
         `/model-hub/annotation-queues/${queueId}/items/${itemId}/annotations/submit/`,
-        { annotations, notes },
-      ),
+        payload,
+      );
+    },
     onSuccess: (_, variables) => {
       invalidateAnnotateItem(queryClient, variables.queueId, variables.itemId);
       queryClient.invalidateQueries({

--- a/frontend/src/sections/annotations/queues/__tests__/annotate-components.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/annotate-components.test.jsx
@@ -2,9 +2,11 @@
  * Phase 2B-3C – Annotation workspace component tests.
  * Tests: LabelInput, AnnotateHeader, AnnotateFooter, AnnotationHistory
  */
+/* eslint-disable react/prop-types */
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, userEvent, waitFor } from "src/utils/test-utils";
 import LabelInput from "../annotate/label-input";
+import LabelPanel from "../annotate/label-panel";
 import AnnotateHeader from "../annotate/annotate-header";
 import AnnotateFooter from "../annotate/annotate-footer";
 import AnnotationHistory from "../annotate/annotation-history";
@@ -17,6 +19,10 @@ vi.mock("src/components/iconify", () => ({
 
 vi.mock("src/utils/format-time", () => ({
   fDateTime: () => "Jan 1, 2025 12:00",
+}));
+
+vi.mock("src/sections/common/CellMarkdown", () => ({
+  default: ({ text }) => <div>{text}</div>,
 }));
 
 // Mock API hook for annotation history
@@ -191,6 +197,150 @@ describe("LabelInput", () => {
       await user.click(screen.getByText("Yes"));
       expect(onChange).toHaveBeenCalledWith({ value: "up" });
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LabelPanel
+// ---------------------------------------------------------------------------
+describe("LabelPanel", () => {
+  it("submits separate notes for each note-enabled label", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <LabelPanel
+        labels={[
+          {
+            id: "ql-1",
+            label_id: "label-1",
+            name: "Content",
+            type: "thumbs_up_down",
+            settings: {},
+            allow_notes: true,
+          },
+          {
+            id: "ql-2",
+            label_id: "label-2",
+            name: "Latency",
+            type: "thumbs_up_down",
+            settings: {},
+            allow_notes: true,
+          },
+        ]}
+        annotations={[]}
+        onSubmit={onSubmit}
+        queueId="queue-1"
+        itemId="item-1"
+      />,
+    );
+
+    await user.click(screen.getAllByText("Yes")[0]);
+    await user.click(screen.getAllByText("No")[1]);
+    const noteFields = screen.getAllByPlaceholderText(
+      "Add notes for this label...",
+    );
+    await user.type(noteFields[0], "content note");
+    await user.type(noteFields[1], "latency note");
+    await user.click(screen.getByRole("button", { name: /submit & next/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      annotations: [
+        {
+          label_id: "label-1",
+          value: { value: "up" },
+          notes: "content note",
+        },
+        {
+          label_id: "label-2",
+          value: { value: "down" },
+          notes: "latency note",
+        },
+      ],
+    });
+  });
+
+  it("clears stale label notes when the selected annotator changes", async () => {
+    const label = {
+      id: "ql-1",
+      label_id: "label-1",
+      name: "Content",
+      type: "thumbs_up_down",
+      settings: {},
+      allow_notes: true,
+    };
+    const annotations = [
+      {
+        label_id: "label-1",
+        value: { value: "up" },
+        notes: "previous annotator note",
+      },
+    ];
+
+    const { rerender } = render(
+      <LabelPanel
+        labels={[label]}
+        annotations={annotations}
+        onSubmit={() => {}}
+        queueId="queue-1"
+        itemId="item-1"
+        viewingAnnotatorId="user-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("Add notes for this label..."),
+      ).toHaveValue("previous annotator note");
+    });
+
+    rerender(
+      <LabelPanel
+        labels={[label]}
+        annotations={annotations}
+        onSubmit={() => {}}
+        queueId="queue-1"
+        itemId="item-1"
+        viewingAnnotatorId="user-2"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("Add notes for this label..."),
+      ).toHaveValue("");
+    });
+  });
+
+  it("shows selected annotator context and emits annotator changes", async () => {
+    const user = userEvent.setup();
+    const onViewingAnnotatorChange = vi.fn();
+
+    render(
+      <LabelPanel
+        labels={[]}
+        annotations={[]}
+        onSubmit={() => {}}
+        queueId="queue-1"
+        itemId="item-1"
+        annotators={[
+          { user_id: "user-1", name: "Kartik" },
+          { user_id: "user-2", name: "Narda" },
+        ]}
+        currentUserId="user-1"
+        viewingAnnotatorId="user-2"
+        onViewingAnnotatorChange={onViewingAnnotatorChange}
+      />,
+    );
+
+    expect(
+      screen.getByText("You are viewing annotations of Narda"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "Kartik (you)" }));
+
+    expect(onViewingAnnotatorChange).toHaveBeenCalledWith("user-1");
   });
 });
 

--- a/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
@@ -106,53 +106,99 @@ export default function AnnotateWorkspaceView() {
     }
   }, [nextItemData, currentItemId]);
 
-  // Fetch annotate detail for current item
-  const {
-    data: detail,
-    isLoading: detailLoading,
-    error: detailError,
-  } = useAnnotateDetail(queueId, currentItemId);
-
   const { data: progress } = useQueueProgress(queueId);
   const { data: queueDetail } = useAnnotationQueueDetail(queueId);
+  const currentUserId = String(user?.id || user?.pk || "");
 
   const myQueueRole = useMemo(() => {
     if (!queueDetail?.annotators || !user) return null;
     const currentUser = queueDetail.annotators.find(
-      (a) => a.user_id === (user.id || user.pk),
+      (a) => String(a.user_id) === currentUserId,
     );
     return currentUser?.role || null;
-  }, [queueDetail, user]);
+  }, [queueDetail, user, currentUserId]);
 
   const canReview =
     myQueueRole === QUEUE_ROLES.REVIEWER || myQueueRole === QUEUE_ROLES.MANAGER;
+
+  const [viewingAnnotatorId, setViewingAnnotatorId] = useState(null);
+
+  useEffect(() => {
+    if (!queueDetail) return;
+    if (canReview && currentUserId && !viewingAnnotatorId) {
+      setViewingAnnotatorId(currentUserId);
+    } else if (!canReview && viewingAnnotatorId !== null) {
+      setViewingAnnotatorId(null);
+    }
+  }, [canReview, currentUserId, queueDetail, viewingAnnotatorId]);
+
+  const scopedAnnotatorId = canReview ? viewingAnnotatorId : undefined;
+  const isViewingOtherAnnotator =
+    canReview &&
+    !!viewingAnnotatorId &&
+    String(viewingAnnotatorId) !== currentUserId;
+  const detailEnabled =
+    !!queueId &&
+    !!currentItemId &&
+    !!queueDetail &&
+    (!canReview || !!viewingAnnotatorId);
+
+  // Reviewers/managers request one annotator at a time so values from
+  // multiple annotators never merge into a single editable form.
+  const {
+    data: detail,
+    isLoading: detailLoading,
+    isFetching: detailFetching,
+    error: detailError,
+  } = useAnnotateDetail(queueId, currentItemId, {
+    annotatorId: scopedAnnotatorId,
+    enabled: detailEnabled,
+  });
+
+  const lastLoadedAnnotatorIdRef = useRef(null);
+  useEffect(() => {
+    if (detail && !detailFetching) {
+      lastLoadedAnnotatorIdRef.current = scopedAnnotatorId || null;
+    }
+  }, [detail, detailFetching, scopedAnnotatorId]);
+
+  const isAnnotatorSwitchPending =
+    detailFetching &&
+    !!scopedAnnotatorId &&
+    !!lastLoadedAnnotatorIdRef.current &&
+    String(lastLoadedAnnotatorIdRef.current) !== String(scopedAnnotatorId);
 
   // Prefetch adjacent items for instant navigation
   useEffect(() => {
     if (!detail || !queueId) return;
     const nextId = detail.next_item_id;
     const prevId = detail.prev_item_id;
+    const requestOptions = scopedAnnotatorId
+      ? { params: { annotator_id: scopedAnnotatorId } }
+      : undefined;
     if (nextId) {
       queryClient.prefetchQuery({
-        queryKey: annotateKeys.detail(queueId, nextId),
+        queryKey: annotateKeys.detail(queueId, nextId, scopedAnnotatorId),
         queryFn: () =>
           axios.get(
             `/model-hub/annotation-queues/${queueId}/items/${nextId}/annotate-detail/`,
+            requestOptions,
           ),
         staleTime: 1000 * 60 * 2,
       });
     }
     if (prevId) {
       queryClient.prefetchQuery({
-        queryKey: annotateKeys.detail(queueId, prevId),
+        queryKey: annotateKeys.detail(queueId, prevId, scopedAnnotatorId),
         queryFn: () =>
           axios.get(
             `/model-hub/annotation-queues/${queueId}/items/${prevId}/annotate-detail/`,
+            requestOptions,
           ),
         staleTime: 1000 * 60 * 2,
       });
     }
-  }, [detail, queueId, queryClient]);
+  }, [detail, queueId, queryClient, scopedAnnotatorId]);
 
   const labelPanelRef = useRef(null);
   const isDirtyRef = useRef(false);
@@ -172,7 +218,6 @@ export default function AnnotateWorkspaceView() {
 
   // Item is explicitly assigned to someone else (only blocks in manual-assignment mode)
   const assignedUsers = detail?.item?.assigned_users || [];
-  const currentUserId = String(user?.id || user?.pk || "");
   const hasAssignments = assignedUsers.length > 0;
   const isAssignedToMe = assignedUsers.some(
     (a) => String(a.id) === currentUserId,
@@ -192,8 +237,39 @@ export default function AnnotateWorkspaceView() {
   const isBlockedAssignedToOther = !canReview && cannotAnnotate;
   // Backwards-compatible flag passed to header for disabling Skip.
   const isAssignedToOther = cannotAnnotate && !isReviewMode;
+  const labelPanelReadOnly =
+    isViewOnlyForReviewer ||
+    isViewingOtherAnnotator ||
+    isAnnotatorSwitchPending;
+  const labelPanelReadOnlyReason = isAnnotatorSwitchPending
+    ? "Loading selected annotator..."
+    : isViewingOtherAnnotator
+      ? "Viewing another annotator's submissions (read only)"
+      : isViewOnlyForReviewer
+        ? `Assigned to ${assignedToName || "another annotator"} — view only`
+        : null;
 
   const isSubmittingRef = useRef(false);
+
+  const handleViewingAnnotatorChange = useCallback(
+    (id) => {
+      const nextAnnotatorId = id || currentUserId;
+      if (String(nextAnnotatorId) === String(viewingAnnotatorId || "")) {
+        return;
+      }
+      if (
+        !isViewingOtherAnnotator &&
+        isDirtyRef.current &&
+        !window.confirm(
+          "You have unsaved annotations. Switch annotator anyway?",
+        )
+      ) {
+        return;
+      }
+      setViewingAnnotatorId(nextAnnotatorId);
+    },
+    [currentUserId, isViewingOtherAnnotator, viewingAnnotatorId],
+  );
 
   const handleSubmitAndNext = useCallback(
     ({ annotations, notes }) => {
@@ -379,12 +455,30 @@ export default function AnnotateWorkspaceView() {
     } finally {
       setIsFetchingNext(false);
     }
-  }, [historyIndex, itemHistory, queueId, isFetchingNext, enqueueSnackbar, detail]);
+  }, [
+    historyIndex,
+    itemHistory,
+    queueId,
+    isFetchingNext,
+    enqueueSnackbar,
+    detail,
+  ]);
 
   const handleKeyboardSubmit = useCallback(() => {
-    if (isViewOnlyForReviewer || isBlockedAssignedToOther) return;
+    if (
+      isViewOnlyForReviewer ||
+      isBlockedAssignedToOther ||
+      isViewingOtherAnnotator ||
+      isAnnotatorSwitchPending
+    )
+      return;
     labelPanelRef.current?.submit();
-  }, [isViewOnlyForReviewer, isBlockedAssignedToOther]);
+  }, [
+    isViewOnlyForReviewer,
+    isBlockedAssignedToOther,
+    isViewingOtherAnnotator,
+    isAnnotatorSwitchPending,
+  ]);
 
   useKeyboardShortcuts({
     onSubmit: handleKeyboardSubmit,
@@ -394,8 +488,18 @@ export default function AnnotateWorkspaceView() {
     onEscape: handleBack,
   });
 
+  const isInitialDetailLoading =
+    detailEnabled && !detail && (detailLoading || detailFetching);
+  const isWaitingForAnnotatorSelection =
+    !!queueDetail && canReview && !viewingAnnotatorId;
+
   // Loading state
-  if (nextLoading || (detailLoading && !detail)) {
+  if (
+    nextLoading ||
+    !queueDetail ||
+    isWaitingForAnnotatorSelection ||
+    isInitialDetailLoading
+  ) {
     return (
       <Box
         sx={{
@@ -604,12 +708,13 @@ export default function AnnotateWorkspaceView() {
               queueId={queueId}
               itemId={currentItemId}
               onDirtyChange={handleDirtyChange}
-              readOnly={isViewOnlyForReviewer}
-              readOnlyReason={
-                isViewOnlyForReviewer
-                  ? `Assigned to ${assignedToName || "another annotator"} — view only`
-                  : null
-              }
+              readOnly={labelPanelReadOnly}
+              readOnlyReason={labelPanelReadOnlyReason}
+              annotators={canReview ? queueDetail?.annotators || [] : null}
+              viewingAnnotatorId={viewingAnnotatorId}
+              currentUserId={currentUserId}
+              isAnnotatorSwitchPending={isAnnotatorSwitchPending}
+              onViewingAnnotatorChange={handleViewingAnnotatorChange}
             />
           )}
         </Box>

--- a/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/label-panel.jsx
@@ -14,8 +14,9 @@ import {
   Collapse,
   Divider,
   IconButton,
+  MenuItem,
+  Select,
   Stack,
-  TextField,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -155,11 +156,16 @@ const LabelPanel = forwardRef(function LabelPanel(
     onDirtyChange,
     readOnly = false,
     readOnlyReason = null,
+    annotators = null,
+    viewingAnnotatorId = null,
+    currentUserId = null,
+    onViewingAnnotatorChange,
+    isAnnotatorSwitchPending = false,
   },
   ref,
 ) {
   const [values, setValues] = useState({});
-  const [notes, setNotes] = useState("");
+  const [labelNotes, setLabelNotes] = useState({});
   const [showInstructions, setShowInstructions] = useState(!!instructions);
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [showShortcuts, setShowShortcuts] = useState(false);
@@ -175,28 +181,31 @@ const LabelPanel = forwardRef(function LabelPanel(
   // this, navigating to a new un-annotated item can leave the previous
   // item's values pre-filled while the new item's annotations are still
   // fetching, and the user can accidentally re-submit those values onto
-  // the wrong trace.
+  // the wrong trace or annotator.
   useEffect(() => {
     setValues({});
-    setNotes("");
+    setLabelNotes({});
     setErrorLabels(new Set());
     onDirtyChange?.(false);
-  }, [itemId, onDirtyChange]);
+  }, [itemId, viewingAnnotatorId, onDirtyChange]);
 
   // Initialize values from existing annotations once they arrive (or
   // re-arrive after a refetch). Runs after the itemId-change reset above,
   // so values land on the correct item's prior annotations.
   useEffect(() => {
     const initial = {};
+    const initialNotes = {};
     for (const ann of annotations) {
       const labelId = ann.label_id;
       if (labelId) {
         initial[labelId] = ann.value;
+        if (Object.prototype.hasOwnProperty.call(ann, "notes")) {
+          initialNotes[labelId] = ann.notes || "";
+        }
       }
     }
     setValues(initial);
-    const withNotes = annotations.find((a) => a.notes);
-    setNotes(withNotes?.notes || "");
+    setLabelNotes(initialNotes);
     setErrorLabels(new Set());
     onDirtyChange?.(false);
   }, [annotations, onDirtyChange]);
@@ -215,6 +224,15 @@ const LabelPanel = forwardRef(function LabelPanel(
         next.delete(labelId);
         return next;
       });
+      onDirtyChange?.(true);
+    },
+    [onDirtyChange, readOnly],
+  );
+
+  const handleLabelNotesChange = useCallback(
+    (labelId, value) => {
+      if (readOnly) return;
+      setLabelNotes((prev) => ({ ...prev, [labelId]: value }));
       onDirtyChange?.(true);
     },
     [onDirtyChange, readOnly],
@@ -255,17 +273,24 @@ const LabelPanel = forwardRef(function LabelPanel(
       return;
     }
 
+    const labelsById = new Map(labels.map((label) => [label.label_id, label]));
     const annotationsList = Object.entries(currentValues)
       .filter(([_, v]) => v !== null && v !== undefined)
-      .map(([labelId, value]) => ({
-        label_id: labelId,
-        value,
-      }));
+      .map(([labelId, value]) => {
+        const annotation = {
+          label_id: labelId,
+          value,
+        };
+        if (labelsById.get(labelId)?.allow_notes) {
+          annotation.notes = labelNotes[labelId] ?? "";
+        }
+        return annotation;
+      });
     if (annotationsList.length > 0) {
       onDirtyChange?.(false);
-      onSubmit({ annotations: annotationsList, notes });
+      onSubmit({ annotations: annotationsList });
     }
-  }, [notes, onSubmit, labels, onDirtyChange, readOnly]);
+  }, [labelNotes, onSubmit, labels, onDirtyChange, readOnly]);
 
   useImperativeHandle(ref, () => ({ submit: handleSubmit }), [handleSubmit]);
 
@@ -484,14 +509,82 @@ const LabelPanel = forwardRef(function LabelPanel(
         </Box>
       )}
 
+      {Array.isArray(annotators) && annotators.length > 1 && (
+        <Box sx={{ mb: 2 }}>
+          <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+            <Iconify
+              icon="solar:user-id-bold"
+              width={16}
+              sx={{ color: "text.secondary" }}
+            />
+            <Typography variant="subtitle2" color="text.secondary">
+              Viewing annotator
+            </Typography>
+            {isAnnotatorSwitchPending && (
+              <CircularProgress size={12} thickness={5} sx={{ ml: 0.5 }} />
+            )}
+          </Stack>
+          <Select
+            fullWidth
+            size="small"
+            value={viewingAnnotatorId || ""}
+            onChange={(e) => onViewingAnnotatorChange?.(e.target.value || null)}
+            sx={{
+              borderRadius: 0.5,
+              "& .MuiSelect-select": { py: 1 },
+            }}
+          >
+            {annotators.map((annotator) => {
+              const isSelf =
+                currentUserId &&
+                String(annotator.user_id) === String(currentUserId);
+              return (
+                <MenuItem
+                  key={String(annotator.user_id)}
+                  value={String(annotator.user_id)}
+                >
+                  {annotator.name || annotator.email || "Unknown"}
+                  {isSelf ? " (you)" : ""}
+                </MenuItem>
+              );
+            })}
+          </Select>
+          {viewingAnnotatorId &&
+            (() => {
+              const selected = annotators.find(
+                (annotator) =>
+                  String(annotator.user_id) === String(viewingAnnotatorId),
+              );
+              const isSelf =
+                currentUserId &&
+                String(viewingAnnotatorId) === String(currentUserId);
+              const name =
+                selected?.name || selected?.email || "this annotator";
+              return (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block", mt: 0.75 }}
+                >
+                  {isSelf
+                    ? "You are viewing your own annotations"
+                    : `You are viewing annotations of ${name}`}
+                </Typography>
+              );
+            })()}
+          <Divider sx={{ mt: 2 }} />
+        </Box>
+      )}
+
       {/* Label inputs */}
       <Stack
         spacing={2}
         sx={{
           flex: 1,
-          ...(readOnly && {
+          ...((readOnly || isAnnotatorSwitchPending) && {
             pointerEvents: "none",
-            opacity: 0.7,
+            opacity: isAnnotatorSwitchPending ? 0.4 : 0.7,
+            transition: "opacity 120ms ease-out",
           }),
         }}
       >
@@ -510,12 +603,17 @@ const LabelPanel = forwardRef(function LabelPanel(
                   settings: ql.settings || {},
                   description: ql.description,
                   required: ql.required,
+                  allow_notes: ql.allow_notes ?? false,
                 }}
                 value={values[labelId] ?? null}
                 onChange={(val) => handleChange(labelId, val)}
                 index={i}
                 focused={focusedIndex === i}
                 hasError={errorLabels.has(labelId)}
+                labelNotes={labelNotes[labelId] ?? ""}
+                onLabelNotesChange={(val) =>
+                  handleLabelNotesChange(labelId, val)
+                }
                 textFlushRef={
                   ql.type === "text"
                     ? (el) => {
@@ -528,26 +626,6 @@ const LabelPanel = forwardRef(function LabelPanel(
           );
         })}
       </Stack>
-
-      {/* Notes */}
-      <Box sx={{ mt: 2 }}>
-        <TextField
-          fullWidth
-          size="small"
-          multiline
-          minRows={2}
-          maxRows={4}
-          placeholder="Notes (optional)"
-          value={notes}
-          onChange={(e) => {
-            if (readOnly) return;
-            setNotes(e.target.value);
-            onDirtyChange?.(true);
-          }}
-          InputProps={{ readOnly }}
-          sx={{ "& .MuiOutlinedInput-root": { borderRadius: 0.5 } }}
-        />
-      </Box>
 
       {/* Annotation History */}
       <AnnotationHistory queueId={queueId} itemId={itemId} />
@@ -589,6 +667,11 @@ LabelPanel.propTypes = {
   onDirtyChange: PropTypes.func,
   readOnly: PropTypes.bool,
   readOnlyReason: PropTypes.string,
+  annotators: PropTypes.array,
+  viewingAnnotatorId: PropTypes.string,
+  currentUserId: PropTypes.string,
+  onViewingAnnotatorChange: PropTypes.func,
+  isAnnotatorSwitchPending: PropTypes.bool,
 };
 
 export default LabelPanel;

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -473,6 +473,7 @@ class QueueLabelDetailSerializer(serializers.ModelSerializer):
     name = serializers.CharField(source="label.name", read_only=True)
     type = serializers.CharField(source="label.type", read_only=True)
     settings = serializers.JSONField(source="label.settings", read_only=True)
+    allow_notes = serializers.BooleanField(source="label.allow_notes", read_only=True)
     description = serializers.CharField(
         source="label.description", read_only=True, default=None
     )
@@ -486,6 +487,7 @@ class QueueLabelDetailSerializer(serializers.ModelSerializer):
             "type",
             "settings",
             "description",
+            "allow_notes",
             "required",
             "order",
         ]

--- a/futureagi/model_hub/tests/test_annotation_workflow_api.py
+++ b/futureagi/model_hub/tests/test_annotation_workflow_api.py
@@ -34,6 +34,7 @@ from model_hub.models.annotation_queues import (
 )
 from model_hub.models.choices import (
     AnnotationQueueStatusChoices,
+    AnnotatorRole,
     QueueItemStatus,
 )
 from model_hub.models.develop_annotations import AnnotationsLabels
@@ -290,6 +291,94 @@ class TestSubmitAnnotations:
         ann = Score.objects.get(queue_item_id=item_ids[0], label=label, deleted=False)
         assert ann.value == "negative"
 
+    def test_submit_stores_notes_per_label(self, auth_client, queue_with_items, label_b):
+        """Labels with allow_notes keep their own notes instead of sharing one field."""
+        queue_id, item_ids, label = queue_with_items
+        queue = AnnotationQueue.objects.get(pk=queue_id)
+        label.allow_notes = True
+        label.save(update_fields=["allow_notes", "updated_at"])
+        label_b.allow_notes = True
+        label_b.save(update_fields=["allow_notes", "updated_at"])
+        AnnotationQueueLabel.objects.create(
+            queue=queue,
+            label=label_b,
+            order=1,
+            required=False,
+        )
+
+        resp = auth_client.post(
+            submit_annotations_url(queue_id, item_ids[0]),
+            {
+                "annotations": [
+                    {
+                        "label_id": str(label.id),
+                        "value": "positive",
+                        "notes": "sentiment note",
+                    },
+                    {
+                        "label_id": str(label_b.id),
+                        "value": {"rating": 4},
+                        "notes": "quality note",
+                    },
+                ]
+            },
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_200_OK
+        notes_by_label = dict(
+            Score.objects.filter(queue_item_id=item_ids[0], deleted=False).values_list(
+                "label_id", "notes"
+            )
+        )
+        assert notes_by_label[label.id] == "sentiment note"
+        assert notes_by_label[label_b.id] == "quality note"
+
+    def test_submit_only_stores_notes_for_note_enabled_labels(
+        self, auth_client, queue_with_items, label_b
+    ):
+        """Legacy top-level notes are ignored for labels without allow_notes."""
+        queue_id, item_ids, label = queue_with_items
+        queue = AnnotationQueue.objects.get(pk=queue_id)
+        label.allow_notes = True
+        label.save(update_fields=["allow_notes", "updated_at"])
+        label_b.allow_notes = False
+        label_b.save(update_fields=["allow_notes", "updated_at"])
+        AnnotationQueueLabel.objects.create(
+            queue=queue,
+            label=label_b,
+            order=1,
+            required=False,
+        )
+
+        resp = auth_client.post(
+            submit_annotations_url(queue_id, item_ids[0]),
+            {
+                "notes": "legacy shared note",
+                "annotations": [
+                    {
+                        "label_id": str(label.id),
+                        "value": "positive",
+                    },
+                    {
+                        "label_id": str(label_b.id),
+                        "value": {"rating": 4},
+                        "notes": "should be ignored",
+                    },
+                ],
+            },
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_200_OK
+        notes_by_label = dict(
+            Score.objects.filter(queue_item_id=item_ids[0], deleted=False).values_list(
+                "label_id", "notes"
+            )
+        )
+        assert notes_by_label[label.id] == "legacy shared note"
+        assert notes_by_label[label_b.id] == ""
+
     def test_submit_sets_in_progress(self, auth_client, queue_with_items):
         """Item status changes from pending to in_progress on first submit."""
         queue_id, item_ids, label = queue_with_items
@@ -481,6 +570,75 @@ class TestAnnotateDetail:
         assert "annotations" in result
         assert "progress" in result
         assert result["progress"]["total"] == 3
+
+    def test_annotate_detail_includes_label_allow_notes(
+        self, auth_client, queue_with_items
+    ):
+        """Workspace labels expose allow_notes so the UI can render per-label notes."""
+        queue_id, item_ids, label = queue_with_items
+        label.allow_notes = True
+        label.save(update_fields=["allow_notes", "updated_at"])
+
+        resp = auth_client.get(annotate_detail_url(queue_id, item_ids[0]))
+
+        assert resp.status_code == status.HTTP_200_OK
+        result = _result(resp)
+        assert result["labels"][0]["allow_notes"] is True
+
+    def test_reviewer_can_scope_annotate_detail_to_selected_annotator(
+        self, auth_client, queue_with_items, user, second_user, organization
+    ):
+        """Managers can request one annotator's answers instead of merged answers."""
+        queue_id, item_ids, label = queue_with_items
+        item = QueueItem.objects.get(pk=item_ids[0])
+        AnnotationQueueAnnotator.objects.get_or_create(
+            queue_id=queue_id,
+            user=second_user,
+            defaults={"role": AnnotatorRole.ANNOTATOR.value},
+        )
+        Score.objects.create(
+            source_type="dataset_row",
+            dataset_row=item.dataset_row,
+            label=label,
+            annotator=user,
+            value="positive",
+            score_source="human",
+            queue_item=item,
+            organization=organization,
+        )
+        Score.objects.create(
+            source_type="dataset_row",
+            dataset_row=item.dataset_row,
+            label=label,
+            annotator=second_user,
+            value="negative",
+            score_source="human",
+            queue_item=item,
+            organization=organization,
+        )
+
+        resp = auth_client.get(
+            annotate_detail_url(queue_id, item_ids[0]),
+            {"annotator_id": str(second_user.id)},
+        )
+
+        assert resp.status_code == status.HTTP_200_OK
+        annotations = _result(resp)["annotations"]
+        assert len(annotations) == 1
+        assert annotations[0]["value"] == "negative"
+        assert str(annotations[0]["annotator"]) == str(second_user.id)
+
+    def test_reviewer_annotate_detail_rejects_invalid_annotator_selection(
+        self, auth_client, queue_with_items
+    ):
+        queue_id, item_ids, _ = queue_with_items
+
+        resp = auth_client.get(
+            annotate_detail_url(queue_id, item_ids[0]),
+            {"annotator_id": "not-a-uuid"},
+        )
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_annotate_detail_progress_counts(self, auth_client, queue_with_items):
         """Progress counts reflect current state."""

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from datetime import timedelta
 
 import structlog
@@ -1951,7 +1952,7 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
 
         annotations_data = serializer.validated_data["annotations"]
-        notes = serializer.validated_data.get("notes", "")
+        fallback_notes = serializer.validated_data.get("notes", "")
         submitted = 0
 
         # Resolve source FK for Score creation
@@ -1978,6 +1979,10 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             if label.pk not in queue_label_ids:
                 continue
 
+            per_label_notes = (
+                ann_data.get("notes", fallback_notes) if label.allow_notes else ""
+            )
+
             # Upsert Score (unified annotation primitive)
             # Use no_workspace_objects + _id fields to avoid the LEFT JOIN
             # on nullable workspace FK that triggers PostgreSQL's "FOR UPDATE
@@ -1992,7 +1997,7 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                         "source_type": item.source_type,
                         "value": value,
                         "score_source": "human",
-                        "notes": notes,
+                        "notes": per_label_notes,
                         "queue_item": item,
                         "organization": request.organization,
                     },
@@ -2268,7 +2273,17 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
             queue_item=item,
             deleted=False,
         ).select_related("label")
-        if not is_reviewer:
+        raw_annotator_id = request.query_params.get("annotator_id") or None
+        viewing_annotator_id = None
+        if raw_annotator_id and is_reviewer:
+            try:
+                viewing_annotator_id = uuid.UUID(raw_annotator_id)
+            except (ValueError, TypeError):
+                return self._gm.bad_request("Invalid annotator selection.")
+
+        if viewing_annotator_id:
+            annotations_qs = annotations_qs.filter(annotator_id=viewing_annotator_id)
+        elif not is_reviewer:
             annotations_qs = annotations_qs.filter(annotator=request.user)
         annotations = annotations_qs
 


### PR DESCRIPTION
## Summary

Fixes TH-4792 and TH-4733 for the annotation queue workspace.

- Shows a separate note field for each queue label with `allow_notes` enabled, matching the trace annotation behavior.
- Submits notes per annotation instead of using one shared queue-level note, while preserving legacy top-level notes only for note-enabled labels.
- Adds reviewer/manager annotator selection in the queue annotation workspace and scopes annotate-detail requests by selected annotator.
- Keeps other annotators' submissions read-only and clears stale form state while switching annotators.

## Validation

- `cd frontend && yarn test:run src/api/annotation-queues/__tests__/annotation-queues.test.js src/sections/annotations/queues/__tests__/annotate-components.test.jsx` — 45 passed
- `.venv/bin/python -m py_compile model_hub/views/annotation_queues.py model_hub/serializers/annotation_queues.py model_hub/tests/test_annotation_workflow_api.py`
- Focused backend API tests in mounted backend container — 5 passed:
  - `test_submit_stores_notes_per_label`
  - `test_submit_only_stores_notes_for_note_enabled_labels`
  - `test_annotate_detail_includes_label_allow_notes`
  - `test_reviewer_can_scope_annotate_detail_to_selected_annotator`
  - `test_reviewer_annotate_detail_rejects_invalid_annotator_selection`
- `git diff --check`
- Reviewed twice with Claude CLI; second pass reported no blocking/high findings.