### PR TITLE
fix(evals): version-banner sync, save-button gating, and name-length UX

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -387,8 +387,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         evalData?.config?.run_config ||
         evalData?.config?.runConfig ||
         {};
-        
-     const normalizedRunConfig = {
+
+      const normalizedRunConfig = {
         ...rawRunConfig,
         agent_mode:
           rawRunConfig.agent_mode ??
@@ -529,13 +529,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           setContextOptions(["variables_only"]);
         }
       } else if (source === "task") {
-      const seeded = contextOptionsForRowType(sourceRowType);
+        const seeded = contextOptionsForRowType(sourceRowType);
         if (seeded) setContextOptions(seeded);
       }
       setErrorLocalizerEnabled(
         config.error_localizer_enabled ??
-          fullEval.error_localizer_enabled ??
-          false,
+        fullEval.error_localizer_enabled ??
+        false,
       );
 
       // Edit mode: keep the saved name. Create mode: generate a unique name
@@ -630,8 +630,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         setUseInternet(fullEval.config?.check_internet ?? false);
         setErrorLocalizerEnabled(
           fullEval.error_localizer_enabled ??
-            fullEval.config?.error_localizer_enabled ??
-            false,
+          fullEval.config?.error_localizer_enabled ??
+          false,
         );
         setIsDirty(false);
         return;
@@ -837,13 +837,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         );
         return;
       }
-    if (evalType === "llm" && !hasValidPromptMessages) {
-      const errorMessage = "Prompt message is required";
-      setPromptMessageError(errorMessage);
-      enqueueSnackbar(errorMessage, { variant: "error" });
-      return;
+      if (evalType === "llm" && !hasValidPromptMessages) {
+        const errorMessage = "Prompt message is required";
+        setPromptMessageError(errorMessage);
+        enqueueSnackbar(errorMessage, { variant: "error" });
+        return;
+      }
     }
-  }
 
     if (source === "task" && onFiltersChange) {
       onFiltersChange(localFilterForm.getValues("filters") || []);
@@ -1154,7 +1154,16 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             setEvalName(raw);
             setIsDirty(true);
           }}
-          inputProps={{ maxLength: 60 }}
+          inputProps={{ maxLength: 50 }}
+          error={!isEditMode && evalName.length >= 50}
+          helperText={
+            isEditMode
+              ? undefined
+              : evalName.length >= 50
+                ? "Name can't be longer than 50 characters"
+                : `Use lowercase letters, numbers, hyphens (-) and underscores (_) only. ${evalName.length}/50`
+          }
+          FormHelperTextProps={{ sx: { fontSize: "11px", mt: 0.25, mx: 0 } }}
           sx={{ "& .MuiInputBase-root": { fontSize: "13px", height: 34 } }}
         />
       </Box>
