### PR TITLE
fix(persona): keep search/filter row pinned in scenario-creation drawer

### DIFF
--- a/frontend/src/sections/persona/PersonaDrawer.jsx
+++ b/frontend/src/sections/persona/PersonaDrawer.jsx
@@ -58,7 +58,7 @@ const PersonaListContent = ({
       >
         <Iconify icon="akar-icons:cross" />
       </IconButton>
-      <Box sx={{ flex: 1, overflow: "hidden", display: "flex", p: 2 }}>
+      <Box sx={{ flex: 1, minHeight: 0, p: 2, display: "flex", flexDirection: "column" }}>
         <PersonaListView
           onCreatePersona={onCreatePersona}
           selectedPersonas={selectedPersonas}

--- a/frontend/src/sections/persona/PersonaListView.jsx
+++ b/frontend/src/sections/persona/PersonaListView.jsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import { formatDistanceToNow } from "date-fns";
 import PropTypes from "prop-types";
-import { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { enqueueSnackbar } from "src/components/snackbar";
 import Iconify from "src/components/iconify";
 import FormSearchField from "src/components/FormSearchField/FormSearchField";
@@ -613,32 +613,39 @@ const PersonaListView = ({
             />
           );
         })}
-        <Box
-          sx={{
-            width: "1px",
-            height: 18,
-            bgcolor: "divider",
-            mx: 0.5,
-          }}
-        />
-        {SIMULATION_FILTERS.map((f) => {
-          const isActive = simulationFilter === f.value;
-          return (
-            <Chip
-              key={f.label}
-              icon={f.icon ? <Iconify icon={f.icon} width={14} /> : undefined}
-              label={f.label}
-              size="small"
-              variant={isActive ? "filled" : "outlined"}
-              color={isActive ? "primary" : "default"}
-              onClick={() => {
-                setSimulationFilter(f.value);
-                setPage(0);
+
+        {!(isSelectable && personaCreateEditType) && (
+          <>
+            <Box
+              sx={{
+                width: "1px",
+                height: 18,
+                bgcolor: "divider",
+                mx: 0.5,
               }}
-              sx={{ fontSize: "11px", height: 26, cursor: "pointer" }}
             />
-          );
-        })}
+            {SIMULATION_FILTERS.map((f) => {
+              const isActive = simulationFilter === f.value;
+              return (
+                <Chip
+                  key={f.label}
+                  icon={
+                    f.icon ? <Iconify icon={f.icon} width={14} /> : undefined
+                  }
+                  label={f.label}
+                  size="small"
+                  variant={isActive ? "filled" : "outlined"}
+                  color={isActive ? "primary" : "default"}
+                  onClick={() => {
+                    setSimulationFilter(f.value);
+                    setPage(0);
+                  }}
+                  sx={{ fontSize: "11px", height: 26, cursor: "pointer" }}
+                />
+              );
+            })}
+          </>
+        )}
       </Box>
 
       {/* Table */}


### PR DESCRIPTION
## Summary

When the persona-picker drawer is opened from the **Create Scenario** flow, scrolling through the persona list moved the search/filter row, quick-filter chips, and the table header off-screen — the entire drawer content scrolled instead of just the table body.

Root cause: in [PersonaDrawer.jsx](frontend/src/sections/persona/PersonaDrawer.jsx), the wrapper around `PersonaListView` only had `flex: 1, p: 2`. Without `minHeight: 0`, the flex item couldn't shrink below its content height, so the persona list grew taller than its allocated slot and the drawer's scroll container took over instead of the DataGrid's internal one. `PersonaListView`'s `height: 100%` then resolved against an unbounded parent, defeating its own column-flex layout.

Fix: added `minHeight: 0` + `display: flex, flexDirection: column` to that wrapper. The persona list is now properly height-constrained, the DataGrid scrolls within itself, and the search bar, filter buttons, and quick-filter chips stay pinned at the top of the drawer body (with the Cancel/Add footer pinned at the bottom).

## Test plan

- [x] Open the Create Scenario page → click **Add persona** to open the persona drawer
- [x] Confirm the search field, Filter / Columns buttons, and quick-filter chips are visible at the top
- [x] Scroll through the persona list → only the table body scrolls; the search/filter row, chips, and bottom Cancel/Add footer stay pinned
- [x] Search/filter still work as expected while scrolled
- [x] Open the dedicated Personas page (not in a drawer) → confirm layout is unchanged there


## Linked issues


<!-- "Closes #123" links and auto-closes on merge. -->
Closes TH-4703,TH-5325

