### PR TITLE
[TH-5188] Wire `+` icon on FilterChips for Sessions, Users, User Traces

### DIFF
--- a/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
+++ b/frontend/src/sections/projects/SessionsView/Sessions-view.jsx
@@ -202,6 +202,10 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
     "sessionFilterOpen",
     false,
   );
+  // Anchor for the filter popover when opened via the chip-row `+` or
+  // by clicking an existing chip. Null falls back to the toolbar Filter
+  // button (handled by ObserveToolbar).
+  const [externalFilterAnchor, setExternalFilterAnchor] = useState(null);
 
   const hasActiveFilter = extraFilters.length > 0;
 
@@ -954,7 +958,13 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         onSaveView={handleSaveView}
         graphFilters={extraFilters}
         isFilterOpen={isFilterOpen}
-        onFilterToggle={() => setIsFilterOpen(!isFilterOpen)}
+        externalFilterAnchor={externalFilterAnchor}
+        onFilterToggle={() => {
+          // Clear any chip-row anchor so the popover re-anchors to the
+          // toolbar Filter button on the next open.
+          setExternalFilterAnchor(null);
+          setIsFilterOpen(!isFilterOpen);
+        }}
         filterFields={sessionFilterFields}
         onApplyExtraFilters={setExtraFilters}
         // Columns
@@ -1061,9 +1071,23 @@ const SessionsView = ({ mode = "project", userIdForUserMode = null }) => {
         }))}
         fieldLabelMap={filterChipLabelMap}
         onRemoveFilter={(idx) => {
+          // Chips are keyed by array index, so any removal re-mounts the
+          // later chips and invalidates a chip-anchored popover ref.
+          setExternalFilterAnchor(null);
           setExtraFilters((prev) => prev.filter((_, i) => i !== idx));
         }}
-        onClearAll={() => setExtraFilters([])}
+        onClearAll={() => {
+          setExternalFilterAnchor(null);
+          setExtraFilters([]);
+        }}
+        onAddFilter={(anchorEl) => {
+          setExternalFilterAnchor(anchorEl || null);
+          setIsFilterOpen(true);
+        }}
+        onChipClick={(_idx, anchorEl) => {
+          setExternalFilterAnchor(anchorEl || null);
+          setIsFilterOpen(true);
+        }}
       />
 
       {/* Graph — hidden in user mode (no project context) */}

--- a/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
+++ b/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
@@ -32,6 +32,10 @@ const UserTraceTabV2 = ({ dateFilter }) => {
     "userTraceFilterOpen",
     false,
   );
+  // Anchor for the filter popover when opened via the chip-row `+` or
+  // by clicking an existing chip. Null falls back to the toolbar Filter
+  // button (handled by ObserveToolbar).
+  const [externalFilterAnchor, setExternalFilterAnchor] = useState(null);
   const [openCustomColumn, setOpenCustomColumn] = useState(false);
   const [columnConfigureAnchor, setColumnConfigureAnchor] = useState(null);
   const openColumnConfigure = Boolean(columnConfigureAnchor);
@@ -157,7 +161,13 @@ const UserTraceTabV2 = ({ dateFilter }) => {
         // Filter
         hasActiveFilter={extraFilters.length > 0}
         isFilterOpen={isFilterOpen}
-        onFilterToggle={() => setIsFilterOpen(!isFilterOpen)}
+        externalFilterAnchor={externalFilterAnchor}
+        onFilterToggle={() => {
+          // Clear any chip-row anchor so the popover re-anchors to the
+          // toolbar Filter button on the next open.
+          setExternalFilterAnchor(null);
+          setIsFilterOpen(!isFilterOpen);
+        }}
         onApplyExtraFilters={setExtraFilters}
         // Columns / Display
         columns={columns}
@@ -179,10 +189,24 @@ const UserTraceTabV2 = ({ dateFilter }) => {
           display_name:
             columnLabelLookup[f?.column_id] ?? f?.display_name,
         }))}
