### PR TITLE
feat(eval-mapping): expose all DB columns + derived aggregates in picker

### DIFF
--- a/futureagi/tracer/tests/test_derived_fields_resolver.py
+++ b/futureagi/tracer/tests/test_derived_fields_resolver.py
@@ -1,0 +1,257 @@
+"""Tests for the trace + session derived-field resolver branches.
+
+Pins aggregate formulas, the ``status`` precedence rule, and per-instance
+memoisation. Mirrors ``list_traces`` / ``list_sessions``.
+"""
+
+import pytest
+
+# Cycle-breaker — same rationale as the other resolver tests.
+import model_hub.tasks  # noqa: F401, E402
+
+from datetime import timedelta  # noqa: E402
+
+from django.utils import timezone  # noqa: E402
+
+from tracer.models.observation_span import ObservationSpan  # noqa: E402
+from tracer.models.trace import Trace  # noqa: E402
+from tracer.models.trace_session import TraceSession  # noqa: E402
+from tracer.utils.eval import (  # noqa: E402
+    _SESSION_DERIVED_FIELDS,
+    _TRACE_DERIVED_FIELDS,
+    _compute_session_derived,
+    _compute_trace_derived,
+    _resolve_session_path,
+    _resolve_trace_path,
+)
+
+
+def _make_span(trace, project, *, sid, parent=None, **fields):
+    defaults = dict(
+        id=sid,
+        project=project,
+        trace=trace,
+        parent_span_id=parent,
+        name=f"span-{sid}",
+        observation_type=fields.pop("observation_type", "llm"),
+        start_time=fields.pop("start_time", None),
+        end_time=fields.pop("end_time", None),
+        latency_ms=fields.pop("latency_ms", None),
+        prompt_tokens=fields.pop("prompt_tokens", 0),
+        completion_tokens=fields.pop("completion_tokens", 0),
+        total_tokens=fields.pop("total_tokens", 0),
+        cost=fields.pop("cost", 0.0),
+        status=fields.pop("status", "OK"),
+        input=fields.pop("input", None),
+    )
+    defaults.update(fields)
+    return ObservationSpan.objects.create(**defaults)
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestTraceDerivedFields:
+    """Aggregate formulas from ``tracer/views/trace.py``."""
+
+    def test_aggregates_match_summary_reduction(self, observe_project):
+        trace = Trace.objects.create(project=observe_project)
+        now = timezone.now()
+        _make_span(
+            trace,
+            observe_project,
+            sid="t-root",
+            parent=None,
+            observation_type="chain",
+            name="root-chain",
+            start_time=now,
+            latency_ms=1500,
+            prompt_tokens=100,
+            completion_tokens=200,
+            total_tokens=300,
+            cost=0.0012,
+            status="OK",
+            input={"messages": [{"role": "user", "content": "hi"}]},
+        )
+        # Child error — bumps error_count but not status (root-only).
+        _make_span(
+            trace,
+            observe_project,
+            sid="t-child-1",
+            parent="t-root",
+            prompt_tokens=50,
+            completion_tokens=70,
+            total_tokens=120,
+            cost=0.0008,
+            status="ERROR",
+        )
+
+        derived = _compute_trace_derived(trace)
+        assert derived["node_type"] == "chain"
+        assert derived["trace_name"] == "root-chain"
+        assert derived["start_time"] == now
+        assert derived["status"] == "OK"
+        assert derived["total_tokens"] == 420
+        assert derived["total_prompt_tokens"] == 150
+        assert derived["total_completion_tokens"] == 270
+        assert derived["total_cost"] == round(0.0012 + 0.0008, 6)
+        # Root spans only.
+        assert derived["total_duration_ms"] == 1500
+        assert derived["total_spans"] == 2
+        assert derived["error_count"] == 1
+
+    def test_status_promotes_to_error_when_root_errors(self, observe_project):
+        trace = Trace.objects.create(project=observe_project)
+        _make_span(
+            trace, observe_project, sid="r1", parent=None, status="ERROR"
+        )
+        _make_span(
+            trace, observe_project, sid="r2", parent=None, status="OK"
+        )
+        assert _compute_trace_derived(trace)["status"] == "ERROR"
+
+    def test_status_unset_with_no_root_status(self, observe_project):
+        trace = Trace.objects.create(project=observe_project)
+        _make_span(
+            trace, observe_project, sid="r1", parent=None, status="UNSET"
+        )
+        assert _compute_trace_derived(trace)["status"] == "UNSET"
+
+    def test_node_type_falls_back_when_no_root(self, observe_project):
+        """No root span -> ``unknown`` / ``[ Incomplete Trace ]`` /
+        Trace.created_at."""
+        trace = Trace.objects.create(project=observe_project)
+        derived = _compute_trace_derived(trace)
+        assert derived["node_type"] == "unknown"
+        assert derived["trace_name"] == "[ Incomplete Trace ]"
+        assert derived["start_time"] == trace.created_at
+
+    def test_resolver_routes_through_derived_branch(self, observe_project):
+        trace = Trace.objects.create(project=observe_project)
+        _make_span(
+            trace,
+            observe_project,
+            sid="r1",
+            parent=None,
+            total_tokens=42,
+            cost=0.005,
+        )
+        assert _resolve_trace_path(trace, "total_tokens") == 42
+        assert _resolve_trace_path(trace, "total_cost") == 0.005
+
+    def test_per_instance_cache_avoids_duplicate_queries(
+        self, observe_project, django_assert_num_queries
+    ):
+        trace = Trace.objects.create(project=observe_project)
+        _make_span(trace, observe_project, sid="r1", parent=None, total_tokens=10)
+
+        _compute_trace_derived(trace)  # warm
+        with django_assert_num_queries(0):
+            _compute_trace_derived(trace)
+            _compute_trace_derived(trace)
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestSessionDerivedFields:
+    """Aggregate formulas from ``tracer/views/trace_session.py``."""
+
+    def test_aggregates_across_session_spans(self, observe_project):
+        session = TraceSession.objects.create(
+            project=observe_project, name="s"
+        )
+        t0 = Trace.objects.create(project=observe_project, session=session)
+        t1 = Trace.objects.create(project=observe_project, session=session)
+        start_ts = timezone.now()
+        _make_span(
+            t0,
+            observe_project,
+            sid="s0",
+            parent=None,
+            start_time=start_ts,
+            end_time=start_ts + timedelta(seconds=1),
+            total_tokens=10,
+            prompt_tokens=4,
+            completion_tokens=6,
+            cost=0.001,
+            input={"first": True},
+        )
+        _make_span(
+            t1,
+            observe_project,
+            sid="s1",
+            parent=None,
+            start_time=start_ts + timedelta(seconds=5),
+            end_time=start_ts + timedelta(seconds=10),
+            total_tokens=20,
+            prompt_tokens=8,
+            completion_tokens=12,
+            cost=0.003,
+            input={"last": True},
+        )
+
+        derived = _compute_session_derived(session)
+        assert derived["total_tokens"] == 30
+        assert derived["total_prompt_tokens"] == 12
+        assert derived["total_completion_tokens"] == 18
+        assert derived["total_cost"] == round(0.001 + 0.003, 6)
+        assert derived["start_time"] == start_ts
+        assert derived["end_time"] == start_ts + timedelta(seconds=10)
+        assert derived["duration"] == 10.0
+        assert derived["total_traces"] == 2
+        assert derived["first_message"] == {"first": True}
+        assert derived["last_message"] == {"last": True}
+
+    def test_empty_session_returns_zeros_not_nulls(self, observe_project):
+        """Coalesce parity with list_sessions."""
+        session = TraceSession.objects.create(
+            project=observe_project, name="empty"
+        )
+        derived = _compute_session_derived(session)
+        assert derived["total_tokens"] == 0
+        assert derived["total_cost"] == 0.0
+        assert derived["total_traces"] == 0
+        assert derived["duration"] == 0
+        assert derived["first_message"] is None
+        assert derived["last_message"] is None
+
+    def test_resolver_routes_through_derived_branch(self, observe_project):
+        session = TraceSession.objects.create(
+            project=observe_project, name="rs"
+        )
+        trace = Trace.objects.create(project=observe_project, session=session)
+        _make_span(
+            trace, observe_project, sid="x", parent=None, total_tokens=77
+        )
+        assert _resolve_session_path(session, "total_tokens") == 77
+
+    def test_derived_fields_whitelist_pins_the_set(self):
+        """Tripwire when the sets change; picker tests need updating too."""
+        assert _TRACE_DERIVED_FIELDS == frozenset(
+            {
+                "node_type",
+                "trace_name",
+                "start_time",
+                "status",
+                "total_tokens",
+                "total_prompt_tokens",
+                "total_completion_tokens",
+                "total_cost",
+                "total_duration_ms",
+                "total_spans",
+                "error_count",
+            }
+        )
+        assert _SESSION_DERIVED_FIELDS == frozenset(
+            {
+                "total_tokens",
+                "total_prompt_tokens",
+                "total_completion_tokens",
+                "total_cost",
+                "start_time",
+                "end_time",
+                "duration",
+                "total_traces",
+                "first_message",
+                "last_message",
+            }
+        )

