### PR TITLE
fix(observe): expose and resolve Trace ID / Span ID filters on task surfaces

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1560,6 +1560,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     isSimulator={String(sourceRowType || "")
                       .toLowerCase()
                       .startsWith("voice")}
+                    rowType={sourceRowType}
                   />
                 </Box>
               )}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -1038,6 +1038,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     isSimulator={String(sourceRowType || "")
                       .toLowerCase()
                       .startsWith("voice")}
+                    rowType={sourceRowType}
                   />
                 </Box>
               )}

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -1337,6 +1337,7 @@ const TracingTestMode = React.forwardRef(
               setValue={internalFilterForm.setValue}
               projectId={selectedProjectId}
               isSimulator={isVoiceProject}
+              rowType={rowType}
             />
           </Box>
         )}

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -780,6 +780,7 @@ const TaskConfigPanel = ({
                 setValue={setValue}
                 projectId={project}
                 isSimulator={isVoiceProject}
+                rowType={rowType}
               />
             </FilterErrorBoundary>
           </Box>

--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -187,8 +187,25 @@ FilterChip.propTypes = {
   onRemove: PropTypes.func.isRequired,
 };
 
+// Map task rowType → TraceFilterPanel `tab` so the property picker
+// surfaces Trace ID / Span ID the same way LLM Tracing does. Callers
+// use inconsistent casing ("spans"/"Span", "traces"/"Trace") so we
+// normalize. Sessions / voiceCalls return null (no id fields).
+const rowTypeToFilterTab = (rowType) => {
+  const key = String(rowType || "").toLowerCase();
+  if (key === "spans" || key === "span") return "spans";
+  if (key === "traces" || key === "trace") return "trace";
+  return null;
+};
+
 // ── Main ──
-const TaskFilterBar = ({ control, setValue, projectId, isSimulator = false }) => {
+const TaskFilterBar = ({
+  control,
+  setValue,
+  projectId,
+  isSimulator = false,
+  rowType,
+}) => {
   // Read the form filters (old format) and mirror them in local state (new format).
   const formFilters = useWatch({ control, name: "filters" });
   const [panelFilters, setPanelFilters] = useState(() =>
@@ -351,6 +368,7 @@ const TaskFilterBar = ({ control, setValue, projectId, isSimulator = false }) =>
         currentFilters={panelFilters}
         projectId={projectId}
         isSimulator={isSimulator}
+        tab={rowTypeToFilterTab(rowType)}
         onApply={(next) => applyPanelFilters(next || [])}
       />
     </Box>
@@ -362,6 +380,7 @@ TaskFilterBar.propTypes = {
   setValue: PropTypes.func.isRequired,
   projectId: PropTypes.string,
   isSimulator: PropTypes.bool,
+  rowType: PropTypes.string,
 };
 
 export default TaskFilterBar;

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -50,6 +50,10 @@ const COL_TYPE_MAP = {
   annotation: "ANNOTATION",
 };
 
+// Direct id columns the backend resolves without col_type — injecting one
+// routes the filter through the metrics pipeline and silently returns 0.
+const ID_COLUMNS = new Set(["trace_id", "span_id"]);
+
 // eslint-disable-next-line react-refresh/only-export-components
 export function buildApiFilterArray(oldFormatFilters, startDate, endDate) {
   const userFilters = (oldFormatFilters || [])
@@ -57,6 +61,7 @@ export function buildApiFilterArray(oldFormatFilters, startDate, endDate) {
     .map((f) => {
       const isAttribute = f.property === "attributes";
       const columnId = isAttribute ? f.propertyId : f.property;
+      const isIdColumn = ID_COLUMNS.has(columnId);
       const colType =
         COL_TYPE_MAP[f.fieldCategory] ||
         (isAttribute ? "SPAN_ATTRIBUTE" : "SYSTEM_METRIC");
@@ -66,7 +71,7 @@ export function buildApiFilterArray(oldFormatFilters, startDate, endDate) {
           filter_type: f?.filterConfig?.filterType || "text",
           filter_op: f?.filterConfig?.filterOp || "equals",
           filter_value: f?.filterConfig?.filterValue,
-          col_type: colType,
+          ...(!isIdColumn && { col_type: colType }),
         },
       };
     });


### PR DESCRIPTION
## Linear

[TH-4962](https://linear.app/future-agi/issue/TH-4962/observe-expose-and-resolve-trace-id-span-id-filters-on-task-surfaces)

## Summary

Fixes two distinct bugs around `trace_id` / `span_id` filtering on the Task / EvalPicker surfaces:

1. **Property picker was missing the fields.** On `/dashboard/tasks/create` (and the EvalPicker / TracingTestMode flows) the filter property picker did not list "Trace ID" or "Span ID" — yet the same component renders them on the LLM Tracing page. Root cause: `TraceFilterPanel.getTraceFilterFields(tab)` gates those fields on a `tab` prop. `ObserveToolbar` forwards it; `TaskFilterBar` never did.
2. **Even with the field typed in via "Specify", filtering returned 0 rows.** Root cause: `buildApiFilterArray` always injected `col_type` (defaulting to `SYSTEM_METRIC`). The backend resolves `trace_id` / `span_id` as direct columns only when `col_type` is absent — presence routes them through the metrics pipeline, which has no row for those ids and silently returns 0. Verified via curl on both `list_spans_observe` and `list_traces_of_session`.

## Changes

- `TaskFilterBar` accepts a `rowType` prop and maps it (case-insensitively) to the panel's `tab` so consumers get the correct id-field set. Sessions / voiceCalls fall through to no id fields.
- Four call sites (`TaskConfigPanel`, `EvalPickerCreateNew`, `EvalPickerConfigFull`, `TracingTestMode`) pass their existing row-type variable through.
- `buildApiFilterArray` introduces an `ID_COLUMNS` whitelist and omits `col_type` for `trace_id` / `span_id`. One change fixes all four consumers of the helper.

## Test plan

- [ ] Open `/dashboard/tasks/create` with a project that has spans → property picker shows Trace ID + Span ID
- [ ] Switch "Run evaluations on" to Traces → only Trace ID shows (no Span ID)
- [ ] Switch to Sessions / Voice → no id fields (preserves prior behavior)
- [ ] Type a real trace_id in the filter → Live Preview returns the matching row (previously returned 0)
- [ ] Repeat the trace_id filter in EvalPicker → same fix applies
- [ ] LLM Tracing page filter behavior unchanged (regression check)

## Follow-ups (separate PR)

- Hoist `ID_COLUMNS` into a shared constant so it can't drift from `TraceFilterPanel.jsx`'s `ID_FIELDS`.
- Stop `TaskFilterBar.convertNewToOld` from force-defaulting `fieldCategory: "system"` for rows where the panel left it undefined.