### PR TITLE
fix(eval-picker): hide Dataset row context toggle in tasks drawer [TH-5252]

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1398,6 +1398,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     setContextOptions(v);
                     setIsDirty(true);
                   }}
+                  hideDatasetContextToggle={source === "task"}
                 />
               )}
 

--- a/frontend/src/sections/evals/components/InstructionEditor.jsx
+++ b/frontend/src/sections/evals/components/InstructionEditor.jsx
@@ -284,6 +284,7 @@ const InstructionEditor = ({
   onSelectedKBsChange,
   activeContextOptions,
   onActiveContextOptionsChange,
+  hideDatasetContextToggle = false,
 }) => {
   const modelBarDisabled = modelSelectorDisabled ?? disabled;
   const quillRef = useRef(null);
@@ -979,6 +980,7 @@ const InstructionEditor = ({
               onSelectedKBsChange={onSelectedKBsChange}
               activeContextOptions={activeContextOptions}
               onActiveContextOptionsChange={onActiveContextOptionsChange}
+              hideDatasetContextToggle={hideDatasetContextToggle}
             />
           </Box>
           {!aiOpen && (
@@ -1023,6 +1025,7 @@ InstructionEditor.propTypes = {
   onTemplateFormatChange: PropTypes.func,
   datasetColumns: PropTypes.array,
   datasetJsonSchemas: PropTypes.object,
+  hideDatasetContextToggle: PropTypes.bool,
 };
 
 export default InstructionEditor;

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -575,6 +575,7 @@ const ModelSelector = ({
   onSelectedKBsChange,
   activeContextOptions: activeContextOptionsProp,
   onActiveContextOptionsChange,
+  hideDatasetContextToggle = false,
 }) => {
   // For each field, pick "controlled" (parent-driven) or "uncontrolled" (local state).
   const [modeLocal, setModeLocal] = useState("agent");
@@ -1672,7 +1673,10 @@ const ModelSelector = ({
             {/* ══ Data Injection submenu ══ */}
             {plusSubmenu === "injection" && (
               <Box>
-                {CONTEXT_OPTIONS.map((opt) => {
+                {CONTEXT_OPTIONS.filter(
+                  (opt) =>
+                    !(hideDatasetContextToggle && opt.value === "dataset_row"),
+                ).map((opt) => {
                   const isActive = activeContextOptions.includes(opt.value);
                   return (
                     <MenuItem
@@ -1797,6 +1801,7 @@ ModelSelector.propTypes = {
   disabled: PropTypes.bool,
   showMode: PropTypes.bool,
   showPlus: PropTypes.bool,
+  hideDatasetContextToggle: PropTypes.bool,
 };
 
 export default ModelSelector;


### PR DESCRIPTION
## Summary

The "Dataset row context" toggle in the Data Injection submenu maps to the backend `full_row` flag, which only reads from dataset `Cell` rows (`futureagi/model_hub/views/eval_runner.py:2079`). For task evals — spans / traces / sessions / voiceCalls — it's a no-op, so the toggle is dead UI in the tasks drawer.

This filters it out specifically for `source === "task"`. All other flows (datasets, develop, experiment, test) are unchanged.

## Linear

- [TH-5252 — Make the data injection toggles dynamic, no need for dataset in tasks drawer](https://linear.app/future-agi/issue/TH-5252/make-the-data-injection-toggles-dynamic-no-need-for-dataset-in-tasks)

## Implementation

- `ModelSelector.jsx` — new optional `hideDatasetContextToggle` prop (default `false`); filters `dataset_row` out of the Data Injection submenu render.
- `InstructionEditor.jsx` — accepts and forwards the prop.
- `EvalPickerConfigFull.jsx` — sets `hideDatasetContextToggle={source === "task"}` at the single `<InstructionEditor>` callsite.

The LLM-as-a-Judge path (`MessageEditor` via `LLMPromptEditor`) renders `ModelSelector` with `showPlus={false}`, so the Data Injection submenu was never reachable there — no change needed.

## Note on existing saved task evals

If a task eval was previously saved with `dataset_row` selected, the submenu will open with no toggle showing as active (the saved value matches nothing in the filtered list). This is purely cosmetic — the backend already ignores `full_row` for task runs. If we want auto-cleanup later, the loader in `EvalPickerConfigFull.jsx:518-530` can replace `dataset_row` with `contextOptionsForRowType(sourceRowType)` when `source === "task"`. Punting on that until we see if anyone is actually affected.

## Test plan

- [ ] Tasks drawer → Agents tab → click `+` → Data Injection → "Dataset row context" is **not** present. Other 5 toggles render normally.
- [ ] Dataset → create/edit eval (Agent) → Data Injection submenu → "Dataset row context" **still present**.
- [ ] Develop / Experiment / Test flows → Data Injection submenu → "Dataset row context" **still present**.
- [ ] LLM-as-a-Judge tab in tasks drawer → no `+` button (expected; unchanged).
- [ ] Existing task eval saved with `dataset_row` → opens without error, no toggle active in submenu, save/run still works (backend no-op).