### PR TITLE
fix: route system code evals by entry-point shape, not substring grep

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -1706,11 +1706,7 @@ def custom_code_eval(code, language=None, **kwargs):
     Returns:
         dict: {"result": float, "reason": str}
     """
-    code_execution = CodeExecution(code=code)
-
-    if language:
-        code_execution.language = language
-
+    code_execution = CodeExecution(code=code, language=language)
     result = code_execution.execute(kwargs)
 
     status = result.get("status")

--- a/futureagi/agentic_eval/core_evals/fi_utils/fi_code_execution.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/fi_code_execution.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import subprocess
 import tempfile
 from typing import Any
@@ -11,6 +12,14 @@ from agentic_eval.core_evals.fi_utils.fi_code_base import Step
 logger = structlog.get_logger(__name__)
 
 
+# Entry-point signatures: every code eval must define `evaluate(...)` or `main(...)`.
+_PY_ENTRY = re.compile(r"\bdef\s+(evaluate|main)\s*\(")
+_JS_ENTRY = re.compile(r"\bfunction\s+(evaluate|main)\s*\(")
+# Line-anchored fallback — avoids matching arbitrary substrings inside Python
+# string literals / sets of keyword tokens (see code_bleu, tool_call_accuracy).
+_JS_FALLBACK = re.compile(r"^\s*(function\s|const\s|let\s|var\s)", re.MULTILINE)
+
+
 class CodeExecution(Step):
     """
     Step that executes user-provided code in a sandboxed environment.
@@ -20,32 +29,26 @@ class CodeExecution(Step):
 
     Attributes:
         code: The code to execute.
