### PR TITLE
Fix/code evals variables and cancellation errors

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -73,6 +73,7 @@ import {
   buildEvalTemplateConfig,
   buildCompositeSourceModeProps,
   contextOptionsForRowType,
+  extractCodeEvaluateParams,
   getSourceModeVariables,
   hasNonEmptyPromptMessage,
 } from "./evalPickerConfigUtils";
@@ -97,6 +98,7 @@ const SOURCE_LABELS = {
 
 const getEvalPromptText = (evalData, config = {}) =>
   evalData?.instructions || config?.rule_prompt || "";
+
 
 const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const { isOSS } = useDeploymentMode();
@@ -259,6 +261,14 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       [];
 
     if (evalType === "code") {
+      // Live-parse the user's `def evaluate(...)` signature so adding /
+      // renaming a parameter immediately surfaces a new mapping row.
+      // Fall back to the saved mapping + template required_keys when the
+      // code can't be parsed (non-python language, no `def evaluate`).
+      const liveParams = extractCodeEvaluateParams(code, codeLanguage);
+      if (liveParams.length > 0) {
+        return [...new Set([...liveParams, ...requiredKeys])];
+      }
       const savedMapping = normalizedEvalData?.mapping || {};
       const savedStdvars = ["input", "output", "expected"].filter(
         (v) => v in savedMapping,
@@ -290,6 +300,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     isSystemEval,
     compositeDetail,
     templateFormat,
+    code,
+    codeLanguage,
   ]);
 
 

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -48,7 +48,11 @@ import DatasetTestMode from "src/sections/evals/components/DatasetTestMode";
 import TracingTestMode from "src/sections/evals/components/TracingTestMode";
 import SimulationTestMode from "src/sections/evals/components/SimulationTestMode";
 import { useEvalPickerContext } from "./context/EvalPickerContext";
-import { contextOptionsForRowType } from "./evalPickerConfigUtils";
+import {
+  contextOptionsForRowType,
+  extractCodeEvaluateParams,
+} from "./evalPickerConfigUtils";
+
 const TRACING_ROW_TYPE_TO_KEY = {
   Span: "spans",
   Trace: "traces",
@@ -620,9 +624,14 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
 
   // Variables from instructions
   const variables = useMemo(() => {
-    const codeStdVars =
-      evalType === "code" ? ["input", "output", "expected"] : [];
-    if (!instructions && evalType !== "code") return [];
+    if (evalType === "code") {
+      // Live-parse the user's `def evaluate(...)` signature so adding /
+      // renaming a parameter immediately surfaces a new mapping row.
+      const liveParams = extractCodeEvaluateParams(code, codeLanguage);
+      if (liveParams.length > 0) return [...new Set(liveParams)];
+      return ["input", "output", "expected"];
+    }
+    if (!instructions) return [];
     let vars;
     if (templateFormat === "jinja") {
       vars = extractJinjaVariables(instructions || "");
@@ -631,8 +640,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         (instructions || "").match(/\{\{\s*([^{}]+?)\s*\}\}/g) || [];
       vars = matches.map((m) => m.replace(/\{\{|\}\}/g, "").trim());
     }
-    return [...new Set([...codeStdVars, ...vars])];
-  }, [instructions, evalType, templateFormat]);
+    return [...new Set(vars)];
+  }, [instructions, evalType, templateFormat, code, codeLanguage]);
 
   return (
     <Box

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.js
@@ -14,6 +14,8 @@ const ROW_TYPE_CONTEXT_OPTIONS = {
 export const contextOptionsForRowType = (rowType) =>
   ROW_TYPE_CONTEXT_OPTIONS[rowType] || null;
 
+export { extractCodeEvaluateParams } from "src/utils/codeEvalParams";
+
 export const hasNonEmptyPromptMessage = (messages = []) =>
   messages.some((message) => {
     if (!["system", "user"].includes(message?.role)) return false;

--- a/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
+++ b/frontend/src/sections/common/EvalPicker/evalPickerConfigUtils.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCompositeSourceModeProps,
   contextOptionsForRowType,
+  extractCodeEvaluateParams,
   getSourceModeVariables,
 } from "./evalPickerConfigUtils";
 
@@ -19,6 +20,196 @@ describe("contextOptionsForRowType", () => {
     expect(contextOptionsForRowType(null)).toBeNull();
     expect(contextOptionsForRowType("")).toBeNull();
     expect(contextOptionsForRowType("unknown")).toBeNull();
+  });
+});
+
+describe("extractCodeEvaluateParams", () => {
+  describe("guard clauses", () => {
+    it("returns an empty array for empty / missing code", () => {
+      expect(extractCodeEvaluateParams("", "python")).toEqual([]);
+      expect(extractCodeEvaluateParams(null, "python")).toEqual([]);
+      expect(extractCodeEvaluateParams(undefined, "python")).toEqual([]);
+    });
+
+    it("returns an empty array for unsupported languages", () => {
+      const code = "def evaluate(input, output): return 0";
+      expect(extractCodeEvaluateParams(code, "ruby")).toEqual([]);
+      expect(extractCodeEvaluateParams(code, "go")).toEqual([]);
+    });
+
+    it("defaults to python parsing when language is falsy", () => {
+      const code = "def evaluate(input, output): return 0";
+      expect(extractCodeEvaluateParams(code, undefined)).toEqual([
+        "input",
+        "output",
+      ]);
+      expect(extractCodeEvaluateParams(code, "")).toEqual(["input", "output"]);
+    });
+  });
+
+  describe("python", () => {
+    it("parses the default template signature", () => {
+      const code = `def evaluate(input: Any, output: Any, expected: Any, context: dict, **kwargs):
+    return {"score": 1.0}`;
+      expect(extractCodeEvaluateParams(code, "python")).toEqual([
+        "input",
+        "output",
+        "expected",
+      ]);
+    });
+
+    it("includes user-added params alongside the standard ones", () => {
+      const code = `def evaluate(input: Any, output: Any, expected: Any, random: Any, context: dict, **kwargs):
+    return {"score": 1.0}`;
+      expect(extractCodeEvaluateParams(code, "python")).toEqual([
+        "input",
+        "output",
+        "expected",
+        "random",
+      ]);
+    });
+
+    it("strips inline comments in multi-line signatures", () => {
+      const code = `def evaluate(
+    input: Any,       # Input to the AI system
+    output: Any,
+    expected: Any,    # Ground truth (may be None)
+    context: dict,    # Mode-specific data
+    **kwargs          # Additional mapped variables
+):
+    return {"score": 1.0}`;
+      expect(extractCodeEvaluateParams(code, "python")).toEqual([
+        "input",
+        "output",
+        "expected",
+      ]);
+    });
+
+    it("keeps params with nested generics intact (depth-aware split)", () => {
+      const code = `def evaluate(input: Dict[str, int], output: List[Tuple[str, int]], expected: Any):
+    return {"score": 1.0}`;
+      expect(extractCodeEvaluateParams(code, "python")).toEqual([
+        "input",
+        "output",
+        "expected",
+      ]);
+    });
+
+    it("ignores *args and **kwargs", () => {
+      const code = `def evaluate(input, output, *args, **kwargs):
+    return {"score": 1.0}`;
+      expect(extractCodeEvaluateParams(code, "python")).toEqual([
+        "input",
+        "output",
+      ]);
+    });
+
+    it("ignores reserved params (context, self, cls)", () => {
+      const code = `def evaluate(self, cls, input, context, custom):
+    return {"score": 1.0}`;
+      expect(extractCodeEvaluateParams(code, "python")).toEqual([
+        "input",
+        "custom",
+      ]);
+    });
+
+    it("drops type annotations and default values", () => {
+      const code = `def evaluate(input: str = "x", output: int = 1, expected = None):
+    return {"score": 1.0}`;
+      expect(extractCodeEvaluateParams(code, "python")).toEqual([
+        "input",
+        "output",
+        "expected",
+      ]);
+    });
+
+    it("returns an empty array when there is no def evaluate", () => {
+      expect(
+        extractCodeEvaluateParams("def other(a, b): pass", "python"),
+      ).toEqual([]);
+      expect(extractCodeEvaluateParams("print('hi')", "python")).toEqual([]);
+    });
+
+    it("handles a parameter-less signature", () => {
+      expect(
+        extractCodeEvaluateParams("def evaluate():\n    return None", "python"),
+      ).toEqual([]);
+    });
+  });
+
+  describe("javascript", () => {
+    it("parses the default destructured template", () => {
+      const code = `function evaluate({ input, output, expected, context, ...kwargs }) {
+  return { score: 1.0 };
+}`;
+      expect(extractCodeEvaluateParams(code, "javascript")).toEqual([
+        "input",
+        "output",
+        "expected",
+      ]);
+    });
+
+    it("includes user-added params alongside the standard ones", () => {
+      const code = `function evaluate({ input, output, expected, random, context, ...kwargs }) {
+  return { score: 1.0 };
+}`;
+      expect(extractCodeEvaluateParams(code, "javascript")).toEqual([
+        "input",
+        "output",
+        "expected",
+        "random",
+      ]);
+    });
+
+    it("strips // and /* */ comments inside the destructuring", () => {
+      const code = `function evaluate({
+  input,    // the input
+  output,   /* the output */
+  expected,
+  random,
+  context,
+  ...kwargs
+}) {
+  return { score: 1.0 };
+}`;
+      expect(extractCodeEvaluateParams(code, "javascript")).toEqual([
+        "input",
+        "output",
+        "expected",
+        "random",
+      ]);
+    });
+
+    it("drops destructuring renames and default values", () => {
+      const code = `function evaluate({ input, output: out, expected = null, random }) {}`;
+      expect(extractCodeEvaluateParams(code, "javascript")).toEqual([
+        "input",
+        "output",
+        "expected",
+        "random",
+      ]);
+    });
+
+    it("ignores ...rest params", () => {
+      const code = `function evaluate({ input, output, ...rest }) {}`;
+      expect(extractCodeEvaluateParams(code, "javascript")).toEqual([
+        "input",
+        "output",
+      ]);
+    });
+
+    it("returns an empty array when not destructured", () => {
+      // Parser intentionally only supports the destructured-object form
+      // the JS template uses.
+      const code = `function evaluate(input, output, expected) { return 0; }`;
+      expect(extractCodeEvaluateParams(code, "javascript")).toEqual([]);
+    });
+
+    it("returns an empty array when there is no function evaluate", () => {
+      expect(
+        extractCodeEvaluateParams("function other(a) {}", "javascript"),
+      ).toEqual([]);
+    });
   });
 });
 

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -289,14 +289,20 @@ const getDataSource = (
           }
         }
       } catch (e) {
-        // React Query throws `CancelledError` when a new query supersedes
-        // an in-flight one (common during bulk stop-eval / invalidations).
-        // It's expected flow control, not a real failure — don't log or
-        // flip the grid into failed state for it.
+        // Flow-control errors from request cancellation are not real failures:
+        //   • React Query throws CancelledError when a new query supersedes an
+        //     in-flight one (common during bulk stop-eval / invalidations).
+        //   • Axios throws CanceledError (one L) / code ERR_CANCELED when the
+        //     underlying request is aborted before React Query wraps it.
+        //   • Fetch / AbortController surfaces AbortError.
+        // Don't log or flip the grid into failed state for any of these.
         const err = /** @type {any} */ (e);
+        const name = err?.name || err?.constructor?.name;
         const isCancelled =
-          err?.name === "CancelledError" ||
-          err?.constructor?.name === "CancelledError";
+          name === "CancelledError" ||
+          name === "CanceledError" ||
+          name === "AbortError" ||
+          err?.code === "ERR_CANCELED";
         if (isCancelled) return;
         logger.error("[getRows] failed", {
           message: e instanceof Error ? e.message : String(e),

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -1205,6 +1205,8 @@ const EvalCreatePage = () => {
                         : instructions
                   }
                   evalType={mode === "composite" ? "llm" : evalType}
+                  code={code}
+                  codeLanguage={codeLanguage}
                   requiredKeys={
                     mode === "composite" ? compositeUnionKeys : undefined
                   }

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -1743,6 +1743,8 @@ const EvalDetailPage = () => {
                           : instructions
                     }
                     evalType={evalType}
+                    code={code}
+                    codeLanguage={codeLanguage}
                     requiredKeys={variables}
                     showVersions={!(isSystemEval && evalType === "code")}
                     errorLocalizerEnabled={errorLocalizerEnabled}

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -25,6 +25,7 @@ import Iconify from "src/components/iconify";
 import SvgColor from "src/components/svg-color";
 import { useCreditExhaustion } from "src/hooks/use-credit-exhaustion";
 import axios, { endpoints } from "src/utils/axios";
+import { extractCodeEvaluateParams } from "src/utils/codeEvalParams";
 import { extractJinjaVariables } from "src/utils/jinjaVariables";
 import { canonicalEntries } from "src/utils/utils";
 import { camelCaseToTitleCase } from "src/utils/utils";
@@ -628,6 +629,8 @@ const TestPlayground = React.forwardRef(
       templateFormat = "mustache",
       functionParamsSchema = null,
       configParamsDesc = null,
+      code = "",
+      codeLanguage = "python",
       onReadyChange,
     },
     ref,
@@ -741,14 +744,20 @@ const TestPlayground = React.forwardRef(
         return Array.isArray(requiredKeys) ? [...new Set(requiredKeys)] : [];
       }
 
-      // For code evals: use explicit requiredKeys if provided (e.g. system evals define these),
-      // otherwise fall back to the standard input/output/expected trio.
+      // For code evals: live-parse the user's `def evaluate(...)` / JS
+      // destructuring signature so new params surface in the mapping panel
+      // as soon as they're typed. Fall back to explicit requiredKeys
+      // (system evals define these) and finally to the standard trio.
       let codeStdVars = [];
       if (evalType === "code") {
-        codeStdVars =
-          Array.isArray(requiredKeys) && requiredKeys.length > 0
-            ? requiredKeys
-            : ["input", "output", "expected"];
+        const liveParams = extractCodeEvaluateParams(code, codeLanguage);
+        if (liveParams.length > 0) {
+          codeStdVars = liveParams;
+        } else if (Array.isArray(requiredKeys) && requiredKeys.length > 0) {
+          codeStdVars = requiredKeys;
+        } else {
+          codeStdVars = ["input", "output", "expected"];
+        }
       }
 
       if (!instructions && evalType !== "code") return [...codeStdVars];
@@ -762,7 +771,15 @@ const TestPlayground = React.forwardRef(
         vars = matches.map((m) => m.replace(/\{\{|\}\}/g, "").trim());
       }
       return [...new Set([...codeStdVars, ...vars])];
-    }, [instructions, evalType, requiredKeys, isComposite, templateFormat]);
+    }, [
+      instructions,
+      evalType,
+      requiredKeys,
+      isComposite,
+      templateFormat,
+      code,
+      codeLanguage,
+    ]);
 
     // Custom input values
     const [inputValues, setInputValues] = useState({});
