### PR TITLE
fix: hide draft evals from eval drawer

### DIFF
--- a/futureagi/model_hub/tests/test_evaluation_api.py
+++ b/futureagi/model_hub/tests/test_evaluation_api.py
@@ -475,6 +475,35 @@ class TestGetEvalsListView:
 
         assert response.status_code == status.HTTP_200_OK
 
+    def test_get_evals_list_excludes_draft_templates(
+        self, auth_client, dataset, organization, workspace
+    ):
+        """Draft templates are stored as visible_ui=False and stay out of the drawer."""
+        visible_template = EvalTemplate.objects.create(
+            name="visible-user-eval",
+            organization=organization,
+            workspace=workspace,
+            owner="user",
+            visible_ui=True,
+        )
+        draft_template = EvalTemplate.objects.create(
+            name="draft-hidden-eval",
+            organization=organization,
+            workspace=workspace,
+            owner="user",
+            visible_ui=False,
+        )
+
+        response = auth_client.get(f"/model-hub/develops/{dataset.id}/get_evals_list/")
+
+        assert response.status_code == status.HTTP_200_OK
+        names = {
+            item["name"]
+            for item in response.data["result"]["evals"]
+            if item["id"] in {str(visible_template.id), str(draft_template.id)}
+        }
+        assert names == {"visible-user-eval"}
+
     def test_get_evals_list_invalid_dataset(self, auth_client):
         """Test that invalid dataset_id returns error."""
         fake_dataset_id = uuid.uuid4()

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -6450,7 +6450,7 @@ class GetEvalsListView(APIView):
         )
 
         eval_templates = EvalTemplate.no_workspace_objects.filter(
-            organization__isnull=True, deleted=False
+            organization__isnull=True, deleted=False, visible_ui=True
         )
 
         # IMPORTANT: do NOT call insert_evals_template() here.
@@ -6573,10 +6573,13 @@ class GetEvalsListView(APIView):
                 organization=organization,
                 deleted=False,
                 template__deleted=False,
+                template__visible_ui=True,
             )
         else:
             # Filter by show_in_sidebar even when user_evals is provided
-            user_evals = user_evals.filter(show_in_sidebar=True)
+            user_evals = user_evals.filter(
+                show_in_sidebar=True, template__visible_ui=True
+            )
 
         if search_text:
             user_evals = user_evals.filter(name__icontains=search_text)
@@ -6598,7 +6601,10 @@ class GetEvalsListView(APIView):
         )
 
         eval_templates = EvalTemplate.objects.filter(
-            organization=organization, owner=OwnerChoices.USER.value, deleted=False
+            organization=organization,
+            owner=OwnerChoices.USER.value,
+            deleted=False,
+            visible_ui=True,
         ).prefetch_related("evaluators__user", "versions__created_by")
 
         if search_text:
@@ -6658,7 +6664,7 @@ class GetEvalsListView(APIView):
         self, validated_data, organization, search_text
     ):
         eval_templates = EvalTemplate.objects.filter(
-            organization=organization, deleted=False
+            organization=organization, deleted=False, visible_ui=True
         )
         if search_text:
             eval_templates = eval_templates.filter(Q(name__icontains=search_text))


### PR DESCRIPTION
## Summary

Draft eval templates are persisted with `visible_ui=False`, but the legacy dataset eval drawer endpoint was still returning them. This updates `GetEvalsListView` so preset, user-built, previously configured, and attached user eval paths all honor `visible_ui` before returning drawer results.

This keeps autosaved draft backing records available for create/test/publish flows without exposing them in the eval selection drawer.

## Linked issues

Closes TH-4915

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

```bash
set -a && source .env.test && set +a && .venv/bin/pytest model_hub/tests/test_evaluation_api.py::TestGetEvalsListView -v
```

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
