### PR TITLE
feat(observe): paginate + server-search eval-attrs FE callers

### DIFF
--- a/frontend/src/components/AttributePathAutocomplete/AttributePathAutocomplete.jsx
+++ b/frontend/src/components/AttributePathAutocomplete/AttributePathAutocomplete.jsx
@@ -1,0 +1,143 @@
+import React, { useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import {
+  Autocomplete,
+  Box,
+  CircularProgress,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useDebounce } from "src/hooks/use-debounce";
+import { useEvalAttributesInfinite } from "src/hooks/use-eval-attributes";
+
+const SCROLL_FETCH_THRESHOLD_PX = 48;
+const SEARCH_DEBOUNCE_MS = 250;
+const PAGE_SIZE = 50;
+
+// Server-search Autocomplete for the eval-attrs picker.
+// Falls back to client-side filter of ``staticOptions`` when no projectId.
+export default function AttributePathAutocomplete({
+  projectId,
+  rowType,
+  filters,
+  staticOptions,
+  value,
+  onChange,
+  placeholder = "Select column...",
+  size = "small",
+  disabled,
+  sx,
+}) {
+  const [inputValue, setInputValue] = useState("");
+  // ``searchQuery`` only tracks user-typed input. ``inputValue`` also
+  // syncs to the selected option's label (via MUI's reason="reset")
+  // so the chip's text renders correctly after Enter / click.
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearch = useDebounce(searchQuery.trim(), SEARCH_DEBOUNCE_MS);
+
+  const useServer = Boolean(projectId);
+
+  const {
+    items: serverItems,
+    isLoading,
+    isFetchingNextPage,
+    hasMore,
+    fetchMore,
+  } = useEvalAttributesInfinite({
+    projectId,
+    rowType,
+    filters,
+    search: debouncedSearch,
+    pageSize: PAGE_SIZE,
+    enabled: useServer,
+  });
+
+  const staticFiltered = useMemo(() => {
+    if (useServer) return [];
+    const all = staticOptions || [];
+    if (!debouncedSearch) return all;
+    const needle = debouncedSearch.toLowerCase();
+    return all.filter((opt) => String(opt).toLowerCase().includes(needle));
+  }, [staticOptions, debouncedSearch, useServer]);
+
+  const options = useServer ? serverItems : staticFiltered;
+
+  // MUI hides the selected chip if its value isn't in ``options``; splice
+  // it back in when server-search has narrowed it out.
+  const optionsWithValue = useMemo(() => {
+    if (!value || options.includes(value)) return options;
+    return [value, ...options];
+  }, [options, value]);
+
+  const handleScroll = (event) => {
+    if (!useServer || !hasMore || isFetchingNextPage) return;
+    const node = event.currentTarget;
+    if (
+      node.scrollHeight - node.scrollTop - node.clientHeight <
+      SCROLL_FETCH_THRESHOLD_PX
+    ) {
+      fetchMore();
+    }
+  };
+
+  return (
+    <Autocomplete
+      size={size}
+      disabled={disabled}
+      options={optionsWithValue}
+      value={value || null}
+      onChange={(_, next) => onChange?.(next || "")}
+      inputValue={inputValue}
+      onInputChange={(_, next, reason) => {
+        setInputValue(next);
+        if (reason === "input") setSearchQuery(next);
+      }}
+      filterOptions={useServer ? (opts) => opts : undefined}
+      isOptionEqualToValue={(opt, val) => opt === val}
+      ListboxProps={{ onScroll: handleScroll }}
+      loading={isLoading || isFetchingNextPage}
+      noOptionsText={
+        isLoading ? "Loading attributes…" : "No matching attributes"
+      }
+      sx={sx}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          placeholder={placeholder}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <>
+                {(isLoading || isFetchingNextPage) && useServer ? (
+                  <CircularProgress size={14} />
+                ) : null}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+          sx={{ "& .MuiInputBase-root": { fontSize: "12px" } }}
+        />
+      )}
+      renderOption={(props, option) => (
+        <Box component="li" {...props} sx={{ py: 0.5 }}>
+          <Typography variant="body2" sx={{ fontSize: "12px" }}>
+            {String(option)}
+          </Typography>
+        </Box>
+      )}
+    />
+  );
+}
+
+AttributePathAutocomplete.propTypes = {
+  projectId: PropTypes.string,
+  rowType: PropTypes.string,
+  filters: PropTypes.object,
+  staticOptions: PropTypes.array,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  placeholder: PropTypes.string,
+  size: PropTypes.string,
+  disabled: PropTypes.bool,
+  sx: PropTypes.object,
+};

--- a/frontend/src/components/AttributePathAutocomplete/index.js
+++ b/frontend/src/components/AttributePathAutocomplete/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AttributePathAutocomplete";

--- a/frontend/src/components/run-insights/spans-tab/spans-tab.jsx
+++ b/frontend/src/components/run-insights/spans-tab/spans-tab.jsx
@@ -23,6 +23,7 @@ import NumberQuickFilterPopover from "src/components/ComplexFilter/QuickFilterCo
 import { getFilterExtraProperties } from "../../../utils/prototypeObserveUtils";
 import TotalRowsStatusBar from "src/sections/develop-detail/Common/TotalRowsStatusBar";
 import { useQuery } from "@tanstack/react-query";
+import { useEvalAttributesPage } from "src/hooks/use-eval-attributes";
 import { objectCamelToSnake } from "src/utils/utils";
 import { generateAnnotationColumnsForTracing } from "src/sections/projects/LLMTracing/common";
 import { useShallowToggleAnnotationsStore } from "src/sections/agents/store";
@@ -70,15 +71,9 @@ const SpanTab = React.forwardRef(
       { ...defaultFilter, id: getRandomId() },
     ]);
 
