### PR TITLE
fix(evals): forward picker runtime overrides on test endpoints (TH-5276, TH-5279)

### DIFF
--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -539,6 +539,7 @@ const DatasetTestMode = React.forwardRef(
       compositeAdhocConfig = null,
       sourceColumns,
       extraColumns,
+      runtimeOverrides,
     },
     ref,
   ) => {
@@ -1083,6 +1084,9 @@ const DatasetTestMode = React.forwardRef(
                   if (contextOptions.includes("call_context")) flags.call_context = true;
                   return Object.keys(flags).length > 0 ? { data_injection: flags } : {};
                 })(),
+                ...(runtimeOverrides && Object.keys(runtimeOverrides).length > 0
+                  ? { run_config: runtimeOverrides }
+                  : {}),
               },
               input_data_types: inputDataTypes,
               row_context: rowContext,
@@ -1724,6 +1728,7 @@ DatasetTestMode.propTypes = {
   extraColumns: PropTypes.array,
   isComposite: PropTypes.bool,
   compositeAdhocConfig: PropTypes.object,
+  runtimeOverrides: PropTypes.object,
 };
 
 export default DatasetTestMode;

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -14,7 +14,7 @@ import {
   Typography,
 } from "@mui/material";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Iconify from "src/components/iconify";
 import axios, { endpoints } from "src/utils/axios";
 import { useNavigate, useParams } from "react-router";
