### PR TITLE
fix(observe): bypass HYDRATE_STRING_OP for Trace ID / Span ID rows

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -1553,9 +1553,13 @@ const TraceFilterPanel = ({
         const enriched = currentFilters.map((f) => {
           const prop = properties.find((p) => p.id === f.field);
           const fieldType = f.fieldType || prop?.type || "string";
-          const hydratedOp =
-            (fieldType === "string" || fieldType === "text") &&
-            HYDRATE_STRING_OP[f.operator]
+          // ID-only fields (trace_id / span_id) bypass the string-op
+          // rewrite — ID_ONLY_OPS = [{ value: "is" }] so anything other
+          // than "is" renders blank in the operator Select.
+          const hydratedOp = ID_ONLY_FIELDS.has(f.field)
+            ? "is"
+            : (fieldType === "string" || fieldType === "text") &&
+                HYDRATE_STRING_OP[f.operator]
               ? HYDRATE_STRING_OP[f.operator]
               : f.operator;
           // Scalar legacy `equals` value → array for the multi-select picker.


### PR DESCRIPTION
## Summary

Follow-up to #432. ID-only fields (`trace_id` / `span_id`) bypass the canonical string-op rewrite during saved-view hydration.

## Bug

After the canonical-ops migration, saved views with a `trace_id` (or `span_id`) filter persisted as `operator: "equals"` got rewritten to `"in"` by `HYDRATE_STRING_OP` when the panel opened. But `ID_ONLY_FIELDS` are restricted to `ID_ONLY_OPS = [{ value: "is" }]`, so `"in"` isn't a valid menu option — the operator `<Select>` rendered blank.

Reproducible by: saving a view with a `trace_id` filter on the LLM Tracing page → re-opening the filter panel from that view → the operator dropdown is empty for the trace_id row.

## Fix

One-line bypass in the saved-view hydrate effect — id-only fields force `operator: "is"` regardless of what's persisted:

```js
const hydratedOp = ID_ONLY_FIELDS.has(f.field)
  ? "is"
  : (fieldType === "string" || fieldType === "text") &&
      HYDRATE_STRING_OP[f.operator]
    ? HYDRATE_STRING_OP[f.operator]
    : f.operator;
```

Mirrors the same bypass added in `handlePropertySelect` (default-op path) for fresh property picks — that fix went out as part of #461. Both paths now consistently force `"is"` for id-only fields.

## Files changed

- `frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx` (+7 / −3)

## Test plan

- [ ] Save an LLM Tracing view with a `trace_id` filter → re-open → operator Select shows "is" (not blank).
- [ ] Same on a `span_id` filter.
- [ ] Saved views with other string-field filters (`name`, `user_id`, …) still hydrate `equals` → `in` as #432 intends.
- [ ] Saved views with `trace_id` persisted as the legacy `"is"` op still render correctly (no regression).