-        onRemoveFilter={(idx) =>
-          setExtraFilters((prev) => prev.filter((_, i) => i !== idx))
-        }
-        onClearAll={() => setExtraFilters([])}
+        onRemoveFilter={(idx) => {
+          // Chips are keyed by array index, so any removal re-mounts the
+          // later chips and invalidates a chip-anchored popover ref.
+          setExternalFilterAnchor(null);
+          setExtraFilters((prev) => prev.filter((_, i) => i !== idx));
+        }}
+        onClearAll={() => {
+          setExternalFilterAnchor(null);
+          setExtraFilters([]);
+        }}
+        onAddFilter={(anchorEl) => {
+          setExternalFilterAnchor(anchorEl || null);
+          setIsFilterOpen(true);
+        }}
+        onChipClick={(_idx, anchorEl) => {
+          setExternalFilterAnchor(anchorEl || null);
+          setIsFilterOpen(true);
+        }}
       />
 
       <TraceGrid

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -238,6 +238,10 @@ const UsersView = ({
   // --- Extra filters from TraceFilterPanel (popover) ---
   const [extraFilters, setExtraFilters] = useState([]);
   const [isFilterOpen, setIsFilterOpen] = useUrlState("userFilterOpen", false);
+  // Anchor for the filter popover when opened via the chip-row `+` or
+  // by clicking an existing chip. Null falls back to the toolbar Filter
+  // button (handled by ObserveToolbar).
+  const [externalFilterAnchor, setExternalFilterAnchor] = useState(null);
 
   const hasActiveFilter = extraFilters.length > 0;
 
@@ -785,7 +789,13 @@ const UsersView = ({
         onSaveView={handleSaveView}
         graphFilters={extraFilters}
         isFilterOpen={isFilterOpen}
-        onFilterToggle={() => setIsFilterOpen(!isFilterOpen)}
+        externalFilterAnchor={externalFilterAnchor}
+        onFilterToggle={() => {
+          // Clear any chip-row anchor so the popover re-anchors to the
+          // toolbar Filter button on the next open.
+          setExternalFilterAnchor(null);
+          setIsFilterOpen(!isFilterOpen);
+        }}
         filterFields={USER_FILTER_FIELDS}
         onApplyExtraFilters={setExtraFilters}
         // Columns (Display panel)
@@ -852,9 +862,23 @@ const UsersView = ({
             USER_FILTER_FIELDS.find((c) => c.id === f.column_id)?.name,
         }))}
         onRemoveFilter={(idx) => {
+          // Chips are keyed by array index, so any removal re-mounts the
+          // later chips and invalidates a chip-anchored popover ref.
+          setExternalFilterAnchor(null);
           setExtraFilters((prev) => prev.filter((_, i) => i !== idx));
         }}
-        onClearAll={() => setExtraFilters([])}
+        onClearAll={() => {
+          setExternalFilterAnchor(null);
+          setExtraFilters([]);
+        }}
+        onAddFilter={(anchorEl) => {
+          setExternalFilterAnchor(anchorEl || null);
+          setIsFilterOpen(true);
+        }}
+        onChipClick={(_idx, anchorEl) => {
+          setExternalFilterAnchor(anchorEl || null);
+          setIsFilterOpen(true);
+        }}
       />
 
       {/* Graph — hidden in cross-project mode (no project context to


### PR DESCRIPTION
## Summary
- The `+` button next to active filter chips (and click-to-edit on the chips themselves) was a no-op on the Sessions tab, Users tab, and the user-detail Traces sub-tab. On Trace and Spans (rendered by `LLMTracingView`) it correctly opens the filter popover anchored to the click target.
- Root cause: `<FilterChips>` exposes `onAddFilter?.(anchorEl)` / `onChipClick`, and only `LLMTracingView` was passing them — the other three call sites silently dropped the click.
- Fix: port the same pattern to the three other consumers — add an `externalFilterAnchor` state, pass it through `<ObserveToolbar>` (already supported there), wire `onAddFilter` + `onChipClick`, and clear the anchor on toggle/remove/clear so the popover never tries to re-anchor on a node that's about to unmount.
- Skipped the `setFilterTarget("primary")` call from the reference impl — those three views don't have compare mode, so there's no secondary filter target to set.

Closes TH-5188

## Linear Ticket
[TH-5188](https://linear.app/future-agi/issue/TH-5188/add-icon-beside-active-filter-isnt-doing-anything-ideally-should-open)

## Files Changed
- `frontend/src/sections/projects/SessionsView/Sessions-view.jsx` — Sessions tab.
- `frontend/src/sections/projects/UsersView/UsersView.jsx` — Users tab.
- `frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx` — user-detail Traces sub-tab (same dead handler; bundled to avoid a follow-up PR).

## Test plan
- [ ] Observe → Sessions: add a filter via the toolbar Filter button so a chip appears; click the `+` next to the chip → popover opens anchored next to `+`. Click the chip → popover opens anchored to that chip.
- [ ] Observe → Users: same checks.
- [ ] User detail → Traces sub-tab: same checks.
- [ ] Toolbar Filter button still toggles the popover correctly on all three (anchor resets between chip-row and toolbar opens).
- [ ] Removing the last chip / clear-all does not leave a stale anchor; reopening the popover anchors to the toolbar button again.
- [ ] Trace and Spans tabs unchanged.