### PR TITLE
fix(eval-picker): data-injection bypass + capability chip styling

### DIFF
--- a/.github/reviewer-config.json
+++ b/.github/reviewer-config.json
@@ -1,0 +1,144 @@
+{
+  "_comment": "Config for .github/workflows/reviewer-assigner.yml. Path globs use ** and * (labeler-style). Overlaps are resolved by longest-literal-prefix-wins.",
+  "fallback_lead": "atharva-bhange",
+  "teams": {
+    "morpheus": {
+      "display_name": "Morpheus",
+      "ownership": "Simulation + Simulation SDK + Annotation queues",
+      "lead": "khushalsonawat",
+      "members": ["khushalsonawat", "definitelynotchirag", "cdileep23", "KarthikAvinashFI", "hadarishav"],
+      "paths": [
+        "futureagi/simulate/**",
+        "futureagi/sdk/simulate/**",
+        "frontend/src/sections/scenarios/**",
+        "frontend/src/sections/annotations/**",
+        "frontend/src/sections/persona/**",
+        "frontend/src/sections/journey/**"
+      ]
+    },
+    "heimdall": {
+      "display_name": "heimdall",
+      "ownership": "Observe + Tracing SDK + Dashboard",
+      "lead": "atharva-bhange",
+      "members": ["atharva-bhange", "JayaSurya-27", "commitPirate", "sarthakFuture"],
+      "paths": [
+        "futureagi/tracer/**",
+        "futureagi/sockets/**",
+        "futureagi/analytics/**",
+        "frontend/src/sections/dashboards/**",
+        "frontend/src/sections/overview/**",
+        "frontend/src/sections/project/**",
+        "frontend/src/sections/project-detail/**",
+        "frontend/src/sections/projects/**"
+      ]
+    },
+    "turing": {
+      "display_name": "Turing",
+      "ownership": "Platform Evals + Evals SDK + Falcon",
+      "lead": "hadarishav",
+      "members": ["hadarishav", "KarthikAvinashFI", "cdileep23", "azain-commits"],
+      "paths": [
+        "futureagi/evaluations/**",
+        "futureagi/agentic_eval/**",
+        "futureagi/ee/evals/**",
+        "futureagi/ee/falcon_ai/**",
+        "futureagi/ee/turing/**",
+        "frontend/src/sections/evals/**",
+        "frontend/src/sections/falcon-ai/**"
+      ]
+    },
+    "n11n": {
+      "display_name": "n11n",
+      "ownership": "Agent + Prompt playground",
+      "lead": "JayaSurya-27",
+      "members": ["JayaSurya-27", "commitPirate", "Tanmaycode1"],
+      "paths": [
+        "futureagi/ee/prompts/**",
+        "futureagi/ee/agenthub/**",
+        "frontend/src/sections/agent-playground/**",
+        "frontend/src/sections/agents/**",
+        "frontend/src/sections/prompt/**",
+        "frontend/src/sections/prompt-v2/**",
+        "frontend/src/sections/workbench/**",
+        "frontend/src/sections/workbench-v2/**"
+      ]
+    },
+    "quest": {
+      "display_name": "quest",
+      "ownership": "Experiments",
+      "lead": "atharva-bhange",
+      "members": ["atharva-bhange", "cdileep23", "Tanmaycode1"],
+      "paths": [
+        "futureagi/ee/experiments/**",
+        "frontend/src/sections/experiment-detail/**",
+        "frontend/src/sections/test/**",
+        "frontend/src/sections/test-detail/**",
+        "frontend/src/sections/tasks/**"
+      ]
+    },
+    "adam": {
+      "display_name": "Adam",
+      "ownership": "Platform Optimization + Opt. SDK + Gateway",
+      "lead": "NVJKKartik",
+      "members": ["NVJKKartik", "azain-commits", "hadarishav"],
+      "paths": [
+        "agentcc-gateway/**",
+        "futureagi/agentcc/**",
+        "futureagi/ee/agent_opt/**",
+        "futureagi/ee/agentcc-gateway/**",
+        "frontend/src/sections/gateway/**",
+        "frontend/src/sections/develop/**",
+        "frontend/src/sections/develop-detail/**"
+      ]
+    },
+    "beacon": {
+      "display_name": "Beacon",
+      "ownership": "Error Feed",
+      "lead": "hadarishav",
+      "members": ["hadarishav", "NVJKKartik"],
+      "paths": [
+        "futureagi/tracer/views/feed/**",
+        "frontend/src/sections/alerts/**",
+        "frontend/src/sections/error/**"
+      ]
+    },
+    "frame": {
+      "display_name": "Frame",
+      "ownership": "Datasets + Future AGI + RBAC + Pricing & billing",
+      "lead": "khushalsonawat",
+      "members": ["khushalsonawat", "sarthakFuture", "azain-commits", "cdileep23", "Tanmaycode1"],
+      "paths": [
+        "futureagi/accounts/**",
+        "futureagi/saml2_auth/**",
+        "futureagi/model_hub/**",
+        "futureagi/ee/usage/**",
+        "futureagi/ee/billing*",
+        "futureagi/integrations/**",
+        "frontend/src/sections/account/**",
+        "frontend/src/sections/auth/**",
+        "frontend/src/sections/data/**",
+        "frontend/src/sections/knowledge-base/**",
+        "frontend/src/sections/model/**",
+        "frontend/src/sections/huggingface/**",
+        "frontend/src/sections/settings/**",
+        "frontend/src/sections/keys/**",
+        "frontend/src/sections/user/**",
+        "frontend/src/sections/address/**"
+      ]
+    }
+  },
+  "users": {
+    "khushalsonawat":      { "slack_id": "U087FCUQ77E", "display_name": "Khushal" },
+    "atharva-bhange":      { "slack_id": "U071K8LUQE5", "display_name": "Atharva" },
+    "definitelynotchirag": { "slack_id": "U0ACG3CS7EY", "display_name": "Chirag" },
+    "cdileep23":           { "slack_id": "U099M4FQV97", "display_name": "Dileep" },
+    "KarthikAvinashFI":    { "slack_id": "U09808798MU", "display_name": "Karthik Avinash" },
+    "hadarishav":          { "slack_id": "U07UPK1NZGA", "display_name": "Rishav" },
+    "JayaSurya-27":        { "slack_id": "U083MBRARTL", "display_name": "Jaya" },
+    "commitPirate":        { "slack_id": "U09LC0C8NKE", "display_name": "Nosang" },
+    "sarthakFuture":       { "slack_id": "U07V82HJ17H", "display_name": "Sarthak" },
+    "azain-commits":       { "slack_id": "U09GEEBEATS", "display_name": "Azain" },
+    "NVJKKartik":          { "slack_id": "U0851KZFTV4", "display_name": "Kartik" },
+    "Tanmaycode1":         { "slack_id": "U0ARCAND0R1", "display_name": "Tanmay" }
+  }
+}

