### PR TITLE
fix(simulate): render zeroed eval metric when all runs error

### DIFF
--- a/frontend/src/sections/test-detail/PerformanceMetrics/DeterministicEvaluationChart.jsx
+++ b/frontend/src/sections/test-detail/PerformanceMetrics/DeterministicEvaluationChart.jsx
@@ -11,6 +11,48 @@ import { getLabel } from "./common";
 const DeterministicEvaluationChart = ({ title, data }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
+
+  // Empty-state placeholder: no data points (e.g. every call errored on this
+  // eval) — render the title with a muted message instead of an empty chart.
+  if (!data || data.length === 0) {
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        sx={{ width: "100%", maxWidth: 320 }}
+      >
+        <Typography
+          sx={{
+            typography: "s2",
+            fontWeight: "fontWeightMedium",
+            color: "text.primary",
+          }}
+        >
+          {getLabel(title)}
+        </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: 115,
+          }}
+        >
+          <Typography
+            sx={{
+              typography: "s3",
+              color: "text.disabled",
+              fontStyle: "italic",
+            }}
+          >
+            No data — every eval run errored
+          </Typography>
+        </Box>
+      </Box>
+    );
+  }
+
   const series = data.map((item) => item.value);
   const labels = data.map((item) => item.name);
   const colors = data.map((item) => item.color);

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -100,6 +100,7 @@ except ImportError:
     ConversationMetricsCalculator = None
     PhoneNumberService = None
     decide_processing_skip = None
+from simulate.utils.eval_summary import derive_kpi_output_type
 from simulate.utils.processing_outcomes import (
     build_skipped_eval_output_payload,
     set_processing_skip_metadata,
@@ -4819,6 +4820,8 @@ class TestExecutor:
                             "error": "error",
                             "name": eval_config.name,
                             "timestamp": timezone.now().isoformat(),
+                            "output": None,
+                            "output_type": derive_kpi_output_type(eval_template),
                         }
                         call_execution.eval_outputs[str(eval_config.id)] = error_result
                         call_execution.eval_outputs[str(eval_config.id)][
@@ -4931,6 +4934,8 @@ class TestExecutor:
                 "error": "error",
                 "name": eval_config.name,
                 "timestamp": timezone.now().isoformat(),
+                "output": None,
+                "output_type": derive_kpi_output_type(eval_config.eval_template),
             }
             call_execution.eval_outputs[str(eval_config.id)] = error_result
             call_execution.eval_outputs[str(eval_config.id)][

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -38,6 +38,7 @@ from simulate.temporal.types.activities import (
     RunToolCallEvaluationInput,
     RunToolCallEvaluationOutput,
 )
+from simulate.utils.eval_summary import derive_kpi_output_type
 
 logger = structlog.get_logger(__name__)
 
@@ -717,6 +718,8 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
                     "error": "error",
                     "name": eval_config.name,
                     "timestamp": timezone.now().isoformat(),
+                    "output": None,
+                    "output_type": derive_kpi_output_type(eval_template),
                 }
                 call_execution.eval_outputs[str(eval_config.id)] = error_result
                 call_execution.save(update_fields=["eval_outputs"])
@@ -837,6 +840,8 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
             "error": "error",
             "name": eval_config.name,
             "timestamp": timezone.now().isoformat(),
+            "output": None,
+            "output_type": derive_kpi_output_type(eval_config.eval_template),
         }
         call_execution.eval_outputs[str(eval_config.id)] = error_result
         call_execution.save(update_fields=["eval_outputs"])
@@ -977,11 +982,11 @@ def _run_evaluations_standalone(
         if eval_config_ids:
             eval_configs = SimulateEvalConfig.objects.filter(
                 id__in=eval_config_ids, deleted=False
-            )
+            ).select_related("eval_template")
         else:
             eval_configs = SimulateEvalConfig.objects.filter(
                 run_test=run_test, deleted=False
-            )
+            ).select_related("eval_template")
 
         if not eval_configs.exists():
             logger.info(f"No evaluation configs found for run test {run_test.id}")
