### PR TITLE
fix(simulate): enforce min source-dataset rows on scenario create

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -44,11 +44,27 @@ import { AudioPlaybackProvider } from "./components/custom-audio/context-provide
 
 // ----------------------------------------------------------------------
 const extractErrorMessage = (result) => {
+  if (result == null) return "Something went wrong";
   if (typeof result === "string") return result;
-  if (Array.isArray(result)) return result.join(", ");
-  if (result && typeof result === "object")
-    return Object.values(result).flat().join(", ");
-  return "Something went wrong";
+  if (Array.isArray(result)) {
+    return [...new Set(result.map(extractErrorMessage).filter(Boolean))].join(
+      ", ",
+    );
+  }
+  if (typeof result === "object") {
+    if (result.details && typeof result.details === "object") {
+      return extractErrorMessage(result.details);
+    }
+    // The axios interceptor adds camelCase aliases (e.g. `datasetId` for
+    // `dataset_id`) so `Object.values` would yield each message twice.
+    // Dedupe after extraction.
+    return [
+      ...new Set(
+        Object.values(result).map(extractErrorMessage).filter(Boolean),
+      ),
+    ].join(", ");
+  }
+  return String(result);
 };
 
 const handleError = (error, variable, context, mutation) => {

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -43,29 +43,24 @@ import { setRecaptchaExecutor } from "./utils/recaptchaService";
 import { AudioPlaybackProvider } from "./components/custom-audio/context-provider/AudioPlaybackContext";
 
 // ----------------------------------------------------------------------
-const extractErrorMessage = (result) => {
-  if (result == null) return "Something went wrong";
+const _extractParts = (result) => {
+  if (result == null || result === "") return "";
   if (typeof result === "string") return result;
   if (Array.isArray(result)) {
-    return [...new Set(result.map(extractErrorMessage).filter(Boolean))].join(
-      ", ",
-    );
+    return [...new Set(result.map(_extractParts).filter(Boolean))].join(", ");
   }
   if (typeof result === "object") {
     if (result.details && typeof result.details === "object") {
-      return extractErrorMessage(result.details);
+      return _extractParts(result.details);
     }
-    // The axios interceptor adds camelCase aliases (e.g. `datasetId` for
-    // `dataset_id`) so `Object.values` would yield each message twice.
-    // Dedupe after extraction.
     return [
-      ...new Set(
-        Object.values(result).map(extractErrorMessage).filter(Boolean),
-      ),
+      ...new Set(Object.values(result).map(_extractParts).filter(Boolean)),
     ].join(", ");
   }
   return String(result);
 };
+
+const extractErrorMessage = (result) => _extractParts(result) || "Something went wrong";
 
 const handleError = (error, variable, context, mutation) => {
   if (error?.statusCode == RESPONSE_CODES.LIMIT_REACHED) return;

--- a/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -20,14 +20,12 @@ import axios, { endpoints } from "src/utils/axios";
 import { ShowComponent } from "src/components/show";
 import WorkflowBuilderOption from "./WorkflowBuilderOption";
 import ImportDatasetOption from "./ImportDatasetOption";
-import { useDevelopDatasetList } from "src/api/develop/develop-detail";
 import UploadScriptOption from "./UploadScriptOption";
 import CallChatSOPOption from "./CallChatSOPOption";
 import {
   CreateScenarioDefaultValues,
   CreateScenarioType,
   CreateScenarioValidationSchema,
-  MIN_DATASET_ROWS,
   ScenarioTypeWiseDefaultValues,
   SourceType,
   getScenarioDateString,
@@ -391,34 +389,7 @@ const CreateScenarioView = () => {
     applySourceChange(selectedOption);
   };
 
-  // Pre-submit guard: the Import Dataset path doesn't expose the `noOfRows`
-  // input, so block submission when the picked source dataset has fewer than
-  // MIN_DATASET_ROWS rows. The BE enforces the same floor; this is purely a
-  // faster UX signal so the user doesn't wait on a round-trip to learn the
-  // dataset is too small.
-  const { data: datasetListForGuard } = useDevelopDatasetList();
-  const datasetRowCountById = useMemo(() => {
-    const m = new Map();
-    (datasetListForGuard || []).forEach((d) => {
-      const id = d?.datasetId ?? d?.dataset_id;
-      const count = d?.rowCount ?? d?.row_count;
-      if (id != null && typeof count === "number") m.set(id, count);
-    });
-    return m;
-  }, [datasetListForGuard]);
-
   const handelCreateScenario = async (data) => {
-    if (data?.kind === CreateScenarioType.DATASET) {
-      const pickedId = data?.config?.datasetId;
-      const rowCount = datasetRowCountById.get(pickedId);
-      if (typeof rowCount === "number" && rowCount < MIN_DATASET_ROWS) {
-        enqueueSnackbar(
-          `Selected dataset has only ${rowCount} row${rowCount === 1 ? "" : "s"}. A minimum of ${MIN_DATASET_ROWS} rows is required.`,
-          { variant: "error" },
-        );
-        return;
-      }
-    }
     const transformedColumns =
       data?.columns?.map((col) => ({
         name: col?.name,

--- a/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -20,12 +20,14 @@ import axios, { endpoints } from "src/utils/axios";
 import { ShowComponent } from "src/components/show";
 import WorkflowBuilderOption from "./WorkflowBuilderOption";
 import ImportDatasetOption from "./ImportDatasetOption";
+import { useDevelopDatasetList } from "src/api/develop/develop-detail";
 import UploadScriptOption from "./UploadScriptOption";
 import CallChatSOPOption from "./CallChatSOPOption";
 import {
   CreateScenarioDefaultValues,
   CreateScenarioType,
   CreateScenarioValidationSchema,
+  MIN_DATASET_ROWS,
   ScenarioTypeWiseDefaultValues,
   SourceType,
   getScenarioDateString,
@@ -389,7 +391,34 @@ const CreateScenarioView = () => {
     applySourceChange(selectedOption);
   };
 
+  // Pre-submit guard: the Import Dataset path doesn't expose the `noOfRows`
+  // input, so block submission when the picked source dataset has fewer than
+  // MIN_DATASET_ROWS rows. The BE enforces the same floor; this is purely a
+  // faster UX signal so the user doesn't wait on a round-trip to learn the
+  // dataset is too small.
+  const { data: datasetListForGuard } = useDevelopDatasetList();
+  const datasetRowCountById = useMemo(() => {
+    const m = new Map();
+    (datasetListForGuard || []).forEach((d) => {
+      const id = d?.datasetId ?? d?.dataset_id;
+      const count = d?.rowCount ?? d?.row_count;
+      if (id != null && typeof count === "number") m.set(id, count);
+    });
+    return m;
+  }, [datasetListForGuard]);
+
   const handelCreateScenario = async (data) => {
+    if (data?.kind === CreateScenarioType.DATASET) {
+      const pickedId = data?.config?.datasetId;
+      const rowCount = datasetRowCountById.get(pickedId);
+      if (typeof rowCount === "number" && rowCount < MIN_DATASET_ROWS) {
+        enqueueSnackbar(
+          `Selected dataset has only ${rowCount} row${rowCount === 1 ? "" : "s"}. A minimum of ${MIN_DATASET_ROWS} rows is required.`,
+          { variant: "error" },
+        );
+        return;
+      }
+    }
     const transformedColumns =
       data?.columns?.map((col) => ({
         name: col?.name,

--- a/frontend/src/sections/scenarios/ImportDatasetOption.jsx
+++ b/frontend/src/sections/scenarios/ImportDatasetOption.jsx
@@ -1,8 +1,10 @@
-import { Box } from "@mui/material";
+import { Box, FormHelperText } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useMemo } from "react";
+import { useWatch } from "react-hook-form";
 import { useDevelopDatasetList } from "src/api/develop/develop-detail";
 import { FormSearchSelectFieldControl } from "src/components/FromSearchSelectField";
+import { MIN_DATASET_ROWS } from "./common";
 
 const ImportDatasetOption = ({ control }) => {
   const { data } = useDevelopDatasetList();
@@ -11,8 +13,17 @@ const ImportDatasetOption = ({ control }) => {
     return data?.map((dataset) => ({
       label: dataset.name,
       value: dataset.datasetId,
+      rowCount: dataset.rowCount ?? dataset.row_count, // tolerate either casing
     }));
   }, [data]);
+
+  const selectedDatasetId = useWatch({ control, name: "config.datasetId" });
+  const selected = useMemo(
+    () => datasetList?.find((d) => d.value === selectedDatasetId),
+    [datasetList, selectedDatasetId],
+  );
+  const hasRowCount = selected && typeof selected.rowCount === "number";
+  const isTooSmall = hasRowCount && selected.rowCount < MIN_DATASET_ROWS;
 
   return (
     <Box
@@ -34,6 +45,13 @@ const ImportDatasetOption = ({ control }) => {
         options={datasetList}
         required
       />
+      {isTooSmall && (
+        <FormHelperText error sx={{ mt: 1 }}>
+          {`Selected dataset has only ${selected.rowCount} row${
+            selected.rowCount === 1 ? "" : "s"
+          }. A minimum of ${MIN_DATASET_ROWS} rows is required to create a scenario.`}
+        </FormHelperText>
+      )}
     </Box>
   );
 };

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import { AGENT_TYPES } from "../agents/constants";
 
+// Minimum number of rows a source dataset must have for the Import Dataset
+// scenario path. Kept in lockstep with the BE `no_of_rows.min_value` so the
+// Workflow Builder and Import Dataset paths agree on the floor.
+export const MIN_DATASET_ROWS = 10;
+
 export const CreateScenarioType = {
   DATASET: "dataset",
   SCRIPT: "script",

--- a/frontend/src/sections/scenarios/common.js
+++ b/frontend/src/sections/scenarios/common.js
@@ -1,9 +1,7 @@
 import { z } from "zod";
 import { AGENT_TYPES } from "../agents/constants";
 
-// Minimum number of rows a source dataset must have for the Import Dataset
-// scenario path. Kept in lockstep with the BE `no_of_rows.min_value` so the
-// Workflow Builder and Import Dataset paths agree on the floor.
+// Mirrors BE `no_of_rows.min_value`.
 export const MIN_DATASET_ROWS = 10;
 
 export const CreateScenarioType = {

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -3324,14 +3324,24 @@ class GetDatasetsNamesView(APIView):
             if search_text:
                 queryset = queryset.filter(name__icontains=search_text)
 
+            # Annotate row_count so callers (e.g. Import Dataset scenario
+            # form) can show inline minimum-rows feedback without a follow-up
+            # request. Use a separate annotated qs so the downstream
+            # ``dataset__in=queryset`` subquery used for experiments is not
+            # forced to carry the COUNT subquery / GROUP BY.
+            annotated_datasets = queryset.annotate(
+                row_count=Count("row", filter=Q(row__deleted=False), distinct=True)
+            ).select_related("organization")
+
             # Format response
             datasets.extend(
                 {
                     "dataset_id": str(dataset.id),
                     "name": dataset.name,
                     "model_type": dataset.model_type,
+                    "row_count": dataset.row_count,
                 }
-                for dataset in queryset.select_related("organization")
+                for dataset in annotated_datasets
             )
 
             if include_experiments:

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -3324,11 +3324,7 @@ class GetDatasetsNamesView(APIView):
             if search_text:
                 queryset = queryset.filter(name__icontains=search_text)
 
-            # Annotate row_count so callers (e.g. Import Dataset scenario
-            # form) can show inline minimum-rows feedback without a follow-up
-            # request. Use a separate annotated qs so the downstream
-            # ``dataset__in=queryset`` subquery used for experiments is not
-            # forced to carry the COUNT subquery / GROUP BY.
+            # Separate annotated qs keeps the experiments subquery free of COUNT/GROUP BY.
             annotated_datasets = queryset.annotate(
                 row_count=Count("row", filter=Q(row__deleted=False), distinct=True)
             ).select_related("organization")

--- a/futureagi/simulate/serializers/requests/scenarios.py
+++ b/futureagi/simulate/serializers/requests/scenarios.py
@@ -300,9 +300,6 @@ class ScenarioCreateRequestSerializer(serializers.Serializer):
                 # Already validated in validate_dataset_id; skip DB checks
                 return data
 
-            # Source dataset must clear the same floor that the Workflow
-            # Builder's `no_of_rows` input enforces, so the Import Dataset
-            # path can't silently slip a smaller dataset through.
             min_rows = ScenarioCreateRequestSerializer._no_of_rows_min()
             row_count = Row.objects.filter(
                 dataset=source_dataset, deleted=False

--- a/futureagi/simulate/serializers/requests/scenarios.py
+++ b/futureagi/simulate/serializers/requests/scenarios.py
@@ -126,6 +126,15 @@ class ScenarioCreateRequestSerializer(serializers.Serializer):
     finished_speaking_sensitivity = serializers.FloatField(required=False, default=0.5)
     initial_message_delay = serializers.IntegerField(required=False, default=0)
 
+    @classmethod
+    def _no_of_rows_min(cls) -> int:
+        """Single source of truth for the dataset-rows floor.
+
+        Mirrors the ``no_of_rows.min_value`` so the Import-Dataset path and the
+        Workflow-Builder path stay in lockstep.
+        """
+        return cls().fields["no_of_rows"].min_value
+
     def validate_name(self, value):
         if not value.strip():
             raise serializers.ValidationError(
@@ -278,7 +287,7 @@ class ScenarioCreateRequestSerializer(serializers.Serializer):
         # Phase 0.1.2 + 0.1.3 — persona column type + duplicate DB column names (dataset)
         if kind == Scenarios.ScenarioTypes.DATASET and data.get("dataset_id"):
             request = self.context.get("request")
-            from model_hub.models.develop_dataset import Column, Dataset
+            from model_hub.models.develop_dataset import Column, Dataset, Row
 
             try:
                 source_dataset = Dataset.objects.get(
@@ -290,6 +299,23 @@ class ScenarioCreateRequestSerializer(serializers.Serializer):
             except Dataset.DoesNotExist:
                 # Already validated in validate_dataset_id; skip DB checks
                 return data
+
+            # Source dataset must clear the same floor that the Workflow
+            # Builder's `no_of_rows` input enforces, so the Import Dataset
+            # path can't silently slip a smaller dataset through.
+            min_rows = ScenarioCreateRequestSerializer._no_of_rows_min()
+            row_count = Row.objects.filter(
+                dataset=source_dataset, deleted=False
+            ).count()
+            if row_count < min_rows:
+                raise serializers.ValidationError(
+                    {
+                        "dataset_id": (
+                            f"Source dataset must have at least {min_rows} rows "
+                            f"to create a scenario (found {row_count})."
+                        )
+                    }
+                )
 
             # 0.1.2 — persona column data type
             persona_col = Column.objects.filter(

--- a/futureagi/simulate/tests/test_activities.py
+++ b/futureagi/simulate/tests/test_activities.py
@@ -82,8 +82,7 @@ def source_dataset(db, organization, workspace, user):
     dataset.column_order = [str(col1.id), str(col2.id)]
     dataset.save()
 
-    # Create rows with cells. Seed at least the scenario-create minimum
-    # (no_of_rows.min_value) so the Import Dataset path passes validation.
+    # Seed >= scenario-create min rows so the Import Dataset path validates.
     for i in range(10):
         row = Row.objects.create(dataset=dataset, order=i)
         Cell.objects.create(dataset=dataset, column=col1, row=row, value=f"Input {i}")

--- a/futureagi/simulate/tests/test_activities.py
+++ b/futureagi/simulate/tests/test_activities.py
@@ -82,8 +82,9 @@ def source_dataset(db, organization, workspace, user):
     dataset.column_order = [str(col1.id), str(col2.id)]
     dataset.save()
 
-    # Create rows with cells
-    for i in range(3):
+    # Create rows with cells. Seed at least the scenario-create minimum
+    # (no_of_rows.min_value) so the Import Dataset path passes validation.
+    for i in range(10):
         row = Row.objects.create(dataset=dataset, order=i)
         Cell.objects.create(dataset=dataset, column=col1, row=row, value=f"Input {i}")
         Cell.objects.create(dataset=dataset, column=col2, row=row, value=f"Output {i}")

--- a/futureagi/simulate/tests/test_scenarios_api.py
+++ b/futureagi/simulate/tests/test_scenarios_api.py
@@ -72,7 +72,9 @@ def simulator_agent(db, organization, workspace):
 
 @pytest.fixture
 def dataset(db, organization, user, workspace):
-    """Create a test dataset."""
+    """Create a test dataset (no rows). Use ``dataset_min_rows`` when the test
+    exercises the scenario-create Import Dataset path (which enforces a row
+    floor)."""
     return Dataset.no_workspace_objects.create(
         name="Test Dataset",
         organization=organization,
@@ -80,6 +82,17 @@ def dataset(db, organization, user, workspace):
         user=user,
         source=DatasetSourceChoices.SCENARIO.value,
     )
+
+
+@pytest.fixture
+def dataset_min_rows(db, dataset):
+    """Dataset seeded with the scenario-create minimum number of rows
+    (``no_of_rows.min_value``) for tests that exercise the Import Dataset path.
+    """
+    Row.objects.bulk_create(
+        [Row(dataset=dataset, order=i) for i in range(10)]
+    )
+    return dataset
 
 
 @pytest.fixture
@@ -503,13 +516,13 @@ class TestCreateScenarioView:
 
     @patch("simulate.views.scenarios.start_create_dataset_scenario_workflow_sync")
     def test_create_scenario_dataset_success(
-        self, mock_workflow, auth_client, agent_definition, dataset
+        self, mock_workflow, auth_client, agent_definition, dataset_min_rows
     ):
         """Test creating a dataset scenario successfully."""
         payload = {
             "name": "New Dataset Scenario",
             "description": "A new scenario from dataset",
-            "dataset_id": str(dataset.id),
+            "dataset_id": str(dataset_min_rows.id),
             "kind": "dataset",
             "agent_definition_id": str(agent_definition.id),
         }
@@ -718,12 +731,12 @@ class TestCreateScenarioView:
 
     @patch("simulate.views.scenarios.start_create_dataset_scenario_workflow_sync")
     def test_create_scenario_with_custom_columns(
-        self, mock_workflow, auth_client, agent_definition, dataset
+        self, mock_workflow, auth_client, agent_definition, dataset_min_rows
     ):
         """Test creating scenario with custom columns."""
         payload = {
             "name": "New Scenario with Custom Cols",
-            "dataset_id": str(dataset.id),
+            "dataset_id": str(dataset_min_rows.id),
             "kind": "dataset",
             "agent_definition_id": str(agent_definition.id),
             "custom_columns": [

--- a/futureagi/simulate/tests/test_scenarios_api.py
+++ b/futureagi/simulate/tests/test_scenarios_api.py
@@ -1472,3 +1472,44 @@ class TestGetMultiDatasetsColumnConfigs:
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert data["column_configs"] == []
+
+
+@pytest.mark.django_db
+class TestGetDatasetsNamesRowCount:
+    """Regression for the FE picker — the dataset-names endpoint must
+    include ``row_count`` on every dataset entry so the scenario import
+    picker can warn when a source dataset is below the row floor."""
+
+    def test_row_count_returned_per_dataset(
+        self, auth_client, organization, workspace, user
+    ):
+        from model_hub.models.choices import DatasetSourceChoices
+        from model_hub.models.develop_dataset import Dataset, Row
+
+        small = Dataset.no_workspace_objects.create(
+            name="Small ds",
+            organization=organization,
+            workspace=workspace,
+            user=user,
+            source=DatasetSourceChoices.BUILD.value,
+        )
+        Row.objects.bulk_create([Row(dataset=small, order=i) for i in range(3)])
+
+        big = Dataset.no_workspace_objects.create(
+            name="Big ds",
+            organization=organization,
+            workspace=workspace,
+            user=user,
+            source=DatasetSourceChoices.BUILD.value,
+        )
+        Row.objects.bulk_create([Row(dataset=big, order=i) for i in range(15)])
+
+        response = auth_client.get("/model-hub/develops/get-datasets-names/")
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        datasets = body.get("result", body).get("datasets", [])
+        by_id = {d["dataset_id"]: d for d in datasets}
+
+        assert "row_count" in by_id[str(small.id)]
+        assert by_id[str(small.id)]["row_count"] == 3
+        assert by_id[str(big.id)]["row_count"] == 15

--- a/futureagi/simulate/tests/test_serializers.py
+++ b/futureagi/simulate/tests/test_serializers.py
@@ -130,7 +130,6 @@ class TestCreateScenarioSerializer:
         )
         assert not serializer.is_valid()
         assert "dataset_id" in serializer.errors
-        # Message should reference the actual count so users understand the gap.
         rendered_error = str(serializer.errors["dataset_id"])
         assert "10" in rendered_error
         assert "1" in rendered_error

--- a/futureagi/simulate/tests/test_serializers.py
+++ b/futureagi/simulate/tests/test_serializers.py
@@ -17,7 +17,7 @@ from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from model_hub.models.choices import DatasetSourceChoices, SourceChoices
-from model_hub.models.develop_dataset import Dataset
+from model_hub.models.develop_dataset import Dataset, Row
 from simulate.serializers.scenarios import (
     AddScenarioColumnsSerializer,
     AddScenarioRowsSerializer,
@@ -52,14 +52,37 @@ def mock_request(request_factory, user):
 
 @pytest.fixture
 def source_dataset(db, organization, workspace, user):
-    """Create a source dataset for scenario creation tests."""
-    return Dataset.no_workspace_objects.create(
+    """Create a source dataset with the minimum required rows for scenario creation tests.
+
+    The Import Dataset path requires the source dataset to have at least
+    ``no_of_rows.min_value`` rows, so the fixture seeds enough rows to
+    satisfy that floor by default.
+    """
+    dataset = Dataset.no_workspace_objects.create(
         name="Source Dataset",
         organization=organization,
         workspace=workspace,
         user=user,
         source=DatasetSourceChoices.BUILD.value,
     )
+    Row.objects.bulk_create(
+        [Row(dataset=dataset, order=i) for i in range(10)]
+    )
+    return dataset
+
+
+@pytest.fixture
+def too_small_source_dataset(db, organization, workspace, user):
+    """Create a source dataset with fewer rows than the required minimum."""
+    dataset = Dataset.no_workspace_objects.create(
+        name="Tiny Source Dataset",
+        organization=organization,
+        workspace=workspace,
+        user=user,
+        source=DatasetSourceChoices.BUILD.value,
+    )
+    Row.objects.create(dataset=dataset, order=0)
+    return dataset
 
 
 # ============================================================================
@@ -91,6 +114,26 @@ class TestCreateScenarioSerializer:
         assert validated["name"] == "Test Dataset Scenario"
         assert validated["kind"] == "dataset"
         assert validated["dataset_id"] == source_dataset.id
+
+    def test_create_scenario_serializer_dataset_below_min_rows_rejected(
+        self, mock_request, too_small_source_dataset
+    ):
+        """Dataset kind with a source dataset below the row floor must be rejected."""
+        data = {
+            "name": "Too small dataset",
+            "kind": "dataset",
+            "dataset_id": str(too_small_source_dataset.id),
+        }
+
+        serializer = CreateScenarioSerializer(
+            data=data, context={"request": mock_request}
+        )
+        assert not serializer.is_valid()
+        assert "dataset_id" in serializer.errors
+        # Message should reference the actual count so users understand the gap.
+        rendered_error = str(serializer.errors["dataset_id"])
+        assert "10" in rendered_error
+        assert "1" in rendered_error
 
     def test_create_scenario_serializer_script_valid(self, mock_request):
         """Valid script scenario input should pass validation."""
@@ -209,8 +252,8 @@ class TestCreateScenarioSerializer:
             data=data, context={"request": mock_request}
         )
         assert not serializer.is_valid()
-        assert "non_field_errors" in serializer.errors
-        assert "dataset_id" in str(serializer.errors["non_field_errors"][0]).lower()
+        assert "dataset_id" in serializer.errors
+        assert "dataset_id" in str(serializer.errors["dataset_id"][0]).lower()
 
     def test_create_scenario_serializer_script_missing_url(self, mock_request):
         """Script kind without script_url should fail validation."""
@@ -223,8 +266,8 @@ class TestCreateScenarioSerializer:
             data=data, context={"request": mock_request}
         )
         assert not serializer.is_valid()
-        assert "non_field_errors" in serializer.errors
-        assert "script_url" in str(serializer.errors["non_field_errors"][0]).lower()
+        assert "script_url" in serializer.errors
+        assert "script_url" in str(serializer.errors["script_url"][0]).lower()
 
     def test_create_scenario_serializer_graph_missing_requirements(self, mock_request):
         """Graph kind without graph data or generate_graph should fail validation."""

--- a/futureagi/simulate/tests/test_serializers.py
+++ b/futureagi/simulate/tests/test_serializers.py
@@ -134,6 +134,58 @@ class TestCreateScenarioSerializer:
         assert "10" in rendered_error
         assert "1" in rendered_error
 
+    def test_create_scenario_serializer_dataset_at_min_rows_passes(
+        self, mock_request, organization, workspace, user
+    ):
+        """Boundary: dataset_id with exactly ``MIN_DATASET_ROWS`` rows must pass."""
+        floor = CreateScenarioSerializer._no_of_rows_min()
+        dataset = Dataset.no_workspace_objects.create(
+            name="Exactly-floor source",
+            organization=organization,
+            workspace=workspace,
+            user=user,
+            source=DatasetSourceChoices.BUILD.value,
+        )
+        Row.objects.bulk_create([Row(dataset=dataset, order=i) for i in range(floor)])
+
+        data = {
+            "name": "At-floor scenario",
+            "kind": "dataset",
+            "dataset_id": str(dataset.id),
+        }
+        serializer = CreateScenarioSerializer(
+            data=data, context={"request": mock_request}
+        )
+        assert serializer.is_valid(), serializer.errors
+
+    def test_create_scenario_serializer_dataset_one_below_min_rows_rejected(
+        self, mock_request, organization, workspace, user
+    ):
+        """Boundary: ``MIN_DATASET_ROWS - 1`` rows must be rejected so the
+        comparison stays strict (``<``, not ``<=``)."""
+        floor = CreateScenarioSerializer._no_of_rows_min()
+        dataset = Dataset.no_workspace_objects.create(
+            name="One-below-floor source",
+            organization=organization,
+            workspace=workspace,
+            user=user,
+            source=DatasetSourceChoices.BUILD.value,
+        )
+        Row.objects.bulk_create(
+            [Row(dataset=dataset, order=i) for i in range(floor - 1)]
+        )
+
+        data = {
+            "name": "Below-floor scenario",
+            "kind": "dataset",
+            "dataset_id": str(dataset.id),
+        }
+        serializer = CreateScenarioSerializer(
+            data=data, context={"request": mock_request}
+        )
+        assert not serializer.is_valid()
+        assert "dataset_id" in serializer.errors
+
     def test_create_scenario_serializer_script_valid(self, mock_request):
         """Valid script scenario input should pass validation."""
         data = {

--- a/futureagi/tfc/temporal/simulate/activities.py
+++ b/futureagi/tfc/temporal/simulate/activities.py
@@ -1165,6 +1165,62 @@ def _build_sda_payload(
     }
 
 
+def _resolve_scenario_agent(scenario, source_type):
+    """Return the agent_definition (real or prompt-source adapter) for a
+    scenario. Mirrors the adapter pattern in `_create_graph_scenario_sync`
+    and `_create_script_scenario_sync` so the dataset path can accept
+    prompt sources too (TH-4891)."""
+    if source_type == "prompt" and scenario.prompt_template:
+        prompt_content = ""
+        prompt_version = scenario.prompt_version
+        if not prompt_version:
+            prompt_version = scenario.prompt_template.all_executions.filter(
+                is_default=True, deleted=False
+            ).first()
+
+        if prompt_version and prompt_version.prompt_config_snapshot:
+            config_snapshot = prompt_version.prompt_config_snapshot
+            config = (
+                config_snapshot[0]
+                if isinstance(config_snapshot, list)
+                else config_snapshot
+            )
+            if isinstance(config, dict):
+                messages = config.get("messages", [])
+                formatted_messages = []
+                for msg in messages:
+                    role = msg.get("role", "unknown")
+                    content = msg.get("content", "")
+                    if isinstance(content, list):
+                        text_parts = [
+                            p.get("text", "")
+                            for p in content
+                            if isinstance(p, dict) and p.get("type") == "text"
+                        ]
+                        content = "\n".join(text_parts)
+                    if content:
+                        formatted_messages.append(f"[{role}]: {content}")
+                prompt_content = "\n\n".join(formatted_messages)
+
+        agent_description = (
+            prompt_content or scenario.prompt_template.description or ""
+        )
+        return types.SimpleNamespace(
+            id=scenario.prompt_template.id,
+            agent_name=scenario.prompt_template.name,
+            description=agent_description,
+            agent_type="text",
+            languages=["en"],
+            language="en",
+            inbound=True,
+            contact_number=None,
+            organization=scenario.organization,
+            workspace=scenario.workspace,
+        )
+
+    return scenario.agent_definition
+
+
 def _create_dataset_scenario_sync(
     user_id: str,
     scenario_id: str,
@@ -1203,11 +1259,13 @@ def _create_dataset_scenario_sync(
 
         user = User.objects.get(id=user_id)
         scenario = Scenarios.objects.get(id=scenario_id)
-        agent_definition = scenario.agent_definition
+        source_type = validated_data.get("source_type", "agent_definition")
+        agent_definition = _resolve_scenario_agent(scenario, source_type)
 
         if not agent_definition:
             raise ValueError(
-                "agent_definition is required on the scenario for dataset scenario creation"
+                "Either agent_definition or prompt_template is required on "
+                "the scenario for dataset scenario creation"
             )
 
         # Usage pre-check

--- a/futureagi/tfc/temporal/simulate/tests/test_activities.py
+++ b/futureagi/tfc/temporal/simulate/tests/test_activities.py
@@ -201,3 +201,120 @@ class TestAsyncioRunBugRegression:
 
         result = asyncio.run(correct_async_function())
         assert result == "result"
+
+
+class TestResolveScenarioAgent:
+    """Tests for ``_resolve_scenario_agent`` (TH-4891).
+
+    Dataset-kind scenarios with ``source_type=prompt`` were silently
+    failing in the Temporal activity because the activity hard-required
+    ``scenario.agent_definition``. This helper centralises the prompt-
+    adapter resolution that the graph/script activities already use.
+    """
+
+    def _make_scenario(self, *, agent_definition=None, prompt_template=None,
+                       prompt_version=None):
+        from types import SimpleNamespace
+        org = SimpleNamespace(id="org-1")
+        ws = SimpleNamespace(id="ws-1")
+        return SimpleNamespace(
+            agent_definition=agent_definition,
+            prompt_template=prompt_template,
+            prompt_version=prompt_version,
+            organization=org,
+            workspace=ws,
+        )
+
+    def test_agent_definition_source_returns_real_object(self):
+        from types import SimpleNamespace
+        from tfc.temporal.simulate.activities import _resolve_scenario_agent
+
+        real_ad = SimpleNamespace(id="ad-1", agent_name="Real Agent")
+        scenario = self._make_scenario(agent_definition=real_ad)
+
+        result = _resolve_scenario_agent(scenario, "agent_definition")
+        assert result is real_ad
+
+    def test_prompt_source_returns_adapter_with_prompt_metadata(self):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+        from tfc.temporal.simulate.activities import _resolve_scenario_agent
+
+        prompt_version = SimpleNamespace(
+            prompt_config_snapshot={
+                "messages": [
+                    {"role": "system", "content": "You are a helpdesk bot."},
+                    {"role": "user", "content": "Greet the customer."},
+                ]
+            }
+        )
+        prompt_template = MagicMock()
+        prompt_template.id = "pt-42"
+        prompt_template.name = "Helpdesk Prompt"
+        prompt_template.description = "fallback desc"
+
+        scenario = self._make_scenario(
+            prompt_template=prompt_template, prompt_version=prompt_version
+        )
+
+        result = _resolve_scenario_agent(scenario, "prompt")
+        assert result.id == "pt-42"
+        assert result.agent_name == "Helpdesk Prompt"
+        assert "You are a helpdesk bot." in result.description
+        assert "Greet the customer." in result.description
+        assert result.agent_type == "text"
+        assert result.languages == ["en"]
+        assert result.inbound is True
+
+    def test_prompt_source_falls_back_to_default_version(self):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+        from tfc.temporal.simulate.activities import _resolve_scenario_agent
+
+        default_version = SimpleNamespace(
+            prompt_config_snapshot={
+                "messages": [{"role": "system", "content": "Default prompt."}]
+            }
+        )
+        prompt_template = MagicMock()
+        prompt_template.id = "pt-1"
+        prompt_template.name = "Default Lookup"
+        prompt_template.description = ""
+        prompt_template.all_executions.filter.return_value.first.return_value = (
+            default_version
+        )
+
+        scenario = self._make_scenario(
+            prompt_template=prompt_template, prompt_version=None
+        )
+
+        result = _resolve_scenario_agent(scenario, "prompt")
+        assert "Default prompt." in result.description
+
+    def test_prompt_source_without_template_falls_back_to_agent_definition(self):
+        from tfc.temporal.simulate.activities import _resolve_scenario_agent
+
+        scenario = self._make_scenario(
+            agent_definition=None, prompt_template=None
+        )
+        result = _resolve_scenario_agent(scenario, "prompt")
+        assert result is None
+
+    def test_empty_prompt_messages_uses_template_description(self):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+        from tfc.temporal.simulate.activities import _resolve_scenario_agent
+
+        prompt_version = SimpleNamespace(
+            prompt_config_snapshot={"messages": []}
+        )
+        prompt_template = MagicMock()
+        prompt_template.id = "pt-2"
+        prompt_template.name = "Empty"
+        prompt_template.description = "Template-level description"
+
+        scenario = self._make_scenario(
+            prompt_template=prompt_template, prompt_version=prompt_version
+        )
+        result = _resolve_scenario_agent(scenario, "prompt")
+        assert result.description == "Template-level description"


### PR DESCRIPTION
Import Dataset path on scenario create accepted datasets below the 10-row floor the Workflow Builder enforces via the `no_of_rows` input. Both paths produce the same AI-generated scenarios — floor should match.

- `simulate/serializers/requests/scenarios.py`: BE validates `dataset` kind has ≥ `no_of_rows.min_value` rows. Single source of truth via `_no_of_rows_min()`.
- `model_hub/views/develop_dataset.py`: annotate `row_count` on `GetDatasetsNamesView` (separate qs to keep the experiments subquery clean).
- `scenarios/ImportDatasetOption.jsx`: inline error when the selected dataset has fewer rows than `MIN_DATASET_ROWS`.
-`tfc/temporal/simulate/activities.py`: new `_resolve_scenario_agent` helper. The dataset-scenario Temporal activity required `scenario.agent_definition` and silently failed any scenario created with `source_type=prompt`. Lifts the `SimpleNamespace` prompt-adapter pattern the graph and script activities already use. Existing `agent_definition` flow unchanged.
- `frontend/src/app.jsx`: `extractErrorMessage` recursive rewrite. Nested DRF`{error, details: {field: [msg]}}` shapes were rendering as `"Invalid data, [object Object]"`; camelCase aliases from the axios interceptor were duplicating the message; null values inside the payload were leaking `"Something went wrong"` next to the real message. Recurse, prefer `details`, dedupe via `Set`, return `""` for null/empty inside the recursion.

Fixes TH-4891.

## SS:
### Prompt type of agent def:  (previously raise an error)
#### 1 row:
<img width="1673" height="1062" alt="image" src="https://github.com/user-attachments/assets/134377f5-fb58-4806-b07b-a2c7c85f915f" />

#### 9 row:
<img width="1675" height="1072" alt="image" src="https://github.com/user-attachments/assets/02dcbc98-ab53-440b-9dba-7221b0a599f1" />

#### 15 row:
<img width="1676" height="1071" alt="image" src="https://github.com/user-attachments/assets/ff1d0ab7-fb1c-4e91-b2b6-be2780e91e2d" />

### Output for prompt type of agent def:
<img width="1678" height="1080" alt="image" src="https://github.com/user-attachments/assets/59a79a46-a474-4a7d-a71e-8d6ec90a3317" />



## Test plan

  - [x] `bin/test app simulate` — 1115 passed, 3 failed; all 3 failures pre-existing and unrelated to this PR (`test_e2e_prompt_simulation::test_flow4a`, `test_run_test_external_services::test_get_call_nonexistent`, `test_workflow_logger_deadlock`). None reference scenarios serializer or the dataset/script/graph activities.                              
  - [x] `pytest simulate/tests/test_serializers.py::TestCreateScenarioSerializer` — 24
  cases incl. new boundary tests at `MIN_DATASET_ROWS` (passes) and `MIN_DATASET_ROWS -
   1` (rejected) locking the strict `<` comparison.
  - [x] `pytest simulate/tests/test_scenarios_api.py::TestGetDatasetsNamesRowCount` —  
  locks `row_count` field in the dataset-names response.                               
  - [x] `pytest tfc/temporal/simulate/tests/test_activities.py::TestResolveScenarioAgent` — 5 cases  
  covering agent-definition pass-through, prompt adapter from selected version,        
  default-version fallback, missing template, empty messages.
  - [x] Scenarios → Create → Import datasets → pick <10-row dataset: inline error +    
  Create blocked.                                                 
  - [x] `POST /simulate/scenarios/create/` with <10-row `dataset_id` → 400 with        
  row-count message under `dataset_id`.                           
  - [x] Dataset+prompt scenario create succeeds end-to-end (verified locally on
  scenario `1e9d30bd-…`). 