@@ -1839,6 +1856,8 @@ TestPlayground.propTypes = {
   model: PropTypes.string,
   functionParamsSchema: PropTypes.object,
   configParamsDesc: PropTypes.object,
+  code: PropTypes.string,
+  codeLanguage: PropTypes.string,
   onReadyChange: PropTypes.func,
 };
 

--- a/frontend/src/utils/codeEvalParams.js
+++ b/frontend/src/utils/codeEvalParams.js
@@ -1,0 +1,66 @@
+// Parser for the user-typed `evaluate(...)` signature in code evals.
+// Used by the variable-mapping UI so new params surface live as the user types.
+
+const RESERVED_CODE_PARAMS = new Set(["context", "self", "cls"]);
+
+// Depth-aware split on `,` so generics like `Dict[str, int]` and nested
+// destructuring patterns survive intact.
+const splitTopLevelCommas = (raw) => {
+  const parts = [];
+  let depth = 0;
+  let buf = "";
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (ch === "(" || ch === "[" || ch === "{") depth += 1;
+    else if (ch === ")" || ch === "]" || ch === "}") depth -= 1;
+    if (ch === "," && depth === 0) {
+      parts.push(buf);
+      buf = "";
+    } else {
+      buf += ch;
+    }
+  }
+  if (buf.trim()) parts.push(buf);
+  return parts;
+};
+
+// Pull mappable parameter names out of an `evaluate(...)` signature. Supports:
+//   • Python: `def evaluate(input: Any, output: Any, ...)`
+//   • JavaScript: `function evaluate({ input, output, ...kwargs })`
+export const extractCodeEvaluateParams = (code, language) => {
+  if (!code) return [];
+
+  let raw;
+  if (!language || language === "python") {
+    const m = code.match(/def\s+evaluate\s*\(([\s\S]*?)\)/);
+    if (!m) return [];
+    // Strip Python line comments (`# ...`) so inline-doc params parse cleanly
+    // when the signature spans multiple lines.
+    raw = m[1].replace(/#[^\n]*/g, "");
+  } else if (language === "javascript") {
+    // JS template destructures a single object arg:
+    //   function evaluate({ input, output, expected, ...kwargs })
+    const m = code.match(/function\s+evaluate\s*\(\s*\{([\s\S]*?)\}\s*\)/);
+    if (!m) return [];
+    // Strip JS line and block comments inside the destructuring pattern.
+    raw = m[1]
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/[^\n]*/g, "");
+  } else {
+    return [];
+  }
+
+  const names = [];
+  for (const part of splitTopLevelCommas(raw)) {
+    const p = part.trim();
+    if (!p) continue;
+    if (p.startsWith("*") || p.startsWith("...")) continue;
+    // Strip type annotation (`: Any`), default value (`= 1`), and destructuring
+    // rename (`foo: bar`) — first token before any of `:=` is the bound name.
+    const name = p.split(/[:=]/)[0].trim();
+    if (!name) continue;
+    if (RESERVED_CODE_PARAMS.has(name)) continue;
+    names.push(name);
+  }
+  return names;
+};


