### PR TITLE
fix(tasks): cell-chip hover color + persist popover when cursor moves onto it

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
+++ b/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
@@ -9,7 +9,7 @@ import {
   Typography,
 } from "@mui/material";
 import { formatDistanceToNow } from "date-fns";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 import _ from "lodash";
@@ -74,6 +74,19 @@ StatusBadge.propTypes = {
 const HoverChipList = ({ items, label, emptyText }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
+  // Short delay before closing lets the cursor cross the gap from the
+  // trigger Box into the Popover Paper without dismissing it.
+  const closeTimerRef = useRef(null);
+  const openPopover = (e) => {
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    setAnchorEl(e.currentTarget);
+  };
+  const scheduleClose = () => {
+    closeTimerRef.current = setTimeout(() => setAnchorEl(null), 120);
+  };
+  const cancelClose = () => {
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+  };
 
   if (!items?.length) {
     return (
@@ -99,13 +112,21 @@ const HoverChipList = ({ items, label, emptyText }) => {
     fontSize: "12px",
     height: 22,
     "& .MuiChip-label": { px: 0.75 },
+    "&:hover, &.MuiChip-clickable:hover": {
+      backgroundColor: (theme) =>
+        alpha(
+          theme.palette.primary.main,
+          0.1 + theme.palette.action.hoverOpacity,
+        ),
+      color: "primary.main",
+    },
   };
 
   return (
     <>
       <Box
-        onMouseEnter={(e) => setAnchorEl(e.currentTarget)}
-        onMouseLeave={() => setAnchorEl(null)}
+        onMouseEnter={openPopover}
+        onMouseLeave={scheduleClose}
         sx={{ display: "flex", alignItems: "center", height: "100%", gap: 0.5 }}
       >
         <Chip label={firstItem} size="small" sx={chipStyles} />
@@ -127,6 +148,8 @@ const HoverChipList = ({ items, label, emptyText }) => {
         transformOrigin={{ vertical: "top", horizontal: "left" }}
         disableRestoreFocus
         PaperProps={{
+          onMouseEnter: cancelClose,
+          onMouseLeave: scheduleClose,
           sx: {
             pointerEvents: "auto",
             p: 1.5,


### PR DESCRIPTION
## Summary

Two fixes in the `HoverChipList` cell renderer used by `TaskListView` (Tasks / Evals list):

- **Hover color.** The chip had no `:hover` state, so the primary-tinted background looked static when the user pointed at it. Added a theme-aware hover that bumps the base alpha by `theme.palette.action.hoverOpacity` (`0.1 + 0.08 = 0.18`), keeping text at `primary.main` so MUI's default chip hover doesn't shift it. Adapts automatically if the global hover intensity is ever retuned in `palette.js`.
- **Popover persistence.** Hovering the cell opened a `Popover` listing the full set of evals/tasks, but moving the cursor toward the Popover crossed out of the trigger `Box`, fired `onMouseLeave`, and dismissed the popover instantly — even though `pointerEvents: "auto"` was set on the Paper. Replaced the immediate `setAnchorEl(null)` with a 120 ms `scheduleClose`, and added `onMouseEnter` (`cancelClose`) / `onMouseLeave` (`scheduleClose`) handlers on `PaperProps` so the cursor can cross the gap and dwell inside the popover.

Closes TH-5230

## Linear Ticket
[TH-5230 — change hover color for cell chip](https://linear.app/future-agi/issue/TH-5230/change-hover-color-for-cell-chip)

## Files Changed
- `frontend/src/sections/common/EvalsTasks/TaskListView.jsx`

## Test plan
- [ ] Hover over a chip cell in the Tasks list → chip background visibly darkens.
- [ ] Hover over a multi-item cell ("+N others"), move cursor down into the Popover → list stays open while cursor is inside.
- [ ] Move cursor away from both chip and Popover → Popover dismisses after ~120ms.
- [ ] No regression: single-item cells render as before, empty cells still show the dash.
- [ ] Dark mode: hover state stays primary-tinted (uses theme palette, no hardcoded colors).