### PR TITLE
fix(evals + tasks): data injection, switch guard, dup choices, chip polish

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -28,6 +28,7 @@ import React, {
 } from "react";
 import { useWatch } from "react-hook-form";
 import Iconify from "src/components/iconify";
+import { ShowComponent } from "src/components/show/ShowComponent";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import TaskFilterBar from "src/sections/tasks/components/TaskFilterBar";
 import { buildApiFilterArray } from "src/sections/tasks/components/TaskLivePreview";
@@ -290,6 +291,16 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     compositeDetail,
     templateFormat,
   ]);
+
+
+  const hasDataInjection = useMemo(
+    () =>
+      evalType === "agent" &&
+      (source === "task" || source === "tracing") &&
+      Array.isArray(contextOptions) &&
+      contextOptions.some((o) => o && o !== "variables_only"),
+    [evalType, source, contextOptions],
+  );
 
   const visibleCodeParamEntries = useMemo(() => {
     if (!functionParamsSchema) return [];
@@ -1778,6 +1789,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             settings only. */}
         {source !== "composite" &&
           !sourceReady &&
+          !hasDataInjection &&
           !testError &&
           !testPassed && (
             <Typography
@@ -1821,7 +1833,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           } else if (!hasInstructions) {
             testDisabled = true;
             testDisabledReason = "Add instructions before running a test.";
-          } else if (!hasVariables) {
+          } else if (!hasVariables && !hasDataInjection) {
             testDisabled = true;
             testDisabledReason =
               templateFormat === "jinja"
@@ -1829,38 +1841,42 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                 : "Your Mustache template has no variables. Add a {{variable}} placeholder (e.g. {{input}}) so test input can be passed in.";
           }
 
-          if (!testDisabled && !sourceReady) {
+          if (!testDisabled && !sourceReady && !hasDataInjection) {
             testDisabled = true;
             testDisabledReason = "Map all variables before running a test.";
           }
 
           return (
-            <CustomTooltip
-              show={testDisabled && !!testDisabledReason}
-              type=""
-              title={testDisabledReason}
-              arrow
+            <ShowComponent
+              condition={!hasDataInjection }
             >
-              <span>
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  size="small"
-                  onClick={handleTestEvaluation}
-                  disabled={testDisabled}
-                  startIcon={
-                    isTesting ? (
-                      <CircularProgress size={14} />
-                    ) : (
-                      <Iconify icon="mdi:play-circle-outline" width={16} />
-                    )
-                  }
-                  sx={{ textTransform: "none" }}
-                >
-                  {isTesting ? "Testing..." : "Test Evaluation"}
-                </Button>
-              </span>
-            </CustomTooltip>
+              <CustomTooltip
+                show={testDisabled && !!testDisabledReason}
+                type=""
+                title={testDisabledReason}
+                arrow
+              >
+                <span>
+                  <Button
+                    variant="outlined"
+                    color="primary"
+                    size="small"
+                    onClick={handleTestEvaluation}
+                    disabled={testDisabled}
+                    startIcon={
+                      isTesting ? (
+                        <CircularProgress size={14} />
+                      ) : (
+                        <Iconify icon="mdi:play-circle-outline" width={16} />
+                      )
+                    }
+                    sx={{ textTransform: "none" }}
+                  >
+                    {isTesting ? "Testing..." : "Test Evaluation"}
+                  </Button>
+                </span>
+              </CustomTooltip>
+            </ShowComponent>
           );
         })()}
 
