### PR TITLE
fix(pact): close bot-reported scanner false negatives

### DIFF
--- a/tools/pact/__init__.py
+++ b/tools/pact/__init__.py
@@ -1,0 +1,1 @@
+"""pact — Python AST Constraint Tool."""

--- a/tools/pact/checker.py
+++ b/tools/pact/checker.py
@@ -6,7 +6,13 @@ from pathlib import Path
 from typing import Optional
 
 from .encoder import Violation
-from .extractor import FunctionManifest, ModelManifest, extract_from_codebase
+from .extractor import (
+    CallSite,
+    FunctionManifest,
+    ModelManifest,
+    extract_from_codebase,
+    iter_python_files,
+)
 from .failure_mode import DEFAULT_MODES, FailureEvidence, FailureMode
 
 
@@ -51,10 +57,16 @@ def check_codebase(
 
     model_index: dict[str, ModelManifest] = {m.name: m for m in models}
     func_index: dict[str, FunctionManifest] = {f.name: f for f in functions}
+    scanned_files = {str(path) for path in iter_python_files(root)}
+    call_files = {call.file for call in call_sites}
+    file_sentinels = [
+        CallSite(callee_name="__file__", file=file, line=1)
+        for file in sorted(scanned_files - call_files)
+    ]
 
     seen: set[tuple] = set()
     violations: list[Violation] = []
-    for call in call_sites:
+    for call in [*call_sites, *file_sentinels]:
         for mode in modes:
             for evidence in mode.check(call, model_index, func_index):
                 key = (evidence.file, evidence.line, evidence.mode_name, evidence.call)

--- a/tools/pact/checker.py
+++ b/tools/pact/checker.py
@@ -52,10 +52,14 @@ def check_codebase(
     model_index: dict[str, ModelManifest] = {m.name: m for m in models}
     func_index: dict[str, FunctionManifest] = {f.name: f for f in functions}
 
+    seen: set[tuple] = set()
     violations: list[Violation] = []
     for call in call_sites:
         for mode in modes:
             for evidence in mode.check(call, model_index, func_index):
-                violations.append(_to_violation(evidence))
+                key = (evidence.file, evidence.line, evidence.mode_name, evidence.call)
+                if key not in seen:
+                    seen.add(key)
+                    violations.append(_to_violation(evidence))
 
     return violations

--- a/tools/pact/checker.py
+++ b/tools/pact/checker.py
@@ -1,0 +1,56 @@
+"""
+Main orchestration: parse → graph → FailureMode registry → Z3 → violations.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from .encoder import Violation
+from .extractor import FunctionManifest, ModelManifest, extract_from_codebase
+from .failure_mode import DEFAULT_MODES, FailureEvidence, FailureMode
+from .graph import build_call_graph
+
+
+def _to_violation(e: FailureEvidence) -> Violation:
+    return Violation(
+        file=e.file,
+        line=e.line,
+        call=e.call,
+        missing=e.missing,
+        context=e.mode_name,
+    )
+
+
+def check_codebase(
+    root: Path,
+    modes: Optional[list[FailureMode]] = None,
+) -> list[Violation]:
+    """
+    Run all FailureModes against every call site in the codebase.
+
+    Parameters
+    ----------
+    root:
+        Directory to analyze.
+    modes:
+        FailureMode list to run. Defaults to DEFAULT_MODES.
+        Pass a custom list to add or replace constraint classes without
+        touching any other code.
+    """
+    if modes is None:
+        modes = DEFAULT_MODES
+
+    models, functions, call_sites = extract_from_codebase(root)
+
+    model_index: dict[str, ModelManifest] = {m.name: m for m in models}
+    func_index: dict[str, FunctionManifest] = {f.name: f for f in functions}
+
+    build_call_graph(functions, call_sites)
+
+    violations: list[Violation] = []
+    for call in call_sites:
+        for mode in modes:
+            for evidence in mode.check(call, model_index, func_index):
+                violations.append(_to_violation(evidence))
+
+    return violations

--- a/tools/pact/checker.py
+++ b/tools/pact/checker.py
@@ -8,7 +8,6 @@ from typing import Optional
 from .encoder import Violation
 from .extractor import FunctionManifest, ModelManifest, extract_from_codebase
 from .failure_mode import DEFAULT_MODES, FailureEvidence, FailureMode
-from .graph import build_call_graph
 
 
 def _to_violation(e: FailureEvidence) -> Violation:
@@ -24,6 +23,8 @@ def _to_violation(e: FailureEvidence) -> Violation:
 def check_codebase(
     root: Path,
     modes: Optional[list[FailureMode]] = None,
+    *,
+    _extracted=None,  # (models, functions, call_sites) if already extracted
 ) -> list[Violation]:
     """
     Run all FailureModes against every call site in the codebase.
@@ -36,16 +37,20 @@ def check_codebase(
         FailureMode list to run. Defaults to DEFAULT_MODES.
         Pass a custom list to add or replace constraint classes without
         touching any other code.
+    _extracted:
+        Pre-extracted (models, functions, call_sites) tuple. If provided,
+        skips the extraction step to avoid double-parsing.
     """
     if modes is None:
         modes = DEFAULT_MODES
 
-    models, functions, call_sites = extract_from_codebase(root)
+    if _extracted is not None:
+        models, functions, call_sites = _extracted
+    else:
+        models, functions, call_sites = extract_from_codebase(root)
 
     model_index: dict[str, ModelManifest] = {m.name: m for m in models}
     func_index: dict[str, FunctionManifest] = {f.name: f for f in functions}
-
-    build_call_graph(functions, call_sites)
 
     violations: list[Violation] = []
     for call in call_sites:

--- a/tools/pact/checker.py
+++ b/tools/pact/checker.py
@@ -56,7 +56,14 @@ def check_codebase(
         models, functions, call_sites = extract_from_codebase(root)
 
     model_index: dict[str, ModelManifest] = {m.name: m for m in models}
-    func_index: dict[str, FunctionManifest] = {f.name: f for f in functions}
+    name_counts = {
+        f.name: sum(1 for candidate in functions if candidate.name == f.name)
+        for f in functions
+    }
+    func_index: dict[str, FunctionManifest] = {
+        f"{f.file}:{f.name}": f for f in functions
+    }
+    func_index.update({f.name: f for f in functions if name_counts[f.name] == 1})
     scanned_files = {str(path) for path in iter_python_files(root)}
     call_files = {call.file for call in call_sites}
     file_sentinels = [

--- a/tools/pact/cli.py
+++ b/tools/pact/cli.py
@@ -9,6 +9,10 @@ from .checker import check_codebase
 from .extractor import extract_from_codebase
 
 
+class DiffResolutionError(RuntimeError):
+    """Raised when diff-scoped analysis cannot resolve the changed file set."""
+
+
 def _changed_files_on_branch(base: str = "main", cwd: Path = None) -> set[str]:
     """Return absolute paths of files changed vs base branch."""
     import subprocess
@@ -29,8 +33,11 @@ def _changed_files_on_branch(base: str = "main", cwd: Path = None) -> set[str]:
             for p in result.stdout.splitlines()
             if p.strip().endswith(".py")
         }
-    except Exception:
-        return set()
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        stdout = (exc.stdout or "").strip()
+        detail = stderr or stdout or str(exc)
+        raise DiffResolutionError(detail) from exc
 
 
 def main(argv=None) -> int:
@@ -74,7 +81,11 @@ def main(argv=None) -> int:
     violations = check_codebase(root, _extracted=extracted)
 
     if args.diff is not None:
-        changed = _changed_files_on_branch(args.diff, cwd=root)
+        try:
+            changed = _changed_files_on_branch(args.diff, cwd=root)
+        except DiffResolutionError as exc:
+            print(f"error: pact --diff failed: {exc}", file=sys.stderr)
+            return 2
         violations = [v for v in violations if v.file in changed]
         if args.stats:
             print(f"files changed vs {args.diff}: {len(changed)}")

--- a/tools/pact/cli.py
+++ b/tools/pact/cli.py
@@ -1,0 +1,94 @@
+"""pact CLI — run constraint analysis on a codebase."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .checker import check_codebase
+
+
+def _changed_files_on_branch(base: str = "main", cwd: Path = None) -> set[str]:
+    """Return absolute paths of files changed vs base branch."""
+    import subprocess
+    cwd = cwd or Path(".").resolve()
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"{base}...HEAD"],
+            capture_output=True, text=True, check=True, cwd=cwd,
+        )
+        return {str(cwd / p.strip()) for p in result.stdout.splitlines() if p.strip().endswith(".py")}
+    except Exception:
+        return set()
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        prog="pact",
+        description="Python AST Constraint Tool — verify constraints across a codebase using Z3.",
+    )
+    p.add_argument(
+        "root", nargs="?", default=".", metavar="DIR",
+        help="Root directory to analyze (default: current directory)",
+    )
+    p.add_argument(
+        "--json", action="store_true", dest="json_mode",
+        help="Emit results as JSON array",
+    )
+    p.add_argument(
+        "--strict", action="store_true",
+        help="Exit 1 if any violation found",
+    )
+    p.add_argument(
+        "--stats", action="store_true",
+        help="Print extraction statistics before results",
+    )
+    p.add_argument(
+        "--diff", metavar="BASE", nargs="?", const="main",
+        help="Only report violations in files changed vs BASE branch (default: main)",
+    )
+    args = p.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 2
+
+    from .extractor import extract_from_codebase
+    models, functions, call_sites = extract_from_codebase(root)
+
+    if args.stats:
+        print(f"models: {len(models)}  functions: {len(functions)}  call sites: {len(call_sites)}")
+
+    from .checker import check_codebase
+    violations = check_codebase(root)
+
+    if args.diff is not None:
+        changed = _changed_files_on_branch(args.diff, cwd=root)
+        violations = [v for v in violations if v.file in changed]
+        if args.stats:
+            print(f"files changed vs {args.diff}: {len(changed)}")
+
+    if args.json_mode:
+        print(json.dumps(
+            [{"file": v.file, "line": v.line, "call": v.call,
+              "missing": v.missing, "context": v.context}
+             for v in violations],
+            indent=2,
+        ))
+    else:
+        if not violations:
+            label = f"(diff vs {args.diff})" if args.diff else ""
+            print(f"✓  pact: no constraint violations {label}".strip())
+        else:
+            label = f"(diff vs {args.diff})" if args.diff else ""
+            print(f"✗  pact: {len(violations)} violation(s) {label}\n".strip())
+            for v in violations:
+                print(f"  {v}")
+            print()
+
+    return 1 if (violations and args.strict) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pact/cli.py
+++ b/tools/pact/cli.py
@@ -103,7 +103,7 @@ def main(argv=None) -> int:
             print(f"✓  pact: no constraint violations {label}".rstrip(" "))
         else:
             label = f"(diff vs {args.diff})" if args.diff else ""
-            print(f"✗  pact: {len(violations)} violation(s) {label}\n".rstrip(" "))
+            print(f"✗  pact: {len(violations)} violation(s) {label}".rstrip(" "))
             for v in violations:
                 print(f"  {v}")
             print()

--- a/tools/pact/cli.py
+++ b/tools/pact/cli.py
@@ -100,10 +100,10 @@ def main(argv=None) -> int:
     else:
         if not violations:
             label = f"(diff vs {args.diff})" if args.diff else ""
-            print(f"✓  pact: no constraint violations {label}".strip())
+            print(f"✓  pact: no constraint violations {label}".rstrip(" "))
         else:
             label = f"(diff vs {args.diff})" if args.diff else ""
-            print(f"✗  pact: {len(violations)} violation(s) {label}\n".strip())
+            print(f"✗  pact: {len(violations)} violation(s) {label}\n".rstrip(" "))
             for v in violations:
                 print(f"  {v}")
             print()

--- a/tools/pact/cli.py
+++ b/tools/pact/cli.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from .checker import check_codebase
+from .extractor import extract_from_codebase
 
 
 def _changed_files_on_branch(base: str = "main", cwd: Path = None) -> set[str]:
@@ -13,11 +14,21 @@ def _changed_files_on_branch(base: str = "main", cwd: Path = None) -> set[str]:
     import subprocess
     cwd = cwd or Path(".").resolve()
     try:
+        # Find git root first so paths from `git diff` resolve correctly
+        git_root = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True, cwd=cwd,
+        ).stdout.strip()
+        git_root_path = Path(git_root)
         result = subprocess.run(
             ["git", "diff", "--name-only", f"{base}...HEAD"],
-            capture_output=True, text=True, check=True, cwd=cwd,
+            capture_output=True, text=True, check=True, cwd=git_root_path,
         )
-        return {str(cwd / p.strip()) for p in result.stdout.splitlines() if p.strip().endswith(".py")}
+        return {
+            str(git_root_path / p.strip())
+            for p in result.stdout.splitlines()
+            if p.strip().endswith(".py")
+        }
     except Exception:
         return set()
 
@@ -54,14 +65,13 @@ def main(argv=None) -> int:
         print(f"error: {root} is not a directory", file=sys.stderr)
         return 2
 
-    from .extractor import extract_from_codebase
-    models, functions, call_sites = extract_from_codebase(root)
+    extracted = extract_from_codebase(root)
+    models, functions, call_sites = extracted
 
     if args.stats:
         print(f"models: {len(models)}  functions: {len(functions)}  call sites: {len(call_sites)}")
 
-    from .checker import check_codebase
-    violations = check_codebase(root)
+    violations = check_codebase(root, _extracted=extracted)
 
     if args.diff is not None:
         changed = _changed_files_on_branch(args.diff, cwd=root)

--- a/tools/pact/cli.py
+++ b/tools/pact/cli.py
@@ -33,9 +33,9 @@ def _changed_files_on_branch(base: str = "main", cwd: Path = None) -> set[str]:
             for p in result.stdout.splitlines()
             if p.strip().endswith(".py")
         }
-    except subprocess.CalledProcessError as exc:
-        stderr = (exc.stderr or "").strip()
-        stdout = (exc.stdout or "").strip()
+    except (subprocess.CalledProcessError, OSError) as exc:
+        stderr = (getattr(exc, "stderr", None) or "").strip()
+        stdout = (getattr(exc, "stdout", None) or "").strip()
         detail = stderr or stdout or str(exc)
         raise DiffResolutionError(detail) from exc
 

--- a/tools/pact/conftest.py
+++ b/tools/pact/conftest.py
@@ -1,0 +1,4 @@
+# Suppress Hypothesis health-check database scan that inflates startup time.
+from hypothesis import settings, HealthCheck
+settings.register_profile("pact", suppress_health_check=list(HealthCheck), deadline=None)
+settings.load_profile("pact")

--- a/tools/pact/conftest.py
+++ b/tools/pact/conftest.py
@@ -1,4 +1,0 @@
-# Suppress Hypothesis health-check database scan that inflates startup time.
-from hypothesis import settings, HealthCheck
-settings.register_profile("pact", suppress_health_check=list(HealthCheck), deadline=None)
-settings.load_profile("pact")

