### PR TITLE
fix(evals): distinguish skipped eval rows from failures (TH-4910)

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -216,7 +216,13 @@ const VoiceRightPanel = ({
       let score = null;
       let scoreLabel;
 
-      if (typeof rawValue === "number") {
+      // TH-4910 — ``skipped`` is propagated by the backend voice
+      // serializer when the span lacked the mapped attribute. Wins over
+      // the typed branches below so any residual rawValue is ignored
+      // and the badge goes gray with the "Skipped" label.
+      if (e?.skipped) {
+        scoreLabel = "Skipped";
+      } else if (typeof rawValue === "number") {
         // Numbers in [0, 1] → percent. Numbers already in [0, 100] → as-is.
         score =
           rawValue <= 1 ? Math.round(rawValue * 100) : Math.round(rawValue);

--- a/frontend/src/sections/common/EvalsTasks/TaskLogsView.jsx
+++ b/frontend/src/sections/common/EvalsTasks/TaskLogsView.jsx
@@ -393,6 +393,7 @@ const TaskLogsView = ({ evalTaskId, taskStatus }) => {
   const {
     success_count: successCount = 0,
     errors_count: errorsCount = 0,
+    skipped_count: skippedCount = 0,
     total_count: totalCount = 0,
     start_time: startTime,
     end_time: endTime,
@@ -432,7 +433,17 @@ const TaskLogsView = ({ evalTaskId, taskStatus }) => {
                 : "No data"}
           </Typography>
           <Typography variant="caption" color="text.secondary">
-            {totalCount > 0 ? `${successCount} / ${totalCount} passed` : "—"}
+            {/* TH-4910 — when every row was skipped (mapped attribute
+                missing on the matching spans), don't lie with
+                "0/N passed". Show "N/N skipped" instead, or append a
+                "· M skipped" tail when mixed. */}
+            {totalCount > 0
+              ? skippedCount === totalCount
+                ? `${skippedCount} / ${totalCount} skipped`
+                : `${successCount} / ${totalCount} passed${
+                    skippedCount > 0 ? ` · ${skippedCount} skipped` : ""
+                  }`
+              : "—"}
           </Typography>
         </Box>
         <LinearProgress
@@ -480,6 +491,16 @@ const TaskLogsView = ({ evalTaskId, taskStatus }) => {
           value={errorsCount ?? 0}
           color="error.main"
           bgColor={alpha(theme.palette.error.main, 0.1)}
+        />
+        {/* TH-4910 — skipped (mapped attribute missing on the span);
+            displayed as its own tile so customers can see at a glance
+            that the failures aren't real eval failures. */}
+        <StatCard
+          icon="solar:forbidden-circle-linear"
+          label="Skipped"
+          value={skippedCount ?? 0}
+          color="text.secondary"
+          bgColor={alpha(theme.palette.text.secondary, 0.08)}
         />
         <StatCard
           icon="solar:layers-linear"
@@ -649,17 +670,32 @@ const TaskLogsView = ({ evalTaskId, taskStatus }) => {
             borderColor: "divider",
           }}
         >
+          {/* TH-4910 — don't claim "completed successfully" when every
+              row was actually skipped. Use a neutral icon + accurate
+              copy explaining why nothing ran. */}
           <Iconify
-            icon="solar:check-circle-bold"
+            icon={
+              skippedCount === totalCount
+                ? "solar:forbidden-circle-bold"
+                : "solar:check-circle-bold"
+            }
             width={32}
-            sx={{ color: "success.main", mb: 1 }}
+            sx={{
+              color:
+                skippedCount === totalCount ? "text.secondary" : "success.main",
+              mb: 1,
+            }}
           />
           <Typography
             variant="body2"
             color="text.secondary"
             sx={{ fontSize: "13px" }}
           >
-            All evaluations completed successfully
+            {skippedCount === totalCount
+              ? `All ${totalCount} evaluation${totalCount === 1 ? "" : "s"} were skipped — the mapped attribute wasn't present on the matching spans.`
+              : skippedCount > 0
+                ? `${successCount} eval${successCount === 1 ? "" : "s"} succeeded · ${skippedCount} skipped (mapped attribute missing)`
+                : "All evaluations completed successfully"}
           </Typography>
         </Box>
       )}

--- a/frontend/src/sections/test-detail/CellRenderers/EvalCellRenderer.jsx
+++ b/frontend/src/sections/test-detail/CellRenderers/EvalCellRenderer.jsx
@@ -62,6 +62,27 @@ const EvalCellRenderer = ({ value: evalData }) => {
           <Skeleton sx={{ width: "100%", height: "20px" }} variant="rounded" />
         </Box>
       );
+    // TH-4910 — skipped wins over error so a missing-attribute row
+    // renders the neutral "Skipped" label instead of red "Error".
+    if (evalData?.skipped) {
+      return (
+        <Box
+          sx={{
+            color: "text.secondary",
+            opacity: 1,
+            flex: 1,
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+          title="Eval skipped — required attribute not present on span"
+        >
+          <Typography variant="body2" align="center">
+            Skipped
+          </Typography>
+        </Box>
+      );
+    }
     if (evalData?.error) {
       return (
         <Box
@@ -97,7 +118,10 @@ const EvalCellRenderer = ({ value: evalData }) => {
       return (
         <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
           {evalData?.value?.map((item, idx) => {
-            const label = typeof item === "object" ? (item?.choice ?? item?.value ?? JSON.stringify(item)) : item;
+            const label =
+              typeof item === "object"
+                ? item?.choice ?? item?.value ?? JSON.stringify(item)
+                : item;
             return (
               <Chip
                 color="primary"

--- a/futureagi/ai_tools/tools/tracing/get_eval_task_logs.py
+++ b/futureagi/ai_tools/tools/tracing/get_eval_task_logs.py
@@ -45,12 +45,21 @@ class GetEvalTaskLogsTool(BaseTool):
         except EvalTask.DoesNotExist:
             return ToolResult.not_found("EvalTask", str(params.eval_task_id))
 
+        # TH-4910: skipped rows have error=True + skipped_reason set; exclude
+        # them from both error_count and the error_message aggregate.
         log_stats = EvalLogger.objects.filter(
             eval_task_id=str(params.eval_task_id), deleted=False
         ).aggregate(
-            errors_count=Count("id", filter=Q(error=True)),
-            success_count=Count("id", filter=Q(error=False)),
-            errors_message=ArrayAgg("eval_explanation", filter=Q(error=True)),
+            errors_count=Count(
+                "id", filter=Q(error=True) & Q(skipped_reason__isnull=True)
+            ),
+            success_count=Count(
+                "id", filter=Q(error=False) & Q(skipped_reason__isnull=True)
+            ),
+            errors_message=ArrayAgg(
+                "eval_explanation",
+                filter=Q(error=True) & Q(skipped_reason__isnull=True),
+            ),
         )
 
         total_count = log_stats["errors_count"] + log_stats["success_count"]

--- a/futureagi/tracer/migrations/0078_backfill_skipped_eval_loggers.py
+++ b/futureagi/tracer/migrations/0078_backfill_skipped_eval_loggers.py
@@ -1,0 +1,56 @@
+"""TH-4910: backfill legacy "Required attribute" rows to the skipped sentinel.
+
+Before this PR, when ``_process_mapping`` raised because a span lacked
+the attribute its eval mapping pointed at, the dispatch wrote an
+``EvalLogger`` row with ``error=True`` and ``error_message`` starting
+with "Error during evaluation: Required attribute". The dashboard then
+rendered "Fail" / "Error" — the bug Mudflap / Ghosted-Prod filed.
+
+The new code branches on ``EvalSkippedMissingAttribute`` and writes
+the row with the sentinel ``output_str = "__SKIPPED_MISSING_ATTRIBUTE__"``,
+``error=False``, ``error_message=NULL`` so the read paths render it as
+"Skipped".
+
+Existing rows from before this PR still have the legacy shape. This
+migration rewrites them to the new shape in a single UPDATE so customer
+dashboards reflect the fix without waiting for the eval task to re-run.
+
+Forward-only — the rewrite clears ``error_message``, so reverse can't
+reconstruct which rows were the originals.
+"""
+
+from django.db import migrations
+
+
+# Inlined (rather than imported from tracer.utils.eval) so the migration
+# is stable even if the constant is renamed later. Migrations are
+# historical artefacts; they shouldn't depend on the live module.
+LEGACY_ERROR_PREFIX = "Error during evaluation: Required attribute"
+SKIPPED_OUTPUT_STR = "__SKIPPED_MISSING_ATTRIBUTE__"
+
+
+def forward(apps, schema_editor):
+    EvalLogger = apps.get_model("tracer", "EvalLogger")
+    EvalLogger.objects.filter(
+        error=True,
+        error_message__startswith=LEGACY_ERROR_PREFIX,
+    ).update(
+        error=False,
+        error_message=None,
+        output_str=SKIPPED_OUTPUT_STR,
+    )
+
+
+def reverse(apps, schema_editor):
+    """No-op — the rewrite cleared ``error_message`` so reverse is lossy."""
+    return
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tracer", "0077_merge_20260514_1559"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse),
+    ]

--- a/futureagi/tracer/migrations/0079_evallogger_skipped_reason.py
+++ b/futureagi/tracer/migrations/0079_evallogger_skipped_reason.py
@@ -1,0 +1,26 @@
+"""TH-4910: add ``skipped_reason`` column to ``tracer_eval_logger``.
+
+Set when ``_process_mapping`` raises a missing-attribute error so the
+row is rendered as "Skipped" (not "Fail") and excluded from
+failure-rate metrics. See ``tracer.utils.eval.EvalSkippedMissingAttribute``.
+
+Nullable + non-indexed: read paths use ``skipped_reason IS NOT NULL``
+as a coarse filter that piggy-backs on existing per-task / per-span
+indexes upstream, so a dedicated index is unnecessary.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tracer", "0078_backfill_skipped_eval_loggers"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evallogger",
+            name="skipped_reason",
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/futureagi/tracer/migrations/0080_backfill_evallogger_skipped_reason.py
+++ b/futureagi/tracer/migrations/0080_backfill_evallogger_skipped_reason.py
@@ -1,0 +1,99 @@
+"""TH-4910: backfill ``skipped_reason`` on rows the prior bug created.
+
+Two shapes existed before this PR landed:
+
+1. **Legacy prod shape** — ``error=True`` and ``error_message`` starting
+   with "Error during evaluation: Required attribute". The dispatch
+   raised on a missing span attribute and we wrote a generic error
+   row. These rows render as "Fail" on customer dashboards — the bug
+   Mudflap / Ghosted-Prod filed.
+
+2. **Intermediate sentinel shape** — ``output_str =
+   "__SKIPPED_MISSING_ATTRIBUTE__"`` with ``error=False``. Created by
+   the first attempt at this fix (migration 0078). Only ever appears
+   on local DBs that ran the earlier version.
+
+Both shapes get rewritten to the ticket-prescribed shape: ``error=True``,
+``skipped_reason = "missing_required_attribute: <attr>"``, and the
+sentinel cleared from ``output_str``. The attribute name is parsed
+from ``error_message`` (legacy) or ``output_metadata.missing_attribute``
+(sentinel); when parsing fails we still set the prefix so the row is at
+least classified as skipped.
+
+Forward-only. Reverse is a no-op because the attribute name is also
+re-derived from the same fields the forward pass overwrites.
+"""
+
+import re
+
+from django.db import migrations
+
+
+LEGACY_ERROR_PREFIX = "Error during evaluation: Required attribute"
+STALE_SENTINEL = "__SKIPPED_MISSING_ATTRIBUTE__"
+SKIPPED_REASON_PREFIX = "missing_required_attribute"
+# Matches the format raised by ``EvalSkippedMissingAttribute.__init__``:
+#   "Required attribute 'X' for key 'Y' not found for span Z"
+_ATTR_RE = re.compile(r"Required attribute '([^']+)'")
+
+
+def _reason_for(row):
+    """Derive ``skipped_reason`` from whichever shape this row is in."""
+    attr = None
+    if row.error_message:
+        match = _ATTR_RE.search(row.error_message)
+        if match:
+            attr = match.group(1)
+    if not attr and isinstance(row.output_metadata, dict):
+        attr = row.output_metadata.get("missing_attribute")
+    if attr:
+        return f"{SKIPPED_REASON_PREFIX}: {attr}"
+    return SKIPPED_REASON_PREFIX
+
+
+def forward(apps, schema_editor):
+    EvalLogger = apps.get_model("tracer", "EvalLogger")
+
+    # Legacy shape: error=True + "Required attribute" prefix.
+    legacy = EvalLogger.objects.filter(
+        error=True,
+        error_message__startswith=LEGACY_ERROR_PREFIX,
+        skipped_reason__isnull=True,
+    )
+    for row in legacy.iterator():
+        row.skipped_reason = _reason_for(row)
+        row.save(update_fields=["skipped_reason"])
+
+    # Intermediate shape: sentinel in output_str. Flip error back to True
+    # to match the new contract and clear the sentinel.
+    sentinel = EvalLogger.objects.filter(output_str=STALE_SENTINEL)
+    for row in sentinel.iterator():
+        row.skipped_reason = _reason_for(row)
+        row.error = True
+        row.error_message = (
+            row.error_message
+            or f"Required attribute not found (backfilled from sentinel)"
+        )
+        row.output_str = None
+        row.save(
+            update_fields=[
+                "skipped_reason",
+                "error",
+                "error_message",
+                "output_str",
+            ]
+        )
+
+
+def reverse(apps, schema_editor):
+    return
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tracer", "0079_evallogger_skipped_reason"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse),
+    ]

--- a/futureagi/tracer/models/observation_span.py
+++ b/futureagi/tracer/models/observation_span.py
@@ -311,6 +311,12 @@ class EvalLogger(BaseModel):
     )
     error = models.BooleanField(default=False)
     error_message = models.TextField(null=True, blank=True)
+    # TH-4910 — set to "missing_required_attribute: <attr>" when an eval
+    # was skipped because the mapped span attribute was absent. Distinct
+    # from a real eval failure: read paths filter on
+    # ``skipped_reason IS NOT NULL`` to render "Skipped" instead of
+    # "Fail" and exclude these rows from failure-rate metrics.
+    skipped_reason = models.TextField(null=True, blank=True)
 
     def __str__(self):
         return f"Eval Log {self.id}"

--- a/futureagi/tracer/services/clickhouse/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/span_list.py
@@ -245,8 +245,12 @@ class SpanListQueryBuilder(BaseQueryBuilder):
             countIf(
                 error = 0 AND ifNull(output_str, '') != 'ERROR'
             ) AS success_count,
+            -- TH-4910: skipped rows have error=1; exclude so error_count
+            -- reflects real failures only ("skipped doesn't count toward
+            -- failure rate" per the ticket).
             countIf(
-                error = 1 OR ifNull(output_str, '') = 'ERROR'
+                (error = 1 OR ifNull(output_str, '') = 'ERROR')
+                AND skipped_reason IS NULL
             ) AS error_count,
             count() AS eval_count,
             groupArrayIf(

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -577,10 +577,22 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             pass_rate = _get(row, "pass_rate", 3)
             success_count = _get(row, "success_count", 4, 0) or 0
             error_count = _get(row, "error_count", 5, 0) or 0
-            str_lists = _get(row, "str_lists", 7, []) or []
+            # TH-4910 — ``skipped_count`` is emitted by callers that
+            # opted into the skipped-sentinel grouping (currently
+            # ``VoiceCallListQueryBuilder.build_eval_query``). Defaults
+            # to 0 for callers that haven't.
+            skipped_count = _get(row, "skipped_count", 6, 0) or 0
+            str_lists = _get(row, "str_lists", 8, []) or []
 
-            # All rows errored — surface an explicit error marker so the
-            # UI can render an error state (distinct from "no eval run").
+            # Skipped takes precedence over error: the eval pipeline
+            # never ran, so surfacing "Error" would falsely flag the
+            # model — exactly the bug TH-4910 was filed to fix.
+            if success_count == 0 and skipped_count > 0 and error_count == 0:
+                result.setdefault(trace_id, {})[config_id] = {"skipped": True}
+                continue
+
+            # All non-skipped rows errored — explicit error marker
+            # distinct from "no eval run" / "skipped".
             if success_count == 0 and error_count > 0:
                 result.setdefault(trace_id, {})[config_id] = {"error": True}
                 continue

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -429,8 +429,12 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             countIf(
                 error = 0 AND ifNull(output_str, '') != 'ERROR'
             ) AS success_count,
+            -- TH-4910: skipped rows have error=1; exclude so error_count
+            -- reflects real failures only ("skipped doesn't count toward
+            -- failure rate" per the ticket).
             countIf(
-                error = 1 OR ifNull(output_str, '') = 'ERROR'
+                (error = 1 OR ifNull(output_str, '') = 'ERROR')
+                AND skipped_reason IS NULL
             ) AS error_count,
             count() AS eval_count,
             groupArrayIf(

--- a/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
@@ -212,9 +212,20 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
         if not trace_ids or not self.eval_config_ids:
             return "", {}
 
+        # TH-4910: rows tagged with ``EVAL_SKIPPED_OUTPUT_STR`` in
+        # ``output_str`` are skipped (eval pipeline never ran), not real
+        # results. Exclude them from score aggregates and surface a
+        # ``skipped_count`` so the caller's pivot
+        # (TraceListQueryBuilder.pivot_eval_results) can emit a
+        # ``{"skipped": True}`` marker for the (trace, config) pair.
+        # Imported here (not at module top) to avoid a circular import
+        # between ``tracer.utils.eval`` and the CH-side service code.
+        from tracer.utils.eval import EVAL_SKIPPED_OUTPUT_STR
+
         params: Dict[str, Any] = {
             "trace_ids": tuple(trace_ids),
             "eval_config_ids": tuple(self.eval_config_ids),
+            "skipped_sentinel": EVAL_SKIPPED_OUTPUT_STR,
         }
 
         query = f"""
@@ -223,9 +234,19 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
             toString(custom_eval_config_id) AS eval_config_id,
             -- ifNotFinite(, NULL): avg over an all-NULL group returns NaN, which
             -- json.dumps(allow_nan=False) rejects. NULL serializes as null.
-            ifNotFinite(avg(output_float), NULL) AS avg_score,
-            ifNotFinite(avg(CASE WHEN output_bool = 1 THEN 100.0 ELSE 0.0 END), NULL)
-                AS pass_rate,
+            ifNotFinite(
+                avgIf(output_float, ifNull(output_str, '') != %(skipped_sentinel)s),
+                NULL
+            ) AS avg_score,
+            ifNotFinite(
+                avgIf(
+                    CASE WHEN output_bool = 1 THEN 100.0 ELSE 0.0 END,
+                    ifNull(output_str, '') != %(skipped_sentinel)s
+                ),
+                NULL
+            ) AS pass_rate,
+            countIf(ifNull(output_str, '') != %(skipped_sentinel)s) AS success_count,
+            countIf(ifNull(output_str, '') = %(skipped_sentinel)s) AS skipped_count,
             count() AS eval_count,
             any(output_str_list) AS output_str_list
         FROM {self.EVAL_TABLE} FINAL

--- a/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
@@ -212,20 +212,14 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
         if not trace_ids or not self.eval_config_ids:
             return "", {}
 
-        # TH-4910: rows tagged with ``EVAL_SKIPPED_OUTPUT_STR`` in
-        # ``output_str`` are skipped (eval pipeline never ran), not real
-        # results. Exclude them from score aggregates and surface a
-        # ``skipped_count`` so the caller's pivot
-        # (TraceListQueryBuilder.pivot_eval_results) can emit a
-        # ``{"skipped": True}`` marker for the (trace, config) pair.
-        # Imported here (not at module top) to avoid a circular import
-        # between ``tracer.utils.eval`` and the CH-side service code.
-        from tracer.utils.eval import EVAL_SKIPPED_OUTPUT_STR
-
+        # TH-4910: ``skipped_reason IS NOT NULL`` flags rows the
+        # dispatch wrote because the span lacked the mapped attribute
+        # (eval pipeline never ran). Excluded from score aggregates;
+        # surfaced as ``skipped_count`` so pivot_eval_results can emit
+        # a ``{"skipped": True}`` marker.
         params: Dict[str, Any] = {
             "trace_ids": tuple(trace_ids),
             "eval_config_ids": tuple(self.eval_config_ids),
-            "skipped_sentinel": EVAL_SKIPPED_OUTPUT_STR,
         }
 
         query = f"""
@@ -235,18 +229,18 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
             -- ifNotFinite(, NULL): avg over an all-NULL group returns NaN, which
             -- json.dumps(allow_nan=False) rejects. NULL serializes as null.
             ifNotFinite(
-                avgIf(output_float, ifNull(output_str, '') != %(skipped_sentinel)s),
+                avgIf(output_float, skipped_reason IS NULL),
                 NULL
             ) AS avg_score,
             ifNotFinite(
                 avgIf(
                     CASE WHEN output_bool = 1 THEN 100.0 ELSE 0.0 END,
-                    ifNull(output_str, '') != %(skipped_sentinel)s
+                    skipped_reason IS NULL
                 ),
                 NULL
             ) AS pass_rate,
-            countIf(ifNull(output_str, '') != %(skipped_sentinel)s) AS success_count,
-            countIf(ifNull(output_str, '') = %(skipped_sentinel)s) AS skipped_count,
+            countIf(skipped_reason IS NULL) AS success_count,
+            countIf(skipped_reason IS NOT NULL) AS skipped_count,
             count() AS eval_count,
             any(output_str_list) AS output_str_list
         FROM {self.EVAL_TABLE} FINAL

--- a/futureagi/tracer/services/clickhouse/schema.py
+++ b/futureagi/tracer/services/clickhouse/schema.py
@@ -280,6 +280,10 @@ CREATE TABLE IF NOT EXISTS tracer_eval_logger (
     -- Error tracking
     error UInt8 DEFAULT 0,
     error_message Nullable(String),
+    -- TH-4910: distinguishes skipped (missing required span attr) from a
+    -- real eval failure. Skipped rows still set error=1 per the ticket
+    -- contract; read paths filter on ``skipped_reason IS NOT NULL``.
+    skipped_reason Nullable(String),
 
     -- Explanation / metadata
     eval_explanation Nullable(String),
@@ -1026,7 +1030,8 @@ SELECT
     countIf(e.output_float IS NOT NULL)                            AS float_count,
     countIf(e.output_bool = 1)                                     AS bool_pass,
     countIf(e.output_bool = 0 AND e.output_bool IS NOT NULL)       AS bool_fail,
-    countIf(e.error = 1)                                           AS error_count
+    -- TH-4910: exclude skipped rows from error_count; they're not failures.
+    countIf(e.error = 1 AND e.skipped_reason IS NULL)              AS error_count
 
 FROM tracer_eval_logger AS e
 WHERE e._peerdb_is_deleted = 0
@@ -1873,6 +1878,11 @@ POST_DDL_ALTERS: List[str] = [
     "idx_trace_session_id trace_session_id TYPE bloom_filter GRANULARITY 1",
     "ALTER TABLE tracer_eval_logger ADD INDEX IF NOT EXISTS "
     "idx_target_type target_type TYPE bloom_filter GRANULARITY 1",
+    # TH-4910: skipped vs failed distinction. Nullable column, no index —
+    # voice/eval read paths filter on ``skipped_reason IS NOT NULL`` as a
+    # coarse classifier riding on existing per-task / per-trace indexes.
+    "ALTER TABLE tracer_eval_logger ADD COLUMN IF NOT EXISTS "
+    "skipped_reason Nullable(String)",
 ]
 
 
@@ -1931,7 +1941,8 @@ MV_RECREATE_MANIFEST: Dict[str, Dict[str, Optional[str]]] = {
                 countIf(e.output_float IS NOT NULL)                            AS float_count,
                 countIf(e.output_bool = 1)                                     AS bool_pass,
                 countIf(e.output_bool = 0 AND e.output_bool IS NOT NULL)       AS bool_fail,
-                countIf(e.error = 1)                                           AS error_count
+                -- TH-4910: exclude skipped rows from error_count.
+                countIf(e.error = 1 AND e.skipped_reason IS NULL)              AS error_count
 
             FROM tracer_eval_logger AS e
             WHERE e._peerdb_is_deleted = 0

--- a/futureagi/tracer/tests/test_process_mapping.py
+++ b/futureagi/tracer/tests/test_process_mapping.py
@@ -4,7 +4,7 @@ import uuid
 
 import pytest
 
-from tracer.utils.eval import _process_mapping
+from tracer.utils.eval import EvalSkippedMissingAttribute, _process_mapping
 
 
 @pytest.fixture
@@ -91,7 +91,27 @@ def test_provider_transcript_alias_resolves(_span_with_attrs, missing_eval_templ
 
 def test_missing_attribute_raises(_span_with_attrs, missing_eval_template_id):
     span = _span_with_attrs({"unrelated": "value"})
+    # ``EvalSkippedMissingAttribute`` is a ``ValueError`` subclass so
+    # legacy ``except ValueError`` clauses still catch it.
     with pytest.raises(ValueError, match="Required attribute 'input'"):
         _process_mapping(
             {"prompt": "input"}, span, eval_template_id=missing_eval_template_id
         )
+
+
+def test_missing_attribute_raises_typed_skip_exception(
+    _span_with_attrs, missing_eval_template_id
+):
+    # TH-4910 contract: dispatch sites detect ``EvalSkippedMissingAttribute``
+    # specifically and write a *skipped* row, distinct from a real eval
+    # failure. If this assertion ever regresses to a plain ``ValueError``
+    # the "Skipped" vs "Fail" distinction collapses silently — no test
+    # would catch it without this one.
+    span = _span_with_attrs({"unrelated": "value"})
+    with pytest.raises(EvalSkippedMissingAttribute) as excinfo:
+        _process_mapping(
+            {"prompt": "input"}, span, eval_template_id=missing_eval_template_id
+        )
+    assert excinfo.value.attribute == "input"
+    assert excinfo.value.key == "prompt"
+    assert excinfo.value.span_id == str(span.id)

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -37,6 +37,41 @@ custom_prompt_eval_types = ["CustomPrompt"]
 EXPERIMENT = "experiment"
 OBSERVE = "observe"
 
+
+# TH-4910 — distinct ``output_str`` sentinel for eval rows that were
+# skipped because the dispatch had no input data (the span lacked the
+# attribute the mapping pointed at). Tighter than bare ``"SKIPPED"`` so
+# a customer's custom eval can't accidentally collide by emitting that
+# string itself. Read by:
+#   * ``_create_error_eval_logger`` (this file, write site)
+#   * ``tracer.views.eval_task.get_eval_task_logs`` (count aggregate)
+#   * ``tracer.views.trace.populate_call_logs_result`` (PG voice list)
+#   * ``tracer.views.trace.voice_call_detail`` (PG voice detail)
+#   * ``tracer.views.trace._voice_call_detail_clickhouse`` (CH voice detail)
+#   * ``tracer.services.clickhouse.query_builders.voice_call_list``
+#     (CH voice list builder)
+# Anyone touching the sentinel string must update all six call sites.
+EVAL_SKIPPED_OUTPUT_STR = "__SKIPPED_MISSING_ATTRIBUTE__"
+
+
+class EvalSkippedMissingAttribute(ValueError):
+    """Raised by ``_process_mapping`` when the span has no value for the
+    attribute that the eval config's mapping points at.
+
+    Subclasses ``ValueError`` so legacy ``except ValueError`` handlers
+    in the dispatch chain still catch it. The typed identity lets
+    ``_create_error_eval_logger`` mark the resulting ``EvalLogger`` row
+    as **skipped** (TH-4910) instead of as a real eval failure.
+    """
+
+    def __init__(self, attribute: str, key: str, span_id: str):
+        self.attribute = attribute
+        self.key = key
+        self.span_id = span_id
+        super().__init__(
+            f"Required attribute '{attribute}' for key '{key}' not found for span {span_id}"
+        )
+
 # Re-export for backward compat
 from tracer.utils.eval_helpers import resolve_eval_config_id  # noqa: F401, E402
 
@@ -435,8 +470,15 @@ def _process_mapping(
             logger.error(
                 f"Required attribute '{attribute}' for key '{key}' not found for span {span.id}"
             )
-            raise ValueError(
-                f"Required attribute '{attribute}' for key '{key}' not found for span {span.id}"
+            # TH-4910: the eval did not run — span had no value for the
+            # mapped attribute. Raise a typed subclass of ``ValueError``
+            # so the dispatch chain's ``except ValueError`` clauses still
+            # catch it and ``_create_error_eval_logger`` can detect the
+            # type and write a *skipped* row instead of a failure row.
+            # DO NOT change this exception class without also updating
+            # ``_create_error_eval_logger`` — they are a contract pair.
+            raise EvalSkippedMissingAttribute(
+                attribute=attribute, key=key, span_id=str(span.id)
             )
 
     return parsed_mapping
@@ -1100,10 +1142,43 @@ def _create_error_eval_logger(
     custom_eval_config: CustomEvalConfig,
     eval_task_id: str,
     error_message: str,
+    exc: BaseException | None = None,
 ):
+    """Persist an EvalLogger row for a failed (or skipped) eval dispatch.
+
+    TH-4910: when ``exc`` is a ``EvalSkippedMissingAttribute`` instance,
+    the span had no value for the mapped attribute — the eval pipeline
+    never ran. That row is written as **skipped** (``output_str`` set
+    to ``EVAL_SKIPPED_OUTPUT_STR``, ``error=False``) so the read paths
+    can render "Skipped" instead of "Fail" / "Error".
+
+    All other paths keep the legacy error shape.
     """
-    Create an error eval logger for the given observation span, custom eval config, and eval task id.
-    """
+    if isinstance(exc, EvalSkippedMissingAttribute):
+        EvalLogger.objects.create(
+            trace=observation_span.trace,
+            observation_span=observation_span,
+            output_metadata={
+                "skipped": True,
+                "missing_attribute": exc.attribute,
+                "mapping_key": exc.key,
+            },
+            eval_explanation=(
+                f"Skipped: required attribute '{exc.attribute}' for key "
+                f"'{exc.key}' not present on span"
+            ),
+            results_explanation={"reason": str(exc)},
+            eval_task_id=eval_task_id,
+            custom_eval_config=custom_eval_config,
+            # Skipped rows are NOT eval failures — leave ``error`` /
+            # ``error_message`` empty so failure-rate aggregates and the
+            # error_groups grouping in get_eval_task_logs ignore them.
+            error=False,
+            error_message=None,
+            output_str=EVAL_SKIPPED_OUTPUT_STR,
+        )
+        return
+
     EvalLogger.objects.create(
         trace=observation_span.trace,
         observation_span=observation_span,
@@ -1175,8 +1250,13 @@ def evaluate_observation_span(
         )
         return True
     except ValueError as e:
+        # ``EvalSkippedMissingAttribute`` is a ``ValueError`` subclass —
+        # caught here and passed through ``exc`` so the helper can write
+        # a *skipped* row instead of an error row (TH-4910).
         logger.error(f"Error during evaluation in evaluate_observation_span: {e}")
-        _create_error_eval_logger(observation_span, custom_eval_config, None, str(e))
+        _create_error_eval_logger(
+            observation_span, custom_eval_config, None, str(e), exc=e
+        )
         return False
 
     except Exception as e:
@@ -1314,13 +1394,18 @@ def evaluate_observation_span_observe(
                         eval_task.failed_spans if eval_task.failed_spans else []
                     )
 
-                    failed_spans.append(
-                        {
-                            "observation_span_id": observation_span_id,
-                            "custom_eval_config_id": custom_eval_config_id,
-                            "error": str(e),
-                        }
-                    )
+                    # TH-4910: tag the entry as skipped when the cause
+                    # was a missing-attribute exception so downstream
+                    # consumers of ``failed_spans`` can re-categorise
+                    # without re-parsing the message.
+                    entry = {
+                        "observation_span_id": observation_span_id,
+                        "custom_eval_config_id": custom_eval_config_id,
+                        "error": str(e),
+                    }
+                    if isinstance(e, EvalSkippedMissingAttribute):
+                        entry["reason"] = "skipped_missing_attribute"
+                    failed_spans.append(entry)
 
                     eval_task.failed_spans = failed_spans
                     eval_task.save(update_fields=["failed_spans", "updated_at"])
@@ -1330,8 +1415,10 @@ def evaluate_observation_span_observe(
                 logger.error(
                     f"Error during updating failed spans in exception handling evaluate_observation_span_observe: {e}"
                 )
+        # TH-4910 — pass ``exc=e`` so the helper can detect a
+        # ``EvalSkippedMissingAttribute`` and write a skipped row.
         _create_error_eval_logger(
-            observation_span, custom_eval_config, eval_task_id, str(e)
+            observation_span, custom_eval_config, eval_task_id, str(e), exc=e
         )
 
         return False

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -38,20 +38,12 @@ EXPERIMENT = "experiment"
 OBSERVE = "observe"
 
 
-# TH-4910 — distinct ``output_str`` sentinel for eval rows that were
-# skipped because the dispatch had no input data (the span lacked the
-# attribute the mapping pointed at). Tighter than bare ``"SKIPPED"`` so
-# a customer's custom eval can't accidentally collide by emitting that
-# string itself. Read by:
-#   * ``_create_error_eval_logger`` (this file, write site)
-#   * ``tracer.views.eval_task.get_eval_task_logs`` (count aggregate)
-#   * ``tracer.views.trace.populate_call_logs_result`` (PG voice list)
-#   * ``tracer.views.trace.voice_call_detail`` (PG voice detail)
-#   * ``tracer.views.trace._voice_call_detail_clickhouse`` (CH voice detail)
-#   * ``tracer.services.clickhouse.query_builders.voice_call_list``
-#     (CH voice list builder)
-# Anyone touching the sentinel string must update all six call sites.
-EVAL_SKIPPED_OUTPUT_STR = "__SKIPPED_MISSING_ATTRIBUTE__"
+# TH-4910 — prefix written into ``EvalLogger.skipped_reason`` when the
+# dispatch had no input data (the span lacked the attribute the eval
+# mapping pointed at). Read by ``get_eval_task_logs`` aggregates and
+# the voice render paths to distinguish "Skipped" from "Fail" and to
+# exclude skipped rows from failure-rate metrics.
+EVAL_SKIPPED_REASON_PREFIX = "missing_required_attribute"
 
 
 class EvalSkippedMissingAttribute(ValueError):
@@ -1148,11 +1140,10 @@ def _create_error_eval_logger(
 
     TH-4910: when ``exc`` is a ``EvalSkippedMissingAttribute`` instance,
     the span had no value for the mapped attribute — the eval pipeline
-    never ran. That row is written as **skipped** (``output_str`` set
-    to ``EVAL_SKIPPED_OUTPUT_STR``, ``error=False``) so the read paths
-    can render "Skipped" instead of "Fail" / "Error".
-
-    All other paths keep the legacy error shape.
+    never ran. That row is written as **skipped** (``error=True`` with
+    ``skipped_reason`` set per the ticket contract) so failure-rate
+    aggregates that exclude ``skipped_reason IS NOT NULL`` ignore it
+    while the read paths still render "Skipped" instead of "Fail".
     """
     if isinstance(exc, EvalSkippedMissingAttribute):
         EvalLogger.objects.create(
@@ -1170,12 +1161,9 @@ def _create_error_eval_logger(
             results_explanation={"reason": str(exc)},
             eval_task_id=eval_task_id,
             custom_eval_config=custom_eval_config,
-            # Skipped rows are NOT eval failures — leave ``error`` /
-            # ``error_message`` empty so failure-rate aggregates and the
-            # error_groups grouping in get_eval_task_logs ignore them.
-            error=False,
-            error_message=None,
-            output_str=EVAL_SKIPPED_OUTPUT_STR,
+            error=True,
+            error_message=str(exc),
+            skipped_reason=f"{EVAL_SKIPPED_REASON_PREFIX}: {exc.attribute}",
         )
         return
 

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -35,7 +35,10 @@ class _RegexpReplace(Func):
 
 
 # Re-exported for back-compat; canonical definition lives in `tracer.utils.eval`.
-from tracer.utils.eval import _walk_dotted_path  # noqa: E402, F401
+from tracer.utils.eval import (  # noqa: E402, F401
+    EVAL_SKIPPED_OUTPUT_STR,
+    _walk_dotted_path,
+)
 
 
 # Per-variable size cap to keep the panel payload bounded — a single
@@ -268,10 +271,24 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                 or self.request.user.organization,
             )
 
-            # Pass/fail counts — cheap aggregate, two indexed COUNTs.
+            # Pass / fail / skipped counts — cheap aggregate, three
+            # indexed COUNTs.
+            # TH-4910: skipped rows carry ``output_str = EVAL_SKIPPED_OUTPUT_STR``
+            # (sentinel written by ``_create_error_eval_logger`` when the
+            # span lacked the mapped attribute). They are neither a
+            # success nor a failure — they get their own bucket and are
+            # excluded from the success denominator so the failure rate
+            # doesn't get diluted.
             counts = EvalLogger.objects.filter(eval_task_id=eval_task_id).aggregate(
                 errors_count=Count("id", filter=Q(error=True)),
-                success_count=Count("id", filter=Q(error=False)),
+                success_count=Count(
+                    "id",
+                    filter=Q(error=False)
+                    & ~Q(output_str=EVAL_SKIPPED_OUTPUT_STR),
+                ),
+                skipped_count=Count(
+                    "id", filter=Q(output_str=EVAL_SKIPPED_OUTPUT_STR)
+                ),
             )
 
             # ── Pre-aggregate error groups in SQL ──
@@ -327,13 +344,18 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                 for row in error_groups_qs
             ]
 
-            total_count = counts["errors_count"] + counts["success_count"]
+            total_count = (
+                counts["errors_count"]
+                + counts["success_count"]
+                + counts["skipped_count"]
+            )
 
             result = {
                 "start_time": eval_task.start_time,
                 "end_time": eval_task.end_time,
                 "errors_count": counts["errors_count"],
                 "success_count": counts["success_count"],
+                "skipped_count": counts["skipped_count"],
                 "total_count": total_count,
                 "error_groups": error_groups,
                 # Indicates whether we capped at _ERROR_GROUPS_LIMIT — the

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -35,10 +35,7 @@ class _RegexpReplace(Func):
 
 
 # Re-exported for back-compat; canonical definition lives in `tracer.utils.eval`.
-from tracer.utils.eval import (  # noqa: E402, F401
-    EVAL_SKIPPED_OUTPUT_STR,
-    _walk_dotted_path,
-)
+from tracer.utils.eval import _walk_dotted_path  # noqa: E402, F401
 
 
 # Per-variable size cap to keep the panel payload bounded — a single
@@ -273,21 +270,20 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
 
             # Pass / fail / skipped counts — cheap aggregate, three
             # indexed COUNTs.
-            # TH-4910: skipped rows carry ``output_str = EVAL_SKIPPED_OUTPUT_STR``
-            # (sentinel written by ``_create_error_eval_logger`` when the
-            # span lacked the mapped attribute). They are neither a
-            # success nor a failure — they get their own bucket and are
-            # excluded from the success denominator so the failure rate
-            # doesn't get diluted.
+            # TH-4910: skipped rows carry ``skipped_reason`` and are
+            # neither a success nor a failure — excluded from both
+            # buckets so the failure rate isn't diluted.
             counts = EvalLogger.objects.filter(eval_task_id=eval_task_id).aggregate(
-                errors_count=Count("id", filter=Q(error=True)),
+                errors_count=Count(
+                    "id",
+                    filter=Q(error=True) & Q(skipped_reason__isnull=True),
+                ),
                 success_count=Count(
                     "id",
-                    filter=Q(error=False)
-                    & ~Q(output_str=EVAL_SKIPPED_OUTPUT_STR),
+                    filter=Q(error=False) & Q(skipped_reason__isnull=True),
                 ),
                 skipped_count=Count(
-                    "id", filter=Q(output_str=EVAL_SKIPPED_OUTPUT_STR)
+                    "id", filter=Q(skipped_reason__isnull=False)
                 ),
             )
 
@@ -323,7 +319,11 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             )
 
             error_groups_qs = (
-                EvalLogger.objects.filter(eval_task_id=eval_task_id, error=True)
+                EvalLogger.objects.filter(
+                    eval_task_id=eval_task_id,
+                    error=True,
+                    skipped_reason__isnull=True,
+                )
                 .annotate(normalized=normalized_expr)
                 .values("normalized")
                 .annotate(
@@ -492,10 +492,17 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                 if earliest:
                     start_date = earliest
 
-            success_count = period_qs.filter(error=False).count()
-            error_count = period_qs.filter(error=True).count()
+            # TH-4910: skipped rows (error=True + skipped_reason set) must
+            # not count toward error_count or dilute the pass_rate denominator.
+            success_count = period_qs.filter(
+                error=False, skipped_reason__isnull=True
+            ).count()
+            error_count = period_qs.filter(
+                error=True, skipped_reason__isnull=True
+            ).count()
+            denom = success_count + error_count
             pass_rate = (
-                round((success_count / runs_period * 100), 2) if runs_period > 0 else 0
+                round((success_count / denom * 100), 2) if denom > 0 else 0
             )
 
             # ── Chart data — bucket by period and aggregate ──

--- a/futureagi/tracer/views/project_version.py
+++ b/futureagi/tracer/views/project_version.py
@@ -1269,6 +1269,7 @@ class ProjectVersionView(BaseModelViewSetMixin, ModelViewSet):
                                 custom_eval_config_id=custom_eval_config_id,
                             )
                             .filter(Q(error=True) | Q(output_str="ERROR"))
+                            .filter(skipped_reason__isnull=True)
                             .order_by("-created_at")
                             .first()
                         )

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -65,6 +65,7 @@ from tracer.services.clickhouse.query_builders import (
 from tracer.services.clickhouse.query_service import AnalyticsQueryService, QueryType
 from tracer.services.observability_providers import ObservabilityService
 from tracer.utils.aggregates import JSONBObjectAgg
+from tracer.utils.eval import EVAL_SKIPPED_OUTPUT_STR  # TH-4910 skipped sentinel
 from tracer.utils.annotations import (
     build_annotation_subqueries as _build_annotation_subqueries_impl,
 )
@@ -1131,6 +1132,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 metric_type = getattr(trace, f"metric_type_{config.id}", None)
                 reason = getattr(trace, f"metric_reason_{config.id}", None)
                 error = getattr(trace, f"error_{config.id}", False)
+                skipped = bool(getattr(trace, f"skipped_{config.id}", False))
                 metric_name = getattr(config, "name", None) or (
                     getattr(config, "eval_template", None).name
                     if getattr(config, "eval_template", None)
@@ -1142,6 +1144,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     "output_type": metric_type,
                     "reason": reason,
                     "error": error,
+                    "skipped": skipped,
                 }
 
                 if isinstance(data, list):
@@ -1328,6 +1331,18 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                         metric_subquery.values("eval_explanation")
                     ),
                     f"error_{config.id}": Subquery(metric_subquery.values("error")),
+                    # TH-4910 — does this (trace, config) pair have a
+                    # row tagged with the skipped sentinel? Used by
+                    # ``populate_call_logs_result`` to surface
+                    # ``metric_entry["skipped"]`` so the FE renders
+                    # "Skipped" not "Fail" / "Error".
+                    f"skipped_{config.id}": Exists(
+                        EvalLogger.objects.filter(
+                            trace_id=OuterRef("id"),
+                            custom_eval_config_id=config.id,
+                            output_str=EVAL_SKIPPED_OUTPUT_STR,
+                        )
+                    ),
                 }
             )
         return eval_configs, base_query
@@ -3670,16 +3685,23 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                         "output": None,
                         "reason": None,
                         "error": None,
+                        "skipped": False,
                     }
                     continue
 
+                # TH-4910 — skipped sentinel takes precedence so the
+                # cell renders "Skipped" not the residual Pass/Fail.
+                is_skipped = log.output_str == EVAL_SKIPPED_OUTPUT_STR
                 metric_entry = {
                     "name": metric_name,
                     "output_type": output_type,
                     "reason": log.eval_explanation,
                     "error": log.error,
+                    "skipped": is_skipped,
                 }
-                if log.output_str_list:
+                if is_skipped:
+                    metric_entry["output"] = None
+                elif log.output_str_list:
                     metric_entry["output"] = log.output_str_list
                 elif output_type == "Pass/Fail" and log.output_bool is not None:
                     metric_entry["output"] = "Pass" if log.output_bool else "Fail"
@@ -3932,12 +3954,22 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         eval_outputs = {}
         trace_evals: Dict[str, Any] = {}
         if eval_config_ids:
+            # TH-4910: ``output_str = EVAL_SKIPPED_OUTPUT_STR`` flags rows
+            # the dispatch wrote because the span had no value for the
+            # mapped attribute. Excluded from score aggregates and
+            # surfaced as ``skipped_count`` so the pivot can emit a
+            # ``{"skipped": True}`` marker for the (trace, config) pair.
             eval_query = f"""
             SELECT
                 trace_id,
                 toString(custom_eval_config_id) AS eval_config_id,
-                avg(output_float) AS avg_score,
-                avg(CASE WHEN output_bool = 1 THEN 100.0 ELSE 0.0 END) AS pass_rate,
+                avgIf(output_float, ifNull(output_str, '') != %(skipped_sentinel)s) AS avg_score,
+                avgIf(
+                    CASE WHEN output_bool = 1 THEN 100.0 ELSE 0.0 END,
+                    ifNull(output_str, '') != %(skipped_sentinel)s
+                ) AS pass_rate,
+                countIf(ifNull(output_str, '') != %(skipped_sentinel)s) AS success_count,
+                countIf(ifNull(output_str, '') = %(skipped_sentinel)s) AS skipped_count,
                 count() AS eval_count,
                 any(output_str_list) AS output_str_list
             FROM tracer_eval_logger FINAL
@@ -3951,6 +3983,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 {
                     "trace_id": str(trace_id),
                     "eval_config_ids": tuple(eval_config_ids),
+                    "skipped_sentinel": EVAL_SKIPPED_OUTPUT_STR,
                 },
                 timeout_ms=30000,
             )
@@ -3981,13 +4014,25 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     "output": None,
                     "reason": None,
                     "error": None,
+                    "skipped": False,
                 }
                 continue
 
             scores = trace_evals[config_id]
-            metric_entry = {"name": metric_name, "output_type": output_type}
+            metric_entry = {
+                "name": metric_name,
+                "output_type": output_type,
+                "skipped": False,
+            }
             if isinstance(scores, dict):
-                if scores.get("per_choice"):
+                # TH-4910 — skipped marker propagated by the CH pivot.
+                # Beats any residual avg/per-choice that might be in the
+                # dict for a (trace, config) pair where the only rows
+                # were skipped.
+                if scores.get("skipped"):
+                    metric_entry["skipped"] = True
+                    metric_entry["output"] = None
+                elif scores.get("per_choice"):
                     metric_entry["output"] = [
                         k for k, v in scores["per_choice"].items() if v > 0
                     ]

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -65,7 +65,6 @@ from tracer.services.clickhouse.query_builders import (
 from tracer.services.clickhouse.query_service import AnalyticsQueryService, QueryType
 from tracer.services.observability_providers import ObservabilityService
 from tracer.utils.aggregates import JSONBObjectAgg
-from tracer.utils.eval import EVAL_SKIPPED_OUTPUT_STR  # TH-4910 skipped sentinel
 from tracer.utils.annotations import (
     build_annotation_subqueries as _build_annotation_subqueries_impl,
 )
@@ -1332,15 +1331,13 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     ),
                     f"error_{config.id}": Subquery(metric_subquery.values("error")),
                     # TH-4910 — does this (trace, config) pair have a
-                    # row tagged with the skipped sentinel? Used by
-                    # ``populate_call_logs_result`` to surface
-                    # ``metric_entry["skipped"]`` so the FE renders
-                    # "Skipped" not "Fail" / "Error".
+                    # skipped row? Surfaced as ``metric_entry["skipped"]``
+                    # so the FE renders "Skipped" not "Fail" / "Error".
                     f"skipped_{config.id}": Exists(
                         EvalLogger.objects.filter(
                             trace_id=OuterRef("id"),
                             custom_eval_config_id=config.id,
-                            output_str=EVAL_SKIPPED_OUTPUT_STR,
+                            skipped_reason__isnull=False,
                         )
                     ),
                 }
@@ -2429,9 +2426,15 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                         }
                     ),
                     total_evaluations=models.Count("id"),
+                    # TH-4910: skipped rows have error=True; exclude so this
+                    # count reflects real eval failures only.
                     error_count=models.Count(
                         Case(
-                            When(Q(output_str="ERROR") | Q(error=True), then=1),
+                            When(
+                                (Q(output_str="ERROR") | Q(error=True))
+                                & Q(skipped_reason__isnull=True),
+                                then=1,
+                            ),
                             output_field=models.IntegerField(),
                         )
                     ),
@@ -3689,9 +3692,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     }
                     continue
 
-                # TH-4910 — skipped sentinel takes precedence so the
-                # cell renders "Skipped" not the residual Pass/Fail.
-                is_skipped = log.output_str == EVAL_SKIPPED_OUTPUT_STR
+                # TH-4910 — skipped takes precedence so the cell
+                # renders "Skipped" not the residual Pass/Fail.
+                is_skipped = log.skipped_reason is not None
                 metric_entry = {
                     "name": metric_name,
                     "output_type": output_type,
@@ -3954,22 +3957,22 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         eval_outputs = {}
         trace_evals: Dict[str, Any] = {}
         if eval_config_ids:
-            # TH-4910: ``output_str = EVAL_SKIPPED_OUTPUT_STR`` flags rows
-            # the dispatch wrote because the span had no value for the
+            # TH-4910: ``skipped_reason IS NOT NULL`` flags rows the
+            # dispatch wrote because the span had no value for the
             # mapped attribute. Excluded from score aggregates and
             # surfaced as ``skipped_count`` so the pivot can emit a
             # ``{"skipped": True}`` marker for the (trace, config) pair.
-            eval_query = f"""
+            eval_query = """
             SELECT
                 trace_id,
                 toString(custom_eval_config_id) AS eval_config_id,
-                avgIf(output_float, ifNull(output_str, '') != %(skipped_sentinel)s) AS avg_score,
+                avgIf(output_float, skipped_reason IS NULL) AS avg_score,
                 avgIf(
                     CASE WHEN output_bool = 1 THEN 100.0 ELSE 0.0 END,
-                    ifNull(output_str, '') != %(skipped_sentinel)s
+                    skipped_reason IS NULL
                 ) AS pass_rate,
-                countIf(ifNull(output_str, '') != %(skipped_sentinel)s) AS success_count,
-                countIf(ifNull(output_str, '') = %(skipped_sentinel)s) AS skipped_count,
+                countIf(skipped_reason IS NULL) AS success_count,
+                countIf(skipped_reason IS NOT NULL) AS skipped_count,
                 count() AS eval_count,
                 any(output_str_list) AS output_str_list
             FROM tracer_eval_logger FINAL
@@ -3983,7 +3986,6 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 {
                     "trace_id": str(trace_id),
                     "eval_config_ids": tuple(eval_config_ids),
-                    "skipped_sentinel": EVAL_SKIPPED_OUTPUT_STR,
                 },
                 timeout_ms=30000,
             )


### PR DESCRIPTION
## Summary
- Adds `skipped_reason TEXT` column to `tracer_eval_logger`. When `_process_mapping` raises a missing-attribute error the row is now written with `error=True + skipped_reason="missing_required_attribute: <attr>"` instead of the generic error shape.
- FE renders "Skipped" (not "Fail") for these rows and the failure-rate metric excludes them. The frontend contract is unchanged — the API still emits `skipped: true` on metric entries and `skipped_count` on aggregates.
- Migration 0079 adds the column; 0080 backfills both the legacy `error=True + "Required attribute" prefix` shape and any intermediate-sentinel rows.

## Ticket
[TH-4910](https://linear.app/futureagi/issue/TH-4910)

## Test plan
- [x] `manage.py migrate tracer` applies 0079 + 0080 cleanly
- [x] Eval task view: 17 rows backfilled show `error=True + skipped_reason` set, `output_str=NULL`
- [x] Task Logs view renders **17 / 17 skipped**, 0 Errors, 17 Skipped, no Error Log section
- [x] Voice cell renderer + voice drawer continue to render "Skipped"
- [ ] CI tests green