### PR TITLE
fix(usage): wire period_end through usage detail dimension queries (TH-4894)

### DIFF
--- a/frontend/src/sections/settings/UsageSummaryV2/UsageChart.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageChart.jsx
@@ -15,6 +15,7 @@ import axios, { endpoints } from "src/utils/axios";
 UsageChart.propTypes = {
   dimension: PropTypes.string.isRequired,
   period: PropTypes.string,
+  periodEnd: PropTypes.string,
   freeAllowance: PropTypes.number,
   displayUnit: PropTypes.string,
 };
@@ -22,16 +23,17 @@ UsageChart.propTypes = {
 export default function UsageChart({
   dimension,
   period,
+  periodEnd,
   freeAllowance,
   displayUnit,
 }) {
   const theme = useTheme();
 
   const { data: seriesData, isLoading } = useQuery({
-    queryKey: ["v2-usage-time-series", dimension, period],
+    queryKey: ["v2-usage-time-series", dimension, period, periodEnd],
     queryFn: () =>
       axios.get(endpoints.settings.v2.usageTimeSeries, {
-        params: { dimension, period },
+        params: { dimension, period, ...(periodEnd ? { period_end: periodEnd } : {}) },
       }),
     select: (res) => res.data?.result?.series || [],
     enabled: !!dimension,

--- a/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
@@ -937,7 +937,8 @@ export default function UsageSummaryV2() {
       {overview?.dimensions?.length > 0 && (
         <DimensionDetail
           dimensions={overview.dimensions}
-          period={overview.period}
+          period={periodParams.period}
+          periodEnd={periodParams.period_end}
         />
       )}
     </Box>
@@ -949,9 +950,10 @@ export default function UsageSummaryV2() {
 DimensionDetail.propTypes = {
   dimensions: PropTypes.arrayOf(dimensionPropType).isRequired,
   period: PropTypes.string,
+  periodEnd: PropTypes.string,
 };
 
-function DimensionDetail({ dimensions, period }) {
+function DimensionDetail({ dimensions, period, periodEnd }) {
   const theme = useTheme();
   const [selectedDim, setSelectedDim] = useState(dimensions[0]?.key || "");
 
@@ -1019,6 +1021,7 @@ function DimensionDetail({ dimensions, period }) {
         <UsageChart
           dimension={selectedDim}
           period={period}
+          periodEnd={periodEnd}
           freeAllowance={selected.free_allowance}
           displayUnit={selected.display_unit}
         />
@@ -1032,6 +1035,7 @@ function DimensionDetail({ dimensions, period }) {
         <WorkspaceBreakdown
           dimension={selectedDim}
           period={period}
+          periodEnd={periodEnd}
           displayUnit={selected.display_unit}
         />
       </Paper>

--- a/frontend/src/sections/settings/UsageSummaryV2/WorkspaceBreakdown.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/WorkspaceBreakdown.jsx
@@ -32,18 +32,24 @@ function formatUsageCompact(value, _unit) {
 WorkspaceBreakdown.propTypes = {
   dimension: PropTypes.string.isRequired,
   period: PropTypes.string,
+  periodEnd: PropTypes.string,
   displayUnit: PropTypes.string,
 };
 
-export default function WorkspaceBreakdown({ dimension, period, displayUnit }) {
+export default function WorkspaceBreakdown({
+  dimension,
+  period,
+  periodEnd,
+  displayUnit,
+}) {
   const [orderBy, setOrderBy] = useState("usage");
   const [order, setOrder] = useState("desc");
 
   const { data: workspaces, isLoading } = useQuery({
-    queryKey: ["v2-workspace-breakdown", dimension, period],
+    queryKey: ["v2-workspace-breakdown", dimension, period, periodEnd],
     queryFn: () =>
       axios.get(endpoints.settings.v2.usageWorkspaceBreakdown, {
-        params: { dimension, period },
+        params: { dimension, period, ...(periodEnd ? { period_end: periodEnd } : {}) },
       }),
     select: (res) => res.data?.result?.workspaces || [],
     enabled: !!dimension,


### PR DESCRIPTION
## Summary

Selecting 3M / 6M / 12M on `settings/usage-summary` rendered an empty dimension detail (chart + workspace breakdown) even though the per-product gauges showed data. Root cause: `DimensionDetail` was sourcing `period` from the overview response (which only echoes the *start* month) and `period_end` was never forwarded to the child queries at all, so the time-series and workspace breakdown endpoints were queried for a single old month with no data.

This change:

- Pulls `period` / `periodEnd` from the request params (`periodParams`) instead of from the overview response and forwards both into `DimensionDetail`.
- Threads `periodEnd` through `UsageChart` and `WorkspaceBreakdown`, adds it to the axios params (as `period_end`) and to the React Query cache key so range changes invalidate correctly.

Pairs with the backend change in [future-agi/ee#47](https://github.com/future-agi/ee/pull/47) which adds `period_end` to the matching endpoints and falls back to monthly buckets from `UsageSummary` for multi-month ranges.

## Linked issues

TH-4894

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

Local frontend (`localhost:3031/dashboard/settings/usage-summary`) against the patched backend on `localhost:8000`:

- MTD → daily chart preserved for every dimension.
- 3M / 6M / 12M → chart populates for all dimensions including `voice_sim_minutes` and `text_sim_tokens` (which previously rendered empty).
- Workspace breakdown table populates for ranges where `UsageEventLog` covers the period (limitation called out in the backend PR).
- Network tab confirms the request URL includes `period_end=...` and the query key invalidates on range changes.

## Checklist

- [x] No hardcoded secrets, URLs, or PII