### PR TITLE
fix(simulate): hotfix run-tests 500 on non-numeric template_version (TH-4931) [dev]

### DIFF
--- a/futureagi/simulate/serializers/response/scenarios.py
+++ b/futureagi/simulate/serializers/response/scenarios.py
@@ -31,7 +31,7 @@ class PromptVersionDetailResponseSerializer(serializers.Serializer):
     """Nested serializer for prompt version detail in scenario responses."""
 
     id = serializers.UUIDField(read_only=True)
-    template_version = serializers.IntegerField(read_only=True)
+    template_version = serializers.CharField(read_only=True, allow_null=True)
     is_default = serializers.BooleanField(read_only=True)
     commit_message = serializers.CharField(read_only=True, allow_null=True)
 
@@ -154,7 +154,7 @@ class ScenarioResponseSerializer(serializers.ModelSerializer):
         if obj.prompt_version:
             return PromptVersionDetailResponseSerializer(obj.prompt_version).data
         return None
-    
+
     def validate_name(self, value):
         """Validate that name is not empty or just whitespace"""
         if not value.strip():
@@ -202,9 +202,7 @@ class ScenarioDetailResponseSerializer(serializers.Serializer):
     updated_at = serializers.DateTimeField(read_only=True)
     deleted = serializers.BooleanField(read_only=True)
     deleted_at = serializers.DateTimeField(read_only=True, allow_null=True)
-    status = serializers.ChoiceField(
-        choices=StatusType.get_choices(), read_only=True
-    )
+    status = serializers.ChoiceField(choices=StatusType.get_choices(), read_only=True)
     agent_type = serializers.CharField(read_only=True, allow_null=True)
     graph = serializers.DictField(read_only=True)
     prompts = serializers.ListField(

--- a/futureagi/simulate/tests/test_run_test_list_api.py
+++ b/futureagi/simulate/tests/test_run_test_list_api.py
@@ -1,0 +1,99 @@
+"""
+API tests for GET /simulate/run-tests/ (RunTestListView).
+"""
+
+import pytest
+from rest_framework import status
+
+from model_hub.models.run_prompt import PromptTemplate, PromptVersion
+from simulate.models import AgentDefinition, RunTest, Scenarios
+
+
+@pytest.fixture
+def agent_definition(db, organization, workspace):
+    return AgentDefinition.objects.create(
+        agent_name="Test Agent",
+        agent_type=AgentDefinition.AgentTypeChoices.TEXT,
+        inbound=True,
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+@pytest.fixture
+def prompt_template(db, organization, workspace):
+    return PromptTemplate.objects.create(
+        name="Test prompt template",
+        organization=organization,
+        workspace=workspace,
+    )
+
+
+@pytest.fixture
+def prompt_version_v10(db, prompt_template):
+    # template_version is a CharField on the model — the response serializer
+    # must accept any string, not just numeric values.
+    return PromptVersion.objects.create(
+        original_template=prompt_template,
+        template_version="v10",
+    )
+
+
+@pytest.fixture
+def scenario_with_prompt_version(
+    db,
+    organization,
+    workspace,
+    agent_definition,
+    prompt_template,
+    prompt_version_v10,
+):
+    return Scenarios.objects.create(
+        name="Scenario linked to v10 prompt version",
+        source="seed",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        source_type=Scenarios.SourceTypes.AGENT_DEFINITION,
+        organization=organization,
+        workspace=workspace,
+        agent_definition=agent_definition,
+        prompt_template=prompt_template,
+        prompt_version=prompt_version_v10,
+    )
+
+
+@pytest.fixture
+def run_test_with_v10_scenario(
+    db,
+    organization,
+    workspace,
+    agent_definition,
+    scenario_with_prompt_version,
+):
+    run_test = RunTest.objects.create(
+        name="Run test referencing v10-prompt scenario",
+        organization=organization,
+        workspace=workspace,
+        agent_definition=agent_definition,
+        source_type=RunTest.SourceTypes.AGENT_DEFINITION,
+    )
+    run_test.scenarios.set([scenario_with_prompt_version])
+    return run_test
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestRunTestListPromptVersionRegression:
+    def test_list_succeeds_when_scenario_prompt_version_is_non_numeric(
+        self, auth_client, run_test_with_v10_scenario
+    ):
+        response = auth_client.get("/simulate/run-tests/?page=1&limit=25&search=")
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+
+        body = response.json()
+        run_test = next(
+            r for r in body["results"] if r["id"] == str(run_test_with_v10_scenario.id)
+        )
+        scenario = run_test["scenarios_detail"][0]
+        assert scenario["prompt_version_detail"]["template_version"] == "v10"


### PR DESCRIPTION
## Summary

Sibling of #437 (main PR). Dev keeps parity with the production hotfix going out on `main`.

`GET /simulate/run-tests/` was returning HTTP 500 in production with `invalid literal for int() with base 10: 'v10'`.

`PromptVersionDetailResponseSerializer.template_version` (`futureagi/simulate/serializers/response/scenarios.py:34`) was declared as `IntegerField`, but the underlying model field `PromptVersion.template_version` (`futureagi/model_hub/models/run_prompt.py:255`) is a `CharField(max_length=50)` holding values like `"v10"`. Serializing any scenario whose `prompt_version` had a non-numeric `template_version` triggered `int("v10")`, propagated up through `ScenarioResponseSerializer.scenarios_detail`, and crashed with 500.

Same path also affects `GET /simulate/scenarios/` listing and any other endpoint that returns a `Scenario` with a `prompt_version` via `ScenarioResponseSerializer`.

## Root cause

Introduced in `dd93037` (PR #189 — *"scenarios and evals apis"*) as part of the response-serializer restructuring refactor. The field type was hand-typed and didn't match the model.

## Fix

```diff
-    template_version = serializers.IntegerField(read_only=True)
+    template_version = serializers.CharField(read_only=True, allow_null=True)
```

No frontend impact — the sibling code path (`RunTestSerializer.get_prompt_version_detail`, `simulate/serializers/run_test.py:158`) already returns the raw string.

## Test plan

- [x] Regression test added: `simulate/tests/test_run_test_list_api.py::TestRunTestListPromptVersionRegression::test_list_succeeds_when_scenario_prompt_version_is_non_numeric` — creates a run-test linked to a scenario whose `PromptVersion.template_version = "v10"`, asserts the listing returns 200.
- [x] Test passes against live Postgres in test stack.
- [x] Pre-commit clean.
- [x] Local dev stack reproduces: endpoint returns 403 (auth-gated) instead of 500.
- [x] The run test page loads successfully without 500
- [x] The `/simulate/scenario` endpoint loads successfully
- [x] The scenario detail page loads successfully
- [x] The prompt workbench loads successfully
- [x] The simulation tab in the workbench loads successfully
- [x] A fresh run of inbound voice simulation is starting and working.

## Video

https://github.com/user-attachments/assets/e26396a6-76d3-4f1e-9240-08cfbdd6feec

https://github.com/user-attachments/assets/92fd3491-f8c0-4dc5-92e9-9b85f3a2e13a


## Due diligence

See #437 for the full audit of the response-serializer refactor (the only confirmed crash bug is the one fixed here; one latent code smell on `variable_names` was identified and intentionally not bundled into this hotfix to avoid response-shape changes).

Refs: TH-4931