### PR TITLE
style(evals): violet capability chips + thin delete icon + single-select data injection

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -47,6 +47,23 @@ import DatasetTestMode from "src/sections/evals/components/DatasetTestMode";
 import TracingTestMode from "src/sections/evals/components/TracingTestMode";
 import SimulationTestMode from "src/sections/evals/components/SimulationTestMode";
 import { useEvalPickerContext } from "./context/EvalPickerContext";
+import { contextOptionsForRowType } from "./evalPickerConfigUtils";
+const dataInjectionFromContextOptions = (opts) => {
+  if (
+    !opts ||
+    opts.length === 0 ||
+    (opts.length === 1 && opts[0] === "variables_only")
+  ) {
+    return { variables_only: true };
+  }
+  const flags = {};
+  if (opts.includes("dataset_row")) flags.full_row = true;
+  if (opts.includes("span_context")) flags.span_context = true;
+  if (opts.includes("trace_context")) flags.trace_context = true;
+  if (opts.includes("session_context")) flags.session_context = true;
+  if (opts.includes("call_context")) flags.call_context = true;
+  return Object.keys(flags).length > 0 ? flags : { variables_only: true };
+};
 
 const PYTHON_CODE_TEMPLATE = `from typing import Any
 
@@ -90,6 +107,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     onFiltersChange,
     filterForm: localFilterForm,
   } = useEvalPickerContext();
+  console.log("EvalPickerCreateNew source info", { source, sourceId, sourceRowType, sourceColumns });
   const { enqueueSnackbar } = useSnackbar();
   const { isOSS } = useDeploymentMode();
   const createEval = useCreateEval();
@@ -114,6 +132,9 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   const [templateFormat, setTemplateFormat] = useState("mustache");
   const [datasetColumns, setDatasetColumns] = useState([]);
   const [datasetJsonSchemas, setDatasetJsonSchemas] = useState({});
+  const [contextOptions, setContextOptions] = useState(
+    () => contextOptionsForRowType(sourceRowType) || ["variables_only"],
+  );
 
   const localFormFilters = useWatch({
     control: localFilterForm.control,
@@ -248,6 +269,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
           ? fewShotExamples.map((ds) => ({ id: ds.id, name: ds.name }))
           : undefined,
       template_format: templateFormat,
+      data_injection:
+        evalType === "agent"
+          ? dataInjectionFromContextOptions(contextOptions)
+          : undefined,
     }),
     [
       evalType,
@@ -261,6 +286,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       messages,
       fewShotExamples,
       templateFormat,
+      contextOptions,
     ],
   );
 
@@ -441,7 +467,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       if (source === "task" && onFiltersChange) {
         onFiltersChange(localFilterForm.getValues("filters") || []);
       }
-      // Now add to the current context
+      // Now add to the current context. data_injection (seeded from
+      // sourceRowType) is forwarded so the consumer's serializeEvalConfig
+      // captures it inside config.run_config — same shape an existing
+      // eval would emit through EvalPickerConfigFull.
       onSave({
         templateId: draftId,
         evalTemplateId: draftId,
@@ -451,6 +480,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         evalType,
         outputType,
         instructions,
+        data_injection:
+          evalType === "agent"
+            ? dataInjectionFromContextOptions(contextOptions)
+            : undefined,
       });
     } catch (error) {
       enqueueSnackbar(error?.message || "Failed to save", { variant: "error" });
@@ -471,6 +504,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     evalType,
     outputType,
     instructions,
+    contextOptions,
     enqueueSnackbar,
     isOSS,
     source,
@@ -843,6 +877,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     datasetColumns={datasetColumns}
                     datasetJsonSchemas={datasetJsonSchemas}
                     mappedVariables={sourceMapping}
+                    activeContextOptions={contextOptions}
+                    onActiveContextOptionsChange={setContextOptions}
                   />
                   {errors.instructions && (
                     <Typography variant="caption" color="error.main">

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -107,7 +107,6 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     onFiltersChange,
     filterForm: localFilterForm,
   } = useEvalPickerContext();
-  console.log("EvalPickerCreateNew source info", { source, sourceId, sourceRowType, sourceColumns });
   const { enqueueSnackbar } = useSnackbar();
   const { isOSS } = useDeploymentMode();
   const createEval = useCreateEval();

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
@@ -7,7 +7,7 @@ const OUTPUT_TYPE_CONFIG_MAP = {
 const ROW_TYPE_CONTEXT_OPTIONS = {
   spans: ["span_context"],
   traces: ["trace_context"],
-  sessions: ["session_context", "trace_context"],
+  sessions: ["session_context"],
   voiceCalls: ["call_context"],
 };
 

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -10,6 +10,7 @@ import {
   TextField,
   Tooltip,
   Typography,
+  alpha,
 } from "@mui/material";
 import {
   useInfiniteQuery,
@@ -147,6 +148,55 @@ const FAGI_MODELS = [
 
 export const FAGI_MODEL_VALUES = new Set(FAGI_MODELS.map((m) => m.value));
 
+const CHIP_STYLES = {
+  backgroundColor: (theme) =>
+    alpha(
+      theme.palette.primary.main,
+      theme.palette.mode === "dark" ? 0.24 : 0.1,
+    ),
+  "&:hover": {
+    backgroundColor: (theme) =>
+      alpha(
+        theme.palette.primary.main,
+        theme.palette.mode === "dark" ? 0.32 : 0.16,
+      ),
+  },
+  color: (theme) =>
+    theme.palette.mode === "dark"
+      ? theme.palette.primary.light
+      : theme.palette.primary.main,
+  border: "1px solid",
+  borderColor: (theme) =>
+    alpha(
+      theme.palette.primary.main,
+      theme.palette.mode === "dark" ? 0.4 : 0.2,
+    ),
+  borderRadius: "4px",
+  fontWeight: 500,
+  fontSize: "11px",
+  height: 22,
+  "& .MuiChip-label": { px: 0.75 },
+  "& .MuiChip-icon": {
+    color: "inherit",
+  },
+  "& .MuiChip-deleteIcon": {
+    margin: "0 4px 0 -2px",
+    color: (theme) =>
+      theme.palette.mode === "dark"
+        ? theme.palette.primary.light
+        : theme.palette.primary.main,
+    transition: "color 0.15s ease",
+    "&:hover": {
+      color: (theme) =>
+        theme.palette.mode === "dark"
+          ? theme.palette.primary.contrastText
+          : theme.palette.primary.dark,
+    },
+  },
+};
+
+const DELETE_ICON = <Iconify icon="mdi:close" width={12} />;
+
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
 // Summary Chip — resolves name for both presets and custom templates
@@ -179,7 +229,8 @@ function SummaryChip({ activeSummary, onClick, onDelete }) {
       label={chipLabel}
       onClick={onClick}
       onDelete={onDelete}
-      sx={{ height: 22, fontSize: "11px", fontWeight: 500, cursor: "pointer" }}
+      deleteIcon={DELETE_ICON}
+      sx={{ ...CHIP_STYLES, cursor: "pointer" }}
     />
   );
 }
@@ -802,7 +853,8 @@ const ModelSelector = ({
           icon={<Iconify icon="mdi:web" width={12} sx={{ ml: 0.5 }} />}
           label="Internet"
           onDelete={() => setUseInternet(false)}
-          sx={{ height: 22, fontSize: "11px", fontWeight: 500 }}
+          deleteIcon={DELETE_ICON}
+          sx={CHIP_STYLES}
         />
       )}
       {showPlus && activeSummary && activeSummary !== "concise" && (
@@ -859,7 +911,8 @@ const ModelSelector = ({
               onDelete={() =>
                 setActiveConnectorIds((p) => p.filter((x) => x !== cId))
               }
-              sx={{ height: 22, fontSize: "11px", fontWeight: 500 }}
+              deleteIcon={DELETE_ICON}
+              sx={CHIP_STYLES}
             />
           );
         })}
@@ -897,12 +950,8 @@ const ModelSelector = ({
               setPlusSubmenu("knowledge");
             }}
             onDelete={() => setSelectedKBs([])}
-            sx={{
-              height: 22,
-              fontSize: "11px",
-              fontWeight: 500,
-              cursor: "pointer",
-            }}
+            deleteIcon={DELETE_ICON}
+            sx={{ ...CHIP_STYLES, cursor: "pointer" }}
           />
         </Tooltip>
       )}
@@ -944,12 +993,8 @@ const ModelSelector = ({
                 setPlusSubmenu("injection");
               }}
               onDelete={() => setActiveContextOptions(["variables_only"])}
-              sx={{
-                height: 22,
-                fontSize: "11px",
-                fontWeight: 500,
-                cursor: "pointer",
-              }}
+              deleteIcon={DELETE_ICON}
+              sx={{ ...CHIP_STYLES, cursor: "pointer" }}
             />
           </Tooltip>
         )}
@@ -1552,7 +1597,8 @@ const ModelSelector = ({
                               prev.filter((x) => x !== kbId),
                             )
                           }
-                          sx={{ height: 20, fontSize: "11px" }}
+                          deleteIcon={DELETE_ICON}
+                          sx={{ ...CHIP_STYLES, height: 20 }}
                         />
                       );
                     })}
@@ -1634,16 +1680,13 @@ const ModelSelector = ({
                       onClick={() => {
                         setActiveContextOptions((prev) => {
                           if (opt.isDefault) {
-                            // Clicking "variables_only" deselects everything else
+                            // Clicking "variables_only" clears any active context.
                             return ["variables_only"];
                           }
-                          // Toggle the clicked option
-                          let next = prev.includes(opt.value)
-                            ? prev.filter((x) => x !== opt.value)
-                            : [...prev.filter((x) => x !== "variables_only"), opt.value];
-                          // If nothing left, revert to variables_only
-                          if (next.length === 0) next = ["variables_only"];
-                          return next;
+                          if (prev.includes(opt.value)) {
+                            return ["variables_only"];
+                          }
+                          return [opt.value];
                         });
                       }}
                       sx={{


### PR DESCRIPTION
## Summary
Restyles the active capability chips in ModelSelector (the +menu rendered
inside InstructionEditor + the LLM-tab ModelSelector) to a shared violet
theme matching `RunTestsContent.jsx`'s chipStyles, swaps MUI's default
heavy CancelIcon for a thin Iconify X, and tightens the data-injection
submenu to single-select so the `+N context` chip never grows past
`+1 context`.

Re-applies commit `ed69e03` whose changes were lost in a working-tree
revert; no behavior change beyond what was already approved on that
commit.

## Why
- Capability chips read inconsistently across surfaces (RunTests was
  already violet, evals were plain gray). Now both use the same shared
  palette so a configured eval looks the same wherever it shows.
- Default `CancelIcon` (filled circle with X cutout) reads as a button,
  not a tertiary affordance. Replaced with a 12px Iconify `mdi:close`.
- Data injection was multi-select but `normalize_eval_runtime_config`
  only meaningfully consumes one context per eval — multi-select gave
  users false confidence that they could combine contexts.

## Scope
- `frontend/src/sections/evals/components/ModelSelector.jsx`
  - New `CHIP_STYLES` constant (violet bg/border/color, hover state,
    icon-inherit, custom delete-icon coloring for both themes).
  - New `DELETE_ICON` constant (`<Iconify icon="mdi:close" width={12} />`).
  - Applied to: SummaryChip, Internet, Connector, KB count, Context,
    in-submenu KB pills.
  - Data-injection submenu `onClick`: clicking a non-default option now
    replaces the active selection; clicking the active option (or
    `variables_only`) clears back to `variables_only`.

## Test plan
- [x] Capability chips render in violet on both light and dark themes
- [x] Leading icons visible against the violet bg (inherit color works)
- [x] Delete icon is a thin X with no circular background
- [x] Hover on delete: color deepens (no background ring)
- [x] Single-select data injection: switching options replaces, doesn't add
- [x] Chip never reads more than `+1 context`
- [x] Clicking active option toggles back to `variables_only`
- [x] Other surfaces (RunTests, Tracing, Simulation, Test, Dataset) unchanged


