### PR TITLE
fix(evals): forward enriched contexts to composite eval children (TH-5261)

### DIFF
--- a/futureagi/model_hub/tasks/composite_runner.py
+++ b/futureagi/model_hub/tasks/composite_runner.py
@@ -241,6 +241,26 @@ class CompositeEvaluationRunner:
 
         return dict(zip(required_field, mapping_values, strict=False))
 
+    def _build_row_context(self, row: Row) -> dict | None:
+        """Build ``{column_name: value}`` for every cell in the row."""
+        try:
+            row_dict: dict = {}
+            for cell in Cell.objects.filter(row=row, deleted=False).select_related("column"):
+                col_name = cell.column.name if cell.column else None
+                if not col_name:
+                    continue
+                val = cell.value
+                if isinstance(val, str):
+                    try:
+                        val = json.loads(val)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                row_dict[col_name] = val
+            return row_dict or None
+        except Exception as e:
+            logger.warning("composite_runner_row_context_build_failed", error=str(e))
+            return None
+
     # ------------------------------------------------------------------
     # Persistence
     # ------------------------------------------------------------------
@@ -540,6 +560,8 @@ class CompositeEvaluationRunner:
 
             model = self.user_eval_metric.model or ModelChoices.TURING_LARGE.value
 
+            row_context = self._build_row_context(row)
+
             outcome = execute_composite_children_sync(
                 parent=self.template,
                 child_links=self.children,
@@ -550,6 +572,7 @@ class CompositeEvaluationRunner:
                 model=model,
                 source="composite_eval_dataset",
                 weight_overrides=weight_overrides,
+                row_context=row_context,
             )
 
             self._write_cell(column, row, outcome)

--- a/futureagi/model_hub/tests/test_composite_wiring_phase_c.py
+++ b/futureagi/model_hub/tests/test_composite_wiring_phase_c.py
@@ -298,3 +298,75 @@ class TestTraceSpanCompositeBranch:
 
         mock_composite.assert_called_once()
         assert result == {"value": 0.5}
+
+
+@pytest.mark.django_db
+class TestCompositeOnSpanContextForwarding:
+    """`_execute_composite_on_span` forwards canonical span/trace/session contexts (TH-5261)."""
+
+    def test_span_composite_always_forwards_canonical_span_context(
+        self, aggregated_composite
+    ):
+        from tracer.utils import eval as tracer_eval
+
+        recorded: dict = {}
+
+        def _capture(**kwargs):
+            recorded.update(kwargs)
+
+            class _Outcome:
+                aggregate_score = 0.7
+                aggregate_pass = True
+                summary = "ok"
+                child_results = []
+                error_localizer_results = None
+
+            return _Outcome()
+
+        fake_span = MagicMock()
+        fake_span.id = "span-abc"
+        fake_span.project.organization = MagicMock()
+        fake_span.project.workspace = MagicMock()
+        fake_span.trace = None  # trace/session contexts absent cleanly
+        # build_span_context uses getattr with defaults — sufficient for capture.
+        fake_span.name = "user.message"
+        fake_span.observation_type = "span"
+        fake_span.status = "OK"
+        fake_span.status_message = None
+        fake_span.model = "turing_large"
+        fake_span.latency_ms = 12
+        fake_span.total_tokens = 100
+        fake_span.cost = 0
+
+        fake_cfg = MagicMock()
+        fake_cfg.eval_template = aggregated_composite
+        fake_cfg.eval_template.template_type = "composite"
+        fake_cfg.config = {}
+        fake_cfg.model = "turing_large"
+
+        with (
+            patch.object(
+                tracer_eval.ObservationSpan.objects, "select_related"
+            ) as mock_span_select,
+            patch.object(tracer_eval.CustomEvalConfig.objects, "get") as mock_cfg_get,
+            patch(
+                "model_hub.utils.composite_execution.execute_composite_children_sync",
+                side_effect=_capture,
+            ),
+        ):
+            mock_span_select.return_value.get.return_value = fake_span
+            mock_cfg_get.return_value = fake_cfg
+            tracer_eval._execute_composite_on_span(
+                observation_span_id="span-abc",
+                custom_eval_config_id="cfg-1",
+                eval_task_id="task-1",
+                run_params={"input": "hello"},
+            )
+
+        assert recorded.get("source") == "tracer_composite"
+        ctx = recorded.get("span_context")
+        assert ctx is not None, "span_context must always be forwarded"
+        assert ctx.get("id") == "span-abc"
+        assert ctx.get("name") == "user.message"
+        assert "trace_context" not in recorded
+        assert "session_context" not in recorded

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -732,11 +732,6 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
         config = eval_config.config.copy() if eval_config.config else {}
         organization = call_execution.test_execution.run_test.organization
 
