### PR TITLE
fix(storage): add timeout to ffmpeg subprocess calls

### DIFF
--- a/futureagi/tfc/utils/storage.py
+++ b/futureagi/tfc/utils/storage.py
@@ -645,6 +645,8 @@ def convert_to_mp3(audio_bytes):
             raise Exception(f"FFmpeg Conversion Error: {stderr.decode('utf-8')}")
 
         return stdout, "mp3"
+    except TimeoutError:
+        raise
     except Exception as e:
         traceback.print_exc()
         raise ValueError(get_storage_error_message("UNABLE_TO_PROCESS_AUDIO")) from e

--- a/futureagi/tfc/utils/storage.py
+++ b/futureagi/tfc/utils/storage.py
@@ -592,7 +592,12 @@ def detect_audio_format(audio_bytes):
         stderr=subprocess.PIPE,
     )
 
-    stdout, stderr = process.communicate(input=audio_bytes)
+    try:
+        stdout, stderr = process.communicate(input=audio_bytes, timeout=10)
+    except subprocess.TimeoutExpired as e:
+        process.kill()
+        process.communicate()
+        raise TimeoutError("Audio format detection timed out (exceeded 10s)") from e
 
     if process.returncode != 0:
         raise Exception(f"FFmpeg Error: {stderr.decode('utf-8')}")
@@ -627,7 +632,14 @@ def convert_to_mp3(audio_bytes):
             stderr=subprocess.PIPE,
         )
 
-        stdout, stderr = process.communicate(input=audio_bytes)
+        try:
+            stdout, stderr = process.communicate(input=audio_bytes, timeout=60)
+        except subprocess.TimeoutExpired as e:
+            process.kill()
+            process.communicate()
+            raise TimeoutError(
+                "Audio conversion timed out (exceeded 60s for 50MB max input)"
+            ) from e
 
         if process.returncode != 0:
             raise Exception(f"FFmpeg Conversion Error: {stderr.decode('utf-8')}")

--- a/futureagi/tfc/utils/tests/test_storage_subprocess_timeout.py
+++ b/futureagi/tfc/utils/tests/test_storage_subprocess_timeout.py
@@ -19,9 +19,10 @@ class TestDetectAudioFormatTimeout:
         from tfc.utils.storage import detect_audio_format
 
         mock_process = MagicMock()
-        mock_process.communicate.side_effect = subprocess.TimeoutExpired(
-            cmd="ffmpeg", timeout=10
-        )
+        mock_process.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="ffmpeg", timeout=10),
+            (b"", b""),  # second call after kill for reaping
+        ]
         mock_process.kill = MagicMock()
 
         with patch("subprocess.Popen", return_value=mock_process):
@@ -86,29 +87,24 @@ class TestDetectAudioFormatTimeout:
 class TestConvertToMp3Timeout:
     """convert_to_mp3 should timeout after 60 seconds."""
 
-    def test_raises_timeout_error_internally(self):
-        """The inner TimeoutError should be raised before the outer except catches it.
+    def test_raises_timeout_error_on_hang(self):
+        """Hanging ffmpeg process should be killed and TimeoutError raised.
 
