### PR TITLE
fix(auth): clear remaining in-memory stores on same-tab logout (extends #82)

### DIFF
--- a/frontend/src/auth/context/jwt/auth-provider.jsx
+++ b/frontend/src/auth/context/jwt/auth-provider.jsx
@@ -18,7 +18,7 @@ import { identifyPostHogUser, resetPostHogUser } from "src/utils/PostHog";
 import { useQueryClient } from "@tanstack/react-query";
 import { setUser } from "@sentry/react";
 import logger from "src/utils/logger";
-import useFalconStore from "src/sections/falcon-ai/store/useFalconStore";
+import { resetAllUserStores } from "src/utils/auth/clearStores";
 
 // Session storage key for per-tab user tracking
 const SESSION_USER_ID_KEY = "currentUserId";
@@ -309,7 +309,7 @@ export function AuthProvider({ children }) {
       sessionStorage.removeItem("2fa_challenge");
       sessionStorage.removeItem(SESSION_USER_ID_KEY);
       localStorage.removeItem("initial-render"); // Clear flag so next login triggers redirect logic
-      useFalconStore.getState().resetAll();
+      resetAllUserStores();
       dispatch({
         type: "LOGOUT",
       });

--- a/frontend/src/components/GraphBuilder/store/graphStore.js
+++ b/frontend/src/components/GraphBuilder/store/graphStore.js
@@ -229,7 +229,20 @@ export const useGraphStore = create((set, get) => ({
       activeEdgeId: null,
     });
   },
+
+  reset: () => {
+    set({
+      nodes: getInitialNodes(),
+      edges: initialEdges,
+      activeNodeId: null,
+      activeEdgeId: null,
+    });
+  },
 }));
