### PR TITLE
[TH-4801] Hydrate + persist custom columns across observe surfaces

### DIFF
--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -40,11 +40,8 @@ import NoRowsOverlay from "src/sections/project-detail/CompareDrawer/NoRowsOverl
 
 const CELL_HEIGHT_MAP = { Short: 40, Medium: 52, Large: 68, "Extra Large": 88 };
 
-// Inline cell renderer for custom columns. Standard CallLogs cells wrap
-// content in a Box with `px: 1.5, py: 0.5` (CallLogsCellRenderer.jsx:262-274)
-// — without matching that here the custom-col content rendered flush
-// against the cell's left edge, breaking visual alignment with the rest of
-// the row.
+// Padding matches CallLogsCellRenderer.jsx so custom-col cells align with
+// the rest of the row.
 const CustomColCellRenderer = (params) => {
   const v = params?.value;
   const display = v == null || v === "" ? "-" : v;
@@ -65,8 +62,6 @@ const CustomColCellRenderer = (params) => {
   );
 };
 
-// Loading skeleton — same shape as the standard helper.jsx `LoadingSkeleton`,
-// inlined so the custom-col defs aren't coupled to that internal helper.
 const CustomColLoadingSkeleton = () => (
   <Skeleton
     variant="rectangular"
@@ -85,11 +80,8 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
     onConfigLoaded = () => {},
     enabled = true,
     onSelectionChanged,
-    // Optional richer selection callback — fires alongside onSelectionChanged
-    // with {traceIds, isAllOnPageSelected, currentPageSize, totalPages,
-    // pageLimit}. Used by LLMTracingView's simulator branch to decide when
-    // to show the "select all matching filter" banner (Phase 9 of the
-    // annotation-queue-bulk-select revamp).
+    // Richer selection callback used by LLMTracingView's simulator branch
+    // to decide when to show the "select all matching filter" banner.
     onSelectionMeta,
     cellHeight = "Short",
     columnVisibility,
@@ -117,9 +109,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
       reset: state.reset,
     }));
 
