### PR TITLE
fix(evals): per-attachment rule_prompt override (TH-4908)

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -437,10 +437,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         ...(fullEval.config || {}),
         ...normalizedRunConfig,
       };
-      // Per-attachment saved override (TH-4908): a rule_prompt / messages saved
-      // on THIS attachment (evalData.config) must win over the template default,
-      // otherwise the editor re-hydrates from the template — hiding the override,
-      // killing the "Customized" banner, and clobbering the override on save.
+      // Saved per-attachment override must win over the template default,
+      // else re-opening hydrates from the template and a save clobbers it.
       const savedConfig = evalData?.config || {};
       if (savedConfig.rule_prompt) {
         config.rule_prompt = savedConfig.rule_prompt;
@@ -1357,19 +1355,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                 )}
 
               {(() => {
-                // Precedence matches getEvalPromptText (rule_prompt wins) so the
-                // banner's "View template" / "Reset to default" use the same base
-                // the engine treats as the template default.
+                // Same precedence as getEvalPromptText so View/Reset use the engine's base.
                 const templateDefault =
                   fullEval?.config?.rule_prompt ||
                   fullEval?.instructions ||
                   fullEval?.criteria ||
                   "";
-                // The editable prompt lives in `messages` for llm evals and in
-                // `instructions` for agent evals — compare the right one. The
-                // load effect hydrates this from the saved per-attachment
-                // override, so a comparison against the template detects a
-                // customization on open AND clears correctly on "Reset".
+                // llm evals hold the prompt in messages, agent evals in instructions.
                 const currentPrompt =
                   (evalType === "llm"
                     ? messages?.[0]?.content || instructions

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -11,6 +11,7 @@ import {
   Select,
   Slider,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
@@ -111,7 +112,7 @@ const SOURCE_NAME_SLUGS = {
 };
 
 const getEvalPromptText = (evalData, config = {}) =>
-  evalData?.instructions || config?.rule_prompt || "";
+  config?.rule_prompt || evalData?.instructions || "";
 
 
 const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
@@ -1341,6 +1342,108 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     </Typography>
                   </Box>
                 )}
+
+              {(() => {
+                const templateDefault =
+                  fullEval?.instructions ||
+                  fullEval?.criteria ||
+                  fullEval?.config?.rule_prompt ||
+                  "";
+                const showBanner =
+                  !isComposite &&
+                  (evalType === "agent" || evalType === "llm") &&
+                  dataReady &&
+                  isEditMode &&
+                  instructions &&
+                  templateDefault &&
+                  instructions.trim() !== templateDefault.trim();
+                if (!showBanner) return null;
+                return (
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 1,
+                      px: 1.5,
+                      py: 1,
+                      borderRadius: 1,
+                      border: "1px solid",
+                      borderColor: (theme) => theme.palette.info.light,
+                      bgcolor: (theme) =>
+                        theme.palette.mode === "dark"
+                          ? "rgba(33,150,243,0.08)"
+                          : "rgba(33,150,243,0.06)",
+                    }}
+                  >
+                    <Iconify
+                      icon="eva:info-outline"
+                      width={16}
+                      sx={{ color: "info.dark", flexShrink: 0 }}
+                    />
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        fontSize: "12px",
+                        color: "info.dark",
+                        flex: 1,
+                        lineHeight: 1.4,
+                      }}
+                    >
+                      This prompt is customized for this evaluation. The
+                      template default is different.
+                    </Typography>
+                    <Tooltip
+                      placement="top"
+                      title={
+                        <Box
+                          sx={{
+                            whiteSpace: "pre-wrap",
+                            fontSize: "11px",
+                            maxWidth: 360,
+                            py: 0.5,
+                          }}
+                        >
+                          {templateDefault || "(empty)"}
+                        </Box>
+                      }
+                    >
+                      <Button
+                        size="small"
+                        variant="text"
+                        sx={{
+                          textTransform: "none",
+                          fontSize: "11px",
+                          py: 0.25,
+                          minWidth: 0,
+                        }}
+                      >
+                        View template
+                      </Button>
+                    </Tooltip>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={() => {
+                        setInstructions(templateDefault);
+                        if (evalType === "llm") {
+                          setMessages([
+                            { role: "system", content: templateDefault },
+                          ]);
+                        }
+                        setIsDirty(true);
+                      }}
+                      sx={{
+                        textTransform: "none",
+                        fontSize: "11px",
+                        py: 0.25,
+                        flexShrink: 0,
+                      }}
+                    >
+                      Reset to default
+                    </Button>
+                  </Box>
+                );
+              })()}
 
               {/* Agent type — only render after data loads so Quill
                   initializes with the actual instructions content */}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -114,7 +114,6 @@ const SOURCE_NAME_SLUGS = {
 const getEvalPromptText = (evalData, config = {}) =>
   config?.rule_prompt || evalData?.instructions || "";
 
-
 const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const { isOSS } = useDeploymentMode();
   const {
@@ -212,9 +211,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
 
   // Derived
   const evalType =
-    normalizedFullEval?.evalType ||
-    normalizedEvalData?.evalType ||
-    "llm";
+    normalizedFullEval?.evalType || normalizedEvalData?.evalType || "llm";
   const isSystemEval = normalizedFullEval?.owner === "system";
   const isComposite =
     (normalizedFullEval?.templateType || normalizedEvalData?.templateType) ===
@@ -304,7 +301,10 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     // System evals + Jinja mode: use static required_keys.
     // Jinja's extractJinjaVariables() only returns root names (e.g. "file")
     // not full paths (e.g. "file.code"), so requiredKeys is authoritative.
-    if ((isSystemEval || templateFormat === "jinja") && requiredKeys.length > 0) {
+    if (
+      (isSystemEval || templateFormat === "jinja") &&
+      requiredKeys.length > 0
+    ) {
       return [...new Set(requiredKeys)];
     }
 
@@ -328,7 +328,6 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     code,
     codeLanguage,
   ]);
-
 
   const hasDataInjection = useMemo(
     () =>
@@ -379,7 +378,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     // React Query can return cached detail first and fresh network detail next.
     // Re-hydrate while the form is still clean so fresh fields (e.g.
     // instructions/error_localizer_enabled) are not dropped.
-    if (fullEval && (!initialLoadDone.current || !isDirty) && !selectedVersionId) {
+    if (
+      fullEval &&
+      (!initialLoadDone.current || !isDirty) &&
+      !selectedVersionId
+    ) {
       // Merge template config with any saved runtime overrides from the
       // user eval (run_config). Edit mode: evalData.run_config holds the
       // previously saved model, agentMode, passThreshold, etc.
@@ -435,6 +438,17 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         ...(fullEval.config || {}),
         ...normalizedRunConfig,
       };
+      // Per-attachment saved override (TH-4908): a rule_prompt / messages saved
+      // on THIS attachment (evalData.config) must win over the template default,
+      // otherwise the editor re-hydrates from the template — hiding the override,
+      // killing the "Customized" banner, and clobbering the override on save.
+      const savedConfig = evalData?.config || {};
+      if (savedConfig.rule_prompt) {
+        config.rule_prompt = savedConfig.rule_prompt;
+      }
+      if (savedConfig.messages && savedConfig.messages.length > 0) {
+        config.messages = savedConfig.messages;
+      }
       const promptText = getEvalPromptText(fullEval, config);
       // Set template format BEFORE instructions so the InstructionEditor
       // mounts with the correct key and doesn't lose content on remount.
@@ -446,7 +460,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       // description/criteria text, not a Jinja prompt. Only populate the
       // state slot that matches the eval type so the variable extractor
       // and editors see clean data.
-      const _type = normalizedFullEval?.evalType || normalizedEvalData?.evalType || "llm";
+      const _type =
+        normalizedFullEval?.evalType || normalizedEvalData?.evalType || "llm";
       if (_type === "code") {
         setInstructions("");
         setCode(getEvalCode(normalizedFullEval));
@@ -462,7 +477,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       // canonical value, so we intentionally prefer `fullEval.model`
       // over `evalData.model` to avoid the chip rendering "small".
       setModel(
-        config?.model || fullEval?.model || evalData?.model || ("turing_large"),
+        config?.model || fullEval?.model || evalData?.model || "turing_large",
       );
       setOutputType(fullEval.output_type || "pass_fail");
       // Prefer user's saved run_config overrides (edit flow) over template defaults
@@ -523,7 +538,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         if (di.full_row || di.fullRow) opts.push("dataset_row");
         if (di.span_context || di.spanContext) opts.push("span_context");
         if (di.trace_context || di.traceContext) opts.push("trace_context");
-        if (di.session_context || di.sessionContext) opts.push("session_context");
+        if (di.session_context || di.sessionContext)
+          opts.push("session_context");
         if (di.call_context || di.callContext) opts.push("call_context");
         if (opts.length > 0) {
           setContextOptions(opts);
@@ -550,7 +566,9 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         setEvalName(evalData?.name || fullEval.name || "");
       } else {
         const baseName =
-          fullEval.name || normalizedEvalData?.name || getEvalBaseName(fullEval);
+          fullEval.name ||
+          normalizedEvalData?.name ||
+          getEvalBaseName(fullEval);
         const sanitized = baseName
           .toLowerCase()
           .replace(/\s+/g, "_")
@@ -585,9 +603,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       if (!vId && fullEval) {
         // Type-aware split — see initial-load effect above.
         const _type =
-          normalizedFullEval?.evalType ||
-          normalizedEvalData?.evalType ||
-          "llm";
+          normalizedFullEval?.evalType || normalizedEvalData?.evalType || "llm";
         const promptText = getEvalPromptText(fullEval, fullEval.config || {});
         if (_type === "code") {
           setInstructions("");
@@ -596,7 +612,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           setInstructions(promptText);
           setCode("");
         }
-        setModel(fullEval.config?.model || fullEval.model || ("turing_large"));
+        setModel(fullEval.config?.model || fullEval.model || "turing_large");
         if (fullEval.config?.messages?.length > 0) {
           setMessages(fullEval.config.messages);
         } else if (_type === "llm" && promptText) {
@@ -645,9 +661,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         // Type-aware split — version snapshot's `criteria` is the code
         // text for code evals, the prompt for agent/llm.
         const _type =
-          normalizedFullEval?.evalType ||
-          normalizedEvalData?.evalType ||
-          "llm";
+          normalizedFullEval?.evalType || normalizedEvalData?.evalType || "llm";
         if (_type === "code") {
           setInstructions("");
           setCode(config.code || "");
@@ -655,7 +669,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           setInstructions(promptText);
           setCode("");
         }
-        setModel(config.model || ("turing_large"));
+        setModel(config.model || "turing_large");
         if (config.messages?.length > 0) {
           setMessages(config.messages);
         } else if (_type === "llm" && promptText) {
@@ -1349,14 +1363,22 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   fullEval?.criteria ||
                   fullEval?.config?.rule_prompt ||
                   "";
+                // The editable prompt lives in `messages` for llm evals and in
+                // `instructions` for agent evals — compare the right one. The
+                // load effect hydrates this from the saved per-attachment
+                // override, so a comparison against the template detects a
+                // customization on open AND clears correctly on "Reset".
+                const currentPrompt =
+                  (evalType === "llm"
+                    ? messages?.[0]?.content || instructions
+                    : instructions) || "";
                 const showBanner =
                   !isComposite &&
                   (evalType === "agent" || evalType === "llm") &&
                   dataReady &&
-                  isEditMode &&
-                  instructions &&
                   templateDefault &&
-                  instructions.trim() !== templateDefault.trim();
+                  currentPrompt.trim() &&
+                  currentPrompt.trim() !== templateDefault.trim();
                 if (!showBanner) return null;
                 return (
                   <Box
@@ -1669,7 +1691,6 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   sx={{ alignItems: "flex-start" }}
                 />
               )}
-
             </Box>
           }
           rightPanel={
@@ -1990,55 +2011,57 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           </Typography>
         )}
 
-        {source !== "composite" && source !== "workbench" && (() => {
-          const hasInstructions = !!(instructions || "").trim();
-          const hasVariables =
-            Array.isArray(variables) && variables.length > 0;
+        {source !== "composite" &&
+          source !== "workbench" &&
+          (() => {
+            const hasInstructions = !!(instructions || "").trim();
+            const hasVariables =
+              Array.isArray(variables) && variables.length > 0;
 
-          let testDisabled = false;
-          let testDisabledReason = "";
+            let testDisabled = false;
+            let testDisabledReason = "";
 
-          if (isTesting) {
-            testDisabled = true;
-            testDisabledReason = "Test is already running.";
-          } else if (isComposite) {
-            // Composite templates have no instructions/variables of their
-            // own — they're driven by child evaluations + required_keys.
-            // Skip the content checks; sourceReady below still applies.
-          } else if (evalType === "code") {
-            if (!(code || "").trim()) {
+            if (isTesting) {
               testDisabled = true;
-              testDisabledReason = "Write some code before running a test.";
-            } else {
-              const missingRequiredParam = visibleCodeParamEntries.find(
-                ([key, schema]) => {
-                  if (!schema?.required) return false;
-                  if (schema.nullable) return false;
-                  if (schema.default !== null && schema.default !== undefined)
-                    return false;
-                  const v = codeParams[key];
-                  return (
-                    v === undefined ||
-                    v === null ||
-                    (typeof v === "string" && v.trim() === "")
-                  );
-                },
-              );
-              if (missingRequiredParam) {
+              testDisabledReason = "Test is already running.";
+            } else if (isComposite) {
+              // Composite templates have no instructions/variables of their
+              // own — they're driven by child evaluations + required_keys.
+              // Skip the content checks; sourceReady below still applies.
+            } else if (evalType === "code") {
+              if (!(code || "").trim()) {
                 testDisabled = true;
-                testDisabledReason = `Set ${missingRequiredParam[0]} before running a test.`;
+                testDisabledReason = "Write some code before running a test.";
+              } else {
+                const missingRequiredParam = visibleCodeParamEntries.find(
+                  ([key, schema]) => {
+                    if (!schema?.required) return false;
+                    if (schema.nullable) return false;
+                    if (schema.default !== null && schema.default !== undefined)
+                      return false;
+                    const v = codeParams[key];
+                    return (
+                      v === undefined ||
+                      v === null ||
+                      (typeof v === "string" && v.trim() === "")
+                    );
+                  },
+                );
+                if (missingRequiredParam) {
+                  testDisabled = true;
+                  testDisabledReason = `Set ${missingRequiredParam[0]} before running a test.`;
+                }
               }
+            } else if (!hasInstructions) {
+              testDisabled = true;
+              testDisabledReason = "Add instructions before running a test.";
+            } else if (!hasVariables && !hasDataInjection) {
+              testDisabled = true;
+              testDisabledReason =
+                templateFormat === "jinja"
+                  ? "Your Jinja template has no variables. Reference an input with a {{ variable }} expression or a {% ... %} block (e.g. {{ input }}) so test input can be passed in."
+                  : "Your Mustache template has no variables. Add a {{variable}} placeholder (e.g. {{input}}) so test input can be passed in.";
             }
-          } else if (!hasInstructions) {
-            testDisabled = true;
-            testDisabledReason = "Add instructions before running a test.";
-          } else if (!hasVariables && !hasDataInjection) {
-            testDisabled = true;
-            testDisabledReason =
-              templateFormat === "jinja"
-                ? "Your Jinja template has no variables. Reference an input with a {{ variable }} expression or a {% ... %} block (e.g. {{ input }}) so test input can be passed in."
-                : "Your Mustache template has no variables. Add a {{variable}} placeholder (e.g. {{input}}) so test input can be passed in.";
-          }
 
           if (!testDisabled && !sourceReady) {
             testDisabled = true;
@@ -2046,9 +2069,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           }
 
           return (
-            <ShowComponent
-              condition={!hasDataInjection}
-            >
+            <ShowComponent condition={!hasDataInjection}>
               <CustomTooltip
                 show={testDisabled && !!testDisabledReason}
                 type=""
@@ -2081,8 +2102,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
 
         {(() => {
           const hasInstructions = !!(instructions || "").trim();
-          const hasVariables =
-            Array.isArray(variables) && variables.length > 0;
+          const hasVariables = Array.isArray(variables) && variables.length > 0;
           const actionLabel =
             source === "composite"
               ? "adding this evaluation to the composite"

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1357,10 +1357,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                 )}
 
               {(() => {
+                // Precedence matches getEvalPromptText (rule_prompt wins) so the
+                // banner's "View template" / "Reset to default" use the same base
+                // the engine treats as the template default.
                 const templateDefault =
+                  fullEval?.config?.rule_prompt ||
                   fullEval?.instructions ||
                   fullEval?.criteria ||
-                  fullEval?.config?.rule_prompt ||
                   "";
                 // The editable prompt lives in `messages` for llm evals and in
                 // `instructions` for agent evals — compare the right one. The

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -11,7 +11,6 @@ import {
   Select,
   Slider,
   TextField,
-  Tooltip,
   Typography,
 } from "@mui/material";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
@@ -552,8 +551,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       }
       setErrorLocalizerEnabled(
         config.error_localizer_enabled ??
-        fullEval.error_localizer_enabled ??
-        false,
+          fullEval.error_localizer_enabled ??
+          false,
       );
 
       // Edit mode: keep the saved name. Create mode: generate a unique name
@@ -648,8 +647,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         setUseInternet(fullEval.config?.check_internet ?? false);
         setErrorLocalizerEnabled(
           fullEval.error_localizer_enabled ??
-          fullEval.config?.error_localizer_enabled ??
-          false,
+            fullEval.config?.error_localizer_enabled ??
+            false,
         );
         setIsDirty(false);
         return;
@@ -1414,8 +1413,10 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                       This prompt is customized for this evaluation. The
                       template default is different.
                     </Typography>
-                    <Tooltip
-                      placement="top"
+                    <CustomTooltip
+                      show
+                      type=""
+                      arrow
                       title={
                         <Box
                           sx={{
@@ -1429,19 +1430,21 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                         </Box>
                       }
                     >
-                      <Button
-                        size="small"
-                        variant="text"
-                        sx={{
-                          textTransform: "none",
-                          fontSize: "11px",
-                          py: 0.25,
-                          minWidth: 0,
-                        }}
-                      >
-                        View template
-                      </Button>
-                    </Tooltip>
+                      <span>
+                        <Button
+                          size="small"
+                          variant="text"
+                          sx={{
+                            textTransform: "none",
+                            fontSize: "11px",
+                            py: 0.25,
+                            minWidth: 0,
+                          }}
+                        >
+                          View template
+                        </Button>
+                      </span>
+                    </CustomTooltip>
                     <Button
                       size="small"
                       variant="outlined"
@@ -1601,7 +1604,10 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     Code evaluator returns a score between 0 and 1. Set a pass
                     threshold below.
                   </Typography>
-                  <Typography variant="subtitle2"  sx={{ mb: 0.5,color:"text.primary" }}>
+                  <Typography
+                    variant="subtitle2"
+                    sx={{ mb: 0.5, color: "text.primary" }}
+                  >
                     Pass Threshold
                   </Typography>
                   <Typography
@@ -1765,27 +1771,27 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   source === "workbench" ||
                   source === "run-experiment" ||
                   source === "run-optimization") && (
-                    <DatasetTestMode
-                      ref={sourceRef}
-                      templateId={templateId}
-                      variables={variables}
-                      model={model}
-                      codeParams={codeParams}
-                      onTestResult={handleTestResult}
-                      onClearResult={handleClearTestResult}
-                      onColumnsLoaded={handleColumnsLoaded}
-                      initialDatasetId={sourceId}
-                      onReadyChange={handleSourceReadyChange}
-                      contextOptions={contextOptions}
-                      errorLocalizerEnabled={errorLocalizerEnabled}
-                      initialMapping={evalData?.mapping}
-                      {...compositeSourceModeProps}
-                      sourceColumns={
-                        source === "workbench" ? sourceColumns : null
-                      }
-                      extraColumns={extraColumns}
-                    />
-                  )}
+                  <DatasetTestMode
+                    ref={sourceRef}
+                    templateId={templateId}
+                    variables={variables}
+                    model={model}
+                    codeParams={codeParams}
+                    onTestResult={handleTestResult}
+                    onClearResult={handleClearTestResult}
+                    onColumnsLoaded={handleColumnsLoaded}
+                    initialDatasetId={sourceId}
+                    onReadyChange={handleSourceReadyChange}
+                    contextOptions={contextOptions}
+                    errorLocalizerEnabled={errorLocalizerEnabled}
+                    initialMapping={evalData?.mapping}
+                    {...compositeSourceModeProps}
+                    sourceColumns={
+                      source === "workbench" ? sourceColumns : null
+                    }
+                    extraColumns={extraColumns}
+                  />
+                )}
                 {source === "tracing" && (
                   <TracingTestMode
                     ref={sourceRef}
@@ -1894,49 +1900,51 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   />
                 )}
 
-                {source !== "composite" && visibleCodeParamEntries.length > 0 && (
-                  <Box sx={{ mt: 2 }}>
-                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                      Parameters
-                    </Typography>
-                    {visibleCodeParamEntries.map(([key, schema]) => (
-                      <TextField
-                        key={key}
-                        fullWidth
-                        size="small"
-                        type={
-                          schema?.type === "integer" || schema?.type === "number"
-                            ? "number"
-                            : "text"
-                        }
-                        label={key}
-                        value={codeParams[key] ?? ""}
-                        onChange={(e) => {
-                          // BE's `type: number` schema rejects strings; coerce here.
-                          const raw = e.target.value;
-                          const isNumeric =
+                {source !== "composite" &&
+                  visibleCodeParamEntries.length > 0 && (
+                    <Box sx={{ mt: 2 }}>
+                      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                        Parameters
+                      </Typography>
+                      {visibleCodeParamEntries.map(([key, schema]) => (
+                        <TextField
+                          key={key}
+                          fullWidth
+                          size="small"
+                          type={
                             schema?.type === "integer" ||
-                            schema?.type === "number";
-                          let next = raw;
-                          if (isNumeric && raw !== "") {
-                            const n = Number(raw);
-                            if (!Number.isNaN(n)) next = n;
+                            schema?.type === "number"
+                              ? "number"
+                              : "text"
                           }
-                          handleCodeParamChange(key, next);
-                        }}
-                        helperText={
-                          configParamsDesc?.[key] || schema?.description || ""
-                        }
-                        placeholder={
-                          schema?.nullable
-                            ? "optional"
-                            : String(schema?.default ?? "")
-                        }
-                        sx={{ mb: 1 }}
-                      />
-                    ))}
-                  </Box>
-                )}
+                          label={key}
+                          value={codeParams[key] ?? ""}
+                          onChange={(e) => {
+                            // BE's `type: number` schema rejects strings; coerce here.
+                            const raw = e.target.value;
+                            const isNumeric =
+                              schema?.type === "integer" ||
+                              schema?.type === "number";
+                            let next = raw;
+                            if (isNumeric && raw !== "") {
+                              const n = Number(raw);
+                              if (!Number.isNaN(n)) next = n;
+                            }
+                            handleCodeParamChange(key, next);
+                          }}
+                          helperText={
+                            configParamsDesc?.[key] || schema?.description || ""
+                          }
+                          placeholder={
+                            schema?.nullable
+                              ? "optional"
+                              : String(schema?.default ?? "")
+                          }
+                          sx={{ mb: 1 }}
+                        />
+                      ))}
+                    </Box>
+                  )}
               </Box>
             </Box>
           }
@@ -2068,37 +2076,37 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             testDisabledReason = "Map all variables before running a test.";
           }
 
-          return (
-            <ShowComponent condition={!hasDataInjection}>
-              <CustomTooltip
-                show={testDisabled && !!testDisabledReason}
-                type=""
-                title={testDisabledReason}
-                arrow
-              >
-                <span>
-                  <Button
-                    variant="outlined"
-                    color="primary"
-                    size="small"
-                    onClick={handleTestEvaluation}
-                    disabled={testDisabled}
-                    startIcon={
-                      isTesting ? (
-                        <CircularProgress size={14} />
-                      ) : (
-                        <Iconify icon="mdi:play-circle-outline" width={16} />
-                      )
-                    }
-                    sx={{ textTransform: "none" }}
-                  >
-                    {isTesting ? "Testing..." : "Test Evaluation"}
-                  </Button>
-                </span>
-              </CustomTooltip>
-            </ShowComponent>
-          );
-        })()}
+            return (
+              <ShowComponent condition={!hasDataInjection}>
+                <CustomTooltip
+                  show={testDisabled && !!testDisabledReason}
+                  type=""
+                  title={testDisabledReason}
+                  arrow
+                >
+                  <span>
+                    <Button
+                      variant="outlined"
+                      color="primary"
+                      size="small"
+                      onClick={handleTestEvaluation}
+                      disabled={testDisabled}
+                      startIcon={
+                        isTesting ? (
+                          <CircularProgress size={14} />
+                        ) : (
+                          <Iconify icon="mdi:play-circle-outline" width={16} />
+                        )
+                      }
+                      sx={{ textTransform: "none" }}
+                    >
+                      {isTesting ? "Testing..." : "Test Evaluation"}
+                    </Button>
+                  </span>
+                </CustomTooltip>
+              </ShowComponent>
+            );
+          })()}
 
         {(() => {
           const hasInstructions = !!(instructions || "").trim();

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -126,6 +126,8 @@ const ConfiguredEvalCard = ({ evalItem, onEdit, onRemove }) => {
 
   const hasError = !evalItem?.id;
 
+  const isCustomized = Boolean(evalItem?.is_customized);
+
   return (
     <Box
       sx={{
@@ -166,6 +168,24 @@ const ConfiguredEvalCard = ({ evalItem, onEdit, onRemove }) => {
           >
             {name}
           </Typography>
+
+          {isCustomized && (
+            <Tooltip title="This evaluation runs a custom prompt for this task — the template default is different.">
+              <Chip
+                label="Customized"
+                size="small"
+                variant="outlined"
+                sx={{
+                  height: 18,
+                  fontSize: "10px",
+                  fontWeight: 500,
+                  borderColor: "divider",
+                  color: "text.secondary",
+                  "& .MuiChip-label": { px: 0.75 },
+                }}
+              />
+            </Tooltip>
+          )}
 
           {/* Type-specific metadata — code shows language, llm/agent
               show model. Output type is always informative. */}
@@ -459,6 +479,7 @@ const TaskConfigPanel = ({
               ...corePayload.config,
             },
             mapping: evalConfig.mapping || {},
+            is_customized: resp?.result?.is_customized ?? false,
           };
         } else {
           const { data: resp } = await axios.post(

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -365,8 +365,6 @@ const TaskConfigPanel = ({
     keyName: "_fieldId",
   });
 
-
-
   const [pendingProject, setPendingProject] = useState(null);
 
   const handleProjectFieldChange = useCallback(
@@ -449,7 +447,6 @@ const TaskConfigPanel = ({
 
       const serialized = serializeEvalConfig(evalConfig);
 
-
       const corePayload = {
         eval_template: tplId,
         name: evalConfig.name,
@@ -496,13 +493,14 @@ const TaskConfigPanel = ({
               ...corePayload.config,
             },
             mapping: evalConfig.mapping || {},
+            is_customized: resp?.result?.is_customized ?? false,
           };
         }
       } catch (error) {
         enqueueSnackbar(
           error?.response?.data?.result ||
-          error?.response?.data?.error ||
-          "Failed to save evaluation",
+            error?.response?.data?.error ||
+            "Failed to save evaluation",
           { variant: "error" },
         );
         throw error;
@@ -549,7 +547,8 @@ const TaskConfigPanel = ({
     if (!stored) return null;
     // API response uses `eval_template` for the template FK;
     // locally-added evals use `templateId` / `template_id`.
-    const tplId = stored.templateId || stored.template_id || stored.eval_template;
+    const tplId =
+      stored.templateId || stored.template_id || stored.eval_template;
 
     const savedErrorLocalizer =
       stored.error_localizer_enabled ?? stored.error_localizer;
@@ -701,16 +700,16 @@ const TaskConfigPanel = ({
                         bgcolor:
                           rowType === t.value
                             ? (theme) =>
-                              theme.palette.mode === "dark"
-                                ? "rgba(255,255,255,0.12)"
-                                : "background.paper"
+                                theme.palette.mode === "dark"
+                                  ? "rgba(255,255,255,0.12)"
+                                  : "background.paper"
                             : "transparent",
                         boxShadow:
                           rowType === t.value
                             ? (theme) =>
-                              theme.palette.mode === "dark"
-                                ? "none"
-                                : "0 1px 3px rgba(0,0,0,0.08)"
+                                theme.palette.mode === "dark"
+                                  ? "none"
+                                  : "0 1px 3px rgba(0,0,0,0.08)"
                             : "none",
                         borderRadius: "6px",
                         fontWeight: rowType === t.value ? 600 : 400,

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -414,6 +414,14 @@ def create_eval_instance(
     # Apply version overrides
     config, criteria = apply_version_overrides(config, resolved_version, criteria)
 
+    # Per-attachment rule_prompt override wins over template + version.
+    # `runtime_config` is UserEvalMetric.config (dataset path) or
+    # CustomEvalConfig.config (tracer path). If the user has set their
+    # own `rule_prompt` on the attachment, honor it. Empty string falls
+    # back via the `or` short-circuit.
+    if runtime_config and (runtime_config.get("rule_prompt") or None):
+        config["rule_prompt"] = runtime_config["rule_prompt"]
+
     # Runtime override merge.
     #
     # Priority (lowest to highest): template default → UserEvalMetric.run_config

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -455,12 +455,9 @@ def create_eval_instance(
     ):
         config = eval_template.config.get("config")
 
-    # Per-attachment rule_prompt override wins over template + version.
-    # `runtime_config` is UserEvalMetric.config (dataset path) or
-    # CustomEvalConfig.config (tracer path). Applied AFTER the function-eval
-    # config reassignments above, otherwise those wipe the override for
-    # function-param / function_eval templates. Blank / whitespace-only
-    # values fall back to the template (matching is_rule_prompt_customized).
+    # Per-attachment rule_prompt override. Must run AFTER the function-eval
+    # config reassignments above, which would otherwise wipe it. Blank values
+    # fall back to the template.
     if config is not None and runtime_config:
         _rule_prompt_override = runtime_config.get("rule_prompt")
         if _rule_prompt_override and _rule_prompt_override.strip():

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -414,14 +414,6 @@ def create_eval_instance(
     # Apply version overrides
     config, criteria = apply_version_overrides(config, resolved_version, criteria)
 
-    # Per-attachment rule_prompt override wins over template + version.
-    # `runtime_config` is UserEvalMetric.config (dataset path) or
-    # CustomEvalConfig.config (tracer path). If the user has set their
-    # own `rule_prompt` on the attachment, honor it. Empty string falls
-    # back via the `or` short-circuit.
-    if runtime_config and (runtime_config.get("rule_prompt") or None):
-        config["rule_prompt"] = runtime_config["rule_prompt"]
-
     # Runtime override merge.
     #
     # Priority (lowest to highest): template default → UserEvalMetric.run_config
@@ -462,6 +454,17 @@ def create_eval_instance(
         and eval_type_id_check != "CustomCodeEval"
     ):
         config = eval_template.config.get("config")
+
+    # Per-attachment rule_prompt override wins over template + version.
+    # `runtime_config` is UserEvalMetric.config (dataset path) or
+    # CustomEvalConfig.config (tracer path). Applied AFTER the function-eval
+    # config reassignments above, otherwise those wipe the override for
+    # function-param / function_eval templates. Blank / whitespace-only
+    # values fall back to the template (matching is_rule_prompt_customized).
+    if config is not None and runtime_config:
+        _rule_prompt_override = runtime_config.get("rule_prompt")
+        if _rule_prompt_override and _rule_prompt_override.strip():
+            config["rule_prompt"] = _rule_prompt_override
 
     # Add knowledge base if provided
     if kb_id and config:

--- a/futureagi/evaluations/engine/tests/test_rule_prompt_override.py
+++ b/futureagi/evaluations/engine/tests/test_rule_prompt_override.py
@@ -1,6 +1,6 @@
 """
 Regression tests for the per-attachment ``rule_prompt`` override in
-``evaluations.engine.instance.create_eval_instance`` (TH-4908).
+``evaluations.engine.instance.create_eval_instance``.
 
 The override (``runtime_config['rule_prompt']`` from CustomEvalConfig.config /
 UserEvalMetric.config) must win over the template default. Critically it must be
@@ -59,7 +59,7 @@ def _run(template_config, runtime_config):
 
 def test_override_survives_function_eval_reassignment(stub_db_helpers):
     # function_eval templates reassign `config` to template.config["config"];
-    # the override must land AFTER that, not before (the original TH-4908 bug).
+    # the override must land AFTER that, not before.
     captured = _run(
         template_config={
             "eval_type_id": "DeterministicEvaluator",

--- a/futureagi/evaluations/engine/tests/test_rule_prompt_override.py
+++ b/futureagi/evaluations/engine/tests/test_rule_prompt_override.py
@@ -1,0 +1,103 @@
+"""
+Regression tests for the per-attachment ``rule_prompt`` override in
+``evaluations.engine.instance.create_eval_instance`` (TH-4908).
+
+The override (``runtime_config['rule_prompt']`` from CustomEvalConfig.config /
+UserEvalMetric.config) must win over the template default. Critically it must be
+applied AFTER the function-eval ``config`` reassignments, otherwise a
+``function_eval`` template silently discards the customer's prompt.
+
+These exercise the real ``create_eval_instance`` (DB-touching helpers stubbed),
+so they fail if the override is ever moved back above the reassignment.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from evaluations.engine import instance as engine_instance
+
+
+class _CapturingEval:
+    """Stand-in evaluator that records the kwargs it was constructed with."""
+
+    def __init__(self, **kwargs):
+        self.captured = kwargs
+
+
+@pytest.fixture
+def stub_db_helpers(monkeypatch):
+    """Make create_eval_instance run without touching the DB / version model."""
+    monkeypatch.setattr(engine_instance, "resolve_version", lambda *a, **k: None)
+    monkeypatch.setattr(
+        engine_instance,
+        "prepare_eval_config",
+        lambda eval_template, config, **k: (config, None),
+    )
+    monkeypatch.setattr(
+        engine_instance,
+        "apply_version_overrides",
+        lambda config, version, criteria: (config, criteria),
+    )
+
+
+def _template(config):
+    return SimpleNamespace(config=config, organization=None)
+
+
+def _run(template_config, runtime_config):
+    inst, _ = engine_instance.create_eval_instance(
+        eval_class=_CapturingEval,
+        eval_template=_template(template_config),
+        config={},
+        runtime_config=runtime_config,
+    )
+    return inst.captured
+
+
+def test_override_survives_function_eval_reassignment(stub_db_helpers):
+    # function_eval templates reassign `config` to template.config["config"];
+    # the override must land AFTER that, not before (the original TH-4908 bug).
+    captured = _run(
+        template_config={
+            "eval_type_id": "DeterministicEvaluator",
+            "function_eval": True,
+            "config": {"rule_prompt": "TEMPLATE DEFAULT"},
+        },
+        runtime_config={"rule_prompt": "CUSTOM FOR IFORM"},
+    )
+    assert captured["rule_prompt"] == "CUSTOM FOR IFORM"
+
+
+def test_override_applies_for_non_function_eval(stub_db_helpers):
+    captured = _run(
+        template_config={"eval_type_id": "CustomPromptEvaluator"},
+        runtime_config={"rule_prompt": "CUSTOM FOR IFORM"},
+    )
+    assert captured["rule_prompt"] == "CUSTOM FOR IFORM"
+
+
+def test_empty_override_falls_back_to_template(stub_db_helpers):
+    captured = _run(
+        template_config={
+            "eval_type_id": "DeterministicEvaluator",
+            "function_eval": True,
+            "config": {"rule_prompt": "TEMPLATE DEFAULT"},
+        },
+        runtime_config={"rule_prompt": "   "},
+    )
+    assert captured["rule_prompt"] == "TEMPLATE DEFAULT"
+
+
+def test_no_runtime_config_keeps_template_default(stub_db_helpers):
+    captured = _run(
+        template_config={
+            "eval_type_id": "DeterministicEvaluator",
+            "function_eval": True,
+            "config": {"rule_prompt": "TEMPLATE DEFAULT"},
+        },
+        runtime_config=None,
+    )
+    assert captured["rule_prompt"] == "TEMPLATE DEFAULT"

--- a/futureagi/evaluations/engine/tests/test_rule_prompt_override.py
+++ b/futureagi/evaluations/engine/tests/test_rule_prompt_override.py
@@ -5,7 +5,7 @@ Regression tests for the per-attachment ``rule_prompt`` override in
 The override (``runtime_config['rule_prompt']`` from CustomEvalConfig.config /
 UserEvalMetric.config) must win over the template default. Critically it must be
 applied AFTER the function-eval ``config`` reassignments, otherwise a
-``function_eval`` template silently discards the customer's prompt.
+``function_eval`` template silently discards the saved per-attachment override.
 
 These exercise the real ``create_eval_instance`` (DB-touching helpers stubbed),
 so they fail if the override is ever moved back above the reassignment.

--- a/futureagi/tracer/serializers/custom_eval_config.py
+++ b/futureagi/tracer/serializers/custom_eval_config.py
@@ -7,6 +7,24 @@ from tracer.models.custom_eval_config import CustomEvalConfig
 from tracer.models.project import Project
 
 
+def is_rule_prompt_customized(custom_eval_config):
+    """Return True when CustomEvalConfig.config.rule_prompt overrides the eval template default.
+
+    Empty / whitespace-only overrides are treated as not-customized so the runtime falls back to
+    the template. Comparison against both `eval_template.config.rule_prompt` and
+    `eval_template.criteria` (the deterministic-eval slot) so saved-without-edit attachments
+    don't trip the flag.
+    """
+    config = getattr(custom_eval_config, "config", None) or {}
+    saved = (config.get("rule_prompt") or "").strip()
+    if not saved:
+        return False
+    tpl = custom_eval_config.eval_template
+    tpl_prompt = ((tpl.config or {}).get("rule_prompt") or "").strip()
+    tpl_criteria = (tpl.criteria or "").strip()
+    return saved != tpl_prompt and saved != tpl_criteria
+
+
 class CustomEvalConfigSerializer(serializers.ModelSerializer):
     eval_template = serializers.PrimaryKeyRelatedField(
         queryset=EvalTemplate.objects.all(), many=False
@@ -22,6 +40,7 @@ class CustomEvalConfigSerializer(serializers.ModelSerializer):
     )
 
     eval_group = serializers.SerializerMethodField()
+    is_customized = serializers.SerializerMethodField()
 
     class Meta:
         model = CustomEvalConfig
@@ -37,12 +56,16 @@ class CustomEvalConfigSerializer(serializers.ModelSerializer):
             "kb_id",
             "model",
             "eval_group",
+            "is_customized",
         ]
 
     def get_eval_group(self, obj):
         if obj.eval_group:
             return obj.eval_group.name
         return None
+
+    def get_is_customized(self, obj):
+        return is_rule_prompt_customized(obj)
 
     def validate(self, attrs):
         eval_template = attrs.get("eval_template") or getattr(

--- a/futureagi/tracer/serializers/custom_eval_config.py
+++ b/futureagi/tracer/serializers/custom_eval_config.py
@@ -11,18 +11,27 @@ def is_rule_prompt_customized(custom_eval_config):
     """Return True when CustomEvalConfig.config.rule_prompt overrides the eval template default.
 
     Empty / whitespace-only overrides are treated as not-customized so the runtime falls back to
-    the template. Comparison against both `eval_template.config.rule_prompt` and
-    `eval_template.criteria` (the deterministic-eval slot) so saved-without-edit attachments
-    don't trip the flag.
+    the template. The saved value is compared against every slot the template default can live in:
+      - ``eval_template.config.rule_prompt`` (top level)
+      - ``eval_template.config.config.rule_prompt`` (nested — function_eval templates reassign
+        config to this dict in engine/instance.py)
+      - ``eval_template.criteria`` (the deterministic-eval slot)
+    so a saved-without-edit attachment doesn't trip the flag regardless of eval type.
     """
     config = getattr(custom_eval_config, "config", None) or {}
     saved = (config.get("rule_prompt") or "").strip()
     if not saved:
         return False
     tpl = custom_eval_config.eval_template
-    tpl_prompt = ((tpl.config or {}).get("rule_prompt") or "").strip()
-    tpl_criteria = (tpl.criteria or "").strip()
-    return saved != tpl_prompt and saved != tpl_criteria
+    tpl_config = tpl.config or {}
+    nested = tpl_config.get("config")
+    nested = nested if isinstance(nested, dict) else {}
+    template_defaults = {
+        (tpl_config.get("rule_prompt") or "").strip(),
+        (nested.get("rule_prompt") or "").strip(),
+        (tpl.criteria or "").strip(),
+    }
+    return saved not in template_defaults
 
 
 class CustomEvalConfigSerializer(serializers.ModelSerializer):

--- a/futureagi/tracer/views/custom_eval_config.py
+++ b/futureagi/tracer/views/custom_eval_config.py
@@ -34,8 +34,10 @@ class CustomEvalConfigView(BaseModelViewSetMixin, ModelViewSet):
 
     def get_queryset(self):
         custom_eval_config_id = self.kwargs.get("pk")
-        # Get base queryset with automatic filtering from mixin
-        queryset = super().get_queryset()
+        # Get base queryset with automatic filtering from mixin.
+        # select_related the template so the serializer's is_customized
+        # flag (which reads eval_template.config/criteria) doesn't N+1.
+        queryset = super().get_queryset().select_related("eval_template")
 
         if custom_eval_config_id:
             queryset = queryset.filter(id=custom_eval_config_id)

--- a/futureagi/tracer/views/custom_eval_config.py
+++ b/futureagi/tracer/views/custom_eval_config.py
@@ -23,6 +23,7 @@ from tracer.serializers.custom_eval_config import (
     CustomEvalConfigSerializer,
     GetCustomEvalTemplateSerializer,
     RunEvaluationSerializer,
+    is_rule_prompt_customized,
 )
 from tracer.utils.eval import evaluate_observation_span
 
@@ -88,7 +89,12 @@ class CustomEvalConfigView(BaseModelViewSetMixin, ModelViewSet):
             serializer.validated_data["mapping"] = mapping
             custom_eval_config = serializer.save()
 
-            return self._gm.success_response({"id": str(custom_eval_config.id)})
+            return self._gm.success_response(
+                {
+                    "id": str(custom_eval_config.id),
+                    "is_customized": is_rule_prompt_customized(custom_eval_config),
+                }
+            )
 
         except Exception as e:
             traceback.print_exc()
@@ -147,9 +153,14 @@ class CustomEvalConfigView(BaseModelViewSetMixin, ModelViewSet):
                         mapping.pop(key)
                 serializer.validated_data["mapping"] = mapping
 
-            serializer.save()
+            custom_eval_config = serializer.save()
 
-            return self._gm.success_response({"id": str(custom_eval_config.id)})
+            return self._gm.success_response(
+                {
+                    "id": str(custom_eval_config.id),
+                    "is_customized": is_rule_prompt_customized(custom_eval_config),
+                }
+            )
 
         except Exception as e:
             traceback.print_exc()

--- a/futureagi/tracer/views/custom_eval_config.py
+++ b/futureagi/tracer/views/custom_eval_config.py
@@ -88,6 +88,9 @@ class CustomEvalConfigView(BaseModelViewSetMixin, ModelViewSet):
 
             serializer.validated_data["mapping"] = mapping
             custom_eval_config = serializer.save()
+            # Reuse the already-fetched template so is_rule_prompt_customized
+            # doesn't fire an extra FK query for the response.
+            custom_eval_config.eval_template = eval_template
 
             return self._gm.success_response(
                 {
@@ -107,7 +110,9 @@ class CustomEvalConfigView(BaseModelViewSetMixin, ModelViewSet):
         try:
             custom_eval_config_id = kwargs.get("pk")
             try:
-                custom_eval_config = CustomEvalConfig.objects.get(
+                custom_eval_config = CustomEvalConfig.objects.select_related(
+                    "eval_template"
+                ).get(
                     id=custom_eval_config_id,
                     project__organization=getattr(request, "organization", None)
                     or request.user.organization,

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -1617,6 +1617,8 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
 
             # Build rich eval objects so the frontend can render eval cards
             # with name, mapping, model, template info — not just bare UUIDs.
+            from tracer.serializers.custom_eval_config import is_rule_prompt_customized
+
             evals_rich = []
             for eval_config in queryset.evals.select_related("eval_template").all():
                 template = eval_config.eval_template
@@ -1637,6 +1639,7 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                         "outputType": (
                             template.output_type_normalized if template else None
                         ),
+                        "is_customized": is_rule_prompt_customized(eval_config),
                     }
                 )
 


### PR DESCRIPTION
## Summary

Per-attachment `rule_prompt` (UserEvalMetric.config / CustomEvalConfig.config) now wins over the eval template default at the engine layer, so per-customer prompt customization no longer requires editing the shared template.

Adds a server-computed `is_customized` flag on configured eval cards, driving a Customized chip + an inline banner with View template / Reset to default in the eval edit drawer.

## What changed

- `evaluations/engine/instance.py` — engine honors `runtime_config.rule_prompt` after version overrides (load-bearing fix)
- `tracer/serializers/custom_eval_config.py` — `is_customized` SerializerMethodField + `is_rule_prompt_customized()` helper
- `tracer/views/eval_task.py` — wires `is_customized` into the task GET response
- `EvalPickerConfigFull.jsx` — banner with View template + Reset; flipped `getEvalPromptText` so override wins over template default
- `TaskConfigPanel.jsx` — Customized chip on configured eval cards

## Test plan

- [x] Backend engine override: 3 cases via Django shell (no override → template, override → wins, empty → template)
- [x] Server `is_customized` flag toggles on/off correctly with DB state
- [x] Chip renders/hides based on flag (verified in browser)
- [x] Banner fires when prompt text diverges from template (typed real input)
- [x] Reset to default reverts text + hides banner
- [x] A/B tested save endpoint vanilla vs with-PR — no regression
- [x] Frontend lint clean
- [ ] Tracer-side end-to-end eval run (inferred via shared engine; not run live)

## Known follow-ups

- `isInstructionsReadOnly = isSystemEval` gate still blocks UI editing for system evals (out of scope; customer can use API)
- `model` / `output` / `pass_threshold` override pattern (ticket suggests; scoped out)