### PR TITLE
hotfix(observe): custom-column hydration + Trace/Span ID filters (cherry-pick #423 + #431)

### DIFF
--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -16,6 +16,7 @@ import {
   Pagination,
   PaginationItem,
   Select,
+  Skeleton,
   Stack,
   Typography,
   useTheme,
@@ -39,6 +40,37 @@ import NoRowsOverlay from "src/sections/project-detail/CompareDrawer/NoRowsOverl
 
 const CELL_HEIGHT_MAP = { Short: 40, Medium: 52, Large: 68, "Extra Large": 88 };
 
+// Padding matches CallLogsCellRenderer.jsx so custom-col cells align with
+// the rest of the row.
+const CustomColCellRenderer = (params) => {
+  const v = params?.value;
+  const display = v == null || v === "" ? "-" : v;
+  return (
+    <Box
+      sx={{
+        px: 1.5,
+        py: 0.5,
+        display: "flex",
+        alignItems: "center",
+        height: "100%",
+      }}
+    >
+      <Typography variant="body2" sx={{ fontSize: 13 }} noWrap>
+        {String(display)}
+      </Typography>
+    </Box>
+  );
+};
+
+const CustomColLoadingSkeleton = () => (
+  <Skeleton
+    variant="rectangular"
+    width="80%"
+    height={15}
+    sx={{ mx: 1, borderRadius: 0.5 }}
+  />
+);
+
 const CallLogsGrid = React.forwardRef(function CallLogsGrid(
   {
     id,
@@ -48,11 +80,8 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
     onConfigLoaded = () => {},
     enabled = true,
     onSelectionChanged,
-    // Optional richer selection callback — fires alongside onSelectionChanged
-    // with {traceIds, isAllOnPageSelected, currentPageSize, totalPages,
-    // pageLimit}. Used by LLMTracingView's simulator branch to decide when
-    // to show the "select all matching filter" banner (Phase 9 of the
-    // annotation-queue-bulk-select revamp).
+    // Richer selection callback used by LLMTracingView's simulator branch
+    // to decide when to show the "select all matching filter" banner.
     onSelectionMeta,
     cellHeight = "Short",
     columnVisibility,
@@ -80,9 +109,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
       reset: state.reset,
     }));
 
-  // Highlight the row whose detail drawer is currently open. Mirrors the
-  // TraceGrid activeTraceId pattern so the experience matches the trace
-  // detail drawer the user referenced.
+  // Highlight the row whose detail drawer is open (mirrors TraceGrid).
   const { testDetailDrawerOpen } = useTestDetailSideDrawerStoreShallow(
     (state) => ({
       testDetailDrawerOpen: state.testDetailDrawerOpen,
@@ -267,15 +294,52 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
       .filter((c) => !existingFields.has(c.id))
       .map((c) => ({
         headerName: c.name,
-        field: c.id,
+        // colId (not field) so AG Grid doesn't deep-resolve the dotted path
+        // — list_voice_calls returns flat rows; the valueGetter below handles
+        // the resolution.
+        colId: c.id,
         flex: 0,
         minWidth: 120,
         hide: c.isVisible === false,
-        valueGetter: (params) => params.data?.[c.id] ?? "-",
+        cellRenderer: isLoading ? CustomColLoadingSkeleton : CustomColCellRenderer,
+        valueGetter: (params) => {
+          if (!params.data) return null;
+          let value = params.data[c.id];
+          if (value === undefined && c.id.includes(".")) {
+            value = c.id
+              .split(".")
+              .reduce((obj, key) => obj?.[key], params.data);
+          }
+          // /eval-attributes serves Vapi attribute paths with namespace
+          // prefixes (call.*, vapi.*) but /list_voice_calls returns them
+          // as flat keys. Whitelisted — a generic "drop leading segments"
+          // would false-positive on paths like phone_number.id → row.id.
+          const VOICE_FLAT_NAMESPACE_PREFIXES = ["call.", "vapi."];
+          if (value === undefined) {
+            const matchedPrefix = VOICE_FLAT_NAMESPACE_PREFIXES.find((p) =>
+              c.id.startsWith(p),
+            );
+            if (matchedPrefix) {
+              value = params.data[c.id.slice(matchedPrefix.length)];
+            }
+          }
+          if (value === undefined || value === null) return null;
+          if (Array.isArray(value) || typeof value === "object") {
+            return JSON.stringify(value);
+          }
+          return String(value);
+        },
       }));
 
-    return [...updated, ...newCustomDefs];
-  }, [callLogsColumnDefs, columnVisibility]);
+    // Group under a "Custom Columns" header for parity with the other grids.
+    if (newCustomDefs.length > 0) {
+      return [
+        ...updated,
+        { headerName: "Custom Columns", children: newCustomDefs },
+      ];
+    }
+    return updated;
+  }, [callLogsColumnDefs, columnVisibility, isLoading]);
   useEffect(() => {
     return () => {
       resetToggleAnnotationsStore();

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1560,6 +1560,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     isSimulator={String(sourceRowType || "")
                       .toLowerCase()
                       .startsWith("voice")}
+                    rowType={sourceRowType}
                   />
                 </Box>
               )}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -1038,6 +1038,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     isSimulator={String(sourceRowType || "")
                       .toLowerCase()
                       .startsWith("voice")}
+                    rowType={sourceRowType}
                   />
                 </Box>
               )}

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -1337,6 +1337,7 @@ const TracingTestMode = React.forwardRef(
               setValue={internalFilterForm.setValue}
               projectId={selectedProjectId}
               isSimulator={isVoiceProject}
+              rowType={rowType}
             />
           </Box>
         )}

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -920,9 +920,12 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const primaryCallLogsGridRef = useRef(null);
   const compareCallLogsGridRef = useRef(null);
   const columnConfigureRef = useRef();
-  // Saved-view columnState queued before the active sub-tab's primary grid
-  // mounted. Drained by onGridReady on the primary grid.
+  // Drained by onGridReady on the primary grid.
   const pendingColumnStateRef = useRef(null);
+  // applyColumnState alone can't persist hide across columnDefs rebuilds —
+  // getTraceListColumnDefs sets hide explicitly from col.isVisible, so we
+  // need to update col.isVisible in the columns state for hide to stick.
+  const pendingHideMapRef = useRef(null);
 
   const {
     setHeaderConfig,
@@ -933,10 +936,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   } = useObserveHeader();
 
   const { data: projectDetail } = useGetProjectDetails(observeId, !isUserMode);
-  // In user mode the grid should behave like an OBSERVE project (no project
-  // context, no simulator/prototype quirks). Defaulting to OBSERVE keeps the
-  // many `projectSource === OBSERVE` checks (grid enabled, display logic,
-  // etc.) on the happy path.
+  // User mode: behave like an OBSERVE project so the many projectSource
+  // checks stay on the happy path.
   const projectSource = isUserMode
     ? PROJECT_SOURCE.OBSERVE
     : projectDetail?.source;
@@ -1080,10 +1081,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     getFilterExtraProperties,
   );
 
-  // In user mode every grid is scoped by user_id. Inject a structural
-  // filter (similar to the implicit date filter) that prepends to every
-  // validated filter list. The filter lives in the primary `filters`
-  // array, NOT extraFilters, so it doesn't render as a removable chip.
+  // User mode injects a structural user_id filter into the primary filters
+  // (not extraFilters, so it doesn't render as a removable chip).
   const userScopeFilter = useMemo(
     () =>
       isUserMode && userIdForUserMode
@@ -1109,11 +1108,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     [userScopeFilter, primarySpanValidatedFiltersRaw],
   );
 
-  // Drop out of filter-mode selection when the selection state becomes
-  // inconsistent (grid cleared, tab switched, project changed, or the
-  // filter itself changed so the opt-in no longer matches the current
-  // view). The user can always re-opt-in from the banner. Mirrored for
-  // the spans tab via `spanFilterSelectionMode`.
+  // Drop filter-mode opt-in when the selection becomes inconsistent (grid
+  // cleared, tab switched, project changed, filter changed). User can
+  // re-opt-in via the banner. Mirrored for spans below.
   useEffect(() => {
     if (!allTracesSelected) setFilterSelectionMode(false);
   }, [allTracesSelected]);
@@ -1127,9 +1124,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   useEffect(() => {
     setSpanFilterSelectionMode(false);
   }, [primarySpanValidatedFilters]);
