### PR TITLE
fix(query-builders): exclude ClickHouse nil UUID from session results

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/base.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/base.py
@@ -9,6 +9,10 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from typing import Any, Dict, Generator, List, Optional, Tuple
 
+# ClickHouse zero-value for UUID columns. dictGetOrDefault on Nullable(UUID)
+# dictionary columns may return this instead of NULL — see dashboard.py:1919.
+NIL_UUID = "00000000-0000-0000-0000-000000000000"
+
 
 def _parse_dt(val: Any) -> Optional[datetime]:
     """Parse a datetime value from various formats.

--- a/futureagi/tracer/services/clickhouse/query_builders/session_analytics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_analytics.py
@@ -9,7 +9,7 @@ tables with efficient ClickHouse GROUP BY queries on the denormalized
 
 from typing import Any, Dict, List, Optional, Tuple
 
-from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
+from tracer.services.clickhouse.query_builders.base import NIL_UUID, BaseQueryBuilder
 
 
 class SessionAnalyticsQueryBuilder(BaseQueryBuilder):
@@ -93,6 +93,7 @@ class SessionAnalyticsQueryBuilder(BaseQueryBuilder):
         FROM {self.TABLE}
         {self.project_where()}
           AND trace_session_id != ''
+          AND trace_session_id != toUUID('{NIL_UUID}')
         GROUP BY trace_session_id
         ORDER BY started_at DESC
         """

--- a/futureagi/tracer/services/clickhouse/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_list.py
@@ -13,7 +13,7 @@ ID) into every span row, we can compute per-session aggregates in a single
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
+from tracer.services.clickhouse.query_builders.base import NIL_UUID, BaseQueryBuilder
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
 from tracer.utils.filter_operators import normalize_filter_op
 
@@ -134,6 +134,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
         FROM {self.TABLE}
         {self.project_where()}
           AND trace_session_id IS NOT NULL
+          AND trace_session_id != toUUID('{NIL_UUID}')
           AND (parent_span_id IS NULL OR parent_span_id = '')
           AND start_time >= %(start_date)s
           AND start_time < %(end_date)s
@@ -209,6 +210,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
         FROM {self.TABLE}
         {self.project_where()}
           AND trace_session_id IS NOT NULL
+          AND trace_session_id != toUUID('{NIL_UUID}')
           AND (parent_span_id IS NULL OR parent_span_id = '')
           AND start_time >= %(start_date)s
           AND start_time < %(end_date)s
@@ -250,6 +252,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
             FROM {self.TABLE}
             {self.project_where()}
               AND trace_session_id IS NOT NULL
+              AND trace_session_id != toUUID('{NIL_UUID}')
               AND (parent_span_id IS NULL OR parent_span_id = '')
               AND start_time >= %(start_date)s
               AND start_time < %(end_date)s
@@ -329,13 +332,16 @@ class SessionListQueryBuilder(BaseQueryBuilder):
             )
 
         for row in rows:
+            session_id = str(_get(row, "session_id", 0, ""))
+            if session_id == NIL_UUID:
+                continue
             session_start = _get(row, "session_start", 1)
             session_end = _get(row, "session_end", 2)
             duration_val = _get(row, "duration", 3, 0)
 
             results.append(
                 {
-                    "session_id": str(_get(row, "session_id", 0, "")),
+                    "session_id": session_id,
                     "session_name": None,
                     "start_time": (
                         session_start.isoformat()

--- a/futureagi/tracer/services/clickhouse/query_builders/session_time_series.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_time_series.py
@@ -17,7 +17,7 @@ shape — but the numbers reflect session-level aggregation.
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
+from tracer.services.clickhouse.query_builders.base import NIL_UUID, BaseQueryBuilder
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
 
 
@@ -97,6 +97,7 @@ class SessionTimeSeriesQueryBuilder(BaseQueryBuilder):
               AND start_time >= %(start_date)s
               AND start_time < %(end_date)s
               AND trace_session_id IS NOT NULL
+              AND trace_session_id != toUUID('{NIL_UUID}')
               AND {where_clause}
             GROUP BY trace_session_id
         )

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -103,7 +103,9 @@ class TestClickHouseSchema:
         assert "allow_nullable_key = 1" in CDC_EVAL_LOGGER
 
         # New TRACE_SESSION_DICT exists and points at the trace_session table
-        assert "CREATE DICTIONARY IF NOT EXISTS trace_session_dict" in TRACE_SESSION_DICT
+        assert (
+            "CREATE DICTIONARY IF NOT EXISTS trace_session_dict" in TRACE_SESSION_DICT
+        )
         assert "trace_session" in TRACE_SESSION_DICT
         assert "project_id UUID" in TRACE_SESSION_DICT
 
@@ -996,9 +998,7 @@ class TestClickHouseFilterBuilder:
         assert "output_float IS NOT NULL" in where
 
     @pytest.mark.django_db
-    def test_translate_pass_fail_eval_filter_uses_output_bool(
-        self, custom_eval_config
-    ):
+    def test_translate_pass_fail_eval_filter_uses_output_bool(self, custom_eval_config):
         """Pass/fail evals must use output_bool, not stale mixed fields."""
         from tracer.services.clickhouse.query_builders.filters import (
             ClickHouseFilterBuilder,
@@ -2165,6 +2165,77 @@ class TestSessionListQueryBuilder:
         query2, _ = builder2.build_count_query()
         assert "count() AS total" in query2
         assert "GROUP BY" in query2
+
+    def test_build_excludes_nil_uuid(self):
+        """build() should exclude the ClickHouse nil UUID from session results."""
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        builder = SessionListQueryBuilder(
+            project_id="test-project-id",
+            filters=[],
+            page_number=0,
+            page_size=10,
+        )
+        query, _ = builder.build()
+        assert "00000000-0000-0000-0000-000000000000" in query
+
+    def test_count_query_excludes_nil_uuid(self):
+        """Both simple and aggregated count queries should exclude the nil UUID."""
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        # Simple count path
+        builder = SessionListQueryBuilder(
+            project_id="test-project-id",
+            filters=[],
+            page_number=0,
+            page_size=10,
+        )
+        builder.build()
+        query, _ = builder.build_count_query()
+        assert "00000000-0000-0000-0000-000000000000" in query
+
+        # Aggregated count path
+        builder2 = SessionListQueryBuilder(
+            project_id="test-project-id",
+            filters=[
+                {
+                    "column_id": "duration",
+                    "filter_config": {
+                        "filter_op": "greater_than",
+                        "filter_value": 60,
+                    },
+                }
+            ],
+            page_number=0,
+            page_size=10,
+        )
+        builder2.build()
+        query2, _ = builder2.build_count_query()
+        assert "00000000-0000-0000-0000-000000000000" in query2
+
+    def test_format_sessions_skips_nil_uuid(self):
+        """format_sessions() should drop rows with the nil UUID session_id."""
+        from datetime import datetime
+
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        columns = [
+            "session_id",
+            "session_start",
+            "session_end",
+            "duration",
+            "total_cost",
+            "total_tokens",
+            "traces_count",
+        ]
+        now = datetime.utcnow()
+        rows = [
+            ("00000000-0000-0000-0000-000000000000", now, now, 0, 0.0, 0, 1),
+            ("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", now, now, 10, 1.5, 100, 3),
+        ]
+        result = SessionListQueryBuilder.format_sessions(rows, columns)
+        assert len(result) == 1
+        assert result[0]["session_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
 
 @pytest.mark.unit
@@ -6851,6 +6922,12 @@ class TestSessionAnalyticsQueryBuilder:
         assert "count(DISTINCT trace_id)" in query
         assert "sum(total_tokens)" in query
         assert "sum(cost)" in query
+
+    def test_session_navigation_excludes_nil_uuid(self):
+        """Navigation query should exclude the ClickHouse nil UUID."""
+        builder = self._make_builder()
+        query, _ = builder.build_session_navigation_query()
+        assert "00000000-0000-0000-0000-000000000000" in query
 
     # -- User stats query --
 

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -38,8 +38,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
+from tracer.services.clickhouse.query_builders.base import NIL_UUID
+
 logger = structlog.get_logger(__name__)
-from futureagi.tracer.services.clickhouse.query_builders.base import NIL_UUID
 from model_hub.models.choices import AnnotationTypeChoices
 from model_hub.models.develop_annotations import AnnotationsLabels
 from model_hub.models.score import Score

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -39,6 +39,7 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
 logger = structlog.get_logger(__name__)
+from futureagi.tracer.services.clickhouse.query_builders.base import NIL_UUID
 from model_hub.models.choices import AnnotationTypeChoices
 from model_hub.models.develop_annotations import AnnotationsLabels
 from model_hub.models.score import Score
@@ -5458,8 +5459,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 "provider": row.get("provider"),
                 "session_id": (
                     None
-                    if str(row.get("trace_session_id", ""))
-                    == "00000000-0000-0000-0000-000000000000"
+                    if str(row.get("trace_session_id", "")) == NIL_UUID
                     else row.get("trace_session_id")
                 ),
                 "tags": row.get("trace_tags") or [],

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -3242,11 +3242,19 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     data = getattr(trace, f"metric_{config.id}")
                     if data and "score" in data:
                         score = data["score"]
-                        result[str(config.id)] = round(score, 2) if score is not None else None
+                        result[str(config.id)] = (
+                            round(score, 2) if score is not None else None
+                        )
                     elif data:
                         for key, value in data.items():
-                            score = value["score"] if isinstance(value, dict) and "score" in value else None
-                            result[str(config.id) + "**" + key] = round(score, 2) if score is not None else None
+                            score = (
+                                value["score"]
+                                if isinstance(value, dict) and "score" in value
+                                else None
+                            )
+                            result[str(config.id) + "**" + key] = (
+                                round(score, 2) if score is not None else None
+                            )
 
                 # Add Root Span Annotations
                 for label in annotation_labels:
@@ -4786,9 +4794,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         eval_config_ids = []
         if org_scope:
             eval_configs = CustomEvalConfig.objects.filter(
-                id__in=EvalLogger.objects.filter(
-                    trace__project_id__in=org_project_ids
-                )
+                id__in=EvalLogger.objects.filter(trace__project_id__in=org_project_ids)
                 .values("custom_eval_config_id")
                 .distinct(),
                 deleted=False,
@@ -5263,9 +5269,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                         if isinstance(scores, dict):
                             if scores.get("per_choice"):
                                 metric_entry["output"] = [
-                                    k
-                                    for k, v in scores["per_choice"].items()
-                                    if v > 0
+                                    k for k, v in scores["per_choice"].items() if v > 0
                                 ]
                                 metric_entry["output_type"] = "str_list"
                             elif "str_list" in scores and scores["str_list"]:
@@ -5452,7 +5456,12 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 "cost": row.get("cost"),
                 "model": row.get("model"),
                 "provider": row.get("provider"),
-                "session_id": row.get("trace_session_id"),
+                "session_id": (
+                    None
+                    if str(row.get("trace_session_id", ""))
+                    == "00000000-0000-0000-0000-000000000000"
+                    else row.get("trace_session_id")
+                ),
                 "tags": row.get("trace_tags") or [],
             }
 

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -58,6 +58,7 @@ from tracer.models.observation_span import (
 )
 from tracer.models.project import Project
 from tracer.models.trace import Trace
+from tracer.services.clickhouse.query_builders.base import NIL_UUID
 
 session_logger = structlog.get_logger(__name__)
 from tfc.utils.pagination import ExtendedPageNumberPagination
@@ -681,7 +682,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     WHERE project_id = %(project_id)s
                       AND _peerdb_is_deleted = 0
                       AND trace_session_id IS NOT NULL
-                      AND trace_session_id != toUUID('00000000-0000-0000-0000-000000000000')
+                      AND trace_session_id != toUUID('{NIL_UUID}')
                       AND (parent_span_id IS NULL OR parent_span_id = '')
                     GROUP BY trace_session_id
                 )
@@ -698,9 +699,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     f"AND toString({ch_column}) ILIKE %(search)s" if search else ""
                 )
                 nil_uuid_clause = (
-                    f"AND {ch_column} != toUUID('00000000-0000-0000-0000-000000000000')"
-                    if is_uuid
-                    else ""
+                    f"AND {ch_column} != toUUID('{NIL_UUID}')" if is_uuid else ""
                 )
                 query = f"""
                 SELECT DISTINCT {select_expr} AS val
@@ -1429,7 +1428,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                 _eu_qs = _eu_qs.filter(project_id=project_id)
             _ids = [str(u) for u in _eu_qs.values_list("id", flat=True)]
             if not _ids:
-                _ids = ["00000000-0000-0000-0000-000000000000"]
+                _ids = [NIL_UUID]
             filters.append(
                 {
                     "column_id": "end_user_id",

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -60,8 +60,8 @@ from tracer.models.project import Project
 from tracer.models.trace import Trace
 
 session_logger = structlog.get_logger(__name__)
-from tracer.models.trace_session import TraceSession
 from tfc.utils.pagination import ExtendedPageNumberPagination
+from tracer.models.trace_session import TraceSession
 from tracer.serializers.eval_task import PaginationQuerySerializer
 from tracer.serializers.trace_session import (
     TraceSessionExportSerializer,
@@ -681,6 +681,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     WHERE project_id = %(project_id)s
                       AND _peerdb_is_deleted = 0
                       AND trace_session_id IS NOT NULL
+                      AND trace_session_id != toUUID('00000000-0000-0000-0000-000000000000')
                       AND (parent_span_id IS NULL OR parent_span_id = '')
                     GROUP BY trace_session_id
                 )
@@ -696,12 +697,18 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                 search_clause = (
                     f"AND toString({ch_column}) ILIKE %(search)s" if search else ""
                 )
+                nil_uuid_clause = (
+                    f"AND {ch_column} != toUUID('00000000-0000-0000-0000-000000000000')"
+                    if is_uuid
+                    else ""
+                )
                 query = f"""
                 SELECT DISTINCT {select_expr} AS val
                 FROM spans
                 WHERE project_id = %(project_id)s
                   AND _peerdb_is_deleted = 0
                   AND {ch_column} IS NOT NULL
+                  {nil_uuid_clause}
                   AND (parent_span_id IS NULL OR parent_span_id = '')
                   {search_clause}
                 ORDER BY val
@@ -1911,6 +1918,4 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
             return self._gm.success_response(paginated.data)
         except Exception as e:
             logger.exception(f"Error in fetching session eval logs: {str(e)}")
-            return self._gm.bad_request(
-                f"Error fetching session eval logs: {str(e)}"
-            )
+            return self._gm.bad_request(f"Error fetching session eval logs: {str(e)}")


### PR DESCRIPTION
## Summary

### What
Session list APIs were returning a phantom session with ID `00000000-0000-0000-0000-000000000000` (nil UUID). This PR adds nil UUID exclusion to all ClickHouse session query builders and adds defensive filtering at the view and formatter levels.

### Why
When a trace has no session (`session_id = NULL` in PostgreSQL), PeerDB replicates it to ClickHouse. The `trace_dict` dictionary stores this NULL value, but when the `spans_mv` materialized view calls `dictGetOrDefault('trace_dict', 'session_id', ...)`, ClickHouse's dictionary Nullable handling returns the UUID type's zero-value (`00000000-0000-0000-0000-000000000000`) instead of proper NULL. This nil UUID is then stored in the `spans` table as a valid non-NULL value and passes through the existing `IS NOT NULL` filter in session queries.

This is a **known behavior** already documented in the codebase — `tracer/views/dashboard.py:1919-1924` has an explicit comment: *"PeerDB CDC replicates PostgreSQL NULL UUIDs as ClickHouse's default UUID value (all zeroes) because CH's UUID type is non-nullable by default — the Nullable wrapper isn't always preserved through the MV chain."* The dashboard views already filtered this out, but the session query builders were missed.

### Fix approach
- **Query-level**: Every ClickHouse query that filters `trace_session_id IS NOT NULL` now also excludes `toUUID('00000000-...')`. This prevents nil UUID sessions from being counted (correct pagination) or returned.
- **Format-level**: `format_sessions()` skips nil UUID rows as a defensive guard.
- **View-level**: Trace list API converts nil UUID session_id to `None` in responses.
- **No data migration needed** — the fix works at query time on existing data.

## Linked issues

Fixes TH-5108, TH-5166

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Files changed

| File | Change |
|------|--------|
| `query_builders/base.py` | Added `NIL_UUID` constant |
| `query_builders/session_list.py` | 3 SQL filters + `format_sessions` guard |
| `query_builders/session_analytics.py` | 1 SQL filter in navigation query |
| `query_builders/session_time_series.py` | 1 SQL filter |
| `views/trace_session.py` | 2 inline SQL filters in `get_session_filter_values` |
| `views/trace.py` | nil UUID → `None` in trace list ClickHouse response |
| `tests/test_clickhouse.py` | 4 new tests |

## Test scenarios and flows covered

### Scenario 1: Session list query excludes nil UUID
The main `build()` query in `SessionListQueryBuilder` groups spans by `trace_session_id`. Previously, spans with `trace_session_id = 00000000-...` (from traces with no session) were included in the GROUP BY and returned as a phantom session. Now the WHERE clause excludes them.

### Scenario 2: Session count queries exclude nil UUID
Both the simple count path (`count(DISTINCT trace_session_id)`) and the aggregated count path (used when HAVING filters are present) now exclude the nil UUID. This ensures pagination metadata (`total_rows`) is correct and doesn't include the phantom session.

### Scenario 3: Session navigation query excludes nil UUID
`SessionAnalyticsQueryBuilder.build_session_navigation_query()` lists all sessions for navigation UI. The nil UUID was previously included. Now filtered out alongside the existing empty-string check.

### Scenario 4: Session time-series excludes nil UUID
`SessionTimeSeriesQueryBuilder.build()` aggregates session metrics into time buckets. The nil UUID session was contributing phantom data points. Now excluded.

### Scenario 5: Session filter values exclude nil UUID
The `get_session_filter_values()` inline SQL in `trace_session.py` returns distinct values for filter dropdowns. The nil UUID was appearing as a selectable session/user filter value. Now excluded for UUID columns.

### Scenario 6: Trace list API sanitizes nil UUID
The ClickHouse-backed trace list endpoint includes `session_id` per trace. Traces with `trace_session_id = 00000000-...` now return `session_id: null` instead of the nil UUID string.

### Scenario 7: Defensive filtering in format_sessions
Even if the nil UUID somehow bypasses the SQL filter (e.g., ClickHouse version differences), `format_sessions()` skips rows with the nil UUID session_id before they reach the API response.

## Test cases

All tests are in `tracer/tests/test_clickhouse.py`:

### New tests (4)

| # | Test | Class | What it verifies |
|---|------|-------|-----------------|
| 1 | `test_build_excludes_nil_uuid` | `TestSessionListQueryBuilder` | `build()` query string contains the nil UUID exclusion |
| 2 | `test_count_query_excludes_nil_uuid` | `TestSessionListQueryBuilder` | Both simple and aggregated count queries contain nil UUID exclusion |
| 3 | `test_format_sessions_skips_nil_uuid` | `TestSessionListQueryBuilder` | `format_sessions()` drops rows with nil UUID, keeps valid sessions |
| 4 | `test_session_navigation_excludes_nil_uuid` | `TestSessionAnalyticsQueryBuilder` | Navigation query contains nil UUID exclusion |

### Existing tests that continue to pass (29)

| # | Test | Class | What it verifies |
|---|------|-------|-----------------|
| 1 | `test_build_query` | `TestSessionListQueryBuilder` | build() produces GROUP BY query |
| 2 | `test_build_query_selects_session_aggregates` | `TestSessionListQueryBuilder` | Query includes min/max/uniq aggregates |
| 3 | `test_build_count_query_simple` | `TestSessionListQueryBuilder` | Count uses count(DISTINCT) without HAVING |
| 4 | `test_build_count_query_with_having` | `TestSessionListQueryBuilder` | Count uses subquery with HAVING filters |
| 5 | `test_having_filter_normalizes_operator_alias` | `TestSessionListQueryBuilder` | UI operator aliases are normalized |
| 6 | `test_having_filter_unknown_operator_does_not_fall_back_to_equals` | `TestSessionListQueryBuilder` | Unknown operators produce 0=1 |
| 7 | `test_build_with_user_id` | `TestSessionListQueryBuilder` | User ID filter applied to query |
| 8 | `test_build_excludes_null_session_ids` | `TestSessionListQueryBuilder` | IS NOT NULL filter present |
| 9 | `test_build_uses_uniq_not_uniqExact` | `TestSessionListQueryBuilder` | Uses approximate uniq() |
| 10 | `test_has_having_filters_false_for_no_aggregate_filters` | `TestSessionListQueryBuilder` | Non-aggregate filters don't trigger HAVING |
| 11 | `test_has_having_filters_true_for_aggregate_filters` | `TestSessionListQueryBuilder` | Aggregate filters trigger HAVING |
| 12 | `test_span_attributes_query_root_spans_only` | `TestSessionListQueryBuilder` | Attributes query filters root spans |
| 13 | `test_span_attributes_query_has_limit` | `TestSessionListQueryBuilder` | Attributes query has LIMIT 500 |
| 14 | `test_span_attributes_query_empty_sessions` | `TestSessionListQueryBuilder` | Empty sessions return empty query |
| 15 | `test_count_query_routes_correctly` | `TestSessionListQueryBuilder` | Count routes to simple vs aggregated path |
| 16 | `test_build_raises_not_implemented` | `TestSessionAnalyticsQueryBuilder` | build() raises NotImplementedError |
| 17 | `test_session_metrics_query_structure` | `TestSessionAnalyticsQueryBuilder` | Metrics query has GROUP BY and aggregates |
| 18 | `test_session_metrics_query_selects_time_columns` | `TestSessionAnalyticsQueryBuilder` | Metrics includes time columns |
| 19 | `test_session_metrics_query_has_project_filter` | `TestSessionAnalyticsQueryBuilder` | Metrics filters by project_id |
| 20 | `test_session_navigation_query_structure` | `TestSessionAnalyticsQueryBuilder` | Navigation query structure is correct |
| 21 | `test_session_navigation_has_aggregate_columns` | `TestSessionAnalyticsQueryBuilder` | Navigation includes count/tokens/cost |
| 22 | `test_user_stats_query_structure` | `TestSessionAnalyticsQueryBuilder` | User stats aggregates by end_user_id |
| 23 | `test_user_stats_has_project_filter` | `TestSessionAnalyticsQueryBuilder` | User stats filters by project_id |
| 24 | `test_first_last_message_query_structure` | `TestSessionAnalyticsQueryBuilder` | First/last message query structure |
| 25 | `test_first_message_orders_asc` | `TestSessionAnalyticsQueryBuilder` | First message ordered ASC |
| 26 | `test_last_message_orders_desc` | `TestSessionAnalyticsQueryBuilder` | Last message ordered DESC |
| 27 | `test_first_last_message_uses_limit_1_by` | `TestSessionAnalyticsQueryBuilder` | Uses LIMIT 1 BY for efficiency |
| 28 | `test_first_last_message_filters_root_spans` | `TestSessionAnalyticsQueryBuilder` | Filters to root spans only |
| 29 | `test_first_last_message_selects_io` | `TestSessionAnalyticsQueryBuilder` | Selects input/output columns |

## How was this tested?

```bash
# Run only new nil UUID tests (4 tests)
uv run python -m pytest tracer/tests/test_clickhouse.py -k "nil_uuid" -v

# Run all session query builder tests — old + new (33 tests)
uv run python -m pytest tracer/tests/test_clickhouse.py -k "TestSessionListQueryBuilder or TestSessionAnalyticsQueryBuilder" -v

# Run all clickhouse tests (426 tests)
uv run python -m pytest tracer/tests/test_clickhouse.py -v

# Run all tracer unit tests (875 tests)
uv run python -m pytest tracer/tests/ -m "unit" -q
```

**Results:** 426/426 clickhouse tests pass, 875/875 tracer unit tests pass, zero regressions.

## Screenshots of the test cases

# Run all session query builder tests (old + new)
  uv run python -m pytest tracer/tests/test_clickhouse.py -k "TestSessionListQueryBuilder or TestSessionAnalyticsQueryBuilder" -v
  
  
<img width="1512" height="982" alt="Screenshot 2026-05-18 at 8 23 22 PM" src="https://github.com/user-attachments/assets/632df2ed-25e2-49b9-8bf8-94978ca0cd6c" />

# Run all clickhouse tests (426 tests)
  uv run python -m pytest tracer/tests/test_clickhouse.py -v
<img width="1512" height="982" alt="Screenshot 2026-05-18 at 8 27 09 PM" src="https://github.com/user-attachments/assets/28ad4b2c-9a75-4b48-aaa1-2c2cb6552070" />

 # Run all tracer unit tests (875 tests)
  uv run python -m pytest tracer/tests/ -m "unit" -q

<img width="1512" height="982" alt="Screenshot 2026-05-18 at 8 28 00 PM" src="https://github.com/user-attachments/assets/2099735d-a6ce-4e53-a2d8-325a3325c0b6" />

## Linear
Fixes TH-5108, TH-5166

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)