### PR TITLE
fix(annotations): voice queue source and call UI regressions

### DIFF
--- a/frontend/src/api/scores/__tests__/scores.test.js
+++ b/frontend/src/api/scores/__tests__/scores.test.js
@@ -1,0 +1,79 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import axios from "src/utils/axios";
+import { useBulkCreateScores } from "../scores";
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+function createQueryWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function QueryWrapper({ children }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  }
+
+  QueryWrapper.propTypes = {
+    children: PropTypes.node,
+  };
+
+  return QueryWrapper;
+}
+
+describe("Scores API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useBulkCreateScores", () => {
+    it("sends trace scores with a separate span notes source", async () => {
+      axios.post.mockResolvedValueOnce({
+        data: { result: { scores: [], errors: [] } },
+      });
+
+      const { result } = renderHook(() => useBulkCreateScores(), {
+        wrapper: createQueryWrapper(),
+      });
+
+      result.current.mutate({
+        sourceType: "trace",
+        sourceId: "trace-1",
+        scores: [{ label_id: "label-1", value: { value: "up" } }],
+        spanNotes: "whole item note",
+        includeSpanNotes: true,
+        spanNotesSourceId: "span-1",
+      });
+
+      await waitFor(() => {
+        expect(axios.post).toHaveBeenCalledWith("/model-hub/scores/bulk/", {
+          source_type: "trace",
+          source_id: "trace-1",
+          scores: [{ label_id: "label-1", value: { value: "up" } }],
+          notes: "",
+          score_source: "human",
+          span_notes: "whole item note",
+          span_notes_source_id: "span-1",
+        });
+      });
+    });
+  });
+});

