### PR TITLE
[TH-4895] fix(observe): hide Fix with Falcon on passed evals

### DIFF
--- a/frontend/src/components/traceDetail/EvalsTabView.jsx
+++ b/frontend/src/components/traceDetail/EvalsTabView.jsx
@@ -70,6 +70,16 @@ export function collectAllEvalsFromEntry(entry) {
   return rows;
 }
 
+// `score >= 50` matches the summary's totalPass threshold. Some evals
+// (label-based pass/fail) may come through with no numeric score — fall back
+// to the textual label so we still hide Fix on those. Anything else (null
+// score, arbitrary label) is treated as not-passed and keeps the button.
+const isPassedEval = (ev) => {
+  if (ev?.score != null) return ev.score >= 50;
+  const label = (ev?.score_label || "").trim().toLowerCase();
+  return label === "pass" || label === "passed" || label === "true";
+};
+
 /** Score → colored background + text — traffic-light pattern */
 export function scoreColor(score) {
   if (score == null)
@@ -299,43 +309,43 @@ const EvalTableRow = ({ ev, onSelectSpan, showSpanColumn, onFixWithFalcon }) => 
             />
           )}
 
-          {/* Fix with Falcon — always shown whenever the row is expanded,
-              regardless of whether there's an explanation or error
-              localization data, so users can always escalate a failing
-              eval for a proposed fix. */}
-          <Box
-            onClick={(e) => {
-              e.stopPropagation();
-              if (onFixWithFalcon) {
-                onFixWithFalcon({ level: "eval", ev });
-              } else {
-                defaultFixNotice();
-              }
-            }}
-            sx={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 0.5,
-              px: 0.75,
-              py: 0.25,
-              alignSelf: "flex-start",
-              border: "1px solid",
-              borderColor: (theme) => alpha(theme.palette.primary.main, 0.4),
-              borderRadius: "4px",
-              cursor: "pointer",
-              bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
-              "&:hover": {
-                bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
-              },
-            }}
-          >
-            <Iconify icon="mdi:creation" width={12} color="primary.main" />
-            <Typography
-              sx={{ fontSize: 10, fontWeight: 600, color: "primary.main" }}
+          {/* Fix with Falcon — hidden for passed evals (nothing to fix);
+              shown for failed and unscored rows whenever expanded. */}
+          {!isPassedEval(ev) && (
+            <Box
+              onClick={(e) => {
+                e.stopPropagation();
+                if (onFixWithFalcon) {
+                  onFixWithFalcon({ level: "eval", ev });
+                } else {
+                  defaultFixNotice();
+                }
+              }}
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.5,
+                px: 0.75,
+                py: 0.25,
+                alignSelf: "flex-start",
+                border: "1px solid",
+                borderColor: (theme) => alpha(theme.palette.primary.main, 0.4),
+                borderRadius: "4px",
+                cursor: "pointer",
+                bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
+                "&:hover": {
+                  bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+                },
+              }}
             >
-              Fix with Falcon
-            </Typography>
-          </Box>
+              <Iconify icon="mdi:creation" width={12} color="primary.main" />
+              <Typography
+                sx={{ fontSize: 10, fontWeight: 600, color: "primary.main" }}
+              >
+                Fix with Falcon
+              </Typography>
+            </Box>
+          )}
         </Box>
       )}
     </>
