### PR TITLE
feat(admin): pin generate-invoice link next to custom-pricing

### DIFF
--- a/futureagi/tfc/templates/admin/index.html
+++ b/futureagi/tfc/templates/admin/index.html
@@ -5,10 +5,14 @@
 <div id="custom-admin-links" style="margin-bottom: 20px;">
   <div class="module" style="margin-bottom: 0;">
     <table>
-      <caption><a href="{% url 'admin:custom-pricing' %}" class="section" title="Custom Pricing Manager">Custom Tools</a></caption>
+      <caption><a href="{% url 'admin:custom-pricing' %}" class="section" title="Custom Tools">Custom Tools</a></caption>
       <tr>
         <th scope="row"><a href="{% url 'admin:custom-pricing' %}">Custom Pricing Manager</a></th>
         <td><a href="{% url 'admin:custom-pricing' %}">Open</a></td>
+      </tr>
+      <tr>
+        <th scope="row"><a href="{% url 'admin:generate-invoice' %}">Generate Invoice</a></th>
+        <td><a href="{% url 'admin:generate-invoice' %}">Open</a></td>
       </tr>
     </table>
   </div>

--- a/futureagi/tfc/templates/admin/usage/generate_invoice.html
+++ b/futureagi/tfc/templates/admin/usage/generate_invoice.html
@@ -45,7 +45,7 @@
     <h3>Select Organization &amp; Period</h3>
     <div class="gi-grid">
       <div class="gi-field">
-        <label>Organization (Custom Plan)</label>
+        <label>Organization</label>
         <select id="gi-org-id">
           <option value="">-- Select an organization --</option>
         </select>


### PR DESCRIPTION
## Summary
- Adds a **Generate Invoice** row to the Django admin index under the existing **Custom Tools** card, mirroring the existing **Custom Pricing Manager** entry.
- Uses the `admin:generate-invoice` URL name (assumed to mirror the `admin:custom-pricing` convention defined in the EE-side admin URLconf).

## Test plan
- [ ] Log into `/admin/` as a staff user.
- [ ] Confirm the **Custom Tools** card on the admin index now shows both `Custom Pricing Manager` and `Generate Invoice` rows.
- [ ] Click `Generate Invoice` and verify it routes to the existing generate-invoice page (`tfc/templates/admin/usage/generate_invoice.html`).

## Notes
- The companion "show all orgs (not only custom plan orgs) in the generate-invoice dropdown" change lives in the EE `ee/usage/...` view that builds `org_choices_json` and is **not** included here — that change cannot be made from this OSS checkout.