--- a/.github/scripts/reviewer-assigner.mjs
+++ b/.github/scripts/reviewer-assigner.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+// Reviewer Assigner: routes PRs to team leads, DM-pings stale reviewers,
+// and posts a daily reviewer-load summary. Driven by .github/reviewer-config.json.
+//
+// Modes (selected via MODE env var):
+//   assign   — request the right team lead(s) on PRs that have no reviewer
+//   ping     — DM each pending reviewer of an open PR >3 days old (gated by REVIEWER_PING_ENABLED)
+//   summary  — post sorted "reviewer → open PR count" to SLACK_WEBHOOK_URL
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = resolve(__dirname, '..', 'reviewer-config.json');
+
+const {
+  MODE,
+  GITHUB_TOKEN,
+  GITHUB_REPOSITORY,
+  PR_NUMBER,
+  SLACK_BOT_TOKEN,
+  SLACK_WEBHOOK_URL,
+  REVIEWER_PING_ENABLED,
+  DRY_RUN,
+} = process.env;
+
+if (!MODE) die('MODE env var is required (assign|ping|summary)');
+if (!GITHUB_TOKEN) die('GITHUB_TOKEN is required');
+if (!GITHUB_REPOSITORY) die('GITHUB_REPOSITORY is required');
+
+const [OWNER, REPO] = GITHUB_REPOSITORY.split('/');
+const GH_API = 'https://api.github.com';
+const PING_AGE_DAYS = 3;
+const dryRun = DRY_RUN === 'true';
+
+const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+
+const ghHeaders = {
+  Accept: 'application/vnd.github+json',
+  Authorization: `Bearer ${GITHUB_TOKEN}`,
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': `${OWNER}-${REPO}-reviewer-assigner`,
+};
+
+// ─── small helpers ────────────────────────────────────────────────────────────
+
+function die(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+function log(...args) {
+  console.log(...args);
+}
+
+async function gh(path, init = {}) {
+  const res = await fetch(`${GH_API}${path}`, { ...init, headers: { ...ghHeaders, ...(init.headers || {}) } });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub ${init.method || 'GET'} ${path} → ${res.status}: ${body}`);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+async function ghPaginated(path) {
+  // Walk Link headers until no `rel="next"`.
+  const out = [];
+  let url = `${GH_API}${path}`;
+  while (url) {
+    const res = await fetch(url, { headers: ghHeaders });
+    if (!res.ok) throw new Error(`GitHub GET ${url} → ${res.status}: ${await res.text()}`);
+    out.push(...(await res.json()));
+    const link = res.headers.get('link');
+    const next = link?.split(',').map((s) => s.trim()).find((s) => s.endsWith('rel="next"'));
+    url = next ? next.slice(1, next.indexOf('>')) : null;
+  }
+  return out;
+}
+
+// Convert a labeler-style glob (** and *) to a RegExp. Anchored at both ends.
+function globToRegex(glob) {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*' && glob[i + 1] === '*') {
+      re += '.*';
+      i++;
+    } else if (c === '*') {
+      re += '[^/]*';
+    } else if (/[.+?^${}()|[\]\\]/.test(c)) {
+      re += '\\' + c;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp('^' + re + '$');
+}
+
+// Specificity = length of the literal prefix before the first wildcard.
+// Used to pick the owning team when multiple globs match the same file.
+function globSpecificity(glob) {
+  const i = glob.search(/[*?]/);
+  return i === -1 ? glob.length : i;
+}
+
+// Precompile globs once.
+const compiledTeams = Object.entries(config.teams).map(([id, t]) => ({
+  id,
+  ...t,
+  compiledPaths: t.paths.map((p) => ({ glob: p, re: globToRegex(p), specificity: globSpecificity(p) })),
+}));
+
+// Find the team that owns a given file path (most-specific-glob-wins).
+function ownerOf(file) {
+  let best = null;
+  for (const team of compiledTeams) {
+    for (const p of team.compiledPaths) {
+      if (p.re.test(file)) {
+        if (!best || p.specificity > best.specificity) best = { team, specificity: p.specificity };
+        break; // one team can only "claim" via its most-specific own glob anyway
+      }
+    }
+  }
+  return best?.team || null;
+}
+
+// Find every team that has `gh-user` as its lead (a person may lead multiple teams).
+function teamsLedBy(ghUser) {
+  return compiledTeams.filter((t) => t.lead === ghUser);
+}
+
+function userMeta(ghUser) {
+  return config.users[ghUser] || null;
+}
+
+function slackMention(ghUser) {
+  const u = userMeta(ghUser);
+  return u?.slack_id ? `<@${u.slack_id}>` : ghUser;
+}
+
+// ─── mode: assign ─────────────────────────────────────────────────────────────
+
+async function assignForPr(prNumber) {
+  log(`\n— PR #${prNumber} —`);
+  const pr = await gh(`/repos/${OWNER}/${REPO}/pulls/${prNumber}`);
+
+  if (pr.state !== 'open') {
+    log(`  state=${pr.state}, skipping`);
+    return;
+  }
+  if ((pr.requested_reviewers?.length ?? 0) > 0 || (pr.requested_teams?.length ?? 0) > 0) {
+    log(`  already has reviewers (${pr.requested_reviewers.map((r) => r.login).join(',')} + teams=${pr.requested_teams.length}), skipping`);
+    return;
+  }
+
+  const files = await ghPaginated(`/repos/${OWNER}/${REPO}/pulls/${prNumber}/files?per_page=100`);
+  const matchedTeams = new Map(); // id → team
+  for (const f of files) {
+    const t = ownerOf(f.filename);
+    if (t) matchedTeams.set(t.id, t);
+  }
+
+  let leads = [...new Set([...matchedTeams.values()].map((t) => t.lead))];
+  const author = pr.user?.login;
+  leads = leads.filter((l) => l !== author);
+
+  if (leads.length === 0) {
+    if (config.fallback_lead && config.fallback_lead !== author) {
+      leads = [config.fallback_lead];
+      log(`  no team matched (or author was the only lead) → fallback ${config.fallback_lead}`);
+    } else {
+      log('  no reviewers to assign (no match and author == fallback)');
+      return;
+    }
+  }
+
+  log(`  assigning: ${leads.join(', ')}`);
+  if (dryRun) {
+    log('  DRY_RUN: skipping API calls');
+    return;
+  }
+
+  await gh(`/repos/${OWNER}/${REPO}/pulls/${prNumber}/requested_reviewers`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reviewers: leads }),
+  });
+
+  if (matchedTeams.size > 1) {
+    const lines = [...matchedTeams.values()].map(
+      (t) => `• **${t.display_name}** (${t.ownership}) — @${t.lead}`,
+    );
+    const body = `This PR touches code owned by multiple teams:\n\n${lines.join('\n')}\n\nPlease coordinate on review.`;
+    await gh(`/repos/${OWNER}/${REPO}/issues/${prNumber}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body }),
+    });
+    log(`  posted cross-team coordination comment (${matchedTeams.size} teams)`);
+  }
+}
+
+async function runAssign() {
+  let prs;
+  if (PR_NUMBER) {
+    prs = [Number(PR_NUMBER)];
+  } else {
+    log('No PR_NUMBER → sweeping all open PRs');
+    const open = await ghPaginated(`/repos/${OWNER}/${REPO}/pulls?state=open&per_page=100`);
+    prs = open.map((p) => p.number);
+  }
+  for (const n of prs) {
+    try {
+      await assignForPr(n);
+    } catch (e) {
+      console.error(`PR #${n}: ${e.message}`);
+    }
+  }
+}
+
+// ─── mode: ping ───────────────────────────────────────────────────────────────
+
+async function postSlackDm(slackId, text) {
+  if (dryRun) {
+    log(`  DRY_RUN: would DM ${slackId}: ${text.slice(0, 80)}…`);
+    return;
+  }
+  const res = await fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SLACK_BOT_TOKEN}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify({ channel: slackId, text, unfurl_links: false }),
+  });
+  const json = await res.json();
+  if (!json.ok) throw new Error(`Slack chat.postMessage failed for ${slackId}: ${json.error}`);
+}
+
+function pingBodyFor(reviewerGh, pr, ageDays, authorGh) {
+  // Lead the DM with an explicit <@slack_id> mention so Slack treats this as a
+  // hard "you were mentioned" event — guarantees a push/badge even for users
+  // with stricter bot-DM notification rules.
+  const slackMentionOfRecipient = `<@${userMeta(reviewerGh).slack_id}>`;
+  const prLink = `<${pr.html_url}|PR #${pr.number} — ${pr.title}>`;
+  const lines = [`${slackMentionOfRecipient} reminder: ${prLink} has been waiting on your review for ${ageDays} day${ageDays === 1 ? '' : 's'}.`];
+  const ledTeams = teamsLedBy(reviewerGh);
+  if (ledTeams.length) {
+    for (const t of ledTeams) {
+      const candidates = t.members
+        .filter((m) => m !== reviewerGh && m !== authorGh)
+        .map((m) => userMeta(m)?.display_name || m);
+      if (candidates.length) {
+        lines.push('', `You can reassign this to a ${t.display_name} teammate if you'd like: ${candidates.join(', ')}.`);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+async function runPing() {
+  if (REVIEWER_PING_ENABLED !== 'true') {
+    log('REVIEWER_PING_ENABLED != "true" → ping disabled, exiting');
+    return;
+  }
+  if (!SLACK_BOT_TOKEN) die('SLACK_BOT_TOKEN is required for ping mode');
+
+  const open = await ghPaginated(`/repos/${OWNER}/${REPO}/pulls?state=open&per_page=100`);
+  const now = Date.now();
+  const threshold = PING_AGE_DAYS * 24 * 3600 * 1000;
+
+  for (const pr of open) {
+    if (pr.draft) continue;
+    const ageMs = now - new Date(pr.created_at).getTime();
+    if (ageMs <= threshold) continue;
+    const ageDays = Math.floor(ageMs / (24 * 3600 * 1000));
+    const authorGh = pr.user?.login;
+    const reviewers = pr.requested_reviewers || [];
+    if (!reviewers.length) continue;
+
+    for (const r of reviewers) {
+      const gh = r.login;
+      const meta = userMeta(gh);
+      if (!meta?.slack_id) {
+        log(`  PR #${pr.number}: reviewer @${gh} has no Slack ID in config — skipping`);
+        continue;
+      }
+      const body = pingBodyFor(gh, pr, ageDays, authorGh);
+      try {
+        await postSlackDm(meta.slack_id, body);
+        log(`  PR #${pr.number}: DM'd @${gh} (${meta.slack_id})`);
+      } catch (e) {
+        console.error(`  PR #${pr.number}: failed to DM @${gh}: ${e.message}`);
+      }
+    }
+  }
+}
+
+// ─── mode: summary ────────────────────────────────────────────────────────────
+
+async function runSummary() {
+  if (!SLACK_WEBHOOK_URL) die('SLACK_WEBHOOK_URL is required for summary mode');
+
+  const open = await ghPaginated(`/repos/${OWNER}/${REPO}/pulls?state=open&per_page=100`);
+  const counts = new Map();
+  for (const pr of open) {
+    if (pr.draft) continue;
+    for (const r of pr.requested_reviewers || []) {
+      counts.set(r.login, (counts.get(r.login) || 0) + 1);
+    }
+  }
+
+  if (counts.size === 0) {
+    log('No pending reviewers — skipping summary post');
+    return;
+  }
+
+  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  const today = new Date().toISOString().slice(0, 10);
+  const lines = [`*Open PR Review Load — ${today}*`];
+  for (const [gh, n] of sorted) {
+    lines.push(`• ${slackMention(gh)} — ${n} PR${n === 1 ? '' : 's'}`);
+  }
+  const text = lines.join('\n');
+
+  if (dryRun) {
+    log('DRY_RUN: would post summary:\n' + text);
+    return;
+  }
+
+  const res = await fetch(SLACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) throw new Error(`Slack webhook → ${res.status}: ${await res.text()}`);
+  log(`Posted summary (${sorted.length} reviewers).`);
+}
+
+// ─── entrypoint ───────────────────────────────────────────────────────────────
+
+const RUNNERS = { assign: runAssign, ping: runPing, summary: runSummary };
+const runner = RUNNERS[MODE];
+if (!runner) die(`Unknown MODE: ${MODE}`);
+runner().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/.github/workflows/reviewer-assigner.yml
+++ b/.github/workflows/reviewer-assigner.yml
@@ -8,6 +8,10 @@ on:
       pr_number:
         description: 'PR number to assign (leave blank to sweep all open PRs)'
         required: false
+      run_pings:
+        description: 'Also run ping (Slack DMs) and summary jobs. Default off — flip this on to test the daily reminder flow manually.'
+        type: boolean
+        default: false
   schedule:
     # 10:00 IST (UTC+5:30) → 04:30 UTC — same morning slot as pr-digest.
     - cron: '30 4 * * *'
@@ -34,7 +38,10 @@ jobs:
         run: node .github/scripts/reviewer-assigner.mjs
 
   ping:
-    if: github.repository == 'future-agi/future-agi' && github.event_name == 'schedule'
+    if: >-
+      github.repository == 'future-agi/future-agi' &&
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' && inputs.run_pings))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -49,12 +56,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          # Off by default. Set the repo secret to the literal string "true" to enable.
-          REVIEWER_PING_ENABLED: ${{ secrets.REVIEWER_PING_ENABLED }}
+          # Cron runs respect the repo secret as the on/off switch.
+          # Manual dispatch with run_pings=true forces the gate open so a tester
+          # doesn't have to flip the secret each time.
+          REVIEWER_PING_ENABLED: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_pings) && 'true' || secrets.REVIEWER_PING_ENABLED }}
         run: node .github/scripts/reviewer-assigner.mjs
 
   summary:
-    if: github.repository == 'future-agi/future-agi' && github.event_name == 'schedule'
+    if: >-
+      github.repository == 'future-agi/future-agi' &&
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' && inputs.run_pings))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/reviewer-assigner.yml
+++ b/.github/workflows/reviewer-assigner.yml
@@ -1,0 +1,72 @@
+name: Reviewer Assigner
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to assign (leave blank to sweep all open PRs)'
+        required: false
+  schedule:
+    # 10:00 IST (UTC+5:30) → 04:30 UTC — same morning slot as pr-digest.
+    - cron: '30 4 * * *'
+
+jobs:
+  assign:
+    if: github.repository == 'future-agi/future-agi' && github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write   # needed to post the cross-team coordination comment
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Assign reviewers
+        env:
+          MODE: assign
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: node .github/scripts/reviewer-assigner.mjs
+
+  ping:
+    if: github.repository == 'future-agi/future-agi' && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: DM stale reviewers
+        env:
+          MODE: ping
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Off by default. Set the repo secret to the literal string "true" to enable.
+          REVIEWER_PING_ENABLED: ${{ secrets.REVIEWER_PING_ENABLED }}
+        run: node .github/scripts/reviewer-assigner.mjs
+
+  summary:
+    if: github.repository == 'future-agi/future-agi' && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Post reviewer-load summary
+        env:
+          MODE: summary
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: node .github/scripts/reviewer-assigner.mjs

--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -32,7 +32,10 @@ import axios, { endpoints } from "src/utils/axios";
 import { useSnackbar } from "notistack";
 import { useRouter } from "src/routes/hooks";
 import { useDebounce } from "src/hooks/use-debounce";
-import { EvalPickerDrawer } from "src/sections/common/EvalPicker";
+import {
+  EvalPickerDrawer,
+  serializeEvalConfig,
+} from "src/sections/common/EvalPicker";
 import EmptyLayout from "../EmptyLayout/EmptyLayout";
 import SvgColor from "../svg-color";
 import { FormSearchSelectFieldState } from "../FromSearchSelectField";
@@ -178,8 +181,18 @@ const CreateRunTestPage = ({ open, onClose }) => {
   const [openEvaluationDialog, setOpenEvaluationDialog] = useState(false);
   const [openUpdateKeysDialog, setOpenUpdateKeysDialog] = useState(false);
   // When non-null, the new EvalPickerDrawer opens directly at the config
-  // step with this template loaded (edit flow).
-  const [editingEvalItem, setEditingEvalItem] = useState(null);
+  // step with the matching row from `evaluationsConfig` loaded (edit flow).
+  // We track only the id and look the row up at render time so we never
+  // hold a stale snapshot if `evaluationsConfig` changes underneath us.
+  const [editingEvalId, setEditingEvalId] = useState(null);
+  const editingEvalItem = useMemo(
+    () =>
+      editingEvalId
+        ? evaluationsConfig.find((e) => e.evalId === editingEvalId) || null
+        : null,
+    [editingEvalId, evaluationsConfig],
+  );
+
   useEffect(() => {
     if (open) {
       setActiveStep(0);
@@ -197,7 +210,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
       });
       setEvaluationsConfig([]);
       setOpenEvaluationDialog(false);
-      setEditingEvalItem(null);
+      setEditingEvalId(null);
       setCompleted({});
     }
   }, [open]);
