### PR TITLE
TH-4685: Enable logs in simulation call details

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceLogsView.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceLogsView.jsx
@@ -12,7 +12,6 @@ import {
   CircularProgress,
   Collapse,
   Stack,
-  Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
@@ -493,6 +492,10 @@ const VoiceLogsView = ({ callLogId, vapiId, module, callLogs }) => {
     enabled: !useClientSide && !!(module === "simulate" ? callLogId : vapiId),
     initialPageParam: 1,
     staleTime: 30_000,
+    refetchInterval: (query) => {
+      const pages = query.state.data?.pages || [];
+      return pages.some((p) => p?.results?.ingestion_pending) ? 2000 : false;
+    },
     meta: { errorHandled: true },
   });
 
@@ -572,6 +575,9 @@ const VoiceLogsView = ({ callLogId, vapiId, module, callLogs }) => {
   const totalCount = useClientSide
     ? callLogs?.length || 0
     : serverQuery.data?.pages?.[0]?.count || 0;
+  const ingestionPending =
+    !useClientSide &&
+    (serverQuery.data?.pages || []).some((p) => p?.results?.ingestion_pending);
 
   const handleToggle = (id) => {
     setExpanded((prev) => {
@@ -752,6 +758,26 @@ const VoiceLogsView = ({ callLogId, vapiId, module, callLogs }) => {
             }}
           >
             <CircularProgress size={18} thickness={5} />
+          </Box>
+        ) : ingestionPending && allRows.length === 0 ? (
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              minHeight: 160,
+              p: 2,
+              gap: 0.75,
+            }}
+          >
+            <CircularProgress size={18} thickness={5} />
+            <Typography sx={{ fontSize: 12, color: "text.secondary" }}>
+              Collecting logs from provider
+            </Typography>
+            <Typography sx={{ fontSize: 10.5, color: "text.disabled" }}>
+              This usually takes a few seconds
+            </Typography>
           </Box>
         ) : allRows.length === 0 ? (
           <Box

--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -37,6 +37,13 @@ const TABS = {
   SCENARIO: "scenario",
 };
 
+const hasAttributeContent = (value) => {
+  if (!value) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return true;
+};
+
 const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab }) => {
   const [currentTab, setCurrentTab] = useState(TABS.ANALYTICS);
   const isSimulate = data?.module === "simulate";
@@ -135,7 +142,7 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab 
       });
     }
     return t;
