### PR TITLE
fix(tasks): mirror PR #432 canonical filter ops on task surfaces

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
@@ -1,18 +1,72 @@
 import { getNumberValidation } from "src/utils/validation";
 import { z } from "zod";
 
+const RANGE_OPS = new Set(["between", "not_between"]);
+const LIST_OPS = new Set(["in", "not_in"]);
+
+// Group multiple form rows for the same (columnId, op) into a single wire
+// entry. Scalar rows for list ops collapse to array `filterValue`; multiple
+// scalar rows for a single-value op (legacy multi-value `equals` from saved
+// tasks) are promoted to `in` so the BE filter validator accepts them.
 export const extractAttributeFilters = (filters) => {
-  const attributeFilters = filters
-    ?.filter((filter) => filter?.property === "attributes")
-    .map(({ property, propertyId, id, ...rest }) => ({
-      ...rest,
-      columnId: propertyId,
+  const merged = new Map();
+  (filters || [])
+    .filter((f) => f?.property === "attributes")
+    .forEach((f) => {
+      const columnId = f.propertyId;
+      if (!columnId) return;
+      const op = f?.filterConfig?.filterOp || "equals";
+      const filterType = f?.filterConfig?.filterType || "text";
+      const key = `${columnId}|${op}|${filterType}`;
+      if (!merged.has(key)) {
+        merged.set(key, {
+          columnId,
+          op,
+          filterType,
+          rangeValue: undefined,
+          values: [],
+        });
+      }
+      const entry = merged.get(key);
+      const v = f?.filterConfig?.filterValue;
+      if (RANGE_OPS.has(op)) {
+        entry.rangeValue = Array.isArray(v) ? v : entry.rangeValue;
+      } else if (LIST_OPS.has(op)) {
+        const arr = Array.isArray(v)
+          ? v
+          : v !== undefined && v !== null && v !== ""
+            ? [v]
+            : [];
+        entry.values.push(...arr);
+      } else if (v !== undefined && v !== null && v !== "") {
+        entry.values.push(v);
+      }
+    });
+
+  return Array.from(merged.values()).map((entry) => {
+    let filterValue;
+    let filterOp = entry.op;
+    if (RANGE_OPS.has(filterOp)) {
+      filterValue = entry.rangeValue;
+    } else if (LIST_OPS.has(filterOp)) {
+      filterValue = entry.values;
+    } else if (entry.values.length > 1) {
+      // Multiple scalar rows under a single-value op → promote to `in`.
+      filterOp = "in";
+      filterValue = entry.values;
+    } else if (entry.values.length === 1) {
+      filterValue = entry.values[0];
+    }
+    return {
+      columnId: entry.columnId,
       filterConfig: {
-        ...rest?.filterConfig,
+        filterType: entry.filterType,
+        filterOp,
         colType: "SPAN_ATTRIBUTE",
+        ...(filterValue !== undefined && { filterValue }),
       },
-    }));
-  return attributeFilters ?? [];
+    };
+  });
 };
 
 export const getNewTaskFilters = (data, projectId, ignoreDate = false) => {
@@ -20,13 +74,22 @@ export const getNewTaskFilters = (data, projectId, ignoreDate = false) => {
 
   const attributeFilters = extractAttributeFilters(data?.filters);
 
+  // System filters: spread array `filterValue` (from canonical `in`/`not_in`
+  // or `between` rows) into the per-field array so the BE wire stays in the
+  // historical `{ field: [v1, v2, ...] }` shape it expects.
   data?.filters?.forEach((filter) => {
+    if (filter?.property === "attributes") return;
+    const val = filter?.filterConfig?.filterValue;
+    const vals = Array.isArray(val)
+      ? val
+      : val !== undefined && val !== null && val !== ""
+        ? [val]
+        : [];
+    if (vals.length === 0) return;
     if (filter?.property in filters) {
-      if (filter?.property === "attributes") return;
-      filters[filter?.property].push(filter?.filterConfig?.filterValue);
+      filters[filter?.property].push(...vals);
     } else {
-      if (filter?.property === "attributes") return;
-      filters[filter?.property] = [filter?.filterConfig?.filterValue];
+      filters[filter?.property] = [...vals];
     }
   });
 

--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -120,9 +120,16 @@ const TaskDetailPage = () => {
     (editType) => {
       const data = formValues;
       const attributeFilters = extractAttributeFilters(data?.filters);
+      // observation_type rows may now carry an array `filterValue` (canonical
+      // `in`/`not_in`) or a scalar (legacy `equals`). Flatten + drop empties
+      // so the BE always sees a flat list of selected values.
       const observationTypes = (data.filters || [])
         .filter((f) => f.property === "observation_type")
-        .map((f) => f?.filterConfig?.filterValue);
+        .flatMap((f) => {
+          const v = f?.filterConfig?.filterValue;
+          if (Array.isArray(v)) return v;
+          return v !== undefined && v !== null && v !== "" ? [v] : [];
+        });
 
       const transformedData = {
         evals: data.evalsDetails?.map((item) => item.id || item) || [],

--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -6,79 +6,151 @@ import Iconify from "src/components/iconify";
 import { getRandomId } from "src/utils/utils";
 import TraceFilterPanel from "src/sections/projects/LLMTracing/TraceFilterPanel";
 
-// ── Operator maps (new panel format ↔ old task filter format) ──
-const OP_NEW_TO_OLD = {
-  is: "equals",
-  is_not: "not_equals",
-  contains: "contains",
-  not_contains: "not_contains",
-  equal_to: "equal_to",
-  not_equal_to: "not_equal_to",
-  greater_than: "greater_than",
-  greater_than_or_equal: "greater_than_or_equal",
-  less_than: "less_than",
-  less_than_or_equal: "less_than_or_equal",
-  between: "between",
-  not_between: "not_between",
-};
+// ── Operator handling — canonical backend ops ──
+//
+// `TraceFilterPanel` (PR #432 / TH-4924) emits canonical backend op names
+// directly: `equals`, `not_equals`, `in`, `not_in`, `contains`,
+// `not_contains`, `starts_with`, `ends_with`, `is_null`, `is_not_null`,
+// `greater_than`, `greater_than_or_equal`, `less_than`,
+// `less_than_or_equal`, `between`, `not_between`. The thumbs / categorical
+// / id-only dropdowns inside the panel still emit legacy `is`/`is_not` —
+// alias those to canonical so the wire is consistent.
+const LEGACY_OP_ALIAS = { is: "equals", is_not: "not_equals" };
 
-const OP_OLD_TO_NEW = {
-  equals: "is",
-  not_equals: "is_not",
-  contains: "contains",
-  not_contains: "not_contains",
-  is: "is",
-  is_not: "is_not",
-  equal_to: "equal_to",
-  not_equal_to: "not_equal_to",
-  greater_than: "greater_than",
-  greater_than_or_equal: "greater_than_or_equal",
-  less_than: "less_than",
-  less_than_or_equal: "less_than_or_equal",
-  between: "between",
-  not_between: "not_between",
+const RANGE_OPS = new Set(["between", "not_between"]);
+const LIST_OPS = new Set(["in", "not_in"]);
+const NO_VALUE_OPS = new Set(["is_null", "is_not_null"]);
+
+// Legacy string ops persisted before TH-4924 land in form state as
+// `equals`/`not_equals`. Rewrite to `in`/`not_in` on read so the new
+// panel renders the row under the multi-value picker.
+const HYDRATE_STRING_OP = { equals: "in", not_equals: "not_in" };
+
+const isStringLike = (fieldType) =>
+  fieldType === "text" || fieldType === "string";
+
+const coerceForType = (val, fieldType) => {
+  if (val === null || val === undefined || val === "") return val;
+  if (Array.isArray(val)) return val.map((v) => coerceForType(v, fieldType));
+  if (fieldType === "number") {
+    const n = Number(val);
+    return Number.isNaN(n) ? val : n;
+  }
+  if (fieldType === "boolean") {
+    if (val === true || val === false) return val;
+    if (val === "true") return true;
+    if (val === "false") return false;
+  }
+  return val;
 };
 
 const OP_DISPLAY = {
-  is: "is",
-  is_not: "is not",
+  // canonical
+  equals: "equals",
+  not_equals: "not equals",
+  in: "is one of",
+  not_in: "is not one of",
   contains: "contains",
   not_contains: "not contains",
-  equal_to: "=",
-  not_equal_to: "≠",
+  starts_with: "starts with",
+  ends_with: "ends with",
+  is_null: "is null",
+  is_not_null: "is not null",
   greater_than: ">",
   greater_than_or_equal: "≥",
   less_than: "<",
   less_than_or_equal: "≤",
   between: "between",
   not_between: "not between",
+  // legacy (still rendered if a stale row survives until the next save)
+  is: "is",
+  is_not: "is not",
+  equal_to: "=",
+  not_equal_to: "≠",
 };
 
-// ── new panel filter → old task form filter(s) ──
-// Each picked value becomes a separate row so the backend's
-// `getNewTaskFilters` pushes them into the same property array.
-// We stash `fieldCategory` and `fieldLabel` on each row so the live
-// preview (which reads raw useWatch values) can reconstruct the
-// tracing API array without losing metadata. Zod strips these at
-// submit time so the backend payload is unaffected.
+// ── new panel filter → form filter(s) ──
+//
+// List ops (`in`/`not_in`) carry the full array on a single form row so
+// the wire keeps the BE's canonical shape; range ops carry a 2-element
+// array; no-value ops omit `filterValue`; other ops explode into one
+// scalar row per value so system-filter accumulation keeps working.
+// `fieldCategory` / `fieldLabel` are stashed for the live preview and
+// chip rendering — zod strips them on submit.
 function convertNewToOld(newFilters) {
   const out = [];
   (newFilters || []).forEach((f) => {
     if (!f?.field) return;
-    const values = Array.isArray(f.value) ? f.value : [f.value];
     const isAttribute = f.fieldCategory === "attribute";
-    values.forEach((v) => {
+    const fieldType = f.fieldType || "string";
+    const filterType =
+      fieldType === "number"
+        ? "number"
+        : fieldType === "boolean"
+          ? "boolean"
+          : "text";
+    const op = LEGACY_OP_ALIAS[f.operator] || f.operator || "equals";
+
+    const base = {
+      property: isAttribute ? "attributes" : f.field,
+      propertyId: f.field,
+      fieldCategory: f.fieldCategory || "system",
+      fieldLabel: f.fieldLabel || f.field,
+    };
+
+    if (NO_VALUE_OPS.has(op)) {
+      out.push({
+        id: getRandomId(),
+        ...base,
+        filterConfig: { filterType, filterOp: op },
+      });
+      return;
+    }
+
+    if (RANGE_OPS.has(op)) {
+      const arr = Array.isArray(f.value) ? f.value : [];
+      if (arr.length < 2) return;
+      out.push({
+        id: getRandomId(),
+        ...base,
+        filterConfig: {
+          filterType,
+          filterOp: op,
+          filterValue: coerceForType(arr.slice(0, 2), fieldType),
+        },
+      });
+      return;
+    }
+
+    if (LIST_OPS.has(op)) {
+      const arr = (Array.isArray(f.value) ? f.value : [f.value]).filter(
+        (v) => v !== undefined && v !== null && v !== "",
+      );
+      if (arr.length === 0) return;
+      out.push({
+        id: getRandomId(),
+        ...base,
+        filterConfig: {
+          filterType,
+          filterOp: op,
+          filterValue: coerceForType(arr, fieldType),
+        },
+      });
+      return;
+    }
+
+    // Single-value ops: explode any incoming array (legacy multi-value
+    // `equals` from saved tasks) into one scalar row per value.
+    const arr = Array.isArray(f.value) ? f.value : [f.value];
+    arr.forEach((v) => {
       if (v === undefined || v === null || v === "") return;
       out.push({
         id: getRandomId(),
-        property: isAttribute ? "attributes" : f.field,
-        propertyId: f.field,
-        fieldCategory: f.fieldCategory || "system",
-        fieldLabel: f.fieldLabel || f.field,
+        ...base,
         filterConfig: {
-          filterType: f.fieldType === "number" ? "number" : "text",
-          filterOp: OP_NEW_TO_OLD[f.operator] || f.operator || "equals",
-          filterValue: v,
+          filterType,
+          filterOp: op,
+          filterValue: coerceForType(v, fieldType),
         },
       });
     });
@@ -86,7 +158,7 @@ function convertNewToOld(newFilters) {
   return out;
 }
 
-// ── old task form filter → new panel format (one row per property+op group) ──
+// ── form filter → new panel format (one row per property+op group) ──
 function convertOldToNew(oldFilters) {
   const groups = new Map();
   (oldFilters || []).forEach((f) => {
@@ -94,22 +166,43 @@ function convertOldToNew(oldFilters) {
     const isAttribute = f.property === "attributes";
     const field = isAttribute ? f.propertyId : f.property;
     if (!field) return;
-    const op = f?.filterConfig?.filterOp || "equals";
+
+    const rawOp = f?.filterConfig?.filterOp || "equals";
     const category = f.fieldCategory || (isAttribute ? "attribute" : "system");
+    const ft = f?.filterConfig?.filterType;
+    const fieldType =
+      ft === "number" ? "number" : ft === "boolean" ? "boolean" : "string";
+
+    // Aliased legacy → canonical first, then string-specific rehydration.
+    let op = LEGACY_OP_ALIAS[rawOp] || rawOp;
+    if (isStringLike(fieldType) && HYDRATE_STRING_OP[op]) {
+      op = HYDRATE_STRING_OP[op];
+    }
+
     const key = `${field}|${op}|${category}`;
     if (!groups.has(key)) {
       groups.set(key, {
         field,
         fieldLabel: f.fieldLabel || field,
-        fieldType:
-          f?.filterConfig?.filterType === "number" ? "number" : "string",
+        fieldType,
         fieldCategory: category,
-        operator: OP_OLD_TO_NEW[op] || op,
+        operator: op,
         value: [],
       });
     }
+
+    if (NO_VALUE_OPS.has(op)) return;
+
     const val = f?.filterConfig?.filterValue;
-    if (val !== undefined && val !== null && val !== "") {
+    if (RANGE_OPS.has(op)) {
+      // Range: the form row carries the [low, high] array directly.
+      groups.get(key).value = Array.isArray(val) ? val : [];
+      return;
+    }
+    if (val === undefined || val === null || val === "") return;
+    if (Array.isArray(val)) {
+      groups.get(key).value.push(...val);
+    } else {
       groups.get(key).value.push(val);
     }
   });
@@ -118,7 +211,7 @@ function convertOldToNew(oldFilters) {
 
 // ── Chip display for an active filter ──
 const FilterChip = ({ filter, onRemove }) => {
-  const opLabel = OP_DISPLAY[filter.operator] || filter.operator || "is";
+  const opLabel = OP_DISPLAY[filter.operator] || filter.operator || "equals";
   const valueStr = Array.isArray(filter.value)
     ? filter.value.join(", ")
     : String(filter.value ?? "");

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -54,27 +54,87 @@ const COL_TYPE_MAP = {
 // routes the filter through the metrics pipeline and silently returns 0.
 const ID_COLUMNS = new Set(["trace_id", "span_id"]);
 
+const RANGE_OPS = new Set(["between", "not_between"]);
+const LIST_OPS = new Set(["in", "not_in"]);
+
+// Form rows from `TaskFilterBar.convertNewToOld` carry scalar `filterValue`
+// for single-value ops and arrays for `in`/`not_in`/`between`/`not_between`.
+// Multiple scalar rows for the same (field, op) need to be merged into one
+// wire entry so the BE `in` validator gets a single array clause instead of
+// N independently-evaluated scalar clauses.
+function mergeRowsByFieldAndOp(rows) {
+  const merged = new Map();
+  rows.forEach((f) => {
+    const isAttribute = f.property === "attributes";
+    const columnId = isAttribute ? f.propertyId : f.property;
+    if (!columnId) return;
+    const op = f?.filterConfig?.filterOp || "equals";
+    const filterType = f?.filterConfig?.filterType || "text";
+    const key = `${columnId}|${op}|${f.fieldCategory || "system"}|${filterType}`;
+    if (!merged.has(key)) {
+      merged.set(key, {
+        columnId,
+        fieldCategory: f.fieldCategory,
+        op,
+        filterType,
+        isAttribute,
+        value: undefined,
+        values: [],
+      });
+    }
+    const entry = merged.get(key);
+    const v = f?.filterConfig?.filterValue;
+    if (RANGE_OPS.has(op)) {
+      // Range rows already carry the [low, high] array.
+      entry.value = Array.isArray(v) ? v : entry.value;
+    } else if (LIST_OPS.has(op)) {
+      const arr = Array.isArray(v) ? v : v != null && v !== "" ? [v] : [];
+      entry.values.push(...arr);
+    } else if (v !== undefined && v !== null && v !== "") {
+      entry.values.push(v);
+    }
+  });
+  return Array.from(merged.values());
+}
+
 // eslint-disable-next-line react-refresh/only-export-components
 export function buildApiFilterArray(oldFormatFilters, startDate, endDate) {
-  const userFilters = (oldFormatFilters || [])
-    .filter((f) => f?.propertyId || f?.property)
-    .map((f) => {
-      const isAttribute = f.property === "attributes";
-      const columnId = isAttribute ? f.propertyId : f.property;
-      const isIdColumn = ID_COLUMNS.has(columnId);
+  const userFilters = mergeRowsByFieldAndOp(oldFormatFilters || []).map(
+    (entry) => {
+      const isIdColumn = ID_COLUMNS.has(entry.columnId);
       const colType =
-        COL_TYPE_MAP[f.fieldCategory] ||
-        (isAttribute ? "SPAN_ATTRIBUTE" : "SYSTEM_METRIC");
+        COL_TYPE_MAP[entry.fieldCategory] ||
+        (entry.isAttribute ? "SPAN_ATTRIBUTE" : "SYSTEM_METRIC");
+      let filterValue;
+      if (RANGE_OPS.has(entry.op)) {
+        filterValue = entry.value;
+      } else if (LIST_OPS.has(entry.op)) {
+        filterValue = entry.values;
+      } else if (entry.values.length > 1) {
+        // Multiple scalar rows under a single-value op — collapse to `in`.
+        filterValue = entry.values;
+      } else if (entry.values.length === 1) {
+        filterValue = entry.values[0];
+      } else {
+        filterValue = undefined;
+      }
+      const filterOp =
+        !RANGE_OPS.has(entry.op) &&
+        !LIST_OPS.has(entry.op) &&
+        Array.isArray(filterValue)
+          ? "in"
+          : entry.op;
       return {
-        column_id: columnId,
+        column_id: entry.columnId,
         filter_config: {
-          filter_type: f?.filterConfig?.filterType || "text",
-          filter_op: f?.filterConfig?.filterOp || "equals",
-          filter_value: f?.filterConfig?.filterValue,
+          filter_type: entry.filterType,
+          filter_op: filterOp,
+          ...(filterValue !== undefined && { filter_value: filterValue }),
           ...(!isIdColumn && { col_type: colType }),
         },
       };
-    });
+    },
+  );
 
   if (startDate && endDate) {
     userFilters.push({


### PR DESCRIPTION
## Summary

Task-side mirror of #432 (TH-4924). PR #432 canonicalized the SPAN_ATTRIBUTE filter op vocabulary on the LLM Tracing UI (`TraceFilterPanel` + `ObserveToolbar`) and the BE filter engines. This PR applies the same canonical ops to the **Task** filter UI (`TaskFilterBar` + `TaskLivePreview`) so saved tasks and the Live Preview speak the same wire vocabulary as the rest of the platform.

## What changed

`TaskFilterBar.jsx`
- Drops `OP_NEW_TO_OLD` / `OP_OLD_TO_NEW` translation maps — panel emits canonical op names directly per #432.
- Adds `LEGACY_OP_ALIAS = { is: "equals", is_not: "not_equals" }` — same shim #432 added in `ObserveToolbar`, for thumbs / categorical / id-only dropdowns that still emit legacy ops.
- Adds `RANGE_OPS`, `LIST_OPS`, `NO_VALUE_OPS` constants matching #432.
- Adds `coerceForType` helper — casts number / boolean values to native types before they reach form state.
- Adds `HYDRATE_STRING_OP = { equals: "in", not_equals: "not_in" }` — rewrites legacy ops on read so tasks saved before TH-4924 still render under the new multi-value picker.
- `OP_DISPLAY` now keys on canonical names; legacy keys retained as fallback so a stale row in form state still renders a label.

`TaskLivePreview.jsx`
- Adds `mergeRowsByFieldAndOp` — collapses multi-scalar form rows for the same `(field, op)` into one wire entry with an array value, so the BE `in` validator gets a single array clause instead of N independent equality clauses.
- `buildApiFilterArray` now promotes multi-scalar rows under single-value ops to `in` automatically.
- Continues to omit `col_type` for `trace_id` / `span_id` (PR #431 contract).

`TaskDetailPage.jsx`, `NewTaskDrawer/validation.js`
- Minor follow-ups so edit-mode hydration and form-level validation accept the canonical op vocabulary.

## Wire-shape example

`<numeric attribute> equals 100`:

```json
{
  "column_id": "<attr>",
  "filter_config": {
    "filter_type": "number",
    "filter_op": "equals",
    "filter_value": 100,
    "col_type": "SPAN_ATTRIBUTE"
  }
}
```

(`filter_op: "equal_to"` → `"equals"`, `filter_value: "100"` → `100`.)

## Files changed

- `frontend/src/sections/tasks/components/TaskFilterBar.jsx`
- `frontend/src/sections/tasks/components/TaskLivePreview.jsx`
- `frontend/src/sections/tasks/TaskDetailPage.jsx`
- `frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js`

## Open question for review

The chip label for `in` / `not_in` in `OP_DISPLAY` is **"is one of" / "is not one of"**, whereas #432's `TraceFilterPanel` text-op dropdown labels `in` / `not_in` as **"equals" / "not equals"**. The Task UI is multi-value-heavy so "is one of" reads more accurately for chip context — happy to align with the LLM Tracing label if you'd prefer consistency.

## Test plan

- [ ] New numeric task filter (`equals 100`) → wire sends `filter_op: "equals"`, `filter_value: 100` (number, not string).
- [ ] New text task filter with multi-pick → wire sends `filter_op: "in"`, `filter_value: ["a","b"]`.
- [ ] Boolean attribute filter → wire sends native `true` / `false`.
- [ ] Range filter (`between`) → wire sends `[low, high]` array.
- [ ] Edit a task saved **before** TH-4924 (legacy ops in stored filters) → row rehydrates correctly under the new picker.
- [ ] Trace ID / Span ID filters still work (no `col_type` regression).
- [ ] Task Live Preview returns the expected rows for each op above.