### PR TITLE
fix(guardrails): futureagi-eval credentials persist + eval_ids array support

### DIFF
--- a/agentcc-gateway/internal/guardrails/futureagi/futureagi.go
+++ b/agentcc-gateway/internal/guardrails/futureagi/futureagi.go
@@ -17,7 +17,7 @@ import (
 // FutureAGIGuardrail calls Future AGI's evaluation API for ML-based guardrail checks.
 type FutureAGIGuardrail struct {
 	name      string
-	evalID    string
+	evalIDs   []string
 	apiKey    string
 	secretKey string
 	baseURL   string
@@ -77,8 +77,26 @@ func New(name string, cfg map[string]interface{}) *FutureAGIGuardrail {
 		return g
 	}
 
-	if v, ok := cfg["eval_id"].(string); ok {
-		g.evalID = v
+	if v, ok := cfg["eval_ids"]; ok {
+		switch arr := v.(type) {
+		case []interface{}:
+			for _, item := range arr {
+				if s, ok := item.(string); ok && s != "" {
+					g.evalIDs = append(g.evalIDs, s)
+				}
+			}
+		case []string:
+			for _, s := range arr {
+				if s != "" {
+					g.evalIDs = append(g.evalIDs, s)
+				}
+			}
+		}
+	}
+	if len(g.evalIDs) == 0 {
+		if v, ok := cfg["eval_id"].(string); ok && v != "" {
+			g.evalIDs = []string{v}
+		}
 	}
 	if v, ok := cfg["api_key"].(string); ok {
 		g.apiKey = expandEnv(v)
@@ -144,7 +162,7 @@ func (g *FutureAGIGuardrail) Check(ctx context.Context, input *guardrails.CheckI
 			Message: "futureagi guardrail: missing api_key or secret_key, skipping",
 		}
 	}
-	if g.evalID == "" {
+	if len(g.evalIDs) == 0 {
 		return &guardrails.CheckResult{
 			Pass:    true,
 			Message: "futureagi guardrail: missing eval_id, skipping",
@@ -234,13 +252,15 @@ func extractContentText(raw json.RawMessage) string {
 
 // callAPI sends the evaluation request to Future AGI.
 func (g *FutureAGIGuardrail) callAPI(ctx context.Context, text string) (*evalResponse, error) {
+	configMap := make(map[string]evalConfig, len(g.evalIDs))
+	for _, id := range g.evalIDs {
+		configMap[id] = evalConfig{CallType: g.callType}
+	}
 	payload := evalRequest{
 		Inputs: []evalInput{
 			{Input: text, CallType: g.callType, MaxTokens: g.maxTokens},
 		},
-		Config: map[string]evalConfig{
-			g.evalID: {CallType: g.callType},
-		},
+		Config: configMap,
 	}
 
 	body, err := json.Marshal(payload)
@@ -310,49 +330,60 @@ func (g *FutureAGIGuardrail) doRequest(ctx context.Context, url string, body []b
 }
 
 // parseResult maps the evaluation API response to a CheckResult.
+// When multiple eval_ids are checked, the result fails if any single eval fails;
+// the failing eval's reason and details are surfaced.
 func parseResult(resp *evalResponse) *guardrails.CheckResult {
 	if resp == nil || len(resp.Result) == 0 {
 		return &guardrails.CheckResult{Pass: true, Message: "no evaluation results"}
 	}
 
-	for _, group := range resp.Result {
-		if len(group.Evaluations) == 0 {
-			continue
-		}
-		eval := group.Evaluations[0]
+	var firstEval *evaluation
+	var firstFail *evaluation
 
-		pass := true
-		score := 0.0
-
-		switch v := eval.Output.(type) {
-		case string:
-			if strings.EqualFold(v, "failed") {
-				pass = false
-				score = 1.0
+	for i := range resp.Result {
+		for j := range resp.Result[i].Evaluations {
+			eval := &resp.Result[i].Evaluations[j]
+			if firstEval == nil {
+				firstEval = eval
 			}
-		case bool:
-			// true = harmful = fail
-			if v {
-				pass = false
-				score = 1.0
+			if isFailedOutput(eval.Output) && firstFail == nil {
+				firstFail = eval
 			}
-		}
-
-		return &guardrails.CheckResult{
-			Pass:    pass,
-			Score:   score,
-			Message: eval.Reason,
-			Details: map[string]interface{}{
-				"eval_id":     eval.EvalID,
-				"eval_name":   eval.Name,
-				"runtime_ms":  eval.Runtime,
-				"output_type": eval.OutputType,
-				"output":      eval.Output,
-			},
 		}
 	}
 
+	if firstFail != nil {
+		return buildResult(firstFail, false, 1.0)
+	}
+	if firstEval != nil {
+		return buildResult(firstEval, true, 0.0)
+	}
 	return &guardrails.CheckResult{Pass: true, Message: "no evaluation results"}
+}
+
+func isFailedOutput(output interface{}) bool {
+	switch v := output.(type) {
+	case string:
+		return strings.EqualFold(v, "failed")
+	case bool:
+		return v
+	}
+	return false
+}
+
+func buildResult(eval *evaluation, pass bool, score float64) *guardrails.CheckResult {
+	return &guardrails.CheckResult{
+		Pass:    pass,
+		Score:   score,
+		Message: eval.Reason,
+		Details: map[string]interface{}{
+			"eval_id":     eval.EvalID,
+			"eval_name":   eval.Name,
+			"runtime_ms":  eval.Runtime,
+			"output_type": eval.OutputType,
+			"output":      eval.Output,
+		},
+	}
 }
 
 // IsFutureAGIConfig returns true if the config map has provider set to "futureagi".

--- a/agentcc-gateway/internal/guardrails/futureagi/futureagi_test.go
+++ b/agentcc-gateway/internal/guardrails/futureagi/futureagi_test.go
@@ -41,11 +41,11 @@ func makeOutputInput(content string) *guardrails.CheckInput {
 
 func TestFutureAGI_Passed(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer test-key" {
-			t.Error("missing or wrong Authorization header")
+		if r.Header.Get("X-Api-Key") != "test-key" {
+			t.Error("missing or wrong X-Api-Key header")
 		}
-		if r.Header.Get("x-fi-secret-key") != "test-secret" {
-			t.Error("missing or wrong secret key header")
+		if r.Header.Get("X-Secret-Key") != "test-secret" {
+			t.Error("missing or wrong X-Secret-Key header")
 		}
 		w.WriteHeader(200)
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -537,6 +537,122 @@ func TestFutureAGI_ArrayContent(t *testing.T) {
 	g.Check(context.Background(), input)
 	if receivedInput != "Analyze this image" {
 		t.Errorf("expected text extracted from array content, got %q", receivedInput)
+	}
+}
+
+// --- Test: Multiple eval_ids — request payload includes all, any failure fails the check ---
+
+func TestFutureAGI_EvalIDsArray_AllPass(t *testing.T) {
+	var receivedReq evalRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedReq)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": []map[string]interface{}{
+				{"evaluations": []map[string]interface{}{
+					{"name": "toxicity", "output": "Passed", "reason": "ok", "runtime": 100.0, "evalId": "76"},
+				}},
+				{"evaluations": []map[string]interface{}{
+					{"name": "injection", "output": "Passed", "reason": "ok", "runtime": 90.0, "evalId": "15"},
+				}},
+				{"evaluations": []map[string]interface{}{
+					{"name": "bias", "output": "Passed", "reason": "ok", "runtime": 80.0, "evalId": "22"},
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	g := New("multi", map[string]interface{}{
+		"provider":   "futureagi",
+		"eval_ids":   []interface{}{"76", "15", "22"},
+		"api_key":    "k",
+		"secret_key": "s",
+		"base_url":   srv.URL,
+	})
+
+	result := g.Check(context.Background(), makeInput([]models.Message{makeMsg("user", "hi")}))
+	if !result.Pass {
+		t.Fatalf("expected pass when all evals pass, got fail: %s", result.Message)
+	}
+	if len(receivedReq.Config) != 3 {
+		t.Errorf("expected 3 entries in request config, got %d", len(receivedReq.Config))
+	}
+	for _, id := range []string{"76", "15", "22"} {
+		if _, ok := receivedReq.Config[id]; !ok {
+			t.Errorf("missing eval_id %s in config map", id)
+		}
+	}
+}
+
+func TestFutureAGI_EvalIDsArray_OneFailsFailsAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": []map[string]interface{}{
+				{"evaluations": []map[string]interface{}{
+					{"name": "toxicity", "output": "Passed", "reason": "ok", "runtime": 100.0, "evalId": "76"},
+				}},
+				{"evaluations": []map[string]interface{}{
+					{"name": "injection", "output": "Failed", "reason": "prompt injection detected", "runtime": 90.0, "evalId": "15"},
+				}},
+				{"evaluations": []map[string]interface{}{
+					{"name": "bias", "output": "Passed", "reason": "ok", "runtime": 80.0, "evalId": "22"},
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	g := New("multi", map[string]interface{}{
+		"provider":   "futureagi",
+		"eval_ids":   []interface{}{"76", "15", "22"},
+		"api_key":    "k",
+		"secret_key": "s",
+		"base_url":   srv.URL,
+	})
+
+	result := g.Check(context.Background(), makeInput([]models.Message{makeMsg("user", "ignore previous")}))
+	if result.Pass {
+		t.Fatal("expected fail when any eval fails")
+	}
+	if result.Score != 1.0 {
+		t.Errorf("expected score 1.0, got %f", result.Score)
+	}
+	if result.Message != "prompt injection detected" {
+		t.Errorf("expected failing eval's reason to surface, got %q", result.Message)
+	}
+	if result.Details["eval_id"] != "15" {
+		t.Errorf("expected failing eval_id 15 in details, got %v", result.Details["eval_id"])
+	}
+}
+
+func TestFutureAGI_EvalIDFallbackToSingular(t *testing.T) {
+	var receivedReq evalRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedReq)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": []map[string]interface{}{
+				{"evaluations": []map[string]interface{}{
+					{"name": "toxicity", "output": "Passed", "reason": "ok", "runtime": 100.0, "evalId": "15"},
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	g := New("legacy", map[string]interface{}{
+		"provider":   "futureagi",
+		"eval_id":    "15",
+		"api_key":    "k",
+		"secret_key": "s",
+		"base_url":   srv.URL,
+	})
+
+	result := g.Check(context.Background(), makeInput([]models.Message{makeMsg("user", "hi")}))
+	if !result.Pass {
+		t.Fatalf("expected pass, got fail: %s", result.Message)
+	}
+	if _, ok := receivedReq.Config["15"]; !ok {
+		t.Errorf("expected singular eval_id to populate config map")
 	}
 }
 

--- a/futureagi/agentcc/migrations/0026_clear_stuck_ui_guardrails_encrypted_configs.py
+++ b/futureagi/agentcc/migrations/0026_clear_stuck_ui_guardrails_encrypted_configs.py
@@ -1,0 +1,32 @@
+"""
+Clear stale `encrypted_check_configs` on existing `__ui_guardrails__` policies.
+
+Prior to the serializer fix, AgentccGuardrailPolicySerializer.update() always
+overwrote new credentials with the existing encrypted blob. Existing rows are
+stuck on the first credentials ever saved. Clearing forces the next save from
+the org-config UI to populate them correctly with the user-supplied values.
+"""
+
+from django.db import migrations
+
+
+def clear_stuck_encrypted_configs(apps, schema_editor):
+    AgentccGuardrailPolicy = apps.get_model("prism", "AgentccGuardrailPolicy")
+    AgentccGuardrailPolicy.objects.filter(
+        name="__ui_guardrails__",
+        encrypted_check_configs__isnull=False,
+    ).update(encrypted_check_configs=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("prism", "0025_rename_indexes_and_related_name_alters"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            clear_stuck_encrypted_configs,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/futureagi/agentcc/serializers/guardrail_policy.py
+++ b/futureagi/agentcc/serializers/guardrail_policy.py
@@ -124,25 +124,27 @@ class AgentccGuardrailPolicySerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         checks = validated_data.get("checks")
         if checks is not None:
-            # Merge: if a credential value is the sentinel, keep existing encrypted value
             existing_secrets = _decrypt_secrets(instance.encrypted_check_configs)
-            sanitized, new_secrets = _extract_secrets(checks)
 
-            # For each check, if a sensitive key was sentinel (not in new_secrets),
-            # preserve the existing encrypted value
-            for check in sanitized:
+            # Capture which sensitive keys the user *explicitly* sent as the
+            # sentinel — those mean "keep existing encrypted value". Must do
+            # this BEFORE _extract_secrets, which sanitizes everything to
+            # sentinel and would otherwise make every key look preserved.
+            preserve = {}  # {check_name: set(keys)}
+            for check in checks:
                 name = check.get("name")
                 cfg = check.get("config")
                 if not name or not isinstance(cfg, dict):
                     continue
-                for key in list(cfg.keys()):
-                    if (
-                        key in SENSITIVE_KEYS
-                        and cfg[key] == ENCRYPTED_SENTINEL
-                        and name in existing_secrets
-                        and key in existing_secrets[name]
-                    ):
-                        # Preserve existing secret
+                for key, value in cfg.items():
+                    if key in SENSITIVE_KEYS and value == ENCRYPTED_SENTINEL:
+                        preserve.setdefault(name, set()).add(key)
+
+            sanitized, new_secrets = _extract_secrets(checks)
+
+            for name, keys in preserve.items():
+                for key in keys:
+                    if name in existing_secrets and key in existing_secrets[name]:
                         new_secrets.setdefault(name, {})[key] = existing_secrets[name][
                             key
                         ]

--- a/futureagi/agentcc/services/config_push.py
+++ b/futureagi/agentcc/services/config_push.py
@@ -3,6 +3,8 @@ Config Push Service — pushes per-org configs from Django to the Go gateway.
 Called when org configs are created, activated, or deleted.
 """
 
+import copy
+
 import structlog
 from django.conf import settings as django_settings
 
@@ -49,6 +51,32 @@ _RULE_PROVIDER_DEFAULTS = {
     "tool-permissions": "tool_permissions",
     "mcp-security": "mcp_security",
 }
+
+
+def _normalize_eval_ids(cfg):
+    """
+    Normalize futureagi eval id config so the gateway receives both shapes:
+    - eval_ids: ["76", "15", "22"] — array, what the new gateway iterates
+    - eval_id: "76" — first id, fallback for older gateway builds
+
+    Accepts either input shape. No-op if neither is present.
+    """
+    if not isinstance(cfg, dict):
+        return
+    raw = cfg.get("eval_ids")
+    if raw is None and "eval_id" in cfg:
+        raw = [cfg.get("eval_id")]
+    if raw is None:
+        return
+    if not isinstance(raw, (list, tuple)):
+        raw = [raw]
+    eval_ids = [str(i) for i in raw if i not in (None, "")]
+    if eval_ids:
+        cfg["eval_ids"] = eval_ids
+        cfg["eval_id"] = eval_ids[0]
+    else:
+        cfg.pop("eval_ids", None)
+        cfg.pop("eval_id", None)
 
 
 def _inject_guardrail_credentials(checks):
@@ -119,10 +147,16 @@ def _transform_guardrails(guardrails_data, org_id=None):
 
     Django stores: {"rules": [{"name": "pii-detector", "action": "block", ...}], "enabled": true}
     Gateway expects: {"checks": {"pii-detection": {"enabled": true, "action": "block", ...}}}
+
+    Deep-copies the input because downstream helpers (_inject_guardrail_credentials,
+    _inject_fi_credentials) mutate sub-dicts in place — without the copy those
+    mutations would leak back into the caller's Django model instance and the
+    next AgentccOrgConfigSerializer(config).data would render decrypted secrets.
     """
     if not guardrails_data:
         return guardrails_data
 
+    guardrails_data = copy.deepcopy(guardrails_data)
     raw_checks = guardrails_data.get("checks")
     rules = guardrails_data.get("rules")
 
@@ -138,10 +172,7 @@ def _transform_guardrails(guardrails_data, org_id=None):
             cfg = dict(rule.get("config") or {})
             if rule_name in _RULE_PROVIDER_DEFAULTS and "provider" not in cfg:
                 cfg["provider"] = _RULE_PROVIDER_DEFAULTS[rule_name]
-            if "eval_ids" in cfg and "eval_id" not in cfg:
-                ids = cfg.pop("eval_ids", [])
-                if ids:
-                    cfg["eval_id"] = str(ids[0])
+            _normalize_eval_ids(cfg)
             checks[registry_name] = {
                 "enabled": rule.get("enabled", True),
                 "action": rule.get("action", "block"),
@@ -176,14 +207,7 @@ def _transform_guardrails(guardrails_data, org_id=None):
                 else cfg
             )
             inner = clean_cfg.get("config") if isinstance(clean_cfg, dict) else None
-            if (
-                isinstance(inner, dict)
-                and "eval_ids" in inner
-                and "eval_id" not in inner
-            ):
-                ids = inner.pop("eval_ids", [])
-                if ids:
-                    inner["eval_id"] = str(ids[0])
+            _normalize_eval_ids(inner)
             mapped[registry_name] = clean_cfg
         if org_id:
             _inject_fi_credentials(mapped, org_id)
@@ -203,10 +227,7 @@ def _transform_guardrails(guardrails_data, org_id=None):
         cfg = dict(rule.get("config") or {})
         if rule_name in _RULE_PROVIDER_DEFAULTS and "provider" not in cfg:
             cfg["provider"] = _RULE_PROVIDER_DEFAULTS[rule_name]
-        if "eval_ids" in cfg and "eval_id" not in cfg:
-            ids = cfg.pop("eval_ids", [])
-            if ids:
-                cfg["eval_id"] = str(ids[0])
+        _normalize_eval_ids(cfg)
         checks[registry_name] = {
             "enabled": rule.get("enabled", True),
             "action": rule.get("action", "block"),
@@ -230,13 +251,29 @@ def _transform_guardrails(guardrails_data, org_id=None):
     return result
 
 
+def _normalize_url(url):
+    """Strip trailing slash and lowercase scheme+host for comparison."""
+    if not url or not isinstance(url, str):
+        return ""
+    return url.strip().rstrip("/").lower()
+
+
 def _inject_fi_credentials(checks, org_id):
     """
-    Auto-inject the org's FI platform API credentials into futureagi-eval config.
-    Since FutureAGI IS the platform, the org's own api_key/secret_key are already
-    stored in the OrgApiKey model — no need for users to configure them manually.
+    Inject the org's FI platform credentials into futureagi-eval config.
+
+    Behavior:
+    - base_url missing → fill with django_settings.BASE_URL, force-inject the
+      org's OrgApiKey for api_key/secret_key. This is the common case: the
+      guardrail is calling its own platform, and the user shouldn't have to
+      know their own platform's API key.
+    - base_url present and matches this platform's BASE_URL → same as above,
+      force-inject (heals user-typed wrong keys for the local platform).
+    - base_url points at a *different* environment (e.g. local gateway
+      explicitly targeting https://dev.api.futureagi.com) → respect whatever
+      api_key/secret_key the user provided. Local keys would 401 against the
+      remote env, so auto-injecting would break this case.
     """
-    # Check both possible names (pre and post registry mapping)
     fi_check = checks.get("futureagi-eval")
     if fi_check is None:
         return
@@ -246,8 +283,19 @@ def _inject_fi_credentials(checks, org_id):
 
     cfg = fi_check.get("config") or {}
 
-    # Only inject if not already set (don't overwrite explicit config)
-    if cfg.get("api_key") and cfg.get("secret_key"):
+    cfg.setdefault("call_type", "protect")
+    cfg.setdefault("base_url", django_settings.BASE_URL)
+    fi_check["config"] = cfg
+
+    targets_local_platform = _normalize_url(cfg.get("base_url")) == _normalize_url(
+        django_settings.BASE_URL
+    )
+    if not targets_local_platform:
+        logger.info(
+            "fi_credentials_skipped_cross_env",
+            org_id=str(org_id),
+            base_url=cfg.get("base_url"),
+        )
         return
 
     try:
@@ -260,11 +308,8 @@ def _inject_fi_credentials(checks, org_id):
             deleted=False,
         ).first()
         if org_key:
-            cfg.setdefault("api_key", org_key.api_key)
-            cfg.setdefault("secret_key", org_key.secret_key)
-            cfg.setdefault("base_url", django_settings.BASE_URL)
-            cfg.setdefault("call_type", "protect")
-            fi_check["config"] = cfg
+            cfg["api_key"] = org_key.api_key
+            cfg["secret_key"] = org_key.secret_key
             logger.info(
                 "fi_credentials_injected",
                 org_id=str(org_id),


### PR DESCRIPTION
## Summary

Fixes the futureagi-eval guardrail flow end-to-end. Previously, configuring this rule from the org-config UI would result in stale/wrong credentials being pushed to the gateway, causing every protect call to 401 against the platform — even with valid keys typed in the UI. Multi-eval-id configs also silently dropped 2 of 3 evals.

Two interacting Django bugs caused the credential staleness:

1. **`AgentccGuardrailPolicySerializer.update` preserved old encrypted secrets even when the user submitted new real values.** The "preserve sentinel" loop ran *after* `_extract_secrets` had already sanitized every sensitive key to `__encrypted__`, so the condition always matched and blindly overwrote `new_secrets` with whatever was in `encrypted_check_configs` — making it sticky from the first write. Now we capture which keys arrived as sentinel from the user *before* sanitization, and only those preserve from the existing blob.
2. **`_transform_guardrails` was passed `config.guardrails` by reference**, and `_inject_guardrail_credentials` / `_inject_fi_credentials` mutate sub-dicts in place. The mutation leaked back into the Django model instance, so the subsequent `AgentccOrgConfigSerializer(config).data` rendered decrypted secrets to the API caller. Deep-copy at the top of `_transform_guardrails` contains the mutation.

Plus three orthogonal correctness fixes that surfaced while debugging:
- `_inject_fi_credentials` now skips auto-injection when the rule's `base_url` points at a *different* platform than this Django's `BASE_URL`. The previous "always overwrite" broke the legit "local Django pushing a config that targets dev.api.futureagi.com" case (overwrote dev keys with local ones, guaranteed 401). Same-env saves still self-heal a user-typed wrong key.
- Gateway `FutureAGIGuardrail` reads `cfg["eval_ids"]` as an array (`cfg["eval_id"]` singular fallback for back-compat), iterates every eval in the response, and fails the check if any single eval fails — the failing eval's reason/details are surfaced. Django push transform sends both `eval_ids` array and `eval_id` first-element so old/new gateway builds both work during rollout.
- Fixed pre-existing `futureagi_test.go` header assertions (was checking `Authorization: Bearer` / `x-fi-secret-key` but production sends `X-Api-Key` / `X-Secret-Key` — `TestFutureAGI_Passed` had been silently asserting wrong).

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

**Gateway (Go) unit tests** — all 24 pass, including 3 new ones:
\`\`\`
go test ./internal/guardrails/futureagi/ -v
# TestFutureAGI_EvalIDsArray_AllPass            PASS
# TestFutureAGI_EvalIDsArray_OneFailsFailsAll   PASS
# TestFutureAGI_EvalIDFallbackToSingular        PASS
# (+ 21 existing tests, including fixed TestFutureAGI_Passed)
\`\`\`

**End-to-end manual verification against local Django + dev backend:**
1. POST \`/agentcc/org-configs/\` with valid dev keys + \`base_url=https://dev.api.futureagi.com\` and 3 \`eval_ids\` \`["76","15","22"]\`
2. Confirmed response no longer leaks decrypted secrets (rendered as `__encrypted__` instead of plaintext) — fix #2
3. Confirmed POSTing new keys actually persists (re-fetch shows the new value, not a stuck old value) — fix #1
4. Confirmed gateway receives \`eval_ids\` array via \`GET /-/orgs/{org_id}/config\` admin endpoint
5. Confirmed protect calls now return 200 from dev (was 401 before)

**Migration step required on deploy:** existing orgs whose policy got stuck on stale `encrypted_check_configs` will continue to use those values until cleared. One-shot:
\`\`\`bash
docker exec backend python -c "
import os; os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tfc.settings.settings')
import django; django.setup()
from agentcc.models.guardrail_policy import AgentccGuardrailPolicy
n = AgentccGuardrailPolicy.no_workspace_objects.filter(name='__ui_guardrails__').update(encrypted_check_configs=None)
print(f'cleared {n} policies')
"
\`\`\`
After clear, the next save from the org config UI will populate \`encrypted_check_configs\` correctly.

## Screenshots / recordings (if UI)

N/A — backend + gateway only.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective (gateway side; Django changes verified via end-to-end repro)
- [ ] \`make check-all\` / \`yarn check-all\` passes locally
- [x] I've updated the documentation where relevant (inline docstrings on the changed functions)
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA