### PR TITLE
fix(tasks): invalidate task list cache after detail page mutations

### DIFF
--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -72,6 +72,7 @@ const TaskDetailPage = () => {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });
+      queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
       enqueueSnackbar("Task updated successfully", { variant: "success" });
     },
     onError: (err) => {
@@ -85,6 +86,7 @@ const TaskDetailPage = () => {
     mutationFn: () => axios.post(endpoints.project.pauseEvalTask(taskId)),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });
+      queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
       enqueueSnackbar("Task paused", { variant: "success" });
     },
   });
@@ -93,6 +95,7 @@ const TaskDetailPage = () => {
     mutationFn: () => axios.post(endpoints.project.resumeEvalTask(taskId)),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });
+      queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
       enqueueSnackbar("Task resumed", { variant: "success" });
     },
   });
@@ -105,6 +108,7 @@ const TaskDetailPage = () => {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });
+      queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
       enqueueSnackbar("Task renamed", { variant: "success" });
     },
   });


### PR DESCRIPTION
## Summary

Task detail page mutations (`update`, `pause`, `resume`, `rename`) only invalidated the `["taskDetails", taskId]` query cache but not the `["eval-tasks"]` list query. This caused the tasks dashboard to show stale data (e.g. old sampling rate) after editing a task from the detail page until a hard refresh. Added `["eval-tasks"]` cache invalidation to all four mutation `onSuccess` handlers.

## Linked issues

Closes #TH-5016

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

1. Seeded eval tasks with different sampling rates into local DB
2. Opened task detail page, changed sampling from 50% → 100%, saved
3. Navigated back to tasks list — confirmed the updated value appears immediately without a page refresh
4. Tested pause/resume/rename flows — list reflects changes on return

## Screenshots / recordings (if UI)


https://github.com/user-attachments/assets/6b87b24e-aa07-4e27-8cef-c777778ff1b3



## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)