### PR TITLE
feat: add Agent Playground code execution node

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Every arrow is an open, documented interface: **OpenTelemetry OTLP** for traces,
   <img alt="Future AGI architecture — client SDKs → traceAI + Agent Command Center → Django platform → PostgreSQL, ClickHouse, Redis, RabbitMQ" src=".github/assets/architecture.svg" width="100%">
 </picture> -->
 
-**Runtime:** Python 3.11+ (Django 4.2 + Channels) · Go 1.23+ (gateway) · React 18 + Vite · Node 20+.
+**Runtime:** Python 3.11+ (Django 4.2 + Channels) · Go 1.23+ (gateway) · React 18 + Vite · Node 20+ · Docker.
 **Data:** PostgreSQL (metadata) · ClickHouse (spans + time-series) · Redis (state) · RabbitMQ + Temporal (jobs).
 
 <details><summary>Component breakdown (per-package)</summary>

--- a/frontend/src/api/agent-playground/node-templates.js
+++ b/frontend/src/api/agent-playground/node-templates.js
@@ -1,6 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
-import { NODE_TYPES } from "../../sections/agent-playground/utils/constants";
+import {
+  NODE_TYPE_CONFIG,
+  NODE_TYPES,
+} from "../../sections/agent-playground/utils/constants";
 
 /**
  * Hook for fetching graphs that can be referenced as agent nodes.
@@ -19,7 +22,7 @@ export const useGetReferenceableGraphs = (graphId, options = {}) =>
   });
 
 /**
- * Hook for fetching node templates. Filters to llm_prompt only for now.
+ * Hook for fetching node templates.
  * Maps API shape to NodeCard shape: { id, node_template_id, title, description, iconSrc, color }
  * @param {object} options - Additional react-query options
  */
@@ -29,15 +32,21 @@ export const useGetNodeTemplates = (options = {}) =>
     queryFn: () => axios.get(endpoints.agentPlayground.nodeTemplates),
     select: (res) =>
       (res.data?.result?.node_templates ?? [])
-        .filter((t) => t.name === NODE_TYPES.LLM_PROMPT)
-        .map((t) => ({
-          id: t.name,
-          node_template_id: t.id,
-          title: t.display_name,
-          description: t.description,
-          iconSrc: "/assets/icons/ic_chat_single.svg",
-          color: "orange.500",
-        })),
+        .filter((t) =>
+          [NODE_TYPES.LLM_PROMPT, NODE_TYPES.CODE_EXECUTION].includes(t.name),
+        )
+        .map((t) => {
+          const config = NODE_TYPE_CONFIG[t.name];
+
+          return {
+            id: t.name,
+            node_template_id: t.id,
+            title: t.display_name ?? config.title,
+            description: t.description ?? config.description,
+            iconSrc: config.iconSrc,
+            color: config.color,
+          };
+        }),
     staleTime: 5 * 60 * 1000,
     ...options,
   });

--- a/frontend/src/api/agent-playground/nodes.js
+++ b/frontend/src/api/agent-playground/nodes.js
@@ -62,6 +62,51 @@ export const useUpdateNode = (options = {}) =>
     ...options,
   });
 
+const canonicalCodeExecutionResult = (result) => {
+  if (!result || typeof result !== "object") return result;
+
+  const metadata = result.metadata || {};
+  return {
+    ok: result.ok,
+    value: result.value,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exit_code: result.exit_code ?? result.exitCode ?? null,
+    duration_ms: result.duration_ms ?? result.durationMs ?? 0,
+    error: result.error ?? null,
+    metadata: {
+      language: metadata.language,
+      runner: metadata.runner ?? null,
+      timed_out: metadata.timed_out ?? metadata.timedOut ?? false,
+      memory_mb: metadata.memory_mb ?? metadata.memoryMb ?? null,
+    },
+  };
+};
+
+const canonicalTestExecutionOutput = (output) => {
+  if (!output?.result) return output;
+  return { ...output, result: canonicalCodeExecutionResult(output.result) };
+};
+
+export const testNodeExecutionApi = async (payload) => {
+  const res = await axios.post(
+    endpoints.agentPlayground.testNodeExecution(
+      payload.graphId,
+      payload.versionId,
+      payload.nodeId,
+    ),
+    payload.data,
+  );
+  return canonicalTestExecutionOutput(res.data?.result);
+};
+
+export const useTestNodeExecution = (options = {}) =>
+  useMutation({
+    mutationFn: testNodeExecutionApi,
+    meta: { errorHandled: true },
+    ...options,
+  });
+
 /**
  * Deletes a node via DELETE. Backend cascades: soft-deletes edges,
  * connections, ports, PromptTemplateNode, and the node itself.

--- a/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
@@ -12,7 +12,7 @@ import {
   useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { PromptNode, AgentNode, EvalNode } from "./nodes";
+import { PromptNode, AgentNode, EvalNode, CodeExecutionNode } from "./nodes";
 import { AnimatedEdge } from "./edges";
 import { enqueueSnackbar } from "notistack";
 import {
@@ -35,7 +35,8 @@ import logger from "src/utils/logger";
 
 const nodeTypes = {
   [NODE_TYPES.LLM_PROMPT]: PromptNode,
-  agent: AgentNode,
+  [NODE_TYPES.CODE_EXECUTION]: CodeExecutionNode,
+  [NODE_TYPES.AGENT]: AgentNode,
   eval: EvalNode,
 };
 

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeConfigurationForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeConfigurationForm.jsx
@@ -1,10 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { PromptNodeForm, EvalsNodeForm, AgentNodeForm } from "./forms";
+import {
+  PromptNodeForm,
+  EvalsNodeForm,
+  AgentNodeForm,
+  CodeExecutionNodeForm,
+} from "./forms";
 import { NODE_TYPES } from "../../utils/constants";
 
 const FORM_COMPONENTS = {
   [NODE_TYPES.LLM_PROMPT]: PromptNodeForm,
+  [NODE_TYPES.CODE_EXECUTION]: CodeExecutionNodeForm,
   eval: EvalsNodeForm,
   [NODE_TYPES.AGENT]: AgentNodeForm,
 };
@@ -20,7 +26,11 @@ export default function NodeConfigurationForm({ nodeType, nodeId }) {
 }
 
 NodeConfigurationForm.propTypes = {
-  nodeType: PropTypes.oneOf([NODE_TYPES.LLM_PROMPT, "eval", NODE_TYPES.AGENT])
-    .isRequired,
+  nodeType: PropTypes.oneOf([
+    NODE_TYPES.LLM_PROMPT,
+    NODE_TYPES.CODE_EXECUTION,
+    "eval",
+    NODE_TYPES.AGENT,
+  ]).isRequired,
   nodeId: PropTypes.string.isRequired,
 };

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/CodeExecutionNodeForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/CodeExecutionNodeForm.jsx
@@ -20,6 +20,7 @@ import {
 import { useAgentPlaygroundStoreShallow } from "../../../store";
 import usePartialNodeUpdate from "../../hooks/usePartialNodeUpdate";
 import { useSaveDraftContext } from "../../saveDraftContext";
+import { getCodeExecutionEditorLanguage } from "./codeExecutionNodeFormUtils";
 
 function buildConfig(values) {
   return {
@@ -51,7 +52,7 @@ export default function CodeExecutionNodeForm({ nodeId }) {
   const { mutateAsync: testNode, isPending: isTesting } =
     useTestNodeExecution();
 
-  const editorLanguage = language === "python" ? "python" : "javascript";
+  const editorLanguage = getCodeExecutionEditorLanguage(language);
   const [testInputs, setTestInputs] = useState("{}");
 
   const saveConfig = handleSubmit(async (values) => {

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/CodeExecutionNodeForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/CodeExecutionNodeForm.jsx
@@ -1,0 +1,253 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import {
+  Alert,
+  Box,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
+import Editor from "@monaco-editor/react";
+import { Controller, useFormContext, useWatch } from "react-hook-form";
+import { enqueueSnackbar } from "notistack";
+import { useTestNodeExecution } from "src/api/agent-playground/agent-playground";
+import {
+  CODE_EXECUTION_DEFAULT_CONFIG,
+  CODE_EXECUTION_LANGUAGES,
+} from "../../../utils/constants";
+import { useAgentPlaygroundStoreShallow } from "../../../store";
+import usePartialNodeUpdate from "../../hooks/usePartialNodeUpdate";
+import { useSaveDraftContext } from "../../saveDraftContext";
+
+function buildConfig(values) {
+  return {
+    ...CODE_EXECUTION_DEFAULT_CONFIG,
+    language: values.language ?? CODE_EXECUTION_DEFAULT_CONFIG.language,
+    code: values.code ?? CODE_EXECUTION_DEFAULT_CONFIG.code,
+    timeout_ms: Number(
+      values.timeout_ms ?? CODE_EXECUTION_DEFAULT_CONFIG.timeout_ms,
+    ),
+    memory_mb: Number(
+      values.memory_mb ?? CODE_EXECUTION_DEFAULT_CONFIG.memory_mb,
+    ),
+  };
+}
+
+export default function CodeExecutionNodeForm({ nodeId }) {
+  const { control, handleSubmit, getValues } = useFormContext();
+  const [testResult, setTestResult] = useState(null);
+  const language = useWatch({ control, name: "language" }) || "python";
+
+  const { currentAgent, updateNodeData, clearSelectedNode } =
+    useAgentPlaygroundStoreShallow((state) => ({
+      currentAgent: state.currentAgent,
+      updateNodeData: state.updateNodeData,
+      clearSelectedNode: state.clearSelectedNode,
+    }));
+  const { partialUpdate, isPending } = usePartialNodeUpdate();
+  const { ensureDraft } = useSaveDraftContext();
+  const { mutateAsync: testNode, isPending: isTesting } =
+    useTestNodeExecution();
+
+  const editorLanguage = language === "python" ? "python" : "javascript";
+  const [testInputs, setTestInputs] = useState("{}");
+
+  const saveConfig = handleSubmit(async (values) => {
+    const config = buildConfig(values);
+    updateNodeData(nodeId, { config });
+
+    const draftResult = await ensureDraft({ skipDirtyCheck: true });
+    if (draftResult === false) return;
+
+    if (draftResult !== "created") {
+      try {
+        await partialUpdate(nodeId, { config });
+      } catch {
+        enqueueSnackbar("Failed to save code node", { variant: "error" });
+        return;
+      }
+    }
+
+    clearSelectedNode();
+  });
+
+  const runTest = async () => {
+    const config = buildConfig(getValues());
+    let inputs;
+    try {
+      inputs = JSON.parse(testInputs || "{}");
+    } catch {
+      enqueueSnackbar("Test inputs must be valid JSON", { variant: "error" });
+      return;
+    }
+    if (!inputs || Array.isArray(inputs) || typeof inputs !== "object") {
+      enqueueSnackbar("Test inputs must be a JSON object", {
+        variant: "error",
+      });
+      return;
+    }
+
+    try {
+      const result = await testNode({
+        graphId: currentAgent?.id,
+        versionId: currentAgent?.version_id,
+        nodeId,
+        data: {
+          config,
+          inputs,
+        },
+      });
+      setTestResult(result?.result || result);
+    } catch {
+      enqueueSnackbar("Failed to test code node", { variant: "error" });
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.5,
+        height: "100%",
+      }}
+    >
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: "auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+        }}
+      >
+        <Stack direction="row" spacing={1.5}>
+          <Controller
+            name="language"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                select
+                label="Language"
+                size="small"
+                fullWidth
+              >
+                {CODE_EXECUTION_LANGUAGES.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
+          <Controller
+            name="timeout_ms"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                type="number"
+                label="Timeout"
+                size="small"
+                fullWidth
+                inputProps={{ min: 100, max: 30000, step: 100 }}
+              />
+            )}
+          />
+          <Controller
+            name="memory_mb"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                type="number"
+                label="Memory"
+                size="small"
+                fullWidth
+                inputProps={{ min: 32, max: 512, step: 32 }}
+              />
+            )}
+          />
+        </Stack>
+
+        <Controller
+          name="code"
+          control={control}
+          render={({ field }) => (
+            <Box sx={{ border: 1, borderColor: "divider", minHeight: 360 }}>
+              <Editor
+                height="360px"
+                language={editorLanguage}
+                theme="vs-dark"
+                value={field.value || ""}
+                onChange={(value) => field.onChange(value || "")}
+                options={{
+                  minimap: { enabled: false },
+                  fontSize: 13,
+                  scrollBeyondLastLine: false,
+                  wordWrap: "on",
+                }}
+              />
+            </Box>
+          )}
+        />
+
+        <TextField
+          label="Test inputs"
+          value={testInputs}
+          onChange={(event) => setTestInputs(event.target.value)}
+          multiline
+          minRows={4}
+          size="small"
+          inputProps={{ spellCheck: false }}
+        />
+
+        {testResult && (
+          <Alert severity={testResult.ok ? "success" : "warning"}>
+            <Typography variant="caption" component="pre" sx={{ m: 0 }}>
+              {JSON.stringify(testResult, null, 2)}
+            </Typography>
+          </Alert>
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "flex-end",
+          gap: 1,
+          pt: 1.5,
+          borderTop: 1,
+          borderColor: "divider",
+        }}
+      >
+        <LoadingButton
+          type="button"
+          size="small"
+          variant="text"
+          loading={isTesting}
+          onClick={runTest}
+        >
+          Test
+        </LoadingButton>
+        <LoadingButton
+          type="button"
+          size="small"
+          variant="outlined"
+          loading={isPending}
+          onClick={saveConfig}
+        >
+          Save
+        </LoadingButton>
+      </Box>
+    </Box>
+  );
+}
+
+CodeExecutionNodeForm.propTypes = {
+  nodeId: PropTypes.string.isRequired,
+};

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/__tests__/CodeExecutionNodeForm.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/__tests__/CodeExecutionNodeForm.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { getCodeExecutionEditorLanguage } from "../codeExecutionNodeFormUtils";
+
+describe("CodeExecutionNodeForm", () => {
+  it("maps TypeScript to Monaco's TypeScript grammar", () => {
+    expect(getCodeExecutionEditorLanguage("typescript")).toBe("typescript");
+  });
+
+  it("keeps Python and JavaScript editor grammars exact", () => {
+    expect(getCodeExecutionEditorLanguage("python")).toBe("python");
+    expect(getCodeExecutionEditorLanguage("javascript")).toBe("javascript");
+  });
+});

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/codeExecutionNodeFormUtils.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/codeExecutionNodeFormUtils.js
@@ -1,0 +1,3 @@
+export function getCodeExecutionEditorLanguage(language) {
+  return language === "typescript" ? "typescript" : language;
+}

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/index.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/index.js
@@ -1,3 +1,4 @@
 export { default as PromptNodeForm } from "./PromptNodeForm";
 export { default as EvalsNodeForm } from "./EvalsNodeForm";
 export { default as AgentNodeForm } from "./AgentNodeForm";
+export { default as CodeExecutionNodeForm } from "./CodeExecutionNodeForm";

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
@@ -92,7 +92,10 @@ export const getPromptNodeFormSchema = () =>
     prompt_version_id: z.string().nullable().optional().default(null),
     prompt_template_id: z.string().nullable().optional().default(null),
     outputFormat: z.string().optional().default("string"),
-    templateFormat: z.enum(["mustache", "jinja"]).optional().default("mustache"),
+    templateFormat: z
+      .enum(["mustache", "jinja"])
+      .optional()
+      .default("mustache"),
     modelConfig: modelConfigSchema,
     messages: z
       .array(getMessageValidationSchema())
@@ -127,6 +130,16 @@ export const agentNodeFormSchema = z.object({
     .optional(),
 });
 
+export const codeExecutionNodeFormSchema = z.object({
+  nodeType: z.literal(NODE_TYPES.CODE_EXECUTION).optional(),
+  nodeId: z.string().optional(),
+  name: z.string().optional(),
+  language: z.enum(["python", "javascript", "typescript"]),
+  code: z.string().min(1, "Code is required").max(20000),
+  timeout_ms: z.coerce.number().int().min(100).max(30000),
+  memory_mb: z.coerce.number().int().min(32).max(512),
+});
+
 /**
  * Schema for Eval Node Form
  */