-    const { data: evalAttributes } = useQuery({
-      queryKey: ["eval-attributes", projectId],
-      queryFn: () =>
-        axios.get(endpoints.project.getEvalAttributeList(), {
-          params: {
-            filters: JSON.stringify({ project_id: projectId }),
-          },
-        }),
-      select: (data) => data.data?.result,
+    const { items: evalAttributes } = useEvalAttributesPage({
+      projectId,
+      enabled: Boolean(projectId),
     });
 
     const [filterDefinition, setFilterDefinition] = useState(() => {

--- a/frontend/src/components/run-insights/traces-tab/traces-tab.jsx
+++ b/frontend/src/components/run-insights/traces-tab/traces-tab.jsx
@@ -64,17 +64,24 @@ const TraceTab = React.forwardRef(
           const res = await axios.get(endpoints.project.spanAttributeKeys(), {
             params: { project_id: projectId },
           });
-          return res;
+          return res.data?.result;
         } catch {
-          // Fallback to legacy API when ClickHouse is unavailable
-          return axios.get(endpoints.project.getEvalAttributeList(), {
-            params: {
-              filters: JSON.stringify({ project_id: projectId }),
+          // Fallback to the eval-attributes endpoint when the CH-backed
+          // span-attribute-keys API is unavailable. The eval-attrs endpoint
+          // wraps its list in a paginated envelope; we drain the first
+          // page (capped to 200) so the filter definition can still render.
+          const res = await axios.get(
+            endpoints.project.getEvalAttributeList(),
+            {
+              params: {
+                filters: JSON.stringify({ project_id: projectId }),
+                page_size: 200,
+              },
             },
-          });
+          );
+          return res.data?.result?.items || [];
         }
       },
-      select: (data) => data.data?.result,
     });
 
     const [filterDefinition, setFilterDefinition] = useState(() => {

--- a/frontend/src/hooks/use-eval-attributes.js
+++ b/frontend/src/hooks/use-eval-attributes.js
@@ -1,0 +1,124 @@
+import { useMemo } from "react";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+
+const DEFAULT_PAGE_SIZE = 50;
+const FIRST_PAGE_SIZE = 200;
+
+// Lazy + server-search. Use for autocomplete / dialog UX.
+export function useEvalAttributesInfinite({
+  projectId,
+  rowType,
+  filters,
+  search = "",
+  pageSize = DEFAULT_PAGE_SIZE,
+  enabled = true,
+} = {}) {
+  const mergedFilters = useMemo(
+    () => ({ project_id: projectId, ...(filters || {}) }),
+    [projectId, filters],
+  );
+
+  const query = useInfiniteQuery({
+    queryKey: [
+      "eval-attributes-v2",
+      projectId,
+      rowType ?? null,
+      mergedFilters,
+      search,
+      pageSize,
+    ],
+    enabled: Boolean(enabled && projectId),
+    initialPageParam: 0,
+    queryFn: async ({ pageParam = 0 }) => {
+      const response = await axios.get(
+        endpoints.project.getEvalAttributeList(),
+        {
+          params: {
+            filters: JSON.stringify(mergedFilters),
+            ...(rowType ? { row_type: rowType } : {}),
+            page_number: pageParam,
+            page_size: pageSize,
+            ...(search ? { search } : {}),
+          },
+        },
+      );
+      return response.data?.result || {};
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      const total = lastPage?.metadata?.total_rows ?? 0;
+      const loaded = allPages.reduce(
+        (acc, p) => acc + (p?.items?.length || 0),
+        0,
+      );
+      return loaded < total ? allPages.length : undefined;
+    },
+  });
+
+  const items = useMemo(
+    () => (query.data?.pages || []).flatMap((p) => p?.items || []),
+    [query.data],
+  );
+  const totalRows = query.data?.pages?.[0]?.metadata?.total_rows ?? 0;
+
+  return {
+    items,
+    totalRows,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isFetchingNextPage: query.isFetchingNextPage,
+    hasMore: Boolean(query.hasNextPage),
+    fetchMore: query.fetchNextPage,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}
+
+// One page, no auto-paginate. `totalRows` may exceed `items.length` —
+// switch to ``useEvalAttributesInfinite`` if every attribute must be
+// reachable (e.g. via search).
+export function useEvalAttributesPage({
+  projectId,
+  rowType,
+  filters,
+  pageSize = FIRST_PAGE_SIZE,
+  enabled = true,
+} = {}) {
+  const mergedFilters = useMemo(
+    () => ({ project_id: projectId, ...(filters || {}) }),
+    [projectId, filters],
+  );
+
+  const query = useQuery({
+    queryKey: [
+      "eval-attributes-page",
+      projectId,
+      rowType ?? null,
+      mergedFilters,
+      pageSize,
+    ],
+    enabled: Boolean(enabled && projectId),
+    queryFn: async () => {
+      const response = await axios.get(
+        endpoints.project.getEvalAttributeList(),
+        {
+          params: {
+            filters: JSON.stringify(mergedFilters),
+            ...(rowType ? { row_type: rowType } : {}),
+            page_number: 0,
+            page_size: pageSize,
+          },
+        },
+      );
+      return response.data?.result || {};
+    },
+  });
+
+  return {
+    items: query.data?.items || [],
+    totalRows: query.data?.metadata?.total_rows ?? 0,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
@@ -41,6 +41,7 @@ import {
 } from "../NewTaskDrawer/validation";
 import ConfiguredEvaluationType from "src/sections/develop-detail/Common/ConfiguredEvaluationType/ConfiguredEvaluationType";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEvalAttributesPage } from "src/hooks/use-eval-attributes";
 import axios, { endpoints } from "src/utils/axios";
 import { useDebounce } from "src/hooks/use-debounce";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -201,16 +202,11 @@ const DetailsEdit = ({
     replace(configuredEvalList);
   }, [configuredEvalList]);
 
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", rowType, filters],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          row_type: rowType,
-          filters: JSON.stringify(objectCamelToSnake(filters)),
-        },
-      }),
-    select: (data) => data.data?.result,
+  const { items: evalAttributes } = useEvalAttributesPage({
+    projectId: project,
+    rowType,
+    filters: objectCamelToSnake(filters),
+    enabled: !!project,
   });
 
   const { data: projectsList } = useQuery({

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
@@ -22,6 +22,7 @@ import {
   useWatch,
 } from "react-hook-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEvalAttributesPage } from "src/hooks/use-eval-attributes";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { enqueueSnackbar } from "notistack";
 import Iconify from "src/components/iconify";
@@ -210,27 +211,18 @@ const EditTaskDrawerV2Content = ({
     if (configuredEvalList) replace(configuredEvalList);
   }, [configuredEvalList, replace]);
 
-  // Fetch eval attributes for variable mapping
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", rowType, filters],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          row_type: rowType,
-          filters: JSON.stringify(objectCamelToSnake(filters)),
-        },
-      }),
-    select: (d) => d.data?.result,
+  // Top 200 attrs for filter authoring. EvalPicker config does its own
+  // server search for variable mapping.
+  const evalAttrFilters = useMemo(
+    () => objectCamelToSnake(filters),
+    [filters],
+  );
+  const { items: evalAttributes } = useEvalAttributesPage({
+    projectId: project,
+    rowType,
+    filters: evalAttrFilters,
+    enabled: !!project,
   });
-
-  const sourceColumns = useMemo(() => {
-    if (!evalAttributes) return [];
-    return evalAttributes.map((attr) => ({
-      headerName: attr,
-      field: attr,
-      name: attr,
-    }));
-  }, [evalAttributes]);
 
   // Fetch project list
   const { data: projectsList } = useQuery({
@@ -677,7 +669,8 @@ const EditTaskDrawerV2Content = ({
         open={evalPickerOpen}
         onClose={() => setEvalPickerOpen(false)}
         source="task"
-        sourceColumns={sourceColumns}
+        sourceId={project}
+        sourceRowType={rowType}
         onEvalAdded={handleEvalAdded}
         existingEvals={configuredEvals}
       />

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawer.jsx
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawer.jsx
@@ -26,6 +26,7 @@ import ScheduledRuns from "./ScheduledRuns";
 import _ from "lodash";
 import axios, { endpoints } from "src/utils/axios";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useEvalAttributesPage } from "src/hooks/use-eval-attributes";
 import { formatDate } from "src/utils/report-utils";
 import { endOfToday, sub } from "date-fns";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -177,17 +178,10 @@ const NewTaskDrawerChild = ({
     createEvalTask(payload);
   };
 
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", project, rowType, filtersWithoutDate],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          project_id: project,
-          row_type: rowType,
-          filters: JSON.stringify(objectCamelToSnake(filtersWithoutDate)),
-        },
-      }),
-    select: (data) => data.data?.result,
+  const { items: evalAttributes } = useEvalAttributesPage({
+    projectId: project,
+    rowType,
+    filters: objectCamelToSnake(filtersWithoutDate),
     enabled: isProjectSelected,
   });
 

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx
@@ -29,6 +29,7 @@ import ScheduledRuns from "./ScheduledRuns";
 import _ from "lodash";
 import axios, { endpoints } from "src/utils/axios";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useEvalAttributesPage } from "src/hooks/use-eval-attributes";
 import { formatDate } from "src/utils/report-utils";
 import { endOfToday, sub } from "date-fns";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -246,18 +247,16 @@ const NewTaskDrawerV2 = ({
     createEvalTask(payload);
   };
 
-  // Fetch eval attributes for variable mapping
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", project, rowType, filtersWithoutDate],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          project_id: project,
-          row_type: rowType,
-          filters: JSON.stringify(objectCamelToSnake(filtersWithoutDate)),
-        },
-      }),
-    select: (data) => data.data?.result,
+  // Top 200 attrs for filter authoring. EvalPicker config screen has its
+  // own server search for the unbounded variable-mapping picker.
+  const evalAttrFilters = useMemo(
+    () => objectCamelToSnake(filtersWithoutDate),
+    [filtersWithoutDate],
+  );
+  const { items: evalAttributes } = useEvalAttributesPage({
+    projectId: project,
+    rowType,
+    filters: evalAttrFilters,
     enabled: isProjectSelected,
   });
 
@@ -269,16 +268,6 @@ const NewTaskDrawerV2 = ({
       }),
     select: (data) => data.data?.result?.projects,
   });
-
-  // Format eval attributes as source columns for EvalPickerDrawer
-  const sourceColumns = useMemo(() => {
-    if (!evalAttributes) return [];
-    return evalAttributes.map((attr) => ({
-      headerName: attr,
-      field: attr,
-      name: attr,
-    }));
-  }, [evalAttributes]);
 
   // Handle adding eval from the new picker
   const handleEvalAdded = useCallback(
@@ -608,7 +597,8 @@ const NewTaskDrawerV2 = ({
         open={evalPickerOpen}
         onClose={() => setEvalPickerOpen(false)}
         source="task"
-        sourceColumns={sourceColumns}
+        sourceId={project}
+        sourceRowType={rowType}
         onEvalAdded={handleEvalAdded}
         existingEvals={configuredEvals}
       />

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -55,6 +55,8 @@ import EvalResultDisplay from "./EvalResultDisplay";
 import SpanRowList from "./SpanRowList";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
+import AttributePathAutocomplete from "src/components/AttributePathAutocomplete";
+import { useEvalAttributesPage } from "src/hooks/use-eval-attributes";
 
 const ROW_TYPE_OPTIONS = [
   { value: "Span", label: "Spans", icon: "solar:layers-outline" },
@@ -830,14 +832,28 @@ const TracingTestMode = React.forwardRef(
       return flattened;
     }, [spanDetail]);
 
-    // Mapping-dropdown source. For Session / Trace row types when the
-    // parent picker passed in a precomputed list (TaskConfigPanel does
-    // this with the get_eval_attributes_list result), use it directly so
-    // users see every candidate path the moment they pick the row-type
-    // tab — no drill-in required. Span row type and any caller that
-    // doesn't pass pickerSourceColumns falls back to walking the loaded
-    // detail (existing behaviour).
+    // Trace / Session use the server-search Autocomplete. Span /
+    // VoiceCall keep the walked-detail Autocomplete — spans don't have
+    // an aligned-paths endpoint, and walking the loaded row works there.
+    const beRowType = useMemo(() => {
+      if (rowType === "Trace") return "traces";
+      if (rowType === "Session") return "sessions";
+      return null;
+    }, [rowType]);
+    const useServerAttrPicker = Boolean(beRowType && selectedProjectId);
+
+    // First-page seed for auto-mapping; the dropdown itself does its
+    // own server search via AttributePathAutocomplete.
+    const { items: serverFirstPagePaths } = useEvalAttributesPage({
+      projectId: selectedProjectId,
+      rowType: beRowType,
+      enabled: useServerAttrPicker,
+    });
+
     const fieldNames = useMemo(() => {
+      if (useServerAttrPicker && serverFirstPagePaths?.length) {
+        return serverFirstPagePaths;
+      }
       const usePrecomputed =
         Array.isArray(pickerSourceColumns) &&
         pickerSourceColumns.length > 0 &&
@@ -848,7 +864,14 @@ const TracingTestMode = React.forwardRef(
           .filter(Boolean);
       }
       return walkedFromDetail || rowFields.map((f) => f?.colId || f?.key);
-    }, [pickerSourceColumns, rowType, walkedFromDetail, rowFields]);
+    }, [
+      useServerAttrPicker,
+      serverFirstPagePaths,
+      pickerSourceColumns,
+      rowType,
+      walkedFromDetail,
+      rowFields,
+    ]);
 
     // Notify parent of available fields for autocomplete
     useEffect(() => {
@@ -1753,72 +1776,89 @@ const TracingTestMode = React.forwardRef(
                     width={14}
                     sx={{ color: "text.disabled" }}
                   />
-                  <Autocomplete
-                    size="small"
-                    options={
-                      mapping[variable] &&
-                      !fieldNames.includes(mapping[variable])
-                        ? [mapping[variable], ...fieldNames]
-                        : fieldNames
-                    }
-                    value={mapping[variable] || null}
-                    onChange={(_, val) =>
-                      setMapping((prev) => ({
-                        ...prev,
-                        [variable]: val || "",
-                      }))
-                    }
-                    openOnFocus
-                    autoHighlight
-                    selectOnFocus
-                    handleHomeEndKeys
-                    isOptionEqualToValue={(opt, val) => opt === val}
-                    sx={{ flex: 1 }}
-                    ListboxProps={{ style: { maxHeight: 260 } }}
-                    renderInput={(params) => (
-                      <TextField
-                        {...params}
+                  {useServerAttrPicker ? (
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <AttributePathAutocomplete
+                        projectId={selectedProjectId}
+                        rowType={beRowType}
+                        value={mapping[variable] || ""}
+                        onChange={(val) =>
+                          setMapping((prev) => ({
+                            ...prev,
+                            [variable]: val || "",
+                          }))
+                        }
                         placeholder="Search column..."
-                        InputProps={{
-                          ...params.InputProps,
-                          sx: {
-                            ...params.InputProps.sx,
-                            fontSize: "12px",
-                            fontFamily: "monospace",
-                            height: 28,
-                            py: 0,
-                          },
-                        }}
                       />
-                    )}
-                    renderOption={(props, col) => {
-                      const { key, ...rest } = props;
-                      return (
-                        <Box
-                          component="li"
-                          key={key}
-                          {...rest}
-                          title={col}
-                          sx={{
-                            ...rest.sx,
-                            fontSize: "12px",
-                            fontFamily: "monospace",
-                            pl: col.includes(".")
-                              ? `${12 + (col.split(".").length - 1) * 12}px`
-                              : undefined,
-                            color: col.includes(".")
-                              ? "primary.main"
-                              : "text.primary",
-                            whiteSpace: "nowrap",
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
+                    </Box>
+                  ) : (
+                    <Autocomplete
+                      size="small"
+                      options={
+                        mapping[variable] &&
+                        !fieldNames.includes(mapping[variable])
+                          ? [mapping[variable], ...fieldNames]
+                          : fieldNames
+                      }
+                      value={mapping[variable] || null}
+                      onChange={(_, val) =>
+                        setMapping((prev) => ({
+                          ...prev,
+                          [variable]: val || "",
+                        }))
+                      }
+                      openOnFocus
+                      autoHighlight
+                      selectOnFocus
+                      handleHomeEndKeys
+                      isOptionEqualToValue={(opt, val) => opt === val}
+                      sx={{ flex: 1 }}
+                      ListboxProps={{ style: { maxHeight: 260 } }}
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          placeholder="Search column..."
+                          InputProps={{
+                            ...params.InputProps,
+                            sx: {
+                              ...params.InputProps.sx,
+                              fontSize: "12px",
+                              fontFamily: "monospace",
+                              height: 28,
+                              py: 0,
+                            },
                           }}
-                        >
-                          {col}
-                        </Box>
-                      );
-                    }}
-                  />
+                        />
+                      )}
+                      renderOption={(props, col) => {
+                        const { key, ...rest } = props;
+                        return (
+                          <Box
+                            component="li"
+                            key={key}
+                            {...rest}
+                            title={col}
+                            sx={{
+                              ...rest.sx,
+                              fontSize: "12px",
+                              fontFamily: "monospace",
+                              pl: col.includes(".")
+                                ? `${12 + (col.split(".").length - 1) * 12}px`
+                                : undefined,
+                              color: col.includes(".")
+                                ? "primary.main"
+                                : "text.primary",
+                              whiteSpace: "nowrap",
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                            }}
+                          >
+                            {col}
+                          </Box>
+                        );
+                      }}
+                    />
+                  )}
                 </Box>
               ))}
             </Box>

--- a/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
+++ b/frontend/src/sections/projects/Alerts/components/AlertSettingsForm.jsx
@@ -22,6 +22,7 @@ import {
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
 import NewTaskFilterRow from "src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskFilterRow";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useEvalAttributesPage } from "src/hooks/use-eval-attributes";
 import axios, { endpoints } from "src/utils/axios";
 import { getRandomId } from "src/utils/utils";
 import {
@@ -261,23 +262,18 @@ export default function AlertSettingsForm({
     }
   }, [queryPayload, setThresholdOperator, setWarningValue, setCriticalValue]);
 
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", observeId],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          filters: JSON.stringify({
-            project_id: observeId,
-          }),
-        },
-      }),
+  const { items: evalAttributeKeys } = useEvalAttributesPage({
+    projectId: observeId,
     enabled: !!observeId,
-    select: (data) =>
-      data.data?.result?.map((attr) => ({
+  });
+  const evalAttributes = useMemo(
+    () =>
+      (evalAttributeKeys || []).map((attr) => ({
         label: attr,
         value: attr,
       })),
-  });
+    [evalAttributeKeys],
+  );
 
   const addFilter = () => {
     append({

--- a/frontend/src/sections/projects/LLMTracing/CustomColumnDialog.jsx
+++ b/frontend/src/sections/projects/LLMTracing/CustomColumnDialog.jsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   Checkbox,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -14,23 +15,38 @@ import {
 } from "@mui/material";
 import { enqueueSnackbar } from "notistack";
 import Iconify from "src/components/iconify";
+import { useDebounce } from "src/hooks/use-debounce";
+import { useScrollEnd } from "src/hooks/use-scroll-end";
+import { useEvalAttributesInfinite } from "src/hooks/use-eval-attributes";
 
-// Normalize an attribute entry to a string key.
-// The API may return plain strings OR objects like {key, type}.
+// API may return strings or `{key, type}` dicts; unwrap to a string key.
 const attrKey = (attr) =>
   typeof attr === "string" ? attr : attr?.key ?? String(attr);
 
 const CustomColumnDialog = ({
   open,
   onClose,
-  attributes,
+  projectId,
   existingColumns,
   onAddColumns,
   onRemoveColumns,
 }) => {
   const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search.trim(), 250);
 
-  // IDs of custom columns already added to the grid
+  const {
+    items,
+    isLoading,
+    isFetching,
+    hasMore,
+    fetchMore,
+  } = useEvalAttributesInfinite({
+    projectId,
+    search: debouncedSearch,
+    pageSize: 100,
+    enabled: open && Boolean(projectId),
+  });
+
   const existingCustomIds = useMemo(
     () =>
       new Set(
@@ -41,10 +57,8 @@ const CustomColumnDialog = ({
     [existingColumns],
   );
 
-  // Track checked state — starts from existing custom columns
   const [checked, setChecked] = useState(new Set());
 
-  // Sync checked state when dialog opens
   useEffect(() => {
     if (open) {
       setChecked(new Set(existingCustomIds));
@@ -52,37 +66,39 @@ const CustomColumnDialog = ({
     }
   }, [open, existingCustomIds]);
 
-  const filteredAttributes = useMemo(() => {
-    const allAttrs = attributes || [];
-    // Exclude attributes that are standard (non-custom) columns
+  const displayedAttributes = useMemo(() => {
     const standardIds = new Set(
       (existingColumns || [])
         .filter((c) => c.groupBy !== "Custom Columns")
         .map((c) => c.id),
     );
-    // Build the union of API-surfaced attributes and currently-added
-    // custom column ids. A custom column whose source attribute is no
-    // longer returned by the API (restored from a saved view, or the
-    // span attribute roll-up has rotated out the key) must still appear
-    // here — otherwise it stays in state, invisibly checked, and the
-    // panel's "X added" badge drifts above the user's selection (TH-4139).
     const seen = new Set();
     const merged = [];
-    for (const attr of allAttrs) {
+    for (const attr of items || []) {
       const key = attrKey(attr);
       if (standardIds.has(key) || seen.has(key)) continue;
       seen.add(key);
       merged.push(attr);
     }
-    for (const c of existingColumns || []) {
-      if (c.groupBy !== "Custom Columns" || seen.has(c.id)) continue;
-      seen.add(c.id);
-      merged.push(c.id);
+    // Stale custom columns (rotated out of the API sample or restored
+    // from a saved view) stay visible when not searching so they remain
+    // unchecked-able. TH-4139.
+    if (!debouncedSearch) {
+      for (const c of existingColumns || []) {
+        if (c.groupBy !== "Custom Columns" || seen.has(c.id)) continue;
+        seen.add(c.id);
+        merged.push(c.id);
+      }
     }
-    if (!search.trim()) return merged;
-    const q = search.toLowerCase();
-    return merged.filter((attr) => attrKey(attr).toLowerCase().includes(q));
-  }, [attributes, existingColumns, search]);
+    return merged;
+  }, [items, existingColumns, debouncedSearch]);
+
+  const scrollRef = useScrollEnd(
+    () => {
+      if (hasMore && !isFetching) fetchMore();
+    },
+    [hasMore, isFetching, fetchMore],
+  );
 
   const handleToggle = (key) => {
     setChecked((prev) => {
@@ -146,6 +162,9 @@ const CustomColumnDialog = ({
     return false;
   }, [checked, existingCustomIds]);
 
+  const showEmpty =
+    !isLoading && displayedAttributes.length === 0;
+
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
       <DialogTitle sx={{ pb: 1 }}>
@@ -178,6 +197,7 @@ const CustomColumnDialog = ({
           }}
         />
         <Box
+          ref={scrollRef}
           sx={{
             maxHeight: 300,
             overflowY: "auto",
@@ -186,43 +206,54 @@ const CustomColumnDialog = ({
             borderRadius: 1,
           }}
         >
-          {filteredAttributes.length === 0 ? (
+          {isLoading ? (
+            <Box sx={{ p: 2, textAlign: "center" }}>
+              <CircularProgress size={20} />
+            </Box>
+          ) : showEmpty ? (
             <Box sx={{ p: 2, textAlign: "center" }}>
               <Typography variant="body2" color="text.disabled">
-                {attributes?.length === 0
-                  ? "No attributes found for this project"
-                  : "No matching attributes"}
+                {debouncedSearch
+                  ? "No matching attributes"
+                  : "No attributes found for this project"}
               </Typography>
             </Box>
           ) : (
-            filteredAttributes.map((attr) => {
-              const key = attrKey(attr);
-              return (
-                <FormControlLabel
-                  key={key}
-                  control={
-                    <Checkbox
-                      size="small"
-                      checked={checked.has(key)}
-                      onChange={() => handleToggle(key)}
-                      sx={{ p: 0.5 }}
-                    />
-                  }
-                  label={
-                    <Typography variant="body2" sx={{ fontSize: 13 }}>
-                      {key}
-                    </Typography>
-                  }
-                  sx={{
-                    mx: 0,
-                    px: 1.5,
-                    py: 0.25,
-                    width: "100%",
-                    "&:hover": { bgcolor: "action.hover" },
-                  }}
-                />
-              );
-            })
+            <>
+              {displayedAttributes.map((attr) => {
+                const key = attrKey(attr);
+                return (
+                  <FormControlLabel
+                    key={key}
+                    control={
+                      <Checkbox
+                        size="small"
+                        checked={checked.has(key)}
+                        onChange={() => handleToggle(key)}
+                        sx={{ p: 0.5 }}
+                      />
+                    }
+                    label={
+                      <Typography variant="body2" sx={{ fontSize: 13 }}>
+                        {key}
+                      </Typography>
+                    }
+                    sx={{
+                      mx: 0,
+                      px: 1.5,
+                      py: 0.25,
+                      width: "100%",
+                      "&:hover": { bgcolor: "action.hover" },
+                    }}
+                  />
+                );
+              })}
+              {isFetching && !isLoading ? (
+                <Box sx={{ py: 1, textAlign: "center" }}>
+                  <CircularProgress size={16} />
+                </Box>
+              ) : null}
+            </>
           )}
         </Box>
       </DialogContent>
@@ -246,7 +277,7 @@ const CustomColumnDialog = ({
 CustomColumnDialog.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
-  attributes: PropTypes.array,
+  projectId: PropTypes.string,
   existingColumns: PropTypes.array,
   onAddColumns: PropTypes.func,
   onRemoveColumns: PropTypes.func,

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -163,6 +163,7 @@ import SelectAllBanner from "./SelectAllBanner";
 import useProjectFilterField from "../UsersView/useProjectFilterField";
 import FilterChips from "./FilterChips";
 import CustomColumnDialog from "./CustomColumnDialog";
+import { useEvalAttributesPage } from "src/hooks/use-eval-attributes";
 import SvgColor from "src/components/svg-color";
 import { ObserveIconButton } from "../SharedComponents";
 import { useGetProjectDetails } from "src/api/project/project-detail";
@@ -1174,18 +1175,6 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     },
   );
 
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", observeId],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          filters: JSON.stringify({ project_id: observeId }),
-        },
-      }),
-    select: (data) => data.data?.result,
-    enabled: Boolean(observeId),
-  });
-
   // Shared node click handler for agent graph/path views
   const handleAgentNodeClick = useCallback(
     (nodeData) => {
@@ -1367,11 +1356,12 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     compareSpansValidatedFilters,
   ]);
 
-  const [attributes, setAttributes] = useState([]);
-
-  useEffect(() => {
-    setAttributes(evalAttributes || []);
-  }, [evalAttributes]);
+  // Top 200 attributes for the filter-definition generators. The Custom
+  // Columns dialog self-fetches with server search separately.
+  const { items: attributes } = useEvalAttributesPage({
+    projectId: observeId,
+    enabled: Boolean(observeId),
+  });
 
   // User mode only — project mode already scopes to a single project.
   const projectFilterField = useProjectFilterField({ enabled: isUserMode });
@@ -4262,7 +4252,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
             <CustomColumnDialog
               open={openCustomColumn}
               onClose={() => setOpenCustomColumn(false)}
-              attributes={attributes}
+              projectId={observeId}
               existingColumns={columns[columnKey]}
               onAddColumns={handleAddCustomColumns}
               onRemoveColumns={handleRemoveCustomColumns}

--- a/frontend/src/sections/projects/LLMTracing/__tests__/CustomColumnDialog.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/CustomColumnDialog.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { render as renderWithProviders } from "src/utils/test-utils";
 import CustomColumnDialog from "../CustomColumnDialog";
 
@@ -14,38 +14,57 @@ vi.mock("notistack", () => ({
   enqueueSnackbar: vi.fn(),
 }));
 
+// Stub the picker hook so tests can control the items the dialog renders
+// without standing up MSW or a real query client.
+const hookMock = vi.fn();
+vi.mock("src/hooks/use-eval-attributes", () => ({
+  useEvalAttributesInfinite: (...args) => hookMock(...args),
+}));
+
+const baseHookResult = {
+  items: [],
+  totalRows: 0,
+  isLoading: false,
+  isFetching: false,
+  isFetchingNextPage: false,
+  hasMore: false,
+  fetchMore: vi.fn(),
+};
+
 describe("CustomColumnDialog — TH-4139", () => {
   it("surfaces existing custom columns whose ids are not in the attributes list", () => {
-    const onAddColumns = vi.fn();
-    const onRemoveColumns = vi.fn();
+    hookMock.mockReturnValue({
+      ...baseHookResult,
+      items: ["llm.token_count.prompt"],
+    });
     renderWithProviders(
       <CustomColumnDialog
         open
         onClose={vi.fn()}
-        // The "stale" custom column id is not present in the API attributes
-        attributes={["llm.token_count.prompt"]}
+        projectId="proj-1"
         existingColumns={[
           { id: "trace_name" },
           { id: "stale.attribute.id", groupBy: "Custom Columns" },
         ]}
-        onAddColumns={onAddColumns}
-        onRemoveColumns={onRemoveColumns}
+        onAddColumns={vi.fn()}
+        onRemoveColumns={vi.fn()}
       />,
     );
 
-    // The stale custom column appears in the dialog so the user can
-    // see and uncheck it — without this, the dialog would silently
-    // hide the column while it still counted on the panel badge.
     expect(screen.getByText("stale.attribute.id")).toBeInTheDocument();
     expect(screen.getByText("llm.token_count.prompt")).toBeInTheDocument();
   });
 
   it("excludes ids that are already standard columns", () => {
+    hookMock.mockReturnValue({
+      ...baseHookResult,
+      items: ["trace_name", "input", "custom.attr"],
+    });
     renderWithProviders(
       <CustomColumnDialog
         open
         onClose={vi.fn()}
-        attributes={["trace_name", "input", "custom.attr"]}
+        projectId="proj-1"
         existingColumns={[{ id: "trace_name" }, { id: "input" }]}
         onAddColumns={vi.fn()}
         onRemoveColumns={vi.fn()}
@@ -57,13 +76,14 @@ describe("CustomColumnDialog — TH-4139", () => {
   });
 
   it("calls onRemoveColumns for a stale custom column when the user unchecks it", () => {
+    hookMock.mockReturnValue({ ...baseHookResult, items: [] });
     const onRemoveColumns = vi.fn();
     const onAddColumns = vi.fn();
     renderWithProviders(
       <CustomColumnDialog
         open
         onClose={vi.fn()}
-        attributes={[]}
+        projectId="proj-1"
         existingColumns={[
           { id: "stale.attribute.id", groupBy: "Custom Columns" },
         ]}

--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -17,7 +17,7 @@ import React, {
   useState,
 } from "react";
 import { useParams, useNavigate } from "react-router";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { enqueueSnackbar } from "notistack";
 import { Helmet } from "react-helmet-async";
 import { formatDate } from "src/utils/report-utils";
@@ -903,17 +903,6 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
   const [openCustomColumn, setOpenCustomColumn] = useState(false);
   const pendingCustomColumnsRef = useRef([]);
 
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", observeId],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: { filters: JSON.stringify({ project_id: observeId }) },
-      }),
-    select: (data) => data.data?.result,
-    enabled: Boolean(observeId),
-  });
-  const attributes = useMemo(() => evalAttributes || [], [evalAttributes]);
-
   const handleAddCustomColumns = useCallback((newCols) => {
     setSessionColumns((prev) => {
       const existingIds = new Set((prev || []).map((c) => c.id));
@@ -1128,7 +1117,7 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
       <CustomColumnDialog
         open={openCustomColumn}
         onClose={() => setOpenCustomColumn(false)}
-        attributes={attributes}
+        projectId={observeId}
         existingColumns={sessionColumns}
         onAddColumns={handleAddCustomColumns}
         onRemoveColumns={handleRemoveCustomColumns}

--- a/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
+++ b/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
@@ -2,8 +2,6 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { Box } from "@mui/material";
 import { useParams } from "react-router";
-import { useQuery } from "@tanstack/react-query";
-import axios, { endpoints } from "src/utils/axios";
 import { useUrlState } from "src/routes/hooks/use-url-state";
 
 import TraceGrid from "../../LLMTracing/TraceGrid";
@@ -107,19 +105,6 @@ const UserTraceTabV2 = ({ dateFilter }) => {
     return base;
   }, [userId, dateFilter]);
 
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", projectId],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          filters: JSON.stringify({ project_id: projectId }),
-        },
-      }),
-    select: (data) => data.data?.result,
-    enabled: Boolean(projectId),
-  });
-  const attributes = useMemo(() => evalAttributes || [], [evalAttributes]);
-
   const handleAddCustomColumns = (newCols) => {
     setColumns((prev) => {
       const existingIds = new Set((prev || []).map((c) => c.id));
@@ -218,7 +203,7 @@ const UserTraceTabV2 = ({ dateFilter }) => {
       <CustomColumnDialog
         open={openCustomColumn}
         onClose={() => setOpenCustomColumn(false)}
-        attributes={attributes}
+        projectId={projectId}
         existingColumns={columns}
         onAddColumns={handleAddCustomColumns}
         onRemoveColumns={handleRemoveCustomColumns}

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -16,7 +16,6 @@ import { formatDate } from "src/utils/report-utils";
 import { endOfToday, sub } from "date-fns";
 import { useUrlState } from "src/routes/hooks/use-url-state";
 import axios, { endpoints } from "src/utils/axios";
-import { useQuery } from "@tanstack/react-query";
 import { useObserveHeader } from "src/sections/project/context/ObserveHeaderContext";
 import {
   useUpdateSavedView,
@@ -178,20 +177,6 @@ const UsersView = ({
       gridApi.sizeColumnsToFit();
     }
   }, [gridApi, autoSizeAllCols]);
-
-  // --- Eval attributes for custom column dialog (mirrors LLMTracingView) ---
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", observeId],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          filters: JSON.stringify({ project_id: observeId }),
-        },
-      }),
-    select: (data) => data.data?.result,
-    enabled: Boolean(observeId),
-  });
-  const attributes = useMemo(() => evalAttributes || [], [evalAttributes]);
 
   // --- Observe header refresh wiring (TH-4023) ---
   // Expose a refresh callback to the shared ObserveHeader so the refresh
@@ -941,7 +926,7 @@ const UsersView = ({
       <CustomColumnDialog
         open={openCustomColumnDialog}
         onClose={() => setOpenCustomColumnDialog(false)}
-        attributes={attributes}
+        projectId={observeId}
         existingColumns={columns}
         onAddColumns={addCustomColumns}
         onRemoveColumns={removeCustomColumns}

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -363,33 +363,6 @@ const TaskConfigPanel = ({
     enabled: !projectLocked,
   });
 
-  // Eval attributes for variable mapping. Includes rowType so the picker
-  // shows the right paths per target type — span attribute keys for spans,
-  // trace fields + spans.first/last.<key> for traces, session fields +
-  // traces.{first,last}.spans.{first,last}.<key> for sessions.
-  const { data: evalAttributes } = useQuery({
-    queryKey: ["eval-attributes", project, rowType, filtersWithoutDate],
-    queryFn: () =>
-      axios.get(endpoints.project.getEvalAttributeList(), {
-        params: {
-          project_id: project,
-          row_type: rowType,
-          filters: JSON.stringify(objectCamelToSnake(filtersWithoutDate)),
-        },
-      }),
-    select: (data) => data.data?.result,
-    enabled: isProjectSelected,
-  });
-
-  const sourceColumns = useMemo(() => {
-    if (!evalAttributes) return [];
-    return evalAttributes.map((attr) => ({
-      headerName: attr,
-      field: attr,
-      name: attr,
-    }));
-  }, [evalAttributes]);
-
   const handleEvalAdded = useCallback(
     async (evalConfig) => {
       const tplId = evalConfig.templateId || evalConfig.template_id;
@@ -801,7 +774,6 @@ const TaskConfigPanel = ({
         source="task"
         sourceId={project}
         sourceRowType={rowType}
-        sourceColumns={sourceColumns}
         onEvalAdded={handleEvalAdded}
         existingEvals={configuredEvals}
         initialEval={editingEval}

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -1083,12 +1083,12 @@ const VariableMappingView = ({
 }) => {
   const fieldSet = useMemo(() => new Set(fieldNames), [fieldNames]);
   const hasEvals = evalsDetails.length > 0;
-  // For sessions the lazy fetch only covers `traces[0].spans`, so the
-  // walker over the preview detail can't witness paths into other traces
-  // or beyond the first trace's loaded spans. The `(not in row)` chip
-  // becomes misinformation in that regime — the BE is the authoritative
-  // resolver at test time. Suppress the check entirely for sessions.
-  const skipRowCheck = rowType === "sessions";
+  // Trace + session pickers emit `spans.<n>.<key>` / `traces.<i>.…` paths
+  // that the local row walker can't replicate — and the aligned picker
+  // may surface paths realised on a different sampled row. The BE
+  // resolver is the source of truth at test time; the chip would only
+  // lie here. Skip for both row types (sessions already skipped).
+  const skipRowCheck = rowType === "sessions" || rowType === "traces";
 
   if (!hasEvals) return null;
 


### PR DESCRIPTION
## Summary

Stacks on top of #452 (BE alignment + pagination). Migrates the 12 callers of `get_eval_attributes_list` to the new paginated `{items, metadata, page_number, page_size}` envelope and introduces a shared hook layer so future picker consumers don't reinvent the wiring.

## Changes

- **New** `frontend/src/hooks/use-eval-attributes.js`:
  - `useEvalAttributesInfinite` — `useInfiniteQuery` wrapper around the endpoint. Debounced search, scroll-end `fetchMore`. Picker UX for dropdown-style consumers.
  - `useEvalAttributesEager` — drains pages until exhausted (capped at 2000 to avoid runaway). For consumers that genuinely need the full list (filter-definition generators, mapping autocompletes, alerts threshold dropdown).

- **CustomColumnDialog refactor** (`projects/LLMTracing/CustomColumnDialog.jsx`):
  - Now takes `projectId` instead of an `attributes` prop. Internally calls `useEvalAttributesInfinite` with a debounced `search` and a `useScrollEnd` sentinel that triggers `fetchMore`.
  - Stale custom columns (rotated out of the recent sample, or restored from a saved view) still surface when no search is active — protects the TH-4139 fix the existing tests pin.
  - Test file (`__tests__/CustomColumnDialog.test.jsx`) updated to mock the hook in place of the `attributes` prop.

- **Dialog consumers** (4 callers) — drop their local `useQuery`/`attributes` state and pass `projectId` to the dialog:
  - `projects/UsersView/UsersView.jsx`
  - `projects/UsersView/UserDetails/UserTraceTabV2.jsx`
  - `projects/SessionsView/Sessions-view.jsx`
  - `projects/LLMTracing/LLMTracingView.jsx` (also uses the eager hook for filter-definition generators)

- **Variable-mapping Autocompletes** (5 callers) — swap `useQuery` → `useEvalAttributesEager`:
  - `tasks/components/TaskConfigPanel.jsx`
  - `common/EvalsTasks/NewTaskDrawer/NewTaskDrawer.jsx`
  - `common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx`
  - `common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx`
  - `common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx`

- **Filter-definition generators** (2 callers) — eager hook:
  - `components/run-insights/spans-tab/spans-tab.jsx`
  - `sections/projects/Alerts/components/AlertSettingsForm.jsx` (threshold dropdown, mapped to `{label, value}`)

- **traces-tab** — keeps its CH-first `spanAttributeKeys()` primary endpoint; only the fallback path was updated to read `.result.items` from the new envelope.

## Test plan

- [ ] Open Custom Columns dialog on the prod project from #452's reproduction (`8eb3023d-…` / `696ed10e-…`); confirm initial load is fast, typing in search debounces and re-fetches, scroll loads more.
- [ ] Open New Task drawer on a project; in the variable-mapping autocomplete, confirm the full list renders without lag.
- [ ] Filter dropdowns on the run-insights span/trace tabs and the Alerts threshold dropdown still populate.
- [ ] Re-run the eval task previously failing against `spans.87.timeline` with a corrected mapping picked from the now-aligned list; confirm `failed_spans` no longer contains misalignment errors.

`frontend/node_modules` was empty locally so CI is the first place vitest/eslint run for this branch.

## Targets

Targets the BE branch `feat/eval-attrs-be-aligned-paged` so reviewers see only the FE diff and so the working tree contains the combined BE + FE for local testing. After PR1 merges into the parent feature branch, the base will be retargeted to `feat/eval-attrs-aligned-paged`.