### PR TITLE
fix(evals): show "No input" instead of leaked "result: Fail" in usage logs

### DIFF
--- a/frontend/src/sections/evals/components/EvalUsageTab.jsx
+++ b/frontend/src/sections/evals/components/EvalUsageTab.jsx
@@ -176,15 +176,22 @@ const useColumns = () =>
         header: "Input",
         meta: { flex: 2 },
         minSize: 200,
-        cell: ({ getValue }) => (
-          <Typography
-            variant="body2"
-            noWrap
-            sx={{ fontSize: "12px", color: "text.secondary" }}
-          >
-            {getValue() || "—"}
-          </Typography>
-        ),
+        cell: ({ getValue }) => {
+          const v = getValue();
+          return (
+            <Typography
+              variant="body2"
+              noWrap
+              sx={{
+                fontSize: "12px",
+                color: v ? "text.secondary" : "text.disabled",
+                fontStyle: v ? "normal" : "italic",
+              }}
+            >
+              {v || "No input"}
+            </Typography>
+          );
+        },
       },
       {
         id: "reason",

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -4471,6 +4471,7 @@ class EvalUsageStatsView(APIView):
                 "error_localizer",
                 "kb_id",
                 "row_context",
+                "result",
             }
 
             for log in logs_page:


### PR DESCRIPTION
## Summary

The Evaluation Logs table on **Eval Details → Usage** sometimes rendered `result: Fail` in the **Input** column for failed runs that had no real user input. Two contributors:

1. `EvalUsageStatsView` (`futureagi/model_hub/views/separate_evals.py`) builds the per-row Input string from `config.mappings`, filtering non-input keys via `_skip_keys`. `result` was missing from that set, so it leaked into the summary.
2. The Input column cell's empty-state fallback was `"—"`; the ticket asks for an explicit `No input` label.

This PR adds `result` to `_skip_keys` and updates the cell renderer to show `No input` (dimmed + italic) when the value is empty.

## Linked issues

Closes TH-4036

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- Inspected the seocompliant eval template's Usage tab in the screenshot from the ticket — rows that previously read `result: Fail` will now read `No input`.
- Both edits are read-side / presentation-only:
  - Backend: only affects the Input string built for the usage response. No change to chart aggregation, score/result parsing, stored `APICallLog.config`, or any other consumer.
  - Frontend: only swaps the fallback literal + dims styling when empty.

## Screenshots / recordings (if UI)

_Before:_ Input column shows `result: Fail` for failed runs with no input (see Linear TH-4036).
_After:_ Same rows show `No input` (italic, dimmed).

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] No hardcoded secrets, URLs, or PII

> Note: backend test coverage for the `result`-key filtering can be added in `futureagi/model_hub/tests/test_usage_feedback.py` if desired — happy to follow up.