### PR TITLE
fix(eval): allow trace-target rows in get_evaluation_details + UI empty-state [TH-5322]

### DIFF
--- a/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
+++ b/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
@@ -88,6 +88,8 @@ const EvalErrorLocalization = ({
     },
     enabled: traceFetchEnabled,
     refetchOnWindowFocus: false,
+    // Suppress global onError toast (app.jsx); inline empty state already rendered.
+    meta: { errorHandled: true },
   });
 
   useEffect(() => {

--- a/frontend/src/components/traceDetailDrawer/dialogue-boxes/view-details.jsx
+++ b/frontend/src/components/traceDetailDrawer/dialogue-boxes/view-details.jsx
@@ -28,7 +28,7 @@ const ViewDetailsModal = ({ open, onClose, selectedViewDetail, title }) => {
   const ids = selectedViewDetail?.id.split("**");
   const observationSpanId = ids?.pop();
   const customEvalConfigId = ids?.[0];
-  const { data, isPending } = useQuery({
+  const { data, isPending, isError, error } = useQuery({
     queryKey: ["span-details", customEvalConfigId, observationSpanId],
     queryFn: () =>
       axios.get(
@@ -36,7 +36,15 @@ const ViewDetailsModal = ({ open, onClose, selectedViewDetail, title }) => {
       ),
     enabled: !!customEvalConfigId && !!observationSpanId,
     select: (d) => d?.data?.result,
+    retry: false,
+    // Suppress global onError toast (app.jsx); inline empty state below.
+    meta: { errorHandled: true },
   });
+
+  const emptyStateMessage =
+    typeof error?.result === "string"
+      ? error.result
+      : "No evaluation details available for this row.";
   const input1 = useMemo(() => {
     if (!isPending) {
       const input1 = data?.errorAnalysis?.input1;
@@ -85,6 +93,43 @@ const ViewDetailsModal = ({ open, onClose, selectedViewDetail, title }) => {
             <Iconify icon="mingcute:close-line" />
           </IconButton>
         </Box>
+        {isError ? (
+          <Box
+            sx={{
+              flexGrow: 1,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: theme.spacing(1),
+              padding: theme.spacing(3),
+              gap: 1,
+              flexDirection: "column",
+              textAlign: "center",
+            }}
+          >
+            <Iconify
+              icon="mdi:information-outline"
+              width={20}
+              color="text.secondary"
+            />
+            <Typography
+              fontSize={typographyTheme.body2.fontSize}
+              color="text.secondary"
+            >
+              {emptyStateMessage}
+            </Typography>
+            <Typography
+              fontSize={typographyTheme.caption.fontSize}
+              color="text.disabled"
+            >
+              This evaluation hasn&apos;t produced a result for this span yet,
+              or the previous result was removed.
+            </Typography>
+          </Box>
+        ) : (
+        <>
         <Box
           sx={{
             gap: "8px",
@@ -334,6 +379,8 @@ const ViewDetailsModal = ({ open, onClose, selectedViewDetail, title }) => {
             </Typography>
           )}
         </Box>
+        </>
+        )}
         {/* <Box
           sx={{
             display:'flex',

--- a/futureagi/tracer/tests/test_eval_logger_schema.py
+++ b/futureagi/tracer/tests/test_eval_logger_schema.py
@@ -192,22 +192,14 @@ class TestEvalLoggerConflationOnRootSpan:
 class TestEvalLoggerReaderAudit:
     """Pin the reader-audit fixes that keep session rows off span/trace surfaces."""
 
-    def test_get_evaluation_details_clickhouse_filters_target_type_span(
+    def test_get_evaluation_details_clickhouse_filters_target_type_span_and_trace(
         self, observation_span, custom_eval_config
     ):
-        """``_get_evaluation_details_clickhouse`` adds ``target_type='span'`` to its WHERE.
-
-        We don't need a real ClickHouse here — just assert the helper builds
-        a query string with the new filter. Pre-PR3 the WHERE clause was
-        keyed only on observation_span_id + custom_eval_config_id.
-        """
+        """CH query allows span+trace targets and excludes session rows."""
         from tracer.views.observation_span import ObservationSpanView
 
         view = ObservationSpanView()
         analytics = MagicMock()
-        # Make the executed query observable; return an empty .data so the
-        # helper short-circuits to a 'no row' response (we only care about the
-        # SQL it built, not the result handling).
         analytics.execute_ch_query.return_value.data = []
 
         view._get_evaluation_details_clickhouse(
@@ -216,11 +208,101 @@ class TestEvalLoggerReaderAudit:
             analytics=analytics,
         )
 
-        # The query string is the first positional arg.
         sent_query = analytics.execute_ch_query.call_args.args[0]
-        assert "target_type = 'span'" in sent_query, (
-            f"expected target_type='span' filter in CH query, got:\n{sent_query}"
+        assert "target_type IN ('span', 'trace')" in sent_query, (
+            f"expected target_type IN ('span', 'trace') filter in CH query, got:\n{sent_query}"
         )
+        assert "'session'" not in sent_query, (
+            "session-target rows must not be reachable via this endpoint; "
+            f"got:\n{sent_query}"
+        )
+
+    def test_get_evaluation_details_pg_excludes_session_rows(
+        self,
+        auth_client,
+        observe_project,
+        trace_session,
+        custom_eval_config,
+    ):
+        """Endpoint must never surface session-target rows (HTTP-level pin)."""
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        observe_config = CustomEvalConfig.objects.create(
+            name="Observe Eval Session-Excluded",
+            project=observe_project,
+            eval_template=custom_eval_config.eval_template,
+            config={"output": "Pass/Fail"},
+            mapping={"input": "input"},
+        )
+        EvalLogger.objects.create(
+            target_type=EvalTargetType.SESSION,
+            observation_span=None,
+            trace=None,
+            trace_session=trace_session,
+            custom_eval_config=observe_config,
+            output_bool=True,
+            eval_explanation="session-only row",
+        )
+
+        response = auth_client.get(
+            "/tracer/observation-span/get_evaluation_details/",
+            {
+                "observation_span_id": "0000000000000000",
+                "custom_eval_config_id": str(observe_config.id),
+            },
+        )
+        assert response.status_code == 400
+        body = response.json()
+        assert body.get("status") is False
+        assert "No eval logger found" in str(body.get("result", ""))
+
+    def test_get_evaluation_details_pg_excludes_session_rows_when_span_row_absent(
+        self,
+        observe_project,
+        observation_span,
+        trace_session,
+        custom_eval_config,
+    ):
+        """Query-level pin: target_type__in filter is what excludes session rows."""
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        observe_config = CustomEvalConfig.objects.create(
+            name="Observe Eval Query-Level",
+            project=observe_project,
+            eval_template=custom_eval_config.eval_template,
+            config={"output": "Pass/Fail"},
+            mapping={"input": "input"},
+        )
+        span_row = EvalLogger.objects.create(
+            target_type=EvalTargetType.SPAN,
+            observation_span=observation_span,
+            trace=observation_span.trace,
+            custom_eval_config=observe_config,
+            output_bool=True,
+        )
+        EvalLogger.objects.create(
+            target_type=EvalTargetType.SESSION,
+            observation_span=None,
+            trace=None,
+            trace_session=trace_session,
+            custom_eval_config=observe_config,
+            output_bool=False,
+        )
+
+        endpoint_filter = EvalLogger.objects.filter(
+            observation_span_id=observation_span.id,
+            custom_eval_config_id=observe_config.id,
+            target_type__in=["span", "trace"],
+        )
+        assert endpoint_filter.count() == 1
+        assert endpoint_filter.first().id == span_row.id
+
+        session_row = EvalLogger.objects.filter(
+            custom_eval_config_id=observe_config.id,
+            target_type=EvalTargetType.SESSION,
+        ).first()
+        assert session_row is not None
+        assert session_row.observation_span_id is None
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -3101,6 +3101,8 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         self, observation_span_id, custom_eval_config_id, analytics
     ):
         """Get evaluation details from ClickHouse."""
+        # Span- and trace-target rows both anchor to observation_span_id;
+        # session rows don't and are served by /trace-session/:id/eval_logs/.
         query = """
             SELECT
                 output_float,
@@ -3114,7 +3116,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             FROM tracer_eval_logger FINAL
             WHERE observation_span_id = %(span_id)s
               AND custom_eval_config_id = %(config_id)s
-              AND target_type = 'span'
+              AND target_type IN ('span', 'trace')
               AND _peerdb_is_deleted = 0
               AND (deleted = 0 OR deleted IS NULL)
             LIMIT 1
@@ -3211,9 +3213,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                         "CH eval details failed, falling back to PG", error=str(e)
                     )
 
+            # Mirror the ClickHouse filter; excludes session-target rows.
             eval_logger = EvalLogger.objects.filter(
                 observation_span_id=observation_span_id,
                 custom_eval_config_id=custom_eval_config_id,
+                target_type__in=["span", "trace"],
             ).first()
 
             if not eval_logger:


### PR DESCRIPTION
## Summary

- **Backend**: `ObservationSpanView.get_evaluation_details` (both ClickHouse and Postgres paths) now allows `target_type IN ('span', 'trace')` instead of `'span'` only. Trace-target evals anchor to the trace's root span (same `observation_span_id` shape as span rows per migration 0075) and are legitimately surfaced on the trace-detail UI that triggers this endpoint. Session-target rows stay excluded — they live under `/tracer/trace-session/:id/eval_logs/` and have `observation_span_id=NULL`.
- **Frontend (View Details modal)**: when the endpoint returns the legitimate "No eval logger found" 400 (row soft-deleted after a config edit, eval not yet re-run, etc.), render a single centered empty-state card instead of broken Score / Explanation / Possible Error panels. Adds `meta: { errorHandled: true }` on the two `useQuery` callers (`view-details.jsx` and `EvalErrorLocalization.jsx`) so the global `QueryCache.onError` toast in `app.jsx` doesn't stack on top of the inline state.
- **Tests**: updated `test_get_evaluation_details_clickhouse_filters_target_type_span_and_trace` to assert the widened WHERE clause and explicitly verify `'session'` is not in it; added `test_get_evaluation_details_pg_excludes_session_rows` (HTTP round-trip via `auth_client`) and `test_get_evaluation_details_pg_excludes_session_rows_when_span_row_absent` (query-level pin).

## Why

Prod check on `/tracer/observation-span/get_evaluation_details/` was 400ing for trace-target eval rows. Audit on prod US PG showed **845 live `target_type='trace'` rows** invisible to this endpoint via the ClickHouse path (CH query hardcoded `target_type = 'span'`). The PG path has no `target_type` filter but is bypassed because the CH branch returns the 400 directly (the surrounding `try/except` only falls back on exception, not on a `bad_request` return). Once the CH filter is widened to include `'trace'`, those trace-target evals resolve as intended.

Separately, the modal had no graceful state for the case where the eval row genuinely doesn't exist (soft-deleted while the BE keeps emitting a `loading: True` placeholder in `evals_metrics` for any config attached to `project_version.eval_tags`). User-visible result was a broken modal + a global error toast. The inline empty-state mirrors the existing "no error localizer" UI pattern.

## Test plan

- [ ] Run `futureagi/tracer/tests/test_eval_logger_schema.py::TestEvalLoggerReaderAudit` — all 3 tests pass:
  - `test_get_evaluation_details_clickhouse_filters_target_type_span_and_trace`
  - `test_get_evaluation_details_pg_excludes_session_rows`
  - `test_get_evaluation_details_pg_excludes_session_rows_when_span_row_absent`
- [ ] Manual: open the trace-detail drawer on a trace whose eval has `target_type='trace'`, click "View Detail" on the eval cell — modal renders score chip + explanation + (if present) error-localization card instead of 400ing.
- [ ] Manual: open "View Detail" on an eval whose underlying `EvalLogger` is soft-deleted — modal renders the empty-state card ("No evaluation details available for this row...") with no global error toast.
- [ ] Manual: confirm spans tab evals row's inline error-localization card no longer throws a global toast on `getEvalDetails` 400.