@@ -1890,7 +1906,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           } else if (!hasInstructions) {
             addDisabled = true;
             addDisabledReason = `Add instructions before ${actionLabel}.`;
-          } else if (!hasVariables) {
+          } else if (!hasVariables && !hasDataInjection) {
             addDisabled = true;
             addDisabledReason =
               templateFormat === "jinja"
@@ -1900,7 +1916,12 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
 
           // Non-composite flows additionally require the full source config
           // (name / output type / etc.) to be valid.
-          if (!addDisabled && source !== "composite" && !sourceReady) {
+          if (
+            !addDisabled &&
+            source !== "composite" &&
+            !sourceReady &&
+            !hasDataInjection
+          ) {
             addDisabled = true;
             addDisabledReason = `Map all variables before ${actionLabel}.`;
           }

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -22,6 +22,7 @@ import React, {
 } from "react";
 import { useWatch } from "react-hook-form";
 import Iconify from "src/components/iconify";
+import { ShowComponent } from "src/components/show/ShowComponent";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import TaskFilterBar from "src/sections/tasks/components/TaskFilterBar";
 import { buildApiFilterArray } from "src/sections/tasks/components/TaskLivePreview";
@@ -47,6 +48,30 @@ import DatasetTestMode from "src/sections/evals/components/DatasetTestMode";
 import TracingTestMode from "src/sections/evals/components/TracingTestMode";
 import SimulationTestMode from "src/sections/evals/components/SimulationTestMode";
 import { useEvalPickerContext } from "./context/EvalPickerContext";
+import { contextOptionsForRowType } from "./evalPickerConfigUtils";
+const TRACING_ROW_TYPE_TO_KEY = {
+  Span: "spans",
+  Trace: "traces",
+  Session: "sessions",
+  VoiceCall: "voiceCalls",
+};
+
+const dataInjectionFromContextOptions = (opts) => {
+  if (
+    !opts ||
+    opts.length === 0 ||
+    (opts.length === 1 && opts[0] === "variables_only")
+  ) {
+    return { variables_only: true };
+  }
+  const flags = {};
+  if (opts.includes("dataset_row")) flags.full_row = true;
+  if (opts.includes("span_context")) flags.span_context = true;
+  if (opts.includes("trace_context")) flags.trace_context = true;
+  if (opts.includes("session_context")) flags.session_context = true;
+  if (opts.includes("call_context")) flags.call_context = true;
+  return Object.keys(flags).length > 0 ? flags : { variables_only: true };
+};
 
 const PYTHON_CODE_TEMPLATE = `from typing import Any
 
@@ -114,6 +139,17 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   const [templateFormat, setTemplateFormat] = useState("mustache");
   const [datasetColumns, setDatasetColumns] = useState([]);
   const [datasetJsonSchemas, setDatasetJsonSchemas] = useState({});
+  const [contextOptions, setContextOptions] = useState(
+    () => contextOptionsForRowType(sourceRowType) || ["variables_only"],
+  );
+
+
+  const handleSourceRowTypeChange = useCallback((rt) => {
+    const map =  TRACING_ROW_TYPE_TO_KEY;
+    const key = map[rt];
+    const seeded = key ? contextOptionsForRowType(key) : null;
+    if (seeded) setContextOptions(seeded);
+  }, []);
 
   const localFormFilters = useWatch({
     control: localFilterForm.control,
@@ -248,6 +284,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
           ? fewShotExamples.map((ds) => ({ id: ds.id, name: ds.name }))
           : undefined,
       template_format: templateFormat,
+      data_injection:
+        evalType === "agent"
+          ? dataInjectionFromContextOptions(contextOptions)
+          : undefined,
     }),
     [
       evalType,
@@ -261,6 +301,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       messages,
       fewShotExamples,
       templateFormat,
+      contextOptions,
     ],
   );
 
@@ -296,6 +337,15 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     }
   }, [draftId, buildPayload, updateDraft, handleTestResult]);
 
+  const hasDataInjection = useMemo(
+    () =>
+      evalType === "agent" &&
+      (source === "task" || source === "tracing") &&
+      Array.isArray(contextOptions) &&
+      contextOptions.some((o) => o && o !== "variables_only"),
+    [evalType, source, contextOptions],
+  );
+
   // Validate all required fields for single-eval mode. Composite mode has
   // its own light validation (name + at least one child) inside
   // handleSaveAndAddComposite, so this gate is only applied to the
@@ -322,14 +372,15 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       if (!code.trim()) next.instructions = "Code is required";
     } else if (!instructions.trim()) {
       next.instructions = "Instructions are required";
-    } else if (!/\{\{\s*[^{}]+?\s*\}\}/.test(instructions)) {
+    } else if (
+      !hasDataInjection &&
+      !/\{\{\s*[^{}]+?\s*\}\}/.test(instructions)
+    ) {
       next.instructions =
         "Instructions must contain at least one template variable (e.g. {{input}})";
     }
 
-    // Mapping — no dataset to map against in the composite child-picker flow,
-    // so skip this check. Matches the canSave bypass below.
-    if (!sourceReady && source !== "composite") {
+    if (!sourceReady && source !== "composite" && !hasDataInjection) {
       next.mapping = "Map all variables before saving";
     }
 
@@ -365,6 +416,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     passThreshold,
     outputType,
     choiceScores,
+    hasDataInjection,
   ]);
 
   // Field-change wrappers — set the value and clear the corresponding
@@ -441,7 +493,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       if (source === "task" && onFiltersChange) {
         onFiltersChange(localFilterForm.getValues("filters") || []);
       }
-      // Now add to the current context
+      // Now add to the current context. data_injection (seeded from
+      // sourceRowType) is forwarded so the consumer's serializeEvalConfig
+      // captures it inside config.run_config — same shape an existing
+      // eval would emit through EvalPickerConfigFull.
       onSave({
         templateId: draftId,
         evalTemplateId: draftId,
@@ -451,6 +506,10 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         evalType,
         outputType,
         instructions,
+        data_injection:
+          evalType === "agent"
+            ? dataInjectionFromContextOptions(contextOptions)
+            : undefined,
       });
     } catch (error) {
       enqueueSnackbar(error?.message || "Failed to save", { variant: "error" });
@@ -471,6 +530,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     evalType,
     outputType,
     instructions,
+    contextOptions,
     enqueueSnackbar,
     isOSS,
     source,
@@ -556,7 +616,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     ? !!name.trim() && selectedChildren.length > 0
     : name.trim() &&
       (evalType === "code" ? code.trim() : instructions.trim()) &&
-      (source === "composite" || sourceReady);
+      (source === "composite" || sourceReady || hasDataInjection);
 
   // Variables from instructions
   const variables = useMemo(() => {
@@ -843,6 +903,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     datasetColumns={datasetColumns}
                     datasetJsonSchemas={datasetJsonSchemas}
                     mappedVariables={sourceMapping}
+                    activeContextOptions={contextOptions}
+                    onActiveContextOptionsChange={setContextOptions}
                   />
                   {errors.instructions && (
                     <Typography variant="caption" color="error.main">
@@ -1085,6 +1147,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     variables={isComposite ? compositeUnionKeys : variables}
                     onTestResult={handleTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
+                    onRowTypeChange={handleSourceRowTypeChange}
                     isComposite={isComposite}
                     compositeAdhocConfig={compositeAdhocConfig}
                   />
@@ -1178,7 +1241,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
             </Typography>
           </Box>
         )}
-        {!sourceReady && !testError && !testPassed && (
+        {!sourceReady && !hasDataInjection && !testError && !testPassed && (
           <Typography
             variant="caption"
             color="text.disabled"
@@ -1189,28 +1252,32 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
           </Typography>
         )}
 
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={handleTestEvaluation}
-          disabled={
-            isTesting ||
-            !sourceReady ||
-            !draftId ||
-            isComposite ||
-            source === "workbench"
-          }
-          startIcon={
-            isTesting ? (
-              <CircularProgress size={14} />
-            ) : (
-              <Iconify icon="mdi:play-circle-outline" width={16} />
-            )
-          }
-          sx={{ textTransform: "none" }}
+        <ShowComponent
+          condition={!hasDataInjection }
         >
-          {isTesting ? "Testing..." : "Test Evaluation"}
-        </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleTestEvaluation}
+            disabled={
+              isTesting ||
+              (!sourceReady && !hasDataInjection) ||
+              !draftId ||
+              isComposite ||
+              source === "workbench"
+            }
+            startIcon={
+              isTesting ? (
+                <CircularProgress size={14} />
+              ) : (
+                <Iconify icon="mdi:play-circle-outline" width={16} />
+              )
+            }
+            sx={{ textTransform: "none" }}
+          >
+            {isTesting ? "Testing..." : "Test Evaluation"}
+          </Button>
+        </ShowComponent>
 
         <LoadingButton
           variant="contained"

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
@@ -7,7 +7,7 @@ const OUTPUT_TYPE_CONFIG_MAP = {
 const ROW_TYPE_CONTEXT_OPTIONS = {
   spans: ["span_context"],
   traces: ["trace_context"],
-  sessions: ["session_context", "trace_context"],
+  sessions: ["session_context"],
   voiceCalls: ["call_context"],
 };
 

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
@@ -10,10 +10,7 @@ describe("contextOptionsForRowType", () => {
   it("maps each known row type to its default data_injection flags", () => {
     expect(contextOptionsForRowType("spans")).toEqual(["span_context"]);
     expect(contextOptionsForRowType("traces")).toEqual(["trace_context"]);
-    expect(contextOptionsForRowType("sessions")).toEqual([
-      "session_context",
-      "trace_context",
-    ]);
+    expect(contextOptionsForRowType("sessions")).toEqual(["session_context"]);
     expect(contextOptionsForRowType("voiceCalls")).toEqual(["call_context"]);
   });
 

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -10,6 +10,7 @@ import {
   TextField,
   Tooltip,
   Typography,
+  alpha,
 } from "@mui/material";
 import {
   useInfiniteQuery,
@@ -147,6 +148,55 @@ const FAGI_MODELS = [
 
 export const FAGI_MODEL_VALUES = new Set(FAGI_MODELS.map((m) => m.value));
 
+const CHIP_STYLES = {
+  backgroundColor: (theme) =>
+    alpha(
+      theme.palette.primary.main,
+      theme.palette.mode === "dark" ? 0.24 : 0.1,
+    ),
+  "&:hover": {
+    backgroundColor: (theme) =>
+      alpha(
+        theme.palette.primary.main,
+        theme.palette.mode === "dark" ? 0.32 : 0.16,
+      ),
+  },
+  color: (theme) =>
+    theme.palette.mode === "dark"
+      ? theme.palette.primary.light
+      : theme.palette.primary.main,
+  border: "1px solid",
+  borderColor: (theme) =>
+    alpha(
+      theme.palette.primary.main,
+      theme.palette.mode === "dark" ? 0.4 : 0.2,
+    ),
+  borderRadius: "4px",
+  fontWeight: 500,
+  fontSize: "11px",
+  height: 22,
+  "& .MuiChip-label": { px: 0.75 },
+  "& .MuiChip-icon": {
+    color: "inherit",
+  },
+  "& .MuiChip-deleteIcon": {
+    margin: "0 4px 0 -2px",
+    color: (theme) =>
+      theme.palette.mode === "dark"
+        ? theme.palette.primary.light
+        : theme.palette.primary.main,
+    transition: "color 0.15s ease",
+    "&:hover": {
+      color: (theme) =>
+        theme.palette.mode === "dark"
+          ? theme.palette.primary.contrastText
+          : theme.palette.primary.dark,
+    },
+  },
+};
+
+const DELETE_ICON = <Iconify icon="mdi:close" width={12} />;
+
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
 // Summary Chip — resolves name for both presets and custom templates
@@ -179,7 +229,8 @@ function SummaryChip({ activeSummary, onClick, onDelete }) {
       label={chipLabel}
       onClick={onClick}
       onDelete={onDelete}
-      sx={{ height: 22, fontSize: "11px", fontWeight: 500, cursor: "pointer" }}
+      deleteIcon={DELETE_ICON}
+      sx={{ ...CHIP_STYLES, cursor: "pointer" }}
     />
   );
 }
@@ -802,7 +853,8 @@ const ModelSelector = ({
           icon={<Iconify icon="mdi:web" width={12} sx={{ ml: 0.5 }} />}
           label="Internet"
           onDelete={() => setUseInternet(false)}
-          sx={{ height: 22, fontSize: "11px", fontWeight: 500 }}
+          deleteIcon={DELETE_ICON}
+          sx={CHIP_STYLES}
         />
       )}
       {showPlus && activeSummary && activeSummary !== "concise" && (
@@ -859,7 +911,8 @@ const ModelSelector = ({
               onDelete={() =>
                 setActiveConnectorIds((p) => p.filter((x) => x !== cId))
               }
-              sx={{ height: 22, fontSize: "11px", fontWeight: 500 }}
+              deleteIcon={DELETE_ICON}
+              sx={CHIP_STYLES}
             />
           );
         })}
@@ -897,12 +950,8 @@ const ModelSelector = ({
               setPlusSubmenu("knowledge");
             }}
             onDelete={() => setSelectedKBs([])}
-            sx={{
-              height: 22,
-              fontSize: "11px",
-              fontWeight: 500,
-              cursor: "pointer",
-            }}
+            deleteIcon={DELETE_ICON}
+            sx={{ ...CHIP_STYLES, cursor: "pointer" }}
           />
         </Tooltip>
       )}
@@ -944,12 +993,8 @@ const ModelSelector = ({
                 setPlusSubmenu("injection");
               }}
               onDelete={() => setActiveContextOptions(["variables_only"])}
-              sx={{
-                height: 22,
-                fontSize: "11px",
-                fontWeight: 500,
-                cursor: "pointer",
-              }}
+              deleteIcon={DELETE_ICON}
+              sx={{ ...CHIP_STYLES, cursor: "pointer" }}
             />
           </Tooltip>
         )}
@@ -1552,7 +1597,8 @@ const ModelSelector = ({
                               prev.filter((x) => x !== kbId),
                             )
                           }
-                          sx={{ height: 20, fontSize: "11px" }}
+                          deleteIcon={DELETE_ICON}
+                          sx={{ ...CHIP_STYLES, height: 20 }}
                         />
                       );
                     })}

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -27,6 +27,7 @@ import {
   serializeEvalConfig,
 } from "src/sections/common/EvalPicker";
 import { enqueueSnackbar } from "src/components/snackbar";
+import ModalWrapper from "src/components/ModalWrapper/ModalWrapper";
 import TaskSchedulingSection from "./TaskSchedulingSection";
 import { getNewTaskFilters } from "src/sections/tasks/schema";
 import { objectCamelToSnake } from "src/utils/utils";
@@ -334,6 +335,7 @@ const TaskConfigPanel = ({
     fields: configuredEvals,
     append: addEval,
     remove: removeEval,
+    replace: replaceEvals,
     update: updateEval,
   } = useFieldArray({
     name: "evalsDetails",
@@ -342,6 +344,32 @@ const TaskConfigPanel = ({
     // the `id` field (which holds the real CustomEvalConfig UUID from the API).
     keyName: "_fieldId",
   });
+
+
+
+  const [pendingProject, setPendingProject] = useState(null);
+
+  const handleProjectFieldChange = useCallback(
+    (newVal) => {
+      if (!newVal || newVal === project) return;
+      if (configuredEvals.length === 0) return;
+      setPendingProject(project);
+    },
+    [project, configuredEvals.length],
+  );
+
+  const handleConfirmProjectChange = useCallback(() => {
+    replaceEvals([]);
+    setPendingProject(null);
+  }, [replaceEvals]);
+
+  const handleCancelProjectChange = useCallback(() => {
+    setValue("project", pendingProject, {
+      shouldDirty: false,
+      shouldValidate: false,
+    });
+    setPendingProject(null);
+  }, [pendingProject, setValue]);
 
   const evalsDetailsErrorMessage = _.get(errors, "evalsDetails")?.message || "";
 
@@ -582,6 +610,7 @@ const TaskConfigPanel = ({
                     value: p.id,
                   })) || []
                 }
+                onChange={handleProjectFieldChange}
                 style={{ width: "100%" }}
                 noOptions="No projects available"
               />
@@ -808,6 +837,18 @@ const TaskConfigPanel = ({
         onFiltersChange={(f) =>
           setValue("filters", f || [], { shouldDirty: true })
         }
+      />
+
+      <ModalWrapper
+        open={!!pendingProject}
+        onClose={handleCancelProjectChange}
+        onCancelBtn={handleCancelProjectChange}
+        onSubmit={handleConfirmProjectChange}
+        title="Switch project?"
+        subTitle="Switching the project will remove the evaluations you've already added to this task."
+        actionBtnTitle="Confirm"
+        cancelBtnTitle="Cancel"
+        isValid
       />
     </>
   );

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -683,6 +683,7 @@ const TaskLivePreview = forwardRef(function TaskLivePreview(
                   bgcolor: "background.neutral",
                   color: "text.secondary",
                   "& .MuiChip-label": { px: 0.75 },
+                    "&:hover": { bgcolor: "background.neutral" },
                 }}
               />
             )}
@@ -1171,6 +1172,7 @@ const VariableMappingView = ({
                       bgcolor: "background.neutral",
                       color: "text.secondary",
                       "& .MuiChip-label": { px: 0.5 },
+                      "&:hover": { bgcolor: "background.neutral" },
                     }}
                   />
                 )}
@@ -1184,6 +1186,7 @@ const VariableMappingView = ({
                       bgcolor: "background.neutral",
                       color: "text.secondary",
                       "& .MuiChip-label": { px: 0.5 },
+                      "&:hover": { bgcolor: "background.neutral" },
                     }}
                   />
                 )}

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -572,7 +572,7 @@ const TaskLivePreview = forwardRef(function TaskLivePreview(
           const savedMapping = evalItem?.mapping || {};
           const playgroundConfig = {
             ...(Object.keys(diFlags).length > 0
-              ? { data_injection: diFlags }
+              ? { run_config: { data_injection: diFlags } }
               : {}),
           };
           if (!isSession) {

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -46,7 +46,7 @@ function snakeToCamelKey(key) {
 // phantom aliases like `numOfWords` for a template variable the user named
 // `num_of_words`. The outer field itself still gets a camelCase alias — only
 // the inner keys of that object are left alone (TH-4375).
-const USER_KEYED_MAP_FIELDS = new Set(["variable_names", "mapping", "placeholders", "params", "headers"]);
+const USER_KEYED_MAP_FIELDS = new Set(["variable_names", "mapping", "placeholders", "params", "headers", "choice_scores"]);
 
 // Build a camelCase→snake_case lookup table for each object we alias.
 function buildAliasTable(obj) {


### PR DESCRIPTION
## Summary

- **Eval picker (data injection + chips):** extend the data-injection bypass to every Save/Test gate and the Update form; switch the data-injection MenuItem to single-select; restyle capability chips to violet with a thin Iconify close icon.
- **Project switch guard:** in task create mode, picking a different project while evals are already configured opens a confirmation modal (`ModalWrapper`). Confirming clears the evals; cancelling reverts the project field via `setValue`.
- **Duplicate choice rows in eval output:** add `choice_scores` to the axios `USER_KEYED_MAP_FIELDS` denylist so the response interceptor no longer injects camelCase aliases onto user-authored choice labels (root cause of the duplicated `escalation_failed` / `escalationFailed` rows in `OutputTypeConfig`).
- **Chip hover polish:** lock `bgcolor: background.neutral` on hover for the model / code-language chips in `TaskLivePreview` so they don't flash darker.

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes TH-4918

## Test plan

### Data injection / eval picker
- [x] In a brand-new eval, set context to a non-default option from task  (e.g. `span`) — Save / Test gates accept the form without complaining about missing variable mapping.
- [x] Open an existing eval in the **Update** form with data injection enabled — Save still works without unrelated mapping errors.
- [x] In the data-injection submenu, clicking an already-active option reverts to `variables_only` (single-select toggle).
- [x] Capability chips (Internet, Connectors, Knowledge Base, Data Injection) render in violet with the thin × close icon.

### Project switch guard
- [x] In task **create** mode, with zero evals configured: switching projects updates instantly, no modal.
- [x] With ≥1 configured eval: switching projects opens the `ModalWrapper` titled "Switch project?".
  - [x] **Confirm** → project switches and the configured-evals list is empty.
  - [x] **Cancel** (button) → project field reverts to the previous selection; configured evals remain intact.
  - [x] **Close** (X) → same as cancel.
- [x] In task **edit** mode, the project field is the disabled `TextField` — no modal possible.

### Duplicate choice rows
- [x] Open an eval whose `choice_scores` keys contain underscores (e.g. `escalation_failed`, `happy_product_purchase`).
- [x] The Output Type → Choices / Scoring panel shows exactly one row per choice (no `escalationFailed` twin).
- [x] Save the eval, reopen — still one row per choice; no stale camelCase keys roundtripped to the backend.
- [x] Adding a new choice / renaming a choice / removing a choice all preserve the canonical key form.