+
+export const resetGraphStore = () => {
+  useGraphStore.getState().reset();
+};
 
 export function getNodeLabel(nodeType) {
   switch (nodeType) {

--- a/frontend/src/sections/agents/store/agentDetailsStore.js
+++ b/frontend/src/sections/agents/store/agentDetailsStore.js
@@ -44,6 +44,7 @@ export const useAgentDetailsStore = create((set, get) => ({
       selectedVersion: null,
       agentName: "",
       agentDetails: {},
+      latestVersionNumber: 0,
     });
     // Clear URL params when resetting
     const url = new URL(window.location);

--- a/frontend/src/utils/auth/__tests__/clearStores.test.js
+++ b/frontend/src/utils/auth/__tests__/clearStores.test.js
@@ -27,6 +27,7 @@ describe("resetAllUserStores", () => {
       .getState()
       .setGlobalVariables({ apiKey: "sk-leaked" });
     useAgentDetailsStore.getState().setAgentName("leaked-agent");
+    useAgentDetailsStore.getState().setLatestVersionNumber(42);
     usePromptStore.setState({ searchQuery: "leaked-search" });
     useGraphStore.getState().addNode("conversation", { x: 0, y: 0 }, false);
 
@@ -56,6 +57,7 @@ describe("resetAllUserStores", () => {
       {},
     );
     expect(useAgentDetailsStore.getState().agentName).toBe("");
+    expect(useAgentDetailsStore.getState().latestVersionNumber).toBe(0);
     expect(usePromptStore.getState().searchQuery).toBe("");
     expect(useGraphStore.getState().nodes.length).toBe(initialGraphNodeCount);
     expect(useGraphStore.getState().edges).toEqual([]);

--- a/frontend/src/utils/auth/__tests__/clearStores.test.js
+++ b/frontend/src/utils/auth/__tests__/clearStores.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { resetAllUserStores } from "../clearStores";
+import useFalconStore from "src/sections/falcon-ai/store/useFalconStore";
+import { useAgentPlaygroundStore } from "src/sections/agent-playground/store/agent-playground-store";
+import { useWorkflowRunStore } from "src/sections/agent-playground/store/workflow-run-store";
+import { useGlobalVariablesDrawerStore } from "src/sections/agent-playground/store/global-variables-drawer-store";
+import { useAgentDetailsStore } from "src/sections/agents/store/agentDetailsStore";
+import { usePromptStore } from "src/sections/workbench-v2/store/usePromptStore";
+import { useGraphStore } from "src/components/GraphBuilder/store/graphStore";
+
+beforeEach(() => {
+  resetAllUserStores();
+});
+
+describe("resetAllUserStores", () => {
+  it("resets Falcon, agent-playground, workflow-run, globals, agent-details, prompt, and graph stores in one call", () => {
+    useFalconStore.getState().openSidebar();
+    useFalconStore
+      .getState()
+      .addMessage({ id: "m1", role: "user", content: "leaked" });
+    useAgentPlaygroundStore.setState({ currentAgent: { id: "agent-1" } });
+    useWorkflowRunStore
+      .getState()
+      .setRunResults("node-1", { output: "leaked-run" });
+    useGlobalVariablesDrawerStore
+      .getState()
+      .setGlobalVariables({ apiKey: "sk-leaked" });
+    useAgentDetailsStore.getState().setAgentName("leaked-agent");
+    usePromptStore.setState({ searchQuery: "leaked-search" });
+    useGraphStore.getState().addNode("conversation", { x: 0, y: 0 }, false);
+
+    const initialGraphNodeCount = 1;
+    expect(useFalconStore.getState().isSidebarOpen).toBe(true);
+    expect(useFalconStore.getState().messages.length).toBeGreaterThan(0);
+    expect(useAgentPlaygroundStore.getState().currentAgent).not.toBeNull();
+    expect(
+      Object.keys(useWorkflowRunStore.getState().runResults).length,
+    ).toBeGreaterThan(0);
+    expect(useGlobalVariablesDrawerStore.getState().globalVariables).toEqual({
+      apiKey: "sk-leaked",
+    });
+    expect(useAgentDetailsStore.getState().agentName).toBe("leaked-agent");
+    expect(usePromptStore.getState().searchQuery).toBe("leaked-search");
+    expect(useGraphStore.getState().nodes.length).toBeGreaterThan(
+      initialGraphNodeCount,
+    );
+
+    resetAllUserStores();
+
+    expect(useFalconStore.getState().isSidebarOpen).toBe(false);
+    expect(useFalconStore.getState().messages).toEqual([]);
+    expect(useAgentPlaygroundStore.getState().currentAgent).toBeNull();
+    expect(useWorkflowRunStore.getState().runResults).toEqual({});
+    expect(useGlobalVariablesDrawerStore.getState().globalVariables).toEqual(
+      {},
+    );
+    expect(useAgentDetailsStore.getState().agentName).toBe("");
+    expect(usePromptStore.getState().searchQuery).toBe("");
+    expect(useGraphStore.getState().nodes.length).toBe(initialGraphNodeCount);
+    expect(useGraphStore.getState().edges).toEqual([]);
+  });
+
+  it("continues resetting remaining stores when one reset throws", () => {
+    useFalconStore.getState().openSidebar();
+    usePromptStore.setState({ searchQuery: "leaked-after-throw" });
+
+    const original = useAgentDetailsStore.getState().resetAgentDetails;
+    useAgentDetailsStore.setState({
+      resetAgentDetails: () => {
+        throw new Error("simulated reset failure");
+      },
+    });
+
+    try {
+      expect(() => resetAllUserStores()).not.toThrow();
+      expect(useFalconStore.getState().isSidebarOpen).toBe(false);
+      expect(usePromptStore.getState().searchQuery).toBe("");
+    } finally {
+      useAgentDetailsStore.setState({ resetAgentDetails: original });
+    }
+  });
+
+  it("is idempotent", () => {
+    expect(() => {
+      resetAllUserStores();
+      resetAllUserStores();
+      resetAllUserStores();
+    }).not.toThrow();
+    expect(useFalconStore.getState().isSidebarOpen).toBe(false);
+  });
+});

--- a/frontend/src/utils/auth/clearStores.js
+++ b/frontend/src/utils/auth/clearStores.js
@@ -1,0 +1,49 @@
+import useFalconStore from "src/sections/falcon-ai/store/useFalconStore";
+import { resetAgentPlaygroundStore } from "src/sections/agent-playground/store/agent-playground-store";
+import { resetWorkflowRunStore } from "src/sections/agent-playground/store/workflow-run-store";
+import { resetGlobalVariablesDrawerStore } from "src/sections/agent-playground/store/global-variables-drawer-store";
+import { resetTemplateLoadingStore } from "src/sections/agent-playground/store/template-loading-store";
+import { useAgentDetailsStore } from "src/sections/agents/store/agentDetailsStore";
+import { resetPromptState } from "src/sections/workbench-v2/store/usePromptStore";
+import { resetGraphStore } from "src/components/GraphBuilder/store/graphStore";
+import { resetAllStates as resetDevelopDetailStates } from "src/sections/develop-detail/states";
+import logger from "src/utils/logger";
+
+// Resets the in-memory Zustand stores that hold user-scoped data.
+//
+// Called from the auth provider's same-tab logout flow so the previous user's
+// data does not surface to the next user signing in on the same tab. The
+// cross-tab logout path already triggers a full page reload, which drops
+// all module-level Zustand state implicitly; only the in-app logout needs
+// this explicit reset.
+//
+// Tokens, sessionStorage organization/workspace, and the react-query cache
+// are cleared elsewhere in the logout callback. This helper targets the
+// in-memory store surface only.
+//
+// PR #82 introduced the pattern for useFalconStore. This is the same pattern
+// extended to the remaining stores that hold user-scoped data.
+export const resetAllUserStores = () => {
+  const resets = [
+    ["falcon", () => useFalconStore.getState().resetAll()],
+    ["agent-playground", resetAgentPlaygroundStore],
+    ["workflow-run", resetWorkflowRunStore],
+    ["global-variables-drawer", resetGlobalVariablesDrawerStore],
+    ["template-loading", resetTemplateLoadingStore],
+    [
+      "agent-details",
+      () => useAgentDetailsStore.getState().resetAgentDetails(),
+    ],
+    ["prompt", resetPromptState],
+    ["graph-builder", resetGraphStore],
+    ["develop-detail", resetDevelopDetailStates],
+  ];
+
+  for (const [name, reset] of resets) {
+    try {
+      reset();
+    } catch (error) {
+      logger.error(`Failed to reset ${name} store on logout`, error);
+    }
+  }
+};


### PR DESCRIPTION
## Summary

Extends PR #82 (which wired `useFalconStore.resetAll()` into in-app logout) to the rest of the in-memory Zustand stores that survive same-tab logout/login. Adds a `resetAllUserStores()` helper that resets the Falcon, agent-playground (workflow + run + globals + template loading), agent-details, prompt, graph-builder, and develop-detail stores in sequence with per-store `try/catch` isolation, then swaps the inline call in `logout` for the central helper.

The cross-tab logout path needs no change — it already hard-reloads (`window.location.href = "/auth/jwt/login"`), which drops every module-level Zustand store implicitly. Only the same-tab in-app logout path leaked, exactly as PR #82's body described.

## Linked issues

Closes #408

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Added `src/utils/auth/__tests__/clearStores.test.js` with three cases:
  - Integration: mutate state in Falcon, agent-playground, workflow-run, globals, agent-details, prompt, and graph stores; call `resetAllUserStores()`; assert every store back to initial state.
  - Resilience: patch one store's reset to throw; assert `resetAllUserStores()` does not throw and the remaining stores still reset.
  - Idempotency: three consecutive calls are a no-op after the first.
- `yarn vitest run` — full suite, 110 files / 1130 tests pass (including the three new ones).
- `yarn type-check` — clean (no `tsconfig.json`, skipped per the script).
- `npx eslint src/utils/auth/clearStores.js src/utils/auth/__tests__/clearStores.test.js src/components/GraphBuilder/store/graphStore.js src/auth/context/jwt/auth-provider.jsx` — clean.
- `npx prettier --check` against the same files — clean.
- `yarn build` — bundles successfully (Sentry source-map upload requires a token; the build artifact is built either way).
- Manual repro pre-fix, against the issue's step list:
  1. Sign in as user A, open `/dashboard/agent-playground`, add a node, set a global variable, run once.
  2. Profile → Logout (in-app SPA navigation).
  3. Sign in as user B on the same tab.
  4. Open Agent Playground → before this PR, user A's nodes / global variables / run results were visible; after this PR, the playground opens in initial state.

## Scope boundary

Stores wired in this PR are the high-sensitivity / agent-and-prompt cluster identified in #408:

- `useFalconStore` (already wired in #82, replaced with the central call)
- `useAgentPlaygroundStore`
- `useWorkflowRunStore`
- `useGlobalVariablesDrawerStore`
- `useTemplateLoadingStore`
- `useAgentDetailsStore`
- `usePromptStore`
- `useGraphStore` (this store had no `reset()` method — added one matching the `nodes / edges / activeNodeId / activeEdgeId` initial state, plus a `resetGraphStore()` module export to match the convention used by the other stores)
- `develop-detail/states.jsx` `resetAllStates()` (already existed, only called from a page mount; now also called from logout)

Stores left for a follow-up PR (all have existing reset exports, just need wiring): the Alerts cluster, LLM Tracing, Sessions Replay, TracesDrawer, test / test-detail / TestRuns, Simulate detail, EditSyntheticData. Plus a few that need new resets first (CallLogsDetailDrawer, feed, error-feed, createNewAgent). The full list is in #408.

## Screenshots / recordings (if UI)

N/A — internal-state change. The user-visible behavior change is "after same-tab logout/login, in-memory stores are at initial state instead of the previous user's values".

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `yarn check-all` not present in `frontend/package.json`; ran `yarn vitest run` + `yarn type-check` + `eslint` + `prettier --check` + `yarn build` individually instead.
- [ ] I've updated the documentation where relevant — no user-facing doc surface for this change
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) — will sign on first CLA-bot prompt