-        We patch at the Popen level and verify TimeoutError is raised with
-        the correct message. The outer except re-wraps as ValueError, but
-        we verify the __cause__ chain preserves our TimeoutError.
+        With `except TimeoutError: raise` before `except Exception`, the
+        TimeoutError propagates directly to callers without being wrapped.
         """
         from tfc.utils.storage import convert_to_mp3
 
         mock_process = MagicMock()
-        mock_process.communicate.side_effect = subprocess.TimeoutExpired(
-            cmd="ffmpeg", timeout=60
-        )
+        mock_process.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="ffmpeg", timeout=60),
+            (b"", b""),  # second call after kill for reaping
+        ]
         mock_process.kill = MagicMock()
 
         with patch("subprocess.Popen", return_value=mock_process):
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(TimeoutError, match="exceeded 60s"):
                 convert_to_mp3(b"fake audio bytes")
-
-        # Verify the ValueError wraps our TimeoutError (exception chain)
-        assert exc_info.value.__cause__ is not None
-        assert isinstance(exc_info.value.__cause__, TimeoutError)
-        assert "exceeded 60s" in str(exc_info.value.__cause__)
 
         mock_process.kill.assert_called_once()
 
@@ -153,7 +149,7 @@ class TestConvertToMp3Timeout:
         mock_process.kill = MagicMock()
 
         with patch("subprocess.Popen", return_value=mock_process):
-            with pytest.raises(ValueError):
+            with pytest.raises(TimeoutError):
                 convert_to_mp3(b"fake audio bytes")
 
         mock_process.kill.assert_called_once()

--- a/futureagi/tfc/utils/tests/test_storage_subprocess_timeout.py
+++ b/futureagi/tfc/utils/tests/test_storage_subprocess_timeout.py
@@ -1,0 +1,160 @@
+"""
+Tests for subprocess timeout handling in storage audio utilities.
+
+Verifies that detect_audio_format and convert_to_mp3 enforce timeouts
+on ffmpeg subprocess calls to prevent indefinite hangs.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestDetectAudioFormatTimeout:
+    """detect_audio_format should timeout after 10 seconds."""
+
+    def test_raises_timeout_error_on_hang(self):
+        """Hanging ffmpeg process should be killed and TimeoutError raised."""
+        from tfc.utils.storage import detect_audio_format
+
+        mock_process = MagicMock()
+        mock_process.communicate.side_effect = subprocess.TimeoutExpired(
+            cmd="ffmpeg", timeout=10
+        )
+        mock_process.kill = MagicMock()
+
+        with patch("subprocess.Popen", return_value=mock_process):
+            with pytest.raises(TimeoutError, match="exceeded 10s"):
+                detect_audio_format(b"fake audio bytes")
+
+        mock_process.kill.assert_called_once()
+
+    def test_passes_timeout_10s_to_communicate(self):
+        """communicate() must be called with timeout=10."""
+        from tfc.utils.storage import detect_audio_format
+
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            b"",
+            b"Input #0, mp3, from 'pipe:':\n  Duration: 00:00:05.00",
+        )
+        mock_process.returncode = 0
+
+        with patch("subprocess.Popen", return_value=mock_process):
+            detect_audio_format(b"fake audio bytes")
+
+        mock_process.communicate.assert_called_once_with(
+            input=b"fake audio bytes", timeout=10
+        )
+
+    def test_normal_audio_returns_format(self):
+        """Valid audio should return detected format string."""
+        from tfc.utils.storage import detect_audio_format
+
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            b"",
+            b"Input #0, mp3, from 'pipe:':\n  Duration: 00:00:05.00",
+        )
+        mock_process.returncode = 0
+
+        with patch("subprocess.Popen", return_value=mock_process):
+            result = detect_audio_format(b"fake audio bytes")
+
+        assert result == "mp3"
+
+    def test_kills_then_reaps_on_timeout(self):
+        """After timeout, kill() then communicate() to prevent zombie."""
+        from tfc.utils.storage import detect_audio_format
+
+        mock_process = MagicMock()
+        mock_process.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="ffmpeg", timeout=10),
+            (b"", b""),  # second call after kill for reaping
+        ]
+        mock_process.kill = MagicMock()
+
+        with patch("subprocess.Popen", return_value=mock_process):
+            with pytest.raises(TimeoutError):
+                detect_audio_format(b"fake audio bytes")
+
+        mock_process.kill.assert_called_once()
+        assert mock_process.communicate.call_count == 2
+
+
+class TestConvertToMp3Timeout:
+    """convert_to_mp3 should timeout after 60 seconds."""
+
+    def test_raises_timeout_error_internally(self):
+        """The inner TimeoutError should be raised before the outer except catches it.
+
+        We patch at the Popen level and verify TimeoutError is raised with
+        the correct message. The outer except re-wraps as ValueError, but
+        we verify the __cause__ chain preserves our TimeoutError.
+        """
+        from tfc.utils.storage import convert_to_mp3
+
+        mock_process = MagicMock()
+        mock_process.communicate.side_effect = subprocess.TimeoutExpired(
+            cmd="ffmpeg", timeout=60
+        )
+        mock_process.kill = MagicMock()
+
+        with patch("subprocess.Popen", return_value=mock_process):
+            with pytest.raises(ValueError) as exc_info:
+                convert_to_mp3(b"fake audio bytes")
+
+        # Verify the ValueError wraps our TimeoutError (exception chain)
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, TimeoutError)
+        assert "exceeded 60s" in str(exc_info.value.__cause__)
+
+        mock_process.kill.assert_called_once()
+
+    def test_passes_timeout_60s_to_communicate(self):
+        """communicate() must be called with timeout=60."""
+        from tfc.utils.storage import convert_to_mp3
+
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (b"mp3 output", b"")
+        mock_process.returncode = 0
+
+        with patch("subprocess.Popen", return_value=mock_process):
+            convert_to_mp3(b"fake audio bytes")
+
+        mock_process.communicate.assert_called_once_with(
+            input=b"fake audio bytes", timeout=60
+        )
+
+    def test_normal_conversion_succeeds(self):
+        """Valid audio should convert and return (bytes, 'mp3')."""
+        from tfc.utils.storage import convert_to_mp3
+
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (b"mp3 output bytes", b"")
+        mock_process.returncode = 0
+
+        with patch("subprocess.Popen", return_value=mock_process):
+            result, fmt = convert_to_mp3(b"fake audio bytes")
+
+        assert result == b"mp3 output bytes"
+        assert fmt == "mp3"
+
+    def test_kills_then_reaps_on_timeout(self):
+        """After timeout, kill() then communicate() to prevent zombie."""
+        from tfc.utils.storage import convert_to_mp3
+
+        mock_process = MagicMock()
+        mock_process.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="ffmpeg", timeout=60),
+            (b"", b""),  # second call after kill for reaping
+        ]
+        mock_process.kill = MagicMock()
+
+        with patch("subprocess.Popen", return_value=mock_process):
+            with pytest.raises(ValueError):
+                convert_to_mp3(b"fake audio bytes")
+
+        mock_process.kill.assert_called_once()
+        assert mock_process.communicate.call_count == 2


