### PR TITLE
feat(eval-task): support composite evals on trace + session row types [TH-5158]

### DIFF
--- a/futureagi/tracer/tests/test_eval_task.py
+++ b/futureagi/tracer/tests/test_eval_task.py
@@ -450,3 +450,76 @@ class TestEvalTaskRowTypePersistence:
 
         eval_task.refresh_from_db()
         assert eval_task.row_type == original_row_type
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestCompositeEvalAcrossRowTypes:
+    """Composite eval templates are now valid on every row_type (TH-5158).
+
+    Earlier the runtime raised ``NotImplementedError`` for composite + non-span
+    row_type; the API layer never blocked it, so these tests pin the new
+    behaviour: composite + traces / sessions creates a task cleanly.
+    """
+
+    @pytest.fixture
+    def composite_custom_eval_config(self, db, project, organization, workspace):
+        from model_hub.models.evals_metric import (
+            CompositeEvalChild,
+            EvalTemplate,
+        )
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        parent = EvalTemplate.objects.create(
+            name="Composite (api test)",
+            description="composite parent",
+            organization=organization,
+            workspace=workspace,
+            template_type="composite",
+            aggregation_enabled=True,
+            aggregation_function="weighted_avg",
+            pass_threshold=0.5,
+            config={"type": "composite"},
+        )
+        child = EvalTemplate.objects.create(
+            name="Child (api test)",
+            description="composite child",
+            organization=organization,
+            workspace=workspace,
+            template_type="single",
+            config={"type": "pass_fail", "criteria": "ok"},
+            pass_threshold=0.5,
+        )
+        CompositeEvalChild.objects.create(parent=parent, child=child, order=0, weight=1.0)
+        return CustomEvalConfig.objects.create(
+            name="Composite custom config",
+            project=project,
+            eval_template=parent,
+            config={"threshold": 0.5},
+            mapping={"input": "input", "output": "output"},
+            filters={},
+        )
+
+    @pytest.mark.parametrize("row_type", ["traces", "sessions"])
+    def test_composite_template_now_allowed_for_row_type(
+        self, auth_client, project, composite_custom_eval_config, row_type
+    ):
+        """Creating a composite-eval task with row_type=traces|sessions succeeds."""
+        response = auth_client.post(
+            "/tracer/eval-task/",
+            {
+                "project": str(project.id),
+                "name": f"composite {row_type} task",
+                "run_type": "continuous",
+                "sampling_rate": 100,
+                "row_type": row_type,
+                "evals": [str(composite_custom_eval_config.id)],
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        task_id = get_result(response)["id"]
+        task = EvalTask.objects.get(id=task_id)
+        assert task.row_type == row_type
+        assert task.evals.filter(id=composite_custom_eval_config.id).exists()

--- a/futureagi/tracer/tests/test_eval_task_runtime.py
+++ b/futureagi/tracer/tests/test_eval_task_runtime.py
@@ -652,3 +652,586 @@ class TestRowTypeConflationOnRootSpan:
         )
         assert all(r.target_type == "span" for r in rows_span_only)
         assert len(rows_span_only) < len(rows_default)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Composite evals on trace + session row types (TH-5158)
+# ────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def composite_eval_template(db, organization, workspace):
+    """A composite parent with two single children linked via CompositeEvalChild.
+
+    Children expose tiny stub configs; the test stubs out
+    ``execute_composite_children_sync`` so the children never actually run.
+    """
+    from model_hub.models.evals_metric import CompositeEvalChild, EvalTemplate
+
+    parent = EvalTemplate.objects.create(
+        name="Composite Parent",
+        description="Composite for trace/session tests",
+        organization=organization,
+        workspace=workspace,
+        template_type="composite",
+        aggregation_enabled=True,
+        aggregation_function="weighted_avg",
+        pass_threshold=0.5,
+        config={"type": "composite"},
+    )
+    children = [
+        EvalTemplate.objects.create(
+            name=f"Child {i}",
+            description=f"Child eval {i}",
+            organization=organization,
+            workspace=workspace,
+            template_type="single",
+            config={"type": "pass_fail", "criteria": "ok"},
+            pass_threshold=0.5,
+        )
+        for i in range(2)
+    ]
+    for i, child in enumerate(children):
+        CompositeEvalChild.objects.create(
+            parent=parent, child=child, order=i, weight=1.0
+        )
+    return {"parent": parent, "children": children}
+
+
+def _composite_outcome(score=0.8, summary="ok", aggregate_pass=True):
+    """Build a deterministic CompositeRunOutcome for stubbing."""
+    from model_hub.types import CompositeChildResult
+    from model_hub.utils.composite_execution import CompositeRunOutcome
+
+    return CompositeRunOutcome(
+        child_results=[
+            CompositeChildResult(
+                child_id="c0",
+                child_name="Child 0",
+                order=0,
+                score=0.9,
+                output=True,
+                reason="c0 ok",
+                output_type="Pass/Fail",
+                status="completed",
+                weight=1.0,
+            ),
+            CompositeChildResult(
+                child_id="c1",
+                child_name="Child 1",
+                order=1,
+                score=0.7,
+                output=True,
+                reason="c1 ok",
+                output_type="Pass/Fail",
+                status="completed",
+                weight=1.0,
+            ),
+        ],
+        aggregate_score=score,
+        aggregate_pass=aggregate_pass,
+        summary=summary,
+        error_localizer_results=None,
+        log_id=None,
+    )
+
+
+@pytest.fixture
+def stub_composite_children(monkeypatch):
+    """Patch ``execute_composite_children_sync`` with a recorded stub.
+
+    Returns ``calls`` (list of kwargs dicts) and ``set_outcome(outcome)`` /
+    ``set_exception(exc)`` hooks so tests can flip happy/error paths.
+    """
+    state = {"outcome": _composite_outcome(), "exception": None}
+    calls: list[dict] = []
+
+    def _stub(**kwargs):
+        calls.append(kwargs)
+        if state["exception"] is not None:
+            raise state["exception"]
+        return state["outcome"]
+
+    # Patched at the canonical module path; both new helpers do
+    # `from model_hub.utils.composite_execution import execute_composite_children_sync`
+    # at call time, so this catches both.
+    monkeypatch.setattr(
+        "model_hub.utils.composite_execution.execute_composite_children_sync",
+        _stub,
+    )
+
+    class _Hooks:
+        def set_outcome(self, outcome):
+            state["outcome"] = outcome
+
+        def set_exception(self, exc):
+            state["exception"] = exc
+
+        @property
+        def calls(self):
+            return calls
+
+    return _Hooks()
+
+
+@pytest.fixture
+def composite_trace_task(db, populated_observe_project, composite_eval_template):
+    """Trace-level eval task wired to a composite parent template."""
+    from tracer.models.eval_task import RowType
+
+    project = populated_observe_project["project"]
+    config = CustomEvalConfig.objects.create(
+        project=project,
+        eval_template=composite_eval_template["parent"],
+        name="Composite Trace Eval",
+        config={"output": "Pass/Fail"},
+        mapping={"input": "input", "output": "output"},
+        model="turing_large",
+    )
+    task = EvalTask.objects.create(
+        project=project,
+        name="Composite traces task",
+        filters={"project_id": str(project.id)},
+        sampling_rate=100.0,
+        run_type=RunType.HISTORICAL,
+        spans_limit=1000,
+        status=EvalTaskStatus.PENDING,
+        row_type=RowType.TRACES,
+    )
+    task.evals.add(config)
+    return {"task": task, "config": config, "project": project}
+
+
+@pytest.fixture
+def composite_session_task(db, populated_observe_project, composite_eval_template):
+    """Session-level eval task wired to a composite parent template."""
+    from tracer.models.eval_task import RowType
+
+    project = populated_observe_project["project"]
+    config = CustomEvalConfig.objects.create(
+        project=project,
+        eval_template=composite_eval_template["parent"],
+        name="Composite Session Eval",
+        config={"output": "Pass/Fail"},
+        mapping={"input": "traces.0.input", "output": "traces.0.output"},
+        model="turing_large",
+    )
+    task = EvalTask.objects.create(
+        project=project,
+        name="Composite sessions task",
+        filters={"project_id": str(project.id)},
+        sampling_rate=100.0,
+        run_type=RunType.HISTORICAL,
+        spans_limit=1000,
+        status=EvalTaskStatus.PENDING,
+        row_type=RowType.SESSIONS,
+    )
+    task.evals.add(config)
+    return {"task": task, "config": config, "project": project}
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestCompositeEvalOnTrace:
+    """Composite eval fan-out for ``row_type=traces``."""
+
+    def test_creates_one_eval_logger_per_trace(
+        self,
+        populated_observe_project,
+        composite_trace_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """4 traces × 1 composite -> 4 EvalLogger rows, all target_type='trace'."""
+        task = composite_trace_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        rows = EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False)
+        assert rows.count() == 4
+        assert all(r.target_type == "trace" for r in rows)
+        assert all(r.trace_id is not None for r in rows)
+        assert all(r.observation_span_id is not None for r in rows)
+        assert all(r.trace_session_id is None for r in rows)
+
+    def test_writes_children_metadata(
+        self,
+        populated_observe_project,
+        composite_trace_task,
+        composite_eval_template,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        task = composite_trace_task["task"]
+        parent = composite_eval_template["parent"]
+        process_eval_task._original_func(str(task.id))
+
+        row = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).first()
+        meta = row.output_metadata
+        assert meta["composite_id"] == str(parent.id)
+        assert meta["aggregation_enabled"] is True
+        assert meta["aggregate_pass"] is True
+        assert isinstance(meta["children"], list)
+        assert [c["order"] for c in meta["children"]] == [0, 1]
+
+    def test_writes_aggregate_score_to_output_float(
+        self,
+        populated_observe_project,
+        composite_trace_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        task = composite_trace_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        for row in EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False):
+            assert row.output_float == pytest.approx(0.8)
+
+    def test_writes_summary_to_eval_explanation(
+        self,
+        populated_observe_project,
+        composite_trace_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        task = composite_trace_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        for row in EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False):
+            assert row.eval_explanation == "ok"
+
+    def test_dedup_on_second_tick(
+        self,
+        populated_observe_project,
+        composite_trace_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        task = composite_trace_task["task"]
+        process_eval_task._original_func(str(task.id))
+        first = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).count()
+        process_eval_task._original_func(str(task.id))
+        second = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).count()
+        assert second == first
+
+    def test_anchors_to_root_span(
+        self,
+        populated_observe_project,
+        composite_trace_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """Trace composite row's observation_span = the trace's root span."""
+        task = composite_trace_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        rows = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).select_related("observation_span")
+        for row in rows:
+            assert row.observation_span.parent_span_id is None
+            assert row.observation_span.trace_id == row.trace_id
+
+    def test_skips_zero_span_trace(
+        self,
+        populated_observe_project,
+        composite_trace_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """Composite on a zero-span trace short-circuits in the activity, before our branch.
+
+        The anchor-miss path (`evaluate_trace_observe :: _find_anchor_span is None`)
+        runs before the composite delegation, so no EvalLogger row is written
+        and the failure is recorded on EvalTask.failed_spans.
+        """
+        from tracer.models.trace import Trace
+        from tracer.utils.eval import evaluate_trace_observe
+
+        empty_trace = Trace.objects.create(
+            project=populated_observe_project["project"],
+            name="empty composite trace",
+            input={},
+            output={},
+        )
+        task = composite_trace_task["task"]
+        config = composite_trace_task["config"]
+
+        result = evaluate_trace_observe._original_func(
+            trace_id=str(empty_trace.id),
+            custom_eval_config_id=str(config.id),
+            eval_task_id=str(task.id),
+        )
+        assert result is False
+        assert EvalLogger.objects.filter(trace_id=empty_trace.id).count() == 0
+
+        task.refresh_from_db()
+        assert any(
+            entry.get("trace_id") == str(empty_trace.id)
+            for entry in (task.failed_spans or [])
+        )
+
+    def test_forwards_trace_context_to_children(
+        self,
+        populated_observe_project,
+        composite_trace_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """The composite call gets `trace_context` + source='tracer_composite'."""
+        task = composite_trace_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        assert len(stub_composite_children.calls) == 4
+        for call in stub_composite_children.calls:
+            assert call["source"] == "tracer_composite"
+            ctx = call.get("trace_context")
+            assert ctx is not None
+            assert "trace_id" in ctx and "anchor_span_id" in ctx
+
+    def test_writes_error_row_when_children_raise(
+        self,
+        populated_observe_project,
+        composite_trace_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """An exception inside the composite engine still yields one EvalLogger row."""
+        stub_composite_children.set_exception(RuntimeError("boom"))
+        task = composite_trace_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        rows = list(
+            EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False)
+        )
+        assert len(rows) == 4
+        for row in rows:
+            assert row.error is True
+            assert row.output_str == "ERROR"
+            assert row.target_type == "trace"
+            assert row.trace_id is not None
+            assert row.observation_span_id is not None
+            assert row.trace_session_id is None
+            assert "boom" in (row.error_message or "")
+
+    def test_skips_parent_cost_log(
+        self,
+        populated_observe_project,
+        composite_trace_task,
+        stub_composite_children,
+        inline_temporal,
+        monkeypatch,
+    ):
+        """The composite path does not call the parent cost-log; children log their own."""
+        calls = []
+
+        def _spy(**kwargs):
+            calls.append(kwargs)
+            return None  # would normally short-circuit downstream; never reached for composite
+
+        monkeypatch.setattr(
+            "tracer.utils.eval.log_and_deduct_cost_for_api_request", _spy
+        )
+        task = composite_trace_task["task"]
+        process_eval_task._original_func(str(task.id))
+        assert calls == []
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestCompositeEvalOnSession:
+    """Composite eval fan-out for ``row_type=sessions``."""
+
+    def test_creates_one_eval_logger_per_session(
+        self,
+        populated_observe_project,
+        composite_session_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """2 sessions × 1 composite -> 2 EvalLogger rows, all target_type='session'."""
+        task = composite_session_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        rows = EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False)
+        assert rows.count() == 2
+        assert all(r.target_type == "session" for r in rows)
+
+    def test_eval_logger_has_null_span_and_trace(
+        self,
+        populated_observe_project,
+        composite_session_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        task = composite_session_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        for row in EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False):
+            assert row.observation_span_id is None
+            assert row.trace_id is None
+            assert row.trace_session_id is not None
+
+    def test_writes_children_metadata(
+        self,
+        populated_observe_project,
+        composite_session_task,
+        composite_eval_template,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        task = composite_session_task["task"]
+        parent = composite_eval_template["parent"]
+        process_eval_task._original_func(str(task.id))
+
+        row = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).first()
+        meta = row.output_metadata
+        assert meta["composite_id"] == str(parent.id)
+        assert meta["aggregation_enabled"] is True
+        assert meta["aggregate_pass"] is True
+        assert [c["order"] for c in meta["children"]] == [0, 1]
+
+    def test_writes_aggregate_score(
+        self,
+        populated_observe_project,
+        composite_session_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        task = composite_session_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        for row in EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False):
+            assert row.output_float == pytest.approx(0.8)
+
+    def test_dedup_on_second_tick(
+        self,
+        populated_observe_project,
+        composite_session_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        task = composite_session_task["task"]
+        process_eval_task._original_func(str(task.id))
+        first = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).count()
+        process_eval_task._original_func(str(task.id))
+        second = EvalLogger.objects.filter(
+            eval_task_id=str(task.id), deleted=False
+        ).count()
+        assert second == first
+
+    def test_forwards_session_context_to_children(
+        self,
+        populated_observe_project,
+        composite_session_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        task = composite_session_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        assert len(stub_composite_children.calls) == 2
+        for call in stub_composite_children.calls:
+            assert call["source"] == "tracer_composite"
+            ctx = call.get("session_context")
+            assert ctx is not None
+            assert "session_id" in ctx
+
+    def test_sets_workspace_context(
+        self,
+        populated_observe_project,
+        composite_session_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+        monkeypatch,
+    ):
+        """Session composite path mirrors the single-eval session path's workspace ContextVar set."""
+        calls = []
+
+        def _spy(*, workspace, organization, **kwargs):
+            calls.append({"workspace": workspace, "organization": organization})
+
+        monkeypatch.setattr(
+            "tfc.middleware.workspace_context.set_workspace_context", _spy
+        )
+        task = composite_session_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        # One call per session evaluated
+        assert len(calls) >= 2
+        project = populated_observe_project["project"]
+        for entry in calls:
+            assert entry["organization"].id == project.organization.id
+
+    def test_writes_error_row_when_children_raise(
+        self,
+        populated_observe_project,
+        composite_session_task,
+        stub_composite_children,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        stub_composite_children.set_exception(RuntimeError("boom"))
+        task = composite_session_task["task"]
+        process_eval_task._original_func(str(task.id))
+
+        rows = list(
+            EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False)
+        )
+        assert len(rows) == 2
+        for row in rows:
+            assert row.error is True
+            assert row.output_str == "ERROR"
+            assert row.target_type == "session"
+            assert row.observation_span_id is None
+            assert row.trace_id is None
+            assert row.trace_session_id is not None
+            assert "boom" in (row.error_message or "")
+
+    def test_skips_parent_cost_log(
+        self,
+        populated_observe_project,
+        composite_session_task,
+        stub_composite_children,
+        inline_temporal,
+        monkeypatch,
+    ):
+        calls = []
+
+        def _spy(**kwargs):
+            calls.append(kwargs)
+            return None
+
+        monkeypatch.setattr(
+            "tracer.utils.eval.log_and_deduct_cost_for_api_request", _spy
+        )
+        task = composite_session_task["task"]
+        process_eval_task._original_func(str(task.id))
+        assert calls == []

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -670,7 +670,7 @@ def _execute_composite_on_span(
             id=custom_eval_config_id, deleted=False
         )
     except (ObservationSpan.DoesNotExist, CustomEvalConfig.DoesNotExist) as e:
-        raise ValueError(f"Trace composite eval load failed: {e}") from e
+        raise ValueError(f"Span composite eval load failed: {e}") from e
 
     parent = custom_eval_config.eval_template
     org = observation_span.project.organization
@@ -750,6 +750,277 @@ def _execute_composite_on_span(
 
     if value != "ERROR":
         logger_kwargs["value"] = value
+        if isinstance(value, bool):
+            logger_kwargs["output_bool"] = value
+        elif isinstance(value, float) or isinstance(value, int):
+            logger_kwargs["output_float"] = float(value)
+        elif isinstance(value, list):
+            logger_kwargs["output_str_list"] = value
+        else:
+            logger_kwargs["output_str"] = str(value)
+
+    return logger_kwargs
+
+
+def _execute_composite_on_trace(
+    *,
+    trace: Trace,
+    anchor_span: ObservationSpan,
+    custom_eval_config: CustomEvalConfig,
+    eval_task_id,
+    run_params=None,
+    feedback_id=None,
+):
+    """Execute a composite `EvalTemplate` against a Trace.
+
+    Twin of `_execute_composite_on_span` but anchored to a trace. Resolves
+    the composite's child links, delegates to `execute_composite_children_sync`,
+    and returns a `logger_kwargs` dict shaped like the trace single-eval
+    path at the bottom of `_execute_evaluation_for_trace` (target_type=trace,
+    trace + anchor_span set, trace_session NULL). The caller writes the
+    EvalLogger row.
+    """
+    from model_hub.models.evals_metric import CompositeEvalChild
+    from model_hub.utils.composite_execution import execute_composite_children_sync
+
+    parent = custom_eval_config.eval_template
+    org = trace.project.organization
+    workspace = trace.project.workspace
+    if workspace is None:
+        workspace = Workspace.objects.get(
+            organization=org,
+            is_default=True,
+            is_active=True,
+        )
+
+    child_links = list(
+        CompositeEvalChild.objects.filter(parent=parent, deleted=False)
+        .select_related("child", "pinned_version")
+        .order_by("order")
+    )
+    if not child_links:
+        raise ValueError(f"Composite {parent.id} has no children — cannot run on trace.")
+
+    # Mirror the single-eval trace path: set the workspace ContextVar so child
+    # evals' tools (explore_trace etc.) see the right org scope.
+    try:
+        from tfc.middleware.workspace_context import set_workspace_context
+
+        set_workspace_context(workspace=workspace, organization=org)
+    except Exception as _ctx_err:
+        logger.debug(
+            "Failed to set workspace context for composite trace eval",
+            error=str(_ctx_err),
+        )
+
+    try:
+        outcome = execute_composite_children_sync(
+            parent=parent,
+            child_links=child_links,
+            mapping=run_params or {},
+            config=custom_eval_config.config or {},
+            org=org,
+            workspace=workspace,
+            model=custom_eval_config.model,
+            trace_context={
+                "trace_id": str(trace.id),
+                "anchor_span_id": str(anchor_span.id),
+            },
+            source="tracer_composite",
+        )
+
+        value = (
+            outcome.aggregate_score
+            if parent.aggregation_enabled
+            else (outcome.summary or "")
+        )
+        response = {
+            "data": run_params,
+            "failure": False,
+            "reason": outcome.summary or "",
+            "runtime": 0,
+            "model": custom_eval_config.model,
+            "metrics": None,
+            "metadata": {
+                "composite_id": str(parent.id),
+                "aggregation_enabled": parent.aggregation_enabled,
+                "aggregation_function": parent.aggregation_function,
+                "aggregate_pass": outcome.aggregate_pass,
+                "children": [cr.model_dump() for cr in outcome.child_results],
+            },
+            "output": "score" if parent.aggregation_enabled else "text",
+        }
+        logger_kwargs = {
+            "target_type": EvalTargetType.TRACE.value,
+            "trace": trace,
+            "observation_span": anchor_span,
+            "trace_session": None,
+            "output_metadata": response["metadata"],
+            "eval_explanation": outcome.summary or "",
+            "results_explanation": response,
+            "eval_task_id": eval_task_id,
+            "custom_eval_config": custom_eval_config,
+            "eval_type_id": None,
+        }
+    except Exception as e:
+        traceback.print_exc()
+        logger_kwargs = {
+            "target_type": EvalTargetType.TRACE.value,
+            "trace": trace,
+            "observation_span": anchor_span,
+            "trace_session": None,
+            "output_metadata": {
+                "error": str(e),
+                "composite_id": str(parent.id),
+            },
+            "eval_explanation": f"Composite eval failed: {e}",
+            "results_explanation": {"reason": str(e)},
+            "output_str": "ERROR",
+            "error": True,
+            "error_message": f"Composite eval failed: {e}",
+            "custom_eval_config": custom_eval_config,
+            "eval_type_id": None,
+            "eval_task_id": eval_task_id,
+        }
+        value = "ERROR"
+
+    if value != "ERROR":
+        if isinstance(value, bool):
+            logger_kwargs["output_bool"] = value
+        elif isinstance(value, float) or isinstance(value, int):
+            logger_kwargs["output_float"] = float(value)
+        elif isinstance(value, list):
+            logger_kwargs["output_str_list"] = value
+        else:
+            logger_kwargs["output_str"] = str(value)
+
+    return logger_kwargs
+
+
+def _execute_composite_on_session(
+    *,
+    trace_session: TraceSession,
+    custom_eval_config: CustomEvalConfig,
+    eval_task_id,
+    run_params=None,
+    feedback_id=None,
+):
+    """Execute a composite `EvalTemplate` against a TraceSession.
+
+    Twin of `_execute_composite_on_trace` but session-scoped. Writes a
+    target_type='session' EvalLogger shape (trace_session set, observation_span
+    + trace NULL). Sets the workspace ContextVar before delegation so child
+    evals' tools (e.g. explore_trace) see the right org scope.
+    """
+    from model_hub.models.evals_metric import CompositeEvalChild
+    from model_hub.utils.composite_execution import execute_composite_children_sync
+
+    parent = custom_eval_config.eval_template
+    org = trace_session.project.organization
+    workspace = trace_session.project.workspace
+    if workspace is None:
+        workspace = Workspace.objects.get(
+            organization=org,
+            is_default=True,
+            is_active=True,
+        )
+
+    child_links = list(
+        CompositeEvalChild.objects.filter(parent=parent, deleted=False)
+        .select_related("child", "pinned_version")
+        .order_by("order")
+    )
+    if not child_links:
+        raise ValueError(
+            f"Composite {parent.id} has no children — cannot run on session."
+        )
+
+    # The explore_trace tool's live DB actions (list_trace_spans, span_detail)
+    # call get_current_organization() to enforce tenant isolation. The
+    # ContextVar is request-bound and not set in Temporal worker contexts.
+    # Mirror the single-eval session path so children can drill into spans.
+    try:
+        from tfc.middleware.workspace_context import set_workspace_context
+
+        set_workspace_context(
+            workspace=workspace,
+            organization=org,
+        )
+    except Exception as _ctx_err:
+        logger.debug(
+            "Failed to set workspace context for composite session eval",
+            error=str(_ctx_err),
+        )
+
+    try:
+        outcome = execute_composite_children_sync(
+            parent=parent,
+            child_links=child_links,
+            mapping=run_params or {},
+            config=custom_eval_config.config or {},
+            org=org,
+            workspace=workspace,
+            model=custom_eval_config.model,
+            session_context={"session_id": str(trace_session.id)},
+            source="tracer_composite",
+        )
+
+        value = (
+            outcome.aggregate_score
+            if parent.aggregation_enabled
+            else (outcome.summary or "")
+        )
+        response = {
+            "data": run_params,
+            "failure": False,
+            "reason": outcome.summary or "",
+            "runtime": 0,
+            "model": custom_eval_config.model,
+            "metrics": None,
+            "metadata": {
+                "composite_id": str(parent.id),
+                "aggregation_enabled": parent.aggregation_enabled,
+                "aggregation_function": parent.aggregation_function,
+                "aggregate_pass": outcome.aggregate_pass,
+                "children": [cr.model_dump() for cr in outcome.child_results],
+            },
+            "output": "score" if parent.aggregation_enabled else "text",
+        }
+        logger_kwargs = {
+            "target_type": EvalTargetType.SESSION.value,
+            "trace": None,
+            "observation_span": None,
+            "trace_session": trace_session,
+            "output_metadata": response["metadata"],
+            "eval_explanation": outcome.summary or "",
+            "results_explanation": response,
+            "eval_task_id": eval_task_id,
+            "custom_eval_config": custom_eval_config,
+            "eval_type_id": None,
+        }
+    except Exception as e:
+        traceback.print_exc()
+        logger_kwargs = {
+            "target_type": EvalTargetType.SESSION.value,
+            "trace": None,
+            "observation_span": None,
+            "trace_session": trace_session,
+            "output_metadata": {
+                "error": str(e),
+                "composite_id": str(parent.id),
+            },
+            "eval_explanation": f"Composite eval failed: {e}",
+            "results_explanation": {"reason": str(e)},
+            "output_str": "ERROR",
+            "error": True,
+            "error_message": f"Composite eval failed: {e}",
+            "custom_eval_config": custom_eval_config,
+            "eval_type_id": None,
+            "eval_task_id": eval_task_id,
+        }
+        value = "ERROR"
+
+    if value != "ERROR":
         if isinstance(value, bool):
             logger_kwargs["output_bool"] = value
         elif isinstance(value, float) or isinstance(value, int):
@@ -1656,10 +1927,10 @@ def score_categorical(evals: list, value):
 #                   ``first``/``last``); for sessions also
 #                   ``traces.<n>.spans.<m>.<field>``.
 #
-# Composite eval support is intentionally span-only here: the helpers raise
-# NotImplementedError if a composite template is used. Composite fan-out
-# for trace/session subjects is deferred until the UX questions around
-# per-target_type composite templates are settled.
+# Composite eval support spans all three row types: span, trace, and
+# session evaluators each have a `_execute_composite_on_*` helper that
+# fans out to `execute_composite_children_sync` and returns a
+# `logger_kwargs` dict matching the target_type-specific FK shape.
 
 
 # ── Anchor span resolution ──
@@ -1995,17 +2266,24 @@ def _execute_evaluation_for_trace(
     Twin of ``_execute_evaluation`` — same flow (cost log → run_eval → write
     logger), but resolves project/org/workspace off the trace and writes
     a target_type='trace' row anchored to ``anchor_span``. Composite
-    templates raise ``NotImplementedError`` (span-only).
+    templates fan out via ``_execute_composite_on_trace``; children log
+    their own cost rows so the parent cost-log path is skipped.
     """
     from evaluations.constants import FUTUREAGI_EVAL_TYPES
     from evaluations.engine import EvalRequest, run_eval
 
     eval_template = custom_eval_config.eval_template
     if eval_template.template_type == "composite":
-        raise NotImplementedError(
-            "Composite eval templates are span-only. Trace-level "
-            "composite fan-out is not supported yet."
+        logger_kwargs = _execute_composite_on_trace(
+            trace=trace,
+            anchor_span=anchor_span,
+            custom_eval_config=custom_eval_config,
+            eval_task_id=eval_task_id,
+            run_params=run_params,
+            feedback_id=feedback_id,
         )
+        EvalLogger.objects.create(**logger_kwargs)
+        return
     eval_type_id = eval_template.config.get("eval_type_id")
     futureagi_eval = eval_type_id in FUTUREAGI_EVAL_TYPES
 
@@ -2204,16 +2482,25 @@ def _execute_evaluation_for_session(
     run_params: dict,
     feedback_id=None,
 ):
-    """Twin of ``_execute_evaluation_for_trace`` but for sessions."""
+    """Twin of ``_execute_evaluation_for_trace`` but for sessions.
+
+    Composite templates fan out via ``_execute_composite_on_session``;
+    children log their own cost rows so the parent cost-log path is skipped.
+    """
     from evaluations.constants import FUTUREAGI_EVAL_TYPES
     from evaluations.engine import EvalRequest, run_eval
 
     eval_template = custom_eval_config.eval_template
     if eval_template.template_type == "composite":
-        raise NotImplementedError(
-            "Composite eval templates are span-only. Session-level "
-            "composite fan-out is not supported yet."
+        logger_kwargs = _execute_composite_on_session(
+            trace_session=trace_session,
+            custom_eval_config=custom_eval_config,
+            eval_task_id=eval_task_id,
+            run_params=run_params,
+            feedback_id=feedback_id,
         )
+        EvalLogger.objects.create(**logger_kwargs)
+        return
     eval_type_id = eval_template.config.get("eval_type_id")
     futureagi_eval = eval_type_id in FUTUREAGI_EVAL_TYPES
 


### PR DESCRIPTION
## Summary
- Lifts the `NotImplementedError` guard for composite eval templates on `row_type=traces` and `row_type=sessions`. Composite fan-out now works across all three row types with one `EvalLogger` row per `(subject, custom_eval_config, eval_task)`.
- Adds `_execute_composite_on_trace` and `_execute_composite_on_session` in `tracer/utils/eval.py` mirroring `_execute_composite_on_span`. Each resolves the parent's children via `CompositeEvalChild`, delegates to `execute_composite_children_sync` with the right `trace_context` / `session_context`, and returns target-type-shaped `logger_kwargs` (trace anchored to root span via `_find_anchor_span`; session writes with NULL `trace` + `observation_span` per the CHECK constraint). Workspace `ContextVar` is set before fan-out so child evals' tools see the right org scope.
- Skips the parent's `log_and_deduct_cost_for_api_request` for composite: children own their cost rows (parity with the span composite path).
- Drops a stale span-only comment block and fixes the "Trace composite eval load failed" copy-paste in the span loader.

## Test plan
- [x] `uv run pytest tracer/tests/test_eval_task_runtime.py -k Composite -v` — 19/19 passed.
- [x] `uv run pytest tracer/tests/test_eval_task_runtime.py tracer/tests/test_eval_task.py` — 69/69 passed (full eval-task suite, no regressions on the span path).
- [x] `uv run pytest model_hub/tests/test_composite_eval.py` — 15/15 passed (span composite path unchanged).
- [ ] Manual smoke: create a composite `EvalTemplate` with 2+ children, run an eval-task on a project with `row_type=traces` (and again with `row_type=sessions`), confirm one `EvalLogger` row per subject with the composite metadata bag (`composite_id`, `aggregate_pass`, `children`) and the correct FK shape.

## Notes
New tests (`TestCompositeEvalOnTrace`, `TestCompositeEvalOnSession`, `TestCompositeAcrossRowTypes`) cover: happy path, children-metadata payload, aggregate score → `output_float`, summary → `eval_explanation`, dedup-on-second-tick, root-span anchor for traces, zero-span trace short-circuit, `trace_context` / `session_context` forwarding, error-path row shape, parent cost-log skip, and the session workspace-context set. The serializer regression tests confirm the API now accepts composite + traces / sessions cleanly (previously a runtime failure).

Caught during the test run: the new helpers initially copied `value` / `log_id` from the span helper's `logger_kwargs`. The span path strips them in `_write_eval_logger`; the trace/session paths call `EvalLogger.objects.create(**kwargs)` directly, so those keys raised `TypeError`. Removed both before the second test pass.