### PR TITLE
Normalize inner keys in filter parameters for consistency

### DIFF
--- a/futureagi/tracer/tests/test_normalize_filter_params.py
+++ b/futureagi/tracer/tests/test_normalize_filter_params.py
@@ -1,0 +1,239 @@
+"""Tests for _normalize_filter_params: camelCase, snake_case, and mixed filter input.
+
+TH-4902: FilterEngine._normalize_filter_params must normalize inner keys
+(filterOp → filter_op, filterType → filter_type, filterValue → filter_value,
+colType → col_type) in addition to outer keys.
+"""
+
+import pytest
+from django.db.models import Q
+
+from tracer.utils.filters import ColType, FilterEngine
+
+
+class TestNormalizeFilterParams:
+    """Unit tests for FilterEngine._normalize_filter_params."""
+
+    def test_snake_case_passthrough(self):
+        item = {
+            "column_id": "avg_cost",
+            "filter_config": {
+                "filter_type": "number",
+                "filter_op": "greater_than",
+                "filter_value": 0.5,
+                "col_type": "SYSTEM_METRIC",
+            },
+        }
+        col_id, fc = FilterEngine._normalize_filter_params(item)
+        assert col_id == "avg_cost"
+        assert fc["filter_type"] == "number"
+        assert fc["filter_op"] == "greater_than"
+        assert fc["filter_value"] == 0.5
+        assert fc["col_type"] == "SYSTEM_METRIC"
+
+    def test_camel_case_outer_and_inner(self):
+        item = {
+            "columnId": "avg_cost",
+            "filterConfig": {
+                "filterType": "number",
+                "filterOp": "greater_than",
+                "filterValue": 0.5,
+                "colType": "SYSTEM_METRIC",
+            },
+        }
+        col_id, fc = FilterEngine._normalize_filter_params(item)
+        assert col_id == "avg_cost"
+        assert fc["filter_type"] == "number"
+        assert fc["filter_op"] == "greater_than"
+        assert fc["filter_value"] == 0.5
+        assert fc["col_type"] == "SYSTEM_METRIC"
+        # camelCase keys should be gone
+        assert "filterType" not in fc
+        assert "filterOp" not in fc
+        assert "filterValue" not in fc
+        assert "colType" not in fc
+
+    def test_mixed_outer_camel_inner_snake(self):
+        item = {
+            "columnId": "status",
+            "filter_config": {
+                "filter_type": "text",
+                "filter_op": "equals",
+                "filter_value": "ERROR",
+            },
+        }
+        col_id, fc = FilterEngine._normalize_filter_params(item)
+        assert col_id == "status"
+        assert fc["filter_type"] == "text"
+        assert fc["filter_op"] == "equals"
+        assert fc["filter_value"] == "ERROR"
+
+    def test_mixed_outer_snake_inner_camel(self):
+        item = {
+            "column_id": "status",
+            "filterConfig": {
+                "filterType": "text",
+                "filterOp": "not_contains",
+                "filterValue": "voicemail",
+                "colType": "SPAN_ATTRIBUTE",
+            },
+        }
+        col_id, fc = FilterEngine._normalize_filter_params(item)
+        assert col_id == "status"
+        assert fc["filter_type"] == "text"
+        assert fc["filter_op"] == "not_contains"
+        assert fc["filter_value"] == "voicemail"
+        assert fc["col_type"] == "SPAN_ATTRIBUTE"
+
+    def test_empty_filter_config(self):
+        item = {"column_id": "foo"}
+        col_id, fc = FilterEngine._normalize_filter_params(item)
+        assert col_id == "foo"
+        assert fc == {}
+
+    def test_missing_column_id(self):
+        item = {"filter_config": {"filter_op": "equals"}}
+        col_id, fc = FilterEngine._normalize_filter_params(item)
+        assert col_id is None
+        assert fc["filter_op"] == "equals"
+
+    def test_both_camel_and_snake_inner_keys_snake_wins(self):
+        """When both filterOp and filter_op exist, the last writer wins.
+
+        Since dict iteration is insertion-order in Python 3.7+, the key
+        that appears later takes precedence.
+        """
+        item = {
+            "column_id": "x",
+            "filter_config": {
+                "filterOp": "camel_value",
+                "filter_op": "snake_value",
+            },
+        }
+        col_id, fc = FilterEngine._normalize_filter_params(item)
+        # filter_op maps to itself, so it overwrites the earlier filterOp→filter_op
+        assert fc["filter_op"] == "snake_value"
+
+    def test_unknown_inner_keys_preserved(self):
+        item = {
+            "column_id": "x",
+            "filter_config": {
+                "filter_op": "equals",
+                "custom_key": "preserved",
+            },
+        }
+        col_id, fc = FilterEngine._normalize_filter_params(item)
+        assert fc["custom_key"] == "preserved"
+        assert fc["filter_op"] == "equals"
+
+    def test_does_not_mutate_original(self):
+        original_config = {
+            "filterOp": "equals",
+            "filterType": "text",
+            "filterValue": "hello",
+        }
+        item = {"column_id": "x", "filterConfig": original_config}
+        _, fc = FilterEngine._normalize_filter_params(item)
+        # Original should still have camelCase keys
+        assert "filterOp" in original_config
+        assert "filter_op" not in original_config
+        # Normalized should have snake_case
+        assert "filter_op" in fc
+
+
+class TestNormalizeFilterParamsIntegration:
+    """Integration tests: camelCase filters work through consuming methods."""
+
+    def _make_camel_span_attr_filter(self, ftype, op, value):
+        """Build a filter item using camelCase inner keys."""
+        return {
+            "column_id": "test_attr",
+            "filter_config": {
+                "colType": "SPAN_ATTRIBUTE",
+                "filterType": ftype,
+                "filterOp": op,
+                "filterValue": value,
+            },
+        }
+
+    def test_span_attributes_with_camel_case_text_equals(self):
+        """camelCase text equals filter should produce a Q object, not be silently dropped."""
+        f = self._make_camel_span_attr_filter("text", "equals", "hello")
+        q = FilterEngine.get_filter_conditions_for_span_attributes([f])
+        assert q != Q(), "camelCase text/equals filter was silently dropped"
+
+    def test_span_attributes_with_camel_case_text_not_contains(self):
+        """Reproduces the Mudflap iForm-Prod / Ghosted-Prod bug:
+        not_contains "voicemail" with camelCase keys."""
+        f = self._make_camel_span_attr_filter("text", "not_contains", "voicemail")
+        q = FilterEngine.get_filter_conditions_for_span_attributes([f])
+        assert q != Q(), "camelCase text/not_contains filter was silently dropped"
+
+    def test_span_attributes_with_camel_case_text_not_equals(self):
+        """Reproduces the Mudflap iForm-Pre-Prod bug:
+        not_equals "Voicemail" with camelCase keys."""
+        f = self._make_camel_span_attr_filter("text", "not_equals", "Voicemail")
+        q = FilterEngine.get_filter_conditions_for_span_attributes([f])
+        assert q != Q(), "camelCase text/not_equals filter was silently dropped"
+
+    def test_span_attributes_fully_camel_case_outer_and_inner(self):
+        """Fully camelCase payload (both outer and inner keys) through
+        get_filter_conditions_for_span_attributes — the most likely shape
+        of stored Mudflap filter blobs."""
+        f = {
+            "columnId": "test_attr",
+            "filterConfig": {
+                "colType": "SPAN_ATTRIBUTE",
+                "filterType": "text",
+                "filterOp": "not_contains",
+                "filterValue": "voicemail",
+            },
+        }
+        q = FilterEngine.get_filter_conditions_for_span_attributes([f])
+        assert q != Q(), "Fully camelCase filter was silently dropped"
+
+    def test_span_attributes_with_camel_case_number_greater_than(self):
+        f = self._make_camel_span_attr_filter("number", "greater_than", 42)
+        q = FilterEngine.get_filter_conditions_for_span_attributes([f])
+        assert q != Q(), "camelCase number/greater_than filter was silently dropped"
+
+    def test_span_attributes_with_camel_case_boolean_equals(self):
+        f = self._make_camel_span_attr_filter("boolean", "equals", True)
+        q = FilterEngine.get_filter_conditions_for_span_attributes([f])
+        assert q != Q(), "camelCase boolean/equals filter was silently dropped"
+
+    def test_span_attributes_with_camel_case_is_null(self):
+        f = self._make_camel_span_attr_filter("text", "is_null", None)
+        q = FilterEngine.get_filter_conditions_for_span_attributes([f])
+        assert q != Q(), "camelCase text/is_null filter was silently dropped"
+
+    def test_span_attributes_snake_case_still_works(self):
+        """Existing snake_case filters must not regress."""
+        f = {
+            "column_id": "test_attr",
+            "filter_config": {
+                "col_type": "SPAN_ATTRIBUTE",
+                "filter_type": "text",
+                "filter_op": "equals",
+                "filter_value": "hello",
+            },
+        }
+        q = FilterEngine.get_filter_conditions_for_span_attributes([f])
+        assert q != Q(), "snake_case filter should still work"
+
+    def test_non_system_metrics_with_camel_case(self):
+        """camelCase inner keys in non-system metric filters should not be dropped."""
+        f = {
+            "column_id": "some_metric",
+            "filter_config": {
+                "colType": "EVAL_METRIC",
+                "filterType": "number",
+                "filterOp": "greater_than",
+                "filterValue": 0.5,
+            },
+        }
+        # Should not raise or crash; the method should parse inner keys
+        q = FilterEngine.get_filter_conditions_for_non_system_metrics([f])
+        # Even if Q() is returned (column_id might not match a real column),
+        # the point is it shouldn't crash or silently skip due to missing keys.
+        assert isinstance(q, Q)

--- a/futureagi/tracer/utils/filters.py
+++ b/futureagi/tracer/utils/filters.py
@@ -252,8 +252,8 @@ class FilterEngine:
             tuple: (column_id, filter_config) with normalized parameter names
         """
         column_id = filter_item.get("columnId") or filter_item.get("column_id")
-        filter_config = filter_item.get("filterConfig") or filter_item.get(
-            "filter_config", {}
+        filter_config = (
+            filter_item.get("filterConfig") or filter_item.get("filter_config") or {}
         )
 
         if filter_config:

--- a/futureagi/tracer/utils/filters.py
+++ b/futureagi/tracer/utils/filters.py
@@ -64,7 +64,7 @@ def apply_created_at_filters(qs, filters):
     """
     applied = set()
     for i, f in enumerate(filters):
-        cfg = f.get("filter_config") or f.get("filterConfig") or {}
+        _, cfg = FilterEngine._normalize_filter_params(f)
         if cfg.get("filter_type") != "datetime":
             continue
         op = normalize_filter_op(cfg.get("filter_op"))
@@ -229,10 +229,21 @@ class FilterEngine:
         except (ValueError, TypeError, IndexError):
             return False, None
 
+    _INNER_KEY_MAP = {
+        "filterOp": "filter_op",
+        "filterType": "filter_type",
+        "filterValue": "filter_value",
+        "colType": "col_type",
+    }
+
     @staticmethod
     def _normalize_filter_params(filter_item):
         """
         Normalize filter parameters to handle both camelCase and snake_case.
+
+        Normalizes both outer keys (columnId/column_id, filterConfig/filter_config)
+        and inner keys within filter_config (filterOp→filter_op, filterType→filter_type,
+        filterValue→filter_value, colType→col_type).
 
         Args:
             filter_item: Dictionary containing filter parameters
@@ -244,14 +255,23 @@ class FilterEngine:
         filter_config = filter_item.get("filterConfig") or filter_item.get(
             "filter_config", {}
         )
+
+        if filter_config:
+            normalized = {}
+            for key, value in filter_config.items():
+                canonical = FilterEngine._INNER_KEY_MAP.get(key, key)
+                normalized[canonical] = value
+            filter_config = normalized
+
         return column_id, filter_config
 
     def apply_filters(self, filters):
         filtered_objects = self.objects
 
         for filter_item in filters:
-            column_id = filter_item.get("column_id")
-            filter_config = filter_item.get("filter_config", {})
+            column_id, filter_config = FilterEngine._normalize_filter_params(
+                filter_item
+            )
             col_type = filter_config.get("col_type", ColType.NORMAL)
 
             if isinstance(col_type, str):
@@ -290,12 +310,17 @@ class FilterEngine:
 
     def _filter_number(self, objects, column_id, filter_op, filter_value, col_type):
         if filter_op in ("is_null", "is_not_null"):
+
             def _missing(obj):
                 if col_type == ColType.EVAL_METRIC:
-                    return obj.get("evals_metrics", {}).get(column_id, {}).get("score") is None
+                    return (
+                        obj.get("evals_metrics", {}).get(column_id, {}).get("score")
+                        is None
+                    )
                 if col_type == ColType.SYSTEM_METRIC:
                     return obj.get("system_metrics", {}).get(column_id) is None
                 return obj.get(column_id) is None
+
             return [obj for obj in objects if _missing(obj) == (filter_op == "is_null")]
 
         operator_map = {
@@ -342,14 +367,20 @@ class FilterEngine:
 
     def _filter_text(self, objects, column_id, filter_op, filter_value, col_type):
         if filter_op in ("is_null", "is_not_null"):
+
             def _missing(obj):
                 if col_type == ColType.EVAL_METRIC:
-                    v = obj.get("evals_metrics", {}).get(str(column_id), {}).get("score")
+                    v = (
+                        obj.get("evals_metrics", {})
+                        .get(str(column_id), {})
+                        .get("score")
+                    )
                 elif col_type == ColType.SYSTEM_METRIC:
                     v = obj.get("system_metrics", {}).get(column_id)
                 else:
                     v = obj.get(column_id)
                 return v is None or v == ""
+
             return [obj for obj in objects if _missing(obj) == (filter_op == "is_null")]
 
         # Set-membership ops (in/not_in): filter_value is a list of values.
@@ -358,20 +389,24 @@ class FilterEngine:
             if isinstance(filter_value, list):
                 values = [str(v).lower() for v in filter_value]
             else:
-                values = [v.strip().lower() for v in str(filter_value).split(",") if v.strip()]
+                values = [
+                    v.strip().lower() for v in str(filter_value).split(",") if v.strip()
+                ]
             text_ops = {
-                "in":     lambda x: x in values,
+                "in": lambda x: x in values,
                 "not_in": lambda x: x not in values,
             }
         else:
-            fv = (filter_value if isinstance(filter_value, str) else str(filter_value)).lower()
+            fv = (
+                filter_value if isinstance(filter_value, str) else str(filter_value)
+            ).lower()
             text_ops = {
-                "contains":     lambda x: fv in x,
+                "contains": lambda x: fv in x,
                 "not_contains": lambda x: fv not in x,
-                "equals":       lambda x: x == fv,
-                "not_equals":   lambda x: x != fv,
-                "starts_with":  lambda x: x.startswith(fv),
-                "ends_with":    lambda x: x.endswith(fv),
+                "equals": lambda x: x == fv,
+                "not_equals": lambda x: x != fv,
+                "starts_with": lambda x: x.startswith(fv),
+                "ends_with": lambda x: x.endswith(fv),
             }
 
         if filter_op not in text_ops:
@@ -395,12 +430,15 @@ class FilterEngine:
                     result.append(obj)
         return result
 
-    def _filter_boolean(self, objects, column_id, filter_value, col_type, filter_op=None):
+    def _filter_boolean(
+        self, objects, column_id, filter_value, col_type, filter_op=None
+    ):
         filter_op = filter_op or "equals"
 
         if filter_op in ("is_null", "is_not_null"):
             return [
-                obj for obj in objects
+                obj
+                for obj in objects
                 if (obj.get(column_id) is None) == (filter_op == "is_null")
             ]
 
@@ -774,9 +812,7 @@ class FilterEngine:
             column_id, filter_config = FilterEngine._normalize_filter_params(
                 filter_item
             )
-            col_type = (
-                filter_config.get("col_type") or filter_config.get("colType") or ""
-            )
+            col_type = filter_config.get("col_type", "")
 
             if column_id not in FilterEngine.VOICE_SYSTEM_METRIC_IDS:
                 continue
@@ -787,15 +823,9 @@ class FilterEngine:
             if not defn:
                 continue
 
-            filter_op = normalize_filter_op(
-                filter_config.get("filter_op") or filter_config.get("filterOp")
-            )
-            filter_value = filter_config.get(
-                "filter_value", filter_config.get("filterValue")
-            )
-            filter_type = filter_config.get("filter_type") or filter_config.get(
-                "filterType"
-            )
+            filter_op = normalize_filter_op(filter_config.get("filter_op"))
+            filter_value = filter_config.get("filter_value")
+            filter_type = filter_config.get("filter_type")
 
             if not filter_op or filter_value is None or not filter_type:
                 continue
@@ -895,15 +925,16 @@ class FilterEngine:
 
         conditions = []
         for filter_item in filters:
-            column_id = filter_item.get("columnId")
-            filter_config = filter_item.get("filterConfig", {})
+            column_id, filter_config = FilterEngine._normalize_filter_params(
+                filter_item
+            )
 
             if not column_id or not filter_config:
                 continue
 
-            filter_op = normalize_filter_op(filter_config.get("filterOp"))
-            filter_value = filter_config.get("filterValue")
-            filter_type = filter_config.get("filterType")
+            filter_op = normalize_filter_op(filter_config.get("filter_op"))
+            filter_value = filter_config.get("filter_value")
+            filter_type = filter_config.get("filter_type")
 
             if not all([filter_op, filter_value is not None, filter_type]):
                 continue
@@ -1218,8 +1249,9 @@ class FilterEngine:
         having = None
 
         for filter_item in filters:
-            column_id = filter_item.get("columnId")
-            filter_config = filter_item.get("filterConfig", {})
+            column_id, filter_config = FilterEngine._normalize_filter_params(
+                filter_item
+            )
 
             if (
                 not column_id
@@ -1240,9 +1272,9 @@ class FilterEngine:
             ):
                 continue
 
-            filter_type = filter_config.get("filterType")
-            filter_op = normalize_filter_op(filter_config.get("filterOp"))
-            filter_value = filter_config.get("filterValue")
+            filter_type = filter_config.get("filter_type")
+            filter_op = normalize_filter_op(filter_config.get("filter_op"))
+            filter_value = filter_config.get("filter_value")
 
             if filter_type == "number":
                 metric_val = None
@@ -1334,8 +1366,9 @@ class FilterEngine:
     def get_filter_conditions_for_non_system_metrics(filters):
         eval_filter_conditions = Q()
         for filter_item in filters:
-            column_id = filter_item.get("column_id")
-            filter_config = filter_item.get("filter_config", {})
+            column_id, filter_config = FilterEngine._normalize_filter_params(
+                filter_item
+            )
             col_type = (
                 filter_config.get("col_type", ColType.EVAL_METRIC.value)
                 if "col_type" in filter_config
@@ -1423,9 +1456,7 @@ class FilterEngine:
                         positive |= Q(**{f"{metric_column_id}__score__gt": 0})
                     elif normalized in ("failed", "fail", "false", "0"):
                         positive |= Q(**{f"{metric_column_id}__score": 0})
-                    positive |= Q(
-                        **{f"{metric_column_id}__{text_value}__score__gt": 0}
-                    )
+                    positive |= Q(**{f"{metric_column_id}__{text_value}__score__gt": 0})
 
                 if filter_op in ("not_equals", "not_in", "not_contains"):
                     return Q(**{f"{metric_column_id}__isnull": False}) & ~positive
@@ -1846,7 +1877,9 @@ class FilterEngine:
                 # Thumbs Up/Down annotations use keys "thumbs_up"/"thumbs_down"
                 # but the frontend sends display labels "Thumbs Up"/"Thumbs Down".
                 _THUMBS_MAP = {"Thumbs Up": "thumbs_up", "Thumbs Down": "thumbs_down"}
-                raw_values = filter_value if isinstance(filter_value, list) else [filter_value]
+                raw_values = (
+                    filter_value if isinstance(filter_value, list) else [filter_value]
+                )
                 values = [_THUMBS_MAP.get(v, v) for v in raw_values]
                 has_annotation = Q(**{f"{annotation_field}__isnull": False})
 
@@ -2167,12 +2200,10 @@ class FilterEngine:
         # Use span_attributes (canonical) for all filters - eval_attributes is deprecated.
         # Vocabulary mirrors `SPAN_ATTR_ALLOWED_OPS` in `tracer.utils.constants`.
         _null_q = lambda col: (
-            ~Q(span_attributes__has_key=col)
-            | Q(span_attributes__contains={col: None})
+            ~Q(span_attributes__has_key=col) | Q(span_attributes__contains={col: None})
         )
         _not_null_q = lambda col: (
-            Q(span_attributes__has_key=col)
-            & ~Q(span_attributes__contains={col: None})
+            Q(span_attributes__has_key=col) & ~Q(span_attributes__contains={col: None})
         )
 
         text_operator_map = {
@@ -2180,14 +2211,16 @@ class FilterEngine:
             "not_equals": lambda col, val: ~Q(span_attributes__contains={col: val}),
             "in": lambda col, val: Q(
                 **{
-                    f"span_attributes__{col}__in":
+                    f"span_attributes__{col}__in": (
                         val if isinstance(val, list) else [val]
+                    )
                 }
             ),
             "not_in": lambda col, val: ~Q(
                 **{
-                    f"span_attributes__{col}__in":
+                    f"span_attributes__{col}__in": (
                         val if isinstance(val, list) else [val]
+                    )
                 }
             ),
             "contains": lambda col, val: Q(

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -3,11 +3,11 @@ import io
 import json
 import traceback
 from collections import defaultdict
-from typing import Dict, List
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from datetime import datetime
 from time import time
+from typing import Dict, List
 
 import pandas as pd
 import structlog
@@ -70,10 +70,6 @@ from tracer.models.project_version import ProjectVersion
 from tracer.models.span_notes import SpanNotes
 from tracer.models.trace import Trace
 from tracer.models.trace_session import TraceSession
-from tracer.services.clickhouse.query_service import (
-    AnalyticsQueryService,
-    QueryType,
-)
 from tracer.serializers.observation_span import (
     ObservationSpanSerializer,
     SpanExportSerializer,
@@ -81,6 +77,10 @@ from tracer.serializers.observation_span import (
     SubmitFeedbackSerializer,
 )
 from tracer.serializers.trace import TraceSerializer
+from tracer.services.clickhouse.query_service import (
+    AnalyticsQueryService,
+    QueryType,
+)
 from tracer.utils.annotations import build_annotation_subqueries
 from tracer.utils.create_otel_span import create_single_otel_span
 from tracer.utils.eval import (
@@ -852,9 +852,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             if not trace_ids:
                 return self._gm.bad_request("trace_ids is required")
 
-            org = (
-                getattr(request, "organization", None) or request.user.organization
-            )
+            org = getattr(request, "organization", None) or request.user.organization
             spans = ObservationSpan.objects.filter(
                 trace_id__in=trace_ids,
                 parent_span_id__isnull=True,
@@ -2005,18 +2003,18 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         # the filter to `end_user_id` scoped to this project + organization.
         _resolved: List[Dict] = []
         for _f in filters:
-            _col = _f.get("column_id") or _f.get("columnId")
-            _cfg = _f.get("filter_config") or _f.get("filterConfig") or {}
-            _col_type = _cfg.get("col_type") or _cfg.get("colType") or "NORMAL"
+            _col, _cfg = FilterEngine._normalize_filter_params(_f)
+            _col_type = _cfg.get("col_type", "NORMAL")
             if _col == "user_id" and _col_type == "NORMAL":
-                _val = _cfg.get("filter_value", _cfg.get("filterValue"))
+                _val = _cfg.get("filter_value")
                 _vals = _val if isinstance(_val, list) else [_val]
                 _vals = [v for v in _vals if v]
                 if not _vals:
                     _resolved.append(_f)
                     continue
                 _ids = [
-                    str(u) for u in EndUser.objects.filter(
+                    str(u)
+                    for u in EndUser.objects.filter(
                         user_id__in=_vals,
                         organization=request.user.organization,
                         project_id=project_id,
@@ -2025,15 +2023,17 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 ]
                 if not _ids:
                     _ids = ["00000000-0000-0000-0000-000000000000"]
-                _resolved.append({
-                    "column_id": "end_user_id",
-                    "filter_config": {
-                        "col_type": "NORMAL",
-                        "filter_type": "text",
-                        "filter_op": "in",
-                        "filter_value": _ids,
-                    },
-                })
+                _resolved.append(
+                    {
+                        "column_id": "end_user_id",
+                        "filter_config": {
+                            "col_type": "NORMAL",
+                            "filter_type": "text",
+                            "filter_op": "in",
+                            "filter_value": _ids,
+                        },
+                    }
+                )
                 continue
             _resolved.append(_f)
         filters = _resolved
@@ -2189,9 +2189,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         # identifier. CH only stores the UUID; the display fields live on
         # the PG EndUser table.
         end_user_ids = {
-            str(r.get("end_user_id"))
-            for r in result.data
-            if r.get("end_user_id")
+            str(r.get("end_user_id")) for r in result.data if r.get("end_user_id")
         }
         end_user_map = {}
         if end_user_ids:
@@ -2207,9 +2205,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         for row in result.data:
             span_id = str(row.get("id", ""))
             cost = row.get("cost")
-            eu = end_user_map.get(str(row.get("end_user_id"))) if row.get(
-                "end_user_id"
-            ) else None
+            eu = (
+                end_user_map.get(str(row.get("end_user_id")))
+                if row.get("end_user_id")
+                else None
+            )
             entry = {
                 "span_id": span_id,
                 "input": row.get("input", ""),
@@ -2239,11 +2239,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 # columns keyed ``{config_id}**{choice}`` to match the
                 # column config produced by
                 # ``update_column_config_based_on_eval_config``.
-                if (
-                    isinstance(val, dict)
-                    and not val.get("error")
-                    and val
-                ):
+                if isinstance(val, dict) and not val.get("error") and val:
                     for choice, pct in val.items():
                         entry[f"{config_id}**{choice}"] = pct
                 else:
@@ -2982,11 +2978,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         Samples the most recent ``_OBSERVED_MAX_SAMPLE_SIZE`` traces to
         keep the aggregate cheap on large projects.
         """
