### PR TITLE
fix(evals): bump truncation cap to 200K (TH-4905)

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -209,12 +209,12 @@ class CustomPromptEvaluator(LLM):
                 raise ValueError(f"Missing required key in kwargs: {key}")
             value = kwargs[key]
             # Apply context windowing for large values (traces, spans, JSON blobs)
-            if isinstance(value, str) and len(value) > 15000:
-                value = fit_to_context(value, max_total_chars=15000, label=key)
+            if isinstance(value, str) and len(value) > 200000:
+                value = fit_to_context(value, max_total_chars=200000, label=key)
             elif isinstance(value, (dict, list)):
                 serialized = json.dumps(value, default=str)
-                if len(serialized) > 15000:
-                    value = fit_to_context(value, max_total_chars=15000, label=key)
+                if len(serialized) > 200000:
+                    value = fit_to_context(value, max_total_chars=200000, label=key)
             template_context[key] = value
 
         # Render the rule prompt with the template context using Jinja2
@@ -291,12 +291,12 @@ class CustomPromptEvaluator(LLM):
             rendered_prompt += "\n\n## Data\n"
             if isinstance(row_context, (dict, list)):
                 rendered_prompt += fit_row_to_context(
-                    row_context, max_chars=15000
+                    row_context, max_chars=200000
                 )
             else:
                 ctx_str = str(row_context)
-                if len(ctx_str) > 15000:
-                    ctx_str = fit_to_context(ctx_str, max_total_chars=15000, label="data")
+                if len(ctx_str) > 200000:
+                    ctx_str = fit_to_context(ctx_str, max_total_chars=200000, label="data")
                 rendered_prompt += ctx_str
 
         logger.info(

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -18,6 +18,11 @@ from agentic_eval.core_evals.fi_utils.utils import PreserveUndefined
 
 from agentic_eval.core_evals.fi_evals.eval_type import LlmEvalTypeId
 
+# Maximum chars of context that get injected into the eval prompt. Larger
+# values let huge transcripts/raw_logs flow in fully, at the cost of higher
+# TPM/cost per eval. Tuned for the 200K-window judge models. See TH-4905.
+_MAX_CONTEXT_CHARS = 200000
+
 
 class CustomPromptEvaluator(LLM):
     """
@@ -209,12 +214,12 @@ class CustomPromptEvaluator(LLM):
                 raise ValueError(f"Missing required key in kwargs: {key}")
             value = kwargs[key]
             # Apply context windowing for large values (traces, spans, JSON blobs)
-            if isinstance(value, str) and len(value) > 200000:
-                value = fit_to_context(value, max_total_chars=200000, label=key)
+            if isinstance(value, str) and len(value) > _MAX_CONTEXT_CHARS:
+                value = fit_to_context(value, max_total_chars=_MAX_CONTEXT_CHARS, label=key)
             elif isinstance(value, (dict, list)):
                 serialized = json.dumps(value, default=str)
-                if len(serialized) > 200000:
-                    value = fit_to_context(value, max_total_chars=200000, label=key)
+                if len(serialized) > _MAX_CONTEXT_CHARS:
+                    value = fit_to_context(value, max_total_chars=_MAX_CONTEXT_CHARS, label=key)
             template_context[key] = value
 
         # Render the rule prompt with the template context using Jinja2
@@ -291,12 +296,12 @@ class CustomPromptEvaluator(LLM):
             rendered_prompt += "\n\n## Data\n"
             if isinstance(row_context, (dict, list)):
                 rendered_prompt += fit_row_to_context(
-                    row_context, max_chars=200000
+                    row_context, max_chars=_MAX_CONTEXT_CHARS
                 )
             else:
                 ctx_str = str(row_context)
-                if len(ctx_str) > 200000:
-                    ctx_str = fit_to_context(ctx_str, max_total_chars=200000, label="data")
+                if len(ctx_str) > _MAX_CONTEXT_CHARS:
+                    ctx_str = fit_to_context(ctx_str, max_total_chars=_MAX_CONTEXT_CHARS, label="data")
                 rendered_prompt += ctx_str
 
         logger.info(


### PR DESCRIPTION
## Summary

Bumps the `fit_to_context` / `fit_row_to_context` truncation cap from `15000` to `200000` in `futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py`. 7 sites changed.

Nikhil staged this on the dev box; this lands the diff so it ships on the next deploy.

## Fix

- `futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py` — replace `15000` with `200000` at the 5 call sites of `fit_to_context` / `fit_row_to_context` and the 2 length-threshold checks that guard them.

Note: the ticket referenced an older path (`ee/evals/llm/agent_evaluator/evaluator.py`) and a count of 6, plus a `_FINALIZE_MAX_CHARS` constant. The code has been refactored on `dev` — the constant no longer exists and the cap is inlined at 7 call sites, all of which are now bumped. No comment-only references to `15000` remain in this file.

## Linked issues

Closes TH-4905.

## Test plan

- [ ] Diff matches the intent of Nikhil's dev-box backup at `/tmp/evaluator.py.bak.1778360898` (modulo the refactor — 7 sites in the new path vs 6 in the old).
- [ ] Eval runs that previously hit truncation (large transcripts / raw_log dumps) render fully on the new cap.
- [ ] No regression on small-prompt evals (the cap is a ceiling, not a floor).