@@ -618,44 +631,47 @@ const CreateRunTestPage = ({ open, onClose }) => {
     });
   };
 
-  // Transform the new EvalPickerDrawer's camelCase payload into the legacy
-  // `evaluationsConfig` shape expected by the existing render + final POST.
-  // Keeps the rest of CreateRunTestPage untouched.
-  const toLegacyEvalShape = (evalConfig, versionedName) => ({
-    evalId: `${evalConfig.templateId}_${Date.now()}_${Math.random()
-      .toString(36)
-      .slice(2, 8)}`,
-    templateId: evalConfig.templateId,
-    name: versionedName,
-    evalTemplateName: evalConfig.evalTemplate?.name || evalConfig.name,
-    description: evalConfig.evalTemplate?.description || "",
-    type: "user_built",
-    config: {
-      ...(evalConfig.config || {}),
+  
+ 
+  const toLegacyEvalShape = (evalConfig, versionedName) => {
+    const serialized = serializeEvalConfig(evalConfig);
+    return {
+      evalId: `${evalConfig.templateId}_${Date.now()}_${Math.random()
+        .toString(36)
+        .slice(2, 8)}`,
+      templateId: evalConfig.templateId,
+      name: versionedName,
+      evalTemplateName: evalConfig.evalTemplate?.name || evalConfig.name,
+      description: evalConfig.evalTemplate?.description || "",
+      type: "user_built",
       mapping: evalConfig.mapping || {},
-      ...(evalConfig.instructions != null && {
-        instructions: evalConfig.instructions,
-      }),
-      ...(evalConfig.passThreshold != null && {
-        pass_threshold: evalConfig.passThreshold,
-      }),
-      ...(evalConfig.choiceScores &&
-        Object.keys(evalConfig.choiceScores).length > 0 && {
-          choice_scores: evalConfig.choiceScores,
+      config: {
+        ...serialized.config,
+        mapping: evalConfig.mapping || {},
+        ...(evalConfig.instructions != null && {
+          instructions: evalConfig.instructions,
         }),
-    },
-    model: evalConfig.model,
-    evalRequiredKeys:
-      evalConfig.evalTemplate?.required_keys ||
-      evalConfig.evalTemplate?.requiredKeys ||
-      [],
-    evalTemplateTags: evalConfig.evalTemplate?.tags || [],
-    errorLocalizer: false,
-  });
+        ...(evalConfig.passThreshold != null && {
+          pass_threshold: evalConfig.passThreshold,
+        }),
+        ...(evalConfig.choiceScores &&
+          Object.keys(evalConfig.choiceScores).length > 0 && {
+            choice_scores: evalConfig.choiceScores,
+          }),
+      },
+      model: evalConfig.model,
+      evalRequiredKeys:
+        evalConfig.evalTemplate?.required_keys ||
+        evalConfig.evalTemplate?.requiredKeys ||
+        [],
+      evalTemplateTags: evalConfig.evalTemplate?.tags || [],
+      errorLocalizer: !!evalConfig.error_localizer_enabled,
+    };
+  };
 
   const handleAddEvaluation = async (evalConfig) => {
     // Capture edit-target before we close the drawer and clear state.
-    const editingId = editingEvalItem?.evalId || null;
+    const editingId = editingEvalId;
 
     setEvaluationsConfig((prev) => {
       let updated = [...prev];
@@ -671,7 +687,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
     });
 
     setOpenEvaluationDialog(false);
-    setEditingEvalItem(null);
+    setEditingEvalId(null);
   };
 
   const handleRemoveEvaluation = (id, isGroupEval) => {
@@ -810,10 +826,9 @@ const CreateRunTestPage = ({ open, onClose }) => {
       enableToolEvaluation: value,
     }));
   };