@@ -210,6 +210,51 @@ const EvalCreatePage = () => {
 
   // Hook for updating the draft template
   const updateDraft = useUpdateEval(draftId);
+
+  // Picker state bundled into the test request's `config.run_config` so
+  // BE merges it via _RUNTIME_ALLOWED_KEYS.
+  const testRuntimeOverrides = useMemo(() => {
+    if (mode === "composite") return null;
+    const overrides = {
+      output_type: outputType,
+      pass_threshold: passThreshold,
+      multi_choice: multiChoice,
+      check_internet: !!checkInternet,
+    };
+    if (Object.keys(choiceScores || {}).length > 0) {
+      overrides.choice_scores = choiceScores;
+      overrides.choices = Object.keys(choiceScores);
+    }
+    if (evalType === "agent") {
+      overrides.agent_mode = agentMode;
+      overrides.tools = buildToolsPayload(connectorIds);
+      overrides.knowledge_bases = knowledgeBaseIds || [];
+      overrides.data_injection = buildDataInjection(contextOptions);
+      overrides.summary =
+        summaryType === "custom"
+          ? { type: "custom", custom: customSummary || "" }
+          : { type: summaryType };
+    }
+    if (evalType === "llm" && Array.isArray(fewShotExamples) && fewShotExamples.length > 0) {
+      overrides.few_shot_examples = fewShotExamples;
+    }
+    return overrides;
+  }, [
+    mode,
+    evalType,
+    outputType,
+    passThreshold,
+    multiChoice,
+    checkInternet,
+    choiceScores,
+    agentMode,
+    connectorIds,
+    knowledgeBaseIds,
+    contextOptions,
+    summaryType,
+    customSummary,
+    fewShotExamples,
+  ]);
 
   const handleTestResult = useCallback((success, result) => {
     // Stale result from a test that was invalidated by a mode switch — drop it.
@@ -1225,6 +1270,7 @@ const EvalCreatePage = () => {
                     mode === "composite" ? false : errorLocalizerEnabled
                   }
                   templateFormat={templateFormat}
+                  runtimeOverrides={testRuntimeOverrides}
                 />
               </Box>
 

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -595,6 +595,51 @@ const EvalDetailPage = () => {
   const evalType = evalData?.eval_type || "llm";
   const isSystemEval = evalData?.owner === "system";
 
+  // Bundle picker state into the test request's `config.run_config` so the
+  // BE merges it via _RUNTIME_ALLOWED_KEYS — essential for system evals
+  // where updateEval is skipped before the test runs.
+  const testRuntimeOverrides = useMemo(() => {
+    if (isComposite) return null;
+    const overrides = {
+      output_type: outputType,
+      pass_threshold: passThreshold,
+      multi_choice: multiChoice,
+      check_internet: !!checkInternet,
+    };
+    if (Object.keys(choiceScores || {}).length > 0) {
+      overrides.choice_scores = choiceScores;
+      overrides.choices = Object.keys(choiceScores);
+    }
+    if (evalType === "agent") {
+      overrides.agent_mode = agentMode;
+      overrides.tools = build_tools_payload(connectorIds);
+      overrides.knowledge_bases = knowledgeBaseIds || [];
+      overrides.data_injection = buildDataInjection(contextOptions);
+      overrides.summary =
+        summaryType === "custom"
+          ? { type: "custom", custom: "" }
+          : { type: summaryType };
+    }
+    if (evalType === "llm" && Array.isArray(fewShotExamples) && fewShotExamples.length > 0) {
+      overrides.few_shot_examples = fewShotExamples;
+    }
+    return overrides;
+  }, [
+    isComposite,
+    evalType,
+    outputType,
+    passThreshold,
+    multiChoice,
+    checkInternet,
+    choiceScores,
+    agentMode,
+    connectorIds,
+    knowledgeBaseIds,
+    contextOptions,
+    summaryType,
+    fewShotExamples,
+  ]);
+
   // Fetch composite detail (children, weights) when viewing a composite
   const { data: compositeDetail } = useCompositeDetail(evalId, isComposite);
   const updateComposite = useUpdateCompositeEval(evalId);
@@ -1778,6 +1823,7 @@ const EvalDetailPage = () => {
                       setTestPassed(false);
                     }}
                     onReadyChange={setIsPlaygroundReady}
+                    runtimeOverrides={testRuntimeOverrides}
                   />
                 </Box>
 

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -183,6 +183,7 @@ const SimulationTestMode = React.forwardRef(
       initialRunTestId = "",
       isComposite = false,
       compositeAdhocConfig = null,
+      runtimeOverrides,
     },
     ref,
   ) => {
@@ -896,6 +897,9 @@ const SimulationTestMode = React.forwardRef(
                 mapping: evalMapping,
                 ...(Object.keys(codeParams || {}).length > 0
                   ? { params: codeParams }
+                  : {}),
+                ...(runtimeOverrides && Object.keys(runtimeOverrides).length > 0
+                  ? { run_config: runtimeOverrides }
                   : {}),
               },
               ...(_callId ? { call_id: _callId } : {}),
@@ -1779,6 +1783,7 @@ SimulationTestMode.propTypes = {
   initialRunTestId: PropTypes.string,
   isComposite: PropTypes.bool,
   compositeAdhocConfig: PropTypes.object,
+  runtimeOverrides: PropTypes.object,
 };
 
 export default SimulationTestMode;

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -635,6 +635,7 @@ const TestPlayground = React.forwardRef(
       codeLanguage = "python",
       isSystemEval = false,
       onReadyChange,
+      runtimeOverrides,
     },
     ref,
   ) => {
@@ -931,6 +932,11 @@ const TestPlayground = React.forwardRef(
 
         const params = evalType === "code" ? { ...codeParamsRef.current } : {};
 
+        const runConfigOverride =
+          runtimeOverrides && Object.keys(runtimeOverrides).length > 0
+            ? { run_config: runtimeOverrides }
+            : {};
+
         const { data } = await axios.post(
           endpoints.develop.eval.evalPlayground,
           {
@@ -940,6 +946,7 @@ const TestPlayground = React.forwardRef(
             config: {
               mapping,
               ...(evalType === "code" ? { params } : {}),
+              ...runConfigOverride,
             },
           },
         );
@@ -1378,6 +1385,7 @@ const TestPlayground = React.forwardRef(
                   onReadyChange={handleDatasetReady}
                   isComposite={isComposite}
                   compositeAdhocConfig={compositeAdhocConfig}
+                  runtimeOverrides={runtimeOverrides}
                 />
               )}
 
@@ -1395,6 +1403,7 @@ const TestPlayground = React.forwardRef(
                   onReadyChange={handleTracingReady}
                   isComposite={isComposite}
                   compositeAdhocConfig={compositeAdhocConfig}
+                  runtimeOverrides={runtimeOverrides}
                   hostsFilter
                 />
               )}
@@ -1413,6 +1422,7 @@ const TestPlayground = React.forwardRef(
                   onReadyChange={handleSimulationReady}
                   isComposite={isComposite}
                   compositeAdhocConfig={compositeAdhocConfig}
+                  runtimeOverrides={runtimeOverrides}
                 />
               )}
 
@@ -1885,6 +1895,7 @@ TestPlayground.propTypes = {
   codeLanguage: PropTypes.string,
   onReadyChange: PropTypes.func,
   isSystemEval: PropTypes.bool,
+  runtimeOverrides: PropTypes.object,
 };
 
 export default TestPlayground;

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -254,6 +254,7 @@ const TracingTestMode = React.forwardRef(
       // only for source="task" — other surfaces stay locked until each
       // one's resolver is audited.
       allowCustomFieldPath = false,
+      runtimeOverrides,
     },
     ref,
   ) => {
@@ -1097,6 +1098,9 @@ const TracingTestMode = React.forwardRef(
                 ...(Object.keys(codeParams || {}).length > 0
                   ? { params: codeParams }
                   : {}),
+                ...(runtimeOverrides && Object.keys(runtimeOverrides).length > 0
+                  ? { run_config: runtimeOverrides }
+                  : {}),
               },
               ...autoCtx,
             });