-  }, [hasLogs, hasScenarioData]);
+  }, [hasLogs, hasScenarioData, hideAnnotationTab]);
 
   const analyticsProps = useMemo(() => {
     // API-provided per-call metrics (prefer over client-computed values)
@@ -285,11 +292,12 @@ const VoiceRightPanel = ({ data, onCompareBaseline, onAction, hideAnnotationTab 
     //  3. Legacy `trace_details.attributes` for older cached payloads.
     //  4. The span object itself as a last resort.
     return (
-      observationSpan?.span_attributes ||
-      data?.attributes ||
-      data?.trace_details?.attributes ||
-      observationSpan ||
-      null
+      [
+        observationSpan?.span_attributes,
+        data?.attributes,
+        data?.trace_details?.attributes,
+        observationSpan,
+      ].find(hasAttributeContent) || null
     );
   }, [data, observationSpan]);
 

--- a/frontend/src/components/VoiceDetailDrawerV2/__tests__/VoiceLogsView.test.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/__tests__/VoiceLogsView.test.jsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "src/utils/test-utils";
+import VoiceLogsView from "../VoiceLogsView";
+import axios from "src/utils/axios";
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: vi.fn(),
+  },
+  endpoints: {
+    testExecutions: {
+      getDetailLogs: (id) => `/simulate/call-executions/${id}/logs/`,
+    },
+  },
+}));
+
+const renderWithQueryClient = (ui) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+};
+
+describe("VoiceLogsView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches simulation call logs from the call-execution logs endpoint", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        count: 1,
+        results: {
+          source: "customer",
+          ingestion_pending: false,
+          results: [
+            {
+              id: "log-1",
+              logged_at: "2026-05-10T12:00:00.000Z",
+              severity_text: "INFO",
+              category: "model",
+              body: "LLM responded",
+              attributes: { category: "model" },
+              payload: { body: "LLM responded" },
+            },
+          ],
+        },
+      },
+    });
+
+    renderWithQueryClient(
+      <VoiceLogsView module="simulate" callLogId="call-1" />,
+    );
+
+    expect(await screen.findByText("LLM responded")).toBeInTheDocument();
+    expect(screen.getByText("1 logs")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith(
+        "/simulate/call-executions/call-1/logs/",
+        {
+          params: {
+            page: 1,
+            search: "",
+          },
+        },
+      );
+    });
+  });
+
+  it("shows a pending state while backend log ingestion is running", async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        count: 0,
+        results: {
+          source: "customer",
+          ingestion_pending: true,
+          results: [],
+        },
+      },
+    });
+
+    renderWithQueryClient(
+      <VoiceLogsView module="simulate" callLogId="call-1" />,
+    );
+
+    expect(
+      await screen.findByText("Collecting logs from provider"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("This usually takes a few seconds"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows returned rows even if the backend still reports ingestion pending", async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        count: 1,
+        results: {
+          source: "customer",
+          ingestion_pending: true,
+          results: [
+            {
+              id: "log-1",
+              logged_at: "2026-05-10T12:00:00.000Z",
+              severity_text: "INFO",
+              category: "model",
+              body: "Webhook delivered",
+              attributes: { category: "model" },
+              payload: { body: "Webhook delivered" },
+            },
+          ],
+        },
+      },
+    });
+
+    renderWithQueryClient(
+      <VoiceLogsView module="simulate" callLogId="call-1" />,
+    );
+
+    expect(await screen.findByText("Webhook delivered")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Collecting logs from provider"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/VoiceDetailDrawerV2/__tests__/VoiceRightPanel.test.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/__tests__/VoiceRightPanel.test.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "src/utils/test-utils";
+import VoiceRightPanel from "../VoiceRightPanel";
+
+vi.mock("src/sections/falcon-ai/helpers/openFixWithFalcon", () => ({
+  openFixWithFalcon: vi.fn(),
+}));
+
+vi.mock("src/components/ScoresListSection/ScoresListSection", () => ({
+  default: () => <div>Annotations</div>,
+}));
+
+const renderWithQueryClient = (ui) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+};
+
+describe("VoiceRightPanel", () => {
+  it("falls back to simulation attributes when the linked span has empty attributes", async () => {
+    renderWithQueryClient(
+      <VoiceRightPanel
+        data={{
+          id: "call-1",
+          module: "simulate",
+          status: "completed",
+          provider: "vapi",
+          attributes: {
+            raw_log: { room_sid: "RM_test" },
+            "vapi.call_id": "call-1",
+          },
+          observation_span: [
+            {
+              id: "span-1",
+              parent_span_id: null,
+              observation_type: "conversation",
+              span_attributes: {},
+            },
+          ],
+          transcript: [],
+        }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("tab", { name: "Attributes" }));
+
+    expect(screen.getByText("raw_log")).toBeInTheDocument();
+    expect(screen.getByText("vapi.call_id")).toBeInTheDocument();
+  });
+});

--- a/futureagi/simulate/serializers/response/call_execution.py
+++ b/futureagi/simulate/serializers/response/call_execution.py
@@ -19,6 +19,7 @@ class CallExecutionLogsResponseSerializer(serializers.Serializer):
 
     results = CallLogEntryResponseSerializer(many=True, read_only=True)
     source = serializers.CharField(read_only=True)
+    ingestion_pending = serializers.BooleanField(read_only=True)
 
 
 class CallExecutionDeleteResponseSerializer(serializers.Serializer):

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -324,7 +324,31 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
         return vsm.get_recording_urls(provider_payload) or {}
 
     def get_provider(self, obj):
-        """Return the voice provider for this call (e.g. vapi, retell, livekit_bridge)."""
+        """Return the provider that produced this call's stored provider payload.
+
+        The agent definition can be Vapi while the executed call payload is
+        stored under another provider key (for example LiveKit web/SIP flows).
+        The drawer uses this value for both the chip and provider-specific
+        metrics rendering, so prefer the actual payload key when available.
+        """
+        provider_data = getattr(obj, "provider_call_data", None)
+        if isinstance(provider_data, dict):
+            for provider in (
+                ProviderChoices.VAPI.value,
+                ProviderChoices.RETELL.value,
+                ProviderChoices.LIVEKIT.value,
+                ProviderChoices.ELEVEN_LABS.value,
+                ProviderChoices.OTHERS.value,
+            ):
+                if isinstance(provider_data.get(provider), dict) and provider_data.get(
+                    provider
+                ):
+                    return provider
+
+            for provider, payload in provider_data.items():
+                if isinstance(payload, dict) and payload:
+                    return provider
+
         try:
             return obj.test_execution.agent_definition.provider
         except (AttributeError, Exception):
@@ -591,7 +615,9 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
             columns_by_dataset = ctx.get("columns_by_dataset")
             cells_by_row = ctx.get("cells_by_row")
 
-            if rows_map is not None and row_id_str in rows_map:
+            if rows_map is not None:
+                if row_id_str not in rows_map:
+                    return {}
                 # Fast path: use prefetched data
                 row = rows_map[row_id_str]
                 ds_id = str(row.dataset.id) if row.dataset else None
@@ -599,7 +625,10 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
                 row_cells = cells_by_row.get(row_id_str, {})
             else:
                 # Fallback: individual queries (for grouped results or missing context)
-                row = Row.all_objects.get(id=row_id)
+                try:
+                    row = Row.all_objects.get(id=row_id)
+                except Row.DoesNotExist:
+                    return {}
                 dataset_columns = Column.all_objects.filter(
                     id__in=row.dataset.column_order
                 )

--- a/futureagi/simulate/services/branch_deviation_analyzer.py
+++ b/futureagi/simulate/services/branch_deviation_analyzer.py
@@ -696,11 +696,13 @@ class BranchDeviationAnalyzer:
 
             else:
 
-                from ee.voice.utils.transcript_roles import SpeakerRoleResolver
+                from simulate.utils.stored_transcript_roles import (
+                    get_conversational_transcript_roles,
+                )
 
                 transcripts = CallTranscript.objects.filter(
                     call_execution=call_execution,
-                    speaker_role__in=SpeakerRoleResolver.get_conversational_roles(),
+                    speaker_role__in=get_conversational_transcript_roles(),
                 ).order_by("start_time_ms")
 
                 logger.info(

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -36,6 +36,17 @@ from tracer.models.observability_provider import ProviderChoices
 
 logger = structlog.get_logger(__name__)
 
+
+def _empty_call_log_summary(reason: str) -> dict:
+    return {
+        "total_entries": 0,
+        "level_counts": {},
+        "category_counts": {},
+        "last_logged_at": None,
+        "skipped_reason": reason,
+    }
+
+
 try:
     from ee.evals.futureagi.eval_deterministic.evaluator import DeterministicEvaluator
 except ImportError:
@@ -3519,15 +3530,27 @@ class TestExecutor:
             if log_url:
                 call_execution.customer_log_url = log_url
                 update_fields.add("customer_log_url")
-                from ee.voice.tasks.call_log_tasks import ingest_call_logs_task
-
-                ingest_call_logs_task.apply_async(
-                    args=(str(call_execution.id), log_url),
-                    kwargs={
-                        "verify_ssl": False,
-                        "source": CallLogEntry.LogSource.CUSTOMER,
-                    },
-                )
+                call_execution.logs_ingested_at = timezone.now()
+                update_fields.add("logs_ingested_at")
+                try:
+                    from ee.voice.tasks.call_log_tasks import ingest_call_logs_task
+                except ImportError:
+                    call_execution.customer_logs_summary = _empty_call_log_summary(
+                        "ee_voice_not_available"
+                    )
+                    update_fields.add("customer_logs_summary")
+                    logger.info(
+                        "call_log_ingestion_task_unavailable",
+                        call_execution_id=str(call_execution.id),
+                    )
+                else:
+                    ingest_call_logs_task.apply_async(
+                        args=(str(call_execution.id), log_url),
+                        kwargs={
+                            "verify_ssl": False,
+                            "source": CallLogEntry.LogSource.CUSTOMER,
+                        },
+                    )
 
             performance_metrics = call_data.performance_metrics.get(provider, {})
             customer_metrics_result = self.voice_service_manager.get_customer_metrics(
@@ -4284,17 +4307,9 @@ class TestExecutor:
                 "outbound" in call_type_lower and "inbound" not in call_type_lower
             )
 
-        from ee.voice.utils.transcript_roles import SpeakerRoleResolver
-
-        provider = SpeakerRoleResolver.detect_provider(
-            call_execution.provider_call_data
-        )
-        agent_roles, customer_roles = SpeakerRoleResolver.get_skip_decision_role_sets(
-            provider=provider,
-            is_outbound=is_outbound,
-        )
-
         if call_execution.simulation_call_type == CallExecution.SimulationCallType.TEXT:
+            agent_roles = frozenset({ChatMessageModel.RoleChoices.ASSISTANT})
+            customer_roles = frozenset({ChatMessageModel.RoleChoices.USER})
             for chat_message in call_execution.chat_messages.all().order_by(
                 "created_at"
             ):
@@ -4309,6 +4324,27 @@ class TestExecutor:
                     if has_content and role_lower in customer_roles:
                         has_customer_message = True
         else:
+            try:
+                from ee.voice.utils.transcript_roles import SpeakerRoleResolver
+            except ImportError:
+                logger.warning(
+                    "speaker_role_resolver_unavailable_for_voice_presence",
+                    call_execution_id=str(call_execution.id),
+                )
+                agent_roles = frozenset({CallTranscript.SpeakerRole.ASSISTANT})
+                customer_roles = frozenset({CallTranscript.SpeakerRole.USER})
+            else:
+                provider = SpeakerRoleResolver.detect_provider(
+                    call_execution.provider_call_data
+                )
+                (
+                    agent_roles,
+                    customer_roles,
+                ) = SpeakerRoleResolver.get_skip_decision_role_sets(
+                    provider=provider,
+                    is_outbound=is_outbound,
+                )
+
             for role, content in call_execution.transcripts.values_list(
                 "speaker_role", "content"
             ):
@@ -4333,8 +4369,6 @@ class TestExecutor:
         Returns:
             dict: Transcript and voice recording data
         """
-        from ee.voice.utils.transcript_roles import SpeakerRoleResolver
-
         transcript_data = {
             "transcript": "",
             "voice_recording": "",
@@ -4423,21 +4457,39 @@ class TestExecutor:
                                         assistant_chat_transcript_text.append(message)
 
                     else:
-                        eval_provider = SpeakerRoleResolver.detect_provider(
-                            call_execution.provider_call_data
-                        )
-                        eval_dir = (call_execution.call_metadata or {}).get(
-                            "call_direction", ""
-                        )
-                        eval_is_outbound = str(eval_dir).strip().lower() == "outbound"
+                        try:
+                            from ee.voice.utils.transcript_roles import (
+                                SpeakerRoleResolver,
+                            )
+                        except ImportError:
+                            SpeakerRoleResolver = None
+                            logger.warning(
+                                "speaker_role_resolver_unavailable_for_voice_transcript",
+                                call_execution_id=str(call_execution.id),
+                            )
+                        else:
+                            eval_provider = SpeakerRoleResolver.detect_provider(
+                                call_execution.provider_call_data
+                            )
+                            eval_dir = (call_execution.call_metadata or {}).get(
+                                "call_direction", ""
+                            )
+                            eval_is_outbound = (
+                                str(eval_dir).strip().lower() == "outbound"
+                            )
 
                         for transcript in transcripts:
                             if transcript.content.strip():
-                                eval_role = SpeakerRoleResolver.get_eval_role_label(
-                                    transcript.speaker_role,
-                                    provider=eval_provider,
-                                    is_outbound=eval_is_outbound,
-                                )
+                                if SpeakerRoleResolver is None:
+                                    eval_role = transcript.speaker_role
+                                else:
+                                    eval_role = (
+                                        SpeakerRoleResolver.get_eval_role_label(
+                                            transcript.speaker_role,
+                                            provider=eval_provider,
+                                            is_outbound=eval_is_outbound,
+                                        )
+                                    )
                                 transcript_text.append(
                                     f"{eval_role}: {transcript.content}"
                                 )

--- a/futureagi/simulate/services/vapi_chat/service.py
+++ b/futureagi/simulate/services/vapi_chat/service.py
@@ -25,10 +25,12 @@ from simulate.services.types.chat import (
     SendMessageInput,
     SendMessageResult,
 )
+from tfc.ee_stub import _ee_stub
+
 try:
     from ee.voice.services.vapi_service import VapiService
 except ImportError:
-    VapiService = None
+    VapiService = _ee_stub("VapiService")
 
 logger = structlog.get_logger(__name__)
 

--- a/futureagi/simulate/temporal/activities/test_execution.py
+++ b/futureagi/simulate/temporal/activities/test_execution.py
@@ -203,8 +203,11 @@ def _build_voice_settings(
     """Build voice settings from persona data and simulator agent defaults."""
     import os
 
-    from ee.voice.constants.voice_catalog import resolve_voice_id
-    from ee.voice.constants.voice_mapper import select_voice_id
+    try:
+        from ee.voice.constants.voice_catalog import resolve_voice_id
+        from ee.voice.constants.voice_mapper import select_voice_id
+    except ImportError:
+        return {}
     from tracer.models.observability_provider import ProviderChoices
 
     # Voice_id format is determined by the system voice provider (the
@@ -320,9 +323,13 @@ async def create_call_execution_records(
         from simulate.models import Scenarios
         from simulate.models.run_test import CreateCallExecution
         from simulate.models.test_execution import CallExecution, TestExecution
-        from ee.voice.utils.prompt_builder import generate_dynamic_prompt
         from tfc.settings.settings import VAPI_INDIAN_PHONE_NUMBER_ID
         from tfc.temporal.common.heartbeat import Heartbeater
+
+        try:
+            from ee.voice.utils.prompt_builder import generate_dynamic_prompt
+        except ImportError:
+            generate_dynamic_prompt = None
 
         test_execution = await TestExecution.objects.select_related(
             "run_test__workspace",
@@ -460,7 +467,12 @@ async def create_call_execution_records(
 
                         # Generate system prompt using dynamic prompt builder
                         system_prompt = base_prompt
-                        if row_data and simulator_agent and agent_version:
+                        if (
+                            generate_dynamic_prompt
+                            and row_data
+                            and simulator_agent
+                            and agent_version
+                        ):
                             try:
                                 system_prompt = generate_dynamic_prompt(
                                     prompt_template=base_prompt,

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -199,7 +199,6 @@ def _build_transcript_data(call_execution):
     records, and reads recording URLs from call_execution fields.
     """
     from simulate.models import CallTranscript, ChatMessageModel
-    from ee.voice.utils.transcript_roles import SpeakerRoleResolver
 
     transcript_data = {
         "transcript": "",
@@ -271,21 +270,33 @@ def _build_transcript_data(call_execution):
                             elif chat_message.role == "assistant":
                                 assistant_chat_transcript_text.append(message)
             else:
-                provider = SpeakerRoleResolver.detect_provider(
-                    call_execution.provider_call_data
-                )
-                call_dir = (call_execution.call_metadata or {}).get(
-                    "call_direction", ""
-                )
-                is_outbound = str(call_dir).strip().lower() == "outbound"
+                try:
+                    from ee.voice.utils.transcript_roles import SpeakerRoleResolver
+                except ImportError:
+                    SpeakerRoleResolver = None
+                    logger.warning(
+                        "speaker_role_resolver_unavailable_for_xl_transcript",
+                        call_execution_id=str(call_execution.id),
+                    )
+                else:
+                    provider = SpeakerRoleResolver.detect_provider(
+                        call_execution.provider_call_data
+                    )
+                    call_dir = (call_execution.call_metadata or {}).get(
+                        "call_direction", ""
+                    )
+                    is_outbound = str(call_dir).strip().lower() == "outbound"
 
                 for transcript in transcripts:
                     if transcript.content.strip():
-                        eval_role = SpeakerRoleResolver.get_eval_role_label(
-                            transcript.speaker_role,
-                            provider=provider,
-                            is_outbound=is_outbound,
-                        )
+                        if SpeakerRoleResolver is None:
+                            eval_role = transcript.speaker_role
+                        else:
+                            eval_role = SpeakerRoleResolver.get_eval_role_label(
+                                transcript.speaker_role,
+                                provider=provider,
+                                is_outbound=is_outbound,
+                            )
                         transcript_text.append(f"{eval_role}: {transcript.content}")
 
             transcript_data["transcript"] = "\n".join(transcript_text)

--- a/futureagi/simulate/temporal/workflows/rerun_coordinator_workflow.py
+++ b/futureagi/simulate/temporal/workflows/rerun_coordinator_workflow.py
@@ -334,9 +334,14 @@ class RerunCoordinatorWorkflow:
             input: Coordinator input with org_id, workspace_id, etc.
             calls: List of (call_id, eval_only) tuples
         """
-        from ee.voice.temporal.workflows.call_execution_workflow import (
-            CallExecutionWorkflow,
-        )
+        try:
+            from ee.voice.temporal.workflows.call_execution_workflow import (
+                CallExecutionWorkflow,
+            )
+        except ImportError as exc:
+            raise RuntimeError(
+                "Voice call execution workflow is unavailable without Enterprise Edition."
+            ) from exc
 
         for call_id, eval_only in calls:
             # Unique workflow ID includes rerun_id to allow multiple reruns

--- a/futureagi/simulate/temporal/workflows/test_execution_workflow.py
+++ b/futureagi/simulate/temporal/workflows/test_execution_workflow.py
@@ -387,9 +387,14 @@ class TestExecutionWorkflow:
         between each sub-batch to prevent thundering-herd 503s from LiveKit
         agent workers when many calls are initiated simultaneously.
         """
-        from ee.voice.temporal.workflows.call_execution_workflow import (
-            CallExecutionWorkflow,
-        )
+        try:
+            from ee.voice.temporal.workflows.call_execution_workflow import (
+                CallExecutionWorkflow,
+            )
+        except ImportError as exc:
+            raise RuntimeError(
+                "Voice call execution workflow is unavailable without Enterprise Edition."
+            ) from exc
 
         for i, call_id in enumerate(call_ids):
             # Stagger: pause between sub-batches to let agent workers accept dispatches

--- a/futureagi/simulate/tests/test_activities.py
+++ b/futureagi/simulate/tests/test_activities.py
@@ -27,6 +27,10 @@ from simulate.models.simulator_agent import SimulatorAgent
 # ============================================================================
 
 
+def _ee_voice_mapper():
+    return pytest.importorskip("ee.voice.constants.voice_mapper")
+
+
 @pytest.fixture
 def agent_definition(db, organization, workspace):
     """Create a test agent definition."""
@@ -452,7 +456,7 @@ class TestGetPersonasByLanguage:
 
     def test_get_english_personas_default(self):
         """English should be the default language for personas."""
-        from ee.voice.constants.voice_mapper import get_personas_by_language
+        get_personas_by_language = _ee_voice_mapper().get_personas_by_language
 
         personas = get_personas_by_language("en")
         assert isinstance(personas, list)
@@ -460,14 +464,14 @@ class TestGetPersonasByLanguage:
 
     def test_get_english_personas_for_none(self):
         """None language should return English personas."""
-        from ee.voice.constants.voice_mapper import get_personas_by_language
+        get_personas_by_language = _ee_voice_mapper().get_personas_by_language
 
         personas = get_personas_by_language(None)
         assert isinstance(personas, list)
 
     def test_get_hindi_personas(self):
         """Hindi language code should return Hindi personas."""
-        from ee.voice.constants.voice_mapper import get_personas_by_language
+        get_personas_by_language = _ee_voice_mapper().get_personas_by_language
 
         personas = get_personas_by_language("hi")
         assert isinstance(personas, list)
@@ -478,7 +482,7 @@ class TestGetPersonasByLanguage:
 
     def test_get_personas_unknown_language_returns_english(self):
         """Unknown language should default to English personas."""
-        from ee.voice.constants.voice_mapper import get_personas_by_language
+        get_personas_by_language = _ee_voice_mapper().get_personas_by_language
 
         personas = get_personas_by_language("xx")  # Unknown language code
         assert isinstance(personas, list)

--- a/futureagi/simulate/tests/test_call_log_tasks.py
+++ b/futureagi/simulate/tests/test_call_log_tasks.py
@@ -1,18 +1,19 @@
 """
-Tests for the call-log ingestion helper and the Logs reader endpoint.
+Tests for the call-log Logs reader endpoint and core/EE dispatch boundary.
 
 Covers TH-4335:
-- `_ingest_call_logs` extraction preserves the behaviour of the legacy
-  `ingest_call_logs_task` (rows persisted, summary updated, source respected).
-- `ingest_call_logs_task` (the Temporal wrapper) still forwards its args to
-  the helper so the legacy `TestExecutor` code path keeps working.
 - `CallExecutionLogsView` returns HTTP 200 with an empty paginated page
   when the call has no logs (previously returned 400).
+- Lazy backfill dispatches the EE ingestion task only when EE voice is present.
 """
 
+import builtins
+from datetime import timedelta
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
+from django.utils import timezone
 from rest_framework import status
 
 from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
@@ -21,11 +22,16 @@ from simulate.models import AgentDefinition, CallLogEntry, Scenarios
 from simulate.models.run_test import RunTest
 from simulate.models.simulator_agent import SimulatorAgent
 from simulate.models.test_execution import CallExecution, TestExecution
+from simulate.serializers.test_execution import CallExecutionDetailSerializer
 try:
-    from ee.voice.tasks.call_log_tasks import _ingest_call_logs, ingest_call_logs_task
+    from ee.voice.tasks.call_log_tasks import ingest_call_logs_task
 except ImportError:
-    _ingest_call_logs = None
     ingest_call_logs_task = None
+
+requires_ee_voice = pytest.mark.skipif(
+    ingest_call_logs_task is None,
+    reason="EE voice call-log ingestion task is not available in OSS",
+)
 
 
 # ============================================================================
@@ -136,114 +142,35 @@ def call_execution(db, test_execution, scenario):
     )
 
 
-# ============================================================================
-# _ingest_call_logs — helper unit tests
-# ============================================================================
+def test_call_execution_serializer_ignores_missing_scenario_row(call_execution):
+    call_execution.call_metadata = {"row_id": str(uuid4())}
 
-
-def _fake_log_payload(body, severity="INFO", category="llm", ts_ms=1_700_000_000_000):
-    """Build a VAPI-shaped log payload dict."""
-    return {
-        "time": ts_ms,
-        "level": 30,
-        "severityText": severity,
-        "body": body,
-        "attributes": {"category": category},
-    }
-
-
-@pytest.mark.django_db
-class TestIngestCallLogsHelper:
-    """_ingest_call_logs — plain-Python helper extracted from the Temporal
-    task so activities can run ingestion inline without chaining a second
-    Temporal activity."""
-
-    def test_persists_rows_and_summary_for_customer_source(self, call_execution):
-        payloads = [
-            _fake_log_payload("first line"),
-            _fake_log_payload("second line", severity="WARN", category="model"),
-        ]
-        with patch(
-            "simulate.tasks.call_log_tasks.VoiceServiceManager"
-        ) as MockVSM:
-            MockVSM.return_value.iter_call_logs.return_value = iter(payloads)
-
-            ok = _ingest_call_logs(
-                str(call_execution.id),
-                "https://example.com/log",
-                source=CallLogEntry.LogSource.CUSTOMER,
-            )
-
-        assert ok is True
-        rows = CallLogEntry.objects.filter(call_execution=call_execution)
-        assert rows.count() == 2
-        assert set(rows.values_list("source", flat=True)) == {
-            CallLogEntry.LogSource.CUSTOMER
-        }
-
-        call_execution.refresh_from_db()
-        assert call_execution.customer_logs_summary["total_entries"] == 2
-
-    def test_customer_vs_agent_summary_field(self, call_execution):
-        with patch(
-            "simulate.tasks.call_log_tasks.VoiceServiceManager"
-        ) as MockVSM:
-            MockVSM.return_value.iter_call_logs.return_value = iter(
-                [_fake_log_payload("x")]
-            )
-            _ingest_call_logs(
-                str(call_execution.id),
-                "https://example.com/log",
-                source=CallLogEntry.LogSource.AGENT,
-            )
-
-        call_execution.refresh_from_db()
-        # AGENT source populates logs_summary (not customer_logs_summary)
-        assert call_execution.logs_summary == {
-            "total_entries": 1,
-            "level_counts": {"30": 1},
-            "category_counts": {"llm": 1},
-            "last_logged_at": call_execution.logs_summary["last_logged_at"],
-        }
-        assert not call_execution.customer_logs_summary
-
-    def test_missing_call_execution_returns_false_without_raising(self, db):
-        # Non-existent call id should be handled gracefully (False return)
-        # so the caller's own persistence doesn't get rolled back.
-        ok = _ingest_call_logs(
-            "00000000-0000-0000-0000-000000000000",
-            "https://example.com/log",
-            source=CallLogEntry.LogSource.CUSTOMER,
-        )
-        assert ok is False
-
-
-# ============================================================================
-# ingest_call_logs_task — legacy wrapper forwards to helper
-# ============================================================================
-
-
-@pytest.mark.django_db
-def test_ingest_call_logs_task_delegates_to_helper(call_execution):
-    """The Temporal-decorated wrapper must remain a thin pass-through so the
-    legacy TestExecutor code path continues working. Run it on an empty
-    iterator — the wrapper's only job is to forward args to the helper."""
-    with patch(
-        "simulate.tasks.call_log_tasks.VoiceServiceManager"
-    ) as MockVSM:
-        MockVSM.return_value.iter_call_logs.return_value = iter([])
-        ok = ingest_call_logs_task(
-            str(call_execution.id),
-            "https://example.com/log",
-            verify_ssl=False,
-            source=CallLogEntry.LogSource.CUSTOMER,
-        )
-
-    assert ok is True
-    MockVSM.return_value.iter_call_logs.assert_called_once_with(
-        url="https://example.com/log",
-        verify_ssl=False,
+    serializer = CallExecutionDetailSerializer(
+        call_execution,
+        context={
+            "rows_map": {},
+            "columns_by_dataset": {},
+            "cells_by_row": {},
+            "snapshots_by_call": {},
+        },
     )
+
+    assert serializer.data["scenario_columns"] == {}
+
+
+@requires_ee_voice
+def test_temporal_worker_imports_call_log_activity_module():
+    from tfc.temporal.common.registry import (
+        TEMPORAL_ACTIVITY_MODULES,
+        _import_temporal_activity_modules,
+    )
+    from tfc.temporal.drop_in.decorator import _ACTIVITY_REGISTRY
+
+    assert "ee.voice.tasks.call_log_tasks" in TEMPORAL_ACTIVITY_MODULES
+
+    _import_temporal_activity_modules()
+
+    assert _ACTIVITY_REGISTRY["ingest_call_logs_task"]["queue"] == "tasks_l"
 
 
 # ============================================================================
@@ -274,3 +201,192 @@ class TestCallExecutionLogsViewEmpty:
         # The inner `results` dict carries the logs array + source marker
         inner = payload.get("results") or {}
         assert inner.get("results") == []
+        assert inner.get("ingestion_pending") is False
+
+    def test_returns_persisted_customer_logs(self, auth_client, call_execution):
+        CallLogEntry.objects.create(
+            call_execution=call_execution,
+            source=CallLogEntry.LogSource.CUSTOMER,
+            provider=CallLogEntry.Provider.VAPI,
+            logged_at=timezone.now(),
+            level=30,
+            severity_text="INFO",
+            category="model",
+            body="first line",
+            attributes={"category": "model"},
+            payload={"body": "first line", "attributes": {"category": "model"}},
+        )
+
+        response = auth_client.get(self.URL_TEMPLATE.format(call_execution.id))
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        inner = payload.get("results") or {}
+        assert payload.get("count") == 1
+        assert inner.get("source") == CallLogEntry.LogSource.CUSTOMER
+        assert inner.get("ingestion_pending") is False
+        assert inner.get("results")[0]["body"] == "first line"
+
+    def test_lazy_backfill_without_ee_returns_empty_completed(
+        self, auth_client, call_execution, monkeypatch
+    ):
+        call_execution.provider_call_data = {
+            "vapi": {"artifact": {"logUrl": "https://example.com/call.log.gz"}}
+        }
+        call_execution.save(update_fields=["provider_call_data"])
+
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "ee.voice.tasks.call_log_tasks":
+                raise ImportError("No module named 'ee'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        response = auth_client.get(self.URL_TEMPLATE.format(call_execution.id))
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        inner = payload.get("results") or {}
+        assert payload.get("count", 0) == 0
+        assert inner.get("results") == []
+        assert inner.get("ingestion_pending") is False
+
+        call_execution.refresh_from_db()
+        assert call_execution.customer_log_url == "https://example.com/call.log.gz"
+        assert call_execution.customer_logs_summary["total_entries"] == 0
+        assert (
+            call_execution.customer_logs_summary["skipped_reason"]
+            == "ee_voice_not_available"
+        )
+
+    @requires_ee_voice
+    def test_lazy_backfill_dispatches_when_provider_log_url_exists(
+        self, auth_client, call_execution
+    ):
+        call_execution.provider_call_data = {
+            "vapi": {"artifact": {"logUrl": "https://example.com/call.log.gz"}}
+        }
+        call_execution.save(update_fields=["provider_call_data"])
+
+        with patch(
+            "ee.voice.tasks.call_log_tasks.ingest_call_logs_task.apply_async"
+        ) as apply_async:
+            response = auth_client.get(self.URL_TEMPLATE.format(call_execution.id))
+
+        assert response.status_code == status.HTTP_200_OK
+        apply_async.assert_called_once_with(
+            args=(str(call_execution.id), "https://example.com/call.log.gz"),
+            kwargs={
+                "verify_ssl": False,
+                "source": CallLogEntry.LogSource.CUSTOMER,
+            },
+        )
+        call_execution.refresh_from_db()
+        assert call_execution.customer_log_url == "https://example.com/call.log.gz"
+        assert call_execution.logs_ingested_at is not None
+
+        payload = response.json()
+        assert payload.get("count", 0) == 0
+        inner = payload.get("results") or {}
+        assert inner.get("results") == []
+        assert inner.get("ingestion_pending") is True
+
+    @requires_ee_voice
+    def test_stale_ingestion_attempt_is_not_pending_forever(
+        self, auth_client, call_execution
+    ):
+        call_execution.customer_log_url = "https://example.com/call.log.gz"
+        call_execution.logs_ingested_at = timezone.now() - timedelta(minutes=10)
+        call_execution.save(update_fields=["customer_log_url", "logs_ingested_at"])
+
+        with patch(
+            "ee.voice.tasks.call_log_tasks.ingest_call_logs_task.apply_async"
+        ) as apply_async:
+            response = auth_client.get(self.URL_TEMPLATE.format(call_execution.id))
+
+        assert response.status_code == status.HTTP_200_OK
+        apply_async.assert_not_called()
+        payload = response.json()
+        assert payload.get("count", 0) == 0
+        inner = payload.get("results") or {}
+        assert inner.get("results") == []
+        assert inner.get("ingestion_pending") is False
+
+    @pytest.mark.e2e
+    @requires_ee_voice
+    def test_e2e_first_open_pending_then_ingested_rows_are_returned(
+        self, auth_client, call_execution
+    ):
+        """E2E-style API flow: first drawer open starts ingestion, second open
+        returns persisted logs after the ingestion task has completed."""
+
+        call_execution.provider_call_data = {
+            "vapi": {"artifact": {"logUrl": "https://example.com/call.log.gz"}}
+        }
+        call_execution.save(update_fields=["provider_call_data"])
+
+        with patch(
+            "ee.voice.tasks.call_log_tasks.ingest_call_logs_task.apply_async"
+        ) as apply_async:
+            first_response = auth_client.get(
+                self.URL_TEMPLATE.format(call_execution.id)
+            )
+
+        assert first_response.status_code == status.HTTP_200_OK
+        apply_async.assert_called_once()
+        assert first_response.json()["results"]["ingestion_pending"] is True
+
+        CallLogEntry.objects.create(
+            call_execution=call_execution,
+            source=CallLogEntry.LogSource.CUSTOMER,
+            provider=CallLogEntry.Provider.VAPI,
+            logged_at=timezone.now(),
+            level=40,
+            severity_text="ERROR",
+            category="webhook",
+            body="provider webhook failed",
+            attributes={"category": "webhook"},
+            payload={"body": "provider webhook failed"},
+        )
+        call_execution.refresh_from_db()
+        call_execution.customer_logs_summary = {
+            "total_entries": 1,
+            "level_counts": {"40": 1},
+            "category_counts": {"webhook": 1},
+        }
+        call_execution.save(update_fields=["customer_logs_summary"])
+
+        second_response = auth_client.get(self.URL_TEMPLATE.format(call_execution.id))
+
+        assert second_response.status_code == status.HTTP_200_OK
+        payload = second_response.json()
+        assert payload["count"] == 1
+        assert payload["results"]["ingestion_pending"] is False
+        assert payload["results"]["results"][0]["body"] == "provider webhook failed"
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestCallExecutionDetailView:
+    URL_TEMPLATE = "/simulate/call-executions/{}/"
+
+    def test_returns_actual_provider_from_stored_provider_payload(
+        self, auth_client, call_execution
+    ):
+        call_execution.provider_call_data = {
+            "livekit": {
+                "room_sid": "RM_test",
+                "recording": {"stereo": "https://example.com/stereo.wav"},
+            }
+        }
+        call_execution.save(update_fields=["provider_call_data"])
+
+        response = auth_client.get(self.URL_TEMPLATE.format(call_execution.id))
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload["provider"] == "livekit"
+        assert payload["attributes"]["raw_log"]["room_sid"] == "RM_test"

--- a/futureagi/simulate/tests/test_scenario_generation.py
+++ b/futureagi/simulate/tests/test_scenario_generation.py
@@ -26,6 +26,10 @@ from simulate.models.simulator_agent import SimulatorAgent
 # ============================================================================
 
 
+def _ee_voice_mapper():
+    return pytest.importorskip("ee.voice.constants.voice_mapper")
+
+
 @pytest.fixture
 def agent_definition(db, organization, workspace):
     """Create a test agent definition."""
@@ -680,30 +684,27 @@ class TestLanguageBasedPersonaSelection:
 
     def test_english_personas_for_en_agent(self):
         """English agent should use English personas."""
-        from ee.voice.constants.voice_mapper import (
-            ENGLISH_PERSONAS,
-            get_personas_by_language,
-        )
+        voice_mapper = _ee_voice_mapper()
+        ENGLISH_PERSONAS = voice_mapper.ENGLISH_PERSONAS
+        get_personas_by_language = voice_mapper.get_personas_by_language
 
         personas = get_personas_by_language("en")
         assert personas == ENGLISH_PERSONAS
 
     def test_hindi_personas_for_hi_agent(self):
         """Hindi agent should use Hindi personas."""
-        from ee.voice.constants.voice_mapper import (
-            HINDI_PERSONAS,
-            get_personas_by_language,
-        )
+        voice_mapper = _ee_voice_mapper()
+        HINDI_PERSONAS = voice_mapper.HINDI_PERSONAS
+        get_personas_by_language = voice_mapper.get_personas_by_language
 
         personas = get_personas_by_language("hi")
         assert personas == HINDI_PERSONAS
 
     def test_default_to_english_for_unknown_language(self):
         """Unknown language should default to English personas."""
-        from ee.voice.constants.voice_mapper import (
-            ENGLISH_PERSONAS,
-            get_personas_by_language,
-        )
+        voice_mapper = _ee_voice_mapper()
+        ENGLISH_PERSONAS = voice_mapper.ENGLISH_PERSONAS
+        get_personas_by_language = voice_mapper.get_personas_by_language
 
         # Unknown languages should fall back to English
         for lang in ["fr", "es", "de", "ja", "unknown"]:

--- a/futureagi/simulate/tests/test_temporal_activities.py
+++ b/futureagi/simulate/tests/test_temporal_activities.py
@@ -41,6 +41,18 @@ from tracer.models.observability_provider import ProviderChoices
 # ============================================================================
 
 
+def _ee_voice_large():
+    return pytest.importorskip("ee.voice.temporal.activities.voice_large")
+
+
+def _ee_processing_gating():
+    return pytest.importorskip("ee.voice.utils.processing_gating")
+
+
+def _ee_call_execution_workflow():
+    return pytest.importorskip("ee.voice.temporal.workflows.call_execution_workflow")
+
+
 @pytest.fixture
 def agent_definition(db, organization, workspace):
     """Create a test agent definition."""
@@ -897,7 +909,7 @@ class TestFetchAndPersistCallResultActivity:
         self, call_execution
     ):
         """Test that fetch_and_persist_call_result updates CallExecution fields."""
-        from ee.voice.temporal.activities.voice_large import fetch_and_persist_call_result
+        fetch_and_persist_call_result = _ee_voice_large().fetch_and_persist_call_result
         from simulate.temporal.types.activities import FetchAndPersistCallResultInput
         from tfc.temporal.common.heartbeat import Heartbeater
 
@@ -992,7 +1004,7 @@ class TestFetchAndPersistCallResultActivity:
         self, call_execution
     ):
         """Test that fetch_and_persist_call_result handles failed calls."""
-        from ee.voice.temporal.activities.voice_large import fetch_and_persist_call_result
+        fetch_and_persist_call_result = _ee_voice_large().fetch_and_persist_call_result
         from simulate.temporal.types.activities import FetchAndPersistCallResultInput
         from tfc.temporal.common.heartbeat import Heartbeater
 
@@ -1084,7 +1096,7 @@ class TestFetchAndPersistCallResultActivity:
         self, db
     ):
         """Test that fetch_and_persist_call_result returns error for non-existent call."""
-        from ee.voice.temporal.activities.voice_large import fetch_and_persist_call_result
+        fetch_and_persist_call_result = _ee_voice_large().fetch_and_persist_call_result
         from simulate.temporal.types.activities import FetchAndPersistCallResultInput
         from tfc.temporal.common.heartbeat import Heartbeater
 
@@ -1562,9 +1574,16 @@ class TestBuildTranscriptData:
 
         result = _build_transcript_data(call_execution)
 
-        # SpeakerRoleResolver normalizes "user" -> "customer" for evaluation labels.
+        try:
+            import ee.voice.utils.transcript_roles  # noqa: F401
+        except ImportError:
+            user_label = "user"
+        else:
+            # EE SpeakerRoleResolver normalizes "user" to the evaluation label.
+            user_label = "customer"
+
         assert "agent: Hello, how can I help?" in result["transcript"]
-        assert "customer: I need help with my order." in result["transcript"]
+        assert f"{user_label}: I need help with my order." in result["transcript"]
 
     @pytest.mark.django_db(transaction=True)
     def test_build_transcript_data_no_transcripts(self, call_execution):
@@ -2040,7 +2059,7 @@ class TestCallProcessingGatingRules:
     """Tests for conversation-validity gating helper logic."""
 
     def test_transcript_with_both_roles_allows_processing(self):
-        from ee.voice.utils.processing_gating import decide_processing_skip
+        decide_processing_skip = _ee_processing_gating().decide_processing_skip
 
         decision = decide_processing_skip(
             message_count=4,
@@ -2053,7 +2072,7 @@ class TestCallProcessingGatingRules:
         assert decision.processing_skip_reason == ""
 
     def test_transcript_missing_customer_skips_processing(self):
-        from ee.voice.utils.processing_gating import decide_processing_skip
+        decide_processing_skip = _ee_processing_gating().decide_processing_skip
 
         decision = decide_processing_skip(
             message_count=2,
@@ -2066,7 +2085,7 @@ class TestCallProcessingGatingRules:
         assert "customer" in decision.processing_skip_reason.lower()
 
     def test_no_transcript_short_duration_skips_processing(self):
-        from ee.voice.utils.processing_gating import decide_processing_skip
+        decide_processing_skip = _ee_processing_gating().decide_processing_skip
 
         decision = decide_processing_skip(
             message_count=0,
@@ -2118,9 +2137,7 @@ class TestHeartbeatConfiguration:
         import ast
         import inspect
 
-        from ee.voice.temporal.workflows.call_execution_workflow import (
-            CallExecutionWorkflow,
-        )
+        CallExecutionWorkflow = _ee_call_execution_workflow().CallExecutionWorkflow
 
         source = inspect.getsource(CallExecutionWorkflow.run)
 
@@ -2132,9 +2149,7 @@ class TestHeartbeatConfiguration:
         """Verify CallExecutionWorkflow sets heartbeat_timeout for run_simulate_evaluations."""
         import inspect
 
-        from ee.voice.temporal.workflows.call_execution_workflow import (
-            CallExecutionWorkflow,
-        )
+        CallExecutionWorkflow = _ee_call_execution_workflow().CallExecutionWorkflow
 
         source = inspect.getsource(CallExecutionWorkflow.run)
 
@@ -2146,9 +2161,7 @@ class TestHeartbeatConfiguration:
         """Verify CallExecutionWorkflow sets heartbeat_timeout for run_tool_call_evaluation."""
         import inspect
 
-        from ee.voice.temporal.workflows.call_execution_workflow import (
-            CallExecutionWorkflow,
-        )
+        CallExecutionWorkflow = _ee_call_execution_workflow().CallExecutionWorkflow
 
         source = inspect.getsource(CallExecutionWorkflow.run)
 
@@ -2164,9 +2177,7 @@ class TestHeartbeatConfiguration:
         """
         import inspect
 
-        from ee.voice.temporal.workflows.call_execution_workflow import (
-            CallExecutionWorkflow,
-        )
+        CallExecutionWorkflow = _ee_call_execution_workflow().CallExecutionWorkflow
 
         source = inspect.getsource(CallExecutionWorkflow)
         assert "tool-eval-activity" in source
@@ -2175,9 +2186,7 @@ class TestHeartbeatConfiguration:
         """Verify _run_eval_only_mode uses workflow.patched for tool-eval-activity."""
         import inspect
 
-        from ee.voice.temporal.workflows.call_execution_workflow import (
-            CallExecutionWorkflow,
-        )
+        CallExecutionWorkflow = _ee_call_execution_workflow().CallExecutionWorkflow
 
         source = inspect.getsource(CallExecutionWorkflow._run_eval_only_mode)
         assert "tool-eval-activity" in source

--- a/futureagi/simulate/utils/stored_transcript_roles.py
+++ b/futureagi/simulate/utils/stored_transcript_roles.py
@@ -1,0 +1,20 @@
+"""Helpers for generic CallTranscript role filters."""
+
+from simulate.models.test_execution import CallTranscript
+
+
+def get_conversational_transcript_roles() -> list[str]:
+    """Return roles that represent back-and-forth dialogue turns."""
+    return [
+        CallTranscript.SpeakerRole.USER,
+        CallTranscript.SpeakerRole.ASSISTANT,
+    ]
+
+
+def get_displayable_transcript_roles() -> list[str]:
+    """Return transcript roles that should be shown in transcript views."""
+    return [
+        CallTranscript.SpeakerRole.USER,
+        CallTranscript.SpeakerRole.ASSISTANT,
+        CallTranscript.SpeakerRole.SYSTEM,
+    ]

--- a/futureagi/simulate/views/agent_definition.py
+++ b/futureagi/simulate/views/agent_definition.py
@@ -37,10 +37,12 @@ from simulate.serializers.response.agent_definition import (
 from simulate.serializers.response.agent_version import (
     AgentVersionListResponseSerializer,
 )
+from tfc.ee_stub import _ee_stub
+
 try:
     from ee.voice.services.vapi_service import VapiService
 except ImportError:
-    VapiService = None
+    VapiService = _ee_stub("VapiService")
 from tfc.ee_gating import FeatureUnavailable
 from tfc.utils.base_viewset import BaseModelViewSetMixin
 from tfc.utils.error_codes import get_error_message

--- a/futureagi/simulate/views/call_transcript.py
+++ b/futureagi/simulate/views/call_transcript.py
@@ -11,6 +11,7 @@ from accounts.utils import get_request_organization
 from simulate.models import CallExecution, CallTranscript
 from simulate.serializers.test_execution import CallTranscriptSerializer
 from simulate.services.branch_deviation_analyzer import BranchDeviationAnalyzer
+from simulate.utils.stored_transcript_roles import get_displayable_transcript_roles
 
 
 class CallTranscriptView(APIView):
@@ -39,12 +40,10 @@ class CallTranscriptView(APIView):
                 test_execution__organization=user_organization,
             )
 
-            from ee.voice.utils.transcript_roles import SpeakerRoleResolver
-
             # Get all transcripts for this call
             transcripts = CallTranscript.objects.filter(
                 call_execution=call_execution,
-                speaker_role__in=SpeakerRoleResolver.get_displayable_roles(),
+                speaker_role__in=get_displayable_transcript_roles(),
             ).order_by("start_time_ms")
 
             # Serialize the transcripts
@@ -97,9 +96,7 @@ class TestExecutionTranscriptsView(APIView):
             for call_execution in call_executions:
                 # Filter transcripts by speaker role and order by start_time_ms
                 # Since we prefetched, this filtering happens in Python
-                from ee.voice.utils.transcript_roles import SpeakerRoleResolver
-
-                displayable = SpeakerRoleResolver.get_displayable_roles()
+                displayable = get_displayable_transcript_roles()
                 transcripts = [
                     t
                     for t in call_execution.transcripts.all()

--- a/futureagi/simulate/views/livekit_api.py
+++ b/futureagi/simulate/views/livekit_api.py
@@ -15,6 +15,7 @@ import uuid
 from datetime import UTC, datetime
 
 import structlog
+from asgiref.sync import async_to_sync
 from django.conf import settings
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -405,7 +406,6 @@ class ValidateLiveKitCredentialsView(APIView):
         )
 
         from simulate.serializers.agent_definition import _is_masked
-        from ee.voice.services.livekit.service import _run_async
 
         data = request.data
         livekit_url = (data.get("livekit_url") or "").strip()
@@ -483,7 +483,7 @@ class ValidateLiveKitCredentialsView(APIView):
                 await lkapi.aclose()
 
         try:
-            _run_async(_validate())
+            async_to_sync(_validate)()
         except Exception as exc:
             logger.warning(
                 "livekit_validate_credentials_failed",

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -5,6 +5,7 @@ import math
 import os
 import re
 import traceback
+from datetime import timedelta
 from urllib.parse import urlencode
 
 import structlog
@@ -31,6 +32,18 @@ from tracer.models.replay_session import ReplaySession, ReplaySessionStep
 from tracer.models.trace import Trace
 
 logger = structlog.get_logger(__name__)
+
+
+def _empty_call_log_summary(reason: str) -> dict:
+    return {
+        "total_entries": 0,
+        "level_counts": {},
+        "category_counts": {},
+        "last_logged_at": None,
+        "skipped_reason": reason,
+    }
+
+
 from drf_yasg.utils import swagger_auto_schema
 
 from model_hub.models.api_key import ApiKey
@@ -3285,9 +3298,14 @@ class CallExecutionLogsView(APIView):
             customer_call_id = request.query_params.get(
                 "customer_call_id"
             ) or request.query_params.get("vapi_call_id")
+            call_execution_filters = {
+                "test_execution__run_test__organization": user_organization,
+                "test_execution__run_test__deleted": False,
+            }
             if customer_call_id:
                 call_execution = CallExecution.objects.filter(
-                    customer_call_id=customer_call_id
+                    customer_call_id=customer_call_id,
+                    **call_execution_filters,
                 ).first()
                 if not call_execution:
                     return self.gm.bad_request("Call execution not found.")
@@ -3295,15 +3313,15 @@ class CallExecutionLogsView(APIView):
                 call_execution = get_object_or_404(
                     CallExecution,
                     id=call_execution_id,
-                    test_execution__run_test__organization=user_organization,
-                    test_execution__run_test__deleted=False,
+                    **call_execution_filters,
                 )
 
             source = CallLogEntry.LogSource.CUSTOMER
 
-            queryset = CallLogEntry.objects.filter(
+            base_queryset = CallLogEntry.objects.filter(
                 call_execution=call_execution, source=source
             )
+            queryset = base_queryset
 
             severity_text = request.query_params.get("severity_text")
             if severity_text is not None:
@@ -3325,28 +3343,90 @@ class CallExecutionLogsView(APIView):
             # Lazy backfill: observability-off simulate calls never had their
             # artifact log file downloaded at ingest time, but the URL is
             # sitting on `provider_call_data.vapi.artifact.logUrl`. First
-            # Logs-tab open triggers the existing ingest task; subsequent
-            # opens serve the persisted CallLogEntry rows. `customer_log_url`
-            # doubles as the dispatched-flag so we don't re-fire on every
-            # poll while the task runs.
-            if not queryset.exists() and not call_execution.customer_log_url:
-                pcd = call_execution.provider_call_data or {}
-                vapi = pcd.get("vapi") or {}
-                log_url = (vapi.get("artifact") or {}).get("logUrl")
-                if log_url:
-                    call_execution.customer_log_url = log_url
-                    call_execution.save(update_fields=["customer_log_url"])
-                    from simulate.tasks.call_log_tasks import (
-                        ingest_call_logs_task,
+            # Logs-tab open triggers the existing ingest task; the response
+            # marks ingestion as pending so the frontend can poll until rows
+            # exist or the task records an empty summary.
+            has_stored_logs = base_queryset.exists()
+            pcd = call_execution.provider_call_data or {}
+            vapi = pcd.get("vapi") or {}
+            provider_log_url = (vapi.get("artifact") or {}).get("logUrl")
+            log_url = call_execution.customer_log_url or provider_log_url
+            has_ingestion_summary = bool(call_execution.customer_logs_summary)
+            should_start_ingestion = (
+                not has_stored_logs
+                and bool(log_url)
+                and not has_ingestion_summary
+                and call_execution.logs_ingested_at is None
+            )
+
+            if should_start_ingestion:
+                dispatch_started_at = timezone.now()
+                update_kwargs = {"logs_ingested_at": dispatch_started_at}
+                if not call_execution.customer_log_url and provider_log_url:
+                    update_kwargs["customer_log_url"] = provider_log_url
+
+                claimed_ingestion = CallExecution.objects.filter(
+                    id=call_execution.id,
+                    logs_ingested_at__isnull=True,
+                ).update(**update_kwargs)
+
+                if claimed_ingestion:
+                    call_execution.logs_ingested_at = dispatch_started_at
+                    if "customer_log_url" in update_kwargs:
+                        call_execution.customer_log_url = provider_log_url
+
+                    try:
+                        from ee.voice.tasks.call_log_tasks import ingest_call_logs_task
+                    except ImportError:
+                        empty_summary = _empty_call_log_summary(
+                            "ee_voice_not_available"
+                        )
+                        CallExecution.objects.filter(
+                            id=call_execution.id,
+                            logs_ingested_at=dispatch_started_at,
+                        ).update(customer_logs_summary=empty_summary)
+                        call_execution.customer_logs_summary = empty_summary
+                        logger.info(
+                            "call_log_ingestion_task_unavailable",
+                            call_execution_id=str(call_execution.id),
+                        )
+                    else:
+                        try:
+                            ingest_call_logs_task.apply_async(
+                                args=(str(call_execution.id), log_url),
+                                kwargs={
+                                    "verify_ssl": False,
+                                    "source": CallLogEntry.LogSource.CUSTOMER,
+                                },
+                            )
+                        except Exception:
+                            CallExecution.objects.filter(
+                                id=call_execution.id,
+                                logs_ingested_at=dispatch_started_at,
+                            ).update(logs_ingested_at=None)
+                            call_execution.logs_ingested_at = None
+                            raise
+                else:
+                    call_execution.refresh_from_db(
+                        fields=[
+                            "customer_log_url",
+                            "customer_logs_summary",
+                            "logs_ingested_at",
+                        ]
                     )
 
-                    ingest_call_logs_task.apply_async(
-                        args=(str(call_execution.id), log_url),
-                        kwargs={
-                            "verify_ssl": False,
-                            "source": CallLogEntry.LogSource.CUSTOMER,
-                        },
-                    )
+            has_ingestion_summary = bool(call_execution.customer_logs_summary)
+            ingest_attempt_at = call_execution.logs_ingested_at
+            recently_started_ingest = (
+                ingest_attempt_at is None
+                or timezone.now() - ingest_attempt_at < timedelta(minutes=5)
+            )
+            ingestion_pending = (
+                not has_stored_logs
+                and bool(log_url)
+                and not has_ingestion_summary
+                and recently_started_ingest
+            )
 
             # Intentionally return a 200 with an empty page when no rows
             # match — the frontend Logs tab distinguishes "no logs yet /
@@ -3371,7 +3451,11 @@ class CallExecutionLogsView(APIView):
             ]
 
             logs_serializer = CallExecutionLogsResponseSerializer(
-                {"results": results, "source": source}
+                {
+                    "results": results,
+                    "source": source,
+                    "ingestion_pending": ingestion_pending,
+                }
             )
             return paginator.get_paginated_response(logs_serializer.data)
 

--- a/futureagi/tfc/temporal/common/registry.py
+++ b/futureagi/tfc/temporal/common/registry.py
@@ -22,6 +22,60 @@ _activity_registry: Dict[str, List[Callable]] = {}
 _workflows_registered: bool = False
 _activities_registered: bool = False
 
+TEMPORAL_ACTIVITY_MODULES = [
+    # agent_prompt_optimiser eval activities
+    "tfc.temporal.agent_prompt_optimiser.eval_activities",
+    # Background tasks (post-registration, huggingface, etc.)
+    "tfc.temporal.background_tasks.activities",
+    # model_hub tasks
+    "model_hub.tasks.run_prompt",
+    "model_hub.tasks.experiment_runner",
+    "model_hub.tasks.user_evaluation",
+    "model_hub.tasks.insights",
+    "model_hub.tasks.agent",
+    "model_hub.tasks.model_log",
+    "model_hub.tasks.dataset_embeddings",
+    "model_hub.tasks.optimisation_runner",
+    "model_hub.tasks.prompt_template_optimizer",
+    "model_hub.tasks.develop_dataset",
+    # model_hub views
+    "model_hub.views.run_prompt",
+    "model_hub.views.experiment_runner",
+    "model_hub.views.dynamic_columns",
+    "model_hub.views.optimize_dataset",
+    "model_hub.views.prompt_template",
+    "model_hub.views.develop_dataset",
+    "model_hub.views.datasets.create.file_upload",
+    "model_hub.views.utils.evals",
+    # model_hub utils
+    "model_hub.utils.auto_annotate",
+    # tracer tasks
+    "tracer.tasks",
+    "tracer.tasks.trace_scanner",
+    "tracer.tasks.recordings_rehost",
+    "tracer.utils.span",
+    "tracer.utils.eval",
+    "tracer.utils.observability_provider",
+    "tracer.utils.trace_ingestion",
+    "tracer.utils.inline_evals",
+    "tracer.utils.external_eval",
+    "tracer.utils.eval_tasks",
+    "tracer.utils.monitor",
+    # simulate tasks
+    "simulate.tasks.eval_summary_tasks",
+    "simulate.tasks.scenario_tasks",
+    "simulate.services.test_executor",
+    "simulate.tasks.chat_sim",
+    # voice tasks
+    "ee.voice.tasks.call_log_tasks",
+    # integration tasks
+    "integrations.temporal.activities",
+    "integrations.services.langfuse_service",
+    "integrations.transformers.langfuse_transformer",
+    # billing tasks (Phase 4.6 — budget catch-up)
+    "tfc.temporal.schedules.billing",
+]
+
 
 # =============================================================================
 # Registration Functions
@@ -706,60 +760,7 @@ def _import_temporal_activity_modules() -> None:
 
     log = get_logger(__name__)
 
-    # List of modules with @temporal_activity decorators
-    modules_to_import = [
-        # agent_prompt_optimiser eval activities
-        "tfc.temporal.agent_prompt_optimiser.eval_activities",
-        # Background tasks (post-registration, huggingface, etc.)
-        "tfc.temporal.background_tasks.activities",
-        # model_hub tasks
-        "model_hub.tasks.run_prompt",
-        "model_hub.tasks.experiment_runner",
-        "model_hub.tasks.user_evaluation",
-        "model_hub.tasks.insights",
-        "model_hub.tasks.agent",
-        "model_hub.tasks.model_log",
-        "model_hub.tasks.dataset_embeddings",
-        "model_hub.tasks.optimisation_runner",
-        "model_hub.tasks.prompt_template_optimizer",
-        "model_hub.tasks.develop_dataset",
-        # model_hub views
-        "model_hub.views.run_prompt",
-        "model_hub.views.experiment_runner",
-        "model_hub.views.dynamic_columns",
-        "model_hub.views.optimize_dataset",
-        "model_hub.views.prompt_template",
-        "model_hub.views.develop_dataset",
-        "model_hub.views.datasets.create.file_upload",
-        "model_hub.views.utils.evals",
-        # model_hub utils
-        "model_hub.utils.auto_annotate",
-        # tracer tasks
-        "tracer.tasks",
-        "tracer.tasks.trace_scanner",
-        "tracer.tasks.recordings_rehost",
-        "tracer.utils.span",
-        "tracer.utils.eval",
-        "tracer.utils.observability_provider",
-        "tracer.utils.trace_ingestion",
-        "tracer.utils.inline_evals",
-        "tracer.utils.external_eval",
-        "tracer.utils.eval_tasks",
-        "tracer.utils.monitor",
-        # simulate tasks
-        "simulate.tasks.eval_summary_tasks",
-        "simulate.tasks.scenario_tasks",
-        "simulate.services.test_executor",
-        "simulate.tasks.chat_sim",
-        # integration tasks
-        "integrations.temporal.activities",
-        "integrations.services.langfuse_service",
-        "integrations.transformers.langfuse_transformer",
-        # billing tasks (Phase 4.6 — budget catch-up)
-        "tfc.temporal.schedules.billing",
-    ]
-
-    for module_name in modules_to_import:
+    for module_name in TEMPORAL_ACTIVITY_MODULES:
         try:
             __import__(module_name)
             log.debug("module_imported", module=module_name)

--- a/futureagi/tfc/temporal/dataset_optimization/activities.py
+++ b/futureagi/tfc/temporal/dataset_optimization/activities.py
@@ -491,11 +491,19 @@ async def run_optimization_activity(input: Dict[str, Any]) -> Dict[str, Any]:
 
             # Normalize Unicode characters (non-breaking spaces, zero-width chars, etc.)
             # that come from rich text editors / web UI copy-paste
-            from ee.agent_opt.utils.template_variables import (
-                build_template_variable_instruction,
-                extract_template_variables,
-                normalize_prompt_text,
-            )
+            try:
+                from ee.agent_opt.utils.template_variables import (
+                    build_template_variable_instruction,
+                    extract_template_variables,
+                    normalize_prompt_text,
+                )
+            except ImportError:
+                if settings.DEBUG:
+                    logger.warning(
+                        "Could not import ee.agent_opt.utils.template_variables",
+                        exc_info=True,
+                    )
+                return None
 
             initial_prompt = normalize_prompt_text(initial_prompt)
 

--- a/futureagi/tfc/tests/test_ee_gating.py
+++ b/futureagi/tfc/tests/test_ee_gating.py
@@ -97,7 +97,7 @@ class TestIsOss:
         if not has_ee("ee.usage"):
             pytest.skip("ee/ not present — only meaningful with ee/ installed")
 
-        from ee.usage.deployment import DeploymentMode
+        DeploymentMode = pytest.importorskip("ee.usage.deployment").DeploymentMode
 
         # Force DeploymentMode.is_oss() to return True; is_oss() should too.
         with patch.object(DeploymentMode, "is_oss", return_value=True):
@@ -223,7 +223,7 @@ class TestEEFeatureMirror:
         if not has_ee("ee.usage"):
             pytest.skip("ee/ not present")
 
-        from ee.usage.deployment import EE_FEATURES as EE_FEATURES_SOURCE
+        EE_FEATURES_SOURCE = pytest.importorskip("ee.usage.deployment").EE_FEATURES
 
         assert EE_FEATURES_OSS == EE_FEATURES_SOURCE, (
             "tfc.ee_gating.EEFeature has drifted from ee.usage.deployment."

--- a/futureagi/tracer/tests/test_trace.py
+++ b/futureagi/tracer/tests/test_trace.py
@@ -5,8 +5,10 @@ Tests for /tracer/trace/ endpoints.
 """
 
 import uuid
+from unittest.mock import patch
 
 import pytest
+from django.utils import timezone
 from rest_framework import status
 
 from tracer.models.trace import Trace
@@ -167,6 +169,57 @@ class TestTraceListTracesAPI:
         total = metadata.get("total_rows", 0)
         # Should return at most 3 traces
         assert total <= 3
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestVoiceCallListAPI:
+    """Tests for GET /tracer/trace/list_voice_calls/ endpoint."""
+
+    def test_list_voice_calls_falls_back_to_pg_when_clickhouse_fails(
+        self, auth_client, project, trace
+    ):
+        from tracer.models.observation_span import ObservationSpan
+        from tracer.services.clickhouse.query_service import AnalyticsQueryService
+
+        ObservationSpan.objects.create(
+            id=f"conversation_{uuid.uuid4().hex[:16]}",
+            project=project,
+            trace=trace,
+            name="Conversation",
+            observation_type="conversation",
+            start_time=timezone.now(),
+            end_time=timezone.now(),
+            latency_ms=1000,
+            status="OK",
+            provider="vapi",
+            span_attributes={"raw_log": {"id": "provider-call-1"}},
+        )
+
+        with patch.object(
+            AnalyticsQueryService,
+            "should_use_clickhouse",
+            return_value=True,
+        ), patch.object(
+            AnalyticsQueryService,
+            "execute_ch_query",
+            side_effect=Exception("clickhouse unavailable"),
+        ) as ch_query:
+            response = auth_client.get(
+                "/tracer/trace/list_voice_calls/",
+                {
+                    "project_id": str(project.id),
+                    "page": 1,
+                    "page_size": 10,
+                    "filters": "[]",
+                },
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        ch_query.assert_called()
+        payload = response.json()
+        assert payload["count"] >= 1
+        assert payload["results"][0]["trace_id"] == str(trace.id)
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -3328,13 +3328,19 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             # ClickHouse for pagination + PG for span_attributes (hybrid)
             analytics = AnalyticsQueryService()
             if analytics.should_use_clickhouse(QueryType.VOICE_CALL_LIST):
-                return self._list_voice_calls_clickhouse(
-                    request,
-                    project_id,
-                    validated_data,
-                    remove_simulation_calls,
-                    analytics,
-                )
+                try:
+                    return self._list_voice_calls_clickhouse(
+                        request,
+                        project_id,
+                        validated_data,
+                        remove_simulation_calls,
+                        analytics,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "CH voice-call-list failed, falling back to PG",
+                        error=str(e),
+                    )
 
             # Build optimized base query: only traces whose root span is a conversation
             root_span_qs = ObservationSpan.objects.filter(


### PR DESCRIPTION
## Summary
- backfill and persist Vapi customer call logs for simulation call details
- return ingestion state, log summaries, and attributes without getting stuck on provider polling
- render customer/simulation logs and attributes in the voice detail drawer
- add backend and frontend coverage for logs, attributes, and OSS/EE import safety

## Root Cause
Simulation call details could find the call transcript/recording, but customer provider logs were not being ingested from Vapi artifact.logUrl and missing EE task imports could fail or leave the UI in a pending state.

## Validation
- docker exec ws3-backend sh -lc "cd /app/backend && python -m py_compile ..."
- git diff --cached --check
- yarn test:run src/components/VoiceDetailDrawerV2/__tests__/VoiceLogsView.test.jsx src/components/VoiceDetailDrawerV2/__tests__/VoiceRightPanel.test.jsx
- verified 10 seeded Vapi simulation calls locally with logs and attributes visible in the drawer

## Notes
- Branch renamed to follow repo convention: `fix/th-4685-enable-logs-simulation-call-details`.
- Supersedes closed draft PR #396.
- Left unrelated local frontend/yarn.lock churn and futureagi/agentcc-gateway/ out of this PR.