### PR TITLE
fix(simulate): use csat_status for ScoreCellRenderer loading state (TH-4957)

### DIFF
--- a/frontend/src/sections/test-detail/CellRenderers/ScoreCellRenderer.jsx
+++ b/frontend/src/sections/test-detail/CellRenderers/ScoreCellRenderer.jsx
@@ -8,9 +8,6 @@ import { CallExecutionLoadingStatus, TestRunLoadingStatus } from "../common";
 const ScoreCellRenderer = ({ value, data }) => {
   const color = getCsatScoreColor(value);
   if (value === null || value === undefined) {
-    // Precise signal from BE: only show the loading skeleton while CSAT is
-    // actually being computed. Eval-only reruns don't recompute CSAT, so the
-    // BE doesn't transition this back to "running" — the cell stays as "-".
     const callMetadata = data?.callMetadata ?? data?.call_metadata;
     const csatStatus = callMetadata?.csatStatus ?? callMetadata?.csat_status;
     if (csatStatus === "running") {
@@ -27,8 +24,7 @@ const ScoreCellRenderer = ({ value, data }) => {
         </Box>
       );
     }
-    // Fallback for older rows persisted before csat_status was tracked:
-    // infer from the broader call/run loading state.
+    // Fallback for rows persisted before csat_status was tracked.
     if (csatStatus === undefined) {
       const callLoading = CallExecutionLoadingStatus.includes(
         data?.status?.toLowerCase?.(),

--- a/frontend/src/sections/test-detail/CellRenderers/ScoreCellRenderer.jsx
+++ b/frontend/src/sections/test-detail/CellRenderers/ScoreCellRenderer.jsx
@@ -8,13 +8,12 @@ import { CallExecutionLoadingStatus, TestRunLoadingStatus } from "../common";
 const ScoreCellRenderer = ({ value, data }) => {
   const color = getCsatScoreColor(value);
   if (value === null || value === undefined) {
-    const callLoading = CallExecutionLoadingStatus.includes(
-      data?.status?.toLowerCase?.(),
-    );
-    const runLoading = TestRunLoadingStatus.includes(
-      data?.overall_status?.toLowerCase?.(),
-    );
-    if (callLoading || runLoading) {
+    // Precise signal from BE: only show the loading skeleton while CSAT is
+    // actually being computed. Eval-only reruns don't recompute CSAT, so the
+    // BE doesn't transition this back to "running" — the cell stays as "-".
+    const callMetadata = data?.callMetadata ?? data?.call_metadata;
+    const csatStatus = callMetadata?.csatStatus ?? callMetadata?.csat_status;
+    if (csatStatus === "running") {
       return (
         <Box
           sx={{
@@ -27,6 +26,33 @@ const ScoreCellRenderer = ({ value, data }) => {
           <Skeleton sx={{ width: "100%", height: "20px" }} variant="rounded" />
         </Box>
       );
+    }
+    // Fallback for older rows persisted before csat_status was tracked:
+    // infer from the broader call/run loading state.
+    if (csatStatus === undefined) {
+      const callLoading = CallExecutionLoadingStatus.includes(
+        data?.status?.toLowerCase?.(),
+      );
+      const runLoading = TestRunLoadingStatus.includes(
+        data?.overall_status?.toLowerCase?.(),
+      );
+      if (callLoading || runLoading) {
+        return (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              height: "100%",
+              width: "100%",
+            }}
+          >
+            <Skeleton
+              sx={{ width: "100%", height: "20px" }}
+              variant="rounded"
+            />
+          </Box>
+        );
+      }
     }
     return <Typography typography="s1">- </Typography>;
   }


### PR DESCRIPTION
CSAT cell on call-details used `call.status` to decide the loading skeleton. Eval-only reruns flip the call to `ANALYZING` even though CSAT isn't recomputed, so the spinner spun forever then dropped to "—". Now reads the precise `call_metadata.csat_status` written by the paired EE branch.

- Skeleton when `csat_status === "running"`, "—" for any other concrete status.
- Falls back to the old `call.status` / `run.status` inference when `csat_status` is absent (legacy rows).

Paired with future-agi/ee#57.

Linear: TH-4957

## Test plan

- [ ] New run: skeleton until activity finishes, then score or "—".
- [ ] Eval-only rerun (no CSAT recompute): cell stays at "—".
- [ ] Legacy row (no `csat_status`): old behaviour preserved.
