### PR TITLE
fix(eval): JSON-parse stringified parent flat keys in span resolver

### DIFF
--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -75,12 +75,33 @@ _MISSING = object()
 
 
 def _resolve_attr(span_attrs: dict, candidate: str):
-    """Literal lookup, then dotted-path walk. Returns ``_MISSING`` on miss."""
+    """Literal lookup → dotted walk → JSON-parsed parent walk on miss.
+
+    Last step matches the dataset-eval resolver so the trace-eval path
+    can resolve picker paths inside JSON-stringified ``input.value`` /
+    ``output.value`` flat keys.
+    """
     if candidate in span_attrs:
         return span_attrs[candidate]
     walked = _walk_dotted_path(span_attrs, candidate)
     if walked is not None:
         return walked
+
+    from model_hub.utils.json_path_resolver import parse_json_safely
+
+    parts = candidate.split(".")
+    for split_idx in range(len(parts) - 1, 0, -1):
+        prefix = ".".join(parts[:split_idx])
+        remainder = ".".join(parts[split_idx:])
+        for key in (f"{prefix}.value", prefix):
+            if key not in span_attrs:
+                continue
+            parsed, ok = parse_json_safely(span_attrs[key])
+            if not ok:
+                continue
+            walked = _walk_dotted_path(parsed, remainder)
+            if walked is not None:
+                return walked
     return _MISSING
 
 
@@ -1742,8 +1763,9 @@ def _resolve_span_path(span: ObservationSpan, path: str):
         span_attrs = get_span_attributes(span)
         if not rest:
             return span_attrs
-        walked = _walk_dotted_path(span_attrs, rest)
-        return walked if walked is not None else _MISSING
+        # Legacy ``span_attributes.<x>`` paths share resolver semantics
+        # with bare paths.
+        return _resolve_attr(span_attrs, rest)
 
     span_attrs = get_span_attributes(span)
     return _resolve_attr(span_attrs, path)


### PR DESCRIPTION
Closes TH-4950.

The trace-eval resolver in `tracer/utils/eval.py` only walks raw `span_attributes` flat keys. The FE picker surfaces virtual paths from JSON-parsed `input.value` / `output.value` (e.g. `input.contents` on Gemini-shape spans, `input.0.role` on OpenAI arrays), so saved mappings fail at run time even though they look valid in the picker.

## Change

- Extend `_resolve_attr` with a JSON-parsed-parent walk on the miss path. Tries `{prefix}.value` (FI/OTel convention) then `{prefix}` as a flat key, JSON-parses if string, walks the remainder.
- Route `_resolve_span_path`'s legacy `span_attributes.<rest>` branch through `_resolve_attr` for the same coverage.
- Use `parse_json_safely` from `model_hub.utils.json_path_resolver` — same helper the dataset-eval resolver already uses; matches the existing `model_hub` imports in this file.

Purely additive: steps 1 + 2 of `_resolve_attr` are byte-for-byte unchanged. Trace/session resolvers intentionally not touched — those fields are JSONField, already parsed.

## How the fix works

### The data shape

`span_attrs` is a **flat dict** where keys can themselves contain dots — they are not nested:

```python
{
    "input.value":            '{"model": "gemini-2.5-flash", "contents": "What is..."}',  # JSON string
    "input.mime_type":        "application/json",
    "output.value":           '{"candidates": [{"avg_logprobs": -0.5}]}',                  # JSON string
    "llm.token_count.total":  757,
}
```

There is no top-level `"input"` dict. `"input.value"` is one literal key — dot included.

### Why `input.value` always worked

| Step | Result |
|---|---|
| Step 1 — literal lookup `span_attrs["input.value"]` | ✅ hit — returns the JSON string |

Done in step 1. Never enters step 2 or 3.

### Why `input.contents` failed before the patch

| Step | Action | Result |
|---|---|---|
| Step 1 — literal lookup `span_attrs["input.contents"]` | — | ❌ no such literal key |
| Step 2 — walker treats span_attrs as nested dict, tries `span_attrs["input"]` | — | ❌ no top-level `"input"` (only `"input.value"`, `"input.mime_type"`) |
| Result | `_MISSING` | raises `Required attribute 'input.contents' not found` |

### What the new step adds

For each possible split of the candidate path, try the longer side as a flat key (or `{prefix}.value`), JSON-parse if it's a string, then walk the remainder inside the parsed payload.

#### Example 1 — `input.contents` (2 parts)

`parts = ["input", "contents"]`, loop iterates once:

| split_idx | prefix | remainder | try `input.value` | try `input` | outcome |
|---|---|---|---|---|---|
| **1** | `input` | `contents` | ✅ found → JSON-parse → walk `contents` | (not reached) | returns `"What is..."` ✅ |

#### Example 2 — `input.value.candidates.0.avg_logprobs` (5 parts)

`parts = ["input", "value", "candidates", "0", "avg_logprobs"]`, loop counts down:

| split_idx | prefix | remainder | try `{prefix}.value` | try `{prefix}` | outcome |
|---|---|---|---|---|---|
| 4 | `input.value.candidates.0` | `avg_logprobs` | ❌ | ❌ | continue |
| 3 | `input.value.candidates` | `0.avg_logprobs` | ❌ | ❌ | continue |
| **2** | `input.value` | `candidates.0.avg_logprobs` | ❌ | ✅ found → JSON-parse → walk `candidates.0.avg_logprobs` | returns `-0.5` ✅ |

#### Example 3 — `input.value.3` against an OpenAI-shape array

For an OpenAI LLM span, `input.value` is a JSON-stringified array `[{role,content}, {role,content}, ...]`.

| split_idx | prefix | remainder | try `{prefix}.value` | try `{prefix}` | outcome |
|---|---|---|---|---|---|
| 2 | `input.value` | `3` | ❌ | ✅ found → JSON-parse → walk `3` | returns array[3] ✅ |

#### Example 4 — path that genuinely doesn't exist

Mapping `input.contents` on an agent span where `input.value` parses to `{user_id, messages, session_id}` (no `contents` key):

| split_idx | prefix | remainder | try `input.value` | walk `contents` on parsed dict | outcome |
|---|---|---|---|---|---|
| 1 | `input` | `contents` | ✅ found → JSON-parse | ❌ no `"contents"` key in `{user_id, messages, session_id}` | falls through |

Loop exhausts → `_MISSING` → error. Correct behavior — the data genuinely doesn't have that path.

### Why the loop counts down

Always prefer the **longest** prefix that resolves as a flat key. Counting up would hit `input` first (miss) and never try `input.value` (the real boundary). Counting down ensures we find the deepest JSON-parsed-payload boundary first.

### Resolver flow at a glance

| Mapping | Step 1 (literal) | Step 2 (walk) | Step 3 (JSON-parsed parent) |
|---|---|---|---|
| `input.value` | ✅ returns JSON string | — | — |
| `llm.token_count.total` | ✅ returns 757 | — | — |
| `input.contents` (Gemini) | ❌ | ❌ | ✅ via `input.value` → `contents` |
| `input.value.3` (OpenAI) | ❌ | ❌ | ✅ via `input.value` → `3` |
| `output.value.candidates.0.avg_logprobs` | ❌ | ❌ | ✅ via `output.value` → `candidates.0.avg_logprobs` |
| `input.contents` (agent span, no `contents` field) | ❌ | ❌ | ❌ (correct — data genuinely missing) |


## Few runs with json inputs:
### Run 1:
input -> output.value.candidates.0.avg_logprobs
output -> gen_ai.provider.name
context -> input.value

<img width="1627" height="1070" alt="image" src="https://github.com/user-attachments/assets/ee040c3b-0615-42b3-a31b-f8bb2b2ac3b2" />

<img width="1622" height="1067" alt="image" src="https://github.com/user-attachments/assets/11526b23-1b41-47b2-b7ac-70efdb2ce0e3" />



### Run 2: (actual bug reported)

input -> output.value.candidates.0.avg_logprobs
output -> gen_ai.provider.name
context -> input.contents

<img width="1628" height="1069" alt="image" src="https://github.com/user-attachments/assets/3980b88f-6f19-4fd1-b48f-d888dcc413e8" />

<img width="1624" height="1067" alt="image" src="https://github.com/user-attachments/assets/1a18eb68-7267-4037-a6d3-0a3ad28086d2" />


### Run 3:

input -> output.candidates.0.content.parts.0
output -> gen_ai.trace.source
context -> input.value.contents

<img width="1624" height="1071" alt="image" src="https://github.com/user-attachments/assets/3bbcc8cd-5afd-4e66-abd3-5ccf2cb51ccd" />

<img width="1626" height="1069" alt="image" src="https://github.com/user-attachments/assets/b7f231fb-0364-48e9-a7ac-d7b2484e2a32" />


## Test plan

- [x] Local repro: Gemini-shape spans, map `context → input.contents`, run task → all rows resolve with grounded explanations
- [x] `output.value.candidates.0.avg_logprobs`, `llm.token_count.total` resolve as expected
- [x] Existing successful mappings (`input.value`, real nested keys) unchanged