### PR TITLE
fix(contributing): add the Make/yarn targets the docs tell contributo…

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "test:fast": "vitest run --reporter=default --passWithNoTests --maxConcurrency=4 --testTimeout=10000",
     "test:ci": "node --max-old-space-size=4096 ./node_modules/.bin/vitest run --reporter=verbose --coverage",
     "test:changed": "vitest related --run",
-    "check-all": "yarn lint && yarn test:run",
+    "check-all": "yarn lint && yarn type-check && yarn test:run",
     "rm:all": "rm -rf node_modules .next out dist build",
     "re:start": "yarn rm:all && yarn install && yarn dev",
     "re:build": "yarn rm:all && yarn install && node --max-old-space-size=8192 ./node_modules/.bin/vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "test:fast": "vitest run --reporter=default --passWithNoTests --maxConcurrency=4 --testTimeout=10000",
     "test:ci": "node --max-old-space-size=4096 ./node_modules/.bin/vitest run --reporter=verbose --coverage",
     "test:changed": "vitest related --run",
+    "check-all": "yarn lint && yarn test:run",
     "rm:all": "rm -rf node_modules .next out dist build",
     "re:start": "yarn rm:all && yarn install && yarn dev",
     "re:build": "yarn rm:all && yarn install && node --max-old-space-size=8192 ./node_modules/.bin/vite build",

--- a/futureagi/Makefile
+++ b/futureagi/Makefile
@@ -1,6 +1,6 @@
 # Makefile for core-backend
 
-.PHONY: help test test-unit test-integration test-watch test-shell clean lint format mypy
+.PHONY: help test test-unit test-integration test-watch test-shell clean lint format mypy mypy-baseline pre-commit-install pre-commit pre-commit-all check-all
 
 help:
 	@echo "Usage: make <target>"
@@ -15,7 +15,14 @@ help:
 	@echo "Code Quality:"
 	@echo "  lint            Run linters"
 	@echo "  format          Format code"
-	@echo "  mypy            Type checking"
+	@echo "  mypy            Type checking (baseline-driven)"
+	@echo "  mypy-baseline   Regenerate the mypy baseline"
+	@echo "  check-all       Run lint + mypy + tests (pre-PR gate)"
+	@echo ""
+	@echo "Pre-commit hooks (uses .pre-commit-config.yaml):"
+	@echo "  pre-commit-install  Install git hooks (one-time)"
+	@echo "  pre-commit          Run hooks on staged files"
+	@echo "  pre-commit-all      Run hooks on all files"
 	@echo ""
 	@echo "Or use bin/test directly for more options:"
 	@echo "  bin/test help"
@@ -47,6 +54,23 @@ format:
 
 mypy:
 	@./bin/check_mypy.sh
+
+mypy-baseline:
+	@./bin/generate_mypy_baseline.sh
+
+# Pre-commit hooks - delegate to the pre-commit tool (.pre-commit-config.yaml).
+# pre-commit is pinned in requirements-test.txt / pyproject.toml.
+pre-commit-install:
+	@pre-commit install
+
+pre-commit:
+	@pre-commit run
+
+pre-commit-all:
+	@pre-commit run --all-files
+
+# Aggregate quality gate referenced by CONTRIBUTING.md ("make check-all").
+check-all: lint mypy test
 
 # Cleanup
 clean:


### PR DESCRIPTION
<!--
Title (Conventional Commits):
fix(contributing): add the Make/yarn targets the docs tell contributors to run

Copy everything BELOW this comment into the PR description box.
-->

## Summary

`CONTRIBUTING.md` instructs contributors to run `make check-all` / `yarn check-all` to validate a PR, and to run `make pre-commit-install` as one-time setup — but none of those targets exist. A newcomer following the docs fails at step 6 of "Your first PR" with `make: *** No rule to make target 'check-all'`. This PR adds the missing `make`/`yarn` targets as thin wrappers over tooling that already ships in the repo (`.pre-commit-config.yaml`, the pinned `pre-commit`, `bin/generate_mypy_baseline.sh`, `bin/check_mypy.sh`, `bin/test`), so the documented contributor flow actually works. No new dependencies, no behavior change to existing targets.

## Linked issues

No tracked issue — surfaced while following `CONTRIBUTING.md` for a first contribution. (No `Closes #` so nothing is auto-closed.)

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Static / dry-run verification (these targets wrap existing tooling; there is no unit-test harness for Makefile targets):

- `make -n check-all` → resolves to `ruff check . --fix` / `black --check .` / `./bin/check_mypy.sh` / `bin/test`
- `make -n pre-commit-install` → `pre-commit install`
- `make -n mypy-baseline` → `./bin/generate_mypy_baseline.sh`
- `make help` lists the new targets
- `node -e "require('./frontend/package.json')"` → `package.json` is valid JSON; `check-all` script present

A full `make check-all` run was **not** executed here because it spins up the Dockerized backend test stack; this PR only wires targets to tools that already exist and is safe to run by a reviewer.

## Screenshots / recordings (if UI)

N/A — build tooling only, no UI.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works — _N/A: there is no test framework for Makefile/package.json targets; verified via `make -n` dry-runs and a JSON parse (see above)_
- [ ] `make check-all` / `yarn check-all` passes locally — _verified the targets resolve via `make -n`; the full suite (Dockerized) was not run in this environment_
- [x] I've updated the documentation where relevant — _no doc change needed: `CONTRIBUTING.md` already references these targets; this PR makes those references accurate_
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) — _will sign via the first-time-contributor bot link_
