### PR TITLE
fix(eval-picker): surface instruction errors on LLM tab + min-length guard (TH-4990)

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -376,6 +376,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       if (!code.trim()) next.instructions = "Code is required";
     } else if (!instructions.trim()) {
       next.instructions = "Instructions are required";
+    } else if (instructions.trim().length < 10) {
+      next.instructions = "Instructions must be at least 10 characters.";
     } else if (
       !hasDataInjection &&
       !/\{\{\s*[^{}]+?\s*\}\}/.test(instructions)
@@ -948,6 +950,11 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     selectedDatasets={fewShotExamples}
                     onChange={setFewShotExamples}
                   />
+                  {errors.instructions && (
+                    <Typography variant="caption" color="error.main">
+                      {errors.instructions}
+                    </Typography>
+                  )}
                 </>
               )}
 


### PR DESCRIPTION
## Summary

Adding a custom eval from the Sessions surface routes through `EvalPickerCreateNew`, where the **LLM-As-A-Judge** tab was missing the inline `errors.instructions` render that the Agent and Code branches already have. A short or otherwise invalid instruction set the error in `validate()` but never reached the DOM — `handleSaveAndAdd` returned silently and the user saw nothing.

This PR adds the inline error display and a minimum-length guard so users get an explicit message instead of a silent abort.

## Fix

- `frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx`
  - `validate()`: new guard — `instructions.trim().length < 10` → `"Instructions must be at least 10 characters."`, evaluated before the template-variable check so the user sees the length hint first.
  - LLM branch render: added the `{errors.instructions && <Typography variant="caption" color="error.main">…</Typography>}` block after `<FewShotExamples>`, matching the Agent (≈ line 918) and Code (≈ line 964) branches verbatim.

Total: +7 lines, one file.

## Linked issues

Closes TH-4990.
Also closes TH-5004 — duplicate ticket filed 18 min later by the same reporter for the longer-prompt-no-`{{var}}` variant; same root cause, same fix.

## Test plan

- [ ] Open a project → Sessions → "Add Eval" → pick **LLM-As-A-Judge**.
- [ ] Leave instructions empty → click Save → "Instructions are required" appears under the form.
- [ ] Type \`a\` (single character) → click Save → "Instructions must be at least 10 characters." appears. *(covers TH-4990)*
- [ ] Type 10+ chars with no \`{{var}}\` → click Save → "Instructions must contain at least one template variable (e.g. {{input}})" appears. *(covers TH-5004)*
- [ ] Type a valid prompt with at least one \`{{variable}}\` → click Save → succeeds, no inline error.
- [ ] Repeat the same on **Agents** and **Code** tabs → existing behaviour unchanged.