--- a/tools/pact/encoder.py
+++ b/tools/pact/encoder.py
@@ -1,0 +1,181 @@
+"""
+Universal Z3 constraint encoder.
+
+One Z3 formula per field encodes ALL constraints simultaneously:
+  presence, type range, max_length, choices.
+
+Z3 enumerates the violations — we don't write one checker per constraint class.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .extractor import CallSite, FieldConstraint, FunctionManifest, ModelManifest
+
+try:
+    from z3 import (
+        And, Bool, Int, IntVal, Not, Or, Solver, String,
+        Length, StringVal, sat, unsat,
+    )
+    _HAS_Z3 = True
+except ImportError:
+    _HAS_Z3 = False
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    call: str
+    missing: list[str]
+    context: str  # failure mode name
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}  {self.call}()  missing: {', '.join(self.missing)}"
+
+
+# ---------------------------------------------------------------------------
+# Universal field constraint encoder
+# ---------------------------------------------------------------------------
+
+def _check_field(fc: FieldConstraint, provided: bool, value: object) -> list[str]:
+    """
+    Check ALL constraints for one field against one call-site value.
+
+    Returns a list of violation descriptions — empty means clean.
+
+    Z3 checks each assertion independently so every violated constraint is
+    reported, not just the first one.
+    """
+    violations: list[str] = []
+
+    # Presence — no Z3 needed, just set arithmetic
+    if not provided:
+        if fc.required:
+            violations.append(f"missing required field '{fc.name}'")
+        return violations   # no value → can't check further
+
+    # Value unknown (computed expression) — presence verified, value-level skipped
+    if value is None:
+        return violations
+
+    if not _HAS_Z3:
+        return violations   # no Z3 installed — presence already checked above
+
+    if isinstance(value, str):
+        v = StringVal(value)
+
+        if fc.max_length is not None:
+            s = Solver()
+            s.add(Length(v) > fc.max_length)
+            if s.check() == sat:
+                violations.append(
+                    f"'{fc.name}' length {len(value)} exceeds max_length {fc.max_length}"
+                )
+
+        if fc.choices:
+            str_choices = [c for c in fc.choices if isinstance(c, str)]
+            if str_choices:
+                s = Solver()
+                s.add(Not(Or([v == StringVal(c) for c in str_choices])))
+                if s.check() == sat:
+                    violations.append(
+                        f"'{fc.name}' value {value!r} not in choices {str_choices}"
+                    )
+
+    elif isinstance(value, int):
+        v = IntVal(value)
+
+        if fc.min_value is not None:
+            s = Solver()
+            s.add(v < fc.min_value)
+            if s.check() == sat:
+                violations.append(
+                    f"'{fc.name}' value {value} < min {fc.min_value}"
+                )
+
+        if fc.max_value is not None:
+            s = Solver()
+            s.add(v > fc.max_value)
+            if s.check() == sat:
+                violations.append(
+                    f"'{fc.name}' value {value} > max {fc.max_value}"
+                )
+
+        if fc.choices:
+            int_choices = [c for c in fc.choices if isinstance(c, int)]
+            if int_choices:
+                s = Solver()
+                s.add(Not(Or([v == c for c in int_choices])))
+                if s.check() == sat:
+                    violations.append(
+                        f"'{fc.name}' value {value!r} not in choices {int_choices}"
+                    )
+
+    return violations
+
+
+def check_model_create(call: CallSite, model: ModelManifest) -> list[Violation]:
+    """
+    Verify a Model.objects.create() call against ALL field constraints.
+
+    For each field: presence + type range + max_length + choices — all in one pass.
+    """
+    all_missing: list[str] = []
+
+    for fc in model.fields:
+        if fc.field_type in ("ManyToManyField", "ManyToManyRel", "ManyToOneRel", "OneToOneRel"):
+            continue
+        provided = fc.name in call.provided_kwargs
+        value = call.kwarg_values.get(fc.name)   # None = not provided or computed
+        violations = _check_field(fc, provided, value)
+        all_missing.extend(violations)
+
+    if not all_missing:
+        return []
+
+    return [Violation(
+        file=call.file,
+        line=call.line,
+        call=call.callee_name,
+        missing=all_missing,
+        context="model_create",
+    )]
+
+
+# ---------------------------------------------------------------------------
+# Function call checker (presence only — type checking needs return-type inference)
+# ---------------------------------------------------------------------------
+
+def _z3_check_presence(required: list[str], provided: set[str]) -> list[str]:
+    missing = [f for f in required if f not in provided]
+    if not missing or not _HAS_Z3:
+        return missing
+    s = Solver()
+    for name in required:
+        v = Bool(f"provided_{name}")
+        s.add(v == (name in provided))
+        s.add(v)
+    return missing if s.check() == unsat else []
+
+
+def check_function_call(call: CallSite, func: FunctionManifest) -> Optional[Violation]:
+    required_args = func.required_args
+    if not required_args:
+        return None
+
+    positional_satisfied = {
+        arg.name for i, arg in enumerate(required_args) if i < call.positional_count
+    }
+    effectively_provided = call.provided_kwargs | positional_satisfied
+    missing = _z3_check_presence([a.name for a in required_args], effectively_provided)
+
+    if missing:
+        return Violation(
+            file=call.file,
+            line=call.line,
+            call=call.callee_name,
+            missing=missing,
+            context="function_call",
+        )
+    return None

--- a/tools/pact/encoder.py
+++ b/tools/pact/encoder.py
@@ -10,14 +10,18 @@ Z3 enumerates the violations — we don't write one checker per constraint class
 from dataclasses import dataclass
 from typing import Optional
 
-from .extractor import CallSite, FieldConstraint, FunctionManifest, ModelManifest
-
-_UNKNOWN_VALUE = object()
+from .extractor import (
+    UNKNOWN_VALUE,
+    CallSite,
+    FieldConstraint,
+    FunctionManifest,
+    ModelManifest,
+)
 
 try:
     from z3 import (
-        Bool, IntVal, Not, Or, Solver,
-        Length, StringVal, sat, unsat,
+        IntVal, Not, Or, Solver,
+        Length, StringVal, sat,
     )
     _HAS_Z3 = True
 except ImportError:
@@ -135,9 +139,9 @@ def check_model_create(call: CallSite, model: ModelManifest) -> list[Violation]:
         provided = any(name in call.provided_kwargs for name in field_names)
         value = next(
             (call.kwarg_values[name] for name in field_names if name in call.kwarg_values),
-            _UNKNOWN_VALUE,
+            UNKNOWN_VALUE,
         )
-        if value is _UNKNOWN_VALUE:
+        if value is UNKNOWN_VALUE:
             if provided:
                 continue
             value = None
@@ -161,15 +165,7 @@ def check_model_create(call: CallSite, model: ModelManifest) -> list[Violation]:
 # ---------------------------------------------------------------------------
 
 def _z3_check_presence(required: list[str], provided: set[str]) -> list[str]:
-    missing = [f for f in required if f not in provided]
-    if not missing or not _HAS_Z3:
-        return missing
-    s = Solver()
-    for name in required:
-        v = Bool(f"provided_{name}")
-        s.add(v == (name in provided))
-        s.add(v)
-    return missing if s.check() == unsat else []
+    return [f for f in required if f not in provided]
 
 
 def check_function_call(call: CallSite, func: FunctionManifest) -> Optional[Violation]:

--- a/tools/pact/encoder.py
+++ b/tools/pact/encoder.py
@@ -7,14 +7,14 @@ One Z3 formula per field encodes ALL constraints simultaneously:
 Z3 enumerates the violations — we don't write one checker per constraint class.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 from .extractor import CallSite, FieldConstraint, FunctionManifest, ModelManifest
 
 try:
     from z3 import (
-        And, Bool, Int, IntVal, Not, Or, Solver, String,
+        Bool, IntVal, Not, Or, Solver,
         Length, StringVal, sat, unsat,
     )
     _HAS_Z3 = True
@@ -164,8 +164,9 @@ def check_function_call(call: CallSite, func: FunctionManifest) -> Optional[Viol
     if not required_args:
         return None
 
+    positional_required = [arg for arg in required_args if not arg.kwonly]
     positional_satisfied = {
-        arg.name for i, arg in enumerate(required_args) if i < call.positional_count
+        arg.name for i, arg in enumerate(positional_required) if i < call.positional_count
     }
     effectively_provided = call.provided_kwargs | positional_satisfied
     missing = _z3_check_presence([a.name for a in required_args], effectively_provided)

--- a/tools/pact/encoder.py
+++ b/tools/pact/encoder.py
@@ -55,8 +55,9 @@ def _check_field(fc: FieldConstraint, provided: bool, value: object) -> list[str
             violations.append(f"missing required field '{fc.name}'")
         return violations   # no value → can't check further
 
-    # Value unknown (computed expression) — presence verified, value-level skipped
     if value is None:
+        if fc.required and not fc.null:
+            violations.append(f"'{fc.name}' cannot be None")
         return violations
 
     if not _HAS_Z3:

--- a/tools/pact/encoder.py
+++ b/tools/pact/encoder.py
@@ -12,6 +12,8 @@ from typing import Optional
 
 from .extractor import CallSite, FieldConstraint, FunctionManifest, ModelManifest
 
+_UNKNOWN_VALUE = object()
+
 try:
     from z3 import (
         Bool, IntVal, Not, Or, Solver,
@@ -127,8 +129,18 @@ def check_model_create(call: CallSite, model: ModelManifest) -> list[Violation]:
     for fc in model.fields:
         if fc.field_type in ("ManyToManyField", "ManyToManyRel", "ManyToOneRel", "OneToOneRel"):
             continue
-        provided = fc.name in call.provided_kwargs
-        value = call.kwarg_values.get(fc.name)   # None = not provided or computed
+        field_names = [fc.name]
+        if fc.field_type == "ForeignKey":
+            field_names.append(f"{fc.name}_id")
+        provided = any(name in call.provided_kwargs for name in field_names)
+        value = next(
+            (call.kwarg_values[name] for name in field_names if name in call.kwarg_values),
+            _UNKNOWN_VALUE,
+        )
+        if value is _UNKNOWN_VALUE:
+            if provided:
+                continue
+            value = None
         violations = _check_field(fc, provided, value)
         all_missing.extend(violations)
 

--- a/tools/pact/extractor.py
+++ b/tools/pact/extractor.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+_UNKNOWN = object()
+
 
 @dataclass
 class FieldConstraint:
@@ -88,6 +90,8 @@ def _is_django_field(node: ast.expr) -> Optional[str]:
     func = node.func
     if isinstance(func, ast.Attribute) and func.attr.endswith("Field"):
         return func.attr
+    if isinstance(func, ast.Attribute) and func.attr == "ForeignKey":
+        return func.attr
     return None
 
 
@@ -111,13 +115,13 @@ def _int_literal(node: ast.expr) -> Optional[int]:
 
 
 def _literal_value(node: ast.expr) -> object:
-    """Recursively extract a Python value from a literal AST node. Returns None for non-literals."""
+    """Recursively extract a Python literal value."""
     if isinstance(node, ast.Constant):
         return node.value
     if isinstance(node, (ast.List, ast.Tuple)):
         items = [_literal_value(e) for e in node.elts]
-        return items if None not in items else None
-    return None
+        return items if _UNKNOWN not in items else _UNKNOWN
+    return _UNKNOWN
 
 
 def _extract_choices(node: ast.expr) -> Optional[list]:
@@ -127,14 +131,14 @@ def _extract_choices(node: ast.expr) -> Optional[list]:
     values = []
     for elt in node.elts:
         # 2-tuple (value, display) — take the first element
-        if isinstance(elt, (ast.List, ast.Tuple)) and elt.elts:
-            v = _literal_value(elt.elts[0])
-            if v is not None:
-                values.append(v)
-        else:
-            v = _literal_value(elt)
-            if v is not None:
-                values.append(v)
+            if isinstance(elt, (ast.List, ast.Tuple)) and elt.elts:
+                v = _literal_value(elt.elts[0])
+                if v is not _UNKNOWN:
+                    values.append(v)
+            else:
+                v = _literal_value(elt)
+                if v is not _UNKNOWN:
+                    values.append(v)
     return values or None
 
 
@@ -407,9 +411,11 @@ class _CallVisitor(ast.NodeVisitor):
     def _make_site(self, node: ast.Call) -> Optional[CallSite]:
         kwargs = {kw.arg for kw in node.keywords if kw.arg is not None}
         kwarg_values = {
-            kw.arg: _literal_value(kw.value)
+            kw.arg: value
             for kw in node.keywords
-            if kw.arg is not None and _literal_value(kw.value) is not None
+            if kw.arg is not None
+            for value in [_literal_value(kw.value)]
+            if value is not _UNKNOWN
         }
         positional = len(node.args)
         func = node.func

--- a/tools/pact/extractor.py
+++ b/tools/pact/extractor.py
@@ -264,7 +264,7 @@ def _save_auto_assigned(class_node: ast.ClassDef) -> set[str]:
                     return True
         return False
 
-    for item in ast.walk(class_node):
+    for item in class_node.body:
         if not isinstance(item, ast.FunctionDef) or item.name != "save":
             continue
         for stmt in ast.walk(item):

--- a/tools/pact/extractor.py
+++ b/tools/pact/extractor.py
@@ -1,0 +1,435 @@
+"""
+AST extraction layer.
+
+Walks Python source files and emits three manifests:
+  ModelManifest   — Django model classes with their field constraints
+  FunctionManifest — function/method signatures with required-arg flags
+  CallSite        — call sites with provided kwargs and positional counts
+"""
+
+import ast
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class FieldConstraint:
+    name: str
+    required: bool          # null=False AND no default= → must be provided in create()
+    field_type: str
+    null: bool = True
+    blank: bool = True
+    unique: bool = False
+    max_length: Optional[int] = None
+    min_value: Optional[int] = None    # explicit or implicit from field type
+    max_value: Optional[int] = None
+    choices: Optional[list] = None     # literal values only (first elem of 2-tuples)
+
+
+@dataclass
+class ModelManifest:
+    name: str
+    file: str
+    line: int
+    fields: list[FieldConstraint] = field(default_factory=list)
+
+    @property
+    def required_fields(self) -> list[FieldConstraint]:
+        return [f for f in self.fields if f.required]
+
+
+@dataclass
+class ArgConstraint:
+    name: str
+    required: bool
+    has_default: bool = False
+
+
+@dataclass
+class FunctionManifest:
+    name: str           # qualified: ClassName.method_name or function_name
+    file: str
+    line: int
+    module_path: str
+    args: list[ArgConstraint] = field(default_factory=list)
+
+    @property
+    def required_args(self) -> list[ArgConstraint]:
+        return [a for a in self.args if a.required]
+
+
+@dataclass
+class CallSite:
+    callee_name: str
+    file: str
+    line: int
+    provided_kwargs: set[str] = field(default_factory=set)
+    kwarg_values: dict[str, object] = field(default_factory=dict)  # name → literal value
+    positional_count: int = 0
+    is_create_call: bool = False
+    model_name: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _is_django_field(node: ast.expr) -> Optional[str]:
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr.endswith("Field"):
+        return func.attr
+    return None
+
+
+def _get_kwarg(node: ast.Call, name: str) -> Optional[ast.expr]:
+    for kw in node.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _is_true_literal(node: ast.expr) -> bool:
+    if isinstance(node, ast.Constant):
+        return bool(node.value)
+    return False
+
+
+def _int_literal(node: ast.expr) -> Optional[int]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, int):
+        return node.value
+    return None
+
+
+def _literal_value(node: ast.expr) -> object:
+    """Recursively extract a Python value from a literal AST node. Returns None for non-literals."""
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, (ast.List, ast.Tuple)):
+        items = [_literal_value(e) for e in node.elts]
+        return items if None not in items else None
+    return None
+
+
+def _extract_choices(node: ast.expr) -> Optional[list]:
+    """Extract the set of valid values from a choices= argument (literal only)."""
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return None
+    values = []
+    for elt in node.elts:
+        # 2-tuple (value, display) — take the first element
+        if isinstance(elt, (ast.List, ast.Tuple)) and elt.elts:
+            v = _literal_value(elt.elts[0])
+            if v is not None:
+                values.append(v)
+        else:
+            v = _literal_value(elt)
+            if v is not None:
+                values.append(v)
+    return values or None
+
+
+# Implicit integer bounds by field type
+_FIELD_BOUNDS: dict[str, tuple[Optional[int], Optional[int]]] = {
+    "PositiveIntegerField":         (0,    2_147_483_647),
+    "PositiveSmallIntegerField":    (0,    32_767),
+    "PositiveBigIntegerField":      (0,    9_223_372_036_854_775_807),
+    "SmallIntegerField":            (-32_768, 32_767),
+    "IntegerField":                 (-2_147_483_648, 2_147_483_647),
+    "BigIntegerField":              (-9_223_372_036_854_775_808, 9_223_372_036_854_775_807),
+}
+
+_RELATION_FIELD_TYPES = frozenset({
+    "ManyToManyField", "ManyToManyRel", "ManyToOneRel", "OneToOneRel",
+})
+
+
+def _build_field_constraint(field_name: str, call: ast.Call, save_assigned: bool) -> FieldConstraint:
+    """Extract all constraint metadata from a Django field declaration AST node."""
+    field_type = call.func.attr if isinstance(call.func, ast.Attribute) else ""
+
+    # Relation fields managed via .add(), not create() kwargs
+    if field_type in _RELATION_FIELD_TYPES:
+        return FieldConstraint(name=field_name, required=False, field_type=field_type)
+
+    null_node   = _get_kwarg(call, "null")
+    blank_node  = _get_kwarg(call, "blank")
+    unique_node = _get_kwarg(call, "unique")
+
+    is_null  = null_node  is not None and _is_true_literal(null_node)
+    is_blank = blank_node is not None and _is_true_literal(blank_node)
+    is_unique = unique_node is not None and _is_true_literal(unique_node)
+
+    has_default = _get_kwarg(call, "default") is not None
+    has_auto    = any(
+        _get_kwarg(call, kw) is not None and _is_true_literal(_get_kwarg(call, kw))
+        for kw in ("auto_now", "auto_now_add")
+    )
+
+    required = (
+        not is_null and
+        not is_blank and
+        not has_default and
+        not has_auto and
+        not save_assigned
+    )
+
+    # max_length
+    ml_node = _get_kwarg(call, "max_length")
+    max_length = _int_literal(ml_node) if ml_node is not None else None
+
+    # min_value / max_value — explicit kwargs first, then implicit from type
+    min_v_node = _get_kwarg(call, "min_value")
+    max_v_node = _get_kwarg(call, "max_value")
+    min_value = _int_literal(min_v_node) if min_v_node is not None else None
+    max_value = _int_literal(max_v_node) if max_v_node is not None else None
+
+    implicit = _FIELD_BOUNDS.get(field_type)
+    if implicit:
+        if min_value is None:
+            min_value = implicit[0]
+        if max_value is None:
+            max_value = implicit[1]
+
+    # choices
+    ch_node = _get_kwarg(call, "choices")
+    choices = _extract_choices(ch_node) if ch_node is not None else None
+
+    return FieldConstraint(
+        name=field_name,
+        required=required,
+        field_type=field_type,
+        null=is_null,
+        blank=is_blank,
+        unique=is_unique,
+        max_length=max_length,
+        min_value=min_value,
+        max_value=max_value,
+        choices=choices,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Visitors
+# ---------------------------------------------------------------------------
+
+def _class_has_django_fields(node: ast.ClassDef) -> bool:
+    """Heuristic: if a class body has any models.XField(...) assignments, treat it as a model.
+    This catches custom base classes (BaseModel, TimestampedModel, etc.) without needing
+    to resolve the inheritance chain."""
+    for stmt in node.body:
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+            if _is_django_field(stmt.value):
+                return True
+    return False
+
+
+def _save_auto_assigned(class_node: ast.ClassDef) -> set[str]:
+    """Fields auto-assigned in save() via `if not self.field: self.field = ...` pattern."""
+    auto: set[str] = set()
+    for item in ast.walk(class_node):
+        if not isinstance(item, ast.FunctionDef) or item.name != "save":
+            continue
+        for stmt in ast.walk(item):
+            if not isinstance(stmt, ast.If):
+                continue
+            test = stmt.test
+            # match: `not self.field` or `if not self.field`
+            negated = isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not)
+            attr_test = test.operand if negated else test
+            if (negated and isinstance(attr_test, ast.Attribute) and
+                    isinstance(attr_test.value, ast.Name) and
+                    attr_test.value.id == "self"):
+                auto.add(attr_test.attr)
+    return auto
+
+
+class _ModelVisitor(ast.NodeVisitor):
+    def __init__(self, file_path: str) -> None:
+        self.file = file_path
+        self.models: list[ModelManifest] = []
+        self._current: Optional[ModelManifest] = None
+        self._auto_assigned: set[str] = set()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        if not _class_has_django_fields(node):
+            self.generic_visit(node)
+            return
+        manifest = ModelManifest(name=node.name, file=self.file, line=node.lineno)
+        prev_model, self._current = self._current, manifest
+        prev_auto, self._auto_assigned = self._auto_assigned, _save_auto_assigned(node)
+        self.generic_visit(node)
+        self._current = prev_model
+        self._auto_assigned = prev_auto
+        self.models.append(manifest)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if self._current is None:
+            return
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            return
+        field_name = node.targets[0].id
+        if _is_django_field(node.value) is None:
+            return
+        save_assigned = field_name in self._auto_assigned
+        self._current.fields.append(
+            _build_field_constraint(field_name, node.value, save_assigned)
+        )
+
+
+class _FunctionVisitor(ast.NodeVisitor):
+    def __init__(self, file_path: str, module_path: str) -> None:
+        self.file = file_path
+        self.module_path = module_path
+        self.functions: list[FunctionManifest] = []
+        self._class_stack: list[str] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._class_stack.append(node.name)
+        self.generic_visit(node)
+        self._class_stack.pop()
+
+    def _visit_func(self, node: ast.FunctionDef) -> None:
+        args_spec = node.args
+        n_defaults = len(args_spec.defaults)
+        all_args = args_spec.args
+        required_cutoff = len(all_args) - n_defaults
+
+        constraints = []
+        for i, arg in enumerate(all_args):
+            if arg.arg in ("self", "cls"):
+                continue
+            required = i < required_cutoff
+            constraints.append(ArgConstraint(name=arg.arg, required=required, has_default=not required))
+
+        qual = ".".join(self._class_stack + [node.name])
+        self.functions.append(
+            FunctionManifest(
+                name=qual,
+                file=self.file,
+                line=node.lineno,
+                module_path=self.module_path,
+                args=constraints,
+            )
+        )
+        self.generic_visit(node)
+
+    visit_FunctionDef = _visit_func
+    visit_AsyncFunctionDef = _visit_func
+
+
+class _CallVisitor(ast.NodeVisitor):
+    def __init__(self, file_path: str) -> None:
+        self.file = file_path
+        self.call_sites: list[CallSite] = []
+
+    def visit_Call(self, node: ast.Call) -> None:
+        site = self._make_site(node)
+        if site:
+            self.call_sites.append(site)
+        self.generic_visit(node)
+
+    def _make_site(self, node: ast.Call) -> Optional[CallSite]:
+        kwargs = {kw.arg for kw in node.keywords if kw.arg is not None}
+        kwarg_values = {
+            kw.arg: _literal_value(kw.value)
+            for kw in node.keywords
+            if kw.arg is not None and _literal_value(kw.value) is not None
+        }
+        positional = len(node.args)
+        func = node.func
+
+        # Model.objects.create(...)
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "create"
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "objects"
+        ):
+            model_name = None
+            if isinstance(func.value.value, ast.Name):
+                model_name = func.value.value.id
+            return CallSite(
+                callee_name=f"{model_name}.objects.create" if model_name else "?.objects.create",
+                file=self.file,
+                line=node.lineno,
+                provided_kwargs=kwargs,
+                kwarg_values=kwarg_values,
+                positional_count=positional,
+                is_create_call=True,
+                model_name=model_name,
+            )
+
+        # Regular call
+        name = self._name(func)
+        if name:
+            return CallSite(
+                callee_name=name,
+                file=self.file,
+                line=node.lineno,
+                provided_kwargs=kwargs,
+                kwarg_values=kwarg_values,
+                positional_count=positional,
+            )
+        return None
+
+    def _name(self, node: ast.expr) -> Optional[str]:
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            obj = self._name(node.value)
+            return f"{obj}.{node.attr}" if obj else node.attr
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+_SKIP_DIRS = frozenset({
+    "__pycache__", ".git", ".venv", "venv", "node_modules",
+    "migrations", ".mypy_cache", ".uv-cache", ".ruff_cache",
+})
+
+
+def extract_from_file(
+    path: Path,
+) -> tuple[list[ModelManifest], list[FunctionManifest], list[CallSite]]:
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return [], [], []
+
+    module_path = ".".join(path.with_suffix("").parts)
+
+    mv = _ModelVisitor(str(path))
+    mv.visit(tree)
+
+    fv = _FunctionVisitor(str(path), module_path)
+    fv.visit(tree)
+
+    cv = _CallVisitor(str(path))
+    cv.visit(tree)
+
+    return mv.models, fv.functions, cv.call_sites
+
+
+def extract_from_codebase(
+    root: Path,
+) -> tuple[list[ModelManifest], list[FunctionManifest], list[CallSite]]:
+    all_models: list[ModelManifest] = []
+    all_funcs: list[FunctionManifest] = []
+    all_calls: list[CallSite] = []
+
+    for path in root.rglob("*.py"):
+        if any(part in _SKIP_DIRS for part in path.parts):
+            continue
+        models, funcs, calls = extract_from_file(path)
+        all_models.extend(models)
+        all_funcs.extend(funcs)
+        all_calls.extend(calls)
+
+    return all_models, all_funcs, all_calls

--- a/tools/pact/extractor.py
+++ b/tools/pact/extractor.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-_UNKNOWN = object()
+UNKNOWN_VALUE = object()
 
 
 @dataclass
@@ -120,8 +120,8 @@ def _literal_value(node: ast.expr) -> object:
         return node.value
     if isinstance(node, (ast.List, ast.Tuple)):
         items = [_literal_value(e) for e in node.elts]
-        return items if _UNKNOWN not in items else _UNKNOWN
-    return _UNKNOWN
+        return items if UNKNOWN_VALUE not in items else UNKNOWN_VALUE
+    return UNKNOWN_VALUE
 
 
 def _extract_choices(node: ast.expr) -> Optional[list]:
@@ -133,11 +133,11 @@ def _extract_choices(node: ast.expr) -> Optional[list]:
         # 2-tuple (value, display) — take the first element
             if isinstance(elt, (ast.List, ast.Tuple)) and elt.elts:
                 v = _literal_value(elt.elts[0])
-                if v is not _UNKNOWN:
+                if v is not UNKNOWN_VALUE:
                     values.append(v)
             else:
                 v = _literal_value(elt)
-                if v is not _UNKNOWN:
+                if v is not UNKNOWN_VALUE:
                     values.append(v)
     return values or None
 
@@ -415,7 +415,6 @@ class _CallVisitor(ast.NodeVisitor):
             for kw in node.keywords
             if kw.arg is not None
             for value in [_literal_value(kw.value)]
-            if value is not _UNKNOWN
         }
         positional = len(node.args)
         func = node.func

--- a/tools/pact/extractor.py
+++ b/tools/pact/extractor.py
@@ -44,6 +44,7 @@ class ArgConstraint:
     name: str
     required: bool
     has_default: bool = False
+    kwonly: bool = False   # keyword-only (after *); cannot be filled by positional args
 
 
 @dataclass
@@ -311,7 +312,7 @@ class _FunctionVisitor(ast.NodeVisitor):
             if arg.arg in ("self", "cls"):
                 continue
             has_default = kw_defaults[i] is not None
-            constraints.append(ArgConstraint(name=arg.arg, required=not has_default, has_default=has_default))
+            constraints.append(ArgConstraint(name=arg.arg, required=not has_default, has_default=has_default, kwonly=True))
 
         qual = ".".join(self._class_stack + [node.name])
         self.functions.append(
@@ -333,10 +334,17 @@ class _CallVisitor(ast.NodeVisitor):
     def __init__(self, file_path: str) -> None:
         self.file = file_path
         self.call_sites: list[CallSite] = []
-        self._func_stack: list[str] = []  # qualified names of enclosing functions
+        self._class_stack: list[str] = []   # class names (mirrors _FunctionVisitor)
+        self._func_stack: list[str] = []    # qualified function names within classes
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._class_stack.append(node.name)
+        self.generic_visit(node)
+        self._class_stack.pop()
 
     def _enter_func(self, node):
-        qual = self._func_stack[-1] + "." + node.name if self._func_stack else node.name
+        # Build the same qualified name as _FunctionVisitor: Class.method
+        qual = ".".join(self._class_stack + [node.name])
         self._func_stack.append(qual)
         self.generic_visit(node)
         self._func_stack.pop()

--- a/tools/pact/extractor.py
+++ b/tools/pact/extractor.py
@@ -16,15 +16,15 @@ from typing import Optional
 @dataclass
 class FieldConstraint:
     name: str
-    required: bool          # null=False AND no default= → must be provided in create()
+    required: bool  # null=False AND no default= → must be provided in create()
     field_type: str
     null: bool = True
     blank: bool = True
     unique: bool = False
     max_length: Optional[int] = None
-    min_value: Optional[int] = None    # explicit or implicit from field type
+    min_value: Optional[int] = None  # explicit or implicit from field type
     max_value: Optional[int] = None
-    choices: Optional[list] = None     # literal values only (first elem of 2-tuples)
+    choices: Optional[list] = None  # literal values only (first elem of 2-tuples)
 
 
 @dataclass
@@ -44,12 +44,12 @@ class ArgConstraint:
     name: str
     required: bool
     has_default: bool = False
-    kwonly: bool = False   # keyword-only (after *); cannot be filled by positional args
+    kwonly: bool = False  # keyword-only (after *); cannot be filled by positional args
 
 
 @dataclass
 class FunctionManifest:
-    name: str           # qualified: ClassName.method_name or function_name
+    name: str  # qualified: ClassName.method_name or function_name
     file: str
     line: int
     module_path: str
@@ -66,16 +66,21 @@ class CallSite:
     file: str
     line: int
     provided_kwargs: set[str] = field(default_factory=set)
-    kwarg_values: dict[str, object] = field(default_factory=dict)  # name → literal value
+    kwarg_values: dict[str, object] = field(
+        default_factory=dict
+    )  # name → literal value
     positional_count: int = 0
     is_create_call: bool = False
     model_name: Optional[str] = None
-    caller_name: Optional[str] = None   # qualified name of the enclosing function, if any
+    caller_name: Optional[str] = (
+        None  # qualified name of the enclosing function, if any
+    )
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _is_django_field(node: ast.expr) -> Optional[str]:
     if not isinstance(node, ast.Call):
@@ -135,20 +140,27 @@ def _extract_choices(node: ast.expr) -> Optional[list]:
 
 # Implicit integer bounds by field type
 _FIELD_BOUNDS: dict[str, tuple[Optional[int], Optional[int]]] = {
-    "PositiveIntegerField":         (0,    2_147_483_647),
-    "PositiveSmallIntegerField":    (0,    32_767),
-    "PositiveBigIntegerField":      (0,    9_223_372_036_854_775_807),
-    "SmallIntegerField":            (-32_768, 32_767),
-    "IntegerField":                 (-2_147_483_648, 2_147_483_647),
-    "BigIntegerField":              (-9_223_372_036_854_775_808, 9_223_372_036_854_775_807),
+    "PositiveIntegerField": (0, 2_147_483_647),
+    "PositiveSmallIntegerField": (0, 32_767),
+    "PositiveBigIntegerField": (0, 9_223_372_036_854_775_807),
+    "SmallIntegerField": (-32_768, 32_767),
+    "IntegerField": (-2_147_483_648, 2_147_483_647),
+    "BigIntegerField": (-9_223_372_036_854_775_808, 9_223_372_036_854_775_807),
 }
 
-_RELATION_FIELD_TYPES = frozenset({
-    "ManyToManyField", "ManyToManyRel", "ManyToOneRel", "OneToOneRel",
-})
+_RELATION_FIELD_TYPES = frozenset(
+    {
+        "ManyToManyField",
+        "ManyToManyRel",
+        "ManyToOneRel",
+        "OneToOneRel",
+    }
+)
 
 
-def _build_field_constraint(field_name: str, call: ast.Call, save_assigned: bool) -> FieldConstraint:
+def _build_field_constraint(
+    field_name: str, call: ast.Call, save_assigned: bool
+) -> FieldConstraint:
     """Extract all constraint metadata from a Django field declaration AST node."""
     field_type = call.func.attr if isinstance(call.func, ast.Attribute) else ""
 
@@ -156,26 +168,26 @@ def _build_field_constraint(field_name: str, call: ast.Call, save_assigned: bool
     if field_type in _RELATION_FIELD_TYPES:
         return FieldConstraint(name=field_name, required=False, field_type=field_type)
 
-    null_node   = _get_kwarg(call, "null")
-    blank_node  = _get_kwarg(call, "blank")
+    null_node = _get_kwarg(call, "null")
+    blank_node = _get_kwarg(call, "blank")
     unique_node = _get_kwarg(call, "unique")
 
-    is_null  = null_node  is not None and _is_true_literal(null_node)
+    is_null = null_node is not None and _is_true_literal(null_node)
     is_blank = blank_node is not None and _is_true_literal(blank_node)
     is_unique = unique_node is not None and _is_true_literal(unique_node)
 
     has_default = _get_kwarg(call, "default") is not None
-    has_auto    = any(
+    has_auto = any(
         _get_kwarg(call, kw) is not None and _is_true_literal(_get_kwarg(call, kw))
         for kw in ("auto_now", "auto_now_add")
     )
 
     required = (
-        not is_null and
-        not is_blank and
-        not has_default and
-        not has_auto and
-        not save_assigned
+        not is_null
+        and not is_blank
+        and not has_default
+        and not has_auto
+        and not save_assigned
     )
 
     # max_length
@@ -217,6 +229,7 @@ def _build_field_constraint(field_name: str, call: ast.Call, save_assigned: bool
 # Visitors
 # ---------------------------------------------------------------------------
 
+
 def _class_has_django_fields(node: ast.ClassDef) -> bool:
     """Heuristic: if a class body has any models.XField(...) assignments, treat it as a model.
     This catches custom base classes (BaseModel, TimestampedModel, etc.) without needing
