### PR TITLE
feat: enable Agent Playground evaluations

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Future AGI is an **open-source ecosystem** — each SDK is independently usable,
 - [x] LiveKit Configuration via UI
 - [x] System Metric Filtering for Voice
 - [x] Agent Playground
+- [x] Agent Playground eval nodes
 - [x] Dashboards
 - [x] Access platform via MCP
 - [x] Annotation Queues

--- a/frontend/src/api/agent-playground/dataset-execution.js
+++ b/frontend/src/api/agent-playground/dataset-execution.js
@@ -71,6 +71,20 @@ export const useExecuteDataset = (options = {}) =>
   });
 
 /**
+ * Hook for evaluating a completed graph execution.
+ * @param {object} options - useMutation options
+ */
+export const useEvaluateExecution = (options = {}) =>
+  useMutation({
+    mutationFn: ({ graphId, executionId, payload }) =>
+      axios.post(
+        endpoints.agentPlayground.evaluateExecution(graphId, executionId),
+        payload,
+      ),
+    ...options,
+  });
+
+/**
  * Hook for fetching a single node's execution detail (inputs, outputs, usage).
  * @param {string} executionId
  * @param {string} nodeExecutionId

--- a/frontend/src/api/agent-playground/node-templates.js
+++ b/frontend/src/api/agent-playground/node-templates.js
@@ -19,7 +19,7 @@ export const useGetReferenceableGraphs = (graphId, options = {}) =>
   });
 
 /**
- * Hook for fetching node templates. Filters to llm_prompt only for now.
+ * Hook for fetching node templates.
  * Maps API shape to NodeCard shape: { id, node_template_id, title, description, iconSrc, color }
  * @param {object} options - Additional react-query options
  */
@@ -29,14 +29,17 @@ export const useGetNodeTemplates = (options = {}) =>
     queryFn: () => axios.get(endpoints.agentPlayground.nodeTemplates),
     select: (res) =>
       (res.data?.result?.node_templates ?? [])
-        .filter((t) => t.name === NODE_TYPES.LLM_PROMPT)
+        .filter((t) => [NODE_TYPES.LLM_PROMPT, NODE_TYPES.EVAL].includes(t.name))
         .map((t) => ({
           id: t.name,
           node_template_id: t.id,
           title: t.display_name,
           description: t.description,
-          iconSrc: "/assets/icons/ic_chat_single.svg",
-          color: "orange.500",
+          iconSrc:
+            t.name === NODE_TYPES.EVAL
+              ? "/assets/icons/ic_check.svg"
+              : "/assets/icons/ic_chat_single.svg",
+          color: t.name === NODE_TYPES.EVAL ? "green.500" : "orange.500",
         })),
     staleTime: 5 * 60 * 1000,
     ...options,

--- a/frontend/src/components/AgentGraph/ExecutionNode.jsx
+++ b/frontend/src/components/AgentGraph/ExecutionNode.jsx
@@ -40,6 +40,11 @@ const ExecutionNode = ({ data }) => {
 
   const inputPorts = ports.filter((p) => p.direction === "input");
   const outputPorts = ports.filter((p) => p.direction === "output");
+  const evaluationResult = nodeExecution?.evaluation_result;
+  const evaluationScore =
+    typeof evaluationResult?.score === "number"
+      ? Math.round(evaluationResult.score * 100)
+      : null;
 
   return (
     <Box sx={{ position: "relative", opacity: isPending ? 0.4 : 1 }}>
@@ -124,14 +129,26 @@ const ExecutionNode = ({ data }) => {
               }}
             />
           </Box>
-          <Typography
-            typography="s2_1"
-            fontWeight="fontWeightMedium"
-            color="text.primary"
-            noWrap
-          >
-            {label}
-          </Typography>
+          <Stack sx={{ minWidth: 0, flex: 1 }} gap={0.25}>
+            <Typography
+              typography="s2_1"
+              fontWeight="fontWeightMedium"
+              color="text.primary"
+              noWrap
+            >
+              {label}
+            </Typography>
+            {evaluationResult && (
+              <Typography
+                typography="s2"
+                color={evaluationResult.passed ? "success.main" : "error.main"}
+                noWrap
+              >
+                {evaluationResult.passed ? "Pass" : "Fail"}
+                {evaluationScore !== null ? ` · ${evaluationScore}%` : ""}
+              </Typography>
+            )}
+          </Stack>
         </Stack>
       </Box>
 
@@ -151,6 +168,7 @@ ExecutionNode.propTypes = {
     selected: PropTypes.bool,
     nodeExecution: PropTypes.shape({
       status: PropTypes.string,
+      evaluation_result: PropTypes.object,
     }),
     ports: PropTypes.array,
   }).isRequired,

--- a/frontend/src/components/AgentGraph/layoutUtils.js
+++ b/frontend/src/components/AgentGraph/layoutUtils.js
@@ -26,6 +26,14 @@ const API_TYPE_MAP = {
   subgraph: "agent",
 };
 
+function getFrontendNodeType(node) {
+  const templateName = node.nodeTemplateName || node.node_template_name;
+  if (node.type === "atomic" && templateName === "evaluation") {
+    return "evaluation";
+  }
+  return API_TYPE_MAP[node.type] || "llm_prompt";
+}
+
 const GREEN_COLOR = "var(--green-500, #22c55e)";
 
 const defaultEdgeStyle = {
@@ -177,8 +185,9 @@ function layoutSubgraph(subGraphData, parentNodeId) {
         label: node.name,
         originalId: node.id,
         apiNodeType: node.type,
-        frontendNodeType: API_TYPE_MAP[node.type] || "llm_prompt",
+        frontendNodeType: getFrontendNodeType(node),
         nodeExecution: exec,
+        ports: node.ports || [],
         hasSubGraph: !!node.subGraph || !!node.sub_graph,
       },
     };
@@ -291,7 +300,7 @@ function assembleRFGraph(executionData, g, allMainEdges, subgraphLayouts) {
         data: {
           label: node.name,
           apiNodeType: node.type,
-          frontendNodeType: API_TYPE_MAP[node.type] || "agent",
+          frontendNodeType: getFrontendNodeType(node),
           nodeExecution: exec,
         },
         style: { width: groupWidth, height: groupHeight },
@@ -307,8 +316,9 @@ function assembleRFGraph(executionData, g, allMainEdges, subgraphLayouts) {
         data: {
           label: node.name,
           apiNodeType: node.type,
-          frontendNodeType: API_TYPE_MAP[node.type] || "llm_prompt",
+          frontendNodeType: getFrontendNodeType(node),
           nodeExecution: exec,
+          ports: node.ports || [],
           hasSubGraph: false,
         },
       });

--- a/frontend/src/sections/agent-playground/AgentBuilder/AgentBuilder.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/AgentBuilder.jsx
@@ -305,6 +305,7 @@ export default function AgentBuilder() {
             {/* Run Agent Panel - Shows output after workflow run */}
             {hasNodes && showOutput && !isLoadingTemplate && (
               <RunAgentPanel
+                graphId={graphId}
                 panelHeight={outputPanelHeight}
                 onResize={setOutputPanelHeight}
                 onClose={handleCloseRunPanel}

--- a/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/GraphView.jsx
@@ -35,8 +35,8 @@ import logger from "src/utils/logger";
 
 const nodeTypes = {
   [NODE_TYPES.LLM_PROMPT]: PromptNode,
-  agent: AgentNode,
-  eval: EvalNode,
+  [NODE_TYPES.AGENT]: AgentNode,
+  [NODE_TYPES.EVAL]: EvalNode,
 };
 
 const edgeTypes = {

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeConfigurationForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/NodeConfigurationForm.jsx
@@ -5,7 +5,7 @@ import { NODE_TYPES } from "../../utils/constants";
 
 const FORM_COMPONENTS = {
   [NODE_TYPES.LLM_PROMPT]: PromptNodeForm,
-  eval: EvalsNodeForm,
+  [NODE_TYPES.EVAL]: EvalsNodeForm,
   [NODE_TYPES.AGENT]: AgentNodeForm,
 };
 
@@ -20,7 +20,10 @@ export default function NodeConfigurationForm({ nodeType, nodeId }) {
 }
 
 NodeConfigurationForm.propTypes = {
-  nodeType: PropTypes.oneOf([NODE_TYPES.LLM_PROMPT, "eval", NODE_TYPES.AGENT])
-    .isRequired,
+  nodeType: PropTypes.oneOf([
+    NODE_TYPES.LLM_PROMPT,
+    NODE_TYPES.EVAL,
+    NODE_TYPES.AGENT,
+  ]).isRequired,
   nodeId: PropTypes.string.isRequired,
 };

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/EvalsNodeForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/EvalsNodeForm.jsx
@@ -48,17 +48,6 @@ export default function EvalsNodeForm({ nodeId }) {
     return node?.data?.evaluators || [];
   }, [getNodeById, nodeId]);
 
-  // Update evaluators in node data
-  const setEvaluators = useCallback(
-    (updater) => {
-      const currentEvaluators = getCurrentEvaluators();
-      const newEvaluators =
-        typeof updater === "function" ? updater(currentEvaluators) : updater;
-      updateNodeData(nodeId, { evaluators: newEvaluators });
-    },
-    [getCurrentEvaluators, updateNodeData, nodeId],
-  );
-
   const persistEvalNode = useCallback(
     async (evaluators, formValues = getValues()) => {
       const node = getNodeById(nodeId);
@@ -119,7 +108,6 @@ export default function EvalsNodeForm({ nodeId }) {
         }));
 
       nextEvaluators = [...currentEvaluators, ...cleanedNew];
-      setEvaluators(nextEvaluators);
     } else {
       nextEvaluators = (() => {
         let updated = [...currentEvaluators];
@@ -147,7 +135,6 @@ export default function EvalsNodeForm({ nodeId }) {
         delete finalEvaluation?.previousId;
         return [...updated, finalEvaluation];
       })();
-      setEvaluators(nextEvaluators);
     }
     await persistEvalNode(nextEvaluators);
     setOpenEvaluationDialog(false);
@@ -173,7 +160,6 @@ export default function EvalsNodeForm({ nodeId }) {
       const targetId = getEvaluatorId(item);
       return targetId !== evalId;
     });
-    setEvaluators(nextEvaluators);
     await persistEvalNode(nextEvaluators);
   };
 

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/EvalsNodeForm.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/EvalsNodeForm.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from "react";
 import PropTypes from "prop-types";
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { Box, Button, MenuItem, Stack, Typography } from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
 import { useFormContext } from "react-hook-form";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import SvgColor from "src/components/svg-color";
@@ -16,9 +17,17 @@ import { useSaveDraftContext } from "../../saveDraftContext";
 import { ShowComponent } from "src/components/show";
 import { useEvaluationContext } from "src/sections/common/EvaluationDrawer/context/EvaluationContext";
 import EvalListItem from "src/sections/agent-playground/components/EvalListItem";
+import usePartialNodeUpdate from "../../hooks/usePartialNodeUpdate";
+import { getEvaluatorId } from "../../../utils/evaluationUtils";
+
+const EVAL_INPUT_COLUMNS = [
+  { field: "input", headerName: "Input", dataType: "text" },
+  { field: "reference", headerName: "Reference", dataType: "text" },
+  { field: "context", headerName: "Context", dataType: "text" },
+];
 
 export default function EvalsNodeForm({ nodeId }) {
-  const { control } = useFormContext();
+  const { control, getValues, handleSubmit } = useFormContext();
   const [openEvaluationDialog, setOpenEvaluationDialog] = useState(false);
   const [selectedEvalItem, setSelectedEvalItem] = useState(null);
 
@@ -30,7 +39,8 @@ export default function EvalsNodeForm({ nodeId }) {
       updateNodeData: state.updateNodeData,
     }),
   );
