### PR TITLE
Fix/eval delete orphaned reason column

### DIFF
--- a/futureagi/ai_tools/tools/datasets/delete_dataset_eval.py
+++ b/futureagi/ai_tools/tools/datasets/delete_dataset_eval.py
@@ -60,68 +60,85 @@ class DeleteDatasetEvalTool(BaseTool):
         columns_deleted = 0
 
         if params.delete_column:
-            # Find and delete result column + reason columns
-            result_cols = Column.objects.filter(
-                dataset=dataset,
-                source_id=str(user_eval.id),
-                deleted=False,
-            )
+            # Stop any in-flight eval runner before deleting columns
+            from model_hub.models.choices import StatusType
 
-            for col in result_cols:
-                # Delete cells
-                cells_deleted += Cell.objects.filter(
-                    column=col, dataset=dataset, deleted=False
-                ).update(deleted=True)
+            if user_eval.status in (
+                StatusType.RUNNING.value,
+                StatusType.NOT_STARTED.value,
+                StatusType.EXPERIMENT_EVALUATION.value,
+            ):
+                try:
+                    from tfc.utils.distributed_state import evaluation_tracker
 
-                # Delete reason columns (source_id contains column ID)
-                reason_cols = Column.objects.filter(
+                    evaluation_tracker.request_cancel(
+                        user_eval.id, reason="eval_deleted"
+                    )
+                except Exception:
+                    pass
+                from model_hub.utils.eval_cell_status import mark_eval_cells_stopped
+
+                mark_eval_cells_stopped(
+                    user_eval, reason="Evaluation deleted by user"
+                )
+
+            # Find eval columns + all dependent reason columns
+            from django.db.models import Q
+
+            all_cols = list(
+                Column.objects.filter(
+                    Q(source_id=str(user_eval.id))
+                    | Q(source_id__endswith=f"-sourceid-{user_eval.id}"),
                     dataset=dataset,
-                    source_id__startswith=f"{col.id}-sourceid-",
                     deleted=False,
                 )
-                deleted_rcs = set()
-                for rc in reason_cols:
-                    cells_deleted += Cell.objects.filter(
-                        column=rc, dataset=dataset, deleted=False
-                    ).update(deleted=True)
-                    deleted_rcs.add(str(rc.id))
-                    rc.deleted = True
-                    rc.save(update_fields=["deleted"])
-                    columns_deleted += 1
+            )
+            col_ids = [c.id for c in all_cols]
+            col_id_strs = {str(c) for c in col_ids}
 
-                # Remove from column order
-                col_id_str = str(col.id)
-                if dataset.column_order and col_id_str in dataset.column_order:
-                    dataset.column_order = [
-                        c
-                        for c in dataset.column_order
-                        if c != col_id_str and c not in deleted_rcs
-                    ]
-                    dataset.save(update_fields=["column_order"])
+            if col_ids:
+                # Bulk delete cells
+                cells_deleted = Cell.objects.filter(
+                    column_id__in=col_ids, deleted=False
+                ).update(deleted=True)
 
-                # Remove from column config
-                dataset.column_config = {
+                # Update dependent metrics BEFORE deleting columns —
+                # get_metrics_using_column scopes by dataset via the
+                # Column row, which must still be visible (deleted=False).
+                eval_col_ids = [
+                    str(c.id) for c in all_cols
+                    if c.source_id == str(user_eval.id)
+                ]
+                for ecid in eval_col_ids:
+                    metrics = UserEvalMetric.get_metrics_using_column(
+                        str(dataset.organization.id), ecid,
+                    )
+                    if metrics:
+                        UserEvalMetric.objects.filter(
+                            id__in=[m.id for m in metrics]
+                        ).update(column_deleted=True)
+
+                # Now safe to delete columns
+                columns_deleted = Column.objects.filter(
+                    id__in=col_ids
+                ).update(deleted=True)
+
+                # Update column_order and column_config
+                new_order = [
+                    c for c in (dataset.column_order or [])
+                    if c not in col_id_strs
+                ]
+                new_config = {
                     k: v
-                    for k, v in dataset.column_config.items()
-                    if k not in deleted_rcs and k != col_id_str
+                    for k, v in (dataset.column_config or {}).items()
+                    if k not in col_id_strs
                 }
-                dataset.save(update_fields=["column_config"])
-
-                col.deleted = True
-                col.save(update_fields=["deleted"])
-                columns_deleted += 1
+                Dataset.objects.filter(id=dataset.id).update(
+                    column_order=new_order, column_config=new_config
+                )
 
             user_eval.deleted = True
             user_eval.save(update_fields=["deleted"])
-
-            # Update metrics for all affected columns
-            metrics = UserEvalMetric.get_metrics_using_column(
-                str(dataset.organization.id),
-                str(col.id),
-            )
-            for metric in metrics:
-                metric.column_deleted = True
-                metric.save()
         else:
             user_eval.show_in_sidebar = False
             user_eval.save(update_fields=["show_in_sidebar"])

--- a/futureagi/model_hub/services/dataset_service.py
+++ b/futureagi/model_hub/services/dataset_service.py
@@ -7,7 +7,7 @@ from typing import Optional
 import structlog
 from django.db.models import Q
 
-from model_hub.models.choices import SourceChoices
+from model_hub.models.choices import SourceChoices, StatusType
 from model_hub.models.develop_annotations import Annotations, AnnotationsLabels
 from model_hub.models.evals_metric import UserEvalMetric
 from model_hub.models.run_prompt import PromptVersion, RunPrompter
@@ -316,7 +316,30 @@ def delete_column(*, dataset_id, column_id, organization=None):
                     f"Failed to cleanup derived variables for column {column.name}: {cleanup_error}"
                 )
         if column.source == SourceChoices.EVALUATION.value:
-            UserEvalMetric.objects.filter(id=column.source_id).update(deleted=True)
+            eval_metric = UserEvalMetric.objects.filter(
+                id=column.source_id
+            ).first()
+            if eval_metric and eval_metric.status in (
+                StatusType.RUNNING.value,
+                StatusType.NOT_STARTED.value,
+                StatusType.EXPERIMENT_EVALUATION.value,
+            ):
+                try:
+                    from tfc.utils.distributed_state import evaluation_tracker
+
+                    evaluation_tracker.request_cancel(
+                        eval_metric.id, reason="eval_column_deleted"
+                    )
+                except Exception:
+                    pass
+                from model_hub.utils.eval_cell_status import mark_eval_cells_stopped
+
+                mark_eval_cells_stopped(
+                    eval_metric, reason="Evaluation column deleted by user"
+                )
+            if eval_metric:
+                eval_metric.deleted = True
+                eval_metric.save(update_fields=["deleted"])
         if column.source == SourceChoices.ANNOTATION_LABEL.value:
             source_parts = column.source_id.split("-sourceid-")
 
@@ -363,15 +386,6 @@ def delete_column(*, dataset_id, column_id, organization=None):
         Q(id=column.id) | Q(source_id__startswith=f"{column.id}")
     ).values_list("id", flat=True)
 
