### PR TITLE
fix(tasks): Create Eval Task wizard — seeding, edit rehydration, null-pk submit guard

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -67,6 +67,7 @@ import { format } from "date-fns";
 import {
   buildEvalTemplateConfig,
   buildCompositeSourceModeProps,
+  contextOptionsForRowType,
   getSourceModeVariables,
   hasNonEmptyPromptMessage,
 } from "./evalPickerConfigUtils";
@@ -466,6 +467,9 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         } else if (di.variables_only || di.variablesOnly) {
           setContextOptions(["variables_only"]);
         }
+      } else if (source === "task") {
+      const seeded = contextOptionsForRowType(sourceRowType);
+        if (seeded) setContextOptions(seeded);
       }
       setErrorLocalizerEnabled(
         config.error_localizer_enabled ??

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
@@ -4,6 +4,16 @@ const OUTPUT_TYPE_CONFIG_MAP = {
   deterministic: "choices",
 };
 
+const ROW_TYPE_CONTEXT_OPTIONS = {
+  spans: ["span_context"],
+  traces: ["trace_context"],
+  sessions: ["session_context", "trace_context"],
+  voiceCalls: ["call_context"],
+};
+
+export const contextOptionsForRowType = (rowType) =>
+  ROW_TYPE_CONTEXT_OPTIONS[rowType] || null;
+
 export const hasNonEmptyPromptMessage = (messages = []) =>
   messages.some((message) => {
     if (!["system", "user"].includes(message?.role)) return false;

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
@@ -2,8 +2,28 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildCompositeSourceModeProps,
+  contextOptionsForRowType,
   getSourceModeVariables,
 } from "./evalPickerConfigUtils";
+
+describe("contextOptionsForRowType", () => {
+  it("maps each known row type to its default data_injection flags", () => {
+    expect(contextOptionsForRowType("spans")).toEqual(["span_context"]);
+    expect(contextOptionsForRowType("traces")).toEqual(["trace_context"]);
+    expect(contextOptionsForRowType("sessions")).toEqual([
+      "session_context",
+      "trace_context",
+    ]);
+    expect(contextOptionsForRowType("voiceCalls")).toEqual(["call_context"]);
+  });
+
+  it("returns null for unknown / missing row types so the caller can fall back", () => {
+    expect(contextOptionsForRowType(undefined)).toBeNull();
+    expect(contextOptionsForRowType(null)).toBeNull();
+    expect(contextOptionsForRowType("")).toBeNull();
+    expect(contextOptionsForRowType("unknown")).toBeNull();
+  });
+});
 
 describe("buildCompositeSourceModeProps", () => {
   it("does not expose adhoc config for non-composite evals", () => {

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
@@ -53,7 +53,17 @@ export const NewTaskValidationSchema = () =>
       evalsDetails: z
         .array(z.any())
         .min(1, { message: "At least one evaluation is required" })
-        .transform((evals) => evals?.map((e) => e.id)),
+        .refine(
+          (evals) =>
+            evals.every(
+              (e) => typeof e?.id === "string" && e?.id?.length > 0,
+            ),
+          {
+            message:
+              "One or more evaluations failed to save. Please remove and re-add them.",
+          },
+        )
+        .transform((evals) => evals.map((e) => e.id)),
       startDate: z.string(),
       endDate: z.string(),
       runType: z.enum(["historical", "continuous"], {

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
@@ -56,11 +56,11 @@ export const NewTaskValidationSchema = () =>
         .refine(
           (evals) =>
             evals.every(
-              (e) => typeof e?.id === "string" && e?.id?.length > 0,
+              (e) => typeof e?.id === "string" && e.id.length > 0,
             ),
           {
             message:
-              "One or more evaluations failed to save. Please remove and re-add them.",
+              "Remove the highlighted evaluation(s) and re-add them before continuing.",
           },
         )
         .transform((evals) => evals.map((e) => e.id)),

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -316,6 +316,7 @@ const TaskConfigPanel = ({
     // the `id` field (which holds the real CustomEvalConfig UUID from the API).
     keyName: "_fieldId",
   });
+  console.log("Configured evals", configuredEvals);
 
   const evalsDetailsErrorMessage = _.get(errors, "evalsDetails")?.message || "";
 
@@ -469,8 +470,12 @@ const TaskConfigPanel = ({
     if (!stored) return null;
     // API response uses `eval_template` for the template FK;
     // locally-added evals use `templateId` / `template_id`.
-    const tplId =
-      stored.templateId || stored.template_id || stored.eval_template;
+    const tplId =  stored.templateId || stored.template_id || stored.eval_template;
+
+    const savedErrorLocalizer =
+      stored.error_localizer_enabled ?? stored.error_localizer;
+    const existingRunConfig =
+      stored.run_config || stored.config?.run_config || {};
     return {
       ...stored,
       id: tplId,
@@ -478,6 +483,13 @@ const TaskConfigPanel = ({
       templateId: tplId,
       // `stored.id` is always the CustomEvalConfig id (from POST response or API load)
       customEvalConfigId: stored.customEvalConfigId || stored.id,
+      run_config: {
+        ...existingRunConfig,
+        ...(stored.model && { model: stored.model }),
+        ...(savedErrorLocalizer !== undefined && {
+          error_localizer_enabled: savedErrorLocalizer,
+        }),
+      },
     };
   }, [editingIndex, configuredEvals]);
   const resolvedProjectName =

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -23,6 +23,7 @@ import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import FilterErrorBoundary from "src/components/ComplexFilter/FilterErrorBoundary";
 import { EvalPickerDrawer } from "src/sections/common/EvalPicker";
+import { enqueueSnackbar } from "src/components/snackbar";
 import TaskSchedulingSection from "./TaskSchedulingSection";
 import { getNewTaskFilters } from "src/sections/tasks/schema";
 import { objectCamelToSnake } from "src/utils/utils";
@@ -425,8 +426,15 @@ const TaskConfigPanel = ({
             templateId: tplId,
           };
         }
-      } catch {
-        // Fall back to local-only entry — task create will still send it
+      } catch (error) {
+       
+        enqueueSnackbar(
+          error?.response?.data?.result ||
+            error?.response?.data?.error ||
+            "Failed to save evaluation",
+          { variant: "error" },
+        );
+        throw error;
       }
 
       if (editingIndex !== null) {

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -119,6 +119,8 @@ const ConfiguredEvalCard = ({ evalItem, onEdit, onRemove }) => {
     evalItem?.evalTemplate?.config?.language ||
     (isCode ? "Python" : null);
 
+  const hasError = !evalItem?.id;
+
   return (
     <Box
       sx={{
@@ -128,13 +130,13 @@ const ConfiguredEvalCard = ({ evalItem, onEdit, onRemove }) => {
         p: 1.5,
         borderRadius: 1,
         border: "1px solid",
-        borderColor: "divider",
+        borderColor: hasError ? "error.main" : "divider",
         bgcolor:
           theme.palette.mode === "dark"
             ? "rgba(255,255,255,0.02)"
             : "rgba(0,0,0,0.01)",
         transition: "border-color 0.15s",
-        "&:hover": { borderColor: "primary.main" },
+        "&:hover": { borderColor: hasError ? "error.main" : "primary.main" },
       }}
     >
       <Box sx={{ flex: 1, minWidth: 0 }}>
@@ -206,6 +208,19 @@ const ConfiguredEvalCard = ({ evalItem, onEdit, onRemove }) => {
             />
           )}
         </Box>
+        {hasError && (
+          <Typography
+            variant="caption"
+            sx={{
+              display: "block",
+              mt: 0.5,
+              fontSize: "11px",
+              color: "error.main",
+            }}
+          >
+            Failed to save — remove and re-add this evaluation.
+          </Typography>
+        )}
         {mappedKeys.length > 0 && (
           <Box sx={{ display: "flex", gap: 0.5, mt: 0.75, flexWrap: "wrap" }}>
             {mappedKeys.slice(0, 4).map((key) => (

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -317,7 +317,6 @@ const TaskConfigPanel = ({
     // the `id` field (which holds the real CustomEvalConfig UUID from the API).
     keyName: "_fieldId",
   });
-  console.log("Configured evals", configuredEvals);
 
   const evalsDetailsErrorMessage = _.get(errors, "evalsDetails")?.message || "";
 


### PR DESCRIPTION
## Summary

Three fixes scoped to the tracing **Create Eval Task** wizard. All FE-only.

### 1. `feat(eval-picker)` — seed `data_injection` from the active row-type tab
When opening the picker from Tasks, pre-enable the context flag that matches the active tab so users don't have to flip it every time:

| Tab | Auto-enabled |
| --- | --- |
| Spans | `span_context` |
| Traces | `trace_context` |
| Sessions | `session_context` + `trace_context` |
| Voice Calls | `call_context` |
| Unknown | `variables_only` (existing fallback) |

Edit-reopen precedence preserved: any saved `data_injection` on the binding's `run_config` still wins. Gated on `source === "task"` so datasets / tracing / simulation / custom surfaces keep their original defaults.

### 2. `fix(tasks)` — rehydrate model and error_localizer on edit-reopen
Staged Tasks evals stored `model` and `error_localizer_enabled` at the top level of the record, but the picker's init effect prefers `config.model` / `config.error_localizer_enabled` (built from `run_config`) over top-level `evalData`. On the pencil/edit click, the template default (`turing_large`, off) won and the user's saved choice was silently dropped.

Nest both keys into `run_config` when constructing `initialEval`. They flow through the picker's existing `normalizedRunConfig` block and win on rehydrate. Saved-binding shape (top-level `error_localizer` with no `_enabled` suffix) is handled as a fallback.

### 3. `fix(tasks)` — block task submit when inline eval fails to persist
The wizard wrapped the per-eval `CustomEvalConfig` POST in a silent `catch {}` and added the half-saved entry to the staged list anyway. At submit time the schema mapped each entry to `e.id` → `undefined` → JSON `null`, and the BE rejected with the cryptic `Invalid pk "None"`.

- Surface the BE error in a snackbar and rethrow so the picker keeps the user on the config step with their inputs intact — the broken entry is never staged.
- Add a schema-level `.refine()` backstop on `evalsDetails` that rejects any missing-id leak with a clear message instead of submitting `null`.

## Test plan

- [x] Repeat for Traces / Sessions / Voice Calls
- [x] Save binding with `data_injection.full_row=true` only → reopen on Sessions tab → shows `full_row`, not the tab default
- [x] Tasks → Spans tab → + Add Eval → pick template → confirm `Span Context` is pre-checked
- [x] Configure inline eval with `model=turing_small` and `error_localizer` ON → save → click pencil → drawer shows `turing_small` + ON (not template defaults)
- [x] Force the per-eval `CustomEvalConfig` POST to fail (e.g. deselect project mid-flow / DevTools throttle to fail) → expect snackbar error, eval NOT added to list, picker stays open
- [x] Create task with at least one valid staged eval → succeeds (no `evals: [null]`)
- [x] Sanity-check other surfaces still default `data_injection` to `variables_only`: datasets, tracing, simulation, custom, composite




## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes TH-4865,TH-4853,TH-4854

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)




<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