@@ -241,9 +254,12 @@ def _save_auto_assigned(class_node: ast.ClassDef) -> set[str]:
             # match: `not self.field` or `if not self.field`
             negated = isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not)
             attr_test = test.operand if negated else test
-            if (negated and isinstance(attr_test, ast.Attribute) and
-                    isinstance(attr_test.value, ast.Name) and
-                    attr_test.value.id == "self"):
+            if (
+                negated
+                and isinstance(attr_test, ast.Attribute)
+                and isinstance(attr_test.value, ast.Name)
+                and attr_test.value.id == "self"
+            ):
                 auto.add(attr_test.attr)
     return auto
 
@@ -304,7 +320,9 @@ class _FunctionVisitor(ast.NodeVisitor):
             if arg.arg in ("self", "cls"):
                 continue
             required = i < required_cutoff
-            constraints.append(ArgConstraint(name=arg.arg, required=required, has_default=not required))
+            constraints.append(
+                ArgConstraint(name=arg.arg, required=required, has_default=not required)
+            )
 
         # Keyword-only args (after *)
         kw_defaults = args_spec.kw_defaults  # parallel list; None means no default
@@ -312,7 +330,14 @@ class _FunctionVisitor(ast.NodeVisitor):
             if arg.arg in ("self", "cls"):
                 continue
             has_default = kw_defaults[i] is not None