-        sample_trace_ids = Trace.objects.filter(
-            project_id=project_id
-        ).order_by("-created_at").values_list("id", flat=True)[
-            : self._OBSERVED_MAX_SAMPLE_SIZE
-        ]
+        sample_trace_ids = (
+            Trace.objects.filter(project_id=project_id)
+            .order_by("-created_at")
+            .values_list("id", flat=True)[: self._OBSERVED_MAX_SAMPLE_SIZE]
+        )
         agg = (
             ObservationSpan.objects.filter(trace_id__in=sample_trace_ids)
             .values("trace_id")
@@ -2997,11 +2993,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
 
     def _max_traces_per_session(self, project_id: str) -> int:
         """Max trace count observed across the project's most recent sessions."""
-        sample_session_ids = TraceSession.objects.filter(
-            project_id=project_id
-        ).order_by("-created_at").values_list("id", flat=True)[
-            : self._OBSERVED_MAX_SAMPLE_SIZE
-        ]
+        sample_session_ids = (
+            TraceSession.objects.filter(project_id=project_id)
+            .order_by("-created_at")
+            .values_list("id", flat=True)[: self._OBSERVED_MAX_SAMPLE_SIZE]
+        )
         agg = (
             Trace.objects.filter(session_id__in=sample_session_ids)
             .values("session_id")

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -3242,11 +3242,19 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     data = getattr(trace, f"metric_{config.id}")
                     if data and "score" in data:
                         score = data["score"]
-                        result[str(config.id)] = round(score, 2) if score is not None else None
+                        result[str(config.id)] = (
+                            round(score, 2) if score is not None else None
+                        )
                     elif data:
                         for key, value in data.items():
-                            score = value["score"] if isinstance(value, dict) and "score" in value else None
-                            result[str(config.id) + "**" + key] = round(score, 2) if score is not None else None
+                            score = (
+                                value["score"]
+                                if isinstance(value, dict) and "score" in value
+                                else None
+                            )
+                            result[str(config.id) + "**" + key] = (
+                                round(score, 2) if score is not None else None
+                            )
 
                 # Add Root Span Annotations
                 for label in annotation_labels:
@@ -4745,11 +4753,10 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             org = getattr(request, "organization", None) or request.user.organization
         _resolved: List[Dict] = []
         for _f in filters:
-            _col = _f.get("column_id") or _f.get("columnId")
-            _cfg = _f.get("filter_config") or _f.get("filterConfig") or {}
-            _col_type = _cfg.get("col_type") or _cfg.get("colType") or "NORMAL"
+            _col, _cfg = FilterEngine._normalize_filter_params(_f)
+            _col_type = _cfg.get("col_type", "NORMAL")
             if _col == "user_id" and _col_type == "NORMAL":
-                _val = _cfg.get("filter_value", _cfg.get("filterValue"))
+                _val = _cfg.get("filter_value")
                 _vals = _val if isinstance(_val, list) else [_val]
                 _vals = [v for v in _vals if v]
                 if not _vals:
@@ -4786,9 +4793,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         eval_config_ids = []
         if org_scope:
             eval_configs = CustomEvalConfig.objects.filter(
-                id__in=EvalLogger.objects.filter(
-                    trace__project_id__in=org_project_ids
-                )
+                id__in=EvalLogger.objects.filter(trace__project_id__in=org_project_ids)
                 .values("custom_eval_config_id")
                 .distinct(),
                 deleted=False,
@@ -5263,9 +5268,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                         if isinstance(scores, dict):
                             if scores.get("per_choice"):
                                 metric_entry["output"] = [
-                                    k
-                                    for k, v in scores["per_choice"].items()
-                                    if v > 0
+                                    k for k, v in scores["per_choice"].items() if v > 0
                                 ]
                                 metric_entry["output_type"] = "str_list"
                             elif "str_list" in scores and scores["str_list"]:

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -60,8 +60,8 @@ from tracer.models.project import Project
 from tracer.models.trace import Trace
 
 session_logger = structlog.get_logger(__name__)
-from tracer.models.trace_session import TraceSession
 from tfc.utils.pagination import ExtendedPageNumberPagination
+from tracer.models.trace_session import TraceSession
 from tracer.serializers.eval_task import PaginationQuerySerializer
 from tracer.serializers.trace_session import (
     TraceSessionExportSerializer,
@@ -1396,11 +1396,10 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         user_id_raw: Optional[str] = user_id_qp or None
         _remaining: List[Dict] = []
         for _f in filters:
-            _col = _f.get("column_id") or _f.get("columnId")
-            _cfg = _f.get("filter_config") or _f.get("filterConfig") or {}
-            _col_type = _cfg.get("col_type") or _cfg.get("colType") or "NORMAL"
+            _col, _cfg = FilterEngine._normalize_filter_params(_f)
+            _col_type = _cfg.get("col_type", "NORMAL")
             if _col == "user_id" and _col_type == "NORMAL":
-                _val = _cfg.get("filter_value", _cfg.get("filterValue"))
+                _val = _cfg.get("filter_value")
                 if isinstance(_val, list):
                     _val = _val[0] if _val else None
                 if _val and not user_id_raw:
@@ -1911,6 +1910,4 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
             return self._gm.success_response(paginated.data)
         except Exception as e:
             logger.exception(f"Error in fetching session eval logs: {str(e)}")
-            return self._gm.bad_request(
-                f"Error fetching session eval logs: {str(e)}"
-            )
+            return self._gm.bad_request(f"Error fetching session eval logs: {str(e)}")


### PR DESCRIPTION
## Why this change

**Linear ticket:** [TH-4902](https://linear.app/future-agi/issue/TH-4902) — `_normalize_filter_params` doesn't normalize inner keys (camelCase filters silently dropped)

`FilterEngine._normalize_filter_params` normalized **outer** keys (`filterConfig` → `filter_config`, `columnId` → `column_id`) but left **inner** keys within `filter_config` untouched (`filterOp`, `filterType`, `filterValue`, `colType`). Any filter stored with camelCase inner keys was silently dropped — `filter_type` returned `None`, the operator lookup was skipped, and no Q-clause or SQL clause was generated.

**Confirmed impact on X-company projects:**

| Project | Task | Stored filter | Result |
|---------|------|---------------|--------|
| iForm-Prod | Ongoing Evals | camelCase `not_contains "voicemail"` | Filter dropped → 6,101 voicemail eval rows leaked through |
| Ghosted-Prod | Ongoing Evals | camelCase `not_contains "voicemail"` | Filter dropped |
| iForm-Pre-Prod | Evals | camelCase `not_equals "Voicemail"` | Filter dropped |

No data migration is needed — `_normalize_filter_params` now normalizes at read time, so old stored data with camelCase keys works transparently. New data from the frontend is already snake_case.

---

## What changed

### Core fix: `tracer/utils/filters.py`

1. **Added `_INNER_KEY_MAP`** — class-level constant mapping `filterOp` → `filter_op`, `filterType` → `filter_type`, `filterValue` → `filter_value`, `colType` → `col_type`.

2. **Extended `_normalize_filter_params`** — after extracting `filter_config`, iterates its keys and replaces camelCase keys with snake_case equivalents. Uses last-writer-wins semantics so if both `filterOp` and `filter_op` are present, snake_case takes precedence.

3. **Routed all filter-processing methods through `_normalize_filter_params`** — methods that previously bypassed it and accessed outer/inner keys directly now go through the normalizer.

4. **Removed redundant camelCase fallbacks** — methods that already called `_normalize_filter_params` but still had manual `get("filter_op") or get("filterOp")` fallbacks were simplified to snake_case-only access.

### View cleanups: `trace.py`, `trace_session.py`, `observation_span.py`

Replaced ad-hoc dual-key access patterns (`_f.get("column_id") or _f.get("columnId")` etc.) with `FilterEngine._normalize_filter_params(_f)` calls.

---

## All flows affected

Every method that processes a list of filter items is now routed through the normalizer. All 12 filter-processing methods + 1 standalone function + 3 view-layer call sites:

### `FilterEngine` methods in `tracer/utils/filters.py`

| Method | What changed |
|--------|-------------|
| `apply_filters` | Was bypassing `_normalize_filter_params`, now uses it |
| `get_filter_conditions_for_system_metrics` | Already used normalizer; inner access was clean |
| `get_filter_conditions_for_voice_system_metrics` | Already used normalizer; **removed redundant camelCase fallbacks** for `filter_op`, `filter_value`, `filter_type`, `col_type` |
| `get_sql_filter_conditions_for_system_metrics` | Was using **only camelCase** (`filterOp`, `filterValue`, `filterType`); now uses normalizer + snake_case |
| `get_sql_filter_conditions_for_cte_system_metrics` | Already used normalizer; inner access was clean |
| `get_sql_filter_conditions_for_cte_eval_metrics` | Already used normalizer; inner access was clean |
| `get_sql_filter_conditions_for_eval_metrics` | Was using **only camelCase**; now uses normalizer + snake_case |
| `get_filter_conditions_for_non_system_metrics` | Was bypassing normalizer (snake_case only); now uses it |
| `get_filter_conditions_for_voice_call_annotations` | Already used normalizer; inner access was clean |
| `get_filter_conditions_for_has_eval` | Already used normalizer; inner access was clean |
| `get_filter_conditions_for_has_annotation` | Already used normalizer; inner access was clean |
| `get_filter_conditions_for_span_attributes` | Already used normalizer; inner access was clean — **this is the primary method from TH-4902** |

### Standalone function

| Function | What changed |
|----------|-------------|
| `apply_created_at_filters` | Was using manual `get("filter_config") or get("filterConfig")` fallback; now uses `FilterEngine._normalize_filter_params` |

### View-layer call sites

| File | What changed |
|------|-------------|
| `tracer/views/trace.py` | Replaced ad-hoc `_f.get("column_id") or _f.get("columnId")` + inner key fallbacks with `_normalize_filter_params` |
| `tracer/views/trace_session.py` | Same cleanup |
| `tracer/views/observation_span.py` | Same cleanup |

---

## Test cases added

**File:** `tracer/tests/test_normalize_filter_params.py` — 18 new tests

### Unit tests — `TestNormalizeFilterParams` (9 tests)

| Test | What it verifies |
|------|-----------------|
| `test_snake_case_passthrough` | Pure snake_case input passes through unchanged (no regression) |
| `test_camel_case_outer_and_inner` | Full camelCase (`columnId` + `filterConfig` + `filterOp/filterType/filterValue/colType`) → all normalized to snake_case, camelCase keys removed |
| `test_mixed_outer_camel_inner_snake` | camelCase outer + snake_case inner → both handled |
| `test_mixed_outer_snake_inner_camel` | snake_case outer + camelCase inner → inner keys normalized (matches X stored data shape) |
| `test_empty_filter_config` | Missing `filter_config` → returns empty dict, no crash |
| `test_missing_column_id` | Missing `column_id` → returns `None`, filter_config still normalized |
| `test_both_camel_and_snake_inner_keys_snake_wins` | Both `filterOp` and `filter_op` present → snake_case value wins (last-writer-wins) |
| `test_unknown_inner_keys_preserved` | Non-standard keys (e.g. `custom_key`) pass through unchanged |
| `test_does_not_mutate_original` | Original `filter_config` dict is not mutated; normalization creates a new dict |

### Integration tests — `TestNormalizeFilterParamsIntegration` (9 tests)

| Test | Flow exercised | What it verifies |
|------|---------------|-----------------|
| `test_span_attributes_with_camel_case_text_equals` | `get_filter_conditions_for_span_attributes` | camelCase text/equals → produces Q object, not silently dropped |
| `test_span_attributes_with_camel_case_text_not_contains` | `get_filter_conditions_for_span_attributes` | **Reproduces X iForm-Prod & Ghosted-Prod bug:** camelCase `not_contains "voicemail"` → produces Q object |
| `test_span_attributes_with_camel_case_text_not_equals` | `get_filter_conditions_for_span_attributes` | **Reproduces X iForm-Pre-Prod bug:** camelCase `not_equals "Voicemail"` → produces Q object |
| `test_span_attributes_fully_camel_case_outer_and_inner` | `get_filter_conditions_for_span_attributes` | Fully camelCase payload (both `columnId`/`filterConfig` outer keys + camelCase inner keys) — the most likely shape of stored X filter blobs |
| `test_span_attributes_with_camel_case_number_greater_than` | `get_filter_conditions_for_span_attributes` | camelCase number/greater_than → not dropped |
| `test_span_attributes_with_camel_case_boolean_equals` | `get_filter_conditions_for_span_attributes` | camelCase boolean/equals → not dropped |
| `test_span_attributes_with_camel_case_is_null` | `get_filter_conditions_for_span_attributes` | camelCase text/is_null → not dropped |
| `test_span_attributes_snake_case_still_works` | `get_filter_conditions_for_span_attributes` | Existing snake_case filters still produce correct Q objects (no regression) |
| `test_non_system_metrics_with_camel_case` | `get_filter_conditions_for_non_system_metrics` | camelCase inner keys in eval metric filters → method doesn't crash or skip |



##Test cases SSs
1) to run new added tests -  bin/test --no-services tracer/tests/test_normalize_filter_params.py -v
<img width="1083" height="539" alt="Screenshot 2026-05-18 at 12 01 40 PM" src="https://github.com/user-attachments/assets/9aa536fc-e3d0-4ccc-b728-32a9befcb884" />

2) To run all filter related tests - bin/test --no-services tracer/tests/test_normalize_filter_params.py tracer/tests/test_filter_engine_parity.py tracer/tests/test_validate_filters_helper.py -v

<img width="1076" height="711" alt="Screenshot 2026-05-18 at 12 02 51 PM" src="https://github.com/user-attachments/assets/0e1b96a3-87c0-40c9-b46d-34aa77c05012" />


## Linked issues

Closes TH-4902

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- 18 new tests in `test_normalize_filter_params.py` (9 unit + 9 integration)
- Existing 55 parity tests in `test_filter_engine_parity.py` pass (no regressions)
- Existing 19 validation tests in `test_validate_filters_helper.py` pass (no regressions)
- All 92 filter-related tests pass

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA