### PR TITLE
fix(eval-task): dispatch voiceCalls row_type through spans flow

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,7 @@ ENV VITE_HOST_API=${VITE_HOST_API} \
 WORKDIR /app
 
 COPY package.json yarn.lock ./
-RUN yarn install
+RUN yarn install --network-timeout 600000
 
 COPY . ./
 RUN yarn build

--- a/futureagi/tracer/tests/test_eval_task_runtime.py
+++ b/futureagi/tracer/tests/test_eval_task_runtime.py
@@ -177,6 +177,96 @@ class TestProcessEvalTaskSpans:
         assert count == 6
 
 
+# ────────────────────────────────────────────────────────────────────────
+# Voice-call dispatch — literal alias of the spans pipeline. Any
+# observation_type narrowing is the caller's job via ``filters``.
+# ────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def voice_call_eval_task(db, populated_observe_project, eval_template):
+    """Historical voiceCalls eval task on the shared 12-span fixture."""
+    from tracer.models.eval_task import RowType
+
+    project = populated_observe_project["project"]
+    config = CustomEvalConfig.objects.create(
+        project=project,
+        eval_template=eval_template,
+        name="Test Voice Eval",
+        config={"output": "Pass/Fail"},
+        mapping={"input": "input", "output": "output"},
+        model="turing_large",
+    )
+    task = EvalTask.objects.create(
+        project=project,
+        name="Test voice calls task",
+        filters={"project_id": str(project.id)},
+        sampling_rate=100.0,
+        run_type=RunType.HISTORICAL,
+        spans_limit=1000,
+        status=EvalTaskStatus.PENDING,
+        row_type=RowType.VOICE_CALLS,
+    )
+    task.evals.add(config)
+    return {"task": task, "config": config, "project": project}
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestProcessEvalTaskVoiceCalls:
+    """Dispatcher must route voiceCalls through the spans flow.
+
+    Regression net for the bug where ``row_type='voiceCalls'`` hit the
+    dispatcher's ``else`` branch (added in fb134ddf) and raised
+    ``ValueError`` — flipping every voiceCalls task in prod to FAILED.
+
+    Behaviour pin: voiceCalls is a literal alias of spans at dispatch.
+    Any observation_type narrowing (e.g. limiting to conversation roots)
+    is the caller's responsibility via ``EvalTask.filters``.
+    """
+
+    def test_dispatches_same_spans_as_spans_path(
+        self,
+        populated_observe_project,
+        voice_call_eval_task,
+        stub_run_eval,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """voiceCalls fan-out matches the spans path on the same project."""
+        task = voice_call_eval_task["task"]
+
+        process_eval_task._original_func(str(task.id))
+
+        rows = EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False)
+        # populated_observe_project has 2 sessions × 2 traces × 3 spans = 12
+        # spans × 1 eval -> 12 EvalLogger rows (no observation_type narrowing).
+        assert rows.count() == 12
+        expected_ids = {s.id for s in populated_observe_project["spans"]}
+        assert {r.observation_span_id for r in rows} == expected_ids
+
+    def test_status_transitions_match_spans_path(
+        self,
+        populated_observe_project,
+        voice_call_eval_task,
+        stub_run_eval,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """voiceCalls inherits the spans drain semantics: PENDING -> RUNNING -> COMPLETED."""
+        task = voice_call_eval_task["task"]
+        assert task.status == EvalTaskStatus.PENDING
+
+        process_eval_task._original_func(str(task.id))
+        task.refresh_from_db()
+        assert task.status == EvalTaskStatus.RUNNING
+
+        process_eval_task._original_func(str(task.id))
+        task.refresh_from_db()
+        assert task.status == EvalTaskStatus.COMPLETED
+
+
 @pytest.mark.integration
 @pytest.mark.api
 @pytest.mark.django_db

--- a/futureagi/tracer/utils/eval_tasks.py
+++ b/futureagi/tracer/utils/eval_tasks.py
@@ -277,7 +277,11 @@ def process_eval_task(eval_task_id: str):
             )
             entity_qs = TraceSession.objects.filter(id__in=matching_session_ids)
             dispatch = evaluate_trace_session_observe
-        elif eval_task.row_type == RowType.SPANS:
+        elif eval_task.row_type in (RowType.SPANS, RowType.VOICE_CALLS):
+            # Voice calls share the spans dispatch — the picker layer
+            # already aliases voiceCalls→spans (observation_span.py:2890),
+            # and any conversation-type narrowing the user wants comes
+            # through ``filters`` like every other span query.
             entity_qs = ObservationSpan.objects.filter(filters)
             dispatch = evaluate_observation_span_observe
         else:


### PR DESCRIPTION
## Summary

- Routes `RowType.VOICE_CALLS` through the existing spans dispatch in `process_eval_task`, fixing 100% prod failure of voiceCalls eval tasks (9/9 historical + continuous in US, all flipped to FAILED with zero `tracer_eval_logger` rows written).
- Adds `TestProcessEvalTaskVoiceCalls` to pin dispatch parity with the spans path.
- Raises `yarn install` network-timeout to 600000 ms in `frontend/Dockerfile` for resilient image builds on slow networks.

## Root cause

The dispatcher in `futureagi/tracer/utils/eval_tasks.py:252-291` only branched on `TRACES`, `SESSIONS`, and `SPANS`. After `fb134ddf` (PR4 cleanup, May 11) tightened the trailing `else` to raise `ValueError` on unknown row_types, every `voiceCalls` task — whose enum value was added in `4f589717` (PR2, May 7) — started crashing at dispatch. The outer `try/except` at line 501-504 caught the error and flipped the task to FAILED, but never wrote anything to `EvalTaskLogger`, leaving every failed task's logger row stuck at `pending`/`running` with `errors=[]`.

Verified in prod US: project `e5862a0e-…`, task `d7e56009-f41e-4d61-b904-f42cacaf0fd7` — 105 conversation spans in the date range, zero logger entries; sibling `row_type=spans` task `cdcf728b-…` on the same project completed normally as the control.

## Approach

`voiceCalls` is a literal alias of `spans` at the dispatcher layer. The picker layer already aliases `voiceCalls→spans` (`observation_span.py:2890`), and the pre-`row_type` runtime had no `observation_type` narrowing — every span matching the user filters was dispatched. Combining `SPANS` and `VOICE_CALLS` into the same `elif` preserves that semantic and keeps the dispatcher minimal:

```python
elif eval_task.row_type in (RowType.SPANS, RowType.VOICE_CALLS):
    entity_qs = ObservationSpan.objects.filter(filters)
    dispatch = evaluate_observation_span_observe
```

Any `observation_type='conversation'` narrowing remains the caller's responsibility via `EvalTask.filters`.

## Test plan

- [x] `uv run pytest futureagi/tracer/tests/test_eval_task_runtime.py -v` — 39/39 pass (2 new voiceCalls cases + full spans/traces/sessions/composite/status-transition suite).
- [ ] Post-deploy: re-run `iForm - Barge Slow - Historical Evals` (`d7e56009-…`) in prod US and confirm `status` transitions through `running` and `EvalLogger` rows land.
- [ ] Post-deploy: smoke-test by creating a new `voiceCalls` historical task and confirming end-to-end completion.

## Follow-ups (out of scope)

- 9 existing `failed` voiceCalls tasks in prod won't auto-recover; users must rerun manually.
- `EvalTaskLogger.errors` stays empty on dispatcher exceptions (`eval_tasks.py:501-504` only logs to app logs and flips status). Surfacing such errors on the logger would prevent future "row_type not dispatched" bugs from hiding in app logs. Worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)