### PR TITLE
feat(eval-task): allow free-typed dotted-path in mapping picker [TH-5068]

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1704,6 +1704,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     errorLocalizerEnabled={errorLocalizerEnabled}
                     localFilters={localApiFilters}
                     pickerSourceColumns={sourceColumns}
+                    allowCustomFieldPath
                     {...compositeSourceModeProps}
                   />
                 )}

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -247,6 +247,13 @@ const TracingTestMode = React.forwardRef(
       // candidate paths immediately, regardless of drill-in depth.
       // When null/empty, falls back to today's walked-detail behaviour.
       pickerSourceColumns = null,
+      // When true, the mapping Autocomplete accepts arbitrary typed values
+      // (freeSolo) instead of being locked to `fieldNames`. The BE resolver
+      // (_walk_dotted_path) already handles arbitrary depths safely across
+      // spans, traces, and sessions. Currently set by EvalPickerConfigFull
+      // only for source="task" — other surfaces stay locked until each
+      // one's resolver is audited.
+      allowCustomFieldPath = false,
     },
     ref,
   ) => {
@@ -1755,6 +1762,7 @@ const TracingTestMode = React.forwardRef(
                   />
                   <Autocomplete
                     size="small"
+                    freeSolo={allowCustomFieldPath}
                     options={
                       mapping[variable] &&
                       !fieldNames.includes(mapping[variable])
@@ -1768,6 +1776,18 @@ const TracingTestMode = React.forwardRef(
                         [variable]: val || "",
                       }))
                     }
+                    {...(allowCustomFieldPath
+                      ? {
+                          inputValue: mapping[variable] || "",
+                          onInputChange: (_, val, reason) => {
+                            if (reason === "reset") return;
+                            setMapping((prev) => ({
+                              ...prev,
+                              [variable]: val || "",
+                            }));
+                          },
+                        }
+                      : {})}
                     openOnFocus
                     autoHighlight
                     selectOnFocus
@@ -1778,7 +1798,11 @@ const TracingTestMode = React.forwardRef(
                     renderInput={(params) => (
                       <TextField
                         {...params}
-                        placeholder="Search column..."
+                        placeholder={
+                          allowCustomFieldPath
+                            ? "Search or type a path (e.g. attributes.input.value)"
+                            : "Search column..."
+                        }
                         InputProps={{
                           ...params.InputProps,
                           sx: {
@@ -1887,6 +1911,7 @@ TracingTestMode.propTypes = {
   isComposite: PropTypes.bool,
   compositeAdhocConfig: PropTypes.object,
   localFilters: PropTypes.array,
+  allowCustomFieldPath: PropTypes.bool,
 };
 
 export default TracingTestMode;


### PR DESCRIPTION
## Summary
- In the Eval Task create/edit mapping step, the variable-mapping `Autocomplete` now accepts free-typed dotted paths in addition to the existing dropdown suggestions. Users can pick a known column or type a deeper path (e.g. `attributes.llm.token_count.completion`) that isn't pre-listed.
- Gated on `source === "task"` only — all other call-sites (Test, Simulation, Composite, Experiment, Dataset, etc.) stay restricted-to-dropdown until each one's resolver is audited.
- No backend change. `_walk_dotted_path` (`futureagi/tracer/utils/eval.py:53`) already handles arbitrary depths safely across spans, traces, and sessions, with existing test coverage at depths 4–6.

## Files changed
- `frontend/src/sections/evals/components/TracingTestMode.jsx` — new `allowCustomFieldPath` prop; when true, the mapping Autocomplete becomes `freeSolo` with a controlled `inputValue`/`onInputChange` that ignores MUI's blur-reset. Placeholder hints at free-typing. propTypes updated.
- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx` — passes `allowCustomFieldPath` on the `source === "task"` TracingTestMode mount only.

## Surfaces affected
All three task create/edit surfaces (they all converge on `source="task"`):
- `/dashboard/tasks/create` and `/dashboard/tasks/:taskId` (standalone page via `TaskConfigPanel`)
- Legacy slide-in drawers (`NewTaskDrawer` + `EditTaskDrawer/DetailsEdit`) — route through `EvaluationDrawer module="task"`
- `NewTaskDrawerV2`/`EditTaskDrawerV2` (currently unmounted; covered if/when wired up)

## Test plan
- [ ] `/dashboard/tasks/create` → configure eval against a **Span** row → type a deep path (e.g. `attributes.llm.token_count.completion`) → eval runs and resolves the value.
- [ ] Same on **Trace** row type with a path under `spans.0.span_attributes.*`.
- [ ] Same on **Session** row type with `traces.0.spans.0.span_attributes.*`.
- [ ] Edit an existing task at `/dashboard/tasks/:taskId` → same flow works.
- [ ] Open the legacy task drawers from `EvalsTasksView` (Create + Edit Task) → free-type works.
- [ ] Open an eval configurator from Test / Simulation / Composite / Experiment surfaces → mapping field is still locked to dropdown (no freeSolo).
- [ ] Bad path resolves to the usual missing-input eval result, not a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)