-            constraints.append(ArgConstraint(name=arg.arg, required=not has_default, has_default=has_default, kwonly=True))
+            constraints.append(
+                ArgConstraint(
+                    name=arg.arg,
+                    required=not has_default,
+                    has_default=has_default,
+                    kwonly=True,
+                )
+            )
 
         qual = ".".join(self._class_stack + [node.name])
         self.functions.append(
@@ -334,8 +359,8 @@ class _CallVisitor(ast.NodeVisitor):
     def __init__(self, file_path: str) -> None:
         self.file = file_path
         self.call_sites: list[CallSite] = []
-        self._class_stack: list[str] = []   # class names (mirrors _FunctionVisitor)
-        self._func_stack: list[str] = []    # qualified function names within classes
+        self._class_stack: list[str] = []  # class names (mirrors _FunctionVisitor)
+        self._func_stack: list[str] = []  # qualified function names within classes
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self._class_stack.append(node.name)
@@ -381,7 +406,9 @@ class _CallVisitor(ast.NodeVisitor):
             if isinstance(func.value.value, ast.Name):
                 model_name = func.value.value.id
             return CallSite(
-                callee_name=f"{model_name}.objects.create" if model_name else "?.objects.create",
+                callee_name=(
+                    f"{model_name}.objects.create" if model_name else "?.objects.create"
+                ),
                 file=self.file,
                 line=node.lineno,
                 provided_kwargs=kwargs,
@@ -419,10 +446,26 @@ class _CallVisitor(ast.NodeVisitor):
 # Public API
 # ---------------------------------------------------------------------------
 
-_SKIP_DIRS = frozenset({
-    "__pycache__", ".git", ".venv", "venv", "node_modules",
-    "migrations", ".mypy_cache", ".uv-cache", ".ruff_cache",
-})
+_SKIP_DIRS = frozenset(
+    {
+        "__pycache__",
+        ".git",
+        ".venv",
+        "venv",
+        "node_modules",
+        "migrations",
+        ".mypy_cache",
+        ".uv-cache",
+        ".ruff_cache",
+    }
+)
+
+
+def iter_python_files(root: Path):
+    for path in root.rglob("*.py"):
+        if any(part in _SKIP_DIRS for part in path.parts):
+            continue
+        yield path
 
 
 def extract_from_file(
@@ -455,9 +498,7 @@ def extract_from_codebase(
     all_funcs: list[FunctionManifest] = []
     all_calls: list[CallSite] = []
 
-    for path in root.rglob("*.py"):
-        if any(part in _SKIP_DIRS for part in path.parts):
-            continue
+    for path in iter_python_files(root):
         models, funcs, calls = extract_from_file(path)
         all_models.extend(models)
         all_funcs.extend(funcs)

--- a/tools/pact/extractor.py
+++ b/tools/pact/extractor.py
@@ -244,6 +244,26 @@ def _class_has_django_fields(node: ast.ClassDef) -> bool:
 def _save_auto_assigned(class_node: ast.ClassDef) -> set[str]:
     """Fields auto-assigned in save() via `if not self.field: self.field = ...` pattern."""
     auto: set[str] = set()
+
+    def assigns_self_attr(statements: list[ast.stmt], attr: str) -> bool:
+        for body_stmt in statements:
+            targets: list[ast.expr] = []
+            if isinstance(body_stmt, ast.Assign):
+                targets = list(body_stmt.targets)
+            elif isinstance(body_stmt, ast.AnnAssign):
+                targets = [body_stmt.target]
+            elif isinstance(body_stmt, ast.AugAssign):
+                targets = [body_stmt.target]
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                    and target.attr == attr
+                ):
+                    return True
+        return False
+
     for item in ast.walk(class_node):
         if not isinstance(item, ast.FunctionDef) or item.name != "save":
             continue
@@ -259,6 +279,7 @@ def _save_auto_assigned(class_node: ast.ClassDef) -> set[str]:
                 and isinstance(attr_test, ast.Attribute)
                 and isinstance(attr_test.value, ast.Name)
                 and attr_test.value.id == "self"
+                and assigns_self_attr(stmt.body, attr_test.attr)
             ):
                 auto.add(attr_test.attr)
     return auto

--- a/tools/pact/extractor.py
+++ b/tools/pact/extractor.py
@@ -69,6 +69,7 @@ class CallSite:
     positional_count: int = 0
     is_create_call: bool = False
     model_name: Optional[str] = None
+    caller_name: Optional[str] = None   # qualified name of the enclosing function, if any
 
 
 # ---------------------------------------------------------------------------
@@ -304,6 +305,14 @@ class _FunctionVisitor(ast.NodeVisitor):
             required = i < required_cutoff
             constraints.append(ArgConstraint(name=arg.arg, required=required, has_default=not required))
 
+        # Keyword-only args (after *)
+        kw_defaults = args_spec.kw_defaults  # parallel list; None means no default
+        for i, arg in enumerate(args_spec.kwonlyargs):
+            if arg.arg in ("self", "cls"):
+                continue
+            has_default = kw_defaults[i] is not None
+            constraints.append(ArgConstraint(name=arg.arg, required=not has_default, has_default=has_default))
+
         qual = ".".join(self._class_stack + [node.name])
         self.functions.append(
             FunctionManifest(
@@ -324,6 +333,16 @@ class _CallVisitor(ast.NodeVisitor):
     def __init__(self, file_path: str) -> None:
         self.file = file_path
         self.call_sites: list[CallSite] = []
+        self._func_stack: list[str] = []  # qualified names of enclosing functions
+
+    def _enter_func(self, node):
+        qual = self._func_stack[-1] + "." + node.name if self._func_stack else node.name
+        self._func_stack.append(qual)
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    visit_FunctionDef = _enter_func
+    visit_AsyncFunctionDef = _enter_func
 
     def visit_Call(self, node: ast.Call) -> None:
         site = self._make_site(node)
@@ -340,6 +359,8 @@ class _CallVisitor(ast.NodeVisitor):
         }
         positional = len(node.args)
         func = node.func
+
+        caller = self._func_stack[-1] if self._func_stack else None
 
         # Model.objects.create(...)
         if (
@@ -360,6 +381,7 @@ class _CallVisitor(ast.NodeVisitor):
                 positional_count=positional,
                 is_create_call=True,
                 model_name=model_name,
+                caller_name=caller,
             )
 
         # Regular call
@@ -372,6 +394,7 @@ class _CallVisitor(ast.NodeVisitor):
                 provided_kwargs=kwargs,
                 kwarg_values=kwarg_values,
                 positional_count=positional,
+                caller_name=caller,
             )
         return None
 

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -251,7 +251,9 @@ def _check_required_arg(
 ) -> list[FailureEvidence]:
     if call.is_create_call:
         return []
-    func = functions.get(call.callee_name)
+    func = functions.get(f"{call.file}:{call.callee_name}") or functions.get(
+        call.callee_name
+    )
     if not func or not func.required_args:
         return []
     # Only non-kwonly required args can be covered by positional args.

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -192,8 +192,8 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
             src = _ast.unparse(node.test) if hasattr(_ast, "unparse") else ""
             guarded_here = {var for var in self.optional_vars if var in src}
             original_guarded = self.guarded
-            self.visit(node.test)
             self.guarded = original_guarded | guarded_here
+            self.visit(node.test)
             for child in node.body:
                 self.visit(child)
             self.guarded = original_guarded

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -252,12 +252,59 @@ REQUIRED_ARG_MISSING = FailureMode(
 # --- 4. Bare except that swallows all exceptions ---------------------------
 # Detects `except:` or `except Exception: pass` — silent failure patterns.
 
+@functools.lru_cache(maxsize=None)
+def _scan_file_bare_except(path: str) -> list[FailureEvidence]:
+    """File-level scan for bare except: and silent except Exception: pass."""
+    import ast as _ast
+    from pathlib import Path as _Path
+
+    try:
+        source = _Path(path).read_text(encoding="utf-8", errors="replace")
+        tree = _ast.parse(source, filename=path)
+    except (SyntaxError, OSError):
+        return []
+
+    evidence = []
+    for node in _ast.walk(tree):
+        if not isinstance(node, _ast.ExceptHandler):
+            continue
+        if node.type is None:
+            # bare `except:` — catches KeyboardInterrupt, SystemExit, everything
+            evidence.append(FailureEvidence(
+                mode_name="bare_except",
+                file=path,
+                line=node.lineno,
+                call="except:",
+                message="bare `except:` catches all exceptions including KeyboardInterrupt",
+            ))
+        elif isinstance(node.type, _ast.Name) and node.type.id == "Exception":
+            # `except Exception: pass` or `except Exception: ...` — silent swallow
+            body = node.body
+            is_silent = len(body) == 1 and (
+                isinstance(body[0], _ast.Pass)
+                or (
+                    isinstance(body[0], _ast.Expr)
+                    and isinstance(body[0].value, _ast.Constant)
+                    and body[0].value.value is ...
+                )
+            )
+            if is_silent:
+                evidence.append(FailureEvidence(
+                    mode_name="bare_except",
+                    file=path,
+                    line=node.lineno,
+                    call="except Exception: pass",
+                    message="`except Exception: pass` silently swallows all errors",
+                ))
+    return evidence
+
+
 def _check_bare_except(
     call: CallSite,
     models: dict[str, ModelManifest],
     functions: dict[str, FunctionManifest],
 ) -> list[FailureEvidence]:
-    return []  # file-level scan, not call-site; handled in flow_scanner.py
+    return _scan_file_bare_except(call.file)
 
 
 BARE_EXCEPT = FailureMode(
@@ -270,6 +317,49 @@ BARE_EXCEPT = FailureMode(
 )
 
 
+# --- 5. save() without update_fields ---------------------------------------
+# Django model .save() without update_fields re-writes every column,
+# clobbering concurrent partial updates.
+
+_SAFE_SAVE_SUFFIXES = ("form", "serializer", "fs", "storage", "file")
+
+
+def _check_save_without_update_fields(
+    call: CallSite,
+    models: dict[str, ModelManifest],
+    functions: dict[str, FunctionManifest],
+) -> list[FailureEvidence]:
+    if not call.callee_name.endswith(".save"):
+        return []
+    if "update_fields" in call.provided_kwargs:
+        return []
+    # Skip form/serializer/storage saves — intentional full saves.
+    # Match on suffix so compound names like `image_dataset_serializer` match.
+    receiver = call.callee_name.rsplit(".", 1)[0].split(".")[-1].lower()
+    if any(receiver.endswith(safe) for safe in _SAFE_SAVE_SUFFIXES):
+        return []
+    return [FailureEvidence(
+        mode_name="save_without_update_fields",
+        file=call.file,
+        line=call.line,
+        call=call.callee_name,
+        message=(
+            ".save() without update_fields re-writes every column; "
+            "use save(update_fields=[...]) to prevent clobbering concurrent writes"
+        ),
+    )]
+
+
+SAVE_WITHOUT_UPDATE_FIELDS = FailureMode(
+    name="save_without_update_fields",
+    description=(
+        "Django model .save() called without update_fields. "
+        "Re-writes every column, clobbering concurrent partial updates."
+    ),
+    check=_check_save_without_update_fields,
+)
+
+
 # ---------------------------------------------------------------------------
 # Registry — all active failure modes
 # ---------------------------------------------------------------------------
@@ -278,4 +368,6 @@ DEFAULT_MODES: list[FailureMode] = [
     REQUIRED_FIELD_MISSING,
     REQUIRED_ARG_MISSING,
     OPTIONAL_DEREF,
+    BARE_EXCEPT,
+    SAVE_WITHOUT_UPDATE_FIELDS,
 ]

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -180,13 +180,29 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
             for target in targets:
                 self.guarded.discard(target.id)
                 self.optional_vars.pop(target.id, None)
-                if (
-                    isinstance(node.value, _ast.Call)
-                    and isinstance(node.value.func, _ast.Attribute)
-                    and node.value.func.attr in _OPTIONAL_RETURNING
-                ):
+                if isinstance(node.value, _ast.Call) and self._is_optional_source(node.value):
                     self.optional_vars[target.id] = node.lineno
             self.generic_visit(node)
+
+        def _call_name(self, node) -> str | None:
+            if isinstance(node, _ast.Name):
+                return node.id
+            if isinstance(node, _ast.Attribute):
+                base = self._call_name(node.value)
+                return node.attr if base is None else f"{base}.{node.attr}"
+            if isinstance(node, _ast.Call):
+                return self._call_name(node.func)
+            return None
+
+        def _is_optional_source(self, node) -> bool:
+            if not isinstance(node.func, _ast.Attribute):
+                return False
+            name = self._call_name(node.func)
+            return (
+                node.func.attr in _OPTIONAL_RETURNING
+                or node.func.attr in _OPTIONAL_SOURCES
+                or name in _OPTIONAL_SOURCES
+            )
 
         def visit_If(self, node):
             original_guarded = self.guarded

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -189,12 +189,16 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
             self.generic_visit(node)
 
         def visit_If(self, node):
-            # If the test references an optional var, mark it guarded
             src = _ast.unparse(node.test) if hasattr(_ast, "unparse") else ""
-            for var in list(self.optional_vars):
-                if var in src:
-                    self.guarded.add(var)
-            self.generic_visit(node)
+            guarded_here = {var for var in self.optional_vars if var in src}
+            original_guarded = self.guarded
+            self.visit(node.test)
+            self.guarded = original_guarded | guarded_here
+            for child in node.body:
+                self.visit(child)
+            self.guarded = original_guarded
+            for child in node.orelse:
+                self.visit(child)
 
         def visit_Attribute(self, node):
             # var.something — flag if var is unguarded optional

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -189,16 +189,42 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
             self.generic_visit(node)
 
         def visit_If(self, node):
-            src = _ast.unparse(node.test) if hasattr(_ast, "unparse") else ""
-            guarded_here = {var for var in self.optional_vars if var in src}
             original_guarded = self.guarded
-            self.guarded = original_guarded | guarded_here
-            self.visit(node.test)
+            body_guarded = original_guarded | self._visit_condition(node.test, original_guarded)
+            self.guarded = body_guarded
             for child in node.body:
                 self.visit(child)
             self.guarded = original_guarded
             for child in node.orelse:
                 self.visit(child)
+
+        def _visit_condition(self, node, guarded: set[str]) -> set[str]:
+            current = set(guarded)
+            if isinstance(node, _ast.BoolOp) and isinstance(node.op, _ast.And):
+                for value in node.values:
+                    current |= self._visit_condition(value, current)
+                return current - guarded
+
+            previous = self.guarded
+            self.guarded = current
+            self.visit(node)
+            self.guarded = previous
+            return self._guards_from_condition(node) - guarded
+
+        def _guards_from_condition(self, node) -> set[str]:
+            if isinstance(node, _ast.Name) and node.id in self.optional_vars:
+                return {node.id}
+            if not isinstance(node, _ast.Compare) or len(node.ops) != 1:
+                return set()
+            if not isinstance(node.left, _ast.Name) or node.left.id not in self.optional_vars:
+                return set()
+            if not node.comparators or not isinstance(node.comparators[0], _ast.Constant):
+                return set()
+            if node.comparators[0].value is not None:
+                return set()
+            if isinstance(node.ops[0], _ast.IsNot):
+                return {node.left.id}
+            return set()
 
         def visit_Attribute(self, node):
             # var.something — flag if var is unguarded optional

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -13,6 +13,7 @@ Inspired by ~/src/z3_spelunking/formal_failure_analysis.py.
 from __future__ import annotations
 
 import ast as pyast
+import functools
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
@@ -127,6 +128,7 @@ _OPTIONAL_SOURCES = frozenset({
 _OPTIONAL_RETURNING = frozenset({"first", "last", "get_or_none", "one_or_none"})
 _SAFE_CHECKS = frozenset({"is None", "is not None", "if not", "if "})
 
+@functools.lru_cache(maxsize=None)
 def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
     """
     File-level scan: find variables assigned from .first()/.last() etc

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -75,15 +75,7 @@ class FailureMode:
 # ---------------------------------------------------------------------------
 
 def _z3_missing(required: list[str], provided: set[str]) -> list[str]:
-    missing = [f for f in required if f not in provided]
-    if not missing or not _HAS_Z3:
-        return missing
-    s = Solver()
-    for name in required:
-        v = Bool(f"provided_{name}")
-        s.add(v == (name in provided))
-        s.add(v)
-    return missing if s.check() == unsat else []
+    return [f for f in required if f not in provided]
 
 
 # --- 1. Universal model constraint check (presence + range + choices + max_length) ---
@@ -198,21 +190,12 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
     return evidence
 
 
-# Scan each file once; report findings only on the first call site per file.
-_optional_deref_cache: dict[str, list[FailureEvidence]] = {}
-_optional_deref_reported: set[str] = set()
-
 def _check_optional_deref(
     call: CallSite,
     models: dict[str, ModelManifest],
     functions: dict[str, FunctionManifest],
 ) -> list[FailureEvidence]:
-    if call.file not in _optional_deref_cache:
-        _optional_deref_cache[call.file] = _scan_file_optional_deref(call.file)
-    if call.file in _optional_deref_reported:
-        return []
-    _optional_deref_reported.add(call.file)
-    return _optional_deref_cache[call.file]
+    return _scan_file_optional_deref(call.file)
 
 
 OPTIONAL_DEREF = FailureMode(
@@ -232,7 +215,7 @@ def _check_required_arg(
     models: dict[str, ModelManifest],
     functions: dict[str, FunctionManifest],
 ) -> list[FailureEvidence]:
-    if call.is_create_call or "." not in call.callee_name:
+    if call.is_create_call:
         return []
     func = functions.get(call.callee_name)
     if not func or not func.required_args:

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -159,15 +159,33 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
             self.optional_vars: dict[str, int] = {}
             self.guarded: set[str] = set()
 
+        def _visit_scope(self, node):
+            outer_optional = self.optional_vars
+            outer_guarded = self.guarded
+            self.optional_vars = {}
+            self.guarded = set()
+            for child in node.body:
+                self.visit(child)
+            self.optional_vars = outer_optional
+            self.guarded = outer_guarded
+
+        def visit_FunctionDef(self, node):
+            self._visit_scope(node)
+
+        def visit_AsyncFunctionDef(self, node):
+            self._visit_scope(node)
+
         def visit_Assign(self, node):
-            if (
-                len(node.targets) == 1
-                and isinstance(node.targets[0], _ast.Name)
-                and isinstance(node.value, _ast.Call)
-                and isinstance(node.value.func, _ast.Attribute)
-                and node.value.func.attr in _OPTIONAL_RETURNING
-            ):
-                self.optional_vars[node.targets[0].id] = node.lineno
+            targets = [target for target in node.targets if isinstance(target, _ast.Name)]
+            for target in targets:
+                self.guarded.discard(target.id)
+                self.optional_vars.pop(target.id, None)
+                if (
+                    isinstance(node.value, _ast.Call)
+                    and isinstance(node.value.func, _ast.Attribute)
+                    and node.value.func.attr in _OPTIONAL_RETURNING
+                ):
+                    self.optional_vars[target.id] = node.lineno
             self.generic_visit(node)
 
         def visit_If(self, node):

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -12,24 +12,18 @@ Inspired by ~/src/z3_spelunking/formal_failure_analysis.py.
 
 from __future__ import annotations
 
-import ast as pyast
 import functools
 from dataclasses import dataclass, field
-from typing import Callable, Optional
-
-try:
-    from z3 import BoolVal, Solver, sat, unsat, Bool, And, Or, Not, Implies
-    _HAS_Z3 = True
-except ImportError:
-    _HAS_Z3 = False
+from typing import Callable
 
 from .encoder import check_model_create
-from .extractor import CallSite, FieldConstraint, FunctionManifest, ModelManifest
+from .extractor import CallSite, FunctionManifest, ModelManifest
 
 
 @dataclass
 class FailureEvidence:
     """Concrete evidence of a FailureMode violation at a specific site."""
+
     mode_name: str
     file: str
     line: int
@@ -46,6 +40,7 @@ class FailureEvidence:
 # The FailureMode type
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class FailureMode:
     """
@@ -61,6 +56,7 @@ class FailureMode:
         Callable(call_site, models, functions) → list[FailureEvidence].
         Pure function — no side effects. Called once per call site.
     """
+
     name: str
     description: str
     check: Callable[
@@ -75,11 +71,13 @@ class FailureMode:
 #  direct use; failure_mode.py is the extensible plugin layer on top)
 # ---------------------------------------------------------------------------
 
+
 def _z3_missing(required: list[str], provided: set[str]) -> list[str]:
     return [f for f in required if f not in provided]
 
 
 # --- 1. Universal model constraint check (presence + range + choices + max_length) ---
+
 
 def _check_model_constraints(
     call: CallSite,
@@ -95,7 +93,8 @@ def _check_model_constraints(
     return [
         FailureEvidence(
             mode_name="model_constraint",
-            file=v.file, line=v.line,
+            file=v.file,
+            line=v.line,
             call=v.call,
             message="; ".join(v.missing),
             missing=v.missing,
@@ -119,14 +118,22 @@ REQUIRED_FIELD_MISSING = FailureMode(
 # call that returns Optional (common Django patterns: .first(), .get_or_none(),
 # dict.get(), os.environ.get()).
 
-_OPTIONAL_SOURCES = frozenset({
-    "first", "last", "get_or_none", "filter().first",
-    "get", "environ.get", "os.environ.get",
-})
+_OPTIONAL_SOURCES = frozenset(
+    {
+        "first",
+        "last",
+        "get_or_none",
+        "filter().first",
+        "get",
+        "environ.get",
+        "os.environ.get",
+    }
+)
 
 
 _OPTIONAL_RETURNING = frozenset({"first", "last", "get_or_none", "one_or_none"})
 _SAFE_CHECKS = frozenset({"is None", "is not None", "if not", "if "})
+
 
 @functools.lru_cache(maxsize=None)
 def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
@@ -153,11 +160,13 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
             self.guarded: set[str] = set()
 
         def visit_Assign(self, node):
-            if (len(node.targets) == 1 and
-                    isinstance(node.targets[0], _ast.Name) and
-                    isinstance(node.value, _ast.Call) and
-                    isinstance(node.value.func, _ast.Attribute) and
-                    node.value.func.attr in _OPTIONAL_RETURNING):
+            if (
+                len(node.targets) == 1
+                and isinstance(node.targets[0], _ast.Name)
+                and isinstance(node.value, _ast.Call)
+                and isinstance(node.value.func, _ast.Attribute)
+                and node.value.func.attr in _OPTIONAL_RETURNING
+            ):
                 self.optional_vars[node.targets[0].id] = node.lineno
             self.generic_visit(node)
 
@@ -171,21 +180,25 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
 
         def visit_Attribute(self, node):
             # var.something — flag if var is unguarded optional
-            if (isinstance(node.value, _ast.Name) and
-                    node.value.id in self.optional_vars and
-                    node.value.id not in self.guarded):
+            if (
+                isinstance(node.value, _ast.Name)
+                and node.value.id in self.optional_vars
+                and node.value.id not in self.guarded
+            ):
                 var = node.value.id
                 assign_line = self.optional_vars[var]
-                evidence.append(FailureEvidence(
-                    mode_name="optional_dereference",
-                    file=path,
-                    line=node.lineno,
-                    call=f"{var}.{node.attr}",
-                    message=(
-                        f"'{var}' assigned from optional source at line {assign_line} "
-                        f"but used without None check"
-                    ),
-                ))
+                evidence.append(
+                    FailureEvidence(
+                        mode_name="optional_dereference",
+                        file=path,
+                        line=node.lineno,
+                        call=f"{var}.{node.attr}",
+                        message=(
+                            f"'{var}' assigned from optional source at line {assign_line} "
+                            f"but used without None check"
+                        ),
+                    )
+                )
             self.generic_visit(node)
 
     _Visitor().visit(tree)
@@ -212,6 +225,7 @@ OPTIONAL_DEREF = FailureMode(
 
 # --- 3. Missing required function argument ---------------------------------
 
+
 def _check_required_arg(
     call: CallSite,
     models: dict[str, ModelManifest],
@@ -227,19 +241,23 @@ def _check_required_arg(
     # index i is never falsely marked covered because positional_count > i.
     positional_required = [a for a in func.required_args if not a.kwonly]
     positional_covered = {
-        arg.name for i, arg in enumerate(positional_required)
+        arg.name
+        for i, arg in enumerate(positional_required)
         if i < call.positional_count
     }
     provided = call.provided_kwargs | positional_covered
     missing = _z3_missing([a.name for a in func.required_args], provided)
     if missing:
-        return [FailureEvidence(
-            mode_name="required_arg_missing",
-            file=call.file, line=call.line,
-            call=call.callee_name,
-            message=f"missing required arg(s): {', '.join(missing)}",
-            missing=missing,
-        )]
+        return [
+            FailureEvidence(
+                mode_name="required_arg_missing",
+                file=call.file,
+                line=call.line,
+                call=call.callee_name,
+                message=f"missing required arg(s): {', '.join(missing)}",
+                missing=missing,
+            )
+        ]
     return []
 
 
@@ -255,6 +273,7 @@ REQUIRED_ARG_MISSING = FailureMode(
 
 # --- 4. Bare except that swallows all exceptions ---------------------------
 # Detects `except:` or `except Exception: pass` — silent failure patterns.
+
 
 @functools.lru_cache(maxsize=None)
 def _scan_file_bare_except(path: str) -> list[FailureEvidence]:
@@ -274,13 +293,15 @@ def _scan_file_bare_except(path: str) -> list[FailureEvidence]:
             continue
         if node.type is None:
             # bare `except:` — catches KeyboardInterrupt, SystemExit, everything
-            evidence.append(FailureEvidence(
-                mode_name="bare_except",
-                file=path,
-                line=node.lineno,
-                call="except:",
-                message="bare `except:` catches all exceptions including KeyboardInterrupt",
-            ))
+            evidence.append(
+                FailureEvidence(
+                    mode_name="bare_except",
+                    file=path,
+                    line=node.lineno,
+                    call="except:",
+                    message="bare `except:` catches all exceptions including KeyboardInterrupt",
+                )
+            )
         elif isinstance(node.type, _ast.Name) and node.type.id == "Exception":
             # `except Exception: pass` or `except Exception: ...` — silent swallow
             body = node.body
@@ -293,13 +314,15 @@ def _scan_file_bare_except(path: str) -> list[FailureEvidence]:
                 )
             )
             if is_silent:
-                evidence.append(FailureEvidence(
-                    mode_name="bare_except",
-                    file=path,
-                    line=node.lineno,
-                    call="except Exception: pass",
-                    message="`except Exception: pass` silently swallows all errors",
-                ))
+                evidence.append(
+                    FailureEvidence(
+                        mode_name="bare_except",
+                        file=path,
+                        line=node.lineno,
+                        call="except Exception: pass",
+                        message="`except Exception: pass` silently swallows all errors",
+                    )
+                )
     return evidence
 
 
@@ -325,7 +348,7 @@ BARE_EXCEPT = FailureMode(
 # Django model .save() without update_fields re-writes every column,
 # clobbering concurrent partial updates.
 
-_SAFE_SAVE_SUFFIXES = ("form", "serializer", "fs", "storage", "file")
+_SAFE_SAVE_RECEIVER_KINDS = frozenset({"form", "serializer", "fs", "storage", "file"})
 
 
 def _check_save_without_update_fields(
@@ -338,20 +361,23 @@ def _check_save_without_update_fields(
     if "update_fields" in call.provided_kwargs:
         return []
     # Skip form/serializer/storage saves — intentional full saves.
-    # Match on suffix so compound names like `image_dataset_serializer` match.
+    # Match on snake_case receiver kind so `image_dataset_serializer` is safe
+    # but `profile.save()` is not misclassified as a file save.
     receiver = call.callee_name.rsplit(".", 1)[0].split(".")[-1].lower()
-    if any(receiver.endswith(safe) for safe in _SAFE_SAVE_SUFFIXES):
+    if receiver.rsplit("_", 1)[-1] in _SAFE_SAVE_RECEIVER_KINDS:
         return []
-    return [FailureEvidence(
-        mode_name="save_without_update_fields",
-        file=call.file,
-        line=call.line,
-        call=call.callee_name,
-        message=(
-            ".save() without update_fields re-writes every column; "
-            "use save(update_fields=[...]) to prevent clobbering concurrent writes"
-        ),
-    )]
+    return [
+        FailureEvidence(
+            mode_name="save_without_update_fields",
+            file=call.file,
+            line=call.line,
+            call=call.callee_name,
+            message=(
+                ".save() without update_fields re-writes every column; "
+                "use save(update_fields=[...]) to prevent clobbering concurrent writes"
+            ),
+        )
+    ]
 
 
 SAVE_WITHOUT_UPDATE_FIELDS = FailureMode(

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -1,0 +1,296 @@
+"""
+FailureMode — declarative constraint objects for pact.
+
+A FailureMode defines a class of bug: what facts trigger it, what Z3 asserts
+about those facts, and what message to show when violated.
+
+This is the plugin layer. New constraint classes are new FailureMode instances —
+no code changes to the checker. The LLM authors FailureModes; Z3 verifies them.
+
+Inspired by ~/src/z3_spelunking/formal_failure_analysis.py.
+"""
+
+from __future__ import annotations
+
+import ast as pyast
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+try:
+    from z3 import BoolVal, Solver, sat, unsat, Bool, And, Or, Not, Implies
+    _HAS_Z3 = True
+except ImportError:
+    _HAS_Z3 = False
+
+from .encoder import check_model_create
+from .extractor import CallSite, FieldConstraint, FunctionManifest, ModelManifest
+
+
+@dataclass
+class FailureEvidence:
+    """Concrete evidence of a FailureMode violation at a specific site."""
+    mode_name: str
+    file: str
+    line: int
+    call: str
+    message: str
+    missing: list[str] = field(default_factory=list)
+    context: str = "failure_mode"
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}  [{self.mode_name}]  {self.call}  — {self.message}"
+
+
+# ---------------------------------------------------------------------------
+# The FailureMode type
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FailureMode:
+    """
+    Declarative specification of a constraint class.
+
+    Parameters
+    ----------
+    name:
+        Short identifier, e.g. "required_field_missing".
+    description:
+        Human-readable explanation of what this catches.
+    check:
+        Callable(call_site, models, functions) → list[FailureEvidence].
+        Pure function — no side effects. Called once per call site.
+    """
+    name: str
+    description: str
+    check: Callable[
+        [CallSite, dict[str, ModelManifest], dict[str, FunctionManifest]],
+        list[FailureEvidence],
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Built-in FailureModes
+# (these replace the hardcoded checks in encoder.py — encoder.py stays for
+#  direct use; failure_mode.py is the extensible plugin layer on top)
+# ---------------------------------------------------------------------------
+
+def _z3_missing(required: list[str], provided: set[str]) -> list[str]:
+    missing = [f for f in required if f not in provided]
+    if not missing or not _HAS_Z3:
+        return missing
+    s = Solver()
+    for name in required:
+        v = Bool(f"provided_{name}")
+        s.add(v == (name in provided))
+        s.add(v)
+    return missing if s.check() == unsat else []
+
+
+# --- 1. Universal model constraint check (presence + range + choices + max_length) ---
+
+def _check_model_constraints(
+    call: CallSite,
+    models: dict[str, ModelManifest],
+    functions: dict[str, FunctionManifest],
+) -> list[FailureEvidence]:
+    if not call.is_create_call or not call.model_name:
+        return []
+    model = models.get(call.model_name)
+    if not model:
+        return []
+    violations = check_model_create(call, model)
+    return [
+        FailureEvidence(
+            mode_name="model_constraint",
+            file=v.file, line=v.line,
+            call=v.call,
+            message="; ".join(v.missing),
+            missing=v.missing,
+        )
+        for v in violations
+    ]
+
+
+REQUIRED_FIELD_MISSING = FailureMode(
+    name="model_constraint",
+    description=(
+        "Model.objects.create() violates one or more field constraints: "
+        "presence, choices, max_length, integer range."
+    ),
+    check=_check_model_constraints,
+)
+
+
+# --- 2. Optional dereference — x.attr where x may be None -----------------
+# Extracted from the AST: detects `x.something` where x is assigned from a
+# call that returns Optional (common Django patterns: .first(), .get_or_none(),
+# dict.get(), os.environ.get()).
+
+_OPTIONAL_SOURCES = frozenset({
+    "first", "last", "get_or_none", "filter().first",
+    "get", "environ.get", "os.environ.get",
+})
+
+
+_OPTIONAL_RETURNING = frozenset({"first", "last", "get_or_none", "one_or_none"})
+_SAFE_CHECKS = frozenset({"is None", "is not None", "if not", "if "})
+
+def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
+    """
+    File-level scan: find variables assigned from .first()/.last() etc
+    that are then attribute-accessed without a None guard in between.
+    Uses the AST control flow visitor from ast_z3_analysis lineage.
+    """
+    import ast as _ast
+    from pathlib import Path as _Path
+
+    try:
+        source = _Path(path).read_text(encoding="utf-8", errors="replace")
+        tree = _ast.parse(source, filename=path)
+    except (SyntaxError, OSError):
+        return []
+
+    evidence = []
+
+    class _Visitor(_ast.NodeVisitor):
+        def __init__(self):
+            # var_name -> line where it was assigned from optional source
+            self.optional_vars: dict[str, int] = {}
+            self.guarded: set[str] = set()
+
+        def visit_Assign(self, node):
+            if (len(node.targets) == 1 and
+                    isinstance(node.targets[0], _ast.Name) and
+                    isinstance(node.value, _ast.Call) and
+                    isinstance(node.value.func, _ast.Attribute) and
+                    node.value.func.attr in _OPTIONAL_RETURNING):
+                self.optional_vars[node.targets[0].id] = node.lineno
+            self.generic_visit(node)
+
+        def visit_If(self, node):
+            # If the test references an optional var, mark it guarded
+            src = _ast.unparse(node.test) if hasattr(_ast, "unparse") else ""
+            for var in list(self.optional_vars):
+                if var in src:
+                    self.guarded.add(var)
+            self.generic_visit(node)
+
+        def visit_Attribute(self, node):
+            # var.something — flag if var is unguarded optional
+            if (isinstance(node.value, _ast.Name) and
+                    node.value.id in self.optional_vars and
+                    node.value.id not in self.guarded):
+                var = node.value.id
+                assign_line = self.optional_vars[var]
+                evidence.append(FailureEvidence(
+                    mode_name="optional_dereference",
+                    file=path,
+                    line=node.lineno,
+                    call=f"{var}.{node.attr}",
+                    message=(
+                        f"'{var}' assigned from optional source at line {assign_line} "
+                        f"but used without None check"
+                    ),
+                ))
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return evidence
+
+
+# Scan each file once; report findings only on the first call site per file.
+_optional_deref_cache: dict[str, list[FailureEvidence]] = {}
+_optional_deref_reported: set[str] = set()
+
+def _check_optional_deref(
+    call: CallSite,
+    models: dict[str, ModelManifest],
+    functions: dict[str, FunctionManifest],
+) -> list[FailureEvidence]:
+    if call.file not in _optional_deref_cache:
+        _optional_deref_cache[call.file] = _scan_file_optional_deref(call.file)
+    if call.file in _optional_deref_reported:
+        return []
+    _optional_deref_reported.add(call.file)
+    return _optional_deref_cache[call.file]
+
+
+OPTIONAL_DEREF = FailureMode(
+    name="optional_dereference",
+    description=(
+        "Attribute access on a value that may be None (e.g. from .first(), "
+        "dict.get(), os.environ.get()). Will raise AttributeError at runtime."
+    ),
+    check=_check_optional_deref,
+)
+
+
+# --- 3. Missing required function argument ---------------------------------
+
+def _check_required_arg(
+    call: CallSite,
+    models: dict[str, ModelManifest],
+    functions: dict[str, FunctionManifest],
+) -> list[FailureEvidence]:
+    if call.is_create_call or "." not in call.callee_name:
+        return []
+    func = functions.get(call.callee_name)
+    if not func or not func.required_args:
+        return []
+    positional_covered = {
+        arg.name for i, arg in enumerate(func.required_args)
+        if i < call.positional_count
+    }
+    provided = call.provided_kwargs | positional_covered
+    missing = _z3_missing([a.name for a in func.required_args], provided)
+    if missing:
+        return [FailureEvidence(
+            mode_name="required_arg_missing",
+            file=call.file, line=call.line,
+            call=call.callee_name,
+            message=f"missing required arg(s): {', '.join(missing)}",
+            missing=missing,
+        )]
+    return []
+
+
+REQUIRED_ARG_MISSING = FailureMode(
+    name="required_arg_missing",
+    description=(
+        "Function called without all required positional arguments. "
+        "Will raise TypeError at runtime."
+    ),
+    check=_check_required_arg,
+)
+
+
+# --- 4. Bare except that swallows all exceptions ---------------------------
+# Detects `except:` or `except Exception: pass` — silent failure patterns.
+
+def _check_bare_except(
+    call: CallSite,
+    models: dict[str, ModelManifest],
+    functions: dict[str, FunctionManifest],
+) -> list[FailureEvidence]:
+    return []  # file-level scan, not call-site; handled in flow_scanner.py
+
+
+BARE_EXCEPT = FailureMode(
+    name="bare_except",
+    description=(
+        "Bare `except:` or `except Exception: pass` silently swallows all errors. "
+        "Makes bugs invisible."
+    ),
+    check=_check_bare_except,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry — all active failure modes
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODES: list[FailureMode] = [
+    REQUIRED_FIELD_MISSING,
+    REQUIRED_ARG_MISSING,
+    OPTIONAL_DEREF,
+]

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -124,11 +124,11 @@ _OPTIONAL_SOURCES = frozenset(
         "last",
         "get_or_none",
         "filter().first",
-        "get",
         "environ.get",
         "os.environ.get",
     }
 )
+_DICT_ANNOTATIONS = frozenset({"dict", "Dict", "Mapping", "MutableMapping"})
 
 
 _OPTIONAL_RETURNING = frozenset({"first", "last", "get_or_none", "one_or_none"})
@@ -157,16 +157,20 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
         def __init__(self):
             # var_name -> line where it was assigned from optional source
             self.optional_vars: dict[str, int] = {}
+            self.dict_vars: set[str] = set()
             self.guarded: set[str] = set()
 
         def _visit_scope(self, node):
             outer_optional = self.optional_vars
+            outer_dict_vars = self.dict_vars
             outer_guarded = self.guarded
             self.optional_vars = {}
+            self.dict_vars = self._dict_args(node)
             self.guarded = set()
             for child in node.body:
                 self.visit(child)
             self.optional_vars = outer_optional
+            self.dict_vars = outer_dict_vars
             self.guarded = outer_guarded
 
         def visit_FunctionDef(self, node):
@@ -180,9 +184,26 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
             for target in targets:
                 self.guarded.discard(target.id)
                 self.optional_vars.pop(target.id, None)
+                self.dict_vars.discard(target.id)
+                if self._is_dict_value(node.value):
+                    self.dict_vars.add(target.id)
                 if isinstance(node.value, _ast.Call) and self._is_optional_source(node.value):
                     self.optional_vars[target.id] = node.lineno
             self.generic_visit(node)
+
+        def _dict_args(self, node) -> set[str]:
+            args = [*node.args.args, *node.args.kwonlyargs]
+            return {
+                arg.arg
+                for arg in args
+                if arg.annotation is not None
+                and self._call_name(arg.annotation) in _DICT_ANNOTATIONS
+            }
+
+        def _is_dict_value(self, node) -> bool:
+            if isinstance(node, _ast.Dict):
+                return True
+            return isinstance(node, _ast.Call) and self._call_name(node.func) == "dict"
 
         def _call_name(self, node) -> str | None:
             if isinstance(node, _ast.Name):
@@ -198,10 +219,12 @@ def _scan_file_optional_deref(path: str) -> list[FailureEvidence]:
             if not isinstance(node.func, _ast.Attribute):
                 return False
             name = self._call_name(node.func)
+            if node.func.attr in _OPTIONAL_RETURNING or name in _OPTIONAL_SOURCES:
+                return True
             return (
-                node.func.attr in _OPTIONAL_RETURNING
-                or node.func.attr in _OPTIONAL_SOURCES
-                or name in _OPTIONAL_SOURCES
+                node.func.attr == "get"
+                and isinstance(node.func.value, _ast.Name)
+                and node.func.value.id in self.dict_vars
             )
 
         def visit_If(self, node):

--- a/tools/pact/failure_mode.py
+++ b/tools/pact/failure_mode.py
@@ -222,8 +222,12 @@ def _check_required_arg(
     func = functions.get(call.callee_name)
     if not func or not func.required_args:
         return []
+    # Only non-kwonly required args can be covered by positional args.
+    # Enumerate positional-only required args separately so a kwonly arg at
+    # index i is never falsely marked covered because positional_count > i.
+    positional_required = [a for a in func.required_args if not a.kwonly]
     positional_covered = {
-        arg.name for i, arg in enumerate(func.required_args)
+        arg.name for i, arg in enumerate(positional_required)
         if i < call.positional_count
     }
     provided = call.provided_kwargs | positional_covered

--- a/tools/pact/graph.py
+++ b/tools/pact/graph.py
@@ -1,0 +1,76 @@
+"""
+Call graph construction.
+
+Builds a directed graph where nodes are qualified function names and
+edges are call relationships. Used to trace data flow across boundaries —
+e.g., to know whether a value that may be None can reach a NOT NULL field.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from .extractor import CallSite, FunctionManifest
+
+try:
+    import networkx as nx
+    _HAS_NX = True
+except ImportError:
+    _HAS_NX = False
+
+
+@dataclass
+class CallGraph:
+    _g: object  # networkx.DiGraph or None
+
+    def reachable_from(self, func_name: str) -> list[str]:
+        if not _HAS_NX or self._g is None:
+            return []
+        if func_name not in self._g:
+            return []
+        return list(nx.descendants(self._g, func_name))
+
+    def callers_of(self, func_name: str) -> list[str]:
+        if not _HAS_NX or self._g is None:
+            return []
+        if func_name not in self._g:
+            return []
+        return list(self._g.predecessors(func_name))
+
+    def call_sites_to(self, func_name: str) -> list[CallSite]:
+        if not _HAS_NX or self._g is None:
+            return []
+        sites = []
+        for _, _, data in self._g.in_edges(func_name, data=True):
+            site = data.get("call_site")
+            if site:
+                sites.append(site)
+        return sites
+
+
+def build_call_graph(
+    functions: list[FunctionManifest],
+    call_sites: list[CallSite],
+) -> CallGraph:
+    if not _HAS_NX:
+        return CallGraph(_g=None)
+
+    G = nx.DiGraph()
+
+    func_names = {f.name for f in functions}
+    # Also index short names (for unqualified calls)
+    short_to_qual: dict[str, str] = {}
+    for f in functions:
+        G.add_node(f.name, manifest=f)
+        short = f.name.split(".")[-1]
+        short_to_qual.setdefault(short, f.name)
+
+    for call in call_sites:
+        target = call.callee_name
+        if target not in func_names:
+            # Try short name resolution
+            short = target.split(".")[-1]
+            target = short_to_qual.get(short, target)
+
+        G.add_edge("__root__", target, call_site=call)
+
+    return CallGraph(_g=G)

--- a/tools/pact/graph.py
+++ b/tools/pact/graph.py
@@ -7,7 +7,6 @@ e.g., to know whether a value that may be None can reach a NOT NULL field.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
 
 from .extractor import CallSite, FunctionManifest
 
@@ -38,6 +37,8 @@ class CallGraph:
 
     def call_sites_to(self, func_name: str) -> list[CallSite]:
         if not _HAS_NX or self._g is None:
+            return []
+        if func_name not in self._g:
             return []
         sites = []
         for _, _, data in self._g.in_edges(func_name, data=True):

--- a/tools/pact/graph.py
+++ b/tools/pact/graph.py
@@ -65,12 +65,11 @@ def build_call_graph(
         short_to_qual.setdefault(short, f.name)
 
     for call in call_sites:
+        source = call.caller_name or "__root__"
         target = call.callee_name
         if target not in func_names:
-            # Try short name resolution
             short = target.split(".")[-1]
             target = short_to_qual.get(short, target)
-
-        G.add_edge("__root__", target, call_site=call)
+        G.add_edge(source, target, call_site=call)
 
     return CallGraph(_g=G)

--- a/tools/pact/pytest.ini
+++ b/tools/pact/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# Standalone pytest config for pact — no Django, no Celery, no external services
+asyncio_mode = off

--- a/tools/pact/scan_prs.py
+++ b/tools/pact/scan_prs.py
@@ -1,0 +1,134 @@
+"""
+Scan all open PRs for pact violations by checking out each branch
+into a temporary git worktree, running pact --diff, and reporting.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+MAX_WORKERS = 5
+
+# Use the venv python if available, otherwise fall back to current interpreter
+_VENV_PYTHON = REPO_ROOT / "futureagi" / ".venv" / "bin" / "python3"
+PYTHON = str(_VENV_PYTHON) if _VENV_PYTHON.exists() else sys.executable
+
+
+def get_open_prs() -> list[dict]:
+    result = subprocess.run(
+        ["gh", "pr", "list", "--repo", "future-agi/future-agi",
+         "--author", "@me", "--state", "open",
+         "--json", "number,title,headRefName"],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def scan_branch(pr: dict, worktree_base: Path) -> dict:
+    num = pr["number"]
+    branch = pr["headRefName"]
+    worktree = worktree_base / f"pr-{num}"
+
+    try:
+        # Create worktree checked out to the fork branch
+        subprocess.run(
+            ["git", "worktree", "add", "--quiet", str(worktree), f"fork/{branch}"],
+            cwd=REPO_ROOT, capture_output=True, check=True,
+        )
+
+        result = subprocess.run(
+            [PYTHON, "-m", "tools.pact.cli", "--diff", "--json", str(worktree)],
+            cwd=worktree,
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+            capture_output=True, text=True, timeout=120,
+        )
+
+        try:
+            violations = json.loads(result.stdout) if result.stdout.strip() else []
+        except json.JSONDecodeError:
+            violations = []
+
+        return {
+            "number": num,
+            "branch": branch,
+            "title": pr["title"],
+            "violations": violations,
+            "error": None,
+        }
+
+    except subprocess.CalledProcessError as e:
+        return {
+            "number": num,
+            "branch": branch,
+            "title": pr["title"],
+            "violations": [],
+            "error": e.stderr.strip() if e.stderr else str(e),
+        }
+    except Exception as e:
+        return {
+            "number": num,
+            "branch": branch,
+            "title": pr["title"],
+            "violations": [],
+            "error": str(e),
+        }
+    finally:
+        try:
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(worktree)],
+                cwd=REPO_ROOT, capture_output=True,
+            )
+        except Exception:
+            pass
+
+
+def main():
+    print("Fetching open PRs...")
+    prs = get_open_prs()
+    print(f"Found {len(prs)} open PRs. Scanning with {MAX_WORKERS} parallel workers...\n")
+
+    worktree_base = Path(tempfile.mkdtemp(prefix="pact-scan-"))
+
+    try:
+        results = []
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+            futures = {pool.submit(scan_branch, pr, worktree_base): pr for pr in prs}
+            for future in as_completed(futures):
+                r = future.result()
+                results.append(r)
+                n_v = len(r["violations"])
+                status = f"{'✗' if n_v else '✓'} #{r['number']:4d}  {n_v:3d} violation(s)  {r['branch']}"
+                if r["error"]:
+                    status += f"  [error: {r['error'][:60]}]"
+                print(status)
+
+        print("\n" + "=" * 70)
+        print("SUMMARY — PRs with violations\n")
+
+        dirty = sorted([r for r in results if r["violations"]], key=lambda x: -len(x["violations"]))
+        if not dirty:
+            print("✓  All PRs clean.")
+        else:
+            for r in dirty:
+                print(f"\n#{r['number']}  {r['branch']}")
+                print(f"  {r['title'][:70]}")
+                for v in r["violations"]:
+                    missing = ", ".join(v["missing"])
+                    short_file = v["file"].replace(str(worktree_base), "").lstrip("/")
+                    # strip the pr-NNN/ prefix
+                    parts = short_file.split("/", 1)
+                    short_file = parts[1] if len(parts) > 1 else short_file
+                    print(f"  {short_file}:{v['line']}  {v['call']}()  missing: {missing}")
+
+    finally:
+        shutil.rmtree(worktree_base, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pact/scan_prs.py
+++ b/tools/pact/scan_prs.py
@@ -48,11 +48,27 @@ def scan_branch(pr: dict, worktree_base: Path) -> dict:
             env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
             capture_output=True, text=True, timeout=120,
         )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            return {
+                "number": num,
+                "branch": branch,
+                "title": pr["title"],
+                "violations": [],
+                "error": detail or f"pact exited with status {result.returncode}",
+            }
 
         try:
             violations = json.loads(result.stdout) if result.stdout.strip() else []
-        except json.JSONDecodeError:
-            violations = []
+        except json.JSONDecodeError as exc:
+            detail = (result.stderr or result.stdout or "").strip()
+            return {
+                "number": num,
+                "branch": branch,
+                "title": pr["title"],
+                "violations": [],
+                "error": f"invalid pact JSON: {detail or exc}",
+            }
 
         return {
             "number": num,

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -679,6 +679,29 @@ def test_optional_deref_condition_access_uses_condition_guard(tmp_path):
     ], "condition-side guarded attribute access must not be reported"
 
 
+def test_optional_deref_bare_attribute_condition_is_flagged(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        def run(users):
+            user = users.first()
+            if user.email:
+                return user.email
+            return None
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    optional_v = [
+        v
+        for v in violations
+        if v.context == "optional_dereference" and v.call == "user.email"
+    ]
+    assert optional_v, "attribute conditions are unsafe without an explicit object guard"
+
+
 # ---------------------------------------------------------------------------
 # graph and scanner failure contracts
 # ---------------------------------------------------------------------------

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -459,6 +459,22 @@ def test_cli_diff_failure_exits_nonzero(monkeypatch, tmp_path, capsys):
     assert "base branch unavailable" in captured.err
 
 
+def test_changed_files_wraps_missing_git(monkeypatch, tmp_path):
+    from . import cli
+
+    def missing_git(*args, **kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(subprocess, "run", missing_git)
+
+    try:
+        cli._changed_files_on_branch("main", cwd=tmp_path)
+    except cli.DiffResolutionError as exc:
+        assert "git" in str(exc)
+    else:
+        raise AssertionError("missing git should raise DiffResolutionError")
+
+
 def test_scan_prs_reports_pact_cli_failure(monkeypatch, tmp_path):
     from . import scan_prs
 

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -124,6 +124,37 @@ def test_optional_field_not_flagged(tmp_path):
     assert not any(v.call == "Note.objects.create" for v in violations)
 
 
+def test_save_guard_without_assignment_does_not_make_field_optional(tmp_path):
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
+        from django.db import models
+        class Widget(models.Model):
+            slug = models.CharField(max_length=64)
+            class Meta: app_label = 'x'
+            def save(self, *args, **kwargs):
+                if not self.slug:
+                    validate_slug_source()
+                return super().save(*args, **kwargs)
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "factory.py",
+        """
+        def make():
+            Widget.objects.create()
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    widget_v = [v for v in violations if v.call == "Widget.objects.create"]
+    assert widget_v, "save guards only suppress required fields when they assign them"
+    assert any("slug" in missing for missing in widget_v[0].missing)
+
+
 # ---------------------------------------------------------------------------
 # required_arg_missing mode
 # ---------------------------------------------------------------------------

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -659,6 +659,26 @@ def test_optional_deref_guard_does_not_dominate_after_if(tmp_path):
     assert optional_v, "a branch-local guard must not dominate later unguarded use"
 
 
+def test_optional_deref_condition_access_uses_condition_guard(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        def run(users):
+            user = users.first()
+            if user and user.email:
+                return user.email
+            return None
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    assert not [
+        v for v in violations if v.context == "optional_dereference"
+    ], "condition-side guarded attribute access must not be reported"
+
+
 # ---------------------------------------------------------------------------
 # graph and scanner failure contracts
 # ---------------------------------------------------------------------------

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -1,0 +1,138 @@
+"""
+Integration tests for the check_codebase() production path.
+
+test_z3_engine.py covers PactEngine (z3_engine.py).
+These tests cover the checker.py → failure_mode.py → encoder.py pipeline,
+which is what cli.py actually calls.
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from .checker import check_codebase
+
+
+def _write_src(tmp_path: Path, filename: str, source: str) -> Path:
+    p = tmp_path / filename
+    p.write_text(textwrap.dedent(source))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# model_constraint violations (REQUIRED_FIELD_MISSING mode)
+# ---------------------------------------------------------------------------
+
+def test_clean_create_produces_no_violation(tmp_path):
+    _write_src(tmp_path, "models.py", """
+        from django.db import models
+        class Widget(models.Model):
+            name = models.CharField(max_length=64)
+            class Meta: app_label = 'x'
+    """)
+    _write_src(tmp_path, "views.py", """
+        from .models import Widget
+        def create(org):
+            Widget.objects.create(name="foo")
+    """)
+    violations = check_codebase(tmp_path)
+    assert not any(v.call == "Widget.objects.create" for v in violations)
+
+
+def test_missing_required_field_flagged(tmp_path):
+    _write_src(tmp_path, "models.py", """
+        from django.db import models
+        class Widget(models.Model):
+            name = models.CharField(max_length=64)
+            class Meta: app_label = 'x'
+    """)
+    _write_src(tmp_path, "views.py", """
+        def create(org):
+            Widget.objects.create()
+    """)
+    violations = check_codebase(tmp_path)
+    widget_v = [v for v in violations if v.call == "Widget.objects.create"]
+    assert widget_v, "expected model_constraint violation for Widget"
+    assert any("name" in m for m in widget_v[0].missing)
+
+
+def test_pre_extracted_skips_double_parse(tmp_path):
+    """Passing _extracted avoids a second extract_from_codebase call."""
+    from .extractor import extract_from_codebase
+
+    _write_src(tmp_path, "models.py", """
+        from django.db import models
+        class Gadget(models.Model):
+            sku = models.CharField(max_length=32)
+            class Meta: app_label = 'x'
+    """)
+    _write_src(tmp_path, "factory.py", """
+        def make():
+            Gadget.objects.create()
+    """)
+    extracted = extract_from_codebase(tmp_path)
+    violations = check_codebase(tmp_path, _extracted=extracted)
+    gadget_v = [v for v in violations if v.call == "Gadget.objects.create"]
+    assert gadget_v, "pre-extracted path should still find violation"
+
+
+def test_optional_field_not_flagged(tmp_path):
+    _write_src(tmp_path, "models.py", """
+        from django.db import models
+        class Note(models.Model):
+            body = models.TextField(blank=True, null=True)
+            class Meta: app_label = 'x'
+    """)
+    _write_src(tmp_path, "factory.py", """
+        def make():
+            Note.objects.create()
+    """)
+    violations = check_codebase(tmp_path)
+    assert not any(v.call == "Note.objects.create" for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# required_arg_missing mode
+# ---------------------------------------------------------------------------
+
+def test_top_level_function_missing_arg_flagged(tmp_path):
+    """Top-level functions (no dot in name) must be checked — regression for
+    the removed '.' not in callee_name guard."""
+    _write_src(tmp_path, "lib.py", """
+        def send_email(to, subject, body):
+            pass
+    """)
+    _write_src(tmp_path, "usage.py", """
+        from lib import send_email
+        def run():
+            send_email("a@b.com", "hello")
+    """)
+    violations = check_codebase(tmp_path)
+    # The call `send_email("a@b.com", "hello")` has 2 positional args but
+    # send_email requires 3 — body is missing.
+    missing_arg_v = [
+        v for v in violations
+        if v.context == "required_arg_missing" and "send_email" in v.call
+    ]
+    assert missing_arg_v, "top-level function call missing required arg should be flagged"
+
+
+def test_kwonly_required_arg_flagged(tmp_path):
+    """Keyword-only required args (after *) must be in FunctionManifest."""
+    _write_src(tmp_path, "lib.py", """
+        def create_user(name, *, role):
+            pass
+    """)
+    _write_src(tmp_path, "usage.py", """
+        from lib import create_user
+        def run():
+            create_user("Alice")
+    """)
+    violations = check_codebase(tmp_path)
+    kwonly_v = [
+        v for v in violations
+        if v.context == "required_arg_missing" and "create_user" in v.call
+    ]
+    assert kwonly_v, "missing required kwarg-only arg should be flagged"
+    assert "role" in kwonly_v[0].missing

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -207,6 +207,35 @@ def test_computed_required_field_value_is_not_treated_as_none(tmp_path):
     ], "computed values prove presence but should not be checked as literal None"
 
 
+def test_computed_required_field_value_is_preserved_as_unknown(tmp_path):
+    from .extractor import UNKNOWN_VALUE, extract_from_codebase
+
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
+        from django.db import models
+        class Widget(models.Model):
+            name = models.CharField(max_length=64)
+            class Meta: app_label = 'x'
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "factory.py",
+        """
+        def make(source):
+            Widget.objects.create(name=source.name)
+    """,
+    )
+
+    _models, _functions, calls = extract_from_codebase(tmp_path)
+    create_call = next(call for call in calls if call.callee_name == "Widget.objects.create")
+
+    assert "name" in create_call.provided_kwargs
+    assert create_call.kwarg_values["name"] is UNKNOWN_VALUE
+
+
 def test_foreign_key_accepts_python_attribute_or_id_kwarg(tmp_path):
     _write_src(
         tmp_path,

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -731,6 +731,70 @@ def test_optional_deref_bare_attribute_condition_is_flagged(tmp_path):
     assert optional_v, "attribute conditions are unsafe without an explicit object guard"
 
 
+def test_optional_deref_dict_get_is_flagged(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        def run(data):
+            value = data.get("name")
+            return value.strip()
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    optional_v = [
+        v
+        for v in violations
+        if v.context == "optional_dereference" and v.call == "value.strip"
+    ]
+    assert optional_v, "dict.get() may return None and must be guarded before dereference"
+
+
+def test_optional_deref_os_environ_get_is_flagged(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        import os
+
+        def run():
+            token = os.environ.get("TOKEN")
+            return token.strip()
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    optional_v = [
+        v
+        for v in violations
+        if v.context == "optional_dereference" and v.call == "token.strip"
+    ]
+    assert optional_v, "os.environ.get() may return None and must be guarded before dereference"
+
+
+def test_optional_deref_dict_get_guard_suppresses_flag(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        def run(data):
+            value = data.get("name")
+            if value is not None:
+                return value.strip()
+            return None
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    assert not [
+        v for v in violations if v.context == "optional_dereference"
+    ], "None guard must dominate dereference inside its branch"
+
+
 # ---------------------------------------------------------------------------
 # graph and scanner failure contracts
 # ---------------------------------------------------------------------------

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -9,8 +9,6 @@ which is what cli.py actually calls.
 import textwrap
 from pathlib import Path
 
-import pytest
-
 from .checker import check_codebase
 
 
@@ -24,33 +22,50 @@ def _write_src(tmp_path: Path, filename: str, source: str) -> Path:
 # model_constraint violations (REQUIRED_FIELD_MISSING mode)
 # ---------------------------------------------------------------------------
 
+
 def test_clean_create_produces_no_violation(tmp_path):
-    _write_src(tmp_path, "models.py", """
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
         from django.db import models
         class Widget(models.Model):
             name = models.CharField(max_length=64)
             class Meta: app_label = 'x'
-    """)
-    _write_src(tmp_path, "views.py", """
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
         from .models import Widget
         def create(org):
             Widget.objects.create(name="foo")
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     assert not any(v.call == "Widget.objects.create" for v in violations)
 
 
 def test_missing_required_field_flagged(tmp_path):
-    _write_src(tmp_path, "models.py", """
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
         from django.db import models
         class Widget(models.Model):
             name = models.CharField(max_length=64)
             class Meta: app_label = 'x'
-    """)
-    _write_src(tmp_path, "views.py", """
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
         def create(org):
             Widget.objects.create()
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     widget_v = [v for v in violations if v.call == "Widget.objects.create"]
     assert widget_v, "expected model_constraint violation for Widget"
@@ -61,16 +76,24 @@ def test_pre_extracted_skips_double_parse(tmp_path):
     """Passing _extracted avoids a second extract_from_codebase call."""
     from .extractor import extract_from_codebase
 
-    _write_src(tmp_path, "models.py", """
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
         from django.db import models
         class Gadget(models.Model):
             sku = models.CharField(max_length=32)
             class Meta: app_label = 'x'
-    """)
-    _write_src(tmp_path, "factory.py", """
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "factory.py",
+        """
         def make():
             Gadget.objects.create()
-    """)
+    """,
+    )
     extracted = extract_from_codebase(tmp_path)
     violations = check_codebase(tmp_path, _extracted=extracted)
     gadget_v = [v for v in violations if v.call == "Gadget.objects.create"]
@@ -78,16 +101,24 @@ def test_pre_extracted_skips_double_parse(tmp_path):
 
 
 def test_optional_field_not_flagged(tmp_path):
-    _write_src(tmp_path, "models.py", """
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
         from django.db import models
         class Note(models.Model):
             body = models.TextField(blank=True, null=True)
             class Meta: app_label = 'x'
-    """)
-    _write_src(tmp_path, "factory.py", """
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "factory.py",
+        """
         def make():
             Note.objects.create()
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     assert not any(v.call == "Note.objects.create" for v in violations)
 
@@ -96,42 +127,63 @@ def test_optional_field_not_flagged(tmp_path):
 # required_arg_missing mode
 # ---------------------------------------------------------------------------
 
+
 def test_top_level_function_missing_arg_flagged(tmp_path):
     """Top-level functions (no dot in name) must be checked — regression for
     the removed '.' not in callee_name guard."""
-    _write_src(tmp_path, "lib.py", """
+    _write_src(
+        tmp_path,
+        "lib.py",
+        """
         def send_email(to, subject, body):
             pass
-    """)
-    _write_src(tmp_path, "usage.py", """
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "usage.py",
+        """
         from lib import send_email
         def run():
             send_email("a@b.com", "hello")
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     # The call `send_email("a@b.com", "hello")` has 2 positional args but
     # send_email requires 3 — body is missing.
     missing_arg_v = [
-        v for v in violations
+        v
+        for v in violations
         if v.context == "required_arg_missing" and "send_email" in v.call
     ]
-    assert missing_arg_v, "top-level function call missing required arg should be flagged"
+    assert (
+        missing_arg_v
+    ), "top-level function call missing required arg should be flagged"
 
 
 def test_kwonly_required_arg_flagged(tmp_path):
     """Keyword-only required args (after *) must be in FunctionManifest."""
-    _write_src(tmp_path, "lib.py", """
+    _write_src(
+        tmp_path,
+        "lib.py",
+        """
         def create_user(name, *, role):
             pass
-    """)
-    _write_src(tmp_path, "usage.py", """
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "usage.py",
+        """
         from lib import create_user
         def run():
             create_user("Alice")
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     kwonly_v = [
-        v for v in violations
+        v
+        for v in violations
         if v.context == "required_arg_missing" and "create_user" in v.call
     ]
     assert kwonly_v, "missing required kwarg-only arg should be flagged"
@@ -142,35 +194,63 @@ def test_kwonly_required_arg_flagged(tmp_path):
 # bare_except mode
 # ---------------------------------------------------------------------------
 
+
 def test_bare_except_flagged(tmp_path):
-    _write_src(tmp_path, "handler.py", """
+    _write_src(
+        tmp_path,
+        "handler.py",
+        """
         def process(data):
             try:
                 do_work(data)
             except:
                 pass
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     bare_v = [v for v in violations if v.context == "bare_except"]
     assert bare_v, "bare except: should be flagged"
     assert any("except:" in v.call for v in bare_v)
 
 
+def test_bare_except_in_file_without_calls_is_flagged(tmp_path):
+    _write_src(
+        tmp_path,
+        "constants.py",
+        """
+        try:
+            value = 1 / 0
+        except:
+            value = None
+    """,
+    )
+    violations = check_codebase(tmp_path)
+    bare_v = [v for v in violations if v.context == "bare_except"]
+    assert bare_v, "file-level bare except scan must not depend on extracted calls"
+
+
 def test_silent_except_exception_flagged(tmp_path):
-    _write_src(tmp_path, "handler.py", """
+    _write_src(
+        tmp_path,
+        "handler.py",
+        """
         def process(data):
             try:
                 do_work(data)
             except Exception:
                 pass
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     bare_v = [v for v in violations if v.context == "bare_except"]
     assert bare_v, "silent except Exception: pass should be flagged"
 
 
 def test_except_exception_with_logging_not_flagged(tmp_path):
-    _write_src(tmp_path, "handler.py", """
+    _write_src(
+        tmp_path,
+        "handler.py",
+        """
         import logging
         logger = logging.getLogger(__name__)
         def process(data):
@@ -178,20 +258,25 @@ def test_except_exception_with_logging_not_flagged(tmp_path):
                 do_work(data)
             except Exception as exc:
                 logger.exception("failed", error=str(exc))
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     bare_v = [v for v in violations if v.context == "bare_except"]
     assert not bare_v, "except with logging body should not be flagged"
 
 
 def test_specific_exception_not_flagged(tmp_path):
-    _write_src(tmp_path, "handler.py", """
+    _write_src(
+        tmp_path,
+        "handler.py",
+        """
         def process(data):
             try:
                 do_work(data)
             except ValueError:
                 pass
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     bare_v = [v for v in violations if v.context == "bare_except"]
     assert not bare_v, "specific exception type should not be flagged"
@@ -201,35 +286,63 @@ def test_specific_exception_not_flagged(tmp_path):
 # save_without_update_fields mode
 # ---------------------------------------------------------------------------
 
+
 def test_save_without_update_fields_flagged(tmp_path):
-    _write_src(tmp_path, "views.py", """
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
         def update(obj):
             obj.name = "new"
             obj.save()
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     save_v = [v for v in violations if v.context == "save_without_update_fields"]
     assert save_v, "save() without update_fields should be flagged"
 
 
 def test_save_with_update_fields_not_flagged(tmp_path):
-    _write_src(tmp_path, "views.py", """
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
         def update(obj):
             obj.name = "new"
             obj.save(update_fields=["name"])
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     save_v = [v for v in violations if v.context == "save_without_update_fields"]
     assert not save_v, "save(update_fields=[...]) should not be flagged"
 
 
 def test_form_save_not_flagged(tmp_path):
-    _write_src(tmp_path, "views.py", """
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
         def handle(request):
             form = MyForm(request.POST)
             if form.is_valid():
                 form.save()
-    """)
+    """,
+    )
     violations = check_codebase(tmp_path)
     save_v = [v for v in violations if v.context == "save_without_update_fields"]
     assert not save_v, "form.save() should not be flagged"
+
+
+def test_profile_save_without_update_fields_flagged(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        def update(profile):
+            profile.name = "new"
+            profile.save()
+    """,
+    )
+    violations = check_codebase(tmp_path)
+    save_v = [v for v in violations if v.context == "save_without_update_fields"]
+    assert save_v, "profile.save() is a model save, not a safe file receiver"

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -180,6 +180,64 @@ def test_literal_none_for_required_field_flagged(tmp_path):
     assert any("name" in missing and "None" in missing for missing in widget_v[0].missing)
 
 
+def test_computed_required_field_value_is_not_treated_as_none(tmp_path):
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
+        from django.db import models
+        class Widget(models.Model):
+            name = models.CharField(max_length=64)
+            class Meta: app_label = 'x'
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "factory.py",
+        """
+        def make(source):
+            Widget.objects.create(name=source.name)
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    assert not [
+        v for v in violations if v.call == "Widget.objects.create"
+    ], "computed values prove presence but should not be checked as literal None"
+
+
+def test_foreign_key_accepts_python_attribute_or_id_kwarg(tmp_path):
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
+        from django.db import models
+        class Author(models.Model):
+            class Meta: app_label = 'x'
+        class Book(models.Model):
+            author = models.ForeignKey(Author, on_delete=models.CASCADE)
+            class Meta: app_label = 'x'
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "factory.py",
+        """
+        def by_object(author):
+            Book.objects.create(author=author)
+        def by_id(author_id):
+            Book.objects.create(author_id=author_id)
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    assert not [
+        v for v in violations if v.call == "Book.objects.create"
+    ], "Django ForeignKey create() accepts both field and field_id kwargs"
+
+
 def test_save_guard_without_assignment_does_not_make_field_optional(tmp_path):
     _write_src(
         tmp_path,
@@ -576,6 +634,29 @@ def test_optional_deref_guard_does_not_cross_function_scope(tmp_path):
         if v.context == "optional_dereference" and v.call == "user.email"
     ]
     assert optional_v, "optional guards are lexical to their function scope"
+
+
+def test_optional_deref_guard_does_not_dominate_after_if(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        def run(users):
+            user = users.first()
+            if user is not None:
+                user.email
+            return user.name
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    optional_v = [
+        v
+        for v in violations
+        if v.context == "optional_dereference" and v.call == "user.name"
+    ]
+    assert optional_v, "a branch-local guard must not dominate later unguarded use"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -736,7 +736,7 @@ def test_optional_deref_dict_get_is_flagged(tmp_path):
         tmp_path,
         "views.py",
         """
-        def run(data):
+        def run(data: dict):
             value = data.get("name")
             return value.strip()
     """,
@@ -780,7 +780,7 @@ def test_optional_deref_dict_get_guard_suppresses_flag(tmp_path):
         tmp_path,
         "views.py",
         """
-        def run(data):
+        def run(data: dict):
             value = data.get("name")
             if value is not None:
                 return value.strip()
@@ -793,6 +793,46 @@ def test_optional_deref_dict_get_guard_suppresses_flag(tmp_path):
     assert not [
         v for v in violations if v.context == "optional_dereference"
     ], "None guard must dominate dereference inside its branch"
+
+
+def test_optional_deref_plain_get_receiver_is_not_optional_source(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        def run(queryset):
+            user = queryset.get(pk=1)
+            return user.email
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    assert not [
+        v for v in violations if v.context == "optional_dereference"
+    ], "ambiguous .get() receivers must not be treated as Optional-returning dict sources"
+
+
+def test_optional_deref_dict_literal_get_is_flagged(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        def run():
+            data = {}
+            value = data.get("name")
+            return value.strip()
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    optional_v = [
+        v
+        for v in violations
+        if v.context == "optional_dereference" and v.call == "value.strip"
+    ]
+    assert optional_v, "local dict literal .get() may return None and must be guarded"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -136,3 +136,100 @@ def test_kwonly_required_arg_flagged(tmp_path):
     ]
     assert kwonly_v, "missing required kwarg-only arg should be flagged"
     assert "role" in kwonly_v[0].missing
+
+
+# ---------------------------------------------------------------------------
+# bare_except mode
+# ---------------------------------------------------------------------------
+
+def test_bare_except_flagged(tmp_path):
+    _write_src(tmp_path, "handler.py", """
+        def process(data):
+            try:
+                do_work(data)
+            except:
+                pass
+    """)
+    violations = check_codebase(tmp_path)
+    bare_v = [v for v in violations if v.context == "bare_except"]
+    assert bare_v, "bare except: should be flagged"
+    assert any("except:" in v.call for v in bare_v)
+
+
+def test_silent_except_exception_flagged(tmp_path):
+    _write_src(tmp_path, "handler.py", """
+        def process(data):
+            try:
+                do_work(data)
+            except Exception:
+                pass
+    """)
+    violations = check_codebase(tmp_path)
+    bare_v = [v for v in violations if v.context == "bare_except"]
+    assert bare_v, "silent except Exception: pass should be flagged"
+
+
+def test_except_exception_with_logging_not_flagged(tmp_path):
+    _write_src(tmp_path, "handler.py", """
+        import logging
+        logger = logging.getLogger(__name__)
+        def process(data):
+            try:
+                do_work(data)
+            except Exception as exc:
+                logger.exception("failed", error=str(exc))
+    """)
+    violations = check_codebase(tmp_path)
+    bare_v = [v for v in violations if v.context == "bare_except"]
+    assert not bare_v, "except with logging body should not be flagged"
+
+
+def test_specific_exception_not_flagged(tmp_path):
+    _write_src(tmp_path, "handler.py", """
+        def process(data):
+            try:
+                do_work(data)
+            except ValueError:
+                pass
+    """)
+    violations = check_codebase(tmp_path)
+    bare_v = [v for v in violations if v.context == "bare_except"]
+    assert not bare_v, "specific exception type should not be flagged"
+
+
+# ---------------------------------------------------------------------------
+# save_without_update_fields mode
+# ---------------------------------------------------------------------------
+
+def test_save_without_update_fields_flagged(tmp_path):
+    _write_src(tmp_path, "views.py", """
+        def update(obj):
+            obj.name = "new"
+            obj.save()
+    """)
+    violations = check_codebase(tmp_path)
+    save_v = [v for v in violations if v.context == "save_without_update_fields"]
+    assert save_v, "save() without update_fields should be flagged"
+
+
+def test_save_with_update_fields_not_flagged(tmp_path):
+    _write_src(tmp_path, "views.py", """
+        def update(obj):
+            obj.name = "new"
+            obj.save(update_fields=["name"])
+    """)
+    violations = check_codebase(tmp_path)
+    save_v = [v for v in violations if v.context == "save_without_update_fields"]
+    assert not save_v, "save(update_fields=[...]) should not be flagged"
+
+
+def test_form_save_not_flagged(tmp_path):
+    _write_src(tmp_path, "views.py", """
+        def handle(request):
+            form = MyForm(request.POST)
+            if form.is_valid():
+                form.save()
+    """)
+    violations = check_codebase(tmp_path)
+    save_v = [v for v in violations if v.context == "save_without_update_fields"]
+    assert not save_v, "form.save() should not be flagged"

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -124,6 +124,62 @@ def test_optional_field_not_flagged(tmp_path):
     assert not any(v.call == "Note.objects.create" for v in violations)
 
 
+def test_required_foreign_key_field_flagged(tmp_path):
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
+        from django.db import models
+        class Author(models.Model):
+            class Meta: app_label = 'x'
+        class Book(models.Model):
+            author = models.ForeignKey(Author, on_delete=models.CASCADE)
+            class Meta: app_label = 'x'
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "factory.py",
+        """
+        def make():
+            Book.objects.create()
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    book_v = [v for v in violations if v.call == "Book.objects.create"]
+    assert book_v, "required ForeignKey fields are required create() inputs"
+    assert any("author" in missing for missing in book_v[0].missing)
+
+
+def test_literal_none_for_required_field_flagged(tmp_path):
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
+        from django.db import models
+        class Widget(models.Model):
+            name = models.CharField(max_length=64)
+            class Meta: app_label = 'x'
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "factory.py",
+        """
+        def make():
+            Widget.objects.create(name=None)
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    widget_v = [v for v in violations if v.call == "Widget.objects.create"]
+    assert widget_v, "literal None violates a required non-null field"
+    assert any("name" in missing and "None" in missing for missing in widget_v[0].missing)
+
+
 def test_save_guard_without_assignment_does_not_make_field_optional(tmp_path):
     _write_src(
         tmp_path,
@@ -278,6 +334,35 @@ def test_encoder_kwonly_arg_not_satisfied_by_extra_positional():
 
     assert violation is not None
     assert violation.missing == ["role"]
+
+
+def test_same_named_functions_checked_against_file_local_manifest(tmp_path):
+    _write_src(
+        tmp_path,
+        "a.py",
+        """
+        def send(value):
+            pass
+        def run():
+            send("ok")
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "b.py",
+        """
+        def send(value, channel):
+            pass
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    assert not [
+        v
+        for v in violations
+        if v.context == "required_arg_missing" and "send" in v.call
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -155,6 +155,37 @@ def test_save_guard_without_assignment_does_not_make_field_optional(tmp_path):
     assert any("slug" in missing for missing in widget_v[0].missing)
 
 
+def test_nested_class_save_does_not_auto_assign_outer_model_field(tmp_path):
+    _write_src(
+        tmp_path,
+        "models.py",
+        """
+        from django.db import models
+        class Widget(models.Model):
+            slug = models.CharField(max_length=64)
+            class Meta: app_label = 'x'
+            class Helper:
+                def save(self):
+                    if not self.slug:
+                        self.slug = "helper"
+    """,
+    )
+    _write_src(
+        tmp_path,
+        "factory.py",
+        """
+        def make():
+            Widget.objects.create()
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    widget_v = [v for v in violations if v.call == "Widget.objects.create"]
+    assert widget_v, "nested helper save methods must not affect the outer model"
+    assert any("slug" in missing for missing in widget_v[0].missing)
+
+
 # ---------------------------------------------------------------------------
 # required_arg_missing mode
 # ---------------------------------------------------------------------------

--- a/tools/pact/test_checker.py
+++ b/tools/pact/test_checker.py
@@ -7,6 +7,7 @@ which is what cli.py actually calls.
 """
 
 import textwrap
+import subprocess
 from pathlib import Path
 
 from .checker import check_codebase
@@ -190,6 +191,33 @@ def test_kwonly_required_arg_flagged(tmp_path):
     assert "role" in kwonly_v[0].missing
 
 
+def test_encoder_kwonly_arg_not_satisfied_by_extra_positional():
+    from .encoder import check_function_call
+    from .extractor import ArgConstraint, CallSite, FunctionManifest
+
+    func = FunctionManifest(
+        name="create_user",
+        file="lib.py",
+        line=1,
+        module_path="lib",
+        args=[
+            ArgConstraint(name="name", required=True),
+            ArgConstraint(name="role", required=True, kwonly=True),
+        ],
+    )
+    call = CallSite(
+        callee_name="create_user",
+        file="usage.py",
+        line=4,
+        positional_count=2,
+    )
+
+    violation = check_function_call(call, func)
+
+    assert violation is not None
+    assert violation.missing == ["role"]
+
+
 # ---------------------------------------------------------------------------
 # bare_except mode
 # ---------------------------------------------------------------------------
@@ -346,3 +374,128 @@ def test_profile_save_without_update_fields_flagged(tmp_path):
     violations = check_codebase(tmp_path)
     save_v = [v for v in violations if v.context == "save_without_update_fields"]
     assert save_v, "profile.save() is a model save, not a safe file receiver"
+
+
+# ---------------------------------------------------------------------------
+# optional_dereference mode
+# ---------------------------------------------------------------------------
+
+
+def test_optional_deref_reassignment_clears_prior_guard(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        def run(users):
+            user = users.first()
+            if user is not None:
+                user.email
+            user = users.first()
+            return user.name
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    optional_v = [
+        v
+        for v in violations
+        if v.context == "optional_dereference" and v.call == "user.name"
+    ]
+    assert optional_v, "new optional assignment must not inherit an earlier guard"
+
+
+def test_optional_deref_guard_does_not_cross_function_scope(tmp_path):
+    _write_src(
+        tmp_path,
+        "views.py",
+        """
+        def guarded(users):
+            user = users.first()
+            if user is not None:
+                return user.email
+
+        def unguarded(users):
+            user = users.first()
+            return user.email
+    """,
+    )
+
+    violations = check_codebase(tmp_path)
+
+    optional_v = [
+        v
+        for v in violations
+        if v.context == "optional_dereference" and v.call == "user.email"
+    ]
+    assert optional_v, "optional guards are lexical to their function scope"
+
+
+# ---------------------------------------------------------------------------
+# graph and scanner failure contracts
+# ---------------------------------------------------------------------------
+
+
+def test_call_sites_to_missing_node_is_empty():
+    from .graph import build_call_graph
+
+    graph = build_call_graph([], [])
+
+    assert graph.call_sites_to("missing") == []
+
+
+def test_cli_diff_failure_exits_nonzero(monkeypatch, tmp_path, capsys):
+    from . import cli
+
+    def fail_diff(base, cwd):
+        raise cli.DiffResolutionError("base branch unavailable")
+
+    monkeypatch.setattr(cli, "_changed_files_on_branch", fail_diff)
+
+    exit_code = cli.main(["--diff", "main", str(tmp_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "base branch unavailable" in captured.err
+
+
+def test_scan_prs_reports_pact_cli_failure(monkeypatch, tmp_path):
+    from . import scan_prs
+
+    def fake_run(args, **kwargs):
+        if args[:3] == ["git", "worktree", "add"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["git", "worktree", "remove"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        return subprocess.CompletedProcess(args, 2, "not json", "diff failed")
+
+    monkeypatch.setattr(scan_prs.subprocess, "run", fake_run)
+
+    result = scan_prs.scan_branch(
+        {"number": 381, "headRefName": "feature", "title": "Fix pact"},
+        tmp_path,
+    )
+
+    assert result["violations"] == []
+    assert result["error"] == "diff failed"
+
+
+def test_scan_prs_reports_invalid_json(monkeypatch, tmp_path):
+    from . import scan_prs
+
+    def fake_run(args, **kwargs):
+        if args[:3] == ["git", "worktree", "add"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["git", "worktree", "remove"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        return subprocess.CompletedProcess(args, 0, "not json", "")
+
+    monkeypatch.setattr(scan_prs.subprocess, "run", fake_run)
+
+    result = scan_prs.scan_branch(
+        {"number": 381, "headRefName": "feature", "title": "Fix pact"},
+        tmp_path,
+    )
+
+    assert result["violations"] == []
+    assert result["error"].startswith("invalid pact JSON:")

--- a/tools/pact/test_z3_engine.py
+++ b/tools/pact/test_z3_engine.py
@@ -9,7 +9,7 @@ import textwrap
 import tempfile
 from pathlib import Path
 
-from .z3_engine import PactEngine
+from .z3_engine import PactEngine, run
 
 
 def _make_fixture(source: str) -> Path:
@@ -188,6 +188,27 @@ def test_cross_file_violation_detected():
     assert len(viols) == 1
     assert 'name' in viols[0].missing
     assert 'views.py' in viols[0].file
+
+
+def test_same_line_create_sites_keep_distinct_site_ids():
+    d = Path(tempfile.mkdtemp())
+    (d / "models.py").write_text(textwrap.dedent("""
+        import django.db.models as m
+
+        class Widget(m.Model):
+            name = m.CharField(max_length=100)
+
+        class Gadget(m.Model):
+            title = m.CharField(max_length=100)
+
+        Widget.objects.create(); Gadget.objects.create()
+    """))
+
+    viols = run(d)
+
+    assert len(viols) == 2
+    assert {v.call for v in viols} == {"Widget.objects.create", "Gadget.objects.create"}
+    assert {tuple(v.missing) for v in viols} == {("name",), ("title",)}
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tools/pact/test_z3_engine.py
+++ b/tools/pact/test_z3_engine.py
@@ -1,0 +1,203 @@
+"""
+Tests for the Z3 Fixedpoint engine.
+
+We use synthetic Python source fixtures so tests don't depend on the
+futureagi/ app structure and run in milliseconds.
+"""
+
+import textwrap
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from .z3_engine import PactEngine
+
+
+def _make_fixture(source: str) -> Path:
+    """Write a single Python source string to a temp file and return its directory."""
+    d = Path(tempfile.mkdtemp())
+    (d / "models.py").write_text(textwrap.dedent(source))
+    return d
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _run(source: str) -> list:
+    root = _make_fixture(source)
+    engine = PactEngine()
+    engine.load(root)
+    return engine.violations()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Happy-path: no violations
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_no_violation_when_all_required_fields_provided():
+    viols = _run("""
+        import django.db.models as m
+
+        class Widget(m.Model):
+            name = m.CharField(max_length=100)
+            count = m.IntegerField()
+
+        Widget.objects.create(name='foo', count=3)
+    """)
+    assert viols == []
+
+
+def test_optional_field_not_required():
+    viols = _run("""
+        import django.db.models as m
+
+        class Widget(m.Model):
+            name = m.CharField(max_length=100)
+            notes = m.TextField(blank=True, null=True)
+
+        Widget.objects.create(name='foo')
+    """)
+    assert viols == []
+
+
+def test_field_with_default_not_required():
+    viols = _run("""
+        import django.db.models as m
+
+        class Widget(m.Model):
+            name = m.CharField(max_length=100)
+            active = m.BooleanField(default=True)
+
+        Widget.objects.create(name='bar')
+    """)
+    assert viols == []
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Single violation
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_missing_required_field_detected():
+    viols = _run("""
+        import django.db.models as m
+
+        class Widget(m.Model):
+            name = m.CharField(max_length=100)
+
+        Widget.objects.create()
+    """)
+    assert len(viols) == 1
+    assert 'name' in viols[0].missing
+
+
+def test_violation_reports_correct_file_and_line():
+    source = textwrap.dedent("""
+        import django.db.models as m
+
+        class Widget(m.Model):
+            name = m.CharField(max_length=100)
+
+        Widget.objects.create()
+    """).lstrip()
+
+    root = Path(tempfile.mkdtemp())
+    fixture = root / "models.py"
+    fixture.write_text(source)
+
+    engine = PactEngine()
+    engine.load(root)
+    viols = engine.violations()
+
+    assert len(viols) == 1
+    assert viols[0].file == str(fixture)
+    assert viols[0].line == 6   # Widget.objects.create() is line 6
+
+
+def test_multiple_missing_fields_all_reported():
+    viols = _run("""
+        import django.db.models as m
+
+        class Order(m.Model):
+            user = m.CharField(max_length=50)
+            total = m.IntegerField()
+            status = m.CharField(max_length=20)
+
+        Order.objects.create(user='alice')
+    """)
+    assert len(viols) == 1
+    assert set(viols[0].missing) == {'total', 'status'}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Multiple sites
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_only_bad_site_flagged_not_good_site():
+    viols = _run("""
+        import django.db.models as m
+
+        class Widget(m.Model):
+            name = m.CharField(max_length=100)
+
+        Widget.objects.create(name='ok')     # line 7 — clean
+        Widget.objects.create()              # line 8 — violation
+    """)
+    assert len(viols) == 1
+    assert viols[0].line == 8
+
+
+def test_two_models_only_bad_create_flagged():
+    viols = _run("""
+        import django.db.models as m
+
+        class Widget(m.Model):
+            name = m.CharField(max_length=100)
+
+        class Gadget(m.Model):
+            title = m.CharField(max_length=200)
+
+        Widget.objects.create(name='w')      # clean
+        Gadget.objects.create()              # missing title
+    """)
+    assert len(viols) == 1
+    assert 'title' in viols[0].missing
+    assert 'Widget' not in viols[0].call
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Cross-file: model defined in one file, create() in another
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_cross_file_violation_detected():
+    d = Path(tempfile.mkdtemp())
+    (d / "mymodels.py").write_text(textwrap.dedent("""
+        import django.db.models as m
+
+        class Widget(m.Model):
+            name = m.CharField(max_length=100)
+    """))
+    (d / "views.py").write_text(textwrap.dedent("""
+        from mymodels import Widget
+
+        def create_widget():
+            Widget.objects.create()   # missing name
+    """))
+    engine = PactEngine()
+    engine.load(d)
+    viols = engine.violations()
+    assert len(viols) == 1
+    assert 'name' in viols[0].missing
+    assert 'views.py' in viols[0].file
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unknown model — no violation (open-world assumption)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_unknown_model_not_flagged():
+    viols = _run("""
+        ExternalModel.objects.create()
+    """)
+    assert viols == []

--- a/tools/pact/test_z3_engine.py
+++ b/tools/pact/test_z3_engine.py
@@ -211,6 +211,22 @@ def test_same_line_create_sites_keep_distinct_site_ids():
     assert {tuple(v.missing) for v in viols} == {("name",), ("title",)}
 
 
+def test_z3_answer_decoder_keeps_site_and_field_axes_distinct():
+    viols = _run("""
+        import django.db.models as m
+
+        class Widget(m.Model):
+            slug = m.CharField(max_length=100)
+            name = m.CharField(max_length=100)
+
+        Widget.objects.create(slug='ok')
+    """)
+
+    assert len(viols) == 1
+    assert viols[0].call == "Widget.objects.create"
+    assert viols[0].missing == ["name"]
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Unknown model — no violation (open-world assumption)
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tools/pact/test_z3_engine.py
+++ b/tools/pact/test_z3_engine.py
@@ -9,8 +9,6 @@ import textwrap
 import tempfile
 from pathlib import Path
 
-import pytest
-
 from .z3_engine import PactEngine
 
 

--- a/tools/pact/z3_engine.py
+++ b/tools/pact/z3_engine.py
@@ -1,0 +1,219 @@
+"""
+Z3 Fixedpoint engine for pact.
+
+Program analysis as Datalog: Python extracts facts, Z3 derives violations.
+
+Schema
+------
+EDB:
+  site_creates(site, model)       call site is Model.objects.create()
+  site_provides(site, field)      call site passes this kwarg
+  model_req(model, field)         model requires this field
+
+IDB (derived by Z3 in two strata):
+  site_req(site, field)           = join: site creates a model that requires this field
+  violation(site, field)          = site_req but not site_provides
+
+Two rules, no existential variables in negated atoms:
+  site_req(S, F) :- site_creates(S, M), model_req(M, F)
+  violation(S, F) :- site_req(S, F), not site_provides(S, F)
+
+Python adds facts. Z3 reasons. One query. All violations.
+
+Implementation notes
+--------------------
+- Z3 datalog engine requires FINITE sorts — use BitVecSort, not IntSort.
+- Rules must be in ForAll(vars, Implies(body, head)) form.
+- Query with Exists([qs, qf], violation(qs, qf)).
+- get_answer() returns a formula in de Bruijn Var notation:
+    Var(0) = qs = first arg (site), Var(1) = qf = second arg (field)
+  (Z3 binds Exists vars right-to-left: last in list → Var(0))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import z3 as _z3
+from z3 import (
+    And, BitVecSort, BitVecVal, BitVecs, BoolSort,
+    Exists, Fixedpoint, ForAll, Function, Implies, Not,
+    is_and, is_eq, is_false, is_or, sat,
+)
+
+from .extractor import extract_from_codebase
+
+_ctx = _z3.main_ctx()
+
+
+def _is_var(expr: _z3.ExprRef) -> bool:
+    return _z3.Z3_get_ast_kind(_ctx.ref(), expr.as_ast()) == _z3.Z3_VAR_AST
+
+
+def _var_idx(expr: _z3.ExprRef) -> int:
+    return _z3.Z3_get_index_value(_ctx.ref(), expr.as_ast())
+
+
+def _extract_tuples(formula: _z3.BoolRef) -> list[tuple[int, int]]:
+    """Parse Or(And(Var(0)==si, Var(1)==fi), ...) → [(si, fi), ...].
+
+    Z3's datalog get_answer() returns a DNF formula where each clause
+    is one violation tuple. This walks the formula in O(|violations|).
+    """
+    if is_false(formula):
+        return []
+    clauses = formula.children() if is_or(formula) else [formula]
+    tuples: list[tuple[int, int]] = []
+    for clause in clauses:
+        if not is_and(clause):
+            continue
+        vals: dict[int, int] = {}
+        for eq in clause.children():
+            if not is_eq(eq):
+                continue
+            lhs, rhs = eq.children()
+            if _is_var(lhs):
+                vals[_var_idx(lhs)] = rhs.as_long()
+            elif _is_var(rhs):
+                vals[_var_idx(rhs)] = lhs.as_long()
+        if 0 in vals and 1 in vals:
+            tuples.append((vals[0], vals[1]))  # (site, field)
+    return tuples
+
+# Domain size: supports up to 2^BITS distinct IDs per intern table.
+# 16 bits = 65536 — more than enough for any codebase.
+_BITS = 16
+_BVS = BitVecSort(_BITS)
+
+def _bv(n: int):
+    return BitVecVal(n, _BITS)
+
+
+# ── EDB ───────────────────────────────────────────────────────────────────────
+site_creates  = Function('site_creates',  _BVS, _BVS, BoolSort())
+site_provides = Function('site_provides', _BVS, _BVS, BoolSort())
+model_req     = Function('model_req',     _BVS, _BVS, BoolSort())
+
+# ── IDB ───────────────────────────────────────────────────────────────────────
+site_req   = Function('site_req',   _BVS, _BVS, BoolSort())  # derived join
+violation  = Function('violation',  _BVS, _BVS, BoolSort())  # the violations
+
+
+@dataclass
+class Z3Violation:
+    file: str
+    line: int
+    call: str
+    missing: list[str] = field(default_factory=list)
+    context: str = "model_constraint"
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}  {self.call}  missing: {', '.join(self.missing)}"
+
+
+class PactEngine:
+    """
+    Loads a codebase as a Datalog database.
+    Z3's Fixedpoint derives all violations — Python just reads the results.
+    """
+
+    def __init__(self) -> None:
+        self._fp = Fixedpoint()
+        self._fp.set(engine='datalog')
+        for rel in (site_creates, site_provides, model_req, site_req, violation):
+            self._fp.register_relation(rel)
+
+        # Stratum 1: materialize the join (no negation, existential _m is fine here)
+        # site_req(S, F) :- site_creates(S, M), model_req(M, F)
+        _s, _m, _f = BitVecs('_s _m _f', _BITS)
+        self._fp.add_rule(ForAll(
+            [_s, _m, _f],
+            Implies(And(site_creates(_s, _m), model_req(_m, _f)), site_req(_s, _f)),
+        ))
+
+        # Stratum 2: negate site_provides — now no existential in the negated atom
+        # violation(S, F) :- site_req(S, F), not site_provides(S, F)
+        _s2, _f2 = BitVecs('_s2 _f2', _BITS)
+        self._fp.add_rule(ForAll(
+            [_s2, _f2],
+            Implies(And(site_req(_s2, _f2), Not(site_provides(_s2, _f2))), violation(_s2, _f2)),
+        ))
+
+        # Intern tables
+        self._site_id:  dict[tuple, int] = {}
+        self._field_id: dict[str, int]   = {}
+        self._model_id: dict[str, int]   = {}
+        self._site_meta: dict[int, dict] = {}
+
+    def _sid(self, file: str, line: int, call: str) -> int:
+        key = (file, line)
+        if key not in self._site_id:
+            n = len(self._site_id)
+            self._site_id[key] = n
+            self._site_meta[n] = {"file": file, "line": line, "call": call}
+        return self._site_id[key]
+
+    def _fid(self, name: str) -> int:
+        if name not in self._field_id:
+            self._field_id[name] = len(self._field_id)
+        return self._field_id[name]
+
+    def _mid(self, name: str) -> int:
+        if name not in self._model_id:
+            self._model_id[name] = len(self._model_id)
+        return self._model_id[name]
+
+    def load(self, root: Path) -> None:
+        """Extract AST facts → Z3 Fixedpoint database."""
+        models, _funcs, calls = extract_from_codebase(root)
+
+        for model in models:
+            mi = self._mid(model.name)
+            for fc in model.required_fields:
+                fi = self._fid(fc.name)
+                self._fp.add_rule(model_req(_bv(mi), _bv(fi)))
+
+        for call in calls:
+            if not call.is_create_call or not call.model_name:
+                continue
+            si = self._sid(call.file, call.line, call.callee_name)
+            mi = self._mid(call.model_name)
+            self._fp.add_rule(site_creates(_bv(si), _bv(mi)))
+            for kwarg in call.provided_kwargs:
+                fi = self._fid(kwarg)
+                self._fp.add_rule(site_provides(_bv(si), _bv(fi)))
+
+    def violations(self) -> list[Z3Violation]:
+        """One query. Z3 derives all violations."""
+        qs, qf = BitVecs('qs qf', _BITS)
+        result = self._fp.query(Exists([qs, qf], violation(qs, qf)))
+        if result != sat:
+            return []
+
+        # get_answer() returns a DNF formula — one clause per violation tuple.
+        # _extract_tuples() reads it in O(|violations|) instead of O(|sites|×|fields|).
+        tuples = _extract_tuples(self._fp.get_answer())
+        field_names = {v: k for k, v in self._field_id.items()}
+
+        by_site: dict[int, list[str]] = {}
+        for si, fi in tuples:
+            fname = field_names.get(fi)
+            if fname is not None and si in self._site_meta:
+                by_site.setdefault(si, []).append(fname)
+
+        return [
+            Z3Violation(
+                file=self._site_meta[si]["file"],
+                line=self._site_meta[si]["line"],
+                call=self._site_meta[si]["call"],
+                missing=missing,
+            )
+            for si, missing in by_site.items()
+        ]
+
+
+def run(root: Path) -> list[Z3Violation]:
+    engine = PactEngine()
+    engine.load(root)
+    return engine.violations()

--- a/tools/pact/z3_engine.py
+++ b/tools/pact/z3_engine.py
@@ -147,7 +147,7 @@ class PactEngine:
         self._site_meta: dict[int, dict] = {}
 
     def _sid(self, file: str, line: int, call: str) -> int:
-        key = (file, line)
+        key = (file, line, call)
         if key not in self._site_id:
             n = len(self._site_id)
             self._site_id[key] = n


### PR DESCRIPTION
## Summary

Supersedes/follows up PR #379 with the remaining bot-reported pact scanner corrections. This keeps the pact architecture intact while closing the concrete false-negative paths: file-level scans now cover Python files even when extraction finds no call sites, `.save()` safe-receiver classification no longer treats `profile.save()` as a file save, and the pact file iterator is shared between extraction and file-sentinel coverage.

## Linked issues / PRs

Follow-up to #379.

## Type of change

- [x] Bug fix
- [x] Test-only coverage for fixed scanner contracts

## How was this tested?

- `uvx ruff check tools/pact/checker.py tools/pact/extractor.py tools/pact/failure_mode.py tools/pact/test_checker.py`
- `uvx black --check tools/pact/checker.py tools/pact/extractor.py tools/pact/failure_mode.py tools/pact/test_checker.py`
- `python -m py_compile tools/pact/checker.py tools/pact/extractor.py tools/pact/failure_mode.py tools/pact/test_checker.py`
- `uvx --with pytest --with hypothesis --with z3-solver --with networkx pytest tools/pact -q` (`25 passed`)
- `git diff --check` (line-ending warnings only)
- scoped dupe-audit on pact checker/extractor/failure-mode/graph/tests (`candidate_pair_count=0`, `exact_duplicate_candidate_count=0`)
