### PR TITLE
chore(infra): mount Vertex AI credentials into agentcc-gateway

### DIFF
--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -101,10 +101,14 @@ services:
       - "${AGENTCC_GATEWAY_PORT:-8090}:8090"
     volumes:
       - ../${AGENTCC_CONFIG_PATH:-agentcc-gateway/config.example.yaml}:/app/config.yaml:ro
+      - ${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}:/app/Vertex_AI_Creds.json:ro
     env_file:
       - .env
     environment:
       - AGENTCC_INTERNAL_API_KEY=${AGENTCC_INTERNAL_API_KEY:-}
+      # Gateway WORKDIR is /, so credentials_file resolution needs an absolute
+      # path. Override the relative value from .env.
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/Vertex_AI_Creds.json
       # Provider creds for the gateway live in agentcc-gateway/config.yaml,
       # which interpolates ${ENV_VAR}s from .env at start. Anything in .env is
       # already passed through via env_file above — no per-provider entries


### PR DESCRIPTION
## Summary

Mount `Vertex_AI_Creds.json` into `agentcc-gateway` and override `GOOGLE_APPLICATION_CREDENTIALS` to the absolute container path. Gateway WORKDIR is `/`, so the relative path in `.env` doesn't resolve at runtime.

Extracted from #131 to land independently.

## Test plan

- [ ] `Vertex_AI_Creds.json` present at repo root + `.env` has `GOOGLE_APPLICATION_CREDENTIALS=Vertex_AI_Creds.json`
- [ ] `./dc.sh r` — agentcc-gateway starts cleanly without override