### PR TITLE
enforce structured JSON output on eval LLM calls and fix Jinja2 templ…

### DIFF
--- a/futureagi/agentic_eval/core/llm/llm.py
+++ b/futureagi/agentic_eval/core/llm/llm.py
@@ -2116,6 +2116,7 @@ class LLM:
                     **payload,
                     num_retries=LITELLM_NUM_RETRIES,
                     retry_strategy=LITELLM_RETRY_STRATEGY,
+                    drop_params=True,
                 )
             else:
                 response = litellm.completion(
@@ -2123,6 +2124,7 @@ class LLM:
                     api_key=self.api_key,
                     num_retries=LITELLM_NUM_RETRIES,
                     retry_strategy=LITELLM_RETRY_STRATEGY,
+                    drop_params=True,
                 )
 
             self._update_token_usage(response)

--- a/futureagi/agentic_eval/core/llm/llm.py
+++ b/futureagi/agentic_eval/core/llm/llm.py
@@ -2006,7 +2006,7 @@ class LLM:
         )
         return response.text
 
-    def call_llm(self, prompt: Messages, provider: str) -> str:
+    def call_llm(self, prompt: Messages, provider: str, response_format: dict | None = None) -> str:
         """
         Call the LLM with the given prompt.
 
@@ -2015,6 +2015,8 @@ class LLM:
 
         Args:
             prompt: List of message dictionaries.
+            provider: Provider name.
+            response_format: Optional response format spec (e.g. {"type": "json_object"}).
 
         Returns:
             The LLM response text.
@@ -2041,12 +2043,15 @@ class LLM:
                 gateway = get_gateway_client()
                 if gateway is not None:
                     logger.info("llm_call_routing", route="agentcc_gateway", model=self.model_name)
-                    response = gateway.chat.completions.create(
-                        model=self.model_name,
-                        messages=prompt,
-                        temperature=self.temperature,
-                        max_tokens=self.max_tokens,
-                    )
+                    gateway_kwargs = {
+                        "model": self.model_name,
+                        "messages": prompt,
+                        "temperature": self.temperature,
+                        "max_tokens": self.max_tokens,
+                    }
+                    if response_format:
+                        gateway_kwargs["response_format"] = response_format
+                    response = gateway.chat.completions.create(**gateway_kwargs)
                     self._update_token_usage(response)
                     self._update_cost(response)
                     content = response.choices[0].message.content
@@ -2074,6 +2079,8 @@ class LLM:
             }
             if not getattr(self, "api_key", None):
                 payload["max_tokens"] = self.max_tokens
+            if response_format:
+                payload["response_format"] = response_format
 
             # Handle API key scenarios
             if isinstance(self.api_key, dict):

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -126,7 +126,6 @@ class CustomPromptEvaluator(LLM):
                         "explanation": {"type": "string"},
                     },
                     "required": ["result", "explanation"],
-                    "additionalProperties": False,
                 },
             },
         }

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -109,6 +109,8 @@ class CustomPromptEvaluator(LLM):
         """
         if self._output_type in ("score", "numeric"):
             result_schema = {"type": "number"}
+        elif self._output_type == "Pass/Fail":
+            result_schema = {"type": "string", "enum": ["Pass", "Fail"]}
         elif self._output_type == "choices" and getattr(self, "_choices", None):
             result_schema = {"type": "string", "enum": self._choices}
         else:

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -3,6 +3,7 @@ import os
 import time
 
 from django.conf import settings
+import jinja2
 from jinja2 import Environment
 
 from agentic_eval.core.llm.llm import LLM
@@ -98,6 +99,35 @@ class CustomPromptEvaluator(LLM):
             kwargs['chat_history'] = json.dumps(kwargs['chat_history'], indent=2)
         # Use rule_prompt as the template
         return self.rule_prompt
