### PR TITLE
fix(evals): add is-not negation support for all eval list filters

### DIFF
--- a/frontend/src/components/filter-panel/FilterPanel.jsx
+++ b/frontend/src/components/filter-panel/FilterPanel.jsx
@@ -1026,12 +1026,15 @@ const FilterPanel = ({
       // Convert object-style filters to rows
       const initial = [];
       for (const [key, val] of Object.entries(currentFilters)) {
+        const isNeg = key.endsWith("_not");
+        const field = isNeg ? key.slice(0, -4) : key;
         if (Array.isArray(val)) {
+          const op = isNeg ? "is_not" : (fieldMap[field]?.type === "enum" ? "is" : "contains");
           val.forEach((v) =>
-            initial.push({ field: key, operator: "is", value: v }),
+            initial.push({ field, operator: op, value: v }),
           );
         } else if (val) {
-          initial.push({ field: key, operator: "contains", value: val });
+          initial.push({ field, operator: isNeg ? "not_equals" : "contains", value: val });
         }
       }
       if (initial.length > 0) setRows(initial);
@@ -1054,8 +1057,10 @@ const FilterPanel = ({
         const isEmpty = !val || (Array.isArray(val) && val.length === 0);
         if (isEmpty) continue;
         const values = Array.isArray(val) ? val : [val];
-        if (!result[row.field]) result[row.field] = [];
-        result[row.field].push(...values);
+        const isNeg = row.operator === "is_not" || row.operator === "not_equals";
+        const key = isNeg ? `${row.field}_not` : row.field;
+        if (!result[key]) result[key] = [];
+        result[key].push(...values);
       }
       onApply(Object.keys(result).length > 0 ? result : null);
     }, 400);
@@ -1286,7 +1291,10 @@ const FilterPanel = ({
               filterFields={filterFields}
               fieldMap={fieldMap}
               onApply={handleApplyFromNlp}
-              initialTokens={[]}
+              initialTokens={rows.filter((r) => {
+                if (Array.isArray(r?.value)) return r.value.length > 0;
+                return Boolean(r?.value);
+              })}
             />
             <Typography
               variant="caption"

--- a/frontend/src/sections/evals/components/EvalsListView.jsx
+++ b/frontend/src/sections/evals/components/EvalsListView.jsx
@@ -293,7 +293,9 @@ const EvalsListView = () => {
   const debouncedSearch = useDebounce(searchQuery.trim(), 500);
 
   // Derive API params
-  const ownerFilter = filters?.owner || "all";
+  const ownerFilter = filters?.owner_not
+    ? (filters.owner_not === "system" ? "user" : "all")
+    : (filters?.owner || "all");
   // `filters.name` from the dropdown is an exact-match list; a single typed
   // value falls back to `search` (fuzzy name__icontains). Multi-select is
   // sent as `filters.names` (name__in).
@@ -307,16 +309,51 @@ const EvalsListView = () => {
     if (!filters) return null;
     const f = {};
     if (filters.eval_type) f.eval_type = filters.eval_type;
+    if (filters.eval_type_not) f.eval_type_not = filters.eval_type_not;
     if (filters.output_type) f.output_type = filters.output_type;
+    if (filters.output_type_not) f.output_type_not = filters.output_type_not;
     if (filters.template_type) f.template_type = filters.template_type;
+    if (filters.template_type_not) f.template_type_not = filters.template_type_not;
     if (filters.tags) f.tags = filters.tags;
+    if (filters.tags_not) f.tags_not = filters.tags_not;
     if (filters.created_by) f.created_by = filters.created_by;
+    if (filters.created_by_not) f.created_by_not = filters.created_by_not;
     if (Array.isArray(filters.name) && filters.name.length > 0) {
       f.names = filters.name;
     } else if (Array.isArray(filters.names) && filters.names.length > 0) {
       f.names = filters.names;
     }
+    if (Array.isArray(filters.name_not) && filters.name_not.length > 0) {
+      f.names_not = filters.name_not;
+    }
     return Object.keys(f).length > 0 ? f : null;
+  }, [filters]);
+
+  // Convert internal API-shaped state back to display-shaped state for
+  // the filter panel. Collapses owner/created_by/owner_not/created_by_not
+  // back to a single "owner" or "owner_not" field with user-visible values.
+  const panelFilters = useMemo(() => {
+    if (!filters) return null;
+    const f = { ...filters };
+    // Reconstruct negated owner display
+    if (Array.isArray(filters.created_by_not) && filters.created_by_not.length > 0) {
+      const negated = [...filters.created_by_not];
+      if (filters.owner_not === "system") negated.push("System");
+      f.owner_not = negated;
+    } else if (filters.owner_not === "system") {
+      f.owner_not = ["System"];
+    }
+    // Reconstruct positive owner display
+    if (Array.isArray(filters.created_by) && filters.created_by.length > 0) {
+      f.owner = [...filters.created_by];
+    } else if (filters.owner === "system") {
+      f.owner = ["System"];
+    } else if (filters.owner === "user" || filters.owner === "all") {
+      delete f.owner;
+    }
+    delete f.created_by;
+    delete f.created_by_not;
+    return f;
   }, [filters]);
 
   // Map TanStack sorting to API params
@@ -644,10 +681,11 @@ const EvalsListView = () => {
   }, []);
 
   const activeFilterCount = useMemo(() => {
-    if (!filters) return 0;
-    return Object.keys(filters).filter((k) => k !== "_tokens" && filters[k])
-      .length;
-  }, [filters]);
+    if (!panelFilters) return 0;
+    return Object.keys(panelFilters).filter(
+      (k) => k !== "_tokens" && panelFilters[k],
+    ).length;
+  }, [panelFilters]);
 
   const handleCancelSelection = useCallback(() => {
     setRowSelection({});
@@ -883,7 +921,7 @@ const EvalsListView = () => {
         open={Boolean(filterAnchorEl)}
         onClose={() => setFilterAnchorEl(null)}
         filterFields={filterFields}
-        currentFilters={filters}
+        currentFilters={panelFilters}
         onApply={(result) => {
           // FilterPanel Basic tab returns {field: [values]}, Query tab returns [{field, op, value}]
           if (!result) {
@@ -891,6 +929,19 @@ const EvalsListView = () => {
             setPage(0);
             return;
           }
+          // Shared: split owner values into system scope + user names
+          const normalizeOwner = (vals, isNeg, target) => {
+            const hasSystem = vals.some((v) => v.toLowerCase() === "system");
+            const userNames = vals.filter((v) => v.toLowerCase() !== "system");
+            if (isNeg) {
+              if (hasSystem) target.owner_not = "system";
+              if (userNames.length) target.created_by_not = userNames;
+            } else {
+              if (hasSystem && !userNames.length) target.owner = "system";
+              else if (!hasSystem && userNames.length) target.owner = "user";
+              if (userNames.length) target.created_by = userNames;
+            }
+          };
           if (Array.isArray(result)) {
             // Query tab — convert token array to flat object
             const flat = {};
@@ -901,46 +952,33 @@ const EvalsListView = () => {
                   ? [t.value]
                   : [];
               if (!val.length) continue;
+              const isNeg = t.operator === "is_not" || t.operator === "not_equals";
               if (t.field === "owner") {
-                const hasSystem = val.some((v) => v.toLowerCase() === "system");
-                const userNames = val.filter(
-                  (v) => v.toLowerCase() !== "system",
-                );
-                if (hasSystem && !userNames.length) flat.owner = "system";
-                else if (!hasSystem && userNames.length) flat.owner = "user";
-                if (userNames.length) flat.created_by = userNames;
+                normalizeOwner(val, isNeg, flat);
               } else if (t.field === "name") {
-                // Single free-text entry → fuzzy `search`; everything else
-                // (including single dropdown pick) → exact match via `name`.
-                // The `apiFilters` memo handles the final name → names/search
-                // transform.
-                if (t.operator === "contains" && val.length === 1) {
+                if (isNeg) {
+                  flat.name_not = val;
+                } else if (t.operator === "contains" && val.length === 1) {
                   flat.search = val[0];
                 } else {
                   flat.name = val;
                 }
               } else {
-                flat[t.field] = val;
+                const key = isNeg ? `${t.field}_not` : t.field;
+                flat[key] = val;
               }
             }
             setFilters(Object.keys(flat).length > 0 ? flat : null);
           } else {
             // Basic tab — already a flat object {field: [values]}.
-            // Leave `flat.name` alone (may be string or array) — `apiFilters`
-            // decides between `names` (exact multi) and `search` (fuzzy one).
             const flat = { ...result };
-            if (flat.owner) {
-              const vals = Array.isArray(flat.owner)
-                ? flat.owner
-                : [flat.owner];
-              const hasSystem = vals.some((v) => v.toLowerCase() === "system");
-              const userNames = vals.filter(
-                (v) => v.toLowerCase() !== "system",
-              );
+            const isNegOwner = Boolean(flat.owner_not);
+            const rawOwner = flat.owner_not || flat.owner;
+            if (rawOwner) {
+              const vals = Array.isArray(rawOwner) ? rawOwner : [rawOwner];
               delete flat.owner;
-              if (hasSystem && !userNames.length) flat.owner = "system";
-              else if (!hasSystem && userNames.length) flat.owner = "user";
-              if (userNames.length) flat.created_by = userNames;
+              delete flat.owner_not;
+              normalizeOwner(vals, isNegOwner, flat);
             }
             setFilters(Object.keys(flat).length > 0 ? flat : null);
           }

--- a/futureagi/model_hub/serializers/eval_list.py
+++ b/futureagi/model_hub/serializers/eval_list.py
@@ -15,7 +15,19 @@ class EvalListFiltersSerializer(serializers.Serializer):
         required=False,
         allow_empty=True,
     )
+    eval_type_not = serializers.ListField(
+        child=serializers.ChoiceField(choices=["llm", "code", "agent"]),
+        required=False,
+        allow_empty=True,
+    )
     output_type = serializers.ListField(
+        child=serializers.ChoiceField(
+            choices=["pass_fail", "percentage", "deterministic"]
+        ),
+        required=False,
+        allow_empty=True,
+    )
+    output_type_not = serializers.ListField(
         child=serializers.ChoiceField(
             choices=["pass_fail", "percentage", "deterministic"]
         ),
@@ -27,7 +39,17 @@ class EvalListFiltersSerializer(serializers.Serializer):
         required=False,
         allow_empty=True,
     )
+    template_type_not = serializers.ListField(
+        child=serializers.ChoiceField(choices=["single", "composite"]),
+        required=False,
+        allow_empty=True,
+    )
     tags = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_empty=True,
+    )
+    tags_not = serializers.ListField(
         child=serializers.CharField(),
         required=False,
         allow_empty=True,
@@ -37,7 +59,17 @@ class EvalListFiltersSerializer(serializers.Serializer):
         required=False,
         allow_empty=True,
     )
+    created_by_not = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_empty=True,
+    )
     names = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_empty=True,
+    )
+    names_not = serializers.ListField(
         child=serializers.CharField(),
         required=False,
         allow_empty=True,

--- a/futureagi/model_hub/tests/test_eval_list.py
+++ b/futureagi/model_hub/tests/test_eval_list.py
@@ -435,6 +435,152 @@ class TestEvalTemplateListAPI:
 
 
 # =============================================================================
+# E2E API Tests: Negation Filters (TH-4359)
+# =============================================================================
+
+
+@pytest.mark.e2e
+@pytest.mark.django_db
+class TestEvalListNegationFilters:
+    """Tests for ``_not`` filter variants added in TH-4359."""
+
+    url = "/model-hub/eval-templates/list/"
+
+    # --- eval_type_not ---
+
+    def test_eval_type_not_excludes_matching(
+        self, auth_client, system_eval_template, user_eval_template, agent_eval_template
+    ):
+        """eval_type_not=['code'] should exclude code evals, keep llm and agent."""
+        response = auth_client.post(
+            self.url,
+            {"filters": {"eval_type_not": ["code"]}, "page_size": 100},
+            format="json",
+        )
+        assert response.status_code == 200
+        items = response.data["result"]["items"]
+        eval_types = {item["eval_type"] for item in items}
+        assert "code" not in eval_types
+
+    def test_eval_type_not_keeps_non_matching(
+        self, auth_client, system_eval_template, user_eval_template, agent_eval_template
+    ):
+        """eval_type_not=['llm'] should still return code and agent evals."""
+        response = auth_client.post(
+            self.url,
+            {"filters": {"eval_type_not": ["llm"]}, "page_size": 100},
+            format="json",
+        )
+        assert response.status_code == 200
+        items = response.data["result"]["items"]
+        item_names = {item["name"] for item in items}
+        assert user_eval_template.name in item_names
+        assert agent_eval_template.name in item_names
+
+    def test_eval_type_not_multiple(
+        self, auth_client, system_eval_template, user_eval_template, agent_eval_template
+    ):
+        """Excluding multiple types leaves only the remaining type."""
+        response = auth_client.post(
+            self.url,
+            {"filters": {"eval_type_not": ["llm", "agent"]}, "page_size": 100},
+            format="json",
+        )
+        assert response.status_code == 200
+        items = response.data["result"]["items"]
+        for item in items:
+            assert item["eval_type"] not in ("llm", "agent")
+
+    # --- created_by_not ---
+
+    def test_created_by_not_excludes_user(
+        self, auth_client, organization, workspace, user
+    ):
+        """created_by_not should exclude evals created by the named user."""
+        from model_hub.models.evals_metric import EvalTemplate, EvalTemplateVersion
+
+        keep_tmpl = EvalTemplate.no_workspace_objects.create(
+            name="keep_this_eval",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+            config={"output": "score"},
+            visible_ui=True,
+        )
+        exclude_tmpl = EvalTemplate.no_workspace_objects.create(
+            name="exclude_this_eval",
+            organization=organization,
+            workspace=workspace,
+            owner=OwnerChoices.USER.value,
+            config={"output": "score"},
+            visible_ui=True,
+        )
+        EvalTemplateVersion.objects.create(
+            eval_template=keep_tmpl,
+            version_number=1,
+            is_default=True,
+            organization=organization,
+            workspace=workspace,
+            created_by=user,
+        )
+        from accounts.models import User
+
+        other_user = User.objects.create_user(
+            email="other@example.com",
+            password="test",
+            name="OtherUser",
+        )
+        EvalTemplateVersion.objects.create(
+            eval_template=exclude_tmpl,
+            version_number=1,
+            is_default=True,
+            organization=organization,
+            workspace=workspace,
+            created_by=other_user,
+        )
+
+        response = auth_client.post(
+            self.url,
+            {
+                "owner_filter": "user",
+                "filters": {"created_by_not": ["OtherUser"]},
+                "page_size": 100,
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+        item_names = {item["name"] for item in response.data["result"]["items"]}
+        assert "exclude_this_eval" not in item_names
+        assert "keep_this_eval" in item_names
+
+    # --- Serializer accepts _not fields ---
+
+    def test_serializer_accepts_eval_type_not(self, auth_client):
+        response = auth_client.post(
+            self.url, {"filters": {"eval_type_not": ["llm"]}}, format="json",
+        )
+        assert response.status_code == 200
+
+    def test_serializer_accepts_output_type_not(self, auth_client):
+        response = auth_client.post(
+            self.url, {"filters": {"output_type_not": ["pass_fail"]}}, format="json",
+        )
+        assert response.status_code == 200
+
+    def test_serializer_accepts_created_by_not(self, auth_client):
+        response = auth_client.post(
+            self.url, {"filters": {"created_by_not": ["SomeUser"]}}, format="json",
+        )
+        assert response.status_code == 200
+
+    def test_serializer_rejects_invalid_eval_type_not(self, auth_client):
+        response = auth_client.post(
+            self.url, {"filters": {"eval_type_not": ["invalid_type"]}}, format="json",
+        )
+        assert response.status_code == 400
+
+
+# =============================================================================
 # E2E API Tests: EvalTemplateBulkDeleteView
 # =============================================================================
 

--- a/futureagi/model_hub/utils/eval_list.py
+++ b/futureagi/model_hub/utils/eval_list.py
@@ -388,14 +388,20 @@ def build_eval_list_queryset(
         # Tags filter
         if _f("tags"):
             qs = qs.filter(eval_tags__overlap=_f("tags"))
+        if _f("tags_not"):
+            qs = qs.exclude(eval_tags__overlap=_f("tags_not"))
 
         # Template type filter (single/composite)
         if _f("template_type"):
             qs = qs.filter(template_type__in=_f("template_type"))
+        if _f("template_type_not"):
+            qs = qs.exclude(template_type__in=_f("template_type_not"))
 
         # Exact-name multi-select (dropdown picker)
         if _f("names"):
             qs = qs.filter(name__in=_f("names"))
+        if _f("names_not"):
+            qs = qs.exclude(name__in=_f("names_not"))
 
         # Created by filter (user names)
         if _f("created_by"):
@@ -428,6 +434,33 @@ def build_eval_list_queryset(
                     | Q(id__in=version_template_ids_email)
                     | org_q
                 )
+
+        # Output type negation filter
+        if _f("output_type_not"):
+            excluded_types = set(_f("output_type_not"))
+            exclude_raw = [
+                raw for raw, normalized in _OUTPUT_TYPE_MAP.items()
+                if normalized in excluded_types
+            ]
+            if exclude_raw:
+                qs = qs.exclude(config__output__in=exclude_raw)
+
+        # Created by exclusion filter
+        if _f("created_by_not"):
+            from model_hub.models.evals_metric import EvalTemplateVersion
+
+            excluded_by_list = _f("created_by_not")
+            exc_ids = EvalTemplateVersion.all_objects.filter(
+                is_default=True,
+                deleted=False,
+            ).filter(
+                Q(created_by__name__in=excluded_by_list)
+                | Q(created_by__email__in=excluded_by_list)
+            ).values_list("eval_template_id", flat=True)
+            org_q = Q(organization__display_name__in=excluded_by_list) | Q(
+                organization__name__in=excluded_by_list
+            )
+            qs = qs.exclude(Q(id__in=exc_ids) | org_q)
 
         # Note: eval_type filter is applied in-memory after fetching because
         # eval_type is derived from multiple fields (config + tags), not a single

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -1331,6 +1331,14 @@ class EvalTemplateListView(APIView):
             if eval_type_filter:
                 qs = qs.filter(eval_type__in=eval_type_filter)
 
+            eval_type_not_filter = (
+                filters.get("eval_type_not")
+                if isinstance(filters, dict)
+                else getattr(filters, "eval_type_not", None)
+            )
+            if eval_type_not_filter:
+                qs = qs.exclude(eval_type__in=eval_type_not_filter)
+
             total = qs.count()
             page = req.get("page", 0)
             page_size = req.get("page_size", 25)

--- a/futureagi/tracer/tests/test_eval_negation_filters.py
+++ b/futureagi/tracer/tests/test_eval_negation_filters.py
@@ -1,0 +1,186 @@
+"""Tests for eval metric negation in the ClickHouse filter builder.
+
+Regression coverage for TH-4359: verifies that negation operators
+produce correct SQL for all three output types (PASS_FAIL, CHOICE, SCORE).
+"""
+
+import pytest
+
+from model_hub.models.choices import OwnerChoices
+from model_hub.models.evals_metric import EvalTemplate
+from tracer.models.custom_eval_config import CustomEvalConfig
+from tracer.services.clickhouse.query_builders.filters import (
+    ClickHouseFilterBuilder,
+)
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def pass_fail_eval(db, organization, workspace, project):
+    tmpl = EvalTemplate.no_workspace_objects.create(
+        name="pf_eval",
+        organization=organization,
+        workspace=workspace,
+        owner=OwnerChoices.USER.value,
+        config={"output": "Pass/Fail"},
+        visible_ui=True,
+    )
+    CustomEvalConfig.objects.create(
+        name="pf_cfg",
+        project=project,
+        eval_template=tmpl,
+        config={},
+        mapping={},
+        filters={},
+    )
+    return tmpl
+
+
+@pytest.fixture
+def choice_eval(db, organization, workspace, project):
+    tmpl = EvalTemplate.no_workspace_objects.create(
+        name="choice_eval",
+        organization=organization,
+        workspace=workspace,
+        owner=OwnerChoices.USER.value,
+        config={"output": "choices"},
+        visible_ui=True,
+    )
+    CustomEvalConfig.objects.create(
+        name="choice_cfg",
+        project=project,
+        eval_template=tmpl,
+        config={},
+        mapping={},
+        filters={},
+    )
+    return tmpl
+
+
+@pytest.fixture
+def score_eval(db, organization, workspace, project):
+    tmpl = EvalTemplate.no_workspace_objects.create(
+        name="score_eval",
+        organization=organization,
+        workspace=workspace,
+        owner=OwnerChoices.USER.value,
+        config={"output": "score"},
+        visible_ui=True,
+    )
+    CustomEvalConfig.objects.create(
+        name="score_cfg",
+        project=project,
+        eval_template=tmpl,
+        config={},
+        mapping={},
+        filters={},
+    )
+    return tmpl
+
+
+# ── PASS_FAIL ────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestPassFailNegation:
+
+    def test_positive_equals_passed(self, pass_fail_eval):
+        b = ClickHouseFilterBuilder()
+        sql = b._build_eval_condition(str(pass_fail_eval.id), "equals", "Passed")
+        assert "output_bool IN" in sql
+        assert "trace_id IN (" in sql
+
+    def test_positive_equals_failed(self, pass_fail_eval):
+        b = ClickHouseFilterBuilder()
+        sql = b._build_eval_condition(str(pass_fail_eval.id), "equals", "Failed")
+        assert "output_bool IN" in sql
+
+    @pytest.mark.parametrize("op", ["not_equals", "is_not", "not_in"])
+    def test_negation_passed(self, pass_fail_eval, op):
+        b = ClickHouseFilterBuilder()
+        sql = b._build_eval_condition(str(pass_fail_eval.id), op, "Passed")
+        assert "output_bool NOT IN" in sql
+        # Must use outer IN (not NOT IN) so unevaluated traces are excluded
+        assert "trace_id IN (" in sql
+        assert "trace_id NOT IN" not in sql
+
+    @pytest.mark.parametrize("op", ["not_equals", "is_not", "not_in"])
+    def test_negation_failed(self, pass_fail_eval, op):
+        b = ClickHouseFilterBuilder()
+        sql = b._build_eval_condition(str(pass_fail_eval.id), op, "Failed")
+        assert "output_bool NOT IN" in sql
+
+
+# ── CHOICE ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestChoiceNegation:
+
+    def test_positive_equals(self, choice_eval):
+        b = ClickHouseFilterBuilder()
+        sql = b._build_eval_condition(str(choice_eval.id), "equals", "Good")
+        assert "output_str =" in sql
+        assert "NOT (" not in sql
+
+    @pytest.mark.parametrize("op", ["not_equals", "is_not", "not_in"])
+    def test_negation_wraps_in_not(self, choice_eval, op):
+        b = ClickHouseFilterBuilder()
+        sql = b._build_eval_condition(str(choice_eval.id), op, "Good")
+        assert "NOT (" in sql
+        assert "output_str =" in sql
+        assert "trace_id IN (" in sql
+        assert "trace_id NOT IN" not in sql
+
+
+# ── SCORE ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestScoreNegation:
+
+    def test_positive_equals(self, score_eval):
+        b = ClickHouseFilterBuilder()
+        sql = b._build_eval_condition(str(score_eval.id), "equals", 75)
+        assert "output_float =" in sql
+        assert "output_float !=" not in sql
+        # 75 / 100 = 0.75
+        score_params = [v for v in b._params.values() if v == 0.75]
+        assert score_params, "Expected 0.75 in params (75 / 100)"
+
+    @pytest.mark.parametrize("op", ["not_equals", "is_not"])
+    def test_negation_uses_not_equal(self, score_eval, op):
+        """not_equals and is_not (alias) produce output_float !=."""
+        b = ClickHouseFilterBuilder()
+        sql = b._build_eval_condition(str(score_eval.id), op, 75)
+        assert "output_float !=" in sql
+        assert "trace_id IN (" in sql
+        assert "trace_id NOT IN" not in sql
+
+    def test_not_in_uses_not_in(self, score_eval):
+        """not_in produces output_float NOT IN for multi-value support."""
+        b = ClickHouseFilterBuilder()
+        sql = b._build_eval_condition(str(score_eval.id), "not_in", 75)
+        assert "output_float NOT IN" in sql
+
+
+# ── Error clause always present ──────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestErrorExclusion:
+    """Errored eval rows should be excluded from both positive and negative filters."""
+
+    @pytest.mark.parametrize("op", ["equals", "not_equals", "is_not"])
+    def test_error_clause_present(self, pass_fail_eval, choice_eval, score_eval, op):
+        for tmpl, value in [
+            (pass_fail_eval, "Passed"),
+            (choice_eval, "Good"),
+            (score_eval, 75),
+        ]:
+            b = ClickHouseFilterBuilder()
+            sql = b._build_eval_condition(str(tmpl.id), op, value)
+            assert "error = 0" in sql, (
+                f"error exclusion missing for {tmpl.name} with op={op}"
+            )


### PR DESCRIPTION
## Summary

Adds `"is not"` (negation) filter support for all eval list filters. Previously, selecting `"is not"` on any filter field (eval type, output type, tags, template type, created by) either did nothing or produced the same result as `"is"` because the frontend dropped the negation operator and the backend had no `_not` filter handling.

This PR wires negation end-to-end across three layers:

- **Frontend**: `FilterPanel` now preserves the negation operator in state round-trips, `EvalsListView` routes `_not` keys through `apiFilters`, and a `panelFilters` memo converts internal API state back to display state so the filter panel shows the correct operator on re-open.
- **Backend serializer**: Accepts `eval_type_not`, `output_type_not`, `template_type_not`, `tags_not`, and `created_by_not` fields.
- **Backend queryset**: Adds `.exclude()` calls mirroring each existing positive filter. No changes to the ClickHouse layer (dev already handles eval metric negation correctly).

Also fixes:

- Query Builder tab now syncs with current filter state instead of resetting to empty
- `activeFilterCount` badge no longer double-counts internal API keys

## Linked issues

Closes #TH-4359

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- 19 unit tests for ClickHouse eval condition negation (`PASS_FAIL`, `CHOICE`, `SCORE`) — `tracer/tests/test_eval_negation_filters.py`
- 8 E2E API tests for eval list negation filters (`eval_type_not`, `created_by_not`, serializer validation) — `model_hub/tests/test_eval_list.py::TestEvalListNegationFilters`
- All 41 existing eval list tests pass with zero regressions
- Manual verification: `"is not"` filters for eval type, output type, tags, template type, and created by all correctly exclude matching evals

## Screenshots / recordings (if UI)

<img width="1558" height="1414" alt="image" src="https://github.com/user-attachments/assets/98257684-1121-44ba-9ef5-790c481446cb" />
<img width="1510" height="728" alt="image" src="https://github.com/user-attachments/assets/78378615-fdb7-4a0c-92bb-bbc206641db4" />

https://github.com/user-attachments/assets/91261e46-b7e5-4d2d-bb59-68d8491dbe81



## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA