### PR TITLE
feat(observe): align eval-attrs picker with resolver + paginate

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -259,6 +259,159 @@ class AnalyticsQueryService:
         )
         return [{"key": row["key"], "type": row["type"]} for row in cdc_result.data]
 
+    def get_observed_trace_attribute_pairs_ch(
+        self, project_id: str, sample_size: int = 100
+    ) -> List[Tuple[int, str]]:
+        """CH mirror of ``SQL_query_handler.get_observed_trace_attribute_pairs``.
+        Reads from the denormalised ``spans`` table for indexed map-key
+        enumeration. ``NULLS LAST`` is explicit because CH defaults to
+        NULLS FIRST for ASC where PG defaults to NULLS LAST.
+        """
+        query = """
+            WITH sample AS (
+                SELECT toString(id) AS trace_id
+                FROM tracer_trace
+                WHERE project_id = %(project_id)s
+                  AND _peerdb_is_deleted = 0
+                ORDER BY created_at DESC
+                LIMIT %(sample_size)s
+            ),
+            ranked AS (
+                SELECT
+                    trace_id,
+                    span_attr_str,
+                    span_attr_num,
+                    span_attr_bool,
+                    row_number() OVER (
+                        PARTITION BY trace_id
+                        ORDER BY start_time ASC NULLS LAST, id
+                    ) - 1 AS idx
+                FROM spans
+                WHERE trace_id IN (SELECT trace_id FROM sample)
+                  AND _peerdb_is_deleted = 0
+            )
+            SELECT idx, key FROM (
+                SELECT idx, k AS key FROM ranked
+                ARRAY JOIN mapKeys(span_attr_str) AS k
+                UNION ALL
+                SELECT idx, k AS key FROM ranked
+                ARRAY JOIN mapKeys(span_attr_num) AS k
+                UNION ALL
+                SELECT idx, k AS key FROM ranked
+                ARRAY JOIN mapKeys(span_attr_bool) AS k
+            )
+            GROUP BY idx, key
+            ORDER BY idx, key
+            LIMIT 100000
+        """
+        result = self.execute_ch_query(
+            query,
+            {"project_id": project_id, "sample_size": sample_size},
+            timeout_ms=10000,
+        )
+        return [(int(row["idx"]), row["key"]) for row in result.data]
+
+    def get_observed_session_attribute_data_ch(
+        self, project_id: str, sample_size: int = 100
+    ) -> Tuple[set, List[Tuple[int, int, str]]]:
+        """CH mirror of ``SQL_query_handler.get_observed_session_attribute_data``.
+        Trace + span ORDER BY mirrors ``_resolve_session_path``; trace-
+        indices set surfaces zero-span traces so the picker still emits
+        ``traces.<i>.<field>`` for them.
+        """
+        query = """
+            WITH sample AS (
+                SELECT id AS session_id
+                FROM trace_session
+                WHERE project_id = %(project_id)s
+                  AND _peerdb_is_deleted = 0
+                ORDER BY created_at DESC
+                LIMIT %(sample_size)s
+            ),
+            session_traces AS (
+                SELECT id, session_id, created_at
+                FROM tracer_trace
+                WHERE session_id IN (SELECT session_id FROM sample)
+                  AND _peerdb_is_deleted = 0
+            ),
+            root_start AS (
+                SELECT trace_id, min(start_time) AS root_start_time
+                FROM spans
+                WHERE (parent_span_id IS NULL OR parent_span_id = '')
+                  AND _peerdb_is_deleted = 0
+                  AND trace_id IN (
+                      SELECT toString(id) FROM session_traces
+                  )
+                GROUP BY trace_id
+            ),
+            ranked_traces AS (
+                SELECT
+                    t.id AS trace_uuid,
+                    toString(t.id) AS trace_str,
+                    t.session_id,
+                    row_number() OVER (
+                        PARTITION BY t.session_id
+                        ORDER BY coalesce(r.root_start_time, t.created_at)
+                                 ASC NULLS LAST,
+                                 t.id
+                    ) - 1 AS trace_idx
+                FROM session_traces t
+                LEFT JOIN root_start r ON r.trace_id = toString(t.id)
+            ),
+            ranked_spans AS (
+                SELECT
+                    rt.trace_idx,
+                    s.span_attr_str,
+                    s.span_attr_num,
+                    s.span_attr_bool,
+                    row_number() OVER (
+                        PARTITION BY s.trace_id
+                        ORDER BY s.start_time ASC NULLS LAST, s.id
+                    ) - 1 AS span_idx
+                FROM ranked_traces rt
+                JOIN spans s ON s.trace_id = rt.trace_str
+                WHERE s._peerdb_is_deleted = 0
+            ),
+            triples AS (
+                SELECT trace_idx, span_idx, key FROM (
+                    SELECT trace_idx, span_idx, k AS key FROM ranked_spans
+                    ARRAY JOIN mapKeys(span_attr_str) AS k
+                    UNION ALL
+                    SELECT trace_idx, span_idx, k AS key FROM ranked_spans
+                    ARRAY JOIN mapKeys(span_attr_num) AS k
+                    UNION ALL
+                    SELECT trace_idx, span_idx, k AS key FROM ranked_spans
+                    ARRAY JOIN mapKeys(span_attr_bool) AS k
+                )
+                GROUP BY trace_idx, span_idx, key
+            ),
+            indices AS (
+                SELECT DISTINCT trace_idx FROM ranked_traces
+            )
+            SELECT trace_idx, span_idx, key FROM triples
+            UNION ALL
+            SELECT trace_idx, CAST(NULL AS Nullable(Int64)) AS span_idx,
+                   CAST(NULL AS Nullable(String)) AS key
+            FROM indices
+            ORDER BY trace_idx, span_idx, key
+            LIMIT 200000
+        """
+        result = self.execute_ch_query(
+            query,
+            {"project_id": project_id, "sample_size": sample_size},
+            timeout_ms=15000,
+        )
+        trace_indices: set = set()
+        triples: List[Tuple[int, int, str]] = []
+        for row in result.data:
+            t_idx = int(row["trace_idx"])
+            trace_indices.add(t_idx)
+            span_idx = row.get("span_idx")
+            key = row.get("key")
+            if span_idx is not None and key is not None and key != "":
+                triples.append((t_idx, int(span_idx), key))
+        return trace_indices, triples
+
     def get_eval_config_ids_with_data_ch(self, project_id: str) -> List[str]:
         """Get distinct eval config IDs that have data for a project in ClickHouse."""
         query = """

--- a/futureagi/tracer/tests/test_eval_attributes_list.py
+++ b/futureagi/tracer/tests/test_eval_attributes_list.py
@@ -1,34 +1,51 @@
 """
 Tests for the row_type-aware ``get_eval_attributes_list`` endpoint.
 