+
+    def _build_response_format(self) -> dict:
+        """Build a json_schema response_format based on the eval output type.
+
+        Uses json_schema (not json_object) so the gateway can translate it
+        to provider-native structured output for all backends (Bedrock,
+        Anthropic, Gemini, OpenAI, etc.).
+        """
+        if self._output_type in ("score", "numeric"):
+            result_schema = {"type": "number"}
+        elif self._output_type == "choices" and getattr(self, "_choices", None):
+            result_schema = {"type": "string", "enum": self._choices}
+        else:
+            result_schema = {"type": "string"}
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "eval_result",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "result": result_schema,
+                        "explanation": {"type": "string"},
+                    },
+                    "required": ["result", "explanation"],
+                    "additionalProperties": False,
+                },
+            },
+        }
 
     def _system_message(self) -> str:
         judge_preamble = (
@@ -201,14 +231,18 @@ class CustomPromptEvaluator(LLM):
             raw_vars = re.findall(r"\{\{\s*([^{}]+?)\s*\}\}", prompt_to_render)
             for var_name in raw_vars:
                 stripped = var_name.strip()
-                if " " in stripped and stripped in safe_context:
-                    # Replace the spaced variable with its value directly
+                if " " in stripped:
+                    if stripped in safe_context:
+                        replacement = str(safe_context.pop(stripped))
+                    else:
+                        # Variable has a space but isn't mapped — substitute it
+                        # as literal text so Jinja2 doesn't crash trying to parse it.
+                        replacement = str(kwargs.get(stripped, "{{" + stripped + "}}"))
                     prompt_to_render = prompt_to_render.replace(
-                        "{{" + var_name + "}}", str(safe_context.pop(stripped))
+                        "{{" + var_name + "}}", replacement
                     )
-                    # Also try with extra whitespace variants
                     prompt_to_render = prompt_to_render.replace(
-                        "{{ " + stripped + " }}", str(template_context.get(stripped, ""))
+                        "{{ " + stripped + " }}", replacement
                     )
 
             # In Jinja mode, parse JSON strings to native objects right
@@ -225,8 +259,16 @@ class CustomPromptEvaluator(LLM):
                             except (ValueError, json.JSONDecodeError):
                                 pass
 
-            template = self.env.from_string(prompt_to_render)
-            rendered_prompt = template.render(**safe_context)
+            try:
+                template = self.env.from_string(prompt_to_render)
+                rendered_prompt = template.render(**safe_context)
+            except jinja2.TemplateSyntaxError:
+                # Fallback: simple string replacement when Jinja2 can't parse
+                # the template (e.g. variable names with spaces).
+                rendered_prompt = prompt_to_render
+                for key, value in safe_context.items():
+                    rendered_prompt = rendered_prompt.replace("{{" + key + "}}", str(value))
+                    rendered_prompt = rendered_prompt.replace("{{ " + key + " }}", str(value))
 
             # Append data section with XML-tagged values for clarity
             if template_context:
@@ -384,6 +426,7 @@ class CustomPromptEvaluator(LLM):
                     messages=messages,
                     temperature=self.temperature,
                     max_tokens=self.max_tokens,
+                    response_format=self._build_response_format(),
                     knowledge_base_id=self.knowledge_base_id,
                     check_internet=self.check_internet,
                     detected_media_types=detected_media_types,
@@ -392,7 +435,8 @@ class CustomPromptEvaluator(LLM):
                 self.cost.update(turing_client.cost)
             else:
                 chat_completion_response = self.call_llm(
-                    prompt=messages, provider=self.provider
+                    prompt=messages, provider=self.provider,
+                    response_format=self._build_response_format(),
                 )
 
             logger.info(

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/tests/test_response_format.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/tests/test_response_format.py
@@ -1,0 +1,87 @@
+"""Tests for CustomPromptEvaluator._build_response_format().
+
+Verifies that the json_schema is correctly typed for each eval output type.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def make_evaluator():
+    """Create a minimal CustomPromptEvaluator without LLM init."""
+    from unittest.mock import patch
+
+    def _make(output_type="score", choices=None):
+        # Patch LLM.__init__ to avoid provider/model setup
+        with patch.object(
+            __import__(
+                "agentic_eval.core_evals.fi_evals.llm.custom_prompt_evaluator.evaluator",
+                fromlist=["CustomPromptEvaluator"],
+            ).CustomPromptEvaluator,
+            "__init__",
+            lambda self, **kw: None,
+        ):
+            from agentic_eval.core_evals.fi_evals.llm.custom_prompt_evaluator.evaluator import (
+                CustomPromptEvaluator,
+            )
+
+            ev = CustomPromptEvaluator.__new__(CustomPromptEvaluator)
+            ev._output_type = output_type
+            ev._choices = choices or []
+            return ev
+
+    return _make
+
+
+class TestBuildResponseFormat:
+    def test_score_type_returns_number_schema(self, make_evaluator):
+        ev = make_evaluator(output_type="score")
+        fmt = ev._build_response_format()
+
+        assert fmt["type"] == "json_schema"
+        schema = fmt["json_schema"]["schema"]
+        assert schema["properties"]["result"]["type"] == "number"
+        assert "explanation" in schema["properties"]
+        assert schema["required"] == ["result", "explanation"]
+
+    def test_numeric_type_returns_number_schema(self, make_evaluator):
+        ev = make_evaluator(output_type="numeric")
+        fmt = ev._build_response_format()
+
+        assert fmt["json_schema"]["schema"]["properties"]["result"]["type"] == "number"
+
+    def test_pass_fail_type_returns_enum(self, make_evaluator):
+        ev = make_evaluator(output_type="Pass/Fail")
+        fmt = ev._build_response_format()
+
+        result_schema = fmt["json_schema"]["schema"]["properties"]["result"]
+        assert result_schema["type"] == "string"
+        assert result_schema["enum"] == ["Pass", "Fail"]
+
+    def test_choices_type_returns_enum(self, make_evaluator):
+        ev = make_evaluator(output_type="choices", choices=["Good", "Bad", "Neutral"])
+        fmt = ev._build_response_format()
+
+        result_schema = fmt["json_schema"]["schema"]["properties"]["result"]
+        assert result_schema["type"] == "string"
+        assert result_schema["enum"] == ["Good", "Bad", "Neutral"]
+
+    def test_unknown_type_returns_string(self, make_evaluator):
+        ev = make_evaluator(output_type="reason")
+        fmt = ev._build_response_format()
+
+        result_schema = fmt["json_schema"]["schema"]["properties"]["result"]
+        assert result_schema["type"] == "string"
+        assert "enum" not in result_schema
+
+    def test_schema_disallows_additional_properties(self, make_evaluator):
+        ev = make_evaluator(output_type="score")
+        fmt = ev._build_response_format()
+
+        assert fmt["json_schema"]["schema"]["additionalProperties"] is False
+
+    def test_schema_name_is_eval_result(self, make_evaluator):
+        ev = make_evaluator(output_type="score")
+        fmt = ev._build_response_format()
+
+        assert fmt["json_schema"]["name"] == "eval_result"

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/tests/test_response_format.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/tests/test_response_format.py
@@ -74,11 +74,11 @@ class TestBuildResponseFormat:
         assert result_schema["type"] == "string"
         assert "enum" not in result_schema
 
-    def test_schema_disallows_additional_properties(self, make_evaluator):
+    def test_schema_has_no_additional_properties(self, make_evaluator):
         ev = make_evaluator(output_type="score")
         fmt = ev._build_response_format()
 
-        assert fmt["json_schema"]["schema"]["additionalProperties"] is False
+        assert "additionalProperties" not in fmt["json_schema"]["schema"]
 
     def test_schema_name_is_eval_result(self, make_evaluator):
         ev = make_evaluator(output_type="score")


### PR DESCRIPTION
## Summary
Eval LLM calls relied purely on prompt instructions ("return JSON") with no schema enforcement, causing models to return free-form text or wrong output types (e.g. "Fail" instead of a numeric 0-1 score). This adds `json_schema` response_format to eval LLM calls — the gateway already translates this to provider-native structured output (Bedrock `output_config`, Gemini `ResponseSchema`, OpenAI passthrough) but evals weren't using it. Also fixes a Jinja2 crash when eval templates contain variable names with spaces (e.g. `{{EXPECTED OUTPUT}}`).

## Linked issues
Closes #

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested
- Ran evals on dataset with `turing_large` (Bedrock Claude) — confirmed structured JSON responses with correct numeric scores
- Verified Jinja2 templates with spaced variable names render without crashing
- Confirmed `response_format` defaults to `None` and has zero impact on non-eval LLM calls

## Screenshots / recordings (if UI)
N/A — backend only change.

## Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)