### PR TITLE
fix(ui): persona dropdown, node header colors, voice phone rule

### DIFF
--- a/frontend/src/components/GraphBuilder/nodes/NodeHeader.jsx
+++ b/frontend/src/components/GraphBuilder/nodes/NodeHeader.jsx
@@ -2,42 +2,12 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Box, Divider, Typography } from "@mui/material";
 import SvgColor from "src/components/svg-color";
-
-const colorMap = (type) => {
-  if (type === "conversation")
-    return {
-      color: "primary.main",
-      icon: "/assets/icons/navbar/ic_prompt.svg",
-      name: "Conversation",
-    };
-  if (type === "end")
-    return {
-      color: "red.600",
-      icon: "/assets/icons/components/ic_end_call.svg",
-      name: "End Call",
-    };
-  if (type === "transfer")
-    return {
-      color: "orange.600",
-      icon: "/assets/icons/components/ic_transfer_call.svg",
-      name: "Transfer Call",
-    };
-  if (type === "endChat")
-    return {
-      color: "red.600",
-      icon: "/assets/icons/ic_end_chat.svg",
-      name: "End Chat",
-    };
-  if (type === "transferChat")
-    return {
-      color: "orange.600",
-      icon: "/assets/icons/ic_transfer_chat.svg",
-      name: "Transfer Chat",
-    };
-};
+import { GRAPH_NODES } from "../common";
 
 const NodeHeader = ({ type, title }) => {
-  const { color, icon, name } = colorMap(type);
+  const node = GRAPH_NODES.find((n) => n.type === type);
+  if (!node) return null;
+  const { color, backgroundColor, icon, name } = node;
   return (
     <>
       <Box
@@ -49,7 +19,7 @@ const NodeHeader = ({ type, title }) => {
       >
         <Box
           sx={{
-            backgroundColor: color,
+            backgroundColor,
             padding: 1,
             borderRadius: "2px",
             width: "24px",
@@ -64,7 +34,7 @@ const NodeHeader = ({ type, title }) => {
             sx={{
               width: "16px",
               height: "16px",
-              color: "common.white",
+              color,
               flexShrink: 0,
             }}
           />

--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -137,11 +137,11 @@ export const createAgentDefinitionSchema = (options) => {
         !isLiveKitProvider(data.provider)
       ) {
         // Phone number is optional when API key + assistant ID are provided (web bridge)
-        const hasWebBridgeCreds =
-          data.apiKey?.trim() && data.assistantId?.trim();
+        // const hasWebBridgeCreds =
+        //   data.apiKey?.trim() && data.assistantId?.trim();
         const hasCountryCode = !!data.countryCode?.trim();
         const hasContactNumber = !!data.contactNumber?.trim();
-        if (!hasWebBridgeCreds) {
+        // if (!hasWebBridgeCreds) {
           if (!hasCountryCode) {
             ctx.addIssue({
               path: ["countryCode"],
@@ -156,7 +156,7 @@ export const createAgentDefinitionSchema = (options) => {
               code: z.ZodIssueCode.custom,
             });
           }
-        } else {
+        // } else {
           // Both are optional, but if one is provided the other is required
           if (hasContactNumber && !hasCountryCode) {
             ctx.addIssue({
@@ -172,7 +172,7 @@ export const createAgentDefinitionSchema = (options) => {
               code: z.ZodIssueCode.custom,
             });
           }
-        }
+        // }
         if (hasContactNumber) {
           // Validate contact number format only if it's provided
           const trimmedNumber = data.contactNumber.trim();

--- a/frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx
@@ -71,7 +71,7 @@ const PersonaBasicInfo = ({ viewOptions, multiple = true }) => {
                 size="small"
                 options={GenderOptions}
                 multiple={multiple}
-                checkbox
+                checkbox={multiple}
                 selectAll
               />
               <FormSearchSelectFieldControl
@@ -83,7 +83,7 @@ const PersonaBasicInfo = ({ viewOptions, multiple = true }) => {
                 size="small"
                 options={AgeGroupOptions}
                 multiple={multiple}
-                checkbox
+                checkbox={multiple}
                 selectAll
               />
               <FormSearchSelectFieldControl
@@ -95,7 +95,7 @@ const PersonaBasicInfo = ({ viewOptions, multiple = true }) => {
                 size="small"
                 options={LocationOptions}
                 multiple={multiple}
-                checkbox
+                checkbox={multiple}
                 selectAll
               />
               <FormSearchSelectFieldControl
@@ -107,7 +107,7 @@ const PersonaBasicInfo = ({ viewOptions, multiple = true }) => {
                 size="small"
                 options={ProfessionOptions}
                 multiple={multiple}
-                checkbox
+                checkbox={multiple}
                 selectAll
               />
             </Box>


### PR DESCRIPTION
## Summary
- **Persona dropdowns** ([PersonaBasicInfo.jsx](frontend/src/sections/persona/PersonaCreateEdit/PersonaBasicInfo.jsx)): single-select fields no longer render per-option checkboxes — the `checkbox` prop on `FormSearchSelectFieldControl` is now gated on `multiple`.
- **Graph builder NodeHeader** ([NodeHeader.jsx](frontend/src/components/GraphBuilder/nodes/NodeHeader.jsx)): drops the local `colorMap` duplicate and reads from the shared `GRAPH_NODES` array. Chip uses the soft tint, icon uses the saturated accent, matching the left-bar style.
- **Voice agent validation** ([helper.jsx](frontend/src/sections/agents/helper.jsx)): the web-bridge bypass (phone optional when `apiKey` + `assistantId` were supplied) is disabled. Voice agents on non-LiveKit providers must now provide both `countryCode` and `contactNumber`.

## Test plan
- [x] Persona create/edit form: with `multiple={false}`, dropdowns (Age, Gender, Location, Profession) render only the row highlight on selected option — no checkbox. With `multiple={true}`, checkboxes still appear.
- [x] Graph view: render each of the 5 node types (Conversation, End Call, Transfer Call, End Chat, Transfer Chat). Header chip uses soft tint, icon uses matching saturated accent, and styles match the GraphBuilder left-bar entries.
- [x] Create-agent flow → Voice + non-LiveKit provider, leave phone fields blank → both `countryCode` and `contactNumber` errors fire; fill them → errors clear and submit succeeds.



<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes TH-4876,TH-4893,TH-4899