--- a/futureagi/tracer/tests/test_eval_attributes_list.py
+++ b/futureagi/tracer/tests/test_eval_attributes_list.py
@@ -64,6 +64,32 @@ class TestGetEvalAttributesListSpans:
         assert "input" in result
         assert not any("." in path for path in result)
 
+    def test_spans_includes_model_columns(
+        self, auth_client, populated_observe_project
+    ):
+        """Span model columns appear alongside span_attributes keys."""
+        project = populated_observe_project["project"]
+        response = auth_client.get(
+            "/tracer/observation-span/get_eval_attributes_list/",
+            {
+                "filters": json.dumps({"project_id": str(project.id)}),
+                "row_type": "spans",
+            },
+        )
+        result = response.json().get("result", [])
+        for col in (
+            "model",
+            "provider",
+            "latency_ms",
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            "metadata",
+            "tags",
+            "status",
+        ):
+            assert col in result, f"missing span model column {col!r} in picker"
+
 
 @pytest.mark.integration
 @pytest.mark.api
@@ -83,17 +109,12 @@ class TestGetEvalAttributesListTraces:
         )
         assert response.status_code == 200
         result = response.json().get("result", [])
-        # All allow-list trace fields surface as bare scalar paths.
-        for field in (
-            "input",
-            "output",
-            "name",
-            "error",
-            "tags",
-            "metadata",
-            "external_id",
-        ):
-            assert field in result
+        # Every Trace column appears; tracks the schema.
+        from tracer.models.trace import Trace
+        from tracer.utils.eval_helpers import evalable_field_names
+
+        for field in evalable_field_names(Trace):
+            assert field in result, f"missing trace column {field!r} in picker"
 
     def test_includes_indexed_span_paths_per_observed_key(
         self, auth_client, populated_observe_project
@@ -118,6 +139,45 @@ class TestGetEvalAttributesListTraces:
             assert f"spans.{i}.output" in result
         # No phantom positions beyond the observed max
         assert "spans.3.input" not in result
+
+    def test_indexed_span_paths_include_model_columns(
+        self, auth_client, populated_observe_project
+    ):
+        """``spans.<n>.<col>`` for span model columns, not only attr keys."""
+        project = populated_observe_project["project"]
+        response = auth_client.get(
+            "/tracer/observation-span/get_eval_attributes_list/",
+            {
+                "filters": json.dumps({"project_id": str(project.id)}),
+                "row_type": "traces",
+            },
+        )
+        result = response.json().get("result", [])
+        for i in range(3):
+            for col in ("model", "provider", "latency_ms", "prompt_tokens"):
+                assert f"spans.{i}.{col}" in result, (
+                    f"missing spans.{i}.{col} in trace picker"
+                )
+
+    def test_includes_trace_derived_fields(
+        self, auth_client, populated_observe_project
+    ):
+        """Derived trace aggregates appear alongside real columns."""
+        from tracer.utils.eval import _TRACE_DERIVED_FIELDS
+
+        project = populated_observe_project["project"]
+        response = auth_client.get(
+            "/tracer/observation-span/get_eval_attributes_list/",
+            {
+                "filters": json.dumps({"project_id": str(project.id)}),
+                "row_type": "traces",
+            },
+        )
+        result = response.json().get("result", [])
+        for derived in _TRACE_DERIVED_FIELDS:
+            assert derived in result, (
+                f"missing derived trace field {derived!r} in picker"
+            )
 
     def test_does_not_expose_first_last_aliases(
         self, auth_client, populated_observe_project
@@ -157,6 +217,26 @@ class TestGetEvalAttributesListSessions:
         result = response.json().get("result", [])
         for field in ("name", "bookmarked"):
             assert field in result
+
+    def test_includes_session_derived_fields(
+        self, auth_client, populated_observe_project
+    ):
+        """Derived session aggregates appear alongside real columns."""
+        from tracer.utils.eval import _SESSION_DERIVED_FIELDS
+
+        project = populated_observe_project["project"]
+        response = auth_client.get(
+            "/tracer/observation-span/get_eval_attributes_list/",
+            {
+                "filters": json.dumps({"project_id": str(project.id)}),
+                "row_type": "sessions",
+            },
+        )
+        result = response.json().get("result", [])
+        for derived in _SESSION_DERIVED_FIELDS:
+            assert derived in result, (
+                f"missing derived session field {derived!r} in picker"
+            )
 
     def test_includes_indexed_traces_with_trace_fields(
         self, auth_client, populated_observe_project

--- a/futureagi/tracer/tests/test_span_path_resolver.py
+++ b/futureagi/tracer/tests/test_span_path_resolver.py
@@ -1,0 +1,118 @@
+"""Tests for ``_resolve_span_path`` model-column branch.
+
+Every concrete ObservationSpan column is reachable by bare name; the
+model branch wins over span_attributes on a name collision.
+"""
+
+import pytest
+
+# Cycle-breaker — same rationale as the other resolver tests.
+import model_hub.tasks  # noqa: F401, E402
+
+from tracer.models.observation_span import ObservationSpan  # noqa: E402
+from tracer.models.trace import Trace  # noqa: E402
+from tracer.utils.eval import (  # noqa: E402
+    _MISSING,
+    _SPAN_PUBLIC_FIELDS,
+    _resolve_span_path,
+)
+from tracer.utils.eval_helpers import evalable_field_names  # noqa: E402
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestResolveSpanPathModelColumns:
+    """Bare-name model column reachability."""
+
+    def _make_span(self, observe_project, **overrides):
+        trace = Trace.objects.create(project=observe_project)
+        defaults = dict(
+            id="span-resolver-1",
+            project=observe_project,
+            trace=trace,
+            name="resolver-target",
+            observation_type="llm",
+            model="gpt-4o",
+            provider="openai",
+            latency_ms=1234,
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            input={"messages": [{"role": "user", "content": "hi"}]},
+            output={"choices": [{"text": "hello"}]},
+            metadata={"customer_id": "cust_42"},
+            # ``model`` here collides with the model column — see
+            # test_model_column_wins_over_span_attributes_collision.
+            span_attributes={
+                "model": "gpt-3.5-from-attrs",
+                "nested": {"deep": "v"},
+            },
+        )
+        defaults.update(overrides)
+        return ObservationSpan.objects.create(**defaults)
+
+    def test_scalar_model_column(self, observe_project):
+        span = self._make_span(observe_project)
+        assert _resolve_span_path(span, "provider") == "openai"
+        assert _resolve_span_path(span, "latency_ms") == 1234
+        assert _resolve_span_path(span, "prompt_tokens") == 10
+        assert _resolve_span_path(span, "total_tokens") == 30
+
+    def test_json_model_column_root_and_dotted(self, observe_project):
+        span = self._make_span(observe_project)
+        # Bare name returns the whole JSON value.
+        assert _resolve_span_path(span, "metadata") == {"customer_id": "cust_42"}
+        # Dotted walk into the JSON column.
+        assert _resolve_span_path(span, "metadata.customer_id") == "cust_42"
+
+    def test_model_column_wins_over_span_attributes_collision(self, observe_project):
+        """Model column wins; span_attributes still reachable via the
+        ``span_attributes.<name>`` head."""
+        span = self._make_span(observe_project)
+        assert _resolve_span_path(span, "model") == "gpt-4o"
+        assert _resolve_span_path(span, "span_attributes.model") == "gpt-3.5-from-attrs"
+
+    def test_span_attributes_fallback_still_works(self, observe_project):
+        """Bare key fallback (legacy ``_resolve_attr`` surface)."""
+        span = self._make_span(observe_project)
+        assert _resolve_span_path(span, "nested.deep") == "v"
+
+    def test_missing_dotted_returns_missing_sentinel(self, observe_project):
+        """Missing key in a dotted walk returns ``_MISSING`` (caller writes
+        an error row)."""
+        span = self._make_span(observe_project, metadata={"x": 1})
+        assert _resolve_span_path(span, "metadata.does_not_exist") is _MISSING
+
+    def test_null_model_column_returns_none(self, observe_project):
+        """Top-level null is a legitimate resolution — not ``_MISSING``."""
+        span = self._make_span(observe_project, metadata=None)
+        assert _resolve_span_path(span, "metadata") is None
+
+
+@pytest.mark.django_db
+class TestSpanPublicFieldsWhitelist:
+    """``_SPAN_PUBLIC_FIELDS`` tracks the model schema."""
+
+    def test_whitelist_matches_evalable_field_names(self):
+        assert _SPAN_PUBLIC_FIELDS == evalable_field_names(ObservationSpan)
+
+    def test_includes_representative_columns(self):
+        for col in (
+            "input",
+            "output",
+            "model",
+            "provider",
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            "latency_ms",
+            "metadata",
+            "tags",
+            "status",
+            "span_attributes",
+        ):
+            assert col in _SPAN_PUBLIC_FIELDS
+
+    def test_excludes_soft_delete_columns(self):
+        assert "deleted" not in _SPAN_PUBLIC_FIELDS
+        assert "deleted_at" not in _SPAN_PUBLIC_FIELDS

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -38,7 +38,11 @@ EXPERIMENT = "experiment"
 OBSERVE = "observe"
 
 # Re-export for backward compat
-from tracer.utils.eval_helpers import resolve_eval_config_id  # noqa: F401, E402
+from tracer.utils.eval_helpers import (  # noqa: F401, E402
+    evalable_field_names,
+    evalable_fk_remap,
+    resolve_eval_config_id,
+)
 
 # Friendly eval-mapping shorthands used in saved configs. The user-
 # facing variable picker (voice projects in particular) lets people map
@@ -185,7 +189,8 @@ def _process_mapping(
             if isinstance(resolved_value, str):
                 parsed_mapping[key] = resolved_value
             else:
-                parsed_mapping[key] = json.dumps(resolved_value)
+                # default=str serializes datetime / UUID columns.
+                parsed_mapping[key] = json.dumps(resolved_value, default=str)
         else:
             logger.error(
                 f"Required attribute '{attribute}' for key '{key}' not found for span {span.id}"
@@ -1478,36 +1483,184 @@ def _resolve_collection_path(items: list, path: str, item_resolver):
     return item_resolver(items[idx], rest)
 
 
-# Allow-list of model attributes the trace + session mapping resolvers
-# expose. Prevents users from mapping eval inputs to internal Django state
-# (``_state``, ``pk``, manager refs, methods, FK-Model objects) and keeps
-# the mappable surface a deliberate API contract — not "whatever happens
-# to be on the model". When a new field is added to one of these models,
-# decide whether it belongs in the eval-mapping surface and update the
-# set if so. Span resolution intentionally has no allow-list — it routes
-# through the OTel ``span_attributes`` JSONField bag, which is the
-# canonical surface the span mapping picker exposes today.
-_TRACE_PUBLIC_FIELDS = frozenset(
-    {"input", "output", "name", "error", "tags", "metadata", "external_id"}
+# Mapping allow-lists, derived from ``Model._meta`` so they track the schema.
+_TRACE_PUBLIC_FIELDS = evalable_field_names(Trace)
+_SPAN_PUBLIC_FIELDS = evalable_field_names(ObservationSpan)
+_SESSION_PUBLIC_FIELDS = evalable_field_names(TraceSession)
+# FK picker-name → ``getattr`` target (``session`` → ``session_id``, …).
+_TRACE_FK_REMAP = evalable_fk_remap(Trace)
+_SPAN_FK_REMAP = evalable_fk_remap(ObservationSpan)
+_SESSION_FK_REMAP = evalable_fk_remap(TraceSession)
+
+
+# Aggregates / root-span shorthands computed at resolve time. Same
+# expressions as ``list_traces`` / ``list_sessions`` — values match the
+# FE tables.
+_TRACE_DERIVED_FIELDS = frozenset(
+    {
+        "node_type",
+        "trace_name",
+        "start_time",
+        "status",
+        "total_tokens",
+        "total_prompt_tokens",
+        "total_completion_tokens",
+        "total_cost",
+        "total_duration_ms",
+        "total_spans",
+        "error_count",
+    }
 )
-_SESSION_PUBLIC_FIELDS = frozenset({"name", "bookmarked"})
+_SESSION_DERIVED_FIELDS = frozenset(
+    {
+        "total_tokens",
+        "total_prompt_tokens",
+        "total_completion_tokens",
+        "total_cost",
+        "start_time",
+        "end_time",
+        "duration",
+        "total_traces",
+        "first_message",
+        "last_message",
+    }
+)
+
+
+def _compute_trace_derived(trace: Trace) -> dict:
+    """Mirrors aggregates in ``list_traces``. Memoised per-instance."""
+    cache = getattr(trace, "_eval_derived_cache", None)
+    if cache is not None:
+        return cache
+
+    from django.db.models import (
+        Count,
+        FloatField,
+        IntegerField,
+        Max,
+        Q,
+        Sum,
+    )
+    from django.db.models.functions import Coalesce
+
+    spans = ObservationSpan.objects.filter(trace_id=trace.id)
+    agg = spans.aggregate(
+        total_tokens=Coalesce(Sum("total_tokens", output_field=IntegerField()), 0),
+        total_prompt_tokens=Coalesce(
+            Sum("prompt_tokens", output_field=IntegerField()), 0
+        ),
+        total_completion_tokens=Coalesce(
+            Sum("completion_tokens", output_field=IntegerField()), 0
+        ),
+        total_cost=Coalesce(Sum("cost", output_field=FloatField()), 0.0),
+        total_spans=Count("id"),
+        error_count=Count("id", filter=Q(status="ERROR")),
+        # Root spans only — matches ``max(root_latencies)`` in trace.py.
+        total_duration_ms=Coalesce(
+            Max("latency_ms", filter=Q(parent_span_id__isnull=True)), 0
+        ),
+    )
+
+    root_span = (
+        spans.filter(parent_span_id__isnull=True).order_by("start_time").first()
+    )
+    root_statuses = set(
+        spans.filter(parent_span_id__isnull=True)
+        .values_list("status", flat=True)
+        .distinct()
+    )
+    if "ERROR" in root_statuses:
+        status = "ERROR"
+    elif "OK" in root_statuses:
+        status = "OK"
+    else:
+        status = "UNSET"
+
+    cache = {
+        "node_type": root_span.observation_type if root_span else "unknown",
+        "trace_name": (
+            root_span.name if root_span else "[ Incomplete Trace ]"
+        ),
+        "start_time": (
+            root_span.start_time
+            if root_span and root_span.start_time
+            else trace.created_at
+        ),
+        "status": status,
+        "total_tokens": agg["total_tokens"],
+        "total_prompt_tokens": agg["total_prompt_tokens"],
+        "total_completion_tokens": agg["total_completion_tokens"],
+        "total_cost": (
+            round(agg["total_cost"], 6) if agg["total_cost"] else 0.0
+        ),
+        "total_duration_ms": agg["total_duration_ms"],
+        "total_spans": agg["total_spans"],
+        "error_count": agg["error_count"],
+    }
+    trace._eval_derived_cache = cache
+    return cache
+
+
+def _compute_session_derived(session: TraceSession) -> dict:
+    """Mirrors aggregates in ``list_sessions``. Memoised per-instance."""
+    cache = getattr(session, "_eval_derived_cache", None)
+    if cache is not None:
+        return cache
+
+    from django.db.models import Count, FloatField, IntegerField, Max, Min, Sum
+    from django.db.models.functions import Coalesce
+
+    spans = ObservationSpan.objects.filter(trace__session_id=session.id)
+    agg = spans.aggregate(
+        total_tokens=Coalesce(Sum("total_tokens", output_field=IntegerField()), 0),
+        total_prompt_tokens=Coalesce(
+            Sum("prompt_tokens", output_field=IntegerField()), 0
+        ),
+        total_completion_tokens=Coalesce(
+            Sum("completion_tokens", output_field=IntegerField()), 0
+        ),
+        total_cost=Coalesce(Sum("cost", output_field=FloatField()), 0.0),
+        start_time=Min("start_time"),
+        end_time=Max("end_time"),
+        total_traces=Count("trace_id", distinct=True),
+    )
+
+    start, end = agg.get("start_time"), agg.get("end_time")
+    if start and end:
+        try:
+            duration = (end - start).total_seconds()
+        except (TypeError, AttributeError):
+            duration = 0
+    else:
+        duration = 0
+
+    first = spans.order_by("start_time").values_list("input", flat=True).first()
+    last = spans.order_by("-start_time").values_list("input", flat=True).first()
+
+    cache = {
+        "total_tokens": agg["total_tokens"],
+        "total_prompt_tokens": agg["total_prompt_tokens"],
+        "total_completion_tokens": agg["total_completion_tokens"],
+        "total_cost": (
+            round(agg["total_cost"], 6) if agg["total_cost"] else 0.0
+        ),
+        "start_time": start,
+        "end_time": end,
+        "duration": duration,
+        "total_traces": agg["total_traces"],
+        "first_message": first,
+        "last_message": last,
+    }
+    session._eval_derived_cache = cache
+    return cache
 
 
 def _resolve_span_path(span: ObservationSpan, path: str):
-    """Walk a path against a span via the ``span_attributes`` bag.
+    """Walk a path against a span.
 
-    Routes through ``_resolve_attr(span_attrs, path)`` — same surface as the
-    pre-existing ``_process_mapping`` resolver, so a saved span mapping that
-    works at the span level also works when the path bottoms out at a span
-    via ``spans.<n>.<field>`` from a trace or session resolver. The SDK
-    mirrors model fields (``input``, ``output``, ``model``, etc.) into
-    ``span_attributes`` during ingestion, so users don't lose access to
-    them.
-
-    The explicit ``span_attributes`` head case lets a path return the
-    whole bag (``spans.0.span_attributes``) or walk into a nested key
-    (``spans.0.span_attributes.foo.bar``) without going through the
-    aliasing fallback in ``_resolve_attr``.
+    Order: ``span_attributes.<...>`` → model column → ``_resolve_attr``
+    fallback (legacy span_attributes lookup with friendly aliases). On a
+    name collision the model column wins.
     """
     from tracer.utils.attribute_accessor import get_span_attributes
 
@@ -1525,6 +1678,13 @@ def _resolve_span_path(span: ObservationSpan, path: str):
         walked = _walk_dotted_path(span_attrs, rest)
         return walked if walked is not None else _MISSING
 
+    if head in _SPAN_PUBLIC_FIELDS:
+        value = getattr(span, _SPAN_FK_REMAP.get(head, head))
+        if not rest:
+            return value
+        walked = _walk_dotted_path(value, rest)
+        return walked if walked is not None else _MISSING
+
     span_attrs = get_span_attributes(span)
     return _resolve_attr(span_attrs, path)
 
@@ -1539,7 +1699,15 @@ def _resolve_trace_path(trace: Trace, path: str):
     rest = parts[1] if len(parts) > 1 else ""
 
     if head in _TRACE_PUBLIC_FIELDS:
-        value = getattr(trace, head)
+        value = getattr(trace, _TRACE_FK_REMAP.get(head, head))
+        if not rest:
+            return value
+        walked = _walk_dotted_path(value, rest)
+        return walked if walked is not None else _MISSING
+
+    if head in _TRACE_DERIVED_FIELDS:
+        derived = _compute_trace_derived(trace)
+        value = derived.get(head)
         if not rest:
             return value
         walked = _walk_dotted_path(value, rest)
@@ -1562,7 +1730,15 @@ def _resolve_session_path(trace_session: TraceSession, path: str):
     rest = parts[1] if len(parts) > 1 else ""
 
     if head in _SESSION_PUBLIC_FIELDS:
-        value = getattr(trace_session, head)
+        value = getattr(trace_session, _SESSION_FK_REMAP.get(head, head))
+        if not rest:
+            return value
+        walked = _walk_dotted_path(value, rest)
+        return walked if walked is not None else _MISSING
+
+    if head in _SESSION_DERIVED_FIELDS:
+        derived = _compute_session_derived(trace_session)
+        value = derived.get(head)
         if not rest:
             return value
         walked = _walk_dotted_path(value, rest)
@@ -1645,7 +1821,10 @@ def _process_trace_mapping(
                 f"Required attribute '{attribute}' for key '{key}' not found "
                 f"on trace {trace.id}"
             )
-        parsed[key] = value if isinstance(value, str) else json.dumps(value)
+        # default=str serializes datetime / UUID columns.
+        parsed[key] = (
+            value if isinstance(value, str) else json.dumps(value, default=str)
+        )
 
     return parsed
 
@@ -1694,7 +1873,10 @@ def _process_session_mapping(
                 f"Required attribute '{attribute}' for key '{key}' not found "
                 f"on session {trace_session.id}"
             )
-        parsed[key] = value if isinstance(value, str) else json.dumps(value)
+        # default=str serializes datetime / UUID columns.
+        parsed[key] = (
+            value if isinstance(value, str) else json.dumps(value, default=str)
+        )
 
     return parsed
 

--- a/futureagi/tracer/utils/eval_helpers.py
+++ b/futureagi/tracer/utils/eval_helpers.py
@@ -1,6 +1,50 @@
 """Lightweight eval utility functions — no heavy imports at module level."""
 
 
+_EVAL_FIELD_DENY = frozenset({"deleted", "deleted_at"})
+
+
+def evalable_field_names(model) -> frozenset:
+    """Concrete DB columns on ``model`` usable as eval mapping targets.
+
+    FKs expose the bare relation name (``session``, ``project``) — the
+    resolver maps it to the underlying ``*_id`` UUID via
+    ``evalable_fk_remap``. Reverse relations and ``_EVAL_FIELD_DENY`` names
+    are excluded.
+    """
+    from django.db.models import ForeignKey, OneToOneField
+
+    names = set()
+    for f in model._meta.get_fields():
+        if f.is_relation and not (f.many_to_one or f.one_to_one):
+            continue
+        if isinstance(f, (ForeignKey, OneToOneField)):
+            names.add(f.name)
+            continue
+        if not getattr(f, "concrete", False):
+            continue
+        if f.name in _EVAL_FIELD_DENY:
+            continue
+        names.add(f.name)
+    return frozenset(names)
+
+
+def evalable_fk_remap(model) -> dict:
+    """Picker-name → ``getattr`` target for FK columns on ``model``.
+
+    ``getattr(trace, "session")`` would return a TraceSession instance —
+    not JSON-serialisable. Resolvers translate FK picker names to their
+    ``*_id`` attname so they read the UUID instead.
+    """
+    from django.db.models import ForeignKey, OneToOneField
+
+    return {
+        f.name: f.attname
+        for f in model._meta.get_fields()
+        if isinstance(f, (ForeignKey, OneToOneField))
+    }
+
+
 def resolve_eval_template_id(eval_id, organization_id=None):
     """Resolve eval template name to UUID, scoped by organization.
 

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -84,9 +84,12 @@ from tracer.serializers.trace import TraceSerializer
 from tracer.utils.annotations import build_annotation_subqueries
 from tracer.utils.create_otel_span import create_single_otel_span
 from tracer.utils.eval import (
+    _SESSION_DERIVED_FIELDS,
+    _TRACE_DERIVED_FIELDS,
     evaluate_observation_span,
     evaluate_observation_span_observe,
 )
+from tracer.utils.eval_helpers import evalable_field_names
 from tracer.utils.eval_tasks import parsing_evaltask_filters
 from tracer.utils.filters import FilterEngine
 from tracer.utils.graphs_optimized import (
@@ -2832,13 +2835,10 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
 
     @action(detail=False, methods=["get"])
     def get_span_attributes_list(self, request, *args, **kwargs):
-        """Distinct span_attributes keys for a project (spans surface).
+        """Span model columns + distinct span_attributes keys for a project.
 
-        Query params:
-            filters: JSON {"project_id": "<uuid>"} (required)
-
-        Returns:
-            List of attribute key strings.
+        Model columns come first (sorted) — durable contract above the
+        project-observed OTel bag keys.
         """
         try:
             filters = self.request.query_params.get("filters", "{}")
@@ -2849,7 +2849,10 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             if not project_id:
                 return self._gm.bad_request("project_id is required")
 
-            result = self._get_span_attribute_keys(project_id)
+            result = self._merge_model_and_attr_keys(
+                self._SPAN_PUBLIC_FIELDS,
+                self._get_span_attribute_keys(project_id),
+            )
             return self._gm.success_response(result)
 
         except Exception as e:
@@ -2918,19 +2921,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 f"error fetching the eval attributes list {str(e)}"
             )
 
-    # Trace + session model fields the resolver allow-lists; mirrors the
-    # frozensets in tracer.utils.eval. Hand-synced so a model change shows
-    # up in both places at review time.
-    _TRACE_PUBLIC_FIELDS = (
-        "input",
-        "output",
-        "name",
-        "error",
-        "tags",
-        "metadata",
-        "external_id",
-    )
-    _SESSION_PUBLIC_FIELDS = ("name", "bookmarked")
+    # Mapping allow-lists, derived from Model._meta — same source the
+    # runtime resolver in tracer.utils.eval uses.
+    _TRACE_PUBLIC_FIELDS = tuple(sorted(evalable_field_names(Trace)))
+    _SPAN_PUBLIC_FIELDS = tuple(sorted(evalable_field_names(ObservationSpan)))
+    _SESSION_PUBLIC_FIELDS = tuple(sorted(evalable_field_names(TraceSession)))
 
     # Cap on how many entities to scan when computing observed maxes.
     # Most projects' traces have a few-to-dozens of spans; bounding the
@@ -3011,32 +3006,54 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         )
         return agg["max_count"] or 0
 
+    @staticmethod
+    def _merge_model_and_attr_keys(model_fields, attr_keys) -> list:
+        """Union: model fields first, then attr keys, no duplicates."""
+        seen = set()
+        merged = []
+        for k in list(model_fields) + list(attr_keys):
+            if k and k not in seen:
+                merged.append(k)
+                seen.add(k)
+        return merged
+
     def _build_trace_attribute_paths(
         self, project_id: str, span_attribute_keys: list
     ) -> list:
-        """Trace-level paths: trace fields + ``spans.<n>.<key>`` for each
-        index up to the observed max spans-per-trace."""
-        paths = list(self._TRACE_PUBLIC_FIELDS)
+        """Trace fields + derived aggregates + ``spans.<n>.<key>``."""
+        paths = self._merge_model_and_attr_keys(
+            self._TRACE_PUBLIC_FIELDS, sorted(_TRACE_DERIVED_FIELDS)
+        )
         max_spans = self._max_spans_per_trace(project_id)
+        span_keys = self._merge_model_and_attr_keys(
+            self._SPAN_PUBLIC_FIELDS, span_attribute_keys
+        )
         for i in range(max_spans):
-            for key in span_attribute_keys:
+            for key in span_keys:
                 paths.append(f"spans.{i}.{key}")
         return paths
 
     def _build_session_attribute_paths(
         self, project_id: str, span_attribute_keys: list
     ) -> list:
-        """Session-level paths: session fields + ``traces.<i>.<trace_field>``
-        + ``traces.<i>.spans.<j>.<key>`` up to the observed max traces-per-
-        session and spans-per-trace."""
-        paths = list(self._SESSION_PUBLIC_FIELDS)
+        """Session fields + derived aggregates + ``traces.<i>.<...>`` +
+        ``traces.<i>.spans.<j>.<key>``."""
+        paths = self._merge_model_and_attr_keys(
+            self._SESSION_PUBLIC_FIELDS, sorted(_SESSION_DERIVED_FIELDS)
+        )
         max_traces = self._max_traces_per_session(project_id)
         max_spans = self._max_spans_per_trace(project_id)
+        trace_fields = self._merge_model_and_attr_keys(
+            self._TRACE_PUBLIC_FIELDS, sorted(_TRACE_DERIVED_FIELDS)
+        )
+        span_keys = self._merge_model_and_attr_keys(
+            self._SPAN_PUBLIC_FIELDS, span_attribute_keys
+        )
         for i in range(max_traces):
-            for trace_field in self._TRACE_PUBLIC_FIELDS:
+            for trace_field in trace_fields:
                 paths.append(f"traces.{i}.{trace_field}")
             for j in range(max_spans):
-                for key in span_attribute_keys:
+                for key in span_keys:
                     paths.append(f"traces.{i}.spans.{j}.{key}")
         return paths
 


### PR DESCRIPTION
## Summary

- ``evalable_field_names()`` / ``evalable_fk_remap()`` derive the trace / span / session whitelist from ``Model._meta`` so the picker + runtime resolver track the schema instead of drifting against a hand-curated set. Replaces the 7-field trace whitelist and the no-model-column span surface that only walked ``span_attributes``.
- FK columns surface as bare relation names (``project``, ``session``, ``project_version``); the resolver remaps them to the ``*_id`` attname so eval inputs still receive the UUID. Plain scalar ``*_id`` columns (``parent_span_id``, ``org_id``, ``eval_id``, ``org_user_id``) keep their names.
- Trace + session derived aggregates (``total_tokens``, ``total_cost``, ``status``, ``duration``, ``first_message``, …) reachable via ``_resolve_*_path``. Same expressions ``list_traces`` / ``list_sessions`` use → values match the FE tables. Memoised per-instance.
- ``_resolve_span_path`` gains a model-column branch (was ``span_attributes`` only). Model column wins on a name collision; OTel keys still reachable via the explicit ``span_attributes.<key>`` head.
- ``json.dumps(value, default=str)`` in the three ``_process_*_mapping`` serialisers so datetime / UUID columns don't TypeError.

## Why

Eval task ``ea47183d-de24-4302-94f7-83e3e4bd59e1`` ran 12 trace rows with ``mapping={"number": "metadata"}``. Every trace had ``metadata=NULL``, so every prompt became ``is this null a integer …``, every row was persisted with ``output_str="integer"`` and ``error=False``. The narrow whitelist made the silent-null path unavoidable for anything but the 7 trace fields the resolver knew about, and the span picker couldn't reach the obvious mapping targets (``model``, ``provider``, ``latency_ms``, etc.) at all.

## Test plan

- [x] ``tracer/tests/test_span_path_resolver.py`` (new, 9 cases) — model column reach, collision precedence, ``_MISSING`` sentinel, ``span_attributes`` fallback.
- [x] ``tracer/tests/test_derived_fields_resolver.py`` (new, 10 cases) — aggregate formulas, status precedence, empty-session zero-not-null, per-instance cache.
- [x] ``tracer/tests/test_eval_attributes_list.py`` strengthened — picker output ⊇ ``evalable_field_names(<model>)``; derived names appear in traces + sessions row_types.
- [x] Local backend smoke: ``get_eval_attributes_list`` returns ``project`` / ``session`` (no ``_id``) for traces, plus ``total_tokens`` / ``duration`` / ``first_message`` for sessions; UUIDs flow through to the LLM input.
- [ ] Re-run a clone of the ``ea47183d-…`` task on dev with a mapping pointing at a real scalar field; confirm LLM receives non-null input and produces meaningful classifications.

## Out of scope

- Silent-null handling: ``_process_*_mapping`` still treats resolved ``None`` for a *required* mapping key as a successful resolution and ``json.dumps``-es it to ``"null"``. Separate PR to escalate that to an error row.