### PR TITLE
feat(infra): add Reviewer Assigner GitHub Action

### DIFF
--- a/.github/reviewer-config.json
+++ b/.github/reviewer-config.json
@@ -1,0 +1,144 @@
+{
+  "_comment": "Config for .github/workflows/reviewer-assigner.yml. Path globs use ** and * (labeler-style). Overlaps are resolved by longest-literal-prefix-wins.",
+  "fallback_lead": "atharva-bhange",
+  "teams": {
+    "morpheus": {
+      "display_name": "Morpheus",
+      "ownership": "Simulation + Simulation SDK + Annotation queues",
+      "lead": "khushalsonawat",
+      "members": ["khushalsonawat", "definitelynotchirag", "cdileep23", "KarthikAvinashFI", "hadarishav"],
+      "paths": [
+        "futureagi/simulate/**",
+        "futureagi/sdk/simulate/**",
+        "frontend/src/sections/scenarios/**",
+        "frontend/src/sections/annotations/**",
+        "frontend/src/sections/persona/**",
+        "frontend/src/sections/journey/**"
+      ]
+    },
+    "heimdall": {
+      "display_name": "heimdall",
+      "ownership": "Observe + Tracing SDK + Dashboard",
+      "lead": "atharva-bhange",
+      "members": ["atharva-bhange", "JayaSurya-27", "commitPirate", "sarthakFuture"],
+      "paths": [
+        "futureagi/tracer/**",
+        "futureagi/sockets/**",
+        "futureagi/analytics/**",
+        "frontend/src/sections/dashboards/**",
+        "frontend/src/sections/overview/**",
+        "frontend/src/sections/project/**",
+        "frontend/src/sections/project-detail/**",
+        "frontend/src/sections/projects/**"
+      ]
+    },
+    "turing": {
+      "display_name": "Turing",
+      "ownership": "Platform Evals + Evals SDK + Falcon",
+      "lead": "hadarishav",
+      "members": ["hadarishav", "KarthikAvinashFI", "cdileep23", "azain-commits"],
+      "paths": [
+        "futureagi/evaluations/**",
+        "futureagi/agentic_eval/**",
+        "futureagi/ee/evals/**",
+        "futureagi/ee/falcon_ai/**",
+        "futureagi/ee/turing/**",
+        "frontend/src/sections/evals/**",
+        "frontend/src/sections/falcon-ai/**"
+      ]
+    },
+    "n11n": {
+      "display_name": "n11n",
+      "ownership": "Agent + Prompt playground",
+      "lead": "JayaSurya-27",
+      "members": ["JayaSurya-27", "commitPirate", "Tanmaycode1"],
+      "paths": [
+        "futureagi/ee/prompts/**",
+        "futureagi/ee/agenthub/**",
+        "frontend/src/sections/agent-playground/**",
+        "frontend/src/sections/agents/**",
+        "frontend/src/sections/prompt/**",
+        "frontend/src/sections/prompt-v2/**",
+        "frontend/src/sections/workbench/**",
+        "frontend/src/sections/workbench-v2/**"
+      ]
+    },
+    "quest": {
+      "display_name": "quest",
+      "ownership": "Experiments",
+      "lead": "atharva-bhange",
+      "members": ["atharva-bhange", "cdileep23", "Tanmaycode1"],
+      "paths": [
+        "futureagi/ee/experiments/**",
+        "frontend/src/sections/experiment-detail/**",
+        "frontend/src/sections/test/**",
+        "frontend/src/sections/test-detail/**",
+        "frontend/src/sections/tasks/**"
+      ]
+    },
+    "adam": {
+      "display_name": "Adam",
+      "ownership": "Platform Optimization + Opt. SDK + Gateway",
+      "lead": "NVJKKartik",
+      "members": ["NVJKKartik", "azain-commits", "hadarishav"],
+      "paths": [
+        "agentcc-gateway/**",
+        "futureagi/agentcc/**",
+        "futureagi/ee/agent_opt/**",
+        "futureagi/ee/agentcc-gateway/**",
+        "frontend/src/sections/gateway/**",
+        "frontend/src/sections/develop/**",
+        "frontend/src/sections/develop-detail/**"
+      ]
+    },
+    "beacon": {
+      "display_name": "Beacon",
+      "ownership": "Error Feed",
+      "lead": "hadarishav",
+      "members": ["hadarishav", "NVJKKartik"],
+      "paths": [
+        "futureagi/tracer/views/feed/**",
+        "frontend/src/sections/alerts/**",
+        "frontend/src/sections/error/**"
+      ]
+    },
+    "frame": {
+      "display_name": "Frame",
+      "ownership": "Datasets + Future AGI + RBAC + Pricing & billing",
+      "lead": "khushalsonawat",
+      "members": ["khushalsonawat", "sarthakFuture", "azain-commits", "cdileep23", "Tanmaycode1"],
+      "paths": [
+        "futureagi/accounts/**",
+        "futureagi/saml2_auth/**",
+        "futureagi/model_hub/**",
+        "futureagi/ee/usage/**",
+        "futureagi/ee/billing*",
+        "futureagi/integrations/**",
+        "frontend/src/sections/account/**",
+        "frontend/src/sections/auth/**",
+        "frontend/src/sections/data/**",
+        "frontend/src/sections/knowledge-base/**",
+        "frontend/src/sections/model/**",
+        "frontend/src/sections/huggingface/**",
+        "frontend/src/sections/settings/**",
+        "frontend/src/sections/keys/**",
+        "frontend/src/sections/user/**",
+        "frontend/src/sections/address/**"
+      ]
+    }
+  },
+  "users": {
+    "khushalsonawat":      { "slack_id": "U087FCUQ77E", "display_name": "Khushal" },
+    "atharva-bhange":      { "slack_id": "U071K8LUQE5", "display_name": "Atharva" },
+    "definitelynotchirag": { "slack_id": "U0ACG3CS7EY", "display_name": "Chirag" },
+    "cdileep23":           { "slack_id": "U099M4FQV97", "display_name": "Dileep" },
+    "KarthikAvinashFI":    { "slack_id": "U09808798MU", "display_name": "Karthik Avinash" },
+    "hadarishav":          { "slack_id": "U07UPK1NZGA", "display_name": "Rishav" },
+    "JayaSurya-27":        { "slack_id": "U083MBRARTL", "display_name": "Jaya" },
+    "commitPirate":        { "slack_id": "U09LC0C8NKE", "display_name": "Nosang" },
+    "sarthakFuture":       { "slack_id": "U07V82HJ17H", "display_name": "Sarthak" },
+    "azain-commits":       { "slack_id": "U09GEEBEATS", "display_name": "Azain" },
+    "NVJKKartik":          { "slack_id": "U0851KZFTV4", "display_name": "Kartik" },
+    "Tanmaycode1":         { "slack_id": "U0ARCAND0R1", "display_name": "Tanmay" }
+  }
+}