-    # Delete the columns (this will cascade delete related cells)
-    Column.objects.filter(
-        Q(id=column.id) | Q(source_id__startswith=f"{column.id}")
-    ).update(deleted=True)
-
-    column.deleted = True
-    column.deleted_at = now
-    column.save(update_fields=["deleted", "deleted_at"])
-
     # Clean up column_order and column_config
     columns_to_delete_strs = set(str(c) for c in columns_to_delete)
     if dataset.column_order:
@@ -386,20 +400,28 @@ def delete_column(*, dataset_id, column_id, organization=None):
         }
     dataset.save(update_fields=["column_order", "column_config"])
 
-    # Mark dependent eval metrics as column_deleted
+    # Mark dependent eval metrics BEFORE deleting columns —
+    # get_metrics_using_column scopes by dataset via the Column row,
+    # which must still be visible (deleted=False).
     try:
         metrics = UserEvalMetric.get_metrics_using_column(
             str(dataset.organization_id), col_id_str
         )
-        for metric in metrics:
-            metric.column_deleted = True
-            metric.save(update_fields=["column_deleted"])
+        if metrics:
+            UserEvalMetric.objects.filter(
+                id__in=[m.id for m in metrics]
+            ).update(column_deleted=True)
     except Exception:
         logger.warning(
             "failed_to_mark_dependent_metrics",
             column_id=col_id_str,
             dataset_id=str(dataset.id),
         )
