### PR TITLE
fix(tracer): TH-4966 use pending_entities for continuous eval sampling

### DIFF
--- a/futureagi/tracer/tests/test_eval_task_runtime.py
+++ b/futureagi/tracer/tests/test_eval_task_runtime.py
@@ -146,6 +146,36 @@ class TestProcessEvalTaskSpans:
 
         assert second_count == first_count
 
+    def test_continuous_run_type_with_sampling_rate(
+        self,
+        populated_observe_project,
+        observe_eval_task,
+        stub_run_eval,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """Continuous tasks must dispatch under sampling_rate without NameError.
+
+        Regression guard for the broken `spans.count()` reference in the
+        is_continuous branch — the queryset was renamed to `pending_entities`
+        but this one call site was missed, so every tick raised NameError
+        and the broad except silently flipped the task to FAILED.
+        """
+        task = observe_eval_task["task"]
+        task.run_type = RunType.CONTINUOUS
+        task.sampling_rate = 50.0
+        task.save()
+
+        process_eval_task._original_func(str(task.id))
+
+        task.refresh_from_db()
+        assert task.status != EvalTaskStatus.FAILED
+        count = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).count()
+        # 50% of 12 pending spans -> 6 sampled at dispatch
+        assert count == 6
+
 
 @pytest.mark.integration
 @pytest.mark.api

--- a/futureagi/tracer/utils/eval_tasks.py
+++ b/futureagi/tracer/utils/eval_tasks.py
@@ -445,7 +445,7 @@ def process_eval_task(eval_task_id: str):
                         # For continuous, sampling applies to the CURRENT
                         # batch of unprocessed spans, not against accumulated
                         # offset.
-                        max_samples = max(int((sampling_rate / 100) * spans.count()), 1)
+                        max_samples = max(int((sampling_rate / 100) * pending_entities.count()), 1)
                     else:
                         max_samples = sample_size - runned_spans_count
                     if cnt is not None:


### PR DESCRIPTION
## Summary
- Continuous-task sampling branch in `process_eval_task` referenced `spans`, a queryset that no longer exists in scope after the rename to `pending_entities`.
- Every cron tick for a CONTINUOUS eval task with sampling raised `NameError`. The broad `except Exception` in `process_eval_task` silently flipped the task to `FAILED` with no traceback to surface it.
- One-line fix: use `pending_entities.count()` so the sampling cap reflects the actual unprocessed batch — which is what the surrounding code (lines 422, 426, 429, 457, 460) already does.

Closes TH-4966.

## Test plan
- [ ] Pick a CONTINUOUS eval task with `sampling_rate` set; confirm a cron tick no longer flips it to `FAILED`
- [ ] Verify processed span count grows on each tick at roughly `sampling_rate%` of the unprocessed batch