### PR TITLE
fix(audio): bound ffmpeg processing time

### DIFF
--- a/futureagi/tfc/utils/storage.py
+++ b/futureagi/tfc/utils/storage.py
@@ -82,6 +82,9 @@ _MIME_TO_EXT = {
     "application/json": "json",
 }
 
+_FFMPEG_DETECT_AUDIO_TIMEOUT_SECONDS = 10
+_FFMPEG_CONVERT_AUDIO_TIMEOUT_SECONDS = 60
+
 
 def _ext_from_mime(content_type: str | None) -> str:
     """Map a MIME type to a canonical file extension (no dot). Returns
@@ -584,6 +587,22 @@ def upload_image_to_s3(
         raise ValueError(get_error_message("ERROR_IMAGE_UPLOAD").format(str(e))) from e
 
 
+def _communicate_ffmpeg(process, audio_bytes, timeout_seconds, operation):
+    try:
+        return process.communicate(input=audio_bytes, timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as e:
+        process.kill()
+        process.communicate()
+        logger.warning(
+            "ffmpeg process timed out",
+            operation=operation,
+            timeout_seconds=timeout_seconds,
+        )
+        raise TimeoutError(
+            f"FFmpeg {operation} timed out after {timeout_seconds} seconds"
+        ) from e
+
+
 def detect_audio_format(audio_bytes):
     process = subprocess.Popen(
         ["ffmpeg", "-i", "-", "-f", "ffmetadata", "-"],
@@ -592,7 +611,12 @@ def detect_audio_format(audio_bytes):
         stderr=subprocess.PIPE,
     )
 
-    stdout, stderr = process.communicate(input=audio_bytes)
+    stdout, stderr = _communicate_ffmpeg(
+        process,
+        audio_bytes,
+        _FFMPEG_DETECT_AUDIO_TIMEOUT_SECONDS,
+        "audio format detection",
+    )
 
     if process.returncode != 0:
         raise Exception(f"FFmpeg Error: {stderr.decode('utf-8')}")
@@ -627,7 +651,12 @@ def convert_to_mp3(audio_bytes):
             stderr=subprocess.PIPE,
         )
 
-        stdout, stderr = process.communicate(input=audio_bytes)
+        stdout, stderr = _communicate_ffmpeg(
+            process,
+            audio_bytes,
+            _FFMPEG_CONVERT_AUDIO_TIMEOUT_SECONDS,
+            "audio conversion",
+        )
 
         if process.returncode != 0:
             raise Exception(f"FFmpeg Conversion Error: {stderr.decode('utf-8')}")

--- a/futureagi/tfc/utils/tests/test_storage_audio_timeouts.py
+++ b/futureagi/tfc/utils/tests/test_storage_audio_timeouts.py
@@ -1,0 +1,39 @@
+import subprocess
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tfc.utils.storage import convert_to_mp3, detect_audio_format
+
+
+def test_detect_audio_format_kills_and_reaps_ffmpeg_on_timeout():
+    process = Mock()
+    process.communicate.side_effect = [
+        subprocess.TimeoutExpired(cmd="ffmpeg", timeout=10),
+        (b"", b""),
+    ]
+
+    with patch("tfc.utils.storage.subprocess.Popen", return_value=process):
+        with pytest.raises(TimeoutError):
+            detect_audio_format(b"audio-bytes")
+
+    process.kill.assert_called_once()
+    process.communicate.assert_any_call(input=b"audio-bytes", timeout=10)
+    process.communicate.assert_any_call()
+
+
+def test_convert_to_mp3_kills_and_reaps_ffmpeg_on_timeout():
+    process = Mock()
+    process.communicate.side_effect = [
+        subprocess.TimeoutExpired(cmd="ffmpeg", timeout=60),
+        (b"", b""),
+    ]
+
+    with patch("tfc.utils.storage.subprocess.Popen", return_value=process):
+        with pytest.raises(ValueError) as exc_info:
+            convert_to_mp3(b"audio-bytes")
+
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+    process.kill.assert_called_once()
+    process.communicate.assert_any_call(input=b"audio-bytes", timeout=60)
+    process.communicate.assert_any_call()


### PR DESCRIPTION
## Summary
- add explicit ffmpeg timeouts for audio format detection and MP3 conversion
- kill and reap timed-out ffmpeg processes before surfacing failure
- cover both timeout paths with focused regression tests

## Tests
- python -m py_compile futureagi/tfc/utils/storage.py futureagi/tfc/utils/tests/test_storage_audio_timeouts.py
- uvx ruff check tfc/utils/tests/test_storage_audio_timeouts.py
- uv run pytest -c NUL -p no:django -p no:ddtrace --confcutdir=tfc/utils/tests tfc/utils/tests/test_storage_audio_timeouts.py -q

Refs #387