### PR TITLE
fix(evals,agents): enable Save & Add for code evals; hide LiveKit provider

### DIFF
--- a/frontend/src/sections/agents/constants.js
+++ b/frontend/src/sections/agents/constants.js
@@ -96,7 +96,8 @@ export const AGENT_TYPES = {
 export const VOICE_CHAT_PROVIDERS = [
   { label: "Vapi", value: "vapi" },
   { label: "Retell", value: "retell" },
-  { label: "LiveKit", value: "livekit_bridge" },
+  // Hidden until LiveKit server stability is restored.
+  // { label: "LiveKit", value: "livekit_bridge" },
   // { label: "ElevenLabs", value: "elevenlabs" },
   { label: "Others", value: "others" },
 ];

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -1157,6 +1157,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     variables={isComposite ? compositeUnionKeys : variables}
                     onTestResult={handleTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
+                    onReadyChange={handleSourceReadyChange}
                     onRowTypeChange={handleSourceRowTypeChange}
                     isComposite={isComposite}
                     compositeAdhocConfig={compositeAdhocConfig}
@@ -1171,6 +1172,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     variables={isComposite ? compositeUnionKeys : variables}
                     onTestResult={handleTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
+                    onReadyChange={handleSourceReadyChange}
                     isComposite={isComposite}
                     compositeAdhocConfig={compositeAdhocConfig}
                   />

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.test.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.test.jsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "src/utils/test-utils";
+
+import EvalPickerProvider from "./context/EvalPickerProvider";
+import EvalPickerCreateNew from "./EvalPickerCreateNew";
+
+const { capturedProps } = vi.hoisted(() => ({
+  capturedProps: { simulation: null, tracing: null, dataset: null },
+}));
+
+vi.mock("src/sections/evals/components/SimulationTestMode", () => {
+  const M = React.forwardRef((props, _ref) => {
+    capturedProps.simulation = props;
+    return <div data-testid="simulation-test-mode" />;
+  });
+  M.displayName = "SimulationTestModeMock";
+  return { default: M };
+});
+
+vi.mock("src/sections/evals/components/TracingTestMode", () => {
+  const M = React.forwardRef((props, _ref) => {
+    capturedProps.tracing = props;
+    return <div data-testid="tracing-test-mode" />;
+  });
+  M.displayName = "TracingTestModeMock";
+  return { default: M };
+});
+
+vi.mock("src/sections/evals/components/DatasetTestMode", () => {
+  const M = React.forwardRef((props, _ref) => {
+    capturedProps.dataset = props;
+    return <div data-testid="dataset-test-mode" />;
+  });
+  M.displayName = "DatasetTestModeMock";
+  return { default: M, JsonValueTree: () => <div /> };
+});
+
+vi.mock("src/sections/evals/components/TestPlayground", () => {
+  const M = React.forwardRef(() => <div />);
+  M.displayName = "TestPlaygroundMock";
+  return { default: M };
+});
+
+vi.mock("src/sections/evals/components/ModelSelector", () => ({
+  default: () => <div />,
+  FAGI_MODEL_VALUES: new Set(),
+}));
+
+vi.mock("src/sections/evals/components/InstructionEditor", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/evals/components/LLMPromptEditor", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/evals/components/CodeEvalEditor", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/evals/components/OutputTypeConfig", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/evals/components/FewShotExamples", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/evals/components/CompositeDetailPanel", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/tasks/components/TaskFilterBar", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("src/sections/tasks/components/TaskLivePreview", () => ({
+  buildApiFilterArray: () => [],
+}));
+
+vi.mock("src/sections/evals/hooks/useCreateEval", () => ({
+  useCreateEval: () => ({ mutateAsync: vi.fn(async () => ({ id: "draft-1" })) }),
+}));
+
+vi.mock("src/sections/evals/hooks/useEvalDetail", () => ({
+  useUpdateEval: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(async () => ({})) }),
+}));
+
+vi.mock("src/sections/evals/hooks/useCompositeEval", () => ({
+  useCreateCompositeEval: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("src/sections/evals/hooks/useCompositeChildrenKeys", () => ({
+  useCompositeChildrenUnionKeys: () => [],
+}));
+
+vi.mock("src/hooks/useDeploymentMode", () => ({
+  useDeploymentMode: () => ({ isOSS: false }),
+}));
+
+vi.mock("notistack", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: vi.fn() }),
+}));
+
+const renderWithSource = (source) =>
+  render(
+    <EvalPickerProvider
+      source={source}
+      sourceId="sim-1"
+      sourceColumns={[]}
+      existingEvals={[]}
+      onEvalAdded={() => {}}
+      onClose={() => {}}
+    >
+      <EvalPickerCreateNew onBack={() => {}} onSave={() => {}} />
+    </EvalPickerProvider>,
+  );
+
+describe("EvalPickerCreateNew — onReadyChange wiring (TH-5013 regression)", () => {
+  beforeEach(() => {
+    capturedProps.simulation = null;
+    capturedProps.tracing = null;
+    capturedProps.dataset = null;
+  });
+
+  it("passes onReadyChange to SimulationTestMode so canSave can flip true after mapping", () => {
+    renderWithSource("simulation");
+    expect(capturedProps.simulation).not.toBeNull();
+    expect(typeof capturedProps.simulation.onReadyChange).toBe("function");
+  });
+
+  it("passes onReadyChange to TracingTestMode for source='tracing'", () => {
+    renderWithSource("tracing");
+    expect(capturedProps.tracing).not.toBeNull();
+    expect(typeof capturedProps.tracing.onReadyChange).toBe("function");
+  });
+
+  it("passes onReadyChange to DatasetTestMode (regression guard for sibling sources)", () => {
+    renderWithSource("dataset");
+    expect(capturedProps.dataset).not.toBeNull();
+    expect(typeof capturedProps.dataset.onReadyChange).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

Two fixes against `dev`:

- **TH-5013** — `EvalPickerCreateNew` was rendering `SimulationTestMode` and `TracingTestMode` without `onReadyChange`, so `sourceReady` in the parent never flipped to true after the user mapped variables. The "Save & Add Evaluation" button stayed disabled even after completing every step. Wire the callback through, matching the pattern already used by `EvalPickerConfigFull` (edit path).
- **TH-4862** — Hide LiveKit from `VOICE_CHAT_PROVIDERS` (comment out, mirroring the existing ElevenLabs precedent) until the LiveKit server is stable. Underlying `livekit_bridge` code paths are left intact so existing agents keep working.

## Linked issues

Refs: TH-5013, TH-4862

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- Added `EvalPickerCreateNew.test.jsx` regression test covering 3 cases:
  - `onReadyChange` is passed to `SimulationTestMode` for `source="simulation"`
  - `onReadyChange` is passed to `TracingTestMode` for `source="tracing"`
  - `onReadyChange` is passed to `DatasetTestMode` for `source="dataset"` (guard against the sibling regression)
- `yarn vitest run src/sections/common/EvalPicker src/sections/agents src/sections/evals` → 32 passed.
- `yarn lint` on changed files → 0 errors.