### PR DESCRIPTION
## Summary

Fixes #387

`detect_audio_format()` and `convert_to_mp3()` called `subprocess.Popen.communicate()` without a timeout, allowing ffmpeg to hang indefinitely on malformed audio input — deadlocking worker threads.

### Changes

#### 1. Timeout on `detect_audio_format` ✅
- **Before**: `process.communicate(input=audio_bytes)` — no timeout
- **After**: `process.communicate(input=audio_bytes, timeout=10)`
- **Rationale**: Only reads ffmpeg metadata headers, completes in <1s normally. 10s is 10× headroom.

#### 2. Timeout on `convert_to_mp3` ✅
- **Before**: `process.communicate(input=audio_bytes)` — no timeout
- **After**: `process.communicate(input=audio_bytes, timeout=60)`
- **Rationale**: Full transcode of up to 50MB (`MAX_AUDIO_FILE_SIZE`). Consistent with `audio_bytes_from_url_or_base64(timeout=60)` in the same file.

#### 3. Zombie process prevention ✅
On `TimeoutExpired`: `process.kill()` → `process.communicate()` (Python docs pattern to drain pipes and reap child).

---

## Test results

### Regression tests added: 8 tests ✅

| Function | Tests |
|----------|-------|
| `detect_audio_format` | TimeoutError raised, timeout=10 passed, normal returns format, kill+reap on timeout |
| `convert_to_mp3` | TimeoutError in chain (wrapped as ValueError by outer except), timeout=60 passed, normal returns (bytes, "mp3"), kill+reap on timeout |

### Lint ✅
- `ruff check` — All checks passed
- `black --check` — No changes needed

---

## Modified files (2)

| File | Change | Added | Removed |
|------|--------|-------|---------|
| `futureagi/tfc/utils/storage.py` | Add timeout + TimeoutExpired handling | +14 | -2 |
| `futureagi/tfc/utils/tests/test_storage_subprocess_timeout.py` | New regression tests | +156 | -0 |

---

## Breaking Changes
None. Normal audio processing is unaffected — timeout only triggers on hangs.

## Checklist
- [x] Tests added (8 unit tests)
- [x] `ruff check` passes
- [x] `black --check` passes
- [x] No hardcoded secrets
- [x] Focused diff — only subprocess timeout changes
- [x] Exception type follows codebase convention (`TimeoutError`)