### PR TITLE
[TH-5233] Task Usage table: clamp width so columns don't get cut off

### DIFF
--- a/frontend/src/components/data-table/DataTable.jsx
+++ b/frontend/src/components/data-table/DataTable.jsx
@@ -117,7 +117,7 @@ export default function DataTable({
   }, [columnVisibility]);
 
   return (
-    <Box sx={{ flex: 1, minHeight: 0 }}>
+    <Box sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
       <DataGrid
         rows={data || []}
         columns={muiColumns}

--- a/frontend/src/sections/tasks/components/TaskUsageTab.jsx
+++ b/frontend/src/sections/tasks/components/TaskUsageTab.jsx
@@ -1148,7 +1148,7 @@ const TaskUsageTab = ({ taskId }) => {
               height. Without it the DataGrid renders every row at
               natural height and the table grows past the viewport,
               hiding the pagination footer and breaking internal scroll. */}
-          <Box sx={{ flex: 1, minHeight: 0, display: "flex" }}>
+          <Box sx={{ flex: 1, minHeight: 0, minWidth: 0, display: "flex" }}>
             <DataTable
               columns={columns}
               data={visibleLogs}


### PR DESCRIPTION
## Summary
- On `Tasks → Usage`, the Evaluation Runs table was drifting wider than its container as data loaded — the right columns (`Ran at`) got cropped and no x-scroll appeared.
- Root cause: the wrapper Box around `DataTable` uses `display: flex` to bound the DataGrid's height (TaskDetailPage clips its tab content with `overflow: hidden`, otherwise pagination would disappear). That made `DataTable`'s inner Box a flex item whose default `min-width: auto` allowed it to grow to its content's natural width, defeating DataGrid's internal x-scroll.
- Fix: add `minWidth: 0` to both layers of the flex chain that wrap `<DataGrid>`, so DataGrid measures a bounded width and engages its own horizontal scroll when columns exceed the available space. The height-bounding `display: flex` workaround stays as-is — both changes are needed together.

Closes TH-5233

## Linear Ticket
[TH-5233](https://linear.app/future-agi/issue/TH-5233/task-usage-table-data-is-cut-off)

## Files Changed
- `frontend/src/components/data-table/DataTable.jsx` — `minWidth: 0` on the inner Box wrapping `<DataGrid>`. Safe for all 18 DataTable consumers: no-op outside flex parents, and inside flex parents it's the standard pattern to allow proper shrinking.
- `frontend/src/sections/tasks/components/TaskUsageTab.jsx` — `minWidth: 0` on the local wrapper that has `display: flex`.

## Test plan
- [ ] Tasks → Usage: Evaluation Runs table fits the container, `Ran at` column fully visible, x-scrollbar appears at the bottom of the table when columns exceed the area.
- [ ] Evals → Usage (sister tab): no visual regression.
- [ ] Tracing → Observe list (heaviest DataTable consumer): no regression.
- [ ] Tasks list + Evals list: no regression.
- [ ] Pagination footer still anchored at the bottom on Tasks → Usage.