@@ -469,46 +479,51 @@ const EvalsTabView = ({
           </Box>
         </Box>
 
-        <Box
-          onClick={() => {
-            if (onFixWithFalcon) {
-              const failing = list.filter(
-                (e) => e.score != null && e.score < 50,
-              );
-              onFixWithFalcon({
-                level: "span",
-                failingEvals: failing,
-                allEvals: list,
-              });
-            } else {
-              defaultFixNotice();
-            }
-          }}
-          sx={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 0.5,
-            mt: 1,
-            px: 1,
-            py: 0.35,
-            border: "1px solid",
-            borderColor: (theme) => alpha(theme.palette.primary.main, 0.4),
-            borderRadius: "6px",
-            cursor: "pointer",
-            bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
-            "&:hover": {
-              bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
-              borderColor: (theme) => alpha(theme.palette.primary.main, 0.5),
-            },
-          }}
-        >
-          <Iconify icon="mdi:creation" width={14} color="primary.main" />
-          <Typography
-            sx={{ fontSize: 11, fontWeight: 600, color: "primary.main" }}
+        {/* Summary-bar Fix with Falcon — hidden when every eval passed
+            (nothing failing to escalate). Uses isPassedEval so unscored /
+            label-based non-passes also keep the button visible (e.g. an
+            eval with score=null and no Pass label still shows up as
+            non-passing in the "X/N passed" text). */}
+        {list.some((e) => !isPassedEval(e)) && (
+          <Box
+            onClick={() => {
+              if (onFixWithFalcon) {
+                const failing = list.filter((e) => !isPassedEval(e));
+                onFixWithFalcon({
+                  level: "span",
+                  failingEvals: failing,
+                  allEvals: list,
+                });
+              } else {
+                defaultFixNotice();
+              }
+            }}
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.5,
+              mt: 1,
+              px: 1,
+              py: 0.35,
+              border: "1px solid",
+              borderColor: (theme) => alpha(theme.palette.primary.main, 0.4),
+              borderRadius: "6px",
+              cursor: "pointer",
+              bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
+              "&:hover": {
+                bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+                borderColor: (theme) => alpha(theme.palette.primary.main, 0.5),
+              },
+            }}
           >
-            Fix with Falcon
-          </Typography>
-        </Box>
+            <Iconify icon="mdi:creation" width={14} color="primary.main" />
+            <Typography
+              sx={{ fontSize: 11, fontWeight: 600, color: "primary.main" }}
+            >
+              Fix with Falcon
+            </Typography>
+          </Box>
+        )}
       </Box>
 
       {/* Search + Add Evals */}


### PR DESCRIPTION
## Summary

The "Fix with Falcon" button was rendered on every expanded eval row regardless of pass/fail, and the summary-bar button was always shown — even when nothing was failing. There's nothing to "fix" on a passed eval, so both buttons now hide in that case.

## Changes (single file: `frontend/src/components/traceDetail/EvalsTabView.jsx`)

- Adds `isPassedEval(ev)` — returns true when:
  - numeric path: `ev.score >= 50` (matches the existing `totalPass` threshold), OR
  - label path: `ev.score_label` lowercased is one of `pass` / `passed` / `true`. The label set was verified against the backend's pass whitelist in `tracer/services/clickhouse/query_builders/dashboard.py` (`'Passed', 'Pass', 'True', 'true'`).
- **Per-row button** wrapped with `!isPassedEval(ev)` — passed rows still expand to show explanation / error localization; only the Fix button is hidden.
- **Summary-bar button** — visibility check switched from `totalFail > 0` (numeric-only) to `list.some((e) => !isPassedEval(e))`. The `failingEvals` payload sent to `onFixWithFalcon` was also switched to `list.filter((e) => !isPassedEval(e))` so the click data always matches what triggered the button to appear.

## Linear

[TH-4895](https://linear.app/future-agi/issue/TH-4895/hide-fix-with-falcon-on-passed-evals)

## Test plan

- [ ] Open a span / voice call where every eval has `score >= 50` → summary Fix button hidden, expanded passed rows show no per-row Fix button.
- [ ] Open one with at least one failing eval (`score < 50`) → summary button visible, per-row Fix on failing rows only.
- [ ] Open one with a label-only Pass eval (`score=null, score_label="Pass"`) → per-row hidden, summary respects it.
- [ ] Open one with an unscored eval (score=null, no pass label, e.g. `tone` showing `—`) → per-row Fix shown, summary button shown.
- [ ] Click summary Fix → Falcon receives only the non-passing evals.

## Known follow-up (out of scope)

`totalPass` / `totalFail` (the "X/N passed" header text and the red "X failed" badge) still use the numeric-only filter from the previous behavior. Aligning them with `isPassedEval` / `isFailedEval` will be a separate change so the display numbers shift in a reviewable diff.