### PR TITLE
Fix/simulation issues may 13 v2

### DIFF
--- a/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
+++ b/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Box, Typography, Grid, Stack, Button } from "@mui/material";
 import PropTypes from "prop-types";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
@@ -47,6 +53,8 @@ const EditAgentDetails = ({
   const { orgLimit } = useAuthContext();
   const { agentDefinitionId } = useParams();
   const [lastFetchedAt, setLastFetchedAt] = useState(null);
+  const [showSyncSuccess, setShowSyncSuccess] = useState(false);
+  const syncSuccessTimeoutRef = useRef(null);
   const apiKey = useWatch({
     control,
     name: "apiKey",
@@ -141,8 +149,57 @@ const EditAgentDetails = ({
       setValue("description", providerData?.prompt, { shouldDirty: true });
       setValue("apiKey", providerData?.api_key, { shouldDirty: true });
       setLastFetchedAt(new Date());
+      setShowSyncSuccess(true);
+    },
+    meta: {
+      errorHandled: true,
+    },
+    onError: () => {
+      enqueueSnackbar({
+        message: `Syncing with ${selectedProvider} failed. Recheck the Assistant ID.`,
+        variant: "error",
+      });
     },
   });
+
+  useEffect(() => {
+    if (showSyncSuccess) {
+      if (syncSuccessTimeoutRef.current) {
+        clearTimeout(syncSuccessTimeoutRef.current);
+      }
+      syncSuccessTimeoutRef.current = setTimeout(() => {
+        setShowSyncSuccess(false);
+      }, 2500);
+    }
+
+    return () => {
+      if (syncSuccessTimeoutRef.current) {
+        clearTimeout(syncSuccessTimeoutRef.current);
+      }
+    };
+  }, [showSyncSuccess]);
+
+  const debounceTimeoutRef = useRef(null);
+
+  const debouncedMutate = useCallback(
+    (data) => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+      debounceTimeoutRef.current = setTimeout(() => {
+        mutate(data);
+      }, 500);
+    },
+    [mutate],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleSyncWithProvider = async () => {
     if (!apiKey || !assistantId) {
@@ -397,46 +454,106 @@ const EditAgentDetails = ({
                 !isLiveKitProvider(selectedProvider)
               }
             >
-              <Stack direction={"row"} alignItems={"center"} gap={2}>
-                <FormTextFieldV2
-                  control={control}
-                  fieldName="assistantId"
-                  placeholder="asst_xxx"
-                  required={observabilityEnabled || keysRequired}
-                  label="Assistant ID"
-                  fullWidth
-                  size="small"
-                  error={errors && !!errors.assistantId?.message}
-                  helperText={errors && errors.assistantId?.message}
-                  sx={{
-                    "& .MuiInputLabel-root": {
-                      fontWeight: 500,
-                    },
-                  }}
-                  onChange={() => {
-                    trigger("assistantId");
-                  }}
-                />
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  sx={{
-                    flexShrink: 0,
-                  }}
-                  startIcon={
+              <Stack direction={"column"} gap={0.75}>
+                <Stack direction={"row"} alignItems={"center"} gap={2}>
+                  <FormTextFieldV2
+                    control={control}
+                    fieldName="assistantId"
+                    placeholder="asst_xxx"
+                    required={observabilityEnabled || keysRequired}
+                    label="Assistant ID"
+                    fullWidth
+                    size="small"
+                    disabled={isPending}
+                    error={errors && !!errors.assistantId?.message}
+                    helperText={errors && errors.assistantId?.message}
+                    sx={{
+                      "& .MuiInputLabel-root": {
+                        fontWeight: 500,
+                      },
+                    }}
+                    onChange={(e) => {
+                      trigger("assistantId");
+                      const value = e.target.value;
+                      if (apiKey && value && selectedProvider) {
+                        debouncedMutate({
+                          api_key: apiKey,
+                          assistant_id: value,
+                          provider: selectedProvider,
+                        });
+                      }
+                    }}
+                  />
+                  <Button
+                    variant="outlined"
+                    color="primary"
+                    disabled={isPending}
+                    sx={{
+                      flexShrink: 0,
+                    }}
+                    startIcon={
+                      <SvgColor
+                        src="/assets/icons/ic_refresh.svg"
+                        sx={{
+                          animation: isPending
+                            ? `${spin} 1s linear infinite`
+                            : "none",
+                        }}
+                      />
+                    }
+                    onClick={handleSyncWithProvider}
+                  >
+                    Sync with provider
+                  </Button>
+                </Stack>
+                <ShowComponent condition={isPending}>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      flexDirection: "row",
+                      alignItems: "center",
+                      gap: 1,
+                      color: "blue.600",
+                    }}
+                  >
                     <SvgColor
                       src="/assets/icons/ic_refresh.svg"
                       sx={{
-                        animation: isPending
-                          ? `${spin} 1s linear infinite`
-                          : "none",
+                        animation: `${spin} 1s linear infinite`,
+                        width: "16px",
+                        height: "16px",
                       }}
                     />
-                  }
-                  onClick={handleSyncWithProvider}
-                >
-                  Sync with provider
-                </Button>
+                    <Typography
+                      typography={"s3"}
+                      fontWeight={"fontWeightMedium"}
+                    >
+                      {`Syncing with ${selectedProvider}...`}
+                    </Typography>
+                  </Box>
+                </ShowComponent>
+                <ShowComponent condition={showSyncSuccess && !isPending}>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      flexDirection: "row",
+                      alignItems: "center",
+                      gap: 0.5,
+                      color: "green.600",
+                    }}
+                  >
+                    <SvgColor
+                      src="/assets/icons/ic_success_fill.svg"
+                      sx={{ width: 16, height: 16, color: "green.600" }}
+                    />
+                    <Typography
+                      typography={"s3"}
+                      fontWeight={"fontWeightMedium"}
+                    >
+                      {`Synced with ${selectedProvider}`}
+                    </Typography>
+                  </Box>
+                </ShowComponent>
               </Stack>
             </ShowComponent>
             <ShowComponent
@@ -477,8 +594,16 @@ const EditAgentDetails = ({
                 helperText={errors && errors.apiKey?.message}
                 fullWidth
                 size="small"
-                onChange={() => {
+                onChange={(e) => {
                   trigger("apiKey");
+                  const value = e.target.value;
+                  if (assistantId && value && selectedProvider) {
+                    debouncedMutate({
+                      api_key: value,
+                      assistant_id: assistantId,
+                      provider: selectedProvider,
+                    });
+                  }
                 }}
               />
             </ShowComponent>

--- a/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
+++ b/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
@@ -151,15 +151,7 @@ const EditAgentDetails = ({
       setLastFetchedAt(new Date());
       setShowSyncSuccess(true);
     },
-    meta: {
-      errorHandled: true,
-    },
-    onError: () => {
-      enqueueSnackbar({
-        message: `Syncing with ${selectedProvider} failed. Recheck the Assistant ID.`,
-        variant: "error",
-      });
-    },
+    
   });
 
   useEffect(() => {

--- a/frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx
+++ b/frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx
@@ -114,10 +114,11 @@ function flattenLeaves(obj, prefix) {
     if (v && typeof v === "object") {
       if (Array.isArray(v)) {
         result.push(...flattenLeaves(v, path));
-      } else if (
-        canonicalKeys(v).length > 0 &&
-        canonicalKeys(v).length < FLATTEN_DICT_LIMIT
-      ) {
+      } else if (canonicalKeys(v).length === 0) {
+        // Empty group — skip entirely so it doesn't show up as a stray
+        // `path: {}` leaf in the vocabulary table.
+        continue;
+      } else if (canonicalKeys(v).length < FLATTEN_DICT_LIMIT) {
         result.push(...flattenLeaves(v, path));
       } else {
         // Empty dict or wider than the limit — emit as a leaf and let


### PR DESCRIPTION
## Summary
- Mirror the Create Agent provider-sync UX in the Edit Agent form: debounced auto-sync on `assistantId` / `apiKey` change, animated `Syncing with {provider}...` indicator, auto-hiding green `Synced with {provider}` confirmation, fields disabled during the request, and snackbar on failure.
- Fix eval simulation preview vocabulary so empty groups are skipped instead of rendering as a stray `path: {}` leaf in `flattenLeaves`.

## Test plan
- [x] Open Edit Agent → type/clear the Assistant ID → "Syncing with vapi..." appears, then green "Synced with vapi", then auto-clears after ~2.5s
- [x] Repeat on the Provider API Key field → same animation flow
- [x] Click the manual "Sync with provider" button → same animation; button + Assistant ID input are disabled mid-request
- [x] Trigger a sync failure (invalid Assistant ID) → snackbar shows the error, no stale "Synced" indicator persists
- [x] Verify existing "Last synced … ago" helper on the prompt field still updates after a successful sync
- [x] Open a simulation eval preview where attributes contain an empty object → no `…: {}` row appears in the vocabulary table


## Linked issues

Closes TH-4859,TH-4808



https://github.com/user-attachments/assets/2807b552-94b7-4427-bdcd-1cd174c3f16d


https://github.com/user-attachments/assets/436fa580-4b65-4a7b-a965-5de5be4cd4fe



## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