-  // Highlight the row whose detail drawer is currently open. Mirrors the
-  // TraceGrid activeTraceId pattern so the experience matches the trace
-  // detail drawer the user referenced.
+  // Highlight the row whose detail drawer is open (mirrors TraceGrid).
   const { testDetailDrawerOpen } = useTestDetailSideDrawerStoreShallow(
     (state) => ({
       testDetailDrawerOpen: state.testDetailDrawerOpen,
@@ -304,48 +294,26 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
       .filter((c) => !existingFields.has(c.id))
       .map((c) => ({
         headerName: c.name,
-        // Use colId rather than `field` for custom cols so AG Grid doesn't
-        // try to deep-resolve the dotted path against the row object (which
-        // for voice/list_voice_calls is FLAT — no nested `call` member). We
-        // do the lookup ourselves in valueGetter below.
+        // colId (not field) so AG Grid doesn't deep-resolve the dotted path
+        // — list_voice_calls returns flat rows; the valueGetter below handles
+        // the resolution.
         colId: c.id,
         flex: 0,
         minWidth: 120,
         hide: c.isVisible === false,
-        // While the first fetch is in-flight, render the same skeleton
-        // bar the standard cols use (helper.jsx:408 LoadingSkeleton). After
-        // load, swap to the styled renderer that gives the custom-col cell
-        // the same px/py padding as the standard CallLogsCellRenderer.
         cellRenderer: isLoading ? CustomColLoadingSkeleton : CustomColCellRenderer,
         valueGetter: (params) => {
           if (!params.data) return null;
-          // 1. Direct lookup (handles attributes whose stored id is the
-          //    literal data key, e.g. "bot_wpm").
           let value = params.data[c.id];
-          // 2. Dot-notation traversal (handles nested response shapes,
-          //    matches TraceGrid/getCustomValueGetter).
           if (value === undefined && c.id.includes(".")) {
             value = c.id
               .split(".")
               .reduce((obj, key) => obj?.[key], params.data);
           }
-          // 3. Voice-specific namespace strip: the /eval-attributes list
-          //    serves Vapi-style attribute paths with explicit namespace
-          //    prefixes (e.g. "call.bot_wpm", "vapi.call_id"), but the
-          //    /list_voice_calls/ response returns those same values as
-          //    top-level flat keys ("bot_wpm", "call_id"). Strip the prefix
-          //    and try direct lookup.
-          //
-          //    Whitelist intentionally — only namespaces where the data is
-          //    proven to live flat in the list response. A generic
-          //    "drop leading segments" fallback would false-positive on
-          //    paths like "phone_number.id" → row.id (the row primary key).
-          //
-          //    Attributes outside this whitelist (conversation.*,
-          //    performance_metrics.*, workflow.*, gen_ai.*, etc.) are
-          //    span-detail paths the list endpoint doesn't include — they
-          //    correctly fall through to "-" until the backend expands the
-          //    list response or removes them from the picker for voice.
+          // /eval-attributes serves Vapi attribute paths with namespace
+          // prefixes (call.*, vapi.*) but /list_voice_calls returns them
+          // as flat keys. Whitelisted — a generic "drop leading segments"
+          // would false-positive on paths like phone_number.id → row.id.
           const VOICE_FLAT_NAMESPACE_PREFIXES = ["call.", "vapi."];
           if (value === undefined) {
             const matchedPrefix = VOICE_FLAT_NAMESPACE_PREFIXES.find((p) =>
@@ -363,10 +331,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
         },
       }));
 
-    // Wrap customs under a "Custom Columns" group header so they render as
-    // a grouped section at the end of the grid (parity with TraceGrid /
-    // SpanGrid / SessionGrid). Without this they appeared as flat columns
-    // alongside the standard ones, with no visual separation.
+    // Group under a "Custom Columns" header for parity with the other grids.
     if (newCustomDefs.length > 0) {
       return [
         ...updated,

--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -16,6 +16,7 @@ import {
   Pagination,
   PaginationItem,
   Select,
+  Skeleton,
   Stack,
   Typography,
   useTheme,
@@ -38,6 +39,42 @@ import { useShallowToggleAnnotationsStore } from "../store";
 import NoRowsOverlay from "src/sections/project-detail/CompareDrawer/NoRowsOverlay";
 
 const CELL_HEIGHT_MAP = { Short: 40, Medium: 52, Large: 68, "Extra Large": 88 };
+
+// Inline cell renderer for custom columns. Standard CallLogs cells wrap
+// content in a Box with `px: 1.5, py: 0.5` (CallLogsCellRenderer.jsx:262-274)
+// — without matching that here the custom-col content rendered flush
+// against the cell's left edge, breaking visual alignment with the rest of
+// the row.
+const CustomColCellRenderer = (params) => {
+  const v = params?.value;
+  const display = v == null || v === "" ? "-" : v;
+  return (
+    <Box
+      sx={{
+        px: 1.5,
+        py: 0.5,
+        display: "flex",
+        alignItems: "center",
+        height: "100%",
+      }}
+    >
+      <Typography variant="body2" sx={{ fontSize: 13 }} noWrap>
+        {String(display)}
+      </Typography>
+    </Box>
+  );
+};
+
+// Loading skeleton — same shape as the standard helper.jsx `LoadingSkeleton`,
+// inlined so the custom-col defs aren't coupled to that internal helper.
+const CustomColLoadingSkeleton = () => (
+  <Skeleton
+    variant="rectangular"
+    width="80%"
+    height={15}
+    sx={{ mx: 1, borderRadius: 0.5 }}
+  />
+);
 
 const CallLogsGrid = React.forwardRef(function CallLogsGrid(
   {
@@ -267,15 +304,77 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
       .filter((c) => !existingFields.has(c.id))
       .map((c) => ({
         headerName: c.name,
-        field: c.id,
+        // Use colId rather than `field` for custom cols so AG Grid doesn't
+        // try to deep-resolve the dotted path against the row object (which
+        // for voice/list_voice_calls is FLAT — no nested `call` member). We
+        // do the lookup ourselves in valueGetter below.
+        colId: c.id,
         flex: 0,
         minWidth: 120,
         hide: c.isVisible === false,
-        valueGetter: (params) => params.data?.[c.id] ?? "-",
+        // While the first fetch is in-flight, render the same skeleton
+        // bar the standard cols use (helper.jsx:408 LoadingSkeleton). After
+        // load, swap to the styled renderer that gives the custom-col cell
+        // the same px/py padding as the standard CallLogsCellRenderer.
+        cellRenderer: isLoading ? CustomColLoadingSkeleton : CustomColCellRenderer,
+        valueGetter: (params) => {
+          if (!params.data) return null;
+          // 1. Direct lookup (handles attributes whose stored id is the
+          //    literal data key, e.g. "bot_wpm").
+          let value = params.data[c.id];
+          // 2. Dot-notation traversal (handles nested response shapes,
+          //    matches TraceGrid/getCustomValueGetter).
+          if (value === undefined && c.id.includes(".")) {
+            value = c.id
+              .split(".")
+              .reduce((obj, key) => obj?.[key], params.data);
+          }
+          // 3. Voice-specific namespace strip: the /eval-attributes list
+          //    serves Vapi-style attribute paths with explicit namespace
+          //    prefixes (e.g. "call.bot_wpm", "vapi.call_id"), but the
+          //    /list_voice_calls/ response returns those same values as
+          //    top-level flat keys ("bot_wpm", "call_id"). Strip the prefix
+          //    and try direct lookup.
+          //
+          //    Whitelist intentionally — only namespaces where the data is
+          //    proven to live flat in the list response. A generic
+          //    "drop leading segments" fallback would false-positive on
+          //    paths like "phone_number.id" → row.id (the row primary key).
+          //
+          //    Attributes outside this whitelist (conversation.*,
+          //    performance_metrics.*, workflow.*, gen_ai.*, etc.) are
+          //    span-detail paths the list endpoint doesn't include — they
+          //    correctly fall through to "-" until the backend expands the
+          //    list response or removes them from the picker for voice.
+          const VOICE_FLAT_NAMESPACE_PREFIXES = ["call.", "vapi."];
+          if (value === undefined) {
+            const matchedPrefix = VOICE_FLAT_NAMESPACE_PREFIXES.find((p) =>
+              c.id.startsWith(p),
+            );
+            if (matchedPrefix) {
+              value = params.data[c.id.slice(matchedPrefix.length)];
+            }
+          }
+          if (value === undefined || value === null) return null;
+          if (Array.isArray(value) || typeof value === "object") {
+            return JSON.stringify(value);
+          }
+          return String(value);
+        },
       }));
 
-    return [...updated, ...newCustomDefs];
-  }, [callLogsColumnDefs, columnVisibility]);
+    // Wrap customs under a "Custom Columns" group header so they render as
+    // a grouped section at the end of the grid (parity with TraceGrid /
+    // SpanGrid / SessionGrid). Without this they appeared as flat columns
+    // alongside the standard ones, with no visual separation.
+    if (newCustomDefs.length > 0) {
+      return [
+        ...updated,
+        { headerName: "Custom Columns", children: newCustomDefs },
+      ];
+    }
+    return updated;
+  }, [callLogsColumnDefs, columnVisibility, isLoading]);
   useEffect(() => {
     return () => {
       resetToggleAnnotationsStore();

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -923,6 +923,13 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   // Saved-view columnState queued before the active sub-tab's primary grid
   // mounted. Drained by onGridReady on the primary grid.
   const pendingColumnStateRef = useRef(null);
+  // Saved-view column visibility, parsed from columnState's `hide` flags.
+  // applyColumnState alone can't persist hide across columnDefs rebuilds —
+  // getTraceListColumnDefs sets `hide: !col?.isVisible` explicitly, so AG
+  // Grid's columnDef value overrides any applied state on the next merge.
+  // To make hide stick, we update col.isVisible in the columns state so
+  // the next columnDefs render reflects the saved-view intent.
+  const pendingHideMapRef = useRef(null);
 
   const {
     setHeaderConfig,
@@ -1719,18 +1726,22 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       setExtraFilters((prev) => (prev.length === 0 ? prev : []));
       setViewMode(DEFAULT_DISPLAY_CONFIG.viewMode);
       pendingColumnStateRef.current = null;
+      pendingHideMapRef.current = null;
       primaryTracePendingRef.current = [];
       compareTracePendingRef.current = [];
       primarySpansPendingRef.current = [];
       compareSpansPendingRef.current = [];
       // Strip saved-view custom cols from all grid slots so they don't
-      // linger on the default tab.
+      // linger on the default tab. Also reset isVisible to true for the
+      // remaining standard cols — the saved view we're leaving may have
+      // hidden some, and TraceGrid's merge now preserves isVisible across
+      // fetches (so it won't naturally reset to the backend default).
       setColumns((prev) => {
         const next = {};
         Object.keys(prev).forEach((ck) => {
-          next[ck] = (prev[ck] || []).filter(
-            (c) => c.groupBy !== "Custom Columns",
-          );
+          next[ck] = (prev[ck] || [])
+            .filter((c) => c.groupBy !== "Custom Columns")
+            .map((c) => (c.isVisible ? c : { ...c, isVisible: true }));
         });
         return next;
       });
@@ -1906,7 +1917,49 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
 
     // Apply column state (widths/order/sort) to the active sub-tab's primary
     // grid. If the grid isn't mounted yet, queue for the onGridReady callback.
+    //
+    // Hide flags need a parallel path: applyColumnState's `hide` doesn't
+    // survive the next columnDefs rebuild (getTraceListColumnDefs sets
+    // `hide: !col?.isVisible` explicitly, which wins over applied state).
+    // Build a colId → hide map and stash it; the `[columns]` drain effect
+    // below updates each col's `isVisible` to match, so the next render
+    // produces columnDefs that already reflect the saved-view's hide
+    // intent. applyColumnState still handles widths/order/sort, which
+    // colDefs don't set explicitly and therefore can persist.
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
+      const hideMap = {};
+      display.columnState.forEach((entry) => {
+        if (entry && entry.colId) hideMap[entry.colId] = !!entry.hide;
+      });
+      // Apply hideMap immediately to all slots so saved-view hide intent
+      // lands in columnDefs even when TraceGrid's merge bails out (e.g.
+      // switching between saved views with identical backend cols, which
+      // makes backendChanged=false → no setColumns call → no drain).
+      setColumns((prev) => {
+        let anyChanged = false;
+        const next = {};
+        Object.keys(prev).forEach((ck) => {
+          let slotChanged = false;
+          const updated = (prev[ck] || []).map((col) => {
+            if (col && col.id in hideMap) {
+              const desiredVisible = !hideMap[col.id];
+              if (col.isVisible !== desiredVisible) {
+                slotChanged = true;
+                return { ...col, isVisible: desiredVisible };
+              }
+            }
+            return col;
+          });
+          next[ck] = slotChanged ? updated : prev[ck];
+          if (slotChanged) anyChanged = true;
+        });
+        return anyChanged ? next : prev;
+      });
+      // Also queue for cols that arrive later via TraceGrid's merge (e.g.
+      // first-load before backend has responded). The [columns] drain
+      // effect re-applies hideMap once cols land.
+      pendingHideMapRef.current = hideMap;
+
       const activeApi =
         selectedTab === "trace"
           ? primaryTraceGridRef.current?.api
@@ -2020,7 +2073,38 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   // unknown cols). This effect catches the case: once customs land in
   // `columns`, re-apply the queued state so widths/order/sort for custom
   // colIds finally stick. Mirrors the drain effect in Sessions-view.
+  //
+  // Also drains the queued hide map by writing the saved-view's hide
+  // intent into each col's `isVisible`. The next columnDefs render then
+  // emits the correct `hide` for AG Grid — without this, the colDef's
+  // explicit `hide: !col?.isVisible` (default-true `isVisible`) wins
+  // over any state previously applied via applyColumnState and the
+  // hidden cols become visible on the very next merge.
   useEffect(() => {
+    if (pendingHideMapRef.current) {
+      const hideMap = pendingHideMapRef.current;
+      setColumns((prev) => {
+        let anyChanged = false;
+        const next = {};
+        Object.keys(prev).forEach((ck) => {
+          let slotChanged = false;
+          const updated = (prev[ck] || []).map((col) => {
+            if (col && col.id in hideMap) {
+              const desiredVisible = !hideMap[col.id];
+              if (col.isVisible !== desiredVisible) {
+                slotChanged = true;
+                return { ...col, isVisible: desiredVisible };
+              }
+            }
+            return col;
+          });
+          next[ck] = slotChanged ? updated : prev[ck];
+          if (slotChanged) anyChanged = true;
+        });
+        return anyChanged ? next : prev;
+      });
+      pendingHideMapRef.current = null;
+    }
     if (!pendingColumnStateRef.current) return;
     const api =
       selectedTab === "trace"

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -2083,6 +2083,13 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   useEffect(() => {
     if (pendingHideMapRef.current) {
       const hideMap = pendingHideMapRef.current;
+      // Did this columns snapshot have ANY col whose id appears in the
+      // hideMap? If not, slots are still empty (or none of the standard
+      // cols have arrived yet) and we MUST NOT clear pendingHideMapRef —
+      // otherwise a cold-load apply effect that queues hideMap, then fires
+      // drain on an empty-slot change, would wipe the queue before
+      // TraceGrid/SpanGrid's first setColumns lands the backend cols.
+      let sawMatch = false;
       setColumns((prev) => {
         let anyChanged = false;
         const next = {};
@@ -2090,6 +2097,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
           let slotChanged = false;
           const updated = (prev[ck] || []).map((col) => {
             if (col && col.id in hideMap) {
+              sawMatch = true;
               const desiredVisible = !hideMap[col.id];
               if (col.isVisible !== desiredVisible) {
                 slotChanged = true;
@@ -2103,7 +2111,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         });
         return anyChanged ? next : prev;
       });
-      pendingHideMapRef.current = null;
+      if (sawMatch) {
+        pendingHideMapRef.current = null;
+      }
     }
     if (!pendingColumnStateRef.current) return;
     const api =

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -920,15 +920,11 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const primaryCallLogsGridRef = useRef(null);
   const compareCallLogsGridRef = useRef(null);
   const columnConfigureRef = useRef();
-  // Saved-view columnState queued before the active sub-tab's primary grid
-  // mounted. Drained by onGridReady on the primary grid.
+  // Drained by onGridReady on the primary grid.
   const pendingColumnStateRef = useRef(null);
-  // Saved-view column visibility, parsed from columnState's `hide` flags.
   // applyColumnState alone can't persist hide across columnDefs rebuilds —
-  // getTraceListColumnDefs sets `hide: !col?.isVisible` explicitly, so AG
-  // Grid's columnDef value overrides any applied state on the next merge.
-  // To make hide stick, we update col.isVisible in the columns state so
-  // the next columnDefs render reflects the saved-view intent.
+  // getTraceListColumnDefs sets hide explicitly from col.isVisible, so we
+  // need to update col.isVisible in the columns state for hide to stick.
   const pendingHideMapRef = useRef(null);
 
   const {
@@ -940,10 +936,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   } = useObserveHeader();
 
   const { data: projectDetail } = useGetProjectDetails(observeId, !isUserMode);
-  // In user mode the grid should behave like an OBSERVE project (no project
-  // context, no simulator/prototype quirks). Defaulting to OBSERVE keeps the
-  // many `projectSource === OBSERVE` checks (grid enabled, display logic,
-  // etc.) on the happy path.
+  // User mode: behave like an OBSERVE project so the many projectSource
+  // checks stay on the happy path.
   const projectSource = isUserMode
     ? PROJECT_SOURCE.OBSERVE
     : projectDetail?.source;
@@ -1087,10 +1081,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     getFilterExtraProperties,
   );
 
-  // In user mode every grid is scoped by user_id. Inject a structural
-  // filter (similar to the implicit date filter) that prepends to every
-  // validated filter list. The filter lives in the primary `filters`
-  // array, NOT extraFilters, so it doesn't render as a removable chip.
+  // User mode injects a structural user_id filter into the primary filters
+  // (not extraFilters, so it doesn't render as a removable chip).
   const userScopeFilter = useMemo(
     () =>
       isUserMode && userIdForUserMode
@@ -1116,11 +1108,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     [userScopeFilter, primarySpanValidatedFiltersRaw],
   );
 
-  // Drop out of filter-mode selection when the selection state becomes
-  // inconsistent (grid cleared, tab switched, project changed, or the
-  // filter itself changed so the opt-in no longer matches the current
-  // view). The user can always re-opt-in from the banner. Mirrored for
-  // the spans tab via `spanFilterSelectionMode`.
+  // Drop filter-mode opt-in when the selection becomes inconsistent (grid
+  // cleared, tab switched, project changed, filter changed). User can
+  // re-opt-in via the banner. Mirrored for spans below.
   useEffect(() => {
     if (!allTracesSelected) setFilterSelectionMode(false);
   }, [allTracesSelected]);
@@ -1134,9 +1124,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   useEffect(() => {
     setSpanFilterSelectionMode(false);
   }, [primarySpanValidatedFilters]);
-  // Simulator: reset filter-mode when the page-full-selection condition
-  // breaks (user unchecks a row, navigates pages, changes filters, or
-  // switches project).
+  // Simulator: reset filter-mode when page-full-selection breaks.
   useEffect(() => {
     if (!simCallMeta.isAllOnPageSelected) {
       setSimCallFilterSelectionMode(false);
@@ -1225,21 +1213,13 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     [extraFilters, setExtraFilters],
   );
 
-  // Callback to receive column config from CallLogsGrid for simulator projects
   const handleSimulatorConfigLoaded = useCallback(
     (config) => {
       if (projectSource === PROJECT_SOURCE.SIMULATOR && config?.length > 0) {
         setColumns((prev) => {
-          // Preserve existing custom columns AND drain pending custom cols
-          // queued by the localStorage hydrate / saved-view apply effect.
-          // Voice projects render through CallLogsGrid (not TraceGrid), so
-          // there's no per-fetch merge step on the grid side to drain those
-          // refs. The apply effect's voice branches drain on saved-view +
-          // back-to-default transitions; this callback handles the path
-          // where the backend column count changes (initial mount, schema
-          // change). Without these drains, custom cols loaded from
-          // localStorage or a saved view sit in the pending ref forever
-          // and never appear in the grid.
+          // Voice projects use CallLogsGrid (no per-fetch merge to drain
+          // pending custom cols), so this callback is the only path that
+          // drains them on backend column-count changes.
           const drainPending = (key, ref) => {
             const existing = prev[key] || [];
             const customCols = existing.filter(
@@ -1331,10 +1311,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     columns,
   ]);
 
-  // Trace + simulator filter-mode reset on filter change. Watches
-  // primaryCombinedFilters (validated + graph filters) because both POSTs
-  // send that combined payload — watching only the validated subset would
-  // leave stale opt-in state when the user toggles a graph eval selection.
+  // Watch combined filters (validated + graph) — both POSTs send the
+  // combined payload, so the validated subset alone would miss graph toggles.
   useEffect(() => {
     setFilterSelectionMode(false);
   }, [primaryCombinedFilters]);
@@ -1395,9 +1373,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     setAttributes(evalAttributes || []);
   }, [evalAttributes]);
 
-  // In user mode surface a "Project" filter so the cross-project user-detail
-  // page can narrow to specific projects. Null in project mode (where the
-  // toolbar already scopes to one project).
+  // User mode only — project mode already scopes to a single project.
   const projectFilterField = useProjectFilterField({ enabled: isUserMode });
   const toolbarFilterFields = useMemo(
     () => (projectFilterField ? [projectFilterField] : undefined),
@@ -1702,27 +1678,18 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     }
   }, [selectedTab, primaryTraceDateFilter, primarySpanDateFilter]);
 
-  // Load filters + display settings from saved view config when a custom view tab is selected
-  // Tracked separately so the null-branch reset only fires on a genuine
-  // saved-view → default transition, not on initial mount where
-  // activeViewConfig is null only because hydration hasn't landed yet.
-  // Without this guard, the destructive resets below would clobber state
-  // that the null-branch localStorage rehydrate and the apply-branch
-  // saved-view writes are about to set themselves.
+  // wasOnSavedViewRef gates the null-branch reset to genuine saved-view →
+  // default transitions so it doesn't clobber state that the mount hydrate
+  // or apply branch is about to set.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const wasOnSavedViewRef = useRef(false);
   useEffect(() => {
     if (!activeViewConfig) {
       const wasOnSavedView = wasOnSavedViewRef.current;
       wasOnSavedViewRef.current = false;
-      if (!wasOnSavedView) return; // initial mount / already on default — nothing to clean up
-      // Back to a default tab — clear local extraFilters so chips from a
-      // prior custom view don't linger. URL-synced display state
-      // (cellHeight / showErrors / showNonAnnotated / hasEvalFilter /
-      // showCompare) is wiped via the parent's URL navigation; viewMode
-      // lives in the Zustand store (no URL key) so we reset it explicitly,
-      // and the active grid's columnState (widths/order/sort) is internal
-      // to AG Grid and likewise needs an imperative reset.
+      if (!wasOnSavedView) return;
+      // Back to default tab — viewMode lives in Zustand (no URL key) so
+      // reset explicitly; AG Grid columnState also needs an imperative reset.
       setExtraFilters((prev) => (prev.length === 0 ? prev : []));
       setViewMode(DEFAULT_DISPLAY_CONFIG.viewMode);
       pendingColumnStateRef.current = null;
@@ -1731,11 +1698,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       compareTracePendingRef.current = [];
       primarySpansPendingRef.current = [];
       compareSpansPendingRef.current = [];
-      // Strip saved-view custom cols from all grid slots so they don't
-      // linger on the default tab. Also reset isVisible to true for the
-      // remaining standard cols — the saved view we're leaving may have
-      // hidden some, and TraceGrid's merge now preserves isVisible across
-      // fetches (so it won't naturally reset to the backend default).
+      // Strip saved-view customs and reset isVisible on the remaining cols —
+      // TraceGrid's merge preserves isVisible across fetches, so leaving a
+      // view that hid columns would otherwise persist the hide state.
       setColumns((prev) => {
         const next = {};
         Object.keys(prev).forEach((ck) => {
@@ -1745,24 +1710,16 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         });
         return next;
       });
-      // Re-hydrate default-tab custom cols from localStorage. The mount-
-      // time useEffect that normally does this is keyed on
-      // displayStorageKey (project-scoped), so it doesn't re-fire on a
-      // same-project tab toggle.
+      // Re-hydrate from localStorage — the mount hydrate is keyed on
+      // displayStorageKey and won't re-fire on a same-project tab toggle.
       try {
         const raw = localStorage.getItem(displayStorageKey);
         const saved = raw ? JSON.parse(raw) : null;
         if (saved?.customColumns) {
-          // Legacy array shape: customs apply to whatever tab is active.
-          // New object shape: customs are pre-split by tab type — hydrate
-          // both refs for each tab so a compare-mode toggle later picks
-          // up the right set without another localStorage read. Each
-          // ref gets its own shallow clone so neither pending refs nor
-          // the columns state they drain into share identity with the
-          // parsed localStorage payload (the parsed object is rooted
-          // somewhere only via the immediate `saved` binding here, but
-          // matching the saved-view branch's clone pattern keeps the
-          // invariant uniform across the file).
+          // customColumns may be a legacy array or new {trace, spans}
+          // object. Hydrate both primary and compare refs for the tab
+          // type so a later compare-mode toggle works without another
+          // localStorage read.
           const cloneEach = (arr) => arr.map((c) => ({ ...c }));
           if (Array.isArray(saved.customColumns)) {
             if (saved.customColumns.length > 0) {
@@ -1790,11 +1747,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       } catch {
         /* ignore corrupted localStorage */
       }
-      // Voice/simulator: drain the freshly-populated pending refs into
-      // columns state directly. handleSimulatorConfigLoaded fires only on
-      // backend column-count changes, which doesn't happen on a saved-view
-      // → default transition, so without this the localStorage customs
-      // we just queued would never reach the grid.
+      // Voice/simulator: handleSimulatorConfigLoaded only fires on column-
+      // count changes, so saved-view → default transitions need an explicit
+      // drain here.
       if (projectSource === PROJECT_SOURCE.SIMULATOR) {
         const draining = primaryTracePendingRef.current || [];
         if (draining.length > 0) {
@@ -1836,12 +1791,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     if (display.hasEvalFilter !== undefined)
       setHasEvalFilter(display.hasEvalFilter);
 
-    // Strip existing custom cols from all grid slots so customs inherited
-    // from a previous tab/view (e.g. default-tab localStorage customs, or
-    // another saved view) don't linger when this saved view's set is
-    // merged in below. Without this, switching from default → saved view
-    // (or view A → view B) ends up showing the union of both sets and
-    // dirty-flags the Save view button.
+    // Strip existing customs so view → view doesn't show the union of both
+    // sets (which would also dirty-flag the Save view button).
     setColumns((prev) => {
       const next = {};
       Object.keys(prev).forEach((ck) => {
@@ -1853,14 +1804,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     });
 
     // Populate both primary and compare refs for the active tab type so a
-    // later toggle into compare mode also hydrates correctly. Each ref
-    // gets its OWN shallow clone of each col — without that, the pending
-    // refs (and eventually `columns[ck]` they drain into) share object
-    // identity with the saved-views query cache. Any later mutation —
-    // adding a new custom, saving as a new view, toggling visibility —
-    // would write through into the cached saved view config and corrupt
-    // its on-screen state until the next refetch. The map-of-map also
-    // isolates primary from compare.
+    // compare-mode toggle later hydrates correctly. Shallow-clone per slot
+    // so mutations don't write through into the saved-views query cache.
     if (display.customColumns?.length > 0) {
       if (selectedTab === "trace") {
         primaryTracePendingRef.current = display.customColumns.map((c) => ({
@@ -1879,21 +1824,12 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       }
     }
 
-    // Voice/simulator projects: CallLogsGrid doesn't have a per-fetch merge
-    // step that drains the pending ref (it only emits its config when the
-    // backend column count changes, which doesn't happen on a same-tab-type
-    // saved-view switch). Drain into columns state directly here so customs
-    // from the new view actually appear. The strip block above already
-    // cleared old customs, so just append the new set.
+    // Voice/simulator: same-tab-type saved-view switch doesn't trigger
+    // handleSimulatorConfigLoaded, so drain into columns directly.
     if (
       projectSource === PROJECT_SOURCE.SIMULATOR &&
       display.customColumns?.length > 0
     ) {
-      // Clone each col per slot so primary-trace and compare-trace each
-      // own independent objects, and neither shares identity with the
-      // saved-views cache. Mirrors the clone in the trace/spans branch
-      // above — without it, downstream mutations would write through
-      // into the cached view config.
       setColumns((prev) => {
         const merge = (key) => {
           const existing = prev[key] || [];
@@ -1909,32 +1845,23 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
           "compare-trace": merge("compare-trace"),
         };
       });
-      // Clear the pending refs so handleSimulatorConfigLoaded doesn't try
-      // to drain them a second time on a later config callback.
+      // Clear pending refs so handleSimulatorConfigLoaded doesn't drain
+      // them again on a later config callback.
       primaryTracePendingRef.current = [];
       compareTracePendingRef.current = [];
     }
 
-    // Apply column state (widths/order/sort) to the active sub-tab's primary
-    // grid. If the grid isn't mounted yet, queue for the onGridReady callback.
-    //
-    // Hide flags need a parallel path: applyColumnState's `hide` doesn't
-    // survive the next columnDefs rebuild (getTraceListColumnDefs sets
-    // `hide: !col?.isVisible` explicitly, which wins over applied state).
-    // Build a colId → hide map and stash it; the `[columns]` drain effect
-    // below updates each col's `isVisible` to match, so the next render
-    // produces columnDefs that already reflect the saved-view's hide
-    // intent. applyColumnState still handles widths/order/sort, which
-    // colDefs don't set explicitly and therefore can persist.
+    // Hide needs a parallel path: applyColumnState's hide doesn't survive
+    // the next columnDefs rebuild (getTraceListColumnDefs sets hide from
+    // col.isVisible, which wins over applied state). The [columns] drain
+    // effect below updates col.isVisible from this map.
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
       const hideMap = {};
       display.columnState.forEach((entry) => {
         if (entry && entry.colId) hideMap[entry.colId] = !!entry.hide;
       });
-      // Apply hideMap immediately to all slots so saved-view hide intent
-      // lands in columnDefs even when TraceGrid's merge bails out (e.g.
-      // switching between saved views with identical backend cols, which
-      // makes backendChanged=false → no setColumns call → no drain).
+      // Apply hideMap immediately so view→view switches with identical
+      // backend cols (no merge → no drain) still pick up the hide intent.
       setColumns((prev) => {
         let anyChanged = false;
         const next = {};
@@ -1955,9 +1882,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         });
         return anyChanged ? next : prev;
       });
-      // Also queue for cols that arrive later via TraceGrid's merge (e.g.
-      // first-load before backend has responded). The [columns] drain
-      // effect re-applies hideMap once cols land.
+      // Queue for cols that arrive later via TraceGrid's merge.
       pendingHideMapRef.current = hideMap;
 
       const activeApi =
@@ -1974,8 +1899,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       }
     }
 
-    // Primary date filter — stored inside display for backend-whitelist compatibility.
-    // Only apply if the saved view has one; old views without it keep the current date.
+    // dateFilter lives inside display because the backend serializer only
+    // whitelists `display` for arbitrary sub-keys.
     if (display.dateFilter) {
       if (selectedTab === "trace") {
         setPrimaryTraceDateFilter(display.dateFilter);
@@ -1984,11 +1909,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       }
     }
 
-    // Apply filters — replace unconditionally so switching views clears stale filters.
-    // Guard with Array.isArray: UsersView writes `filters` as an object
-    // ({extraFilters, dateFilter}), and that config can briefly leak into this
-    // view's apply effect during cross-tab transitions (the route change is
-    // queued in startTransition while activeViewConfig updates synchronously).
+    // Array.isArray guard: UsersView writes `filters` as an object, which
+    // can briefly leak during cross-tab transitions (route change is queued
+    // in startTransition while activeViewConfig updates synchronously).
     const rawFilters = activeViewConfig.filters;
     const nextFilters = (Array.isArray(rawFilters) ? rawFilters : []).map(
       (f) => ({
@@ -2033,9 +1956,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeViewConfig]);
 
-  // Drain the queued saved-view columnState once the active sub-tab's primary
-  // grid mounts. TraceGrid is lazy-loaded so the AG Grid api may not exist
-  // when applyConfig runs — retry a handful of times to catch it.
+  // Drains pendingColumnStateRef once the lazy-loaded grid mounts.
   useEffect(() => {
     if (!pendingColumnStateRef.current) return;
     let attempts = 0;
@@ -2066,29 +1987,17 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     };
   }, [activeViewConfig, selectedTab]);
 
-  // Re-apply queued columnState whenever `columns` updates. The retry effect
-  // above only fires on activeViewConfig/selectedTab change; if it ran
-  // successfully before TraceGrid's merge landed the custom cols, AG Grid
-  // silently dropped state for those colIds (it skips state entries for
-  // unknown cols). This effect catches the case: once customs land in
-  // `columns`, re-apply the queued state so widths/order/sort for custom
-  // colIds finally stick. Mirrors the drain effect in Sessions-view.
-  //
-  // Also drains the queued hide map by writing the saved-view's hide
-  // intent into each col's `isVisible`. The next columnDefs render then
-  // emits the correct `hide` for AG Grid — without this, the colDef's
-  // explicit `hide: !col?.isVisible` (default-true `isVisible`) wins
-  // over any state previously applied via applyColumnState and the
-  // hidden cols become visible on the very next merge.
+  // Re-apply queued columnState + hideMap once `columns` updates. The
+  // retry effect above only fires on activeViewConfig/selectedTab change;
+  // if it ran before custom cols landed, AG Grid dropped their entries.
+  // The hideMap path is necessary because the next columnDefs rebuild
+  // overrides applyColumnState's hide flag from col.isVisible.
   useEffect(() => {
     if (pendingHideMapRef.current) {
       const hideMap = pendingHideMapRef.current;
-      // Did this columns snapshot have ANY col whose id appears in the
-      // hideMap? If not, slots are still empty (or none of the standard
-      // cols have arrived yet) and we MUST NOT clear pendingHideMapRef —
-      // otherwise a cold-load apply effect that queues hideMap, then fires
-      // drain on an empty-slot change, would wipe the queue before
-      // TraceGrid/SpanGrid's first setColumns lands the backend cols.
+      // Only clear pendingHideMapRef if at least one col matched —
+      // otherwise a cold-load drain on empty slots would wipe the queue
+      // before TraceGrid/SpanGrid's first setColumns lands the cols.
       let sawMatch = false;
       setColumns((prev) => {
         let anyChanged = false;
@@ -2139,23 +2048,17 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     ? `user-filters-${userIdForUserMode}`
     : `observe-filters-${observeId}`;
 
-  // Pending custom columns — loaded from view config / localStorage but
-  // not merged into columns state until the backend returns real columns,
-  // so the grid doesn't render with only-custom-col headers mid-load.
-  // One ref per grid instance: a shared ref races across the 4 mounted
-  // grids (whichever fetches first drains the queue, leaving the others
-  // empty).
+  // Pending custom cols, queued until the backend returns real columns so
+  // the grid doesn't render with only-custom-col headers mid-load. One ref
+  // per grid instance — a shared ref would race across the 4 mounted grids.
   const primaryTracePendingRef = useRef([]);
   const compareTracePendingRef = useRef([]);
   const primarySpansPendingRef = useRef([]);
   const compareSpansPendingRef = useRef([]);
 
-  // Load display settings from localStorage on mount (for default tab).
-  // Saved-view tabs hydrate from the backend view config via the
-  // `useEffect([activeViewConfig])` apply effect above; seeding pending
-  // refs from localStorage here on a hard refresh into a saved-view URL
-  // would drain the wrong custom cols into the grid before the view
-  // config arrives.
+  // Mount hydrate for the default tab. Saved-view tabs hydrate via the
+  // apply effect above; seeding here on a saved-view URL would drain the
+  // wrong customs before the view config arrives.
   useEffect(() => {
     if (activeViewTabId) return;
     try {
@@ -2168,14 +2071,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       if (saved.showNonAnnotated) setShowNonAnnotated(saved.showNonAnnotated);
       if (saved.showCompare) setShowCompare(saved.showCompare);
       if (saved.hasEvalFilter) setHasEvalFilter(saved.hasEvalFilter);
-      // Accept both the new object shape ({trace: [], spans: []}) and the
-      // legacy flat array (treated as customs for the current tab only,
-      // for forward-compat with localStorage entries written before the
-      // per-tab split). Each pending ref gets its own shallow clone so
-      // primary/compare don't share object identity and the columns
-      // state they drain into doesn't share identity with anything held
-      // by the saved-views cache (same isolation invariant as the
-      // saved-view apply branch above).
+      // Accept both new {trace, spans} object shape and legacy flat array
+      // (treated as customs for the current tab only).
       if (saved.customColumns) {
         const cloneEach = (arr) => arr.map((c) => ({ ...c }));
         if (Array.isArray(saved.customColumns)) {
@@ -2264,9 +2161,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     return (columns[ck] || []).filter((c) => c.groupBy === "Custom Columns");
   }, [columns, selectedGraph, selectedTab]);
 
-  // Get custom columns for both tab types (used by localStorage save so
-  // adding customs on one tab doesn't wipe the other's customs from the
-  // shared `observe-display-<id>` entry).
+  // Used by the localStorage save so adding customs on one tab doesn't
+  // wipe the other's customs (storage key is project-scoped, not tab-scoped).
   const getCustomColumnsByTab = useCallback(() => {
     const traceKey = `${selectedGraph}-trace`;
     const spansKey = `${selectedGraph}-spans`;
@@ -2282,24 +2178,18 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
 
   const { mutate: updateSavedView } = useUpdateSavedView(observeId);
   const { mutate: createSavedView } = useCreateSavedView(observeId);
-  // Workspace-scoped update for user_detail mode (CrossProjectUserDetailPage).
-  // Always declared (hooks can't be conditional); only invoked when isUserMode.
+  // Workspace-scoped update for user_detail mode — only invoked when isUserMode.
   const { mutate: updateWorkspaceSavedView } =
     useUpdateWorkspaceSavedView(USER_DETAIL_TAB_TYPE);
 
-  // Get active view tab ID from URL. The tab-key URL param differs per
-  // surface: "tab" on ObservePage, "userTab" on CrossProjectUserDetailPage.
   const activeViewTabId = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
     const tab = isUserMode ? params.get("userTab") : params.get("tab");
     return tab?.startsWith("view-") ? tab.replace("view-", "") : null;
-  }, [activeViewConfig, isUserMode]); // re-derive when view config changes
+  }, [activeViewConfig, isUserMode]);
 
-  // Build the full saved view config payload
   const buildViewConfig = useCallback(() => {
-    // Capture current grid column state (widths/order/sort/visibility) of the
-    // active sub-tab's primary grid, so saved views restore the user's exact
-    // column layout. Stashed inside `display` because the backend serializer
+    // columnState lives inside `display` because the backend serializer
     // whitelists `display` for arbitrary subkeys.
     const activeGridApi =
       selectedTab === "trace"
@@ -2314,7 +2204,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       showCompare,
       hasEvalFilter,
       customColumns: getCustomColumns(),
-      // Stash primary date filter inside display for backend-whitelist compatibility
+      // dateFilter lives inside display for backend-whitelist compatibility.
       dateFilter:
         selectedTab === "trace"
           ? primaryTraceDateFilter
@@ -2331,10 +2221,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       filters: mapFilters(
         selectedTab === "trace" ? primaryTraceFilters : primarySpanFilters,
       ),
-      // extraFilters is independent of compare mode — always persist
       extraFilters: extraFilters || [],
     };
-    // Include compare state when compare mode is on
     if (showCompare) {
       config.compareFilters = mapFilters(
         selectedTab === "trace" ? compareTraceFilters : compareSpansFilters,
@@ -2378,8 +2266,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     return () => registerGetTabType(null);
   }, [registerGetTabType, selectedTab]);
 
-  // Explicit "Save view" — overwrite the active saved view's config with the
-  // current live state. Bound to ObserveToolbar's Save view button.
+  // Bound to ObserveToolbar's Save view button.
   const handleSaveView = useCallback(() => {
     if (!activeViewTabId) return;
     const config = buildViewConfig();
@@ -2388,7 +2275,6 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       { id: activeViewTabId, config },
       {
         onSuccess: (response) => {
-          // Refresh the baseline so canSaveView's diff resets to false.
           setActiveViewConfig(response?.data?.result?.config ?? config);
           enqueueSnackbar("View updated", { variant: "success" });
         },
@@ -2405,16 +2291,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     setActiveViewConfig,
   ]);
 
-  // Persist display settings to localStorage on the default tab so personal
-  // preferences (cellHeight, viewMode, …) survive across navigation. The
-  // backend-update branch that used to live here was removed: filter/date
-  // state was never in the dep array, so it silently missed those changes.
-  // Updates to a saved view are now triggered explicitly by handleSaveView
-  // (the Save view button in the toolbar).
+  // Default tab only — saved views go through handleSaveView instead.
   useEffect(() => {
-    // Default tab only — persist personal display preferences to localStorage
-    // so cellHeight / viewMode / etc. survive across navigation. Saved-view
-    // tabs go through the explicit Save view button (handleSaveView) instead.
     if (activeViewTabId) return;
     const currentDisplay = {
       viewMode,
@@ -2423,9 +2301,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       showNonAnnotated,
       showCompare,
       hasEvalFilter,
-      // Object shape keyed by tab type so adding a custom col on spans
-      // doesn't overwrite traces' customs (and vice versa) — the storage
-      // key itself is project-scoped, not tab-scoped.
+      // Keyed by tab type so adding a custom on spans doesn't overwrite
+      // traces' customs (storage key is project-scoped, not tab-scoped).
       customColumns: getCustomColumnsByTab(),
     };
     try {

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -1745,27 +1745,34 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
           // Legacy array shape: customs apply to whatever tab is active.
           // New object shape: customs are pre-split by tab type — hydrate
           // both refs for each tab so a compare-mode toggle later picks
-          // up the right set without another localStorage read.
+          // up the right set without another localStorage read. Each
+          // ref gets its own shallow clone so neither pending refs nor
+          // the columns state they drain into share identity with the
+          // parsed localStorage payload (the parsed object is rooted
+          // somewhere only via the immediate `saved` binding here, but
+          // matching the saved-view branch's clone pattern keeps the
+          // invariant uniform across the file).
+          const cloneEach = (arr) => arr.map((c) => ({ ...c }));
           if (Array.isArray(saved.customColumns)) {
             if (saved.customColumns.length > 0) {
               if (selectedTab === "trace") {
-                primaryTracePendingRef.current = saved.customColumns;
-                compareTracePendingRef.current = saved.customColumns;
+                primaryTracePendingRef.current = cloneEach(saved.customColumns);
+                compareTracePendingRef.current = cloneEach(saved.customColumns);
               } else {
-                primarySpansPendingRef.current = saved.customColumns;
-                compareSpansPendingRef.current = saved.customColumns;
+                primarySpansPendingRef.current = cloneEach(saved.customColumns);
+                compareSpansPendingRef.current = cloneEach(saved.customColumns);
               }
             }
           } else {
             const traceCols = saved.customColumns.trace || [];
             const spansCols = saved.customColumns.spans || [];
             if (traceCols.length > 0) {
-              primaryTracePendingRef.current = traceCols;
-              compareTracePendingRef.current = traceCols;
+              primaryTracePendingRef.current = cloneEach(traceCols);
+              compareTracePendingRef.current = cloneEach(traceCols);
             }
             if (spansCols.length > 0) {
-              primarySpansPendingRef.current = spansCols;
-              compareSpansPendingRef.current = spansCols;
+              primarySpansPendingRef.current = cloneEach(spansCols);
+              compareSpansPendingRef.current = cloneEach(spansCols);
             }
           }
         }
@@ -1835,14 +1842,29 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     });
 
     // Populate both primary and compare refs for the active tab type so a
-    // later toggle into compare mode also hydrates correctly.
+    // later toggle into compare mode also hydrates correctly. Each ref
+    // gets its OWN shallow clone of each col — without that, the pending
+    // refs (and eventually `columns[ck]` they drain into) share object
+    // identity with the saved-views query cache. Any later mutation —
+    // adding a new custom, saving as a new view, toggling visibility —
+    // would write through into the cached saved view config and corrupt
+    // its on-screen state until the next refetch. The map-of-map also
+    // isolates primary from compare.
     if (display.customColumns?.length > 0) {
       if (selectedTab === "trace") {
-        primaryTracePendingRef.current = display.customColumns;
-        compareTracePendingRef.current = display.customColumns;
+        primaryTracePendingRef.current = display.customColumns.map((c) => ({
+          ...c,
+        }));
+        compareTracePendingRef.current = display.customColumns.map((c) => ({
+          ...c,
+        }));
       } else {
-        primarySpansPendingRef.current = display.customColumns;
-        compareSpansPendingRef.current = display.customColumns;
+        primarySpansPendingRef.current = display.customColumns.map((c) => ({
+          ...c,
+        }));
+        compareSpansPendingRef.current = display.customColumns.map((c) => ({
+          ...c,
+        }));
       }
     }
 
@@ -1856,13 +1878,19 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       projectSource === PROJECT_SOURCE.SIMULATOR &&
       display.customColumns?.length > 0
     ) {
+      // Clone each col per slot so primary-trace and compare-trace each
+      // own independent objects, and neither shares identity with the
+      // saved-views cache. Mirrors the clone in the trace/spans branch
+      // above — without it, downstream mutations would write through
+      // into the cached view config.
       setColumns((prev) => {
         const merge = (key) => {
           const existing = prev[key] || [];
           const stripped = existing.filter(
             (c) => c.groupBy !== "Custom Columns",
           );
-          return [...stripped, ...display.customColumns];
+          const fresh = display.customColumns.map((c) => ({ ...c }));
+          return [...stripped, ...fresh];
         };
         return {
           ...prev,
@@ -2049,28 +2077,33 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       // Accept both the new object shape ({trace: [], spans: []}) and the
       // legacy flat array (treated as customs for the current tab only,
       // for forward-compat with localStorage entries written before the
-      // per-tab split).
+      // per-tab split). Each pending ref gets its own shallow clone so
+      // primary/compare don't share object identity and the columns
+      // state they drain into doesn't share identity with anything held
+      // by the saved-views cache (same isolation invariant as the
+      // saved-view apply branch above).
       if (saved.customColumns) {
+        const cloneEach = (arr) => arr.map((c) => ({ ...c }));
         if (Array.isArray(saved.customColumns)) {
           if (saved.customColumns.length > 0) {
             if (selectedTab === "trace") {
-              primaryTracePendingRef.current = saved.customColumns;
-              compareTracePendingRef.current = saved.customColumns;
+              primaryTracePendingRef.current = cloneEach(saved.customColumns);
+              compareTracePendingRef.current = cloneEach(saved.customColumns);
             } else {
-              primarySpansPendingRef.current = saved.customColumns;
-              compareSpansPendingRef.current = saved.customColumns;
+              primarySpansPendingRef.current = cloneEach(saved.customColumns);
+              compareSpansPendingRef.current = cloneEach(saved.customColumns);
             }
           }
         } else {
           const traceCols = saved.customColumns.trace || [];
           const spansCols = saved.customColumns.spans || [];
           if (traceCols.length > 0) {
-            primaryTracePendingRef.current = traceCols;
-            compareTracePendingRef.current = traceCols;
+            primaryTracePendingRef.current = cloneEach(traceCols);
+            compareTracePendingRef.current = cloneEach(traceCols);
           }
           if (spansCols.length > 0) {
-            primarySpansPendingRef.current = spansCols;
-            compareSpansPendingRef.current = spansCols;
+            primarySpansPendingRef.current = cloneEach(spansCols);
+            compareSpansPendingRef.current = cloneEach(spansCols);
           }
         }
       }

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -1223,18 +1223,39 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     (config) => {
       if (projectSource === PROJECT_SOURCE.SIMULATOR && config?.length > 0) {
         setColumns((prev) => {
-          // Preserve existing custom columns when grid reports its base columns
-          const preserveCustom = (key) => {
+          // Preserve existing custom columns AND drain pending custom cols
+          // queued by the localStorage hydrate / saved-view apply effect.
+          // Voice projects render through CallLogsGrid (not TraceGrid), so
+          // there's no merge logic on the grid side to drain those refs —
+          // this callback is the only path that writes to columns["*-trace"]
+          // for voice, so it has to handle the drain itself. Without this,
+          // custom cols loaded from localStorage or a saved view sit in the
+          // pending ref forever and never appear in the grid.
+          const drainPending = (key, ref) => {
             const existing = prev[key] || [];
             const customCols = existing.filter(
               (c) => c.groupBy === "Custom Columns",
             );
-            return [...config, ...customCols];
+            const pending = ref?.current || [];
+            const existingIds = new Set(customCols.map((c) => c.id));
+            const dedupedPending = pending.filter(
+              (c) => !existingIds.has(c.id),
+            );
+            if (pending.length > 0 && ref) {
+              ref.current = [];
+            }
+            return [...config, ...customCols, ...dedupedPending];
           };
           return {
             ...prev,
-            "primary-trace": preserveCustom("primary-trace"),
-            "compare-trace": preserveCustom("compare-trace"),
+            "primary-trace": drainPending(
+              "primary-trace",
+              primaryTracePendingRef,
+            ),
+            "compare-trace": drainPending(
+              "compare-trace",
+              compareTracePendingRef,
+            ),
           };
         });
       }
@@ -1696,7 +1717,85 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       setExtraFilters((prev) => (prev.length === 0 ? prev : []));
       setViewMode(DEFAULT_DISPLAY_CONFIG.viewMode);
       pendingColumnStateRef.current = null;
-      pendingCustomColumnsRef.current = [];
+      primaryTracePendingRef.current = [];
+      compareTracePendingRef.current = [];
+      primarySpansPendingRef.current = [];
+      compareSpansPendingRef.current = [];
+      // Strip saved-view custom cols from all grid slots so they don't
+      // linger on the default tab.
+      setColumns((prev) => {
+        const next = {};
+        Object.keys(prev).forEach((ck) => {
+          next[ck] = (prev[ck] || []).filter(
+            (c) => c.groupBy !== "Custom Columns",
+          );
+        });
+        return next;
+      });
+      // Re-hydrate default-tab custom cols from localStorage. The mount-
+      // time useEffect that normally does this is keyed on
+      // displayStorageKey (project-scoped), so it doesn't re-fire on a
+      // same-project tab toggle.
+      try {
+        const raw = localStorage.getItem(displayStorageKey);
+        const saved = raw ? JSON.parse(raw) : null;
+        if (saved?.customColumns) {
+          // Legacy array shape: customs apply to whatever tab is active.
+          // New object shape: customs are pre-split by tab type — hydrate
+          // both refs for each tab so a compare-mode toggle later picks
+          // up the right set without another localStorage read.
+          if (Array.isArray(saved.customColumns)) {
+            if (saved.customColumns.length > 0) {
+              if (selectedTab === "trace") {
+                primaryTracePendingRef.current = saved.customColumns;
+                compareTracePendingRef.current = saved.customColumns;
+              } else {
+                primarySpansPendingRef.current = saved.customColumns;
+                compareSpansPendingRef.current = saved.customColumns;
+              }
+            }
+          } else {
+            const traceCols = saved.customColumns.trace || [];
+            const spansCols = saved.customColumns.spans || [];
+            if (traceCols.length > 0) {
+              primaryTracePendingRef.current = traceCols;
+              compareTracePendingRef.current = traceCols;
+            }
+            if (spansCols.length > 0) {
+              primarySpansPendingRef.current = spansCols;
+              compareSpansPendingRef.current = spansCols;
+            }
+          }
+        }
+      } catch {
+        /* ignore corrupted localStorage */
+      }
+      // Voice/simulator: drain the freshly-populated pending refs into
+      // columns state directly. handleSimulatorConfigLoaded fires only on
+      // backend column-count changes, which doesn't happen on a saved-view
+      // → default transition, so without this the localStorage customs
+      // we just queued would never reach the grid.
+      if (projectSource === PROJECT_SOURCE.SIMULATOR) {
+        const draining = primaryTracePendingRef.current || [];
+        if (draining.length > 0) {
+          setColumns((prev) => {
+            const merge = (key) => {
+              const existing = prev[key] || [];
+              const stripped = existing.filter(
+                (c) => c.groupBy !== "Custom Columns",
+              );
+              return [...stripped, ...draining];
+            };
+            return {
+              ...prev,
+              "primary-trace": merge("primary-trace"),
+              "compare-trace": merge("compare-trace"),
+            };
+          });
+          primaryTracePendingRef.current = [];
+          compareTracePendingRef.current = [];
+        }
+      }
       const activeApi =
         selectedTab === "trace"
           ? primaryTraceGridRef.current?.api
@@ -1717,9 +1816,62 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     if (display.hasEvalFilter !== undefined)
       setHasEvalFilter(display.hasEvalFilter);
 
-    // Defer custom columns — merged when backend columns arrive
+    // Strip existing custom cols from all grid slots so customs inherited
+    // from a previous tab/view (e.g. default-tab localStorage customs, or
+    // another saved view) don't linger when this saved view's set is
+    // merged in below. Without this, switching from default → saved view
+    // (or view A → view B) ends up showing the union of both sets and
+    // dirty-flags the Save view button.
+    setColumns((prev) => {
+      const next = {};
+      Object.keys(prev).forEach((ck) => {
+        next[ck] = (prev[ck] || []).filter(
+          (c) => c.groupBy !== "Custom Columns",
+        );
+      });
+      return next;
+    });
+
+    // Populate both primary and compare refs for the active tab type so a
+    // later toggle into compare mode also hydrates correctly.
     if (display.customColumns?.length > 0) {
-      pendingCustomColumnsRef.current = display.customColumns;
+      if (selectedTab === "trace") {
+        primaryTracePendingRef.current = display.customColumns;
+        compareTracePendingRef.current = display.customColumns;
+      } else {
+        primarySpansPendingRef.current = display.customColumns;
+        compareSpansPendingRef.current = display.customColumns;
+      }
+    }
+
+    // Voice/simulator projects: CallLogsGrid doesn't have a per-fetch merge
+    // step that drains the pending ref (it only emits its config when the
+    // backend column count changes, which doesn't happen on a same-tab-type
+    // saved-view switch). Drain into columns state directly here so customs
+    // from the new view actually appear. The strip block above already
+    // cleared old customs, so just append the new set.
+    if (
+      projectSource === PROJECT_SOURCE.SIMULATOR &&
+      display.customColumns?.length > 0
+    ) {
+      setColumns((prev) => {
+        const merge = (key) => {
+          const existing = prev[key] || [];
+          const stripped = existing.filter(
+            (c) => c.groupBy !== "Custom Columns",
+          );
+          return [...stripped, ...display.customColumns];
+        };
+        return {
+          ...prev,
+          "primary-trace": merge("primary-trace"),
+          "compare-trace": merge("compare-trace"),
+        };
+      });
+      // Clear the pending refs so handleSimulatorConfigLoaded doesn't try
+      // to drain them a second time on a later config callback.
+      primaryTracePendingRef.current = [];
+      compareTracePendingRef.current = [];
     }
 
     // Apply column state (widths/order/sort) to the active sub-tab's primary
@@ -1841,13 +1993,24 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     ? `user-filters-${userIdForUserMode}`
     : `observe-filters-${observeId}`;
 
-  // Pending custom columns — loaded from localStorage/view config but not
-  // merged into columns state until the backend returns real columns.
-  // This prevents the loading skeleton from showing only custom columns.
-  const pendingCustomColumnsRef = useRef([]);
+  // Pending custom columns — loaded from view config / localStorage but
+  // not merged into columns state until the backend returns real columns,
+  // so the grid doesn't render with only-custom-col headers mid-load.
+  // One ref per grid instance: a shared ref races across the 4 mounted
+  // grids (whichever fetches first drains the queue, leaving the others
+  // empty).
+  const primaryTracePendingRef = useRef([]);
+  const compareTracePendingRef = useRef([]);
+  const primarySpansPendingRef = useRef([]);
+  const compareSpansPendingRef = useRef([]);
 
-  // Load display settings from localStorage on mount (for default tab)
+  // Load display settings from localStorage on mount (for default tab).
+  // Saved-view tabs hydrate from the backend view config (apply effect at
+  // line ~1684); seeding pending refs from localStorage here on a hard
+  // refresh into a saved-view URL drains the wrong custom cols into the
+  // grid before the view config arrives.
   useEffect(() => {
+    if (activeViewTabId) return;
     try {
       const raw = localStorage.getItem(displayStorageKey);
       if (!raw) return;
@@ -1858,9 +2021,33 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       if (saved.showNonAnnotated) setShowNonAnnotated(saved.showNonAnnotated);
       if (saved.showCompare) setShowCompare(saved.showCompare);
       if (saved.hasEvalFilter) setHasEvalFilter(saved.hasEvalFilter);
-      // Defer custom columns — they'll be merged when backend columns arrive
-      if (saved.customColumns?.length > 0) {
-        pendingCustomColumnsRef.current = saved.customColumns;
+      // Accept both the new object shape ({trace: [], spans: []}) and the
+      // legacy flat array (treated as customs for the current tab only,
+      // for forward-compat with localStorage entries written before the
+      // per-tab split).
+      if (saved.customColumns) {
+        if (Array.isArray(saved.customColumns)) {
+          if (saved.customColumns.length > 0) {
+            if (selectedTab === "trace") {
+              primaryTracePendingRef.current = saved.customColumns;
+              compareTracePendingRef.current = saved.customColumns;
+            } else {
+              primarySpansPendingRef.current = saved.customColumns;
+              compareSpansPendingRef.current = saved.customColumns;
+            }
+          }
+        } else {
+          const traceCols = saved.customColumns.trace || [];
+          const spansCols = saved.customColumns.spans || [];
+          if (traceCols.length > 0) {
+            primaryTracePendingRef.current = traceCols;
+            compareTracePendingRef.current = traceCols;
+          }
+          if (spansCols.length > 0) {
+            primarySpansPendingRef.current = spansCols;
+            compareSpansPendingRef.current = spansCols;
+          }
+        }
       }
     } catch {
       /* ignore corrupted localStorage */
@@ -1924,6 +2111,22 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     const ck = `${selectedGraph}-${selectedTab === "spans" ? "spans" : "trace"}`;
     return (columns[ck] || []).filter((c) => c.groupBy === "Custom Columns");
   }, [columns, selectedGraph, selectedTab]);
+
+  // Get custom columns for both tab types (used by localStorage save so
+  // adding customs on one tab doesn't wipe the other's customs from the
+  // shared `observe-display-<id>` entry).
+  const getCustomColumnsByTab = useCallback(() => {
+    const traceKey = `${selectedGraph}-trace`;
+    const spansKey = `${selectedGraph}-spans`;
+    return {
+      trace: (columns[traceKey] || []).filter(
+        (c) => c.groupBy === "Custom Columns",
+      ),
+      spans: (columns[spansKey] || []).filter(
+        (c) => c.groupBy === "Custom Columns",
+      ),
+    };
+  }, [columns, selectedGraph]);
 
   const { mutate: updateSavedView } = useUpdateSavedView(observeId);
   const { mutate: createSavedView } = useCreateSavedView(observeId);
@@ -2068,7 +2271,10 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       showNonAnnotated,
       showCompare,
       hasEvalFilter,
-      customColumns: getCustomColumns(),
+      // Object shape keyed by tab type so adding a custom col on spans
+      // doesn't overwrite traces' customs (and vice versa) — the storage
+      // key itself is project-scoped, not tab-scoped.
+      customColumns: getCustomColumnsByTab(),
     };
     try {
       localStorage.setItem(displayStorageKey, JSON.stringify(currentDisplay));
@@ -2084,7 +2290,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     showCompare,
     hasEvalFilter,
     displayStorageKey,
-    getCustomColumns,
+    getCustomColumnsByTab,
   ]);
 
   const handleAddEvals = useCallback(() => {
@@ -4076,7 +4282,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     hasEvalFilter={hasEvalFilter}
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
-                    pendingCustomColumnsRef={pendingCustomColumnsRef}
+                    pendingCustomColumnsRef={primaryTracePendingRef}
                     showErrors={showErrors}
                     enabled={
                       [
@@ -4114,7 +4320,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     hasEvalFilter={hasEvalFilter}
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
-                    pendingCustomColumnsRef={pendingCustomColumnsRef}
+                    pendingCustomColumnsRef={compareTracePendingRef}
                     projectId={observeId}
                     showErrors={showErrors}
                     enabled={
@@ -4173,7 +4379,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     hasEvalFilter={hasEvalFilter}
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
-                    pendingCustomColumnsRef={pendingCustomColumnsRef}
+                    pendingCustomColumnsRef={primarySpansPendingRef}
                     setFilters={setPrimarySpanFilters}
                     setExtraFilters={setExtraFilters}
                     setFilterOpen={setIsPrimaryFilterOpen}
@@ -4207,7 +4413,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     hasEvalFilter={hasEvalFilter}
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
-                    pendingCustomColumnsRef={pendingCustomColumnsRef}
+                    pendingCustomColumnsRef={compareSpansPendingRef}
                     filters={compareSpansValidatedFilters}
                     extraFilters={extraFilters}
                     ref={compareSpanGridRef}

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -1226,11 +1226,13 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
           // Preserve existing custom columns AND drain pending custom cols
           // queued by the localStorage hydrate / saved-view apply effect.
           // Voice projects render through CallLogsGrid (not TraceGrid), so
-          // there's no merge logic on the grid side to drain those refs —
-          // this callback is the only path that writes to columns["*-trace"]
-          // for voice, so it has to handle the drain itself. Without this,
-          // custom cols loaded from localStorage or a saved view sit in the
-          // pending ref forever and never appear in the grid.
+          // there's no per-fetch merge step on the grid side to drain those
+          // refs. The apply effect's voice branches drain on saved-view +
+          // back-to-default transitions; this callback handles the path
+          // where the backend column count changes (initial mount, schema
+          // change). Without these drains, custom cols loaded from
+          // localStorage or a saved view sit in the pending ref forever
+          // and never appear in the grid.
           const drainPending = (key, ref) => {
             const existing = prev[key] || [];
             const customCols = existing.filter(
@@ -1697,9 +1699,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   // Tracked separately so the null-branch reset only fires on a genuine
   // saved-view → default transition, not on initial mount where
   // activeViewConfig is null only because hydration hasn't landed yet.
-  // Without this guard, the destructive resets below clobber state that
-  // the localStorage rehydrate (line 1816) and the apply branch are
-  // about to set from the saved view itself.
+  // Without this guard, the destructive resets below would clobber state
+  // that the null-branch localStorage rehydrate and the apply-branch
+  // saved-view writes are about to set themselves.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const wasOnSavedViewRef = useRef(false);
   useEffect(() => {
@@ -1983,6 +1985,28 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     };
   }, [activeViewConfig, selectedTab]);
 
+  // Re-apply queued columnState whenever `columns` updates. The retry effect
+  // above only fires on activeViewConfig/selectedTab change; if it ran
+  // successfully before TraceGrid's merge landed the custom cols, AG Grid
+  // silently dropped state for those colIds (it skips state entries for
+  // unknown cols). This effect catches the case: once customs land in
+  // `columns`, re-apply the queued state so widths/order/sort for custom
+  // colIds finally stick. Mirrors the drain effect in Sessions-view.
+  useEffect(() => {
+    if (!pendingColumnStateRef.current) return;
+    const api =
+      selectedTab === "trace"
+        ? primaryTraceGridRef.current?.api
+        : primarySpanGridRef.current?.api;
+    if (!api?.applyColumnState) return;
+    api.applyColumnState({
+      state: pendingColumnStateRef.current,
+      applyOrder: true,
+    });
+    pendingColumnStateRef.current = null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columns]);
+
   // ---------------------------------------------------------------------------
   // View persistence — auto-save display + reset/default
   // ---------------------------------------------------------------------------
@@ -2005,10 +2029,11 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const compareSpansPendingRef = useRef([]);
 
   // Load display settings from localStorage on mount (for default tab).
-  // Saved-view tabs hydrate from the backend view config (apply effect at
-  // line ~1684); seeding pending refs from localStorage here on a hard
-  // refresh into a saved-view URL drains the wrong custom cols into the
-  // grid before the view config arrives.
+  // Saved-view tabs hydrate from the backend view config via the
+  // `useEffect([activeViewConfig])` apply effect above; seeding pending
+  // refs from localStorage here on a hard refresh into a saved-view URL
+  // would drain the wrong custom cols into the grid before the view
+  // config arrives.
   useEffect(() => {
     if (activeViewTabId) return;
     try {

--- a/frontend/src/sections/projects/LLMTracing/Renderers/DefaultCell.jsx
+++ b/frontend/src/sections/projects/LLMTracing/Renderers/DefaultCell.jsx
@@ -23,7 +23,8 @@ const DefaultCell = memo(
     const colId = column?.id;
 
     const showQuickFilter =
-      !RENDERER_CONFIG.ignoredQuickFilters.includes(colId);
+      !RENDERER_CONFIG.ignoredQuickFilters.includes(colId) &&
+      column?.groupBy !== "Custom Columns";
 
     const shouldApplyDateFormat =
       RENDERER_CONFIG.applyDateFormat.includes(colId) && value;

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -385,15 +385,34 @@ const SpanGrid = React.forwardRef(
                 const dedupedPending = pending.filter(
                   (c) => !existingIds.has(c.id),
                 );
-                const backendChanged = !_.isEqual(newCols, currentNonCustom);
+                // backendChanged ignores `isVisible` so a saved-view hide map
+                // applied locally (which makes currentNonCustom differ from
+                // newCols on isVisible only) doesn't keep retriggering the
+                // merge and clobbering local hide state on every page fetch.
+                const stripVis = (cols) =>
+                  (cols || []).map(({ isVisible, ...rest }) => rest);
+                const backendChanged = !_.isEqual(
+                  stripVis(newCols),
+                  stripVis(currentNonCustom),
+                );
                 const hasPending = dedupedPending.length > 0;
                 if (backendChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
+                  // On backendChanged, merge newCols with existing isVisible
+                  // so saved-view hide intent (set on col.isVisible by the
+                  // LLMTracingView [columns] drain) survives across fetches.
                   const finalNonCustom = backendChanged
-                    ? newCols
+                    ? newCols.map((nc) => {
+                        const existing = currentNonCustom.find(
+                          (c) => c.id === nc.id,
+                        );
+                        return existing
+                          ? { ...nc, isVisible: existing.isVisible }
+                          : nc;
+                      })
                     : currentNonCustom;
                   setColumns(
                     allCustom.length > 0

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -385,10 +385,8 @@ const SpanGrid = React.forwardRef(
                 const dedupedPending = pending.filter(
                   (c) => !existingIds.has(c.id),
                 );
-                // backendChanged ignores `isVisible` so a saved-view hide map
-                // applied locally (which makes currentNonCustom differ from
-                // newCols on isVisible only) doesn't keep retriggering the
-                // merge and clobbering local hide state on every page fetch.
+                // Strip isVisible from the diff so saved-view hide maps
+                // don't keep retriggering the merge on every fetch.
                 const stripVis = (cols) =>
                   (cols || []).map(({ isVisible, ...rest }) => rest);
                 const backendChanged = !_.isEqual(
@@ -401,9 +399,8 @@ const SpanGrid = React.forwardRef(
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
-                  // On backendChanged, merge newCols with existing isVisible
-                  // so saved-view hide intent (set on col.isVisible by the
-                  // LLMTracingView [columns] drain) survives across fetches.
+                  // Preserve existing isVisible so saved-view hide intent
+                  // survives backend col changes.
                   const finalNonCustom = backendChanged
                     ? newCols.map((nc) => {
                         const existing = currentNonCustom.find(

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -377,21 +377,28 @@ const SpanGrid = React.forwardRef(
                 const currentNonCustom = (columnsRef.current || []).filter(
                   (c) => c.groupBy !== "Custom Columns",
                 );
-                if (!_.isEqual(newCols, currentNonCustom)) {
-                  const existingCustom = (columnsRef.current || []).filter(
-                    (c) => c.groupBy === "Custom Columns",
-                  );
-                  const pending = pendingCustomColumnsRef?.current || [];
-                  const existingIds = new Set(existingCustom.map((c) => c.id));
-                  const dedupedPending = pending.filter(
-                    (c) => !existingIds.has(c.id),
-                  );
+                const existingCustom = (columnsRef.current || []).filter(
+                  (c) => c.groupBy === "Custom Columns",
+                );
+                const pending = pendingCustomColumnsRef?.current || [];
+                const existingIds = new Set(existingCustom.map((c) => c.id));
+                const dedupedPending = pending.filter(
+                  (c) => !existingIds.has(c.id),
+                );
+                const backendChanged = !_.isEqual(newCols, currentNonCustom);
+                const hasPending = dedupedPending.length > 0;
+                if (backendChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
+                  const finalNonCustom = backendChanged
+                    ? newCols
+                    : currentNonCustom;
                   setColumns(
-                    allCustom.length > 0 ? [...newCols, ...allCustom] : newCols,
+                    allCustom.length > 0
+                      ? [...finalNonCustom, ...allCustom]
+                      : finalNonCustom,
                   );
                 }
               }

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -224,17 +224,10 @@ const TraceGrid = React.forwardRef(
                 const dedupedPending = pending.filter(
                   (c) => !existingIds.has(c.id),
                 );
-                // Re-merge when backend cols changed OR pending has items.
-                // Without the hasPending clause, switching into a saved view
-                // where the backend returns the same standard cols would
-                // skip the merge — pending custom cols would stay in the
-                // ref forever.
-                //
-                // backendChanged is computed ignoring `isVisible` so that a
-                // saved-view hide-map applied locally (which makes
-                // currentNonCustom diverge from newCols on isVisible only)
-                // doesn't keep retriggering the merge and clobbering the
-                // local hide state on every page fetch.
+                // Strip isVisible from the diff so saved-view hide maps
+                // don't keep retriggering the merge on every fetch. The
+                // hasPending clause ensures a saved-view switch with same
+                // backend cols still drains the pending customs.
                 const stripVis = (cols) =>
                   (cols || []).map(({ isVisible, ...rest }) => rest);
                 const backendChanged = !_.isEqual(
@@ -247,11 +240,9 @@ const TraceGrid = React.forwardRef(
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
-                  // When backendChanged, merge newCols with existing isVisible
-                  // so saved-view hide intent (written to col.isVisible by the
-                  // [columns] drain in LLMTracingView) survives across fetches.
-                  // When only pending fired, reuse currentNonCustom to keep
-                  // AG Grid's column identity stable (avoid reorder churn).
+                  // Preserve existing isVisible so saved-view hide intent
+                  // survives backend col changes. Pending-only path reuses
+                  // currentNonCustom to keep column identity stable.
                   const finalNonCustom = backendChanged
                     ? newCols.map((nc) => {
                         const existing = currentNonCustom.find(

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -229,17 +229,38 @@ const TraceGrid = React.forwardRef(
                 // where the backend returns the same standard cols would
                 // skip the merge — pending custom cols would stay in the
                 // ref forever.
-                const backendChanged = !_.isEqual(newCols, currentNonCustom);
+                //
+                // backendChanged is computed ignoring `isVisible` so that a
+                // saved-view hide-map applied locally (which makes
+                // currentNonCustom diverge from newCols on isVisible only)
+                // doesn't keep retriggering the merge and clobbering the
+                // local hide state on every page fetch.
+                const stripVis = (cols) =>
+                  (cols || []).map(({ isVisible, ...rest }) => rest);
+                const backendChanged = !_.isEqual(
+                  stripVis(newCols),
+                  stripVis(currentNonCustom),
+                );
                 const hasPending = dedupedPending.length > 0;
                 if (backendChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
+                  // When backendChanged, merge newCols with existing isVisible
+                  // so saved-view hide intent (written to col.isVisible by the
+                  // [columns] drain in LLMTracingView) survives across fetches.
                   // When only pending fired, reuse currentNonCustom to keep
                   // AG Grid's column identity stable (avoid reorder churn).
                   const finalNonCustom = backendChanged
-                    ? newCols
+                    ? newCols.map((nc) => {
+                        const existing = currentNonCustom.find(
+                          (c) => c.id === nc.id,
+                        );
+                        return existing
+                          ? { ...nc, isVisible: existing.isVisible }
+                          : nc;
+                      })
                     : currentNonCustom;
                   setColumns(
                     allCustom.length > 0

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -216,23 +216,35 @@ const TraceGrid = React.forwardRef(
                 const currentNonCustom = (columnsRef.current || []).filter(
                   (c) => c.groupBy !== "Custom Columns",
                 );
-                if (!_.isEqual(newCols, currentNonCustom)) {
-                  // Merge: existing custom cols + pending (from localStorage/saved view)
-                  const existingCustom = (columnsRef.current || []).filter(
-                    (c) => c.groupBy === "Custom Columns",
-                  );
-                  const pending = pendingCustomColumnsRef?.current || [];
-                  const existingIds = new Set(existingCustom.map((c) => c.id));
-                  const dedupedPending = pending.filter(
-                    (c) => !existingIds.has(c.id),
-                  );
+                const existingCustom = (columnsRef.current || []).filter(
+                  (c) => c.groupBy === "Custom Columns",
+                );
+                const pending = pendingCustomColumnsRef?.current || [];
+                const existingIds = new Set(existingCustom.map((c) => c.id));
+                const dedupedPending = pending.filter(
+                  (c) => !existingIds.has(c.id),
+                );
+                // Re-merge when backend cols changed OR pending has items.
+                // Without the hasPending clause, switching into a saved view
+                // where the backend returns the same standard cols would
+                // skip the merge — pending custom cols would stay in the
+                // ref forever.
+                const backendChanged = !_.isEqual(newCols, currentNonCustom);
+                const hasPending = dedupedPending.length > 0;
+                if (backendChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
-                  // Clear pending after consuming
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
+                  // When only pending fired, reuse currentNonCustom to keep
+                  // AG Grid's column identity stable (avoid reorder churn).
+                  const finalNonCustom = backendChanged
+                    ? newCols
+                    : currentNonCustom;
                   setColumns(
-                    allCustom.length > 0 ? [...newCols, ...allCustom] : newCols,
+                    allCustom.length > 0
+                      ? [...finalNonCustom, ...allCustom]
+                      : finalNonCustom,
                   );
                 }
               }

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -248,10 +248,9 @@ const SessionGrid = React.forwardRef(
                   (c) => !existingIds.has(c.id),
                 );
                 const backendChanged = !_.isEqual(newCols, currentNonCustom);
+                // hasPending ensures same-tab saved-view clicks still drain
+                // queued customs even when backend cols match.
                 const hasPending = dedupedPending.length > 0;
-                // Drain pending even when backend cols are unchanged so a
-                // saved-view click whose tab_type matches the current view
-                // still merges the queued customs into sessionColumns.
                 if (backendChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
                   if (pending.length > 0 && pendingCustomColumnsRef) {

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -239,21 +239,31 @@ const SessionGrid = React.forwardRef(
                 const currentNonCustom = (columnsRef.current || []).filter(
                   (c) => c.groupBy !== "Custom Columns",
                 );
-                if (!_.isEqual(newCols, currentNonCustom)) {
-                  const existingCustom = (columnsRef.current || []).filter(
-                    (c) => c.groupBy === "Custom Columns",
-                  );
-                  const pending = pendingCustomColumnsRef?.current || [];
-                  const existingIds = new Set(existingCustom.map((c) => c.id));
-                  const dedupedPending = pending.filter(
-                    (c) => !existingIds.has(c.id),
-                  );
+                const existingCustom = (columnsRef.current || []).filter(
+                  (c) => c.groupBy === "Custom Columns",
+                );
+                const pending = pendingCustomColumnsRef?.current || [];
+                const existingIds = new Set(existingCustom.map((c) => c.id));
+                const dedupedPending = pending.filter(
+                  (c) => !existingIds.has(c.id),
+                );
+                const backendChanged = !_.isEqual(newCols, currentNonCustom);
+                const hasPending = dedupedPending.length > 0;
+                // Drain pending even when backend cols are unchanged so a
+                // saved-view click whose tab_type matches the current view
+                // still merges the queued customs into sessionColumns.
+                if (backendChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
+                  const finalNonCustom = backendChanged
+                    ? newCols
+                    : currentNonCustom;
                   setColumns(
-                    allCustom.length > 0 ? [...newCols, ...allCustom] : newCols,
+                    allCustom.length > 0
+                      ? [...finalNonCustom, ...allCustom]
+                      : finalNonCustom,
                   );
                 }
               }

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -513,7 +513,13 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         Array.isArray(saved.customColumns) &&
         saved.customColumns.length > 0
       ) {
-        pendingCustomColumnsRef.current = saved.customColumns;
+        // Shallow-clone each col so the pending ref (and `sessionColumns`
+        // it drains into) doesn't share object identity with the parsed
+        // localStorage payload. Mirrors the clone in the saved-view apply
+        // branch — keeps the invariant uniform.
+        pendingCustomColumnsRef.current = saved.customColumns.map((c) => ({
+          ...c,
+        }));
       }
     } catch {
       /* ignore corrupted localStorage */
@@ -651,7 +657,10 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
             Array.isArray(saved.customColumns) &&
             saved.customColumns.length > 0
           ) {
-            pendingCustomColumnsRef.current = saved.customColumns;
+            // Clone each col — see mount-hydrate comment.
+            pendingCustomColumnsRef.current = saved.customColumns.map((c) => ({
+              ...c,
+            }));
             sessionGridApiRef.current?.api?.refreshServerSide?.({
               purge: true,
             });
@@ -713,9 +722,14 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     // Queue the saved view's custom cols for the Session-grid merge to
     // drain into sessionColumns on its next fetch. Defer (don't push
     // directly) so the grid doesn't render with only-custom-col headers
-    // before the standard backend cols land.
+    // before the standard backend cols land. Shallow-clone each col so
+    // the pending ref (and `sessionColumns` after the drain) doesn't
+    // share object identity with `activeViewConfig.display.customColumns`
+    // — any later mutation (visibility toggle, save-as-new) would
+    // otherwise write through into the saved-views cache and corrupt
+    // this view's on-screen state until the next refetch.
     const savedCustomCols = Array.isArray(display.customColumns)
-      ? display.customColumns
+      ? display.customColumns.map((c) => ({ ...c }))
       : [];
     pendingCustomColumnsRef.current = savedCustomCols;
     // Force a Session-grid re-fetch so its merge logic drains the queued

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -583,6 +583,12 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   // Pending column state queued before the grid was ready. Drain effect
   // below applies it once `sessionGridApiRef.current.api` shows up.
   const pendingColumnStateRef = useRef(null);
+  // Queued saved-view refresh, set when the saved-view apply effect fires
+  // before the grid has mounted. Drained in `onGridReady` once the api
+  // shows up. Without this, the apply effect's optional-chain refresh
+  // silently no-ops on hard-refresh-into-saved-view, leaving the pending
+  // custom-col ref stranded.
+  const pendingRefreshRef = useRef(false);
 
   // Apply a saved view's config — push display options into URL-synced
   // state (matches UsersView / LLMTracingView). UserDetailTabBar still
@@ -719,8 +725,17 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     // below — finalFilters doesn't recompute, Session-grid's dataSource
     // memo doesn't recreate, and no fetch fires. The pending ref then
     // sits there forever and customs never appear.
+    //
+    // On a hard refresh the grid api isn't ready yet, so the optional
+    // chain bails silently. Queue the request via `pendingRefreshRef`;
+    // `onGridReady` (below) drains it once the api shows up.
     if (savedCustomCols.length > 0) {
-      sessionGridApiRef.current?.api?.refreshServerSide?.({ purge: true });
+      const api = sessionGridApiRef.current?.api;
+      if (api?.refreshServerSide) {
+        api.refreshServerSide({ purge: true });
+      } else {
+        pendingRefreshRef.current = true;
+      }
     }
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
       // Always queue columnState when there are custom cols pending —
@@ -925,6 +940,14 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
           applyOrder: true,
         });
         pendingColumnStateRef.current = null;
+      }
+      // Drain a queued refresh request — fires when the saved-view apply
+      // effect ran before the grid mounted (hard refresh into a saved
+      // view URL). Without this drain the queued custom-col ref would
+      // sit forever waiting for a fetch that never comes.
+      if (pendingRefreshRef.current && params.api?.refreshServerSide) {
+        params.api.refreshServerSide({ purge: true });
+        pendingRefreshRef.current = false;
       }
     },
     [setHeaderConfig],

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -368,9 +368,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         }
       }
     }
-    // Custom columns: compare sorted id lists. Without this, adding or
-    // removing a custom col on a saved view leaves the Save view button
-    // disabled — users have no way to persist the change.
+    // Custom cols: order is captured by columnState, so we only diff the set.
     const currentCustomIds = (sessionColumns || [])
       .filter((c) => c.groupBy === "Custom Columns")
       .map((c) => c.id)
@@ -397,31 +395,18 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     sessionColumns,
   ]);
 
-  // Defer so the button doesn't flicker during the one-render gap between
-  // filter state updating urgently and activeViewConfig catching up from
-  // startTransition in the apply path.
+  // Deferred so the button doesn't flicker between filter state (urgent)
+  // and activeViewConfig (startTransition) settling.
   const canSaveViewDeferred = useDeferredValue(canSaveView);
 
-  // --- Saved view capture + apply (TH-4578) ---
-  // Build a view-config snapshot that mirrors LLMTracingView's shape. dateFilter
-  // stays inside `display` because the backend's saved-view serializer only
-  // whitelists `display` for arbitrary sub-keys (no top-level `dateFilter`).
-  // Note: in earlier versions this view skipped writing URL-synced state in
-  // the apply effect on the assumption that a click-time seedUrlForView
-  // would populate the URL. That's only true on UserDetailTabBar — the
-  // ObservePage tab-bar path doesn't seed sessionCellHeight / sessionShowCompare /
-  // sessionDateFilter, so display options never made it onto the page when
-  // selecting a sessions saved view from the project's tab bar. Now apply
-  // pushes them into URL state directly (matching UsersView / LLMTracingView).
+  // dateFilter lives inside `display` because the backend serializer only
+  // whitelists `display` for arbitrary sub-keys (no top-level dateFilter).
   const buildViewConfig = useCallback(() => {
     const columnState =
       sessionGridApiRef.current?.api?.getColumnState?.() ?? undefined;
-    // updateObj is the authoritative {col.id: isVisible} source.
     const hasVisibility = updateObj && Object.keys(updateObj).length > 0;
-    // Persist custom columns separately. Their colIds also appear in
-    // columnState, but columnState alone can't recreate them — AG Grid
-    // silently drops state for unknown colIds, so without this list the
-    // custom cols never come back on restore.
+    // customColumns separately: AG Grid drops columnState for unknown colIds,
+    // so without this list the custom cols can't be reconstructed on restore.
     const customColumns = (sessionColumns || []).filter(
       (c) => c.groupBy === "Custom Columns",
     );
@@ -455,44 +440,45 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     return () => registerGetTabType(null);
   }, [registerGetTabType]);
 
-  // Update mutations for the explicit Save view button. Project-scoped on
-  // ObservePage, workspace-scoped (user_detail) on CrossProjectUserDetailPage.
   const { mutate: updateSavedView } = useUpdateSavedView(observeId);
   const { mutate: updateWorkspaceSavedView } =
     useUpdateWorkspaceSavedView(USER_DETAIL_TAB_TYPE);
 
-  // Active saved-view id from URL — "tab" key on ObservePage, "userTab" on
-  // CrossProjectUserDetailPage. Re-derived when activeViewConfig flips.
   const activeViewTabId = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
     const key = isUserMode ? params.get("userTab") : params.get("tab");
     return key?.startsWith("view-") ? key.slice(5) : null;
   }, [activeViewConfig, isUserMode]);
 
-  // localStorage key for default-tab display state. Project-scoped on the
-  // ObservePage path, user-scoped on CrossProjectUserDetailPage. Mirrors
-  // the LLMTracingView / UsersView shape but with a `-sessions-` segment
-  // so the three views don't collide on payload schema.
-  const displayStorageKey = useMemo(
-    () =>
-      isUserMode
-        ? `user-sessions-display-${userIdForUserMode}`
-        : `observe-sessions-display-${observeId}`,
-    [isUserMode, userIdForUserMode, observeId],
-  );
+  const displayStorageKey = isUserMode
+    ? `user-sessions-display-${userIdForUserMode}`
+    : `observe-sessions-display-${observeId}`;
 
-  // Hydrate default-tab display state from localStorage. Custom cols go
-  // through `pendingCustomColumnsRef` so Session-grid's first-fetch merge
-  // drains them — same path the saved-view apply effect uses. The ref
-  // gate fires the hydrate once per project/user; the `activeViewTabId`
-  // check skips it on saved-view URLs where the view config owns state.
   const hydratedKeyRef = useRef(null);
-  // Set immediately after a hydrate so the save effect skips its first
-  // fire — that first fire would otherwise close over the PRE-hydrate
-  // state (the hydrate's setters are queued, not yet committed to this
-  // render) and persist defaults back to localStorage, clobbering the
-  // values we just loaded.
+  // Skips the save effect's first fire after a hydrate. Without this the
+  // first fire closes over pre-hydrate state and overwrites what we just
+  // loaded.
   const skipNextSaveRef = useRef(false);
+
+  const writeDisplayToStorage = useCallback(() => {
+    const customColumns = (sessionColumns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
+    const payload = {
+      cellHeight,
+      showCompare,
+      ...(updateObj && Object.keys(updateObj).length > 0
+        ? { visibleColumns: updateObj }
+        : {}),
+      ...(customColumns.length > 0 ? { customColumns } : {}),
+    };
+    try {
+      localStorage.setItem(displayStorageKey, JSON.stringify(payload));
+    } catch {
+      /* quota exceeded */
+    }
+  }, [displayStorageKey, cellHeight, showCompare, updateObj, sessionColumns]);
+
   useEffect(() => {
     if (activeViewTabId) return;
     if (hydratedKeyRef.current === displayStorageKey) return;
@@ -513,10 +499,8 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         Array.isArray(saved.customColumns) &&
         saved.customColumns.length > 0
       ) {
-        // Shallow-clone each col so the pending ref (and `sessionColumns`
-        // it drains into) doesn't share object identity with the parsed
-        // localStorage payload. Mirrors the clone in the saved-view apply
-        // branch — keeps the invariant uniform.
+        // Shallow-clone so the pending ref doesn't share identity with the
+        // parsed localStorage payload.
         pendingCustomColumnsRef.current = saved.customColumns.map((c) => ({
           ...c,
         }));
@@ -527,9 +511,6 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [displayStorageKey]);
 
-  // Persist display state on every change. Skip until the hydrate has
-  // run for this key, otherwise the initial empty state would overwrite
-  // saved customs before the load effect gets a chance to populate them.
   useEffect(() => {
     if (activeViewTabId) return;
     if (hydratedKeyRef.current !== displayStorageKey) return;
@@ -537,30 +518,8 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       skipNextSaveRef.current = false;
       return;
     }
-    const customColumns = (sessionColumns || []).filter(
-      (c) => c.groupBy === "Custom Columns",
-    );
-    const payload = {
-      cellHeight,
-      showCompare,
-      ...(updateObj && Object.keys(updateObj).length > 0
-        ? { visibleColumns: updateObj }
-        : {}),
-      ...(customColumns.length > 0 ? { customColumns } : {}),
-    };
-    try {
-      localStorage.setItem(displayStorageKey, JSON.stringify(payload));
-    } catch {
-      /* quota exceeded */
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    displayStorageKey,
-    cellHeight,
-    showCompare,
-    updateObj,
-    sessionColumns,
-  ]);
+    writeDisplayToStorage();
+  }, [activeViewTabId, displayStorageKey, writeDisplayToStorage]);
 
   const handleSaveView = useCallback(() => {
     if (!activeViewTabId) return;
@@ -586,28 +545,18 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     setActiveViewConfig,
   ]);
 
-  // Pending column state queued before the grid was ready. Drain effect
-  // below applies it once `sessionGridApiRef.current.api` shows up.
+  // Drained in the api-ready effect below once sessionGridApiRef populates.
   const pendingColumnStateRef = useRef(null);
-  // Queued saved-view refresh, set when the saved-view apply effect fires
-  // before the grid has mounted. Drained in `onGridReady` once the api
-  // shows up. Without this, the apply effect's optional-chain refresh
-  // silently no-ops on hard-refresh-into-saved-view, leaving the pending
-  // custom-col ref stranded.
+  // Set when the apply effect fires before the grid mounts (hard refresh
+  // into a saved view). Drained in onGridReady, otherwise the pending
+  // custom-col ref is stranded.
   const pendingRefreshRef = useRef(false);
 
-  // Apply a saved view's config — push display options into URL-synced
-  // state (matches UsersView / LLMTracingView). UserDetailTabBar still
-  // pre-seeds the same URL keys at click time for snappiness; the writes
-  // here are idempotent for that path and are the only source of truth
-  // for the ObservePage tab-bar path, which doesn't pre-seed display.
   useEffect(() => {
     if (!activeViewConfig) {
-      // Transitioning back to a default tab — wipe everything that was
-      // applied by the saved view. URL-synced display state (cellHeight,
-      // showCompare, dateFilter) reverts via useUrlState as the parent's
-      // navigate() drops those URL keys; everything else has to be reset
-      // here because it lives in plain useState or inside AG Grid.
+      // Default tab — reset everything the saved view applied. URL-synced
+      // state reverts via useUrlState; the rest lives in useState / AG Grid
+      // and needs explicit reset.
       setExtraFilters((prev) => (prev.length === 0 ? prev : []));
       viewLoadedUpdateObjRef.current = null;
       setUpdateObj(initialVisibility);
@@ -625,22 +574,15 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       if (api?.resetColumnState) api.resetColumnState();
       pendingColumnStateRef.current = null;
       pendingCustomColumnsRef.current = [];
-      // Strip saved-view custom cols from sessionColumns so they don't
-      // linger on the default tab. Symmetric with LLMTracingView.
       setSessionColumns((prev) =>
         (prev || []).filter((c) => c.groupBy !== "Custom Columns"),
       );
-      // Re-hydrate default-tab preferences from localStorage. The mount
-      // hydrate effect is keyed on `displayStorageKey` and won't re-fire
-      // on a same-project saved-view → default transition; without this,
-      // going back to default after a saved view would land on factory
-      // defaults instead of the user's preferences. Pending customs go
-      // through the ref and drain on Session-grid's next merge.
+      // Re-hydrate from localStorage — the mount hydrate is keyed on
+      // displayStorageKey and won't re-fire on a same-project saved-view →
+      // default transition.
       try {
         const raw = localStorage.getItem(displayStorageKey);
         if (raw) {
-          // Mirror the mount-hydrate skip-flag so the save effect's next
-          // fire doesn't write the pre-hydrate state back over localStorage.
           skipNextSaveRef.current = true;
           const saved = JSON.parse(raw);
           if (saved.cellHeight) setCellHeight(saved.cellHeight);
@@ -657,7 +599,6 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
             Array.isArray(saved.customColumns) &&
             saved.customColumns.length > 0
           ) {
-            // Clone each col — see mount-hydrate comment.
             pendingCustomColumnsRef.current = saved.customColumns.map((c) => ({
               ...c,
             }));
@@ -679,11 +620,8 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     if (display.dateFilter) {
       setDateFilter(display.dateFilter);
     }
-    // Apply visibleColumns dict — `updateObj` is the single source of truth
-    // for column visibility (drives the ColumnConfigure popover via
-    // displayColumns and is the authoritative {col.id: bool} dict). Push
-    // visibility into AG Grid directly when the api is available so the
-    // grid display matches without waiting for a re-render. Done before the
+    // Push visibility into AG Grid directly when the api is available so
+    // the display matches without waiting for re-render. Done before the
     // snapshot below so canSaveView's baseline matches the just-applied state.
     if (
       display.visibleColumns &&
@@ -702,47 +640,25 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         if (toHide.length) api.setColumnsVisible(toHide, false);
       }
     }
-    // Capture the visibility state at the moment this saved view is loaded,
-    // so canSaveView can compare any subsequent toggles against this
-    // snapshot — covers older views that didn't persist `visibleColumns`.
-    // Use the just-applied dict if it exists, otherwise current updateObj.
+    // Snapshot visibility so canSaveView can diff later toggles; covers
+    // older views that didn't persist visibleColumns.
     viewLoadedUpdateObjRef.current = display.visibleColumns
       ? { ...display.visibleColumns }
       : updateObj
         ? { ...updateObj }
         : null;
-    // Strip existing customs from sessionColumns before queuing this
-    // view's set — guards against view→view transitions and against
-    // a default-tab→saved-view click where default customs would
-    // otherwise stack on top of the saved view's. Symmetric with the
-    // LLMTracingView apply effect.
     setSessionColumns((prev) =>
       (prev || []).filter((c) => c.groupBy !== "Custom Columns"),
     );
-    // Queue the saved view's custom cols for the Session-grid merge to
-    // drain into sessionColumns on its next fetch. Defer (don't push
-    // directly) so the grid doesn't render with only-custom-col headers
-    // before the standard backend cols land. Shallow-clone each col so
-    // the pending ref (and `sessionColumns` after the drain) doesn't
-    // share object identity with `activeViewConfig.display.customColumns`
-    // — any later mutation (visibility toggle, save-as-new) would
-    // otherwise write through into the saved-views cache and corrupt
-    // this view's on-screen state until the next refetch.
+    // Shallow-clone each col so a later mutation (visibility toggle,
+    // save-as-new) doesn't write through into the saved-views cache.
     const savedCustomCols = Array.isArray(display.customColumns)
       ? display.customColumns.map((c) => ({ ...c }))
       : [];
     pendingCustomColumnsRef.current = savedCustomCols;
-    // Force a Session-grid re-fetch so its merge logic drains the queued
-    // customs. Without this, when the saved view's extraFilters happen to
-    // equal the current state (commonly both empty on a hard refresh),
-    // setExtraFilters returns the same array ref via the optimization
-    // below — finalFilters doesn't recompute, Session-grid's dataSource
-    // memo doesn't recreate, and no fetch fires. The pending ref then
-    // sits there forever and customs never appear.
-    //
-    // On a hard refresh the grid api isn't ready yet, so the optional
-    // chain bails silently. Queue the request via `pendingRefreshRef`;
-    // `onGridReady` (below) drains it once the api shows up.
+    // Force a re-fetch so Session-grid's merge drains the queued customs.
+    // When extraFilters happen to equal current state, setExtraFilters
+    // returns the same ref and the dataSource memo never recreates.
     if (savedCustomCols.length > 0) {
       const api = sessionGridApiRef.current?.api;
       if (api?.refreshServerSide) {
@@ -752,12 +668,9 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       }
     }
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
-      // Always queue columnState when there are custom cols pending —
-      // applying it immediately would race the Session-grid merge that
-      // adds the customs to sessionColumns. AG Grid silently drops
-      // applyColumnState entries for colIds it doesn't know about, so
-      // widths/order for custom cols would be lost. The sessionColumns
-      // drain effect below applies the queued state once the customs land.
+      // Queue columnState when customs are pending — AG Grid silently drops
+      // applyColumnState entries for unknown colIds, so widths/order for
+      // custom cols would be lost otherwise. Drained when the customs land.
       if (savedCustomCols.length > 0) {
         pendingColumnStateRef.current = display.columnState;
       } else {
@@ -836,10 +749,8 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     : toggledNodes.length;
 
   const [queueAnchorEl, setQueueAnchorEl] = useState(null);
-  // Opt-in for filter-mode session bulk add. Set to true when
-  // the user clicks the banner's "Select all N matching your filter" link.
-  // Resets when the grid clears select-all, when the project changes, or
-  // when the filter payload changes (the opt-in no longer matches the view).
+  // Opt-in for filter-mode bulk add — set when the SelectAllBanner is
+  // clicked; reset on select-all clear, project change, or filter change.
   const [sessionFilterSelectionMode, setSessionFilterSelectionMode] =
     useState(false);
   useEffect(() => {
@@ -872,11 +783,8 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
           },
         });
       } else if (action === "annotation-queue") {
-        // With filter-mode opt-in (the SelectAllBanner), the popover's
-        // submit posts `{selection: {mode: "filter", ...}}` to the Phase 6
-        // backend endpoint. Without opt-in under select-all we still bail
-        // out — toggledNodes holds the *deselected* rows in that mode and
-        // an enumerated add would be wrong.
+        // Without filter-mode opt-in under select-all, toggledNodes holds
+        // the *deselected* rows — an enumerated add would be wrong.
         if (selectAll && !sessionFilterSelectionMode) {
           enqueueSnackbar(
             "Use the 'Select all matching your filter' banner to add the full set, or deselect 'all' and pick specific rows.",

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -368,6 +368,24 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         }
       }
     }
+    // Custom columns: compare sorted id lists. Without this, adding or
+    // removing a custom col on a saved view leaves the Save view button
+    // disabled — users have no way to persist the change.
+    const currentCustomIds = (sessionColumns || [])
+      .filter((c) => c.groupBy === "Custom Columns")
+      .map((c) => c.id)
+      .sort();
+    const baselineCustomIds = (
+      Array.isArray(baselineDisplay.customColumns)
+        ? baselineDisplay.customColumns
+        : []
+    )
+      .map((c) => c.id)
+      .sort();
+    if (currentCustomIds.length !== baselineCustomIds.length) return true;
+    for (let i = 0; i < currentCustomIds.length; i += 1) {
+      if (currentCustomIds[i] !== baselineCustomIds[i]) return true;
+    }
     return false;
   }, [
     activeViewConfig,
@@ -376,6 +394,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     cellHeight,
     showCompare,
     updateObj,
+    sessionColumns,
   ]);
 
   // Defer so the button doesn't flicker during the one-render gap between
@@ -399,6 +418,13 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       sessionGridApiRef.current?.api?.getColumnState?.() ?? undefined;
     // updateObj is the authoritative {col.id: isVisible} source.
     const hasVisibility = updateObj && Object.keys(updateObj).length > 0;
+    // Persist custom columns separately. Their colIds also appear in
+    // columnState, but columnState alone can't recreate them — AG Grid
+    // silently drops state for unknown colIds, so without this list the
+    // custom cols never come back on restore.
+    const customColumns = (sessionColumns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
     return {
       display: {
         cellHeight,
@@ -406,10 +432,18 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         dateFilter,
         ...(hasVisibility ? { visibleColumns: updateObj } : {}),
         ...(columnState ? { columnState } : {}),
+        ...(customColumns.length > 0 ? { customColumns } : {}),
       },
       extraFilters: extraFilters || [],
     };
-  }, [cellHeight, showCompare, dateFilter, extraFilters, updateObj]);
+  }, [
+    cellHeight,
+    showCompare,
+    dateFilter,
+    extraFilters,
+    updateObj,
+    sessionColumns,
+  ]);
 
   useEffect(() => {
     registerGetViewConfig(buildViewConfig);
@@ -434,6 +468,93 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     const key = isUserMode ? params.get("userTab") : params.get("tab");
     return key?.startsWith("view-") ? key.slice(5) : null;
   }, [activeViewConfig, isUserMode]);
+
+  // localStorage key for default-tab display state. Project-scoped on the
+  // ObservePage path, user-scoped on CrossProjectUserDetailPage. Mirrors
+  // the LLMTracingView / UsersView shape but with a `-sessions-` segment
+  // so the three views don't collide on payload schema.
+  const displayStorageKey = useMemo(
+    () =>
+      isUserMode
+        ? `user-sessions-display-${userIdForUserMode}`
+        : `observe-sessions-display-${observeId}`,
+    [isUserMode, userIdForUserMode, observeId],
+  );
+
+  // Hydrate default-tab display state from localStorage. Custom cols go
+  // through `pendingCustomColumnsRef` so Session-grid's first-fetch merge
+  // drains them — same path the saved-view apply effect uses. The ref
+  // gate fires the hydrate once per project/user; the `activeViewTabId`
+  // check skips it on saved-view URLs where the view config owns state.
+  const hydratedKeyRef = useRef(null);
+  // Set immediately after a hydrate so the save effect skips its first
+  // fire — that first fire would otherwise close over the PRE-hydrate
+  // state (the hydrate's setters are queued, not yet committed to this
+  // render) and persist defaults back to localStorage, clobbering the
+  // values we just loaded.
+  const skipNextSaveRef = useRef(false);
+  useEffect(() => {
+    if (activeViewTabId) return;
+    if (hydratedKeyRef.current === displayStorageKey) return;
+    hydratedKeyRef.current = displayStorageKey;
+    try {
+      const raw = localStorage.getItem(displayStorageKey);
+      if (!raw) return;
+      skipNextSaveRef.current = true;
+      const saved = JSON.parse(raw);
+      if (saved.cellHeight) setCellHeight(saved.cellHeight);
+      if (typeof saved.showCompare === "boolean") {
+        setShowCompare(saved.showCompare);
+      }
+      if (saved.visibleColumns && typeof saved.visibleColumns === "object") {
+        setUpdateObj(saved.visibleColumns);
+      }
+      if (
+        Array.isArray(saved.customColumns) &&
+        saved.customColumns.length > 0
+      ) {
+        pendingCustomColumnsRef.current = saved.customColumns;
+      }
+    } catch {
+      /* ignore corrupted localStorage */
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayStorageKey]);
+
+  // Persist display state on every change. Skip until the hydrate has
+  // run for this key, otherwise the initial empty state would overwrite
+  // saved customs before the load effect gets a chance to populate them.
+  useEffect(() => {
+    if (activeViewTabId) return;
+    if (hydratedKeyRef.current !== displayStorageKey) return;
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false;
+      return;
+    }
+    const customColumns = (sessionColumns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
+    const payload = {
+      cellHeight,
+      showCompare,
+      ...(updateObj && Object.keys(updateObj).length > 0
+        ? { visibleColumns: updateObj }
+        : {}),
+      ...(customColumns.length > 0 ? { customColumns } : {}),
+    };
+    try {
+      localStorage.setItem(displayStorageKey, JSON.stringify(payload));
+    } catch {
+      /* quota exceeded */
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    displayStorageKey,
+    cellHeight,
+    showCompare,
+    updateObj,
+    sessionColumns,
+  ]);
 
   const handleSaveView = useCallback(() => {
     if (!activeViewTabId) return;
@@ -491,6 +612,48 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       }
       if (api?.resetColumnState) api.resetColumnState();
       pendingColumnStateRef.current = null;
+      pendingCustomColumnsRef.current = [];
+      // Strip saved-view custom cols from sessionColumns so they don't
+      // linger on the default tab. Symmetric with LLMTracingView.
+      setSessionColumns((prev) =>
+        (prev || []).filter((c) => c.groupBy !== "Custom Columns"),
+      );
+      // Re-hydrate default-tab preferences from localStorage. The mount
+      // hydrate effect is keyed on `displayStorageKey` and won't re-fire
+      // on a same-project saved-view → default transition; without this,
+      // going back to default after a saved view would land on factory
+      // defaults instead of the user's preferences. Pending customs go
+      // through the ref and drain on Session-grid's next merge.
+      try {
+        const raw = localStorage.getItem(displayStorageKey);
+        if (raw) {
+          // Mirror the mount-hydrate skip-flag so the save effect's next
+          // fire doesn't write the pre-hydrate state back over localStorage.
+          skipNextSaveRef.current = true;
+          const saved = JSON.parse(raw);
+          if (saved.cellHeight) setCellHeight(saved.cellHeight);
+          if (typeof saved.showCompare === "boolean") {
+            setShowCompare(saved.showCompare);
+          }
+          if (
+            saved.visibleColumns &&
+            typeof saved.visibleColumns === "object"
+          ) {
+            setUpdateObj(saved.visibleColumns);
+          }
+          if (
+            Array.isArray(saved.customColumns) &&
+            saved.customColumns.length > 0
+          ) {
+            pendingCustomColumnsRef.current = saved.customColumns;
+            sessionGridApiRef.current?.api?.refreshServerSide?.({
+              purge: true,
+            });
+          }
+        }
+      } catch {
+        /* ignore corrupted localStorage */
+      }
       return;
     }
     const display = activeViewConfig.display || {};
@@ -533,15 +696,51 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       : updateObj
         ? { ...updateObj }
         : null;
+    // Strip existing customs from sessionColumns before queuing this
+    // view's set — guards against view→view transitions and against
+    // a default-tab→saved-view click where default customs would
+    // otherwise stack on top of the saved view's. Symmetric with the
+    // LLMTracingView apply effect.
+    setSessionColumns((prev) =>
+      (prev || []).filter((c) => c.groupBy !== "Custom Columns"),
+    );
+    // Queue the saved view's custom cols for the Session-grid merge to
+    // drain into sessionColumns on its next fetch. Defer (don't push
+    // directly) so the grid doesn't render with only-custom-col headers
+    // before the standard backend cols land.
+    const savedCustomCols = Array.isArray(display.customColumns)
+      ? display.customColumns
+      : [];
+    pendingCustomColumnsRef.current = savedCustomCols;
+    // Force a Session-grid re-fetch so its merge logic drains the queued
+    // customs. Without this, when the saved view's extraFilters happen to
+    // equal the current state (commonly both empty on a hard refresh),
+    // setExtraFilters returns the same array ref via the optimization
+    // below — finalFilters doesn't recompute, Session-grid's dataSource
+    // memo doesn't recreate, and no fetch fires. The pending ref then
+    // sits there forever and customs never appear.
+    if (savedCustomCols.length > 0) {
+      sessionGridApiRef.current?.api?.refreshServerSide?.({ purge: true });
+    }
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
-      const api = sessionGridApiRef.current?.api;
-      if (api?.applyColumnState) {
-        api.applyColumnState({
-          state: display.columnState,
-          applyOrder: true,
-        });
-      } else {
+      // Always queue columnState when there are custom cols pending —
+      // applying it immediately would race the Session-grid merge that
+      // adds the customs to sessionColumns. AG Grid silently drops
+      // applyColumnState entries for colIds it doesn't know about, so
+      // widths/order for custom cols would be lost. The sessionColumns
+      // drain effect below applies the queued state once the customs land.
+      if (savedCustomCols.length > 0) {
         pendingColumnStateRef.current = display.columnState;
+      } else {
+        const api = sessionGridApiRef.current?.api;
+        if (api?.applyColumnState) {
+          api.applyColumnState({
+            state: display.columnState,
+            applyOrder: true,
+          });
+        } else {
+          pendingColumnStateRef.current = display.columnState;
+        }
       }
     }
     const nextExtraFilters = activeViewConfig.extraFilters || [];
@@ -730,6 +929,22 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     },
     [setHeaderConfig],
   );
+
+  // Drain pendingColumnState once sessionColumns updates (custom cols
+  // landed via the Session-grid merge) and the grid api is ready. Catches
+  // the case where the saved view includes both custom cols AND
+  // columnState — applying state before custom cols are merged would
+  // silently drop widths/order/sort for the unknown colIds.
+  useEffect(() => {
+    if (!pendingColumnStateRef.current) return;
+    const api = sessionGridApiRef.current?.api;
+    if (!api?.applyColumnState) return;
+    api.applyColumnState({
+      state: pendingColumnStateRef.current,
+      applyOrder: true,
+    });
+    pendingColumnStateRef.current = null;
+  }, [sessionColumns]);
 
   // --- Column config for display panel ---
   const displayColumns = useMemo(() => {

--- a/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
+++ b/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
@@ -65,7 +65,11 @@ const UserTraceTabV2 = ({ dateFilter }) => {
       if (!raw) return;
       const saved = JSON.parse(raw);
       if (Array.isArray(saved) && saved.length > 0) {
-        pendingCustomColumnsRef.current = saved;
+        // Shallow-clone each col so the pending ref (and `columns` it
+        // drains into) doesn't share object identity with the parsed
+        // localStorage payload. Cheap defensive isolation matching the
+        // LLMTracingView / Sessions-view pattern.
+        pendingCustomColumnsRef.current = saved.map((c) => ({ ...c }));
         skipNextSaveRef.current = true;
       }
     } catch {

--- a/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
+++ b/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
@@ -13,9 +13,9 @@ import FilterChips from "../../LLMTracing/FilterChips";
 import ColumnConfigureDropDown from "src/sections/project-detail/ColumnDropdown/ColumnConfigureDropDown";
 import { transformDateFilterToBackendFilters } from "../common";
 
-// New trace view embedded inside UserDetails. Mounts LLMTracing's TraceGrid
-// pre-filtered to the current user, with the full ObserveToolbar (Filter +
-// Display + Custom Columns) the user gets on the main trace list page.
+// Trace view embedded inside UserDetails — mounts TraceGrid pre-filtered
+// to the current user, with the full ObserveToolbar (filter, display,
+// custom columns).
 const UserTraceTabV2 = ({ dateFilter }) => {
   const { observeId, userId } = useParams();
   const [selectedProjectId] = useUrlState("projectId", null);
@@ -37,26 +37,14 @@ const UserTraceTabV2 = ({ dateFilter }) => {
   const openColumnConfigure = Boolean(columnConfigureAnchor);
   const pendingCustomColumnsRef = useRef([]);
 
-  // Persist custom columns to localStorage so they survive a refresh on
-  // this user-detail trace tab. Scoped per {project, user} to match the
-  // URL — same-user across projects gets its own set since available
-  // attributes (the source for custom cols) is project-specific.
-  const customColsStorageKey = useMemo(
-    () => `user-trace-customcols-${projectId}-${userId}`,
-    [projectId, userId],
-  );
-  // Two-phase guard. The hydrate writes into a ref, not state, so on the
-  // first render `columns` is still empty when the save effect fires in
-  // the same flush — without this gate it would call removeItem and wipe
-  // the saved customs before TraceGrid's merge has a chance to drain the
-  // pending ref into columns state.
-  //
-  // - `hasDrainedRef` flips true on the first render that observes a
-  //   non-empty `columns` array (i.e. after TraceGrid's merge landed).
-  //   Until then the save effect refuses to delete the stored customs.
-  // - `skipNextSaveRef` (mirrors the Sessions / UsersView pattern) skips
-  //   the very next save fire after a hydrate so the in-batch closure
-  //   over pre-hydrate state can't overwrite what we just loaded.
+  // Scoped per {project, user} — same user across projects gets its own
+  // set since available attributes are project-specific.
+  const customColsStorageKey = `user-trace-customcols-${projectId}-${userId}`;
+  // hasDrainedRef gates the save effect until TraceGrid's merge has
+  // landed; without it the first-render empty `columns` would wipe the
+  // saved customs before the pending ref drains. skipNextSaveRef skips
+  // the first save fire after a hydrate so the pre-hydrate closure can't
+  // overwrite what we just loaded.
   const hasDrainedRef = useRef(false);
   const skipNextSaveRef = useRef(false);
   useEffect(() => {
@@ -65,10 +53,8 @@ const UserTraceTabV2 = ({ dateFilter }) => {
       if (!raw) return;
       const saved = JSON.parse(raw);
       if (Array.isArray(saved) && saved.length > 0) {
-        // Shallow-clone each col so the pending ref (and `columns` it
-        // drains into) doesn't share object identity with the parsed
-        // localStorage payload. Cheap defensive isolation matching the
-        // LLMTracingView / Sessions-view pattern.
+        // Shallow-clone so the pending ref doesn't share identity with
+        // the parsed localStorage payload.
         pendingCustomColumnsRef.current = saved.map((c) => ({ ...c }));
         skipNextSaveRef.current = true;
       }
@@ -85,12 +71,8 @@ const UserTraceTabV2 = ({ dateFilter }) => {
     const customCols = (columns || []).filter(
       (c) => c.groupBy === "Custom Columns",
     );
-    // Don't overwrite stored customs until at least one merge has landed,
-    // otherwise the first-render empty `columns` would delete the saved
-    // entry before TraceGrid drains the pending ref.
     if (!hasDrainedRef.current && customCols.length === 0) {
       if ((columns || []).length > 0) {
-        // Real merge with no customs — fine to persist the empty state.
         hasDrainedRef.current = true;
       } else {
         return;

--- a/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
+++ b/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { Box } from "@mui/material";
 import { useParams } from "react-router";
@@ -36,6 +36,42 @@ const UserTraceTabV2 = ({ dateFilter }) => {
   const [columnConfigureAnchor, setColumnConfigureAnchor] = useState(null);
   const openColumnConfigure = Boolean(columnConfigureAnchor);
   const pendingCustomColumnsRef = useRef([]);
+
+  // Persist custom columns to localStorage so they survive a refresh on
+  // this user-detail trace tab. Scoped per {project, user} to match the
+  // URL — same-user across projects gets its own set since available
+  // attributes (the source for custom cols) is project-specific.
+  const customColsStorageKey = useMemo(
+    () => `user-trace-customcols-${projectId}-${userId}`,
+    [projectId, userId],
+  );
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(customColsStorageKey);
+      if (!raw) return;
+      const saved = JSON.parse(raw);
+      if (Array.isArray(saved) && saved.length > 0) {
+        pendingCustomColumnsRef.current = saved;
+      }
+    } catch {
+      /* ignore corrupted localStorage */
+    }
+  }, [customColsStorageKey]);
+
+  useEffect(() => {
+    const customCols = (columns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
+    try {
+      if (customCols.length > 0) {
+        localStorage.setItem(customColsStorageKey, JSON.stringify(customCols));
+      } else {
+        localStorage.removeItem(customColsStorageKey);
+      }
+    } catch {
+      /* quota exceeded */
+    }
+  }, [columns, customColsStorageKey]);
 
   // Build validated filter list: user_id + date range + any user-added extras.
   const validatedFilters = useMemo(() => {

--- a/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
+++ b/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
@@ -45,6 +45,20 @@ const UserTraceTabV2 = ({ dateFilter }) => {
     () => `user-trace-customcols-${projectId}-${userId}`,
     [projectId, userId],
   );
+  // Two-phase guard. The hydrate writes into a ref, not state, so on the
+  // first render `columns` is still empty when the save effect fires in
+  // the same flush — without this gate it would call removeItem and wipe
+  // the saved customs before TraceGrid's merge has a chance to drain the
+  // pending ref into columns state.
+  //
+  // - `hasDrainedRef` flips true on the first render that observes a
+  //   non-empty `columns` array (i.e. after TraceGrid's merge landed).
+  //   Until then the save effect refuses to delete the stored customs.
+  // - `skipNextSaveRef` (mirrors the Sessions / UsersView pattern) skips
+  //   the very next save fire after a hydrate so the in-batch closure
+  //   over pre-hydrate state can't overwrite what we just loaded.
+  const hasDrainedRef = useRef(false);
+  const skipNextSaveRef = useRef(false);
   useEffect(() => {
     try {
       const raw = localStorage.getItem(customColsStorageKey);
@@ -52,6 +66,7 @@ const UserTraceTabV2 = ({ dateFilter }) => {
       const saved = JSON.parse(raw);
       if (Array.isArray(saved) && saved.length > 0) {
         pendingCustomColumnsRef.current = saved;
+        skipNextSaveRef.current = true;
       }
     } catch {
       /* ignore corrupted localStorage */
@@ -59,9 +74,26 @@ const UserTraceTabV2 = ({ dateFilter }) => {
   }, [customColsStorageKey]);
 
   useEffect(() => {
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false;
+      return;
+    }
     const customCols = (columns || []).filter(
       (c) => c.groupBy === "Custom Columns",
     );
+    // Don't overwrite stored customs until at least one merge has landed,
+    // otherwise the first-render empty `columns` would delete the saved
+    // entry before TraceGrid drains the pending ref.
+    if (!hasDrainedRef.current && customCols.length === 0) {
+      if ((columns || []).length > 0) {
+        // Real merge with no customs — fine to persist the empty state.
+        hasDrainedRef.current = true;
+      } else {
+        return;
+      }
+    } else {
+      hasDrainedRef.current = true;
+    }
     try {
       if (customCols.length > 0) {
         localStorage.setItem(customColsStorageKey, JSON.stringify(customCols));

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -324,6 +324,14 @@ const UsersView = ({
     // the backend serializer's allowed_keys whitelists `display` for
     // arbitrary subkeys but does not whitelist a separate `columnState`.
     const columnState = gridApi?.getColumnState?.() ?? undefined;
+    // Persist custom columns separately. Their colIds also appear in
+    // columnState (for widths/order/sort), but the standard col defs come
+    // from the static UsersView baseConfig — the backend doesn't know
+    // about custom cols, so without this list AG Grid won't recreate them
+    // on restore and applyColumnState would silently drop their entries.
+    const customColumns = (columns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
     return {
       display: {
         cellHeight,
@@ -332,6 +340,7 @@ const UsersView = ({
         hasEvalFilter,
         visibleColumns,
         ...(columnState ? { columnState } : {}),
+        ...(customColumns.length > 0 ? { customColumns } : {}),
       },
       filters: {
         extraFilters,
@@ -353,6 +362,100 @@ const UsersView = ({
   // ready. Drained by the effect below when gridApi becomes available.
   const pendingColumnStateRef = useRef(null);
 
+  // localStorage key for default-tab display state (per-project). Mirrors
+  // LLMTracingView's `observe-display-<id>` pattern but with a separate
+  // namespace so the two views don't collide on shape (different fields).
+  const displayStorageKey = useMemo(
+    () => `observe-users-display-${observeId}`,
+    [observeId],
+  );
+
+  // Hydrate default-tab display state from localStorage. Runs when columns
+  // is populated (UsersGrid's mount effect runs first and seeds the default
+  // schema via setColumns) — without this gate, addCustomColumns would
+  // race the schema seed and the customs would be wiped. Guard with a
+  // per-key ref so it only fires once per project, and skip entirely on
+  // a saved-view tab (the view config is the source of truth there).
+  const hydratedKeyRef = useRef(null);
+  // Set immediately after a hydrate so the save effect skips its next
+  // fire — that fire would otherwise close over the PRE-hydrate state
+  // (setters from the hydrate are queued, not committed yet) and write
+  // defaults back over the values we just loaded.
+  const skipNextSaveRef = useRef(false);
+  useEffect(() => {
+    if (activeViewTabId) return;
+    if (!columns || columns.length === 0) return;
+    if (hydratedKeyRef.current === displayStorageKey) return;
+    hydratedKeyRef.current = displayStorageKey;
+    try {
+      const raw = localStorage.getItem(displayStorageKey);
+      if (!raw) return;
+      skipNextSaveRef.current = true;
+      const saved = JSON.parse(raw);
+      if (saved.cellHeight) setCellHeight(saved.cellHeight);
+      if (typeof saved.showErrors === "boolean") setShowErrors(saved.showErrors);
+      if (typeof saved.showNonAnnotated === "boolean") {
+        setShowNonAnnotated(saved.showNonAnnotated);
+      }
+      if (typeof saved.hasEvalFilter === "boolean") {
+        setHasEvalFilter(saved.hasEvalFilter);
+      }
+      if (saved.visibleColumns && typeof saved.visibleColumns === "object") {
+        updateColumnVisibility(saved.visibleColumns);
+      }
+      if (
+        Array.isArray(saved.customColumns) &&
+        saved.customColumns.length > 0
+      ) {
+        addCustomColumns(saved.customColumns);
+      }
+    } catch {
+      /* ignore corrupted localStorage */
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columns, displayStorageKey]);
+
+  // Persist display state to localStorage on every change (default tab
+  // only — saved views own their persistence via the explicit Save view
+  // button). Skip until the initial hydrate has run, otherwise the
+  // empty default state would overwrite saved customs on first paint.
+  useEffect(() => {
+    if (activeViewTabId) return;
+    if (hydratedKeyRef.current !== displayStorageKey) return;
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false;
+      return;
+    }
+    const visibleColumns = (columns || []).reduce((acc, col) => {
+      acc[col.id] = col.isVisible !== false;
+      return acc;
+    }, {});
+    const customColumns = (columns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
+    const payload = {
+      cellHeight,
+      showErrors,
+      showNonAnnotated,
+      hasEvalFilter,
+      visibleColumns,
+      ...(customColumns.length > 0 ? { customColumns } : {}),
+    };
+    try {
+      localStorage.setItem(displayStorageKey, JSON.stringify(payload));
+    } catch {
+      /* quota exceeded */
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    displayStorageKey,
+    columns,
+    cellHeight,
+    showErrors,
+    showNonAnnotated,
+    hasEvalFilter,
+  ]);
+
   const applyConfig = useCallback(
     (config) => {
       if (!config) {
@@ -364,6 +467,14 @@ const UsersView = ({
         setHasEvalFilter(false);
         setDateFilter(getDefaultDateRange());
         pendingColumnStateRef.current = null;
+        // Drop any custom cols left by the saved view we're navigating
+        // away from so the default tab doesn't inherit them.
+        const currentCustomIds = (columns || [])
+          .filter((c) => c.groupBy === "Custom Columns")
+          .map((c) => c.id);
+        if (currentCustomIds.length > 0) {
+          removeCustomColumns(currentCustomIds);
+        }
         // Reset column visibility to the column-config defaults so going back
         // to All Users from a saved view with limited columns shows everything
         // again.
@@ -379,6 +490,44 @@ const UsersView = ({
         }
         // Reset AG Grid column state (widths/order/sort) to coldef defaults.
         if (gridApi?.resetColumnState) gridApi.resetColumnState();
+        // Re-hydrate default-tab preferences from localStorage. The mount-
+        // time hydrate effect is keyed on `displayStorageKey` and won't
+        // re-fire on a same-project saved-view → default transition.
+        // Setters here run after the resets above, so React's batched
+        // render sees the localStorage values as the final state.
+        try {
+          const raw = localStorage.getItem(displayStorageKey);
+          if (raw) {
+            // Mirror the mount-hydrate skip-flag so the save effect's next
+            // fire doesn't write the pre-hydrate state back to localStorage.
+            skipNextSaveRef.current = true;
+            const saved = JSON.parse(raw);
+            if (saved.cellHeight) setCellHeight(saved.cellHeight);
+            if (typeof saved.showErrors === "boolean") {
+              setShowErrors(saved.showErrors);
+            }
+            if (typeof saved.showNonAnnotated === "boolean") {
+              setShowNonAnnotated(saved.showNonAnnotated);
+            }
+            if (typeof saved.hasEvalFilter === "boolean") {
+              setHasEvalFilter(saved.hasEvalFilter);
+            }
+            if (
+              saved.visibleColumns &&
+              typeof saved.visibleColumns === "object"
+            ) {
+              updateColumnVisibility(saved.visibleColumns);
+            }
+            if (
+              Array.isArray(saved.customColumns) &&
+              saved.customColumns.length > 0
+            ) {
+              addCustomColumns(saved.customColumns);
+            }
+          }
+        } catch {
+          /* ignore corrupted localStorage */
+        }
         return;
       }
       const display = config.display || {};
@@ -388,13 +537,38 @@ const UsersView = ({
         setShowErrors(display.showErrors);
       if (typeof display.showNonAnnotated === "boolean")
         setShowNonAnnotated(display.showNonAnnotated);
+      if (typeof display.showNonAnnotated === "boolean")
+        setShowNonAnnotated(display.showNonAnnotated);
       if (typeof display.hasEvalFilter === "boolean")
         setHasEvalFilter(display.hasEvalFilter);
+      // Strip any pre-existing custom cols before adding this view's set,
+      // so view → view doesn't stack customs and default → view doesn't
+      // leak default-tab customs into the saved view's column header.
+      const existingCustomIds = (columns || [])
+        .filter((c) => c.groupBy === "Custom Columns")
+        .map((c) => c.id);
+      if (existingCustomIds.length > 0) {
+        removeCustomColumns(existingCustomIds);
+      }
+      const savedCustomCols = Array.isArray(display.customColumns)
+        ? display.customColumns
+        : [];
+      if (savedCustomCols.length > 0) {
+        addCustomColumns(savedCustomCols);
+      }
       if (display.visibleColumns && columns?.length) {
         updateColumnVisibility(display.visibleColumns);
       }
       if (Array.isArray(display.columnState) && display.columnState.length > 0) {
-        if (gridApi?.applyColumnState) {
+        // Defer columnState whenever custom cols are being added — they
+        // land in the store synchronously but AG Grid's columnDefs prop
+        // only flips on the next render. Applying state in this tick
+        // would silently drop entries for the custom colIds. The
+        // `columns` drain effect re-applies the queued state once the
+        // store update has propagated.
+        if (savedCustomCols.length > 0) {
+          pendingColumnStateRef.current = display.columnState;
+        } else if (gridApi?.applyColumnState) {
           gridApi.applyColumnState({
             state: display.columnState,
             applyOrder: true,
@@ -418,12 +592,19 @@ const UsersView = ({
       setDateFilter,
       setExtraFilters,
       updateColumnVisibility,
+      addCustomColumns,
+      removeCustomColumns,
       columns,
       gridApi,
+      displayStorageKey,
     ],
   );
 
-  // Drain any column state queued before the grid was ready.
+  // Drain any column state queued before the grid was ready, OR queued
+  // because custom cols had to land in the store first. Two triggers:
+  // gridApi flipping from null to ready (initial mount), and `columns`
+  // changing (custom cols just got added → AG Grid columnDefs prop
+  // updated → safe to apply state for the custom colIds).
   useEffect(() => {
     if (gridApi?.applyColumnState && pendingColumnStateRef.current) {
       gridApi.applyColumnState({
@@ -432,7 +613,7 @@ const UsersView = ({
       });
       pendingColumnStateRef.current = null;
     }
-  }, [gridApi]);
+  }, [gridApi, columns]);
 
   // Keep the ref's handles in sync with the latest closures
   useEffect(() => {
@@ -500,6 +681,26 @@ const UsersView = ({
           return true;
         }
       }
+    }
+    // Custom columns: compare the sorted id list against the baseline so
+    // adding/removing a custom col on a saved view dirty-flags the Save
+    // view button. Sort because the user's intent is "which customs are
+    // selected" not "in what order" — order is captured separately in
+    // columnState.
+    const currentCustomIds = (columns || [])
+      .filter((c) => c.groupBy === "Custom Columns")
+      .map((c) => c.id)
+      .sort();
+    const baselineCustomIds = (
+      Array.isArray(baselineDisplay.customColumns)
+        ? baselineDisplay.customColumns
+        : []
+    )
+      .map((c) => c.id)
+      .sort();
+    if (currentCustomIds.length !== baselineCustomIds.length) return true;
+    for (let i = 0; i < currentCustomIds.length; i += 1) {
+      if (currentCustomIds[i] !== baselineCustomIds[i]) return true;
     }
     return false;
   }, [
@@ -574,13 +775,27 @@ const UsersView = ({
 
   // Apply a saved view's config when activeViewConfig changes. Reuses the
   // existing applyConfig — handles extraFilters, dateFilter, display state,
-  // column visibility.
+  // column visibility, custom columns.
   // Dep array intentionally only watches `activeViewConfig`. `applyConfig`'s
   // identity changes whenever `columns` does, and `applyConfig` itself
-  // mutates `columns` via `updateColumnVisibility` — keeping it in deps
-  // creates an infinite re-apply loop.
+  // mutates `columns` via `updateColumnVisibility` / `addCustomColumns` —
+  // keeping it in deps creates an infinite re-apply loop.
+  //
+  // The `wasOnSavedViewRef` gate ensures the null branch of applyConfig
+  // (which strips saved-view-leftover state — custom cols, visibility,
+  // pendingColumnState) only fires on a genuine saved-view → default
+  // transition, not on initial mount where activeViewConfig is null
+  // simply because no view is selected yet.
+  const wasOnSavedViewRef = useRef(false);
   useEffect(() => {
-    if (!activeViewConfig) return;
+    if (!activeViewConfig) {
+      const wasOnSavedView = wasOnSavedViewRef.current;
+      wasOnSavedViewRef.current = false;
+      if (!wasOnSavedView) return;
+      applyConfig(null);
+      return;
+    }
+    wasOnSavedViewRef.current = true;
     applyConfig(activeViewConfig);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeViewConfig]);

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -310,25 +310,17 @@ const UsersView = ({
     useUsersStore.setState({ filters: finalFilters });
   }, [finalFilters]);
 
-  // ---------------------------------------------------------------------------
-  // Saved-view api — populates a ref that the parent UsersPageTabBar drives.
-  // Captures display + filter state into config, and restores it on activation.
-  // ---------------------------------------------------------------------------
+  // Saved-view api — populates a ref the parent UsersPageTabBar drives.
   const getConfig = useCallback(() => {
     const visibleColumns = (columns || []).reduce((acc, col) => {
       acc[col.id] = col.isVisible !== false;
       return acc;
     }, {});
-    // Capture full grid column state (widths, order, sort) so saved views
-    // restore the user's exact column layout. Stash inside `display` since
-    // the backend serializer's allowed_keys whitelists `display` for
-    // arbitrary subkeys but does not whitelist a separate `columnState`.
+    // columnState lives inside `display` because the backend serializer
+    // whitelists `display` for arbitrary sub-keys (no top-level columnState).
     const columnState = gridApi?.getColumnState?.() ?? undefined;
-    // Persist custom columns separately. Their colIds also appear in
-    // columnState (for widths/order/sort), but the standard col defs come
-    // from the static UsersView baseConfig — the backend doesn't know
-    // about custom cols, so without this list AG Grid won't recreate them
-    // on restore and applyColumnState would silently drop their entries.
+    // customColumns separately: AG Grid won't recreate them from columnState
+    // alone since the backend doesn't know about custom cols.
     const customColumns = (columns || []).filter(
       (c) => c.groupBy === "Custom Columns",
     );
@@ -358,29 +350,17 @@ const UsersView = ({
     gridApi,
   ]);
 
-  // Pending column state from a saved view that arrived before the grid was
-  // ready. Drained by the effect below when gridApi becomes available.
+  // Drained when gridApi becomes available (saved view arrived before grid mount).
   const pendingColumnStateRef = useRef(null);
 
-  // localStorage key for default-tab display state (per-project). Mirrors
-  // LLMTracingView's `observe-display-<id>` pattern but with a separate
-  // namespace so the two views don't collide on shape (different fields).
-  const displayStorageKey = useMemo(
-    () => `observe-users-display-${observeId}`,
-    [observeId],
-  );
+  const displayStorageKey = `observe-users-display-${observeId}`;
 
-  // Hydrate default-tab display state from localStorage. Runs when columns
-  // is populated (UsersGrid's mount effect runs first and seeds the default
-  // schema via setColumns) — without this gate, addCustomColumns would
-  // race the schema seed and the customs would be wiped. Guard with a
-  // per-key ref so it only fires once per project, and skip entirely on
-  // a saved-view tab (the view config is the source of truth there).
+  // hydratedKeyRef gates the hydrate to once per project. The columns gate
+  // below ensures UsersGrid's schema seed has landed first — without it,
+  // addCustomColumns would race the seed and the customs would be wiped.
   const hydratedKeyRef = useRef(null);
-  // Set immediately after a hydrate so the save effect skips its next
-  // fire — that fire would otherwise close over the PRE-hydrate state
-  // (setters from the hydrate are queued, not committed yet) and write
-  // defaults back over the values we just loaded.
+  // Skips the save effect's next fire after a hydrate so the pre-hydrate
+  // closure can't overwrite what we just loaded.
   const skipNextSaveRef = useRef(false);
   useEffect(() => {
     if (activeViewTabId) return;
@@ -415,10 +395,8 @@ const UsersView = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [columns, displayStorageKey]);
 
-  // Persist display state to localStorage on every change (default tab
-  // only — saved views own their persistence via the explicit Save view
-  // button). Skip until the initial hydrate has run, otherwise the
-  // empty default state would overwrite saved customs on first paint.
+  // Default tab only — saved views own their persistence via the explicit
+  // Save view button.
   useEffect(() => {
     if (activeViewTabId) return;
     if (hydratedKeyRef.current !== displayStorageKey) return;
@@ -467,17 +445,12 @@ const UsersView = ({
         setHasEvalFilter(false);
         setDateFilter(getDefaultDateRange());
         pendingColumnStateRef.current = null;
-        // Drop any custom cols left by the saved view we're navigating
-        // away from so the default tab doesn't inherit them.
         const currentCustomIds = (columns || [])
           .filter((c) => c.groupBy === "Custom Columns")
           .map((c) => c.id);
         if (currentCustomIds.length > 0) {
           removeCustomColumns(currentCustomIds);
         }
-        // Reset column visibility to the column-config defaults so going back
-        // to All Users from a saved view with limited columns shows everything
-        // again.
         const defaultsVisibility = (getUsersColumnConfig() || []).reduce(
           (acc, col) => {
             acc[col.field] = col.hide === undefined ? true : !col.hide;
@@ -488,18 +461,13 @@ const UsersView = ({
         if (Object.keys(defaultsVisibility).length > 0) {
           updateColumnVisibility(defaultsVisibility);
         }
-        // Reset AG Grid column state (widths/order/sort) to coldef defaults.
         if (gridApi?.resetColumnState) gridApi.resetColumnState();
-        // Re-hydrate default-tab preferences from localStorage. The mount-
-        // time hydrate effect is keyed on `displayStorageKey` and won't
-        // re-fire on a same-project saved-view → default transition.
-        // Setters here run after the resets above, so React's batched
-        // render sees the localStorage values as the final state.
+        // Re-hydrate from localStorage — the mount hydrate is keyed on
+        // displayStorageKey and won't re-fire on a same-project saved-view
+        // → default transition.
         try {
           const raw = localStorage.getItem(displayStorageKey);
           if (raw) {
-            // Mirror the mount-hydrate skip-flag so the save effect's next
-            // fire doesn't write the pre-hydrate state back to localStorage.
             skipNextSaveRef.current = true;
             const saved = JSON.parse(raw);
             if (saved.cellHeight) setCellHeight(saved.cellHeight);
@@ -539,9 +507,8 @@ const UsersView = ({
         setShowNonAnnotated(display.showNonAnnotated);
       if (typeof display.hasEvalFilter === "boolean")
         setHasEvalFilter(display.hasEvalFilter);
-      // Strip any pre-existing custom cols before adding this view's set,
-      // so view → view doesn't stack customs and default → view doesn't
-      // leak default-tab customs into the saved view's column header.
+      // Strip pre-existing customs so view → view doesn't stack, and
+      // default → view doesn't leak default-tab customs into the saved view.
       const existingCustomIds = (columns || [])
         .filter((c) => c.groupBy === "Custom Columns")
         .map((c) => c.id);
@@ -558,12 +525,10 @@ const UsersView = ({
         updateColumnVisibility(display.visibleColumns);
       }
       if (Array.isArray(display.columnState) && display.columnState.length > 0) {
-        // Defer columnState whenever custom cols are being added — they
-        // land in the store synchronously but AG Grid's columnDefs prop
-        // only flips on the next render. Applying state in this tick
-        // would silently drop entries for the custom colIds. The
-        // `columns` drain effect re-applies the queued state once the
-        // store update has propagated.
+        // Defer columnState when custom cols are being added — AG Grid's
+        // columnDefs prop only flips next render, so applying this tick
+        // would drop entries for the custom colIds. Drained by the
+        // `columns` effect once the store update propagates.
         if (savedCustomCols.length > 0) {
           pendingColumnStateRef.current = display.columnState;
         } else if (gridApi?.applyColumnState) {
@@ -598,11 +563,9 @@ const UsersView = ({
     ],
   );
 
-  // Drain any column state queued before the grid was ready, OR queued
-  // because custom cols had to land in the store first. Two triggers:
-  // gridApi flipping from null to ready (initial mount), and `columns`
-  // changing (custom cols just got added → AG Grid columnDefs prop
-  // updated → safe to apply state for the custom colIds).
+  // Drains pendingColumnStateRef on two triggers: gridApi becoming
+  // available, or `columns` changing (custom cols just landed → AG Grid
+  // columnDefs prop updated → safe to apply state for the custom colIds).
   useEffect(() => {
     if (gridApi?.applyColumnState && pendingColumnStateRef.current) {
       gridApi.applyColumnState({
@@ -680,11 +643,7 @@ const UsersView = ({
         }
       }
     }
-    // Custom columns: compare the sorted id list against the baseline so
-    // adding/removing a custom col on a saved view dirty-flags the Save
-    // view button. Sort because the user's intent is "which customs are
-    // selected" not "in what order" — order is captured separately in
-    // columnState.
+    // Custom cols: order is captured by columnState, so we only diff the set.
     const currentCustomIds = (columns || [])
       .filter((c) => c.groupBy === "Custom Columns")
       .map((c) => c.id)
@@ -714,15 +673,10 @@ const UsersView = ({
 
   const canSaveViewDeferred = useDeferredValue(canSaveView);
 
-  // Update mutations for the explicit Save view button. Project-scoped on
-  // ObservePage's Users fixed tab; workspace-scoped (USERS_TAB_TYPE) on the
-  // top-level /dashboard/users page rendered by UserList.
   const { mutate: updateSavedView } = useUpdateSavedView(observeId);
   const { mutate: updateWorkspaceSavedView } =
     useUpdateWorkspaceSavedView(USERS_TAB_TYPE);
 
-  // Active saved-view id from URL — "tab" key on ObservePage, "usersTab" on
-  // UserList. Re-derived when the active config flips.
   const activeViewTabId = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
     const key = isObservePath
@@ -758,9 +712,8 @@ const UsersView = ({
     setActiveViewConfig,
   ]);
 
-  // Register with ObserveHeaderContext so ObserveTabBar's "+" save flow can
-  // snapshot the current Users config when the user is on this fixed tab —
-  // without this, the save POSTs `config: {}` (TH-4578).
+  // ObserveTabBar's "+" save flow needs this — without it the save POSTs
+  // `config: {}` (TH-4578).
   useEffect(() => {
     registerGetViewConfig(getConfig);
     return () => registerGetViewConfig(null);
@@ -771,19 +724,10 @@ const UsersView = ({
     return () => registerGetTabType(null);
   }, [registerGetTabType]);
 
-  // Apply a saved view's config when activeViewConfig changes. Reuses the
-  // existing applyConfig — handles extraFilters, dateFilter, display state,
-  // column visibility, custom columns.
-  // Dep array intentionally only watches `activeViewConfig`. `applyConfig`'s
-  // identity changes whenever `columns` does, and `applyConfig` itself
-  // mutates `columns` via `updateColumnVisibility` / `addCustomColumns` —
-  // keeping it in deps creates an infinite re-apply loop.
-  //
-  // The `wasOnSavedViewRef` gate ensures the null branch of applyConfig
-  // (which strips saved-view-leftover state — custom cols, visibility,
-  // pendingColumnState) only fires on a genuine saved-view → default
-  // transition, not on initial mount where activeViewConfig is null
-  // simply because no view is selected yet.
+  // Deps watch only activeViewConfig — applyConfig's identity changes with
+  // columns, and it mutates columns, so keeping it in deps would loop.
+  // wasOnSavedViewRef gates the null-branch reset to genuine saved-view →
+  // default transitions (not initial mount with no view selected).
   const wasOnSavedViewRef = useRef(false);
   useEffect(() => {
     if (!activeViewConfig) {

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -537,8 +537,6 @@ const UsersView = ({
         setShowErrors(display.showErrors);
       if (typeof display.showNonAnnotated === "boolean")
         setShowNonAnnotated(display.showNonAnnotated);
-      if (typeof display.showNonAnnotated === "boolean")
-        setShowNonAnnotated(display.showNonAnnotated);
       if (typeof display.hasEvalFilter === "boolean")
         setHasEvalFilter(display.hasEvalFilter);
       // Strip any pre-existing custom cols before adding this view's set,


### PR DESCRIPTION
## Summary

Custom columns added on a default observe tab or saved into a view were not reliably reappearing on refresh, tab-switch, or saved-view application. This rewires the hydration + persistence pipeline across **all five observe surfaces** (LLMTracing trace + spans, Sessions, Users, voice / CallLogs) so customs persist, restore, and dirty-flag the Save view button consistently.

### LLMTracing (trace + spans)
- Replaced the shared `pendingCustomColumnsRef` with **four per-grid refs** (primary trace, compare trace, primary spans, compare spans). Eliminates the race where one grid drained the queue before the others fetched.
- Widened `TraceGrid` + `SpanGrid` merge guard to `backendChanged || hasPending` with a `finalNonCustom` fallback — saved-view clicks now drain pendings even when backend columns are unchanged.
- `localStorage` `customColumns` split into `{ trace: [], spans: [] }` so adding customs on one tab no longer wipes the other's customs from the shared `observe-display-` entry. Backward-compat read for the flat array shape.
- Saved-view apply effect strips existing customs from **all** grid slots before queueing the new set, so view A → view B (or default → view) no longer unions customs and dirty-flags the Save view button.
- Mount-time localStorage display effect skips when `activeViewTabId` is set, so a hard refresh on a saved-view URL doesn't drain default-tab customs into the grid before the view config arrives.
- Voice/simulator: `handleSimulatorConfigLoaded` and the saved-view + back-to-default branches drain pending refs directly into `columns` state since `CallLogsGrid` doesn't have a per-fetch merge step.
- Saved-view hide flags now apply correctly to TraceGrid + SpanGrid: hideMap built from `columnState`, applied in the apply effect, queued via `pendingHideMapRef` for cold-load cols, and `backendChanged` computed via `stripVis` so subsequent page fetches don't clobber the local hide state.

### Sessions
- `buildViewConfig` now persists `customColumns` as a separate `display` field; apply effect strips existing customs, queues `savedCustomCols` into `pendingCustomColumnsRef`, defers `columnState` when customs are pending, and forces a `refreshServerSide` so the merge drains the queue.
- `Session-grid` merge guard widened to match the TraceGrid pattern.
- `canSaveView` now compares sorted custom-col IDs against the baseline so adding/removing a custom dirty-flags the button.
- Default-tab localStorage (`observe-sessions-display-` / `user-sessions-display-`) added with hydrate + save effects, back-to-default re-hydrate, and a `skipNextSaveRef` so the first save after hydrate doesn't clobber loaded values with the pre-hydrate state.

### Users
- `getConfig` persists `customColumns`; `applyConfig` strips existing customs via `removeCustomColumns` and adds the saved set via `addCustomColumns`, with `columnState` deferred when customs are pending and drained on the next `columns` change.
- Apply effect always invokes `applyConfig` (including the null branch, gated by `wasOnSavedViewRef`) so saved-view → All Users actually clears customs.
- `canSaveView` compares sorted custom-col IDs.
- New default-tab persistence: `observe-users-display-` with hydrate (gated on `columns.length > 0` so it runs after `UsersGrid` seeds the default schema), save, back-to-default re-hydrate, and `skipNextSaveRef`.

### UserTraceTabV2
- Adds per-`{project, user}` localStorage persistence (`user-trace-customcols-<project>-<user>`) for custom columns so they survive refresh on the in-project user-detail trace tab.

### Voice (CallLogsGrid)
- `effectiveDefs` wraps custom-col defs under a `"Custom Columns"` group header (parity with TraceGrid / Session-grid / UsersGrid).
- New `CustomColCellRenderer` matches the `px/py` padding of the standard `CallLogsCellRenderer`; new `CustomColLoadingSkeleton` renders during the first fetch (toggled via `isLoading`).
- `valueGetter` resolves with three strategies in order: direct lookup, dot-notation traversal, then a tight `call.` / `vapi.` namespace strip for Vapi-style eval-attribute paths that map to flat fields in the `list_voice_calls` response.

Closes TH-4801

## Linear Ticket
[TH-4801](https://linear.app/future-agi/issue/TH-4801)

## Files Changed
- `frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx`
- `frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx`
- `frontend/src/sections/projects/LLMTracing/SpanGrid.jsx`
- `frontend/src/sections/projects/LLMTracing/TraceGrid.jsx`
- `frontend/src/sections/projects/SessionsView/Session-grid.jsx`
- `frontend/src/sections/projects/SessionsView/Sessions-view.jsx`
- `frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx`
- `frontend/src/sections/projects/UsersView/UsersView.jsx`

## Tests verified

### LLMTracing trace + spans
- [x] Hard refresh on saved-view tab → customs appear.
- [x] Click default → saved view → customs appear (merge guard widening).
- [x] Saved view → default → customs disappear, localStorage customs re-hydrate.
- [x] Trace ↔ spans default tabs no longer overwrite each other's localStorage customs (per-tab object shape).
- [x] Hard refresh on `?tab=view-XYZ` doesn't drain default-tab localStorage customs first.

### Sessions
- [x] Saved view: `customColumns` payload now includes customs (was empty before).
- [x] Hard refresh on a sessions saved view URL with customs → customs appear (cold-mount C4 fix).
- [x] Sessions saved view → default → back to saved view → customs still drain.

### Users
- [x] Default-tab localStorage round-trip (add custom → refresh → back).
- [x] Saved view → All Users → no leftover customs.

### UserTraceTabV2
- [x] Add custom col → hard refresh → custom returns (C2 first-render race fix).
- [x] Add custom col → slow fetch / fast back-navigation → reload → custom returns.
- [x] Different user in same project: their custom set is preserved (per-{project, user} scope).

### Voice (simulator projects)
- [x] Custom cols render grouped under "Custom Columns" header.
- [x] Custom col values populate (e.g. `call.bot_wpm` → numeric `bot_wpm`).
- [x] Default-tab custom cols persist on refresh.
- [x] Saved view A → B with different customs.
- [x] Cell padding matches standard cells.
- [x] Loading skeleton renders during first fetch.

### Cross-cutting
- [x] `yarn lint` — 0 errors.
- [x] `yarn test:run` — 1133/1133 passing.