### PR TITLE
fix(billing): emit usage events for voice observability ingestion

### DIFF
--- a/futureagi/tracer/utils/observability_provider.py
+++ b/futureagi/tracer/utils/observability_provider.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from datetime import datetime
 
@@ -26,6 +27,7 @@ from tracer.tasks.recordings_rehost import (
 from tracer.utils.eleven_labs import normalize_eleven_labs_data
 from tracer.utils.otel import ResourceLimitError, get_or_create_project
 from tracer.utils.retell import normalize_retell_data
+from tracer.utils.usage_emit import emit_span_ingestion_usage
 from tracer.utils.vapi import normalize_vapi_data
 
 
@@ -287,6 +289,9 @@ def process_and_store_logs(logs: list, provider: ObservabilityProvider):
 
     normalize_fn = normalization_functions[provider.provider]
 
+    created_count = 0
+    created_payload_bytes = 0
+
     for log in logs:
         normalized_data = normalize_fn(log)
         provider_log_id = normalized_data.get("id")
@@ -336,10 +341,12 @@ def process_and_store_logs(logs: list, provider: ObservabilityProvider):
 
                 if existing_span:
                     span = _update_observation_span(existing_span, normalized_data)
+                    was_created = False
                 else:
                     span = _create_observation_span(
                         project, provider, normalized_data, metadata
                     )
+                    was_created = True
 
                 _maybe_enqueue_recording_rehost(provider, span)
         except Exception as e:
@@ -347,6 +354,30 @@ def process_and_store_logs(logs: list, provider: ObservabilityProvider):
                 f"Error updating or creating observation span for {provider.provider}: {e}"
             )
             continue