@@ -1915,6 +1919,7 @@ TracingTestMode.propTypes = {
   compositeAdhocConfig: PropTypes.object,
   localFilters: PropTypes.array,
   allowCustomFieldPath: PropTypes.bool,
+  runtimeOverrides: PropTypes.object,
 };
 
 export default TracingTestMode;

--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -50,6 +50,7 @@ _RUNTIME_ALLOWED_KEYS = {
         "reverse_output",
         "knowledge_base_id",
         "knowledge_bases",
+        "few_shot_examples",
     },
 }
 


### PR DESCRIPTION
## Summary

Test endpoints (`TestPlayground` → `Dataset/Tracing/SimulationTestMode`, and the Custom tab) previously dropped picker state when calling `evalPlayground`. For **system evals** this is observable: `updateEval` is skipped before the test, so picker selections (connectors, KBs, `pass_threshold`, `few_shot_examples`, etc.) never reached the BE. Customer-reported as *"test evaluation not working with connectors"*.

For user (non-system) evals the bug is masked: `EvalDetailPage.handleTestEvaluation` calls `updateEval` first, persisting picker state to the template, then runs the test — so the saved template carries the new state. System evals can't be edited, so this path doesn't apply.

## What this PR does

Forward picker state under `config.run_config` on every test endpoint POST. The BE's `evaluations/engine/instance.py::create_eval_instance` already merges this layer via `_RUNTIME_ALLOWED_KEYS`. The fix is FE-side wiring + one BE addition to allow `few_shot_examples` as a runtime override for `CustomPromptEvaluator`.

## Files (+120 / -1)

| File | Change |
|---|---|
| `frontend/src/sections/evals/components/EvalCreatePage.jsx` | Build `testRuntimeOverrides` from picker state; pass to `TestPlayground` |
| `frontend/src/sections/evals/components/EvalDetailPage.jsx` | Same |
| `frontend/src/sections/evals/components/TestPlayground.jsx` | Accept `runtimeOverrides`; spread into Custom-tab POST; forward to sub-modes |
| `frontend/src/sections/evals/components/DatasetTestMode.jsx` | Spread `runtimeOverrides` into `config.run_config` of the POST |
| `frontend/src/sections/evals/components/TracingTestMode.jsx` | Same |
| `frontend/src/sections/evals/components/SimulationTestMode.jsx` | Same |
| `futureagi/evaluations/engine/instance.py` | Add `few_shot_examples` to `_RUNTIME_ALLOWED_KEYS["CustomPromptEvaluator"]` |

## What the override bundle carries

For all non-composite evals: `output_type`, `pass_threshold`, `multi_choice`, `check_internet`, `choice_scores`, `choices`.

Agent evals also include: `agent_mode`, `tools` (connectors), `knowledge_bases`, `data_injection`, `summary`.

LLM (CustomPromptEvaluator) evals also include: `few_shot_examples`.

## How `/update/` and `/test/` cohere (intentional, not contract drift)

| Endpoint | Shape | Effect |
|---|---|---|
| `PATCH /eval-templates/{id}/` (save) | top-level fields | Mutates `template.config.*` — next run picks it up as template default |
| `POST /eval-playground` (test) | `config.run_config.{...}` | Treated as runtime overrides, merged on top of template defaults via `_RUNTIME_ALLOWED_KEYS` |

Both pathways converge in `create_eval_instance` — runtime overrides are evaluated **after** template defaults, so when both are present (the user-eval test flow) values from `run_config` win deterministically. For system evals, `run_config` is the only source.

## Out of scope (intentional, documented for follow-up)

- Composite test path (composite execute endpoint has its own config shape — separate audit).
- `buildToolsPayload` shape canonicalization — already covered by `ee#58` BE defensive read + PR 416's `serializeEvalConfig` on the save path.
- Symmetry audit between savable fields and `_RUNTIME_ALLOWED_KEYS` — worth a separate ticket; this PR adds `few_shot_examples` to close the most obvious gap.
- Other surfaces (TaskConfigPanel, SimulationEvaluationDrawer, TestEvaluationDrawer, TestDetailConfigureEval, CreateRunTestPage) — already wired via PR 416's `serializeEvalConfig`.

## Test plan

- [ ] System eval (e.g. `toxicity`) → add an MCP connector in the picker → click Test → connector is honoured by the test run.
- [ ] System eval → change `pass_threshold` in the picker (no save) → Test result reflects the new threshold.
- [ ] LLM (CustomPrompt) eval → add few-shot examples → Test → examples flow through to the prompt.
- [ ] User eval → change `output_type` → Test before save → result uses the new output type (works via `updateEval` then test, with `run_config` redundantly reinforcing).
- [ ] Composite eval → Test still functions as before (no regression — `runtimeOverrides` is null for composites).
- [ ] No regression on existing test runs that don't touch picker state (`run_config` is omitted when overrides bundle is empty).

Linear: TH-5276, TH-5279
