### PR TITLE
fix(tracer): resolve span model fields in eval variable mapping

### DIFF
--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -421,6 +421,11 @@ def _process_mapping(
                 resolved_value = value
                 break
 
+        if resolved_value is _MISSING and attribute in _SPAN_PUBLIC_FIELDS:
+            model_val = getattr(span, attribute, _MISSING)
+            if model_val is not _MISSING:
+                resolved_value = model_val
+
         if resolved_value is not _MISSING:
             if isinstance(resolved_value, str):
                 parsed_mapping[key] = resolved_value
@@ -1733,6 +1738,31 @@ _TRACE_PUBLIC_FIELDS = frozenset(
 )
 _SESSION_PUBLIC_FIELDS = frozenset({"name", "bookmarked"})
 
+# Span model fields that are stored as dedicated DB columns (not inside
+# ``span_attributes``).  The eval mapping picker can expose these via
+# ``spans.<n>.<field>`` paths, but they won't be found by
+# ``_resolve_attr(span_attrs, …)`` because they live on the Django model,
+# not in the JSON bag.  This allow-list mirrors the pattern used by
+# ``_TRACE_PUBLIC_FIELDS`` above.
+_SPAN_PUBLIC_FIELDS = frozenset(
+    {
+        "latency_ms",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "cost",
+        "response_time",
+        "model",
+        "name",
+        "observation_type",
+        "status",
+        "status_message",
+        "provider",
+        "input",
+        "output",
+    }
+)
+
 
 def _resolve_span_path(span: ObservationSpan, path: str):
     """Walk a path against a span via the ``span_attributes`` bag.
@@ -1763,12 +1793,19 @@ def _resolve_span_path(span: ObservationSpan, path: str):
         span_attrs = get_span_attributes(span)
         if not rest:
             return span_attrs
-        # Legacy ``span_attributes.<x>`` paths share resolver semantics
-        # with bare paths.
         return _resolve_attr(span_attrs, rest)
 
     span_attrs = get_span_attributes(span)
-    return _resolve_attr(span_attrs, path)
+    result = _resolve_attr(span_attrs, path)
+    if result is not _MISSING:
+        return result
+
+    if head in _SPAN_PUBLIC_FIELDS and not rest:
+        value = getattr(span, head, _MISSING)
+        if value is not _MISSING:
+            return value
+
+    return _MISSING
 
 
 def _resolve_trace_path(trace: Trace, path: str):

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -3011,6 +3011,21 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         )
         return agg["max_count"] or 0
 
+    _SPAN_PUBLIC_FIELDS = (
+        "latency_ms",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "cost",
+        "response_time",
+        "model",
+        "name",
+        "observation_type",
+        "status",
+        "status_message",
+        "provider",
+    )
+
     def _build_trace_attribute_paths(
         self, project_id: str, span_attribute_keys: list
     ) -> list:
@@ -3019,6 +3034,8 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         paths = list(self._TRACE_PUBLIC_FIELDS)
         max_spans = self._max_spans_per_trace(project_id)
         for i in range(max_spans):
+            for field in self._SPAN_PUBLIC_FIELDS:
+                paths.append(f"spans.{i}.{field}")
             for key in span_attribute_keys:
                 paths.append(f"spans.{i}.{key}")
         return paths
@@ -3036,6 +3053,8 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             for trace_field in self._TRACE_PUBLIC_FIELDS:
                 paths.append(f"traces.{i}.{trace_field}")
             for j in range(max_spans):
+                for field in self._SPAN_PUBLIC_FIELDS:
+                    paths.append(f"traces.{i}.spans.{j}.{field}")
                 for key in span_attribute_keys:
                     paths.append(f"traces.{i}.spans.{j}.{key}")
         return paths


### PR DESCRIPTION
## Summary

- Fix eval task variable mapping failing for span model fields (`latency_ms`, `cost`, `total_tokens`, etc.) that are stored as dedicated DB columns rather than inside the `span_attributes` JSON bag
- Add `_SPAN_PUBLIC_FIELDS` allow-list with `getattr` fallback in both `_resolve_span_path` (trace/session-level evals) and `_process_mapping` (span-level evals)
- Expose span model fields in the eval attribute picker (`get_eval_attributes_list`) so users can discover paths like `spans.0.latency_ms`

## Problem

When doing variable mapping in eval tasks, some variables reference span model fields via paths like `spans.0.latency_ms`. The resolver (`_resolve_span_path`) only searched the `span_attributes` JSONField, but `latency_ms` (and other fields like `cost`, `total_tokens`, `prompt_tokens`) are stored as dedicated columns on `ObservationSpan` — never written into `span_attributes`.

Error: `Required attribute 'spans.0.latency_ms' for key 'latency' not found on trace 066ae56b-...`

## Root Cause

During OTel ingestion, `latency_ms` is computed from `start_time/end_time` and stored in its own `IntegerField` column. The `span_attributes` JSONField only contains the raw OTel attribute bag (`fi.llm.input`, `gen_ai.*`, etc.). The eval resolver had no fallback to check model fields.

## Fix

Mirrors the existing `_TRACE_PUBLIC_FIELDS` pattern: an allow-list of mappable span model fields with a `getattr(span, field)` fallback after `_resolve_attr(span_attrs, ...)` returns `_MISSING`.

## Testing

Reproduced the bug in Docker:
```
_resolve_span_path(span, "latency_ms") == _MISSING: True  # BEFORE
_resolve_span_path(span, "latency_ms") == 0                # AFTER (fix works)
```

Verified existing `span_attributes` resolution still works (no regression):
```
_resolve_span_path(span, "output.value") == "Image processed"  # Still works
```