### PR TITLE
fix(trace-detail): tag input Enter-arrow click adds the tag [TH-5244]

### DIFF
--- a/frontend/src/components/traceDetail/TagInput.jsx
+++ b/frontend/src/components/traceDetail/TagInput.jsx
@@ -120,6 +120,7 @@ const TagInput = ({
         />
         {value.trim() && (
           <Box
+            onMouseDown={(e) => e.preventDefault()}
             onClick={handleSubmit}
             sx={{
               cursor: "pointer",


### PR DESCRIPTION
## Summary

The small Enter-arrow icon at the right of the tag-name input did nothing on click. Keyboard Enter already worked — this only affected the icon click path.

**Cause** — mousedown on the icon blurred the input. The parent `SpanDetailPane` `onBlur` handler then ran `setIsAdding(false)` and unmounted `TagInput` before the icon's `onClick={handleSubmit}` could fire.

**Fix** — one line: `onMouseDown={(e) => e.preventDefault()}` on the icon Box, matching the same guard the color swatches already use (`TagInput.jsx:143`). Preserves focus on the input so the click completes and `handleSubmit` runs.

## Linear

- [TH-5244 — colourful tag button does not work on clicking the enter button](https://linear.app/future-agi/issue/TH-5244/this-colourful-tag-button-does-not-work-on-clicking-the-enter-button)

## Test plan

- [ ] Open a trace → select a span → click `+ tag` → type a name → **click the arrow-return icon** (not keyboard Enter). Tag is added and input closes.
- [ ] Same flow but use keyboard **Enter** — still works (unchanged behavior).
- [ ] Click a color swatch instead of submitting — input stays open with the new color (unchanged).
- [ ] Click outside the tag input area — input closes without adding (blur path still works).