@@ -155,6 +168,8 @@ export function getNodeFormSchema(nodeType) {
       return getPromptNodeFormSchema();
     case NODE_TYPES.AGENT:
       return agentNodeFormSchema;
+    case NODE_TYPES.CODE_EXECUTION:
+      return codeExecutionNodeFormSchema;
     case "eval":
       return evalNodeFormSchema;
     default:

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/nodeFormUtils.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/nodeFormUtils.js
@@ -1,5 +1,8 @@
 import { getRandomId } from "src/utils/utils";
-import { NODE_TYPES } from "../../utils/constants";
+import {
+  CODE_EXECUTION_DEFAULT_CONFIG,
+  NODE_TYPES,
+} from "../../utils/constants";
 
 /**
  * Normalize responseFormat to always return a string (for dropdown/form use).
@@ -156,6 +159,14 @@ export function getDefaultValues(nodeData) {
     };
   }
 
+  if (nodeData?.type === NODE_TYPES.CODE_EXECUTION) {
+    return {
+      ...baseValues,
+      ...CODE_EXECUTION_DEFAULT_CONFIG,
+      ...mergedConfig,
+    };
+  }
+
   if (nodeData?.type === "eval") {
     return {
       ...baseValues,
@@ -296,6 +307,18 @@ export function mapNodeDetailToNodeData(apiNode, existingNode) {
               : existingNode?.data?.config?.payload?.inputMappings || [],
           },
         },
+      },
+    };
+  }
+
+  if (nodeType === NODE_TYPES.CODE_EXECUTION) {
+    return {
+      ...existingNode,
+      data: {
+        ...existingNode?.data,
+        label: apiNode.name || existingNode?.data?.label,
+        ports: apiNode.ports || existingNode?.data?.ports || [],
+        config: apiNode.config || existingNode?.data?.config || {},
       },
     };
   }

--- a/frontend/src/sections/agent-playground/AgentBuilder/__tests__/GraphView.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/__tests__/GraphView.test.jsx
@@ -29,6 +29,7 @@ vi.mock("../nodes", () => ({
   PromptNode: () => <div />,
   AgentNode: () => <div />,
   EvalNode: () => <div />,
+  CodeExecutionNode: () => <div />,
 }));
 
 vi.mock("../edges", () => ({

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/__tests__/useAddNodeOptimistic.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/__tests__/useAddNodeOptimistic.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import useAddNodeOptimistic from "../useAddNodeOptimistic";
 import { useAgentPlaygroundStore } from "../../../store";
+import { NODE_TYPES } from "../../../utils/constants";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -29,9 +30,8 @@ vi.mock("../../../utils/versionPayloadUtils", () => ({
 }));
 
 // Re-import after mocks are set up
-const { addNodeApi } = await import(
-  "src/api/agent-playground/agent-playground"
-);
+const { addNodeApi } =
+  await import("src/api/agent-playground/agent-playground");
 const logger = (await import("src/utils/logger")).default;
 
 // ---------------------------------------------------------------------------
@@ -177,6 +177,50 @@ describe("useAddNodeOptimistic", () => {
       nodeId: "node-123",
       position: { x: 100, y: 200 },
     });
+  });
+
+  it("draft path: creates code nodes with store-computed defaults", async () => {
+    const codeConfig = {
+      language: "python",
+      code: 'result = {"ok": True}',
+      timeout_ms: 5000,
+      memory_mb: 128,
+    };
+    mockEnsureDraft.mockResolvedValue("existing-draft");
+    mockAddOptimisticNode.mockReturnValue({
+      ...defaultOptimisticResult,
+      ports: [
+        { key: "inputs", direction: "input" },
+        { key: "result", direction: "output" },
+      ],
+      config: codeConfig,
+    });
+    mockGetNodeById.mockReturnValue({
+      id: "node-123",
+      type: NODE_TYPES.CODE_EXECUTION,
+    });
+
+    const { result } = renderHook(() => useAddNodeOptimistic());
+
+    await act(async () => {
+      await result.current.addNode({
+        ...defaultPayload,
+        type: NODE_TYPES.CODE_EXECUTION,
+        config: {},
+      });
+    });
+
+    expect(addNodeApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          config: codeConfig,
+          ports: [
+            { key: "inputs", direction: "input" },
+            { key: "result", direction: "output" },
+          ],
+        }),
+      }),
+    );
   });
 
   it("draft path: when addOptimisticNode returns null, returns null without calling addNodeApi", async () => {

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/__tests__/useAddNodeOptimistic.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/__tests__/useAddNodeOptimistic.test.js
@@ -154,7 +154,10 @@ describe("useAddNodeOptimistic", () => {
 
   it("draft path: calls addOptimisticNode, fires addNodeApi, returns { nodeId, position }", async () => {
     mockEnsureDraft.mockResolvedValue("existing-draft");
-    mockAddOptimisticNode.mockReturnValue(defaultOptimisticResult);
+    mockAddOptimisticNode.mockReturnValue({
+      ...defaultOptimisticResult,
+      config: { prompt_template_id: null, prompt_version_id: null },
+    });
     mockGetNodeById.mockReturnValue({ id: "node-123", type: "llm_prompt" });
 
     const { result } = renderHook(() => useAddNodeOptimistic());
@@ -173,6 +176,26 @@ describe("useAddNodeOptimistic", () => {
       defaultPayload.config,
     );
     expect(addNodeApi).toHaveBeenCalled();
+    expect(addNodeApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          prompt_template: expect.objectContaining({
+            messages: [
+              {
+                id: expect.any(String),
+                role: "system",
+                content: [{ type: "text", text: "" }],
+              },
+              {
+                id: expect.any(String),
+                role: "user",
+                content: [{ type: "text", text: "" }],
+              },
+            ],
+          }),
+        }),
+      }),
+    );
     expect(returnValue).toEqual({
       nodeId: "node-123",
       position: { x: 100, y: 200 },

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/useAddNodeOptimistic.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/useAddNodeOptimistic.js
@@ -41,8 +41,15 @@ export default function useAddNodeOptimistic() {
 
       if (!result) return null;
 
-      const { nodeId, edgeId, position, ports, label } = result;
-      const config = payload.config;
+      const {
+        nodeId,
+        edgeId,
+        position,
+        ports,
+        label,
+        config: computedConfig,
+      } = result;
+      const config = computedConfig || payload.config;
 
       // Don't select the node yet — wait until ensureDraft completes
       // to avoid triggering the discard dialog if a drawer is open with dirty form.

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/useAddNodeOptimistic.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/useAddNodeOptimistic.js
@@ -49,7 +49,10 @@ export default function useAddNodeOptimistic() {
         label,
         config: computedConfig,
       } = result;
-      const config = computedConfig || payload.config;
+      const config =
+        payload.type === NODE_TYPES.CODE_EXECUTION
+          ? computedConfig || payload.config
+          : payload.config;
 
       // Don't select the node yet — wait until ensureDraft completes
       // to avoid triggering the discard dialog if a drawer is open with dirty form.

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/useAddNodeOptimistic.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/useAddNodeOptimistic.js
@@ -82,6 +82,9 @@ export default function useAddNodeOptimistic() {
           source_node_id: payload.sourceNodeId,
           ...(payload.sourceNodeId && edgeId && { edge_id: edgeId }),
           ports,
+          ...(payload.type === NODE_TYPES.CODE_EXECUTION && {
+            config,
+          }),
           ...(payload.type === NODE_TYPES.LLM_PROMPT && {
             prompt_template: {
               prompt_template_id: config?.prompt_template_id ?? null,

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/usePartialNodeUpdate.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/usePartialNodeUpdate.js
@@ -48,7 +48,12 @@ export default function usePartialNodeUpdate() {
       const apiPayload =
         node?.type === NODE_TYPES.LLM_PROMPT
           ? buildPatchPayload(updateData, config)
-          : buildAgentPatchPayload(updateData);
+          : node?.type === NODE_TYPES.CODE_EXECUTION
+            ? {
+                ...(updateData.label && { name: updateData.label }),
+                config: updateData.config || {},
+              }
+            : buildAgentPatchPayload(updateData);
 
       return mutateAsync({ graphId, versionId, nodeId, data: apiPayload });
     },

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/BaseNode.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/BaseNode.jsx
@@ -22,6 +22,16 @@ const handleBaseStyle = {
   background: "var(--bg-paper)",
 };
 
+const resolveThemeColor = (theme, token, fallback) => {
+  if (typeof token !== "string" || token.length === 0) return fallback;
+  if (token.startsWith("#") || token.startsWith("rgb")) return token;
+
+  const [paletteKey, shade] = token.split(".");
+  const paletteValue = theme.palette[paletteKey];
+
+  return paletteValue?.[shade] ?? paletteValue?.main ?? fallback;
+};
+
 const BaseNode = ({
   id,
   type,
@@ -33,7 +43,6 @@ const BaseNode = ({
   const outputPort = ports?.find((p) => p.direction === PORT_DIRECTION.OUTPUT);
   const outputPortLabel = outputPort?.display_name;
   const typeConfig = NODE_TYPE_CONFIG[type] ?? {};
-  const iconColor = typeConfig.color ?? "orange.500";
 
   const state = useBaseNodeState({ id, data });
   const {
@@ -46,6 +55,11 @@ const BaseNode = ({
   } = state;
 
   const { boxSx, borderColor, theme } = useBaseNodeStyles(state);
+  const iconColor = resolveThemeColor(
+    theme,
+    typeConfig.color,
+    theme.palette.orange?.[500] ?? theme.palette.primary.main,
+  );
 
   const actions = useBaseNodeActions({ id, ...state });
   const {
@@ -132,7 +146,14 @@ const BaseNode = ({
               height: 20,
               borderRadius: 0.5,
               border: "1px solid",
-              borderColor: "divider",
+              borderColor: alpha(
+                iconColor,
+                theme.palette.mode === "dark" ? 0.42 : 0.28,
+              ),
+              backgroundColor: alpha(
+                iconColor,
+                theme.palette.mode === "dark" ? 0.18 : 0.08,
+              ),
               display: "flex",
               alignItems: "center",
               justifyContent: "center",

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/CodeExecutionNode.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/CodeExecutionNode.jsx
@@ -1,0 +1,27 @@
+import React, { memo } from "react";
+import PropTypes from "prop-types";
+import BaseNode from "./BaseNode";
+import { NODE_TYPES } from "../../utils/constants";
+
+const CodeExecutionNode = ({ id, data, isConnectable, selected }) => {
+  return (
+    <BaseNode
+      id={id}
+      data={data}
+      isConnectable={isConnectable}
+      selected={selected}
+      type={NODE_TYPES.CODE_EXECUTION}
+    />
+  );
+};
+
+CodeExecutionNode.propTypes = {
+  id: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired,
+  isConnectable: PropTypes.bool,
+  selected: PropTypes.bool,
+};
+
+const MemoizedCodeExecutionNode = memo(CodeExecutionNode);
+
+export default MemoizedCodeExecutionNode;

--- a/frontend/src/sections/agent-playground/AgentBuilder/nodes/index.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/nodes/index.js
@@ -2,3 +2,4 @@ export { default as PromptNode } from "./PromptNode";
 export { default as AgentNode } from "./AgentNode";
 export { default as EvalNode } from "./EvalNode";
 export { default as BaseNode } from "./BaseNode";
+export { default as CodeExecutionNode } from "./CodeExecutionNode";

--- a/frontend/src/sections/agent-playground/store/agent-playground-store.js
+++ b/frontend/src/sections/agent-playground/store/agent-playground-store.js
@@ -5,6 +5,8 @@ import { useShallow } from "zustand/react/shallow";
 import { CURRENT_ENVIRONMENT } from "src/config-global";
 import { addEdge, applyNodeChanges, applyEdgeChanges } from "@xyflow/react";
 import {
+  CODE_EXECUTION_DEFAULT_CONFIG,
+  CODE_EXECUTION_PORTS,
   NODE_TYPES,
   NODE_X_OFFSET,
   PORT_KEYS,
@@ -341,25 +343,33 @@ export const useAgentPlaygroundStore = create(
                 prompt_template_id: config?.prompt_template_id ?? null,
                 prompt_version_id: null,
               }
-            : {};
+            : type === NODE_TYPES.CODE_EXECUTION
+              ? { ...CODE_EXECUTION_DEFAULT_CONFIG, ...config }
+              : {};
 
         // Caller-provided config is transient — only for form population, not persisted
         const initialConfig =
           config && Object.keys(config).length > 0 ? config : null;
 
         const isAgent = type === NODE_TYPES.AGENT;
+        const isCodeExecution = type === NODE_TYPES.CODE_EXECUTION;
         const ports = isAgent
           ? undefined
-          : [
-              {
+          : isCodeExecution
+            ? CODE_EXECUTION_PORTS.map((port) => ({
+                ...port,
                 id: crypto.randomUUID(),
-                key: PORT_KEYS.RESPONSE,
-                display_name: generateOutputLabel(nodes),
-                direction: PORT_DIRECTION.OUTPUT,
-                data_schema: { type: "string" },
-                required: true,
-              },
-            ];
+              }))
+            : [
+                {
+                  id: crypto.randomUUID(),
+                  key: PORT_KEYS.RESPONSE,
+                  display_name: generateOutputLabel(nodes),
+                  direction: PORT_DIRECTION.OUTPUT,
+                  data_schema: { type: "string" },
+                  required: true,
+                },
+              ];
 
         const newNode = {
           id: nodeId,

--- a/frontend/src/sections/agent-playground/utils/__tests__/constants.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/constants.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { CODE_EXECUTION_PORTS } from "../constants";
+
+describe("agent playground code execution constants", () => {
+  it("keeps the result port aligned with the runner metadata envelope", () => {
+    const resultPort = CODE_EXECUTION_PORTS.find((port) => port.key === "result");
+
+    expect(resultPort.data_schema.required).toContain("metadata");
+    expect(resultPort.data_schema.properties.metadata.required).toEqual([
+      "language",
+      "runner",
+      "timed_out",
+      "memory_mb",
+    ]);
+  });
+});

--- a/frontend/src/sections/agent-playground/utils/__tests__/versionPayloadUtils.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/versionPayloadUtils.test.js
@@ -120,6 +120,13 @@ describe("buildVersionPayload", () => {
           config: { language: "python", code: "result = inputs" },
           ports: [
             {
+              temp_id: "code-in",
+              key: "inputs",
+              display_name: "inputs",
+              direction: "input",
+              data_schema: { type: "object" },
+            },
+            {
               temp_id: "code-out",
               key: "result",
               display_name: "result",
@@ -139,6 +146,22 @@ describe("buildVersionPayload", () => {
       config: { language: "python", code: "result = inputs" },
     });
     expect(result.nodes[0]).not.toHaveProperty("prompt_template");
+    expect(result.nodes[0].ports).toEqual([
+      {
+        id: "code-in",
+        key: "inputs",
+        display_name: "inputs",
+        direction: "input",
+        data_schema: { type: "object" },
+      },
+      {
+        id: "code-out",
+        key: "result",
+        display_name: "result",
+        direction: "output",
+        data_schema: { type: "object" },
+      },
+    ]);
   });
 
   it("does not include node_template_id for subgraph nodes", () => {

--- a/frontend/src/sections/agent-playground/utils/__tests__/versionPayloadUtils.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/versionPayloadUtils.test.js
@@ -125,6 +125,7 @@ describe("buildVersionPayload", () => {
               display_name: "inputs",
               direction: "input",
               data_schema: { type: "object" },
+              required: false,
             },
             {
               temp_id: "code-out",
@@ -132,6 +133,7 @@ describe("buildVersionPayload", () => {
               display_name: "result",
               direction: "output",
               data_schema: { type: "object" },
+              required: true,
             },
           ],
         },
@@ -153,6 +155,7 @@ describe("buildVersionPayload", () => {
         display_name: "inputs",
         direction: "input",
         data_schema: { type: "object" },
+        required: false,
       },
       {
         id: "code-out",
@@ -160,6 +163,7 @@ describe("buildVersionPayload", () => {
         display_name: "result",
         direction: "output",
         data_schema: { type: "object" },
+        required: true,
       },
     ]);
   });

--- a/frontend/src/sections/agent-playground/utils/__tests__/versionPayloadUtils.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/versionPayloadUtils.test.js
@@ -4,7 +4,7 @@ import {
   parseVersionResponse,
 } from "../versionPayloadUtils";
 import { createPromptNode, createAgentNode, createEdge } from "./fixtures";
-import { API_NODE_TYPES, VERSION_STATUS } from "../constants";
+import { API_NODE_TYPES, NODE_TYPES, VERSION_STATUS } from "../constants";
 
 // ---------------------------------------------------------------------------
 // buildVersionPayload
@@ -106,6 +106,39 @@ describe("buildVersionPayload", () => {
     const nodes = [createPromptNode("p1")];
     const result = buildVersionPayload(nodes, []);
     expect(result.nodes[0].node_template_id).toBe("tpl-prompt");
+  });
+
+  it("serializes code execution nodes with config instead of prompt_template", () => {
+    const nodes = [
+      {
+        id: "code-1",
+        type: NODE_TYPES.CODE_EXECUTION,
+        position: { x: 10, y: 20 },
+        data: {
+          label: "Code",
+          node_template_id: "tpl-code",
+          config: { language: "python", code: "result = inputs" },
+          ports: [
+            {
+              temp_id: "code-out",
+              key: "result",
+              display_name: "result",
+              direction: "output",
+              data_schema: { type: "object" },
+            },
+          ],
+        },
+      },
+    ];
+
+    const result = buildVersionPayload(nodes, []);
+
+    expect(result.nodes[0]).toMatchObject({
+      type: API_NODE_TYPES.ATOMIC,
+      node_template_id: "tpl-code",
+      config: { language: "python", code: "result = inputs" },
+    });
+    expect(result.nodes[0]).not.toHaveProperty("prompt_template");
   });
 
   it("does not include node_template_id for subgraph nodes", () => {
@@ -420,8 +453,52 @@ describe("edge cases", () => {
       const result = parseVersionResponse(apiData);
       expect(result.nodes).toHaveLength(1);
       // Port should still be reconstructed
-      expect(result.nodes[0].data.ports[0].display_name).toBe("response");
+    expect(result.nodes[0].data.ports[0].display_name).toBe("response");
+  });
+
+  it("parses code execution nodes from canonical snake_case response data", () => {
+    const apiData = {
+      nodes: [
+        {
+          id: "code-1",
+          type: API_NODE_TYPES.ATOMIC,
+          name: "Code",
+          node_template_id: "tpl-code",
+          node_template_name: NODE_TYPES.CODE_EXECUTION,
+          config: { language: "python", code: "result = inputs" },
+          position: { x: 1, y: 2 },
+          ports: [
+            {
+              id: "port-1",
+              key: "result",
+              display_name: "result",
+              direction: "output",
+              data_schema: { type: "object" },
+            },
+          ],
+        },
+      ],
+      node_connections: [
+        { id: "edge-1", source_node_id: "code-1", target_node_id: "next-1" },
+      ],
+    };
+
+    const result = parseVersionResponse(apiData);
+
+    expect(result.nodes[0]).toMatchObject({
+      id: "code-1",
+      type: NODE_TYPES.CODE_EXECUTION,
+      data: {
+        node_template_id: "tpl-code",
+        config: { language: "python", code: "result = inputs" },
+      },
     });
+    expect(result.edges[0]).toEqual({
+      id: "edge-1",
+      source: "code-1",
+      target: "next-1",
+    });
+  });
 
     it("handles orphaned edges (referencing non-existent ports)", () => {
       const apiData = {

--- a/frontend/src/sections/agent-playground/utils/constants.js
+++ b/frontend/src/sections/agent-playground/utils/constants.js
@@ -70,7 +70,15 @@ export const CODE_EXECUTION_RESULT_SCHEMA = {
     metadata: {
       type: "object",
       additionalProperties: false,
-      required: ["language", "runner", "timed_out", "memory_mb"],
+      required: [
+        "language",
+        "runner",
+        "timed_out",
+        "memory_mb",
+        "stdout_truncated",
+        "stderr_truncated",
+        "output_limit_bytes",
+      ],
       properties: {
         language: {
           type: "string",
@@ -79,6 +87,9 @@ export const CODE_EXECUTION_RESULT_SCHEMA = {
         runner: { anyOf: [{ type: "string" }, { type: "null" }] },
         timed_out: { type: "boolean" },
         memory_mb: { anyOf: [{ type: "integer" }, { type: "null" }] },
+        stdout_truncated: { type: "boolean" },
+        stderr_truncated: { type: "boolean" },
+        output_limit_bytes: { anyOf: [{ type: "integer" }, { type: "null" }] },
       },
     },
   },

--- a/frontend/src/sections/agent-playground/utils/constants.js
+++ b/frontend/src/sections/agent-playground/utils/constants.js
@@ -3,6 +3,7 @@ export const NODE_X_OFFSET = 450;
 
 export const NODE_TYPES = {
   LLM_PROMPT: "llm_prompt",
+  CODE_EXECUTION: "code_execution",
   AGENT: "agent",
 };
 
@@ -23,7 +24,82 @@ export const NODE_TYPE_CONFIG = {
     color: "orange.500",
   },
   [NODE_TYPES.AGENT]: AGENT_NODE,
+  [NODE_TYPES.CODE_EXECUTION]: {
+    id: NODE_TYPES.CODE_EXECUTION,
+    title: "Code Execution",
+    description: "Run code in an isolated sandbox",
+    iconSrc: "/assets/icons/components/ic_code.svg",
+    color: "success.main",
+  },
 };
+
+export const CODE_EXECUTION_LANGUAGES = [
+  { value: "python", label: "Python" },
+  { value: "javascript", label: "JavaScript" },
+  { value: "typescript", label: "TypeScript" },
+];
+
+export const CODE_EXECUTION_DEFAULT_CONFIG = {
+  language: "python",
+  code: 'result = {"message": "hello from code_execution", "inputs": inputs}',
+  timeout_ms: 5000,
+  memory_mb: 128,
+};
+
+export const CODE_EXECUTION_RESULT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "ok",
+    "value",
+    "stdout",
+    "stderr",
+    "exit_code",
+    "duration_ms",
+    "error",
+    "metadata",
+  ],
+  properties: {
+    ok: { type: "boolean" },
+    value: {},
+    stdout: { type: "string" },
+    stderr: { type: "string" },
+    exit_code: { anyOf: [{ type: "integer" }, { type: "null" }] },
+    duration_ms: { type: "integer", minimum: 0 },
+    error: { anyOf: [{ type: "string" }, { type: "null" }] },
+    metadata: {
+      type: "object",
+      additionalProperties: false,
+      required: ["language", "runner", "timed_out", "memory_mb"],
+      properties: {
+        language: {
+          type: "string",
+          enum: ["python", "javascript", "typescript"],
+        },
+        runner: { anyOf: [{ type: "string" }, { type: "null" }] },
+        timed_out: { type: "boolean" },
+        memory_mb: { anyOf: [{ type: "integer" }, { type: "null" }] },
+      },
+    },
+  },
+};
+
+export const CODE_EXECUTION_PORTS = [
+  {
+    key: "inputs",
+    display_name: "inputs",
+    direction: "input",
+    data_schema: { type: "object" },
+    required: false,
+  },
+  {
+    key: "result",
+    display_name: "result",
+    direction: "output",
+    data_schema: CODE_EXECUTION_RESULT_SCHEMA,
+    required: true,
+  },
+];
 
 export const AGENT_PLAYGROUND_TABS = [
   {

--- a/frontend/src/sections/agent-playground/utils/versionPayloadUtils.js
+++ b/frontend/src/sections/agent-playground/utils/versionPayloadUtils.js
@@ -101,7 +101,11 @@ export function buildVersionPayload(nodes = [], edges = [], options = {}) {
       const effectiveConfig = node.data?._initialConfig
         ? { ...node.data?.config, ...node.data._initialConfig }
         : node.data?.config;
-      apiNode.prompt_template = buildPromptTemplateForApi(effectiveConfig);
+      if (node.type === NODE_TYPES.CODE_EXECUTION) {
+        apiNode.config = effectiveConfig || {};
+      } else {
+        apiNode.prompt_template = buildPromptTemplateForApi(effectiveConfig);
+      }
 
       const atomicOutputPorts = (node.data?.ports || []).filter(
         (p) => p.direction === "output",
@@ -239,12 +243,15 @@ export function parseVersionResponse(apiData) {
   const xyNodes = apiData.nodes.map((node) => {
     const nodeType = mapApiTypeToNodeType(node);
     const isSubgraph = nodeType === NODE_TYPES.AGENT;
+    const isCodeExecution = nodeType === NODE_TYPES.CODE_EXECUTION;
+    const promptTemplate = node.promptTemplate ?? node.prompt_template;
 
     // For atomic nodes, read LLM config from promptTemplate (not config)
-    const formConfig =
-      isSubgraph || !node.promptTemplate
+    const formConfig = isCodeExecution
+      ? node.config || {}
+      : isSubgraph || !promptTemplate
         ? null
-        : transformConfigFromApi(node.promptTemplate);
+        : transformConfigFromApi(promptTemplate);
 
     return {
       id: node.id,
@@ -273,48 +280,69 @@ export function parseVersionResponse(apiData) {
                 required: p.required,
                 ...(p.refPortId && { ref_port_id: p.refPortId }),
               })),
-              versionId: node.refGraphVersionId || "",
-              graphId: node.refGraphId || "",
+              versionId:
+                node.refGraphVersionId || node.ref_graph_version_id || "",
+              graphId: node.refGraphId || node.ref_graph_id || "",
               config: {
-                graphId: node.refGraphId || "",
-                versionId: node.refGraphVersionId || "",
+                graphId: node.refGraphId || node.ref_graph_id || "",
+                versionId:
+                  node.refGraphVersionId || node.ref_graph_version_id || "",
                 payload: {
-                  inputMappings: node.inputMappings || [],
+                  inputMappings: node.inputMappings || node.input_mappings || [],
                 },
               },
-              ref_graph_version_id: node.refGraphVersionId || "",
+              ref_graph_version_id:
+                node.refGraphVersionId || node.ref_graph_version_id || "",
             }
           : {
-              node_template_id: node.nodeTemplateId || null,
-              prompt_template_id: node.promptTemplate?.promptTemplateId || null,
-              prompt_version_id: node.promptTemplate?.promptVersionId || null,
-              config: {
-                ...formConfig,
-                prompt_template_id:
-                  node.promptTemplate?.promptTemplateId || null,
-                prompt_version_id: node.promptTemplate?.promptVersionId || null,
-                payload: {
-                  ...formConfig?.payload,
-                  promptConfig: [
-                    {
-                      configuration: {
-                        ...(node.promptTemplate || {}),
-                        responseFormat: node.prompt_template?.response_format,
+              node_template_id:
+                node.nodeTemplateId || node.node_template_id || null,
+              ...(isCodeExecution
+                ? { config: node.config || {} }
+                : {
+                    prompt_template_id:
+                      promptTemplate?.promptTemplateId ||
+                      promptTemplate?.prompt_template_id ||
+                      null,
+                    prompt_version_id:
+                      promptTemplate?.promptVersionId ||
+                      promptTemplate?.prompt_version_id ||
+                      null,
+                    config: {
+                      ...formConfig,
+                      prompt_template_id:
+                        promptTemplate?.promptTemplateId ||
+                        promptTemplate?.prompt_template_id ||
+                        null,
+                      prompt_version_id:
+                        promptTemplate?.promptVersionId ||
+                        promptTemplate?.prompt_version_id ||
+                        null,
+                      payload: {
+                        ...formConfig?.payload,
+                        promptConfig: [
+                          {
+                            configuration: {
+                              ...(promptTemplate || {}),
+                              responseFormat:
+                                promptTemplate?.responseFormat ||
+                                promptTemplate?.response_format,
+                            },
+                          },
+                        ],
                       },
                     },
-                  ],
-                },
-              },
+                  }),
             }),
       },
     };
   });
 
   // Node connections → React Flow edges (id, source, target)
-  const xyEdges = (apiData.nodeConnections || [])
+  const xyEdges = (apiData.nodeConnections || apiData.node_connections || [])
     .map((nc) => {
-      const sourceNodeId = nc.sourceNodeId;
-      const targetNodeId = nc.targetNodeId;
+      const sourceNodeId = nc.sourceNodeId || nc.source_node_id;
+      const targetNodeId = nc.targetNodeId || nc.target_node_id;
       if (!sourceNodeId || !targetNodeId) return null;
       return {
         id: nc.id || `${sourceNodeId}-${targetNodeId}`,
@@ -332,6 +360,12 @@ export function parseVersionResponse(apiData) {
  */
 function mapApiTypeToNodeType(apiNode) {
   if (apiNode.type === API_NODE_TYPES.ATOMIC) {
+    if (
+      apiNode.nodeTemplateName === NODE_TYPES.CODE_EXECUTION ||
+      apiNode.node_template_name === NODE_TYPES.CODE_EXECUTION
+    ) {
+      return NODE_TYPES.CODE_EXECUTION;
+    }
     return NODE_TYPES.LLM_PROMPT;
   }
   if (apiNode.type === API_NODE_TYPES.SUBGRAPH) {

--- a/frontend/src/sections/agent-playground/utils/versionPayloadUtils.js
+++ b/frontend/src/sections/agent-playground/utils/versionPayloadUtils.js
@@ -91,6 +91,7 @@ export function buildVersionPayload(nodes = [], edges = [], options = {}) {
           display_name: port.display_name,
           direction: port.direction,
           data_schema: port.data_schema || port.dataSchema || {},
+          required: port.required ?? true,
           ...(port.ref_port_id && { ref_port_id: port.ref_port_id }),
         }));
       }

