### PR TITLE
fix(observe,tasks): annotation filter operator visibility + chip label + task filter_type

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -273,10 +273,7 @@ const DEFAULT_OP_FOR_TYPE = {
 // Legacy string-field ops in saved views — rewrite on hydration so the menu renders.
 const HYDRATE_STRING_OP = { equals: "in", not_equals: "not_in" };
 
-// Save path translates `is`/`is_not` → `equals`/`not_equals` (LEGACY_OP_ALIAS
-// in ObserveToolbar) so the backend gets canonical names. Reverse the map for
-// categorical / thumbs fieldTypes so the operator Select can find a matching
-// MenuItem on rehydrate (CATEGORICAL_OPS / THUMBS_OPS use value `is`/`is_not`).
+// Categorical / thumbs ops in saved views — reverse the save-side LEGACY_OP_ALIAS so the menu renders.
 const HYDRATE_CATEGORICAL_OP = { equals: "is", not_equals: "is_not" };
 
 const NO_VALUE_OPS = new Set([
@@ -1073,8 +1070,7 @@ function FilterRow({
         prop.type === "text"
           ? prop.type
           : normalizeFieldType(prop.type);
-      // ID-only fields use ID_ONLY_OPS = [{ value: "is" }] — pick "is" up
-      // front so the operator Select isn't blank on first selection.
+      // ID-only fields only support "is"; fallback would render blank.
       const defaultOp = ID_ONLY_FIELDS.has(prop.id)
         ? "is"
         : DEFAULT_OP_FOR_TYPE[nt] || "equals";
@@ -1563,12 +1559,7 @@ const TraceFilterPanel = ({
         const enriched = currentFilters.map((f) => {
           const prop = properties.find((p) => p.id === f.field);
           const fieldType = f.fieldType || prop?.type || "string";
-          // ID-only fields (trace_id / span_id) bypass the per-type rewrite —
-          // ID_ONLY_OPS = [{ value: "is" }] so any other op renders blank.
-          // For categorical / thumbs: save path translated `is`/`is_not` →
-          // `equals`/`not_equals` (LEGACY_OP_ALIAS), so reverse it here.
-          // For string / text: legacy saves used `equals`/`not_equals` for
-          // what the picker now calls `in`/`not_in`.
+          // Translate wire ops to the picker's MenuItem values, per fieldType.
           const hydratedOp = ID_ONLY_FIELDS.has(f.field)
             ? "is"
             : (fieldType === "categorical" || fieldType === "thumbs") &&

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -296,12 +296,9 @@ const SINGLE_VALUE_OPS = new Set([
   "ends_with",
 ]);
 
-// Ops whose value picker is multi-select. Used by the hydrate path and the
-// operator-change handler to wrap scalar values into arrays when switching
-// to one of these. `is`/`is_not` (categorical/thumbs) aren't in
-// SINGLE_VALUE_OPS, so the picker defaults to multi-select — and a scalar
-// value from the wire breaks it.
-const MULTI_VALUE_OPS = new Set(["in", "not_in", "is", "is_not"]);
+// List ops — multi-select picker. `is`/`is_not` (categorical/thumbs) also
+// use a multi-select picker, so they belong here too.
+const LIST_VALUE_OPS = new Set(["in", "not_in", "is", "is_not"]);
 
 // ---------------------------------------------------------------------------
 // Hook: fetch properties from dashboard metrics
@@ -1115,9 +1112,8 @@ function FilterRow({
       if (SINGLE_VALUE_OPS.has(newOp) && Array.isArray(newVal) && newVal.length > 1) {
         newVal = [newVal[0]];
       }
-      // Scalar → array: any multi-select op (in/not_in/is/is_not) needs
-      // its value as an array, otherwise the picker chokes.
-      if (MULTI_VALUE_OPS.has(newOp) && !Array.isArray(newVal)) {
+      // Single → list: picker expects an array.
+      if (LIST_VALUE_OPS.has(newOp) && !Array.isArray(newVal)) {
         newVal =
           newVal === "" || newVal === null || newVal === undefined
             ? []
@@ -1587,7 +1583,7 @@ const TraceFilterPanel = ({
           let value = f.value;
           if (
             hydratedOp !== f.operator &&
-            MULTI_VALUE_OPS.has(hydratedOp) &&
+            LIST_VALUE_OPS.has(hydratedOp) &&
             !Array.isArray(value)
           ) {
             value =

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -296,8 +296,7 @@ const SINGLE_VALUE_OPS = new Set([
   "ends_with",
 ]);
 
-// List ops — multi-select picker. `is`/`is_not` (categorical/thumbs) also
-// use a multi-select picker, so they belong here too.
+// List ops — multi-select picker.
 const LIST_VALUE_OPS = new Set(["in", "not_in", "is", "is_not"]);
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -273,6 +273,12 @@ const DEFAULT_OP_FOR_TYPE = {
 // Legacy string-field ops in saved views — rewrite on hydration so the menu renders.
 const HYDRATE_STRING_OP = { equals: "in", not_equals: "not_in" };
 
+// Save path translates `is`/`is_not` → `equals`/`not_equals` (LEGACY_OP_ALIAS
+// in ObserveToolbar) so the backend gets canonical names. Reverse the map for
+// categorical / thumbs fieldTypes so the operator Select can find a matching
+// MenuItem on rehydrate (CATEGORICAL_OPS / THUMBS_OPS use value `is`/`is_not`).
+const HYDRATE_CATEGORICAL_OP = { equals: "is", not_equals: "is_not" };
+
 const NO_VALUE_OPS = new Set([
   "is_empty",
   "is_not_empty",
@@ -290,8 +296,12 @@ const SINGLE_VALUE_OPS = new Set([
   "ends_with",
 ]);
 
-// List ops — multi-select picker.
-const LIST_VALUE_OPS = new Set(["in", "not_in"]);
+// Ops whose value picker is multi-select. Used by the hydrate path and the
+// operator-change handler to wrap scalar values into arrays when switching
+// to one of these. `is`/`is_not` (categorical/thumbs) aren't in
+// SINGLE_VALUE_OPS, so the picker defaults to multi-select — and a scalar
+// value from the wire breaks it.
+const MULTI_VALUE_OPS = new Set(["in", "not_in", "is", "is_not"]);
 
 // ---------------------------------------------------------------------------
 // Hook: fetch properties from dashboard metrics
@@ -1067,7 +1077,11 @@ function FilterRow({
         prop.type === "text"
           ? prop.type
           : normalizeFieldType(prop.type);
-      const defaultOp = DEFAULT_OP_FOR_TYPE[nt] || "equals";
+      // ID-only fields use ID_ONLY_OPS = [{ value: "is" }] — pick "is" up
+      // front so the operator Select isn't blank on first selection.
+      const defaultOp = ID_ONLY_FIELDS.has(prop.id)
+        ? "is"
+        : DEFAULT_OP_FOR_TYPE[nt] || "equals";
       let defaultValue;
       if (nt === "number" || nt === "date") defaultValue = "";
       else if (nt === "boolean") defaultValue = "true";
@@ -1101,8 +1115,9 @@ function FilterRow({
       if (SINGLE_VALUE_OPS.has(newOp) && Array.isArray(newVal) && newVal.length > 1) {
         newVal = [newVal[0]];
       }
-      // Single → list: picker expects an array.
-      if (LIST_VALUE_OPS.has(newOp) && !Array.isArray(newVal)) {
+      // Scalar → array: any multi-select op (in/not_in/is/is_not) needs
+      // its value as an array, otherwise the picker chokes.
+      if (MULTI_VALUE_OPS.has(newOp) && !Array.isArray(newVal)) {
         newVal =
           newVal === "" || newVal === null || newVal === undefined
             ? []
@@ -1553,20 +1568,26 @@ const TraceFilterPanel = ({
         const enriched = currentFilters.map((f) => {
           const prop = properties.find((p) => p.id === f.field);
           const fieldType = f.fieldType || prop?.type || "string";
-          // ID-only fields (trace_id / span_id) bypass the string-op
-          // rewrite — ID_ONLY_OPS = [{ value: "is" }] so anything other
-          // than "is" renders blank in the operator Select.
+          // ID-only fields (trace_id / span_id) bypass the per-type rewrite —
+          // ID_ONLY_OPS = [{ value: "is" }] so any other op renders blank.
+          // For categorical / thumbs: save path translated `is`/`is_not` →
+          // `equals`/`not_equals` (LEGACY_OP_ALIAS), so reverse it here.
+          // For string / text: legacy saves used `equals`/`not_equals` for
+          // what the picker now calls `in`/`not_in`.
           const hydratedOp = ID_ONLY_FIELDS.has(f.field)
             ? "is"
-            : (fieldType === "string" || fieldType === "text") &&
-                HYDRATE_STRING_OP[f.operator]
-              ? HYDRATE_STRING_OP[f.operator]
-              : f.operator;
-          // Scalar legacy `equals` value → array for the multi-select picker.
+            : (fieldType === "categorical" || fieldType === "thumbs") &&
+                HYDRATE_CATEGORICAL_OP[f.operator]
+              ? HYDRATE_CATEGORICAL_OP[f.operator]
+              : (fieldType === "string" || fieldType === "text") &&
+                  HYDRATE_STRING_OP[f.operator]
+                ? HYDRATE_STRING_OP[f.operator]
+                : f.operator;
+          // Scalar value → array when rewritten op uses a multi-select picker.
           let value = f.value;
           if (
             hydratedOp !== f.operator &&
-            LIST_VALUE_OPS.has(hydratedOp) &&
+            MULTI_VALUE_OPS.has(hydratedOp) &&
             !Array.isArray(value)
           ) {
             value =

--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -99,9 +99,7 @@ function convertNewToOld(newFilters) {
       property: isAttribute ? "attributes" : f.field,
       propertyId: f.field,
       fieldCategory: f.fieldCategory || "system",
-      // Panel rows store the display name under `fieldName` (set by
-      // PropertyPicker → handlePropertySelect). Fall back to `fieldLabel`
-      // for any caller still using the older key, then the raw id.
+      // Panel rows expose the display name as `fieldName`; fall back for legacy callers.
       fieldLabel: f.fieldName || f.fieldLabel || f.field,
     };
 

--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -88,14 +88,21 @@ function convertNewToOld(newFilters) {
         ? "number"
         : fieldType === "boolean"
           ? "boolean"
-          : "text";
+          : fieldType === "thumbs"
+            ? "thumbs"
+            : fieldType === "categorical"
+              ? "categorical"
+              : "text";
     const op = LEGACY_OP_ALIAS[f.operator] || f.operator || "equals";
 
     const base = {
       property: isAttribute ? "attributes" : f.field,
       propertyId: f.field,
       fieldCategory: f.fieldCategory || "system",
-      fieldLabel: f.fieldLabel || f.field,
+      // Panel rows store the display name under `fieldName` (set by
+      // PropertyPicker → handlePropertySelect). Fall back to `fieldLabel`
+      // for any caller still using the older key, then the raw id.
+      fieldLabel: f.fieldName || f.fieldLabel || f.field,
     };
 
     if (NO_VALUE_OPS.has(op)) {
@@ -243,7 +250,7 @@ const FilterChip = ({ filter, onRemove }) => {
         sx={{ color: "text.disabled" }}
       />
       <Typography sx={{ fontSize: 12, color: "text.secondary" }}>
-        {filter.fieldLabel || filter.field}
+        {filter.fieldName || filter.fieldLabel || filter.field}
       </Typography>
       <Typography sx={{ fontSize: 11, color: "text.disabled" }}>
         {opLabel}


### PR DESCRIPTION
## Summary

Fixes TH-5002 — annotation filter UX issues across Observe (TraceFilterPanel) and Tasks (TaskFilterBar).

### TraceFilterPanel (`frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx`)
- **Operator Select rendered blank for categorical / thumbs filters after hydration.** Save path translates `is`/`is_not` → `equals`/`not_equals` via `LEGACY_OP_ALIAS`, but the hydrate path had no inverse — so the operator dropdown couldn't find a matching MenuItem. Added `HYDRATE_CATEGORICAL_OP` to reverse-translate on hydrate.
- **Operator was blank on first selection for trace_id / span_id properties.** `ID_ONLY_OPS` only contains `{ value: "is" }`, but `defaultOp` fell back to `equals`. Pinned `defaultOp` to `"is"` when picking an ID-only field.
- **Replaced `LIST_VALUE_OPS` with `MULTI_VALUE_OPS`** (now includes `is`/`is_not`) so the scalar→array wrap covers categorical/thumbs ops too, both during hydrate and when the user manually switches ops.

### TaskFilterBar (`frontend/src/sections/tasks/components/TaskFilterBar.jsx`)
- **Tasks page returned 0 rows for thumbs annotations.** `convertNewToOld` collapsed `thumbs`/`categorical` field types into `text` when building the backend payload. Preserved them explicitly in the ternary.
- **FilterChip showed raw field id instead of display name on first add.** Form state and panel rows use slightly different keys (`fieldName` vs `fieldLabel`) and there's a sync delay. Read `fieldName` first, fall back to `fieldLabel`, then the raw id.
- **`convertNewToOld` now carries `fieldName` into `fieldLabel`** so the label survives the round-trip through form state and rehydration.

## Test plan
- [ ] Add a categorical annotation filter, save the view, reload — operator dropdown shows the saved op (`is` / `is_not`), not blank.
- [ ] Same as above for thumbs annotation filters.
- [ ] Pick a `trace_id` / `span_id` property — operator Select shows `is` immediately (not blank).
- [ ] Switch a filter between `is` ↔ `in` and back — value picker keeps working (no crash on scalar/array mismatch).
- [ ] On Tasks page, filter by a thumbs annotation — rows actually return matches (not 0).
- [ ] On Tasks page, the FilterChip shows the display name (e.g. "Tone") on first add, not the raw id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)