-        # Build call_context for data_injection support — gives the eval
-        # agent access to the full call data via explore_trace tool.
-        # Only built when the eval's data_injection.call_context flag is on,
-        # because the payload contains PII (phone_number, recording_url) and
-        # we shouldn't ship it into the LLM prompt unless explicitly enabled.
         from common.utils.data_injection import is_enabled as _di_enabled
 
         _di_cfg = (
@@ -744,37 +739,36 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
             or (config or {}).get("data_injection")
             or {}
         )
-        _call_context = None
-        if _di_enabled(_di_cfg, "call_context"):
-            _call_context = {
-                "id": str(call_execution.id),
-                "status": call_execution.status,
-                "call_type": call_execution.call_type,
-                "simulation_call_type": call_execution.simulation_call_type,
-                "phone_number": call_execution.phone_number,
-                "started_at": str(call_execution.started_at) if call_execution.started_at else None,
-                "ended_at": str(call_execution.ended_at) if call_execution.ended_at else None,
-                "duration_seconds": call_execution.duration_seconds,
-                "recording_url": call_execution.recording_url,
-                "call_summary": call_execution.call_summary,
-                "ended_reason": call_execution.ended_reason,
-                "error_message": call_execution.error_message,
-                "message_count": call_execution.message_count,
-                "overall_score": float(call_execution.overall_score) if call_execution.overall_score is not None else None,
-            }
 