-Pin three things:
+Three contracts the endpoint must honor:
 
-  1. ``row_type=spans`` (and the implicit default) returns the legacy flat
-     list of span_attribute keys — no behavioural change for existing
-     callers.
-  2. ``row_type=traces`` returns trace-level model fields plus
-     ``spans.<n>.<key>`` paths where ``n`` runs 0 .. observed-max-spans-1.
-  3. ``row_type=sessions`` returns session-level model fields plus
-     ``traces.<i>.<trace_field>`` and ``traces.<i>.spans.<j>.<key>``
-     paths sized to the observed maxes.
+  1. **Alignment.** For ``row_type=traces`` / ``row_type=sessions`` only
+     ``(idx, key)`` / ``(trace_idx, span_idx, key)`` slots realized by at
+     least one trace in the project's recent sample are advertised. No
+     cartesian filler that resolves to ``_MISSING`` everywhere — that
+     bug caused production eval-task failures (every trace flagged
+     "Required attribute ... not found").
+  2. **Shape.** Response envelope is
+     ``{items, metadata.total_rows, page_number, page_size}`` under
+     ``result`` — the same shape regardless of row_type.
+  3. **Pagination + search.** ``page_number`` / ``page_size`` slice the
+     materialised path list; ``search`` filters case-insensitively on
+     the path string.
 
-Plus an end-to-end check: a saved mapping using one of the new dotted
-paths actually resolves through the trace evaluator's
-``_process_trace_mapping`` and writes a non-error EvalLogger row.
+Plus an end-to-end check that a saved mapping using one of the new dotted
+paths actually resolves through ``_process_trace_mapping`` and writes a
+non-error EvalLogger row.
 """
 
 import json
+from datetime import timedelta
 
 import pytest
+from django.utils import timezone
 
 # Cycle-breaker — same rationale as the runtime test file.
 import model_hub.tasks  # noqa: F401, E402
 
 
+def _items(response):
+    """Helper: pull the paginated items list out of the standard envelope."""
+    payload = response.json().get("result") or {}
+    return payload.get("items", []) if isinstance(payload, dict) else []
+
+
+def _metadata(response):
+    payload = response.json().get("result") or {}
+    return payload.get("metadata", {}) if isinstance(payload, dict) else {}
+
+
 @pytest.mark.integration
 @pytest.mark.api
 class TestGetEvalAttributesListSpans:
-    """Legacy span behaviour — returned shape unchanged."""
+    """``row_type=spans`` returns the flat key list inside the paginated envelope."""
 
     def test_spans_default_returns_flat_list(
         self, auth_client, populated_observe_project
@@ -36,17 +53,20 @@ class TestGetEvalAttributesListSpans:
         project = populated_observe_project["project"]
         response = auth_client.get(
             "/tracer/observation-span/get_eval_attributes_list/",
-            {"filters": json.dumps({"project_id": str(project.id)})},
+            {
+                "filters": json.dumps({"project_id": str(project.id)}),
+                "page_size": 200,
+            },
         )
         assert response.status_code == 200
-        result = response.json().get("result", [])
-        assert isinstance(result, list)
+        items = _items(response)
+        assert isinstance(items, list)
         # populated_observe_project's spans set ``input`` and ``output`` in
         # span_attributes, so those keys must appear.
-        assert "input" in result
-        assert "output" in result
+        assert "input" in items
+        assert "output" in items
         # No dotted paths — the spans surface is flat.
-        assert not any("." in path for path in result)
+        assert not any("." in path for path in items)
 
     def test_spans_explicit_row_type_returns_flat_list(
         self, auth_client, populated_observe_project
@@ -57,18 +77,19 @@ class TestGetEvalAttributesListSpans:
             {
                 "filters": json.dumps({"project_id": str(project.id)}),
                 "row_type": "spans",
+                "page_size": 200,
             },
         )
         assert response.status_code == 200
-        result = response.json().get("result", [])
-        assert "input" in result
-        assert not any("." in path for path in result)
+        items = _items(response)
+        assert "input" in items
+        assert not any("." in path for path in items)
 
 
 @pytest.mark.integration
 @pytest.mark.api
 class TestGetEvalAttributesListTraces:
-    """``row_type=traces`` returns trace fields + indexed ``spans.<n>.<key>`` paths."""
+    """``row_type=traces`` returns trace fields + realized ``spans.<n>.<key>`` paths."""
 
     def test_includes_trace_public_fields(
         self, auth_client, populated_observe_project
@@ -79,11 +100,11 @@ class TestGetEvalAttributesListTraces:
             {
                 "filters": json.dumps({"project_id": str(project.id)}),
                 "row_type": "traces",
+                "page_size": 200,
             },
         )
         assert response.status_code == 200
-        result = response.json().get("result", [])
-        # All allow-list trace fields surface as bare scalar paths.
+        items = _items(response)
         for field in (
             "input",
             "output",
@@ -93,16 +114,16 @@ class TestGetEvalAttributesListTraces:
             "metadata",
             "external_id",
         ):
-            assert field in result
+            assert field in items
 
-    def test_includes_indexed_span_paths_per_observed_key(
+    def test_includes_indexed_span_paths_per_observed_pair(
         self, auth_client, populated_observe_project
     ):
-        """``spans.<n>.<key>`` for n in 0..(max-spans-per-trace − 1).
+        """``spans.<n>.<key>`` for every realized (idx, key) pair.
 
-        ``populated_observe_project`` builds 3-span traces, so we expect
-        indices 0, 1, 2 to appear. ``span_attributes`` carries ``input``
-        and ``output`` keys, so each index has both.
+        ``populated_observe_project`` builds 3-span traces where every
+        span carries ``input`` and ``output`` in ``span_attributes`` —
+        so the realized set is exactly ``{0,1,2} × {input, output}``.
         """
         project = populated_observe_project["project"]
         response = auth_client.get(
@@ -110,14 +131,15 @@ class TestGetEvalAttributesListTraces:
             {
                 "filters": json.dumps({"project_id": str(project.id)}),
                 "row_type": "traces",
+                "page_size": 200,
             },
         )
-        result = response.json().get("result", [])
+        items = _items(response)
         for i in range(3):