@@ -1627,27 +1636,27 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   source === "workbench" ||
                   source === "run-experiment" ||
                   source === "run-optimization") && (
-                  <DatasetTestMode
-                    ref={sourceRef}
-                    templateId={templateId}
-                    variables={variables}
-                    model={model}
-                    codeParams={codeParams}
-                    onTestResult={handleTestResult}
-                    onClearResult={handleClearTestResult}
-                    onColumnsLoaded={handleColumnsLoaded}
-                    initialDatasetId={sourceId}
-                    onReadyChange={handleSourceReadyChange}
-                    contextOptions={contextOptions}
-                    errorLocalizerEnabled={errorLocalizerEnabled}
-                    initialMapping={evalData?.mapping}
-                    {...compositeSourceModeProps}
-                    sourceColumns={
-                      source === "workbench" ? sourceColumns : null
-                    }
-                    extraColumns={extraColumns}
-                  />
-                )}
+                    <DatasetTestMode
+                      ref={sourceRef}
+                      templateId={templateId}
+                      variables={variables}
+                      model={model}
+                      codeParams={codeParams}
+                      onTestResult={handleTestResult}
+                      onClearResult={handleClearTestResult}
+                      onColumnsLoaded={handleColumnsLoaded}
+                      initialDatasetId={sourceId}
+                      onReadyChange={handleSourceReadyChange}
+                      contextOptions={contextOptions}
+                      errorLocalizerEnabled={errorLocalizerEnabled}
+                      initialMapping={evalData?.mapping}
+                      {...compositeSourceModeProps}
+                      sourceColumns={
+                        source === "workbench" ? sourceColumns : null
+                      }
+                      extraColumns={extraColumns}
+                    />
+                  )}
                 {source === "tracing" && (
                   <TracingTestMode
                     ref={sourceRef}
@@ -1927,7 +1936,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
 
           return (
             <ShowComponent
-              condition={!hasDataInjection }
+              condition={!hasDataInjection}
             >
               <CustomTooltip
                 show={testDisabled && !!testDisabledReason}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -555,8 +555,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           .replace(/[^a-z0-9_-]/g, "");
         const sourceSlug = SOURCE_NAME_SLUGS[source] || "";
         const stamp = format(new Date(), "dd_MMM_yyyy_HH_mm").toLowerCase();
+        const suffix = [sourceSlug, stamp].filter(Boolean).join("_");
+        const maxBaseLen = Math.max(0, 50 - suffix.length - (suffix ? 1 : 0));
+        const truncatedBase = sanitized.slice(0, maxBaseLen).replace(/_+$/, "");
         setEvalName(
-          [sanitized, sourceSlug, stamp].filter(Boolean).join("_"),
+          [truncatedBase, sourceSlug, stamp].filter(Boolean).join("_"),
         );
       }
 

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -1873,7 +1873,7 @@ const EvalDetailPage = () => {
                       variant="contained"
                       size="small"
                       onClick={handleSaveVersion}
-                      disabled={isSaving}
+                      disabled={isSaving || !isDirty}
                       startIcon={
                         isSaving ? (
                           <CircularProgress size={14} />

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -220,6 +220,23 @@ const EvalDetailPage = () => {
 
   // Version viewing state
   const [viewingVersion, setViewingVersion] = useState(null);
+
+  useEffect(() => {
+    if (!viewingVersion || !versionsData?.versions) return;
+    const fresh = versionsData.versions.find((v) => v.id === viewingVersion.id);
+    if (!fresh) return;
+    const freshFlag = fresh.is_default ?? fresh.isDefault ?? false;
+    const localFlag =
+      viewingVersion.is_default ?? viewingVersion.isDefault ?? false;
+    if (freshFlag !== localFlag) {
+      setViewingVersion((prev) =>
+        prev
+          ? { ...prev, is_default: freshFlag, isDefault: freshFlag }
+          : prev,
+      );
+    }
+  }, [versionsData, viewingVersion]);
+
   const defaultVersion = useMemo(() => {
     const list = versionsData?.versions || [];
     if (!list.length) return null;

--- a/frontend/src/sections/evals/components/EvalUsageTab.jsx
+++ b/frontend/src/sections/evals/components/EvalUsageTab.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import {
   Box,
+  ButtonBase,
   Chip,
   IconButton,
   Skeleton,
@@ -409,7 +410,15 @@ const EvalUsageTab = ({
   }, [detailIndex, filteredLogs.length]);
 
   return (
-    <Box sx={{ display: "flex", height: "100%", minHeight: 0 }}>
+    <Box
+      sx={{
+        display: "flex",
+        height: "100%",
+        minHeight: 0,
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
       {/* ── Main content ── */}
       <Box
         sx={{
@@ -418,6 +427,7 @@ const EvalUsageTab = ({
           flexDirection: "column",
           minHeight: 0,
           minWidth: 0,
+          marginRight: detailIndex !== null ? "420px" : 0,
           transition: "margin-right 0.25s",
         }}
       >
@@ -596,14 +606,17 @@ const EvalUsageTab = ({
       >
         <Box
           sx={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+            bottom: 0,
             width: 420,
-            flexShrink: 0,
             borderLeft: "1px solid",
             borderColor: "divider",
             display: "flex",
             flexDirection: "column",
-            height: "100%",
             backgroundColor: "background.paper",
+            zIndex: 1,
           }}
         >
           {/* Header with prev/next */}
@@ -753,17 +766,17 @@ const DetailPanelContent = ({
         }}
       >
         {["formatted", "json"].map((m) => (
-          <Box
+          <ButtonBase
             key={m}
             onClick={() => setViewMode(m)}
+            disableRipple
             sx={{
               px: 1.5,
               py: 0.375,
               borderRadius: "5px",
               fontSize: "11px",
-              cursor: "pointer",
               fontWeight: viewMode === m ? 600 : 400,
-              color: viewMode === m ? "text.primary" : "text.disabled",
+              color: viewMode === m ? "text.primary" : "text.secondary",
               backgroundColor:
                 viewMode === m
                   ? (t) =>
@@ -771,10 +784,16 @@ const DetailPanelContent = ({
                         ? "rgba(255,255,255,0.08)"
                         : "action.hover"
                   : "transparent",
+              "&:hover": {
+                backgroundColor: (t) =>
+                  t.palette.mode === "dark"
+                    ? "rgba(255,255,255,0.04)"
+                    : "action.hover",
+              },
             }}
           >
             {m === "formatted" ? "Formatted" : "JSON"}
-          </Box>
+          </ButtonBase>
         ))}
       </Box>
 


### PR DESCRIPTION

## Summary

Bundle of UX fixes for the evaluation creation/detail flows found during e2e prod testing.

- **Save Version button** ([EvalDetailPage.jsx](frontend/src/sections/evals/components/EvalDetailPage.jsx)) — now disabled until the form is dirty, matching the existing behaviour of the composite "Save Changes" button. Prevents no-op version saves.
- **"Viewing Vx" banner** ([EvalDetailPage.jsx](frontend/src/sections/evals/components/EvalDetailPage.jsx)) — was stuck on screen after promoting the currently-viewed version to default, because the local `viewingVersion` snapshot held a stale `is_default: false`. Added a small effect that reconciles the local copy from the freshly-refetched `versionsData` so the banner clears immediately.
- **Auto-generated eval name** ([EvalPickerConfigFull.jsx](frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx)) — `<sanitized>_<source>_<timestamp>` could blow past the 50-char backend limit on long templates. Now truncates only the base name and preserves the source slug + timestamp (the disambiguators), trimming any trailing `_` left by the slice.
- **Eval name input** ([EvalPickerConfigFull.jsx](frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx)) — `maxLength` lowered from 60 to 50 to match the auto-gen logic; helper text now shows the allowed character set and a live `n/50` counter, switching to an error state at the cap.
- **Usage tab drawer + tab toggle** ([EvalUsageTab.jsx](frontend/src/sections/evals/components/EvalUsageTab.jsx)) — the detail side panel was painted *on top of* the chart and logs table because `<Slide>` doesn't reserve flex space while animating. Repositioned the drawer as an absolutely-positioned overlay anchored to the container, with the main content gaining a `marginRight: 420px` when open (animated via the existing `transition`) so the chart and table actually squeeze instead of being covered. While in there, swapped the **Formatted / JSON** toggle from plain `Box`es to `ButtonBase` (with `text.secondary` on the inactive tab) so the inactive tab no longer reads as disabled and clicks register reliably regardless of focus state.

## Test plan

- [x] Open an eval detail page → confirm **Save Version** is disabled on load and only enables after editing a field
- [x] Save a new version → button re-disables once the save completes
- [x] View a non-default version → "Viewing Vx" banner appears; click **Set as Default** in the version list → banner disappears without needing a refresh
- [x] Create an eval from a long-named template via dataset/experiment/workbench source → auto-generated name is ≤ 50 chars and ends with `_<source>_<ddMMMyyyy_HHmm>`
- [x] Type in the eval name field → helper text shows `Use lowercase letters, numbers, hyphens (-) and underscores (_) only. n/50`
- [x] Reach 50 chars → input stops accepting input, helper text turns red with "Name can't be longer than 50 characters"
- [x] Open an existing eval in edit mode → name field stays disabled with no helper text shown
- [x] Open the Usage tab and click a log row → drawer slides in and the chart + table visibly shrink to the left (no overlap); click another row to confirm the drawer stays in place; click ✕ → main content expands back to full width
- [x] In the drawer, click **Formatted** ↔ **JSON** repeatedly → toggle switches every time, inactive tab still looks clickable (not greyed-out)



## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes TH-5191,TH-5099,TH-5096,TH-5186,TH-5285

