### PR TITLE
fix(test-detail): suggestion card click no longer crashes the UI (TH-4954)

### DIFF
--- a/frontend/src/sections/test-detail/__tests__/getSelectedCallExecutionIds.test.js
+++ b/frontend/src/sections/test-detail/__tests__/getSelectedCallExecutionIds.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getSelectedCallExecutionIds,
+  getSelectedCallExecutionIdsFilter,
+} from "../common";
+import { useTestDetailStore } from "../states";
+
+const resetStore = () => {
+  useTestDetailStore.setState({
+    selectedFixableRecommendations: [],
+    selectedNonFixableRecommendations: [],
+  });
+};
+
+describe("getSelectedCallExecutionIds (TH-4954 regression)", () => {
+  beforeEach(resetStore);
+
+  it("returns [] when nothing is selected", () => {
+    expect(getSelectedCallExecutionIds()).toEqual([]);
+  });
+
+  it("returns IDs from selectedFixableRecommendations using the camelCase key the store writes", () => {
+    // Mirrors what toggleSelectedFixableRecommendation pushes: { index, callExecutionIds }
+    useTestDetailStore.setState({
+      selectedFixableRecommendations: [
+        { index: 0, callExecutionIds: ["a", "b"] },
+        { index: 1, callExecutionIds: ["c"] },
+      ],
+    });
+
+    expect(getSelectedCallExecutionIds().sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns IDs from selectedNonFixableRecommendations", () => {
+    useTestDetailStore.setState({
+      selectedNonFixableRecommendations: [
+        { index: 0, callExecutionIds: ["x", "y"] },
+      ],
+    });
+
+    expect(getSelectedCallExecutionIds().sort()).toEqual(["x", "y"]);
+  });
+
+  it("dedupes IDs across fixable and non-fixable selections", () => {
+    useTestDetailStore.setState({
+      selectedFixableRecommendations: [
+        { index: 0, callExecutionIds: ["a", "b"] },
+      ],
+      selectedNonFixableRecommendations: [
+        { index: 0, callExecutionIds: ["b", "c"] },
+      ],
+    });
+
+    expect(getSelectedCallExecutionIds().sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("getSelectedCallExecutionIdsFilter wraps the IDs into a list filter", () => {
+    useTestDetailStore.setState({
+      selectedFixableRecommendations: [
+        { index: 0, callExecutionIds: ["a", "b"] },
+      ],
+    });
+
+    const filter = getSelectedCallExecutionIdsFilter();
+    expect(filter).toHaveLength(1);
+    expect(filter[0].column_id).toBe("call_execution_id");
+    expect(filter[0].filter_config.filter_op).toBe("in");
+    expect(filter[0].filter_config.filter_type).toBe("list");
+    expect(filter[0].filter_config.filter_value.sort()).toEqual(["a", "b"]);
+  });
+});

--- a/frontend/src/sections/test-detail/common.js
+++ b/frontend/src/sections/test-detail/common.js
@@ -808,12 +808,12 @@ export const getSelectedCallExecutionIds = () => {
   const selectedCallExecutionIdsSet = new Set();
 
   selectedFixableRecommendations.forEach((recommendation) => {
-    recommendation.call_execution_ids.forEach((callExecutionId) => {
+    recommendation.callExecutionIds.forEach((callExecutionId) => {
       selectedCallExecutionIdsSet.add(callExecutionId);
     });
   });
   selectedNonFixableRecommendations.forEach((recommendation) => {
-    recommendation.call_execution_ids.forEach((callExecutionId) => {
+    recommendation.callExecutionIds.forEach((callExecutionId) => {
       selectedCallExecutionIdsSet.add(callExecutionId);
     });
   });


### PR DESCRIPTION
## Summary

Clicking a suggestion card in `FixMyAgentDrawer` crashed with `Cannot read properties of undefined (reading 'forEach')`. The Zustand store writes `{ index, callExecutionIds }` but `getSelectedCallExecutionIds` read `recommendation.call_execution_ids`, which is always undefined.

## Linked issues

Refs: [TH-4954](https://linear.app/future-agi/issue/TH-4954/clicking-on-the-suggestion-card-breaks-the-ui)

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- Added Vitest regression suite covering both fixable / non-fixable selections and the filter wrapper — 5/5 pass.
- `yarn lint:fix` clean on changed files.