### PR TITLE
fix: clarify storage billing cadence

### DIFF
--- a/frontend/src/sections/settings/PricingV3/PricingPage.jsx
+++ b/frontend/src/sections/settings/PricingV3/PricingPage.jsx
@@ -59,6 +59,36 @@ function formatCompact(n) {
   return n.toLocaleString();
 }
 
+function getPricingDisplayUnit(dimKey, pricing) {
+  return pricing.display_unit || dimKey;
+}
+
+function getPricingRateUnit(dimKey, pricing) {
+  const displayUnit = getPricingDisplayUnit(dimKey, pricing);
+  return dimKey === "storage" ? `${displayUnit}/mo` : displayUnit;
+}
+
+function getStorageBillingCopy(storagePricing) {
+  const freeTier = storagePricing?.tiers?.find(
+    (tier) => tier.price_per_unit === 0 && Number.isFinite(tier.up_to),
+  );
+  const paidTier = storagePricing?.tiers?.find(
+    (tier) => Number.isFinite(tier.price_per_unit) && tier.price_per_unit > 0,
+  );
+
+  if (!freeTier || !paidTier) return null;
+
+  const exampleOverage = 10;
+  const exampleUsage = freeTier.up_to + exampleOverage;
+  const exampleCost = paidTier.price_per_unit * exampleOverage;
+  const unit = storagePricing.display_unit || "GB";
+
+  return {
+    allowance: `First ${formatCompact(freeTier.up_to)} ${unit} included each month.`,
+    example: `Example: ${formatCompact(exampleUsage)} ${unit} uses ${formatCompact(exampleOverage)} extra ${unit}, billed at ${fCurrency(paidTier.price_per_unit)}/${unit}/mo for ${fCurrency(exampleCost)}/mo.`,
+  };
+}
+
 // Constants imported from ./constants.js
 
 // ── Tier Card (Free / PAYG) ────────────────────────────────────────────────
@@ -434,8 +464,8 @@ function FeatureMatrix({ plansData }) {
         </TableHead>
         <TableBody>
           {FEATURE_GROUPS.map((group) => (
-            <>
-              <TableRow key={group.name}>
+            <React.Fragment key={group.name}>
+              <TableRow>
                 <TableCell
                   colSpan={6}
                   sx={{
@@ -519,7 +549,7 @@ function FeatureMatrix({ plansData }) {
                   })}
                 </TableRow>
               ))}
-            </>
+            </React.Fragment>
           ))}
         </TableBody>
       </Table>