@@ -1005,7 +1010,7 @@ def _run_evaluations_standalone(
                 call_execution.eval_outputs[str(eval_config.id)] = {
                     "output": None,
                     "reason": "No transcript data available",
-                    "output_type": None,
+                    "output_type": derive_kpi_output_type(eval_config.eval_template),
                     "name": eval_config.name,
                 }
             if not call_execution.call_metadata:

--- a/futureagi/simulate/tests/test_kpi_sql_queries.py
+++ b/futureagi/simulate/tests/test_kpi_sql_queries.py
@@ -493,6 +493,193 @@ class TestGetKpiEvalMetricsQuery:
         # avg of 3, 5, 7 = 5.0
         assert float(numeric_rows[0][3]) == 5.0
 
+    def test_fully_errored_pass_fail_emits_zero_row(self, test_execution, scenario):
+        """Pass/Fail metric where every entry errored still shows up as a
+        scalar row with NULL avg, so the handler renders a 0% bar instead
+        of dropping the metric."""
+        metric_id = str(uuid.uuid4())
+
+        for i in range(2):
+            CallExecution.objects.create(
+                test_execution=test_execution,
+                scenario=scenario,
+                phone_number=f"+600000000{i}",
+                status="completed",
+                eval_outputs={
+                    metric_id: {
+                        "name": "Quality Check",
+                        "error": "error",
+                        "status": "failed",
+                        "output": None,
+                        "output_type": "Pass/Fail",
+                    },
+                },
+            )
+
+        query, params = get_kpi_eval_metrics_query(test_execution.id)
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            rows = cursor.fetchall()
+
+        pass_fail_rows = [r for r in rows if r[2] == "Pass/Fail"]
+        assert len(pass_fail_rows) == 1
+        assert pass_fail_rows[0][1] == "Quality Check"
+        # AVG over all-NULL CASE results yields NULL
+        assert pass_fail_rows[0][3] is None
+
+    def test_fully_errored_score_emits_zero_row(self, test_execution, scenario):
+        """Score metric where every entry errored emits a scalar row with
+        NULL avg."""
+        metric_id = str(uuid.uuid4())
+
+        for i in range(3):
+            CallExecution.objects.create(
+                test_execution=test_execution,
+                scenario=scenario,
+                phone_number=f"+700000000{i}",
+                status="completed",
+                eval_outputs={
+                    metric_id: {
+                        "name": "Accuracy",
+                        "error": "error",
+                        "status": "failed",
+                        "output": None,
+                        "output_type": "score",
+                    },
+                },
+            )
+
+        query, params = get_kpi_eval_metrics_query(test_execution.id)
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            rows = cursor.fetchall()
+
+        score_rows = [r for r in rows if r[2] == "score"]
+        assert len(score_rows) == 1
+        assert score_rows[0][1] == "Accuracy"
+        assert score_rows[0][3] is None
+
+    def test_fully_errored_choices_emits_metric_row(self, test_execution, scenario):
+        """Choices metric where every entry errored emerges from
+        choice_errored_agg so the chart card still renders."""
+        metric_id = str(uuid.uuid4())
+
+        for i in range(2):
+            CallExecution.objects.create(
+                test_execution=test_execution,
+                scenario=scenario,
+                phone_number=f"+800000000{i}",
+                status="completed",
+                eval_outputs={
+                    metric_id: {
+                        "name": "Sentiment",
+                        "error": "error",
+                        "status": "failed",
+                        "output": None,
+                        "output_type": "choices",
+                    },
+                },
+            )
+
+        query, params = get_kpi_eval_metrics_query(test_execution.id)
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            rows = cursor.fetchall()
+
+        choices_rows = [r for r in rows if r[2] == "choices"]
+        assert len(choices_rows) == 1
+        row = choices_rows[0]
+        assert row[1] == "Sentiment"
+        # avg_value, choice_value both NULL; choice_count = 0
+        assert row[3] is None
+        assert row[4] is None
+        assert row[5] == 0
+
+    def test_partial_errored_choices_aggregates_successes_only(
+        self, test_execution, scenario
+    ):
+        """When some entries succeed and others error, choice_errored_agg
+        must NOT emit (bool_and is false); the successful entries are
+        aggregated by the existing choice_agg path."""
+        metric_id = str(uuid.uuid4())
+
+        CallExecution.objects.create(
+            test_execution=test_execution,
+            scenario=scenario,
+            phone_number="+9000000001",
+            status="completed",
+            eval_outputs={
+                metric_id: {
+                    "name": "Sentiment",
+                    "output": "positive",
+                    "output_type": "choices",
+                },
+            },
+        )
+        CallExecution.objects.create(
+            test_execution=test_execution,
+            scenario=scenario,
+            phone_number="+9000000002",
+            status="completed",
+            eval_outputs={
+                metric_id: {
+                    "name": "Sentiment",
+                    "error": "error",
+                    "status": "failed",
+                    "output": None,
+                    "output_type": "choices",
+                },
+            },
+        )
+
+        query, params = get_kpi_eval_metrics_query(test_execution.id)
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            rows = cursor.fetchall()
+
+        choices_rows = [r for r in rows if r[2] == "choices"]
+        # Only the choice_agg row for "positive" should appear — no extra
+        # zero-row from choice_errored_agg.
+        assert len(choices_rows) == 1
+        assert choices_rows[0][4] == "positive"
+        assert choices_rows[0][5] == 1
+
+
+@pytest.mark.unit
+class TestDeriveKpiOutputType:
+    """Maps EvalTemplate.output_type_normalized to the runtime KPI
+    output_type the SQL aggregation pipeline keys off."""
+
+    def test_known_mappings(self):
+        from types import SimpleNamespace
+
+        from simulate.utils.eval_summary import derive_kpi_output_type
+
+        cases = {
+            "pass_fail": "Pass/Fail",
+            "percentage": "score",
+            "deterministic": "choices",
+        }
+        for normalized, expected in cases.items():
+            tpl = SimpleNamespace(output_type_normalized=normalized)
+            assert derive_kpi_output_type(tpl) == expected
+
+    def test_unknown_or_missing_falls_back_to_score(self):
+        from types import SimpleNamespace
+
+        from simulate.utils.eval_summary import derive_kpi_output_type
+
+        assert derive_kpi_output_type(None) == "score"
+        assert (
+            derive_kpi_output_type(SimpleNamespace(output_type_normalized=None))
+            == "score"
+        )
+        assert (
+            derive_kpi_output_type(SimpleNamespace(output_type_normalized="custom"))
+            == "score"
+        )
+        assert derive_kpi_output_type(SimpleNamespace()) == "score"
+
 
 # ============================================================================
 # RunTestKPIsView API Tests

--- a/futureagi/simulate/utils/eval_summary.py
+++ b/futureagi/simulate/utils/eval_summary.py
@@ -3,6 +3,20 @@ import numpy as np
 from simulate.models import CallExecution, SimulateEvalConfig
 
 
+# Maps EvalTemplate.output_type_normalized to the runtime output_type string
+# the KPI aggregation pipeline keys off. Errored evals carry this so the SQL
+# still emits a zero row instead of dropping the metric.
+def derive_kpi_output_type(eval_template):
+    mapping = {
+        "pass_fail": "Pass/Fail",
+        "percentage": "score",
+        "deterministic": "choices",
+    }
+    return mapping.get(
+        getattr(eval_template, "output_type_normalized", None), "score"
+    )
+
+
 def _get_eval_config_for_agent_version(agent_version):
     return SimulateEvalConfig.objects.filter(
         run_test__agent_definition=agent_version.agent_definition,

--- a/futureagi/simulate/utils/sql_query.py
+++ b/futureagi/simulate/utils/sql_query.py
@@ -281,10 +281,8 @@ def get_kpi_eval_metrics_query(test_execution_id):
         GROUP BY metric_id, metric_name
     ),
 
-    -- Choices metrics where every entry errored (output is null). Without
-    -- this branch the metric drops out of the response entirely and the UI
-    -- renders "No evaluation metrics added"; emitting a zero row lets the
-    -- handler register the metric so a zeroed chart card shows instead.
+    -- Choices metrics where every entry has null output: emit a zero row
+    -- so the handler can register the metric instead of dropping it.
     choice_errored_agg AS (
         SELECT
             metric_id,

--- a/futureagi/simulate/utils/sql_query.py
+++ b/futureagi/simulate/utils/sql_query.py
@@ -279,6 +279,26 @@ def get_kpi_eval_metrics_query(test_execution_id):
         FROM eval_entries
         WHERE output_type = 'choices' AND jsonb_typeof(output_raw) = 'number'
         GROUP BY metric_id, metric_name
+    ),
+
+    -- Choices metrics where every entry errored (output is null). Without
+    -- this branch the metric drops out of the response entirely and the UI
+    -- renders "No evaluation metrics added"; emitting a zero row lets the
+    -- handler register the metric so a zeroed chart card shows instead.
+    choice_errored_agg AS (
+        SELECT
+            metric_id,
+            metric_name,
+            'choices' AS output_type,
+            NULL::numeric AS avg_value,
+            NULL::text AS choice_value,
+            0 AS choice_count
+        FROM eval_entries
+        WHERE output_type = 'choices'
+        GROUP BY metric_id, metric_name
+        HAVING bool_and(
+            output_raw IS NULL OR jsonb_typeof(output_raw) = 'null'
+        )
     )
 
     SELECT * FROM scalar_agg
@@ -286,6 +306,8 @@ def get_kpi_eval_metrics_query(test_execution_id):
     SELECT * FROM choice_agg
     UNION ALL
     SELECT * FROM choice_numeric_agg
+    UNION ALL
+    SELECT * FROM choice_errored_agg
     """
     params = [str(test_execution_id)]
     return query, params

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -1514,6 +1514,14 @@ class RunTestKPIsView(APIView):
                         # Numeric choice: already averaged
                         field_name = f"avg_{metric_name.lower().replace(' ', '_')}"
                         eval_averages[field_name] = float(avg_value)
+                    else:
+                        # Fully-errored choices metric: register it so the UI
+                        # renders a zeroed chart card instead of dropping the
+                        # whole eval bar.
+                        choice_metric_ids.add(metric_id)
+                        base_name = metric_name.lower().replace(" ", "_")
+                        if base_name not in choice_counts:
+                            choice_counts[base_name] = {"_metric_id": metric_id}
 
             # Fetch choices config for choice-type eval metrics
             if choice_metric_ids:


### PR DESCRIPTION
## Summary

When every call in a run errors for a given evaluation, the error blob written to `call_execution.eval_outputs` lacks `output` / `output_type` keys, so the KPI aggregation SQL drops the metric entirely and the run-test detail screen falls back to "No evaluation metrics added" even though evals were configured. This change makes the error blob carry an `output_type` derived from `EvalTemplate.output_type_normalized`, and adds a `choice_errored_agg` CTE so choices-type metrics with all-null outputs still emit a zero row. The KPI handler then registers those metrics so the eval bar (or empty deterministic chart) renders at zero instead of disappearing.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `python3 -c "import ast; ast.parse(...)"` parses all five touched files.
- Behaviour verification was done by tracing the data flow end-to-end: error writes now include `output: None` plus a derived `output_type`, the existing `eval_entries` CTE filter (`e.value ? 'output' AND e.value ? 'output_type'`) accepts the new shape, `scalar_agg`'s CASE yields NULL for null outputs and `AVG` ignores them so Pass/Fail and score metrics emerge from `GROUP BY` with `avg_value=NULL` (coerced to 0 in Python), and the new `choice_errored_agg` CTE covers choices-type metrics where every entry is null.
- smoke-tested the run-test detail screen with a run where evals are configured to fail (e.g., wrong column mapping) and confirmed the eval bar renders at 0% / the deterministic chart renders empty rather than the "No evaluation metrics added" empty state.
- Note: existing rows already in the database keep the pre-fix shape until the evals are rerun.

## Screenshots / recordings (if UI)


https://github.com/user-attachments/assets/f11c2338-27e3-41c9-9262-a03ef6b306c4



## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