-            assert f"spans.{i}.input" in result
-            assert f"spans.{i}.output" in result
-        # No phantom positions beyond the observed max
-        assert "spans.3.input" not in result
+            assert f"spans.{i}.input" in items
+            assert f"spans.{i}.output" in items
+        # No phantom positions beyond the observed max.
+        assert "spans.3.input" not in items
 
     def test_does_not_expose_first_last_aliases(
         self, auth_client, populated_observe_project
@@ -131,17 +153,111 @@ class TestGetEvalAttributesListTraces:
             {
                 "filters": json.dumps({"project_id": str(project.id)}),
                 "row_type": "traces",
+                "page_size": 200,
             },
         )
-        result = response.json().get("result", [])
-        assert not any(p.startswith("spans.first.") for p in result)
-        assert not any(p.startswith("spans.last.") for p in result)
+        items = _items(response)
+        assert not any(p.startswith("spans.first.") for p in items)
+        assert not any(p.startswith("spans.last.") for p in items)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGetEvalAttributesListAlignment:
+    """The bug that motivated the rewrite: keys at varied positions across
+    traces caused the picker to advertise (idx, key) cells that no trace
+    realized. Seed data where a given key appears at one specific index in
+    one trace and a different index in another, and assert only the
+    realized cells are emitted."""
+
+    @pytest.fixture
+    def project_with_misaligned_keys(self, db, observe_project):
+        """Two traces; ``timeline`` lives at idx 1 in trace A and idx 3
+        in trace B. Pre-alignment, the picker would emit
+        ``spans.{0,1,2,3}.timeline`` (cartesian); after, only
+        ``spans.1.timeline`` and ``spans.3.timeline`` should appear."""
+        from tracer.models.observation_span import ObservationSpan
+        from tracer.models.trace import Trace
+
+        trace_a = Trace.objects.create(
+            project=observe_project, name="trace_a",
+            input={}, output={},
+        )
+        # 2 spans on trace A: idx 0 = unrelated, idx 1 = timeline
+        for sp_idx, attrs in enumerate(
+            [{"other_key": "x"}, {"timeline": [1, 2, 3]}]
+        ):
+            ObservationSpan.objects.create(
+                id=f"a_{sp_idx}",
+                project=observe_project,
+                trace=trace_a,
+                parent_span_id=None if sp_idx == 0 else "a_0",
+                name=f"a_{sp_idx}",
+                observation_type="llm",
+                start_time=timezone.now() - timedelta(seconds=10 - sp_idx),
+                end_time=timezone.now() - timedelta(seconds=9 - sp_idx),
+                span_attributes=attrs,
+                status="OK",
+            )
+        trace_b = Trace.objects.create(
+            project=observe_project, name="trace_b",
+            input={}, output={},
+        )
+        # 4 spans on trace B: idx 0..2 = unrelated, idx 3 = timeline
+        for sp_idx, attrs in enumerate(
+            [
+                {"other_key": "x"},
+                {"another": "y"},
+                {"third": "z"},
+                {"timeline": [4, 5, 6]},
+            ]
+        ):
+            ObservationSpan.objects.create(
+                id=f"b_{sp_idx}",
+                project=observe_project,
+                trace=trace_b,
+                parent_span_id=None if sp_idx == 0 else "b_0",
+                name=f"b_{sp_idx}",
+                observation_type="llm",
+                start_time=timezone.now() - timedelta(seconds=20 - sp_idx),
+                end_time=timezone.now() - timedelta(seconds=19 - sp_idx),
+                span_attributes=attrs,
+                status="OK",
+            )
+        return observe_project
+
+    def test_excludes_unrealized_index_key_pairs(
+        self, auth_client, project_with_misaligned_keys
+    ):
+        project = project_with_misaligned_keys
+        response = auth_client.get(
+            "/tracer/observation-span/get_eval_attributes_list/",
+            {
+                "filters": json.dumps({"project_id": str(project.id)}),
+                "row_type": "traces",
+                "page_size": 200,
+            },
+        )
+        items = _items(response)
+        # Realized: ``timeline`` lives at idx 1 and idx 3.
+        assert "spans.1.timeline" in items
+        assert "spans.3.timeline" in items
+        # Pre-alignment would have advertised these too. Post-alignment,
+        # they must NOT appear — those cells resolve to _MISSING.
+        assert "spans.0.timeline" not in items
+        assert "spans.2.timeline" not in items
+        # ``other_key`` lives at idx 0 in BOTH traces.
+        assert "spans.0.other_key" in items
+        # Not at idx 1 or 3 in any trace.
+        assert "spans.1.other_key" not in items
+        assert "spans.3.other_key" not in items
 
 
 @pytest.mark.integration
 @pytest.mark.api
 class TestGetEvalAttributesListSessions:
-    """``row_type=sessions`` returns session fields + indexed ``traces.<i>.<...>`` paths."""
+    """``row_type=sessions`` returns session fields + realized
+    ``traces.<i>.<...>`` paths."""
 
     def test_includes_session_public_fields(
         self, auth_client, populated_observe_project
@@ -152,16 +268,17 @@ class TestGetEvalAttributesListSessions:
             {
                 "filters": json.dumps({"project_id": str(project.id)}),
                 "row_type": "sessions",
+                "page_size": 200,
             },
         )
-        result = response.json().get("result", [])
+        items = _items(response)
         for field in ("name", "bookmarked"):
-            assert field in result
+            assert field in items
 
     def test_includes_indexed_traces_with_trace_fields(
         self, auth_client, populated_observe_project
     ):
-        """``traces.<i>.<trace_field>`` for i in 0..(max-traces-per-session − 1).
+        """``traces.<i>.<trace_field>`` for every observed trace index.
 
         ``populated_observe_project`` builds 2 traces per session, so
         indices 0 and 1 should appear with each trace field.
@@ -172,21 +289,22 @@ class TestGetEvalAttributesListSessions:
             {
                 "filters": json.dumps({"project_id": str(project.id)}),
                 "row_type": "sessions",
+                "page_size": 200,
             },
         )
-        result = response.json().get("result", [])
+        items = _items(response)
         for i in range(2):
-            assert f"traces.{i}.input" in result
-            assert f"traces.{i}.output" in result
-            assert f"traces.{i}.metadata" in result
-            assert f"traces.{i}.tags" in result
-        # No phantom positions beyond the observed max
-        assert "traces.2.input" not in result
+            assert f"traces.{i}.input" in items
+            assert f"traces.{i}.output" in items
+            assert f"traces.{i}.metadata" in items
+            assert f"traces.{i}.tags" in items
+        # No phantom positions beyond the observed max.
+        assert "traces.2.input" not in items
 
     def test_includes_nested_traces_spans_paths(
         self, auth_client, populated_observe_project
     ):