+
+        if was_created:
+            created_count += 1
+            for piece in (
+                normalized_data.get("input"),
+                normalized_data.get("output"),
+                normalized_data.get("span_attributes"),
+                metadata,
+            ):
+                if piece is None:
+                    continue
+                try:
+                    created_payload_bytes += len(json.dumps(piece, default=str))
+                except (TypeError, ValueError):
+                    continue
+
+    if created_count:
+        emit_span_ingestion_usage(
+            organization_id=project.organization_id,
+            num_traces=created_count,
+            num_spans=created_count,
+            payload_bytes=created_payload_bytes,
+            source="voice_observability",
+        )
 
 
 def _maybe_enqueue_recording_rehost(

--- a/futureagi/tracer/utils/trace_ingestion.py
+++ b/futureagi/tracer/utils/trace_ingestion.py
@@ -26,6 +26,7 @@ from tracer.utils.otel import bulk_convert_otel_spans_to_observation_spans
 from tracer.utils.parsers import deserialize_trace_payload
 from tracer.utils.pii_scrubber import scrub_pii_in_span_batch
 from tracer.utils.pii_settings import get_pii_settings_for_projects
+from tracer.utils.usage_emit import emit_span_ingestion_usage
 
 OTLP_STATUS_MAP = {
     "STATUS_CODE_UNSET": "UNSET",
@@ -773,51 +774,16 @@ def bulk_create_observation_span_task(
             # 5. Trigger scanner for completed traces (root span with end_time)
             _trigger_trace_scanner(observation_spans_to_create)
 
-        # 6. Usage metering (after commit, outside transaction)
-        try:
-            try:
-                from ee.usage.deployment import DeploymentMode
-            except ImportError:
-                DeploymentMode = None
-
-            if not DeploymentMode.is_oss():
-                try:
-                    from ee.usage.schemas.event_types import BillingEventType
-                except ImportError:
-                    BillingEventType = None
-                try:
-                    from ee.usage.schemas.events import UsageEvent
-                except ImportError:
-                    UsageEvent = None
-                try:
-                    from ee.usage.services.emitter import emit
-                except ImportError:
-                    emit = None
-
-                num_traces = len(
-                    set(p.get("trace") for p in parsed_data_list if p.get("trace"))
-                )
-                num_spans = len(observation_spans_to_create)
-                if num_traces:
-                    emit(
-                        UsageEvent(
-                            org_id=str(organization_id),
-                            event_type=BillingEventType.TRACING_EVENT,
-                            amount=num_traces,
-                            properties={"traces": num_traces},
-                        )
-                    )
-                if num_spans:
-                    emit(
-                        UsageEvent(
-                            org_id=str(organization_id),
-                            event_type=BillingEventType.OBSERVE_ADD,
-                            amount=len(payload_bytes) if payload_bytes else 0,
-                            properties={"source": "trace_span", "spans": num_spans},
-                        )
-                    )
-        except Exception:
-            logger.debug("usage_metering_skipped", exc_info=True)
+        num_traces = len(
+            set(p.get("trace") for p in parsed_data_list if p.get("trace"))
+        )
+        emit_span_ingestion_usage(
+            organization_id=organization_id,
+            num_traces=num_traces,
+            num_spans=len(observation_spans_to_create),
+            payload_bytes=len(payload_bytes) if payload_bytes else 0,
+            source="trace_span",
+        )
 
     except Exception as exc:
         logger.exception(

--- a/futureagi/tracer/utils/usage_emit.py
+++ b/futureagi/tracer/utils/usage_emit.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def emit_span_ingestion_usage(
+    organization_id,
+    num_traces: int,
+    num_spans: int,
+    payload_bytes: int,
+    *,
+    source: str,
+) -> None:
+    try:
+        try:
+            from ee.usage.deployment import DeploymentMode
+        except ImportError:
+            return
+
+        if DeploymentMode.is_oss():
+            return
+
+        from ee.usage.schemas.event_types import BillingEventType
+        from ee.usage.schemas.events import UsageEvent
+        from ee.usage.services.emitter import emit
+
+        org_id_str = str(organization_id)
+
+        if num_traces:
+            emit(
+                UsageEvent(
+                    org_id=org_id_str,
+                    event_type=BillingEventType.TRACING_EVENT,
+                    amount=num_traces,
+                    properties={"traces": num_traces, "source": source},
+                )
+            )
+
+        if num_spans:
+            emit(
+                UsageEvent(
+                    org_id=org_id_str,
+                    event_type=BillingEventType.OBSERVE_ADD,
+                    amount=payload_bytes or 0,
+                    properties={"source": source, "spans": num_spans},
+                )
+            )
+    except Exception:
+        logger.debug("usage_metering_skipped", exc_info=True)


### PR DESCRIPTION
## Summary
- Voice observability ingestion (vapi/retell/eleven_labs via `process_and_store_logs`) was creating `ObservationSpan` and `Trace` rows but never calling `emit()`, so `UsageSummary` had no record of this traffic and Stripe was never told. New code path mirrors what OTLP ingestion already does in `trace_ingestion.py`.
- Extracted the dual-emit (`TRACING_EVENT` + `OBSERVE_ADD`) into `tracer/utils/usage_emit.py` so the OTLP path and the voice obs path call the same helper — single source of truth, drift-proof.
- Emit happens once per polling batch, after all rows commit. Counts creates only; updates are corrections to existing spans (matches OTLP semantics — OTLP has no update path).

## Out of scope (follow-ups)
- Audio rehost bytes (the big stream — voice recordings rehosted to our S3) are not metered yet. Right path is to thread `len(audio_bytes)` back from `convert_audio_url_to_s3_async` and emit a second `OBSERVE_ADD` from `rehost_external_recordings`.
- Backfill for past months (April + May voice obs traffic) is a separate one-off, gated on the audio-rehost emit landing first so the backfill aligns with forward semantics.

## Test plan
- [ ] Run a vapi/retell call through the simulator, confirm `usage:events` Redis stream gets `tracing_event` + `observe_add` entries with `source=voice_observability`
- [ ] Confirm `UsageSummary` row materializes for the org in `dimension=storage` and `dimension=tracing_events` after the consumer flush
- [ ] Re-poll the same call (forces update path), confirm no new emit (only creates bill)
- [ ] OTLP path unchanged: regular SDK trace upload still produces identical `source=trace_span` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)