### PR TITLE
[TH-5023] Fix random error when adding eval (function-params payload + numeric input + required gate)

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1734,7 +1734,19 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                         }
                         label={key}
                         value={codeParams[key] ?? ""}
-                        onChange={(e) => handleCodeParamChange(key, e.target.value)}
+                        onChange={(e) => {
+                          // BE's `type: number` schema rejects strings; coerce here.
+                          const raw = e.target.value;
+                          const isNumeric =
+                            schema?.type === "integer" ||
+                            schema?.type === "number";
+                          let next = raw;
+                          if (isNumeric && raw !== "") {
+                            const n = Number(raw);
+                            if (!Number.isNaN(n)) next = n;
+                          }
+                          handleCodeParamChange(key, next);
+                        }}
                         helperText={
                           configParamsDesc?.[key] || schema?.description || ""
                         }
@@ -1842,6 +1854,25 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             if (!(code || "").trim()) {
               testDisabled = true;
               testDisabledReason = "Write some code before running a test.";
+            } else {
+              const missingRequiredParam = visibleCodeParamEntries.find(
+                ([key, schema]) => {
+                  if (!schema?.required) return false;
+                  if (schema.nullable) return false;
+                  if (schema.default !== null && schema.default !== undefined)
+                    return false;
+                  const v = codeParams[key];
+                  return (
+                    v === undefined ||
+                    v === null ||
+                    (typeof v === "string" && v.trim() === "")
+                  );
+                },
+              );
+              if (missingRequiredParam) {
+                testDisabled = true;
+                testDisabledReason = `Set ${missingRequiredParam[0]} before running a test.`;
+              }
             }
           } else if (!hasInstructions) {
             testDisabled = true;
@@ -1915,6 +1946,26 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             if (!(code || "").trim()) {
               addDisabled = true;
               addDisabledReason = `Write some code before ${actionLabel}.`;
+            } else {
+              // Mirror BE's required-param check so the round-trip never happens.
+              const missingRequiredParam = visibleCodeParamEntries.find(
+                ([key, schema]) => {
+                  if (!schema?.required) return false;
+                  if (schema.nullable) return false;
+                  if (schema.default !== null && schema.default !== undefined)
+                    return false;
+                  const v = codeParams[key];
+                  return (
+                    v === undefined ||
+                    v === null ||
+                    (typeof v === "string" && v.trim() === "")
+                  );
+                },
+              );
+              if (missingRequiredParam) {
+                addDisabled = true;
+                addDisabledReason = `Set ${missingRequiredParam[0]} before ${actionLabel}.`;
+              }
             }
           } else if (!hasInstructions) {
             addDisabled = true;

--- a/frontend/src/sections/common/EvalPicker/serializeEvalConfig.js
+++ b/frontend/src/sections/common/EvalPicker/serializeEvalConfig.js
@@ -42,6 +42,8 @@ export function serializeEvalConfig(evalConfig) {
     mapping: evalConfig.mapping || {},
     config: {
       ...(evalConfig.config || {}),
+      // BE looks up function-param values at `config.params` (normalize_eval_runtime_config).
+      ...(evalConfig.params !== undefined && { params: evalConfig.params }),
       run_config: {
         ...(evalConfig.config?.run_config || {}),
         ...runConfig,

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
@@ -50,7 +50,7 @@ import ScheduledRuns from "../NewTaskDrawer/ScheduledRuns";
 import { getDefaultTaskValues, useGetTaskData } from "../common";
 import TaskConfirmDialog from "./TaskConfirmBox";
 import TaskLogsView from "../TaskLogsView";
-import { EvalPickerDrawer } from "../../EvalPicker";
+import { EvalPickerDrawer, serializeEvalConfig } from "../../EvalPicker";
 
 // ── Configured Eval Card ──
 
@@ -321,6 +321,8 @@ const EditTaskDrawerV2Content = ({
     async (evalConfig) => {
       const tplId = evalConfig.templateId || evalConfig.template_id;
       const existingId = evalConfig.id;
+      // Use serializeEvalConfig so function-params land at config.params.
+      const serialized = serializeEvalConfig(evalConfig);
       try {
         let id;
         if (existingId) {
@@ -331,7 +333,7 @@ const EditTaskDrawerV2Content = ({
               name: evalConfig.name,
               model: evalConfig.model || null,
               mapping: evalConfig.mapping,
-              config: evalConfig.config || {},
+              config: serialized.config,
               error_localizer: evalConfig.errorLocalizerEnabled || false,
             },
           );
@@ -345,7 +347,7 @@ const EditTaskDrawerV2Content = ({
               eval_template: tplId,
               model: evalConfig.model || null,
               mapping: evalConfig.mapping,
-              config: evalConfig.config || {},
+              config: serialized.config,
               filters: getNewTaskFilters(formValues, observeId, true).filters,
               error_localizer: evalConfig.errorLocalizerEnabled || false,
             },

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx
@@ -39,7 +39,7 @@ import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectFie
 import { useNavigate } from "react-router";
 import FilterErrorBoundary from "src/components/ComplexFilter/FilterErrorBoundary";
 import { objectCamelToSnake } from "src/utils/utils";
-import { EvalPickerDrawer } from "../../EvalPicker";
+import { EvalPickerDrawer, serializeEvalConfig } from "../../EvalPicker";
 
 // ── Configured Eval Card ──
 
@@ -285,6 +285,8 @@ const NewTaskDrawerV2 = ({
     async (evalConfig) => {
       const tplId = evalConfig.templateId || evalConfig.template_id;
       const existingId = evalConfig.id;
+      // Use serializeEvalConfig so function-params land at config.params.
+      const serialized = serializeEvalConfig(evalConfig);
       try {
         let id;
         if (existingId) {
@@ -295,7 +297,7 @@ const NewTaskDrawerV2 = ({
               name: evalConfig.name,
               model: evalConfig.model || null,
               mapping: evalConfig.mapping,
-              config: evalConfig.config || {},
+              config: serialized.config,
               error_localizer: evalConfig.errorLocalizerEnabled || false,
             },
           );
@@ -309,7 +311,7 @@ const NewTaskDrawerV2 = ({
               name: evalConfig.name,
               model: evalConfig.model || null,
               mapping: evalConfig.mapping,
-              config: evalConfig.config || {},
+              config: serialized.config,
               error_localizer: evalConfig.errorLocalizerEnabled || false,
             },
           );

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -1458,9 +1458,19 @@ const TestPlayground = React.forwardRef(
                                 : String(schema?.default ?? "")
                             }
                             value={codeParams[key] ?? ""}
-                            onChange={(e) =>
-                              handleCodeParamChange(key, e.target.value)
-                            }
+                            onChange={(e) => {
+                              // BE's `type: number` schema rejects strings; coerce here.
+                              const raw = e.target.value;
+                              const isNumeric =
+                                schema?.type === "integer" ||
+                                schema?.type === "number";
+                              let next = raw;
+                              if (isNumeric && raw !== "") {
+                                const n = Number(raw);
+                                if (!Number.isNaN(n)) next = n;
+                              }
+                              handleCodeParamChange(key, next);
+                            }}
                             sx={{
                               flex: 1,
                               px: 1,


### PR DESCRIPTION
## Summary
Adding a code-eval whose template declared a required `function_params_schema` always failed with `"Failed to create any evaluation configs"`. The BE's `normalize_eval_runtime_config` raises `"<param> is required"` (swallowed by the view as a generic error), driven by three coupled FE bugs:

- `serializeEvalConfig` never landed `params` inside `config.params` — only at the top level and inside `config.run_config.params`, neither of which the BE reads.
- The numeric-param TextField emitted strings even with `type="number"` (HTML behavior); BE's `type: number` schema rejects strings.
- No client-side gate on required params, so incomplete forms hit the API and returned the generic error.

Also fixed two drawers (`NewTaskDrawerV2`, `EditTaskDrawerV2`) that bypassed `serializeEvalConfig` and built the payload manually, dropping the same params.

Closes TH-5023

## Linear Ticket
[TH-5023](https://linear.app/future-agi/issue/TH-5023/random-error-while-adding-eval)

## Files Changed
- `frontend/src/sections/common/EvalPicker/serializeEvalConfig.js` — emit `config.params`
- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx` — string→number coercion on `onChange` + required-param gate on Add and Test buttons
- `frontend/src/sections/evals/components/TestPlayground.jsx` — same numeric coercion
- `frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx` — switch to `serializeEvalConfig`
- `frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx` — switch to `serializeEvalConfig`

## Test plan
- [ ] Add a code-eval with a required `function_params_schema` (e.g. `latency_check` with `max_latency_ms`) — Add button stays disabled until the input is filled, then the create succeeds
- [ ] Verify the request body has `config.params.max_latency_ms` as a **number**, not a string
- [ ] Same flow in: Run-Test eval drawer, Task config panel, NewTaskDrawerV2, EditTaskDrawerV2, Simulation drawer, Test Detail
- [ ] Reopen a saved eval — params rehydrate from `config.params` and the form prefills correctly
- [ ] Test Evaluation button respects the same required-param gate