### PR TITLE
fix(evals): translate stale-state resume error in eval task UI

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/Renderers/RunningStatusRenderer.jsx
+++ b/frontend/src/sections/common/EvalsTasks/Renderers/RunningStatusRenderer.jsx
@@ -7,6 +7,7 @@ import Iconify from "src/components/iconify";
 import { ShowComponent } from "src/components/show";
 import { OutlinedButton } from "src/sections/project-detail/ProjectDetailComponents";
 import axios, { endpoints } from "src/utils/axios";
+import { enqueueSnackbar } from "src/components/snackbar";
 import { black, green, orange, red } from "src/theme/palette";
 import { alpha } from "@mui/material";
 
@@ -54,9 +55,16 @@ const RunningStatusRenderer = ({ value, data, api }) => {
 
   const { mutate: resumeEvalTask } = useMutation({
     mutationFn: () => axios.post(endpoints.project.resumeEvalTask(data.id)),
+    meta: { errorHandled: true },
     onSuccess: (_) => {
       api.applyServerSideTransaction({
         update: [{ ...data, status: "running" }],
+      });
+    },
+    onError: () => {
+      api.refreshServerSide?.();
+      enqueueSnackbar("Failed to resume task. It may have already finished.", {
+        variant: "error",
       });
     },
   });

--- a/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
+++ b/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
@@ -18,6 +18,7 @@ import FormSearchField from "src/components/FormSearchField/FormSearchField";
 import { DataTable, DataTablePagination } from "src/components/data-table";
 import { useDebounce } from "src/hooks/use-debounce";
 import axios, { endpoints } from "src/utils/axios";
+import { enqueueSnackbar } from "src/components/snackbar";
 import DeleteConfirmation from "./DeleteConfirmation";
 
 // ── Status Config ──
@@ -330,7 +331,14 @@ const TaskListView = ({
   const { mutate: resumeTask } = useMutation({
     mutationFn: (taskId) =>
       axios.post(endpoints.project.resumeEvalTask(taskId)),
+    meta: { errorHandled: true },
     onSuccess: () => refetch(),
+    onError: () => {
+      refetch();
+      enqueueSnackbar("Failed to resume task. It may have already finished.", {
+        variant: "error",
+      });
+    },
   });
 
   // Delete mutation

--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -93,10 +93,18 @@ const TaskDetailPage = () => {
 
   const { mutate: resumeTask } = useMutation({
     mutationFn: () => axios.post(endpoints.project.resumeEvalTask(taskId)),
+    meta: { errorHandled: true },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });
       queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
       enqueueSnackbar("Task resumed", { variant: "success" });
+    },
+    onError: () => {
+      queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });
+      queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
+      enqueueSnackbar("Failed to resume task. It may have already finished.", {
+        variant: "error",
+      });
     },
   });
 


### PR DESCRIPTION
## Summary

Resuming an eval task that completed in the background surfaced the raw backend rejection — `Cannot unpause eval task with status 'completed'. Only paused tasks can be resumed.` — in a snackbar. The FE's React Query cache held a stale `paused` status, the Resume button stayed visible, and the click bubbled the BE string straight to the user through the global `MutationCache.onError` in `app.jsx`.

Adds a local `onError` handler to all three Resume mutation surfaces. Each:
- Sets `meta: { errorHandled: true }` so the global handler doesn't double-surface the raw BE string (existing opt-out used in 7+ other places).
- Invalidates / refetches the task data so the stale Resume button disappears.
- Shows a friendly snackbar: `Failed to resume task. It may have already finished.`

## Fix

- `frontend/src/sections/tasks/TaskDetailPage.jsx` — `onError` on `resumeTask`; invalidates `taskDetails` + `eval-tasks` queries.
- `frontend/src/sections/common/EvalsTasks/TaskListView.jsx` — `onError` on `resumeTask`; calls `refetch()`; added `enqueueSnackbar` import.
- `frontend/src/sections/common/EvalsTasks/Renderers/RunningStatusRenderer.jsx` — `onError` on `resumeEvalTask`; calls `api.refreshServerSide?.()`; added `enqueueSnackbar` import.

## Linked issues

Closes TH-4992

## Test plan

- [x] Paused task with status flipped to \`completed\` via Django shell (FE cache stays stale) → Resume on TaskDetailPage header → single friendly snackbar, status badge → Completed, Resume button removed. No raw BE string in the snackbar or console.
- [x] Same repro on TaskListView row icon button → same result.
- [ ] RunningStatusRenderer (project-detail AG-Grid cell) — same patch shape; not manually re-tested.

## Notes on scope

The symmetric Pause buttons on the same surfaces have the identical bug shape (gated on \`running\`/\`pending\`; if BE flips to completed, click → same raw error). Not in this PR — separate follow-up. Same for adding \`refetchInterval\` to \`useGetTaskData\` so the stale button never appears in the first place; this PR only handles the click gracefully.