### PR TITLE
fix(dashboard): wire Trace/Span name filter picker suggestions

### DIFF
--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -497,6 +497,43 @@ class TestMetricsEndpoint:
         ]
         assert str(label.id) not in annotation_ids
 
+    # ------------------------------------------------------------------
+    # /filter_values endpoint — name / span_name col_map coverage.
+    # The handler whitelists allowed system metric column ids; "name"
+    # and "span_name" were missing so the FE picker showed empty
+    # suggestions for Trace Name / Span Name filters.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "metric_name", ["name", "span_name", "service_name"]
+    )
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
+    @patch("tracer.views.dashboard.AnalyticsQueryService")
+    def test_filter_values_accepts_name_aliases(
+        self,
+        mock_analytics_cls,
+        _mock_ch_enabled,
+        metric_name,
+        auth_client,
+        observe_project,
+    ):
+        mock_result = MagicMock()
+        mock_result.data = [{"val": "agent.handle_request"}, {"val": "chain.run"}]
+        mock_analytics_cls.return_value.execute_ch_query.return_value = mock_result
+
+        response = auth_client.get(
+            "/tracer/dashboard/filter_values/"
+            f"?metric_name={metric_name}"
+            "&metric_type=system_metric"
+            f"&project_ids={observe_project.id}"
+            "&source=traces"
+        )
+        assert response.status_code == 200
+        values = response.json()["result"]["values"]
+        labels = [v["label"] for v in values]
+        assert labels == ["agent.handle_request", "chain.run"]
+
 
 # ===========================================================================
 # DashboardQueryBuilder

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -534,6 +534,56 @@ class TestMetricsEndpoint:
         labels = [v["label"] for v in values]
         assert labels == ["agent.handle_request", "chain.run"]
 
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
+    @patch("tracer.views.dashboard.AnalyticsQueryService")
+    def test_filter_values_name_restricts_to_root_spans(
+        self,
+        mock_analytics_cls,
+        _mock_ch_enabled,
+        auth_client,
+        observe_project,
+    ):
+        """`metric_name=name` (Trace Name) must scope to root spans."""
+        mock_result = MagicMock()
+        mock_result.data = []
+        mock_analytics_cls.return_value.execute_ch_query.return_value = mock_result
+
+        auth_client.get(
+            "/tracer/dashboard/filter_values/"
+            f"?metric_name=name&metric_type=system_metric"
+            f"&project_ids={observe_project.id}&source=traces"
+        )
+
+        sql_arg = mock_analytics_cls.return_value.execute_ch_query.call_args[0][0]
+        assert "parent_span_id IS NULL" in sql_arg
+
+    @pytest.mark.parametrize("metric_name", ["span_name", "service_name"])
+    @pytest.mark.django_db
+    @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
+    @patch("tracer.views.dashboard.AnalyticsQueryService")
+    def test_filter_values_span_name_does_not_restrict_to_root(
+        self,
+        mock_analytics_cls,
+        _mock_ch_enabled,
+        metric_name,
+        auth_client,
+        observe_project,
+    ):
+        """span_name / service_name should NOT add the root-span clause."""
+        mock_result = MagicMock()
+        mock_result.data = []
+        mock_analytics_cls.return_value.execute_ch_query.return_value = mock_result
+
+        auth_client.get(
+            "/tracer/dashboard/filter_values/"
+            f"?metric_name={metric_name}&metric_type=system_metric"
+            f"&project_ids={observe_project.id}&source=traces"
+        )
+
+        sql_arg = mock_analytics_cls.return_value.execute_ch_query.call_args[0][0]
+        assert "parent_span_id" not in sql_arg
+
 
 # ===========================================================================
 # DashboardQueryBuilder

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1853,6 +1853,8 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     "observation_type": "observation_type",
                     "span_kind": "observation_type",  # span_kind maps to observation_type in CH
                     "service_name": "name",  # service_name maps to span name
+                    "name": "name",
+                    "span_name": "name",
                     "session": "trace_session_id",
                     "user": "toString(end_user_id)",
                     "tag": "arrayJoin(trace_tags)",
@@ -1871,12 +1873,19 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     # type is non-nullable by default — the Nullable
                     # wrapper isn't always preserved through the MV chain.
                     null_uuid = "00000000-0000-0000-0000-000000000000"
+                    # Trace Name = root span name; restrict to root spans.
+                    root_only_clause = (
+                        "AND parent_span_id IS NULL "
+                        if metric_name == "name"
+                        else ""
+                    )
                     sql = (
                         f"SELECT DISTINCT {col_expr} AS val "
                         f"FROM spans "
                         f"WHERE project_id IN %(project_ids)s "
                         f"AND _peerdb_is_deleted = 0 "
                         f"AND {col_expr} NOT IN ('', '{null_uuid}') "
+                        f"{root_only_clause}"
                         f"ORDER BY val "
                         f"LIMIT 500"
                     )


### PR DESCRIPTION
## Summary

The Observe filter picker's **Trace Name** and **Span Name** options returned empty suggestions. The `/tracer/dashboard/filter_values/` handler's system-metric `col_map` whitelisted `service_name` but not the actual ids the FE sends (`name`, `span_name`), so the request short-circuited with `values: []`. Adds both to the map (both resolve to `spans.name`). For `metric_name=name` (Trace Name), additionally restricts to root spans (`parent_span_id IS NULL`) so child span names don't pollute the Trace Name list — mirrors `ROOT_ONLY_SYSTEM_METRICS` in the CH filter builder.

> Stacked on top of [#404](https://github.com/future-agi/future-agi/pull/404) (\`fix/observe-annotation-filter-missing-options\`). Merge after that one lands.

## Linked issues

Refs [TH-4284](https://linear.app/future-agi/issue/TH-4284/filter-values-are-missing-or-shown-as-uuids)

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Added 5 new tests in \`futureagi/tracer/tests/test_dashboard.py::TestMetricsEndpoint\`:

| Test | Verifies |
|---|---|
| \`test_filter_values_accepts_name_aliases[name]\` | \`metric_name=name\` returns non-empty values (fails on \`dev\` — col_map gap) |
| \`test_filter_values_accepts_name_aliases[span_name]\` | \`metric_name=span_name\` returns non-empty values (fails on \`dev\`) |
| \`test_filter_values_accepts_name_aliases[service_name]\` | Existing alias still works (no regression) |
| \`test_filter_values_name_restricts_to_root_spans\` | \`metric_name=name\` SQL includes \`AND parent_span_id IS NULL\` |
| \`test_filter_values_span_name_does_not_restrict_to_root[span_name|service_name]\` | \`span_name\` / \`service_name\` SQL omits the root-span clause |

\`\`\`sh
bin/test tracer/tests/test_dashboard.py::TestMetricsEndpoint -v --no-cov
# 12 passed (5 new + 7 existing from this branch + parent)
\`\`\`

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] No hardcoded secrets, URLs, or PII