-  const { saveDraft } = useSaveDraftContext();
+  const { ensureDraft } = useSaveDraftContext();
+  const { partialUpdate, isPending } = usePartialNodeUpdate();
 
   // Get current evaluators from node data
   const getCurrentEvaluators = useCallback(() => {
@@ -49,9 +59,49 @@ export default function EvalsNodeForm({ nodeId }) {
     [getCurrentEvaluators, updateNodeData, nodeId],
   );
 
+  const persistEvalNode = useCallback(
+    async (evaluators, formValues = getValues()) => {
+      const node = getNodeById(nodeId);
+      const nodeUpdate = {
+        label: formValues.name,
+        evaluators,
+        config: {
+          ...(node?.data?.config || {}),
+          evaluators,
+          threshold: formValues.threshold ?? 0.5,
+          failAction: formValues.failAction || "continue",
+          payload: { ports: node?.data?.ports || [] },
+        },
+      };
+      const prevData = node?.data;
+      updateNodeData(nodeId, nodeUpdate);
+      const draftResult = await ensureDraft({ skipDirtyCheck: true });
+      if (draftResult === false) {
+        if (prevData) updateNodeData(nodeId, prevData);
+        return;
+      }
+      if (draftResult !== "created") {
+        try {
+          await partialUpdate(nodeId, nodeUpdate);
+        } catch {
+          if (prevData) updateNodeData(nodeId, prevData);
+        }
+      }
+    },
+    [
+      ensureDraft,
+      getNodeById,
+      getValues,
+      nodeId,
+      partialUpdate,
+      updateNodeData,
+    ],
+  );
+
   const handleAddEvaluation = async (newEvaluation) => {
     const currentEvaluators = getCurrentEvaluators();
 
+    let nextEvaluators = currentEvaluators;
     if (newEvaluation?.isGroupEvals) {
       const data = await axios.get(
         `${endpoints.develop.eval.groupEvals}${newEvaluation?.templateId}/`,
@@ -68,19 +118,22 @@ export default function EvalsNodeForm({ nodeId }) {
           evalGroup: newEvaluation?.templateId,
         }));
 
-      setEvaluators((prev) => [...prev, ...cleanedNew]);
+      nextEvaluators = [...currentEvaluators, ...cleanedNew];
+      setEvaluators(nextEvaluators);
     } else {
-      setEvaluators((prev) => {
-        let updated = [...prev];
+      nextEvaluators = (() => {
+        let updated = [...currentEvaluators];
 
-        if (newEvaluation?.previousId) {
+        const previousId =
+          newEvaluation?.previousId || newEvaluation?.previous_id;
+        if (previousId) {
           updated = updated.filter(
-            (item) => item.eval_id !== newEvaluation.previous_id,
+            (item) => getEvaluatorId(item) !== previousId,
           );
         }
         if (newEvaluation?.removableId) {
           updated = updated.filter(
-            (item) => item.id !== newEvaluation.removableId,
+            (item) => getEvaluatorId(item) !== newEvaluation.removableId,
           );
         }
 
@@ -93,13 +146,18 @@ export default function EvalsNodeForm({ nodeId }) {
         const finalEvaluation = { ...newEvaluation, name: versionedName };
         delete finalEvaluation?.previousId;
         return [...updated, finalEvaluation];
-      });
+      })();
+      setEvaluators(nextEvaluators);
     }
-    saveDraft();
+    await persistEvalNode(nextEvaluators);
     setOpenEvaluationDialog(false);
     resetEvalStore();
     setSelectedEvalItem(null);
   };
+
+  const onSubmit = handleSubmit((formData) =>
+    persistEvalNode(getCurrentEvaluators(), formData),
+  );
 
   // Handle edit evaluation
   const handleEditEvalItem = (evalConfig) => {
@@ -110,14 +168,13 @@ export default function EvalsNodeForm({ nodeId }) {
   };
 
   // Handle delete evaluation
-  const handleRemoveEvaluation = (evalId) => {
-    setEvaluators((prev) =>
-      prev.filter((item) => {
-        const targetId = item.eval_id;
-        return targetId !== evalId;
-      }),
-    );
-    saveDraft();
+  const handleRemoveEvaluation = async (evalId) => {
+    const nextEvaluators = getCurrentEvaluators().filter((item) => {
+      const targetId = getEvaluatorId(item);
+      return targetId !== evalId;
+    });
+    setEvaluators(nextEvaluators);
+    await persistEvalNode(nextEvaluators);
   };
 
   return (
@@ -131,6 +188,29 @@ export default function EvalsNodeForm({ nodeId }) {
           label="Node Name"
           required
         />
+        <Stack direction="row" gap={1.5}>
+          <FormTextFieldV2
+            fullWidth
+            size="small"
+            control={control}
+            fieldName="threshold"
+            label="Threshold"
+            fieldType="number"
+            inputProps={{ min: 0, max: 1, step: 0.01 }}
+          />
+          <FormTextFieldV2
+            select
+            fullWidth
+            size="small"
+            control={control}
+            fieldName="failAction"
+            label="Fail Action"
+          >
+            <MenuItem value="continue">Continue</MenuItem>
+            <MenuItem value="stop">Stop</MenuItem>
+            <MenuItem value="route_fallback">Route fallback</MenuItem>
+          </FormTextFieldV2>
+        </Stack>
         <ShowComponent condition={getCurrentEvaluators().length > 0}>
           <Stack direction="column" gap={1.5}>
             <Typography
@@ -142,7 +222,7 @@ export default function EvalsNodeForm({ nodeId }) {
             </Typography>
             {getCurrentEvaluators().map((evalItem) => (
               <EvalListItem
-                key={evalItem.eval_id || evalItem.id}
+                key={getEvaluatorId(evalItem) || evalItem.name}
                 evalItem={evalItem}
                 onEdit={handleEditEvalItem}
                 onRemove={handleRemoveEvaluation}
@@ -176,6 +256,17 @@ export default function EvalsNodeForm({ nodeId }) {
             Add Eval
           </Button>
         </Box>
+        <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+          <LoadingButton
+            type="button"
+            size="small"
+            variant="outlined"
+            loading={isPending}
+            onClick={onSubmit}
+          >
+            Save
+          </LoadingButton>
+        </Box>
       </Stack>
 
       {/* Evaluation Selection Dialog */}
@@ -186,7 +277,7 @@ export default function EvalsNodeForm({ nodeId }) {
           resetEvalStore();
           setSelectedEvalItem(null);
         }}
-        scenarioColumnConfig={[]}
+        scenarioColumnConfig={EVAL_INPUT_COLUMNS}
         onAddEvaluation={handleAddEvaluation}
         selectedEvalItem={selectedEvalItem}
         datasetId={null} // Since we're not tied to a specific dataset

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/__tests__/nodeFormSchemas.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/__tests__/nodeFormSchemas.test.js
@@ -225,8 +225,8 @@ describe("getNodeFormSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("returns eval schema for eval type", () => {
-    const schema = getNodeFormSchema("eval");
+  it("returns eval schema for evaluation type", () => {
+    const schema = getNodeFormSchema(NODE_TYPES.EVAL);
     const result = schema.safeParse({ name: "eval_node" });
     expect(result.success).toBe(true);
   });

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/nodeFormSchemas.js
@@ -131,7 +131,7 @@ export const agentNodeFormSchema = z.object({
  * Schema for Eval Node Form
  */
 export const evalNodeFormSchema = z.object({
-  nodeType: z.literal("eval").optional(),
+  nodeType: z.literal(NODE_TYPES.EVAL).optional(),
   nodeId: z.string().optional(),
   name: z
     .string()
@@ -142,6 +142,11 @@ export const evalNodeFormSchema = z.object({
     )
     .trim(),
   evaluators: z.array(z.any()).optional(),
+  threshold: z.number().min(0).max(1).optional().default(0.5),
+  failAction: z
+    .enum(["continue", "stop", "route_fallback"])
+    .optional()
+    .default("continue"),
 });
 
 /**
@@ -155,7 +160,7 @@ export function getNodeFormSchema(nodeType) {
       return getPromptNodeFormSchema();
     case NODE_TYPES.AGENT:
       return agentNodeFormSchema;
-    case "eval":
+    case NODE_TYPES.EVAL:
       return evalNodeFormSchema;
     default:
       // Return a basic schema for unknown types

--- a/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/nodeFormUtils.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/NodeDrawer/nodeFormUtils.js
@@ -156,10 +156,12 @@ export function getDefaultValues(nodeData) {
     };
   }
 
-  if (nodeData?.type === "eval") {
+  if (nodeData?.type === NODE_TYPES.EVAL) {
     return {
       ...baseValues,
       evaluators: mergedConfig?.evaluators || [],
+      threshold: mergedConfig?.threshold ?? 0.5,
+      failAction: mergedConfig?.failAction || mergedConfig?.fail_action || "continue",
     };
   }
 
@@ -295,6 +297,24 @@ export function mapNodeDetailToNodeData(apiNode, existingNode) {
               ? apiNode.inputMappings
               : existingNode?.data?.config?.payload?.inputMappings || [],
           },
+        },
+      },
+    };
+  }
+
+  if (nodeType === NODE_TYPES.EVAL) {
+    return {
+      ...existingNode,
+      data: {
+        ...existingNode?.data,
+        label: apiNode.name || existingNode?.data?.label,
+        ports: apiNode.ports || existingNode?.data?.ports || [],
+        evaluators: apiNode.config?.evaluators || [],
+        config: {
+          ...existingNode?.data?.config,
+          ...apiNode.config,
+          threshold: apiNode.config?.threshold ?? 0.5,
+          failAction: apiNode.config?.failAction || apiNode.config?.fail_action || "continue",
         },
       },
     };

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/AgentEvaluationPanel.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/AgentEvaluationPanel.jsx
@@ -1,0 +1,228 @@
+import React, { useMemo, useState, useCallback, useEffect } from "react";
+import PropTypes from "prop-types";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Divider,
+  LinearProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
+import EvaluationSelectionDialog from "src/components/run-tests/EvaluationSelectionDialog";
+import { resetEvalStore } from "src/sections/evals/store/useEvalStore";
+import { useEvaluateExecution } from "src/api/agent-playground/agent-playground";
+import {
+  buildAgentEvaluationColumns,
+  getEvaluatorId,
+  hasEvaluatorMappings,
+} from "../../utils/evaluationUtils";
+
+const scoreLabel = (score) =>
+  typeof score === "number" ? `${Math.round(score * 100)}%` : "NA";
+
+const storageKey = (graphId) => `agent-playground:evaluations:${graphId}`;
+
+const loadSavedEvaluators = (graphId) => {
+  if (!graphId) return [];
+  try {
+    return JSON.parse(window.localStorage.getItem(storageKey(graphId)) || "[]");
+  } catch {
+    return [];
+  }
+};
+
+export default function AgentEvaluationPanel({
+  graphId,
+  executionId,
+  executionData,
+}) {
+  const [open, setOpen] = useState(false);
+  const [evaluators, setEvaluators] = useState(() =>
+    loadSavedEvaluators(graphId),
+  );
+  const [summary, setSummary] = useState(
+    executionData?.outputPayload?.agentEvaluations?.at?.(-1) ||
+      executionData?.output_payload?.agent_evaluations?.at?.(-1) ||
+      null,
+  );
+  const columns = useMemo(
+    () => buildAgentEvaluationColumns(executionData),
+    [executionData],
+  );
+  const { mutateAsync, isPending, error } = useEvaluateExecution();
+
+  useEffect(() => {
+    setSummary(
+      executionData?.outputPayload?.agentEvaluations?.at?.(-1) ||
+        executionData?.output_payload?.agent_evaluations?.at?.(-1) ||
+        null,
+    );
+  }, [executionData]);
+
+  useEffect(() => {
+    setEvaluators(loadSavedEvaluators(graphId));
+  }, [graphId]);
+
+  useEffect(() => {
+    if (!graphId) return;
+    window.localStorage.setItem(
+      storageKey(graphId),
+      JSON.stringify(evaluators),
+    );
+  }, [evaluators, graphId]);
+
+  const handleAddEvaluation = useCallback((nextEvaluation) => {
+    setEvaluators((current) => {
+      const previousId =
+        nextEvaluation?.previousId || nextEvaluation?.previous_id;
+      const next = previousId
+        ? current.filter((item) => getEvaluatorId(item) !== previousId)
+        : current;
+      return [...next, nextEvaluation];
+    });
+    setOpen(false);
+    resetEvalStore();
+  }, []);
+
+  const handleEvaluate = useCallback(async () => {
+    const payload = {
+      evaluators,
+      threshold: 0.5,
+    };
+    const response = await mutateAsync({ graphId, executionId, payload });
+    setSummary(response.data?.result || null);
+  }, [evaluators, executionId, graphId, mutateAsync]);
+
+  const canEvaluate =
+    !!graphId && !!executionId && hasEvaluatorMappings(evaluators);
+
+  return (
+    <Box sx={{ px: 2, pt: 2 }}>
+      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+        <Button
+          type="button"
+          size="small"
+          variant="outlined"
+          onClick={() => setOpen(true)}
+          disabled={!executionId || columns.length === 0}
+        >
+          Add Eval
+        </Button>
+        <LoadingButton
+          type="button"
+          size="small"
+          variant="contained"
+          loading={isPending}
+          disabled={!canEvaluate}
+          onClick={handleEvaluate}
+        >
+          Evaluate Agent
+        </LoadingButton>
+        {evaluators.map((item) => (
+          <Chip
+            key={getEvaluatorId(item) || item.name || item.templateName}
+            size="small"
+            label={item.name || item.templateName || "Evaluation"}
+            onDelete={() =>
+              setEvaluators((current) =>
+                current.filter(
+                  (entry) => getEvaluatorId(entry) !== getEvaluatorId(item),
+                ),
+              )
+            }
+          />
+        ))}
+      </Stack>
+      {isPending && <LinearProgress sx={{ mt: 1 }} />}
+      {error && (
+        <Alert severity="error" sx={{ mt: 1 }}>
+          {error?.response?.data?.result || "Failed to evaluate agent"}
+        </Alert>
+      )}
+      {summary && (
+        <Stack spacing={1} sx={{ mt: 1 }}>
+          <Stack
+            direction="row"
+            spacing={1}
+            alignItems="center"
+            flexWrap="wrap"
+          >
+            <Chip
+              size="small"
+              color={summary.passed ? "success" : "error"}
+              label={summary.passed ? "Pass" : "Fail"}
+            />
+            <Typography typography="s2" color="text.secondary">
+              Aggregate score {scoreLabel(summary.score)}
+            </Typography>
+            {summary.history?.length > 0 && (
+              <Typography typography="s2" color="text.secondary">
+                {summary.history.length} historical run
+                {summary.history.length === 1 ? "" : "s"}
+              </Typography>
+            )}
+          </Stack>
+          <Stack spacing={0.75}>
+            {(summary.results || []).map((result) => (
+              <Stack
+                key={result.template_id || result.name}
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                flexWrap="wrap"
+              >
+                <Chip
+                  size="small"
+                  color={result.passed ? "success" : "error"}
+                  label={result.passed ? "Pass" : "Fail"}
+                />
+                <Typography typography="s2" color="text.primary">
+                  {result.name || "Evaluation"}
+                </Typography>
+                <Typography typography="s2" color="text.secondary">
+                  {scoreLabel(result.score)}
+                </Typography>
+              </Stack>
+            ))}
+          </Stack>
+          {summary.history?.length > 1 && (
+            <>
+              <Divider />
+              <Stack direction="row" spacing={0.75} flexWrap="wrap">
+                {summary.history.map((item) => (
+                  <Chip
+                    key={item.execution_id || item.created_at}
+                    size="small"
+                    variant="outlined"
+                    color={item.passed ? "success" : "error"}
+                    label={scoreLabel(item.score)}
+                  />
+                ))}
+              </Stack>
+            </>
+          )}
+        </Stack>
+      )}
+      <EvaluationSelectionDialog
+        open={open}
+        onClose={() => {
+          setOpen(false);
+          resetEvalStore();
+        }}
+        scenarioColumnConfig={columns}
+        onAddEvaluation={handleAddEvaluation}
+        datasetId={null}
+        module="agent-playground"
+      />
+    </Box>
+  );
+}
+
+AgentEvaluationPanel.propTypes = {
+  graphId: PropTypes.string,
+  executionId: PropTypes.string,
+  executionData: PropTypes.object,
+};

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/AgentEvaluationPanel.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/AgentEvaluationPanel.jsx
@@ -92,8 +92,12 @@ export default function AgentEvaluationPanel({
       evaluators,
       threshold: 0.5,
     };
-    const response = await mutateAsync({ graphId, executionId, payload });
-    setSummary(response.data?.result || null);
+    try {
+      const response = await mutateAsync({ graphId, executionId, payload });
+      setSummary(response.data?.result || null);
+    } catch {
+      setSummary(null);
+    }
   }, [evaluators, executionId, graphId, mutateAsync]);
 
   const canEvaluate =

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/RunAgentPanel.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/RunAgentPanel.jsx
@@ -8,11 +8,13 @@ import { useWorkflowRunStoreShallow } from "../../store";
 import NodeOutputDetail from "./NodeOutputDetail";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import PanelErrorBoundary from "../../components/PanelErrorBoundary";
+import AgentEvaluationPanel from "./AgentEvaluationPanel";
 
 const MIN_PANEL_HEIGHT = 200;
 const MAX_PANEL_HEIGHT = 600;
 
 export default function RunAgentPanel({
+  graphId,
   panelHeight,
   onResize,
   executionId,
@@ -163,10 +165,19 @@ export default function RunAgentPanel({
             name="NodeOutputDetail"
             onRetry={() => setSelectedNodeId(null)}
           >
-            <NodeOutputDetail
-              executionId={resolvedExecutionId}
-              nodeExecutionId={selectedNodeExecutionId}
-            />
+            <Box
+              sx={{ height: "100%", display: "flex", flexDirection: "column" }}
+            >
+              <AgentEvaluationPanel
+                graphId={graphId}
+                executionId={executionId}
+                executionData={executionData}
+              />
+              <NodeOutputDetail
+                executionId={resolvedExecutionId}
+                nodeExecutionId={selectedNodeExecutionId}
+              />
+            </Box>
           </PanelErrorBoundary>
         }
       />
@@ -175,6 +186,7 @@ export default function RunAgentPanel({
 }
 
 RunAgentPanel.propTypes = {
+  graphId: PropTypes.string,
   panelHeight: PropTypes.number.isRequired,
   onResize: PropTypes.func.isRequired,
   executionId: PropTypes.string,

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/AgentEvaluationPanel.test.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/AgentEvaluationPanel.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildAgentEvaluationColumns,
+  getEvaluatorId,
+  hasEvaluatorMappings,
+} from "../../../utils/evaluationUtils";
+
+describe("buildAgentEvaluationColumns", () => {
+  it("exposes every graph node output as a mapping target", () => {
+    const columns = buildAgentEvaluationColumns({
+      nodes: [
+        {
+          id: "node-1",
+          name: "Retriever",
+          ports: [
+            { key: "query", direction: "input" },
+            { key: "docs", displayName: "docs", direction: "output" },
+          ],
+        },
+        {
+          id: "node-2",
+          name: "Answer",
+          ports: [
+            { key: "response", display_name: "response", direction: "output" },
+          ],
+        },
+      ],
+    });
+
+    expect(columns).toEqual([
+      {
+        field: "node-1.docs",
+        headerName: "Retriever.docs",
+        dataType: "text",
+      },
+      {
+        field: "node-2.response",
+        headerName: "Answer.response",
+        dataType: "text",
+      },
+    ]);
+  });
+
+  it("requires mappings on every selected evaluator before running", () => {
+    expect(
+      hasEvaluatorMappings([
+        { mapping: { output: "node-1.docs" } },
+        { config: { mapping: { output: "node-2.response" } } },
+      ]),
+    ).toBe(true);
+
+    expect(
+      hasEvaluatorMappings([
+        { mapping: { output: "node-1.docs" } },
+        { config: {} },
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("getEvaluatorId", () => {
+  it("normalizes evaluator identifiers from dialog, persisted, and API shapes", () => {
+    expect(getEvaluatorId({ evalId: "runtime-id" })).toBe("runtime-id");
+    expect(getEvaluatorId({ eval_id: "legacy-id" })).toBe("legacy-id");
+    expect(getEvaluatorId({ templateId: "dialog-template" })).toBe(
+      "dialog-template",
+    );
+    expect(getEvaluatorId({ template_id: "api-template" })).toBe(
+      "api-template",
+    );
+    expect(getEvaluatorId({ id: "fallback-id" })).toBe("fallback-id");
+  });
+});

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/common.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/common.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getNodeConfig } from "../common";
+import { NODE_TYPES } from "../../../utils/constants";
 
 describe("getNodeConfig", () => {
   it("returns prompt config for 'llm_prompt' type", () => {
@@ -14,9 +15,9 @@ describe("getNodeConfig", () => {
     expect(config.color).toBe("purple.500");
   });
 
-  it("returns eval config for 'eval' type", () => {
-    const config = getNodeConfig("eval");
-    expect(config.iconSrc).toContain("ic_rounded_square");
+  it("returns eval config for evaluation type", () => {
+    const config = getNodeConfig(NODE_TYPES.EVAL);
+    expect(config.iconSrc).toContain("ic_check");
     expect(config.color).toBe("green.600");
   });
 

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/common.js
@@ -5,12 +5,12 @@ const NODE_TYPE_CONFIG = {
     iconSrc: "/assets/icons/ic_chat_single.svg",
     color: "orange.500",
   },
-  agent: {
+  [NODE_TYPES.AGENT]: {
     iconSrc: "/assets/icons/navbar/ic_agents.svg",
     color: "purple.500",
   },
-  eval: {
-    iconSrc: "/assets/icons/ic_rounded_square.svg",
+  [NODE_TYPES.EVAL]: {
+    iconSrc: "/assets/icons/ic_check.svg",
     color: "green.600",
   },
   default: {

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/__tests__/usePartialNodeUpdate.test.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/__tests__/usePartialNodeUpdate.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildEvaluationPatchPayload } from "../usePartialNodeUpdate";
+
+describe("buildEvaluationPatchPayload", () => {
+  it("serializes evaluation config with backend field names and output ports", () => {
+    const patch = buildEvaluationPatchPayload({
+      label: "quality_gate",
+      evaluators: [{ templateId: "eval-template-1" }],
+      config: {
+        threshold: 0.75,
+        failAction: "route_fallback",
+        payload: {
+          ports: [
+            { key: "input", direction: "input" },
+            { key: "evaluation_result", direction: "output" },
+            { key: "passthrough", direction: "output" },
+          ],
+        },
+      },
+    });
+
+    expect(patch).toEqual({
+      name: "quality_gate",
+      config: {
+        evaluators: [{ templateId: "eval-template-1" }],
+        threshold: 0.75,
+        fail_action: "route_fallback",
+      },
+      ports: [
+        { key: "evaluation_result", direction: "output" },
+        { key: "passthrough", direction: "output" },
+      ],
+    });
+  });
+});

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/useAddNodeOptimistic.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/useAddNodeOptimistic.js
@@ -108,6 +108,13 @@ export default function useAddNodeOptimistic() {
                   ],
             },
           }),
+          ...(payload.type === NODE_TYPES.EVAL && {
+            config: {
+              evaluators: config?.evaluators || [],
+              threshold: config?.threshold ?? 0.5,
+              fail_action: config?.failAction || config?.fail_action || "continue",
+            },
+          }),
         },
       })
         .then((apiResult) => {

--- a/frontend/src/sections/agent-playground/AgentBuilder/hooks/usePartialNodeUpdate.js
+++ b/frontend/src/sections/agent-playground/AgentBuilder/hooks/usePartialNodeUpdate.js
@@ -30,6 +30,27 @@ function buildAgentPatchPayload(updateData) {
   return patch;
 }
 
+export function buildEvaluationPatchPayload(updateData) {
+  const config = updateData.config || {};
+  const ports = (config.payload?.ports || updateData.ports || []).filter(
+    (port) => port.direction === PORT_DIRECTION.OUTPUT,
+  );
+  const patch = {
+    config: {
+      evaluators: config.evaluators || updateData.evaluators || [],
+      threshold: config.threshold ?? updateData.threshold ?? 0.5,
+      fail_action:
+        config.fail_action ||
+        config.failAction ||
+        updateData.failAction ||
+        "continue",
+    },
+  };
+  if (updateData.label) patch.name = updateData.label;
+  if (ports.length > 0) patch.ports = ports;
+  return patch;
+}
+
 /**
  * Wraps the partial update API.
  * Transforms store-shaped nodeUpdate into contract-shaped PATCH payload
@@ -48,7 +69,9 @@ export default function usePartialNodeUpdate() {
       const apiPayload =
         node?.type === NODE_TYPES.LLM_PROMPT
           ? buildPatchPayload(updateData, config)
-          : buildAgentPatchPayload(updateData);
+          : node?.type === NODE_TYPES.EVAL
+            ? buildEvaluationPatchPayload(updateData)
+            : buildAgentPatchPayload(updateData);
 
       return mutateAsync({ graphId, versionId, nodeId, data: apiPayload });
     },

--- a/frontend/src/sections/agent-playground/components/EvalListItem.jsx
+++ b/frontend/src/sections/agent-playground/components/EvalListItem.jsx
@@ -12,6 +12,7 @@ import {
 import SvgColor from "src/components/svg-color";
 import { ShowComponent } from "src/components/show";
 import { format } from "date-fns";
+import { getEvaluatorId } from "../utils/evaluationUtils";
 
 export default function EvalListItem({ evalItem, onEdit, onRemove }) {
   const theme = useTheme();
@@ -141,7 +142,7 @@ export default function EvalListItem({ evalItem, onEdit, onRemove }) {
         </IconButton>
         <IconButton
           size="small"
-          onClick={() => onRemove(evalItem.eval_id || evalItem.id)}
+          onClick={() => onRemove(getEvaluatorId(evalItem))}
           sx={{
             ml: 1,
             border: "1px solid",
@@ -167,6 +168,9 @@ EvalListItem.propTypes = {
   evalItem: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     evalId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    eval_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    templateId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    template_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     name: PropTypes.string,
     groupName: PropTypes.string,
     evalRequiredKeys: PropTypes.oneOfType([

--- a/frontend/src/sections/agent-playground/components/PreviewGraphInner.jsx
+++ b/frontend/src/sections/agent-playground/components/PreviewGraphInner.jsx
@@ -17,8 +17,8 @@ import { NODE_TYPES } from "../utils/constants";
 // Reuse existing node types
 const nodeTypes = {
   [NODE_TYPES.LLM_PROMPT]: PromptNode,
-  agent: AgentNode,
-  eval: EvalNode,
+  [NODE_TYPES.AGENT]: AgentNode,
+  [NODE_TYPES.EVAL]: EvalNode,
 };
 
 // Wrapper component for preview container styling

--- a/frontend/src/sections/agent-playground/store/agent-playground-store.js
+++ b/frontend/src/sections/agent-playground/store/agent-playground-store.js
@@ -341,6 +341,12 @@ export const useAgentPlaygroundStore = create(
                 prompt_template_id: config?.prompt_template_id ?? null,
                 prompt_version_id: null,
               }
+            : type === NODE_TYPES.EVAL
+              ? {
+                  evaluators: config?.evaluators || [],
+                  threshold: config?.threshold ?? 0.5,
+                  failAction: config?.failAction || "continue",
+                }
             : {};
 
         // Caller-provided config is transient — only for form population, not persisted
@@ -348,8 +354,60 @@ export const useAgentPlaygroundStore = create(
           config && Object.keys(config).length > 0 ? config : null;
 
         const isAgent = type === NODE_TYPES.AGENT;
+        const isEvaluation = type === NODE_TYPES.EVAL;
         const ports = isAgent
           ? undefined
+          : isEvaluation
+            ? [
+                {
+                  id: crypto.randomUUID(),
+                  key: PORT_KEYS.INPUT,
+                  display_name: "input",
+                  direction: PORT_DIRECTION.INPUT,
+                  data_schema: {},
+                  required: true,
+                },
+                {
+                  id: crypto.randomUUID(),
+                  key: "reference",
+                  display_name: "reference",
+                  direction: PORT_DIRECTION.INPUT,
+                  data_schema: {},
+                  required: false,
+                },
+                {
+                  id: crypto.randomUUID(),
+                  key: "context",
+                  display_name: "context",
+                  direction: PORT_DIRECTION.INPUT,
+                  data_schema: {},
+                  required: false,
+                },
+                {
+                  id: crypto.randomUUID(),
+                  key: "evaluation_result",
+                  display_name: "evaluation_result",
+                  direction: PORT_DIRECTION.OUTPUT,
+                  data_schema: { type: "object" },
+                  required: true,
+                },
+                {
+                  id: crypto.randomUUID(),
+                  key: "passthrough",
+                  display_name: generateOutputLabel(nodes),
+                  direction: PORT_DIRECTION.OUTPUT,
+                  data_schema: {},
+                  required: false,
+                },
+                {
+                  id: crypto.randomUUID(),
+                  key: "fallback",
+                  display_name: "fallback",
+                  direction: PORT_DIRECTION.OUTPUT,
+                  data_schema: {},
+                  required: false,
+                },
+              ]
           : [
               {
                 id: crypto.randomUUID(),

--- a/frontend/src/sections/agent-playground/utils/__tests__/fixtures.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/fixtures.js
@@ -107,6 +107,44 @@ export function createAgentNode(id, overrides = {}) {
   };
 }
 
+export function createEvalNode(id, overrides = {}) {
+  const ports = overrides.ports || [
+    {
+      temp_id: `${id}-in`,
+      key: "input",
+      display_name: "input",
+      direction: "input",
+      data_schema: {},
+      required: true,
+    },
+    {
+      temp_id: `${id}-out`,
+      key: "evaluation_result",
+      display_name: "evaluation_result",
+      direction: "output",
+      data_schema: { type: "object" },
+      required: true,
+    },
+  ];
+
+  return {
+    id,
+    type: NODE_TYPES.EVAL,
+    position: { x: 0, y: 0 },
+    data: {
+      label: overrides.label || `Evaluation ${id}`,
+      node_template_id: overrides.node_template_id || "tpl-eval",
+      ports,
+      evaluators: overrides.evaluators || [{ templateId: "eval-template-1" }],
+      config: {
+        evaluators: overrides.evaluators || [{ templateId: "eval-template-1" }],
+        threshold: overrides.threshold ?? 0.8,
+        failAction: overrides.failAction || "route_fallback",
+      },
+    },
+  };
+}
+
 /** Node with empty/no config — will fail validation */
 export function createUnconfiguredNode(id) {
   return {

--- a/frontend/src/sections/agent-playground/utils/__tests__/versionPayloadUtils.test.js
+++ b/frontend/src/sections/agent-playground/utils/__tests__/versionPayloadUtils.test.js
@@ -3,7 +3,12 @@ import {
   buildVersionPayload,
   parseVersionResponse,
 } from "../versionPayloadUtils";
-import { createPromptNode, createAgentNode, createEdge } from "./fixtures";
+import {
+  createPromptNode,
+  createAgentNode,
+  createEvalNode,
+  createEdge,
+} from "./fixtures";
 import { API_NODE_TYPES, VERSION_STATUS } from "../constants";
 
 // ---------------------------------------------------------------------------
@@ -22,6 +27,23 @@ describe("buildVersionPayload", () => {
     const result = buildVersionPayload(nodes, []);
     expect(result.nodes[0].type).toBe(API_NODE_TYPES.SUBGRAPH);
     expect(result.nodes[0].ref_graph_version_id).toBe("v-42");
+  });
+
+  it("maps evaluation nodes to atomic nodes with executable config and ports", () => {
+    const nodes = [createEvalNode("e1")];
+    const result = buildVersionPayload(nodes, []);
+    expect(result.nodes[0].type).toBe(API_NODE_TYPES.ATOMIC);
+    expect(result.nodes[0].node_template_id).toBe("tpl-eval");
+    expect(result.nodes[0].config).toEqual({
+      evaluators: [{ templateId: "eval-template-1" }],
+      threshold: 0.8,
+      fail_action: "route_fallback",
+    });
+    expect(result.nodes[0].ports.map((port) => port.key)).toEqual([
+      "input",
+      "evaluation_result",
+    ]);
+    expect(result.nodes[0]).not.toHaveProperty("prompt_template");
   });
 
   it("uses default DRAFT status", () => {
@@ -158,6 +180,33 @@ describe("parseVersionResponse", () => {
     expect(result.nodes[0].type).toBe("llm_prompt");
     expect(result.nodes[0].data.label).toBe("My Prompt");
     expect(result.nodes[0].position).toEqual({ x: 100, y: 200 });
+  });
+
+  it("maps evaluation template atomic nodes to evaluation frontend nodes", () => {
+    const apiData = {
+      nodes: [
+        {
+          id: "e1",
+          type: "atomic",
+          name: "quality_gate",
+          nodeTemplateId: "tpl-eval",
+          nodeTemplateName: "evaluation",
+          config: {
+            evaluators: [{ templateId: "eval-template-1" }],
+            threshold: 0.9,
+            fail_action: "stop",
+          },
+          ports: [],
+        },
+      ],
+      nodeConnections: [],
+    };
+    const result = parseVersionResponse(apiData);
+    expect(result.nodes[0].type).toBe("evaluation");
+    expect(result.nodes[0].data.config.threshold).toBe(0.9);
+    expect(result.nodes[0].data.evaluators).toEqual([
+      { templateId: "eval-template-1" },
+    ]);
   });
 
   it("maps subgraph API type to AGENT node type", () => {

--- a/frontend/src/sections/agent-playground/utils/constants.js
+++ b/frontend/src/sections/agent-playground/utils/constants.js
@@ -3,6 +3,7 @@ export const NODE_X_OFFSET = 450;
 
 export const NODE_TYPES = {
   LLM_PROMPT: "llm_prompt",
+  EVAL: "evaluation",
   AGENT: "agent",
 };
 
@@ -21,6 +22,13 @@ export const NODE_TYPE_CONFIG = {
     description: "Run a prompt against an LLM",
     iconSrc: "/assets/icons/ic_chat_single.svg",
     color: "orange.500",
+  },
+  [NODE_TYPES.EVAL]: {
+    id: NODE_TYPES.EVAL,
+    title: "Evaluation",
+    description: "Run evals against upstream data",
+    iconSrc: "/assets/icons/ic_check.svg",
+    color: "green.500",
   },
   [NODE_TYPES.AGENT]: AGENT_NODE,
 };

--- a/frontend/src/sections/agent-playground/utils/evaluationUtils.js
+++ b/frontend/src/sections/agent-playground/utils/evaluationUtils.js
@@ -1,0 +1,24 @@
+export const buildAgentEvaluationColumns = (executionData) =>
+  (executionData?.nodes || []).flatMap((node) =>
+    (node.ports || [])
+      .filter((port) => (port.direction || port.portDirection) === "output")
+      .map((port) => ({
+        field: `${node.id}.${port.key}`,
+        headerName: `${node.name}.${port.displayName || port.display_name || port.key}`,
+        dataType: "text",
+      })),
+  );
+
+export const getEvaluatorId = (item) =>
+  item?.evalId ||
+  item?.eval_id ||
+  item?.templateId ||
+  item?.template_id ||
+  item?.id;
+
+export const getEvaluatorMapping = (item) =>
+  item?.mapping || item?.config?.mapping || {};
+
+export const hasEvaluatorMappings = (evaluators) =>
+  evaluators.length > 0 &&
+  evaluators.every((item) => Object.keys(getEvaluatorMapping(item)).length > 0);

--- a/frontend/src/sections/agent-playground/utils/versionPayloadUtils.js
+++ b/frontend/src/sections/agent-playground/utils/versionPayloadUtils.js
@@ -64,6 +64,7 @@ function transformConfigFromApi(apiConfig) {
 export function buildVersionPayload(nodes = [], edges = [], options = {}) {
   const apiNodes = nodes.map((node) => {
     const isSubgraph = node.type === NODE_TYPES.AGENT;
+    const isEvaluation = node.type === NODE_TYPES.EVAL;
 
     const apiNode = {
       id: node.id,
@@ -96,18 +97,22 @@ export function buildVersionPayload(nodes = [], edges = [], options = {}) {
       }
     } else {
       apiNode.node_template_id = node.data?.node_template_id || null;
-      // Merge transient _initialConfig (imported prompt data) over saved config
-      // so the full prompt content is included in the API payload.
-      const effectiveConfig = node.data?._initialConfig
-        ? { ...node.data?.config, ...node.data._initialConfig }
-        : node.data?.config;
-      apiNode.prompt_template = buildPromptTemplateForApi(effectiveConfig);
+      if (isEvaluation) {
+        apiNode.config = buildEvaluationConfigForApi(node.data);
+      } else {
+        // Merge transient _initialConfig (imported prompt data) over saved config
+        // so the full prompt content is included in the API payload.
+        const effectiveConfig = node.data?._initialConfig
+          ? { ...node.data?.config, ...node.data._initialConfig }
+          : node.data?.config;
+        apiNode.prompt_template = buildPromptTemplateForApi(effectiveConfig);
+      }
 
-      const atomicOutputPorts = (node.data?.ports || []).filter(
-        (p) => p.direction === "output",
-      );
-      if (atomicOutputPorts.length > 0) {
-        apiNode.ports = atomicOutputPorts.map((port) => ({
+      const atomicPorts = isEvaluation
+        ? node.data?.ports || []
+        : (node.data?.ports || []).filter((p) => p.direction === "output");
+      if (atomicPorts.length > 0) {
+        apiNode.ports = atomicPorts.map((port) => ({
           id: port.id || port.temp_id,
           key: port.key,
           display_name: port.display_name,
@@ -132,6 +137,16 @@ export function buildVersionPayload(nodes = [], edges = [], options = {}) {
     ...(options.commitMessage && { commit_message: options.commitMessage }),
     nodes: apiNodes,
     node_connections: apiNodeConnections,
+  };
+}
+
+function buildEvaluationConfigForApi(nodeData = {}) {
+  const config = nodeData.config || {};
+  return {
+    evaluators: nodeData.evaluators || config.evaluators || [],
+    threshold: config.threshold ?? nodeData.threshold ?? 0.5,
+    fail_action:
+      config.fail_action || config.failAction || nodeData.failAction || "continue",
   };
 }
 
@@ -239,6 +254,7 @@ export function parseVersionResponse(apiData) {
   const xyNodes = apiData.nodes.map((node) => {
     const nodeType = mapApiTypeToNodeType(node);
     const isSubgraph = nodeType === NODE_TYPES.AGENT;
+    const isEvaluation = nodeType === NODE_TYPES.EVAL;
 
     // For atomic nodes, read LLM config from promptTemplate (not config)
     const formConfig =
@@ -288,23 +304,31 @@ export function parseVersionResponse(apiData) {
               node_template_id: node.nodeTemplateId || null,
               prompt_template_id: node.promptTemplate?.promptTemplateId || null,
               prompt_version_id: node.promptTemplate?.promptVersionId || null,
-              config: {
-                ...formConfig,
-                prompt_template_id:
-                  node.promptTemplate?.promptTemplateId || null,
-                prompt_version_id: node.promptTemplate?.promptVersionId || null,
-                payload: {
-                  ...formConfig?.payload,
-                  promptConfig: [
-                    {
-                      configuration: {
-                        ...(node.promptTemplate || {}),
-                        responseFormat: node.prompt_template?.response_format,
-                      },
+              config: isEvaluation
+                ? {
+                    ...(node.config || {}),
+                    failAction: node.config?.fail_action || node.config?.failAction,
+                  }
+                : {
+                    ...formConfig,
+                    prompt_template_id:
+                      node.promptTemplate?.promptTemplateId || null,
+                    prompt_version_id: node.promptTemplate?.promptVersionId || null,
+                    payload: {
+                      ...formConfig?.payload,
+                      promptConfig: [
+                        {
+                          configuration: {
+                            ...(node.promptTemplate || {}),
+                            responseFormat: node.prompt_template?.response_format,
+                          },
+                        },
+                      ],
                     },
-                  ],
-                },
-              },
+                  },
+              ...(isEvaluation && {
+                evaluators: node.config?.evaluators || [],
+              }),
             }),
       },
     };
@@ -332,6 +356,8 @@ export function parseVersionResponse(apiData) {
  */
 function mapApiTypeToNodeType(apiNode) {
   if (apiNode.type === API_NODE_TYPES.ATOMIC) {
+    const templateName = apiNode.nodeTemplateName || apiNode.node_template_name;
+    if (templateName === NODE_TYPES.EVAL) return NODE_TYPES.EVAL;
     return NODE_TYPES.LLM_PROMPT;
   }
   if (apiNode.type === API_NODE_TYPES.SUBGRAPH) {

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -46,7 +46,13 @@ function snakeToCamelKey(key) {
 // phantom aliases like `numOfWords` for a template variable the user named
 // `num_of_words`. The outer field itself still gets a camelCase alias — only
 // the inner keys of that object are left alone (TH-4375).
-const USER_KEYED_MAP_FIELDS = new Set(["variable_names", "mapping", "placeholders", "params", "headers"]);
+const USER_KEYED_MAP_FIELDS = new Set([
+  "variable_names",
+  "mapping",
+  "placeholders",
+  "params",
+  "headers",
+]);
 
 // Build a camelCase→snake_case lookup table for each object we alias.
 function buildAliasTable(obj) {
@@ -1021,13 +1027,13 @@ export const endpoints = {
       getExperimentDerivedVariables: (expId) =>
         `/model-hub/experiments/v2/${expId}/derived-variables/`,
       feedback: {
-        getTemplate: ( experimentId) =>
+        getTemplate: (experimentId) =>
           `/model-hub/experiments/v2/${experimentId}/feedback/get-template/`,
-        create: ( experimentId) =>
+        create: (experimentId) =>
           `/model-hub/experiments/v2/${experimentId}/feedback/`,
-        getDetails: ( experimentId) =>
+        getDetails: (experimentId) =>
           `/model-hub/experiments/v2/${experimentId}/feedback/get-feedback-details/`,
-        submit: ( experimentId) =>
+        submit: (experimentId) =>
           `/model-hub/experiments/v2/${experimentId}/feedback/submit-feedback/`,
       },
     },
@@ -1418,7 +1424,8 @@ export const endpoints = {
     mcpTools: (id) => `/agentcc/gateways/${id}/mcp-tools/`,
     updateMcpServer: (id) => `/agentcc/gateways/${id}/update-mcp-server/`,
     removeMcpServer: (id) => `/agentcc/gateways/${id}/remove-mcp-server/`,
-    updateMcpGuardrails: (id) => `/agentcc/gateways/${id}/update-mcp-guardrails/`,
+    updateMcpGuardrails: (id) =>
+      `/agentcc/gateways/${id}/update-mcp-guardrails/`,
     testMcpTool: (id) => `/agentcc/gateways/${id}/test-mcp-tool/`,
     mcpResources: (id) => `/agentcc/gateways/${id}/mcp-resources/`,
     mcpPrompts: (id) => `/agentcc/gateways/${id}/mcp-prompts/`,
@@ -1559,6 +1566,8 @@ export const endpoints = {
       `/agent-playground/graphs/${graphId}/dataset/execute/`,
     executionDetail: (graphId, executionId) =>
       `/agent-playground/graphs/${graphId}/executions/${executionId}/`,
+    evaluateExecution: (graphId, executionId) =>
+      `/agent-playground/graphs/${graphId}/executions/${executionId}/evaluate/`,
     nodeExecutionDetail: (executionId, nodeExecutionId) =>
       `/agent-playground/executions/${executionId}/nodes/${nodeExecutionId}/`,
     graphExecutions: (graphId) =>

--- a/futureagi/agent_playground/serializers/node.py
+++ b/futureagi/agent_playground/serializers/node.py
@@ -21,6 +21,9 @@ class NodeReadSerializer(serializers.ModelSerializer):
     node_template_id = serializers.UUIDField(
         source="node_template.id", read_only=True, allow_null=True
     )
+    node_template_name = serializers.CharField(
+        source="node_template.name", read_only=True, allow_null=True
+    )
     ref_graph_version_id = serializers.UUIDField(
         source="ref_graph_version.id", read_only=True, allow_null=True
     )
@@ -49,6 +52,7 @@ class NodeReadSerializer(serializers.ModelSerializer):
             "config",
             "position",
             "node_template_id",
+            "node_template_name",
             "ref_graph_version_id",
             "ref_graph_name",
             "ref_graph_id",
@@ -348,7 +352,10 @@ class PromptTemplateDataSerializer(serializers.Serializer):
         required=False, allow_null=True, allow_blank=True, default=None
     )
     template_format = serializers.CharField(
-        required=False, allow_null=True, allow_blank=True, default=None,
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        default=None,
         help_text="Template format: 'mustache' or 'jinja'",
     )
     save_prompt_version = serializers.BooleanField(required=False, default=False)
@@ -493,6 +500,7 @@ class CreateNodeSerializer(serializers.Serializer):
     ref_graph_version_id = serializers.UUIDField(
         required=False, allow_null=True, default=None
     )
+    config = serializers.JSONField(required=False, default=dict)
     position = serializers.JSONField(required=False, default=dict)
     source_node_id = serializers.UUIDField(
         required=False, allow_null=True, default=None
@@ -548,6 +556,7 @@ class UpdateNodeSerializer(serializers.Serializer):
 
     name = serializers.CharField(required=False, max_length=255)
     position = serializers.JSONField(required=False)
+    config = serializers.JSONField(required=False)
     prompt_template = PromptTemplateDataSerializer(required=False, allow_null=True)
     ref_graph_version_id = serializers.UUIDField(required=False, allow_null=True)
     input_mappings = InputMappingSerializer(

--- a/futureagi/agent_playground/services/engine/runners/__init__.py
+++ b/futureagi/agent_playground/services/engine/runners/__init__.py
@@ -5,6 +5,7 @@ This package contains implementations of BaseNodeRunner for different node templ
 Runners self-register on module import.
 
 Current runners:
+    - evaluation: Platform eval execution using the unified eval engine
     - llm_prompt: LLM completion using LiteLLM
 
 Adding a new runner:
@@ -16,4 +17,5 @@ Adding a new runner:
 
 # Import runner modules to trigger self-registration.
 # Add new runners here as they are created.
+import agent_playground.services.engine.runners.evaluation  # noqa: F401
 import agent_playground.services.engine.runners.llm_prompt  # noqa: F401

--- a/futureagi/agent_playground/services/engine/runners/evaluation.py
+++ b/futureagi/agent_playground/services/engine/runners/evaluation.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any
+
+from agent_playground.services.engine.node_runner import BaseNodeRunner, register_runner
+from agent_playground.services.evaluation import (
+    FAIL_CONTINUE,
+    FAIL_ROUTE_FALLBACK,
+    FAIL_STOP,
+    coerce_threshold,
+    run_evaluation_batch,
+)
+
+
+class EvaluationRunner(BaseNodeRunner):
+    """Execute platform eval templates as an Agent Playground node."""
+
+    def run(
+        self,
+        config: dict[str, Any],
+        inputs: dict[str, Any],
+        execution_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        evaluators = config.get("evaluators") or []
+        threshold = coerce_threshold(config.get("threshold", 0.5))
+        fail_action = config.get("fail_action", FAIL_CONTINUE)
+        if fail_action not in {FAIL_CONTINUE, FAIL_STOP, FAIL_ROUTE_FALLBACK}:
+            raise ValueError(f"Unsupported evaluation fail_action: {fail_action}")
+
+        summary = run_evaluation_batch(
+            evaluators=evaluators,
+            inputs=inputs,
+            execution_context=execution_context,
+            threshold=threshold,
+        )
+        summary["fail_action"] = fail_action
+
+        if not summary["passed"] and fail_action == FAIL_STOP:
+            raise ValueError(
+                "Evaluation failed: " f"score={summary['score']}, threshold={threshold}"
+            )
+
+        passthrough = inputs.get("input")
+        route_fallback = not summary["passed"] and fail_action == FAIL_ROUTE_FALLBACK
+        return {
+            "evaluation_result": summary,
+            "passthrough": None if route_fallback else passthrough,
+            "fallback": passthrough if route_fallback else None,
+        }
+
+
+register_runner("evaluation", EvaluationRunner())

--- a/futureagi/agent_playground/services/evaluation.py
+++ b/futureagi/agent_playground/services/evaluation.py
@@ -205,7 +205,12 @@ def _eval_mapping(spec: dict[str, Any]) -> dict[str, str]:
 
 
 def coerce_threshold(value: Any) -> float:
-    threshold = float(value)
+    if value is None:
+        raise ValueError("Evaluation threshold is required")
+    try:
+        threshold = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Evaluation threshold must be a number") from exc
     if threshold < 0 or threshold > 1:
         raise ValueError("Evaluation threshold must be between 0 and 1")
     return threshold

--- a/futureagi/agent_playground/services/evaluation.py
+++ b/futureagi/agent_playground/services/evaluation.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from statistics import mean
+from typing import Any
+
+from agent_playground.models.choices import PortDirection
+from agent_playground.models.execution_data import ExecutionData
+
+FAIL_CONTINUE = "continue"
+FAIL_STOP = "stop"
+FAIL_ROUTE_FALLBACK = "route_fallback"
+
+FIELD_ALIASES = {
+    "actual": "input",
+    "answer": "input",
+    "code": "input",
+    "expected": "reference",
+    "expected_response": "reference",
+    "output": "input",
+    "prompt": "input",
+    "query": "input",
+    "response": "input",
+    "text": "input",
+}
+_MISSING = object()
+
+
+def run_evaluation_batch(
+    evaluators: list[dict[str, Any]],
+    inputs: dict[str, Any],
+    execution_context: dict[str, Any],
+    threshold: float,
+) -> dict[str, Any]:
+    if not evaluators:
+        raise ValueError("At least one evaluator is required")
+
+    results = [
+        _run_evaluator(spec, inputs, execution_context, threshold)
+        for spec in evaluators
+    ]
+    return _summarize_results(results, threshold)
+
+
+def run_agent_evaluation_batch(
+    evaluators: list[dict[str, Any]],
+    graph_execution,
+    execution_context: dict[str, Any],
+    threshold: float,
+    fallback_mappings: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    if not evaluators:
+        raise ValueError("At least one evaluator is required")
+
+    output_payloads = _execution_output_payloads(graph_execution)
+    results = []
+    for spec in evaluators:
+        mappings = _eval_mapping(spec) or fallback_mappings or {}
+        inputs = _resolve_source_mappings(output_payloads, mappings)
+        results.append(_run_evaluator(spec, inputs, execution_context, threshold))
+
+    return _summarize_results(results, threshold)
+
+
+def _summarize_results(
+    results: list[dict[str, Any]],
+    threshold: float,
+) -> dict[str, Any]:
+    numeric_scores = [
+        result["score"]
+        for result in results
+        if isinstance(result["score"], int | float)
+    ]
+    aggregate_score = mean(numeric_scores) if numeric_scores else None
+    passed = all(result["passed"] for result in results) and (
+        aggregate_score is None or aggregate_score >= threshold
+    )
+    return {
+        "score": aggregate_score,
+        "passed": passed,
+        "threshold": threshold,
+        "results": results,
+    }
+
+
+def _resolve_source_mappings(
+    output_payloads: dict[str, Any],
+    mappings: dict[str, str],
+) -> dict[str, Any]:
+    if not mappings:
+        raise ValueError("Evaluation mappings are required")
+
+    resolved = {}
+    missing = []
+    for eval_key, source in mappings.items():
+        payload = output_payloads.get(source, _MISSING)
+        if payload is _MISSING:
+            missing.append(source)
+            continue
+        resolved[eval_key] = payload
+
+    if missing:
+        raise ValueError(
+            f"Missing execution outputs for mappings: {', '.join(missing)}"
+        )
+    return resolved
+
+
+def _execution_output_payloads(graph_execution) -> dict[str, Any]:
+    rows = (
+        ExecutionData.no_workspace_objects.filter(
+            node_execution__graph_execution=graph_execution,
+            port__direction=PortDirection.OUTPUT,
+        )
+        .select_related("node_execution__node", "port")
+        .order_by("node_execution__node_id", "port__key")
+    )
+    return {f"{row.node_execution.node_id}.{row.port.key}": row.payload for row in rows}
+
+
+def _run_evaluator(
+    spec: dict[str, Any],
+    inputs: dict[str, Any],
+    execution_context: dict[str, Any],
+    threshold: float,
+) -> dict[str, Any]:
+    template = _load_eval_template(spec)
+    resolved_inputs = _resolve_eval_inputs(template, spec, inputs)
+    runtime_config = dict(spec.get("config") or {})
+    runtime_config.pop("mapping", None)
+
+    from evaluations.engine.runner import EvalRequest, run_eval
+
+    result = run_eval(
+        EvalRequest(
+            eval_template=template,
+            inputs=resolved_inputs,
+            model=spec.get("model") or runtime_config.get("model"),
+            runtime_config=runtime_config or None,
+            organization_id=execution_context.get("organization_id"),
+            workspace_id=execution_context.get("workspace_id"),
+        )
+    )
+
+    score = score_value(result.value)
+    passed = result.failure is None and (
+        bool(result.value) if score is None else score >= threshold
+    )
+    return {
+        "template_id": str(template.id),
+        "name": spec.get("name") or template.name,
+        "value": result.value,
+        "score": score,
+        "passed": passed,
+        "threshold": threshold,
+        "reason": result.reason,
+        "failure": result.failure,
+        "output_type": result.output_type,
+        "duration": result.duration,
+        "model": result.model_used,
+    }
+
+
+def _load_eval_template(spec: dict[str, Any]):
+    template_id = (
+        spec.get("templateId")
+        or spec.get("template_id")
+        or spec.get("eval_template_id")
+        or spec.get("id")
+    )
+    if not template_id:
+        raise ValueError("Evaluator config missing templateId")
+
+    from model_hub.models.evals_metric import EvalTemplate
+
+    try:
+        return EvalTemplate.no_workspace_objects.get(id=template_id, deleted=False)
+    except EvalTemplate.DoesNotExist as exc:
+        raise ValueError(f"Evaluation template not found: {template_id}") from exc
+
+
+def _resolve_eval_inputs(
+    template,
+    spec: dict[str, Any],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    mapping = _eval_mapping(spec)
+    keys = (
+        list(template.config.get("required_keys") or [])
+        + list(template.config.get("optional_keys") or [])
+        + list(mapping.keys())
+    )
+    resolved: dict[str, Any] = {}
+    for key in dict.fromkeys(keys):
+        source = mapping.get(key) or FIELD_ALIASES.get(key) or key
+        value = inputs.get(source)
+        if value is None and source != key:
+            value = inputs.get(key)
+        if value is not None:
+            resolved[key] = value
+    return resolved
+
+
+def _eval_mapping(spec: dict[str, Any]) -> dict[str, str]:
+    return spec.get("mapping") or (spec.get("config") or {}).get("mapping") or {}
+
+
+def coerce_threshold(value: Any) -> float:
+    threshold = float(value)
+    if threshold < 0 or threshold > 1:
+        raise ValueError("Evaluation threshold must be between 0 and 1")
+    return threshold
+
+
+def score_value(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, int | float):
+        return float(value) / 100 if value > 1 and value <= 100 else float(value)
+    if isinstance(value, dict):
+        for key in ("score", "value"):
+            score = score_value(value.get(key))
+            if score is not None:
+                return score
+        if "passed" in value:
+            return score_value(value["passed"])
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"pass", "passed", "true", "yes"}:
+            return 1.0
+        if lowered in {"fail", "failed", "false", "no"}:
+            return 0.0
+        try:
+            return score_value(float(lowered))
+        except ValueError:
+            return None
+    return None

--- a/futureagi/agent_playground/services/node_crud.py
+++ b/futureagi/agent_playground/services/node_crud.py
@@ -174,6 +174,7 @@ def create_node(
     source_node_id = data.get("source_node_id")
     prompt_data = data.get("prompt_template")
     ports_data = data.get("ports", [])
+    config = data.get("config") or {}
 
     node_template = None
     ref_graph_version = None
@@ -193,7 +194,7 @@ def create_node(
         ref_graph_version=ref_graph_version,
         type=node_type,
         name=name,
-        config={},
+        config=config,
         position=position,
     )
     node.save(skip_validation=True)
@@ -277,6 +278,8 @@ def update_node(
         node.name = data["name"]
     if "position" in data:
         node.position = data["position"]
+    if "config" in data:
+        node.config = data["config"] or {}
 
     # Handle ref_graph_version_id update (subgraph nodes)
     if "ref_graph_version_id" in data:
@@ -422,7 +425,9 @@ def _resolve_or_create_pt_ptv(
 
     # Build variable_names dict from messages (model_hub convention)
     messages = prompt_data.get("messages", [])
-    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    _tf = prompt_data.get("template_format") or prompt_data.get(
+        "configuration", {}
+    ).get("template_format")
     var_names = _extract_variables(messages, template_format=_tf)
     var_names_dict = prompt_data.get("variable_names") or {v: [] for v in var_names}
     pv_metadata = prompt_data.get("metadata") or {}
@@ -618,7 +623,9 @@ def _reconcile_prompt_ports(node: Node, prompt_data: dict[str, Any]) -> None:
     """
     now = timezone.now()
     messages = prompt_data.get("messages", [])
-    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    _tf = prompt_data.get("template_format") or prompt_data.get(
+        "configuration", {}
+    ).get("template_format")
     new_vars = _extract_variables(messages, template_format=_tf)
 
     existing_input_ports = list(
@@ -675,7 +682,9 @@ def _reconcile_prompt_ports(node: Node, prompt_data: dict[str, Any]) -> None:
 def _create_ports_from_prompt(node: Node, prompt_data: dict[str, Any]) -> None:
     """Create ports for an LLM prompt node from its messages."""
     messages = prompt_data.get("messages", [])
-    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    _tf = prompt_data.get("template_format") or prompt_data.get(
+        "configuration", {}
+    ).get("template_format")
     variables = _extract_variables(messages, template_format=_tf)
 
     # Input ports for each variable
@@ -703,7 +712,9 @@ def _create_ports_from_prompt(node: Node, prompt_data: dict[str, Any]) -> None:
 def _create_input_ports_from_prompt(node: Node, prompt_data: dict[str, Any]) -> None:
     """Create input ports for an LLM prompt node from variables in messages."""
     messages = prompt_data.get("messages", [])
-    _tf = prompt_data.get("template_format") or prompt_data.get("configuration", {}).get("template_format")
+    _tf = prompt_data.get("template_format") or prompt_data.get(
+        "configuration", {}
+    ).get("template_format")
     variables = _extract_variables(messages, template_format=_tf)
 
     for var in variables:
@@ -1079,7 +1090,9 @@ def _replace_output_ports(node: Node, ports_data: list[dict]) -> None:
     _create_ports_from_fe_array(node, ports_data)
 
 
-def _extract_variables(messages: list[dict], template_format: str | None = None) -> list[str]:
+def _extract_variables(
+    messages: list[dict], template_format: str | None = None
+) -> list[str]:
     """Extract unique variable names from message contents, preserving order.
 
     When template_format is "jinja" or "jinja2", uses Jinja2 AST analysis to

--- a/futureagi/agent_playground/templates/_registry.py
+++ b/futureagi/agent_playground/templates/_registry.py
@@ -28,6 +28,7 @@ def register_template(definition: TemplateDefinition) -> None:
 def get_all_templates() -> dict[str, TemplateDefinition]:
     """Import all template modules and return a copy of the registry."""
     # Import template modules to trigger registration
+    import agent_playground.templates.evaluation  # noqa: F401
     import agent_playground.templates.llm_prompt  # noqa: F401
 
     return dict(_TEMPLATE_REGISTRY)

--- a/futureagi/agent_playground/templates/evaluation.py
+++ b/futureagi/agent_playground/templates/evaluation.py
@@ -1,0 +1,36 @@
+from agent_playground.templates._registry import TemplateDefinition, register_template
+
+EVALUATION_TEMPLATE: TemplateDefinition = {
+    "name": "evaluation",
+    "display_name": "Evaluation",
+    "description": "Run one or more eval templates against upstream node data.",
+    "icon": None,
+    "categories": ["eval", "quality", "guardrail"],
+    "input_definition": [
+        {"key": "input", "data_schema": {}},
+        {"key": "reference", "data_schema": {}},
+        {"key": "context", "data_schema": {}},
+    ],
+    "output_definition": [
+        {"key": "evaluation_result", "data_schema": {"type": "object"}},
+        {"key": "passthrough", "data_schema": {}},
+        {"key": "fallback", "data_schema": {}},
+    ],
+    "input_mode": "strict",
+    "output_mode": "strict",
+    "config_schema": {
+        "type": "object",
+        "properties": {
+            "evaluators": {"type": "array", "minItems": 1},
+            "threshold": {"type": "number", "minimum": 0, "maximum": 1},
+            "fail_action": {
+                "type": "string",
+                "enum": ["continue", "stop", "route_fallback"],
+            },
+        },
+        "required": ["evaluators"],
+        "additionalProperties": True,
+    },
+}
+
+register_template(EVALUATION_TEMPLATE)

--- a/futureagi/agent_playground/tests/services/test_evaluation_runner.py
+++ b/futureagi/agent_playground/tests/services/test_evaluation_runner.py
@@ -1,0 +1,187 @@
+"""Tests for the Agent Playground evaluation runner."""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from agent_playground.services import evaluation as evaluation_service
+from agent_playground.services.engine.runners import evaluation
+from evaluations.engine import runner as eval_runner
+
+
+@dataclass
+class FakeEvalResult:
+    value: object
+    data: dict | None = None
+    reason: str | None = None
+    failure: str | None = None
+    runtime: float | None = None
+    model_used: str | None = None
+    metrics: list | None = None
+    metadata: dict | None = None
+    output_type: str = "score"
+    duration: float | None = 0.01
+
+
+@pytest.mark.unit
+def test_evaluation_runner_returns_summary_and_passthrough(monkeypatch):
+    template = SimpleNamespace(
+        id="template-1",
+        name="accuracy",
+        config={"required_keys": ["output"], "optional_keys": ["context"]},
+    )
+    captured = {}
+
+    monkeypatch.setattr(
+        evaluation_service, "_load_eval_template", lambda spec: template
+    )
+
+    def fake_run_eval(request):
+        captured["inputs"] = request.inputs
+        captured["organization_id"] = request.organization_id
+        return FakeEvalResult(value=0.84, reason="good")
+
+    monkeypatch.setattr(eval_runner, "run_eval", fake_run_eval)
+
+    result = evaluation.EvaluationRunner().run(
+        {
+            "evaluators": [
+                {
+                    "templateId": "template-1",
+                    "name": "accuracy",
+                    "config": {"mapping": {"output": "input"}},
+                }
+            ],
+            "threshold": 0.8,
+            "fail_action": "continue",
+        },
+        {"input": "answer", "context": "source doc"},
+        {"organization_id": "org-1", "workspace_id": "ws-1"},
+    )
+
+    assert captured["inputs"] == {"output": "answer", "context": "source doc"}
+    assert captured["organization_id"] == "org-1"
+    assert result["evaluation_result"]["passed"] is True
+    assert result["evaluation_result"]["score"] == 0.84
+    assert result["passthrough"] == "answer"
+    assert result["fallback"] is None
+
+
+@pytest.mark.unit
+def test_evaluation_runner_routes_failed_result_to_fallback(monkeypatch):
+    template = SimpleNamespace(id="template-1", name="toxicity", config={})
+    monkeypatch.setattr(
+        evaluation_service, "_load_eval_template", lambda spec: template
+    )
+    monkeypatch.setattr(
+        eval_runner,
+        "run_eval",
+        lambda request: FakeEvalResult(value=False, reason="unsafe"),
+    )
+
+    result = evaluation.EvaluationRunner().run(
+        {
+            "evaluators": [{"templateId": "template-1"}],
+            "threshold": 0.5,
+            "fail_action": "route_fallback",
+        },
+        {"input": "candidate"},
+        {},
+    )
+
+    assert result["evaluation_result"]["passed"] is False
+    assert result["passthrough"] is None
+    assert result["fallback"] == "candidate"
+
+
+@pytest.mark.unit
+def test_evaluation_runner_stop_action_fails_node(monkeypatch):
+    template = SimpleNamespace(id="template-1", name="faithfulness", config={})
+    monkeypatch.setattr(
+        evaluation_service, "_load_eval_template", lambda spec: template
+    )
+    monkeypatch.setattr(
+        eval_runner,
+        "run_eval",
+        lambda request: FakeEvalResult(value=0.2, reason="mismatch"),
+    )
+
+    with pytest.raises(ValueError, match="Evaluation failed"):
+        evaluation.EvaluationRunner().run(
+            {
+                "evaluators": [{"templateId": "template-1"}],
+                "threshold": 0.5,
+                "fail_action": "stop",
+            },
+            {"input": "candidate"},
+            {},
+        )
+
+
+@pytest.mark.unit
+def test_agent_evaluation_batch_resolves_mappings_per_evaluator(monkeypatch):
+    observed_inputs = []
+
+    monkeypatch.setattr(
+        evaluation_service,
+        "_execution_output_payloads",
+        lambda graph_execution: {
+            "node-a.response": "retrieval-grounded answer",
+            "node-b.response": "final answer",
+        },
+    )
+
+    def fake_run_evaluator(spec, inputs, execution_context, threshold):
+        observed_inputs.append((spec["name"], inputs))
+        return {
+            "name": spec["name"],
+            "score": 0.9,
+            "passed": True,
+            "threshold": threshold,
+        }
+
+    monkeypatch.setattr(evaluation_service, "_run_evaluator", fake_run_evaluator)
+
+    result = evaluation_service.run_agent_evaluation_batch(
+        evaluators=[
+            {
+                "name": "faithfulness",
+                "mapping": {"output": "node-a.response"},
+            },
+            {
+                "name": "answer-quality",
+                "mapping": {"output": "node-b.response"},
+            },
+        ],
+        graph_execution=object(),
+        execution_context={},
+        threshold=0.5,
+    )
+
+    assert observed_inputs == [
+        ("faithfulness", {"output": "retrieval-grounded answer"}),
+        ("answer-quality", {"output": "final answer"}),
+    ]
+    assert result["passed"] is True
+    assert result["score"] == 0.9
+
+
+@pytest.mark.unit
+def test_missing_evaluation_template_raises_contract_error(monkeypatch):
+    class FakeEvalTemplate:
+        class DoesNotExist(Exception):
+            pass
+
+        class no_workspace_objects:
+            @staticmethod
+            def get(**kwargs):
+                raise FakeEvalTemplate.DoesNotExist
+
+    monkeypatch.setattr(
+        "model_hub.models.evals_metric.EvalTemplate",
+        FakeEvalTemplate,
+    )
+
+    with pytest.raises(ValueError, match="Evaluation template not found: missing"):
+        evaluation_service._load_eval_template({"templateId": "missing"})

--- a/futureagi/agent_playground/tests/templates/test_evaluation_template.py
+++ b/futureagi/agent_playground/tests/templates/test_evaluation_template.py
@@ -1,0 +1,84 @@
+"""Tests for the Evaluation node template definition."""
+
+import jsonschema
+import pytest
+from django.core.exceptions import ValidationError
+
+from agent_playground.models import Node, NodeTemplate
+from agent_playground.models.choices import NodeType, PortMode
+from agent_playground.templates import get_all_templates
+from agent_playground.templates.evaluation import EVALUATION_TEMPLATE
+
+
+@pytest.mark.unit
+class TestEvaluationDefinitionStructure:
+    def test_registered_in_registry(self):
+        templates = get_all_templates()
+        assert "evaluation" in templates
+        assert templates["evaluation"] is EVALUATION_TEMPLATE
+
+    def test_ports_are_strict_and_routeable(self):
+        assert EVALUATION_TEMPLATE["input_mode"] == "strict"
+        assert EVALUATION_TEMPLATE["output_mode"] == "strict"
+        assert [port["key"] for port in EVALUATION_TEMPLATE["input_definition"]] == [
+            "input",
+            "reference",
+            "context",
+        ]
+        assert [port["key"] for port in EVALUATION_TEMPLATE["output_definition"]] == [
+            "evaluation_result",
+            "passthrough",
+            "fallback",
+        ]
+
+    def test_config_schema_enforces_evaluators_and_fail_action(self):
+        schema = EVALUATION_TEMPLATE["config_schema"]
+        jsonschema.validate(
+            instance={"evaluators": [{"templateId": "tpl"}], "threshold": 0.7},
+            schema=schema,
+        )
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance={"threshold": 0.7}, schema=schema)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(
+                instance={"evaluators": [{}], "fail_action": "retry"},
+                schema=schema,
+            )
+
+
+@pytest.mark.unit
+class TestEvaluationTemplateDBIntegration:
+    def test_db_creation_and_clean(self, db):
+        template = NodeTemplate.no_workspace_objects.create(**EVALUATION_TEMPLATE)
+        template.clean()
+        assert template.name == "evaluation"
+        assert template.input_mode == PortMode.STRICT
+
+    def test_node_config_validates(self, db, graph_version):
+        template = NodeTemplate.no_workspace_objects.create(**EVALUATION_TEMPLATE)
+        node = Node.no_workspace_objects.create(
+            graph_version=graph_version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="evaluation_gate",
+            config={
+                "evaluators": [{"templateId": "tpl"}],
+                "threshold": 0.7,
+                "fail_action": "continue",
+            },
+            position={"x": 0, "y": 0},
+        )
+        node.clean()
+
+    def test_node_requires_evaluator_config(self, db, graph_version):
+        template = NodeTemplate.no_workspace_objects.create(**EVALUATION_TEMPLATE)
+        node = Node(
+            graph_version=graph_version,
+            node_template=template,
+            type=NodeType.ATOMIC,
+            name="evaluation_gate",
+            config={"threshold": 0.7},
+            position={"x": 0, "y": 0},
+        )
+        with pytest.raises(ValidationError):
+            node.clean()

--- a/futureagi/agent_playground/tests/templates/test_registry.py
+++ b/futureagi/agent_playground/tests/templates/test_registry.py
@@ -17,6 +17,7 @@ class TestGetAllTemplates:
     def test_returns_llm_prompt(self):
         templates = get_all_templates()
         assert "llm_prompt" in templates
+        assert "evaluation" in templates
 
     def test_returns_copy(self):
         """Modifying the returned dict does not affect the registry."""

--- a/futureagi/agent_playground/tests/views/test_graph_execution_views.py
+++ b/futureagi/agent_playground/tests/views/test_graph_execution_views.py
@@ -576,6 +576,33 @@ class TestGraphExecutionEvaluate:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "successful execution" in response.data["result"]
 
+    def test_returns_400_for_null_threshold(
+        self,
+        authenticated_client,
+        graph,
+        active_graph_version,
+    ):
+        execution = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+            status=GraphExecutionStatus.SUCCESS,
+        )
+        url = reverse(
+            "graph-execution-evaluate",
+            kwargs={"graph_id": graph.id, "execution_id": execution.id},
+        )
+        response = authenticated_client.post(
+            url,
+            {
+                "evaluators": [{"templateId": str(uuid.uuid4())}],
+                "threshold": None,
+                "mappings": {"output": f"{uuid.uuid4()}.answer"},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "threshold" in response.data["result"]
+
 
 # =============================================================================
 # Node execution detail

--- a/futureagi/agent_playground/tests/views/test_graph_execution_views.py
+++ b/futureagi/agent_playground/tests/views/test_graph_execution_views.py
@@ -420,6 +420,164 @@ class TestGraphExecutionRetrieve:
 
 
 # =============================================================================
+# Graph execution evaluation
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGraphExecutionEvaluate:
+    """Tests for POST /graphs/<graph_id>/executions/<execution_id>/evaluate/."""
+
+    def test_runs_agent_level_eval_against_mapped_node_outputs(
+        self,
+        authenticated_client,
+        graph,
+        active_graph_version,
+        node_template,
+        monkeypatch,
+    ):
+        node = Node.no_workspace_objects.create(
+            graph_version=active_graph_version,
+            node_template=node_template,
+            type=NodeType.ATOMIC,
+            name="Answer Node",
+            config={},
+            position={"x": 0, "y": 0},
+        )
+        output_port = Port.no_workspace_objects.create(
+            node=node,
+            key="output1",
+            display_name="answer",
+            direction=PortDirection.OUTPUT,
+            data_schema={"type": "string"},
+            required=True,
+        )
+        execution = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+            status=GraphExecutionStatus.SUCCESS,
+            output_payload={},
+        )
+        node_execution = NodeExecution.no_workspace_objects.create(
+            graph_execution=execution,
+            node=node,
+            status=NodeExecutionStatus.SUCCESS,
+        )
+        ExecutionData.no_workspace_objects.create(
+            node_execution=node_execution,
+            port=output_port,
+            payload="Paris",
+        )
+
+        observed = {}
+
+        def fake_run_agent_evaluation_batch(
+            evaluators,
+            graph_execution,
+            execution_context,
+            threshold,
+            fallback_mappings=None,
+        ):
+            observed.update(
+                {
+                    "evaluators": evaluators,
+                    "graph_execution": graph_execution,
+                    "threshold": threshold,
+                    "execution_context": execution_context,
+                    "fallback_mappings": fallback_mappings,
+                }
+            )
+            return {
+                "score": 0.91,
+                "passed": True,
+                "threshold": threshold,
+                "results": [{"name": "accuracy", "score": 0.91, "passed": True}],
+            }
+
+        monkeypatch.setattr(
+            "agent_playground.views.graph_execution.run_agent_evaluation_batch",
+            fake_run_agent_evaluation_batch,
+        )
+
+        url = reverse(
+            "graph-execution-evaluate",
+            kwargs={"graph_id": graph.id, "execution_id": execution.id},
+        )
+        response = authenticated_client.post(
+            url,
+            {
+                "evaluators": [{"templateId": str(uuid.uuid4()), "name": "accuracy"}],
+                "threshold": 0.8,
+                "mappings": {"output": f"{node.id}.output1"},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        result = response.data["result"]
+        assert result["score"] == 0.91
+        assert result["passed"] is True
+        assert result["history"][0]["score"] == 0.91
+        assert observed["graph_execution"] == execution
+        assert observed["fallback_mappings"] == {"output": f"{node.id}.output1"}
+        assert observed["threshold"] == 0.8
+
+        execution.refresh_from_db()
+        assert execution.output_payload["agent_evaluations"][0]["passed"] is True
+
+    def test_returns_400_for_missing_mapped_output(
+        self,
+        authenticated_client,
+        graph,
+        active_graph_version,
+    ):
+        execution = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+            status=GraphExecutionStatus.SUCCESS,
+        )
+        url = reverse(
+            "graph-execution-evaluate",
+            kwargs={"graph_id": graph.id, "execution_id": execution.id},
+        )
+        response = authenticated_client.post(
+            url,
+            {
+                "evaluators": [{"templateId": str(uuid.uuid4())}],
+                "mappings": {"output": f"{uuid.uuid4()}.answer"},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Missing execution outputs" in response.data["result"]
+
+    def test_returns_400_for_incomplete_execution(
+        self,
+        authenticated_client,
+        graph,
+        active_graph_version,
+    ):
+        execution = GraphExecution.no_workspace_objects.create(
+            graph_version=active_graph_version,
+            status=GraphExecutionStatus.RUNNING,
+        )
+        url = reverse(
+            "graph-execution-evaluate",
+            kwargs={"graph_id": graph.id, "execution_id": execution.id},
+        )
+        response = authenticated_client.post(
+            url,
+            {
+                "evaluators": [{"templateId": str(uuid.uuid4())}],
+                "mappings": {"output": f"{uuid.uuid4()}.answer"},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "successful execution" in response.data["result"]
+
+
+# =============================================================================
 # Node execution detail
 # =============================================================================
 

--- a/futureagi/agent_playground/urls.py
+++ b/futureagi/agent_playground/urls.py
@@ -48,6 +48,7 @@ dataset_execute = GraphDatasetViewSet.as_view({"post": "execute"})
 
 execution_list = GraphExecutionViewSet.as_view({"get": "list"})
 execution_detail = GraphExecutionViewSet.as_view({"get": "retrieve"})
+execution_evaluate = GraphExecutionViewSet.as_view({"post": "evaluate"})
 node_execution_detail = GraphExecutionViewSet.as_view({"get": "node_detail"})
 
 version_activate = GraphViewSet.as_view(
@@ -130,6 +131,11 @@ urlpatterns = [
         "graphs/<uuid:graph_id>/executions/<uuid:execution_id>/",
         execution_detail,
         name="graph-execution-detail",
+    ),
+    path(
+        "graphs/<uuid:graph_id>/executions/<uuid:execution_id>/evaluate/",
+        execution_evaluate,
+        name="graph-execution-evaluate",
     ),
     path(
         "executions/<uuid:execution_id>/nodes/<uuid:node_execution_id>/",

--- a/futureagi/agent_playground/views/graph_execution.py
+++ b/futureagi/agent_playground/views/graph_execution.py
@@ -2,7 +2,7 @@ import structlog
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
 
-from agent_playground.models.choices import NodeType
+from agent_playground.models.choices import GraphExecutionStatus, NodeType
 from agent_playground.models.execution_data import ExecutionData
 from agent_playground.models.graph_execution import GraphExecution
 from agent_playground.models.node_execution import NodeExecution
@@ -14,6 +14,10 @@ from agent_playground.serializers.graph_execution import (
 from agent_playground.serializers.graph_version import (
     GraphVersionDetailSerializer,
     prefetch_version_detail,
+)
+from agent_playground.services.evaluation import (
+    coerce_threshold,
+    run_agent_evaluation_batch,
 )
 from common.utils.pagination import paginate_queryset
 from tfc.utils.error_codes import get_error_message
@@ -101,6 +105,54 @@ class GraphExecutionViewSet(GenericViewSet):
                 get_error_message("FAILED_TO_GET_EXECUTION_DETAIL")
             )
 
+    def evaluate(self, request, graph_id=None, execution_id=None):
+        """Run one or more evals against outputs from a completed graph execution."""
+        try:
+            graph_execution = self.get_object()
+            if graph_execution.status != GraphExecutionStatus.SUCCESS:
+                raise ValueError("Agent evaluation requires a successful execution")
+
+            evaluators = request.data.get("evaluators") or []
+            mappings = request.data.get("mappings") or {}
+            threshold = coerce_threshold(request.data.get("threshold", 0.5))
+
+            summary = run_agent_evaluation_batch(
+                evaluators=evaluators,
+                graph_execution=graph_execution,
+                execution_context={
+                    "organization_id": getattr(self.request.organization, "id", None),
+                    "workspace_id": getattr(self.request.workspace, "id", None),
+                },
+                threshold=threshold,
+                fallback_mappings=mappings,
+            )
+            summary["mappings"] = mappings
+
+            output_payload = graph_execution.output_payload or {}
+            agent_evaluations = list(output_payload.get("agent_evaluations") or [])
+            agent_evaluations.append(summary)
+            graph_execution.output_payload = {
+                **output_payload,
+                "agent_evaluations": agent_evaluations[-20:],
+            }
+            graph_execution.save(update_fields=["output_payload", "updated_at"])
+
+            return self._gm.success_response(
+                {
+                    **summary,
+                    "history": self._agent_evaluation_history(graph_execution),
+                }
+            )
+        except GraphExecution.DoesNotExist:
+            return self._gm.not_found(get_error_message("GRAPH_EXECUTION_NOT_FOUND"))
+        except ValueError as e:
+            return self._gm.bad_request(str(e))
+        except Exception as e:
+            logger.exception("Error evaluating graph execution", error=str(e))
+            return self._gm.internal_server_error_response(
+                get_error_message("FAILED_TO_GET_EXECUTION_DETAIL")
+            )
+
     def _build_execution_detail(self, graph_execution):
         """Build hierarchical execution detail for a graph execution.
 
@@ -123,14 +175,27 @@ class GraphExecutionViewSet(GenericViewSet):
             .prefetch_related("child_graph_executions")
         )
         exec_map = {str(ne.node_id): ne for ne in node_executions}
+        eval_result_map = {
+            str(ed.node_execution_id): ed.payload
+            for ed in ExecutionData.no_workspace_objects.filter(
+                node_execution__in=node_executions,
+                port__key="evaluation_result",
+                port__direction="output",
+            ).select_related("port")
+        }
 
         for node_data in version_data.get("nodes", []):
             node_id = str(node_data["id"])
             node_exec = exec_map.get(node_id)
 
-            node_data["node_execution"] = (
+            node_execution_data = (
                 NodeExecutionBriefSerializer(node_exec).data if node_exec else None
             )
+            if node_execution_data and str(node_exec.id) in eval_result_map:
+                node_execution_data["evaluation_result"] = eval_result_map[
+                    str(node_exec.id)
+                ]
+            node_data["node_execution"] = node_execution_data
 
             # For subgraph nodes, recursively attach inner graph
             if node_data["type"] == NodeType.SUBGRAPH and node_exec:
@@ -144,6 +209,30 @@ class GraphExecutionViewSet(GenericViewSet):
         data["nodes"] = version_data.get("nodes", [])
         data["node_connections"] = version_data.get("node_connections", [])
         return data
+
+    def _agent_evaluation_history(self, graph_execution, limit=20):
+        executions = (
+            GraphExecution.no_workspace_objects.filter(
+                graph_version__graph=graph_execution.graph_version.graph,
+            )
+            .exclude(output_payload__isnull=True)
+            .order_by("-created_at")[:limit]
+        )
+        history = []
+        for execution in executions:
+            agent_evaluations = (execution.output_payload or {}).get(
+                "agent_evaluations"
+            ) or []
+            if not agent_evaluations:
+                continue
+            history.append(
+                {
+                    **agent_evaluations[-1],
+                    "execution_id": str(execution.id),
+                    "created_at": execution.created_at.isoformat(),
+                }
+            )
+        return list(reversed(history))
 
     def node_detail(self, request, execution_id=None, node_execution_id=None):
         """


### PR DESCRIPTION
## Summary

Adds first-class Agent Playground evaluations for both inline workflow gates and completed agent runs. This introduces an Evaluation node, persists its evaluator config and strict ports through graph versions, runs platform eval templates during graph execution, and adds an execution-results panel for mapping node outputs into one or more agent-level evaluations.

The implementation keeps evaluation ownership in the existing Agent Playground template/runner/version pipeline, so saved graphs, node PATCHes, execution data, and frontend optimistic state share the same config and port contract.

## Linked issues

Closes #30

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## What changed

- Added an `evaluation` Agent Playground template with strict `input`, `reference`, `context`, `evaluation_result`, `passthrough`, and `fallback` ports.
- Added an Evaluation node runner that executes platform eval templates, applies thresholds, supports `continue`, `stop`, and `route_fallback`, and preserves passthrough data for downstream nodes.
- Added completed-agent evaluation from execution results, including per-evaluator node-output mappings, multi-eval execution, aggregate pass/fail scoring, and saved recent evaluation history on the graph execution payload.
- Wired frontend creation, drawer configuration, save/load, partial PATCH, run-result display, and node score rendering for evaluation nodes.
- Reused the existing evaluation picker and API primitives instead of adding a parallel eval selection system.

## How was this tested?

- `python -m pytest agent_playground/tests/services/test_evaluation_runner.py agent_playground/tests/templates/test_evaluation_template.py agent_playground/tests/views/test_graph_execution_views.py -q --reuse-db` → `34 passed`
- `npm exec -- vitest run src/sections/agent-playground/utils/__tests__/versionPayloadUtils.test.js src/sections/agent-playground/AgentBuilder/RunAgentPanel/__tests__/AgentEvaluationPanel.test.jsx src/sections/agent-playground/AgentBuilder/hooks/__tests__/usePartialNodeUpdate.test.js src/sections/agent-playground/AgentBuilder/NodeDrawer/forms/__tests__/nodeFormSchemas.test.js` → `61 passed`
- `npx eslint` on the changed Agent Playground frontend files
- `uvx ruff check` on the changed backend evaluation files and tests
- `python -m compileall` on the changed backend evaluation files and tests
- `git diff --check`
- `vite.cmd build` on Windows; build completed with existing repo-wide warnings only

## Screenshots / recordings (if UI)

Not attached.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

Note: full repo check-all was not used directly on Windows because the repo test helper currently exports stale compose ports in this checkout. The PR-critical backend suite was run against the live Docker compose test services, and the frontend production build completed through the Windows-valid Vite entrypoint.