### PR TITLE
feat: support nested JSON dot-notation variables in dynamic API column

### DIFF
--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
@@ -22,7 +22,7 @@ import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectFie
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { useAddColumnApiCallStore } from "../../states";
 import { useDevelopDetailContext } from "../../Context/DevelopDetailContext";
-import { useDatasetColumnConfig } from "src/api/develop/develop-detail";
+import { useDatasetColumnConfig, useGetJsonColumnSchema } from "src/api/develop/develop-detail";
 import { ShowComponent } from "src/components/show";
 import DynamicColumnSkeleton from "../DynamicColumnSkeleton";
 import { transformDynamicColumnConfig } from "../common";
@@ -69,8 +69,9 @@ export const AddColumnApiCallChild = ({
   const queryClient = useQueryClient();
 
   const allColumns = useDatasetColumnConfig(dataset);
+  const { data: jsonSchemas = {} } = useGetJsonColumnSchema(dataset);
 
-  const { control, handleSubmit, reset } = useForm({
+  const { control, handleSubmit, reset, setError } = useForm({
     defaultValues: getDefaultValue(),
     resolver: zodResolver(
       getAddColumnApiCallValidation(allColumns, !!onFormSubmit, !!editId),
@@ -160,7 +161,27 @@ export const AddColumnApiCallChild = ({
     };
   };
 
+  // If body is a bare {{variable}}, only allow a top-level JSON/array column
+  // (no dot-paths — input.prompt could resolve to a plain string).
+  const validateBodyVariable = (formValues) => {
+    const body = formValues?.config?.body;
+    if (typeof body !== "string") return true;
+    const m = body.trim().match(/^\{\{(.+)\}\}$/);
+    if (!m) return true;
+    const ref = m[1].trim();
+    // Must be an exact column UUID (36 chars, no trailing path)
+    const col = allColumns.find((c) => c.field === ref);
+    if (col && ["json", "array"].includes(col.dataType)) return true;
+    setError("config.body", {
+      type: "manual",
+      message:
+        "This variable is not a JSON or array column. Wrap it in a JSON object, e.g. {\"key\": \"{{variable}}\"}",
+    });
+    return false;
+  };
+
   const onSubmit = (formValues) => {
+    if (!validateBodyVariable(formValues)) return;
     if (editId) {
       updateColumn({
         config: { ...transformFormToApi(formValues) },
@@ -176,6 +197,7 @@ export const AddColumnApiCallChild = ({
   };
 
   const handlePreview = handleSubmit((formValues) => {
+    if (!validateBodyVariable(formValues)) return;
     if (!onFormSubmit) {
       preview(transformFormToApi(formValues));
     }
@@ -251,6 +273,7 @@ export const AddColumnApiCallChild = ({
             control={control}
             contentFieldName="config.url"
             allColumns={allColumns}
+            jsonSchemas={jsonSchemas}
             placeholder="Enter api endpoint"
             multiline={false}
             label="Add API Endpoint"
@@ -284,6 +307,7 @@ export const AddColumnApiCallChild = ({
                 control={control}
                 fieldName="config.params"
                 allColumns={allColumns}
+                jsonSchemas={jsonSchemas}
               />
             </AccordionDetails>
           </Accordion>
@@ -298,6 +322,7 @@ export const AddColumnApiCallChild = ({
                 control={control}
                 fieldName="config.headers"
                 allColumns={allColumns}
+                jsonSchemas={jsonSchemas}
               />
             </AccordionDetails>
           </Accordion>
@@ -310,6 +335,7 @@ export const AddColumnApiCallChild = ({
             <AccordionDetails sx={{ padding: 0 }}>
               <RequestBody
                 allColumns={allColumns}
+                jsonSchemas={jsonSchemas}
                 contentFieldName="config.body"
                 control={control}
               />

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddColumnApiCall.jsx
@@ -71,7 +71,7 @@ export const AddColumnApiCallChild = ({
   const allColumns = useDatasetColumnConfig(dataset);
   const { data: jsonSchemas = {} } = useGetJsonColumnSchema(dataset);
 
-  const { control, handleSubmit, reset, setError } = useForm({
+  const { control, handleSubmit, reset, setError, getValues } = useForm({
     defaultValues: getDefaultValue(),
     resolver: zodResolver(
       getAddColumnApiCallValidation(allColumns, !!onFormSubmit, !!editId),
@@ -161,6 +161,32 @@ export const AddColumnApiCallChild = ({
     };
   };
 
+  // Block columns whose name contains a dot (dot is the JSON path separator).
+  // Uses raw form values so we have display names + array indices for setError.
+  const validateDotInColumnNames = () => {
+    const dotCols = allColumns.filter((c) => c.headerName?.includes("."));
+    if (!dotCols.length) return true;
+    const raw = getValues()?.config || {};
+    const find = (t) => dotCols.find((c) => t?.includes(c.headerName));
+    const msg = (n) => `"${n}" contains a dot — rename the column to use it as a variable.`;
+
+    let col = find(raw.url);
+    if (col) { setError("config.url", { type: "manual", message: msg(col.headerName) }); return false; }
+    col = find(raw.body);
+    if (col) { setError("config.body", { type: "manual", message: msg(col.headerName) }); return false; }
+    for (let i = 0; i < (raw.params || []).length; i++) {
+      if (raw.params[i]?.type !== "Variable") continue;
+      col = find(raw.params[i].value);
+      if (col) { setError(`config.params.${i}.value`, { type: "manual", message: msg(col.headerName) }); return false; }
+    }
+    for (let i = 0; i < (raw.headers || []).length; i++) {
+      if (raw.headers[i]?.type !== "Variable") continue;
+      col = find(raw.headers[i].value);
+      if (col) { setError(`config.headers.${i}.value`, { type: "manual", message: msg(col.headerName) }); return false; }
+    }
+    return true;
+  };
+
   // If body is a bare {{variable}}, only allow a top-level JSON/array column
   // (no dot-paths — input.prompt could resolve to a plain string).
   const validateBodyVariable = (formValues) => {
@@ -181,6 +207,7 @@ export const AddColumnApiCallChild = ({
   };
 
   const onSubmit = (formValues) => {
+    if (!validateDotInColumnNames()) return;
     if (!validateBodyVariable(formValues)) return;
     if (editId) {
       updateColumn({
@@ -197,6 +224,7 @@ export const AddColumnApiCallChild = ({
   };
 
   const handlePreview = handleSubmit((formValues) => {
+    if (!validateDotInColumnNames()) return;
     if (!validateBodyVariable(formValues)) return;
     if (!onFormSubmit) {
       preview(transformFormToApi(formValues));

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddFieldInput.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/AddFieldInput.jsx
@@ -6,9 +6,10 @@ import { FormSelectField } from "src/components/FormSelectField";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import Iconify from "src/components/iconify";
 import SecretSelect from "src/sections/common/SecretSelect/SecretSelect";
+import RequestBody from "./RequestBody";
 import { getRandomId } from "src/utils/utils";
 
-const ValueSelector = ({ control, field, type, allColumns }) => {
+const ValueSelector = ({ control, field, type, allColumns, jsonSchemas }) => {
   if (type === "PlainText") {
     return (
       <FormTextFieldV2
@@ -24,16 +25,14 @@ const ValueSelector = ({ control, field, type, allColumns }) => {
 
   if (type === "Variable") {
     return (
-      <FormSelectField
+      <RequestBody
         control={control}
-        fieldName={field}
-        size="small"
-        label="Value"
-        fullWidth
-        options={allColumns.map((c) => ({
-          label: c.headerName,
-          value: c.field,
-        }))}
+        contentFieldName={field}
+        allColumns={allColumns}
+        jsonSchemas={jsonSchemas}
+        placeholder="{{variable}}"
+        multiline={false}
+        showHelper={false}
       />
     );
   }
@@ -58,6 +57,7 @@ ValueSelector.propTypes = {
   field: PropTypes.string,
   type: PropTypes.string,
   allColumns: PropTypes.array,
+  jsonSchemas: PropTypes.object,
 };
 
 const AddFieldInputRow = ({
@@ -66,6 +66,7 @@ const AddFieldInputRow = ({
   index,
   onRemove,
   allColumns,
+  jsonSchemas,
 }) => {
   const type = useWatch({ control, name: `${fieldPrefix}.${index}.type` });
 
@@ -96,6 +97,7 @@ const AddFieldInputRow = ({
         field={`${fieldPrefix}.${index}.value`}
         type={type}
         allColumns={allColumns}
+        jsonSchemas={jsonSchemas}
       />
       <IconButton size="small" onClick={() => onRemove(index)}>
         <Iconify
@@ -114,9 +116,10 @@ AddFieldInputRow.propTypes = {
   index: PropTypes.number,
   onRemove: PropTypes.func,
   allColumns: PropTypes.array,
+  jsonSchemas: PropTypes.object,
 };
 
-const AddFieldInput = ({ control, fieldName, allColumns }) => {
+const AddFieldInput = ({ control, fieldName, allColumns, jsonSchemas }) => {
   const { fields, append, remove } = useFieldArray({
     control,
     name: fieldName,
@@ -141,6 +144,7 @@ const AddFieldInput = ({ control, fieldName, allColumns }) => {
           control={control}
           onRemove={remove}
           allColumns={allColumns}
+          jsonSchemas={jsonSchemas}
         />
       ))}
       <Box>
@@ -169,6 +173,7 @@ AddFieldInput.propTypes = {
   control: PropTypes.object,
   fieldName: PropTypes.string,
   allColumns: PropTypes.array,
+  jsonSchemas: PropTypes.object,
 };
 
 export default AddFieldInput;

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
@@ -142,8 +142,8 @@ const RequestBody = ({
     const rect = el.getBoundingClientRect();
 
     if (!multiline) {
-      // Single-line: just below the input
-      setDropdownPosition({ x: rect.left, y: rect.bottom + 2 });
+      // Single-line: just below the input, store right edge for right-aligned dropdown
+      setDropdownPosition({ x: rect.right, y: rect.bottom + 2 });
       return;
     }
 
@@ -207,6 +207,27 @@ const RequestBody = ({
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, [setDropDownPos, showDropdown]);
+
+  // Scroll selected item into view when navigating with arrow keys
+  useEffect(() => {
+    if (showDropdown && dropdownRef.current) {
+      const items = dropdownRef.current.querySelectorAll('[role="menuitem"]');
+      if (items[selectedIndex]) {
+        items[selectedIndex].scrollIntoView({ block: "nearest" });
+      }
+    }
+  }, [selectedIndex, showDropdown]);
+
+  // Close dropdown when anything outside it scrolls
+  useEffect(() => {
+    if (!showDropdown) return;
+    const handler = (e) => {
+      if (dropdownRef.current?.contains(e.target)) return;
+      onCloseDropdown();
+    };
+    window.addEventListener("scroll", handler, true);
+    return () => window.removeEventListener("scroll", handler, true);
+  }, [showDropdown, onCloseDropdown]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -302,6 +323,7 @@ const RequestBody = ({
         display: "flex",
         flexDirection: "column",
         gap: 1.5,
+        ...(!multiline && { flex: 1, minWidth: 120 }),
       }}
     >
       {label && (
@@ -383,15 +405,20 @@ const RequestBody = ({
         createPortal(
           <Paper
             ref={dropdownRef}
-            elevation={3}
+            elevation={8}
             sx={{
               position: "fixed",
               top: dropdownPosition.y,
-              left: dropdownPosition.x,
+              ...(multiline
+                ? { left: dropdownPosition.x }
+                : { right: `calc(100vw - ${dropdownPosition.x}px)` }),
               zIndex: 9999,
-              p: 0.5,
-              maxHeight: 150,
+              py: 0.5,
+              maxHeight: 220,
               overflow: "auto",
+              borderRadius: "8px",
+              border: "1px solid",
+              borderColor: "divider",
             }}
             role="listbox"
           >
@@ -401,10 +428,16 @@ const RequestBody = ({
                 onClick={() => handleVariableSelect(variable)}
                 selected={index === selectedIndex}
                 sx={{
-                  minWidth: 150,
+                  py: 0.75,
+                  px: 1.5,
+                  fontSize: "13px",
+                  fontFamily: "monospace",
+                  borderRadius: "4px",
+                  mx: 0.5,
+                  color: variable.isJsonPath ? "primary.main" : "text.primary",
                   backgroundColor:
                     index === selectedIndex
-                      ? "background.neutral"
+                      ? "action.selected"
                       : "inherit",
                   "&:hover": { backgroundColor: "action.hover" },
                   "&:focus": { outline: "none" },

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
@@ -25,6 +25,7 @@ const RequestBody = ({
   control,
   contentFieldName,
   allColumns,
+  jsonSchemas = {},
   placeholder,
   showHelper = true,
   multiline = true,
@@ -55,11 +56,16 @@ const RequestBody = ({
   const errorMessage = _.get(errors, `${contentFieldName}.message`) || "";
   const isError = !!errorMessage;
 
-  // Valid column names for highlighting
-  const columnNameSet = useMemo(
-    () => new Set(allColumns.map((c) => c.headerName)),
-    [allColumns],
-  );
+  // Valid column names (including JSON paths) for highlighting
+  const columnNameSet = useMemo(() => {
+    const names = new Set(allColumns.map((c) => c.headerName));
+    allColumns.forEach((col) => {
+      jsonSchemas?.[col?.field]?.keys?.forEach((path) => {
+        names.add(`${col.headerName}.${path}`);
+      });
+    });
+    return names;
+  }, [allColumns, jsonSchemas]);
 
   // Highlighted text: green for valid variables, red for invalid/incomplete
   const highlightedContent = useMemo(() => {
@@ -100,22 +106,29 @@ const RequestBody = ({
     return textBeforeCursor.substring(idx + 2, selectionStart);
   }, [value]);
 
-  // Filtered column options for dropdown
+  // Filtered column options for dropdown (including JSON dot-notation paths)
   const columnOptions = useMemo(() => {
-    return allColumns.reduce((filtered, column) => {
-      if (
-        column?.headerName
-          ?.toLowerCase()
-          .startsWith(searchText.toLowerCase())
-      ) {
-        filtered.push({
-          label: column.headerName,
-          value: `{{${column.headerName}}}`,
-        });
+    const options = [];
+    const lower = searchText.toLowerCase();
+
+    allColumns.forEach((column) => {
+      const name = column?.headerName;
+      if (!name) return;
+
+      if (name.toLowerCase().startsWith(lower)) {
+        options.push({ label: name, value: `{{${name}}}` });
       }
-      return filtered;
-    }, []);
-  }, [allColumns, searchText]);
+
+      jsonSchemas?.[column?.field]?.keys?.forEach((path) => {
+        const fullPath = `${name}.${path}`;
+        if (fullPath.toLowerCase().startsWith(lower)) {
+          options.push({ label: fullPath, value: `{{${fullPath}}}` });
+        }
+      });
+    });
+
+    return options;
+  }, [allColumns, jsonSchemas, searchText]);
 
   const onCloseDropdown = useCallback(() => {
     setShowDropdown(false);
@@ -426,6 +439,7 @@ RequestBody.propTypes = {
   control: PropTypes.object,
   contentFieldName: PropTypes.string,
   allColumns: PropTypes.array,
+  jsonSchemas: PropTypes.object,
   placeholder: PropTypes.string,
   showHelper: PropTypes.bool,
   multiline: PropTypes.bool,

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
@@ -222,7 +222,7 @@ const RequestBody = ({
   useEffect(() => {
     if (!showDropdown) return;
     const handler = (e) => {
-      if (dropdownRef.current?.contains(e.target)) return;
+      if (dropdownRef.current && dropdownRef.current.contains(e.target)) return;
       onCloseDropdown();
     };
     window.addEventListener("scroll", handler, true);

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
@@ -122,7 +122,7 @@ const RequestBody = ({
       jsonSchemas?.[column?.field]?.keys?.forEach((path) => {
         const fullPath = `${name}.${path}`;
         if (fullPath.toLowerCase().startsWith(lower)) {
-          options.push({ label: fullPath, value: `{{${fullPath}}}` });
+          options.push({ label: fullPath, value: `{{${fullPath}}}`, isJsonPath: true });
         }
       });
     });

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/RequestBody.jsx
@@ -459,8 +459,8 @@ const RequestBody = ({
           to access variables
         </Typography>
       )}
-      {!!isError && (
-        <FormHelperText sx={{ paddingLeft: 1, marginTop: 0 }} error={!!isError}>
+      {!!errorMessage.trim() && (
+        <FormHelperText sx={{ paddingLeft: 1, marginTop: 0 }} error>
           {errorMessage}
         </FormHelperText>
       )}

--- a/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/validation.js
+++ b/frontend/src/sections/develop-detail/AddColumn/AddColumnApiCall/validation.js
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+const BARE_VARIABLE_RE = /^\s*\{\{[^}]+\}\}\s*$/;
+
 export const getAddColumnApiCallValidation = (
   allColumns,
   isConditionalNode = false,
@@ -18,8 +20,8 @@ export const getAddColumnApiCallValidation = (
         .transform((v) => {
           let content = v;
           allColumns.forEach(({ headerName, field }) => {
-            const pattern = new RegExp(`{{\\s*${headerName}\\s*}}`, "g");
-            content = content.replace(pattern, `{{${field}}}`);
+            const pattern = new RegExp(`{{\\s*${headerName}((?:\\.[^}\\s]+|\\[\\d+\\])*)\\s*}}`, "g");
+            content = content.replace(pattern, `{{${field}$1}}`);
           });
           return content;
         }),
@@ -35,7 +37,14 @@ export const getAddColumnApiCallValidation = (
         )
         .transform((arr) => {
           return arr.reduce((acc, curr) => {
-            acc[curr.name] = { type: curr.type, value: curr.value };
+            let val = curr.value;
+            if (curr.type === "Variable") {
+              allColumns.forEach(({ headerName, field }) => {
+                const p = new RegExp(`{{\\s*${headerName}((?:\\.[^}\\s]+|\\[\\d+\\])*)\\s*}}`, "g");
+                val = val.replace(p, `{{${field}$1}}`);
+              });
+            }
+            acc[curr.name] = { type: curr.type, value: val };
             return acc;
           }, {});
         }),
@@ -50,7 +59,14 @@ export const getAddColumnApiCallValidation = (
         )
         .transform((arr) => {
           return arr.reduce((acc, curr) => {
-            acc[curr.name] = { type: curr.type, value: curr.value };
+            let val = curr.value;
+            if (curr.type === "Variable") {
+              allColumns.forEach(({ headerName, field }) => {
+                const p = new RegExp(`{{\\s*${headerName}((?:\\.[^}\\s]+|\\[\\d+\\])*)\\s*}}`, "g");
+                val = val.replace(p, `{{${field}$1}}`);
+              });
+            }
+            acc[curr.name] = { type: curr.type, value: val };
             return acc;
           }, {});
         }),
@@ -61,14 +77,15 @@ export const getAddColumnApiCallValidation = (
           let content = v;
 
           allColumns.forEach(({ headerName, field }) => {
-            const pattern = new RegExp(`{{\\s*${headerName}\\s*}}`, "g");
-            content = content.replace(pattern, `{{${field}}}`);
+            const pattern = new RegExp(`{{\\s*${headerName}((?:\\.[^}\\s]+|\\[\\d+\\])*)\\s*}}`, "g");
+            content = content.replace(pattern, `{{${field}$1}}`);
           });
 
           return content;
         })
         .refine((value) => {
           if (!value?.length) return true;
+          if (BARE_VARIABLE_RE.test(value)) return true;
           try {
             JSON.parse(value);
             return true;
@@ -78,6 +95,7 @@ export const getAddColumnApiCallValidation = (
         }, "Invalid JSON format")
         .transform((value) => {
           if (!value?.length) return {};
+          if (BARE_VARIABLE_RE.test(value)) return value;
           return JSON.parse(value);
         }),
       outputType: z.string().min(1, "Output type is required"),

--- a/frontend/src/sections/develop-detail/AddColumn/common.js
+++ b/frontend/src/sections/develop-detail/AddColumn/common.js
@@ -165,7 +165,9 @@ export const transformDynamicColumnConfig = (type, config, allColumns) => {
           ...config,
           url: replaceColumnIdWithName(config?.url || "", allColumns),
           body: replaceColumnIdWithName(
-            JSON.stringify(config?.body) || "",
+            typeof config?.body === "string"
+              ? config.body
+              : JSON.stringify(config?.body) || "",
             allColumns,
           ),
           params: Object.entries(config?.params || {}).map(([key, value]) => ({

--- a/frontend/src/sections/develop-detail/AddColumn/common.js
+++ b/frontend/src/sections/develop-detail/AddColumn/common.js
@@ -139,8 +139,8 @@ export const DynamicColumns = [
 export const replaceColumnIdWithName = (text, allColumns) => {
   let updatedText = text;
   allColumns.forEach(({ headerName, field }) => {
-    const pattern = new RegExp(`{{\\s*${field}\\s*}}`, "g");
-    updatedText = updatedText.replace(pattern, `{{${headerName}}}`);
+    const pattern = new RegExp(`{{\\s*${field}((?:\\.[^}\\s]+|\\[\\d+\\])*)\\s*}}`, "g");
+    updatedText = updatedText.replace(pattern, `{{${headerName}$1}}`);
   });
 
   return updatedText;
@@ -149,9 +149,9 @@ export const replaceColumnIdWithName = (text, allColumns) => {
 export const replaceColumnNameWithId = (text, allColumns) => {
   let newText = text;
   allColumns.forEach(({ headerName, field }) => {
-    const pattern = new RegExp(`{{${headerName}}}`, "g");
+    const pattern = new RegExp(`{{${headerName}((?:\\.[^}\\s]+|\\[\\d+\\])*)}}`, "g");
     if (newText && newText.length) {
-      newText = newText.replace(pattern, `{{${field}}}`);
+      newText = newText.replace(pattern, `{{${field}$1}}`);
     }
   });
   return newText;

--- a/frontend/src/sections/develop-detail/AddColumn/common.js
+++ b/frontend/src/sections/develop-detail/AddColumn/common.js
@@ -149,6 +149,7 @@ export const replaceColumnIdWithName = (text, allColumns) => {
 export const replaceColumnNameWithId = (text, allColumns) => {
   let newText = text;
   allColumns.forEach(({ headerName, field }) => {
+    // Note: column names containing dots are not supported (dot is treated as a path separator)
     const pattern = new RegExp(`{{${headerName}((?:\\.[^}\\s]+|\\[\\d+\\])*)}}`, "g");
     if (newText && newText.length) {
       newText = newText.replace(pattern, `{{${field}$1}}`);

--- a/frontend/src/sections/develop-detail/AddColumn/common.js
+++ b/frontend/src/sections/develop-detail/AddColumn/common.js
@@ -171,14 +171,18 @@ export const transformDynamicColumnConfig = (type, config, allColumns) => {
           params: Object.entries(config?.params || {}).map(([key, value]) => ({
             id: getRandomId(),
             name: key,
-            value: value.value,
+            value: value.type === "Variable"
+              ? replaceColumnIdWithName(value.value, allColumns)
+              : value.value,
             type: value.type,
           })),
           headers: Object.entries(config?.headers || {}).map(
             ([key, value]) => ({
               id: getRandomId(),
               name: key,
-              value: value.value,
+              value: value.type === "Variable"
+                ? replaceColumnIdWithName(value.value, allColumns)
+                : value.value,
               type: value.type,
             }),
           ),

--- a/futureagi/model_hub/tests/test_dynamic_columns.py
+++ b/futureagi/model_hub/tests/test_dynamic_columns.py
@@ -1098,6 +1098,56 @@ class TestAddApiColumnViewHelpers(DynamicColumnsBaseTestCase):
 
         assert result == cell.value
 
+    def test_replace_variables_with_dot_notation(self):
+        """Test _replace_variables resolves nested JSON paths."""
+        view = AddApiColumnView()
+        dataset, column, rows = self.create_json_dataset()
+
+        result = view._replace_variables(f"{{{{{column.id}.name}}}}", rows[0])
+        assert result == "User0"
+
+        result = view._replace_variables(f"{{{{{column.id}.nested.key}}}}", rows[0])
+        assert result == "value0"
+
+    def test_replace_variables_with_missing_path(self):
+        """Test _replace_variables returns empty string for missing JSON path."""
+        view = AddApiColumnView()
+        dataset, column, rows = self.create_json_dataset()
+
+        result = view._replace_variables(f"{{{{{column.id}.nonexistent}}}}", rows[0])
+        assert result == ""
+
+    def test_resolve_cell_value_plain_uuid(self):
+        """Test _resolve_cell_value with a plain column UUID (no path)."""
+        dataset, columns, rows = self.create_test_dataset()
+        cell = Cell.objects.get(row=rows[0], column=columns[0])
+
+        result = AddApiColumnView._resolve_cell_value(str(columns[0].id), rows[0])
+        assert result == cell.value
+
+    def test_resolve_cell_value_with_json_path(self):
+        """Test _resolve_cell_value with UUID.dotted.path."""
+        dataset, column, rows = self.create_json_dataset()
+
+        result = AddApiColumnView._resolve_cell_value(f"{column.id}.age", rows[0])
+        assert result == "20"
+
+    def test_resolve_cell_value_nested_path(self):
+        """Test _resolve_cell_value with deeply nested path."""
+        dataset, column, rows = self.create_json_dataset()
+
+        result = AddApiColumnView._resolve_cell_value(f"{column.id}.nested.key", rows[1])
+        assert result == "value1"
+
+    def test_replace_variables_multiple_in_string(self):
+        """Test _replace_variables with multiple variables in one string."""
+        view = AddApiColumnView()
+        dataset, column, rows = self.create_json_dataset()
+
+        template = f"name={{{{{column.id}.name}}}}&age={{{{{column.id}.age}}}}"
+        result = view._replace_variables(template, rows[0])
+        assert result == "name=User0&age=20"
+
 
 # =============================================================================
 # AddVectorDBColumnView Tests

--- a/futureagi/model_hub/views/dynamic_columns.py
+++ b/futureagi/model_hub/views/dynamic_columns.py
@@ -955,7 +955,7 @@ class AddApiColumnView(APIView):
                         if "{{" in raw_val:
                             processed_params[param_name] = self._replace_variables(raw_val, cell.row)
                         else:
-                            processed_params[param_name] = self._resolve_cell_value(raw_val, cell.row)
+                            processed_params[param_name] = self._resolve_cell_value(raw_val, cell.row) or ""
                     except Exception as e:
                         logger.error(f"Error replacing variable: {str(e)}")
 

--- a/futureagi/model_hub/views/dynamic_columns.py
+++ b/futureagi/model_hub/views/dynamic_columns.py
@@ -36,6 +36,7 @@ from model_hub.models.develop_dataset import (
     Dataset,
     Row,
 )
+from model_hub.utils.json_path_resolver import parse_json_safely, resolve_json_path
 from model_hub.utils.utils import (
     contains_sql,
     remove_empty_text_from_messages,
@@ -905,16 +906,32 @@ class AddApiColumnView(APIView):
     _gm = GeneralMethods()
     permission_classes = [IsAuthenticated]
 
+    @staticmethod
+    def _resolve_cell_value(variable_id, row):
+        """Resolve a column reference (UUID, optionally followed by a JSON path) to its value."""
+        base_col_id = variable_id
+        json_path = None
+        if len(variable_id) > 36 and variable_id[36] in ('.', '['):
+            base_col_id = variable_id[:36]
+            json_path = variable_id[37:] if variable_id[36] == '.' else variable_id[36:]
+
+        cell = Cell.objects.get(column__id=base_col_id, row=row)
+        if json_path and cell.value is not None:
+            parsed, is_valid = parse_json_safely(cell.value)
+            if is_valid:
+                return resolve_json_path(parsed, json_path)
+        return cell.value
+
     def _replace_variables(self, value, row):
         """Replace variables in a string with actual cell values"""
         if isinstance(value, str) and re.search(r"\{{.*?\}}", value):
             matches = re.findall(r"\{{(.*?)\}}", value)
             for match in matches:
                 try:
-                    cell = Cell.objects.get(column__id=match, row=row)
+                    cell_value = self._resolve_cell_value(match, row)
                     value = value.replace(
                         f"{{{{{match}}}}}",
-                        str(cell.value) if cell.value is not None else "",
+                        str(cell_value) if cell_value is not None else "",
                     )
                 except Exception as e:
                     logger.error(f"Error replacing variable: {str(e)}")
@@ -934,13 +951,9 @@ class AddApiColumnView(APIView):
                     ).actual_key
                 elif param_config["type"] == "Variable":
                     try:
-                        param_cell = Cell.objects.get(
-                            column__id=self._replace_variables(
-                                param_config["value"], cell.row
-                            ),
-                            row=cell.row,
+                        processed_params[param_name] = self._replace_variables(
+                            param_config["value"], cell.row
                         )
-                        processed_params[param_name] = param_cell.value
                     except Exception as e:
                         logger.error(f"Error replacing variable: {str(e)}")
 
@@ -956,24 +969,29 @@ class AddApiColumnView(APIView):
                     ).actual_key
                 elif header_config["type"] == "Variable":
                     try:
-                        header_cell = Cell.objects.get(
-                            column__id=self._replace_variables(
-                                header_config["value"], cell.row
-                            ),
-                            row=cell.row,
+                        processed_headers[header_name] = self._replace_variables(
+                            header_config["value"], cell.row
                         )
-                        processed_headers[header_name] = header_cell.value
                     except Exception as e:
                         logger.error(f"Error replacing variable: {str(e)}")
 
             # Process body if it exists
             body = {}
             if "body" in config:
-                for key, values in config["body"].items():
-                    if not cell:
-                        body[key] = values
-                    else:
-                        body[key] = self._replace_variables(values, cell.row)
+                raw_body = config["body"]
+                if isinstance(raw_body, str):
+                    if cell and cell.row:
+                        raw_body = self._replace_variables(raw_body, cell.row)
+                    try:
+                        body = json.loads(raw_body)
+                    except (json.JSONDecodeError, ValueError, TypeError):
+                        body = raw_body
+                else:
+                    for key, values in raw_body.items():
+                        if not cell:
+                            body[key] = values
+                        else:
+                            body[key] = self._replace_variables(values, cell.row)
 
             # Process URL — apply variable substitution if a cell/row is available
             url = config["url"]
@@ -986,7 +1004,7 @@ class AddApiColumnView(APIView):
                 url=url,
                 params=processed_params,
                 headers=processed_headers,
-                json=body if isinstance(body, dict) else None,
+                json=body if isinstance(body, (dict, list)) else None,
                 data=body if isinstance(body, str) else None,
                 timeout=30,
             )

--- a/futureagi/model_hub/views/dynamic_columns.py
+++ b/futureagi/model_hub/views/dynamic_columns.py
@@ -951,9 +951,11 @@ class AddApiColumnView(APIView):
                     ).actual_key
                 elif param_config["type"] == "Variable":
                     try:
-                        processed_params[param_name] = self._replace_variables(
-                            param_config["value"], cell.row
-                        )
+                        raw_val = param_config["value"]
+                        if "{{" in raw_val:
+                            processed_params[param_name] = self._replace_variables(raw_val, cell.row)
+                        else:
+                            processed_params[param_name] = self._resolve_cell_value(raw_val, cell.row)
                     except Exception as e:
                         logger.error(f"Error replacing variable: {str(e)}")
 
@@ -969,9 +971,11 @@ class AddApiColumnView(APIView):
                     ).actual_key
                 elif header_config["type"] == "Variable":
                     try:
-                        processed_headers[header_name] = self._replace_variables(
-                            header_config["value"], cell.row
-                        )
+                        raw_val = header_config["value"]
+                        if "{{" in raw_val:
+                            processed_headers[header_name] = self._replace_variables(raw_val, cell.row)
+                        else:
+                            processed_headers[header_name] = self._resolve_cell_value(raw_val, cell.row)
                     except Exception as e:
                         logger.error(f"Error replacing variable: {str(e)}")
 


### PR DESCRIPTION
## Summary

Adds nested JSON dot-notation variable support to the Dynamic API Column feature — the same `{{column.nested.key}}` syntax that already works in Run Prompt and Run Eval on a dataset. Previously, the API column only supported flat column references like `{{column}}`. Now users can reference nested JSON paths in the URL, request body, params, and headers fields, with autocomplete suggestions and green/red highlighting. Also adds the ability to send a bare `{{json_column}}` as the request body directly (without wrapping it in a JSON object), gated to only JSON/array-typed columns.

## Linked issues

Closes #TH-4834

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

### Flow 1: Nested variables in URL field

1. Open a dataset that has a column with JSON values (e.g. column `input` containing `{"prompt": "hello", "config": {"model": "gpt-4"}}`)
2. Click **Add Column → API Calls**
3. In the **URL** field, type `https://api.example.com/{{` — the autocomplete dropdown should show both `input` and nested paths like `input.prompt`, `input.config`, `input.config.model`
4. Select a nested path — it should insert as `{{input.config.model}}`
5. The variable should highlight **green** (valid)
6. Typing `{{input.nonexistent}}` should highlight **red** (invalid)

### Flow 2: Nested variables in Request Body

1. In the **Request Body** field, type `{"prompt": "{{input.prompt}}", "model": "{{input.config.model}}"}`
2. Both variables should highlight green and appear in autocomplete
3. Submit — the backend should resolve each nested path to its actual value from the cell's JSON

### Flow 3: Bare JSON variable as body

1. In the **Request Body**, type just `{{input}}` (where `input` is a JSON-typed column)
2. Submit — should succeed, the entire JSON value of the column is sent as the body
3. Now try `{{input.prompt}}` as bare body (a nested path that resolves to a string) — should show error: *"This variable is not a JSON or array column..."*
4. Try `{{text_column}}` as bare body (a text-typed column) — should also show the error

### Flow 4: Variables in Params and Headers

1. In **Params**, click **Add Field**, set Type to **Variable**
2. Type `{{` in the value field — autocomplete should appear with nested paths
3. Select `{{input.prompt}}` — the param should be sent with the resolved value
4. Do the same for **Headers** — same behavior

### Flow 5: Edit mode round-trip

1. Create an API column using nested variables in URL, body, params, and headers
2. Open the column for editing
3. All fields should show **display names** (e.g. `{{input.prompt}}`), NOT UUIDs (e.g. `{{b1eb7ebc-44c3-40bc-965c-9526c83d630c.prompt}}`)
4. Bare variable body should show as `{{input}}`, not `"{{input}}"` (no extra quotes)
5. Update without changes — should work identically to the original

### Flow 6: Dropdown UX

1. In any `{{` dropdown, use **Arrow Down/Up** keys — the list should scroll to keep the selected item visible
2. While the dropdown is open, scroll the sidebar/drawer — the dropdown should close (not float in a stale position)
3. In params/headers, the dropdown should not overflow or get cropped on the right side

## Changes by file

### Frontend

| File | What changed |
|------|-------------|
| `validation.js` | Name→UUID regex now captures `.path` / `[index]` suffix in URL, body, params, and headers transforms. Body refine/transform allows bare `{{variable}}` through as a string. |
| `common.js` | `replaceColumnIdWithName` / `replaceColumnNameWithId` preserve dot-path suffix. `transformDynamicColumnConfig` converts Variable param/header values back to display names in edit mode. Body string values no longer double-quoted by `JSON.stringify`. |
| `RequestBody.jsx` | Accepts `jsonSchemas` prop. `columnNameSet` and `columnOptions` expanded with JSON paths from schema. Dropdown: right-aligned for single-line fields, scroll-into-view on arrow keys, closes on ancestor scroll. |
| `AddColumnApiCall.jsx` | Fetches JSON schemas via `useGetJsonColumnSchema`. Passes `jsonSchemas` to all RequestBody and AddFieldInput children. `validateBodyVariable` blocks bare non-JSON variables at submit time via `setError`. |
| `AddFieldInput.jsx` | Variable type now uses `RequestBody` (same `{{` autocomplete as URL/body) instead of a flat dropdown. Threads `jsonSchemas` through the component chain. |

### Backend

| File | What changed |
|------|-------------|
| `dynamic_columns.py` | New `_resolve_cell_value` splits UUID from JSON path and resolves via `parse_json_safely` + `resolve_json_path`. `_replace_variables` delegates to it. Variable params/headers use `_replace_variables` (handles `{{uuid.path}}` syntax). Body processing handles string bodies (bare variables) — resolves then tries `json.loads`, falls back to raw string. `isinstance(body, (dict, list))` for the `json=` kwarg. |

## Screenshots / recordings (if UI)

<img width="1958" height="644" alt="image" src="https://github.com/user-attachments/assets/59b7d914-4498-4a79-9edb-ddc7062f9f12" />

<img width="1814" height="1184" alt="image" src="https://github.com/user-attachments/assets/8009b282-5b82-4f71-bb3b-fd0282cffc1a" />


https://github.com/user-attachments/assets/3068166f-b5b5-4343-87ff-1ad17262f253


## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->