### PR TITLE
fix(observe): make column resize handle discoverable [TH-5223]

### DIFF
--- a/frontend/src/styles/clean-data-table.css
+++ b/frontend/src/styles/clean-data-table.css
@@ -9,12 +9,15 @@
   border-bottom: none !important;
 }
 
-/* Hide column resize handles / separators in header */
 .clean-data-table .ag-header-cell-resize {
-  width: 4px !important;
-  opacity: 0;
+  width: 8px !important;
 }
-.clean-data-table .ag-header-cell-resize:hover {
+.clean-data-table .ag-header-cell-resize::after {
+  background-color: var(--resize-handle) !important;
+  opacity: 0.5;
+  transition: opacity 120ms ease;
+}
+.clean-data-table .ag-header-cell-resize:hover::after {
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary

Columns in the observe view were "very difficult to resize" because `clean-data-table.css` was hiding the AG Grid resize handle entirely (`opacity: 0`). The drag itself worked, but users had no visual cue where the column boundary was — they had to blindly hunt a 4px-wide invisible band on the header edge.

**Fix** — paint `.ag-header-cell-resize::after` with `var(--resize-handle)` at `0.5` opacity so the line is faintly visible at rest, brighten to `1` on hover, and widen the hit area from 4px to 8px so it's easier to grab.

(AG Grid Quartz draws the line via the `::after` pseudo-element using `--ag-header-column-resize-handle-color`, which is transparent by default — that's why the previous `opacity` rule on the parent wrapper alone wasn't producing a visible indicator. Targeting `::after` directly with our own `--resize-handle` token sidesteps the theme's hover-only logic.)

## Linear

- [TH-5223 — very difficult to resize columns](https://linear.app/future-agi/issue/TH-5223/very-difficult-to-resize-columns)

## Test plan

- [ ] Open an observe view (LLM tracing). Column header boundaries show a faint vertical line at rest.
- [ ] Move the cursor near a column boundary — the line brightens, cursor changes to col-resize.
- [ ] Drag the handle → column resizes as before.
- [ ] Double-click the handle → AG Grid auto-fits to content (built-in behavior, easier to land now with 8px hit area).
- [ ] Verify in both light and dark mode — `--resize-handle` already has mode-specific values (`#e6e6e6` / `#3f3f46`).