-        eval_result = run_eval_func(
-            config=config,
-            mappings=updated_mapping,
-            template=eval_template,
-            org=organization,
-            model=eval_config.model,
-            kb_id=eval_config.kb_id,
-            error_localizer=eval_config.error_localizer,
-            workspace=call_execution.test_execution.run_test.workspace,
-            source="simulate",
-            call_context=_call_context,
-        )
+        if eval_template.template_type == "composite":
+            _call_context = _build_simulate_call_context(call_execution)
+            eval_result = _run_simulate_composite(
+                eval_template=eval_template,
+                eval_config=eval_config,
+                config=config,
+                mapping=updated_mapping,
+                org=organization,
+                workspace=call_execution.test_execution.run_test.workspace,
+                call_context=_call_context,
+            )
+        else:
+            _call_context = (
+                _build_simulate_call_context(call_execution)
+                if _di_enabled(_di_cfg, "call_context")
+                else None
+            )
+            eval_result = run_eval_func(
+                config=config,
+                mappings=updated_mapping,
+                template=eval_template,
+                org=organization,
+                model=eval_config.model,
+                kb_id=eval_config.kb_id,
+                error_localizer=eval_config.error_localizer,
+                workspace=call_execution.test_execution.run_test.workspace,
+                source="simulate",
+                call_context=_call_context,
+            )
 
         if isinstance(eval_result, str):
             if (
@@ -849,6 +843,84 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
         eval_config.status = StatusType.FAILED.value
         eval_config.save()
         raise
+
+
+def _build_simulate_call_context(call_execution) -> dict:
+    """Build the ``call_context`` payload from a ``CallExecution`` row."""
+    return {
+        "id": str(call_execution.id),
+        "status": call_execution.status,
+        "call_type": call_execution.call_type,
+        "simulation_call_type": call_execution.simulation_call_type,
+        "phone_number": call_execution.phone_number,
+        "started_at": str(call_execution.started_at) if call_execution.started_at else None,
+        "ended_at": str(call_execution.ended_at) if call_execution.ended_at else None,
+        "duration_seconds": call_execution.duration_seconds,
+        "recording_url": call_execution.recording_url,
+        "call_summary": call_execution.call_summary,
+        "ended_reason": call_execution.ended_reason,
+        "error_message": call_execution.error_message,
+        "message_count": call_execution.message_count,
+        "overall_score": float(call_execution.overall_score) if call_execution.overall_score is not None else None,
+    }
+
+
+def _run_simulate_composite(
+    *,
+    eval_template,
+    eval_config,
+    config,
+    mapping,
+    org,
+    workspace,
+    call_context,
+):
+    """Fan out a composite eval against a simulate call; return a single-eval-shaped dict."""
+    from model_hub.models.evals_metric import CompositeEvalChild
+    from model_hub.utils.composite_execution import execute_composite_children_sync
+
+    child_links = list(
+        CompositeEvalChild.objects.filter(parent=eval_template, deleted=False)
+        .select_related("child", "pinned_version")
+        .order_by("order")
+    )
+    if not child_links:
+        raise ValueError(
+            f"Composite eval template '{eval_template.name}' has no children."
+        )
+
+    outcome = execute_composite_children_sync(
+        parent=eval_template,
+        child_links=child_links,
+        mapping=mapping,
+        config=config or {},
+        org=org,
+        workspace=workspace,
+        model=eval_config.model,
+        error_localizer=eval_config.error_localizer,
+        source="simulate_composite",
+        call_context=call_context,
+    )
+
+    if eval_template.aggregation_enabled:
+        output = outcome.aggregate_score
+        output_type = "score"
+    else:
+        output = outcome.summary or ""
+        output_type = "text"
+
+    return {
+        "output": output,
+        "reason": outcome.summary or "",
+        "output_type": output_type,
+        "metadata": {
+            "composite_id": str(eval_template.id),
+            "aggregation_enabled": eval_template.aggregation_enabled,
+            "aggregation_function": eval_template.aggregation_function,
+            "aggregate_pass": outcome.aggregate_pass,
+            "children": [cr.model_dump() for cr in outcome.child_results],
+        },
+    }
 
 
 def _check_eval_completion(call_execution, eval_config_ids=None, run_test=None):

--- a/futureagi/tracer/tests/test_eval_task_runtime.py
+++ b/futureagi/tracer/tests/test_eval_task_runtime.py
@@ -992,7 +992,7 @@ class TestCompositeEvalOnTrace:
         stub_cost_log,
         inline_temporal,
     ):
-        """The composite call gets `trace_context` + source='tracer_composite'."""
+        """Composite call forwards canonical trace_context + span_context (anchor) + session_context."""
         task = composite_trace_task["task"]
         process_eval_task._original_func(str(task.id))
 
@@ -1001,7 +1001,12 @@ class TestCompositeEvalOnTrace:
             assert call["source"] == "tracer_composite"
             ctx = call.get("trace_context")
             assert ctx is not None