### PR DESCRIPTION

## Summary
fix(evals): live-parse evaluate() signature for variable mapping

User-added params on the `def evaluate(...)` / `function evaluate({...})`
signature now surface in the Variable Mapping panel as soon as they're
typed, across EvalCreatePage, EvalDetailPage, EvalPickerCreateNew and
EvalPickerConfigFull.

- Centralize the signature parser in src/utils/codeEvalParams.js so
  TestPlayground (under sections/evals/) can use it without depending
  on the EvalPicker folder
- Support both Python and JavaScript signatures; strip inline `#`,
  `//` and `/* */` comments so multi-line signatures parse cleanly
- Thread code/codeLanguage through TestPlayground so all four entry
  points pick up live params; the standard input/output/expected trio
  remains the fallback when the signature can't be parsed
- Add unit coverage for the parser (guards, Python, JavaScript)
- 
fix(develop): ignore axios/fetch cancellation errors in dataset getRows

The getRows catch only treated React Query's CancelledError as flow
control, so axios cancellations (CanceledError / ERR_CANCELED) and
fetch AbortErrors leaked through — calling params.fail() and filling
the grid with error rows during bulk stop-eval / invalidations.

Extend the cancellation check to cover all three surfaces so the grid
no longer flips into a failed state for in-flight requests that were
superseded.



<!-- "Closes #123" links and auto-closes on merge. -->
Closes TH-4840,TH-4836

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
