### PR TITLE
fix(observe): accept in/not_in on PG system-metric filters

### DIFF
--- a/futureagi/tracer/tests/test_metric_filters_comprehensive.py
+++ b/futureagi/tracer/tests/test_metric_filters_comprehensive.py
@@ -352,6 +352,55 @@ class TestPGMetricFilters:
         )
         assert q != Q()
 
+    # --- in / not_in on system-metric columns ---
+    # Regression: the PG operator_map was missing "in" / "not_in", so the
+    # Observe toolbar's multi-select filters (node_type, status, model, …)
+    # silently dropped on the PG fallback path.
+
+    @staticmethod
+    def _system_metric_filter(column_id, filter_op, filter_value):
+        return {
+            "column_id": column_id,
+            "filter_config": {
+                "filter_type": "text",
+                "filter_op": filter_op,
+                "filter_value": filter_value,
+                "col_type": "SYSTEM_METRIC",
+            },
+        }
+
+    def test_node_type_in_list_produces_q(self):
+        q = FilterEngine.get_filter_conditions_for_system_metrics(
+            [self._system_metric_filter("node_type", "in", ["llm"])]
+        )
+        assert q != Q()
+        assert "node_type__in" in str(q)
+        assert "llm" in str(q)
+
+    def test_node_type_in_multi_value(self):
+        q = FilterEngine.get_filter_conditions_for_system_metrics(
+            [self._system_metric_filter("node_type", "in", ["llm", "chain"])]
+        )
+        assert q != Q()
+        assert "node_type__in" in str(q)
+
+    def test_node_type_not_in_negates(self):
+        q = FilterEngine.get_filter_conditions_for_system_metrics(
+            [self._system_metric_filter("node_type", "not_in", ["llm"])]
+        )
+        assert q != Q()
+        assert q.negated, "not_in should produce a negated Q"
+        assert "node_type__in" in str(q)
+
+    def test_in_with_scalar_value_coerced_to_list(self):
+        """Mirrors CH builder behaviour: scalar value gets wrapped in a list."""
+        q = FilterEngine.get_filter_conditions_for_system_metrics(
+            [self._system_metric_filter("node_type", "in", "llm")]
+        )
+        assert q != Q()
+        assert "node_type__in" in str(q)
+        assert "llm" in str(q)
+
 
 # ============================================================================
 # 3. SpanList ClickHouse filter builder — verify span-level filters

--- a/futureagi/tracer/utils/filters.py
+++ b/futureagi/tracer/utils/filters.py
@@ -596,6 +596,8 @@ class FilterEngine:
             "between": "range",
             "not_between": "exclude",
             "contains": "icontains",
+            "in": "in",
+            "not_in": "in",
         }
 
         # Map column IDs to their aggregated field names
@@ -714,6 +716,12 @@ class FilterEngine:
                 else:
                     # Keep existing behavior for single value contains
                     q_objects.append(Q(**{f"{field_name}__icontains": filter_value}))
+            elif filter_op == "in":
+                values = filter_value if isinstance(filter_value, list) else [filter_value]
+                q_objects.append(Q(**{f"{field_name}__in": values}))
+            elif filter_op == "not_in":
+                values = filter_value if isinstance(filter_value, list) else [filter_value]
+                q_objects.append(~Q(**{f"{field_name}__in": values}))
             elif isinstance(filter_value, list) and filter_op == "equals":
                 q_objects.append(Q(**{f"{field_name}__in": filter_value}))
             elif isinstance(filter_value, list) and filter_op == "not_equals":


### PR DESCRIPTION
## Description

`FilterEngine.get_filter_conditions_for_system_metrics` (the PG-side translator used by `list_spans_observe` when the CH path falls back) had `"in"` / `"not_in"` missing from its `operator_map`. The Observe toolbar has been sending `filter_op: "in"` for every multi-select (since canonical-op migration 0076), so the guard at `filters.py:619` (`if not django_operator: continue`) silently dropped every such filter — `node_type`, `status`, `model`, `span_name`, `trace_name`, `labels`, `session_id`, `prompt_template_version`, …

Symptom: user multi-selects `node_type = [llm]`, CH fails for any reason → request silently falls back to PG → PG drops the filter → user sees all spans, unfiltered, with no error.

The CH builder already handles `in` / `not_in` correctly at `clickhouse/query_builders/filters.py:778-797`. Only the PG path was overlooked.

PR #476 (TH-4888) stops the CH path from crashing in normal operation, so this fallback rarely triggers today. This change is the defense-in-depth so if CH ever fails for any other reason (network, schema, future regression), the PG fallback continues to filter correctly instead of silently lying.

### Changes

`futureagi/tracer/utils/filters.py:589-601` — extended `operator_map`:
```python
"in": "in",
"not_in": "in",
```

`futureagi/tracer/utils/filters.py:719-724` — two new Q-object branches above the existing `equals`/`not_equals` + list fallback. Scalar value gets wrapped to a 1-element list to mirror CH builder behaviour.

```python
elif filter_op == "in":
    values = filter_value if isinstance(filter_value, list) else [filter_value]
    q_objects.append(Q(**{f"{field_name}__in": values}))
elif filter_op == "not_in":
    values = filter_value if isinstance(filter_value, list) else [filter_value]
    q_objects.append(~Q(**{f"{field_name}__in": values}))
```

`futureagi/tracer/tests/test_metric_filters_comprehensive.py` — 4 new regression tests under `TestPGMetricFilters`:
- `test_node_type_in_list_produces_q` — `node_type` + `in` + `["llm"]` produces non-empty Q
- `test_node_type_in_multi_value` — `["llm", "chain"]` still works
- `test_node_type_not_in_negates` — `not_in` produces a negated Q
- `test_in_with_scalar_value_coerced_to_list` — scalar value wrap matches CH builder

Verified all 4 fail against pre-fix code, pass after the fix. Full test file (50 tests) green.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Configuration change

## Checklist

### Code Quality

- [x] I have run \`make pre-commit-all\` and fixed all issues
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run \`make test\` successfully

| Suite | Result |
|---|---|
| \`test_metric_filters_comprehensive.py\` | 50 passed |
| 4 new regression tests | pass with fix, fail without |

### Django-Specific (if applicable)

- [x] I have created/updated migrations if model changes were made (n/a)
- [x] I have run \`python manage.py check\` without errors
- [x] Database migrations are reversible (n/a)

### Documentation

- [x] I have updated the documentation accordingly (n/a — internal fix)
- [x] I have added/updated docstrings for new/modified functions
- [ ] I have updated the CHANGELOG (if applicable)

### Security

- [x] My changes don't introduce security vulnerabilities
- [x] I have not committed any secrets or credentials
- [x] I have run \`make check-secrets\` and addressed any issues

## Pre-commit Hooks

- [x] ✅ Pre-commit hooks are installed (\`make pre-commit-install\`)
- [x] ✅ All pre-commit checks pass (\`make pre-commit-all\`)

## Related Issues

- Follow-up to PR #476 (TH-4888) — defense-in-depth on the PG fallback path

## Screenshots (if applicable)

n/a

## Additional Notes

Out of scope:
- Other \`operator_map\` dicts in \`filters.py\` (lines 419, 853, 945, 1059) — those code paths aren't on the observe span-list flow; worth auditing separately.
- The buggy \`f.get("col_type")\` list-comp in \`observation_span.py\` (4 occurrences) — reads top-level instead of nested \`filter_config\`. Real bug but harmless today (inner handler re-reads correctly). Worth a separate cleanup PR.