-            assert "trace_id" in ctx and "anchor_span_id" in ctx
+            assert ctx.get("id"), "trace_context missing canonical 'id'"
+            assert ctx.get("span_id"), "trace_context missing anchor 'span_id'"
+            assert "span_count" in ctx
+            span_ctx = call.get("span_context")
+            assert span_ctx is not None
+            assert span_ctx.get("id")
 
     def test_writes_error_row_when_children_raise(
         self,
@@ -1161,7 +1166,9 @@ class TestCompositeEvalOnSession:
             assert call["source"] == "tracer_composite"
             ctx = call.get("session_context")
             assert ctx is not None
-            assert "session_id" in ctx
+            assert ctx.get("id"), "session_context missing canonical 'id'"
+            assert "trace_count" in ctx
+            assert "traces" in ctx
 
     def test_sets_workspace_context(
         self,

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -684,6 +684,19 @@ def _execute_composite_on_span(
     if not child_links:
         raise ValueError(f"Composite {parent.id} has no children — cannot run on span.")
 
+    # Forward all available contexts; each child's own data_injection decides.
+    composite_contexts: dict = {
+        "span_context": build_span_context(observation_span),
+    }
+    if observation_span.trace is not None:
+        composite_contexts["trace_context"] = build_trace_context(
+            observation_span.trace, anchor_span_id=str(observation_span.id)
+        )
+        _session = getattr(observation_span.trace, "session", None)
+        _session_ctx = build_session_context(_session) if _session else None
+        if _session_ctx is not None:
+            composite_contexts["session_context"] = _session_ctx
+
     try:
         outcome = execute_composite_children_sync(
             parent=parent,
@@ -694,6 +707,7 @@ def _execute_composite_on_span(
             workspace=workspace,
             model=custom_eval_config.model,
             source="tracer_composite",
+            **composite_contexts,
         )
 
         value = (
@@ -813,6 +827,16 @@ def _execute_composite_on_trace(
             error=str(_ctx_err),
         )
 
+    # Forward all available contexts; each child's own data_injection decides.
+    composite_contexts: dict = {
+        "trace_context": build_trace_context(trace, anchor_span_id=str(anchor_span.id)),
+        "span_context": build_span_context(anchor_span),
+    }
+    _session = getattr(trace, "session", None)
+    _session_ctx = build_session_context(_session) if _session else None
+    if _session_ctx is not None:
+        composite_contexts["session_context"] = _session_ctx
+
     try:
         outcome = execute_composite_children_sync(
             parent=parent,
@@ -822,11 +846,8 @@ def _execute_composite_on_trace(
             org=org,
             workspace=workspace,
             model=custom_eval_config.model,
-            trace_context={
-                "trace_id": str(trace.id),
-                "anchor_span_id": str(anchor_span.id),
-            },
             source="tracer_composite",
+            **composite_contexts,
         )
 
         value = (
@@ -952,6 +973,11 @@ def _execute_composite_on_session(
             error=str(_ctx_err),
         )
 
+    composite_contexts: dict = {}
+    _session_ctx = build_session_context(trace_session)
+    if _session_ctx is not None:
+        composite_contexts["session_context"] = _session_ctx
+
     try:
         outcome = execute_composite_children_sync(
             parent=parent,
@@ -961,8 +987,8 @@ def _execute_composite_on_session(
             org=org,
             workspace=workspace,
             model=custom_eval_config.model,
-            session_context={"session_id": str(trace_session.id)},
             source="tracer_composite",
+            **composite_contexts,
         )
 
         value = (


### PR DESCRIPTION
Composite evals couldn't resolve `{{span.X}}` / `{{trace.X}}` / `{{session.X}}` / `{{call.X}}` / `{{row.X}}` in children's prompts because every fan-out path either sent no contexts or only minimal stubs. Wires it everywhere using `build_*_context` helpers.

| Surface | Before | After |
|---|---|---|
| `_execute_composite_on_span` | nothing | full span/trace/session |
| `_execute_composite_on_trace` | `{trace_id, anchor_span_id}` | full `build_trace_context` + span (anchor) + session |
| `_execute_composite_on_session` | `{session_id}` | full `build_session_context` |
| `composite_runner._run_single_row` | no `row_context` | `row_context` from row cells |
| `simulate xl.py:_run_single_evaluation` | composite path didn't exist | new `_run_simulate_composite`, forwards `call_context` |

Contexts forwarded unconditionally — composite parents are containers, not evaluators; per-child `data_injection` config decides what each child consumes. Verified code / LLM / agent children all tolerate the extra kwargs (`run_eval_func` only injects non-None, base evaluator uses `**kwargs`).

Already correct (no change): `CompositeEvalExecuteView` / `..AdhocExecuteView`, `ai_tools/.../execute_composite_eval.py`. External eval composite has no tracer contexts.

Linear: TH-5261

## Test plan

- [ ] `pytest tracer/tests/test_eval_task_runtime.py::TestCompositeEvalOnTrace tracer/tests/test_eval_task_runtime.py::TestCompositeEvalOnSession model_hub/tests/test_composite_wiring_phase_c.py::TestCompositeOnSpanContextForwarding`
- [ ] Manual: composite with a child using `{{trace.span_count}}` → runs on trace via eval-task → child prompt resolves.
- [ ] Manual: same composite on a simulate test → child resolves `{{call.duration_seconds}}`.
- [ ] Manual: same composite on a dataset → child resolves `{{row.<col>}}`.