-  // Simulator: reset filter-mode when the page-full-selection condition
-  // breaks (user unchecks a row, navigates pages, changes filters, or
-  // switches project).
+  // Simulator: reset filter-mode when page-full-selection breaks.
   useEffect(() => {
     if (!simCallMeta.isAllOnPageSelected) {
       setSimCallFilterSelectionMode(false);
@@ -1218,23 +1213,38 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     [extraFilters, setExtraFilters],
   );
 
-  // Callback to receive column config from CallLogsGrid for simulator projects
   const handleSimulatorConfigLoaded = useCallback(
     (config) => {
       if (projectSource === PROJECT_SOURCE.SIMULATOR && config?.length > 0) {
         setColumns((prev) => {
-          // Preserve existing custom columns when grid reports its base columns
-          const preserveCustom = (key) => {
+          // Voice projects use CallLogsGrid (no per-fetch merge to drain
+          // pending custom cols), so this callback is the only path that
+          // drains them on backend column-count changes.
+          const drainPending = (key, ref) => {
             const existing = prev[key] || [];
             const customCols = existing.filter(
               (c) => c.groupBy === "Custom Columns",
             );
-            return [...config, ...customCols];
+            const pending = ref?.current || [];
+            const existingIds = new Set(customCols.map((c) => c.id));
+            const dedupedPending = pending.filter(
+              (c) => !existingIds.has(c.id),
+            );
+            if (pending.length > 0 && ref) {
+              ref.current = [];
+            }
+            return [...config, ...customCols, ...dedupedPending];
           };
           return {
             ...prev,
-            "primary-trace": preserveCustom("primary-trace"),
-            "compare-trace": preserveCustom("compare-trace"),
+            "primary-trace": drainPending(
+              "primary-trace",
+              primaryTracePendingRef,
+            ),
+            "compare-trace": drainPending(
+              "compare-trace",
+              compareTracePendingRef,
+            ),
           };
         });
       }
@@ -1301,10 +1311,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     columns,
   ]);
 
-  // Trace + simulator filter-mode reset on filter change. Watches
-  // primaryCombinedFilters (validated + graph filters) because both POSTs
-  // send that combined payload — watching only the validated subset would
-  // leave stale opt-in state when the user toggles a graph eval selection.
+  // Watch combined filters (validated + graph) — both POSTs send the
+  // combined payload, so the validated subset alone would miss graph toggles.
   useEffect(() => {
     setFilterSelectionMode(false);
   }, [primaryCombinedFilters]);
@@ -1365,9 +1373,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     setAttributes(evalAttributes || []);
   }, [evalAttributes]);
 
-  // In user mode surface a "Project" filter so the cross-project user-detail
-  // page can narrow to specific projects. Null in project mode (where the
-  // toolbar already scopes to one project).
+  // User mode only — project mode already scopes to a single project.
   const projectFilterField = useProjectFilterField({ enabled: isUserMode });
   const toolbarFilterFields = useMemo(
     () => (projectFilterField ? [projectFilterField] : undefined),
@@ -1672,31 +1678,99 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     }
   }, [selectedTab, primaryTraceDateFilter, primarySpanDateFilter]);
 