--- a/frontend/src/api/scores/scores.js
+++ b/frontend/src/api/scores/scores.js
@@ -95,19 +95,28 @@ export const useCreateScore = () => {
 export const useBulkCreateScores = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ sourceType, sourceId, scores, notes, spanNotes, scoreSource }) => {
+    mutationFn: ({
+      sourceType,
+      sourceId,
+      scores,
+      notes,
+      spanNotes,
+      includeSpanNotes = false,
+      spanNotesSourceId,
+      scoreSource,
+    }) => {
       const payload = {
         source_type: sourceType,
         source_id: sourceId,
         scores,
-        notes,
+        notes: notes || "",
         score_source: scoreSource || "human",
       };
-      // Only include span_notes when the user has actually typed something.
-      // Omitting it entirely prevents the backend from treating an empty
-      // submission as an intentional delete of an existing SpanNote.
-      if (spanNotes) {
-        payload.span_notes = spanNotes;
+      if (includeSpanNotes || spanNotes) {
+        payload.span_notes = spanNotes || "";
+        if (spanNotesSourceId) {
+          payload.span_notes_source_id = spanNotesSourceId;
+        }
       }
       return axios.post("/model-hub/scores/bulk/", payload);
     },
@@ -136,9 +145,16 @@ export const useBulkCreateScores = () => {
       queryClient.invalidateQueries({
         queryKey: scoreKeys.forSource(variables.sourceType, variables.sourceId),
       });
-      queryClient.invalidateQueries({
-        queryKey: ["span-notes", variables.sourceId],
-      });
+      const spanNotesSourceId =
+        variables.spanNotesSourceId ||
+        (variables.sourceType === "observation_span"
+          ? variables.sourceId
+          : null);
+      if (spanNotesSourceId) {
+        queryClient.invalidateQueries({
+          queryKey: ["span-notes", spanNotesSourceId],
+        });
+      }
       // Invalidate queue items for this specific source in case queue items got auto-completed
       queryClient.invalidateQueries({
         queryKey: ["annotation-queues", "for-source"],

--- a/frontend/src/components/CallLogsDetailDrawer/CallLogsDetailDrawer.jsx
+++ b/frontend/src/components/CallLogsDetailDrawer/CallLogsDetailDrawer.jsx
@@ -22,6 +22,7 @@ import AnnotationSidebarContent from "src/components/traceDetailDrawer/Annotatio
 import AddLabelDrawer from "src/components/traceDetailDrawer/AddLabelDrawer";
 import { useParams } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
+import { buildVoiceCallAnnotationSources } from "src/components/voiceAnnotationSources";
 // import ErrorAnalysis from "src/sections/traceDetailDrawer/ErrorAnalysis";
 
 const CallLogSideDrawerChild = ({ data }) => {
@@ -61,6 +62,17 @@ const CallLogSideDrawerChild = ({ data }) => {
     ) ||
     data?.observation_span?.find((s) => !s?.parent_span_id) ||
     data?.observation_span?.[0];
+  const traceId = data?.trace_id || data?.id;
+  const annotationSources = useMemo(
+    () =>
+      buildVoiceCallAnnotationSources({
+        traceId,
+        rootSpanId: rootObsSpan?.id,
+        module: data?.module,
+        callExecutionId: data?.id,
+      }),
+    [traceId, rootObsSpan?.id, data?.module, data?.id],
+  );
 
   return (
     <Box
@@ -244,13 +256,7 @@ const CallLogSideDrawerChild = ({ data }) => {
         }}
       >
         <AnnotationSidebarContent
-          sources={
-            rootObsSpan?.id
-              ? [{ sourceType: "observation_span", sourceId: rootObsSpan.id }]
-              : (data?.trace_id || data?.id)
-              ? [{ sourceType: "trace", sourceId: data?.trace_id || data?.id }]
-              : []
-          }
+          sources={annotationSources}
           onClose={() => setAnnotationSidebarOpen(false)}
           onAddLabel={
             urlAgentDefinitionId || resolvedProjectId

--- a/frontend/src/components/CallLogsDetailDrawer/RightSection.jsx
+++ b/frontend/src/components/CallLogsDetailDrawer/RightSection.jsx
@@ -14,6 +14,7 @@ import TestDetailCallAnalytics from "src/sections/test-detail/TestDetailDrawer/T
 import LoadingStateComponent from "./LoadingStateComponent";
 import { getLoadingStateWithRespectiveStatus } from "src/sections/test-detail/common";
 import ScoresListSection from "src/components/ScoresListSection/ScoresListSection";
+import { buildVoiceCallScoreSource } from "src/components/voiceAnnotationSources";
 import { getSpanAttributes } from "../traceDetailDrawer/DrawerRightRenderer/getSpanData";
 
 const TABS = [
@@ -58,10 +59,12 @@ const RightSection = ({ data, hideAnnotations = false }) => {
     getLoadingStateWithRespectiveStatus(data?.status, data?.simulationCallType);
   // Determine source type and ID for scores — fetch both levels
   const traceId = data?.trace_id || data?.id;
-  const sourceType = observationSpan?.id ? "observation_span" : "trace";
-  const sourceId = observationSpan?.id || traceId;
-  const secondarySourceType = observationSpan?.id ? "trace" : undefined;
-  const secondarySourceId = observationSpan?.id ? traceId : undefined;
+  const { sourceType, sourceId, secondarySourceType, secondarySourceId } =
+    buildVoiceCallScoreSource({
+      traceId,
+      rootSpanId: observationSpan?.id,
+      isSimulate: false,
+    });
 
   return (
     <Stack gap={2} minHeight={300}>

--- a/frontend/src/components/ScoresListSection/ScoresListSection.jsx
+++ b/frontend/src/components/ScoresListSection/ScoresListSection.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
 import {
   Box,
@@ -16,7 +16,9 @@ import {
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import Iconify from "src/components/iconify";
+import { useQueueItemsForSource } from "src/api/annotation-queues/annotation-queues";
 import { useScoresForSource, useSpanNotes } from "src/api/scores/scores";
+import { paths } from "src/routes/paths";
 import { fDateTime } from "src/utils/format-time";
 
 function formatScoreValue(labelType, value) {
@@ -58,12 +60,35 @@ export default function ScoresListSection({
   secondarySourceId,
   title = "Annotations",
   renderActions,
+  openQueueItemOnRowClick = false,
 }) {
   const { data: scores, isLoading } = useScoresForSource(sourceType, sourceId);
   const { data: secondaryScores, isLoading: secondaryLoading } =
     useScoresForSource(secondarySourceType, secondarySourceId);
   const { data: spanNotes = [] } = useSpanNotes(
     sourceType === "observation_span" ? sourceId : null,
+  );
+  const queueTargetSources = useMemo(
+    () =>
+      openQueueItemOnRowClick
+        ? [
+            { sourceType, sourceId },
+            { sourceType: secondarySourceType, sourceId: secondarySourceId },
+          ].filter((source) => source.sourceType && source.sourceId)
+        : [],
+    [
+      openQueueItemOnRowClick,
+      secondarySourceId,
+      secondarySourceType,
+      sourceId,
+      sourceType,
+    ],
+  );
+  const { data: queueEntries = [] } = useQueueItemsForSource(
+    queueTargetSources,
+    {
+      enabled: openQueueItemOnRowClick && queueTargetSources.length > 0,
+    },
   );
 
   const rows = useMemo(() => {
@@ -76,6 +101,9 @@ export default function ScoresListSection({
         seen.add(s.id);
         merged.push({
           id: s.id,
+          labelId: s.labelId || s.label_id,
+          sourceType: s.sourceType || s.source_type,
+          sourceId: s.sourceId || s.source_id,
           labelName: s.labelName,
           labelType: s.labelType,
           value: s.value,
@@ -83,11 +111,71 @@ export default function ScoresListSection({
           scoreSource: s.scoreSource,
           notes: s.notes,
           updatedAt: s.updated_at,
+          queueId: s.queueId || s.queue_id,
+          queueItemId: s.queueItem || s.queue_item,
         });
       }
     }
     return merged;
   }, [scores, secondaryScores]);
+
+  const fallbackQueueTargetsByLabel = useMemo(() => {
+    const byLabel = new Map();
+    const bySourceAndLabel = new Map();
+    for (const entry of Array.isArray(queueEntries) ? queueEntries : []) {
+      const queueId = entry?.queue?.id;
+      const queueItemId = entry?.item?.id;
+      if (!queueId || !queueItemId) continue;
+      const itemSourceType = entry.item.sourceType || entry.item.source_type;
+      const itemSourceId = entry.item.sourceId || entry.item.source_id;
+      for (const label of entry.labels || []) {
+        const target = { queueId, queueItemId };
+        if (itemSourceType && itemSourceId) {
+          bySourceAndLabel.set(
+            `${itemSourceType}:${itemSourceId}:${label.id}`,
+            target,
+          );
+        }
+        if (!byLabel.has(label.id)) {
+          byLabel.set(label.id, target);
+        }
+      }
+    }
+    return { byLabel, bySourceAndLabel };
+  }, [queueEntries]);
+
+  const getQueueTarget = useCallback(
+    (row) => {
+      if (!openQueueItemOnRowClick) return null;
+      if (row.queueId && row.queueItemId) {
+        return { queueId: row.queueId, queueItemId: row.queueItemId };
+      }
+      const sourceKey =
+        row.sourceType && row.sourceId && row.labelId
+          ? `${row.sourceType}:${row.sourceId}:${row.labelId}`
+          : null;
+      if (sourceKey) {
+        const sourceTarget =
+          fallbackQueueTargetsByLabel.bySourceAndLabel.get(sourceKey);
+        if (sourceTarget) return sourceTarget;
+      }
+      return fallbackQueueTargetsByLabel.byLabel.get(row.labelId) || null;
+    },
+    [fallbackQueueTargetsByLabel, openQueueItemOnRowClick],
+  );
+
+  const handleOpenQueueItem = useCallback(
+    (row) => {
+      const target = getQueueTarget(row);
+      if (!target) return;
+      window.open(
+        `${paths.dashboard.annotations.annotate(target.queueId)}?itemId=${target.queueItemId}`,
+        "_blank",
+        "noopener,noreferrer",
+      );
+    },
+    [getQueueTarget],
+  );
 
   if (!sourceId) return null;
 
@@ -221,9 +309,11 @@ export default function ScoresListSection({
               {rows.map((row) => (
                 <TableRow
                   key={row.id}
+                  onClick={() => handleOpenQueueItem(row)}
                   sx={{
                     "&:hover": { bgcolor: "action.hover" },
                     "&:last-child td": { borderBottom: 0 },
+                    cursor: getQueueTarget(row) ? "pointer" : "default",
                   }}
                 >
                   <TableCell sx={{ py: 1 }}>
@@ -361,7 +451,11 @@ export default function ScoresListSection({
                   >
                     <TableCell sx={{ py: 1.5, maxWidth: 480 }}>
                       <Typography
-                        sx={{ fontSize: 13, color: "text.primary", whiteSpace: "pre-wrap" }}
+                        sx={{
+                          fontSize: 13,
+                          color: "text.primary",
+                          whiteSpace: "pre-wrap",
+                        }}
                       >
                         {note.notes}
                       </Typography>
@@ -380,9 +474,16 @@ export default function ScoresListSection({
                             flexShrink: 0,
                           }}
                         >
-                          <Iconify icon="mdi:account" width={12} color="text.secondary" />
+                          <Iconify
+                            icon="mdi:account"
+                            width={12}
+                            color="text.secondary"
+                          />
                         </Box>
-                        <Typography sx={{ fontSize: 12, color: "text.secondary" }} noWrap>
+                        <Typography
+                          sx={{ fontSize: 12, color: "text.secondary" }}
+                          noWrap
+                        >
                           {note.annotator || "—"}
                         </Typography>
                       </Stack>
@@ -405,4 +506,5 @@ ScoresListSection.propTypes = {
   secondarySourceId: PropTypes.string,
   title: PropTypes.string,
   renderActions: PropTypes.node,
+  openQueueItemOnRowClick: PropTypes.bool,
 };

--- a/frontend/src/components/ScoresListSection/__tests__/ScoresListSection.test.jsx
+++ b/frontend/src/components/ScoresListSection/__tests__/ScoresListSection.test.jsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, userEvent } from "src/utils/test-utils";
+import ScoresListSection from "../ScoresListSection";
+
+const mockState = vi.hoisted(() => ({
+  scoresBySource: {},
+  queueEntries: [],
+}));
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon, ...props }) => (
+    <span data-testid="iconify" data-icon={icon} {...props} />
+  ),
+}));
+
+vi.mock("src/utils/format-time", () => ({
+  fDateTime: () => "09 May 2026 7:13 PM",
+}));
+
+vi.mock("src/api/scores/scores", () => ({
+  useScoresForSource: vi.fn((sourceType) => ({
+    isLoading: false,
+    data: mockState.scoresBySource[sourceType] || [],
+  })),
+  useSpanNotes: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock("src/api/annotation-queues/annotation-queues", () => ({
+  useQueueItemsForSource: vi.fn(() => ({
+    data: mockState.queueEntries,
+  })),
+}));
+
+describe("ScoresListSection", () => {
+  const originalOpen = window.open;
+
+  beforeEach(() => {
+    window.open = vi.fn();
+    mockState.scoresBySource = {
+      trace: [
+        {
+          id: "score-1",
+          labelId: "label-1",
+          sourceType: "trace",
+          sourceId: "trace-1",
+          labelName: "category",
+          labelType: "thumbs_up_down",
+          value: { value: "up" },
+          annotatorName: "Kartik",
+          scoreSource: "human",
+          notes: "",
+          updated_at: "2026-05-09T19:13:00Z",
+          queueId: "queue-1",
+          queueItem: "item-1",
+        },
+      ],
+    };
+    mockState.queueEntries = [];
+  });
+
+  afterEach(() => {
+    window.open = originalOpen;
+  });
+
+  it("does not open rows unless queue row linking is enabled", async () => {
+    const user = userEvent.setup();
+
+    render(<ScoresListSection sourceType="trace" sourceId="trace-1" />);
+
+    await user.click(screen.getByText("category"));
+
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("opens the owning annotation queue item in a new tab when enabled", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ScoresListSection
+        sourceType="trace"
+        sourceId="trace-1"
+        openQueueItemOnRowClick
+      />,
+    );
+
+    await user.click(screen.getByText("category"));
+
+    expect(window.open).toHaveBeenCalledWith(
+      "/dashboard/annotations/queues/queue-1/annotate?itemId=item-1",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("falls back to source queue items when the score has no queue item", async () => {
+    const user = userEvent.setup();
+    mockState.scoresBySource = {
+      trace: [
+        {
+          id: "score-1",
+          labelId: "label-1",
+          sourceType: "trace",
+          sourceId: "trace-1",
+          labelName: "category",
+          labelType: "thumbs_up_down",
+          value: { value: "up" },
+          annotatorName: "Kartik",
+          scoreSource: "human",
+          notes: "",
+          updated_at: "2026-05-09T19:13:00Z",
+        },
+      ],
+    };
+    mockState.queueEntries = [
+      {
+        queue: { id: "queue-from-source" },
+        item: {
+          id: "item-from-source",
+          sourceType: "trace",
+          sourceId: "trace-1",
+        },
+        labels: [{ id: "label-1", name: "category" }],
+      },
+    ];
+
+    render(
+      <ScoresListSection
+        sourceType="trace"
+        sourceId="trace-1"
+        openQueueItemOnRowClick
+      />,
+    );
+
+    await user.click(screen.getByText("category"));
+
+    expect(window.open).toHaveBeenCalledWith(
+      "/dashboard/annotations/queues/queue-from-source/annotate?itemId=item-from-source",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+});

--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -13,6 +13,7 @@ import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import CallAnalyticsView from "./CallAnalyticsView";
 import { isLiveKitProvider } from "src/sections/agents/constants";
 import ScoresListSection from "src/components/ScoresListSection/ScoresListSection";
+import { buildVoiceCallScoreSource } from "src/components/voiceAnnotationSources";
 import EvalsTabView from "src/components/traceDetail/EvalsTabView";
 import { openFixWithFalcon } from "src/sections/falcon-ai/helpers/openFixWithFalcon";
 import VoiceLogsView from "./VoiceLogsView";
@@ -37,7 +38,12 @@ const TABS = {
   SCENARIO: "scenario",
 };
 
-const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab }) => {
+const VoiceRightPanel = ({
+  data,
+  onCompareBaseline,
+  onAction,
+  hideAnnotationTab,
+}) => {
   const [currentTab, setCurrentTab] = useState(TABS.ANALYTICS);
   const isSimulate = data?.module === "simulate";
   // Prefer the conversation root span (where voice-call attributes/raw_log
@@ -54,10 +60,7 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab 
       spans[0]
     );
   }, [data?.observation_span]);
-  const canCompare =
-    isSimulate &&
-    !!onCompareBaseline &&
-    !!data?.session_id;
+  const canCompare = isSimulate && !!onCompareBaseline && !!data?.session_id;
 
   const { isCallInProgress, message: loadingMessage } =
     getLoadingStateWithRespectiveStatus(
@@ -135,7 +138,7 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab 
       });
     }
     return t;
-  }, [hasLogs, hasScenarioData]);
+  }, [hasLogs, hasScenarioData, hideAnnotationTab]);
 
   const analyticsProps = useMemo(() => {
     // API-provided per-call metrics (prefer over client-computed values)
@@ -143,8 +146,7 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab 
       turnCount: data?.turn_count,
       talkRatio: data?.talk_ratio,
       agentTalkPercentage: data?.agent_talk_percentage,
-      avgAgentLatencyMs:
-        data?.avg_agent_latency_ms ?? data?.avg_agent_latency,
+      avgAgentLatencyMs: data?.avg_agent_latency_ms ?? data?.avg_agent_latency,
       userWpm: data?.user_wpm,
       botWpm: data?.bot_wpm,
       userInterruptionCount: data?.user_interruption_count,
@@ -172,9 +174,11 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab 
     return {
       transcript: data?.transcript,
       latencies:
-        customerLatencies || extractLatencies(rawLog?.artifact?.performanceMetrics),
+        customerLatencies ||
+        extractLatencies(rawLog?.artifact?.performanceMetrics),
       analysisSummary: rawLog?.summary || data?.call_summary,
-      costBreakdown: customerCost || extractCostBreakdown(rawLog?.costBreakdown),
+      costBreakdown:
+        customerCost || extractCostBreakdown(rawLog?.costBreakdown),
       isLiveKit: isLiveKitProvider(data?.provider),
       apiMetrics,
     };
@@ -184,9 +188,7 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab 
     if (isSimulate) {
       return data?.eval_metrics || data?.eval_outputs || null;
     }
-    return (
-      data?.eval_outputs || observationSpan?.evals_metrics || null
-    );
+    return data?.eval_outputs || observationSpan?.evals_metrics || null;
   }, [isSimulate, data, observationSpan]);
 
   // Normalize voice eval payloads into the shape EvalsTabView expects.
@@ -258,22 +260,15 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab 
 
   const traceId = data?.trace_id || data?.id;
   const annotationSources = useMemo(() => {
-    if (isSimulate) {
-      return {
-        sourceType: "call_execution",
-        sourceId: data?.id,
-      };
-    }
     // observationSpan is already computed above: finds root by parent_span_id === null
     // and observation_type === "conversation", so use it directly instead of [0].
-    const span = observationSpan;
-    return {
-      sourceType: span?.id ? "observation_span" : "trace",
-      sourceId: span?.id || traceId,
-      secondarySourceType: span?.id ? "trace" : undefined,
-      secondarySourceId: span?.id ? traceId : undefined,
-    };
-  }, [isSimulate, data, traceId, observationSpan]);
+    return buildVoiceCallScoreSource({
+      traceId,
+      rootSpanId: observationSpan?.id,
+      isSimulate,
+      callExecutionId: data?.id,
+    });
+  }, [isSimulate, data?.id, traceId, observationSpan?.id]);
 
   const attributesObj = useMemo(() => {
     // Source-of-truth chain, in order of richness:
@@ -391,10 +386,8 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab 
                     context: {
                       trace_id: traceId,
                       call_id: callId,
-                      span_id:
-                        ev.spanId || ev.observation_span_id,
-                      eval_log_id:
-                        ev.eval_log_id || ev.cell_id || ev.log_id,
+                      span_id: ev.spanId || ev.observation_span_id,
+                      eval_log_id: ev.eval_log_id || ev.cell_id || ev.log_id,
                       custom_eval_config_id:
                         ev.custom_eval_config_id || ev.eval_config_id,
                       eval_name: ev.eval_name,
@@ -492,7 +485,7 @@ VoiceRightPanel.propTypes = {
   data: PropTypes.object.isRequired,
   onCompareBaseline: PropTypes.func,
   onAction: PropTypes.func,
-  hideAnnotationTab: PropTypes.bool
+  hideAnnotationTab: PropTypes.bool,
 };
 
 export default VoiceRightPanel;

--- a/frontend/src/components/__tests__/voiceAnnotationSources.test.js
+++ b/frontend/src/components/__tests__/voiceAnnotationSources.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildVoiceCallAnnotationSources,
+  buildVoiceCallScoreSource,
+} from "../voiceAnnotationSources";
+
+describe("voice call annotation source selection", () => {
+  it("uses trace as the direct annotation source for observed calls", () => {
+    expect(
+      buildVoiceCallAnnotationSources({
+        traceId: "trace-1",
+        rootSpanId: "span-1",
+        module: "project",
+      }),
+    ).toEqual([
+      {
+        sourceType: "trace",
+        sourceId: "trace-1",
+        spanNotesSourceId: "span-1",
+      },
+    ]);
+  });
+
+  it("uses trace as the primary score source and keeps span as secondary display", () => {
+    expect(
+      buildVoiceCallScoreSource({
+        traceId: "trace-1",
+        rootSpanId: "span-1",
+        isSimulate: false,
+      }),
+    ).toEqual({
+      sourceType: "trace",
+      sourceId: "trace-1",
+      secondarySourceType: "observation_span",
+      secondarySourceId: "span-1",
+    });
+  });
+
+  it("falls back to call_execution for simulate calls without trace observability", () => {
+    expect(
+      buildVoiceCallAnnotationSources({
+        module: "simulate",
+        callExecutionId: "call-1",
+      }),
+    ).toEqual([{ sourceType: "call_execution", sourceId: "call-1" }]);
+  });
+});

--- a/frontend/src/components/traceDetail/SpanDetailPane.jsx
+++ b/frontend/src/components/traceDetail/SpanDetailPane.jsx
@@ -1443,6 +1443,7 @@ const AnnotationsTabContent = ({ spanId, traceId, onAction }) => (
         secondarySourceType="trace"
         secondarySourceId={traceId}
         title=""
+        openQueueItemOnRowClick
         renderActions={
           onAction ? (
             <Button
@@ -2052,9 +2053,7 @@ const SpanDetailPane = ({
                       variant="caption"
                       sx={{
                         fontSize: 10,
-                        color: matchCount
-                          ? "text.secondary"
-                          : "text.disabled",
+                        color: matchCount ? "text.secondary" : "text.disabled",
                         minWidth: 42,
                         textAlign: "right",
                         fontVariantNumeric: "tabular-nums",
@@ -2133,11 +2132,9 @@ const SpanDetailPane = ({
                   context: {
                     trace_id: traceId,
                     span_id: ev.spanId || ev.observation_span_id || span?.id,
-                    eval_log_id:
-                      ev.eval_log_id || ev.cell_id || ev.log_id,
+                    eval_log_id: ev.eval_log_id || ev.cell_id || ev.log_id,
                     custom_eval_config_id:
-                      ev.custom_eval_config_id ||
-                      ev.eval_config_id,
+                      ev.custom_eval_config_id || ev.eval_config_id,
                     eval_name: ev.eval_name,
                     score: ev.score,
                     explanation: ev.explanation || ev.eval_explanation,

--- a/frontend/src/components/traceDetailDrawer/AnnotationSidebarContent.jsx
+++ b/frontend/src/components/traceDetailDrawer/AnnotationSidebarContent.jsx
@@ -146,7 +146,7 @@ ShortcutsHelp.propTypes = {
 
 /**
  * @param {Object} props
- * @param {Array<{sourceType: string, sourceId: string}>} props.sources
+ * @param {Array<{sourceType: string, sourceId: string, spanNotesSourceId?: string}>} props.sources
  * @param {Function} props.onClose
  * @param {Function} props.onScoresChanged
  */
@@ -159,7 +159,12 @@ export default function AnnotationSidebarContent({
   hideEmpty = false,
 }) {
   const validSources = sources.filter((s) => s.sourceId);
-  const { data: queueItems, isLoading, isFetching, refetch } = useQueueItemsForSource(validSources);
+  const {
+    data: queueItems,
+    isLoading,
+    isFetching,
+    refetch,
+  } = useQueueItemsForSource(validSources);
   const [showShortcuts, setShowShortcuts] = useState(false);
 
   if (validSources.length === 0) {
@@ -188,8 +193,12 @@ export default function AnnotationSidebarContent({
 
   // Build a lookup from source_type → sourceId for saving scores
   const sourceMap = {};
+  const spanNotesSourceMap = {};
   for (const s of validSources) {
     sourceMap[s.sourceType] = s.sourceId;
+    if (s.spanNotesSourceId) {
+      spanNotesSourceMap[s.sourceType] = s.spanNotesSourceId;
+    }
   }
 
   return (
@@ -231,7 +240,9 @@ export default function AnnotationSidebarContent({
                     icon="mingcute:refresh-2-line"
                     width={16}
                     sx={{
-                      animation: isFetching ? "spin 1s linear infinite" : "none",
+                      animation: isFetching
+                        ? "spin 1s linear infinite"
+                        : "none",
                       "@keyframes spin": {
                         from: { transform: "rotate(0deg)" },
                         to: { transform: "rotate(360deg)" },
@@ -316,6 +327,7 @@ export default function AnnotationSidebarContent({
                 key={queueEntry.queue.id}
                 queueEntry={queueEntry}
                 sourceMap={sourceMap}
+                spanNotesSourceMap={spanNotesSourceMap}
                 onScoresChanged={onScoresChanged}
                 showShortcuts={showShortcuts}
                 setShowShortcuts={setShowShortcuts}
@@ -343,6 +355,7 @@ AnnotationSidebarContent.propTypes = {
     PropTypes.shape({
       sourceType: PropTypes.string,
       sourceId: PropTypes.string,
+      spanNotesSourceId: PropTypes.string,
     }),
   ),
   onClose: PropTypes.func,
@@ -358,13 +371,22 @@ AnnotationSidebarContent.propTypes = {
 function QueueAnnotationSection({
   queueEntry,
   sourceMap,
+  spanNotesSourceMap,
   onScoresChanged,
   _showShortcuts,
   setShowShortcuts,
 }) {
-  const { queue, item, labels, existingScores, existingNotes, existingLabelNotes } = queueEntry;
+  const {
+    queue,
+    item,
+    labels,
+    existingScores,
+    existingNotes,
+    existingLabelNotes,
+  } = queueEntry;
   const [values, setValues] = useState({});
   const [notes, setNotes] = useState("");
+  const [notesTouched, setNotesTouched] = useState(false);
   const [labelNotes, setLabelNotes] = useState({});
   const [showNotes, setShowNotes] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(0);
@@ -372,10 +394,31 @@ function QueueAnnotationSection({
   const isCompleted = item?.status === "completed";
   const containerRef = useRef(null);
   const hasInitializedScoresRef = useRef(false);
+  const hasInitializedNotesRef = useRef(false);
+  const itemSourceType =
+    item?.sourceType || item?.source_type || Object.keys(sourceMap)[0];
+  const sourceId = sourceMap[itemSourceType];
+  const spanNotesSourceId =
+    spanNotesSourceMap[itemSourceType] ||
+    queueEntry.spanNotesSourceId ||
+    queueEntry.span_notes_source_id ||
+    (itemSourceType === "observation_span" ? sourceId : undefined);
+  const sourceLabel = SOURCE_TYPE_LABELS[itemSourceType] || itemSourceType;
+  const sourceKey = `${queue.id}:${item?.id || "default"}:${itemSourceType || ""}:${sourceId || ""}`;
 
   const handleLabelNotesChange = useCallback((labelId, val) => {
     setLabelNotes((prev) => ({ ...prev, [labelId]: val }));
   }, []);
+
+  useEffect(() => {
+    hasInitializedScoresRef.current = false;
+    hasInitializedNotesRef.current = false;
+    setValues({});
+    setLabelNotes({});
+    setNotes("");
+    setNotesTouched(false);
+    setShowNotes(false);
+  }, [sourceKey]);
 
   // Pre-populate form with existing scores and notes when editing — only once
   useEffect(() => {
@@ -390,16 +433,13 @@ function QueueAnnotationSection({
         setLabelNotes(existingLabelNotes);
       }
     }
-    if (existingNotes && !hasInitializedScoresRef.current) {
+    if (existingNotes && !hasInitializedNotesRef.current) {
+      hasInitializedNotesRef.current = true;
       setNotes(existingNotes);
+      setNotesTouched(false);
       setShowNotes(true);
     }
   }, [existingScores, existingNotes, existingLabelNotes]);
-
-  const itemSourceType =
-    item?.sourceType || item?.source_type || Object.keys(sourceMap)[0];
-  const sourceId = sourceMap[itemSourceType];
-  const sourceLabel = SOURCE_TYPE_LABELS[itemSourceType] || itemSourceType;
 
   const handleChange = useCallback((labelId, value) => {
     setValues((prev) => ({ ...prev, [labelId]: value }));
@@ -425,14 +465,35 @@ function QueueAnnotationSection({
     if (scores.length === 0) return;
 
     bulkCreate(
-      { sourceType: itemSourceType, sourceId, scores, notes: "", spanNotes: notes },
+      {
+        sourceType: itemSourceType,
+        sourceId,
+        scores,
+        notes: "",
+        spanNotes: notes,
+        spanNotesSourceId,
+        includeSpanNotes: Boolean(
+          spanNotesSourceId && (notesTouched || notes || existingNotes),
+        ),
+      },
       {
         onSuccess: () => {
           onScoresChanged?.();
         },
       },
     );
-  }, [values, notes, labelNotes, itemSourceType, sourceId, bulkCreate, onScoresChanged]);
+  }, [
+    values,
+    notes,
+    notesTouched,
+    existingNotes,
+    labelNotes,
+    itemSourceType,
+    sourceId,
+    spanNotesSourceId,
+    bulkCreate,
+    onScoresChanged,
+  ]);
 
   // Keyboard shortcut handler — scoped to this section's container
   useEffect(() => {
@@ -613,7 +674,9 @@ function QueueAnnotationSection({
               index={i}
               focused={focusedIndex === i}
               labelNotes={labelNotes[label.id] || ""}
-              onLabelNotesChange={(val) => handleLabelNotesChange(label.id, val)}
+              onLabelNotesChange={(val) =>
+                handleLabelNotesChange(label.id, val)
+              }
             />
           </Box>
         ))}
@@ -628,12 +691,16 @@ function QueueAnnotationSection({
               maxRows={4}
               placeholder="Add your notes here..."
               value={notes}
-              onChange={(e) => setNotes(e.target.value)}
+              onChange={(e) => {
+                setNotesTouched(true);
+                setNotes(e.target.value);
+              }}
               autoFocus
             />
             <IconButton
               size="small"
               onClick={() => {
+                setNotesTouched(true);
                 setShowNotes(false);
                 setNotes("");
               }}
@@ -707,8 +774,11 @@ QueueAnnotationSection.propTypes = {
     existingScores: PropTypes.object,
     existingNotes: PropTypes.string,
     existingLabelNotes: PropTypes.object,
+    spanNotesSourceId: PropTypes.string,
+    span_notes_source_id: PropTypes.string,
   }).isRequired,
   sourceMap: PropTypes.object.isRequired,
+  spanNotesSourceMap: PropTypes.object.isRequired,
   onScoresChanged: PropTypes.func,
   _showShortcuts: PropTypes.bool,
   setShowShortcuts: PropTypes.func,

--- a/frontend/src/components/voiceAnnotationSources.js
+++ b/frontend/src/components/voiceAnnotationSources.js
@@ -1,0 +1,51 @@
+export function buildVoiceCallAnnotationSources({
+  traceId,
+  rootSpanId,
+  module,
+  callExecutionId,
+}) {
+  if (module === "simulate" && callExecutionId) {
+    return [{ sourceType: "call_execution", sourceId: callExecutionId }];
+  }
+  // A voice call is a trace-level object. The root conversation span is useful
+  // for analytics and item notes, but direct call annotation must create trace
+  // annotations.
+  if (traceId) {
+    return [
+      {
+        sourceType: "trace",
+        sourceId: traceId,
+        spanNotesSourceId: rootSpanId || undefined,
+      },
+    ];
+  }
+  if (rootSpanId) {
+    return [{ sourceType: "observation_span", sourceId: rootSpanId }];
+  }
+  return [];
+}
+
+export function buildVoiceCallScoreSource({
+  traceId,
+  rootSpanId,
+  isSimulate,
+  callExecutionId,
+}) {
+  if (isSimulate && callExecutionId) {
+    return { sourceType: "call_execution", sourceId: callExecutionId };
+  }
+  // Keep span as secondary read-only context only; new call annotations save
+  // against the trace so default queues do not receive span items.
+  if (traceId) {
+    return {
+      sourceType: "trace",
+      sourceId: traceId,
+      secondarySourceType: rootSpanId ? "observation_span" : undefined,
+      secondarySourceId: rootSpanId || undefined,
+    };
+  }
+  if (rootSpanId) {
+    return { sourceType: "observation_span", sourceId: rootSpanId };
+  }
+  return { sourceType: "trace", sourceId: "" };
+}

--- a/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
+++ b/frontend/src/sections/annotations/queues/__tests__/content-panel.test.jsx
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "src/utils/test-utils";
+import ContentPanel from "../annotate/content-panel";
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon, ...props }) => (
+    <span data-testid="iconify" data-icon={icon} {...props} />
+  ),
+}));
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: vi.fn(() =>
+      Promise.resolve({
+        data: {
+          status: "completed",
+          simulation_call_type: "voice",
+          scenario: "Greet the customer",
+          scenario_columns: {
+            persona: { column_name: "persona", value: "Impatient customer" },
+          },
+          transcripts: [],
+          eval_outputs: {},
+        },
+      }),
+    ),
+  },
+  endpoints: {
+    testExecutions: {
+      callDetail: (id) => `/simulate/call-executions/${id}/`,
+    },
+  },
+}));
+
+vi.mock("src/components/VoiceDetailDrawerV2/ScenarioView", () => ({
+  default: ({ data }) => (
+    <div data-testid="new-scenario-view">{data.scenario}</div>
+  ),
+}));
+
+vi.mock("src/components/VoiceDetailDrawerV2", () => ({
+  default: () => <div data-testid="voice-drawer" />,
+}));
+
+vi.mock("src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom", () => ({
+  default: () => <div data-testid="audio-player" />,
+}));
+
+vi.mock("src/components/CallLogsDetailDrawer/LeftSection", () => ({
+  default: () => <div data-testid="left-section" />,
+}));
+
+vi.mock(
+  "src/sections/test-detail/TestDetailDrawer/TestDetailDrawerRightSection",
+  () => ({
+    default: () => <div data-testid="right-section" />,
+  }),
+);
+
+vi.mock("src/components/CallLogsDetailDrawer/RightSection", () => ({
+  default: () => <div data-testid="call-right-section" />,
+}));
+
+vi.mock("src/components/traceDetailDrawer/trace-detail-drawer", () => ({
+  default: () => <div data-testid="trace-detail-drawer" />,
+}));
+
+vi.mock("src/components/traceDetail/SpanTreeTimeline", () => ({
+  default: () => <div data-testid="span-tree" />,
+}));
+
+vi.mock("src/components/traceDetail/SpanDetailPane", () => ({
+  default: () => <div data-testid="span-detail" />,
+}));
+
+vi.mock("src/components/traceDetail/TraceLeftPanel", () => ({
+  default: () => <div data-testid="trace-left-panel" />,
+}));
+
+vi.mock("src/components/traceDetail/DrawerToolbar", () => ({
+  default: () => <div data-testid="drawer-toolbar" />,
+}));
+
+vi.mock("src/components/traceDetail/TraceDisplayPanel", () => ({
+  default: () => <div data-testid="trace-display-panel" />,
+  DEFAULT_VIEW_CONFIG: {},
+}));
+
+vi.mock("src/api/project/trace-detail", () => ({
+  useGetTraceDetail: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock("src/api/project/saved-views", () => ({
+  useGetSavedViews: () => ({ data: { custom_views: [] } }),
+  useDeleteSavedView: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("src/components/imagine/ImagineTab", () => ({
+  default: () => <div data-testid="imagine-tab" />,
+}));
+
+vi.mock("src/components/imagine/useImagineStore", () => ({
+  default: {
+    getState: () => ({
+      reset: vi.fn(),
+    }),
+  },
+}));
+
+describe("Annotation queue ContentPanel", () => {
+  it("uses the new scenario view for call execution queue items", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ContentPanel
+          item={{
+            source_type: "call_execution",
+            source_content: { call_id: "call-1" },
+          }}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("new-scenario-view")).toHaveTextContent(
+        "Greet the customer",
+      );
+    });
+  });
+});

--- a/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/content-panel.jsx
@@ -51,17 +51,16 @@ import useImagineStore from "src/components/imagine/useImagineStore";
 import ConfirmDialog from "src/components/custom-dialog/confirm-dialog";
 import CallStatus from "src/sections/test/CallLogs/CallStatus";
 import { format, isValid } from "date-fns";
-import TestDetailDrawerScenarioTable from "src/sections/test-detail/TestDetailDrawer/TestDetailDrawerScenarioTable";
 import AudioPlayerCustom from "src/sections/test-detail/TestDetailDrawer/AudioPlayerCustom";
 import LeftSection from "src/components/CallLogsDetailDrawer/LeftSection";
 import TestDetailDrawerRightSection from "src/sections/test-detail/TestDetailDrawer/TestDetailDrawerRightSection";
-import RightSection from "src/components/CallLogsDetailDrawer/RightSection";
 import { AGENT_TYPES } from "src/sections/agents/constants";
 import { formatDurationSafe } from "src/components/CallLogsDrawer/CustomCallLogHeader";
 import { getCsatScoreColor } from "src/components/CallLogsDrawer/common";
 import SvgColor from "src/components/svg-color";
 import { useVoiceCallDetail } from "src/sections/agents/helper";
 import VoiceDetailDrawerV2 from "src/components/VoiceDetailDrawerV2";
+import ScenarioView from "src/components/VoiceDetailDrawerV2/ScenarioView";
 
 const CustomJsonViewer = lazy(
   () => import("src/components/custom-json-viewer/CustomJsonViewer"),
@@ -646,7 +645,7 @@ function VoiceCallContent({ traceId }) {
     evalMetrics: callData.eval_outputs || {},
     evalOutputs: callData.eval_outputs || {},
     overallStatus: callData.overall_status || callData.status,
-     turn_count: callData.turn_count,
+    turn_count: callData.turn_count,
     talk_ratio: callData.talk_ratio,
     agent_talk_percentage: callData.agent_talk_percentage,
     avg_agent_latency_ms: callData.avg_agent_latency_ms,
@@ -1190,7 +1189,7 @@ PrototypeContent.propTypes = {
 // ---------------------------------------------------------------------------
 // Simulation Content — reuses the same components as the Call Log Details drawer
 // ---------------------------------------------------------------------------
-function SimulationContent({ content, hideAnnotationTab=false }) {
+function SimulationContent({ content, hideAnnotationTab = false }) {
   const callId = content?.call_id;
 
   const { data: callData, isLoading } = useQuery({
@@ -1243,6 +1242,7 @@ function SimulationContent({ content, hideAnnotationTab=false }) {
     duration: callData.duration || callData.duration_seconds,
     scenario: callData.scenario || callData.scenario_name,
     scenarioId: callData.scenario_id,
+    scenario_columns: callData.scenario_columns || {},
     scenarioColumns: callData.scenario_columns || {},
     customerName: callData.customer_name,
     phoneNumber: callData.phone_number,
@@ -1411,17 +1411,7 @@ function SimulationContent({ content, hideAnnotationTab=false }) {
         )}
       </Box>
 
-      {/* Scenario Details */}
-      <Box
-        sx={{
-          "& .MuiBox-root": {
-            width: "100% !important",
-            flexShrink: "1 !important",
-          },
-        }}
-      >
-        <TestDetailDrawerScenarioTable data={drawerData} />
-      </Box>
+      <ScenarioView data={drawerData} />
 
       {/* Recording — only for voice */}
       {isVoice && (
@@ -1489,7 +1479,7 @@ function SimulationContent({ content, hideAnnotationTab=false }) {
 
 SimulationContent.propTypes = {
   content: PropTypes.object,
-    hideAnnotationTab: PropTypes.bool,
+  hideAnnotationTab: PropTypes.bool,
 };
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx
@@ -28,6 +28,8 @@ import {
   useVoiceCallDetail,
 } from "src/sections/agents/helper";
 import VoiceDetailDrawerV2 from "src/components/VoiceDetailDrawerV2";
+import { buildVoiceCallAnnotationSources } from "src/components/voiceAnnotationSources";
+
 const BaselineVsReplayHeader = lazy(() => import("./BasLineCompare/Header"));
 
 const TestDetailSideDrawerChild = ({
@@ -131,7 +133,10 @@ const TestDetailSideDrawerChild = ({
       return {
         ...base,
         ...callExecDetail,
-        transcript: mergeTranscripts(base.transcript, callExecDetail.transcript),
+        transcript: mergeTranscripts(
+          base.transcript,
+          callExecDetail.transcript,
+        ),
       };
     }
     return base;
@@ -427,6 +432,16 @@ const TestDetailSideDrawerChild = ({
     );
   }, [mergedData?.observation_span]);
 
+  const annotationSources = useMemo(
+    () =>
+      buildVoiceCallAnnotationSources({
+        traceId,
+        rootSpanId: rootObsSpanId,
+        module: urlModule,
+        callExecutionId: data?.id,
+      }),
+    [traceId, rootObsSpanId, urlModule, data?.id],
+  );
 
   if (!data || isFetching === "initial") {
     return null;
@@ -648,27 +663,7 @@ const TestDetailSideDrawerChild = ({
         }}
       >
         <AnnotationSidebarContent
-          sources={
-            urlModule === "project"
-              ? [
-                  ...(rootObsSpanId
-                    ? [
-                        {
-                          sourceType: "observation_span",
-                          sourceId: rootObsSpanId,
-                        },
-                      ]
-                    : (data?.trace_id || data?.id)
-                    ? [
-                        {
-                          sourceType: "trace",
-                          sourceId: data?.trace_id || data?.id,
-                        },
-                      ]
-                    : []),
-                ]
-              : [{ sourceType: "call_execution", sourceId: data?.id }]
-          }
+          sources={annotationSources}
           onClose={() => setAnnotationSidebarOpen(false)}
           onScoresChanged={() => {
             queryClient.invalidateQueries({
@@ -730,7 +725,6 @@ const TestDetailSideDrawer = ({
   const handleClose = () => {
     removeRowIndex();
   };
-
 
   const hasUrlRowIndex =
     updatedRowIndex !== undefined && updatedRowIndex !== null;

--- a/futureagi/model_hub/serializers/scores.py
+++ b/futureagi/model_hub/serializers/scores.py
@@ -19,6 +19,7 @@ class ScoreSerializer(serializers.ModelSerializer):
         source="annotator.email", read_only=True, default=None
     )
     source_id = serializers.SerializerMethodField()
+    queue_id = serializers.SerializerMethodField()
 
     class Meta:
         model = Score
@@ -38,6 +39,7 @@ class ScoreSerializer(serializers.ModelSerializer):
             "annotator_name",
             "annotator_email",
             "queue_item",
+            "queue_id",
             "created_at",
             "updated_at",
         ]
@@ -45,6 +47,9 @@ class ScoreSerializer(serializers.ModelSerializer):
 
     def get_source_id(self, obj):
         return str(obj.get_source_id()) if obj.get_source_id() else None
+
+    def get_queue_id(self, obj):
+        return str(obj.queue_item.queue_id) if obj.queue_item_id else None
 
 
 class CreateScoreSerializer(serializers.Serializer):
@@ -78,8 +83,13 @@ class BulkCreateScoresSerializer(serializers.Serializer):
         min_length=1,
     )
     notes = serializers.CharField(required=False, allow_blank=True, default="")
-    span_notes = serializers.CharField(required=False, allow_blank=True, allow_null=True, default=None)
-    
+    span_notes = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=None
+    )
+    span_notes_source_id = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=None
+    )
+
     def validate_scores(self, value):
         for score in value:
             if "label_id" not in score or "value" not in score:

--- a/futureagi/model_hub/tests/test_scores_api.py
+++ b/futureagi/model_hub/tests/test_scores_api.py
@@ -319,6 +319,224 @@ class TestBulkCreateScores:
         assert len(result["scores"]) == 1
         assert len(result["errors"]) == 1
 
+    def test_trace_bulk_create_can_save_notes_on_root_span(
+        self, auth_client, trace, observation_span, thumbs_label, user
+    ):
+        """Call drawer labels save on trace while item notes stay on root span."""
+        from tracer.models.span_notes import SpanNotes
+
+        payload = {
+            "source_type": "trace",
+            "source_id": str(trace.id),
+            "scores": [
+                {"label_id": str(thumbs_label.id), "value": {"value": "up"}},
+            ],
+            "span_notes": "whole call note",
+            "span_notes_source_id": observation_span.id,
+        }
+        resp = auth_client.post(f"{SCORE_URL}bulk/", payload, format="json")
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert Score.objects.filter(
+            trace=trace,
+            label=thumbs_label,
+            annotator=user,
+            deleted=False,
+        ).exists()
+        assert SpanNotes.objects.get(
+            span=observation_span,
+            created_by_user=user,
+        ).notes == "whole call note"
+
+        clear_resp = auth_client.post(
+            f"{SCORE_URL}bulk/",
+            {**payload, "span_notes": ""},
+            format="json",
+        )
+
+        assert clear_resp.status_code == status.HTTP_200_OK, clear_resp.data
+        assert not SpanNotes.objects.filter(
+            span=observation_span,
+            created_by_user=user,
+        ).exists()
+
+    def test_for_source_prefills_span_notes_for_trace_queue_item(
+        self,
+        auth_client,
+        observe_project,
+        trace,
+        observation_span,
+        thumbs_label,
+        user,
+        workspace,
+    ):
+        """Reopening trace call annotation should prefill notes from root span."""
+        import json
+
+        from tracer.models.span_notes import SpanNotes
+
+        queue = AnnotationQueue.objects.create(
+            name="Trace call queue",
+            status=AnnotationQueueStatusChoices.ACTIVE.value,
+            project=observe_project,
+            organization=user.organization,
+            workspace=workspace,
+            created_by=user,
+        )
+        AnnotationQueueLabel.objects.create(queue=queue, label=thumbs_label)
+        QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.TRACE.value,
+            trace=trace,
+            organization=user.organization,
+            workspace=workspace,
+        )
+        SpanNotes.objects.create(
+            span=observation_span,
+            notes="whole call note",
+            created_by_user=user,
+            created_by_annotator=user.email,
+        )
+
+        resp = auth_client.get(
+            "/model-hub/annotation-queues/for-source/",
+            {
+                "sources": json.dumps(
+                    [
+                        {
+                            "source_type": "trace",
+                            "source_id": str(trace.id),
+                            "span_notes_source_id": observation_span.id,
+                        }
+                    ]
+                )
+            },
+        )
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        result = resp.data["result"]
+        assert len(result) == 1
+        assert result[0]["item"]["source_id"] == str(trace.id)
+        assert result[0]["existing_notes"] == "whole call note"
+        assert result[0]["span_notes_source_id"] == observation_span.id
+
+    def test_queue_annotate_detail_prefills_and_saves_item_notes(
+        self,
+        auth_client,
+        observe_project,
+        trace,
+        observation_span,
+        thumbs_label,
+        user,
+        workspace,
+    ):
+        """Queue workspace whole-item notes use the trace root span."""
+        from tracer.models.span_notes import SpanNotes
+
+        queue = AnnotationQueue.objects.create(
+            name="Trace workspace queue",
+            status=AnnotationQueueStatusChoices.ACTIVE.value,
+            project=observe_project,
+            organization=user.organization,
+            workspace=workspace,
+            created_by=user,
+        )
+        AnnotationQueueLabel.objects.create(queue=queue, label=thumbs_label)
+        item = QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.TRACE.value,
+            trace=trace,
+            organization=user.organization,
+            workspace=workspace,
+        )
+        SpanNotes.objects.create(
+            span=observation_span,
+            notes="existing whole item note",
+            created_by_user=user,
+            created_by_annotator=user.email,
+        )
+
+        detail_resp = auth_client.get(
+            f"/model-hub/annotation-queues/{queue.id}/items/{item.id}/annotate-detail/",
+        )
+
+        assert detail_resp.status_code == status.HTTP_200_OK, detail_resp.data
+        detail = detail_resp.data["result"]
+        assert detail["existing_notes"] == "existing whole item note"
+        assert detail["span_notes_source_id"] == observation_span.id
+
+        submit_resp = auth_client.post(
+            f"/model-hub/annotation-queues/{queue.id}/items/{item.id}/annotations/submit/",
+            {
+                "annotations": [
+                    {
+                        "label_id": str(thumbs_label.id),
+                        "value": {"value": "up"},
+                    }
+                ],
+                "item_notes": "updated whole item note",
+            },
+            format="json",
+        )
+
+        assert submit_resp.status_code == status.HTTP_200_OK, submit_resp.data
+        assert SpanNotes.objects.get(
+            span=observation_span,
+            created_by_user=user,
+        ).notes == "updated whole item note"
+
+    def test_for_source_scores_include_queue_target(
+        self,
+        auth_client,
+        observe_project,
+        trace,
+        thumbs_label,
+        user,
+        workspace,
+    ):
+        """Read-only annotation tables can deep-link back to the queue item."""
+        queue = AnnotationQueue.objects.create(
+            name="Trace linked score queue",
+            status=AnnotationQueueStatusChoices.ACTIVE.value,
+            project=observe_project,
+            organization=user.organization,
+            workspace=workspace,
+            created_by=user,
+        )
+        AnnotationQueueLabel.objects.create(queue=queue, label=thumbs_label)
+        item = QueueItem.objects.create(
+            queue=queue,
+            source_type=QueueItemSourceType.TRACE.value,
+            trace=trace,
+            organization=user.organization,
+            workspace=workspace,
+        )
+
+        submit_resp = auth_client.post(
+            f"/model-hub/annotation-queues/{queue.id}/items/{item.id}/annotations/submit/",
+            {
+                "annotations": [
+                    {
+                        "label_id": str(thumbs_label.id),
+                        "value": {"value": "up"},
+                    }
+                ]
+            },
+            format="json",
+        )
+        assert submit_resp.status_code == status.HTTP_200_OK, submit_resp.data
+
+        resp = auth_client.get(
+            f"{SCORE_URL}for-source/",
+            {"source_type": "trace", "source_id": str(trace.id)},
+        )
+
+        assert resp.status_code == status.HTTP_200_OK, resp.data
+        result = resp.data["result"]
+        assert len(result) == 1
+        assert str(result[0]["queue_item"]) == str(item.id)
+        assert result[0]["queue_id"] == str(queue.id)
+
 
 @pytest.mark.django_db
 class TestListScores:

--- a/futureagi/model_hub/views/scores.py
+++ b/futureagi/model_hub/views/scores.py
@@ -12,7 +12,6 @@ from model_hub.models.annotation_queues import QueueItem
 from model_hub.models.choices import QueueItemStatus
 from model_hub.models.develop_annotations import AnnotationsLabels
 from model_hub.models.score import SCORE_SOURCE_FK_MAP, Score
-from tracer.models.span_notes import SpanNotes
 from model_hub.serializers.scores import (
     BulkCreateScoresSerializer,
     CreateScoreSerializer,
@@ -22,6 +21,7 @@ from model_hub.utils.annotation_queue_helpers import resolve_source_object
 from tfc.constants.roles import OrganizationRoles
 from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.pagination import ExtendedPageNumberPagination
+from tracer.models.span_notes import SpanNotes
 
 logger = structlog.get_logger(__name__)
 
@@ -111,7 +111,6 @@ def _auto_create_queue_items_for_default_queues(source_type, source_obj, label_i
     from model_hub.models.annotation_queues import (
         SOURCE_TYPE_FK_MAP,
         AnnotationQueue,
-        AnnotationQueueLabel,
     )
     from model_hub.models.choices import AnnotationQueueStatusChoices
 
@@ -174,7 +173,7 @@ def _auto_create_queue_items_for_default_queues(source_type, source_obj, label_i
     ).distinct()
 
     for queue in default_queues:
-        QueueItem.objects.get_or_create(
+        item, _ = QueueItem.objects.get_or_create(
             queue=queue,
             source_type=source_type,
             **{f"{fk_field}_id": source_obj.pk},
@@ -185,6 +184,16 @@ def _auto_create_queue_items_for_default_queues(source_type, source_obj, label_i
                 "status": QueueItemStatus.PENDING.value,
             },
         )
+        Score.no_workspace_objects.filter(
+            source_type=source_type,
+            **{f"{fk_field}_id": source_obj.pk},
+            label_id__in=queue.queue_labels.filter(deleted=False).values_list(
+                "label_id", flat=True
+            ),
+            organization=queue.organization,
+            queue_item__isnull=True,
+            deleted=False,
+        ).update(queue_item=item)
 
 
 class ScoreViewSet(viewsets.ModelViewSet):
@@ -206,7 +215,7 @@ class ScoreViewSet(viewsets.ModelViewSet):
         qs = Score.objects.filter(
             organization=self.request.organization,
             deleted=False,
-        ).select_related("label", "annotator")
+        ).select_related("label", "annotator", "queue_item__queue")
 
         # Filter by source
         source_type = self.request.query_params.get("source_type")
@@ -313,6 +322,7 @@ class ScoreViewSet(viewsets.ModelViewSet):
         source_type = data["source_type"]
         source_id = data["source_id"]
         span_notes = data.get("span_notes")  # None when field was not sent
+        span_notes_source_id = data.get("span_notes_source_id")
 
         fk_field = SCORE_SOURCE_FK_MAP.get(source_type)
         if not fk_field:
@@ -323,6 +333,21 @@ class ScoreViewSet(viewsets.ModelViewSet):
         )
         if not source_obj:
             return self._gm.not_found(f"Source not found: {source_type}={source_id}")
+
+        span_notes_target = None
+        if span_notes is not None:
+            if source_type == "observation_span":
+                span_notes_target = source_obj
+            elif span_notes_source_id:
+                span_notes_target = resolve_source_object(
+                    "observation_span",
+                    span_notes_source_id,
+                    organization=request.organization,
+                )
+                if not span_notes_target:
+                    return self._gm.not_found(
+                        f"Span notes source not found: {span_notes_source_id}"
+                    )
 
         created_scores = []
         errors = []
@@ -359,13 +384,13 @@ class ScoreViewSet(viewsets.ModelViewSet):
                 )
                 created_scores.append(score)
 
-            # span_notes is None when the field was omitted from the request
-            # (user did not interact with the notes field at all).
-            # Only touch SpanNotes when the field was explicitly sent.
-            if source_type == "observation_span" and span_notes is not None:
+            # span_notes is None when the field was omitted from the request.
+            # For call annotations, labels save on the trace while item notes
+            # still belong to the root observation span.
+            if span_notes_target is not None:
                 if span_notes:
                     SpanNotes.objects.update_or_create(
-                        span=source_obj,
+                        span=span_notes_target,
                         created_by_user=request.user,
                         defaults={
                             "notes": span_notes,
@@ -375,7 +400,7 @@ class ScoreViewSet(viewsets.ModelViewSet):
                 else:
                     # User explicitly cleared the notes field — delete the SpanNote
                     SpanNotes.objects.filter(
-                        span=source_obj,
+                        span=span_notes_target,
                         created_by_user=request.user,
                     ).delete()
 
@@ -431,7 +456,7 @@ class ScoreViewSet(viewsets.ModelViewSet):
                 organization=request.organization,
                 deleted=False,
             )
-            .select_related("label", "annotator")
+            .select_related("label", "annotator", "queue_item__queue")
             .order_by("label__name", "-created_at")
         )
 


### PR DESCRIPTION
## Summary

Fixes the next annotation queue stack covering TH-4782, TH-4759, and TH-4055.

- routes observed voice call annotation writes to trace scores while keeping whole-item notes on the root conversation span
- keeps simulation queue annotations scoped to `call_execution`
- stores and reloads queue item notes for trace call annotations via `span_notes_source_id`
- lets annotation rows in trace drawers deep-link to the owning queue item in a new tab
- replaces the old scenario table in annotation queue call-execution content with the newer voice drawer scenario view
- returns queue metadata on score reads so the frontend can link a score back to its queue item

## Validation

- `cd frontend && yarn test:run src/api/scores/__tests__/scores.test.js src/components/__tests__/voiceAnnotationSources.test.js src/components/ScoresListSection/__tests__/ScoresListSection.test.jsx src/sections/annotations/queues/__tests__/content-panel.test.jsx src/sections/annotations/queues/__tests__/annotate-components.test.jsx`
- `cd futureagi && set -a && source .env.test.local && set +a && .venv/bin/pytest model_hub/tests/test_scores_api.py -q`
- `cd frontend && yarn eslint src/api/scores/scores.js src/api/scores/__tests__/scores.test.js src/components/CallLogsDetailDrawer/CallLogsDetailDrawer.jsx src/components/CallLogsDetailDrawer/RightSection.jsx src/components/ScoresListSection/ScoresListSection.jsx src/components/ScoresListSection/__tests__/ScoresListSection.test.jsx src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx src/components/traceDetail/SpanDetailPane.jsx src/components/traceDetailDrawer/AnnotationSidebarContent.jsx src/components/__tests__/voiceAnnotationSources.test.js src/components/voiceAnnotationSources.js src/sections/annotations/queues/annotate/content-panel.jsx src/sections/annotations/queues/__tests__/content-panel.test.jsx src/sections/test-detail/TestDetailDrawer/TestDetailSideDrawer.jsx`

Lint completed with pre-existing warnings in `SpanDetailPane.jsx` and `TestDetailSideDrawer.jsx`, no errors.