### PR TITLE
fix: align KB eval propagation and connector updates

### DIFF
--- a/frontend/src/components/custom-audio/audioHelper.js
+++ b/frontend/src/components/custom-audio/audioHelper.js
@@ -4,6 +4,7 @@ import {
   blobUrlManager,
   audioContextManager,
 } from "src/utils/memory-management";
+import { canonicalEntries } from "src/utils/utils";
 
 export const formatTime = (seconds) => {
   if (!seconds || isNaN(seconds)) return "0:00";
@@ -24,9 +25,11 @@ export const getColorByWeight = (weight) => {
 
 export const transformAudioData = (valueInfos) => {
   const metadata = valueInfos;
-  if (!metadata?.errorAnalysis) return [];
+  const errorAnalysis = metadata?.errorAnalysis || metadata?.error_analysis;
+  if (!errorAnalysis) return [];
 
-  return Object.values(metadata?.errorAnalysis)
+  return canonicalEntries(errorAnalysis)
+    .map(([, value]) => value)
     .flat()
     .map(({ orgSegment, rankReason, weight }, index) => {
       if (!orgSegment) return null;

--- a/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
+++ b/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
@@ -8,6 +8,7 @@ import axios, { endpoints } from "src/utils/axios";
 import Iconify from "src/components/iconify";
 import { enqueueSnackbar } from "notistack";
 import ErrorLocalizeCard from "src/sections/common/ErrorLocalizeCard";
+import { canonicalEntries } from "src/utils/utils";
 
 /**
  * Unified error-localization section for an eval row. Supports two
@@ -197,7 +198,7 @@ const EvalErrorLocalization = ({
   if (analysis) {
     const entries =
       analysis && typeof analysis === "object" && !Array.isArray(analysis)
-        ? Object.entries(analysis).filter(
+        ? canonicalEntries(analysis).filter(
             ([, v]) => Array.isArray(v) && v.length > 0,
           )
         : null;

--- a/frontend/src/components/traceDetailDrawer/dialogue-boxes/view-details.jsx
+++ b/frontend/src/components/traceDetailDrawer/dialogue-boxes/view-details.jsx
@@ -19,6 +19,7 @@ import { getChipColor, getChipLabel, getFontColor } from "../common";
 import CellMarkdown from "src/sections/common/CellMarkdown";
 import AudioErrorCard from "src/components/custom-audio/AudioErrorCard";
 import { AudioPlaybackProvider } from "src/components/custom-audio/context-provider/AudioPlaybackContext";
+import { canonicalEntries } from "src/utils/utils";
 
 const ViewDetailsModal = ({ open, onClose, selectedViewDetail, title }) => {
   const theme = useTheme();
@@ -296,7 +297,11 @@ const ViewDetailsModal = ({ open, onClose, selectedViewDetail, title }) => {
                 typeof data === "object" &&
                 data?.errorAnalysis &&
                 (() => {
-                  const hasOrgSegment = Object.values(data?.errorAnalysis)
+                  const errorAnalysisEntries = canonicalEntries(
+                    data?.errorAnalysis,
+                  );
+                  const hasOrgSegment = errorAnalysisEntries
+                    .map(([, value]) => value)
                     .flat()
                     .some((entry) => entry?.orgSegment);
 
@@ -311,7 +316,7 @@ const ViewDetailsModal = ({ open, onClose, selectedViewDetail, title }) => {
                     );
                   }
 
-                  return Object.entries(data?.errorAnalysis)
+                  return errorAnalysisEntries
                     .filter(([_, value]) => value?.length)
                     .map(([key, value]) => (
                       <ErrorLocalizeCard

--- a/frontend/src/sections/common/ErrorLocalizeCard.jsx
+++ b/frontend/src/sections/common/ErrorLocalizeCard.jsx
@@ -308,6 +308,73 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
     setHoveredData(null);
   }, [value, datapoint, column]);
 
+  const renderLocalizerDetails = (item) => {
+    const reason = item?.reason;
+    const improvement = item?.improvement;
+    const rankReason = item?.rank_reason || item?.rankReason;
+
+    if (!reason && !improvement && !rankReason) return null;
+
+    return (
+      <Box
+        sx={{
+          mt: 1,
+          p: 1.25,
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: "6px",
+          backgroundColor: "background.paper",
+        }}
+      >
+        {reason && (
+          <Box sx={{ mb: improvement || rankReason ? 1 : 0 }}>
+            <Typography
+              variant="caption"
+              fontWeight={600}
+              color="text.primary"
+              sx={{ display: "block", mb: 0.25 }}
+            >
+              Reason
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {reason}
+            </Typography>
+          </Box>
+        )}
+        {improvement && (
+          <Box sx={{ mb: rankReason ? 1 : 0 }}>
+            <Typography
+              variant="caption"
+              fontWeight={600}
+              color="text.primary"
+              sx={{ display: "block", mb: 0.25 }}
+            >
+              Suggested fix
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {improvement}
+            </Typography>
+          </Box>
+        )}
+        {rankReason && (
+          <Box>
+            <Typography
+              variant="caption"
+              fontWeight={600}
+              color="text.primary"
+              sx={{ display: "block", mb: 0.25 }}
+            >
+              Severity
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {rankReason}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    );
+  };
+
   const highlightText = (text, startEx, endEx, weight, data) => {
     if (!text) return "";
     let fullText = text;
@@ -505,26 +572,43 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
                               )}
                             </Box>
                           </Typography>
+                          {renderLocalizerDetails(i)}
                           {value.length > 1 && index < value.length - 1 && (
                             <Divider />
                           )}
                         </React.Fragment>
                       ))
                     ) : (
-                      // Show single paragraph with all highlights when expanded
-                      <Typography
-                        sx={{
-                          marginY: theme.spacing(1.5),
-                          overflowY: "auto",
-                          ...sx,
-                        }}
-                        variant="s2"
-                      >
-                        {renderTextWithAllHighlights(
-                          datapoint?.input_data[datapoint.selected_input_key],
-                          value,
-                        )}
-                      </Typography>
+                      <>
+                        <Typography
+                          sx={{
+                            marginY: theme.spacing(1.5),
+                            overflowY: "auto",
+                            ...sx,
+                          }}
+                          variant="s2"
+                        >
+                          {renderTextWithAllHighlights(
+                            datapoint?.input_data[datapoint.selected_input_key],
+                            value,
+                          )}
+                        </Typography>
+                        <Box
+                          sx={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 1,
+                          }}
+                        >
+                          {value.map((item, index) => (
+                            <React.Fragment
+                              key={item.unitKey || item.unit_key || index}
+                            >
+                              {renderLocalizerDetails(item)}
+                            </React.Fragment>
+                          ))}
+                        </Box>
+                      </>
                     )}
                     <ShowComponent condition={showMoreCondition}>
                       <Box
@@ -655,7 +739,7 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
                     key={imageKey}
                     imageUrl={imageData?.dataFile}
                     value={value}
-                    weight={datapoint?.errorAnalysis[0]?.weight}
+                    weight={value?.[0]?.weight}
                     boxWidth={400}
                     boxHeight={400}
                   />
@@ -670,7 +754,7 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
 };
 
 ErrorLocalizeCard.propTypes = {
-  value: PropTypes.object,
+  value: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   column: PropTypes.string,
   sx: PropTypes.object,
   datapoint: PropTypes.object,

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawer/DatapointDrawer.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawer/DatapointDrawer.jsx
@@ -30,6 +30,7 @@ import { ShowComponent } from "src/components/show";
 import ImageDatapointCard from "src/sections/common/ImageDatapointCard";
 import CellMarkdown from "src/sections/common/CellMarkdown";
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
+import { canonicalEntries } from "src/utils/utils";
 
 const SkeletonLoader = () => (
   <Box
@@ -707,9 +708,11 @@ const DatapointDrawerChild = ({
                     typeof runEval?.valueInfos === "object" &&
                     runEval?.valueInfos?.errorAnalysis &&
                     (() => {
-                      const hasOrgSegment = Object.values(
+                      const errorAnalysisEntries = canonicalEntries(
                         runEval?.valueInfos?.errorAnalysis,
-                      )
+                      );
+                      const hasOrgSegment = errorAnalysisEntries
+                        .map(([, value]) => value)
                         .flat()
                         .some((entry) => entry?.orgSegment);
 
@@ -722,7 +725,7 @@ const DatapointDrawerChild = ({
                         );
                       }
 
-                      return Object.entries(runEval?.valueInfos?.errorAnalysis)
+                      return errorAnalysisEntries
                         .filter(([_, value]) => value?.length)
                         .map(([key, value]) => (
                           <ErrorLocalizeCard

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -49,6 +49,7 @@ import ScoresListSection from "src/components/ScoresListSection/ScoresListSectio
 import AddLabelDrawer from "src/components/traceDetailDrawer/AddLabelDrawer";
 import { useEvalsList } from "src/sections/common/EvaluationDrawer/getEvalsList";
 import CompositeResultView from "src/sections/evals/components/CompositeResultView";
+import { canonicalEntries } from "src/utils/utils";
 
 const SkeletonLoader = () => (
   <Box
@@ -1365,19 +1366,9 @@ const ErrorLocalizationCellSection = ({ evalOpen, onAnalysisLoaded }) => {
   const renderAnalysis =
     inlineAnalysis ||
     (pollData?.status === "completed" ? pollData?.error_analysis : null);
-  const renderAnalysisEntries = Object.entries(renderAnalysis || {})
-    .filter(([key]) => {
-      // Keep canonical snake_case keys and drop alias-only keys like
-      // `input1` when `input_1` exists.
-      if (key.includes("_")) return true;
-      if (/[A-Z]/.test(key)) return false;
-      const snakeWithNumericBoundary = key.replace(
-        /([a-zA-Z])([0-9])/g,
-        "$1_$2",
-      );
-      return !renderAnalysis?.[snakeWithNumericBoundary];
-    })
-    .filter(([_, value]) => Array.isArray(value) && value.length > 0);
+  const renderAnalysisEntries = canonicalEntries(renderAnalysis || {}).filter(
+    ([_, value]) => Array.isArray(value) && value.length > 0,
+  );
   const hasRenderAnalysis = renderAnalysisEntries.length > 0;
   const renderAnalysisForDisplay = Object.fromEntries(renderAnalysisEntries);
   const renderSelectedInputKey =
@@ -1432,14 +1423,14 @@ const ErrorLocalizationCellSection = ({ evalOpen, onAnalysisLoaded }) => {
               );
             }
             return renderAnalysisEntries.map(([key, value]) => (
-                <ErrorLocalizeCard
-                  key={key}
-                  value={value}
-                  column={renderSelectedInputKey}
-                  tabValue="raw"
-                  datapoint={renderValueInfos}
-                />
-              ));
+              <ErrorLocalizeCard
+                key={key}
+                value={value}
+                column={renderSelectedInputKey}
+                tabValue="raw"
+                datapoint={renderValueInfos}
+              />
+            ));
           })()}
         </Box>
       </Box>

--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx
@@ -19,6 +19,7 @@ import CellMarkdown from "src/sections/common/CellMarkdown";
 import JsonCodeView from "src/components/code/json-code-view";
 import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 import { useAuthContext } from "src/auth/hooks";
+import { canonicalEntries } from "src/utils/utils";
 
 const LogDrawerRight = ({
   output,
@@ -28,6 +29,17 @@ const LogDrawerRight = ({
 }) => {
   const theme = useTheme();
   const { role } = useAuthContext();
+  const errorAnalysis = error?.error_analysis || error?.errorAnalysis;
+  const selectedInputKey = error?.selected_input_key || error?.selectedInputKey;
+  const canonicalErrorAnalysis = Object.fromEntries(
+    canonicalEntries(errorAnalysis || {}),
+  );
+  const errorDatapoint = {
+    ...error,
+    selected_input_key: selectedInputKey,
+    input_data: error?.input_data || error?.inputData,
+    input_types: error?.input_types || error?.inputTypes,
+  };
 
   return (
     <Box
@@ -161,23 +173,23 @@ const LogDrawerRight = ({
           >
             {error &&
               typeof error === "object" &&
-              error?.errorAnalysis &&
+              errorAnalysis &&
               (() => {
-                return Object.entries(error?.errorAnalysis)
+                return canonicalEntries(errorAnalysis)
                   .filter(([_key, value]) => value.length)
                   .map(([key, value]) => (
                     <ErrorLocalizeCard
                       key={key}
                       value={value}
-                      column={error?.selectedInputKey}
+                      column={selectedInputKey || key}
                       tabValue="raw"
-                      datapoint={error}
+                      datapoint={errorDatapoint}
                     />
                   ));
               })()}
           </Box>
         </Box>
-        {error && typeof error === "object" && error?.errorAnalysis && (
+        {error && typeof error === "object" && errorAnalysis && (
           <Box
             sx={{
               display: "flex",
@@ -243,7 +255,7 @@ const LogDrawerRight = ({
                   },
                 }}
               >
-                <JsonCodeView data={error?.errorAnalysis || {}} />
+                <JsonCodeView data={canonicalErrorAnalysis} />
               </Box>
             </Box>
           </Box>

--- a/frontend/src/sections/evals/components/EvalGroundTruthTab.jsx
+++ b/frontend/src/sections/evals/components/EvalGroundTruthTab.jsx
@@ -24,7 +24,7 @@ import { useSnackbar } from "notistack";
 import { AgGridReact } from "ag-grid-react";
 import { useAgTheme } from "src/hooks/use-ag-theme";
 import Iconify from "src/components/iconify";
-import { canonicalKeys } from "src/utils/utils";
+import { canonicalEntries } from "src/utils/utils";
 
 import {
   useDevelopDatasetList,
@@ -1351,7 +1351,7 @@ const TestRetrieval = ({ gtId }) => {
                   sx={{ fontSize: "10px", height: 18 }}
                 />
               </Box>
-              {Object.entries(r.row_data || r.rowData || {})
+              {canonicalEntries(r.row_data || r.rowData || {})
                 .slice(0, 4)
                 .map(([k, v]) => (
                   <Typography

--- a/frontend/src/sections/evals/components/EvalResultDisplay.jsx
+++ b/frontend/src/sections/evals/components/EvalResultDisplay.jsx
@@ -11,6 +11,7 @@ import React, { useMemo, useState } from "react";
 import Editor from "@monaco-editor/react";
 import ErrorLocalizeCard from "src/sections/common/ErrorLocalizeCard";
 import CompositeResultView from "./CompositeResultView";
+import { canonicalEntries } from "src/utils/utils";
 
 /**
  * Shared eval result display component.
@@ -386,7 +387,18 @@ function normalizeLocalizerEntries(val) {
  * Handles three states: running (spinner), completed (ErrorLocalizeCard), or absent (nothing).
  */
 const ErrorLocalizationSection = ({ result }) => {
-  const errorDetails = result?.error_details || result?.error_analysis;
+  const rawErrorDetails = result?.error_details || result?.error_analysis;
+  const detailsEnvelope =
+    rawErrorDetails &&
+    !Array.isArray(rawErrorDetails) &&
+    typeof rawErrorDetails === "object" &&
+    (rawErrorDetails.error_analysis || rawErrorDetails.errorAnalysis)
+      ? rawErrorDetails
+      : null;
+  const errorDetails =
+    detailsEnvelope?.error_analysis ||
+    detailsEnvelope?.errorAnalysis ||
+    rawErrorDetails;
   const errorLocalizerStatus = result?.error_localizer_status;
   const errorLocalizerMessage = result?.error_localizer_message;
 
@@ -488,16 +500,28 @@ const ErrorLocalizationSection = ({ result }) => {
   const entriesMap =
     !Array.isArray(errorDetails) && typeof errorDetails === "object"
       ? Object.fromEntries(
-          Object.entries(errorDetails).map(([k, v]) => [
+          canonicalEntries(errorDetails).map(([k, v]) => [
             k,
             normalizeLocalizerEntries(v),
           ]),
         )
       : null;
 
-  const selectedInputKey = result?.selected_input_key;
-  const inputData = result?.input_data;
-  const inputTypes = result?.input_types;
+  const selectedInputKey =
+    result?.selected_input_key ||
+    result?.selectedInputKey ||
+    detailsEnvelope?.selected_input_key ||
+    detailsEnvelope?.selectedInputKey;
+  const inputData =
+    result?.input_data ||
+    result?.inputData ||
+    detailsEnvelope?.input_data ||
+    detailsEnvelope?.inputData;
+  const inputTypes =
+    result?.input_types ||
+    result?.inputTypes ||
+    detailsEnvelope?.input_types ||
+    detailsEnvelope?.inputTypes;
 
   // ErrorLocalizeCard reads a mix of camelCase (`datapoint.selectedInputKey`)
   // and snake_case (`datapoint.input_data[datapoint.selected_input_key]`).

--- a/frontend/src/sections/experiment-detail/ExperimentData/ViewEvalDetailsModal.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ViewEvalDetailsModal.jsx
@@ -22,6 +22,7 @@ import {
   getStatusColor,
 } from "src/sections/develop-detail/DataTab/common";
 import CellMarkdown from "src/sections/common/CellMarkdown";
+import { canonicalEntries } from "src/utils/utils";
 
 export default function ViewDetailsModal({
   evalDetail,
@@ -41,6 +42,12 @@ export default function ViewDetailsModal({
       return JSON.parse(evalDetail?.cellValue?.replace(/'/g, '"'));
     }
   }, [evalDetail?.cellValue]);
+  const metadataErrorAnalysis =
+    evalDetail?.valueInfos?.metadata?.errorAnalysis ||
+    evalDetail?.valueInfos?.metadata?.error_analysis;
+  const metadataErrorAnalysisEntries = canonicalEntries(
+    metadataErrorAnalysis || {},
+  );
 
   return (
     <Dialog
@@ -204,17 +211,15 @@ export default function ViewDetailsModal({
             Possible Error
           </Typography>
           {/* <FailedFetchingError /> */}
-          {evalDetail?.valueInfos?.metadata?.errorAnalysis?.input1 &&
-            evalDetail?.valueInfos?.metadata?.errorAnalysis?.input1?.length <
-              1 && (
-              <Typography
-                color={"text.disabled"}
-                typography={"s1"}
-                fontWeight={"fontWeightRegular"}
-              >
-                No error found
-              </Typography>
-            )}
+          {metadataErrorAnalysisEntries.length === 0 && (
+            <Typography
+              color={"text.disabled"}
+              typography={"s1"}
+              fontWeight={"fontWeightRegular"}
+            >
+              No error found
+            </Typography>
+          )}
           <Box
             sx={{
               display: "flex",
@@ -226,11 +231,10 @@ export default function ViewDetailsModal({
           >
             {evalDetail &&
               typeof evalDetail?.valueInfos?.metadata === "object" &&
-              evalDetail?.valueInfos?.metadata?.errorAnalysis &&
+              metadataErrorAnalysis &&
               (() => {
-                const hasOrgSegment = Object.values(
-                  evalDetail.valueInfos.metadata.errorAnalysis,
-                )
+                const hasOrgSegment = metadataErrorAnalysisEntries
+                  .map(([, value]) => value)
                   .flat()
                   .some((entry) => entry.orgSegment);
 
@@ -243,9 +247,7 @@ export default function ViewDetailsModal({
                   );
                 }
 
-                return Object.entries(
-                  evalDetail.valueInfos.metadata.errorAnalysis,
-                )
+                return metadataErrorAnalysisEntries
                   .filter(([_, value]) => value.length)
                   .map(([key, value]) => (
                     <ErrorLocalizeCard

--- a/frontend/src/sections/falcon-ai/hooks/useFalconAPI.js
+++ b/frontend/src/sections/falcon-ai/hooks/useFalconAPI.js
@@ -1,4 +1,5 @@
 import axiosInstance, { endpoints } from "src/utils/axios";
+import { useQuery } from "@tanstack/react-query";
 
 export async function fetchConversations({
   limit = 20,
@@ -65,6 +66,24 @@ export async function fetchConnectors() {
 export async function fetchConnector(id) {
   const { data } = await axiosInstance.get(endpoints.falconAI.connector(id));
   return data;
+}
+
+export const falconAIQueryKeys = {
+  connector: (id) => ["falcon-ai", "connector", id],
+};
+
+export function useConnector(id, options = {}) {
+  const { enabled = true, ...queryOptions } = options;
+
+  return useQuery({
+    queryKey: falconAIQueryKeys.connector(id),
+    queryFn: async () => {
+      const data = await fetchConnector(id);
+      return data?.result || data;
+    },
+    enabled: Boolean(id) && enabled,
+    ...queryOptions,
+  });
 }
 
 export async function createConnector(payload) {

--- a/frontend/src/sections/falcon-ai/hooks/useFalconAPI.js
+++ b/frontend/src/sections/falcon-ai/hooks/useFalconAPI.js
@@ -63,11 +63,6 @@ export async function fetchConnectors() {
   return data;
 }
 
-export async function fetchConnector(id) {
-  const { data } = await axiosInstance.get(endpoints.falconAI.connector(id));
-  return data;
-}
-
 export const falconAIQueryKeys = {
   connector: (id) => ["falcon-ai", "connector", id],
 };
@@ -78,7 +73,9 @@ export function useConnector(id, options = {}) {
   return useQuery({
     queryKey: falconAIQueryKeys.connector(id),
     queryFn: async () => {
-      const data = await fetchConnector(id);
+      const { data } = await axiosInstance.get(
+        endpoints.falconAI.connector(id),
+      );
       return data?.result || data;
     },
     enabled: Boolean(id) && enabled,

--- a/frontend/src/sections/falcon-ai/hooks/useFalconAPI.js
+++ b/frontend/src/sections/falcon-ai/hooks/useFalconAPI.js
@@ -62,6 +62,11 @@ export async function fetchConnectors() {
   return data;
 }
 
+export async function fetchConnector(id) {
+  const { data } = await axiosInstance.get(endpoints.falconAI.connector(id));
+  return data;
+}
+
 export async function createConnector(payload) {
   const { data } = await axiosInstance.post(
     endpoints.falconAI.connectors,
@@ -104,10 +109,10 @@ export async function authenticateConnector(id) {
   return data;
 }
 
-export async function updateConnectorTools(id, tools) {
+export async function updateConnectorTools(id, enabledToolNames) {
   const { data } = await axiosInstance.patch(
     endpoints.falconAI.connectorTools(id),
-    { tools },
+    { enabled_tool_names: enabledToolNames },
   );
   return data;
 }

--- a/frontend/src/sections/settings/falcon-ai-connectors/ConnectorSettingsPage.jsx
+++ b/frontend/src/sections/settings/falcon-ai-connectors/ConnectorSettingsPage.jsx
@@ -20,7 +20,7 @@ import { alpha, useTheme } from "@mui/material/styles";
 import Iconify from "src/components/iconify";
 import {
   fetchConnectors,
-  fetchConnector,
+  useConnector,
   createConnector,
   updateConnector,
   deleteConnector,
@@ -76,6 +76,10 @@ export default function ConnectorSettingsPage() {
   const [selectedId, setSelectedId] = useState(null);
   const [isEditing, setIsEditing] = useState(false);
   const [isNew, setIsNew] = useState(false);
+  const { data: selectedConnector, refetch: refetchSelectedConnector } =
+    useConnector(selectedId, {
+      enabled: Boolean(selectedId) && !isNew,
+    });
 
   const loadConnectors = useCallback(async ({ showSpinner = true } = {}) => {
     try {
@@ -102,16 +106,21 @@ export default function ConnectorSettingsPage() {
         return;
       }
       try {
-        const data = await fetchConnector(id);
-        const detail = data.result || data;
-        setConnectors((prev) =>
-          prev.map((c) => (c.id === detail.id ? { ...c, ...detail } : c)),
-        );
+        if (id === selectedId) {
+          const { data: detail } = await refetchSelectedConnector();
+          if (detail?.id) {
+            setConnectors((prev) =>
+              prev.map((c) => (c.id === detail.id ? { ...c, ...detail } : c)),
+            );
+            return;
+          }
+        }
+        await loadConnectors({ showSpinner: false });
       } catch {
         await loadConnectors({ showSpinner: false });
       }
     },
-    [loadConnectors],
+    [loadConnectors, refetchSelectedConnector, selectedId],
   );
 
   useEffect(() => {
@@ -136,7 +145,12 @@ export default function ConnectorSettingsPage() {
     return () => window.removeEventListener("message", handler);
   }, [loadConnectors, refreshSelected, selectedId]);
 
-  const selected = connectors.find((c) => c.id === selectedId) || null;
+  const selectedFromList = connectors.find((c) => c.id === selectedId) || null;
+  const selected =
+    selectedConnector?.id != null &&
+    String(selectedConnector.id) === String(selectedId)
+      ? { ...(selectedFromList || {}), ...selectedConnector }
+      : selectedFromList;
   const filtered = connectors.filter(
     (c) => !search || c.name?.toLowerCase().includes(search.toLowerCase()),
   );
@@ -153,8 +167,11 @@ export default function ConnectorSettingsPage() {
     setIsEditing(true);
   };
 
-  const handleSaved = () => {
-    loadConnectors();
+  const handleSaved = async () => {
+    await loadConnectors();
+    if (selectedId && !isNew) {
+      await refetchSelectedConnector();
+    }
     setIsEditing(false);
     setIsNew(false);
   };
@@ -518,7 +535,8 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
       } else {
         setFeedback({
           severity: "success",
-          message: result?.message || result?.detail || "Authentication updated.",
+          message:
+            result?.message || result?.detail || "Authentication updated.",
         });
         await onRefresh();
       }

--- a/frontend/src/sections/settings/falcon-ai-connectors/ConnectorSettingsPage.jsx
+++ b/frontend/src/sections/settings/falcon-ai-connectors/ConnectorSettingsPage.jsx
@@ -20,6 +20,7 @@ import { alpha, useTheme } from "@mui/material/styles";
 import Iconify from "src/components/iconify";
 import {
   fetchConnectors,
+  fetchConnector,
   createConnector,
   updateConnector,
   deleteConnector,
@@ -53,6 +54,16 @@ function getStatusInfo(connector) {
   return { label: "Pending", color: "warning" };
 }
 
+function getActionErrorMessage(error, fallback) {
+  return (
+    error?.response?.data?.detail ||
+    error?.response?.data?.error ||
+    error?.response?.data?.message ||
+    error?.message ||
+    fallback
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main Page
 // ---------------------------------------------------------------------------
@@ -66,9 +77,11 @@ export default function ConnectorSettingsPage() {
   const [isEditing, setIsEditing] = useState(false);
   const [isNew, setIsNew] = useState(false);
 
-  const loadConnectors = useCallback(async () => {
+  const loadConnectors = useCallback(async ({ showSpinner = true } = {}) => {
     try {
-      setLoading(true);
+      if (showSpinner) {
+        setLoading(true);
+      }
       const data = await fetchConnectors();
       const results = data.results || data || [];
       setConnectors(Array.isArray(results) ? results : []);
@@ -76,9 +89,30 @@ export default function ConnectorSettingsPage() {
     } catch {
       setError("Failed to load connectors.");
     } finally {
-      setLoading(false);
+      if (showSpinner) {
+        setLoading(false);
+      }
     }
   }, []);
+
+  const refreshSelected = useCallback(
+    async (id) => {
+      if (!id) {
+        await loadConnectors({ showSpinner: false });
+        return;
+      }
+      try {
+        const data = await fetchConnector(id);
+        const detail = data.result || data;
+        setConnectors((prev) =>
+          prev.map((c) => (c.id === detail.id ? { ...c, ...detail } : c)),
+        );
+      } catch {
+        await loadConnectors({ showSpinner: false });
+      }
+    },
+    [loadConnectors],
+  );
 
   useEffect(() => {
     loadConnectors();
@@ -96,11 +130,11 @@ export default function ConnectorSettingsPage() {
           /* */
         }
       }
-      await loadConnectors();
+      await refreshSelected(selectedId);
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [loadConnectors, selectedId]);
+  }, [loadConnectors, refreshSelected, selectedId]);
 
   const selected = connectors.find((c) => c.id === selectedId) || null;
   const filtered = connectors.filter(
@@ -178,6 +212,7 @@ export default function ConnectorSettingsPage() {
           </Typography>
         </Box>
         <Button
+          type="button"
           variant="contained"
           startIcon={<Iconify icon="mdi:plus" width={18} />}
           onClick={handleNew}
@@ -324,7 +359,7 @@ export default function ConnectorSettingsPage() {
               connector={selected}
               onEdit={() => setIsEditing(true)}
               onDelete={() => handleDelete(selected.id)}
-              onRefresh={loadConnectors}
+              onRefresh={() => refreshSelected(selected.id)}
             />
           ) : (
             <Box
@@ -361,6 +396,7 @@ export default function ConnectorSettingsPage() {
               </Typography>
               {connectors.length === 0 && (
                 <Button
+                  type="button"
                   variant="outlined"
                   startIcon={<Iconify icon="mdi:plus" width={16} />}
                   onClick={handleNew}
@@ -387,9 +423,14 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
   const [testing, setTesting] = useState(false);
   const [discovering, setDiscovering] = useState(false);
   const [reauthing, setReauthing] = useState(false);
+  const [feedback, setFeedback] = useState(null);
 
   const tools = connector.discovered_tools || [];
-  const enabledTools = connector.enabled_tools || [];
+  const enabledTools = connector.enabled_tool_names || [];
+
+  useEffect(() => {
+    setFeedback(null);
+  }, [connector.id]);
 
   const isToolEnabled = (toolName) => {
     if (enabledTools.length === 0 && tools.length > 0) return true; // all enabled by default
@@ -397,41 +438,95 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
   };
 
   const handleTest = async () => {
+    setFeedback(null);
     setTesting(true);
     try {
-      await testConnector(connector.id);
-      onRefresh();
-    } catch {
-      /* */
+      const result = await testConnector(connector.id);
+      if (result?.status === false || result?.result?.success === false) {
+        setFeedback({
+          severity: "error",
+          message:
+            result?.error || result?.result?.error || "Connection test failed.",
+        });
+      } else {
+        setFeedback({
+          severity: "success",
+          message:
+            result?.message || result?.detail || "Connection test succeeded.",
+        });
+      }
+      await onRefresh();
+    } catch (error) {
+      setFeedback({
+        severity: "error",
+        message: getActionErrorMessage(error, "Connection test failed."),
+      });
     } finally {
       setTesting(false);
     }
   };
 
   const handleDiscover = async () => {
+    setFeedback(null);
     setDiscovering(true);
     try {
-      await discoverConnectorTools(connector.id);
-      onRefresh();
-    } catch {
-      /* */
+      const result = await discoverConnectorTools(connector.id);
+      if (result?.status === false) {
+        setFeedback({
+          severity: "error",
+          message: result?.error || "Tool discovery failed.",
+        });
+      } else {
+        const discoveredCount =
+          result?.discovered_count ??
+          (Array.isArray(result?.result?.discovered_tools)
+            ? result.result.discovered_tools.length
+            : null);
+        setFeedback({
+          severity: "success",
+          message:
+            discoveredCount == null
+              ? "Tool discovery completed."
+              : `Discovered ${discoveredCount} tool${discoveredCount === 1 ? "" : "s"}.`,
+        });
+      }
+      await onRefresh();
+    } catch (error) {
+      setFeedback({
+        severity: "error",
+        message: getActionErrorMessage(error, "Tool discovery failed."),
+      });
     } finally {
       setDiscovering(false);
     }
   };
 
   const handleReauth = async () => {
+    setFeedback(null);
     setReauthing(true);
     try {
       const result = await authenticateConnector(connector.id);
-      const authUrl = result?.authorization_url;
+      const authUrl =
+        result?.authorizationUrl ||
+        result?.authorization_url ||
+        result?.auth_url ||
+        result?.oauth_url ||
+        result?.result?.authorizationUrl ||
+        result?.result?.authorization_url;
       if (authUrl) {
         window.open(authUrl, "falcon_oauth", "width=600,height=700,popup=yes");
       } else {
-        onRefresh();
+        setFeedback({
+          severity: "success",
+          message: result?.message || result?.detail || "Authentication updated.",
+        });
+        await onRefresh();
       }
-    } catch {
-      /* */
+    } catch (error) {
+      setFeedback({
+        severity: "error",
+        message: getActionErrorMessage(error, "Authentication failed."),
+      });
     } finally {
       setReauthing(false);
     }
@@ -446,9 +541,12 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
     }
     try {
       await updateConnectorTools(connector.id, updated);
-      onRefresh();
-    } catch {
-      /* */
+      await onRefresh();
+    } catch (error) {
+      setFeedback({
+        severity: "error",
+        message: getActionErrorMessage(error, "Failed to update tools."),
+      });
     }
   };
 
@@ -578,9 +676,16 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
         </Alert>
       )}
 
+      {feedback && (
+        <Alert severity={feedback.severity} sx={{ mb: 2, fontSize: 12 }}>
+          {feedback.message}
+        </Alert>
+      )}
+
       {/* Actions */}
       <Box sx={{ display: "flex", gap: 1, mb: 3, flexWrap: "wrap" }}>
         <Button
+          type="button"
           size="small"
           variant="outlined"
           startIcon={<Iconify icon="mdi:pencil-outline" width={14} />}
@@ -591,6 +696,7 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
         </Button>
         {connector.auth_type === "oauth" && (
           <Button
+            type="button"
             size="small"
             variant="outlined"
             startIcon={<Iconify icon="mdi:refresh" width={14} />}
@@ -602,6 +708,7 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
           </Button>
         )}
         <Button
+          type="button"
           size="small"
           variant="outlined"
           startIcon={<Iconify icon="mdi:magnify" width={14} />}
@@ -612,6 +719,7 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
           {discovering ? "Discovering..." : "Discover Tools"}
         </Button>
         <Button
+          type="button"
           size="small"
           variant="outlined"
           startIcon={<Iconify icon="mdi:connection" width={14} />}
@@ -622,6 +730,7 @@ function ConnectorDetail({ connector, onEdit, onDelete, onRefresh }) {
           {testing ? "Testing..." : "Test Connection"}
         </Button>
         <Button
+          type="button"
           size="small"
           variant="outlined"
           color="error"
@@ -729,7 +838,7 @@ ConnectorDetail.propTypes = {
     is_active: PropTypes.bool,
     last_error: PropTypes.string,
     discovered_tools: PropTypes.array,
-    enabled_tools: PropTypes.array,
+    enabled_tool_names: PropTypes.array,
   }).isRequired,
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
@@ -967,6 +1076,7 @@ function ConnectorEditor({ connector, onSaved, onCancel }) {
 
       <Box sx={{ display: "flex", gap: 1, mt: 1 }}>
         <Button
+          type="button"
           variant="contained"
           size="small"
           onClick={handleSave}
@@ -981,6 +1091,7 @@ function ConnectorEditor({ connector, onSaved, onCancel }) {
           {saving ? "Saving..." : isEdit ? "Save" : "Create"}
         </Button>
         <Button
+          type="button"
           variant="outlined"
           size="small"
           onClick={onCancel}

--- a/frontend/src/sections/test-detail/TestDetailDrawer/EvalSection.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/EvalSection.jsx
@@ -16,6 +16,7 @@ import ErrorLocalizeCard from "src/sections/common/ErrorLocalizeCard";
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import Iconify from "src/components/iconify";
+import { canonicalEntries } from "src/utils/utils";
 
 const WrapperBox = styled(Box)(({ theme }) => ({
   display: "flex",
@@ -289,7 +290,10 @@ const EvalDrawerSection = () => {
               >
                 {errorAnalysis &&
                   (() => {
-                    const hasOrgSegment = Object.values(errorAnalysis)
+                    const errorAnalysisEntries =
+                      canonicalEntries(errorAnalysis);
+                    const hasOrgSegment = errorAnalysisEntries
+                      .map(([, value]) => value)
                       .flat()
                       .some((entry) => entry?.orgSegment);
 
@@ -302,7 +306,7 @@ const EvalDrawerSection = () => {
                       );
                     }
 
-                    return Object.entries(errorAnalysis)
+                    return errorAnalysisEntries
                       .filter(([_, value]) => value?.length)
                       .map(([key, value]) => (
                         <ErrorLocalizeCard

--- a/futureagi/ai_tools/tools/evaluations/create_eval_template.py
+++ b/futureagi/ai_tools/tools/evaluations/create_eval_template.py
@@ -159,7 +159,7 @@ class CreateEvalTemplateInput(PydanticBaseModel):
         description=(
             "Explanation style for agent evals: "
             "{'type': 'concise'} (default), 'short', 'long', or "
-            "{'type': 'custom', 'custom_instructions': '...'}."
+            "{'type': 'custom', 'custom': '...'}."
         ),
     )
 

--- a/futureagi/ai_tools/tools/evaluations/update_eval_template.py
+++ b/futureagi/ai_tools/tools/evaluations/update_eval_template.py
@@ -136,7 +136,7 @@ class UpdateEvalTemplateInput(PydanticBaseModel):
         description=(
             "Explanation style for agent evals: "
             "{'type': 'concise'} (default), 'short', 'long', or "
-            "{'type': 'custom', 'custom_instructions': '...'}."
+            "{'type': 'custom', 'custom': '...'}."
         ),
     )
 

--- a/futureagi/ai_tools/tools/web/brave_search.py
+++ b/futureagi/ai_tools/tools/web/brave_search.py
@@ -1,13 +1,9 @@
-"""
-Brave Web Search tool for AI agents.
+"""Brave web search tool for AI agents."""
 
-Uses the Brave Search API to search the web and return structured results.
-Requires BRAVE_SEARCH_API_KEY environment variable.
-Free tier: 2000 queries/month at https://brave.com/search/api/
-"""
-
+import html
 import os
-from typing import Optional
+import re
+from urllib.parse import urlparse
 
 import requests
 import structlog
@@ -19,7 +15,137 @@ from ai_tools.registry import register_tool
 
 logger = structlog.get_logger(__name__)
 
-BRAVE_API_URL = "https://api.search.brave.com/res/v1/web/search"
+BRAVE_WEB_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
+BRAVE_LLM_CONTEXT_URL = "https://api.search.brave.com/res/v1/llm/context"
+BRAVE_DEFAULT_COUNTRY = "US"
+BRAVE_DEFAULT_SEARCH_LANG = "en"
+MAX_RESULTS_FOR_LLM = 3
+MAX_SNIPPET_CHARS = 180
+MAX_EXTRA_SNIPPET_CHARS = 120
+RECENT_QUERY_TERMS = (
+    "latest",
+    "current",
+    "today",
+    "newest",
+    "recent",
+    "now",
+    "this year",
+    "announced",
+    "released",
+)
+QUERY_STOPWORDS = {
+    "about",
+    "after",
+    "before",
+    "best",
+    "check",
+    "current",
+    "does",
+    "find",
+    "for",
+    "from",
+    "has",
+    "have",
+    "into",
+    "latest",
+    "look",
+    "model",
+    "new",
+    "newest",
+    "now",
+    "official",
+    "recent",
+    "released",
+    "search",
+    "the",
+    "today",
+    "verify",
+    "what",
+    "when",
+    "where",
+    "which",
+    "with",
+}
+DOMAIN_STOPWORDS = {
+    "api",
+    "app",
+    "blog",
+    "com",
+    "docs",
+    "help",
+    "io",
+    "net",
+    "news",
+    "org",
+    "support",
+    "www",
+}
+
+
+def _clean_text(value: str | None) -> str:
+    if not value:
+        return ""
+    text = html.unescape(value)
+    text = re.sub(r"</?(strong|em|mark|b|i)>", "", text)
+    text = re.sub(r"<[^>]+>", "", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _truncate(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - 3].rstrip() + "..."
+
+
+def _infer_freshness(query: str, freshness: str | None) -> str | None:
+    if freshness:
+        return freshness
+    lowered = query.lower()
+    if any(term in lowered for term in RECENT_QUERY_TERMS):
+        return "py"
+    return None
+
+
+def _hostname(url: str) -> str:
+    try:
+        return (urlparse(url).hostname or "").removeprefix("www.")
+    except Exception:
+        return ""
+
+
+def _tokens(value: str) -> set[str]:
+    tokens = set()
+    for token in re.findall(r"[a-z0-9]+(?:[.-][a-z0-9]+)*", value.lower()):
+        if len(token) < 3 and not any(ch.isdigit() for ch in token):
+            continue
+        if token in QUERY_STOPWORDS:
+            continue
+        tokens.add(token)
+        if len(token) > 4 and token.endswith("s"):
+            tokens.add(token[:-1])
+    return tokens
+
+
+def _source_type(query: str, url: str, title: str) -> str:
+    query_tokens = _tokens(query)
+    host = _hostname(url)
+    host_tokens = {
+        token
+        for token in re.split(r"[\W_]+", host.lower())
+        if len(token) >= 3 and token not in DOMAIN_STOPWORDS
+    }
+
+    if query_tokens & host_tokens:
+        return "primary"
+    return "secondary_or_unknown"
+
+
+def _sort_key(item: dict) -> tuple[int, int]:
+    priority = {
+        "primary": 0,
+        "secondary_or_unknown": 1,
+    }
+    return priority.get(item["source_type"], 3), item["rank"]
 
 
 class BraveSearchInput(PydanticBaseModel):
@@ -30,7 +156,7 @@ class BraveSearchInput(PydanticBaseModel):
         le=20,
         description="Number of results to return (default 5, max 20)",
     )
-    freshness: Optional[str] = Field(
+    freshness: str | None = Field(
         default=None,
         description=(
             "Filter by content freshness. Options: "
@@ -44,9 +170,10 @@ class BraveSearchInput(PydanticBaseModel):
 class BraveSearchTool(BaseTool):
     name = "web_search"
     description = (
-        "Search the web using Brave Search to find current information, "
-        "verify facts, look up recent events, or gather evidence. "
-        "Returns titles, URLs, and descriptions of matching web pages."
+        "Search the web using Brave Search to verify facts, look up recent events, "
+        "or gather evidence. Returns source URLs, source dates when available, "
+        "and extracted grounding snippets optimized for LLM use. For latest/current "
+        "claims, pass a freshness filter such as 'pm' or 'py'."
     )
     category = "web"
     input_model = BraveSearchInput
@@ -63,25 +190,168 @@ class BraveSearchTool(BaseTool):
         headers = {
             "Accept": "application/json",
             "Accept-Encoding": "gzip",
+            "Cache-Control": "no-cache",
             "X-Subscription-Token": api_key,
         }
 
+        freshness = _infer_freshness(params.query, params.freshness)
+        use_llm_context = os.getenv("BRAVE_SEARCH_USE_LLM_CONTEXT", "").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+        if use_llm_context:
+            context_result = self._execute_llm_context(params, headers, freshness)
+            if context_result is not None:
+                return context_result
+
+        return self._execute_web_search(params, headers, freshness)
+
+    def _request_json(self, url: str, headers: dict, query_params: dict) -> dict:
+        response = requests.get(
+            url,
+            headers=headers,
+            params=query_params,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _execute_llm_context(
+        self,
+        params: BraveSearchInput,
+        headers: dict,
+        freshness: str | None,
+    ) -> ToolResult | None:
         query_params = {
             "q": params.query,
             "count": params.count,
+            "country": BRAVE_DEFAULT_COUNTRY,
+            "search_lang": BRAVE_DEFAULT_SEARCH_LANG,
+            "maximum_number_of_urls": min(params.count, MAX_RESULTS_FOR_LLM),
+            "maximum_number_of_tokens": 1800,
+            "maximum_number_of_snippets": min(params.count * 2, 10),
+            "maximum_number_of_snippets_per_url": 1,
+            "context_threshold_mode": "balanced",
         }
-        if params.freshness:
-            query_params["freshness"] = params.freshness
+        if freshness:
+            query_params["freshness"] = freshness
 
         try:
-            response = requests.get(
-                BRAVE_API_URL,
-                headers=headers,
-                params=query_params,
-                timeout=15,
+            data = self._request_json(BRAVE_LLM_CONTEXT_URL, headers, query_params)
+        except requests.exceptions.Timeout:
+            return ToolResult.error(
+                "Brave LLM Context request timed out. Try again.",
+                error_code="TIMEOUT",
             )
-            response.raise_for_status()
-            data = response.json()
+        except requests.exceptions.HTTPError as e:
+            status = e.response.status_code if e.response else "unknown"
+            logger.warning(
+                "brave_llm_context_unavailable",
+                status=status,
+                query=params.query,
+            )
+            return None
+        except Exception as e:
+            logger.warning("brave_llm_context_error", error=str(e), query=params.query)
+            return None
+
+        generic_results = data.get("grounding", {}).get("generic", []) or []
+        sources = data.get("sources", {}) or {}
+
+        if not generic_results:
+            return None
+
+        lines = [f"## Web Search Results for: {params.query}\n"]
+        result_data = []
+        ranked_results = []
+
+        for rank, result in enumerate(generic_results[: params.count], 1):
+            url = result.get("url", "")
+            source_meta = sources.get(url, {}) if url else {}
+            title = _clean_text(
+                result.get("title") or source_meta.get("title") or "Untitled"
+            )
+            hostname = source_meta.get("hostname") or ""
+            age = source_meta.get("age")
+            snippets = [
+                _truncate(_clean_text(snippet), MAX_SNIPPET_CHARS)
+                for snippet in (result.get("snippets") or [])[:1]
+                if _clean_text(snippet)
+            ]
+            ranked_results.append(
+                {
+                    "rank": rank,
+                    "title": title,
+                    "url": url,
+                    "hostname": hostname or _hostname(url),
+                    "age": age,
+                    "source_type": _source_type(params.query, url, title),
+                    "snippets": snippets,
+                }
+            )
+
+        for i, result in enumerate(
+            sorted(ranked_results, key=_sort_key)[:MAX_RESULTS_FOR_LLM], 1
+        ):
+            age = result["age"]
+
+            lines.append(f"### {i}. {result['title']}")
+            lines.append(f"Source type: {result['source_type']}")
+            lines.append(f"URL: {result['url']}")
+            if age:
+                if isinstance(age, list):
+                    lines.append(f"Date: {', '.join(str(item) for item in age[:2])}")
+                else:
+                    lines.append(f"Date: {age}")
+            for snippet in result["snippets"]:
+                lines.append(f"Snippet: {snippet}")
+            lines.append("")
+
+            result_data.append(
+                {
+                    "title": result["title"],
+                    "url": result["url"],
+                    "hostname": result["hostname"],
+                    "age": result["age"],
+                    "source_type": result["source_type"],
+                    "snippets": result["snippets"],
+                }
+            )
+
+        return ToolResult(
+            content="\n".join(lines),
+            data={
+                "query": params.query,
+                "source": "brave_llm_context",
+                "freshness": freshness,
+                "results": result_data,
+            },
+        )
+
+    def _execute_web_search(
+        self,
+        params: BraveSearchInput,
+        headers: dict,
+        freshness: str | None,
+    ) -> ToolResult:
+        query_params = {
+            "q": params.query,
+            "count": params.count,
+            "country": BRAVE_DEFAULT_COUNTRY,
+            "search_lang": BRAVE_DEFAULT_SEARCH_LANG,
+            "safesearch": "moderate",
+            "spellcheck": "1",
+            "text_decorations": "0",
+            "extra_snippets": "1",
+            "include_fetch_metadata": "1",
+            "result_filter": "web",
+        }
+        if freshness:
+            query_params["freshness"] = freshness
+
+        try:
+            data = self._request_json(BRAVE_WEB_SEARCH_URL, headers, query_params)
         except requests.exceptions.Timeout:
             return ToolResult.error(
                 "Brave Search request timed out. Try again.",
@@ -100,44 +370,73 @@ class BraveSearchTool(BaseTool):
                 error_code="INTERNAL_ERROR",
             )
 
-        # Parse results
         web_results = data.get("web", {}).get("results", [])
 
         if not web_results:
             return ToolResult(
                 content=f"No web results found for: **{params.query}**",
-                data={"query": params.query, "results": []},
+                data={"query": params.query, "freshness": freshness, "results": []},
             )
 
-        # Format results for LLM consumption
         lines = [f"## Web Search Results for: {params.query}\n"]
         result_data = []
+        ranked_results = []
 
-        for i, result in enumerate(web_results[: params.count], 1):
-            title = result.get("title", "Untitled")
+        for rank, result in enumerate(web_results[: params.count], 1):
+            title = _clean_text(result.get("title") or "Untitled")
             url = result.get("url", "")
-            description = result.get("description", "No description")
-            # Clean HTML tags from description
-            description = (
-                description.replace("<strong>", "**")
-                .replace("</strong>", "**")
-                .replace("<em>", "_")
-                .replace("</em>", "_")
+            description = _truncate(
+                _clean_text(result.get("description") or "No description"),
+                MAX_SNIPPET_CHARS,
+            )
+            age = result.get("age") or result.get("page_age")
+            extra_snippets = [
+                _truncate(_clean_text(snippet), MAX_EXTRA_SNIPPET_CHARS)
+                for snippet in (result.get("extra_snippets") or [])[:1]
+                if _clean_text(snippet)
+            ]
+            ranked_results.append(
+                {
+                    "rank": rank,
+                    "title": title,
+                    "url": url,
+                    "hostname": _hostname(url),
+                    "age": age,
+                    "source_type": _source_type(params.query, url, title),
+                    "description": description,
+                    "extra_snippets": extra_snippets,
+                }
             )
 
-            lines.append(f"### {i}. {title}")
-            lines.append(f"**URL:** {url}")
-            lines.append(f"{description}\n")
+        for i, result in enumerate(
+            sorted(ranked_results, key=_sort_key)[:MAX_RESULTS_FOR_LLM], 1
+        ):
+            lines.append(f"### {i}. {result['title']}")
+            lines.append(f"Source type: {result['source_type']}")
+            lines.append(f"URL: {result['url']}")
+            if result["age"]:
+                lines.append(f"Date: {result['age']}")
+            lines.append(f"Snippet: {result['description']}")
+            lines.append("")
 
             result_data.append(
                 {
-                    "title": title,
-                    "url": url,
-                    "description": description,
+                    "title": result["title"],
+                    "url": result["url"],
+                    "hostname": result["hostname"],
+                    "age": result["age"],
+                    "source_type": result["source_type"],
+                    "description": result["description"],
+                    "extra_snippets": result["extra_snippets"],
                 }
             )
 
         return ToolResult(
             content="\n".join(lines),
-            data={"query": params.query, "results": result_data},
+            data={
+                "query": params.query,
+                "source": "brave_web_search",
+                "freshness": freshness,
+                "results": result_data,
+            },
         )

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -641,6 +641,28 @@ def _get_input_type(input):
     return input_type
 
 
+def _eval_passed(value) -> bool:
+    """
+    Determine if an eval result represents a passing evaluation.
+    Returns True if the eval passed (error localizer should be skipped).
+    """
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value >= 0.8
+    if isinstance(value, str):
+        return value.lower() in ("passed", "pass", "true", "1")
+    if isinstance(value, list):
+        return all(_eval_passed(v) for v in value) if value else False
+    if isinstance(value, dict):
+        inner = value.get("result") or value.get("output")
+        if inner is not None:
+            return _eval_passed(inner)
+    return False
+
+
 def _validate_error_localizer_fields(rule_prompt, input_data, eval_result):
     """
     Validate required fields for error localization.
@@ -838,10 +860,13 @@ def _get_input_keys(input_data):
 
 
 def trigger_error_localization_for_standalone(evaluation: Evaluation):
-    """
-    Helper function to create ErrorLocalizerTask for standalone evaluations.
-    """
     try:
+        if _eval_passed(evaluation.data):
+            logger.info(
+                f"Skipping error localization for passing eval {evaluation.id}"
+            )
+            return None
+
         input_keys = _get_input_keys(evaluation.input_data)
         input_types = _get_input_type(evaluation.input_data)
 

--- a/futureagi/model_hub/tests/test_background_helpers.py
+++ b/futureagi/model_hub/tests/test_background_helpers.py
@@ -419,6 +419,59 @@ class TestValidateAllFiles:
         assert "Unexpected" in result["files_with_issues"][0]["error"]
 
 
+class TestCreateKnowledgeBaseEntitlements:
+    @patch("model_hub.views.develop_dataset.User.objects.get")
+    @patch("model_hub.views.develop_dataset.KnowledgeBaseFile.objects.filter")
+    @patch("ee.usage.services.entitlements.Entitlements.check_feature")
+    @patch("ee.usage.services.entitlements.Entitlements.can_create")
+    @patch("model_hub.views.develop_dataset.log_and_deduct_cost_for_resource_request")
+    def test_post_uses_entitlements_instead_of_legacy_resource_limit(
+        self,
+        mock_legacy_limit,
+        mock_can_create,
+        mock_check_feature,
+        mock_kb_filter,
+        mock_user_get,
+    ):
+        from ee.usage.models.usage import APICallStatusChoices
+        from model_hub.views.develop_dataset import CreateKnowledgeBaseView
+
+        view = CreateKnowledgeBaseView()
+        view._gm = MagicMock()
+        view._gm.bad_request.return_value = MagicMock(status_code=400)
+        view._gm.too_many_requests.return_value = MagicMock(status_code=429)
+
+        org = MagicMock()
+        org.id = "org-1"
+
+        request = MagicMock()
+        request.organization = org
+        request.user.id = "user-1"
+        request.user.organization = org
+        request.workspace = MagicMock()
+        request.data = {"name": "KB allowed by entitlements"}
+        request.FILES.getlist.return_value = []
+
+        mock_user_get.return_value.name = "tester"
+        mock_kb_filter.return_value.count.return_value = 0
+        mock_can_create.return_value = MagicMock(allowed=True)
+        mock_check_feature.return_value = MagicMock(allowed=True)
+        mock_legacy_limit.return_value = MagicMock(
+            status=APICallStatusChoices.RESOURCE_LIMIT.value
+        )
+
+        view.validate_all_files = MagicMock(
+            return_value={"valid": False, "files_with_issues": []}
+        )
+
+        response = view.post(request)
+
+        mock_can_create.assert_called_once_with("org-1", "knowledge_bases", 0)
+        mock_check_feature.assert_called_once_with("org-1", "has_knowledge_base")
+        mock_legacy_limit.assert_not_called()
+        assert response.status_code == 400
+
+
 @pytest.mark.django_db
 class TestCreateFilesAndUpload:
     """Tests for create_files_and_upload method."""

--- a/futureagi/model_hub/types.py
+++ b/futureagi/model_hub/types.py
@@ -144,7 +144,7 @@ class EvalCreateRequest(BaseModel):
         None  # {variables_only, dataset_row, trace_context, ...}
     )
     summary: dict | None = (
-        None  # {type: short|long|concise|custom, custom_instructions: str}
+        None  # {type: short|long|concise|custom, custom: str}
     )
     # Template format — determines how variables are extracted
     template_format: Literal["mustache", "jinja"] = "mustache"

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -14059,15 +14059,11 @@ class CreateKnowledgeBaseView(APIView):
             if updated_size > MAX_KB_SIZE:
                 return self._gm.bad_request(get_error_message("MAX_KB_SIZE_EXCEEDED"))
 
-            # New entitlement check (Phase 3)
+            entitlements_checked = False
             try:
-                from model_hub.models.develop_dataset import KnowledgeBase
-                try:
-                    from ee.usage.services.entitlements import Entitlements
-                except ImportError:
-                    Entitlements = None
+                from ee.usage.services.entitlements import Entitlements
 
-                kb_count = KnowledgeBase.objects.filter(
+                kb_count = KnowledgeBaseFile.objects.filter(
                     organization=org, deleted=False
                 ).count()
                 ent_check = Entitlements.can_create(
@@ -14076,30 +14072,30 @@ class CreateKnowledgeBaseView(APIView):
                 if not ent_check.allowed:
                     return self._gm.forbidden_response(ent_check.reason)
 
-                # Also check boolean feature
                 feat_check = Entitlements.check_feature(
                     str(org.id), "has_knowledge_base"
                 )
                 if not feat_check.allowed:
                     return self._gm.forbidden_response(feat_check.reason)
+                entitlements_checked = True
             except ImportError:
                 pass
 
-            # Legacy resource limit check (kept for backward compat during migration)
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                organization=org,
-                api_call_type=APICallTypeChoices.KNOWLEDGE_BASE.value,
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(
-                    get_error_message("KB_CREATION_LIMIT_REACHED")
+            if not entitlements_checked:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    organization=org,
+                    api_call_type=APICallTypeChoices.KNOWLEDGE_BASE.value,
+                    workspace=request.workspace,
                 )
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(
+                        get_error_message("KB_CREATION_LIMIT_REACHED")
+                    )
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
 
             # Validate ALL files FIRST (before creating KB)
             # Uses is_file_readable for full validation (password check, content parsing)

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1171,23 +1171,25 @@ class EvaluationRunner:
             )
             if should_run_error_localizer:
                 from model_hub.tasks.user_evaluation import (
+                    _eval_passed,
                     trigger_error_localization_for_column,
                 )
 
-                cell = Cell.objects.filter(
-                    column__id=self.replace_column_id, row=row, deleted=False
-                ).first()
+                if not _eval_passed(value):
+                    cell = Cell.objects.filter(
+                        column__id=self.replace_column_id, row=row, deleted=False
+                    ).first()
 
-                trigger_error_localization_for_column(
-                    eval_template=self.user_eval_metric.template,
-                    config=config_error,
-                    required_field=required_field_error,
-                    mapping=mapping_error,
-                    eval_result=value,
-                    response=response,
-                    cell=cell,
-                    log_id=str(api_call_log_row.log_id),
-                )
+                    trigger_error_localization_for_column(
+                        eval_template=self.user_eval_metric.template,
+                        config=config_error,
+                        required_field=required_field_error,
+                        mapping=mapping_error,
+                        eval_result=value,
+                        response=response,
+                        cell=cell,
+                        log_id=str(api_call_log_row.log_id),
+                    )
 
         except Exception as e:
             logger.exception(f"Error in evaluation of row: {str(e)}")
@@ -1860,7 +1862,9 @@ class EvaluationRunner:
         required_field, mapping = self._prepare_mapping_data(row, mappings)
         config_copy = config.copy()
         eval_instance = self._create_eval_instance(
-            config=config, model=self.user_eval_metric.model
+            config=config,
+            model=self.user_eval_metric.model,
+            kb_id=getattr(self.user_eval_metric, "kb_id", None),
         )
 
         config_error = self._prepare_eval_config(config_copy)
@@ -1986,6 +1990,8 @@ class EvaluationRunner:
             gt_config_in_template = self.eval_template.config.get("ground_truth")
             if gt_config_in_template and gt_config_in_template.get("enabled"):
                 from model_hub.utils.ground_truth_retrieval import (
+                    format_few_shot_examples,
+                    get_ground_truth_few_shot_examples,
                     load_ground_truth_config,
                 )
 
@@ -2000,8 +2006,31 @@ class EvaluationRunner:
                         if gt_obj:
                             gt_config["embedding_status"] = gt_obj.embedding_status
                     except Exception:
-                        pass
-                    _mapped["ground_truth_config"] = gt_config
+                        gt_obj = None
+
+                    template_eval_type_id = self.eval_template.config.get(
+                        "eval_type_id", ""
+                    )
+                    if (
+                        template_eval_type_id == "CustomPromptEvaluator"
+                        and gt_obj
+                        and gt_obj.embedding_status == "completed"
+                    ):
+                        gt_examples = get_ground_truth_few_shot_examples(
+                            gt_config, _mapped
+                        )
+                        if gt_examples:
+                            injection_format = gt_config.get(
+                                "injection_format", "structured"
+                            )
+                            formatted = format_few_shot_examples(
+                                gt_examples,
+                                gt_obj.role_mapping,
+                                injection_format,
+                            )
+                            _mapped["ground_truth_few_shot"] = formatted
+                    else:
+                        _mapped["ground_truth_config"] = gt_config
 
         # For code evals, inject static user-defined params stored in the
         # UserEvalMetric config so they reach evaluate() as **kwargs.

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -290,11 +290,16 @@ def run_eval_func(
             template.config.get("ground_truth") if template.config else None
         )
         if gt_config_in_template and gt_config_in_template.get("enabled"):
-            from model_hub.utils.ground_truth_retrieval import load_ground_truth_config
+            from model_hub.utils.ground_truth_retrieval import (
+                format_few_shot_examples,
+                get_ground_truth_few_shot_examples,
+                load_ground_truth_config,
+            )
 
             gt_config = load_ground_truth_config(template)
             if gt_config:
                 # Enrich with embedding_status from the GT model
+                gt_obj = None
                 try:
                     from model_hub.models.evals_metric import EvalGroundTruth
 
@@ -305,7 +310,25 @@ def run_eval_func(
                         gt_config["embedding_status"] = gt_obj.embedding_status
                 except Exception:
                     pass
-                _run_kwargs["ground_truth_config"] = gt_config
+
+                if (
+                    eval_id == "CustomPromptEvaluator"
+                    and gt_obj
+                    and gt_obj.embedding_status == "completed"
+                ):
+                    gt_examples = get_ground_truth_few_shot_examples(
+                        gt_config, _run_kwargs
+                    )
+                    if gt_examples:
+                        injection_format = gt_config.get(
+                            "injection_format", "structured"
+                        )
+                        formatted = format_few_shot_examples(
+                            gt_examples, gt_obj.role_mapping, injection_format
+                        )
+                        _run_kwargs["ground_truth_few_shot"] = formatted
+                else:
+                    _run_kwargs["ground_truth_config"] = gt_config
 
         # Preprocess inputs for code evals that need external data (e.g. CLIP embeddings)
         if _is_code_eval:
@@ -434,19 +457,21 @@ def run_eval_func(
 
         if error_localizer:
             from model_hub.tasks.user_evaluation import (
+                _eval_passed,
                 trigger_error_localization_for_playground,
             )
 
-            logger.info(
-                f"sending to error localizer: {api_call_log_row.log_id}, {value}, {param_values}, {response.get('reason')}"
-            )
-            trigger_error_localization_for_playground(
-                eval_template=template,
-                log=api_call_log_row,
-                value=value,
-                mapping=mappings,
-                eval_explanation=response.get("reason"),
-            )
+            if not _eval_passed(value):
+                logger.info(
+                    f"sending to error localizer: {api_call_log_row.log_id}, {value}, {param_values}, {response.get('reason')}"
+                )
+                trigger_error_localization_for_playground(
+                    eval_template=template,
+                    log=api_call_log_row,
+                    value=value,
+                    mapping=mappings,
+                    eval_explanation=response.get("reason"),
+                )
 
         return output
 

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -121,6 +121,31 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
         raise ValueError(
             f"eval_type_id not found in EvalTemplate config for {eval_template.name}"
         )
+    # The SDK wraps user eval_config in {"params": {...}} (see
+    # ConfigureEvaluationsSerializer / normalize_eval_runtime_config), so look
+    # in both the top level (legacy/internal callers) and inside ``params``
+    # (SDK callers).
+    _params = (eval_config or {}).get("params") or {}
+    kb_id = (
+        (eval_config or {}).get("kb_id")
+        or (eval_config or {}).get("knowledge_base_id")
+        or _params.get("kb_id")
+        or _params.get("knowledge_base_id")
+    )
+
+    # Build the runtime_config that is forwarded to the engine. Downstream
+    # consumers (``create_eval_instance``) look at top-level keys like
+    # ``run_config`` for AgentEvaluator overrides, but the SDK wraps user
+    # input in ``params``. Lift any non-schema keys from ``params`` to the
+    # top level so multi-KB (``knowledge_bases``) and other runtime overrides
+    # work over the SDK as well.
+    if isinstance(_params, dict) and _params:
+        _engine_runtime_config = {
+            **(eval_config or {}),
+            **{k: v for k, v in _params.items() if k not in ("params",)},
+        }
+    else:
+        _engine_runtime_config = eval_config
 
     futureagi_eval = eval_type_id in FUTUREAGI_EVAL_TYPES
 
@@ -168,6 +193,7 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
         futureagi_eval,
         gt_inputs,
         model=model,
+        kb_id=kb_id,
         workspace=workspace,
     )
 
@@ -178,7 +204,8 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
                 eval_template=eval_template,
                 inputs=gt_inputs,
                 model=model,
-                runtime_config=eval_config,
+                kb_id=kb_id,
+                runtime_config=_engine_runtime_config,
                 organization_id=str(user.organization.id),
                 workspace_id=str(workspace.id) if workspace else None,
             )

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -766,14 +766,17 @@ def _execute_evaluation(
             ).get(pk=eval_log.pk)
 
         if custom_eval_config.error_localizer:
-            trigger_error_localization_for_span(
-                eval_template=eval_model,
-                eval_logger=eval_log,
-                mapping=raw_mapping,
-                eval_explanation=logger_kwargs.get("eval_explanation", ""),
-                value=value,
-                log_id=str(log_id),
-            )
+            from model_hub.tasks.user_evaluation import _eval_passed
+
+            if not _eval_passed(value):
+                trigger_error_localization_for_span(
+                    eval_template=eval_model,
+                    eval_logger=eval_log,
+                    mapping=raw_mapping,
+                    eval_explanation=logger_kwargs.get("eval_explanation", ""),
+                    value=value,
+                    log_id=str(log_id),
+                )
 
         if type == EXPERIMENT:
             # updating project version config


### PR DESCRIPTION
## Summary

This PR fixes the KB evaluation execution path end-to-end and tightens the surrounding tooling/runtime contracts. It propagates `kb_id` through dataset/playground/SDK eval execution, skips error localization for passing evals, refreshes Falcon connector state correctly in the UI, and aligns the eval-template/brave-search tool surfaces with the runtime behavior we validated through live API calls.

## Linked issues

N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `set -a && source .env.test && set +a && .venv/bin/pytest ee/evals/llm/agent_evaluator/tests/test_kb_prompt.py model_hub/tests/test_background_helpers.py::TestCreateKnowledgeBaseEntitlements -v`
- `set -a && source .env.test && set +a && .venv/bin/python -m py_compile ee/evals/llm/agent_evaluator/evaluator.py ee/evals/llm/agent_evaluator/tests/test_kb_prompt.py model_hub/tasks/user_evaluation.py model_hub/views/develop_dataset.py model_hub/views/eval_runner.py model_hub/views/utils/evals.py model_hub/tests/test_background_helpers.py sdk/utils/evaluations.py tracer/utils/eval.py ai_tools/tools/evaluations/create_eval_template.py ai_tools/tools/evaluations/update_eval_template.py ai_tools/tools/web/brave_search.py`
- `GIT_MASTER=1 git diff --check HEAD~6..HEAD`
- Live API validation:
  - `POST /model-hub/knowledge-base/`
  - `POST /model-hub/knowledge-base/files/`
  - `POST /model-hub/eval-playground/` → `Passed` with `tools_used=['search_knowledge_base']`
  - `fi.evals.evaluate(..., config={'kb_id': ...})` → `passed=True`
  - `POST /model-hub/develops/<dataset_id>/add_user_eval/` → persisted `kb_id` and started runner path

## Screenshots / recordings (if UI)

None.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)