-  // Load filters + display settings from saved view config when a custom view tab is selected
-  // Tracked separately so the null-branch reset only fires on a genuine
-  // saved-view → default transition, not on initial mount where
-  // activeViewConfig is null only because hydration hasn't landed yet.
-  // Without this guard, the destructive resets below clobber state that
-  // the localStorage rehydrate (line 1816) and the apply branch are
-  // about to set from the saved view itself.
+  // wasOnSavedViewRef gates the null-branch reset to genuine saved-view →
+  // default transitions so it doesn't clobber state that the mount hydrate
+  // or apply branch is about to set.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const wasOnSavedViewRef = useRef(false);
   useEffect(() => {
     if (!activeViewConfig) {
       const wasOnSavedView = wasOnSavedViewRef.current;
       wasOnSavedViewRef.current = false;
-      if (!wasOnSavedView) return; // initial mount / already on default — nothing to clean up
-      // Back to a default tab — clear local extraFilters so chips from a
-      // prior custom view don't linger. URL-synced display state
-      // (cellHeight / showErrors / showNonAnnotated / hasEvalFilter /
-      // showCompare) is wiped via the parent's URL navigation; viewMode
-      // lives in the Zustand store (no URL key) so we reset it explicitly,
-      // and the active grid's columnState (widths/order/sort) is internal
-      // to AG Grid and likewise needs an imperative reset.
+      if (!wasOnSavedView) return;
+      // Back to default tab — viewMode lives in Zustand (no URL key) so
+      // reset explicitly; AG Grid columnState also needs an imperative reset.
       setExtraFilters((prev) => (prev.length === 0 ? prev : []));
       setViewMode(DEFAULT_DISPLAY_CONFIG.viewMode);
       pendingColumnStateRef.current = null;
-      pendingCustomColumnsRef.current = [];
+      pendingHideMapRef.current = null;
+      primaryTracePendingRef.current = [];
+      compareTracePendingRef.current = [];
+      primarySpansPendingRef.current = [];
+      compareSpansPendingRef.current = [];
+      // Strip saved-view customs and reset isVisible on the remaining cols —
+      // TraceGrid's merge preserves isVisible across fetches, so leaving a
+      // view that hid columns would otherwise persist the hide state.
+      setColumns((prev) => {
+        const next = {};
+        Object.keys(prev).forEach((ck) => {
+          next[ck] = (prev[ck] || [])
+            .filter((c) => c.groupBy !== "Custom Columns")
+            .map((c) => (c.isVisible ? c : { ...c, isVisible: true }));
+        });
+        return next;
+      });
+      // Re-hydrate from localStorage — the mount hydrate is keyed on
+      // displayStorageKey and won't re-fire on a same-project tab toggle.
+      try {
+        const raw = localStorage.getItem(displayStorageKey);
+        const saved = raw ? JSON.parse(raw) : null;
+        if (saved?.customColumns) {
+          // customColumns may be a legacy array or new {trace, spans}
+          // object. Hydrate both primary and compare refs for the tab
+          // type so a later compare-mode toggle works without another
+          // localStorage read.
+          const cloneEach = (arr) => arr.map((c) => ({ ...c }));
+          if (Array.isArray(saved.customColumns)) {
+            if (saved.customColumns.length > 0) {
+              if (selectedTab === "trace") {
+                primaryTracePendingRef.current = cloneEach(saved.customColumns);
+                compareTracePendingRef.current = cloneEach(saved.customColumns);
+              } else {
+                primarySpansPendingRef.current = cloneEach(saved.customColumns);
+                compareSpansPendingRef.current = cloneEach(saved.customColumns);
+              }
+            }
+          } else {
+            const traceCols = saved.customColumns.trace || [];
+            const spansCols = saved.customColumns.spans || [];
+            if (traceCols.length > 0) {
+              primaryTracePendingRef.current = cloneEach(traceCols);
+              compareTracePendingRef.current = cloneEach(traceCols);
+            }
+            if (spansCols.length > 0) {
+              primarySpansPendingRef.current = cloneEach(spansCols);
+              compareSpansPendingRef.current = cloneEach(spansCols);
+            }
+          }
+        }
+      } catch {
+        /* ignore corrupted localStorage */
+      }
+      // Voice/simulator: handleSimulatorConfigLoaded only fires on column-
+      // count changes, so saved-view → default transitions need an explicit
+      // drain here.
+      if (projectSource === PROJECT_SOURCE.SIMULATOR) {
+        const draining = primaryTracePendingRef.current || [];
+        if (draining.length > 0) {
+          setColumns((prev) => {
+            const merge = (key) => {
+              const existing = prev[key] || [];
+              const stripped = existing.filter(
+                (c) => c.groupBy !== "Custom Columns",
+              );
+              return [...stripped, ...draining];
+            };
+            return {
+              ...prev,
+              "primary-trace": merge("primary-trace"),
+              "compare-trace": merge("compare-trace"),
+            };
+          });
+          primaryTracePendingRef.current = [];
+          compareTracePendingRef.current = [];
+        }
+      }
       const activeApi =
         selectedTab === "trace"
           ? primaryTraceGridRef.current?.api
@@ -1717,14 +1791,100 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     if (display.hasEvalFilter !== undefined)
       setHasEvalFilter(display.hasEvalFilter);
 
-    // Defer custom columns — merged when backend columns arrive
+    // Strip existing customs so view → view doesn't show the union of both
+    // sets (which would also dirty-flag the Save view button).
+    setColumns((prev) => {
+      const next = {};
+      Object.keys(prev).forEach((ck) => {
+        next[ck] = (prev[ck] || []).filter(
+          (c) => c.groupBy !== "Custom Columns",
+        );
+      });
+      return next;
+    });
+
+    // Populate both primary and compare refs for the active tab type so a
+    // compare-mode toggle later hydrates correctly. Shallow-clone per slot
+    // so mutations don't write through into the saved-views query cache.
     if (display.customColumns?.length > 0) {
-      pendingCustomColumnsRef.current = display.customColumns;
+      if (selectedTab === "trace") {
+        primaryTracePendingRef.current = display.customColumns.map((c) => ({
+          ...c,
+        }));
+        compareTracePendingRef.current = display.customColumns.map((c) => ({
+          ...c,
+        }));
+      } else {
+        primarySpansPendingRef.current = display.customColumns.map((c) => ({
+          ...c,
+        }));
+        compareSpansPendingRef.current = display.customColumns.map((c) => ({
+          ...c,
+        }));
+      }
     }
 
-    // Apply column state (widths/order/sort) to the active sub-tab's primary
-    // grid. If the grid isn't mounted yet, queue for the onGridReady callback.
+    // Voice/simulator: same-tab-type saved-view switch doesn't trigger
+    // handleSimulatorConfigLoaded, so drain into columns directly.
+    if (
+      projectSource === PROJECT_SOURCE.SIMULATOR &&
+      display.customColumns?.length > 0
+    ) {
+      setColumns((prev) => {
+        const merge = (key) => {
+          const existing = prev[key] || [];
+          const stripped = existing.filter(
+            (c) => c.groupBy !== "Custom Columns",
+          );
+          const fresh = display.customColumns.map((c) => ({ ...c }));
+          return [...stripped, ...fresh];
+        };
+        return {
+          ...prev,
+          "primary-trace": merge("primary-trace"),
+          "compare-trace": merge("compare-trace"),
+        };
+      });
+      // Clear pending refs so handleSimulatorConfigLoaded doesn't drain
+      // them again on a later config callback.
+      primaryTracePendingRef.current = [];
+      compareTracePendingRef.current = [];
+    }
+
+    // Hide needs a parallel path: applyColumnState's hide doesn't survive
+    // the next columnDefs rebuild (getTraceListColumnDefs sets hide from
+    // col.isVisible, which wins over applied state). The [columns] drain
+    // effect below updates col.isVisible from this map.
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
+      const hideMap = {};
+      display.columnState.forEach((entry) => {
+        if (entry && entry.colId) hideMap[entry.colId] = !!entry.hide;
+      });
+      // Apply hideMap immediately so view→view switches with identical
+      // backend cols (no merge → no drain) still pick up the hide intent.
+      setColumns((prev) => {
+        let anyChanged = false;
+        const next = {};
+        Object.keys(prev).forEach((ck) => {
+          let slotChanged = false;
+          const updated = (prev[ck] || []).map((col) => {
+            if (col && col.id in hideMap) {
+              const desiredVisible = !hideMap[col.id];
+              if (col.isVisible !== desiredVisible) {
+                slotChanged = true;
+                return { ...col, isVisible: desiredVisible };
+              }
+            }
+            return col;
+          });
+          next[ck] = slotChanged ? updated : prev[ck];
+          if (slotChanged) anyChanged = true;
+        });
+        return anyChanged ? next : prev;
+      });
+      // Queue for cols that arrive later via TraceGrid's merge.
+      pendingHideMapRef.current = hideMap;
+
       const activeApi =
         selectedTab === "trace"
           ? primaryTraceGridRef.current?.api
@@ -1739,8 +1899,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       }
     }
 
-    // Primary date filter — stored inside display for backend-whitelist compatibility.
-    // Only apply if the saved view has one; old views without it keep the current date.
+    // dateFilter lives inside display because the backend serializer only
+    // whitelists `display` for arbitrary sub-keys.
     if (display.dateFilter) {
       if (selectedTab === "trace") {
         setPrimaryTraceDateFilter(display.dateFilter);
@@ -1749,11 +1909,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       }
     }
 
-    // Apply filters — replace unconditionally so switching views clears stale filters.
-    // Guard with Array.isArray: UsersView writes `filters` as an object
-    // ({extraFilters, dateFilter}), and that config can briefly leak into this
-    // view's apply effect during cross-tab transitions (the route change is
-    // queued in startTransition while activeViewConfig updates synchronously).
+    // Array.isArray guard: UsersView writes `filters` as an object, which
+    // can briefly leak during cross-tab transitions (route change is queued
+    // in startTransition while activeViewConfig updates synchronously).
     const rawFilters = activeViewConfig.filters;
     const nextFilters = (Array.isArray(rawFilters) ? rawFilters : []).map(
       (f) => ({
@@ -1798,9 +1956,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeViewConfig]);
 
-  // Drain the queued saved-view columnState once the active sub-tab's primary
-  // grid mounts. TraceGrid is lazy-loaded so the AG Grid api may not exist
-  // when applyConfig runs — retry a handful of times to catch it.
+  // Drains pendingColumnStateRef once the lazy-loaded grid mounts.
   useEffect(() => {
     if (!pendingColumnStateRef.current) return;
     let attempts = 0;
@@ -1831,6 +1987,57 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     };
   }, [activeViewConfig, selectedTab]);
 
+  // Re-apply queued columnState + hideMap once `columns` updates. The
+  // retry effect above only fires on activeViewConfig/selectedTab change;
+  // if it ran before custom cols landed, AG Grid dropped their entries.
+  // The hideMap path is necessary because the next columnDefs rebuild
+  // overrides applyColumnState's hide flag from col.isVisible.
+  useEffect(() => {
+    if (pendingHideMapRef.current) {
+      const hideMap = pendingHideMapRef.current;
+      // Only clear pendingHideMapRef if at least one col matched —
+      // otherwise a cold-load drain on empty slots would wipe the queue
+      // before TraceGrid/SpanGrid's first setColumns lands the cols.
+      let sawMatch = false;
+      setColumns((prev) => {
+        let anyChanged = false;
+        const next = {};
+        Object.keys(prev).forEach((ck) => {
+          let slotChanged = false;
+          const updated = (prev[ck] || []).map((col) => {
+            if (col && col.id in hideMap) {
+              sawMatch = true;
+              const desiredVisible = !hideMap[col.id];
+              if (col.isVisible !== desiredVisible) {
+                slotChanged = true;
+                return { ...col, isVisible: desiredVisible };
+              }
+            }
+            return col;
+          });
+          next[ck] = slotChanged ? updated : prev[ck];
+          if (slotChanged) anyChanged = true;
+        });
+        return anyChanged ? next : prev;
+      });
+      if (sawMatch) {
+        pendingHideMapRef.current = null;
+      }
+    }
+    if (!pendingColumnStateRef.current) return;
+    const api =
+      selectedTab === "trace"
+        ? primaryTraceGridRef.current?.api
+        : primarySpanGridRef.current?.api;
+    if (!api?.applyColumnState) return;
+    api.applyColumnState({
+      state: pendingColumnStateRef.current,
+      applyOrder: true,
+    });
+    pendingColumnStateRef.current = null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columns]);
+
   // ---------------------------------------------------------------------------
   // View persistence — auto-save display + reset/default
   // ---------------------------------------------------------------------------
@@ -1841,13 +2048,19 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     ? `user-filters-${userIdForUserMode}`
     : `observe-filters-${observeId}`;
 
-  // Pending custom columns — loaded from localStorage/view config but not
-  // merged into columns state until the backend returns real columns.
-  // This prevents the loading skeleton from showing only custom columns.
-  const pendingCustomColumnsRef = useRef([]);
+  // Pending custom cols, queued until the backend returns real columns so
+  // the grid doesn't render with only-custom-col headers mid-load. One ref
+  // per grid instance — a shared ref would race across the 4 mounted grids.
+  const primaryTracePendingRef = useRef([]);
+  const compareTracePendingRef = useRef([]);
+  const primarySpansPendingRef = useRef([]);
+  const compareSpansPendingRef = useRef([]);
 
-  // Load display settings from localStorage on mount (for default tab)
+  // Mount hydrate for the default tab. Saved-view tabs hydrate via the
+  // apply effect above; seeding here on a saved-view URL would drain the
+  // wrong customs before the view config arrives.
   useEffect(() => {
+    if (activeViewTabId) return;
     try {
       const raw = localStorage.getItem(displayStorageKey);
       if (!raw) return;
@@ -1858,9 +2071,32 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       if (saved.showNonAnnotated) setShowNonAnnotated(saved.showNonAnnotated);
       if (saved.showCompare) setShowCompare(saved.showCompare);
       if (saved.hasEvalFilter) setHasEvalFilter(saved.hasEvalFilter);
-      // Defer custom columns — they'll be merged when backend columns arrive
-      if (saved.customColumns?.length > 0) {
-        pendingCustomColumnsRef.current = saved.customColumns;
+      // Accept both new {trace, spans} object shape and legacy flat array
+      // (treated as customs for the current tab only).
+      if (saved.customColumns) {
+        const cloneEach = (arr) => arr.map((c) => ({ ...c }));
+        if (Array.isArray(saved.customColumns)) {
+          if (saved.customColumns.length > 0) {
+            if (selectedTab === "trace") {
+              primaryTracePendingRef.current = cloneEach(saved.customColumns);
+              compareTracePendingRef.current = cloneEach(saved.customColumns);
+            } else {
+              primarySpansPendingRef.current = cloneEach(saved.customColumns);
+              compareSpansPendingRef.current = cloneEach(saved.customColumns);
+            }
+          }
+        } else {
+          const traceCols = saved.customColumns.trace || [];
+          const spansCols = saved.customColumns.spans || [];
+          if (traceCols.length > 0) {
+            primaryTracePendingRef.current = cloneEach(traceCols);
+            compareTracePendingRef.current = cloneEach(traceCols);
+          }
+          if (spansCols.length > 0) {
+            primarySpansPendingRef.current = cloneEach(spansCols);
+            compareSpansPendingRef.current = cloneEach(spansCols);
+          }
+        }
       }
     } catch {
       /* ignore corrupted localStorage */
@@ -1925,26 +2161,35 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     return (columns[ck] || []).filter((c) => c.groupBy === "Custom Columns");
   }, [columns, selectedGraph, selectedTab]);
 
+  // Used by the localStorage save so adding customs on one tab doesn't
+  // wipe the other's customs (storage key is project-scoped, not tab-scoped).
+  const getCustomColumnsByTab = useCallback(() => {
+    const traceKey = `${selectedGraph}-trace`;
+    const spansKey = `${selectedGraph}-spans`;
+    return {
+      trace: (columns[traceKey] || []).filter(
+        (c) => c.groupBy === "Custom Columns",
+      ),
+      spans: (columns[spansKey] || []).filter(
+        (c) => c.groupBy === "Custom Columns",
+      ),
+    };
+  }, [columns, selectedGraph]);
+
   const { mutate: updateSavedView } = useUpdateSavedView(observeId);
   const { mutate: createSavedView } = useCreateSavedView(observeId);
-  // Workspace-scoped update for user_detail mode (CrossProjectUserDetailPage).
-  // Always declared (hooks can't be conditional); only invoked when isUserMode.
+  // Workspace-scoped update for user_detail mode — only invoked when isUserMode.
   const { mutate: updateWorkspaceSavedView } =
     useUpdateWorkspaceSavedView(USER_DETAIL_TAB_TYPE);
 
-  // Get active view tab ID from URL. The tab-key URL param differs per
-  // surface: "tab" on ObservePage, "userTab" on CrossProjectUserDetailPage.
   const activeViewTabId = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
     const tab = isUserMode ? params.get("userTab") : params.get("tab");
     return tab?.startsWith("view-") ? tab.replace("view-", "") : null;
-  }, [activeViewConfig, isUserMode]); // re-derive when view config changes
+  }, [activeViewConfig, isUserMode]);
 
