### PR TITLE
fix(persona): support multi-value and is-not filters on persona list

### DIFF
--- a/frontend/src/api/persona/persona.js
+++ b/frontend/src/api/persona/persona.js
@@ -43,28 +43,22 @@ export const useGetPersonasPaginated = ({
   page = 1,
   pageSize = 25,
   search = null,
-  type = null,
-  simulationType = null,
+  // Array of {column_id, filter_config: {filter_op, filter_value}}.
+  filterClauses = null,
   enabled = true,
 } = {}) => {
+  const clauses =
+    Array.isArray(filterClauses) && filterClauses.length ? filterClauses : null;
+  const filtersJson = clauses ? JSON.stringify(clauses) : null;
   return useQuery({
-    queryKey: [
-      "personas",
-      "paginated",
-      page,
-      pageSize,
-      search,
-      type,
-      simulationType,
-    ],
+    queryKey: ["personas", "paginated", page, pageSize, search, filtersJson],
     queryFn: async () => {
       const { data } = await axios.get(endpoints.persona.list, {
         params: {
           page,
           limit: pageSize,
           search: search || undefined,
-          type: type || undefined,
-          simulation_type: simulationType || undefined,
+          filters: filtersJson || undefined,
         },
       });
       return data?.result;

--- a/frontend/src/components/filter-panel/FilterPanel.jsx
+++ b/frontend/src/components/filter-panel/FilterPanel.jsx
@@ -968,6 +968,8 @@ const FilterPanel = ({
   // a `projectId` the panel falls back to the legacy build_filters path.
   projectId,
   source = "traces",
+  // Opt-in: emit rows shape with operator; default keeps legacy object shape.
+  emitRowsFormat = false,
 }) => {
   const fieldMap = useMemo(
     () => Object.fromEntries(filterFields.map((f) => [f.value, f])),
@@ -1048,6 +1050,21 @@ const FilterPanel = ({
     if (!open) return;
     if (applyTimerRef.current) clearTimeout(applyTimerRef.current);
     applyTimerRef.current = setTimeout(() => {
+      if (emitRowsFormat) {
+        const tokens = [];
+        for (const row of rows) {
+          const val = row.value;
+          const isEmpty = !val || (Array.isArray(val) && val.length === 0);
+          if (isEmpty) continue;
+          tokens.push({
+            field: row.field,
+            operator: row.operator,
+            value: Array.isArray(val) ? val : [val],
+          });
+        }
+        onApply(tokens.length > 0 ? tokens : null);
+        return;
+      }
       const result = {};
       for (const row of rows) {
         const val = row.value;
@@ -1320,6 +1337,7 @@ FilterPanel.propTypes = {
   width: PropTypes.number,
   projectId: PropTypes.string,
   source: PropTypes.string,
+  emitRowsFormat: PropTypes.bool,
 };
 
 export { QueryInput };

--- a/frontend/src/sections/persona/PersonaListView.jsx
+++ b/frontend/src/sections/persona/PersonaListView.jsx
@@ -86,13 +86,16 @@ const PersonaListView = ({
   const { role } = useAuthContext();
   const canCreate = RolePermission.SIMULATION_AGENT[PERMISSIONS.CREATE][role];
 
-  // State
+  // Each filter holds `is` (include) and `is_not` (exclude) buckets so a
+  // field can carry both clauses at once.
   const [searchQuery, setSearchQuery] = useState("");
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(25);
-  const [typeFilter, setTypeFilter] = useState(null);
+  const [typeFilter, setTypeFilter] = useState({ is: [], is_not: [] });
   const [simulationFilter, setSimulationFilter] = useState(
-    isSelectable ? personaCreateEditType : null,
+    isSelectable && personaCreateEditType
+      ? { is: [personaCreateEditType], is_not: [] }
+      : { is: [], is_not: [] },
   );
   const [rowSelection, setRowSelection] = useState({});
   const [columnVisibility, setColumnVisibility] = useState({});
@@ -109,12 +112,33 @@ const PersonaListView = ({
 
   const debouncedSearch = useDebounce(searchQuery.trim(), 400);
 
+  // Canonical clause shape shared with ComplexFilter / _apply_filters / FilterEngine.
+  const filterClauses = useMemo(() => {
+    const out = [];
+    const push = (columnId, state) => {
+      if (state.is.length) {
+        out.push({
+          column_id: columnId,
+          filter_config: { filter_op: "is", filter_value: state.is },
+        });
+      }
+      if (state.is_not.length) {
+        out.push({
+          column_id: columnId,
+          filter_config: { filter_op: "is_not", filter_value: state.is_not },
+        });
+      }
+    };
+    push("type", typeFilter);
+    push("simulation_type", simulationFilter);
+    return out;
+  }, [typeFilter, simulationFilter]);
+
   const { data, isLoading, isFetching } = useGetPersonasPaginated({
     page: page + 1,
     pageSize,
     search: debouncedSearch || null,
-    type: typeFilter,
-    simulationType: simulationFilter,
+    filterClauses,
   });
 
   const items = useMemo(() => data?.results || [], [data]);
@@ -436,42 +460,67 @@ const PersonaListView = ({
     return fields;
   }, [isSelectable, personaCreateEditType]);
 
+  // Rows shape preserves the operator dropdown selection across reopens.
   const currentFilters = useMemo(() => {
-    const f = {};
-    if (typeFilter) f.type = [typeFilter];
-    if (simulationFilter) f.simulation_type = [simulationFilter];
-    return Object.keys(f).length ? f : null;
+    const rows = [];
+    const push = (field, state) => {
+      if (state.is.length) {
+        rows.push({ field, operator: "is", value: state.is });
+      }
+      if (state.is_not.length) {
+        rows.push({ field, operator: "is_not", value: state.is_not });
+      }
+    };
+    push("type", typeFilter);
+    push("simulation_type", simulationFilter);
+    return rows.length ? rows : null;
   }, [typeFilter, simulationFilter]);
 
-  const activeFilterCount = (typeFilter ? 1 : 0) + (simulationFilter ? 1 : 0);
+  const activeFilterCount =
+    (typeFilter.is.length || typeFilter.is_not.length ? 1 : 0) +
+    (simulationFilter.is.length || simulationFilter.is_not.length ? 1 : 0);
 
   const handleFilterApply = useCallback(
     (result) => {
       const lockedSim =
         isSelectable && personaCreateEditType ? personaCreateEditType : null;
+      const empty = () => ({ is: [], is_not: [] });
+      const lockedSimState = () =>
+        lockedSim ? { is: [lockedSim], is_not: [] } : empty();
       if (!result) {
-        setTypeFilter(null);
-        setSimulationFilter(lockedSim);
+        setTypeFilter(empty());
+        setSimulationFilter(lockedSimState());
         setPage(0);
         return;
       }
-      const pickFirst = (v) => (Array.isArray(v) ? v[0] : v) || null;
+      // Fresh inner arrays per field; shallow spread would alias them.
+      const next = { type: empty(), simulation_type: empty() };
       if (Array.isArray(result)) {
-        const flat = {};
         for (const t of result) {
-          const val = Array.isArray(t.value)
+          if (!next[t.field]) continue;
+          const vals = Array.isArray(t.value)
             ? t.value
             : t.value
               ? [t.value]
               : [];
-          if (val.length) flat[t.field] = val;
+          if (!vals.length) continue;
+          const bucket = t.operator === "is_not" ? "is_not" : "is";
+          next[t.field][bucket].push(...vals);
         }
-        setTypeFilter(pickFirst(flat.type));
-        setSimulationFilter(lockedSim ?? pickFirst(flat.simulation_type));
       } else {
-        setTypeFilter(pickFirst(result.type));
-        setSimulationFilter(lockedSim ?? pickFirst(result.simulation_type));
+        // Legacy object shape from FilterPanel — operator absent, assume `is`.
+        for (const field of Object.keys(next)) {
+          const v = result[field];
+          if (Array.isArray(v)) next[field].is = v.filter(Boolean);
+          else if (v) next[field].is = [v];
+        }
       }
+      for (const field of Object.keys(next)) {
+        next[field].is = Array.from(new Set(next[field].is));
+        next[field].is_not = Array.from(new Set(next[field].is_not));
+      }
+      setTypeFilter(next.type);
+      setSimulationFilter(lockedSim ? lockedSimState() : next.simulation_type);
       setPage(0);
     },
     [isSelectable, personaCreateEditType],
@@ -596,7 +645,11 @@ const PersonaListView = ({
         }}
       >
         {QUICK_FILTERS.map((f) => {
-          const isActive = typeFilter === f.value;
+          const isActive =
+            typeFilter.is_not.length === 0 &&
+            (f.value === null
+              ? typeFilter.is.length === 0
+              : typeFilter.is.length === 1 && typeFilter.is[0] === f.value);
           return (
             <Chip
               key={f.label}
@@ -606,7 +659,10 @@ const PersonaListView = ({
               variant={isActive ? "filled" : "outlined"}
               color={isActive ? "primary" : "default"}
               onClick={() => {
-                setTypeFilter(f.value);
+                setTypeFilter({
+                  is: f.value ? [f.value] : [],
+                  is_not: [],
+                });
                 setPage(0);
               }}
               sx={{ fontSize: "11px", height: 26, cursor: "pointer" }}
@@ -622,7 +678,12 @@ const PersonaListView = ({
           }}
         />
         {SIMULATION_FILTERS.map((f) => {
-          const isActive = simulationFilter === f.value;
+          const isActive =
+            simulationFilter.is_not.length === 0 &&
+            (f.value === null
+              ? simulationFilter.is.length === 0
+              : simulationFilter.is.length === 1 &&
+                simulationFilter.is[0] === f.value);
           return (
             <Chip
               key={f.label}
@@ -632,7 +693,10 @@ const PersonaListView = ({
               variant={isActive ? "filled" : "outlined"}
               color={isActive ? "primary" : "default"}
               onClick={() => {
-                setSimulationFilter(f.value);
+                setSimulationFilter({
+                  is: f.value ? [f.value] : [],
+                  is_not: [],
+                });
                 setPage(0);
               }}
               sx={{ fontSize: "11px", height: 26, cursor: "pointer" }}
@@ -662,9 +726,13 @@ const PersonaListView = ({
         getRowId={(row) => row.id}
         enableSelection
         emptyMessage={
-          typeFilter === "custom"
+          typeFilter.is_not.length === 0 &&
+          typeFilter.is.length === 1 &&
+          typeFilter.is[0] === "custom"
             ? "You haven't created any custom personas yet"
-            : typeFilter === "prebuilt"
+            : typeFilter.is_not.length === 0 &&
+                typeFilter.is.length === 1 &&
+                typeFilter.is[0] === "prebuilt"
               ? "No prebuilt personas found"
               : "No personas found"
         }
@@ -691,6 +759,7 @@ const PersonaListView = ({
         currentFilters={currentFilters}
         onApply={handleFilterApply}
         aiPlaceholder="e.g. 'show custom voice personas'"
+        emitRowsFormat
       />
 
       {/* Columns popover */}

--- a/futureagi/simulate/tests/test_persona_list_filters.py
+++ b/futureagi/simulate/tests/test_persona_list_filters.py
@@ -1,0 +1,362 @@
+"""
+Tests for the persona list endpoint's filter pipeline.
+
+Covers the `filters` query param introduced for multi-value selection and
+the is/is_not operator on `GET /simulate/api/personas/`. The endpoint
+parses a JSON array of {column_id, filter_config: {filter_op, filter_value}}
+clauses and applies each to the queryset via `__in` / `.exclude(__in=...)`.
+"""
+
+import json
+from contextlib import contextmanager
+
+import pytest
+from rest_framework import status
+
+from simulate.models import Persona
+from tfc.middleware.workspace_context import (
+    clear_workspace_context,
+    get_current_organization,
+    get_current_workspace,
+    set_workspace_context,
+)
+
+PERSONA_LIST_URL = "/simulate/api/personas/"
+
+
+@contextmanager
+def _no_workspace_context():
+    """Suspend the thread-local workspace/org so save signals don't auto-attach
+    them — required when creating SYSTEM personas (DB check constraint forbids
+    org/workspace on system rows)."""
+    ws = get_current_workspace()
+    org = get_current_organization()
+    clear_workspace_context()
+    try:
+        yield
+    finally:
+        set_workspace_context(workspace=ws, organization=org)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def system_voice_persona(db):
+    """A prebuilt (system) voice persona — visible to every workspace."""
+    with _no_workspace_context():
+        return Persona.no_workspace_objects.create(
+            name="System Voice",
+            persona_type=Persona.PersonaType.SYSTEM,
+            simulation_type=Persona.SimulationTypeChoices.VOICE,
+        )
+
+
+@pytest.fixture
+def system_text_persona(db):
+    """A prebuilt (system) chat persona."""
+    with _no_workspace_context():
+        return Persona.no_workspace_objects.create(
+            name="System Chat",
+            persona_type=Persona.PersonaType.SYSTEM,
+            simulation_type=Persona.SimulationTypeChoices.TEXT,
+        )
+
+
+@pytest.fixture
+def workspace_voice_persona(db, organization, workspace):
+    """A custom (workspace) voice persona in the test workspace."""
+    return Persona.objects.create(
+        name="Workspace Voice",
+        persona_type=Persona.PersonaType.WORKSPACE,
+        simulation_type=Persona.SimulationTypeChoices.VOICE,
+        organization=organization,
+        workspace=workspace,
+    )
+
+
+@pytest.fixture
+def workspace_text_persona(db, organization, workspace):
+    """A custom (workspace) chat persona in the test workspace."""
+    return Persona.objects.create(
+        name="Workspace Chat",
+        persona_type=Persona.PersonaType.WORKSPACE,
+        simulation_type=Persona.SimulationTypeChoices.TEXT,
+        organization=organization,
+        workspace=workspace,
+    )
+
+
+@pytest.fixture
+def all_personas(
+    system_voice_persona,
+    system_text_persona,
+    workspace_voice_persona,
+    workspace_text_persona,
+):
+    """Convenience fixture that materializes all four persona variants."""
+    return {
+        "system_voice": system_voice_persona,
+        "system_text": system_text_persona,
+        "workspace_voice": workspace_voice_persona,
+        "workspace_text": workspace_text_persona,
+    }
+
+
+def _body(response):
+    """Persona list view wraps DRF's paginated payload in {status, result}."""
+    data = response.json()
+    return data.get("result", data)
+
+
+def _names(response):
+    return {p["name"] for p in _body(response)["results"]}
+
+
+def _count(response):
+    return _body(response)["count"]
+
+
+def _filters_param(*clauses):
+    return {"filters": json.dumps(list(clauses))}
+
+
+def _clause(column_id, op, value):
+    if not isinstance(value, list):
+        value = [value]
+    return {
+        "column_id": column_id,
+        "filter_config": {"filter_op": op, "filter_value": value},
+    }
+
+
+# ============================================================================
+# Happy-path filter application
+# ============================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestPersonaListFiltersHappyPath:
+    """Each filter clause shape from the FE maps to the right ORM call."""
+
+    def test_no_filters_returns_all_visible_personas(self, auth_client, all_personas):
+        response = auth_client.get(PERSONA_LIST_URL)
+
+        assert response.status_code == status.HTTP_200_OK
+        names = _names(response)
+        assert names == {
+            "System Voice",
+            "System Chat",
+            "Workspace Voice",
+            "Workspace Chat",
+        }
+
+    def test_is_prebuilt_returns_only_system_personas(
+        self, auth_client, all_personas
+    ):
+        response = auth_client.get(
+            PERSONA_LIST_URL, _filters_param(_clause("type", "is", ["prebuilt"]))
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _names(response) == {"System Voice", "System Chat"}
+
+    def test_is_custom_returns_only_workspace_personas(
+        self, auth_client, all_personas
+    ):
+        response = auth_client.get(
+            PERSONA_LIST_URL, _filters_param(_clause("type", "is", ["custom"]))
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _names(response) == {"Workspace Voice", "Workspace Chat"}
+
+    def test_is_multi_value_returns_union(self, auth_client, all_personas):
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(_clause("type", "is", ["prebuilt", "custom"])),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(_names(response)) == 4
+
+    def test_is_not_prebuilt_excludes_system_personas(
+        self, auth_client, all_personas
+    ):
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(_clause("type", "is_not", ["prebuilt"])),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _names(response) == {"Workspace Voice", "Workspace Chat"}
+
+    def test_is_plus_is_not_on_same_field_applied_together(
+        self, auth_client, all_personas
+    ):
+        # type IN (prebuilt, custom) AND type NOT IN (custom) → only prebuilt
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(
+                _clause("type", "is", ["prebuilt", "custom"]),
+                _clause("type", "is_not", ["custom"]),
+            ),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _names(response) == {"System Voice", "System Chat"}
+
+    def test_cross_field_is_and_is_not(self, auth_client, all_personas):
+        # type IS prebuilt AND simulation_type IS NOT voice → System Chat only
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(
+                _clause("type", "is", ["prebuilt"]),
+                _clause("simulation_type", "is_not", ["voice"]),
+            ),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _names(response) == {"System Chat"}
+
+    def test_contradiction_returns_zero_rows_not_500(
+        self, auth_client, all_personas
+    ):
+        # type IS prebuilt AND type IS NOT prebuilt → impossible, empty result
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(
+                _clause("type", "is", ["prebuilt"]),
+                _clause("type", "is_not", ["prebuilt"]),
+            ),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _count(response) == 0
+
+    def test_simulation_type_is_voice(self, auth_client, all_personas):
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(_clause("simulation_type", "is", ["voice"])),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _names(response) == {"System Voice", "Workspace Voice"}
+
+    def test_filter_combined_with_search(self, auth_client, all_personas):
+        # Search narrows by name; filter narrows by type. Both should apply.
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            {
+                "search": "Workspace",
+                **_filters_param(_clause("simulation_type", "is", ["text"])),
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _names(response) == {"Workspace Chat"}
+
+
+# ============================================================================
+# Defensive parsing — bad clauses must never crash get_queryset
+# ============================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestPersonaListFiltersDefensiveParsing:
+    """Regression guard: a bad clause must not make get_queryset return a
+    Response (which used to crash the paginator with `object has no len()`)."""
+
+    def test_malformed_json_returns_200_no_filters_applied(
+        self, auth_client, all_personas
+    ):
+        response = auth_client.get(PERSONA_LIST_URL, {"filters": "not-json"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _count(response) == 4
+
+    def test_filters_is_not_a_list_returns_200(self, auth_client, all_personas):
+        response = auth_client.get(
+            PERSONA_LIST_URL, {"filters": json.dumps({"not": "a list"})}
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _count(response) == 4
+
+    def test_unknown_column_id_is_skipped(self, auth_client, all_personas):
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(_clause("not_a_real_column", "is", ["whatever"])),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _count(response) == 4
+
+    def test_unknown_simulation_type_value_is_skipped(
+        self, auth_client, all_personas
+    ):
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(_clause("simulation_type", "is", ["bogus_value"])),
+        )
+
+        # All values invalid → clause produces no `valid` list → skipped.
+        # Endpoint behaves as if the clause weren't there.
+        assert response.status_code == status.HTTP_200_OK
+        assert _count(response) == 4
+
+    def test_unknown_operator_is_skipped(self, auth_client, all_personas):
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(_clause("type", "starts_with", ["prebuilt"])),
+        )
+
+        # Unknown op falls through both `if op == "is"` and `elif op == "is_not"`.
+        assert response.status_code == status.HTTP_200_OK
+        assert _count(response) == 4
+
+    def test_clause_is_a_string_not_a_dict_is_skipped(
+        self, auth_client, all_personas
+    ):
+        response = auth_client.get(
+            PERSONA_LIST_URL, {"filters": json.dumps(["just a string"])}
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _count(response) == 4
+
+    def test_filter_config_missing_is_skipped(self, auth_client, all_personas):
+        response = auth_client.get(
+            PERSONA_LIST_URL, {"filters": json.dumps([{"column_id": "type"}])}
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _count(response) == 4
+
+    def test_filter_value_is_a_non_string_is_skipped(
+        self, auth_client, all_personas
+    ):
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(_clause("type", "is", [123, None, {"k": "v"}])),
+        )
+
+        # No element survives `isinstance(v, str)` — clause becomes a no-op.
+        assert response.status_code == status.HTTP_200_OK
+        assert _count(response) == 4
+
+    def test_partially_invalid_values_use_only_the_valid_ones(
+        self, auth_client, all_personas
+    ):
+        # Mix valid + invalid: only `prebuilt` survives mapping.
+        response = auth_client.get(
+            PERSONA_LIST_URL,
+            _filters_param(_clause("type", "is", ["prebuilt", "bogus", 42])),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _names(response) == {"System Voice", "System Chat"}

--- a/futureagi/simulate/views/persona.py
+++ b/futureagi/simulate/views/persona.py
@@ -1,3 +1,5 @@
+import json
+
 import structlog
 from django.db.models import Q
 from rest_framework import status, viewsets
@@ -103,14 +105,6 @@ class PersonaViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
             # If no organization context, only show system personas
             queryset = queryset.filter(persona_type=Persona.PersonaType.SYSTEM)
 
-        # Apply type filter (prebuilt/custom)
-        persona_type_param = self.request.query_params.get("type", None)
-        if persona_type_param:
-            if persona_type_param.lower() == "prebuilt":
-                queryset = queryset.filter(persona_type=Persona.PersonaType.SYSTEM)
-            elif persona_type_param.lower() == "custom":
-                queryset = queryset.filter(persona_type=Persona.PersonaType.WORKSPACE)
-
         # Apply search filter
         search_param = self.request.query_params.get("search", None)
         if search_param:
@@ -120,15 +114,62 @@ class PersonaViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 | Q(keywords__icontains=search_param)
             )
 
-        simulation_type_param = self.request.query_params.get("simulation_type", None)
-        if simulation_type_param:
-            simulation_type_param = simulation_type_param.lower()
-            if simulation_type_param not in [
-                choice[0] for choice in Persona.SimulationTypeChoices.choices
-            ]:
-                return self._gm.bad_request("Invalid simulation type")
+        # `filters` is a JSON array of {column_id, filter_config: {filter_op,
+        # filter_value}}. Unknown columns/ops are skipped silently so a bad
+        # clause can't make get_queryset return a non-QuerySet.
+        persona_type_map = {
+            "prebuilt": Persona.PersonaType.SYSTEM,
+            "custom": Persona.PersonaType.WORKSPACE,
+        }
+        valid_simulation_choices = {
+            choice[0] for choice in Persona.SimulationTypeChoices.choices
+        }
+        try:
+            clauses = json.loads(self.request.query_params.get("filters", "[]"))
+            if not isinstance(clauses, list):
+                clauses = []
+        except (TypeError, ValueError):
+            clauses = []
+        for clause in clauses:
+            if not isinstance(clause, dict):
+                continue
+            column_id = clause.get("column_id")
+            cfg = clause.get("filter_config") or {}
+            op = cfg.get("filter_op")
+            raw_value = cfg.get("filter_value")
+            values = (
+                raw_value
+                if isinstance(raw_value, list)
+                else [raw_value]
+                if raw_value
+                else []
+            )
 
-            queryset = queryset.filter(simulation_type=simulation_type_param)
+            if column_id == "type":
+                mapped = [
+                    persona_type_map[v.lower()]
+                    for v in values
+                    if isinstance(v, str) and v.lower() in persona_type_map
+                ]
+                if not mapped:
+                    continue
+                if op == "is":
+                    queryset = queryset.filter(persona_type__in=mapped)
+                elif op == "is_not":
+                    queryset = queryset.exclude(persona_type__in=mapped)
+            elif column_id == "simulation_type":
+                valid = [
+                    v.lower()
+                    for v in values
+                    if isinstance(v, str)
+                    and v.lower() in valid_simulation_choices
+                ]
+                if not valid:
+                    continue
+                if op == "is":
+                    queryset = queryset.filter(simulation_type__in=valid)
+                elif op == "is_not":
+                    queryset = queryset.exclude(simulation_type__in=valid)
 
         return queryset.select_related("organization", "workspace").order_by(
             "-created_at"


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

The persona list filter previously sent one value per field and silently dropped the operator selection, so selecting multiple values (e.g. `Category = Prebuilt + Custom`) collapsed to a single equality check and the `Is not` operator did nothing. This PR moves per-field state into independent `{is, is_not}` buckets, preserves the operator coming out of the FilterPanel via a new opt-in `emitRowsFormat` flag, and serializes the active filters as a single `filters` JSON param using the same `{column_id, filter_config: {filter_op, filter_value}}` shape that ComplexFilter and the existing in-codebase filter engines already speak. The backend reads that payload and applies each clause with `.filter(__in)` / `.exclude(__in)`; unknown columns or operators are skipped so a malformed clause can't make `get_queryset` return a non-QuerySet.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Manual on local:
- Selected multiple `Category` values from the basic filter; list narrowed correctly to the union and the network call carried both values.
- Switched the `Category` operator to `Is not` and confirmed the matching personas were excluded.
- Created an `Is` + `Is not` pair on the same field; closed and reopened the panel and both rows came back with their original operators.
- Verified the legacy single-value path (quick filter chips) still works as before.

Syntax-checked the touched files with `python3 -c "import ast; ast.parse(...)"` and `node --check`; full `yarn check-all` / `make check-all` not run, please smoke-test before merge.

## Test Checklist
- [ ] Open /dashboard/personas, click Filter → Basic, set Category Is prebuilt → only system personas show
- [ ] Add value: Category Is [prebuilt, custom] → all personas show
- [ ] Change to Category Is not prebuilt → only custom personas show
- [ ] Two rows: Category Is prebuilt + Category Is not custom → only system personas show
- [ ] Close filter popover, reopen → both rows still there with original Is / Is not operators
- [ ] Network tab → request has single `filters=` JSON param, no `type=` or `type_op=`
- [ ] Set Category Is prebuilt AND Category Is not prebuilt → empty list, no 500
- [ ] Clear all → list returns to default, no `filters` param in URL
- [ ] Quick chip "Future AGI Built" click → only system personas show, chip highlights
- [ ] Persona picker drawer (in scenario flow with locked voice type) → only voice personas show, Agent Type filter absent
- [ ] Bulk delete a custom persona → snackbar fires, list refreshes


## Screenshots / recordings (if UI)

https://github.com/user-attachments/assets/23ba1fad-808d-4ac1-82a1-440db6d80983




## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