+
+    # Now safe to delete columns
+    Column.objects.filter(
+        Q(id=column.id) | Q(source_id__startswith=f"{column.id}")
+    ).update(deleted=True)
 
     return {
         "dataset_id": str(dataset.id),

--- a/futureagi/model_hub/services/experiment_utils.py
+++ b/futureagi/model_hub/services/experiment_utils.py
@@ -68,21 +68,28 @@ def maybe_complete_experiment_after_eval_stop(experiment_id) -> bool:
 
 
 def is_user_eval_stopped(user_eval_metric_id) -> bool:
-    """Check if a UserEvalMetric has been stopped via StopUserEvalView.
+    """Check if a UserEvalMetric has been stopped or deleted.
 
-    StopUserEvalView sets status=CANCELLED and marks the current running
-    cells with a "User stopped evaluation" reason. This guard lets the
-    Temporal activities and sync runners skip cell writes that would
-    otherwise clobber the stop marker once the in-flight worker finishes.
+    StopUserEvalView sets status=ERROR and marks the current running
+    cells with a "User stopped evaluation" reason. DeleteEvalsView sets
+    deleted=True. This guard lets the Temporal activities and sync
+    runners skip cell writes that would otherwise clobber the stop/delete
+    marker once the in-flight worker finishes.
     """
     if not user_eval_metric_id:
         return False
     try:
-        status = (
-            UserEvalMetric.objects.filter(id=user_eval_metric_id, deleted=False)
-            .values_list("status", flat=True)
+        result = (
+            UserEvalMetric.all_objects.filter(id=user_eval_metric_id)
+            .values_list("status", "deleted")
             .first()
         )
-        return status == StatusType.CANCELLED.value
+        if result is None:
+            return False
+        status, deleted = result
+        return deleted or status in (
+            StatusType.CANCELLED.value,
+            StatusType.ERROR.value,
+        )
     except Exception:
         return False

--- a/futureagi/model_hub/tests/test_evaluation_api.py
+++ b/futureagi/model_hub/tests/test_evaluation_api.py
@@ -585,6 +585,166 @@ class TestDeleteEvalsView:
             status.HTTP_403_FORBIDDEN,
         ]
 
+    def test_delete_running_eval_cancels_runner(
+        self, auth_client, dataset, user_eval_metric
+    ):
+        """Deleting a running eval should cancel the runner before soft-deleting."""
+        user_eval_metric.status = StatusType.RUNNING.value
+        user_eval_metric.save(update_fields=["status"])
+
+        with patch(
+            "tfc.utils.distributed_state.evaluation_tracker"
+        ) as mock_tracker, patch(
+            "model_hub.utils.eval_cell_status.mark_eval_cells_stopped"
+        ) as mock_mark_stopped:
+            response = auth_client.delete(
+                f"/model-hub/develops/{dataset.id}/delete_user_eval/{user_eval_metric.id}/",
+                {"delete_column": True},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_tracker.request_cancel.assert_called_once_with(
+            user_eval_metric.id, reason="eval_deleted"
+        )
+        mock_mark_stopped.assert_called_once()
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.deleted is True
+
+    def test_delete_eval_with_column_and_reason_column(
+        self, auth_client, dataset, user_eval_metric
+    ):
+        """Deleting an eval with delete_column=True removes eval column AND reason column."""
+        # Create eval column
+        eval_col = Column.objects.create(
+            name="Test Eval",
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.EVALUATION.value,
+            source_id=str(user_eval_metric.id),
+        )
+        dataset.column_order.append(str(eval_col.id))
+        dataset.save()
+
+        # Create reason column (source_id pattern: "{eval_col.id}-sourceid-{metric_id}")
+        reason_col = Column.objects.create(
+            name="Test Eval-reason",
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.EVALUATION_REASON.value,
+            source_id=f"{eval_col.id}-sourceid-{user_eval_metric.id}",
+        )
+        dataset.column_order.append(str(reason_col.id))
+        dataset.save()
+
+        response = auth_client.delete(
+            f"/model-hub/develops/{dataset.id}/delete_user_eval/{user_eval_metric.id}/",
+            {"delete_column": True},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        # Both columns should be soft-deleted
+        eval_col.refresh_from_db()
+        reason_col.refresh_from_db()
+        assert eval_col.deleted is True
+        assert reason_col.deleted is True
+
+        # Both should be removed from column_order
+        dataset.refresh_from_db()
+        assert str(eval_col.id) not in dataset.column_order
+        assert str(reason_col.id) not in dataset.column_order
+
+    def test_delete_column_of_running_eval_cancels_runner(
+        self, auth_client, dataset, user_eval_metric
+    ):
+        """Deleting the column of a running eval should cancel the runner."""
+        user_eval_metric.status = StatusType.RUNNING.value
+        user_eval_metric.save(update_fields=["status"])
+
+        # Create eval column
+        eval_col = Column.objects.create(
+            name="Running Eval",
+            dataset=dataset,
+            data_type=DataTypeChoices.TEXT.value,
+            source=SourceChoices.EVALUATION.value,
+            source_id=str(user_eval_metric.id),
+        )
+        dataset.column_order.append(str(eval_col.id))
+        dataset.save()
+
+        with patch(
+            "tfc.utils.distributed_state.evaluation_tracker"
+        ) as mock_tracker, patch(
+            "model_hub.utils.eval_cell_status.mark_eval_cells_stopped"
+        ) as mock_mark_stopped:
+            response = auth_client.delete(
+                f"/model-hub/develops/{dataset.id}/delete_column/{eval_col.id}/",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_tracker.request_cancel.assert_called_once_with(
+            user_eval_metric.id, reason="eval_column_deleted"
+        )
+        mock_mark_stopped.assert_called_once()
+
+        # Eval metric should be soft-deleted
+        user_eval_metric.refresh_from_db()
+        assert user_eval_metric.deleted is True
+
+
+# ==================== is_user_eval_stopped Tests ====================
+
+
+@pytest.mark.django_db
+class TestIsUserEvalStopped:
+    """Tests for is_user_eval_stopped — the per-cell guard in the eval runner."""
+
+    def test_returns_false_for_running_eval(self, user_eval_metric):
+        from model_hub.services.experiment_utils import is_user_eval_stopped
+
+        user_eval_metric.status = StatusType.RUNNING.value
+        user_eval_metric.save(update_fields=["status"])
+
+        assert is_user_eval_stopped(user_eval_metric.id) is False
+
+    def test_returns_true_for_error_status(self, user_eval_metric):
+        """StopUserEvalView sets ERROR — guard must catch it."""
+        from model_hub.services.experiment_utils import is_user_eval_stopped
+
+        user_eval_metric.status = StatusType.ERROR.value
+        user_eval_metric.save(update_fields=["status"])
+
+        assert is_user_eval_stopped(user_eval_metric.id) is True
+
+    def test_returns_true_for_cancelled_status(self, user_eval_metric):
+        from model_hub.services.experiment_utils import is_user_eval_stopped
+
+        user_eval_metric.status = StatusType.CANCELLED.value
+        user_eval_metric.save(update_fields=["status"])
+
+        assert is_user_eval_stopped(user_eval_metric.id) is True
+
+    def test_returns_true_for_deleted_eval(self, user_eval_metric):
+        """DeleteEvalsView sets deleted=True — guard must catch it."""
+        from model_hub.services.experiment_utils import is_user_eval_stopped
+
+        user_eval_metric.deleted = True
+        user_eval_metric.save(update_fields=["deleted"])
+
+        assert is_user_eval_stopped(user_eval_metric.id) is True
+
+    def test_returns_false_for_nonexistent_id(self):
+        from model_hub.services.experiment_utils import is_user_eval_stopped
+
+        assert is_user_eval_stopped(uuid.uuid4()) is False
+
+    def test_returns_false_for_none(self):
+        from model_hub.services.experiment_utils import is_user_eval_stopped
+
+        assert is_user_eval_stopped(None) is False
+
 
 # ==================== StopUserEvalView Tests ====================
 

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -3887,9 +3887,35 @@ class DeleteColumnView(APIView):
                             f"Failed to cleanup derived variables for column {column.name}: {cleanup_error}"
                         )
                 if column.source == SourceChoices.EVALUATION.value:
-                    UserEvalMetric.objects.filter(id=column.source_id).update(
-                        deleted=True
-                    )
+                    eval_metric = UserEvalMetric.objects.filter(
+                        id=column.source_id
+                    ).first()
+                    if eval_metric and eval_metric.status in (
+                        StatusType.RUNNING.value,
+                        StatusType.NOT_STARTED.value,
+                        StatusType.EXPERIMENT_EVALUATION.value,
+                    ):
+                        try:
+                            from tfc.utils.distributed_state import (
+                                evaluation_tracker,
+                            )
+
+                            evaluation_tracker.request_cancel(
+                                eval_metric.id, reason="eval_column_deleted"
+                            )
+                        except Exception:
+                            pass
+                        from model_hub.utils.eval_cell_status import (
+                            mark_eval_cells_stopped,
+                        )
+
+                        mark_eval_cells_stopped(
+                            eval_metric,
+                            reason="Evaluation column deleted by user",
+                        )
+                    if eval_metric:
+                        eval_metric.deleted = True
+                        eval_metric.save(update_fields=["deleted"])
                 if column.source == SourceChoices.ANNOTATION_LABEL.value:
                     source_parts = column.source_id.split("-sourceid-")
 
@@ -3936,28 +3962,30 @@ class DeleteColumnView(APIView):
                     Q(id=column.id) | Q(source_id__startswith=f"{column.id}")
                 ).values_list("id", flat=True)
 
+                col_ids_to_remove = {str(c) for c in columns_to_delete}
                 dataset.column_order = [
                     col_id
                     for col_id in dataset.column_order
-                    if col_id not in map(str, columns_to_delete)
+                    if col_id not in col_ids_to_remove
                 ]
                 dataset.save(update_fields=["column_order"])
 
-            # Delete the columns (this will cascade delete related cells)
-            Column.objects.filter(
-                Q(id=column.id) | Q(source_id__startswith=f"{column.id}")
-            ).update(deleted=True)
-
-            # Delete the column (this will cascade delete related cells)
-            column.deleted = True
-            column.save()
+            # Update metrics BEFORE deleting columns — get_metrics_using_column
+            # scopes by dataset via the Column row, which must still be
+            # visible (deleted=False) for BaseModelManager to find it.
             metrics = UserEvalMetric.get_metrics_using_column(
                 getattr(request, "organization", None) or request.user.organization.id,
                 column_id,
             )
-            for metric in metrics:
-                metric.column_deleted = True
-                metric.save()
+            if metrics:
+                UserEvalMetric.objects.filter(
+                    id__in=[m.id for m in metrics]
+                ).update(column_deleted=True)
+
+            # Now safe to delete columns
+            Column.objects.filter(
+                Q(id=column.id) | Q(source_id__startswith=f"{column.id}")
+            ).update(deleted=True)
 
             return self._gm.success_response("Column deleted successfully")
 
@@ -7208,6 +7236,26 @@ class DeleteEvalsView(APIView):
                         "An experiment must have at least one evaluation."
                     )
 
+            # Stop any in-flight eval runner before deleting columns
+            if delete_column and eval_metric.status in (
+                StatusType.RUNNING.value,
+                StatusType.NOT_STARTED.value,
+                StatusType.EXPERIMENT_EVALUATION.value,
+            ):
+                try:
+                    from tfc.utils.distributed_state import evaluation_tracker
+
+                    evaluation_tracker.request_cancel(
+                        eval_metric.id, reason="eval_deleted"
+                    )
+                except Exception:
+                    pass
+                from model_hub.utils.eval_cell_status import mark_eval_cells_stopped
+
+                mark_eval_cells_stopped(
+                    eval_metric, reason="Evaluation deleted by user"
+                )
+
             if delete_column:
                 if experiment_id:
                     # Experiment evals: one EXPERIMENT_EVALUATION column per EDT
@@ -7252,9 +7300,6 @@ class DeleteEvalsView(APIView):
                         source_id=eval_metric.id, deleted=False
                     ).first()
                     if column:
-                        # Get the main column
-                        column = get_object_or_404(Column, source_id=eval_metric.id)
-
                         # Delete all cells associated with the column and its dependent columns
                         Cell.objects.filter(
                             Q(column=column)
@@ -7275,12 +7320,15 @@ class DeleteEvalsView(APIView):
                                 deleted=False,
                             ).values_list("id", flat=True)
 
-                            dataset.column_order = [
+                            col_ids_to_remove = {str(c) for c in columns_to_delete}
+                            new_column_order = [
                                 col_id
                                 for col_id in dataset.column_order
-                                if col_id not in map(str, columns_to_delete)
+                                if col_id not in col_ids_to_remove
                             ]
-                            dataset.save()
+                            Dataset.objects.filter(id=dataset.id).update(
+                                column_order=new_column_order
+                            )
 
                         # Update metrics BEFORE deleting columns — the
                         # lookup scopes by dataset via the Column row, which
@@ -7291,9 +7339,10 @@ class DeleteEvalsView(APIView):
                             or request.user.organization.id,
                             column.id,
                         )
-                        for metric in metrics:
-                            metric.column_deleted = True
-                            metric.save()
+                        if metrics:
+                            UserEvalMetric.objects.filter(
+                                id__in=[m.id for m in metrics]
+                            ).update(column_deleted=True)
 
                         # Delete all related columns
                         Column.objects.filter(

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -949,6 +949,13 @@ class EvaluationRunner:
         scope) or we look it up by the experiment eval column's
         deterministic source_id.
         """
+        # Guard: if the eval was stopped or deleted while we were running,
+        # don't create a new reason column — it would be orphaned.
+        from model_hub.services.experiment_utils import is_user_eval_stopped
+
+        if is_user_eval_stopped(self.user_eval_metric_id):
+            return None
+
         source = SourceChoices.EVALUATION_REASON.value
         source_id = f"{self.replace_column_id}-sourceid-{self.user_eval_metric_id}"
         if self.experiment_dataset:
@@ -1034,14 +1041,15 @@ class EvaluationRunner:
                 reason_column = self._create_reason_column(
                     self.dataset, reason_column_name
                 )
-                self._create_reason_cell(
-                    self.dataset,
-                    reason_column,
-                    row,
-                    response,
-                    response.get("reason"),
-                    CellStatus.PASS.value,
-                )
+                if reason_column is not None:
+                    self._create_reason_cell(
+                        self.dataset,
+                        reason_column,
+                        row,
+                        response,
+                        response.get("reason"),
+                        CellStatus.PASS.value,
+                    )
             value = self.format_output(response, row)
 
             config_dict = json.loads(api_call_log_row.config)
@@ -1210,14 +1218,15 @@ class EvaluationRunner:
                 reason_column = self._create_reason_column(
                     self.dataset, reason_column_name
                 )
-                self._create_reason_cell(
-                    self.dataset,
-                    reason_column,
-                    row,
-                    {"reason": "No reasoning available. Please rerun the evaluation."},
-                    "No reasoning available. Please rerun the evaluation.",
-                    CellStatus.ERROR.value,
-                )
+                if reason_column is not None:
+                    self._create_reason_cell(
+                        self.dataset,
+                        reason_column,
+                        row,
+                        {"reason": "No reasoning available. Please rerun the evaluation."},
+                        "No reasoning available. Please rerun the evaluation.",
+                        CellStatus.ERROR.value,
+                    )
 
         return response, status, value
 
@@ -2796,16 +2805,17 @@ class EvaluationRunner:
                             reason_column = self._create_reason_column(
                                 dataset, reason_column_name
                             )
-                            self._create_reason_cell(
-                                dataset,
-                                reason_column,
-                                row,
-                                {
-                                    "reason": "No reasoning available. Please rerun the evaluation."
-                                },
-                                "No reasoning available. Please rerun the evaluation.",
-                                CellStatus.ERROR.value,
-                            )
+                            if reason_column is not None:
+                                self._create_reason_cell(
+                                    dataset,
+                                    reason_column,
+                                    row,
+                                    {
+                                        "reason": "No reasoning available. Please rerun the evaluation."
+                                    },
+                                    "No reasoning available. Please rerun the evaluation.",
+                                    CellStatus.ERROR.value,
+                                )
                     except Exception as cell_error:
                         logger.error(f"Failed to update cell to ERROR: {cell_error}")
 

--- a/futureagi/model_hub/views/experiment_runner.py
+++ b/futureagi/model_hub/views/experiment_runner.py
@@ -871,7 +871,8 @@ class ExperimentRunner:
                                 f"{user_eval_metric.name}-reason",
                                 parent_column=eval_column,
                             )
