### PR TITLE
fix(http): bound dataset media fetches

### DIFF
--- a/futureagi/agentic_eval/core/utils/functions.py
+++ b/futureagi/agentic_eval/core/utils/functions.py
@@ -50,6 +50,7 @@ except ImportError:
     summary_judgement_prompt_ragrank_v2 = ""
 
 model_name = "anthropic"
+_MEDIA_DOWNLOAD_TIMEOUT_SECONDS = 30
 
 
 def encode_image(image_path):
@@ -422,7 +423,7 @@ def generate_combined_subcriterias(client, criterias, user_defined_metrics):
 
 def download_image_to_base64(url):
     # Download the image
-    response = requests.get(url)
+    response = requests.get(url, timeout=_MEDIA_DOWNLOAD_TIMEOUT_SECONDS)
 
     # Check if the request was successful
     if response.status_code == 200:
@@ -445,7 +446,7 @@ def download_image_to_base64(url):
         )
 
 def download_audio_to_base64(url):
-    response = requests.get(url)
+    response = requests.get(url, timeout=_MEDIA_DOWNLOAD_TIMEOUT_SECONDS)
     if response.status_code == 200:
         audio_base64 = base64.b64encode(response.content).decode("utf-8")
         return audio_base64

--- a/futureagi/model_hub/views/utils/hugginface.py
+++ b/futureagi/model_hub/views/utils/hugginface.py
@@ -21,6 +21,8 @@ from tfc.settings.settings import (
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.storage import upload_audio_to_s3_duration, upload_image_to_s3
 
+_HUGGINGFACE_DATASET_INFO_TIMEOUT_SECONDS = 30
+
 
 def get_huggingface_dataset_info(dataset_path, organization_id):
     if not organization_id:
@@ -36,7 +38,11 @@ def get_huggingface_dataset_info(dataset_path, organization_id):
     )
     headers = {"Authorization": f"Bearer {auth_token}"}
     API_URL = f"https://datasets-server.huggingface.co/info?dataset={dataset_path}"
-    response = requests.get(API_URL, headers=headers)
+    response = requests.get(
+        API_URL,
+        headers=headers,
+        timeout=_HUGGINGFACE_DATASET_INFO_TIMEOUT_SECONDS,
+    )
     if response.status_code != 200:
         raise Exception(f"{response.status_code}")
     response = response.json()


### PR DESCRIPTION
## Summary
- add explicit timeouts to Hugging Face dataset metadata fetches
- add explicit timeouts to image/audio media downloads used by eval helpers
- keep the follow-up scoped to #499 paths not covered by #500

## Tests
- python -m py_compile futureagi/model_hub/views/utils/hugginface.py futureagi/agentic_eval/core/utils/functions.py
- git diff --check

## Notes
- uvx ruff check model_hub/views/utils/hugginface.py agentic_eval/core/utils/functions.py is blocked by pre-existing module hygiene in these files: E402 imports after logger, import ordering, and one stale whitespace line.

Refs #499