### PR TITLE
fix(test-detail): use csat_status for ScoreCellRenderer loading skeleton

### DIFF
--- a/frontend/src/sections/test-detail/CellRenderers/ScoreCellRenderer.jsx
+++ b/frontend/src/sections/test-detail/CellRenderers/ScoreCellRenderer.jsx
@@ -8,13 +8,12 @@ import { CallExecutionLoadingStatus, TestRunLoadingStatus } from "../common";
 const ScoreCellRenderer = ({ value, data }) => {
   const color = getCsatScoreColor(value);
   if (value === null || value === undefined) {
-    const callLoading = CallExecutionLoadingStatus.includes(
-      data?.status?.toLowerCase?.(),
-    );
-    const runLoading = TestRunLoadingStatus.includes(
-      data?.overall_status?.toLowerCase?.(),
-    );
-    if (callLoading || runLoading) {
+    // Precise signal from BE: only show the loading skeleton while CSAT is
+    // actually being computed. Eval-only reruns don't recompute CSAT, so the
+    // BE doesn't transition this back to "running" — the cell stays as "-".
+    const callMetadata = data?.callMetadata ?? data?.call_metadata;
+    const csatStatus = callMetadata?.csatStatus ?? callMetadata?.csat_status;
+    if (csatStatus === "running") {
       return (
         <Box
           sx={{
@@ -27,6 +26,33 @@ const ScoreCellRenderer = ({ value, data }) => {
           <Skeleton sx={{ width: "100%", height: "20px" }} variant="rounded" />
         </Box>
       );
+    }
+    // Fallback for older rows persisted before csat_status was tracked:
+    // infer from the broader call/run loading state.
+    if (csatStatus === undefined) {
+      const callLoading = CallExecutionLoadingStatus.includes(
+        data?.status?.toLowerCase?.(),
+      );
+      const runLoading = TestRunLoadingStatus.includes(
+        data?.overall_status?.toLowerCase?.(),
+      );
+      if (callLoading || runLoading) {
+        return (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              height: "100%",
+              width: "100%",
+            }}
+          >
+            <Skeleton
+              sx={{ width: "100%", height: "20px" }}
+              variant="rounded"
+            />
+          </Box>
+        );
+      }
     }
     return <Typography typography="s1">- </Typography>;
   }


### PR DESCRIPTION
## Summary

The CSAT score cell on the test-detail page was showing a loading skeleton during eval-only reruns even though CSAT wasn't being recomputed — because it inferred its loading state from the broader call/run status. The BE now writes a precise `call_metadata.csat_status` field; this PR makes the FE read that field directly.

Paired with the BE change in [`future-agi/ee#56`](https://github.com/future-agi/ee/pull/56) (`feat(simulate): track csat_status on call_metadata for precise FE loading state`).

## Changes

`frontend/src/sections/test-detail/CellRenderers/ScoreCellRenderer.jsx`:

- When `data.callMetadata.csatStatus` (or snake_case `csat_status`) is `"running"`, show the loading skeleton.
- When the field is undefined (legacy rows persisted before the BE started writing it), fall back to the existing broader call/run loading inference so older calls continue to render exactly as before.
- Otherwise render `"-"` for null/undefined values.

## Why this matters

Eval-only reruns recompute the eval cells but not CSAT. The previous broader-status inference flipped the CSAT cell to a skeleton during those reruns and then back to the persisted score — visually misleading. With the precise status field, the CSAT cell stays on its last persisted score during eval reruns and only animates while CSAT itself is actually being computed.

## Test plan

- [ ] Trigger a new call. CSAT cell shows skeleton while `csat_status = 'running'`, then renders the score when `'completed'`.
- [ ] Run an eval-only rerun on a call with an existing CSAT score. Verify the CSAT cell does NOT flip to skeleton.
- [ ] Take a legacy call (no `csat_status` set, but `overall_score = null`) that's still in `CallExecutionLoadingStatus` — verify the fallback path still shows the skeleton.