-  const handleEditEvalItem = (evalConfig) => {
-    // Pass through to the new picker via `initialEval`: it only needs `.id`
-    // (the eval template id) to load the full template at the config step.
-    setEditingEvalItem(evalConfig);
+
+  const handleEditEvalItem = (evalItem) => {
+    setEditingEvalId(evalItem.evalId);
     setOpenEvaluationDialog(true);
   };
   useEffect(() => {
@@ -1535,7 +1550,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
                   variant="contained"
                   startIcon={<Iconify icon="eva:plus-fill" />}
                   onClick={() => {
-                    setEditingEvalItem(null);
+                    setEditingEvalId(null);
                     setOpenEvaluationDialog(true);
                   }}
                   sx={{
@@ -1568,7 +1583,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
                       variant="outlined"
                       size="small"
                       onClick={() => {
-                        setEditingEvalItem(null);
+                        setEditingEvalId(null);
                         setOpenEvaluationDialog(true);
                       }}
                       startIcon={
@@ -2325,20 +2340,14 @@ const CreateRunTestPage = ({ open, onClose }) => {
         open={openEvaluationDialog}
         onClose={() => {
           setOpenEvaluationDialog(false);
-          setEditingEvalItem(null);
+          setEditingEvalId(null);
         }}
         source="create-simulate"
         sourceColumns={evalColumnsToDisplay}
         sourcePreviewData={sourcePreviewData}
         onEvalAdded={handleAddEvaluation}
-        initialEval={
-          editingEvalItem
-            ? {
-                id: editingEvalItem.templateId,
-                template_id: editingEvalItem.templateId,
-              }
-            : null
-        }
+        existingEvals={editingEvalItem ? [] : evaluationsConfig}
+        initialEval={editingEvalItem || null}
       />
     </>
   );

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1642,6 +1642,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     onColumnsLoaded={handleColumnsLoaded}
                     onReadyChange={handleSourceReadyChange}
                     previewData={sourcePreviewData}
+                    initialMapping={evalData?.mapping}
                   />
                 )}
                 {source === "task" && (

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -28,6 +28,7 @@ import React, {
 } from "react";
 import { useWatch } from "react-hook-form";
 import Iconify from "src/components/iconify";
+import { ShowComponent } from "src/components/show/ShowComponent";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import TaskFilterBar from "src/sections/tasks/components/TaskFilterBar";
 import { buildApiFilterArray } from "src/sections/tasks/components/TaskLivePreview";
@@ -290,6 +291,16 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     compositeDetail,
     templateFormat,
   ]);
+
+
+  const hasDataInjection = useMemo(
+    () =>
+      evalType === "agent" &&
+      (source === "task" || source === "tracing") &&
+      Array.isArray(contextOptions) &&
+      contextOptions.some((o) => o && o !== "variables_only"),
+    [evalType, source, contextOptions],
+  );
 
   const visibleCodeParamEntries = useMemo(() => {
     if (!functionParamsSchema) return [];
@@ -1777,6 +1788,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             settings only. */}
         {source !== "composite" &&
           !sourceReady &&
+          !hasDataInjection &&
           !testError &&
           !testPassed && (
             <Typography
@@ -1820,7 +1832,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           } else if (!hasInstructions) {
             testDisabled = true;
             testDisabledReason = "Add instructions before running a test.";
-          } else if (!hasVariables) {
+          } else if (!hasVariables && !hasDataInjection) {
             testDisabled = true;
             testDisabledReason =
               templateFormat === "jinja"
@@ -1828,38 +1840,42 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                 : "Your Mustache template has no variables. Add a {{variable}} placeholder (e.g. {{input}}) so test input can be passed in.";
           }
 
-          if (!testDisabled && !sourceReady) {
+          if (!testDisabled && !sourceReady && !hasDataInjection) {
             testDisabled = true;
             testDisabledReason = "Map all variables before running a test.";
           }
 
           return (
-            <CustomTooltip
-              show={testDisabled && !!testDisabledReason}
-              type=""
-              title={testDisabledReason}
-              arrow
+            <ShowComponent
+              condition={!hasDataInjection }
             >
-              <span>
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  size="small"
-                  onClick={handleTestEvaluation}
-                  disabled={testDisabled}
-                  startIcon={
-                    isTesting ? (
-                      <CircularProgress size={14} />
-                    ) : (
-                      <Iconify icon="mdi:play-circle-outline" width={16} />
-                    )
-                  }
-                  sx={{ textTransform: "none" }}
-                >
-                  {isTesting ? "Testing..." : "Test Evaluation"}
-                </Button>
-              </span>
-            </CustomTooltip>
+              <CustomTooltip
+                show={testDisabled && !!testDisabledReason}
+                type=""
+                title={testDisabledReason}
+                arrow
+              >
+                <span>
+                  <Button
+                    variant="outlined"
+                    color="primary"
+                    size="small"
+                    onClick={handleTestEvaluation}
+                    disabled={testDisabled}
+                    startIcon={
+                      isTesting ? (
+                        <CircularProgress size={14} />
+                      ) : (
+                        <Iconify icon="mdi:play-circle-outline" width={16} />
+                      )
+                    }
+                    sx={{ textTransform: "none" }}
+                  >
+                    {isTesting ? "Testing..." : "Test Evaluation"}
+                  </Button>
+                </span>
+              </CustomTooltip>
+            </ShowComponent>
           );
         })()}
 
@@ -1889,7 +1905,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           } else if (!hasInstructions) {
             addDisabled = true;
             addDisabledReason = `Add instructions before ${actionLabel}.`;
-          } else if (!hasVariables) {
+          } else if (!hasVariables && !hasDataInjection) {
             addDisabled = true;
             addDisabledReason =
               templateFormat === "jinja"
@@ -1899,7 +1915,12 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
 
           // Non-composite flows additionally require the full source config
           // (name / output type / etc.) to be valid.
-          if (!addDisabled && source !== "composite" && !sourceReady) {
+          if (
+            !addDisabled &&
+            source !== "composite" &&
+            !sourceReady &&
+            !hasDataInjection
+          ) {
             addDisabled = true;
             addDisabledReason = `Map all variables before ${actionLabel}.`;
           }

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -47,6 +47,23 @@ import DatasetTestMode from "src/sections/evals/components/DatasetTestMode";
 import TracingTestMode from "src/sections/evals/components/TracingTestMode";
 import SimulationTestMode from "src/sections/evals/components/SimulationTestMode";
 import { useEvalPickerContext } from "./context/EvalPickerContext";
+import { contextOptionsForRowType } from "./evalPickerConfigUtils";
+const dataInjectionFromContextOptions = (opts) => {
+  if (
+    !opts ||
+    opts.length === 0 ||
+    (opts.length === 1 && opts[0] === "variables_only")
+  ) {
+    return { variables_only: true };
+  }
+  const flags = {};
+  if (opts.includes("dataset_row")) flags.full_row = true;
+  if (opts.includes("span_context")) flags.span_context = true;
+  if (opts.includes("trace_context")) flags.trace_context = true;
+  if (opts.includes("session_context")) flags.session_context = true;
+  if (opts.includes("call_context")) flags.call_context = true;
+  return Object.keys(flags).length > 0 ? flags : { variables_only: true };
+};
 
 const PYTHON_CODE_TEMPLATE = `from typing import Any
 
@@ -114,6 +131,9 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   const [templateFormat, setTemplateFormat] = useState("mustache");
   const [datasetColumns, setDatasetColumns] = useState([]);
   const [datasetJsonSchemas, setDatasetJsonSchemas] = useState({});
+  const [contextOptions, setContextOptions] = useState(
+    () => contextOptionsForRowType(sourceRowType) || ["variables_only"],
+  );
 
   const localFormFilters = useWatch({
     control: localFilterForm.control,
@@ -248,6 +268,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
           ? fewShotExamples.map((ds) => ({ id: ds.id, name: ds.name }))
           : undefined,
       template_format: templateFormat,
+      data_injection:
+        evalType === "agent"
+          ? dataInjectionFromContextOptions(contextOptions)
+          : undefined,
     }),
     [
       evalType,
@@ -261,6 +285,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       messages,
       fewShotExamples,
       templateFormat,
+      contextOptions,
     ],
   );
 
@@ -441,7 +466,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       if (source === "task" && onFiltersChange) {
         onFiltersChange(localFilterForm.getValues("filters") || []);
       }
-      // Now add to the current context
+      // Now add to the current context. data_injection (seeded from
+      // sourceRowType) is forwarded so the consumer's serializeEvalConfig
+      // captures it inside config.run_config — same shape an existing
+      // eval would emit through EvalPickerConfigFull.
       onSave({
         templateId: draftId,
         evalTemplateId: draftId,
@@ -451,6 +479,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         evalType,
         outputType,
         instructions,
+        data_injection:
+          evalType === "agent"
+            ? dataInjectionFromContextOptions(contextOptions)
+            : undefined,
       });
     } catch (error) {
       enqueueSnackbar(error?.message || "Failed to save", { variant: "error" });
@@ -471,6 +503,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     evalType,
     outputType,
     instructions,
+    contextOptions,
     enqueueSnackbar,
     isOSS,
     source,
@@ -843,6 +876,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     datasetColumns={datasetColumns}
                     datasetJsonSchemas={datasetJsonSchemas}
                     mappedVariables={sourceMapping}
+                    activeContextOptions={contextOptions}
+                    onActiveContextOptionsChange={setContextOptions}
                   />
                   {errors.instructions && (
                     <Typography variant="caption" color="error.main">

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -22,6 +22,7 @@ import React, {
 } from "react";
 import { useWatch } from "react-hook-form";
 import Iconify from "src/components/iconify";
+import { ShowComponent } from "src/components/show/ShowComponent";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import TaskFilterBar from "src/sections/tasks/components/TaskFilterBar";
 import { buildApiFilterArray } from "src/sections/tasks/components/TaskLivePreview";
@@ -48,6 +49,13 @@ import TracingTestMode from "src/sections/evals/components/TracingTestMode";
 import SimulationTestMode from "src/sections/evals/components/SimulationTestMode";
 import { useEvalPickerContext } from "./context/EvalPickerContext";
 import { contextOptionsForRowType } from "./evalPickerConfigUtils";
+const TRACING_ROW_TYPE_TO_KEY = {
+  Span: "spans",
+  Trace: "traces",
+  Session: "sessions",
+  VoiceCall: "voiceCalls",
+};
+
 const dataInjectionFromContextOptions = (opts) => {
   if (
     !opts ||
@@ -134,6 +142,14 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   const [contextOptions, setContextOptions] = useState(
     () => contextOptionsForRowType(sourceRowType) || ["variables_only"],
   );
+
+
+  const handleSourceRowTypeChange = useCallback((rt) => {
+    const map =  TRACING_ROW_TYPE_TO_KEY;
+    const key = map[rt];
+    const seeded = key ? contextOptionsForRowType(key) : null;
+    if (seeded) setContextOptions(seeded);
+  }, []);
 
   const localFormFilters = useWatch({
     control: localFilterForm.control,
@@ -321,6 +337,15 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     }
   }, [draftId, buildPayload, updateDraft, handleTestResult]);
 
+  const hasDataInjection = useMemo(
+    () =>
+      evalType === "agent" &&
+      (source === "task" || source === "tracing") &&
+      Array.isArray(contextOptions) &&
+      contextOptions.some((o) => o && o !== "variables_only"),
+    [evalType, source, contextOptions],
+  );
+
   // Validate all required fields for single-eval mode. Composite mode has
   // its own light validation (name + at least one child) inside
   // handleSaveAndAddComposite, so this gate is only applied to the
@@ -347,14 +372,15 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       if (!code.trim()) next.instructions = "Code is required";
     } else if (!instructions.trim()) {
       next.instructions = "Instructions are required";
-    } else if (!/\{\{\s*[^{}]+?\s*\}\}/.test(instructions)) {
+    } else if (
+      !hasDataInjection &&
+      !/\{\{\s*[^{}]+?\s*\}\}/.test(instructions)
+    ) {
       next.instructions =
         "Instructions must contain at least one template variable (e.g. {{input}})";
     }
 
-    // Mapping — no dataset to map against in the composite child-picker flow,
-    // so skip this check. Matches the canSave bypass below.
-    if (!sourceReady && source !== "composite") {
+    if (!sourceReady && source !== "composite" && !hasDataInjection) {
       next.mapping = "Map all variables before saving";
     }
 
@@ -390,6 +416,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     passThreshold,
     outputType,
     choiceScores,
+    hasDataInjection,
   ]);
 
   // Field-change wrappers — set the value and clear the corresponding
@@ -589,7 +616,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     ? !!name.trim() && selectedChildren.length > 0
     : name.trim() &&
       (evalType === "code" ? code.trim() : instructions.trim()) &&
-      (source === "composite" || sourceReady);
+      (source === "composite" || sourceReady || hasDataInjection);
 
   // Variables from instructions
   const variables = useMemo(() => {
@@ -1120,6 +1147,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     variables={isComposite ? compositeUnionKeys : variables}
                     onTestResult={handleTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
+                    onRowTypeChange={handleSourceRowTypeChange}
                     isComposite={isComposite}
                     compositeAdhocConfig={compositeAdhocConfig}
                   />
@@ -1213,7 +1241,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
             </Typography>
           </Box>
         )}
-        {!sourceReady && !testError && !testPassed && (
+        {!sourceReady && !hasDataInjection && !testError && !testPassed && (
           <Typography
             variant="caption"
             color="text.disabled"
@@ -1224,28 +1252,32 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
           </Typography>
         )}
 
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={handleTestEvaluation}
-          disabled={
-            isTesting ||
-            !sourceReady ||
-            !draftId ||
-            isComposite ||
-            source === "workbench"
-          }
-          startIcon={
-            isTesting ? (
-              <CircularProgress size={14} />
-            ) : (
-              <Iconify icon="mdi:play-circle-outline" width={16} />
-            )
-          }
-          sx={{ textTransform: "none" }}
+        <ShowComponent
+          condition={!hasDataInjection }
         >
-          {isTesting ? "Testing..." : "Test Evaluation"}
-        </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleTestEvaluation}
+            disabled={
+              isTesting ||
+              (!sourceReady && !hasDataInjection) ||
+              !draftId ||
+              isComposite ||
+              source === "workbench"
+            }
+            startIcon={
+              isTesting ? (
+                <CircularProgress size={14} />
+              ) : (
+                <Iconify icon="mdi:play-circle-outline" width={16} />
+              )
+            }
+            sx={{ textTransform: "none" }}
+          >
+            {isTesting ? "Testing..." : "Test Evaluation"}
+          </Button>
+        </ShowComponent>
 
         <LoadingButton
           variant="contained"

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -49,6 +49,7 @@ import TracingTestMode from "src/sections/evals/components/TracingTestMode";
 import SimulationTestMode from "src/sections/evals/components/SimulationTestMode";
 import { useEvalPickerContext } from "./context/EvalPickerContext";
 import { contextOptionsForRowType } from "./evalPickerConfigUtils";
+
 const TRACING_ROW_TYPE_TO_KEY = {
   Span: "spans",
   Trace: "traces",
@@ -143,9 +144,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     () => contextOptionsForRowType(sourceRowType) || ["variables_only"],
   );
 
-
   const handleSourceRowTypeChange = useCallback((rt) => {
-    const map =  TRACING_ROW_TYPE_TO_KEY;
+    const map = TRACING_ROW_TYPE_TO_KEY;
     const key = map[rt];
     const seeded = key ? contextOptionsForRowType(key) : null;
     if (seeded) setContextOptions(seeded);

--- a/frontend/src/sections/common/EvalPicker/EvalPickerList.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerList.jsx
@@ -508,7 +508,8 @@ const EvalPickerList = ({ onSelectEval }) => {
         (e) =>
           e.id === evalId ||
           e.eval_template_id === evalId ||
-          e.template_id === evalId,
+          e.template_id === evalId ||
+          e["templateId"] === evalId,
       ),
     [existingEvals],
   );

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
@@ -7,7 +7,7 @@ const OUTPUT_TYPE_CONFIG_MAP = {
 const ROW_TYPE_CONTEXT_OPTIONS = {
   spans: ["span_context"],
   traces: ["trace_context"],
-  sessions: ["session_context", "trace_context"],
+  sessions: ["session_context"],
   voiceCalls: ["call_context"],
 };
 

--- a/frontend/src/sections/common/EvalPicker/index.js
+++ b/frontend/src/sections/common/EvalPicker/index.js
@@ -7,3 +7,4 @@ export { default as EvalPickerCreateNew } from "./EvalPickerCreateNew";
 export { useEvalPickerContext } from "./context/EvalPickerContext";
 export { default as EvalPickerProvider } from "./context/EvalPickerProvider";
 export { useEvalPickerData } from "./hooks/useEvalPickerData";
+export { serializeEvalConfig } from "./serializeEvalConfig";

--- a/frontend/src/sections/common/EvalPicker/serializeEvalConfig.js
+++ b/frontend/src/sections/common/EvalPicker/serializeEvalConfig.js
@@ -1,0 +1,53 @@
+// Translate the camelCase output of EvalPickerConfigFull.handleAdd into the
+// snake_case payload accepted by simulate/run-tests/eval-configs/update and
+// the simulate add endpoint. RUN_CONFIG_KEYS mirrors the BE's
+//
+// Each runtime override is emitted in two places:
+//   1. Inside `config.run_config.*` — canonical location consumed by the BE's
+//      normalize_eval_runtime_config + the simulation runner (xl.py:741-786).
+//   2. Mirrored at the payload root — picked up by EvalPickerConfigFull's
+//      init-effect fallbacks (`evalData?.<key>`) on edit-reopen, so the
+//      prefill renders the user's saved choice instead of the template
+//      default whenever the BE round-trips fields at the top level.
+// `error_localizer_enabled` rides in run_config too (alongside the top-level
+// `error_localizer: bool`), so `config.error_localizer_enabled` resolves on
+// edit-reopen without a per-drawer rehydration patch.
+const RUN_CONFIG_KEYS = [
+  "model",
+  "agent_mode",
+  "check_internet",
+  "summary",
+  "tools",
+  "knowledge_bases",
+  "mcp_connectors",
+  "data_injection",
+  "pass_threshold",
+  "params",
+];
+
+export function serializeEvalConfig(evalConfig) {
+
+  const runConfig = {};
+  for (const k of RUN_CONFIG_KEYS) {
+    if (evalConfig[k] !== undefined) runConfig[k] = evalConfig[k];
+  }
+  if (evalConfig.error_localizer_enabled !== undefined) {
+    runConfig.error_localizer_enabled = !!evalConfig.error_localizer_enabled;
+  }
+  return {
+   ...runConfig,
+    template_id: evalConfig.templateId,
+    name: evalConfig.name,
+    model: evalConfig.model,
+    mapping: evalConfig.mapping || {},
+    config: {
+      ...(evalConfig.config || {}),
+      run_config: {
+        ...(evalConfig.config?.run_config || {}),
+        ...runConfig,
+      },
+    },
+    error_localizer: !!evalConfig.error_localizer_enabled,
+    filters: evalConfig.filters || {},
+  };
+}

--- a/frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx
+++ b/frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx
@@ -162,10 +162,15 @@ const CreateSimulationPreviewMode = React.forwardRef(
       onReadyChange,
       onTestResult,
       previewData,
+      initialMapping = null,
     },
     ref,
   ) => {
-    const [mapping, setMapping] = useState({});
+    const [mapping, setMapping] = useState(
+      initialMapping && typeof initialMapping === "object"
+        ? { ...initialMapping }
+        : {},
+    );
     const [tableSearch, setTableSearch] = useState("");
     const [expandedCols, setExpandedCols] = useState({});
 

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -10,6 +10,7 @@ import {
   TextField,
   Tooltip,
   Typography,
+  alpha,
 } from "@mui/material";
 import {
   useInfiniteQuery,
@@ -147,6 +148,55 @@ const FAGI_MODELS = [
 
 export const FAGI_MODEL_VALUES = new Set(FAGI_MODELS.map((m) => m.value));
 
+const CHIP_STYLES = {
+  backgroundColor: (theme) =>
+    alpha(
+      theme.palette.primary.main,
+      theme.palette.mode === "dark" ? 0.24 : 0.1,
+    ),
+  "&:hover": {
+    backgroundColor: (theme) =>
+      alpha(
+        theme.palette.primary.main,
+        theme.palette.mode === "dark" ? 0.32 : 0.16,
+      ),
+  },
+  color: (theme) =>
+    theme.palette.mode === "dark"
+      ? theme.palette.primary.light
+      : theme.palette.primary.main,
+  border: "1px solid",
+  borderColor: (theme) =>
+    alpha(
+      theme.palette.primary.main,
+      theme.palette.mode === "dark" ? 0.4 : 0.2,
+    ),
+  borderRadius: "4px",
+  fontWeight: 500,
+  fontSize: "11px",
+  height: 22,
+  "& .MuiChip-label": { px: 0.75 },
+  "& .MuiChip-icon": {
+    color: "inherit",
+  },
+  "& .MuiChip-deleteIcon": {
+    margin: "0 4px 0 -2px",
+    color: (theme) =>
+      theme.palette.mode === "dark"
+        ? theme.palette.primary.light
+        : theme.palette.primary.main,
+    transition: "color 0.15s ease",
+    "&:hover": {
+      color: (theme) =>
+        theme.palette.mode === "dark"
+          ? theme.palette.primary.contrastText
+          : theme.palette.primary.dark,
+    },
+  },
+};
+
+const DELETE_ICON = <Iconify icon="mdi:close" width={12} />;
+
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
 // Summary Chip — resolves name for both presets and custom templates
@@ -179,7 +229,8 @@ function SummaryChip({ activeSummary, onClick, onDelete }) {
       label={chipLabel}
       onClick={onClick}
       onDelete={onDelete}
-      sx={{ height: 22, fontSize: "11px", fontWeight: 500, cursor: "pointer" }}
+      deleteIcon={DELETE_ICON}
+      sx={{ ...CHIP_STYLES, cursor: "pointer" }}
     />
   );
 }
@@ -802,7 +853,8 @@ const ModelSelector = ({
           icon={<Iconify icon="mdi:web" width={12} sx={{ ml: 0.5 }} />}
           label="Internet"
           onDelete={() => setUseInternet(false)}
-          sx={{ height: 22, fontSize: "11px", fontWeight: 500 }}
+          deleteIcon={DELETE_ICON}
+          sx={CHIP_STYLES}
         />
       )}
       {showPlus && activeSummary && activeSummary !== "concise" && (
@@ -859,7 +911,8 @@ const ModelSelector = ({
               onDelete={() =>
                 setActiveConnectorIds((p) => p.filter((x) => x !== cId))
               }
-              sx={{ height: 22, fontSize: "11px", fontWeight: 500 }}
+              deleteIcon={DELETE_ICON}
+              sx={CHIP_STYLES}
             />
           );
         })}
@@ -897,12 +950,8 @@ const ModelSelector = ({
               setPlusSubmenu("knowledge");
             }}
             onDelete={() => setSelectedKBs([])}
-            sx={{
-              height: 22,
-              fontSize: "11px",
-              fontWeight: 500,
-              cursor: "pointer",
-            }}
+            deleteIcon={DELETE_ICON}
+            sx={{ ...CHIP_STYLES, cursor: "pointer" }}
           />
         </Tooltip>
       )}
@@ -944,12 +993,8 @@ const ModelSelector = ({
                 setPlusSubmenu("injection");
               }}
               onDelete={() => setActiveContextOptions(["variables_only"])}
-              sx={{
-                height: 22,
-                fontSize: "11px",
-                fontWeight: 500,
-                cursor: "pointer",
-              }}
+              deleteIcon={DELETE_ICON}
+              sx={{ ...CHIP_STYLES, cursor: "pointer" }}
             />
           </Tooltip>
         )}
@@ -1552,7 +1597,8 @@ const ModelSelector = ({
                               prev.filter((x) => x !== kbId),
                             )
                           }
-                          sx={{ height: 20, fontSize: "11px" }}
+                          deleteIcon={DELETE_ICON}
+                          sx={{ ...CHIP_STYLES, height: 20 }}
                         />
                       );
                     })}
@@ -1634,16 +1680,13 @@ const ModelSelector = ({
                       onClick={() => {
                         setActiveContextOptions((prev) => {
                           if (opt.isDefault) {
-                            // Clicking "variables_only" deselects everything else
+                            // Clicking "variables_only" clears any active context.
                             return ["variables_only"];
                           }
-                          // Toggle the clicked option
-                          let next = prev.includes(opt.value)
-                            ? prev.filter((x) => x !== opt.value)
-                            : [...prev.filter((x) => x !== "variables_only"), opt.value];
-                          // If nothing left, revert to variables_only
-                          if (next.length === 0) next = ["variables_only"];
-                          return next;
+                          if (prev.includes(opt.value)) {
+                            return ["variables_only"];
+                          }
+                          return [opt.value];
                         });
                       }}
                       sx={{

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -23,7 +23,11 @@ import Iconify from "src/components/iconify";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import FilterErrorBoundary from "src/components/ComplexFilter/FilterErrorBoundary";
-import { EvalPickerDrawer } from "src/sections/common/EvalPicker";
+
+import {
+  EvalPickerDrawer,
+  serializeEvalConfig,
+} from "src/sections/common/EvalPicker";
 import TaskSchedulingSection from "./TaskSchedulingSection";
 import { getNewTaskFilters } from "src/sections/tasks/schema";
 import { objectCamelToSnake } from "src/utils/utils";
@@ -389,74 +393,72 @@ const TaskConfigPanel = ({
 
   const handleEvalAdded = useCallback(
     async (evalConfig) => {
-     
       const tplId = evalConfig.templateId || evalConfig.template_id;
-      let finalEval = { ...evalConfig, template_id: tplId };
 
       // When editing, configuredEvals[editingIndex].id is always the CustomEvalConfig id
       // (set from POST response on first add, or from the API on task load)
       const customEvalConfigId =
         editingIndex !== null ? configuredEvals[editingIndex]?.id : undefined;
 
+      const serialized = serializeEvalConfig(evalConfig);
+      const kbList = Array.isArray(evalConfig.knowledge_bases)
+        ? evalConfig.knowledge_bases
+        : [];
+      const kbId = kbList[0] || null;
+
+      const corePayload = {
+        eval_template: tplId,
+        name: evalConfig.name,
+        model: evalConfig.model || null,
+        mapping: evalConfig.mapping || {},
+        config: {
+          ...serialized.config,
+          mapping: evalConfig.mapping || {},
+        },
+        error_localizer: !!evalConfig.errorLocalizerEnabled,
+        kb_id: kbId,
+      };
+
+      let finalEval = { ...evalConfig, template_id: tplId };
       try {
         if (customEvalConfigId) {
           const { data: resp } = await axios.patch(
             endpoints.project.updateEvalTaskConfig(customEvalConfigId),
-            {
-              eval_template: tplId,
-              name: evalConfig.name,
-              model: evalConfig.model || null,
-              mapping: evalConfig.mapping,
-              config: {
-                ...(evalConfig.config || {}),
-                mapping: evalConfig.mapping,
-                ...(evalConfig.data_injection
-                  ? { run_config: { data_injection: evalConfig.data_injection } }
-                  : {}),
-              },
-              error_localizer: evalConfig.errorLocalizerEnabled || false,
-            },
+            corePayload,
           );
           finalEval = {
             ...evalConfig,
             id: resp?.result?.id ?? customEvalConfigId,
             template_id: tplId,
             templateId: tplId,
+            config: {
+              ...(evalConfig.config || {}),
+              ...corePayload.config,
+            },
+            mapping: evalConfig.mapping || {},
           };
         } else {
           const { data: resp } = await axios.post(
             endpoints.project.createEvalTaskConfig(),
-            {
-              project: project,
-              eval_template: tplId,
-              name: evalConfig.name,
-              model: evalConfig.model || null,
-              mapping: evalConfig.mapping,
-              config: {
-                ...(evalConfig.config || {}),
-                mapping: evalConfig.mapping,
-                ...(evalConfig.data_injection
-                  ? { run_config: { data_injection: evalConfig.data_injection } }
-                  : {}),
-              },
-              error_localizer: evalConfig.errorLocalizerEnabled || false,
-            },
+            { project, ...corePayload },
           );
-          // Store the custom_eval_config id separately — keep template_id intact
-          // so the eval card and test runner can still look up the template.
           finalEval = {
             ...evalConfig,
             id: resp?.result?.id,
             template_id: tplId,
             templateId: tplId,
+            config: {
+              ...(evalConfig.config || {}),
+              ...corePayload.config,
+            },
+            mapping: evalConfig.mapping || {},
           };
         }
       } catch (error) {
-       
         enqueueSnackbar(
           error?.response?.data?.result ||
-            error?.response?.data?.error ||
-            "Failed to save evaluation",
+          error?.response?.data?.error ||
+          "Failed to save evaluation",
           { variant: "error" },
         );
         throw error;
@@ -503,7 +505,7 @@ const TaskConfigPanel = ({
     if (!stored) return null;
     // API response uses `eval_template` for the template FK;
     // locally-added evals use `templateId` / `template_id`.
-    const tplId =  stored.templateId || stored.template_id || stored.eval_template;
+    const tplId = stored.templateId || stored.template_id || stored.eval_template;
 
     const savedErrorLocalizer =
       stored.error_localizer_enabled ?? stored.error_localizer;
@@ -654,16 +656,16 @@ const TaskConfigPanel = ({
                         bgcolor:
                           rowType === t.value
                             ? (theme) =>
-                                theme.palette.mode === "dark"
-                                  ? "rgba(255,255,255,0.12)"
-                                  : "background.paper"
+                              theme.palette.mode === "dark"
+                                ? "rgba(255,255,255,0.12)"
+                                : "background.paper"
                             : "transparent",
                         boxShadow:
                           rowType === t.value
                             ? (theme) =>
-                                theme.palette.mode === "dark"
-                                  ? "none"
-                                  : "0 1px 3px rgba(0,0,0,0.08)"
+                              theme.palette.mode === "dark"
+                                ? "none"
+                                : "0 1px 3px rgba(0,0,0,0.08)"
                             : "none",
                         borderRadius: "6px",
                         fontWeight: rowType === t.value ? 600 : 400,

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -16,7 +16,6 @@ import {
 } from "@mui/material";
 import { useFieldArray, useFormState, useWatch } from "react-hook-form";
 import { useQuery } from "@tanstack/react-query";
-import { enqueueSnackbar } from "notistack";
 import axios, { endpoints } from "src/utils/axios";
 import _ from "lodash";
 import Iconify from "src/components/iconify";

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -401,10 +401,7 @@ const TaskConfigPanel = ({
         editingIndex !== null ? configuredEvals[editingIndex]?.id : undefined;
 
       const serialized = serializeEvalConfig(evalConfig);
-      const kbList = Array.isArray(evalConfig.knowledge_bases)
-        ? evalConfig.knowledge_bases
-        : [];
-      const kbId = kbList[0] || null;
+
 
       const corePayload = {
         eval_template: tplId,
@@ -416,7 +413,6 @@ const TaskConfigPanel = ({
           mapping: evalConfig.mapping || {},
         },
         error_localizer: !!evalConfig.errorLocalizerEnabled,
-        kb_id: kbId,
       };
 
       let finalEval = { ...evalConfig, template_id: tplId };

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -572,7 +572,7 @@ const TaskLivePreview = forwardRef(function TaskLivePreview(
           const savedMapping = evalItem?.mapping || {};
           const playgroundConfig = {
             ...(Object.keys(diFlags).length > 0
-              ? { data_injection: diFlags }
+              ? { run_config: { data_injection: diFlags } }
               : {}),
           };
           if (!isSession) {

--- a/frontend/src/sections/test-detail/TestDetailConfigureEval.jsx
+++ b/frontend/src/sections/test-detail/TestDetailConfigureEval.jsx
@@ -4,7 +4,10 @@ import { useParams } from "react-router";
 
 import axios, { endpoints } from "src/utils/axios";
 import { enqueueSnackbar } from "src/components/snackbar";
-import { EvalPickerDrawer } from "src/sections/common/EvalPicker";
+import {
+  EvalPickerDrawer,
+  serializeEvalConfig,
+} from "src/sections/common/EvalPicker";
 import {
   chatEvalColumns,
   voiceEvalColumns,
@@ -85,27 +88,10 @@ const TestDetailConfigureEval = () => {
     refreshGrid?.();
   }, [queryClient, testId, refreshGrid]);
 
-  // Bridge — the new picker returns a camelCase config; the backend expects
-  // snake_case. Config Eval is always an edit flow (the user is reconfiguring
-  // an existing SimulateEvalConfig bound to a grid column), so we always
-  // route through the update endpoint.
   const handleEvalAdded = useCallback(
     async (evalConfig) => {
       if (!testId || !editingEvalItem?.id) return;
-      const payload = {
-        template_id: evalConfig.templateId,
-        name: evalConfig.name,
-        model: evalConfig.model,
-        mapping: evalConfig.mapping || {},
-        config: {
-          ...(evalConfig.config || {}),
-          ...(evalConfig.data_injection
-            ? { run_config: { data_injection: evalConfig.data_injection } }
-            : {}),
-        },
-        error_localizer: evalConfig.error_localizer_enabled || false,
-        filters: {},
-      };
+      const payload = serializeEvalConfig(evalConfig);
       try {
         await updateEvalAsync({
           evalConfigId: editingEvalItem.id,

--- a/frontend/src/sections/test/TestEvaluationDrawer.jsx
+++ b/frontend/src/sections/test/TestEvaluationDrawer.jsx
@@ -6,7 +6,10 @@ import { useParams } from "react-router";
 
 import axios, { endpoints } from "src/utils/axios";
 import { enqueueSnackbar } from "src/components/snackbar";
-import { EvalPickerDrawer } from "src/sections/common/EvalPicker";
+import {
+  EvalPickerDrawer,
+  serializeEvalConfig,
+} from "src/sections/common/EvalPicker";
 import {
   chatEvalColumns,
   voiceEvalColumns,
@@ -90,23 +93,12 @@ const TestEvaluationDrawer = ({ executionIds, onSuccessOfAdditionOfEvals }) => {
     });
   }, [queryClient, testId]);
 
-  // Bridge — the new drawer returns a camelCase config; the backend expects
-  // snake_case. When `editingEvalItem` is set we route to the update endpoint
-  // and keep the existing SimulateEvalConfig row; otherwise we create a new
-  // config via the add endpoint.
+
   const handleEvalAdded = useCallback(
     async (evalConfig) => {
       if (!testId) return;
       const editing = editingEvalItem;
-      const payload = {
-        template_id: evalConfig.templateId,
-        name: evalConfig.name,
-        model: evalConfig.model,
-        mapping: evalConfig.mapping || {},
-        config: evalConfig.config || {},
-        error_localizer: false,
-        filters: {},
-      };
+      const payload = serializeEvalConfig(evalConfig);
       try {
         if (editing?.id) {
           await updateEvalAsync({

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationDrawer.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationDrawer.jsx
@@ -6,7 +6,10 @@ import { useParams } from "react-router";
 
 import axios, { endpoints } from "src/utils/axios";
 import { enqueueSnackbar } from "src/components/snackbar";
-import { EvalPickerDrawer } from "src/sections/common/EvalPicker";
+import {
+  EvalPickerDrawer,
+  serializeEvalConfig,
+} from "src/sections/common/EvalPicker";
 import { chatEvalColumns } from "src/components/run-tests/common";
 
 import SimulationEvaluationPage from "./SimulationEvaluationPage";
@@ -76,26 +79,11 @@ const SimulationEvaluationDrawer = ({ open, onClose, onSuccess }) => {
     refetchSimulation?.();
   }, [queryClient, promptTemplateId, simulationId, refetchSimulation]);
 
-  // Bridge — the new drawer returns a camelCase config; the backend expects
-  // snake_case. When `editingEvalItem` is set we route to the update endpoint
-  // and keep the existing SimulateEvalConfig row; otherwise we create a new
-  // config via the add endpoint.
   const handleEvalAdded = useCallback(
     async (evalConfig) => {
       if (!simulationId) return;
       const editing = editingEvalItem;
-      const payload = {
-        template_id: evalConfig.templateId,
-        name: evalConfig.name,
-        model: evalConfig.model,
-        mapping: evalConfig.mapping || {},
-        // Backend merges with the stored template config via
-        // normalize_eval_runtime_config, so passing the full template config
-        // (or an empty object) both work.
-        config: evalConfig.config || {},
-        error_localizer: false,
-        filters: {},
-      };
+      const payload = serializeEvalConfig(evalConfig);
       try {
         if (editing?.id) {
           await updateEvalAsync({


### PR DESCRIPTION
## Summary

FE-only PR extracted from #288 so the BE work there can be reviewed independently. Two commits, both authored by @cdileep23:

- **style(evals)**: violet capability chips, thin delete icon, single-select data-injection control on eval picker
- **fix(eval-picker)**: extend the data-injection bypass to all Save / Test gates and the Update form (so an eval with `data_injection` enabled doesn't get blocked by the variable-mapping gate)

## Why split

PR #288 carries the BE wiring for runtime override coverage + version snapshot completeness + session/trace context loading. Mixing FE picker changes in there made the BE diff harder to review. Splitting keeps each PR focused.

## Test plan

- [ ] Open the eval-picker drawer — verify the capability chips render with the new violet styling
- [ ] On an eval template with `data_injection` enabled (e.g. `session_context: true`), confirm the Save / Test / Add Evaluation buttons activate without requiring a variable mapping
- [ ] Same on the Update / edit flow (pencil button on an attached eval)