--- a/frontend/src/sections/agent-playground/utils/versionPayloadUtils.js
+++ b/frontend/src/sections/agent-playground/utils/versionPayloadUtils.js
@@ -107,11 +107,12 @@ export function buildVersionPayload(nodes = [], edges = [], options = {}) {
         apiNode.prompt_template = buildPromptTemplateForApi(effectiveConfig);
       }
 
-      const atomicOutputPorts = (node.data?.ports || []).filter(
-        (p) => p.direction === "output",
+      const atomicPorts = (node.data?.ports || []).filter(
+        (port) =>
+          node.type === NODE_TYPES.CODE_EXECUTION || port.direction === "output",
       );
-      if (atomicOutputPorts.length > 0) {
-        apiNode.ports = atomicOutputPorts.map((port) => ({
+      if (atomicPorts.length > 0) {
+        apiNode.ports = atomicPorts.map((port) => ({
           id: port.id || port.temp_id,
           key: port.key,
           display_name: port.display_name,

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1579,6 +1579,8 @@ export const endpoints = {
       `/agent-playground/graphs/${graphId}/versions/${versionId}/nodes/${nodeId}/`,
     possibleEdgeMappings: (graphId, versionId, nodeId) =>
       `/agent-playground/graphs/${graphId}/versions/${versionId}/nodes/${nodeId}/possible-edge-mappings/`,
+    testNodeExecution: (graphId, versionId, nodeId) =>
+      `/agent-playground/graphs/${graphId}/versions/${versionId}/nodes/${nodeId}/test-execution/`,
   },
   mcp: {
     config: "/mcp/config/",

--- a/futureagi/agent_playground/migrations/0012_seed_code_execution_template.py
+++ b/futureagi/agent_playground/migrations/0012_seed_code_execution_template.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+def seed_code_execution_template(apps, schema_editor):
+    from agent_playground.templates.code_execution import CODE_EXECUTION_TEMPLATE
+
+    NodeTemplate = apps.get_model("agent_playground", "NodeTemplate")
+    defaults = {k: v for k, v in CODE_EXECUTION_TEMPLATE.items() if k != "name"}
+    NodeTemplate.objects.update_or_create(
+        name=CODE_EXECUTION_TEMPLATE["name"],
+        defaults=defaults,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("agent_playground", "0011_alter_prompttemplatenode_prompt_template_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_code_execution_template, migrations.RunPython.noop),
+    ]

--- a/futureagi/agent_playground/migrations/0012_seed_code_execution_template.py
+++ b/futureagi/agent_playground/migrations/0012_seed_code_execution_template.py
@@ -1,9 +1,115 @@
 from django.db import migrations
 
+CODE_EXECUTION_TEMPLATE = {
+    "name": "code_execution",
+    "display_name": "Code Execution",
+    "description": (
+        "Run Python, JavaScript, or TypeScript in an isolated Docker sandbox. "
+        "The node receives a JSON object as inputs and emits a structured result."
+    ),
+    "icon": None,
+    "categories": ["code", "transform", "execution"],
+    "input_definition": [
+        {
+            "key": "inputs",
+            "display_name": "inputs",
+            "data_schema": {"type": "object"},
+            "required": False,
+        }
+    ],
+    "output_definition": [
+        {
+            "key": "result",
+            "display_name": "result",
+            "data_schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "ok",
+                    "value",
+                    "stdout",
+                    "stderr",
+                    "exit_code",
+                    "duration_ms",
+                    "error",
+                    "metadata",
+                ],
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "value": {},
+                    "stdout": {"type": "string"},
+                    "stderr": {"type": "string"},
+                    "exit_code": {
+                        "anyOf": [{"type": "integer"}, {"type": "null"}]
+                    },
+                    "duration_ms": {"type": "integer", "minimum": 0},
+                    "error": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": [
+                            "language",
+                            "runner",
+                            "timed_out",
+                            "memory_mb",
+                            "stdout_truncated",
+                            "stderr_truncated",
+                            "output_limit_bytes",
+                        ],
+                        "properties": {
+                            "language": {
+                                "type": "string",
+                                "enum": ["python", "javascript", "typescript"],
+                            },
+                            "runner": {
+                                "anyOf": [{"type": "string"}, {"type": "null"}]
+                            },
+                            "timed_out": {"type": "boolean"},
+                            "memory_mb": {
+                                "anyOf": [{"type": "integer"}, {"type": "null"}]
+                            },
+                            "stdout_truncated": {"type": "boolean"},
+                            "stderr_truncated": {"type": "boolean"},
+                            "output_limit_bytes": {
+                                "anyOf": [{"type": "integer"}, {"type": "null"}]
+                            },
+                        },
+                    },
+                },
+            },
+            "required": True,
+        }
+    ],
+    "input_mode": "strict",
+    "output_mode": "strict",
+    "config_schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["language", "code"],
+        "properties": {
+            "language": {
+                "type": "string",
+                "enum": ["python", "javascript", "typescript"],
+            },
+            "code": {"type": "string", "minLength": 1, "maxLength": 20000},
+            "timeout_ms": {
+                "type": "integer",
+                "minimum": 100,
+                "maximum": 30000,
+                "default": 5000,
+            },
+            "memory_mb": {
+                "type": "integer",
+                "minimum": 32,
+                "maximum": 512,
+                "default": 128,
+            },
+        },
+    },
+}
+
 
 def seed_code_execution_template(apps, schema_editor):
-    from agent_playground.templates.code_execution import CODE_EXECUTION_TEMPLATE
-
     NodeTemplate = apps.get_model("agent_playground", "NodeTemplate")
     defaults = {k: v for k, v in CODE_EXECUTION_TEMPLATE.items() if k != "name"}
     NodeTemplate.objects.update_or_create(

--- a/futureagi/agent_playground/serializers/node.py
+++ b/futureagi/agent_playground/serializers/node.py
@@ -21,6 +21,9 @@ class NodeReadSerializer(serializers.ModelSerializer):
     node_template_id = serializers.UUIDField(
         source="node_template.id", read_only=True, allow_null=True
     )
+    node_template_name = serializers.CharField(
+        source="node_template.name", read_only=True, allow_null=True, default=None
+    )
     ref_graph_version_id = serializers.UUIDField(
         source="ref_graph_version.id", read_only=True, allow_null=True
     )
@@ -49,6 +52,7 @@ class NodeReadSerializer(serializers.ModelSerializer):
             "config",
             "position",
             "node_template_id",
+            "node_template_name",
             "ref_graph_version_id",
             "ref_graph_name",
             "ref_graph_id",
@@ -348,7 +352,10 @@ class PromptTemplateDataSerializer(serializers.Serializer):
         required=False, allow_null=True, allow_blank=True, default=None
     )
     template_format = serializers.CharField(
-        required=False, allow_null=True, allow_blank=True, default=None,
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        default=None,
         help_text="Template format: 'mustache' or 'jinja'",
     )
     save_prompt_version = serializers.BooleanField(required=False, default=False)
@@ -497,6 +504,7 @@ class CreateNodeSerializer(serializers.Serializer):
     source_node_id = serializers.UUIDField(
         required=False, allow_null=True, default=None
     )
+    config = serializers.JSONField(required=False, default=dict)
     prompt_template = PromptTemplateDataSerializer(
         required=False, allow_null=True, default=None
     )
@@ -539,6 +547,10 @@ class CreateNodeSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 {"input_mappings": "Only supported for subgraph nodes"}
             )
+        if attrs.get("config") and node_type == NodeType.SUBGRAPH:
+            raise serializers.ValidationError(
+                {"config": "Subgraph nodes derive config from ref_graph_version_id."}
+            )
 
         return attrs
 
@@ -548,6 +560,7 @@ class UpdateNodeSerializer(serializers.Serializer):
 
     name = serializers.CharField(required=False, max_length=255)
     position = serializers.JSONField(required=False)
+    config = serializers.JSONField(required=False)
     prompt_template = PromptTemplateDataSerializer(required=False, allow_null=True)
     ref_graph_version_id = serializers.UUIDField(required=False, allow_null=True)
     input_mappings = InputMappingSerializer(

--- a/futureagi/agent_playground/services/engine/runners/__init__.py
+++ b/futureagi/agent_playground/services/engine/runners/__init__.py
@@ -5,6 +5,7 @@ This package contains implementations of BaseNodeRunner for different node templ
 Runners self-register on module import.
 
 Current runners:
+    - code_execution: Isolated Docker-backed code execution
     - llm_prompt: LLM completion using LiteLLM
 
 Adding a new runner:
@@ -16,4 +17,5 @@ Adding a new runner:
 
 # Import runner modules to trigger self-registration.
 # Add new runners here as they are created.
+import agent_playground.services.engine.runners.code_execution  # noqa: F401
 import agent_playground.services.engine.runners.llm_prompt  # noqa: F401

--- a/futureagi/agent_playground/services/engine/runners/code_execution.py
+++ b/futureagi/agent_playground/services/engine/runners/code_execution.py
@@ -1,0 +1,450 @@
+"""
+Docker-backed runner for the Agent Playground code_execution node.
+
+The Django worker never evaluates user code. Execution is delegated to a short-lived
+Docker container with no network, a read-only code mount, a tmpfs scratch area, a
+memory cap, and an explicit timeout. If Docker is not available, the runner fails
+closed with a structured SANDBOX_UNAVAILABLE result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jsonschema import ValidationError as JsonSchemaValidationError
+from jsonschema import validate as validate_json_schema
+
+from agent_playground.services.engine.node_runner import BaseNodeRunner, register_runner
+from agent_playground.templates.code_execution import CODE_EXECUTION_TEMPLATE
+
+_RESULT_MARKER = "__FAGI_CODE_RESULT__"
+_CONFIG_SCHEMA = CODE_EXECUTION_TEMPLATE["config_schema"]
+_SUPPORTED_LANGUAGES = frozenset(_CONFIG_SCHEMA["properties"]["language"]["enum"])
+_CONFIG_DEFAULTS = {"timeout_ms": 5000, "memory_mb": 128}
+_SANDBOX_UNAVAILABLE = (
+    "SANDBOX_UNAVAILABLE: Docker is required for isolated code execution."
+)
+_IMAGE_UNAVAILABLE = "SANDBOX_UNAVAILABLE: Docker image '{image}' is not available and could not be pulled."
+_IMAGE_PULL_TIMEOUT_MS = 120000
+
+
+@dataclass(frozen=True)
+class SandboxResult:
+    ok: bool
+    value: Any
+    stdout: str
+    stderr: str
+    exit_code: int | None
+    duration_ms: int
+    language: str = "python"
+    runner: str | None = "python"
+    timed_out: bool = False
+    memory_mb: int | None = None
+    error: str | None = None
+
+
+class CodeExecutionError(RuntimeError):
+    """Execution failure that preserves the code node's structured result."""
+
+    def __init__(self, result: SandboxResult) -> None:
+        super().__init__(result.error or "Code execution failed.")
+        self.result = result
+        self.outputs = {"result": _result_payload(result)}
+
+
+class DockerCodeSandbox:
+    """Minimal Docker adapter with fail-closed capability probing."""
+
+    def available(self) -> bool:
+        if shutil.which("docker") is None:
+            return False
+        try:
+            completed = subprocess.run(
+                ["docker", "info", "--format", "{{.ServerVersion}}"],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=3,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return completed.returncode == 0
+
+    def run(
+        self,
+        *,
+        language: str,
+        code: str,
+        inputs: dict[str, Any],
+        timeout_ms: int,
+        memory_mb: int,
+    ) -> SandboxResult:
+        if language not in _SUPPORTED_LANGUAGES:
+            return SandboxResult(
+                ok=False,
+                value=None,
+                stdout="",
+                stderr="",
+                exit_code=None,
+                duration_ms=0,
+                language=language,
+                runner=None,
+                error=f"Unsupported language '{language}'.",
+            )
+        if not self.available():
+            return SandboxResult(
+                ok=False,
+                value=None,
+                stdout="",
+                stderr="",
+                exit_code=None,
+                duration_ms=0,
+                language=language,
+                runner=self._runner_for_language(language),
+                memory_mb=memory_mb,
+                error=_SANDBOX_UNAVAILABLE,
+            )
+        image = self._image_for_language(language)
+        if not self._ensure_image(image):
+            return SandboxResult(
+                ok=False,
+                value=None,
+                stdout="",
+                stderr="",
+                exit_code=None,
+                duration_ms=0,
+                language=language,
+                runner=self._runner_for_language(language),
+                memory_mb=memory_mb,
+                error=_IMAGE_UNAVAILABLE.format(image=image),
+            )
+
+        with tempfile.TemporaryDirectory(prefix="fagi-code-") as tmp:
+            workdir = Path(tmp)
+            try:
+                (workdir / "inputs.json").write_text(
+                    json.dumps(inputs), encoding="utf-8"
+                )
+            except (OSError, TypeError) as exc:
+                return SandboxResult(
+                    ok=False,
+                    value=None,
+                    stdout="",
+                    stderr="",
+                    exit_code=None,
+                    duration_ms=0,
+                    language=language,
+                    runner=self._runner_for_language(language),
+                    memory_mb=memory_mb,
+                    error=f"INPUT_SERIALIZATION_FAILED: {exc}",
+                )
+            script_path, command = self._write_runner(workdir, language, code)
+            container_name = f"fagi-code-{uuid.uuid4().hex}"
+            docker_cmd = [
+                "docker",
+                "run",
+                "--rm",
+                "--name",
+                container_name,
+                "--network",
+                "none",
+                "--memory",
+                f"{memory_mb}m",
+                "--cpus",
+                "1",
+                "--pids-limit",
+                "64",
+                "--cap-drop",
+                "ALL",
+                "--security-opt",
+                "no-new-privileges",
+                "--user",
+                "65534:65534",
+                "--read-only",
+                "--tmpfs",
+                "/tmp:rw,nosuid,nodev,noexec,size=16m",
+                "-v",
+                f"{workdir.resolve()}:/workspace:ro",
+                "-w",
+                "/workspace",
+                image,
+                *command,
+                f"/workspace/{script_path.name}",
+            ]
+            started = time.monotonic()
+            try:
+                completed = subprocess.run(
+                    docker_cmd,
+                    capture_output=True,
+                    check=False,
+                    text=True,
+                    timeout=timeout_ms / 1000,
+                )
+                duration_ms = int((time.monotonic() - started) * 1000)
+            except subprocess.TimeoutExpired as exc:
+                self._remove_container(container_name)
+                return SandboxResult(
+                    ok=False,
+                    value=None,
+                    stdout=exc.stdout or "",
+                    stderr=exc.stderr or "",
+                    exit_code=None,
+                    duration_ms=int((time.monotonic() - started) * 1000),
+                    language=language,
+                    runner=self._runner_for_language(language),
+                    timed_out=True,
+                    memory_mb=memory_mb,
+                    error=f"TIMEOUT: execution exceeded {timeout_ms} ms.",
+                )
+            except OSError as exc:
+                return SandboxResult(
+                    ok=False,
+                    value=None,
+                    stdout="",
+                    stderr=str(exc),
+                    exit_code=None,
+                    duration_ms=int((time.monotonic() - started) * 1000),
+                    language=language,
+                    runner=self._runner_for_language(language),
+                    memory_mb=memory_mb,
+                    error=f"SANDBOX_EXECUTION_FAILED: {exc}",
+                )
+
+            stdout, value, found_marker = self._parse_stdout(completed.stdout)
+            error = None if completed.returncode == 0 else completed.stderr.strip()
+            if completed.returncode != 0 and not error:
+                error = "Execution failed without stderr."
+            if completed.returncode == 0 and not found_marker:
+                error = "Execution completed without runner result marker."
+
+            return SandboxResult(
+                ok=completed.returncode == 0 and found_marker,
+                value=value,
+                stdout=stdout,
+                stderr=completed.stderr,
+                exit_code=completed.returncode,
+                duration_ms=duration_ms,
+                language=language,
+                runner=self._runner_for_language(language),
+                memory_mb=memory_mb,
+                error=error,
+            )
+
+    def _write_runner(
+        self, workdir: Path, language: str, code: str
+    ) -> tuple[Path, list[str]]:
+        if language == "python":
+            path = workdir / "runner.py"
+            path.write_text(self._python_wrapper(code), encoding="utf-8")
+            return path, ["python"]
+
+        extension = "ts" if language == "typescript" else "mjs"
+        path = workdir / f"runner.{extension}"
+        path.write_text(self._node_wrapper(code), encoding="utf-8")
+        if language == "typescript":
+            return path, ["node", "--experimental-strip-types"]
+        return path, ["node"]
+
+    def _image_for_language(self, language: str) -> str:
+        if language == "python":
+            return os.environ.get(
+                "FAGI_CODE_EXECUTION_PYTHON_IMAGE", "python:3.12-alpine"
+            )
+        return os.environ.get("FAGI_CODE_EXECUTION_NODE_IMAGE", "node:22-alpine")
+
+    def _runner_for_language(self, language: str) -> str | None:
+        if language == "python":
+            return "python"
+        if language in {"javascript", "typescript"}:
+            return "node"
+        return None
+
+    def _ensure_image(self, image: str) -> bool:
+        if self._image_exists(image):
+            return True
+        return self._pull_image(image)
+
+    def _image_exists(self, image: str) -> bool:
+        try:
+            completed = subprocess.run(
+                ["docker", "image", "inspect", image],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=3,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return completed.returncode == 0
+
+    def _pull_image(self, image: str) -> bool:
+        timeout_ms = self._image_pull_timeout_ms()
+        try:
+            completed = subprocess.run(
+                ["docker", "pull", image],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=timeout_ms / 1000,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return completed.returncode == 0
+
+    def _image_pull_timeout_ms(self) -> int:
+        raw_timeout = os.environ.get("FAGI_CODE_EXECUTION_IMAGE_PULL_TIMEOUT_MS")
+        if raw_timeout is None:
+            return _IMAGE_PULL_TIMEOUT_MS
+        try:
+            timeout_ms = int(raw_timeout)
+        except ValueError:
+            return _IMAGE_PULL_TIMEOUT_MS
+        return max(1000, timeout_ms)
+
+    def _python_wrapper(self, code: str) -> str:
+        return "\n".join(
+            [
+                "import json",
+                "import os",
+                "import sys",
+                "import traceback",
+                "inputs = json.load(open('/workspace/inputs.json', encoding='utf-8'))",
+                "scope = {'inputs': inputs, 'result': None}",
+                "def _emit(payload, exit_code):",
+                "    sys.__stdout__.write('__FAGI_CODE_RESULT__' + json.dumps(payload, default=str) + '\\n')",
+                "    sys.__stdout__.flush()",
+                "    os._exit(exit_code)",
+                "try:",
+                f"    exec(compile({code!r}, '<code_execution>', 'exec'), scope)",
+                "    payload = {'ok': True, 'result': scope.get('result')}",
+                "    _emit(payload, 0)",
+                "except Exception:",
+                "    error = traceback.format_exc()",
+                "    sys.__stderr__.write(error)",
+                "    sys.__stderr__.flush()",
+                "    _emit({'ok': False, 'error': error}, 1)",
+            ]
+        )
+
+    def _node_wrapper(self, code: str) -> str:
+        return "\n".join(
+            [
+                "import { readFileSync } from 'node:fs';",
+                "const writeStdout = process.stdout.write.bind(process.stdout);",
+                "const writeStderr = process.stderr.write.bind(process.stderr);",
+                "const inputs = JSON.parse(readFileSync('/workspace/inputs.json', 'utf8'));",
+                "let result = null;",
+                "const emit = (payload, exitCode) => {",
+                "  writeStdout('__FAGI_CODE_RESULT__' + JSON.stringify(payload) + '\\n');",
+                "  process.exit(exitCode);",
+                "};",
+                "try {",
+                "  result = await (async () => {",
+                code,
+                "    return typeof result === 'undefined' ? null : result;",
+                "  })();",
+                "  emit({ ok: true, result }, 0);",
+                "} catch (error) {",
+                "  const message = String(error?.stack || error);",
+                "  writeStderr(message + '\\n');",
+                "  emit({ ok: false, error: message }, 1);",
+                "}",
+            ]
+        )
+
+    def _parse_stdout(self, stdout: str) -> tuple[str, Any, bool]:
+        lines = stdout.splitlines()
+        marker_index = None
+        payload = None
+        for index in range(len(lines) - 1, -1, -1):
+            line = lines[index]
+            if not line.startswith(_RESULT_MARKER):
+                continue
+            try:
+                payload = json.loads(line[len(_RESULT_MARKER) :])
+            except json.JSONDecodeError:
+                continue
+            marker_index = index
+            break
+        if marker_index is None:
+            return stdout, None, False
+        visible_stdout = "\n".join([*lines[:marker_index], *lines[marker_index + 1 :]])
+        return visible_stdout, payload.get("result"), True
+
+    def _remove_container(self, container_name: str) -> None:
+        try:
+            subprocess.run(
+                ["docker", "rm", "-f", container_name],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+        except OSError:
+            pass
+
+
+class CodeExecutionRunner(BaseNodeRunner):
+    """Run code_execution nodes through the configured sandbox adapter."""
+
+    def __init__(self, sandbox: DockerCodeSandbox | None = None) -> None:
+        self.sandbox = sandbox or DockerCodeSandbox()
+
+    def run(
+        self,
+        config: dict[str, Any],
+        inputs: dict[str, Any],
+        execution_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        config = _validate_config(config)
+
+        result = self.sandbox.run(
+            language=config["language"],
+            code=config["code"],
+            inputs=inputs,
+            timeout_ms=int(config.get("timeout_ms") or 5000),
+            memory_mb=int(config.get("memory_mb") or 128),
+        )
+        if not result.ok and execution_context.get("raise_on_error", True):
+            raise CodeExecutionError(result)
+        return {"result": _result_payload(result)}
+
+
+def _validate_config(config: dict[str, Any]) -> dict[str, Any]:
+    if config is not None and not isinstance(config, dict):
+        raise ValueError("Invalid code execution config: config must be an object")
+    normalized = {**_CONFIG_DEFAULTS, **(config or {})}
+    try:
+        validate_json_schema(normalized, _CONFIG_SCHEMA)
+    except JsonSchemaValidationError as exc:
+        raise ValueError(f"Invalid code execution config: {exc.message}") from exc
+    return normalized
+
+
+def _result_payload(result: SandboxResult) -> dict[str, Any]:
+    return {
+        "ok": result.ok,
+        "value": result.value,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "exit_code": result.exit_code,
+        "duration_ms": result.duration_ms,
+        "error": result.error,
+        "metadata": {
+            "language": result.language,
+            "runner": result.runner,
+            "timed_out": result.timed_out,
+            "memory_mb": result.memory_mb,
+        },
+    }
+
+
+register_runner("code_execution", CodeExecutionRunner())

--- a/futureagi/agent_playground/services/engine/runners/code_execution.py
+++ b/futureagi/agent_playground/services/engine/runners/code_execution.py
@@ -37,6 +37,7 @@ _SANDBOX_UNAVAILABLE = (
 _IMAGE_UNAVAILABLE = "SANDBOX_UNAVAILABLE: Docker image '{image}' is not available and could not be pulled."
 _IMAGE_PULL_TIMEOUT_MS = 120000
 _OUTPUT_LIMIT_BYTES = 131072
+_RESULT_TAIL_BYTES = 65536
 
 
 @dataclass(frozen=True)
@@ -61,6 +62,7 @@ class SandboxResult:
 class BoundedProcessResult:
     returncode: int | None
     stdout: str
+    stdout_for_parser: str
     stderr: str
     stdout_truncated: bool
     stderr_truncated: bool
@@ -240,7 +242,10 @@ class DockerCodeSandbox:
                     error=f"SANDBOX_EXECUTION_FAILED: {exc}",
                 )
 
-            stdout, value, found_marker = self._parse_stdout(completed.stdout)
+            payload, found_marker = self._parse_result_payload(
+                completed.stdout_for_parser
+            )
+            stdout = self._strip_result_marker(completed.stdout)
             error = None if completed.returncode == 0 else completed.stderr.strip()
             if completed.returncode != 0 and not error:
                 error = "Execution failed without stderr."
@@ -249,7 +254,7 @@ class DockerCodeSandbox:
 
             return SandboxResult(
                 ok=completed.returncode == 0 and found_marker,
-                value=value,
+                value=payload.get("result") if payload else None,
                 stdout=stdout,
                 stderr=completed.stderr,
                 exit_code=completed.returncode,
@@ -398,24 +403,31 @@ class DockerCodeSandbox:
             ]
         )
 
-    def _parse_stdout(self, stdout: str) -> tuple[str, Any, bool]:
-        lines = stdout.splitlines()
-        marker_index = None
-        payload = None
-        for index in range(len(lines) - 1, -1, -1):
-            line = lines[index]
-            if not line.startswith(_RESULT_MARKER):
-                continue
-            try:
-                payload = json.loads(line[len(_RESULT_MARKER) :])
-            except json.JSONDecodeError:
-                continue
-            marker_index = index
-            break
-        if marker_index is None:
-            return stdout, None, False
-        visible_stdout = "\n".join([*lines[:marker_index], *lines[marker_index + 1 :]])
-        return visible_stdout, payload.get("result"), True
+    def _parse_result_payload(self, stdout: str) -> tuple[dict[str, Any] | None, bool]:
+        marker_index = stdout.rfind(_RESULT_MARKER)
+        if marker_index == -1:
+            return None, False
+        decoder = json.JSONDecoder()
+        try:
+            payload, _ = decoder.raw_decode(stdout[marker_index + len(_RESULT_MARKER) :])
+        except json.JSONDecodeError:
+            return None, False
+        if not isinstance(payload, dict):
+            return None, False
+        return payload, True
+
+    def _strip_result_marker(self, stdout: str) -> str:
+        marker_index = stdout.rfind(_RESULT_MARKER)
+        if marker_index == -1:
+            return stdout
+        decoder = json.JSONDecoder()
+        payload_start = marker_index + len(_RESULT_MARKER)
+        try:
+            _, payload_end = decoder.raw_decode(stdout[payload_start:])
+        except json.JSONDecodeError:
+            return stdout
+        visible = stdout[:marker_index] + stdout[payload_start + payload_end :]
+        return visible.lstrip("\n") if marker_index == 0 else visible.rstrip("\n")
 
     def _remove_container(self, container_name: str) -> None:
         try:
@@ -509,12 +521,19 @@ def _run_bounded_subprocess(
 
     stdout_chunks: list[bytes] = []
     stderr_chunks: list[bytes] = []
+    stdout_tail = bytearray()
     stdout_state = {"size": 0, "truncated": False}
     stderr_state = {"size": 0, "truncated": False}
 
     stdout_thread = threading.Thread(
         target=_drain_bounded_stream,
-        args=(process.stdout, stdout_chunks, stdout_state, output_limit_bytes),
+        args=(
+            process.stdout,
+            stdout_chunks,
+            stdout_state,
+            output_limit_bytes,
+            stdout_tail,
+        ),
         daemon=True,
     )
     stderr_thread = threading.Thread(
@@ -539,6 +558,10 @@ def _run_bounded_subprocess(
     return BoundedProcessResult(
         returncode=None if timed_out else returncode,
         stdout=_coerce_subprocess_text(b"".join(stdout_chunks)),
+        stdout_for_parser=_coerce_subprocess_text(
+            b"".join(stdout_chunks)
+            + (bytes(stdout_tail) if stdout_state["truncated"] else b"")
+        ),
         stderr=_coerce_subprocess_text(b"".join(stderr_chunks)),
         stdout_truncated=stdout_state["truncated"],
         stderr_truncated=stderr_state["truncated"],
@@ -546,7 +569,13 @@ def _run_bounded_subprocess(
     )
 
 
-def _drain_bounded_stream(stream, chunks: list[bytes], state: dict, limit: int) -> None:
+def _drain_bounded_stream(
+    stream,
+    chunks: list[bytes],
+    state: dict,
+    limit: int,
+    tail: bytearray | None = None,
+) -> None:
     if stream is None:
         return
     while True:
@@ -558,6 +587,10 @@ def _drain_bounded_stream(stream, chunks: list[bytes], state: dict, limit: int) 
             chunks.append(chunk[:remaining])
         if len(chunk) > remaining:
             state["truncated"] = True
+        if tail is not None:
+            tail.extend(chunk)
+            if len(tail) > _RESULT_TAIL_BYTES:
+                del tail[: len(tail) - _RESULT_TAIL_BYTES]
         state["size"] += len(chunk)
 
 

--- a/futureagi/agent_playground/services/engine/runners/code_execution.py
+++ b/futureagi/agent_playground/services/engine/runners/code_execution.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 import uuid
 from dataclasses import dataclass
@@ -35,6 +36,7 @@ _SANDBOX_UNAVAILABLE = (
 )
 _IMAGE_UNAVAILABLE = "SANDBOX_UNAVAILABLE: Docker image '{image}' is not available and could not be pulled."
 _IMAGE_PULL_TIMEOUT_MS = 120000
+_OUTPUT_LIMIT_BYTES = 131072
 
 
 @dataclass(frozen=True)
@@ -49,7 +51,20 @@ class SandboxResult:
     runner: str | None = "python"
     timed_out: bool = False
     memory_mb: int | None = None
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+    output_limit_bytes: int | None = None
     error: str | None = None
+
+
+@dataclass(frozen=True)
+class BoundedProcessResult:
+    returncode: int | None
+    stdout: str
+    stderr: str
+    stdout_truncated: bool
+    stderr_truncated: bool
+    timed_out: bool
 
 
 class CodeExecutionError(RuntimeError):
@@ -111,6 +126,7 @@ class DockerCodeSandbox:
                 language=language,
                 runner=self._runner_for_language(language),
                 memory_mb=memory_mb,
+                output_limit_bytes=self._output_limit_bytes(),
                 error=_SANDBOX_UNAVAILABLE,
             )
         image = self._image_for_language(language)
@@ -125,6 +141,7 @@ class DockerCodeSandbox:
                 language=language,
                 runner=self._runner_for_language(language),
                 memory_mb=memory_mb,
+                output_limit_bytes=self._output_limit_bytes(),
                 error=_IMAGE_UNAVAILABLE.format(image=image),
             )
 
@@ -145,6 +162,7 @@ class DockerCodeSandbox:
                     language=language,
                     runner=self._runner_for_language(language),
                     memory_mb=memory_mb,
+                    output_limit_bytes=self._output_limit_bytes(),
                     error=f"INPUT_SERIALIZATION_FAILED: {exc}",
                 )
             script_path, command = self._write_runner(workdir, language, code)
@@ -181,30 +199,32 @@ class DockerCodeSandbox:
                 f"/workspace/{script_path.name}",
             ]
             started = time.monotonic()
+            output_limit_bytes = self._output_limit_bytes()
             try:
-                completed = subprocess.run(
+                completed = _run_bounded_subprocess(
                     docker_cmd,
-                    capture_output=True,
-                    check=False,
-                    text=True,
                     timeout=timeout_ms / 1000,
+                    output_limit_bytes=output_limit_bytes,
                 )
                 duration_ms = int((time.monotonic() - started) * 1000)
-            except subprocess.TimeoutExpired as exc:
-                self._remove_container(container_name)
-                return SandboxResult(
-                    ok=False,
-                    value=None,
-                    stdout=_coerce_subprocess_text(exc.stdout),
-                    stderr=_coerce_subprocess_text(exc.stderr),
-                    exit_code=None,
-                    duration_ms=int((time.monotonic() - started) * 1000),
-                    language=language,
-                    runner=self._runner_for_language(language),
-                    timed_out=True,
-                    memory_mb=memory_mb,
-                    error=f"TIMEOUT: execution exceeded {timeout_ms} ms.",
-                )
+                if completed.timed_out:
+                    self._remove_container(container_name)
+                    return SandboxResult(
+                        ok=False,
+                        value=None,
+                        stdout=completed.stdout,
+                        stderr=completed.stderr,
+                        exit_code=None,
+                        duration_ms=duration_ms,
+                        language=language,
+                        runner=self._runner_for_language(language),
+                        timed_out=True,
+                        memory_mb=memory_mb,
+                        stdout_truncated=completed.stdout_truncated,
+                        stderr_truncated=completed.stderr_truncated,
+                        output_limit_bytes=output_limit_bytes,
+                        error=f"TIMEOUT: execution exceeded {timeout_ms} ms.",
+                    )
             except OSError as exc:
                 return SandboxResult(
                     ok=False,
@@ -216,6 +236,7 @@ class DockerCodeSandbox:
                     language=language,
                     runner=self._runner_for_language(language),
                     memory_mb=memory_mb,
+                    output_limit_bytes=output_limit_bytes,
                     error=f"SANDBOX_EXECUTION_FAILED: {exc}",
                 )
 
@@ -236,6 +257,9 @@ class DockerCodeSandbox:
                 language=language,
                 runner=self._runner_for_language(language),
                 memory_mb=memory_mb,
+                stdout_truncated=completed.stdout_truncated,
+                stderr_truncated=completed.stderr_truncated,
+                output_limit_bytes=output_limit_bytes,
                 error=error,
             )
 
@@ -312,6 +336,16 @@ class DockerCodeSandbox:
         except ValueError:
             return _IMAGE_PULL_TIMEOUT_MS
         return max(1000, timeout_ms)
+
+    def _output_limit_bytes(self) -> int:
+        raw_limit = os.environ.get("FAGI_CODE_EXECUTION_OUTPUT_LIMIT_BYTES")
+        if raw_limit is None:
+            return _OUTPUT_LIMIT_BYTES
+        try:
+            limit = int(raw_limit)
+        except ValueError:
+            return _OUTPUT_LIMIT_BYTES
+        return max(1024, limit)
 
     def _python_wrapper(self, code: str) -> str:
         return "\n".join(
@@ -446,6 +480,9 @@ def _result_payload(result: SandboxResult) -> dict[str, Any]:
             "runner": result.runner,
             "timed_out": result.timed_out,
             "memory_mb": result.memory_mb,
+            "stdout_truncated": result.stdout_truncated,
+            "stderr_truncated": result.stderr_truncated,
+            "output_limit_bytes": result.output_limit_bytes,
         },
     }
 
@@ -456,6 +493,72 @@ def _coerce_subprocess_text(value: str | bytes | None) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
     return value
+
+
+def _run_bounded_subprocess(
+    command: list[str],
+    *,
+    timeout: float,
+    output_limit_bytes: int,
+) -> BoundedProcessResult:
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    stdout_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
+    stdout_state = {"size": 0, "truncated": False}
+    stderr_state = {"size": 0, "truncated": False}
+
+    stdout_thread = threading.Thread(
+        target=_drain_bounded_stream,
+        args=(process.stdout, stdout_chunks, stdout_state, output_limit_bytes),
+        daemon=True,
+    )
+    stderr_thread = threading.Thread(
+        target=_drain_bounded_stream,
+        args=(process.stderr, stderr_chunks, stderr_state, output_limit_bytes),
+        daemon=True,
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+
+    timed_out = False
+    try:
+        returncode = process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        process.kill()
+        returncode = process.wait()
+
+    stdout_thread.join()
+    stderr_thread.join()
+
+    return BoundedProcessResult(
+        returncode=None if timed_out else returncode,
+        stdout=_coerce_subprocess_text(b"".join(stdout_chunks)),
+        stderr=_coerce_subprocess_text(b"".join(stderr_chunks)),
+        stdout_truncated=stdout_state["truncated"],
+        stderr_truncated=stderr_state["truncated"],
+        timed_out=timed_out,
+    )
+
+
+def _drain_bounded_stream(stream, chunks: list[bytes], state: dict, limit: int) -> None:
+    if stream is None:
+        return
+    while True:
+        chunk = stream.read(8192)
+        if not chunk:
+            return
+        remaining = limit - state["size"]
+        if remaining > 0:
+            chunks.append(chunk[:remaining])
+        if len(chunk) > remaining:
+            state["truncated"] = True
+        state["size"] += len(chunk)
 
 
 register_runner("code_execution", CodeExecutionRunner())

--- a/futureagi/agent_playground/services/engine/runners/code_execution.py
+++ b/futureagi/agent_playground/services/engine/runners/code_execution.py
@@ -195,8 +195,8 @@ class DockerCodeSandbox:
                 return SandboxResult(
                     ok=False,
                     value=None,
-                    stdout=exc.stdout or "",
-                    stderr=exc.stderr or "",
+                    stdout=_coerce_subprocess_text(exc.stdout),
+                    stderr=_coerce_subprocess_text(exc.stderr),
                     exit_code=None,
                     duration_ms=int((time.monotonic() - started) * 1000),
                     language=language,
@@ -251,6 +251,9 @@ class DockerCodeSandbox:
         path = workdir / f"runner.{extension}"
         path.write_text(self._node_wrapper(code), encoding="utf-8")
         if language == "typescript":
+            (workdir / "package.json").write_text(
+                json.dumps({"type": "module"}), encoding="utf-8"
+            )
             return path, ["node", "--experimental-strip-types"]
         return path, ["node"]
 
@@ -445,6 +448,14 @@ def _result_payload(result: SandboxResult) -> dict[str, Any]:
             "memory_mb": result.memory_mb,
         },
     }
+
+
+def _coerce_subprocess_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
 
 
 register_runner("code_execution", CodeExecutionRunner())

--- a/futureagi/agent_playground/services/node_crud.py
+++ b/futureagi/agent_playground/services/node_crud.py
@@ -8,6 +8,7 @@ import re
 from typing import Any
 from uuid import UUID
 
+import jsonschema
 import structlog
 from django.core.exceptions import ValidationError
 from django.utils import timezone
@@ -171,6 +172,7 @@ def create_node(
     node_id = data["id"]
     name = data["name"]
     position = data.get("position", {})
+    config = data.get("config") or {}
     source_node_id = data.get("source_node_id")
     prompt_data = data.get("prompt_template")
     ports_data = data.get("ports", [])
@@ -180,6 +182,7 @@ def create_node(
 
     if node_type == NodeType.ATOMIC:
         node_template = _resolve_node_template(data["node_template_id"])
+        _validate_config_against_template(node_template, config)
     elif node_type == NodeType.SUBGRAPH:
         ref_gv_id = data.get("ref_graph_version_id")
         if ref_gv_id:
@@ -193,7 +196,7 @@ def create_node(
         ref_graph_version=ref_graph_version,
         type=node_type,
         name=name,
-        config={},
+        config=config,
         position=position,
     )
     node.save(skip_validation=True)
@@ -240,6 +243,9 @@ def create_node(
     # Handle explicit FE ports (used for non-LLM atomic nodes or when FE sends ports)
     elif ports_data:
         _create_ports_from_fe_array(node, ports_data)
+        _create_ports_from_template_definition(node)
+    elif node_template:
+        _create_ports_from_template_definition(node)
 
     # Create NodeConnection if source_node_id provided
     nc = None
@@ -277,6 +283,10 @@ def update_node(
         node.name = data["name"]
     if "position" in data:
         node.position = data["position"]
+    if "config" in data:
+        node.config = data["config"] or {}
+        if node.type == NodeType.ATOMIC and node.node_template:
+            _validate_config_against_template(node.node_template, node.config)
 
     # Handle ref_graph_version_id update (subgraph nodes)
     if "ref_graph_version_id" in data:
@@ -396,6 +406,17 @@ def _resolve_node_template(node_template_id: UUID) -> NodeTemplate:
     return NodeTemplate.no_workspace_objects.get(id=node_template_id)
 
 
+def _validate_config_against_template(
+    node_template: NodeTemplate, config: dict[str, Any]
+) -> None:
+    if node_template.input_mode == PortMode.DYNAMIC:
+        return
+    try:
+        jsonschema.validate(instance=config or {}, schema=node_template.config_schema)
+    except jsonschema.ValidationError as e:
+        raise ValidationError(f"Invalid config: {e.message}") from e
+
+
 def _resolve_ref_graph_version(ref_graph_version_id: UUID) -> GraphVersion:
     return GraphVersion.no_workspace_objects.get(id=ref_graph_version_id)
 
@@ -422,7 +443,9 @@ def _resolve_or_create_pt_ptv(
 
     # Build variable_names dict from messages (model_hub convention)
     messages = prompt_data.get("messages", [])
-    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    _tf = prompt_data.get("template_format") or prompt_data.get(
+        "configuration", {}
+    ).get("template_format")
     var_names = _extract_variables(messages, template_format=_tf)
     var_names_dict = prompt_data.get("variable_names") or {v: [] for v in var_names}
     pv_metadata = prompt_data.get("metadata") or {}
@@ -618,7 +641,9 @@ def _reconcile_prompt_ports(node: Node, prompt_data: dict[str, Any]) -> None:
     """
     now = timezone.now()
     messages = prompt_data.get("messages", [])
-    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    _tf = prompt_data.get("template_format") or prompt_data.get(
+        "configuration", {}
+    ).get("template_format")
     new_vars = _extract_variables(messages, template_format=_tf)
 
     existing_input_ports = list(
@@ -675,7 +700,9 @@ def _reconcile_prompt_ports(node: Node, prompt_data: dict[str, Any]) -> None:
 def _create_ports_from_prompt(node: Node, prompt_data: dict[str, Any]) -> None:
     """Create ports for an LLM prompt node from its messages."""
     messages = prompt_data.get("messages", [])
-    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    _tf = prompt_data.get("template_format") or prompt_data.get(
+        "configuration", {}
+    ).get("template_format")
     variables = _extract_variables(messages, template_format=_tf)
 
     # Input ports for each variable
@@ -703,7 +730,9 @@ def _create_ports_from_prompt(node: Node, prompt_data: dict[str, Any]) -> None:
 def _create_input_ports_from_prompt(node: Node, prompt_data: dict[str, Any]) -> None:
     """Create input ports for an LLM prompt node from variables in messages."""
     messages = prompt_data.get("messages", [])
-    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    _tf = prompt_data.get("template_format") or prompt_data.get(
+        "configuration", {}
+    ).get("template_format")
     variables = _extract_variables(messages, template_format=_tf)
 
     for var in variables:
@@ -741,8 +770,36 @@ def _create_ports_from_fe_array(node: Node, ports_data: list[dict]) -> None:
             display_name=pd["display_name"],
             direction=pd["direction"],
             data_schema=pd.get("data_schema", {}),
+            required=pd.get("required", True),
             ref_port_id=pd.get("ref_port_id"),
         ).save(skip_validation=True)
+
+
+def _create_ports_from_template_definition(node: Node) -> None:
+    """Create atomic node ports from the registered template contract."""
+    if not node.node_template:
+        return
+
+    definitions = [
+        (PortDirection.INPUT, node.node_template.input_definition),
+        (PortDirection.OUTPUT, node.node_template.output_definition),
+    ]
+    existing_keys = set(
+        Port.no_workspace_objects.filter(node=node).values_list("key", flat=True)
+    )
+    for direction, port_definitions in definitions:
+        for port_definition in port_definitions:
+            key = port_definition["key"]
+            if key in existing_keys:
+                continue
+            Port(
+                node=node,
+                key=key,
+                display_name=port_definition.get("display_name") or key,
+                direction=direction,
+                data_schema=port_definition.get("data_schema", {}),
+                required=port_definition.get("required", True),
+            ).save(skip_validation=True)
 
 
 def _create_subgraph_ports(node: Node, ref_graph_version: GraphVersion) -> None:
@@ -1079,7 +1136,9 @@ def _replace_output_ports(node: Node, ports_data: list[dict]) -> None:
     _create_ports_from_fe_array(node, ports_data)
 
 
-def _extract_variables(messages: list[dict], template_format: str | None = None) -> list[str]:
+def _extract_variables(
+    messages: list[dict], template_format: str | None = None
+) -> list[str]:
     """Extract unique variable names from message contents, preserving order.
 
     When template_format is "jinja" or "jinja2", uses Jinja2 AST analysis to

--- a/futureagi/agent_playground/services/node_crud.py
+++ b/futureagi/agent_playground/services/node_crud.py
@@ -130,7 +130,16 @@ def _auto_create_edges_for_node(
                             )
             else:
                 # Simple variable: match by display_name
-                out_port = output_ports_by_name.get(in_port.display_name)
+                if node.node_template and node.node_template.name == "code_execution":
+                    out_port = (
+                        Port.no_workspace_objects.filter(
+                            node=nc.source_node, direction=PortDirection.OUTPUT
+                        )
+                        .order_by("created_at")
+                        .first()
+                    )
+                else:
+                    out_port = output_ports_by_name.get(in_port.display_name)
                 if out_port:
                     try:
                         Edge(

--- a/futureagi/agent_playground/templates/_registry.py
+++ b/futureagi/agent_playground/templates/_registry.py
@@ -28,6 +28,7 @@ def register_template(definition: TemplateDefinition) -> None:
 def get_all_templates() -> dict[str, TemplateDefinition]:
     """Import all template modules and return a copy of the registry."""
     # Import template modules to trigger registration
+    import agent_playground.templates.code_execution  # noqa: F401
     import agent_playground.templates.llm_prompt  # noqa: F401
 
     return dict(_TEMPLATE_REGISTRY)

--- a/futureagi/agent_playground/templates/code_execution.py
+++ b/futureagi/agent_playground/templates/code_execution.py
@@ -24,7 +24,15 @@ CODE_EXECUTION_RESULT_SCHEMA = {
         "metadata": {
             "type": "object",
             "additionalProperties": False,
-            "required": ["language", "runner", "timed_out", "memory_mb"],
+            "required": [
+                "language",
+                "runner",
+                "timed_out",
+                "memory_mb",
+                "stdout_truncated",
+                "stderr_truncated",
+                "output_limit_bytes",
+            ],
             "properties": {
                 "language": {
                     "type": "string",
@@ -33,6 +41,11 @@ CODE_EXECUTION_RESULT_SCHEMA = {
                 "runner": {"anyOf": [{"type": "string"}, {"type": "null"}]},
                 "timed_out": {"type": "boolean"},
                 "memory_mb": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+                "stdout_truncated": {"type": "boolean"},
+                "stderr_truncated": {"type": "boolean"},
+                "output_limit_bytes": {
+                    "anyOf": [{"type": "integer"}, {"type": "null"}],
+                },
             },
         },
     },

--- a/futureagi/agent_playground/templates/code_execution.py
+++ b/futureagi/agent_playground/templates/code_execution.py
@@ -1,0 +1,94 @@
+from agent_playground.templates._registry import TemplateDefinition, register_template
+
+CODE_EXECUTION_RESULT_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "ok",
+        "value",
+        "stdout",
+        "stderr",
+        "exit_code",
+        "duration_ms",
+        "error",
+        "metadata",
+    ],
+    "properties": {
+        "ok": {"type": "boolean"},
+        "value": {},
+        "stdout": {"type": "string"},
+        "stderr": {"type": "string"},
+        "exit_code": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+        "duration_ms": {"type": "integer", "minimum": 0},
+        "error": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        "metadata": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["language", "runner", "timed_out", "memory_mb"],
+            "properties": {
+                "language": {
+                    "type": "string",
+                    "enum": ["python", "javascript", "typescript"],
+                },
+                "runner": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                "timed_out": {"type": "boolean"},
+                "memory_mb": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+            },
+        },
+    },
+}
+
+CODE_EXECUTION_TEMPLATE: TemplateDefinition = {
+    "name": "code_execution",
+    "display_name": "Code Execution",
+    "description": (
+        "Run Python, JavaScript, or TypeScript in an isolated Docker sandbox. "
+        "The node receives a JSON object as inputs and emits a structured result."
+    ),
+    "icon": None,
+    "categories": ["code", "transform", "execution"],
+    "input_definition": [
+        {
+            "key": "inputs",
+            "display_name": "inputs",
+            "data_schema": {"type": "object"},
+            "required": False,
+        }
+    ],
+    "output_definition": [
+        {
+            "key": "result",
+            "display_name": "result",
+            "data_schema": CODE_EXECUTION_RESULT_SCHEMA,
+            "required": True,
+        }
+    ],
+    "input_mode": "strict",
+    "output_mode": "strict",
+    "config_schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["language", "code"],
+        "properties": {
+            "language": {
+                "type": "string",
+                "enum": ["python", "javascript", "typescript"],
+            },
+            "code": {"type": "string", "minLength": 1, "maxLength": 20000},
+            "timeout_ms": {
+                "type": "integer",
+                "minimum": 100,
+                "maximum": 30000,
+                "default": 5000,
+            },
+            "memory_mb": {
+                "type": "integer",
+                "minimum": 32,
+                "maximum": 512,
+                "default": 128,
+            },
+        },
+    },
+}
+
+register_template(CODE_EXECUTION_TEMPLATE)

--- a/futureagi/agent_playground/tests/services/engine/test_code_execution_runner.py
+++ b/futureagi/agent_playground/tests/services/engine/test_code_execution_runner.py
@@ -234,18 +234,57 @@ def test_code_execution_runner_can_return_structured_error_for_test_mode():
 def test_docker_sandbox_uses_last_valid_result_marker():
     sandbox = DockerCodeSandbox()
 
-    stdout, value, found_marker = sandbox._parse_stdout(
-        "\n".join(
-            [
-                "__FAGI_CODE_RESULT__not-json",
-                "visible",
-                '__FAGI_CODE_RESULT__{"ok": true, "result": {"answer": 42}}',
-            ]
-        )
+    stdout = "\n".join(
+        [
+            "__FAGI_CODE_RESULT__not-json",
+            "visible",
+            '__FAGI_CODE_RESULT__{"ok": true, "result": {"answer": 42}}',
+        ]
     )
+    payload, found_marker = sandbox._parse_result_payload(stdout)
+    visible_stdout = sandbox._strip_result_marker(stdout)
 
-    assert stdout == "__FAGI_CODE_RESULT__not-json\nvisible"
-    assert value == {"answer": 42}
+    assert visible_stdout == "__FAGI_CODE_RESULT__not-json\nvisible"
+    assert payload["result"] == {"answer": 42}
+    assert found_marker is True
+
+
+def test_docker_sandbox_parses_result_marker_without_trailing_newline():
+    sandbox = DockerCodeSandbox()
+    stdout = 'debug__FAGI_CODE_RESULT__{"ok": true, "result": 7}'
+
+    payload, found_marker = sandbox._parse_result_payload(stdout)
+    visible_stdout = sandbox._strip_result_marker(stdout)
+
+    assert visible_stdout == "debug"
+    assert payload["result"] == 7
+    assert found_marker is True
+
+
+def test_docker_sandbox_parses_result_marker_from_truncated_tail(monkeypatch):
+    monkeypatch.setenv("FAGI_CODE_EXECUTION_OUTPUT_LIMIT_BYTES", "1024")
+
+    result = _run_bounded_subprocess(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                [
+                    "import sys",
+                    "sys.stdout.write('x' * 2048)",
+                    "sys.stdout.write('__FAGI_CODE_RESULT__' + '{\"ok\": true, \"result\": 5}')",
+                ]
+            ),
+        ],
+        timeout=5,
+        output_limit_bytes=1024,
+    )
+    sandbox = DockerCodeSandbox()
+    payload, found_marker = sandbox._parse_result_payload(result.stdout_for_parser)
+
+    assert result.stdout_truncated is True
+    assert len(result.stdout) == 1024
+    assert payload["result"] == 5
     assert found_marker is True
 
 
@@ -264,6 +303,7 @@ def test_docker_sandbox_fails_when_runner_marker_is_missing(monkeypatch):
         lambda *args, **kwargs: BoundedProcessResult(
             returncode=0,
             stdout="visible only",
+            stdout_for_parser="visible only",
             stderr="",
             stdout_truncated=False,
             stderr_truncated=False,
@@ -321,6 +361,7 @@ def test_docker_sandbox_pulls_missing_image_before_execution(monkeypatch):
         or BoundedProcessResult(
             returncode=0,
             stdout='__FAGI_CODE_RESULT__{"result": 1}',
+            stdout_for_parser='__FAGI_CODE_RESULT__{"result": 1}',
             stderr="",
             stdout_truncated=False,
             stderr_truncated=False,
@@ -393,6 +434,7 @@ def test_docker_sandbox_marks_timeout_metadata(monkeypatch):
         lambda *args, **kwargs: BoundedProcessResult(
             returncode=None,
             stdout="partial",
+            stdout_for_parser="partial",
             stderr="",
             stdout_truncated=False,
             stderr_truncated=False,
@@ -432,6 +474,7 @@ def test_docker_sandbox_decodes_timeout_output_bytes(monkeypatch):
         lambda *args, **kwargs: BoundedProcessResult(
             returncode=None,
             stdout="partial stdout",
+            stdout_for_parser="partial stdout",
             stderr="partial stderr",
             stdout_truncated=False,
             stderr_truncated=False,
@@ -582,6 +625,7 @@ def test_docker_sandbox_runs_with_least_privilege_flags(monkeypatch):
         or BoundedProcessResult(
             returncode=0,
             stdout='__FAGI_CODE_RESULT__{"result": 1}',
+            stdout_for_parser='__FAGI_CODE_RESULT__{"result": 1}',
             stderr="",
             stdout_truncated=False,
             stderr_truncated=False,

--- a/futureagi/agent_playground/tests/services/engine/test_code_execution_runner.py
+++ b/futureagi/agent_playground/tests/services/engine/test_code_execution_runner.py
@@ -385,6 +385,64 @@ def test_docker_sandbox_marks_timeout_metadata(monkeypatch):
     assert result.memory_mb == 64
 
 
+def test_docker_sandbox_decodes_timeout_output_bytes(monkeypatch):
+    sandbox = DockerCodeSandbox()
+
+    monkeypatch.setattr(sandbox, "available", lambda: True)
+    monkeypatch.setattr(sandbox, "_ensure_image", lambda image: True)
+    monkeypatch.setattr(
+        sandbox,
+        "_write_runner",
+        lambda workdir, language, code: (Path("runner.py"), ["python"]),
+    )
+    monkeypatch.setattr(sandbox, "_remove_container", lambda container_name: None)
+
+    import subprocess
+
+    def raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(
+            args[0],
+            timeout=1,
+            output=b"partial stdout",
+            stderr=b"partial stderr",
+        )
+
+    monkeypatch.setattr(
+        "agent_playground.services.engine.runners.code_execution.subprocess.run",
+        raise_timeout,
+    )
+
+    result = sandbox.run(
+        language="python",
+        code="while True: pass",
+        inputs={},
+        timeout_ms=1000,
+        memory_mb=64,
+    )
+
+    assert result.ok is False
+    assert result.stdout == "partial stdout"
+    assert result.stderr == "partial stderr"
+    assert isinstance(result.stdout, str)
+    assert isinstance(result.stderr, str)
+
+
+def test_typescript_runner_declares_esm_package(tmp_path):
+    sandbox = DockerCodeSandbox()
+
+    path, command = sandbox._write_runner(
+        tmp_path,
+        "typescript",
+        "const value: number = inputs.value; return value;",
+    )
+
+    assert path.name == "runner.ts"
+    assert command == ["node", "--experimental-strip-types"]
+    assert (tmp_path / "package.json").read_text(encoding="utf-8") == (
+        '{"type": "module"}'
+    )
+
+
 def test_docker_sandbox_returns_structured_failure_for_unserializable_inputs():
     sandbox = DockerCodeSandbox()
     sandbox.available = lambda: True

--- a/futureagi/agent_playground/tests/services/engine/test_code_execution_runner.py
+++ b/futureagi/agent_playground/tests/services/engine/test_code_execution_runner.py
@@ -1,12 +1,15 @@
+import sys
 from pathlib import Path
 
 import jsonschema
 
 from agent_playground.services.engine.runners.code_execution import (
+    BoundedProcessResult,
     CodeExecutionError,
     CodeExecutionRunner,
     DockerCodeSandbox,
     SandboxResult,
+    _run_bounded_subprocess,
 )
 from agent_playground.templates.code_execution import CODE_EXECUTION_TEMPLATE
 
@@ -50,6 +53,9 @@ def test_code_execution_runner_delegates_to_sandbox():
         "runner": "python",
         "timed_out": False,
         "memory_mb": None,
+        "stdout_truncated": False,
+        "stderr_truncated": False,
+        "output_limit_bytes": None,
     }
     assert sandbox.calls == [
         {
@@ -108,6 +114,9 @@ def test_code_execution_template_result_schema_matches_runner_payload():
             "runner": "node",
             "timed_out": False,
             "memory_mb": 128,
+            "stdout_truncated": False,
+            "stderr_truncated": False,
+            "output_limit_bytes": 131072,
         },
     }
 
@@ -182,6 +191,9 @@ def test_code_execution_runner_fails_graph_on_execution_error():
                     "runner": "python",
                     "timed_out": False,
                     "memory_mb": None,
+                    "stdout_truncated": False,
+                    "stderr_truncated": False,
+                    "output_limit_bytes": None,
                 },
             }
         }
@@ -248,12 +260,15 @@ def test_docker_sandbox_fails_when_runner_marker_is_missing(monkeypatch):
         lambda workdir, language, code: (Path("runner.py"), ["python"]),
     )
     monkeypatch.setattr(
-        "agent_playground.services.engine.runners.code_execution.subprocess.run",
-        lambda *args, **kwargs: type(
-            "Result",
-            (),
-            {"returncode": 0, "stdout": "visible only", "stderr": ""},
-        )(),
+        "agent_playground.services.engine.runners.code_execution._run_bounded_subprocess",
+        lambda *args, **kwargs: BoundedProcessResult(
+            returncode=0,
+            stdout="visible only",
+            stderr="",
+            stdout_truncated=False,
+            stderr_truncated=False,
+            timed_out=False,
+        ),
     )
 
     result = sandbox.run(
@@ -300,6 +315,18 @@ def test_docker_sandbox_pulls_missing_image_before_execution(monkeypatch):
         "agent_playground.services.engine.runners.code_execution.subprocess.run",
         fake_run,
     )
+    monkeypatch.setattr(
+        "agent_playground.services.engine.runners.code_execution._run_bounded_subprocess",
+        lambda command, **kwargs: commands.append(command)
+        or BoundedProcessResult(
+            returncode=0,
+            stdout='__FAGI_CODE_RESULT__{"result": 1}',
+            stderr="",
+            stdout_truncated=False,
+            stderr_truncated=False,
+            timed_out=False,
+        ),
+    )
 
     result = sandbox.run(
         language="python",
@@ -331,7 +358,7 @@ def test_docker_sandbox_returns_structured_failure_when_docker_run_cannot_start(
         raise OSError("docker disappeared")
 
     monkeypatch.setattr(
-        "agent_playground.services.engine.runners.code_execution.subprocess.run",
+        "agent_playground.services.engine.runners.code_execution._run_bounded_subprocess",
         raise_os_error,
     )
 
@@ -361,12 +388,15 @@ def test_docker_sandbox_marks_timeout_metadata(monkeypatch):
     )
     monkeypatch.setattr(sandbox, "_remove_container", lambda container_name: None)
 
-    import subprocess
-
     monkeypatch.setattr(
-        "agent_playground.services.engine.runners.code_execution.subprocess.run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            subprocess.TimeoutExpired(args[0], timeout=1, output="partial")
+        "agent_playground.services.engine.runners.code_execution._run_bounded_subprocess",
+        lambda *args, **kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout="partial",
+            stderr="",
+            stdout_truncated=False,
+            stderr_truncated=False,
+            timed_out=True,
         ),
     )
 
@@ -397,19 +427,16 @@ def test_docker_sandbox_decodes_timeout_output_bytes(monkeypatch):
     )
     monkeypatch.setattr(sandbox, "_remove_container", lambda container_name: None)
 
-    import subprocess
-
-    def raise_timeout(*args, **kwargs):
-        raise subprocess.TimeoutExpired(
-            args[0],
-            timeout=1,
-            output=b"partial stdout",
-            stderr=b"partial stderr",
-        )
-
     monkeypatch.setattr(
-        "agent_playground.services.engine.runners.code_execution.subprocess.run",
-        raise_timeout,
+        "agent_playground.services.engine.runners.code_execution._run_bounded_subprocess",
+        lambda *args, **kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout="partial stdout",
+            stderr="partial stderr",
+            stdout_truncated=False,
+            stderr_truncated=False,
+            timed_out=True,
+        ),
     )
 
     result = sandbox.run(
@@ -425,6 +452,28 @@ def test_docker_sandbox_decodes_timeout_output_bytes(monkeypatch):
     assert result.stderr == "partial stderr"
     assert isinstance(result.stdout, str)
     assert isinstance(result.stderr, str)
+
+
+def test_bounded_subprocess_drains_and_truncates_output():
+    result = _run_bounded_subprocess(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "sys.stdout.write('x' * 2048); "
+                "sys.stderr.write('y' * 2048)"
+            ),
+        ],
+        timeout=5,
+        output_limit_bytes=1024,
+    )
+
+    assert result.returncode == 0
+    assert len(result.stdout.encode("utf-8")) == 1024
+    assert len(result.stderr.encode("utf-8")) == 1024
+    assert result.stdout_truncated is True
+    assert result.stderr_truncated is True
 
 
 def test_typescript_runner_declares_esm_package(tmp_path):
@@ -526,6 +575,18 @@ def test_docker_sandbox_runs_with_least_privilege_flags(monkeypatch):
     monkeypatch.setattr(
         "agent_playground.services.engine.runners.code_execution.subprocess.run",
         fake_run,
+    )
+    monkeypatch.setattr(
+        "agent_playground.services.engine.runners.code_execution._run_bounded_subprocess",
+        lambda command, **kwargs: commands.append(command)
+        or BoundedProcessResult(
+            returncode=0,
+            stdout='__FAGI_CODE_RESULT__{"result": 1}',
+            stderr="",
+            stdout_truncated=False,
+            stderr_truncated=False,
+            timed_out=False,
+        ),
     )
 
     sandbox.run(

--- a/futureagi/agent_playground/tests/services/engine/test_code_execution_runner.py
+++ b/futureagi/agent_playground/tests/services/engine/test_code_execution_runner.py
@@ -1,0 +1,514 @@
+from pathlib import Path
+
+import jsonschema
+
+from agent_playground.services.engine.runners.code_execution import (
+    CodeExecutionError,
+    CodeExecutionRunner,
+    DockerCodeSandbox,
+    SandboxResult,
+)
+from agent_playground.templates.code_execution import CODE_EXECUTION_TEMPLATE
+
+
+class _FakeSandbox:
+    def __init__(self, result=None):
+        self.calls = []
+        self.result = result
+
+    def run(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.result or SandboxResult(
+            ok=True,
+            value={"answer": 42},
+            stdout="",
+            stderr="",
+            exit_code=0,
+            duration_ms=7,
+        )
+
+
+def test_code_execution_runner_delegates_to_sandbox():
+    sandbox = _FakeSandbox()
+    runner = CodeExecutionRunner(sandbox=sandbox)
+
+    outputs = runner.run(
+        {
+            "language": "python",
+            "code": "result = {'answer': inputs['x']}",
+            "timeout_ms": 1000,
+            "memory_mb": 64,
+        },
+        {"x": 42},
+        {"node_id": "node-1"},
+    )
+
+    assert outputs["result"]["ok"] is True
+    assert outputs["result"]["value"] == {"answer": 42}
+    assert outputs["result"]["metadata"] == {
+        "language": "python",
+        "runner": "python",
+        "timed_out": False,
+        "memory_mb": None,
+    }
+    assert sandbox.calls == [
+        {
+            "language": "python",
+            "code": "result = {'answer': inputs['x']}",
+            "inputs": {"x": 42},
+            "timeout_ms": 1000,
+            "memory_mb": 64,
+        }
+    ]
+
+
+def test_code_execution_runner_preserves_nested_value_metadata():
+    runner = CodeExecutionRunner(
+        sandbox=_FakeSandbox(
+            SandboxResult(
+                ok=True,
+                value={
+                    "value": 8,
+                    "metadata": {"row_count": 2, "source": "probe"},
+                },
+                stdout="rows 2",
+                stderr="",
+                exit_code=0,
+                duration_ms=11,
+            )
+        )
+    )
+
+    outputs = runner.run(
+        {"language": "python", "code": "result = {'value': 8}"},
+        {"inputs": {"records": [{"x": 3}, {"x": 5}]}},
+        {},
+    )
+
+    assert outputs["result"]["value"]["metadata"] == {
+        "row_count": 2,
+        "source": "probe",
+    }
+    assert outputs["result"]["stdout"] == "rows 2"
+    assert outputs["result"]["duration_ms"] == 11
+
+
+def test_code_execution_template_result_schema_matches_runner_payload():
+    schema = CODE_EXECUTION_TEMPLATE["output_definition"][0]["data_schema"]
+    payload = {
+        "ok": False,
+        "value": {"metadata": {"source": "probe"}},
+        "stdout": "visible",
+        "stderr": "traceback",
+        "exit_code": 1,
+        "duration_ms": 12,
+        "error": "traceback",
+        "metadata": {
+            "language": "javascript",
+            "runner": "node",
+            "timed_out": False,
+            "memory_mb": 128,
+        },
+    }
+
+    jsonschema.validate(payload, schema)
+
+
+def test_code_execution_runner_rejects_unsupported_language():
+    runner = CodeExecutionRunner(sandbox=_FakeSandbox())
+
+    try:
+        runner.run({"language": "ruby", "code": "puts 1"}, {}, {})
+    except ValueError as exc:
+        assert "Invalid code execution config" in str(exc)
+    else:
+        raise AssertionError("Expected unsupported language to fail before sandbox.")
+
+
+def test_code_execution_runner_rejects_invalid_resource_limits():
+    runner = CodeExecutionRunner(sandbox=_FakeSandbox())
+
+    try:
+        runner.run(
+            {"language": "python", "code": "result = 1", "memory_mb": 4096}, {}, {}
+        )
+    except ValueError as exc:
+        assert "Invalid code execution config" in str(exc)
+    else:
+        raise AssertionError("Expected invalid memory limit to fail before sandbox.")
+
+
+def test_code_execution_runner_rejects_non_object_config():
+    runner = CodeExecutionRunner(sandbox=_FakeSandbox())
+
+    try:
+        runner.run(["not", "an", "object"], {}, {})
+    except ValueError as exc:
+        assert "config must be an object" in str(exc)
+    else:
+        raise AssertionError("Expected non-object config to fail before sandbox.")
+
+
+def test_code_execution_runner_fails_graph_on_execution_error():
+    runner = CodeExecutionRunner(
+        sandbox=_FakeSandbox(
+            SandboxResult(
+                ok=False,
+                value=None,
+                stdout="",
+                stderr="boom",
+                exit_code=1,
+                duration_ms=7,
+                error="boom",
+            )
+        )
+    )
+
+    try:
+        runner.run({"language": "python", "code": "raise Exception()"}, {}, {})
+    except CodeExecutionError as exc:
+        assert str(exc) == "boom"
+        assert exc.outputs == {
+            "result": {
+                "ok": False,
+                "value": None,
+                "stdout": "",
+                "stderr": "boom",
+                "exit_code": 1,
+                "duration_ms": 7,
+                "error": "boom",
+                "metadata": {
+                    "language": "python",
+                    "runner": "python",
+                    "timed_out": False,
+                    "memory_mb": None,
+                },
+            }
+        }
+    else:
+        raise AssertionError("Expected graph execution failure.")
+
+
+def test_code_execution_runner_can_return_structured_error_for_test_mode():
+    runner = CodeExecutionRunner(
+        sandbox=_FakeSandbox(
+            SandboxResult(
+                ok=False,
+                value=None,
+                stdout="",
+                stderr="boom",
+                exit_code=1,
+                duration_ms=7,
+                error="boom",
+            )
+        )
+    )
+
+    outputs = runner.run(
+        {"language": "python", "code": "raise Exception()"},
+        {},
+        {"raise_on_error": False},
+    )
+
+    assert outputs["result"]["ok"] is False
+    assert outputs["result"]["error"] == "boom"
+    assert outputs["result"]["stdout"] == ""
+    assert outputs["result"]["stderr"] == "boom"
+    assert outputs["result"]["exit_code"] == 1
+    assert outputs["result"]["duration_ms"] == 7
+    assert outputs["result"]["metadata"]["timed_out"] is False
+
+
+def test_docker_sandbox_uses_last_valid_result_marker():
+    sandbox = DockerCodeSandbox()
+
+    stdout, value, found_marker = sandbox._parse_stdout(
+        "\n".join(
+            [
+                "__FAGI_CODE_RESULT__not-json",
+                "visible",
+                '__FAGI_CODE_RESULT__{"ok": true, "result": {"answer": 42}}',
+            ]
+        )
+    )
+
+    assert stdout == "__FAGI_CODE_RESULT__not-json\nvisible"
+    assert value == {"answer": 42}
+    assert found_marker is True
+
+
+def test_docker_sandbox_fails_when_runner_marker_is_missing(monkeypatch):
+    sandbox = DockerCodeSandbox()
+
+    monkeypatch.setattr(sandbox, "available", lambda: True)
+    monkeypatch.setattr(sandbox, "_ensure_image", lambda image: True)
+    monkeypatch.setattr(
+        sandbox,
+        "_write_runner",
+        lambda workdir, language, code: (Path("runner.py"), ["python"]),
+    )
+    monkeypatch.setattr(
+        "agent_playground.services.engine.runners.code_execution.subprocess.run",
+        lambda *args, **kwargs: type(
+            "Result",
+            (),
+            {"returncode": 0, "stdout": "visible only", "stderr": ""},
+        )(),
+    )
+
+    result = sandbox.run(
+        language="python",
+        code="result = None",
+        inputs={},
+        timeout_ms=1000,
+        memory_mb=128,
+    )
+
+    assert result.ok is False
+    assert result.stdout == "visible only"
+    assert result.error == "Execution completed without runner result marker."
+    assert result.language == "python"
+    assert result.runner == "python"
+    assert result.memory_mb == 128
+
+
+def test_docker_sandbox_pulls_missing_image_before_execution(monkeypatch):
+    sandbox = DockerCodeSandbox()
+    commands = []
+
+    monkeypatch.setattr(sandbox, "available", lambda: True)
+    monkeypatch.setattr(sandbox, "_image_exists", lambda image: False)
+    monkeypatch.setattr(
+        sandbox,
+        "_write_runner",
+        lambda workdir, language, code: (Path("runner.py"), ["python"]),
+    )
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return type(
+            "Result",
+            (),
+            {
+                "returncode": 0,
+                "stdout": '__FAGI_CODE_RESULT__{"result": 1}',
+                "stderr": "",
+            },
+        )()
+
+    monkeypatch.setattr(
+        "agent_playground.services.engine.runners.code_execution.subprocess.run",
+        fake_run,
+    )
+
+    result = sandbox.run(
+        language="python",
+        code="result = 1",
+        inputs={},
+        timeout_ms=1000,
+        memory_mb=128,
+    )
+
+    assert result.ok is True
+    assert commands[0] == ["docker", "pull", "python:3.12-alpine"]
+    assert commands[1][0:3] == ["docker", "run", "--rm"]
+
+
+def test_docker_sandbox_returns_structured_failure_when_docker_run_cannot_start(
+    monkeypatch,
+):
+    sandbox = DockerCodeSandbox()
+
+    monkeypatch.setattr(sandbox, "available", lambda: True)
+    monkeypatch.setattr(sandbox, "_ensure_image", lambda image: True)
+    monkeypatch.setattr(
+        sandbox,
+        "_write_runner",
+        lambda workdir, language, code: (Path("runner.py"), ["python"]),
+    )
+
+    def raise_os_error(*args, **kwargs):
+        raise OSError("docker disappeared")
+
+    monkeypatch.setattr(
+        "agent_playground.services.engine.runners.code_execution.subprocess.run",
+        raise_os_error,
+    )
+
+    result = sandbox.run(
+        language="python",
+        code="result = 1",
+        inputs={},
+        timeout_ms=1000,
+        memory_mb=128,
+    )
+
+    assert result.ok is False
+    assert result.exit_code is None
+    assert result.error == "SANDBOX_EXECUTION_FAILED: docker disappeared"
+    assert result.timed_out is False
+
+
+def test_docker_sandbox_marks_timeout_metadata(monkeypatch):
+    sandbox = DockerCodeSandbox()
+
+    monkeypatch.setattr(sandbox, "available", lambda: True)
+    monkeypatch.setattr(sandbox, "_ensure_image", lambda image: True)
+    monkeypatch.setattr(
+        sandbox,
+        "_write_runner",
+        lambda workdir, language, code: (Path("runner.py"), ["python"]),
+    )
+    monkeypatch.setattr(sandbox, "_remove_container", lambda container_name: None)
+
+    import subprocess
+
+    monkeypatch.setattr(
+        "agent_playground.services.engine.runners.code_execution.subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(args[0], timeout=1, output="partial")
+        ),
+    )
+
+    result = sandbox.run(
+        language="javascript",
+        code="while (true) {}",
+        inputs={},
+        timeout_ms=1000,
+        memory_mb=64,
+    )
+
+    assert result.ok is False
+    assert result.timed_out is True
+    assert result.language == "javascript"
+    assert result.runner == "node"
+    assert result.memory_mb == 64
+
+
+def test_docker_sandbox_returns_structured_failure_for_unserializable_inputs():
+    sandbox = DockerCodeSandbox()
+    sandbox.available = lambda: True
+    sandbox._ensure_image = lambda image: True
+
+    result = sandbox.run(
+        language="python",
+        code="result = 1",
+        inputs={"bad": {object()}},
+        timeout_ms=1000,
+        memory_mb=128,
+    )
+
+    assert result.ok is False
+    assert result.error.startswith("INPUT_SERIALIZATION_FAILED:")
+    assert result.memory_mb == 128
+
+
+def test_docker_sandbox_fails_before_execution_when_image_cannot_be_pulled(monkeypatch):
+    sandbox = DockerCodeSandbox()
+
+    monkeypatch.setattr(sandbox, "available", lambda: True)
+    monkeypatch.setattr(sandbox, "_image_exists", lambda image: False)
+    monkeypatch.setattr(sandbox, "_pull_image", lambda image: False)
+
+    result = sandbox.run(
+        language="python",
+        code="result = 1",
+        inputs={},
+        timeout_ms=1000,
+        memory_mb=128,
+    )
+
+    assert result.ok is False
+    assert result.error == (
+        "SANDBOX_UNAVAILABLE: Docker image 'python:3.12-alpine' is not available "
+        "and could not be pulled."
+    )
+
+
+def test_docker_sandbox_uses_safe_default_for_invalid_pull_timeout(monkeypatch):
+    sandbox = DockerCodeSandbox()
+
+    monkeypatch.setenv("FAGI_CODE_EXECUTION_IMAGE_PULL_TIMEOUT_MS", "not-an-int")
+
+    assert sandbox._image_pull_timeout_ms() == 120000
+
+
+def test_docker_sandbox_clamps_tiny_pull_timeout(monkeypatch):
+    sandbox = DockerCodeSandbox()
+
+    monkeypatch.setenv("FAGI_CODE_EXECUTION_IMAGE_PULL_TIMEOUT_MS", "1")
+
+    assert sandbox._image_pull_timeout_ms() == 1000
+
+
+def test_docker_sandbox_runs_with_least_privilege_flags(monkeypatch):
+    sandbox = DockerCodeSandbox()
+    commands = []
+
+    monkeypatch.setattr(sandbox, "available", lambda: True)
+    monkeypatch.setattr(sandbox, "_ensure_image", lambda image: True)
+    monkeypatch.setattr(
+        sandbox,
+        "_write_runner",
+        lambda workdir, language, code: (Path("runner.py"), ["python"]),
+    )
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return type(
+            "Result",
+            (),
+            {
+                "returncode": 0,
+                "stdout": '__FAGI_CODE_RESULT__{"result": 1}',
+                "stderr": "",
+            },
+        )()
+
+    monkeypatch.setattr(
+        "agent_playground.services.engine.runners.code_execution.subprocess.run",
+        fake_run,
+    )
+
+    sandbox.run(
+        language="python",
+        code="result = 1",
+        inputs={},
+        timeout_ms=1000,
+        memory_mb=128,
+    )
+
+    docker_cmd = commands[0]
+    assert "--network" in docker_cmd and "none" in docker_cmd
+    assert "--read-only" in docker_cmd
+    assert "--cap-drop" in docker_cmd and "ALL" in docker_cmd
+    assert "--security-opt" in docker_cmd and "no-new-privileges" in docker_cmd
+    assert "--pids-limit" in docker_cmd and "64" in docker_cmd
+    assert "--user" in docker_cmd and "65534:65534" in docker_cmd
+
+
+def test_docker_sandbox_fails_closed_when_daemon_is_unavailable(monkeypatch):
+    sandbox = DockerCodeSandbox()
+
+    monkeypatch.setattr(
+        "agent_playground.services.engine.runners.code_execution.shutil.which",
+        lambda executable: "docker" if executable == "docker" else None,
+    )
+    monkeypatch.setattr(
+        "agent_playground.services.engine.runners.code_execution.subprocess.run",
+        lambda *args, **kwargs: type("Result", (), {"returncode": 1})(),
+    )
+
+    result = sandbox.run(
+        language="python",
+        code="result = 1",
+        inputs={},
+        timeout_ms=1000,
+        memory_mb=128,
+    )
+
+    assert result.ok is False
+    assert (
+        result.error
+        == "SANDBOX_UNAVAILABLE: Docker is required for isolated code execution."
+    )

--- a/futureagi/agent_playground/tests/services/test_node_crud.py
+++ b/futureagi/agent_playground/tests/services/test_node_crud.py
@@ -13,20 +13,18 @@ from agent_playground.models.node_connection import NodeConnection
 from agent_playground.models.node_template import NodeTemplate
 from agent_playground.models.port import Port
 from agent_playground.models.prompt_template_node import PromptTemplateNode
+from agent_playground.serializers.node import CreateNodeSerializer
 from agent_playground.services.node_crud import (
     _build_prompt_config_snapshot,
     _create_default_output_port_from_prompt,
-    _create_edges_from_input_mappings,
     _create_input_ports_from_prompt,
     _create_subgraph_input_ports,
-    _create_subgraph_input_ports_from_mappings,
     _create_subgraph_output_ports,
     _dedupe_name,
     _extract_variables,
     _get_next_template_version,
     _output_data_schema,
     _replace_output_ports,
-    _update_subgraph_input_mappings,
     _validate_subgraph_fe_ports,
     cascade_soft_delete_node,
     cascade_soft_delete_node_connection,
@@ -94,6 +92,96 @@ class TestCreateNode:
         assert node.type == NodeType.ATOMIC
         assert node.node_template == node_template
         assert nc is None
+
+    def test_create_atomic_node_validates_template_config(
+        self, db, graph_version, user, organization, workspace
+    ):
+        template = NodeTemplate.no_workspace_objects.create(
+            name="strict_code_config",
+            display_name="Strict Code Config",
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["language", "code"],
+                "properties": {
+                    "language": {"type": "string", "enum": ["python"]},
+                    "code": {"type": "string", "minLength": 1},
+                },
+            },
+        )
+
+        with pytest.raises(ValidationError, match="Invalid config"):
+            create_node(
+                graph_version,
+                {
+                    "id": uuid.uuid4(),
+                    "type": NodeType.ATOMIC,
+                    "name": "Code Node",
+                    "node_template_id": template.id,
+                    "config": {"language": "ruby", "code": "puts 1"},
+                },
+                user,
+                organization,
+                workspace,
+            )
+
+    def test_create_atomic_node_persists_template_config(
+        self, db, graph_version, user, organization, workspace
+    ):
+        template = NodeTemplate.no_workspace_objects.create(
+            name="code_execution",
+            display_name="Code Execution",
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["language", "code"],
+                "properties": {
+                    "language": {"type": "string", "enum": ["python"]},
+                    "code": {"type": "string", "minLength": 1},
+                    "timeout_ms": {"type": "integer"},
+                },
+            },
+        )
+        config = {
+            "language": "python",
+            "code": "result = inputs",
+            "timeout_ms": 1000,
+        }
+
+        node, _ = create_node(
+            graph_version,
+            {
+                "id": uuid.uuid4(),
+                "type": NodeType.ATOMIC,
+                "name": "Code Node",
+                "node_template_id": template.id,
+                "config": config,
+            },
+            user,
+            organization,
+            workspace,
+        )
+
+        assert node.config == config
+
+    def test_create_node_serializer_preserves_atomic_config(self):
+        config = {"language": "python", "code": "result = inputs"}
+        serializer = CreateNodeSerializer(
+            data={
+                "id": uuid.uuid4(),
+                "type": NodeType.ATOMIC,
+                "name": "Code Node",
+                "node_template_id": uuid.uuid4(),
+                "config": config,
+            }
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["config"] == config
 
     def test_create_llm_node_auto_creates_pt_pv(
         self, db, graph_version, llm_node_template, user, organization, workspace
@@ -686,6 +774,47 @@ class TestUpdateNode:
         )
         assert updated.position == {"x": 42, "y": 99}
 
+    def test_update_atomic_node_validates_template_config(
+        self, db, graph_version, user, organization, workspace
+    ):
+        template = NodeTemplate.no_workspace_objects.create(
+            name="strict_update_config",
+            display_name="Strict Update Config",
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["language", "code"],
+                "properties": {
+                    "language": {"type": "string", "enum": ["python"]},
+                    "code": {"type": "string", "minLength": 1},
+                },
+            },
+        )
+        node, _ = create_node(
+            graph_version,
+            {
+                "id": uuid.uuid4(),
+                "type": NodeType.ATOMIC,
+                "name": "Code Node",
+                "node_template_id": template.id,
+                "config": {"language": "python", "code": "result = 1"},
+            },
+            user,
+            organization,
+            workspace,
+        )
+
+        with pytest.raises(ValidationError, match="Invalid config"):
+            update_node(
+                node,
+                {"config": {"language": "javascript", "code": "result = 1"}},
+                user,
+                organization,
+                workspace,
+            )
+
     def test_update_prompt_template_updates_pv(
         self,
         db,
@@ -966,7 +1095,7 @@ class TestUpdateNode:
         initial_port.save(skip_validation=True)
 
         # Create NodeConnection
-        old_nc = NodeConnection.no_workspace_objects.create(
+        NodeConnection.no_workspace_objects.create(
             graph_version=graph_version,
             source_node=old_source,
             target_node=subgraph_node,
@@ -999,7 +1128,7 @@ class TestUpdateNode:
         new_port.save(skip_validation=True)
 
         # Create NodeConnection for new source
-        new_nc = NodeConnection.no_workspace_objects.create(
+        NodeConnection.no_workspace_objects.create(
             graph_version=graph_version,
             source_node=new_source,
             target_node=subgraph_node,
@@ -1581,7 +1710,7 @@ class TestCascadeSoftDeleteNodeConnection:
         node_connection,
     ):
         # Create a NodeConnection + edge from node → third_node (unrelated to node_connection)
-        nc_to_third = NodeConnection.no_workspace_objects.create(
+        NodeConnection.no_workspace_objects.create(
             graph_version=graph_version,
             source_node=node,
             target_node=third_node,
@@ -2424,7 +2553,7 @@ class TestUpdateNodeRefGraphVersion:
         old_output.save(skip_validation=True)
 
         # Update with new output ports only
-        updated = update_node(
+        update_node(
             node,
             {
                 "ports": [
@@ -3618,7 +3747,7 @@ class TestAutoCreateEdgesForNode:
         )
 
         # Create second NodeConnection manually
-        nc2 = NodeConnection.no_workspace_objects.create(
+        NodeConnection.no_workspace_objects.create(
             graph_version=graph_version,
             source_node=source_node_2,
             target_node=target_node,

--- a/futureagi/agent_playground/tests/templates/test_seed_command.py
+++ b/futureagi/agent_playground/tests/templates/test_seed_command.py
@@ -16,12 +16,17 @@ class TestSeedNodeTemplatesCommand:
         """Running the command creates the template record."""
         call_command("seed_node_templates")
         assert NodeTemplate.no_workspace_objects.filter(name="llm_prompt").exists()
+        assert NodeTemplate.no_workspace_objects.filter(name="code_execution").exists()
 
     def test_idempotent(self, db):
         """Running the command twice produces exactly one record."""
         call_command("seed_node_templates")
         call_command("seed_node_templates")
         assert NodeTemplate.no_workspace_objects.filter(name="llm_prompt").count() == 1
+        assert (
+            NodeTemplate.no_workspace_objects.filter(name="code_execution").count()
+            == 1
+        )
 
     def test_updates_safe_fields(self, db):
         """Re-running after a safe field change updates the record."""
@@ -76,13 +81,15 @@ class TestSeedNodeTemplatesCommand:
     def test_created_template_passes_clean(self, db):
         """The seeded template passes model validation."""
         call_command("seed_node_templates")
-        template = NodeTemplate.no_workspace_objects.get(name="llm_prompt")
-        template.clean()  # should not raise
+        for name in ("llm_prompt", "code_execution"):
+            template = NodeTemplate.no_workspace_objects.get(name=name)
+            template.clean()  # should not raise
 
     def test_template_filter(self, db):
         """--template flag seeds only the specified template."""
-        call_command("seed_node_templates", template="llm_prompt")
-        assert NodeTemplate.no_workspace_objects.filter(name="llm_prompt").exists()
+        call_command("seed_node_templates", template="code_execution")
+        assert not NodeTemplate.no_workspace_objects.filter(name="llm_prompt").exists()
+        assert NodeTemplate.no_workspace_objects.filter(name="code_execution").exists()
 
     def test_template_filter_unknown(self, db):
         """--template with unknown name prints error and creates nothing."""

--- a/futureagi/agent_playground/tests/templates/test_seed_command.py
+++ b/futureagi/agent_playground/tests/templates/test_seed_command.py
@@ -93,5 +93,6 @@ class TestSeedNodeTemplatesCommand:
 
     def test_template_filter_unknown(self, db):
         """--template with unknown name prints error and creates nothing."""
+        existing_count = NodeTemplate.no_workspace_objects.count()
         call_command("seed_node_templates", template="nonexistent")
-        assert NodeTemplate.no_workspace_objects.count() == 0
+        assert NodeTemplate.no_workspace_objects.count() == existing_count

--- a/futureagi/agent_playground/tests/utils/test_version_content.py
+++ b/futureagi/agent_playground/tests/utils/test_version_content.py
@@ -418,6 +418,76 @@ class TestUpdateVersionContent:
         edges = Edge.no_workspace_objects.filter(graph_version=graph_version)
         assert edges.count() == 1
 
+    def test_auto_creates_code_execution_input_edge(self, graph, graph_version, db):
+        producer = NodeTemplate.no_workspace_objects.create(
+            name="vc_code_source",
+            display_name="Code Source",
+            description="test",
+            categories=["test"],
+            input_definition=[],
+            output_definition=[
+                {
+                    "key": "response",
+                    "display_name": "response",
+                    "data_schema": {"type": "object"},
+                },
+            ],
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={},
+        )
+        code_template, _ = NodeTemplate.no_workspace_objects.get_or_create(
+            name="code_execution",
+            defaults={
+                "display_name": "Code Execution",
+                "description": "test",
+                "categories": ["code"],
+                "input_definition": [
+                    {
+                        "key": "inputs",
+                        "display_name": "inputs",
+                        "data_schema": {"type": "object"},
+                        "required": False,
+                    },
+                ],
+                "output_definition": [],
+                "input_mode": PortMode.STRICT,
+                "output_mode": PortMode.STRICT,
+                "config_schema": {},
+            },
+        )
+        source_id = str(uuid.uuid4())
+        code_id = str(uuid.uuid4())
+
+        update_version_content(
+            graph=graph,
+            version=graph_version,
+            nodes_data=[
+                {
+                    "id": source_id,
+                    "type": NodeType.ATOMIC,
+                    "name": "source",
+                    "node_template_id": str(producer.id),
+                },
+                {
+                    "id": code_id,
+                    "type": NodeType.ATOMIC,
+                    "name": "code",
+                    "node_template_id": str(code_template.id),
+                    "config": {"language": "python", "code": "result = inputs"},
+                },
+            ],
+            new_status=GraphVersionStatus.DRAFT,
+            commit_message=None,
+            node_connections_data=[
+                {"source_node_id": source_id, "target_node_id": code_id}
+            ],
+        )
+
+        edge = Edge.no_workspace_objects.get(graph_version=graph_version)
+        assert edge.source_port.display_name == "response"
+        assert edge.target_port.display_name == "inputs"
+
     def test_no_edges_when_names_dont_match(self, graph, graph_version, db):
         """Test that no edges are created when display_names don't match."""
         producer = NodeTemplate.no_workspace_objects.create(

--- a/futureagi/agent_playground/tests/views/test_node_views.py
+++ b/futureagi/agent_playground/tests/views/test_node_views.py
@@ -7,10 +7,11 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from agent_playground.models.choices import NodeType, PortDirection
+from agent_playground.models.choices import NodeType, PortDirection, PortMode
 from agent_playground.models.edge import Edge
 from agent_playground.models.node import Node
 from agent_playground.models.node_connection import NodeConnection
+from agent_playground.models.node_template import NodeTemplate
 from agent_playground.models.port import Port
 
 # ── helpers ────────────────────────────────────────────────────────────
@@ -26,6 +27,13 @@ def _node_create_url(graph, version):
 def _node_detail_url(graph, version, node_id):
     return reverse(
         "graph-version-node-detail",
+        kwargs={"pk": graph.id, "version_id": version.id, "node_id": node_id},
+    )
+
+
+def _node_test_execution_url(graph, version, node_id):
+    return reverse(
+        "node-test-execution",
         kwargs={"pk": graph.id, "version_id": version.id, "node_id": node_id},
     )
 
@@ -54,6 +62,39 @@ class TestCreateNodeAPI:
         assert response.data["status"] is True
         assert response.data["result"]["id"] == fe_id
         assert response.data["result"]["type"] == "atomic"
+
+    def test_create_atomic_node_preserves_config(
+        self, authenticated_client, graph, graph_version
+    ):
+        template = NodeTemplate.no_workspace_objects.create(
+            name="code_execution",
+            display_name="Code Execution",
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["language", "code"],
+                "properties": {
+                    "language": {"type": "string", "enum": ["python"]},
+                    "code": {"type": "string", "minLength": 1},
+                },
+            },
+        )
+        config = {"language": "python", "code": "result = inputs"}
+        url = _node_create_url(graph, graph_version)
+        payload = {
+            "id": str(uuid.uuid4()),
+            "type": "atomic",
+            "name": "Code Node",
+            "node_template_id": str(template.id),
+            "config": config,
+        }
+
+        response = authenticated_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["result"]["config"] == config
 
     def test_create_llm_node_auto_creates_pt_pv(
         self, authenticated_client, graph, graph_version, llm_node_template
@@ -948,6 +989,70 @@ class TestNodeSyncSideEffects:
         assert response.status_code == status.HTTP_201_CREATED
 
 
+@pytest.mark.unit
+class TestCodeExecutionNodeAPI:
+    def test_test_execution_allows_missing_workspace_context(
+        self, api_client, graph, graph_version, user, organization
+    ):
+        api_client.force_authenticate(user=user)
+        api_client.set_organization(organization)
+        template = NodeTemplate.no_workspace_objects.create(
+            name="code_execution",
+            display_name="Code Execution",
+            input_mode=PortMode.STRICT,
+            output_mode=PortMode.STRICT,
+            config_schema={
+                "type": "object",
+                "required": ["language", "code"],
+                "properties": {
+                    "language": {"type": "string", "enum": ["python"]},
+                    "code": {"type": "string", "minLength": 1},
+                },
+            },
+        )
+        node = Node(
+            graph_version=graph_version,
+            type=NodeType.ATOMIC,
+            name="Code Node",
+            node_template=template,
+            config={"language": "python", "code": "result = inputs"},
+            position={},
+        )
+        node.save(skip_validation=True)
+        captured_context = {}
+
+        class FakeRunner:
+            def run(self, config, inputs, execution_context):
+                captured_context.update(execution_context)
+                return {
+                    "result": {
+                        "ok": True,
+                        "value": inputs,
+                        "stdout": "",
+                        "stderr": "",
+                        "exit_code": 0,
+                        "duration_ms": 1,
+                        "error": None,
+                    }
+                }
+
+        url = _node_test_execution_url(graph, graph_version, node.id)
+        with patch("agent_playground.views.node.get_runner", return_value=FakeRunner()):
+            response = api_client.post(
+                url,
+                {
+                    "config": {"language": "python", "code": "result = inputs"},
+                    "inputs": {"x": 1},
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert captured_context["workspace_id"] is None
+        assert response.data["result"]["result"]["value"] == {"x": 1}
+        api_client.stop_workspace_injection()
+
+
 # =====================================================================
 # NEW BEHAVIOR TESTS — subgraph without ref, PATCH with ref,
 # LLM with new prompt fields, retrieve with full expansion
@@ -1292,13 +1397,13 @@ class TestNodePossibleEdgeMappings:
         )
 
         # Create output ports
-        port_a1 = Port.no_workspace_objects.create(
+        Port.no_workspace_objects.create(
             node=node_a,
             key="output1",
             display_name="result",
             direction=PortDirection.OUTPUT,
         )
-        port_b1 = Port.no_workspace_objects.create(
+        Port.no_workspace_objects.create(
             node=node_b,
             key="output1",
             display_name="data",

--- a/futureagi/agent_playground/urls.py
+++ b/futureagi/agent_playground/urls.py
@@ -67,6 +67,7 @@ node_detail = NodeCrudViewSet.as_view(
     }
 )
 node_possible_mappings = NodeCrudViewSet.as_view({"get": "possible_edge_mappings"})
+node_test_execution = NodeCrudViewSet.as_view({"post": "test_execution"})
 port_update = PortCrudViewSet.as_view({"patch": "partial_update"})
 nc_create = NodeConnectionCrudViewSet.as_view({"post": "create"})
 nc_delete = NodeConnectionCrudViewSet.as_view({"delete": "destroy"})
@@ -151,6 +152,11 @@ urlpatterns = [
         "graphs/<uuid:pk>/versions/<uuid:version_id>/nodes/<uuid:node_id>/possible-edge-mappings/",
         node_possible_mappings,
         name="node-possible-edge-mappings",
+    ),
+    path(
+        "graphs/<uuid:pk>/versions/<uuid:version_id>/nodes/<uuid:node_id>/test-execution/",
+        node_test_execution,
+        name="node-test-execution",
     ),
     # ── Port update ──────────────────────────────────────────────────
     path(

--- a/futureagi/agent_playground/utils/version_content.py
+++ b/futureagi/agent_playground/utils/version_content.py
@@ -23,7 +23,6 @@ from agent_playground.services.engine.utils.json_path import parse_variable
 from agent_playground.services.node_crud import (
     _create_default_output_port_from_prompt,
     _create_input_ports_from_prompt,
-    _create_ports_from_prompt,
     _default_prompt_data,
     _resolve_or_create_pt_ptv,
 )
@@ -299,7 +298,19 @@ def _auto_create_edges(
                             ).save()
                 else:
                     # Simple variable: match by display_name
-                    out_port = output_ports_by_name.get(in_port.display_name)
+                    if (
+                        nc.target_node.node_template
+                        and nc.target_node.node_template.name == "code_execution"
+                    ):
+                        out_port = (
+                            Port.no_workspace_objects.filter(
+                                node=nc.source_node, direction=PortDirection.OUTPUT
+                            )
+                            .order_by("created_at")
+                            .first()
+                        )
+                    else:
+                        out_port = output_ports_by_name.get(in_port.display_name)
                     if out_port:
                         Edge(
                             graph_version=version,
@@ -314,8 +325,8 @@ def _resolve_node_template(node_template_id: str | None) -> NodeTemplate | None:
         return None
     try:
         return NodeTemplate.no_workspace_objects.get(id=node_template_id)
-    except NodeTemplate.DoesNotExist:
-        raise ValidationError(f"Node template '{node_template_id}' not found")
+    except NodeTemplate.DoesNotExist as exc:
+        raise ValidationError(f"Node template '{node_template_id}' not found") from exc
 
 
 def _resolve_ref_graph_version(ref_graph_version_id: str | None) -> GraphVersion | None:
@@ -324,10 +335,10 @@ def _resolve_ref_graph_version(ref_graph_version_id: str | None) -> GraphVersion
         return None
     try:
         return GraphVersion.no_workspace_objects.get(id=ref_graph_version_id)
-    except GraphVersion.DoesNotExist:
+    except GraphVersion.DoesNotExist as exc:
         raise ValidationError(
             f"Referenced graph version '{ref_graph_version_id}' not found"
-        )
+        ) from exc
 
 
 def create_node(
@@ -374,8 +385,8 @@ def _resolve_ref_port(ref_port_id: str | None) -> Port | None:
         return None
     try:
         return Port.no_workspace_objects.get(id=ref_port_id)
-    except Port.DoesNotExist:
-        raise ValidationError(f"Referenced port '{ref_port_id}' not found")
+    except Port.DoesNotExist as exc:
+        raise ValidationError(f"Referenced port '{ref_port_id}' not found") from exc
 
 
 def create_port(

--- a/futureagi/agent_playground/views/node.py
+++ b/futureagi/agent_playground/views/node.py
@@ -17,6 +17,7 @@ from agent_playground.serializers.node import (
     UpdateNodeSerializer,
 )
 from agent_playground.services.dataset_bridge import sync_dataset_columns
+from agent_playground.services.engine.node_runner import get_runner
 from agent_playground.services.node_crud import (
     cascade_soft_delete_node,
     create_node,
@@ -257,4 +258,48 @@ class NodeCrudViewSet(ModelViewSet):
             logger.exception("Error getting possible edge mappings", error=str(e))
             return self._gm.internal_server_error_response(
                 get_error_message("FAILED_TO_GET_EDGE_MAPPINGS")
+            )
+
+    def test_execution(self, request, pk=None, version_id=None, node_id=None):
+        """POST /graphs/{pk}/versions/{version_id}/nodes/{node_id}/test-execution/"""
+        try:
+            _, version = get_graph_and_version(request, pk, version_id)
+            node = self.get_queryset().get(id=node_id, graph_version=version)
+
+            if not node.node_template or node.node_template.name != "code_execution":
+                return self._gm.bad_request("Only code_execution nodes can be tested.")
+
+            config = request.data.get("config") or node.config or {}
+            inputs = request.data.get("inputs") or {}
+            if not isinstance(inputs, dict):
+                return self._gm.bad_request("Code execution inputs must be an object.")
+            runner = get_runner("code_execution")
+            outputs = runner.run(
+                config,
+                inputs,
+                {
+                    "node_id": str(node.id),
+                    "organization_id": str(request.organization.id),
+                    "workspace_id": (
+                        str(request.workspace.id)
+                        if getattr(request, "workspace", None)
+                        else None
+                    ),
+                    "raise_on_error": False,
+                },
+            )
+            return self._gm.success_response(outputs)
+
+        except Graph.DoesNotExist:
+            return self._gm.not_found(get_error_message("GRAPH_NOT_FOUND"))
+        except GraphVersion.DoesNotExist:
+            return self._gm.not_found(get_error_message("VERSION_NOT_FOUND"))
+        except Node.DoesNotExist:
+            return self._gm.not_found(get_error_message("NODE_NOT_FOUND"))
+        except (ValidationError, IntegrityError, ValueError) as e:
+            return self._gm.bad_request(str(e))
+        except Exception as e:
+            logger.exception("Error testing code execution node", error=str(e))
+            return self._gm.internal_server_error_response(
+                "Failed to test code execution node"
             )

--- a/futureagi/agent_playground/views/node.py
+++ b/futureagi/agent_playground/views/node.py
@@ -4,6 +4,7 @@ from django.db import IntegrityError, transaction
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
 
+import agent_playground.services.engine.runners  # noqa: F401
 from agent_playground.models.choices import PortDirection
 from agent_playground.models.graph import Graph
 from agent_playground.models.graph_version import GraphVersion

--- a/futureagi/tfc/temporal/agent_playground/activities.py
+++ b/futureagi/tfc/temporal/agent_playground/activities.py
@@ -306,6 +306,12 @@ def _execute_node_sync(
 
         except Exception as e:
             failure_outputs = getattr(e, "outputs", {}) or {}
+            node_execution.status = NodeExecutionStatus.FAILED
+            node_execution.completed_at = timezone.now()
+            node_execution.error_message = str(e)
+            node_execution.save(
+                update_fields=["status", "completed_at", "error_message"]
+            )
             if failure_outputs:
                 route_node_outputs(
                     node_id=UUID(node_id),
@@ -324,14 +330,6 @@ def _execute_node_sync(
                 outputs=failure_outputs,
                 status="FAILED",
                 metadata={"graph_execution_id": graph_execution_id, "error": str(e)},
-            )
-
-            # Mark as FAILED
-            node_execution.status = NodeExecutionStatus.FAILED
-            node_execution.completed_at = timezone.now()
-            node_execution.error_message = str(e)
-            node_execution.save(
-                update_fields=["status", "completed_at", "error_message"]
             )
 
             activity.logger.exception(f"Node {node_id} failed: {e}")

--- a/futureagi/tfc/temporal/agent_playground/activities.py
+++ b/futureagi/tfc/temporal/agent_playground/activities.py
@@ -305,6 +305,15 @@ def _execute_node_sync(
             }
 
         except Exception as e:
+            failure_outputs = getattr(e, "outputs", {}) or {}
+            if failure_outputs:
+                route_node_outputs(
+                    node_id=UUID(node_id),
+                    node_execution=node_execution,
+                    topology=topology,
+                    outputs=failure_outputs,
+                )
+
             # Call output sinks on FAILED so they can record the failure
             _call_sinks_safe(
                 resolved_sinks,
@@ -312,7 +321,7 @@ def _execute_node_sync(
                 node_name=node.name,
                 template_name=template_name,
                 inputs=locals().get("inputs", {}),
-                outputs={},
+                outputs=failure_outputs,
                 status="FAILED",
                 metadata={"graph_execution_id": graph_execution_id, "error": str(e)},
             )
@@ -329,7 +338,7 @@ def _execute_node_sync(
             return {
                 "node_id": node_id,
                 "status": "FAILED",
-                "outputs": {},
+                "outputs": failure_outputs,
                 "error": str(e),
             }
 
@@ -655,9 +664,8 @@ def _setup_module_execution_sync(
             store_node_inputs,
         )
 
-        # Get parent topology and module node
+        # Get parent topology
         parent_topology = GraphTopology.from_dict(topology_data)
-        module_node = parent_topology.get_node(UUID(module_node_id))
 
         # Get child graph version ID
         child_graph_version_id = parent_topology.get_module_child_graph_version_id(
@@ -768,11 +776,8 @@ def _finalize_module_execution_sync(
     close_old_connections()
 
     try:
-        from agent_playground.models import GraphExecution, NodeExecution
-        from agent_playground.models.choices import (
-            GraphExecutionStatus,
-            NodeExecutionStatus,
-        )
+        from agent_playground.models import NodeExecution
+        from agent_playground.models.choices import NodeExecutionStatus
         from agent_playground.services.engine import (
             GraphAnalyzer,
             GraphTopology,

--- a/futureagi/tfc/temporal/agent_playground/tests/test_e2e_workflow.py
+++ b/futureagi/tfc/temporal/agent_playground/tests/test_e2e_workflow.py
@@ -35,7 +35,6 @@ from agent_playground.services.engine.output_sink import get_sink
 from tfc.temporal.agent_playground.activities import ALL_ACTIVITIES
 from tfc.temporal.agent_playground.types import (
     ExecuteGraphInput,
-    ExecuteNodeStandaloneInput,
     OutputSinkConfig,
 )
 from tfc.temporal.agent_playground.workflows import GraphExecutionWorkflow
@@ -358,6 +357,65 @@ class TestFailurePropagation:
         assert node_execs["B"].status == NodeExecutionStatus.FAILED
         assert node_execs["C"].status == NodeExecutionStatus.SUCCESS
         assert node_execs["D"].status == NodeExecutionStatus.SKIPPED
+
+    async def test_failure_outputs_route_after_failed_state(
+        self, workflow_environment, graph_builder, monkeypatch
+    ):
+        """Failure payload routing must observe the persisted FAILED node state."""
+        from agent_playground.services.engine.analyzer import GraphAnalyzer
+        from agent_playground.services.engine.node_runner import (
+            BaseNodeRunner,
+            register_runner,
+        )
+        from tfc.temporal.agent_playground.activities import _execute_node_sync
+
+        class FailureWithOutputs(Exception):
+            outputs = {"result": {"ok": False, "error": "boom"}}
+
+        class FailureOutputRunner(BaseNodeRunner):
+            def run(self, config, inputs, execution_context):
+                raise FailureWithOutputs("boom")
+
+        register_runner("failure_output_template", FailureOutputRunner())
+
+        builder = graph_builder
+        builder.add_node(
+            "A",
+            template_name="failure_output_template",
+            inputs=["user_input"],
+            outputs=["result"],
+        )
+        version = await sync_to_async(builder.build)()
+        execution = await _create_graph_execution(version, {"user_input": "hello"})
+        topology_data = await sync_to_async(
+            lambda: GraphAnalyzer.analyze(version.id).to_dict()
+        )()
+        node_id = await sync_to_async(
+            lambda: str(version.nodes.get(name="A").id)
+        )()
+
+        import agent_playground.services.engine as engine
+
+        original_route_node_outputs = engine.route_node_outputs
+        observed_statuses = []
+
+        def route_spy(*args, **kwargs):
+            node_execution = kwargs["node_execution"]
+            node_execution.refresh_from_db()
+            observed_statuses.append(node_execution.status)
+            return original_route_node_outputs(*args, **kwargs)
+
+        monkeypatch.setattr(engine, "route_node_outputs", route_spy)
+
+        result = await sync_to_async(_execute_node_sync)(
+            str(execution.id),
+            str(version.id),
+            node_id,
+            topology_data=topology_data,
+        )
+
+        assert result["status"] == "FAILED"
+        assert observed_statuses == [NodeExecutionStatus.FAILED]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds a Agent Playground `code_execution` node for Python, JavaScript, and TypeScript transforms over JSON inputs.

The node uses the existing template, `Node.config`, runner registry, CRUD, graph-version payload, route, and React Flow form surfaces. Execution is Docker-isolated and fail-closed with daemon probing, image preflight, no network, read-only root/code mount, tmpfs scratch, dropped capabilities, `no-new-privileges`, non-root UID, process/memory/CPU bounds, and explicit timeout handling.

This also validates non-dynamic atomic node config against the owning `NodeTemplate.config_schema` before create/update persistence. The `result` output port now exposes the canonical runner-envelope schema, and the drawer test action accepts explicit JSON-object inputs.

## Linked issues

Closes #27

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)


## How was this tested?

- Backend `ruff check` on changed Python files
- Backend `compileall` / `py_compile` on changed Python files
- Targeted frontend ESLint and Prettier checks
- Agent Playground frontend Vitest suite: `576 passed`
- Targeted drift-pass Vitest: `67 passed`
- Vite production build passed
- `git diff --check`
- `CODE_EXECUTION_TEMPLATE` imports
- Live Docker adapter proof against Docker daemon `29.1.3` with `python:3.12-alpine`, `node:22-alpine`, and TypeScript-on-Node
- Sandbox matrix covered image preflight, nested JSON transforms, async JavaScript, TypeScript reduce, marker-spoofing attempts, denied network path, read-only `/workspace`, timeout failure, structured graph-mode failure payload retention, and graph-mode exception propagation

The new CRUD/view/runner tests are included and compile successfully.

## Screenshots / recordings (if UI)

Not attached. The UI change is the Agent Playground node configuration drawer for the new Code Execution node, including language/resource controls, Monaco editor, save flow, and test-execution action.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)