### PR TITLE
fix(bedrock): inject additionalProperties:false into Converse outputConfig

### DIFF
--- a/agentcc-gateway/internal/providers/bedrock/converse.go
+++ b/agentcc-gateway/internal/providers/bedrock/converse.go
@@ -242,6 +242,10 @@ func buildConverseOutputFormat(rf *models.ResponseFormat) *converseTextFormat {
 		name = wrapper.Name
 		description = wrapper.Description
 	}
+	// Bedrock's Converse outputConfig requires `additionalProperties: false` on
+	// every `object` schema. Inject it transparently so callers can ship
+	// OpenAI-shape json_schema without provider-specific tweaks.
+	schema = ensureObjectAdditionalPropertiesFalse(schema)
 	return &converseTextFormat{
 		Type: "json_schema",
 		Structure: converseTextStructure{
@@ -699,4 +703,46 @@ func (s *converseStreamState) parseConverseEvent(msg *eventStreamMessage) (*mode
 	}
 
 	return nil, false, nil
+}
+
+// ensureObjectAdditionalPropertiesFalse walks a JSON schema tree and adds
+// `additionalProperties: false` to every `object` node that lacks it. Bedrock's
+// Converse API rejects object schemas missing this field. Callers ship
+// OpenAI-shape json_schema (where the field is optional) and we normalize here.
+func ensureObjectAdditionalPropertiesFalse(schema json.RawMessage) json.RawMessage {
+	if len(schema) == 0 {
+		return schema
+	}
+	var node interface{}
+	if err := json.Unmarshal(schema, &node); err != nil {
+		return schema
+	}
+	walked := walkSchemaAddObjectAP(node)
+	out, err := json.Marshal(walked)
+	if err != nil {
+		return schema
+	}
+	return out
+}
+
+func walkSchemaAddObjectAP(n interface{}) interface{} {
+	switch v := n.(type) {
+	case map[string]interface{}:
+		if t, ok := v["type"].(string); ok && t == "object" {
+			if _, has := v["additionalProperties"]; !has {
+				v["additionalProperties"] = false
+			}
+		}
+		for k, vv := range v {
+			v[k] = walkSchemaAddObjectAP(vv)
+		}
+		return v
+	case []interface{}:
+		for i, x := range v {
+			v[i] = walkSchemaAddObjectAP(x)
+		}
+		return v
+	default:
+		return n
+	}
 }


### PR DESCRIPTION
## Summary

Bedrock's Converse API rejects object schemas missing `additionalProperties: false`:
```
output_config.format.schema: For 'object' type, 'additionalProperties' must be explicitly set to false
```

Callers ship OpenAI-shape `response_format` where this field is optional. The gateway now walks the schema and injects the field transparently before forwarding — callers stay provider-agnostic.

## Behavior

- Only runs when `response_format.type == "json_schema"` (no-op for plain completions)
- Walks the schema tree recursively — handles nested objects in `properties`
- Preserves existing `additionalProperties` if the caller already set one
- Scoped to `buildConverseOutputFormat`; other providers untouched

## Test plan

- [x] Structured-output requests succeed end-to-end
- [x] Plain completions (no `response_format`) — no-op, behavior unchanged
- [x] Schemas that already include `additionalProperties` — not overwritten