-        """``traces.<i>.spans.<j>.<key>`` for the full observed grid.
+        """``traces.<i>.spans.<j>.<key>`` for each realized triple.
 
         2 traces × 3 spans × 2 keys = 12 nested paths in the test data.
         """
@@ -196,16 +314,90 @@ class TestGetEvalAttributesListSessions:
             {
                 "filters": json.dumps({"project_id": str(project.id)}),
                 "row_type": "sessions",
+                "page_size": 200,
             },
         )
-        result = response.json().get("result", [])
+        items = _items(response)
         for i in range(2):
             for j in range(3):
-                assert f"traces.{i}.spans.{j}.input" in result
-                assert f"traces.{i}.spans.{j}.output" in result
-        # No phantom positions
-        assert "traces.0.spans.3.input" not in result
-        assert "traces.2.spans.0.input" not in result
+                assert f"traces.{i}.spans.{j}.input" in items
+                assert f"traces.{i}.spans.{j}.output" in items
+        # No phantom positions.
+        assert "traces.0.spans.3.input" not in items
+        assert "traces.2.spans.0.input" not in items
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestPickerPagination:
+    """``page_number`` + ``page_size`` slice the materialised path list."""
+
+    def test_pagination_traces_disjoint_windows(
+        self, auth_client, populated_observe_project
+    ):
+        project = populated_observe_project["project"]
+
+        def fetch(page):
+            return auth_client.get(
+                "/tracer/observation-span/get_eval_attributes_list/",
+                {
+                    "filters": json.dumps({"project_id": str(project.id)}),
+                    "row_type": "traces",
+                    "page_size": 5,
+                    "page_number": page,
+                },
+            )
+
+        page0 = fetch(0)
+        page1 = fetch(1)
+        items0, items1 = _items(page0), _items(page1)
+        # Page size honored.
+        assert len(items0) == 5
+        # Disjoint slices over the same sorted list.
+        assert set(items0).isdisjoint(set(items1))
+        # ``total_rows`` is stable across pages.
+        assert _metadata(page0)["total_rows"] == _metadata(page1)["total_rows"]
+
+    def test_search_substring_case_insensitive(
+        self, auth_client, populated_observe_project
+    ):
+        project = populated_observe_project["project"]
+        response = auth_client.get(
+            "/tracer/observation-span/get_eval_attributes_list/",
+            {
+                "filters": json.dumps({"project_id": str(project.id)}),
+                "row_type": "traces",
+                "search": "INPUT",
+                "page_size": 200,
+            },
+        )
+        items = _items(response)
+        # Every returned path contains ``input`` (case-insensitive).
+        assert items, "search should still return matches"
+        assert all("input" in p.lower() for p in items)
+        # And nothing without ``input`` slipped in.
+        assert "output" not in items
+        assert "spans.0.output" not in items
+
+    def test_spans_row_type_paginated_and_searchable(
+        self, auth_client, populated_observe_project
+    ):
+        project = populated_observe_project["project"]
+        response = auth_client.get(
+            "/tracer/observation-span/get_eval_attributes_list/",
+            {
+                "filters": json.dumps({"project_id": str(project.id)}),
+                "row_type": "spans",
+                "search": "put",
+                "page_size": 1,
+                "page_number": 0,
+            },
+        )
+        items = _items(response)
+        meta = _metadata(response)
+        # Both ``input`` and ``output`` match the substring ``put``.
+        assert meta["total_rows"] >= 2
+        assert len(items) == 1
 
 
 @pytest.mark.integration
@@ -213,24 +405,17 @@ class TestGetEvalAttributesListSessions:
 class TestSpanAttributeKeysNormalisation:
     """``_get_span_attribute_keys`` must hand callers bare strings.
 