-        language: The programming language ('python' or 'javascript').
+        language: 'python' or 'javascript'. None triggers auto-detect.
     """
 
     code: str
-    language: str = "python"
+    language: str | None = None
     name: str | None = None
 
     def detect_language(self, code: str) -> str:
-        """Detect the programming language based on code content."""
-        if any(
-            keyword in code.lower()
-            for keyword in [
-                "function",
-                "var ",
-                "let ",
-                "const ",
-                "console.log",
-                "=>",
-            ]
-        ):
+        """Detect language by entry-point shape (`def evaluate` vs `function evaluate`).
+
+        Substring matching on ``"function"`` / ``"const"`` / ``"let"`` would
+        mis-route Python evals that mention those words as data (e.g. inside
+        a keyword set) to the JS executor.
+        """
+        if _JS_ENTRY.search(code):
             return "javascript"
-        elif any(
-            keyword in code.lower()
-            for keyword in ["def ", "import ", "from ", "class ", "if __name__"]
-        ):
+        if _PY_ENTRY.search(code):
             return "python"
+        if _JS_FALLBACK.search(code):
+            return "javascript"
         return "python"
 
     def execute_python(self, input_data: dict[str, Any]) -> dict[str, Any] | None:
@@ -109,8 +112,9 @@ class CodeExecution(Step):
         if not isinstance(input_data, dict):
             raise TypeError("Input data must be a dictionary.")
 
-        # Auto-detect language if not explicitly set
-        if not hasattr(self, "language") or self.language == "python":
+        # Only sniff when the caller didn't tell us — explicit "python"
+        # / "javascript" must be honoured even if the body looks ambiguous.
+        if not self.language:
             self.language = self.detect_language(self.code)
 
         if self.language == "javascript":

--- a/futureagi/agentic_eval/core_evals/fi_utils/tests/test_code_execution_language.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/tests/test_code_execution_language.py
@@ -1,0 +1,69 @@
+"""
+Regression tests for CodeExecution language detection.
+
+A prior implementation substring-matched JS-flavoured keywords
+(``"function"``, ``"const"``, ``"let"``, ``"var "``) anywhere in the
+lowercased source. Python evals that happened to mention those tokens as
+data (e.g. ``code_bleu`` ships a keyword set containing the strings
+``"function"`` / ``"const"`` / ``"let"`` / ``"var"``) were routed to the
+Node.js executor and failed with ``SyntaxError: Unexpected identifier``.
+
+These tests pin the entry-point-shaped detection contract:
+  - ``def evaluate(...)``  → python
+  - ``function evaluate(...)`` → javascript
+  - explicit ``language=`` always wins over auto-detect
+"""
+
+import pytest
+
+from agentic_eval.core_evals.fi_utils.fi_code_execution import CodeExecution
+
+
+class TestDetectLanguageEntryPoint:
+    def test_python_def_evaluate(self):
+        code = "def evaluate(output, expected, **kwargs):\n    return output == expected\n"
+        assert CodeExecution(code=code).detect_language(code) == "python"
+
+    def test_js_function_evaluate(self):
+        code = "function evaluate(output, expected) { return output === expected; }\n"
+        assert CodeExecution(code=code).detect_language(code) == "javascript"
+
+    def test_python_with_function_keyword_in_data(self):
+        # Mirrors code_bleu.yaml: the word "function" appears inside a Python
+        # keyword-set literal. Must NOT be routed to JS.
+        code = """
+def evaluate(input, output, expected, context, **kwargs):
+    kws = {"def", "class", "function", "const", "let", "var"}
+    return {"score": 1.0, "reason": str(kws)}
+"""
+        assert CodeExecution(code=code).detect_language(code) == "python"
+
+    def test_python_with_arrow_substring_in_string(self):
+        # Arrow ``=>`` inside a Python string literal should not flip routing.
+        code = """
+def evaluate(**kwargs):
+    arrow = "a => b"
+    return {"score": 1.0, "reason": arrow}
+"""
+        assert CodeExecution(code=code).detect_language(code) == "python"
+
+
+class TestExplicitLanguageWins:
+    def test_explicit_python_not_overridden(self):
+        # Even when the body looks JS-shaped, explicit language="python" must hold.
+        code = "function evaluate() { return true; }"
+        step = CodeExecution(code=code, language="python")
+        # Don't call execute (no sandbox here) — just assert no auto-rewrite.
+        assert step.language == "python"
+
+    def test_explicit_javascript_not_overridden(self):
+        code = "def evaluate(**kwargs):\n    return True\n"
+        step = CodeExecution(code=code, language="javascript")
+        assert step.language == "javascript"
+
+    def test_no_language_defaults_to_none(self):
+        # Default must be None — a literal "python" default would be
+        # indistinguishable from "explicitly python" and re-trigger the old
+        # always-detect bug.
+        step = CodeExecution(code="def evaluate(): pass")
+        assert step.language is None

--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 3
+SYSTEM_EVALS_VERSION = 4
 
 SYSTEM_EVALS_DIR = Path(__file__).resolve().parent.parent.parent / "system_evals"
 CATALOG_YAML = (


### PR DESCRIPTION
## Summary

- `CodeExecution.detect_language()` previously substring-matched JS-flavoured tokens (`function`, `const`, `let`, `var `, `=>`) anywhere in lowercased source. Python evals that mention those words as **data** (`code_bleu`'s keyword set, `tool_call_accuracy`) were routed to the Node.js executor and crashed with `SyntaxError: Unexpected identifier`.
- Detection now keys off entry-point shape — `def evaluate(...)` vs `function evaluate(...)`.
- Default `language` is now `None`. Previously the default was `"python"`, which the old `execute()` treated as "unset" and overrode via the buggy detector — so explicit `language="python"` from the caller was never honoured.
- Bump `SYSTEM_EVALS_VERSION` (3 → 4) to force a one-shot YAML reseed on next deploy. Reconciles drift cases where prod runs older code than the YAML on disk: `no_invalid_links`, `bleu_score`, `levenshtein_similarity`, `semantic_list_contains`.

Ref: Linear TH-4844.

## Test plan

- [x] `CodeExecution(code=code_bleu_body).detect_language(...)` → `python` (verified in dev container against the real DB row)
- [x] Same for `tool_call_accuracy` → `python`
- [x] `custom_code_eval(code=code_bleu_body, output=..., expected=...)` end-to-end returns a valid CodeBLEU score (was crashing in JS executor before)
- [x] Explicit `language="javascript"` survives `execute()` even when body looks Python-shaped
- [x] `seed_system_evals --force --dry-run` against local DB → 153 unchanged, 0 would-update (round-trip clean)
- [ ] Post-deploy: confirm cloud DB picks up the YAML state for the four drifted evals after `SYSTEM_EVALS_VERSION` bump triggers reseed
- [ ] Post-deploy: re-test the four drifted evals through Playground to confirm new behavior matches description