-                            cols_ids_to_update.append(reason_column.id)
+                            if reason_column is not None:
+                                cols_ids_to_update.append(reason_column.id)
 
                     cols_ids_to_update.append(eval_column.id)
 

--- a/futureagi/tfc/temporal/experiments/activities.py
+++ b/futureagi/tfc/temporal/experiments/activities.py
@@ -2075,19 +2075,20 @@ def _create_error_eval_cells_sync(
                     reason_column = runner._create_reason_column(
                         dataset, reason_column_name, parent_column=eval_column
                     )
-                    reason_cells = [
-                        Cell(
-                            dataset=dataset,
-                            column=reason_column,
-                            row=row,
-                            value=error_message,
-                            status=CellStatus.ERROR.value,
-                            value_infos=json.dumps({"reason": error_message}),
-                        )
-                        for row in row_map.values()
-                    ]
-                    if reason_cells:
-                        Cell.objects.bulk_create(reason_cells, ignore_conflicts=True)
+                    if reason_column is not None:
+                        reason_cells = [
+                            Cell(
+                                dataset=dataset,
+                                column=reason_column,
+                                row=row,
+                                value=error_message,
+                                status=CellStatus.ERROR.value,
+                                value_infos=json.dumps({"reason": error_message}),
+                            )
+                            for row in row_map.values()
+                        ]
+                        if reason_cells:
+                            Cell.objects.bulk_create(reason_cells, ignore_conflicts=True)
 
             except Exception as e:
                 activity.logger.exception(


### PR DESCRIPTION
## Summary

When a user deletes an eval column while the eval is still running, the reason column survives as an orphan. The running eval worker recreates it via `get_or_create` after soft-deletion because (a) no cancellation signal was sent to the worker, (b) `is_user_eval_stopped()` was dead code that never returned `True`, and (c) `_create_reason_column` had no guard to prevent orphaned column creation. This PR fixes the race condition across all 4 deletion entry points (REST + MCP), fixes the broken stop-guard, and includes minor perf fixes in the deletion paths.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [x] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Ran eval on dataset, deleted the eval column via UI while running → reason column no longer survives
- Tested MCP `delete_dataset_eval` tool via Falcon AI while eval was running → clean deletion
- Verified `is_user_eval_stopped()` returns `True` for `ERROR` status and deleted evals via Django shell

## What changed and why

**Bug fixes:**
- `_create_reason_column()` now checks `is_user_eval_stopped()` and returns `None` if eval is deleted/stopped — prevents orphaned column creation via `get_or_create`
- All 5 callers of `_create_reason_column` (`eval_runner.py` ×3, `experiment_runner.py` ×1, `activities.py` ×1) handle `None` return
- `is_user_eval_stopped()` fixed:
  - uses `all_objects` (deleted evals were invisible)
  - checks `ERROR` status (`StopUserEvalView` sets `ERROR` not `CANCELLED`)
  - checks `deleted` flag
- Added `evaluation_tracker.request_cancel()` + `mark_eval_cells_stopped()` before soft-deletion in all 4 entry points:
  - `DeleteColumnView`
  - `DeleteEvalsView`
  - `dataset_service.delete_column()`
  - MCP `delete_dataset_eval`
- Fixed `get_metrics_using_column()` ordering in:
  - `DeleteColumnView`
  - `dataset_service.delete_column()`
  - MCP tool
  - Previously ran after column deletion causing org-wide fallback scan
- Fixed `UnboundLocalError` in MCP `delete_dataset_eval` when `result_cols` was empty

**Perf fixes (while in these files):**
- Removed duplicate column query in `DeleteEvalsView` (`.first()` then `get_object_or_404` for same column)
- `dataset.save()` → `Dataset.objects.filter().update()` in `DeleteEvalsView` to skip `full_clean()` column table validation
- `map(str, columns_to_delete)` → `set` in `DeleteEvalsView` and `DeleteColumnView` (`O(n×m)` → `O(n)`)
- N+1 metric `.save()` loops → bulk `.update()` in:
  - `DeleteEvalsView`
  - `DeleteColumnView`
  - `dataset_service.delete_column()`
- Removed duplicate `column.save()` in `DeleteColumnView` (already covered by bulk update)
- Replaced per-column N+1 loop in MCP tool with bulk queries

## Screenshots / recordings (if UI)

#overall (preexisitng issues not from my branch)

<img width="789" height="535" alt="Screenshot 2026-05-12 at 3 14 05 PM" src="https://github.com/user-attachments/assets/375ca215-9643-4614-9a88-1254350c5521" />

#my tests
<img width="1564" height="1340" alt="image" src="https://github.com/user-attachments/assets/e10bf5c1-2bc9-41b4-8114-a44326d30b41" />

https://github.com/user-attachments/assets/bbe324dd-ab6e-429f-8283-5d8c5780999d

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)