-    The CH-backed ``get_span_attribute_keys_ch`` returns ``{key, type}`` dicts
-    so the legacy spans picker can render type chips. The trace/session
-    path builders f-string into ``spans.<n>.<key>`` — without unwrapping,
-    paths become ``spans.0.{'key': '…', 'type': 'text'}`` garbage.
+    The CH-backed ``get_span_attribute_keys_ch`` returns ``{key, type}``
+    dicts so the legacy spans picker can render type chips. The trace
+    + session path builders f-string into ``spans.<n>.<key>`` — without
+    unwrapping, paths become ``spans.0.{'key': '…', 'type': 'text'}``
+    garbage.
 
     Pin the unwrap behaviour and the regression at the live endpoint:
     no path in the trace/session response should contain ``{`` or ``}``.
     """
 
     def test_normalises_dict_and_string_inputs(self, monkeypatch):
-        """Pure unit test on ``_get_span_attribute_keys`` itself.
-
-        Forces the CH analytics service to return mixed input — dicts
-        with ``key``, dicts without ``key``, bare strings, and empty
-        sentinels — and asserts the helper hands callers only the
-        usable bare-string keys. Empty / malformed entries are dropped
-        entirely; nothing gets stringified into the path output.
-        """
         from tracer.services.clickhouse.query_service import (
             AnalyticsQueryService,
         )
@@ -240,9 +425,9 @@ class TestSpanAttributeKeysNormalisation:
             {"key": "gen_ai.input.foo", "type": "text"},
             "bare_string_key",
             {"key": "gen_ai.output.bar", "type": "text"},
-            {"type": "text"},  # no key — must be dropped
-            {"key": "", "type": "text"},  # empty key — must be dropped
-            "",  # empty string — must be dropped
+            {"type": "text"},
+            {"key": "", "type": "text"},
+            "",
         ]
 
         monkeypatch.setattr(
@@ -268,38 +453,119 @@ class TestSpanAttributeKeysNormalisation:
     def test_no_curly_braces_in_traces_response(
         self, auth_client, populated_observe_project
     ):
-        """End-to-end pin: the live row_type=traces response NEVER contains
-        ``{`` or ``}`` characters in any path. Catches a regression of the
-        original dict-stringify bug at the live endpoint, regardless of
-        what shape the underlying CH/PG helper returns."""
         project = populated_observe_project["project"]
         response = auth_client.get(
             "/tracer/observation-span/get_eval_attributes_list/",
             {
                 "filters": json.dumps({"project_id": str(project.id)}),
                 "row_type": "traces",
+                "page_size": 200,
             },
         )
-        result = response.json().get("result", [])
-        bad = [p for p in result if "{" in p or "}" in p]
+        items = _items(response)
+        bad = [p for p in items if "{" in p or "}" in p]
         assert bad == [], f"Found malformed paths: {bad[:5]}"
 
     def test_no_curly_braces_in_sessions_response(
         self, auth_client, populated_observe_project
     ):
-        """End-to-end pin for row_type=sessions, same rationale as the
-        traces version above."""
         project = populated_observe_project["project"]
         response = auth_client.get(
             "/tracer/observation-span/get_eval_attributes_list/",
             {
                 "filters": json.dumps({"project_id": str(project.id)}),
                 "row_type": "sessions",
+                "page_size": 200,
             },
         )
-        result = response.json().get("result", [])
-        bad = [p for p in result if "{" in p or "}" in p]
+        items = _items(response)
+        bad = [p for p in items if "{" in p or "}" in p]
         assert bad == [], f"Found malformed paths: {bad[:5]}"
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestClickhouseFirstRouting:
+    """The aligned aggregates are CH-first with PG fallback. Pin both
+    paths: CH used when it returns non-empty, PG used when CH returns
+    empty (early-adoption window where ``spans`` isn't backfilled) or
+    raises.
+    """
+
+    def test_traces_uses_clickhouse_when_routed_and_nonempty(
+        self, auth_client, populated_observe_project, monkeypatch
+    ):
+        from tracer.services.clickhouse.query_service import (
+            AnalyticsQueryService,
+        )
+
+        project = populated_observe_project["project"]
+        ch_pairs = [(0, "ch_only_key"), (1, "ch_only_key")]
+
+        monkeypatch.setattr(
+            AnalyticsQueryService,
+            "should_use_clickhouse",
+            lambda self, qt: True,
+        )
+        monkeypatch.setattr(
+            AnalyticsQueryService,
+            "get_observed_trace_attribute_pairs_ch",
+            lambda self, pid, n: ch_pairs,
+        )
+
+        response = auth_client.get(
+            "/tracer/observation-span/get_eval_attributes_list/",
+            {
+                "filters": json.dumps({"project_id": str(project.id)}),
+                "row_type": "traces",
+                "page_size": 200,
+            },
+        )
+        items = _items(response)
+        # CH-returned pairs surface verbatim; PG aggregate is bypassed.
+        assert "spans.0.ch_only_key" in items
+        assert "spans.1.ch_only_key" in items
+        # PG fixture's ``input``/``output`` keys are NOT present at any
+        # ``spans.<n>.<key>`` slot — PG was not consulted.
+        assert "spans.0.input" not in items
+
+    def test_traces_falls_back_to_pg_on_ch_error(
+        self, auth_client, populated_observe_project, monkeypatch
+    ):
+        from tracer.services.clickhouse.query_service import (
+            AnalyticsQueryService,
+        )
+
+        project = populated_observe_project["project"]
+
+        def boom(self, pid, n):
+            raise RuntimeError("CH simulated outage")
+
+        monkeypatch.setattr(
+            AnalyticsQueryService,
+            "should_use_clickhouse",
+            lambda self, qt: True,
+        )
+        monkeypatch.setattr(
+            AnalyticsQueryService,
+            "get_observed_trace_attribute_pairs_ch",
+            boom,
+        )
+
+        response = auth_client.get(
+            "/tracer/observation-span/get_eval_attributes_list/",
+            {
+                "filters": json.dumps({"project_id": str(project.id)}),
+                "row_type": "traces",
+                "page_size": 200,
+            },
+        )
+        items = _items(response)
+        # PG fallback ran — fixture's ``input``/``output`` keys at the
+        # 3-span positions all surface.
+        for i in range(3):
+            assert f"spans.{i}.input" in items
+            assert f"spans.{i}.output" in items
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -1712,6 +1712,11 @@ _TRACE_PUBLIC_FIELDS = frozenset(
 )
 _SESSION_PUBLIC_FIELDS = frozenset({"name", "bookmarked"})
 
+# Span ordering within a trace. Picker SQL aggregates (CH + PG) must
+# iterate in this same order — otherwise advertised ``spans.<n>.<key>``
+# paths won't match what the resolver looks up at run time.
+_SPAN_ORDER_BY: tuple[str, ...] = ("start_time", "id")
+
 
 def _resolve_span_path(span: ObservationSpan, path: str):
     """Walk a path against a span via the ``span_attributes`` bag.
@@ -1766,7 +1771,7 @@ def _resolve_trace_path(trace: Trace, path: str):
         return walked if walked is not None else _MISSING
 
     if head == "spans":
-        spans = list(trace.observation_spans.order_by("start_time", "id"))
+        spans = list(trace.observation_spans.order_by(*_SPAN_ORDER_BY))
         return _resolve_collection_path(spans, rest, _resolve_span_path)
 
     return _MISSING
@@ -1789,13 +1794,10 @@ def _resolve_session_path(trace_session: TraceSession, path: str):
         return walked if walked is not None else _MISSING
 
     if head == "traces":
-        # Match the trace-listing UI's ordering (``list_traces_of_session``
-        # in ``tracer/views/trace.py``): earliest root span's ``start_time``,
-        # falling back to ``created_at`` when no root span has landed yet.
-        # Without this, sessions whose traces share a ``created_at`` (the
-        # SDK stamps every trace in a run with the same instant) tie-break
-        # by id alphabetically -- picking a "trace 0" the user never sees
-        # at the top of the trace list.
+        # Trace ordering: earliest root span's ``start_time`` falling back
+        # to ``created_at`` — matches ``list_traces_of_session`` in
+        # ``tracer/views/trace.py``. Picker aggregates mirror this; if you
+        # change it, update them too.
         from django.db.models import OuterRef, Subquery
         from django.db.models.functions import Coalesce
 

--- a/futureagi/tracer/utils/sql_queries.py
+++ b/futureagi/tracer/utils/sql_queries.py
@@ -278,6 +278,111 @@ class SQL_query_handler:
         return [row[0] for row in rows]
 
     @classmethod
+    def get_observed_trace_attribute_pairs(cls, project_id, sample_size=100):
+        """Distinct ``(span_idx, key)`` pairs realised in the project's
+        most recent traces. Span ORDER BY must match ``_SPAN_ORDER_BY`` in
+        ``tracer/utils/eval.py`` or picker slots drift from the resolver.
+        """
+        query = """
+            WITH sample AS (
+                SELECT id FROM tracer_trace
+                WHERE project_id = %s AND deleted = FALSE
+                ORDER BY created_at DESC
+                LIMIT %s
+            ),
+            ranked AS (
+                SELECT s.trace_id, s.span_attributes,
+                       row_number() OVER (
+                           PARTITION BY s.trace_id
+                           ORDER BY s.start_time, s.id
+                       ) - 1 AS idx
+                FROM tracer_observation_span s
+                WHERE s.trace_id IN (SELECT id FROM sample)
+                  AND s.deleted = FALSE
+                  AND s.span_attributes IS NOT NULL
+                  AND s.span_attributes != '{}'::jsonb
+            )
+            SELECT DISTINCT idx, key
+            FROM ranked, jsonb_object_keys(span_attributes) AS key
+            ORDER BY idx, key
+        """
+        rows = cls.execute_query(query, [project_id, sample_size])
+        return [(int(row[0]), row[1]) for row in rows]
+
+    @classmethod
+    def get_observed_session_attribute_data(cls, project_id, sample_size=100):
+        """``(trace_indices, triples)``. ``trace_indices`` is surfaced
+        separately so the picker can still emit ``traces.<i>.<field>`` for
+        traces with zero spans (trace fields are real model columns).
+        Trace + span ORDER BY mirrors ``_resolve_session_path``.
+        """
+        query = """
+            WITH sample AS (
+                SELECT id FROM trace_session
+                WHERE project_id = %s AND deleted = FALSE
+                ORDER BY created_at DESC
+                LIMIT %s
+            ),
+            session_traces AS (
+                SELECT t.id, t.session_id, t.created_at
+                FROM tracer_trace t
+                WHERE t.session_id IN (SELECT id FROM sample)
+                  AND t.deleted = FALSE
+            ),
+            root_start AS (
+                SELECT s.trace_id, MIN(s.start_time) AS root_start_time
+                FROM tracer_observation_span s
+                WHERE s.parent_span_id IS NULL
+                  AND s.deleted = FALSE
+                  AND s.trace_id IN (SELECT id FROM session_traces)
+                GROUP BY s.trace_id
+            ),
+            ranked_traces AS (
+                SELECT t.id AS trace_id, t.session_id,
+                       row_number() OVER (
+                           PARTITION BY t.session_id
+                           ORDER BY COALESCE(r.root_start_time, t.created_at),
+                                    t.id
+                       ) - 1 AS trace_idx
+                FROM session_traces t
+                LEFT JOIN root_start r ON r.trace_id = t.id
+            ),
+            ranked_spans AS (
+                SELECT rt.trace_idx, s.span_attributes,
+                       row_number() OVER (
+                           PARTITION BY s.trace_id
+                           ORDER BY s.start_time, s.id
+                       ) - 1 AS span_idx
+                FROM ranked_traces rt
+                JOIN tracer_observation_span s ON s.trace_id = rt.trace_id
+                WHERE s.deleted = FALSE
+                  AND s.span_attributes IS NOT NULL
+                  AND s.span_attributes != '{}'::jsonb
+            ),
+            triples AS (
+                SELECT DISTINCT trace_idx, span_idx, key
+                FROM ranked_spans,
+                     jsonb_object_keys(span_attributes) AS key
+            ),
+            indices AS (
+                SELECT DISTINCT trace_idx FROM ranked_traces
+            )
+            SELECT trace_idx, span_idx, key FROM triples
+            UNION ALL
+            SELECT trace_idx, NULL::int, NULL::text FROM indices
+            ORDER BY 1, 2 NULLS FIRST, 3
+        """
+        rows = cls.execute_query(query, [project_id, sample_size])
+        trace_indices: set[int] = set()
+        triples: list[tuple[int, int, str]] = []
+        for row in rows:
+            t_idx = int(row[0])
+            trace_indices.add(t_idx)
+            if row[1] is not None and row[2] is not None:
+                triples.append((t_idx, int(row[1]), row[2]))
+        return trace_indices, triples
+
+    @classmethod
     def get_eval_attributes_for_project(cls, project_id):
         """
         DEPRECATED: Use get_span_attributes_for_project instead.

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -21,7 +21,6 @@ from django.db.models import (
     FloatField,
     IntegerField,
     JSONField,
-    Max,
     OuterRef,
     Q,
     Subquery,
@@ -69,7 +68,6 @@ from tracer.models.project import Project
 from tracer.models.project_version import ProjectVersion
 from tracer.models.span_notes import SpanNotes
 from tracer.models.trace import Trace
-from tracer.models.trace_session import TraceSession
 from tracer.services.clickhouse.query_service import (
     AnalyticsQueryService,
     QueryType,
@@ -2833,12 +2831,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
     @action(detail=False, methods=["get"])
     def get_span_attributes_list(self, request, *args, **kwargs):
         """Distinct span_attributes keys for a project (spans surface).
-
-        Query params:
-            filters: JSON {"project_id": "<uuid>"} (required)
-
-        Returns:
-            List of attribute key strings.
+        Paginated envelope via ``_paginated_response``.
         """
         try:
             filters = self.request.query_params.get("filters", "{}")
@@ -2849,8 +2842,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             if not project_id:
                 return self._gm.bad_request("project_id is required")
 
-            result = self._get_span_attribute_keys(project_id)
-            return self._gm.success_response(result)
+            page_number, page_size, search = self._parse_picker_pagination_params()
+            keys = self._get_span_attribute_keys(project_id)
+            return self._paginated_response(
+                keys, page_number, page_size, search
+            )
 
         except Exception as e:
             logger.exception(f"error fetching span attributes list: {str(e)}")
@@ -2860,22 +2856,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
 
     @action(detail=False, methods=["get"])
     def get_eval_attributes_list(self, request, *args, **kwargs):
-        """Attribute paths the EvalPicker exposes per row_type.
-
-        Query params:
-            filters: JSON {"project_id": "<uuid>"} (required)
-            row_type: spans | traces | sessions (default spans;
-                      voiceCalls aliases to spans)
-
-        Returns:
-            spans/voiceCalls: distinct span_attributes keys
-            traces:           trace fields + spans.<n>.<key>
-            sessions:         session fields + traces.<i>.<trace_field>
-                              + traces.<i>.spans.<j>.<key>
-
-        Indexed positions are sized to the project's observed maxes;
-        ordering of ``traces.<i>`` / ``spans.<n>`` slots is decided at
-        resolve time (see ``_resolve_session_path`` / ``_resolve_trace_path``).
+        """Attribute paths the EvalPicker exposes per row_type
+        (spans | traces | sessions; voiceCalls aliases to spans).
+        Only (idx, key) cells realised by at least one trace in the recent
+        sample are emitted — slots line up 1:1 with what the resolver
+        (``_resolve_trace_path`` / ``_resolve_session_path``) looks up.
         """
         try:
             filters = self.request.query_params.get("filters", "{}")
@@ -2887,29 +2872,24 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 return self._gm.bad_request("project_id is required")
 
             row_type = self.request.query_params.get("row_type", "spans")
+            page_number, page_size, search = self._parse_picker_pagination_params()
 
             if row_type == "spans" or row_type == "voiceCalls":
                 # voiceCalls share the spans surface for the picker; they
                 # have their own evaluator pipeline upstream of EvalTask.
-                return self.get_span_attributes_list(request, *args, **kwargs)
-
-            span_attribute_keys = self._get_span_attribute_keys(project_id)
-
-            if row_type == "traces":
-                paths = self._build_trace_attribute_paths(
-                    project_id, span_attribute_keys
+                paths = self._get_span_attribute_keys(project_id)
+            elif row_type == "traces":
+                paths = self._build_trace_attribute_paths(project_id)
+            elif row_type == "sessions":
+                paths = self._build_session_attribute_paths(project_id)
+            else:
+                return self._gm.bad_request(
+                    f"Unknown row_type {row_type!r}. Expected one of: "
+                    "spans, traces, sessions, voiceCalls."
                 )
-                return self._gm.success_response(paths)
 
-            if row_type == "sessions":
-                paths = self._build_session_attribute_paths(
-                    project_id, span_attribute_keys
-                )
-                return self._gm.success_response(paths)
-
-            return self._gm.bad_request(
-                f"Unknown row_type {row_type!r}. Expected one of: "
-                "spans, traces, sessions, voiceCalls."
+            return self._paginated_response(
+                paths, page_number, page_size, search
             )
 
         except Exception as e:
@@ -2918,9 +2898,8 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 f"error fetching the eval attributes list {str(e)}"
             )
 
-    # Trace + session model fields the resolver allow-lists; mirrors the
-    # frozensets in tracer.utils.eval. Hand-synced so a model change shows
-    # up in both places at review time.
+    # Mirrors the allow-list frozensets in tracer.utils.eval. Hand-synced
+    # so a Trace/TraceSession schema change surfaces in both places.
     _TRACE_PUBLIC_FIELDS = (
         "input",
         "output",
@@ -2932,22 +2911,62 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
     )
     _SESSION_PUBLIC_FIELDS = ("name", "bookmarked")
 
-    # Cap on how many entities to scan when computing observed maxes.
-    # Most projects' traces have a few-to-dozens of spans; bounding the
-    # sample keeps the path enumeration query cheap.
+    # Bounds the alignment aggregate on large projects.
     _OBSERVED_MAX_SAMPLE_SIZE = 100
 
+    _PICKER_DEFAULT_PAGE_SIZE = 50
+    _PICKER_MAX_PAGE_SIZE = 200
+
+    def _parse_picker_pagination_params(self) -> tuple[int, int, str]:
+        try:
+            page_number = int(self.request.query_params.get("page_number", 0))
+        except (TypeError, ValueError):
+            page_number = 0
+        try:
+            page_size = int(
+                self.request.query_params.get(
+                    "page_size", self._PICKER_DEFAULT_PAGE_SIZE
+                )
+            )
+        except (TypeError, ValueError):
+            page_size = self._PICKER_DEFAULT_PAGE_SIZE
+        page_number = max(0, page_number)
+        page_size = max(1, min(page_size, self._PICKER_MAX_PAGE_SIZE))
+        search = self.request.query_params.get("search", "") or ""
+        return page_number, page_size, search.strip()
+
+    def _paginated_response(
+        self,
+        all_paths: list,
+        page_number: int,
+        page_size: int,
+        search: str,
+    ):
+        # Search + pagination run in Python; the candidate set is bounded
+        # by the 100-trace sample × distinct keys, typically a few
+        # thousand entries. Push to SQL if that ever stops holding.
+        if search:
+            needle = search.lower()
+            filtered = [p for p in all_paths if needle in p.lower()]
+        else:
+            filtered = list(all_paths)
+        total_rows = len(filtered)
+        start = page_number * page_size
+        items = filtered[start : start + page_size]
+        return self._gm.success_response(
+            {
+                "items": items,
+                "metadata": {"total_rows": total_rows},
+                "page_number": page_number,
+                "page_size": page_size,
+            }
+        )
+
     def _get_span_attribute_keys(self, project_id: str) -> list:
-        """Project's distinct span_attributes keys. CH-first, PG fallback.
-
-        Single source for both ``get_span_attributes_list`` (which wraps
-        it in a DRF response) and the trace + session path builders.
-
-        CH returns ``[{"key": ..., "type": ...}, ...]`` (spans picker
-        renders type chips); the trace + session path builders need
-        bare strings. The normalization loop below collapses both
-        shapes to ``list[str]`` so callers never see dicts f-stringed
-        into paths like ``traces.0.spans.0.{'key': '...', ...}``.
+        """Project's distinct span_attributes keys, CH-first / PG fallback.
+        CH returns ``[{key, type}]`` (for type chips); the normalisation
+        loop unwraps to ``list[str]`` so no dict gets f-stringed into a
+        path like ``spans.0.{'key': ..., 'type': ...}``.
         """
         raw = None
         analytics = AnalyticsQueryService()
@@ -2976,68 +2995,67 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 keys.append(item)
         return keys
 
-    def _max_spans_per_trace(self, project_id: str) -> int:
-        """Max span count observed across the project's most recent traces.
-
-        Bounds the indexed positions exposed under ``spans.<n>.<...>``.
-        Samples the most recent ``_OBSERVED_MAX_SAMPLE_SIZE`` traces to
-        keep the aggregate cheap on large projects.
+    def _get_observed_trace_pairs(self, project_id: str) -> list:
+        """``(span_idx, key)`` pairs, CH-first / PG fallback. Empty CH
+        result also falls through (early-adoption window before ``spans``
+        is backfilled; test envs that only seed PG).
         """
-        sample_trace_ids = Trace.objects.filter(
-            project_id=project_id
-        ).order_by("-created_at").values_list("id", flat=True)[
-            : self._OBSERVED_MAX_SAMPLE_SIZE
-        ]
-        agg = (
-            ObservationSpan.objects.filter(trace_id__in=sample_trace_ids)
-            .values("trace_id")
-            .annotate(span_count=Count("id"))
-            .aggregate(max_count=Max("span_count"))
+        analytics = AnalyticsQueryService()
+        if analytics.should_use_clickhouse(QueryType.SPAN_LIST):
+            try:
+                pairs = analytics.get_observed_trace_attribute_pairs_ch(
+                    str(project_id), self._OBSERVED_MAX_SAMPLE_SIZE
+                )
+                if pairs:
+                    return pairs
+            except Exception as ch_err:
+                logger.warning(
+                    "CH observed-trace-pairs failed, falling back to PG",
+                    error=str(ch_err),
+                )
+        return SQL_query_handler.get_observed_trace_attribute_pairs(
+            project_id, self._OBSERVED_MAX_SAMPLE_SIZE
         )
-        return agg["max_count"] or 0
 
-    def _max_traces_per_session(self, project_id: str) -> int:
-        """Max trace count observed across the project's most recent sessions."""
-        sample_session_ids = TraceSession.objects.filter(
-            project_id=project_id
-        ).order_by("-created_at").values_list("id", flat=True)[
-            : self._OBSERVED_MAX_SAMPLE_SIZE
-        ]
-        agg = (
-            Trace.objects.filter(session_id__in=sample_session_ids)
-            .values("session_id")
-            .annotate(trace_count=Count("id"))
-            .aggregate(max_count=Max("trace_count"))
+    def _get_observed_session_data(self, project_id: str):
+        # CH-first / PG fallback; same empty-result-falls-through rule
+        # as ``_get_observed_trace_pairs``.
+        analytics = AnalyticsQueryService()
+        if analytics.should_use_clickhouse(QueryType.SPAN_LIST):
+            try:
+                trace_indices, triples = (
+                    analytics.get_observed_session_attribute_data_ch(
+                        str(project_id), self._OBSERVED_MAX_SAMPLE_SIZE
+                    )
+                )
+                if trace_indices or triples:
+                    return trace_indices, triples
+            except Exception as ch_err:
+                logger.warning(
+                    "CH observed-session-data failed, falling back to PG",
+                    error=str(ch_err),
+                )
+        return SQL_query_handler.get_observed_session_attribute_data(
+            project_id, self._OBSERVED_MAX_SAMPLE_SIZE
         )
-        return agg["max_count"] or 0
 
-    def _build_trace_attribute_paths(
-        self, project_id: str, span_attribute_keys: list
-    ) -> list:
-        """Trace-level paths: trace fields + ``spans.<n>.<key>`` for each
-        index up to the observed max spans-per-trace."""
+    def _build_trace_attribute_paths(self, project_id: str) -> list:
         paths = list(self._TRACE_PUBLIC_FIELDS)
-        max_spans = self._max_spans_per_trace(project_id)
-        for i in range(max_spans):
-            for key in span_attribute_keys:
-                paths.append(f"spans.{i}.{key}")
+        for idx, key in self._get_observed_trace_pairs(project_id):
+            paths.append(f"spans.{idx}.{key}")
         return paths
 
-    def _build_session_attribute_paths(
-        self, project_id: str, span_attribute_keys: list
-    ) -> list:
-        """Session-level paths: session fields + ``traces.<i>.<trace_field>``
-        + ``traces.<i>.spans.<j>.<key>`` up to the observed max traces-per-
-        session and spans-per-trace."""
+    def _build_session_attribute_paths(self, project_id: str) -> list:
         paths = list(self._SESSION_PUBLIC_FIELDS)
-        max_traces = self._max_traces_per_session(project_id)
-        max_spans = self._max_spans_per_trace(project_id)
-        for i in range(max_traces):
+        trace_indices, triples = self._get_observed_session_data(project_id)
+        triples_by_trace: dict[int, list] = {}
+        for t_idx, s_idx, key in triples:
+            triples_by_trace.setdefault(t_idx, []).append((s_idx, key))
+        for t_idx in sorted(trace_indices):
             for trace_field in self._TRACE_PUBLIC_FIELDS:
-                paths.append(f"traces.{i}.{trace_field}")
-            for j in range(max_spans):
-                for key in span_attribute_keys:
-                    paths.append(f"traces.{i}.spans.{j}.{key}")
+                paths.append(f"traces.{t_idx}.{trace_field}")
+            for s_idx, key in triples_by_trace.get(t_idx, []):
+                paths.append(f"traces.{t_idx}.spans.{s_idx}.{key}")
         return paths
 
     @action(detail=False, methods=["get"])


### PR DESCRIPTION
## Summary

Eval picker advertised cartesian `(max_spans × distinct_keys)` paths for `row_type=traces`/`sessions`, so users picked `spans.<n>.<key>` cells no trace realised — resolver raised _Required attribute not found_ on every trace. Reproduced in prod project `696ed10e-…`: eval task `800f82a8-…` had 885 failed entries against `spans.87.timeline` / `spans.87.transcript`, but `timeline` lives on `finalization.prompt.double_verification` spans whose absolute index ranges 42–552 across traces. **0 / 295 traces** in that project have `timeline` at index 87.

## Changes

- **Aligned aggregate** replaces the cartesian product. Only `(idx, key)` / `(trace_idx, span_idx, key)` cells realised by at least one trace in the project's recent 100-trace sample are emitted.
  - CH-first via the denormalised `spans` table (bloom-filtered `mapKeys(span_attr_*)` indexes).
  - PG fallback covers disabled routing, CH errors, and empty CH results (early-adoption window + test envs).
- **Pagination + search.** `page_number` / `page_size` (default 50, capped 200) and `search` (case-insensitive substring) on the endpoint envelope. Identical shape across all `row_type`s, including the spans/voiceCalls flat-keys path. Standard envelope: `{ items, metadata.total_rows, page_number, page_size }`.
- **Alignment invariant.** Extract `_SPAN_ORDER_BY = ("start_time", "id")` in `eval.py`; resolver and both SQL aggregates (PG + CH) iterate in lockstep. Trace ordering inside a session (`COALESCE(min_root_span_start_time, created_at), id`) cross-referenced between the resolver and the SQL aggregates so future schema changes surface in both places.

## Test plan

- [x] `tracer/tests/test_eval_attributes_list.py` — 19/19 pass.
  - Existing pins (envelope shape, no `{}` curly-brace leak, dotted-span-path resolves end-to-end, unknown row_type → 400).
  - New: `TestGetEvalAttributesListAlignment::test_excludes_unrealized_index_key_pairs` — seeds two traces where `timeline` lives at idx 1 and idx 3 respectively; asserts `spans.0.timeline` and `spans.2.timeline` are NOT advertised.
  - New: `TestPickerPagination` — disjoint pages, case-insensitive substring search, spans-flat path also paginated/searchable.
  - New: `TestClickhouseFirstRouting` — CH path consumed when routed and non-empty; PG fallback on CH error.
- [ ] Local sanity hit against the EU API to confirm the prod project no longer offers `spans.87.timeline`.
- [ ] FE migration follows in next PR on this feature branch.

## Targets

This PR targets the feature branch `feat/eval-attrs-aligned-paged`. The FE migration (CustomColumnDialog server search, mapping autocompletes via `useInfiniteQuery`, run-insights tabs, etc.) lands as a second PR onto the same feature branch before merging the whole thing to `dev`.