-  // Build the full saved view config payload
   const buildViewConfig = useCallback(() => {
-    // Capture current grid column state (widths/order/sort/visibility) of the
-    // active sub-tab's primary grid, so saved views restore the user's exact
-    // column layout. Stashed inside `display` because the backend serializer
+    // columnState lives inside `display` because the backend serializer
     // whitelists `display` for arbitrary subkeys.
     const activeGridApi =
       selectedTab === "trace"
@@ -1959,7 +2204,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       showCompare,
       hasEvalFilter,
       customColumns: getCustomColumns(),
-      // Stash primary date filter inside display for backend-whitelist compatibility
+      // dateFilter lives inside display for backend-whitelist compatibility.
       dateFilter:
         selectedTab === "trace"
           ? primaryTraceDateFilter
@@ -1976,10 +2221,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       filters: mapFilters(
         selectedTab === "trace" ? primaryTraceFilters : primarySpanFilters,
       ),
-      // extraFilters is independent of compare mode — always persist
       extraFilters: extraFilters || [],
     };
-    // Include compare state when compare mode is on
     if (showCompare) {
       config.compareFilters = mapFilters(
         selectedTab === "trace" ? compareTraceFilters : compareSpansFilters,
@@ -2023,8 +2266,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     return () => registerGetTabType(null);
   }, [registerGetTabType, selectedTab]);
 
-  // Explicit "Save view" — overwrite the active saved view's config with the
-  // current live state. Bound to ObserveToolbar's Save view button.
+  // Bound to ObserveToolbar's Save view button.
   const handleSaveView = useCallback(() => {
     if (!activeViewTabId) return;
     const config = buildViewConfig();
@@ -2033,7 +2275,6 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       { id: activeViewTabId, config },
       {
         onSuccess: (response) => {
-          // Refresh the baseline so canSaveView's diff resets to false.
           setActiveViewConfig(response?.data?.result?.config ?? config);
           enqueueSnackbar("View updated", { variant: "success" });
         },
@@ -2050,16 +2291,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     setActiveViewConfig,
   ]);
 
-  // Persist display settings to localStorage on the default tab so personal
-  // preferences (cellHeight, viewMode, …) survive across navigation. The
-  // backend-update branch that used to live here was removed: filter/date
-  // state was never in the dep array, so it silently missed those changes.
-  // Updates to a saved view are now triggered explicitly by handleSaveView
-  // (the Save view button in the toolbar).
+  // Default tab only — saved views go through handleSaveView instead.
   useEffect(() => {
-    // Default tab only — persist personal display preferences to localStorage
-    // so cellHeight / viewMode / etc. survive across navigation. Saved-view
-    // tabs go through the explicit Save view button (handleSaveView) instead.
     if (activeViewTabId) return;
     const currentDisplay = {
       viewMode,
@@ -2068,7 +2301,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       showNonAnnotated,
       showCompare,
       hasEvalFilter,
-      customColumns: getCustomColumns(),
+      // Keyed by tab type so adding a custom on spans doesn't overwrite
+      // traces' customs (storage key is project-scoped, not tab-scoped).
+      customColumns: getCustomColumnsByTab(),
     };
     try {
       localStorage.setItem(displayStorageKey, JSON.stringify(currentDisplay));
@@ -2084,7 +2319,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     showCompare,
     hasEvalFilter,
     displayStorageKey,
-    getCustomColumns,
+    getCustomColumnsByTab,
   ]);
 
   const handleAddEvals = useCallback(() => {
@@ -4076,7 +4311,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     hasEvalFilter={hasEvalFilter}
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
-                    pendingCustomColumnsRef={pendingCustomColumnsRef}
+                    pendingCustomColumnsRef={primaryTracePendingRef}
                     showErrors={showErrors}
                     enabled={
                       [
@@ -4114,7 +4349,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     hasEvalFilter={hasEvalFilter}
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
-                    pendingCustomColumnsRef={pendingCustomColumnsRef}
+                    pendingCustomColumnsRef={compareTracePendingRef}
                     projectId={observeId}
                     showErrors={showErrors}
                     enabled={
@@ -4173,7 +4408,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     hasEvalFilter={hasEvalFilter}
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
-                    pendingCustomColumnsRef={pendingCustomColumnsRef}
+                    pendingCustomColumnsRef={primarySpansPendingRef}
                     setFilters={setPrimarySpanFilters}
                     setExtraFilters={setExtraFilters}
                     setFilterOpen={setIsPrimaryFilterOpen}
@@ -4207,7 +4442,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                     hasEvalFilter={hasEvalFilter}
                     cellHeight={cellHeight}
                     metricFilters={metricFilters}
-                    pendingCustomColumnsRef={pendingCustomColumnsRef}
+                    pendingCustomColumnsRef={compareSpansPendingRef}
                     filters={compareSpansValidatedFilters}
                     extraFilters={extraFilters}
                     ref={compareSpanGridRef}

--- a/frontend/src/sections/projects/LLMTracing/Renderers/DefaultCell.jsx
+++ b/frontend/src/sections/projects/LLMTracing/Renderers/DefaultCell.jsx
@@ -23,7 +23,8 @@ const DefaultCell = memo(
     const colId = column?.id;
 
     const showQuickFilter =
-      !RENDERER_CONFIG.ignoredQuickFilters.includes(colId);
+      !RENDERER_CONFIG.ignoredQuickFilters.includes(colId) &&
+      column?.groupBy !== "Custom Columns";
 
     const shouldApplyDateFormat =
       RENDERER_CONFIG.applyDateFormat.includes(colId) && value;

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -377,21 +377,44 @@ const SpanGrid = React.forwardRef(
                 const currentNonCustom = (columnsRef.current || []).filter(
                   (c) => c.groupBy !== "Custom Columns",
                 );
-                if (!_.isEqual(newCols, currentNonCustom)) {
-                  const existingCustom = (columnsRef.current || []).filter(
-                    (c) => c.groupBy === "Custom Columns",
-                  );
-                  const pending = pendingCustomColumnsRef?.current || [];
-                  const existingIds = new Set(existingCustom.map((c) => c.id));
-                  const dedupedPending = pending.filter(
-                    (c) => !existingIds.has(c.id),
-                  );
+                const existingCustom = (columnsRef.current || []).filter(
+                  (c) => c.groupBy === "Custom Columns",
+                );
+                const pending = pendingCustomColumnsRef?.current || [];
+                const existingIds = new Set(existingCustom.map((c) => c.id));
+                const dedupedPending = pending.filter(
+                  (c) => !existingIds.has(c.id),
+                );
+                // Strip isVisible from the diff so saved-view hide maps
+                // don't keep retriggering the merge on every fetch.
+                const stripVis = (cols) =>
+                  (cols || []).map(({ isVisible, ...rest }) => rest);
+                const backendChanged = !_.isEqual(
+                  stripVis(newCols),
+                  stripVis(currentNonCustom),
+                );
+                const hasPending = dedupedPending.length > 0;
+                if (backendChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
+                  // Preserve existing isVisible so saved-view hide intent
+                  // survives backend col changes.
+                  const finalNonCustom = backendChanged
+                    ? newCols.map((nc) => {
+                        const existing = currentNonCustom.find(
+                          (c) => c.id === nc.id,
+                        );
+                        return existing
+                          ? { ...nc, isVisible: existing.isVisible }
+                          : nc;
+                      })
+                    : currentNonCustom;
                   setColumns(
-                    allCustom.length > 0 ? [...newCols, ...allCustom] : newCols,
+                    allCustom.length > 0
+                      ? [...finalNonCustom, ...allCustom]
+                      : finalNonCustom,
                   );
                 }
               }

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -216,23 +216,47 @@ const TraceGrid = React.forwardRef(
                 const currentNonCustom = (columnsRef.current || []).filter(
                   (c) => c.groupBy !== "Custom Columns",
                 );
-                if (!_.isEqual(newCols, currentNonCustom)) {
-                  // Merge: existing custom cols + pending (from localStorage/saved view)
-                  const existingCustom = (columnsRef.current || []).filter(
-                    (c) => c.groupBy === "Custom Columns",
-                  );
-                  const pending = pendingCustomColumnsRef?.current || [];
-                  const existingIds = new Set(existingCustom.map((c) => c.id));
-                  const dedupedPending = pending.filter(
-                    (c) => !existingIds.has(c.id),
-                  );
+                const existingCustom = (columnsRef.current || []).filter(
+                  (c) => c.groupBy === "Custom Columns",
+                );
+                const pending = pendingCustomColumnsRef?.current || [];
+                const existingIds = new Set(existingCustom.map((c) => c.id));
+                const dedupedPending = pending.filter(
+                  (c) => !existingIds.has(c.id),
+                );
+                // Strip isVisible from the diff so saved-view hide maps
+                // don't keep retriggering the merge on every fetch. The
+                // hasPending clause ensures a saved-view switch with same
+                // backend cols still drains the pending customs.
+                const stripVis = (cols) =>
+                  (cols || []).map(({ isVisible, ...rest }) => rest);
+                const backendChanged = !_.isEqual(
+                  stripVis(newCols),
+                  stripVis(currentNonCustom),
+                );
+                const hasPending = dedupedPending.length > 0;
+                if (backendChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
-                  // Clear pending after consuming
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
+                  // Preserve existing isVisible so saved-view hide intent
+                  // survives backend col changes. Pending-only path reuses
+                  // currentNonCustom to keep column identity stable.
+                  const finalNonCustom = backendChanged
+                    ? newCols.map((nc) => {
+                        const existing = currentNonCustom.find(
+                          (c) => c.id === nc.id,
+                        );
+                        return existing
+                          ? { ...nc, isVisible: existing.isVisible }
+                          : nc;
+                      })
+                    : currentNonCustom;
                   setColumns(
-                    allCustom.length > 0 ? [...newCols, ...allCustom] : newCols,
+                    allCustom.length > 0
+                      ? [...finalNonCustom, ...allCustom]
+                      : finalNonCustom,
                   );
                 }
               }

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -239,21 +239,30 @@ const SessionGrid = React.forwardRef(
                 const currentNonCustom = (columnsRef.current || []).filter(
                   (c) => c.groupBy !== "Custom Columns",
                 );
-                if (!_.isEqual(newCols, currentNonCustom)) {
-                  const existingCustom = (columnsRef.current || []).filter(
-                    (c) => c.groupBy === "Custom Columns",
-                  );
-                  const pending = pendingCustomColumnsRef?.current || [];
-                  const existingIds = new Set(existingCustom.map((c) => c.id));
-                  const dedupedPending = pending.filter(
-                    (c) => !existingIds.has(c.id),
-                  );
+                const existingCustom = (columnsRef.current || []).filter(
+                  (c) => c.groupBy === "Custom Columns",
+                );
+                const pending = pendingCustomColumnsRef?.current || [];
+                const existingIds = new Set(existingCustom.map((c) => c.id));
+                const dedupedPending = pending.filter(
+                  (c) => !existingIds.has(c.id),
+                );
+                const backendChanged = !_.isEqual(newCols, currentNonCustom);
+                // hasPending ensures same-tab saved-view clicks still drain
+                // queued customs even when backend cols match.
+                const hasPending = dedupedPending.length > 0;
+                if (backendChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
+                  const finalNonCustom = backendChanged
+                    ? newCols
+                    : currentNonCustom;
                   setColumns(
-                    allCustom.length > 0 ? [...newCols, ...allCustom] : newCols,
+                    allCustom.length > 0
+                      ? [...finalNonCustom, ...allCustom]
+                      : finalNonCustom,
                   );
                 }
               }

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -368,6 +368,22 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         }
       }
     }
+    // Custom cols: order is captured by columnState, so we only diff the set.
+    const currentCustomIds = (sessionColumns || [])
+      .filter((c) => c.groupBy === "Custom Columns")
+      .map((c) => c.id)
+      .sort();
+    const baselineCustomIds = (
+      Array.isArray(baselineDisplay.customColumns)
+        ? baselineDisplay.customColumns
+        : []
+    )
+      .map((c) => c.id)
+      .sort();
+    if (currentCustomIds.length !== baselineCustomIds.length) return true;
+    for (let i = 0; i < currentCustomIds.length; i += 1) {
+      if (currentCustomIds[i] !== baselineCustomIds[i]) return true;
+    }
     return false;
   }, [
     activeViewConfig,
@@ -376,29 +392,24 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     cellHeight,
     showCompare,
     updateObj,
+    sessionColumns,
   ]);
 
-  // Defer so the button doesn't flicker during the one-render gap between
-  // filter state updating urgently and activeViewConfig catching up from
-  // startTransition in the apply path.
+  // Deferred so the button doesn't flicker between filter state (urgent)
+  // and activeViewConfig (startTransition) settling.
   const canSaveViewDeferred = useDeferredValue(canSaveView);
 
-  // --- Saved view capture + apply (TH-4578) ---
-  // Build a view-config snapshot that mirrors LLMTracingView's shape. dateFilter
-  // stays inside `display` because the backend's saved-view serializer only
-  // whitelists `display` for arbitrary sub-keys (no top-level `dateFilter`).
-  // Note: in earlier versions this view skipped writing URL-synced state in
-  // the apply effect on the assumption that a click-time seedUrlForView
-  // would populate the URL. That's only true on UserDetailTabBar — the
-  // ObservePage tab-bar path doesn't seed sessionCellHeight / sessionShowCompare /
-  // sessionDateFilter, so display options never made it onto the page when
-  // selecting a sessions saved view from the project's tab bar. Now apply
-  // pushes them into URL state directly (matching UsersView / LLMTracingView).
+  // dateFilter lives inside `display` because the backend serializer only
+  // whitelists `display` for arbitrary sub-keys (no top-level dateFilter).
   const buildViewConfig = useCallback(() => {
     const columnState =
       sessionGridApiRef.current?.api?.getColumnState?.() ?? undefined;
-    // updateObj is the authoritative {col.id: isVisible} source.
     const hasVisibility = updateObj && Object.keys(updateObj).length > 0;
+    // customColumns separately: AG Grid drops columnState for unknown colIds,
+    // so without this list the custom cols can't be reconstructed on restore.
+    const customColumns = (sessionColumns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
     return {
       display: {
         cellHeight,
@@ -406,10 +417,18 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         dateFilter,
         ...(hasVisibility ? { visibleColumns: updateObj } : {}),
         ...(columnState ? { columnState } : {}),
+        ...(customColumns.length > 0 ? { customColumns } : {}),
       },
       extraFilters: extraFilters || [],
     };
-  }, [cellHeight, showCompare, dateFilter, extraFilters, updateObj]);
+  }, [
+    cellHeight,
+    showCompare,
+    dateFilter,
+    extraFilters,
+    updateObj,
+    sessionColumns,
+  ]);
 
   useEffect(() => {
     registerGetViewConfig(buildViewConfig);
@@ -421,19 +440,86 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     return () => registerGetTabType(null);
   }, [registerGetTabType]);
 
-  // Update mutations for the explicit Save view button. Project-scoped on
-  // ObservePage, workspace-scoped (user_detail) on CrossProjectUserDetailPage.
   const { mutate: updateSavedView } = useUpdateSavedView(observeId);
   const { mutate: updateWorkspaceSavedView } =
     useUpdateWorkspaceSavedView(USER_DETAIL_TAB_TYPE);
 
-  // Active saved-view id from URL — "tab" key on ObservePage, "userTab" on
-  // CrossProjectUserDetailPage. Re-derived when activeViewConfig flips.
   const activeViewTabId = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
     const key = isUserMode ? params.get("userTab") : params.get("tab");
     return key?.startsWith("view-") ? key.slice(5) : null;
   }, [activeViewConfig, isUserMode]);
+
+  const displayStorageKey = isUserMode
+    ? `user-sessions-display-${userIdForUserMode}`
+    : `observe-sessions-display-${observeId}`;
+
+  const hydratedKeyRef = useRef(null);
+  // Skips the save effect's first fire after a hydrate. Without this the
+  // first fire closes over pre-hydrate state and overwrites what we just
+  // loaded.
+  const skipNextSaveRef = useRef(false);
+
+  const writeDisplayToStorage = useCallback(() => {
+    const customColumns = (sessionColumns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
+    const payload = {
+      cellHeight,
+      showCompare,
+      ...(updateObj && Object.keys(updateObj).length > 0
+        ? { visibleColumns: updateObj }
+        : {}),
+      ...(customColumns.length > 0 ? { customColumns } : {}),
+    };
+    try {
+      localStorage.setItem(displayStorageKey, JSON.stringify(payload));
+    } catch {
+      /* quota exceeded */
+    }
+  }, [displayStorageKey, cellHeight, showCompare, updateObj, sessionColumns]);
+
+  useEffect(() => {
+    if (activeViewTabId) return;
+    if (hydratedKeyRef.current === displayStorageKey) return;
+    hydratedKeyRef.current = displayStorageKey;
+    try {
+      const raw = localStorage.getItem(displayStorageKey);
+      if (!raw) return;
+      skipNextSaveRef.current = true;
+      const saved = JSON.parse(raw);
+      if (saved.cellHeight) setCellHeight(saved.cellHeight);
+      if (typeof saved.showCompare === "boolean") {
+        setShowCompare(saved.showCompare);
+      }
+      if (saved.visibleColumns && typeof saved.visibleColumns === "object") {
+        setUpdateObj(saved.visibleColumns);
+      }
+      if (
+        Array.isArray(saved.customColumns) &&
+        saved.customColumns.length > 0
+      ) {
+        // Shallow-clone so the pending ref doesn't share identity with the
+        // parsed localStorage payload.
+        pendingCustomColumnsRef.current = saved.customColumns.map((c) => ({
+          ...c,
+        }));
+      }
+    } catch {
+      /* ignore corrupted localStorage */
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayStorageKey]);
+
+  useEffect(() => {
+    if (activeViewTabId) return;
+    if (hydratedKeyRef.current !== displayStorageKey) return;
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false;
+      return;
+    }
+    writeDisplayToStorage();
+  }, [activeViewTabId, displayStorageKey, writeDisplayToStorage]);
 
   const handleSaveView = useCallback(() => {
     if (!activeViewTabId) return;
@@ -459,22 +545,18 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     setActiveViewConfig,
   ]);
 
-  // Pending column state queued before the grid was ready. Drain effect
-  // below applies it once `sessionGridApiRef.current.api` shows up.
+  // Drained in the api-ready effect below once sessionGridApiRef populates.
   const pendingColumnStateRef = useRef(null);
+  // Set when the apply effect fires before the grid mounts (hard refresh
+  // into a saved view). Drained in onGridReady, otherwise the pending
+  // custom-col ref is stranded.
+  const pendingRefreshRef = useRef(false);
 
-  // Apply a saved view's config — push display options into URL-synced
-  // state (matches UsersView / LLMTracingView). UserDetailTabBar still
-  // pre-seeds the same URL keys at click time for snappiness; the writes
-  // here are idempotent for that path and are the only source of truth
-  // for the ObservePage tab-bar path, which doesn't pre-seed display.
   useEffect(() => {
     if (!activeViewConfig) {
-      // Transitioning back to a default tab — wipe everything that was
-      // applied by the saved view. URL-synced display state (cellHeight,
-      // showCompare, dateFilter) reverts via useUrlState as the parent's
-      // navigate() drops those URL keys; everything else has to be reset
-      // here because it lives in plain useState or inside AG Grid.
+      // Default tab — reset everything the saved view applied. URL-synced
+      // state reverts via useUrlState; the rest lives in useState / AG Grid
+      // and needs explicit reset.
       setExtraFilters((prev) => (prev.length === 0 ? prev : []));
       viewLoadedUpdateObjRef.current = null;
       setUpdateObj(initialVisibility);
@@ -491,6 +573,43 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       }
       if (api?.resetColumnState) api.resetColumnState();
       pendingColumnStateRef.current = null;
+      pendingCustomColumnsRef.current = [];
+      setSessionColumns((prev) =>
+        (prev || []).filter((c) => c.groupBy !== "Custom Columns"),
+      );
+      // Re-hydrate from localStorage — the mount hydrate is keyed on
+      // displayStorageKey and won't re-fire on a same-project saved-view →
+      // default transition.
+      try {
+        const raw = localStorage.getItem(displayStorageKey);
+        if (raw) {
+          skipNextSaveRef.current = true;
+          const saved = JSON.parse(raw);
+          if (saved.cellHeight) setCellHeight(saved.cellHeight);
+          if (typeof saved.showCompare === "boolean") {
+            setShowCompare(saved.showCompare);
+          }
+          if (
+            saved.visibleColumns &&
+            typeof saved.visibleColumns === "object"
+          ) {
+            setUpdateObj(saved.visibleColumns);
+          }
+          if (
+            Array.isArray(saved.customColumns) &&
+            saved.customColumns.length > 0
+          ) {
+            pendingCustomColumnsRef.current = saved.customColumns.map((c) => ({
+              ...c,
+            }));
+            sessionGridApiRef.current?.api?.refreshServerSide?.({
+              purge: true,
+            });
+          }
+        }
+      } catch {
+        /* ignore corrupted localStorage */
+      }
       return;
     }
     const display = activeViewConfig.display || {};
@@ -501,11 +620,8 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     if (display.dateFilter) {
       setDateFilter(display.dateFilter);
     }
-    // Apply visibleColumns dict — `updateObj` is the single source of truth
-    // for column visibility (drives the ColumnConfigure popover via
-    // displayColumns and is the authoritative {col.id: bool} dict). Push
-    // visibility into AG Grid directly when the api is available so the
-    // grid display matches without waiting for a re-render. Done before the
+    // Push visibility into AG Grid directly when the api is available so
+    // the display matches without waiting for re-render. Done before the
     // snapshot below so canSaveView's baseline matches the just-applied state.
     if (
       display.visibleColumns &&
@@ -524,24 +640,49 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         if (toHide.length) api.setColumnsVisible(toHide, false);
       }
     }
-    // Capture the visibility state at the moment this saved view is loaded,
-    // so canSaveView can compare any subsequent toggles against this
-    // snapshot — covers older views that didn't persist `visibleColumns`.
-    // Use the just-applied dict if it exists, otherwise current updateObj.
+    // Snapshot visibility so canSaveView can diff later toggles; covers
+    // older views that didn't persist visibleColumns.
     viewLoadedUpdateObjRef.current = display.visibleColumns
       ? { ...display.visibleColumns }
       : updateObj
         ? { ...updateObj }
         : null;
-    if (Array.isArray(display.columnState) && display.columnState.length > 0) {
+    setSessionColumns((prev) =>
+      (prev || []).filter((c) => c.groupBy !== "Custom Columns"),
+    );
+    // Shallow-clone each col so a later mutation (visibility toggle,
+    // save-as-new) doesn't write through into the saved-views cache.
+    const savedCustomCols = Array.isArray(display.customColumns)
+      ? display.customColumns.map((c) => ({ ...c }))
+      : [];
+    pendingCustomColumnsRef.current = savedCustomCols;
+    // Force a re-fetch so Session-grid's merge drains the queued customs.
+    // When extraFilters happen to equal current state, setExtraFilters
+    // returns the same ref and the dataSource memo never recreates.
+    if (savedCustomCols.length > 0) {
       const api = sessionGridApiRef.current?.api;
-      if (api?.applyColumnState) {
-        api.applyColumnState({
-          state: display.columnState,
-          applyOrder: true,
-        });
+      if (api?.refreshServerSide) {
+        api.refreshServerSide({ purge: true });
       } else {
+        pendingRefreshRef.current = true;
+      }
+    }
+    if (Array.isArray(display.columnState) && display.columnState.length > 0) {
+      // Queue columnState when customs are pending — AG Grid silently drops
+      // applyColumnState entries for unknown colIds, so widths/order for
+      // custom cols would be lost otherwise. Drained when the customs land.
+      if (savedCustomCols.length > 0) {
         pendingColumnStateRef.current = display.columnState;
+      } else {
+        const api = sessionGridApiRef.current?.api;
+        if (api?.applyColumnState) {
+          api.applyColumnState({
+            state: display.columnState,
+            applyOrder: true,
+          });
+        } else {
+          pendingColumnStateRef.current = display.columnState;
+        }
       }
     }
     const nextExtraFilters = activeViewConfig.extraFilters || [];
@@ -608,10 +749,8 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     : toggledNodes.length;
 
   const [queueAnchorEl, setQueueAnchorEl] = useState(null);
-  // Opt-in for filter-mode session bulk add. Set to true when
-  // the user clicks the banner's "Select all N matching your filter" link.
-  // Resets when the grid clears select-all, when the project changes, or
-  // when the filter payload changes (the opt-in no longer matches the view).
+  // Opt-in for filter-mode bulk add — set when the SelectAllBanner is
+  // clicked; reset on select-all clear, project change, or filter change.
   const [sessionFilterSelectionMode, setSessionFilterSelectionMode] =
     useState(false);
   useEffect(() => {
@@ -644,11 +783,8 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
           },
         });
       } else if (action === "annotation-queue") {
-        // With filter-mode opt-in (the SelectAllBanner), the popover's
-        // submit posts `{selection: {mode: "filter", ...}}` to the Phase 6
-        // backend endpoint. Without opt-in under select-all we still bail
-        // out — toggledNodes holds the *deselected* rows in that mode and
-        // an enumerated add would be wrong.
+        // Without filter-mode opt-in under select-all, toggledNodes holds
+        // the *deselected* rows — an enumerated add would be wrong.
         if (selectAll && !sessionFilterSelectionMode) {
           enqueueSnackbar(
             "Use the 'Select all matching your filter' banner to add the full set, or deselect 'all' and pick specific rows.",
@@ -727,9 +863,33 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         });
         pendingColumnStateRef.current = null;
       }
+      // Drain a queued refresh request — fires when the saved-view apply
+      // effect ran before the grid mounted (hard refresh into a saved
+      // view URL). Without this drain the queued custom-col ref would
+      // sit forever waiting for a fetch that never comes.
+      if (pendingRefreshRef.current && params.api?.refreshServerSide) {
+        params.api.refreshServerSide({ purge: true });
+        pendingRefreshRef.current = false;
+      }
     },
     [setHeaderConfig],
   );
+
+  // Drain pendingColumnState once sessionColumns updates (custom cols
+  // landed via the Session-grid merge) and the grid api is ready. Catches
+  // the case where the saved view includes both custom cols AND
+  // columnState — applying state before custom cols are merged would
+  // silently drop widths/order/sort for the unknown colIds.
+  useEffect(() => {
+    if (!pendingColumnStateRef.current) return;
+    const api = sessionGridApiRef.current?.api;
+    if (!api?.applyColumnState) return;
+    api.applyColumnState({
+      state: pendingColumnStateRef.current,
+      applyOrder: true,
+    });
+    pendingColumnStateRef.current = null;
+  }, [sessionColumns]);
 
   // --- Column config for display panel ---
   const displayColumns = useMemo(() => {

--- a/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
+++ b/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { Box } from "@mui/material";
 import { useParams } from "react-router";
@@ -13,9 +13,9 @@ import FilterChips from "../../LLMTracing/FilterChips";
 import ColumnConfigureDropDown from "src/sections/project-detail/ColumnDropdown/ColumnConfigureDropDown";
 import { transformDateFilterToBackendFilters } from "../common";
 
-// New trace view embedded inside UserDetails. Mounts LLMTracing's TraceGrid
-// pre-filtered to the current user, with the full ObserveToolbar (Filter +
-// Display + Custom Columns) the user gets on the main trace list page.
+// Trace view embedded inside UserDetails — mounts TraceGrid pre-filtered
+// to the current user, with the full ObserveToolbar (filter, display,
+// custom columns).
 const UserTraceTabV2 = ({ dateFilter }) => {
   const { observeId, userId } = useParams();
   const [selectedProjectId] = useUrlState("projectId", null);
@@ -36,6 +36,60 @@ const UserTraceTabV2 = ({ dateFilter }) => {
   const [columnConfigureAnchor, setColumnConfigureAnchor] = useState(null);
   const openColumnConfigure = Boolean(columnConfigureAnchor);
   const pendingCustomColumnsRef = useRef([]);
+
+  // Scoped per {project, user} — same user across projects gets its own
+  // set since available attributes are project-specific.
+  const customColsStorageKey = `user-trace-customcols-${projectId}-${userId}`;
+  // hasDrainedRef gates the save effect until TraceGrid's merge has
+  // landed; without it the first-render empty `columns` would wipe the
+  // saved customs before the pending ref drains. skipNextSaveRef skips
+  // the first save fire after a hydrate so the pre-hydrate closure can't
+  // overwrite what we just loaded.
+  const hasDrainedRef = useRef(false);
+  const skipNextSaveRef = useRef(false);
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(customColsStorageKey);
+      if (!raw) return;
+      const saved = JSON.parse(raw);
+      if (Array.isArray(saved) && saved.length > 0) {
+        // Shallow-clone so the pending ref doesn't share identity with
+        // the parsed localStorage payload.
+        pendingCustomColumnsRef.current = saved.map((c) => ({ ...c }));
+        skipNextSaveRef.current = true;
+      }
+    } catch {
+      /* ignore corrupted localStorage */
+    }
+  }, [customColsStorageKey]);
+
+  useEffect(() => {
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false;
+      return;
+    }
+    const customCols = (columns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
+    if (!hasDrainedRef.current && customCols.length === 0) {
+      if ((columns || []).length > 0) {
+        hasDrainedRef.current = true;
+      } else {
+        return;
+      }
+    } else {
+      hasDrainedRef.current = true;
+    }
+    try {
+      if (customCols.length > 0) {
+        localStorage.setItem(customColsStorageKey, JSON.stringify(customCols));
+      } else {
+        localStorage.removeItem(customColsStorageKey);
+      }
+    } catch {
+      /* quota exceeded */
+    }
+  }, [columns, customColsStorageKey]);
 
   // Build validated filter list: user_id + date range + any user-added extras.
   const validatedFilters = useMemo(() => {

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -310,20 +310,20 @@ const UsersView = ({
     useUsersStore.setState({ filters: finalFilters });
   }, [finalFilters]);
 
-  // ---------------------------------------------------------------------------
-  // Saved-view api — populates a ref that the parent UsersPageTabBar drives.
-  // Captures display + filter state into config, and restores it on activation.
-  // ---------------------------------------------------------------------------
+  // Saved-view api — populates a ref the parent UsersPageTabBar drives.
   const getConfig = useCallback(() => {
     const visibleColumns = (columns || []).reduce((acc, col) => {
       acc[col.id] = col.isVisible !== false;
       return acc;
     }, {});
-    // Capture full grid column state (widths, order, sort) so saved views
-    // restore the user's exact column layout. Stash inside `display` since
-    // the backend serializer's allowed_keys whitelists `display` for
-    // arbitrary subkeys but does not whitelist a separate `columnState`.
+    // columnState lives inside `display` because the backend serializer
+    // whitelists `display` for arbitrary sub-keys (no top-level columnState).
     const columnState = gridApi?.getColumnState?.() ?? undefined;
+    // customColumns separately: AG Grid won't recreate them from columnState
+    // alone since the backend doesn't know about custom cols.
+    const customColumns = (columns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
     return {
       display: {
         cellHeight,
@@ -332,6 +332,7 @@ const UsersView = ({
         hasEvalFilter,
         visibleColumns,
         ...(columnState ? { columnState } : {}),
+        ...(customColumns.length > 0 ? { customColumns } : {}),
       },
       filters: {
         extraFilters,
@@ -349,9 +350,89 @@ const UsersView = ({
     gridApi,
   ]);
 
-  // Pending column state from a saved view that arrived before the grid was
-  // ready. Drained by the effect below when gridApi becomes available.
+  // Drained when gridApi becomes available (saved view arrived before grid mount).
   const pendingColumnStateRef = useRef(null);
+
+  const displayStorageKey = `observe-users-display-${observeId}`;
+
+  // hydratedKeyRef gates the hydrate to once per project. The columns gate
+  // below ensures UsersGrid's schema seed has landed first — without it,
+  // addCustomColumns would race the seed and the customs would be wiped.
+  const hydratedKeyRef = useRef(null);
+  // Skips the save effect's next fire after a hydrate so the pre-hydrate
+  // closure can't overwrite what we just loaded.
+  const skipNextSaveRef = useRef(false);
+  useEffect(() => {
+    if (activeViewTabId) return;
+    if (!columns || columns.length === 0) return;
+    if (hydratedKeyRef.current === displayStorageKey) return;
+    hydratedKeyRef.current = displayStorageKey;
+    try {
+      const raw = localStorage.getItem(displayStorageKey);
+      if (!raw) return;
+      skipNextSaveRef.current = true;
+      const saved = JSON.parse(raw);
+      if (saved.cellHeight) setCellHeight(saved.cellHeight);
+      if (typeof saved.showErrors === "boolean") setShowErrors(saved.showErrors);
+      if (typeof saved.showNonAnnotated === "boolean") {
+        setShowNonAnnotated(saved.showNonAnnotated);
+      }
+      if (typeof saved.hasEvalFilter === "boolean") {
+        setHasEvalFilter(saved.hasEvalFilter);
+      }
+      if (saved.visibleColumns && typeof saved.visibleColumns === "object") {
+        updateColumnVisibility(saved.visibleColumns);
+      }
+      if (
+        Array.isArray(saved.customColumns) &&
+        saved.customColumns.length > 0
+      ) {
+        addCustomColumns(saved.customColumns);
+      }
+    } catch {
+      /* ignore corrupted localStorage */
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columns, displayStorageKey]);
+
+  // Default tab only — saved views own their persistence via the explicit
+  // Save view button.
+  useEffect(() => {
+    if (activeViewTabId) return;
+    if (hydratedKeyRef.current !== displayStorageKey) return;
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false;
+      return;
+    }
+    const visibleColumns = (columns || []).reduce((acc, col) => {
+      acc[col.id] = col.isVisible !== false;
+      return acc;
+    }, {});
+    const customColumns = (columns || []).filter(
+      (c) => c.groupBy === "Custom Columns",
+    );
+    const payload = {
+      cellHeight,
+      showErrors,
+      showNonAnnotated,
+      hasEvalFilter,
+      visibleColumns,
+      ...(customColumns.length > 0 ? { customColumns } : {}),
+    };
+    try {
+      localStorage.setItem(displayStorageKey, JSON.stringify(payload));
+    } catch {
+      /* quota exceeded */
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    displayStorageKey,
+    columns,
+    cellHeight,
+    showErrors,
+    showNonAnnotated,
+    hasEvalFilter,
+  ]);
 
   const applyConfig = useCallback(
     (config) => {
@@ -364,9 +445,12 @@ const UsersView = ({
         setHasEvalFilter(false);
         setDateFilter(getDefaultDateRange());
         pendingColumnStateRef.current = null;
-        // Reset column visibility to the column-config defaults so going back
-        // to All Users from a saved view with limited columns shows everything
-        // again.
+        const currentCustomIds = (columns || [])
+          .filter((c) => c.groupBy === "Custom Columns")
+          .map((c) => c.id);
+        if (currentCustomIds.length > 0) {
+          removeCustomColumns(currentCustomIds);
+        }
         const defaultsVisibility = (getUsersColumnConfig() || []).reduce(
           (acc, col) => {
             acc[col.field] = col.hide === undefined ? true : !col.hide;
@@ -377,8 +461,41 @@ const UsersView = ({
         if (Object.keys(defaultsVisibility).length > 0) {
           updateColumnVisibility(defaultsVisibility);
         }
-        // Reset AG Grid column state (widths/order/sort) to coldef defaults.
         if (gridApi?.resetColumnState) gridApi.resetColumnState();
+        // Re-hydrate from localStorage — the mount hydrate is keyed on
+        // displayStorageKey and won't re-fire on a same-project saved-view
+        // → default transition.
+        try {
+          const raw = localStorage.getItem(displayStorageKey);
+          if (raw) {
+            skipNextSaveRef.current = true;
+            const saved = JSON.parse(raw);
+            if (saved.cellHeight) setCellHeight(saved.cellHeight);
+            if (typeof saved.showErrors === "boolean") {
+              setShowErrors(saved.showErrors);
+            }
+            if (typeof saved.showNonAnnotated === "boolean") {
+              setShowNonAnnotated(saved.showNonAnnotated);
+            }
+            if (typeof saved.hasEvalFilter === "boolean") {
+              setHasEvalFilter(saved.hasEvalFilter);
+            }
+            if (
+              saved.visibleColumns &&
+              typeof saved.visibleColumns === "object"
+            ) {
+              updateColumnVisibility(saved.visibleColumns);
+            }
+            if (
+              Array.isArray(saved.customColumns) &&
+              saved.customColumns.length > 0
+            ) {
+              addCustomColumns(saved.customColumns);
+            }
+          }
+        } catch {
+          /* ignore corrupted localStorage */
+        }
         return;
       }
       const display = config.display || {};
@@ -390,11 +507,31 @@ const UsersView = ({
         setShowNonAnnotated(display.showNonAnnotated);
       if (typeof display.hasEvalFilter === "boolean")
         setHasEvalFilter(display.hasEvalFilter);
+      // Strip pre-existing customs so view → view doesn't stack, and
+      // default → view doesn't leak default-tab customs into the saved view.
+      const existingCustomIds = (columns || [])
+        .filter((c) => c.groupBy === "Custom Columns")
+        .map((c) => c.id);
+      if (existingCustomIds.length > 0) {
+        removeCustomColumns(existingCustomIds);
+      }
+      const savedCustomCols = Array.isArray(display.customColumns)
+        ? display.customColumns
+        : [];
+      if (savedCustomCols.length > 0) {
+        addCustomColumns(savedCustomCols);
+      }
       if (display.visibleColumns && columns?.length) {
         updateColumnVisibility(display.visibleColumns);
       }
       if (Array.isArray(display.columnState) && display.columnState.length > 0) {
-        if (gridApi?.applyColumnState) {
+        // Defer columnState when custom cols are being added — AG Grid's
+        // columnDefs prop only flips next render, so applying this tick
+        // would drop entries for the custom colIds. Drained by the
+        // `columns` effect once the store update propagates.
+        if (savedCustomCols.length > 0) {
+          pendingColumnStateRef.current = display.columnState;
+        } else if (gridApi?.applyColumnState) {
           gridApi.applyColumnState({
             state: display.columnState,
             applyOrder: true,
@@ -418,12 +555,17 @@ const UsersView = ({
       setDateFilter,
       setExtraFilters,
       updateColumnVisibility,
+      addCustomColumns,
+      removeCustomColumns,
       columns,
       gridApi,
+      displayStorageKey,
     ],
   );
 
-  // Drain any column state queued before the grid was ready.
+  // Drains pendingColumnStateRef on two triggers: gridApi becoming
+  // available, or `columns` changing (custom cols just landed → AG Grid
+  // columnDefs prop updated → safe to apply state for the custom colIds).
   useEffect(() => {
     if (gridApi?.applyColumnState && pendingColumnStateRef.current) {
       gridApi.applyColumnState({
@@ -432,7 +574,7 @@ const UsersView = ({
       });
       pendingColumnStateRef.current = null;
     }
-  }, [gridApi]);
+  }, [gridApi, columns]);
 
   // Keep the ref's handles in sync with the latest closures
   useEffect(() => {
@@ -501,6 +643,22 @@ const UsersView = ({
         }
       }
     }
+    // Custom cols: order is captured by columnState, so we only diff the set.
+    const currentCustomIds = (columns || [])
+      .filter((c) => c.groupBy === "Custom Columns")
+      .map((c) => c.id)
+      .sort();
+    const baselineCustomIds = (
+      Array.isArray(baselineDisplay.customColumns)
+        ? baselineDisplay.customColumns
+        : []
+    )
+      .map((c) => c.id)
+      .sort();
+    if (currentCustomIds.length !== baselineCustomIds.length) return true;
+    for (let i = 0; i < currentCustomIds.length; i += 1) {
+      if (currentCustomIds[i] !== baselineCustomIds[i]) return true;
+    }
     return false;
   }, [
     activeViewConfig,
@@ -515,15 +673,10 @@ const UsersView = ({
 
   const canSaveViewDeferred = useDeferredValue(canSaveView);
 
-  // Update mutations for the explicit Save view button. Project-scoped on
-  // ObservePage's Users fixed tab; workspace-scoped (USERS_TAB_TYPE) on the
-  // top-level /dashboard/users page rendered by UserList.
   const { mutate: updateSavedView } = useUpdateSavedView(observeId);
   const { mutate: updateWorkspaceSavedView } =
     useUpdateWorkspaceSavedView(USERS_TAB_TYPE);
 
-  // Active saved-view id from URL — "tab" key on ObservePage, "usersTab" on
-  // UserList. Re-derived when the active config flips.
   const activeViewTabId = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
     const key = isObservePath
@@ -559,9 +712,8 @@ const UsersView = ({
     setActiveViewConfig,
   ]);
 
-  // Register with ObserveHeaderContext so ObserveTabBar's "+" save flow can
-  // snapshot the current Users config when the user is on this fixed tab —
-  // without this, the save POSTs `config: {}` (TH-4578).
+  // ObserveTabBar's "+" save flow needs this — without it the save POSTs
+  // `config: {}` (TH-4578).
   useEffect(() => {
     registerGetViewConfig(getConfig);
     return () => registerGetViewConfig(null);
@@ -572,15 +724,20 @@ const UsersView = ({
     return () => registerGetTabType(null);
   }, [registerGetTabType]);
 
-  // Apply a saved view's config when activeViewConfig changes. Reuses the
-  // existing applyConfig — handles extraFilters, dateFilter, display state,
-  // column visibility.
-  // Dep array intentionally only watches `activeViewConfig`. `applyConfig`'s
-  // identity changes whenever `columns` does, and `applyConfig` itself
-  // mutates `columns` via `updateColumnVisibility` — keeping it in deps
-  // creates an infinite re-apply loop.
+  // Deps watch only activeViewConfig — applyConfig's identity changes with
+  // columns, and it mutates columns, so keeping it in deps would loop.
+  // wasOnSavedViewRef gates the null-branch reset to genuine saved-view →
+  // default transitions (not initial mount with no view selected).
+  const wasOnSavedViewRef = useRef(false);
   useEffect(() => {
-    if (!activeViewConfig) return;
+    if (!activeViewConfig) {
+      const wasOnSavedView = wasOnSavedViewRef.current;
+      wasOnSavedViewRef.current = false;
+      if (!wasOnSavedView) return;
+      applyConfig(null);
+      return;
+    }
+    wasOnSavedViewRef.current = true;
     applyConfig(activeViewConfig);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeViewConfig]);

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -780,6 +780,7 @@ const TaskConfigPanel = ({
                 setValue={setValue}
                 projectId={project}
                 isSimulator={isVoiceProject}
+                rowType={rowType}
               />
             </FilterErrorBoundary>
           </Box>

--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -187,8 +187,25 @@ FilterChip.propTypes = {
   onRemove: PropTypes.func.isRequired,
 };
 
+// Map task rowType → TraceFilterPanel `tab` so the property picker
+// surfaces Trace ID / Span ID the same way LLM Tracing does. Callers
+// use inconsistent casing ("spans"/"Span", "traces"/"Trace") so we
+// normalize. Sessions / voiceCalls return null (no id fields).
+const rowTypeToFilterTab = (rowType) => {
+  const key = String(rowType || "").toLowerCase();
+  if (key === "spans" || key === "span") return "spans";
+  if (key === "traces" || key === "trace") return "trace";
+  return null;
+};
+
 // ── Main ──
-const TaskFilterBar = ({ control, setValue, projectId, isSimulator = false }) => {
+const TaskFilterBar = ({
+  control,
+  setValue,
+  projectId,
+  isSimulator = false,
+  rowType,
+}) => {
   // Read the form filters (old format) and mirror them in local state (new format).
   const formFilters = useWatch({ control, name: "filters" });
   const [panelFilters, setPanelFilters] = useState(() =>
@@ -351,6 +368,7 @@ const TaskFilterBar = ({ control, setValue, projectId, isSimulator = false }) =>
         currentFilters={panelFilters}
         projectId={projectId}
         isSimulator={isSimulator}
+        tab={rowTypeToFilterTab(rowType)}
         onApply={(next) => applyPanelFilters(next || [])}
       />
     </Box>
@@ -362,6 +380,7 @@ TaskFilterBar.propTypes = {
   setValue: PropTypes.func.isRequired,
   projectId: PropTypes.string,
   isSimulator: PropTypes.bool,
+  rowType: PropTypes.string,
 };
 
 export default TaskFilterBar;

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -50,6 +50,10 @@ const COL_TYPE_MAP = {
   annotation: "ANNOTATION",
 };
 
+// Direct id columns the backend resolves without col_type — injecting one
+// routes the filter through the metrics pipeline and silently returns 0.
+const ID_COLUMNS = new Set(["trace_id", "span_id"]);
+
 // eslint-disable-next-line react-refresh/only-export-components
 export function buildApiFilterArray(oldFormatFilters, startDate, endDate) {
   const userFilters = (oldFormatFilters || [])
@@ -57,6 +61,7 @@ export function buildApiFilterArray(oldFormatFilters, startDate, endDate) {
     .map((f) => {
       const isAttribute = f.property === "attributes";
       const columnId = isAttribute ? f.propertyId : f.property;
+      const isIdColumn = ID_COLUMNS.has(columnId);
       const colType =
         COL_TYPE_MAP[f.fieldCategory] ||
         (isAttribute ? "SPAN_ATTRIBUTE" : "SYSTEM_METRIC");
@@ -66,7 +71,7 @@ export function buildApiFilterArray(oldFormatFilters, startDate, endDate) {
           filter_type: f?.filterConfig?.filterType || "text",
           filter_op: f?.filterConfig?.filterOp || "equals",
           filter_value: f?.filterConfig?.filterValue,
-          col_type: colType,
+          ...(!isIdColumn && { col_type: colType }),
         },
       };
     });


### PR DESCRIPTION
## Summary

Hotfix branch cut from `main` bundling two already-merged-to-`dev` PRs so the observe fixes ship to prod without waiting on the next `dev → main` promotion.

Both PRs were cherry-picked via `git cherry-pick -m 1` on their `dev` merge commits, so the diff matches exactly what landed on `dev`.

## Bundled PRs

- **#431** — fix(observe): expose and resolve Trace ID / Span ID filters on task surfaces
  - Property picker now lists Trace ID / Span ID on `/dashboard/tasks/create` and EvalPicker / TracingTestMode (was only on LLM Tracing).
  - `buildApiFilterArray` omits `col_type` for `trace_id` / `span_id` so backend resolves them as direct columns (previously routed through metrics pipeline → 0 rows).

- **#423 (TH-4801)** — Hydrate + persist custom columns across observe surfaces
  - LLMTracing (trace + spans), Sessions, Users, UserTraceTabV2, Voice (CallLogs): custom columns now reliably hydrate on refresh, tab-switch, and saved-view apply.
  - Per-grid `pendingCustomColumnsRef`, widened merge guards, per-tab localStorage shape, saved-view strip+queue, and CallLogs custom-col grouping/skeleton.

## Test plan

- [ ] Same test plan as PR #423 (LLMTracing trace+spans, Sessions, Users, UserTraceTabV2, Voice)
- [ ] Same test plan as PR #431 (TaskFilterBar Trace/Span ID surfacing + filter results)
- [ ] CI green
- [ ] Smoke test on staging deploy from this branch before merging to `main`

## Cherry-pick provenance

- `860cfa29` ← `188a4a69` (PR #431 merge into dev)
- `58f69755` ← `15b6333f` (PR #423 merge into dev)