### PR TITLE
fix(model_hub): default new eval template model to turing_large

### DIFF
--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -3156,7 +3156,7 @@ class CustomEvalTemplateCreateView(CreateAPIView):
                     multi_choice=validated_data.get("multi_choice"),
                     proxy_agi=validated_data.get("config", {}).get("proxy_agi", True),
                     visible_ui=validated_data.get("config", {}).get("visible_ui", True),
-                    model=validated_data.get("config", {}).get("model", "turing_small"),
+                    model=validated_data.get("config", {}).get("model", "turing_large"),
                 )
 
                 # Create v0 version for the new template


### PR DESCRIPTION
## Summary
- `CustomEvalTemplateCreateView` (legacy create path in `eval_runner.py`) fell back to `turing_small` when the request's `config.model` was missing.
- Every other create path defaults to `turing_large` (`separate_evals.py` uses `req.model` whose Pydantic default is `turing_large`; copy/composite paths leave it NULL and the detail view resolves to `turing_large`).
- This one-line fix aligns the legacy path with the rest of the codebase so newly created templates default to `turing_large`.

Note: existing rows already on `turing_small` need a separate DB UPDATE — the system-eval seeder doesn't touch the `model` column (not in `_yaml_to_template_fields` and not in `update_fields`), so the cleanup is safe from being undone by reseeding.

## Test plan
- [ ] Create an eval template via the legacy endpoint with no `config.model` → row lands on `turing_large`
- [ ] Create an eval template via the legacy endpoint with `config.model = "turing_small"` → respects override