### PR TITLE
[Bugfix] added one more function from tanstack query

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -23,7 +23,12 @@ import {
   getDatasetQueryKey,
   getDatasetQueryOptions,
 } from "src/api/develop/develop-detail";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  isCancelledError,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useParams } from "react-router";
 import {
   DATASET_TYPES,
@@ -292,14 +297,17 @@ const getDataSource = (
         // Flow-control errors from request cancellation are not real failures:
         //   • React Query throws CancelledError when a new query supersedes an
         //     in-flight one (common during bulk stop-eval / invalidations).
+        //     Its class extends Error but never sets `this.name`, and the
+        //     constructor name gets mangled in production — only `instanceof`
+        //     (via `isCancelledError`) is reliable.
         //   • Axios throws CanceledError (one L) / code ERR_CANCELED when the
         //     underlying request is aborted before React Query wraps it.
         //   • Fetch / AbortController surfaces AbortError.
         // Don't log or flip the grid into failed state for any of these.
-        const err = /** @type {any} */ (e);
-        const name = err?.name || err?.constructor?.name;
+        const err = e;
+        const name = err?.name;
         const isCancelled =
-          name === "CancelledError" ||
+          isCancelledError(err) ||
           name === "CanceledError" ||
           name === "AbortError" ||
           err?.code === "ERR_CANCELED";

--- a/frontend/src/utils/cacheUtils.js
+++ b/frontend/src/utils/cacheUtils.js
@@ -2,7 +2,29 @@
  * Utility functions for managing React Query cache
  */
 
+import { isCancelledError } from "@tanstack/react-query";
+
 import logger from "./logger";
+
+// invalidate/refetch return Promises that reject with a cancellation error
+// whenever react-query supersedes an in-flight fetch for the same key. These
+// callers are intentionally fire-and-forget, so we drop those rejections on
+// the floor and only log real failures.
+//
+// react-query's CancelledError extends Error but never sets `this.name`, so
+// `err.name` is "Error" in production and `err.constructor.name` gets mangled
+// by the minifier — only `isCancelledError` (instanceof check) is reliable.
+// Axios sets `name = "CanceledError"` itself so the name check works there.
+const swallowCancellations = (label) => (error) => {
+  const name = error?.name;
+  const isCancelled =
+    isCancelledError(error) ||
+    name === "CanceledError" ||
+    name === "AbortError" ||
+    error?.code === "ERR_CANCELED";
+  if (isCancelled) return;
+  logger.error(label, error);
+};
 
 /**
  * Invalidates and refetches dataset list cache
@@ -14,18 +36,17 @@ export const invalidateDatasetListCache = (queryClient) => {
     return;
   }
 
-  try {
-    // Invalidate all dataset-related queries
-    queryClient.invalidateQueries({
-      queryKey: ["develop", "dataset-name-list"],
-    });
-    queryClient.invalidateQueries({ queryKey: ["develop", "dataset-list"] });
+  const onError = swallowCancellations("Error invalidating dataset cache:");
 
-    // Force refetch to ensure immediate update
-    queryClient.refetchQueries({ queryKey: ["develop", "dataset-name-list"] });
-  } catch (error) {
-    logger.error("Error invalidating dataset cache:", error);
-  }
+  queryClient
+    .invalidateQueries({ queryKey: ["develop", "dataset-name-list"] })
+    .catch(onError);
+  queryClient
+    .invalidateQueries({ queryKey: ["develop", "dataset-list"] })
+    .catch(onError);
+  queryClient
+    .refetchQueries({ queryKey: ["develop", "dataset-name-list"] })
+    .catch(onError);
 };
 
 /**
@@ -39,12 +60,14 @@ export const invalidateExperimentCache = (queryClient, datasetId = null) => {
     return;
   }
 
-  try {
-    queryClient.invalidateQueries({ queryKey: ["experiments"] });
-    if (datasetId) {
-      queryClient.invalidateQueries({ queryKey: ["experiments", datasetId] });
-    }
-  } catch (error) {
-    logger.error("Error invalidating experiment cache:", error);
+  const onError = swallowCancellations("Error invalidating experiment cache:");
+
+  queryClient
+    .invalidateQueries({ queryKey: ["experiments"] })
+    .catch(onError);
+  if (datasetId) {
+    queryClient
+      .invalidateQueries({ queryKey: ["experiments", datasetId] })
+      .catch(onError);
   }
 };


### PR DESCRIPTION
Fix summary
Symptom: Production console showed CancelledError errors from two paths — the AG-Grid getRows catch in DevelopDataV2.jsx and the fire-and-forget refetchQueries in cacheUtils.js.

Root cause #1 — broken cancellation check (production-only)

React-query's CancelledError extends Error but the constructor never sets this.name → err.name === "Error", not "CancelledError".
The fallback err.constructor.name reads "CancelledError" in dev but gets minified to Xz in prod.
So the existing predicate name === "CancelledError" || ... always returned false in prod, and the cancellation leaked into logger.error("[getRows] failed", ...).
Root cause #2 — try/catch can't catch async rejections

try { queryClient.refetchQueries(...) } catch {} only catches synchronous throws. refetchQueries returns immediately with a pending Promise; the rejection lands on a later microtask, by which time the try block is gone → unhandled rejection.
Fix

Switched the react-query branch to isCancelledError(err) (imported from @tanstack/react-query). It's an instanceof CancelledError check, so it survives minification and doesn't depend on this.name. Axios CanceledError and AbortError already set name correctly, so those branches stayed as name checks.
Replaced the synchronous try/catch in cacheUtils.js with a swallowCancellations(label) handler attached via .catch(...) to each invalidate/refetchQueries call. Cancellations are silently dropped; real errors still log.
