### PR TITLE
fix(observe): render bucket name for categorical evals after agent-evaluator migration

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -203,7 +203,12 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab 
       : Object.entries(evalRows);
 
     return rows.map(([id, e], i) => {
-      const rawValue = e?.score ?? e?.output ?? e?.value;
+      // Categorical evals (post-migration) emit output as a list like ["never"].
+      // Surface the first bucket name so it shows in the badge.
+      let rawValue = e?.score ?? e?.output ?? e?.value;
+      if (Array.isArray(rawValue)) {
+        rawValue = rawValue.length === 1 ? rawValue[0] : rawValue.join(", ");
+      }
       let score = null;
       let scoreLabel;
 

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -86,6 +86,38 @@ from tracer.utils.otel import DECODER, CallAttributes, ConversationAttributes
 from tracer.views.observation_span import get_observation_spans
 
 
+def _is_choices_eval(config) -> bool:
+    """True when the eval template's output_type is 'choices' (categorical)."""
+    tpl = getattr(config, "eval_template", None)
+    if tpl is None:
+        return False
+    return (getattr(tpl, "config", None) or {}).get("output") == "choices"
+
+
+def _score_to_choice(config, score_val):
+    """Map an annotated score (0-100) back to the categorical bucket name via
+    eval_template.choice_scores. Returns the bucket whose stored score is
+    closest to the normalized (0-1) input. None if no choice_scores exist."""
+    tpl = getattr(config, "eval_template", None)
+    if tpl is None:
+        return None
+    choice_scores = getattr(tpl, "choice_scores", None) or {}
+    if not choice_scores:
+        return None
+    normalized = float(score_val) / 100.0
+    best = None
+    best_dist = None
+    for bucket, bucket_score in choice_scores.items():
+        try:
+            dist = abs(float(bucket_score) - normalized)
+        except (TypeError, ValueError):
+            continue
+        if best_dist is None or dist < best_dist:
+            best_dist = dist
+            best = bucket
+    return best
+
+
 def _sanitize_nonfinite_floats(value):
     """Recursively replace NaN/+-Infinity floats with ``None``.
 
@@ -1151,6 +1183,14 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     score_val = data.get("score")
                     if metric_type == EvalOutputType.PASS_FAIL:
                         metric_entry["output"] = "Pass" if score_val > 0 else "Fail"
+                    elif _is_choices_eval(config) and isinstance(score_val, (int, float)):
+                        # Categorical eval post-migration: agent eval stored
+                        # output_float; annotation gave us score (0-100). Translate
+                        # back to bucket name via eval_template.choice_scores.
+                        # Emit as list w/ output_type='choices' so it matches the
+                        # column config and the existing choices cell renderer.
+                        bucket = _score_to_choice(config, score_val)
+                        metric_entry["output"] = [bucket] if bucket else []
                     else:
                         metric_entry["output"] = (
                             round(score_val, 2)
@@ -3675,6 +3715,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     metric_entry["output"] = log.output_str_list
                 elif output_type == "Pass/Fail" and log.output_bool is not None:
                     metric_entry["output"] = "Pass" if log.output_bool else "Fail"
+                elif output_type == "choices" and log.output_float is not None:
+                    bucket = _score_to_choice(config, round(log.output_float * 100, 2))
+                    metric_entry["output"] = [bucket] if bucket else []
                 elif log.output_float is not None:
                     metric_entry["output"] = round(log.output_float * 100, 2)
                 else:
@@ -5158,9 +5201,11 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
 
         # Phase 4 (child spans) removed — observation_span is a detail-only field.
 
-        # Build column config
+        # Build column config — match the PG path: skip_choices=True collapses
+        # categorical evals to ONE column (rather than N bucket-columns) so the
+        # post-migration single-value agent eval renders correctly.
         column_config = update_column_config_based_on_eval_config(
-            [], eval_configs, is_simulator=True
+            [], eval_configs, skip_choices=True, is_simulator=True
         )
         column_config = update_span_column_config_based_on_annotations(
             column_config, annotation_labels
@@ -5273,6 +5318,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                                         if score_val and score_val > 0
                                         else "Fail"
                                     )
+                                elif output_type == "choices" and isinstance(score_val, (int, float)):
+                                    bucket = _score_to_choice(config, score_val)
+                                    metric_entry["output"] = [bucket] if bucket else []
                                 else:
                                     metric_entry["output"] = (
                                         round(score_val, 2)

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -1187,10 +1187,13 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                         # Categorical eval post-migration: agent eval stored
                         # output_float; annotation gave us score (0-100). Translate
                         # back to bucket name via eval_template.choice_scores.
-                        # Emit as list w/ output_type='choices' so it matches the
-                        # column config and the existing choices cell renderer.
+                        # Override output_type to "choices" so the frontend
+                        # eval-cell renderer hits the choices branch (otherwise
+                        # metric_type defaults to "score" because output_float
+                        # is set, and the score branch can't render a list).
                         bucket = _score_to_choice(config, score_val)
                         metric_entry["output"] = [bucket] if bucket else []
+                        metric_entry["output_type"] = "choices"
                     else:
                         metric_entry["output"] = (
                             round(score_val, 2)
@@ -3718,6 +3721,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 elif output_type == "choices" and log.output_float is not None:
                     bucket = _score_to_choice(config, round(log.output_float * 100, 2))
                     metric_entry["output"] = [bucket] if bucket else []
+                    metric_entry["output_type"] = "choices"
                 elif log.output_float is not None:
                     metric_entry["output"] = round(log.output_float * 100, 2)
                 else:
@@ -5321,6 +5325,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                                 elif output_type == "choices" and isinstance(score_val, (int, float)):
                                     bucket = _score_to_choice(config, score_val)
                                     metric_entry["output"] = [bucket] if bucket else []
+                                    metric_entry["output_type"] = "choices"
                                 else:
                                     metric_entry["output"] = (
                                         round(score_val, 2)


### PR DESCRIPTION
## Summary
6 categorical evals on a customer's project were rendering 4–5 empty columns each (never / occasionally / frequently / always, or 1–5) post-migration to the agent evaluator. The single float the new eval emits never matched the pre-migration bucket-named columns, so every cell rendered as `-`. Backend now collapses these to one column per eval and translates the float back to the chosen bucket name. Frontend renderer learns to display list values.

## Linear
Fixes [TH-4886](https://linear.app/future-agi/issue/TH-4886/migration-of-old-evals-from-categorical-did-not-run-as-expected)

## Impact
- 6 of 12 categorical evals affected on the impacted project
- Symptom: each categorical eval showed 4–5 columns with all-dash cells
- After: 1 column per eval, cell shows the chosen bucket (`never`, `always`, `1`, …)

## Root cause
- `helper.py::update_column_config_based_on_eval_config` expands a `choices` eval into N columns (one per choice) — by design for the legacy per-choice shape.
- The PG list path already passed `skip_choices=True` to suppress this; the ClickHouse list path did **not**, so customers on the CH route saw the bug.
- Even with one column, the cell value the read path returned was a raw float (`0.0`) because post-migration `EvalLogger.output_float` is a single number — frontend had no way to map that to `"never"`.
- Even after translation, `output_type` stayed as `"score"` (auto-derived from `metric_type`), so the FE eval-cell renderer hit its score branch, called `_.isNumber(["never"])` → false, and rendered blank.

## Fix
| Site | Change |
|---|---|
| `tracer/views/trace.py:5201` (CH list) | Add `skip_choices=True` to match PG path |
| `tracer/views/trace.py:89` (new helpers) | `_is_choices_eval` + `_score_to_choice` (reverse-lookup the bucket whose `choice_scores` value is closest to the annotated score) |
| `tracer/views/trace.py` PG list (~1190), PG detail (~3730), CH detail (~5345) | Emit `output = [bucket_name]` for choices-type results AND override `output_type = "choices"` so the FE dispatches correctly |
| `VoiceRightPanel.jsx:206` (eval-row renderer) | Handle array `rawValue`; surface first bucket as the label |

No DB writes, no schema changes — purely serialization + rendering.

## How this was driven
- Pulled prod data via the SOS link into a local-only `.tmp/prod_snapshot/` (gitignored — customer data never enters the repo).
- Seeded a local repro using a one-off Django mgmt command that takes the prod project / eval-template / trace UUIDs verbatim, so the bug presents 1:1.
- Local doesn't have ClickHouse, but the bug lives in the CH path. Used a "B-trick" — temporarily removed `skip_choices=True` from the PG path locally to mirror the CH path's broken behavior, applied the real fix to both paths, reverted the B-trick before commit.
- Verified end-to-end in browser: grid + detail panel both show `never` / `always` / `1` cleanly.

## Test plan
- [ ] On a project with categorical evals (`AgentEvaluator` with `output: choices` + `choice_scores`), open the Tracing voice-call list — each categorical eval shows as **one** column.
- [ ] Cell for each categorical eval shows the chosen bucket string (not `-`, not `0%`).
- [ ] Open call detail drawer → Evals tab — bucket name renders next to the eval row.
- [ ] Pass/Fail and score evals continue to render unchanged.

## Reviewer
@jaya — please grab when you have a sec 🙏