@@ -706,6 +736,7 @@ export default function PricingPage() {
   const currentAddon = addons.find((a) => a.key === currentPlan);
   const dialogAddon = addons.find((a) => a.key === addonDialog.plan);
   const isDialogLoading = addonMutation.isPending || removeMutation.isPending;
+  const storageBillingCopy = getStorageBillingCopy(data?.pricing?.storage);
 
   // Build plan data map for feature matrix
   const plansData = {};
@@ -885,7 +916,7 @@ export default function PricingPage() {
                               >
                                 {tier.start.toLocaleString()} -{" "}
                                 {tier.end ? tier.end.toLocaleString() : "+"}{" "}
-                                {dim.display_unit}
+                                {getPricingDisplayUnit(dimKey, dim)}
                               </TableCell>
                               <TableCell
                                 sx={{
@@ -894,7 +925,7 @@ export default function PricingPage() {
                                 }}
                               >
                                 {fCurrency(tier.rate, true)} per{" "}
-                                {dim.display_unit}
+                                {getPricingRateUnit(dimKey, dim)}
                               </TableCell>
                             </TableRow>
                           )),
@@ -1069,6 +1100,30 @@ export default function PricingPage() {
             All plans include free usage allowances. You only pay for what
             exceeds the free tier.
           </Typography>
+          {storageBillingCopy && (
+            <Paper
+              variant="outlined"
+              sx={{
+                p: 2,
+                mb: 2,
+                borderRadius: 1,
+                bgcolor: (theme) => alpha(theme.palette.info.main, 0.04),
+                borderColor: (theme) => alpha(theme.palette.info.main, 0.16),
+              }}
+            >
+              <Stack spacing={0.5}>
+                <Typography variant="body2" fontWeight={600}>
+                  Storage overages are billed monthly.
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {storageBillingCopy.allowance}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {storageBillingCopy.example}
+                </Typography>
+              </Stack>
+            </Paper>
+          )}
 
           {data?.pricing && (
             <TableContainer
@@ -1112,6 +1167,8 @@ export default function PricingPage() {
                 <TableBody>
                   {Object.entries(data.pricing).map(([dimKey, pricing]) => {
                     const isSingleTier = pricing.tiers.length === 1;
+                    const displayUnit = getPricingDisplayUnit(dimKey, pricing);
+                    const rateUnit = getPricingRateUnit(dimKey, pricing);
                     return pricing.tiers.map((tier, i) => (
                       <TableRow key={`${dimKey}-${i}`}>
                         {i === 0 ? (
@@ -1136,10 +1193,10 @@ export default function PricingPage() {
                           {isSingleTier
                             ? "Flat rate (non-tiered)"
                             : tier.price_per_unit === 0
-                              ? `First ${formatCompact(tier.up_to || 0)} ${pricing.display_unit} (free)`
+                              ? `First ${formatCompact(tier.up_to || 0)} ${displayUnit} (free)`
                               : tier.up_to
-                                ? `${formatCompact(pricing.tiers[i - 1]?.up_to || 0)} – ${formatCompact(tier.up_to)} ${pricing.display_unit}`
-                                : `${formatCompact(pricing.tiers[i - 1]?.up_to || 0)}+ ${pricing.display_unit}`}
+                                ? `${formatCompact(pricing.tiers[i - 1]?.up_to || 0)} – ${formatCompact(tier.up_to)} ${displayUnit}`
+                                : `${formatCompact(pricing.tiers[i - 1]?.up_to || 0)}+ ${displayUnit}`}
                         </TableCell>
                         <TableCell
                           sx={{
@@ -1168,7 +1225,7 @@ export default function PricingPage() {
                               variant="caption"
                               color="text.secondary"
                             >
-                              per {pricing.display_unit}
+                              per {rateUnit}
                             </Typography>
                           </Stack>
                         </TableCell>

--- a/frontend/src/sections/settings/PricingV3/PricingPage.jsx
+++ b/frontend/src/sections/settings/PricingV3/PricingPage.jsx
@@ -66,6 +66,37 @@ function formatCompact(n) {
   return n.toLocaleString();
 }
 
+function getPricingDisplayUnit(dimKey, pricing) {
+  return pricing.display_unit || dimKey;
+}
+
+function getPricingRateUnit(dimKey, pricing) {
+  const displayUnit = getPricingDisplayUnit(dimKey, pricing);
+  return dimKey === "storage" ? `${displayUnit}/mo` : displayUnit;
+}
+
+function getStorageBillingCopy(storagePricing) {
+  const freeTier = storagePricing?.tiers?.find(
+    (tier) => tier.price_per_unit === 0 && Number.isFinite(tier.up_to),
+  );
+  const paidTier = storagePricing?.tiers?.find(
+    (tier) => Number.isFinite(tier.price_per_unit) && tier.price_per_unit > 0,
+  );
+
+  if (!freeTier || !paidTier) return null;
+
+  // This example assumes the first paid tier covers the first 10 units above the allowance.
+  const exampleOverage = 10;
+  const exampleUsage = freeTier.up_to + exampleOverage;
+  const exampleCost = paidTier.price_per_unit * exampleOverage;
+  const unit = storagePricing.display_unit || "GB";
+
+  return {
+    allowance: `First ${formatCompact(freeTier.up_to)} ${unit} included each month.`,
+    example: `Example: ${formatCompact(exampleUsage)} ${unit} uses ${formatCompact(exampleOverage)} extra ${unit}, billed at ${fCurrency(paidTier.price_per_unit)}/${unit}/mo for ${fCurrency(exampleCost)}/mo.`,
+  };
+}
+
 // Constants imported from ./constants.js
 
 // ── Tier Card (Free / PAYG) ────────────────────────────────────────────────
@@ -727,6 +758,7 @@ export default function PricingPage() {
   const currentAddon = addons.find((a) => a.key === currentPlan);
   const dialogAddon = addons.find((a) => a.key === addonDialog.plan);
   const isDialogLoading = addonMutation.isPending || removeMutation.isPending;
+  const storageBillingCopy = getStorageBillingCopy(data?.pricing?.storage);
 
   // Build plan data map for feature matrix
   const plansData = {};
@@ -912,7 +944,7 @@ export default function PricingPage() {
                               >
                                 {tier.start.toLocaleString()} -{" "}
                                 {tier.end ? tier.end.toLocaleString() : "+"}{" "}
-                                {dim.display_unit}
+                                {getPricingDisplayUnit(dimKey, dim)}
                               </TableCell>
                               <TableCell
                                 sx={{
@@ -921,7 +953,7 @@ export default function PricingPage() {
                                 }}
                               >
                                 {fCurrency(tier.rate, true)} per{" "}
-                                {dim.display_unit}
+                                {getPricingRateUnit(dimKey, dim)}
                               </TableCell>
                             </TableRow>
                           )),
@@ -1096,6 +1128,30 @@ export default function PricingPage() {
             All plans include free usage allowances. You only pay for what
             exceeds the free tier.
           </Typography>
+          {storageBillingCopy && (
+            <Paper
+              variant="outlined"
+              sx={{
+                p: 2,
+                mb: 2,
+                borderRadius: 1,
+                bgcolor: (theme) => alpha(theme.palette.info.main, 0.04),
+                borderColor: (theme) => alpha(theme.palette.info.main, 0.16),
+              }}
+            >
+              <Stack spacing={0.5}>
+                <Typography variant="body2" fontWeight={600}>
+                  Storage overages are billed monthly.
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {storageBillingCopy.allowance}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {storageBillingCopy.example}
+                </Typography>
+              </Stack>
+            </Paper>
+          )}
 
           {data?.pricing && (
             <TableContainer
@@ -1139,6 +1195,8 @@ export default function PricingPage() {
                 <TableBody>
                   {canonicalEntries(data.pricing).map(([dimKey, pricing]) => {
                     const isSingleTier = pricing.tiers.length === 1;
+                    const displayUnit = getPricingDisplayUnit(dimKey, pricing);
+                    const rateUnit = getPricingRateUnit(dimKey, pricing);
                     return pricing.tiers.map((tier, i) => (
                       <TableRow key={`${dimKey}-${i}`}>
                         {i === 0 ? (
@@ -1163,10 +1221,10 @@ export default function PricingPage() {
                           {isSingleTier
                             ? "Flat rate (non-tiered)"
                             : tier.price_per_unit === 0
-                              ? `First ${formatCompact(tier.up_to || 0)} ${pricing.display_unit} (free)`
+                              ? `First ${formatCompact(tier.up_to || 0)} ${displayUnit} (free)`
                               : tier.up_to
-                                ? `${formatCompact(pricing.tiers[i - 1]?.up_to || 0)} – ${formatCompact(tier.up_to)} ${pricing.display_unit}`
-                                : `${formatCompact(pricing.tiers[i - 1]?.up_to || 0)}+ ${pricing.display_unit}`}
+                                ? `${formatCompact(pricing.tiers[i - 1]?.up_to || 0)} – ${formatCompact(tier.up_to)} ${displayUnit}`
+                                : `${formatCompact(pricing.tiers[i - 1]?.up_to || 0)}+ ${displayUnit}`}
                         </TableCell>
                         <TableCell
                           sx={{
@@ -1195,7 +1253,7 @@ export default function PricingPage() {
                               variant="caption"
                               color="text.secondary"
                             >
-                              per {pricing.display_unit}
+                              per {rateUnit}
                             </Typography>
                           </Stack>
                         </TableCell>

--- a/frontend/src/sections/settings/PricingV3/__tests__/PricingPage.test.jsx
+++ b/frontend/src/sections/settings/PricingV3/__tests__/PricingPage.test.jsx
@@ -277,4 +277,57 @@ describe("PricingPage", () => {
       expect(screen.getByText("Storage")).toBeInTheDocument();
     });
   });
+
+  it("clarifies monthly storage allowance and overage billing", async () => {
+    const { default: PricingPage } = await import("../PricingPage");
+    renderWithQuery(<PricingPage />);
+
+    expect(
+      await screen.findByText("Storage overages are billed monthly."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("First 50 GB included each month."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/60 GB uses 10 extra GB/)).toHaveTextContent(
+      "$2.00/GB/mo",
+    );
+    expect(screen.getByText(/60 GB uses 10 extra GB/)).toHaveTextContent(
+      "$20.00/mo",
+    );
+    expect(screen.getAllByText("per GB/mo").length).toBeGreaterThan(0);
+  });
+
+  it("clarifies storage billing cadence for custom pricing tiers", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        result: {
+          ...MOCK_PLANS_RESPONSE.data.result,
+          current_plan: "custom",
+          is_custom_pricing: true,
+          custom_details: {
+            pricing: {
+              storage: {
+                display_name: "Storage",
+                display_unit: "GB",
+                tiers: [
+                  { start: 0, end: 50, rate: 0 },
+                  { start: 50, end: null, rate: 2 },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const { default: PricingPage } = await import("../PricingPage");
+    renderWithQuery(<PricingPage />);
+
+    expect(await screen.findByText("Your pricing tiers")).toBeInTheDocument();
+    expect(
+      screen.getAllByText((_, element) =>
+        Boolean(element?.textContent?.includes("GB/mo")),
+      ).length,
+    ).toBeGreaterThan(0);
+  });
 });

--- a/frontend/src/sections/settings/PricingV3/__tests__/PricingPage.test.jsx
+++ b/frontend/src/sections/settings/PricingV3/__tests__/PricingPage.test.jsx
@@ -278,6 +278,25 @@ describe("PricingPage", () => {
     });
   });
 
+  it("clarifies monthly storage allowance and overage billing", async () => {
+    const { default: PricingPage } = await import("../PricingPage");
+    renderWithQuery(<PricingPage />);
+
+    expect(
+      await screen.findByText("Storage overages are billed monthly."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("First 50 GB included each month."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/60 GB uses 10 extra GB/)).toHaveTextContent(
+      "$2.00/GB/mo",
+    );
+    expect(screen.getByText(/60 GB uses 10 extra GB/)).toHaveTextContent(
+      "$20.00/mo",
+    );
+    expect(screen.getAllByText("per GB/mo").length).toBeGreaterThan(0);
+  });
+
   it("renders custom pricing from the v2 camelCase contract", async () => {
     mockGet.mockResolvedValue({
       data: {
@@ -313,5 +332,6 @@ describe("PricingPage", () => {
     expect(screen.getByText("Your plan features")).toBeInTheDocument();
     expect(screen.getByText("Your pricing tiers")).toBeInTheDocument();
     expect(screen.queryByText("Choose your tier")).not.toBeInTheDocument();
+    expect(screen.getAllByText(/GB\/mo/).length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Clarifies that storage overage pricing on the Pricing page is billed monthly, so `$2/GB` is no longer ambiguous. The change keeps unit formatting local to the existing Pricing V3 owner, applies the same `GB/mo` cadence to standard and custom pricing tables, and adds regression tests for the storage allowance and monthly overage copy.

Also retains a small adjacent React correctness fix: the feature-group `key` now lives on the mapped `React.Fragment`, eliminating the existing missing-key warning.

## Linked issues

Closes #263
Follow-up API contract work: #2653

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `npm run test:run -- src/sections/settings/PricingV3/__tests__/PricingPage.test.jsx`
- `npm run lint` *(passes with existing repo-wide warnings, 0 errors)*
- `npx --no-install prettier --check src/sections/settings/PricingV3/PricingPage.jsx src/sections/settings/PricingV3/__tests__/PricingPage.test.jsx`
- `node --max-old-space-size=8192 ./node_modules/vite/bin/vite.js build`

The branch is rebased onto current `dev`. The custom-pricing regression assertion now extends dev's v2 camelCase-contract test (`isCustomPricing` / `customDetails`) rather than duplicating the obsolete snake_case path.

Note: `frontend/package.json` does not currently define `yarn check-all`, so the available frontend test, lint, formatting, and production-build gates were run instead.

## Screenshots / recordings (if UI)

Screen recording pending: Pricing page standard usage-based and custom-pricing tables.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)