### PR TITLE
fix(http): add timeouts to verify_api_key and ModelServingClient

### DIFF
--- a/futureagi/agentic_eval/clients/model_serving_client.py
+++ b/futureagi/agentic_eval/clients/model_serving_client.py
@@ -4,6 +4,8 @@ import requests
 
 from ..clients.constants import MODEL_SERVING_BASE_URL
 
+_HTTP_REQUEST_TIMEOUT_SECONDS = 30
+
 
 class ModelServingClient:
     _instance = None
@@ -44,7 +46,12 @@ class ModelServingClient:
             requests.HTTPError: If the server responds with a non-2xx status code.
         """
         try:
-            response = requests.get(f"{self.base_url}/{endpoint}", params=params, headers=headers)
+            response = requests.get(
+                f"{self.base_url}/{endpoint}",
+                params=params,
+                headers=headers,
+                timeout=_HTTP_REQUEST_TIMEOUT_SECONDS,
+            )
             response.raise_for_status()  # Raise an exception for HTTP errors
             return response.json()  # Return the JSON response as a dictionary
         except requests.RequestException as exc:
@@ -67,7 +74,12 @@ class ModelServingClient:
             requests.HTTPError: If the server responds with a non-2xx status code.
         """
         try:
-            response = requests.post(f"{self.base_url}/{endpoint}", json=json, headers=headers)
+            response = requests.post(
+                f"{self.base_url}/{endpoint}",
+                json=json,
+                headers=headers,
+                timeout=_HTTP_REQUEST_TIMEOUT_SECONDS,
+            )
             response.raise_for_status()  # Raise an exception for HTTP errors
             return response.json()  # Return the JSON response as a dictionary
         except requests.RequestException as exc:

--- a/futureagi/tracer/services/observability_providers.py
+++ b/futureagi/tracer/services/observability_providers.py
@@ -36,7 +36,7 @@ class ObservabilityService:
         else:
             raise ValueError(f"Invalid choice for provider: {provider}")
         headers = {"Authorization": f"Bearer {api_key}"}
-        response = requests.get(api_endpoint, headers=headers)
+        response = requests.get(api_endpoint, headers=headers, timeout=30)
         return response.status_code
 
     @staticmethod


### PR DESCRIPTION
## Summary

`ObservabilityService.verify_api_key` (`tracer/services/observability_providers.py`) and `ModelServingClient.get` / `.post` (`agentic_eval/clients/model_serving_client.py`) all called `requests.{get,post}` without a `timeout=` kwarg. `requests` defaults to no timeout in that case, so the calling worker blocks forever if the remote endpoint is slow or unreachable.

`verify_api_key` is hit from the UI when a user adds a VAPI or Retell observability provider. The neighbor `verify_assistant_id` already uses `timeout=30`, so this PR matches the surrounding convention.

`ModelServingClient` is the singleton that talks to the model serving service; every eval run goes through it, so a stuck remote would cascade to the worker pool.

These two are the most user-visible hits from the wider set listed in #499. Other files in that issue are left for follow-up PRs.

## Linked issues

Refs #499

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `python3 -m py_compile` on both touched files.
- Manual: pointed `ModelServingClient.base_url` at a tarpit (`https://hang.example.com:81`) and confirmed the call now raises `requests.exceptions.ConnectTimeout` after ~30s instead of blocking the worker indefinitely.
- The chosen `30s` matches the existing convention in `verify_assistant_id` and the per-call `30` / `120` already used elsewhere in `observability_providers.py`.

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA (will sign on first PR if the bot prompts)