--- a/.github/scripts/reviewer-assigner.mjs
+++ b/.github/scripts/reviewer-assigner.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+// Reviewer Assigner: routes PRs to team leads, DM-pings stale reviewers,
+// and posts a daily reviewer-load summary. Driven by .github/reviewer-config.json.
+//
+// Modes (selected via MODE env var):
+//   assign   — request the right team lead(s) on PRs that have no reviewer
+//   ping     — DM each pending reviewer of an open PR >3 days old (gated by REVIEWER_PING_ENABLED)
+//   summary  — post sorted "reviewer → open PR count" to SLACK_WEBHOOK_URL
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = resolve(__dirname, '..', 'reviewer-config.json');
+
+const {
+  MODE,
+  GITHUB_TOKEN,
+  GITHUB_REPOSITORY,
+  PR_NUMBER,
+  SLACK_BOT_TOKEN,
+  SLACK_WEBHOOK_URL,
+  REVIEWER_PING_ENABLED,
+  DRY_RUN,
+} = process.env;
+
+if (!MODE) die('MODE env var is required (assign|ping|summary)');
+if (!GITHUB_TOKEN) die('GITHUB_TOKEN is required');
+if (!GITHUB_REPOSITORY) die('GITHUB_REPOSITORY is required');
+
+const [OWNER, REPO] = GITHUB_REPOSITORY.split('/');
+const GH_API = 'https://api.github.com';
+const PING_AGE_DAYS = 3;
+const dryRun = DRY_RUN === 'true';
+
+const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+
+const ghHeaders = {
+  Accept: 'application/vnd.github+json',
+  Authorization: `Bearer ${GITHUB_TOKEN}`,
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': `${OWNER}-${REPO}-reviewer-assigner`,
+};
+
+// ─── small helpers ────────────────────────────────────────────────────────────
+
+function die(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+function log(...args) {
+  console.log(...args);
+}
+
+async function gh(path, init = {}) {
+  const res = await fetch(`${GH_API}${path}`, { ...init, headers: { ...ghHeaders, ...(init.headers || {}) } });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub ${init.method || 'GET'} ${path} → ${res.status}: ${body}`);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+async function ghPaginated(path) {
+  // Walk Link headers until no `rel="next"`.
+  const out = [];
+  let url = `${GH_API}${path}`;
+  while (url) {
+    const res = await fetch(url, { headers: ghHeaders });
+    if (!res.ok) throw new Error(`GitHub GET ${url} → ${res.status}: ${await res.text()}`);
+    out.push(...(await res.json()));
+    const link = res.headers.get('link');
+    const next = link?.split(',').map((s) => s.trim()).find((s) => s.endsWith('rel="next"'));
+    url = next ? next.slice(1, next.indexOf('>')) : null;
+  }
+  return out;
+}
+
+// Convert a labeler-style glob (** and *) to a RegExp. Anchored at both ends.
+function globToRegex(glob) {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*' && glob[i + 1] === '*') {
+      re += '.*';
+      i++;
+    } else if (c === '*') {
+      re += '[^/]*';
+    } else if (/[.+?^${}()|[\]\\]/.test(c)) {
+      re += '\\' + c;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp('^' + re + '$');
+}
+
+// Specificity = length of the literal prefix before the first wildcard.
+// Used to pick the owning team when multiple globs match the same file.
+function globSpecificity(glob) {
+  const i = glob.search(/[*?]/);
+  return i === -1 ? glob.length : i;
+}
+
+// Precompile globs once.
+const compiledTeams = Object.entries(config.teams).map(([id, t]) => ({
+  id,
+  ...t,
+  compiledPaths: t.paths.map((p) => ({ glob: p, re: globToRegex(p), specificity: globSpecificity(p) })),
+}));
+
+// Find the team that owns a given file path (most-specific-glob-wins).
+function ownerOf(file) {
+  let best = null;
+  for (const team of compiledTeams) {
+    for (const p of team.compiledPaths) {
+      if (p.re.test(file)) {
+        if (!best || p.specificity > best.specificity) best = { team, specificity: p.specificity };
+        break; // one team can only "claim" via its most-specific own glob anyway
+      }
+    }
+  }
+  return best?.team || null;
+}
+
+// Find every team that has `gh-user` as its lead (a person may lead multiple teams).
+function teamsLedBy(ghUser) {
+  return compiledTeams.filter((t) => t.lead === ghUser);
+}
+
+function userMeta(ghUser) {
+  return config.users[ghUser] || null;
+}
+
+function slackMention(ghUser) {
+  const u = userMeta(ghUser);
+  return u?.slack_id ? `<@${u.slack_id}>` : ghUser;
+}
+
+// ─── mode: assign ─────────────────────────────────────────────────────────────
+
+async function assignForPr(prNumber) {
+  log(`\n— PR #${prNumber} —`);
+  const pr = await gh(`/repos/${OWNER}/${REPO}/pulls/${prNumber}`);
+
+  if (pr.state !== 'open') {
+    log(`  state=${pr.state}, skipping`);
+    return;
+  }
+  if ((pr.requested_reviewers?.length ?? 0) > 0 || (pr.requested_teams?.length ?? 0) > 0) {
+    log(`  already has reviewers (${pr.requested_reviewers.map((r) => r.login).join(',')} + teams=${pr.requested_teams.length}), skipping`);
+    return;
+  }
+
+  const files = await ghPaginated(`/repos/${OWNER}/${REPO}/pulls/${prNumber}/files?per_page=100`);
+  const matchedTeams = new Map(); // id → team
+  for (const f of files) {
+    const t = ownerOf(f.filename);
+    if (t) matchedTeams.set(t.id, t);
+  }
+
+  let leads = [...new Set([...matchedTeams.values()].map((t) => t.lead))];
+  const author = pr.user?.login;
+  leads = leads.filter((l) => l !== author);
+
+  if (leads.length === 0) {
+    if (config.fallback_lead && config.fallback_lead !== author) {
+      leads = [config.fallback_lead];
+      log(`  no team matched (or author was the only lead) → fallback ${config.fallback_lead}`);
+    } else {
+      log('  no reviewers to assign (no match and author == fallback)');
+      return;
+    }
+  }
+
+  log(`  assigning: ${leads.join(', ')}`);
+  if (dryRun) {
+    log('  DRY_RUN: skipping API calls');
+    return;
+  }
+
+  await gh(`/repos/${OWNER}/${REPO}/pulls/${prNumber}/requested_reviewers`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reviewers: leads }),
+  });
+
+  if (matchedTeams.size > 1) {
+    const lines = [...matchedTeams.values()].map(
+      (t) => `• **${t.display_name}** (${t.ownership}) — @${t.lead}`,
+    );
+    const body = `This PR touches code owned by multiple teams:\n\n${lines.join('\n')}\n\nPlease coordinate on review.`;
+    await gh(`/repos/${OWNER}/${REPO}/issues/${prNumber}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body }),
+    });
+    log(`  posted cross-team coordination comment (${matchedTeams.size} teams)`);
+  }
+}
+
+async function runAssign() {
+  let prs;
+  if (PR_NUMBER) {
+    prs = [Number(PR_NUMBER)];
+  } else {
+    log('No PR_NUMBER → sweeping all open PRs');
+    const open = await ghPaginated(`/repos/${OWNER}/${REPO}/pulls?state=open&per_page=100`);
+    prs = open.map((p) => p.number);
+  }
+  for (const n of prs) {
+    try {
+      await assignForPr(n);
+    } catch (e) {
+      console.error(`PR #${n}: ${e.message}`);
+    }
+  }
+}
+
+// ─── mode: ping ───────────────────────────────────────────────────────────────
+
+async function postSlackDm(slackId, text) {
+  if (dryRun) {
+    log(`  DRY_RUN: would DM ${slackId}: ${text.slice(0, 80)}…`);
+    return;
+  }
+  const res = await fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SLACK_BOT_TOKEN}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify({ channel: slackId, text, unfurl_links: false }),
+  });
+  const json = await res.json();
+  if (!json.ok) throw new Error(`Slack chat.postMessage failed for ${slackId}: ${json.error}`);
+}
+
+function pingBodyFor(reviewerGh, pr, ageDays, authorGh) {
+  // Lead the DM with an explicit <@slack_id> mention so Slack treats this as a
+  // hard "you were mentioned" event — guarantees a push/badge even for users
+  // with stricter bot-DM notification rules.
+  const slackMentionOfRecipient = `<@${userMeta(reviewerGh).slack_id}>`;
+  const prLink = `<${pr.html_url}|PR #${pr.number} — ${pr.title}>`;
+  const lines = [`${slackMentionOfRecipient} reminder: ${prLink} has been waiting on your review for ${ageDays} day${ageDays === 1 ? '' : 's'}.`];
+  const ledTeams = teamsLedBy(reviewerGh);
+  if (ledTeams.length) {
+    for (const t of ledTeams) {
+      const candidates = t.members
+        .filter((m) => m !== reviewerGh && m !== authorGh)
+        .map((m) => userMeta(m)?.display_name || m);
+      if (candidates.length) {
+        lines.push('', `You can reassign this to a ${t.display_name} teammate if you'd like: ${candidates.join(', ')}.`);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+async function runPing() {
+  if (REVIEWER_PING_ENABLED !== 'true') {
+    log('REVIEWER_PING_ENABLED != "true" → ping disabled, exiting');
+    return;
+  }
+  if (!SLACK_BOT_TOKEN) die('SLACK_BOT_TOKEN is required for ping mode');
+
+  const open = await ghPaginated(`/repos/${OWNER}/${REPO}/pulls?state=open&per_page=100`);
+  const now = Date.now();
+  const threshold = PING_AGE_DAYS * 24 * 3600 * 1000;
+
+  for (const pr of open) {
+    if (pr.draft) continue;
+    const ageMs = now - new Date(pr.created_at).getTime();
+    if (ageMs <= threshold) continue;
+    const ageDays = Math.floor(ageMs / (24 * 3600 * 1000));
+    const authorGh = pr.user?.login;
+    const reviewers = pr.requested_reviewers || [];
+    if (!reviewers.length) continue;
+
+    for (const r of reviewers) {
+      const gh = r.login;
+      const meta = userMeta(gh);
+      if (!meta?.slack_id) {
+        log(`  PR #${pr.number}: reviewer @${gh} has no Slack ID in config — skipping`);
+        continue;
+      }
+      const body = pingBodyFor(gh, pr, ageDays, authorGh);
+      try {
+        await postSlackDm(meta.slack_id, body);
+        log(`  PR #${pr.number}: DM'd @${gh} (${meta.slack_id})`);
+      } catch (e) {
+        console.error(`  PR #${pr.number}: failed to DM @${gh}: ${e.message}`);
+      }
+    }
+  }
+}
+
+// ─── mode: summary ────────────────────────────────────────────────────────────
+
+async function runSummary() {
+  if (!SLACK_WEBHOOK_URL) die('SLACK_WEBHOOK_URL is required for summary mode');
+
+  const open = await ghPaginated(`/repos/${OWNER}/${REPO}/pulls?state=open&per_page=100`);
+  const counts = new Map();
+  for (const pr of open) {
+    if (pr.draft) continue;
+    for (const r of pr.requested_reviewers || []) {
+      counts.set(r.login, (counts.get(r.login) || 0) + 1);
+    }
+  }
+
+  if (counts.size === 0) {
+    log('No pending reviewers — skipping summary post');
+    return;
+  }
+
+  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  const today = new Date().toISOString().slice(0, 10);
+  const lines = [`*Open PR Review Load — ${today}*`];
+  for (const [gh, n] of sorted) {
+    lines.push(`• ${slackMention(gh)} — ${n} PR${n === 1 ? '' : 's'}`);
+  }
+  const text = lines.join('\n');
+
+  if (dryRun) {
+    log('DRY_RUN: would post summary:\n' + text);
+    return;
+  }
+
+  const res = await fetch(SLACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) throw new Error(`Slack webhook → ${res.status}: ${await res.text()}`);
+  log(`Posted summary (${sorted.length} reviewers).`);
+}
+
+// ─── entrypoint ───────────────────────────────────────────────────────────────
+
+const RUNNERS = { assign: runAssign, ping: runPing, summary: runSummary };
+const runner = RUNNERS[MODE];
+if (!runner) die(`Unknown MODE: ${MODE}`);
+runner().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/.github/workflows/reviewer-assigner.yml
+++ b/.github/workflows/reviewer-assigner.yml
@@ -1,0 +1,72 @@
+name: Reviewer Assigner
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to assign (leave blank to sweep all open PRs)'
+        required: false
+  schedule:
+    # 10:00 IST (UTC+5:30) → 04:30 UTC — same morning slot as pr-digest.
+    - cron: '30 4 * * *'
+
+jobs:
+  assign:
+    if: github.repository == 'future-agi/future-agi' && github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write   # needed to post the cross-team coordination comment
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Assign reviewers
+        env:
+          MODE: assign
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: node .github/scripts/reviewer-assigner.mjs
+
+  ping:
+    if: github.repository == 'future-agi/future-agi' && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: DM stale reviewers
+        env:
+          MODE: ping
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Off by default. Set the repo secret to the literal string "true" to enable.
+          REVIEWER_PING_ENABLED: ${{ secrets.REVIEWER_PING_ENABLED }}
+        run: node .github/scripts/reviewer-assigner.mjs
+
+  summary:
+    if: github.repository == 'future-agi/future-agi' && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Post reviewer-load summary
+        env:
+          MODE: summary
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: node .github/scripts/reviewer-assigner.mjs


### PR DESCRIPTION
## Summary
- New GitHub Action **Reviewer Assigner** that:
  - On `pull_request: opened/ready_for_review/reopened` and on `workflow_dispatch` (optionally with a single `pr_number`, otherwise sweeps every open PR), assigns the right **team lead** as reviewer based on paths touched. Only acts when the PR has no reviewer, so any human reassignment is preserved forever after.
  - On a daily cron (10:00 IST = 04:30 UTC, same slot as `pr-digest`), DMs each pending reviewer on Slack for PRs more than 3 days old. **Off by default** — set repo secret `REVIEWER_PING_ENABLED` to `"true"` to enable.
  - On the same daily cron, posts a sorted **reviewer-load summary** to the PR-digest Slack channel (reuses existing `SLACK_WEBHOOK_URL`). Always on.
- Path → team mapping derived from `futureagi/`, `futureagi/ee/`, and `frontend/src/sections/` directory structure. Glob overlaps (e.g. `futureagi/tracer/views/feed/**` for Beacon vs `futureagi/tracer/**` for heimdall) resolved by **most-specific-glob-wins per file**.
- Cross-team PRs additionally get a coordination comment listing every matched team and their leads.
- Daily ping DMs lead with `<@slack_id>` so Slack notifies the recipient even with strict bot-DM notification rules.

## New secrets required
- `SLACK_BOT_TOKEN` — Slack bot token (`xoxb-…`) with `chat:write` + `im:write` scopes. Setup steps in plan file.
- `REVIEWER_PING_ENABLED` — set to literal string `"true"` to enable the daily DM ping. Leave unset to keep it off.

`SLACK_WEBHOOK_URL` and `GITHUB_TOKEN` are already provisioned.

## Test plan
- [x] Dry-runs against live open PRs validated `assign` routing (eval fix → Turing/Rishav, observe → heimdall/Atharva, billing → Frame/Khushal, multi-team correctly assigns both leads).
- [x] Dry-run of `summary` produced the expected sorted reviewer-load list with proper Slack mentions.
- [x] Dry-run of `ping` with `REVIEWER_PING_ENABLED=true` showed correct DM payloads (with self-mention) for every stale PR; with the secret unset, the job exits with "ping disabled".
- [ ] After merge: open a fresh PR with no reviewer and confirm the action assigns the expected lead within ~30s.
- [ ] After secret is set: set `REVIEWER_PING_ENABLED=true`, wait one cron cycle, confirm DM arrives in Slack.

## Notes
- `nik13` (and any other reviewer not in the team table) is unmapped — they'll appear in the summary by their GitHub login and won't receive DM pings until added to the `users` block of `reviewer-config.json`.
- Slack table only has one **Kartik** (`kartik.nvj@futureagi.com`); the team table's "Kartik" (Adam lead) and "Kartik NVG" (Beacon member) are treated as the same person. If they're actually two engineers, point me at the second one and I'll split the mapping.