### PR TITLE
feat(simulate): expand eval context map with Persona attributes + scenario.<col> resolver

### DIFF
--- a/frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx
+++ b/frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx
@@ -16,7 +16,6 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import Iconify from "src/components/iconify";
@@ -63,6 +62,36 @@ const COMMON_RUNTIME_LEAVES = [
   "stereo_recording_url",
 ];
 
+// Persona model fields the call-detail serializer surfaces under
+// persona_profile.<key>. Seeded with RUNTIME_PLACEHOLDER in preview so the
+// dropdown vocabulary is consistent with SimulationTestMode — actual values
+// resolve at simulation run time from the bound Persona model.
+const PERSONA_PROFILE_LEAVES = [
+  "name",
+  "description",
+  "gender",
+  "age_group",
+  "occupation",
+  "location",
+  "personality",
+  "communication_style",
+  "languages",
+  "accent",
+  "tone",
+  "verbosity",
+  "punctuation",
+  "emoji_usage",
+  "slang_usage",
+  "typos_frequency",
+  "regional_mix",
+  "conversation_speed",
+  "finished_speaking_sensitivity",
+  "interrupt_sensitivity",
+  "keywords",
+  "simulation_type",
+  "additional_instruction",
+];
+
 const PRIORITY_PREFIXES = [
   "call.transcript",
   "call.summary",
@@ -74,8 +103,8 @@ const PRIORITY_PREFIXES = [
   "call.customer_recording",
   "call.agent_prompt",
   "call.",
-  "scenario.columns.",
   "scenario.info.",
+  "scenario.metadata.",
   "scenario.",
   "simulation.",
   "agent.",
@@ -175,16 +204,11 @@ const CreateSimulationPreviewMode = React.forwardRef(
     const [tableSearch, setTableSearch] = useState("");
     const [expandedCols, setExpandedCols] = useState({});
 
-    // Track displayKey -> UUID for scenario columns. The backend
-    // resolver only accepts column UUIDs, so the saved eval mapping
-    // must persist UUIDs even though the dropdown shows the friendly
-    // `scenario_<name>` label.
-    const scenarioKeyMap = useRef({});
-
     // Build the nested vocabulary dict from the preview data. Real
     // values fill in what the user already chose in the form (agent,
-    // persona, scenario, prompt); placeholder strings seed the runtime
-    // keys so they render in the panel and are pickable in the dropdown.
+    // scenario, prompt); placeholder strings seed the runtime keys
+    // (persona.*, call.*, scenario columns) so they render in the panel
+    // and remain pickable in the dropdown.
     const callDetail = useMemo(() => {
       const ctx = previewData || {};
       const flat = {
@@ -192,10 +216,9 @@ const CreateSimulationPreviewMode = React.forwardRef(
         agent: {},
         persona: {},
         prompt: {},
-        scenario: { info: {}, columns: {} },
+        scenario: { info: {}, metadata: {} },
         call: {},
       };
-      scenarioKeyMap.current = {};
 
       const isText = ctx.sim_call_type === "text" || ctx.simCallType === "text";
 
@@ -224,16 +247,13 @@ const CreateSimulationPreviewMode = React.forwardRef(
         if (snap.description) flat.agent.description = snap.description;
       }
 
-      // ── Persona (simulator agent) ──
-      const persona = ctx.simulator_agent;
-      if (persona) {
-        if (persona.name) flat.persona.name = persona.name;
-        if (persona.prompt) flat.persona.prompt = persona.prompt;
-        if (persona.description) flat.persona.description = persona.description;
-        if (persona.voice_name) flat.persona.voice_name = persona.voice_name;
-        if (persona.model) flat.persona.model = persona.model;
-        if (persona.initial_message)
-          flat.persona.initial_message = persona.initial_message;
+      // Persona attributes (Persona model fields, not SimulatorAgent). At
+      // form-time the bound Persona is not yet resolved (selection happens
+      // via scenario.metadata.persona_ids or per-row row_data.persona at
+      // run time) — seed placeholders so the dropdown still surfaces the
+      // vocabulary.
+      for (const leaf of PERSONA_PROFILE_LEAVES) {
+        flat.persona[leaf] = RUNTIME_PLACEHOLDER;
       }
 
       // ── Prompt template (prompt-type sims) ──
@@ -255,15 +275,15 @@ const CreateSimulationPreviewMode = React.forwardRef(
         if (scenarioRow.source) flat.scenario.info.source = scenarioRow.source;
       }
 
-      // ── Scenario columns (per-row dataset cells) ──
-      // Shape: { <uuid>: { name, type } }. Display path is
-      // `scenario.columns.<name>`; persisted mapping value is the UUID.
+      // Scenario columns surface as `scenario.<column_name>` — backend
+      // resolver matches Column.name within the call's dataset (TH-4952).
+      // `info` and `metadata` are reserved sub-keys (backend resolver
+      // skips them before column lookup, see xl.py:683).
       const scenarioColumns = ctx.scenario_columns || {};
-      for (const [uuid, col] of Object.entries(scenarioColumns)) {
+      for (const col of Object.values(scenarioColumns)) {
         const colName = col?.name;
-        if (!colName) continue;
-        flat.scenario.columns[colName] = RUNTIME_PLACEHOLDER;
-        scenarioKeyMap.current[`scenario.columns.${colName}`] = uuid;
+        if (!colName || colName === "info" || colName === "metadata") continue;
+        flat.scenario[colName] = RUNTIME_PLACEHOLDER;
       }
 
       // ── Runtime vocabulary nested under `call.*` — always rendered
@@ -322,15 +342,7 @@ const CreateSimulationPreviewMode = React.forwardRef(
       });
     }, [variables, fieldNames]);
 
-    // Translate display keys → persistence keys (scenario UUIDs) before
-    // emitting to the parent. Same contract as SimulationTestMode.
-    const persistedMapping = useMemo(() => {
-      const out = {};
-      for (const [variable, field] of Object.entries(mapping)) {
-        out[variable] = scenarioKeyMap.current[field] || field;
-      }
-      return out;
-    }, [mapping, callDetail]);
+    const persistedMapping = useMemo(() => ({ ...mapping }), [mapping]);
 
     const isReady = useMemo(
       () => variables.length > 0 && variables.every((v) => !!mapping[v]),

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -75,8 +75,8 @@ const PRIORITY_PREFIXES = [
   "call.agent_prompt",
   "call.", // remaining call-level leaves
   "eval_", // resolved eval results (still flat)
-  "scenario.columns.",
   "scenario.info.",
+  "scenario.metadata.",
   "scenario.",
   "simulation.",
   "agent.",
@@ -249,18 +249,12 @@ const SimulationTestMode = React.forwardRef(
     const [tableSearch, setTableSearch] = useState("");
     const [expandedCols, setExpandedCols] = useState({});
 
-    // Variable mapping (stores display keys internally; scenario fields are
-    // translated to their UUID via scenarioKeyMap when emitted to the parent).
     // Seeded from `initialMapping` when editing an existing eval (TH-4302).
     const [mapping, setMapping] = useState(
       initialMapping && typeof initialMapping === "object"
         ? { ...initialMapping }
         : {},
     );
-    // displayKey ("scenario_<col_name>") -> scenario column UUID. The backend
-    // resolver at run time only accepts scenario column UUIDs, not names, so
-    // we persist the UUID while the dropdown still shows the friendly label.
-    const scenarioKeyMap = useRef({});
 
     // Eval result
     const [, setIsRunning] = useState(false);
@@ -436,6 +430,8 @@ const SimulationTestMode = React.forwardRef(
             "customer_call_id",
             "eval_outputs",
             "scenario_columns",
+            "persona_profile",
+            "scenario_metadata",
             "eval_metrics",
             "is_snapshot",
             "snapshot_timestamp",
@@ -477,7 +473,7 @@ const SimulationTestMode = React.forwardRef(
             simulation: {},
             agent: {},
             persona: {},
-            scenario: { info: {}, columns: {} },
+            scenario: { info: {}, metadata: {} },
             call: {},
           };
 
@@ -499,19 +495,6 @@ const SimulationTestMode = React.forwardRef(
               if (ad.description) flat.agent.description = ad.description;
             }
 
-            const persona = runTestContext.simulator_agent_detail;
-            if (persona) {
-              if (persona.name) flat.persona.name = persona.name;
-              if (persona.prompt) flat.persona.prompt = persona.prompt;
-              if (persona.description)
-                flat.persona.description = persona.description;
-              if (persona.voice_name)
-                flat.persona.voice_name = persona.voice_name;
-              if (persona.model) flat.persona.model = persona.model;
-              if (persona.initial_message)
-                flat.persona.initial_message = persona.initial_message;
-            }
-
             const promptTemplate = runTestContext.prompt_template_detail;
             if (promptTemplate) {
               flat.prompt = {};
@@ -521,17 +504,50 @@ const SimulationTestMode = React.forwardRef(
             }
           }
 
-          // -- Scenario columns: display key `scenario.columns.<name>`,
-          // persisted mapping value is the column UUID (backend resolver
-          // accepts UUIDs, not names).
+          // Scenario columns surface as `scenario.<column_name>` — backend
+          // resolver matches Column.name within the call's dataset (TH-4952).
+          // `info` and `metadata` are reserved sub-keys (backend resolver
+          // skips them before column lookup, see xl.py:683) so columns with
+          // those names cannot be addressed via the eval-mapping dropdown.
           const sc = callData.scenario_columns;
-          scenarioKeyMap.current = {};
           if (sc && typeof sc === "object") {
-            for (const [uuid, col] of Object.entries(sc)) {
-              if (col?.column_name && col?.value !== undefined) {
-                flat.scenario.columns[col.column_name] = col.value;
-                scenarioKeyMap.current[`scenario.columns.${col.column_name}`] =
-                  uuid;
+            for (const col of Object.values(sc)) {
+              if (
+                col?.column_name &&
+                col?.value !== undefined &&
+                col.column_name !== "info" &&
+                col.column_name !== "metadata"
+              ) {
+                flat.scenario[col.column_name] = col.value;
+              }
+            }
+          }
+
+          // Persona attributes (Persona model fields + Persona.metadata) —
+          // sourced from the new `persona_profile` field on CallExecutionDetailSerializer.
+          const personaProfile = callData.persona_profile;
+          if (personaProfile && typeof personaProfile === "object") {
+            for (const [key, value] of Object.entries(personaProfile)) {
+              if (key === "metadata" && value && typeof value === "object") {
+                for (const [metaKey, metaValue] of Object.entries(value)) {
+                  if (metaValue !== "" && metaValue != null) {
+                    flat.persona.metadata = flat.persona.metadata || {};
+                    flat.persona.metadata[metaKey] = metaValue;
+                  }
+                }
+              } else if (value !== "" && value != null) {
+                flat.persona[key] = value;
+              }
+            }
+          }
+
+          // Free-form Scenarios.metadata sub-keys — sourced from the new
+          // `scenario_metadata` field (internal keys already denylisted server-side).
+          const scenarioMeta = callData.scenario_metadata;
+          if (scenarioMeta && typeof scenarioMeta === "object") {
+            for (const [key, value] of Object.entries(scenarioMeta)) {
+              if (value !== "" && value != null) {
+                flat.scenario.metadata[key] = value;
               }
             }
           }
@@ -806,17 +822,7 @@ const SimulationTestMode = React.forwardRef(
       [selectedRunTestId, variables, mapping],
     );
 
-    // Translate scenario display keys → UUIDs before handing mapping to
-    // the parent. The backend resolver matches on column UUID, so without
-    // this, saved evals that reference scenario columns fail at run time
-    // with "Column mapping mismatch".
-    const persistedMapping = useMemo(() => {
-      const out = {};
-      for (const [variable, field] of Object.entries(mapping)) {
-        out[variable] = scenarioKeyMap.current[field] || field;
-      }
-      return out;
-    }, [mapping, callDetail]);
+    const persistedMapping = useMemo(() => ({ ...mapping }), [mapping]);
 
     useEffect(() => {
       onReadyChange?.(isReady, persistedMapping);

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -173,6 +173,14 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
     # Dynamic scenario columns - these will be populated based on scenarios
     scenario_columns = serializers.SerializerMethodField()
 
+    # Persona profile attributes (gender, age_group, etc.) + free-form
+    # persona.metadata sub-keys. Frontend flattener emits flat.persona.<X>
+    # / flat.persona.metadata.<X> from these.
+    persona_profile = serializers.SerializerMethodField()
+
+    # Free-form Scenarios.metadata sub-keys (with internal references denylisted).
+    scenario_metadata = serializers.SerializerMethodField()
+
     # Graph-related field
     scenario_id = serializers.SerializerMethodField()
 
@@ -229,6 +237,8 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
             "eval_outputs",
             "eval_metrics",
             "scenario_columns",
+            "persona_profile",
+            "scenario_metadata",
             "ended_reason",
             "simulator_agent_name",
             "simulator_agent_id",
@@ -681,6 +691,54 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
             scenario_data = {}
 
         return scenario_data
+
+    def get_persona_profile(self, obj):
+        """Persona attributes + Persona.metadata for the user-facing eval
+        mapping dropdown. Persona model fields only — SimulatorAgent fields
+        are deliberately excluded (legacy `persona.<sim_field>` mappings
+        still resolve at runtime via the eval-context resolver, but the
+        dropdown source must never list them).
+        """
+        if isinstance(obj, dict):
+            return {}
+        from simulate.utils.eval_context import (
+            flatten_persona,
+            resolve_persona_for_call,
+        )
+
+        persona = resolve_persona_for_call(obj)
+        if persona is None:
+            return {}
+
+        flat = flatten_persona(persona)
+        out = {}
+        for key, value in flat.items():
+            if not key.startswith("persona."):
+                continue
+            suffix = key[len("persona.") :]
+            if suffix.startswith("metadata."):
+                out.setdefault("metadata", {})[suffix[len("metadata.") :]] = value
+            else:
+                out[suffix] = value
+        return out
+
+    def get_scenario_metadata(self, obj):
+        """Free-form Scenarios.metadata sub-keys, with internal reference keys
+        denylisted (matches the eval context map's _SCENARIO_METADATA_DENYLIST).
+        """
+        if isinstance(obj, dict):
+            return {}
+        scenario = getattr(obj, "scenario", None)
+        if not scenario or not scenario.metadata:
+            return {}
+        from simulate.utils.eval_context import flatten_jsonfield_value
+
+        denylist = {"persona_ids", "agent_definition_version_id"}
+        return {
+            key: flatten_jsonfield_value(value)
+            for key, value in scenario.metadata.items()
+            if key not in denylist
+        }
 
     def get_scenario_id(self, obj):
         """Get scenario ID"""

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -42,6 +42,7 @@ from simulate.utils.eval_context import (
     flatten_jsonfield_value,
     flatten_persona_for_resolver,
     resolve_persona_for_call,
+    resolve_scenario_column_by_name,
 )
 from simulate.utils.eval_summary import derive_kpi_output_type
 
@@ -592,6 +593,10 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
                 continue
             if value in context_map:
                 continue
+            if value.startswith("scenario."):
+                # Resolved by the scenario.<col> branch in the main loop;
+                # never a Column.id, so don't probe the mismatch table.
+                continue
             if value in scenario_column_order_set:
                 cell_column_ids.append(value)
             else:
@@ -675,6 +680,13 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
                     updated_mapping[key] = transcript_data.get(legacy_key, "")
             elif value in context_map:
                 updated_mapping[key] = context_map[value]
+            elif value.startswith("scenario.") and not (
+                value.startswith("scenario.info.")
+                or value.startswith("scenario.metadata.")
+            ):
+                updated_mapping[key] = resolve_scenario_column_by_name(
+                    call_execution, value[len("scenario.") :]
+                )
             elif value in scenario_column_order_set:
                 if not row_id:
                     updated_mapping[key] = ""

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -39,12 +39,17 @@ from simulate.temporal.types.activities import (
     RunToolCallEvaluationOutput,
 )
 from simulate.utils.eval_context import (
+    flatten_jsonfield_value,
     flatten_persona_for_resolver,
     resolve_persona_for_call,
 )
 from simulate.utils.eval_summary import derive_kpi_output_type
 
 logger = structlog.get_logger(__name__)
+
+_SCENARIO_METADATA_DENYLIST = frozenset(
+    {"persona_ids", "agent_definition_version_id"}
+)
 
 # ============================================================================
 # EVALUATION ACTIVITIES
@@ -379,10 +384,6 @@ CONTEXT_MAP_DOT_ALIASES = {
     "prompt_template": "prompt.name",
     "prompt_template_name": "prompt.name",
     "prompt_template_description": "prompt.description",
-    "scenario_info_name": "scenario.name",
-    "scenario_info_description": "scenario.description",
-    "scenario_info_type": "scenario.type",
-    "scenario_info_source": "scenario.source",
     "call_summary": "call.summary",
     "ended_reason": "call.ended_reason",
     "duration_seconds": "call.duration_seconds",
@@ -492,17 +493,22 @@ def _build_simulation_context_map(call_execution, agent_version):
         # Back-compat alias: the frontend flattens this as "prompt_template".
         ctx["prompt_template"] = _s(prompt_template.name)
 
-    # Scenario-row metadata (Scenarios FK on CallExecution). Dataset cell
-    # values are still resolved via the scenario-column-UUID branch in the
-    # main loop — these keys only cover the Scenarios row itself, prefixed
-    # `scenario_info_` so they don't collide with user-named dataset
-    # columns like `scenario_name`.
+    # scenario.info.* — keeps bare scenario.<X> free for dataset-column lookups.
     scenario = getattr(call_execution, "scenario", None)
     if scenario:
-        ctx["scenario_info_name"] = _s(scenario.name)
-        ctx["scenario_info_description"] = _s(scenario.description)
-        ctx["scenario_info_type"] = _s(scenario.scenario_type)
-        ctx["scenario_info_source"] = _s(scenario.source)
+        ctx["scenario.info.name"] = _s(scenario.name)
+        ctx["scenario.info.description"] = _s(scenario.description)
+        ctx["scenario.info.type"] = _s(scenario.scenario_type)
+        ctx["scenario.info.source"] = _s(scenario.source)
+        ctx["scenario_info_name"] = ctx["scenario.info.name"]
+        ctx["scenario_info_description"] = ctx["scenario.info.description"]
+        ctx["scenario_info_type"] = ctx["scenario.info.type"]
+        ctx["scenario_info_source"] = ctx["scenario.info.source"]
+
+        for _key, _value in (scenario.metadata or {}).items():
+            if _key in _SCENARIO_METADATA_DENYLIST:
+                continue
+            ctx[f"scenario.metadata.{_key}"] = flatten_jsonfield_value(_value)
 
     # Expose every entry under its dot-hierarchy alias too. This lets the
     # new frontend dropdowns persist `agent.name` style mapping values

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -415,6 +415,48 @@ TRANSCRIPT_DOT_ALIASES = {
 }
 
 
+def _resolve_persona_for_call(call_execution):
+    """Pick the Persona used for this specific call.
+
+    Priority:
+    1. call_metadata.row_data.persona (UUID) — baked into the dataset row
+       at execution time by temporal/activities/test_execution.py.
+    2. First Persona referenced by scenario.metadata.persona_ids
+       (ordered by created_at — stable across runs).
+    3. None — `persona.*` keys resolve to "".
+    """
+    from simulate.models import Persona
+
+    metadata = call_execution.call_metadata or {}
+    row_data = metadata.get("row_data") or {}
+    row_persona_id = row_data.get("persona")
+    if row_persona_id:
+        try:
+            return Persona.no_workspace_objects.get(
+                id=row_persona_id, deleted=False
+            )
+        except (Persona.DoesNotExist, ValueError):
+            pass
+
+    scenario = getattr(call_execution, "scenario", None)
+    if not scenario:
+        return None
+    scenario_meta = scenario.metadata or {}
+    persona_ids = scenario_meta.get("persona_ids") or []
+    if not persona_ids:
+        return None
+    try:
+        return (
+            Persona.no_workspace_objects.filter(
+                id__in=persona_ids, deleted=False
+            )
+            .order_by("created_at")
+            .first()
+        )
+    except ValueError:
+        return None
+
+
 def _build_simulation_context_map(call_execution, agent_version):
     """
     Build a flat {key: string} map of simulation context that eval configs

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -38,6 +38,10 @@ from simulate.temporal.types.activities import (
     RunToolCallEvaluationInput,
     RunToolCallEvaluationOutput,
 )
+from simulate.utils.eval_context import (
+    flatten_persona_for_resolver,
+    resolve_persona_for_call,
+)
 from simulate.utils.eval_summary import derive_kpi_output_type
 
 logger = structlog.get_logger(__name__)
@@ -372,12 +376,6 @@ CONTEXT_MAP_DOT_ALIASES = {
     "agent_model": "agent.model",
     "agent_language": "agent.language",
     "agent_description": "agent.description",
-    "persona_name": "persona.name",
-    "persona_prompt": "persona.prompt",
-    "persona_description": "persona.description",
-    "persona_voice_name": "persona.voice_name",
-    "persona_model": "persona.model",
-    "persona_initial_message": "persona.initial_message",
     "prompt_template": "prompt.name",
     "prompt_template_name": "prompt.name",
     "prompt_template_description": "prompt.description",
@@ -413,48 +411,6 @@ TRANSCRIPT_DOT_ALIASES = {
     # transcript_data — handled inline in _run_single_evaluation.
     "call.agent_prompt": "agent_prompt",
 }
-
-
-def _resolve_persona_for_call(call_execution):
-    """Pick the Persona used for this specific call.
-
-    Priority:
-    1. call_metadata.row_data.persona (UUID) — baked into the dataset row
-       at execution time by temporal/activities/test_execution.py.
-    2. First Persona referenced by scenario.metadata.persona_ids
-       (ordered by created_at — stable across runs).
-    3. None — `persona.*` keys resolve to "".
-    """
-    from simulate.models import Persona
-
-    metadata = call_execution.call_metadata or {}
-    row_data = metadata.get("row_data") or {}
-    row_persona_id = row_data.get("persona")
-    if row_persona_id:
-        try:
-            return Persona.no_workspace_objects.get(
-                id=row_persona_id, deleted=False
-            )
-        except (Persona.DoesNotExist, ValueError):
-            pass
-
-    scenario = getattr(call_execution, "scenario", None)
-    if not scenario:
-        return None
-    scenario_meta = scenario.metadata or {}
-    persona_ids = scenario_meta.get("persona_ids") or []
-    if not persona_ids:
-        return None
-    try:
-        return (
-            Persona.no_workspace_objects.filter(
-                id__in=persona_ids, deleted=False
-            )
-            .order_by("created_at")
-            .first()
-        )
-    except ValueError:
-        return None
 
 
 def _build_simulation_context_map(call_execution, agent_version):
@@ -521,16 +477,14 @@ def _build_simulation_context_map(call_execution, agent_version):
     ctx["agent_description"] = _agent("description", "description")
     ctx["agent_model"] = _agent("model", "model")
 
-    if simulator_agent:
-        ctx["persona_name"] = _s(simulator_agent.name)
-        ctx["persona_prompt"] = _s(simulator_agent.prompt)
-        # Back-compat alias: the UI dropdown has historically shown
-        # "persona_description" (serializer exposed `prompt` under a
-        # `description` alias). Keep the mapping value resolvable.
-        ctx["persona_description"] = _s(simulator_agent.prompt)
-        ctx["persona_voice_name"] = _s(simulator_agent.voice_name)
-        ctx["persona_model"] = _s(simulator_agent.model)
-        ctx["persona_initial_message"] = _s(simulator_agent.initial_message)
+    persona = resolve_persona_for_call(call_execution)
+    ctx.update(flatten_persona_for_resolver(persona, simulator_agent))
+
+    # Underscore back-compat for pre-2026-04-13 configs that used persona_name etc.
+    for _suffix in ("name", "prompt", "description", "voice_name", "model", "initial_message"):
+        _dot = f"persona.{_suffix}"
+        if _dot in ctx:
+            ctx[f"persona_{_suffix}"] = ctx[_dot]
 
     if prompt_template:
         ctx["prompt_template_name"] = _s(prompt_template.name)

--- a/futureagi/simulate/tests/factories.py
+++ b/futureagi/simulate/tests/factories.py
@@ -1,0 +1,154 @@
+"""Reusable factory helpers for simulate-app tests.
+
+Designed as composable building blocks. Anything you can build with these
+should be wireable into an integration test without re-stitching the
+underlying FK chains.
+
+Why a module of plain functions instead of pytest fixtures: factories are
+called multiple times per test (e.g. "create 3 columns") which is awkward
+with fixtures. Plain functions compose naturally; tests that need them
+declared at fixture level can wrap them via a one-line conftest fixture.
+"""
+
+from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from simulate.models import AgentDefinition, Persona, Scenarios
+from simulate.models.run_test import RunTest
+from simulate.models.simulator_agent import SimulatorAgent
+from simulate.models.test_execution import CallExecution, TestExecution
+
+
+def make_persona(organization, workspace, **overrides):
+    """Create a Persona row with sane defaults; overrides win."""
+    defaults = dict(
+        name="Test Persona",
+        organization=organization,
+        workspace=workspace,
+        persona_type=Persona.PersonaType.WORKSPACE,
+    )
+    defaults.update(overrides)
+    return Persona.objects.create(**defaults)
+
+
+def make_agent_definition(organization, workspace, *, agent_type=None):
+    return AgentDefinition.objects.create(
+        agent_name="Test Agent",
+        agent_type=agent_type or AgentDefinition.AgentTypeChoices.VOICE,
+        inbound=True,
+        description="Test agent",
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+def make_simulator_agent(organization, workspace, **overrides):
+    defaults = dict(
+        name="Sim",
+        prompt="You are a simulator",
+        voice_provider="elevenlabs",
+        voice_name="marissa",
+        model="gpt-4",
+        organization=organization,
+        workspace=workspace,
+    )
+    defaults.update(overrides)
+    return SimulatorAgent.objects.create(**defaults)
+
+
+def make_dataset_with_columns(organization, workspace, user, column_specs):
+    """Create a Dataset with the named columns and a single Row.
+
+    `column_specs` is a list of (column_name, cell_value) tuples. Returns
+    (dataset, row, columns_by_name).
+    """
+    dataset = Dataset.no_workspace_objects.create(
+        name="Test Dataset",
+        organization=organization,
+        workspace=workspace,
+        user=user,
+        source=DatasetSourceChoices.SCENARIO.value,
+    )
+    columns_by_name = {}
+    column_order = []
+    for col_name, _ in column_specs:
+        col = Column.objects.create(
+            dataset=dataset,
+            name=col_name,
+            data_type="text",
+            source=SourceChoices.OTHERS.value,
+        )
+        columns_by_name[col_name] = col
+        column_order.append(str(col.id))
+    dataset.column_order = column_order
+    dataset.save()
+
+    row = Row.objects.create(dataset=dataset, order=0)
+    for col_name, cell_value in column_specs:
+        Cell.objects.create(
+            dataset=dataset,
+            column=columns_by_name[col_name],
+            row=row,
+            value=cell_value,
+        )
+    return dataset, row, columns_by_name
+
+
+def make_scenario(
+    organization, workspace, agent_definition, *, dataset=None, metadata=None
+):
+    return Scenarios.objects.create(
+        name="Test Scenario",
+        description="Test scenario description",
+        source="Test source",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=organization,
+        workspace=workspace,
+        dataset=dataset,
+        agent_definition=agent_definition,
+        status=StatusType.COMPLETED.value,
+        metadata=metadata or {},
+    )
+
+
+def make_run_test(
+    organization, workspace, agent_definition, *, simulator_agent=None, scenarios=None
+):
+    rt = RunTest.objects.create(
+        name="Test Run",
+        description="Test run description",
+        agent_definition=agent_definition,
+        simulator_agent=simulator_agent,
+        organization=organization,
+        workspace=workspace,
+    )
+    if scenarios:
+        for scenario in scenarios:
+            rt.scenarios.add(scenario)
+    return rt
+
+
+def make_test_execution(
+    run_test, *, agent_definition, simulator_agent=None, status=None
+):
+    return TestExecution.objects.create(
+        run_test=run_test,
+        status=status or TestExecution.ExecutionStatus.COMPLETED,
+        simulator_agent=simulator_agent,
+        agent_definition=agent_definition,
+    )
+
+
+def make_call_execution(test_execution, scenario, *, row_id=None, row_data=None):
+    call_metadata = {}
+    if row_id is not None:
+        call_metadata["row_id"] = str(row_id)
+    if row_data is not None:
+        call_metadata["row_data"] = row_data
+    return CallExecution.objects.create(
+        test_execution=test_execution,
+        scenario=scenario,
+        phone_number="+1234567890",
+        status=CallExecution.CallStatus.COMPLETED,
+        call_metadata=call_metadata,
+    )

--- a/futureagi/simulate/tests/test_call_detail_serializer.py
+++ b/futureagi/simulate/tests/test_call_detail_serializer.py
@@ -9,52 +9,18 @@ CreateSimulationPreviewMode.jsx.
 
 import pytest
 
-from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
-from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
-from simulate.models import AgentDefinition, Persona, Scenarios
-from simulate.models.run_test import RunTest
-from simulate.models.simulator_agent import SimulatorAgent
-from simulate.models.test_execution import CallExecution, TestExecution
 from simulate.serializers.test_execution import CallExecutionDetailSerializer
+from simulate.tests.factories import (
+    make_agent_definition,
+    make_call_execution,
+    make_persona,
+    make_run_test,
+    make_scenario,
+    make_simulator_agent,
+    make_test_execution,
+)
 
 pytestmark = pytest.mark.integration
-
-
-def _make_persona(organization, workspace, **overrides):
-    defaults = dict(
-        name="Test Persona",
-        organization=organization,
-        workspace=workspace,
-        persona_type=Persona.PersonaType.WORKSPACE,
-    )
-    defaults.update(overrides)
-    return Persona.objects.create(**defaults)
-
-
-def _make_agent_definition(organization, workspace):
-    return AgentDefinition.objects.create(
-        agent_name="Test Agent",
-        agent_type=AgentDefinition.AgentTypeChoices.VOICE,
-        inbound=True,
-        description="Test agent",
-        organization=organization,
-        workspace=workspace,
-        languages=["en"],
-    )
-
-
-def _make_simulator(organization, workspace, **overrides):
-    defaults = dict(
-        name="Sim",
-        prompt="You are a simulator",
-        voice_provider="elevenlabs",
-        voice_name="marissa",
-        model="gpt-4",
-        organization=organization,
-        workspace=workspace,
-    )
-    defaults.update(overrides)
-    return SimulatorAgent.objects.create(**defaults)
 
 
 def _make_call(
@@ -65,61 +31,42 @@ def _make_call(
     scenario_metadata=None,
     simulator=None,
 ):
-    """Bootstrap a CallExecution with optional persona / scenario.metadata wiring."""
-    agent_def = _make_agent_definition(organization, workspace)
-    simulator = simulator or _make_simulator(organization, workspace)
+    """Bootstrap a CallExecution with optional persona / scenario.metadata wiring.
+
+    Composes primitives from `simulate.tests.factories` — kept here (not in
+    the shared factories module) because the persona-resolution wiring is
+    specific to this suite's contract assertions.
+    """
+    agent_def = make_agent_definition(organization, workspace)
+    simulator = simulator or make_simulator_agent(organization, workspace)
 
     metadata = scenario_metadata or {}
     if persona is not None and "persona_ids" not in metadata:
         metadata["persona_ids"] = [str(persona.id)]
 
-    scenario = Scenarios.objects.create(
-        name="Test Scenario",
-        description="d",
-        source="s",
-        scenario_type=Scenarios.ScenarioTypes.DATASET,
-        organization=organization,
-        workspace=workspace,
-        agent_definition=agent_def,
-        status=StatusType.COMPLETED.value,
-        metadata=metadata,
+    scenario = make_scenario(
+        organization, workspace, agent_def, metadata=metadata
     )
-
-    rt = RunTest.objects.create(
-        name="rt",
-        description="d",
-        agent_definition=agent_def,
+    rt = make_run_test(
+        organization,
+        workspace,
+        agent_def,
         simulator_agent=simulator,
-        organization=organization,
-        workspace=workspace,
+        scenarios=[scenario],
     )
-    rt.scenarios.add(scenario)
-
-    te = TestExecution.objects.create(
-        run_test=rt,
-        status=TestExecution.ExecutionStatus.COMPLETED,
-        simulator_agent=simulator,
-        agent_definition=agent_def,
+    te = make_test_execution(
+        rt, agent_definition=agent_def, simulator_agent=simulator
     )
 
-    call_metadata = {}
-    if persona is not None:
-        call_metadata["row_data"] = {"persona": str(persona.id)}
-
-    return CallExecution.objects.create(
-        test_execution=te,
-        scenario=scenario,
-        phone_number="+1234567890",
-        status=CallExecution.CallStatus.COMPLETED,
-        call_metadata=call_metadata,
-    )
+    row_data = {"persona": str(persona.id)} if persona is not None else None
+    return make_call_execution(te, scenario, row_data=row_data)
 
 
 @pytest.mark.django_db
 def test_persona_profile_exposes_persona_model_attributes(
     organization, workspace
 ):
-    persona = _make_persona(
+    persona = make_persona(
         organization,
         workspace,
         name="Alice",
@@ -149,8 +96,8 @@ def test_persona_profile_excludes_simulator_fields(organization, workspace):
     still resolve at runtime via the eval-context resolver — but the
     dropdown source must never list them.
     """
-    persona = _make_persona(organization, workspace, name="Alice")
-    simulator = _make_simulator(
+    persona = make_persona(organization, workspace, name="Alice")
+    simulator = make_simulator_agent(
         organization, workspace, voice_name="alloy", prompt="You are helpful"
     )
     call = _make_call(
@@ -170,7 +117,7 @@ def test_persona_profile_excludes_simulator_fields(organization, workspace):
 def test_persona_profile_empty_when_no_persona_bound(organization, workspace):
     """If the scenario has no persona_ids and no row_data.persona, the
     profile is an empty dict (no SimulatorAgent stand-in)."""
-    simulator = _make_simulator(organization, workspace, voice_name="alloy")
+    simulator = make_simulator_agent(organization, workspace, voice_name="alloy")
     call = _make_call(organization, workspace, simulator=simulator)
 
     data = CallExecutionDetailSerializer(call).data
@@ -185,7 +132,7 @@ def test_persona_profile_nests_metadata_under_metadata_key(
     """Persona.metadata sub-keys should land under persona_profile["metadata"]
     so the frontend flattener can emit flat.persona.metadata.<key>.
     """
-    persona = _make_persona(
+    persona = make_persona(
         organization,
         workspace,
         metadata={"region": "EMEA", "vip_tier": "gold"},
@@ -200,7 +147,7 @@ def test_persona_profile_nests_metadata_under_metadata_key(
 
 @pytest.mark.django_db
 def test_persona_profile_multi_value_list_joined(organization, workspace):
-    persona = _make_persona(
+    persona = make_persona(
         organization,
         workspace,
         languages=["English", "Hindi", "Marathi"],

--- a/futureagi/simulate/tests/test_call_detail_serializer.py
+++ b/futureagi/simulate/tests/test_call_detail_serializer.py
@@ -1,0 +1,271 @@
+"""Integration tests for CallExecutionDetailSerializer's persona_profile and
+scenario_metadata fields.
+
+These fields drive the eval-mapping dropdown on the frontend — the dropdown
+auto-derives options from the serialized call-detail payload, so the shape
+asserted here is the contract with SimulationTestMode.jsx /
+CreateSimulationPreviewMode.jsx.
+"""
+
+import pytest
+
+from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from simulate.models import AgentDefinition, Persona, Scenarios
+from simulate.models.run_test import RunTest
+from simulate.models.simulator_agent import SimulatorAgent
+from simulate.models.test_execution import CallExecution, TestExecution
+from simulate.serializers.test_execution import CallExecutionDetailSerializer
+
+pytestmark = pytest.mark.integration
+
+
+def _make_persona(organization, workspace, **overrides):
+    defaults = dict(
+        name="Test Persona",
+        organization=organization,
+        workspace=workspace,
+        persona_type=Persona.PersonaType.WORKSPACE,
+    )
+    defaults.update(overrides)
+    return Persona.objects.create(**defaults)
+
+
+def _make_agent_definition(organization, workspace):
+    return AgentDefinition.objects.create(
+        agent_name="Test Agent",
+        agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+        inbound=True,
+        description="Test agent",
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+def _make_simulator(organization, workspace, **overrides):
+    defaults = dict(
+        name="Sim",
+        prompt="You are a simulator",
+        voice_provider="elevenlabs",
+        voice_name="marissa",
+        model="gpt-4",
+        organization=organization,
+        workspace=workspace,
+    )
+    defaults.update(overrides)
+    return SimulatorAgent.objects.create(**defaults)
+
+
+def _make_call(
+    organization,
+    workspace,
+    *,
+    persona=None,
+    scenario_metadata=None,
+    simulator=None,
+):
+    """Bootstrap a CallExecution with optional persona / scenario.metadata wiring."""
+    agent_def = _make_agent_definition(organization, workspace)
+    simulator = simulator or _make_simulator(organization, workspace)
+
+    metadata = scenario_metadata or {}
+    if persona is not None and "persona_ids" not in metadata:
+        metadata["persona_ids"] = [str(persona.id)]
+
+    scenario = Scenarios.objects.create(
+        name="Test Scenario",
+        description="d",
+        source="s",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=organization,
+        workspace=workspace,
+        agent_definition=agent_def,
+        status=StatusType.COMPLETED.value,
+        metadata=metadata,
+    )
+
+    rt = RunTest.objects.create(
+        name="rt",
+        description="d",
+        agent_definition=agent_def,
+        simulator_agent=simulator,
+        organization=organization,
+        workspace=workspace,
+    )
+    rt.scenarios.add(scenario)
+
+    te = TestExecution.objects.create(
+        run_test=rt,
+        status=TestExecution.ExecutionStatus.COMPLETED,
+        simulator_agent=simulator,
+        agent_definition=agent_def,
+    )
+
+    call_metadata = {}
+    if persona is not None:
+        call_metadata["row_data"] = {"persona": str(persona.id)}
+
+    return CallExecution.objects.create(
+        test_execution=te,
+        scenario=scenario,
+        phone_number="+1234567890",
+        status=CallExecution.CallStatus.COMPLETED,
+        call_metadata=call_metadata,
+    )
+
+
+@pytest.mark.django_db
+def test_persona_profile_exposes_persona_model_attributes(
+    organization, workspace
+):
+    persona = _make_persona(
+        organization,
+        workspace,
+        name="Alice",
+        gender=["female"],
+        age_group=["28-35"],
+        occupation=["Software Engineer"],
+        tone="casual",
+        verbosity="brief",
+    )
+    call = _make_call(organization, workspace, persona=persona)
+
+    data = CallExecutionDetailSerializer(call).data
+
+    profile = data["persona_profile"]
+    assert profile["name"] == "Alice"
+    assert profile["gender"] == "female"
+    assert profile["age_group"] == "28-35"
+    assert profile["occupation"] == "Software Engineer"
+    assert profile["tone"] == "casual"
+    assert profile["verbosity"] == "brief"
+
+
+@pytest.mark.django_db
+def test_persona_profile_excludes_simulator_fields(organization, workspace):
+    """SimulatorAgent fields must NOT show up in the user-facing persona profile,
+    even when a SimulatorAgent is bound. Legacy persona.<sim_field> mappings
+    still resolve at runtime via the eval-context resolver — but the
+    dropdown source must never list them.
+    """
+    persona = _make_persona(organization, workspace, name="Alice")
+    simulator = _make_simulator(
+        organization, workspace, voice_name="alloy", prompt="You are helpful"
+    )
+    call = _make_call(
+        organization, workspace, persona=persona, simulator=simulator
+    )
+
+    data = CallExecutionDetailSerializer(call).data
+
+    profile = data["persona_profile"]
+    assert profile["name"] == "Alice"
+    assert "voice_name" not in profile
+    assert "prompt" not in profile
+    assert "initial_message" not in profile
+
+
+@pytest.mark.django_db
+def test_persona_profile_empty_when_no_persona_bound(organization, workspace):
+    """If the scenario has no persona_ids and no row_data.persona, the
+    profile is an empty dict (no SimulatorAgent stand-in)."""
+    simulator = _make_simulator(organization, workspace, voice_name="alloy")
+    call = _make_call(organization, workspace, simulator=simulator)
+
+    data = CallExecutionDetailSerializer(call).data
+
+    assert data["persona_profile"] == {}
+
+
+@pytest.mark.django_db
+def test_persona_profile_nests_metadata_under_metadata_key(
+    organization, workspace
+):
+    """Persona.metadata sub-keys should land under persona_profile["metadata"]
+    so the frontend flattener can emit flat.persona.metadata.<key>.
+    """
+    persona = _make_persona(
+        organization,
+        workspace,
+        metadata={"region": "EMEA", "vip_tier": "gold"},
+    )
+    call = _make_call(organization, workspace, persona=persona)
+
+    data = CallExecutionDetailSerializer(call).data
+
+    assert data["persona_profile"]["metadata"]["region"] == "EMEA"
+    assert data["persona_profile"]["metadata"]["vip_tier"] == "gold"
+
+
+@pytest.mark.django_db
+def test_persona_profile_multi_value_list_joined(organization, workspace):
+    persona = _make_persona(
+        organization,
+        workspace,
+        languages=["English", "Hindi", "Marathi"],
+    )
+    call = _make_call(organization, workspace, persona=persona)
+
+    data = CallExecutionDetailSerializer(call).data
+
+    assert data["persona_profile"]["languages"] == "English, Hindi, Marathi"
+
+
+@pytest.mark.django_db
+def test_scenario_metadata_exposes_user_keys(organization, workspace):
+    call = _make_call(
+        organization,
+        workspace,
+        scenario_metadata={
+            "custom_instruction": "Be empathetic.",
+            "campaign_id": "Q2-launch",
+        },
+    )
+
+    data = CallExecutionDetailSerializer(call).data
+
+    metadata = data["scenario_metadata"]
+    assert metadata["custom_instruction"] == "Be empathetic."
+    assert metadata["campaign_id"] == "Q2-launch"
+
+
+@pytest.mark.django_db
+def test_scenario_metadata_filters_internal_reference_keys(
+    organization, workspace
+):
+    """persona_ids and agent_definition_version_id must NOT leak via the
+    serializer — same denylist as the eval context map.
+    """
+    call = _make_call(
+        organization,
+        workspace,
+        scenario_metadata={
+            "custom_instruction": "..",
+            "persona_ids": ["aaa-bbb"],
+            "agent_definition_version_id": "ccc-ddd",
+        },
+    )
+
+    data = CallExecutionDetailSerializer(call).data
+
+    assert "persona_ids" not in data["scenario_metadata"]
+    assert "agent_definition_version_id" not in data["scenario_metadata"]
+    assert data["scenario_metadata"]["custom_instruction"] == ".."
+
+
+@pytest.mark.django_db
+def test_scenario_metadata_jsonfield_values_flattened(organization, workspace):
+    call = _make_call(
+        organization,
+        workspace,
+        scenario_metadata={
+            "tags": ["urgent", "billing"],
+            "single_tag": ["solo"],
+        },
+    )
+
+    data = CallExecutionDetailSerializer(call).data
+
+    assert data["scenario_metadata"]["tags"] == "urgent, billing"
+    assert data["scenario_metadata"]["single_tag"] == "solo"

--- a/futureagi/simulate/tests/test_xl_eval_context.py
+++ b/futureagi/simulate/tests/test_xl_eval_context.py
@@ -1,0 +1,225 @@
+"""Tests for the eval context map and mapping resolver in xl.py.
+
+Covers:
+- _resolve_persona_for_call: picks the Persona used for a given CallExecution.
+- _flatten_persona / _flatten_persona_for_resolver: build the persona.* namespace.
+- _build_simulation_context_map: full context map assembly.
+- _translate_mapping_value: resolver branches including scenario.<column_name>.
+"""
+
+import pytest
+
+from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
+
+# These exercise the resolver against a real DB graph (Persona, Scenarios,
+# Dataset, CallExecution) — integration scope, not pure unit. Per the
+# project convention these live in @pytest.mark.integration.
+pytestmark = pytest.mark.integration
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from simulate.models import AgentDefinition, Persona, Scenarios
+from simulate.models.run_test import RunTest
+from simulate.models.simulator_agent import SimulatorAgent
+from simulate.models.test_execution import CallExecution, TestExecution
+
+
+# ---------------------------------------------------------------------------
+# Test helpers — module-scope factories. Kept in this file (not conftest) so
+# the persona/simulator coverage doesn't bleed into unrelated suites.
+# ---------------------------------------------------------------------------
+
+
+def _make_persona(organization, workspace, **overrides):
+    """Create a Persona row with sane defaults; overrides win."""
+    defaults = dict(
+        name="Test Persona",
+        organization=organization,
+        workspace=workspace,
+        persona_type=Persona.PersonaType.WORKSPACE,
+    )
+    defaults.update(overrides)
+    return Persona.objects.create(**defaults)
+
+
+def _make_agent_definition(organization, workspace):
+    return AgentDefinition.objects.create(
+        agent_name="Test Agent",
+        agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+        inbound=True,
+        description="Test agent",
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+def _make_dataset_with_columns(organization, workspace, user, column_specs):
+    """Create a Dataset with the named columns and a single Row.
+
+    `column_specs` is a list of (column_name, cell_value) tuples. Returns
+    (dataset, row, columns_by_name).
+    """
+    dataset = Dataset.no_workspace_objects.create(
+        name="Test Dataset",
+        organization=organization,
+        workspace=workspace,
+        user=user,
+        source=DatasetSourceChoices.SCENARIO.value,
+    )
+    columns_by_name = {}
+    column_order = []
+    for col_name, _ in column_specs:
+        col = Column.objects.create(
+            dataset=dataset,
+            name=col_name,
+            data_type="text",
+            source=SourceChoices.OTHERS.value,
+        )
+        columns_by_name[col_name] = col
+        column_order.append(str(col.id))
+    dataset.column_order = column_order
+    dataset.save()
+
+    row = Row.objects.create(dataset=dataset, order=0)
+    for col_name, cell_value in column_specs:
+        Cell.objects.create(
+            dataset=dataset,
+            column=columns_by_name[col_name],
+            row=row,
+            value=cell_value,
+        )
+    return dataset, row, columns_by_name
+
+
+def _make_scenario(
+    organization, workspace, agent_definition, dataset=None, metadata=None
+):
+    return Scenarios.objects.create(
+        name="Test Scenario",
+        description="Test scenario description",
+        source="Test source",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=organization,
+        workspace=workspace,
+        dataset=dataset,
+        agent_definition=agent_definition,
+        status=StatusType.COMPLETED.value,
+        metadata=metadata or {},
+    )
+
+
+def _make_run_test(organization, workspace, agent_definition, simulator_agent, scenario):
+    rt = RunTest.objects.create(
+        name="Test Run",
+        description="Test run description",
+        agent_definition=agent_definition,
+        simulator_agent=simulator_agent,
+        organization=organization,
+        workspace=workspace,
+    )
+    rt.scenarios.add(scenario)
+    return rt
+
+
+def _make_call_execution(test_execution, scenario, row_id=None, row_data=None):
+    call_metadata = {}
+    if row_id is not None:
+        call_metadata["row_id"] = str(row_id)
+    if row_data is not None:
+        call_metadata["row_data"] = row_data
+    return CallExecution.objects.create(
+        test_execution=test_execution,
+        scenario=scenario,
+        phone_number="+1234567890",
+        status=CallExecution.CallStatus.COMPLETED,
+        call_metadata=call_metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 1.1 — _resolve_persona_for_call
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def persona_setup(db, organization, workspace, user):
+    """Bootstraps the dependency graph: AgentDefinition → Scenario → RunTest
+    → TestExecution. Returns a closure that builds a CallExecution with
+    arbitrary scenario_metadata / row_data.
+    """
+    agent_def = _make_agent_definition(organization, workspace)
+    simulator = SimulatorAgent.objects.create(
+        name="Sim",
+        prompt="You are a simulator",
+        voice_provider="elevenlabs",
+        voice_name="marissa",
+        model="gpt-4",
+        organization=organization,
+        workspace=workspace,
+    )
+
+    def _build(scenario_metadata=None, row_data=None):
+        scenario = _make_scenario(
+            organization,
+            workspace,
+            agent_def,
+            metadata=scenario_metadata or {},
+        )
+        rt = _make_run_test(organization, workspace, agent_def, simulator, scenario)
+        te = TestExecution.objects.create(
+            run_test=rt,
+            status=TestExecution.ExecutionStatus.COMPLETED,
+            simulator_agent=simulator,
+            agent_definition=agent_def,
+        )
+        return _make_call_execution(te, scenario, row_data=row_data)
+
+    return _build
+
+
+@pytest.mark.django_db
+def test_resolve_persona_prefers_row_data_persona_id(
+    persona_setup, organization, workspace
+):
+    from simulate.temporal.activities.xl import _resolve_persona_for_call
+
+    persona_a = _make_persona(organization, workspace, name="A")
+    persona_b = _make_persona(organization, workspace, name="B")
+
+    call = persona_setup(
+        scenario_metadata={"persona_ids": [str(persona_a.id), str(persona_b.id)]},
+        row_data={"persona": str(persona_b.id)},
+    )
+
+    resolved = _resolve_persona_for_call(call)
+
+    assert resolved is not None
+    assert resolved.id == persona_b.id
+
+
+@pytest.mark.django_db
+def test_resolve_persona_falls_back_to_first_in_metadata(
+    persona_setup, organization, workspace
+):
+    from simulate.temporal.activities.xl import _resolve_persona_for_call
+
+    persona_a = _make_persona(organization, workspace, name="A")
+    persona_b = _make_persona(organization, workspace, name="B")
+
+    call = persona_setup(
+        scenario_metadata={"persona_ids": [str(persona_a.id), str(persona_b.id)]},
+        row_data={},
+    )
+
+    resolved = _resolve_persona_for_call(call)
+
+    assert resolved is not None
+    assert resolved.id == persona_a.id
+
+
+@pytest.mark.django_db
+def test_resolve_persona_returns_none_when_no_persona_ids(persona_setup):
+    from simulate.temporal.activities.xl import _resolve_persona_for_call
+
+    call = persona_setup(scenario_metadata={}, row_data={})
+
+    assert _resolve_persona_for_call(call) is None

--- a/futureagi/simulate/tests/test_xl_eval_context.py
+++ b/futureagi/simulate/tests/test_xl_eval_context.py
@@ -401,3 +401,97 @@ def test_context_map_surfaces_persona_and_legacy_simulator_fields(
     # SimulatorAgent fallback fields under the same namespace (legacy compat).
     assert ctx["persona.voice_name"] == "marissa"
     assert ctx["persona.prompt"] == "You are a simulator"
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3 — scenario.info.* + scenario.metadata.<key>
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_context_map_scenario_metadata_moves_to_info_dot_namespace(persona_setup):
+    """Scenarios-row attributes shift from scenario.{name,description,type,source}
+    to scenario.info.{name,description,type,source} so bare scenario.<X> is
+    reserved for dataset-column lookups in Task 1.4.
+    """
+    from simulate.temporal.activities.xl import _build_simulation_context_map
+
+    call = persona_setup(scenario_metadata={}, row_data={})
+    scenario = call.scenario
+    scenario.name = "Customer support"
+    scenario.description = "Help with refunds"
+    scenario.scenario_type = Scenarios.ScenarioTypes.DATASET
+    scenario.source = "manual entry"
+    scenario.save()
+
+    ctx = _build_simulation_context_map(call, agent_version=None)
+
+    assert ctx["scenario.info.name"] == "Customer support"
+    assert ctx["scenario.info.description"] == "Help with refunds"
+    assert ctx["scenario.info.type"] == Scenarios.ScenarioTypes.DATASET
+    assert ctx["scenario.info.source"] == "manual entry"
+
+
+@pytest.mark.django_db
+def test_context_map_preserves_scenario_info_underscore_aliases(persona_setup):
+    """Pre-2026-04-13 saved configs referenced scenario_info_name etc.
+    directly. Those underscore aliases keep resolving.
+    """
+    from simulate.temporal.activities.xl import _build_simulation_context_map
+
+    call = persona_setup(scenario_metadata={}, row_data={})
+    scenario = call.scenario
+    scenario.name = "Help with refunds"
+    scenario.save()
+
+    ctx = _build_simulation_context_map(call, agent_version=None)
+
+    assert ctx["scenario_info_name"] == "Help with refunds"
+
+
+@pytest.mark.django_db
+def test_context_map_scenario_metadata_keys_surface_dynamically(persona_setup):
+    """Scenarios.metadata is free-form. Every user-supplied key surfaces under
+    scenario.metadata.<key>. Internal references (persona_ids, agent_definition_version_id)
+    are filtered out so they don't leak into eval prompts.
+    """
+    from simulate.temporal.activities.xl import _build_simulation_context_map
+
+    call = persona_setup(
+        scenario_metadata={
+            "custom_instruction": "Be empathetic.",
+            "campaign_id": "Q2-launch",
+            "persona_ids": ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"],
+            "agent_definition_version_id": "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff",
+        },
+        row_data={},
+    )
+
+    ctx = _build_simulation_context_map(call, agent_version=None)
+
+    assert ctx["scenario.metadata.custom_instruction"] == "Be empathetic."
+    assert ctx["scenario.metadata.campaign_id"] == "Q2-launch"
+    # Internal-reference keys filtered out.
+    assert "scenario.metadata.persona_ids" not in ctx
+    assert "scenario.metadata.agent_definition_version_id" not in ctx
+
+
+@pytest.mark.django_db
+def test_context_map_scenario_metadata_jsonfield_flattening(persona_setup):
+    """scenario.metadata.<key> values run through flatten_jsonfield_value,
+    so lists/dicts get the same normalization as Persona attributes.
+    """
+    from simulate.temporal.activities.xl import _build_simulation_context_map
+
+    call = persona_setup(
+        scenario_metadata={
+            "tags": ["urgent", "billing"],
+            "single_tag": ["solo"],
+        },
+        row_data={},
+    )
+
+    ctx = _build_simulation_context_map(call, agent_version=None)
+
+    assert ctx["scenario.metadata.tags"] == "urgent, billing"
+    assert ctx["scenario.metadata.single_tag"] == "solo"

--- a/futureagi/simulate/tests/test_xl_eval_context.py
+++ b/futureagi/simulate/tests/test_xl_eval_context.py
@@ -9,127 +9,21 @@ Covers:
 
 import pytest
 
-from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
-from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
-from simulate.models import AgentDefinition, Persona, Scenarios
-from simulate.models.run_test import RunTest
-from simulate.models.simulator_agent import SimulatorAgent
-from simulate.models.test_execution import CallExecution, TestExecution
+from model_hub.models.choices import SourceChoices
+from model_hub.models.develop_dataset import Column
+from simulate.models import Scenarios
+from simulate.tests.factories import (
+    make_agent_definition,
+    make_call_execution,
+    make_dataset_with_columns,
+    make_persona,
+    make_run_test,
+    make_scenario,
+    make_simulator_agent,
+    make_test_execution,
+)
 
 pytestmark = pytest.mark.integration
-
-
-# ---------------------------------------------------------------------------
-# Test helpers — module-scope factories. Kept in this file (not conftest) so
-# the persona/simulator coverage doesn't bleed into unrelated suites.
-# ---------------------------------------------------------------------------
-
-
-def _make_persona(organization, workspace, **overrides):
-    """Create a Persona row with sane defaults; overrides win."""
-    defaults = dict(
-        name="Test Persona",
-        organization=organization,
-        workspace=workspace,
-        persona_type=Persona.PersonaType.WORKSPACE,
-    )
-    defaults.update(overrides)
-    return Persona.objects.create(**defaults)
-
-
-def _make_agent_definition(organization, workspace):
-    return AgentDefinition.objects.create(
-        agent_name="Test Agent",
-        agent_type=AgentDefinition.AgentTypeChoices.VOICE,
-        inbound=True,
-        description="Test agent",
-        organization=organization,
-        workspace=workspace,
-        languages=["en"],
-    )
-
-
-def _make_dataset_with_columns(organization, workspace, user, column_specs):
-    """Create a Dataset with the named columns and a single Row.
-
-    `column_specs` is a list of (column_name, cell_value) tuples. Returns
-    (dataset, row, columns_by_name).
-    """
-    dataset = Dataset.no_workspace_objects.create(
-        name="Test Dataset",
-        organization=organization,
-        workspace=workspace,
-        user=user,
-        source=DatasetSourceChoices.SCENARIO.value,
-    )
-    columns_by_name = {}
-    column_order = []
-    for col_name, _ in column_specs:
-        col = Column.objects.create(
-            dataset=dataset,
-            name=col_name,
-            data_type="text",
-            source=SourceChoices.OTHERS.value,
-        )
-        columns_by_name[col_name] = col
-        column_order.append(str(col.id))
-    dataset.column_order = column_order
-    dataset.save()
-
-    row = Row.objects.create(dataset=dataset, order=0)
-    for col_name, cell_value in column_specs:
-        Cell.objects.create(
-            dataset=dataset,
-            column=columns_by_name[col_name],
-            row=row,
-            value=cell_value,
-        )
-    return dataset, row, columns_by_name
-
-
-def _make_scenario(
-    organization, workspace, agent_definition, dataset=None, metadata=None
-):
-    return Scenarios.objects.create(
-        name="Test Scenario",
-        description="Test scenario description",
-        source="Test source",
-        scenario_type=Scenarios.ScenarioTypes.DATASET,
-        organization=organization,
-        workspace=workspace,
-        dataset=dataset,
-        agent_definition=agent_definition,
-        status=StatusType.COMPLETED.value,
-        metadata=metadata or {},
-    )
-
-
-def _make_run_test(organization, workspace, agent_definition, simulator_agent, scenario):
-    rt = RunTest.objects.create(
-        name="Test Run",
-        description="Test run description",
-        agent_definition=agent_definition,
-        simulator_agent=simulator_agent,
-        organization=organization,
-        workspace=workspace,
-    )
-    rt.scenarios.add(scenario)
-    return rt
-
-
-def _make_call_execution(test_execution, scenario, row_id=None, row_data=None):
-    call_metadata = {}
-    if row_id is not None:
-        call_metadata["row_id"] = str(row_id)
-    if row_data is not None:
-        call_metadata["row_data"] = row_data
-    return CallExecution.objects.create(
-        test_execution=test_execution,
-        scenario=scenario,
-        phone_number="+1234567890",
-        status=CallExecution.CallStatus.COMPLETED,
-        call_metadata=call_metadata,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -143,32 +37,27 @@ def persona_setup(db, organization, workspace, user):
     → TestExecution. Returns a closure that builds a CallExecution with
     arbitrary scenario_metadata / row_data.
     """
-    agent_def = _make_agent_definition(organization, workspace)
-    simulator = SimulatorAgent.objects.create(
-        name="Sim",
-        prompt="You are a simulator",
-        voice_provider="elevenlabs",
-        voice_name="marissa",
-        model="gpt-4",
-        organization=organization,
-        workspace=workspace,
-    )
+    agent_def = make_agent_definition(organization, workspace)
+    simulator = make_simulator_agent(organization, workspace)
 
     def _build(scenario_metadata=None, row_data=None):
-        scenario = _make_scenario(
+        scenario = make_scenario(
             organization,
             workspace,
             agent_def,
             metadata=scenario_metadata or {},
         )
-        rt = _make_run_test(organization, workspace, agent_def, simulator, scenario)
-        te = TestExecution.objects.create(
-            run_test=rt,
-            status=TestExecution.ExecutionStatus.COMPLETED,
+        rt = make_run_test(
+            organization,
+            workspace,
+            agent_def,
             simulator_agent=simulator,
-            agent_definition=agent_def,
+            scenarios=[scenario],
         )
-        return _make_call_execution(te, scenario, row_data=row_data)
+        te = make_test_execution(
+            rt, agent_definition=agent_def, simulator_agent=simulator
+        )
+        return make_call_execution(te, scenario, row_data=row_data)
 
     return _build
 
@@ -179,8 +68,8 @@ def test_resolve_persona_prefers_row_data_persona_id(
 ):
     from simulate.utils.eval_context import resolve_persona_for_call
 
-    persona_a = _make_persona(organization, workspace, name="A")
-    persona_b = _make_persona(organization, workspace, name="B")
+    persona_a = make_persona(organization, workspace, name="A")
+    persona_b = make_persona(organization, workspace, name="B")
 
     call = persona_setup(
         scenario_metadata={"persona_ids": [str(persona_a.id), str(persona_b.id)]},
@@ -199,8 +88,8 @@ def test_resolve_persona_falls_back_to_first_in_metadata(
 ):
     from simulate.utils.eval_context import resolve_persona_for_call
 
-    persona_a = _make_persona(organization, workspace, name="A")
-    persona_b = _make_persona(organization, workspace, name="B")
+    persona_a = make_persona(organization, workspace, name="A")
+    persona_b = make_persona(organization, workspace, name="B")
 
     call = persona_setup(
         scenario_metadata={"persona_ids": [str(persona_a.id), str(persona_b.id)]},
@@ -236,7 +125,7 @@ def test_user_facing_flatten_persona_excludes_simulator_fields(
     """
     from simulate.utils.eval_context import flatten_persona
 
-    persona = _make_persona(
+    persona = make_persona(
         organization,
         workspace,
         name="Alice",
@@ -261,7 +150,7 @@ def test_user_facing_flatten_persona_excludes_simulator_fields(
 def test_flatten_persona_multi_value_list_joins_with_comma(organization, workspace):
     from simulate.utils.eval_context import flatten_persona
 
-    persona = _make_persona(
+    persona = make_persona(
         organization,
         workspace,
         languages=["English", "Hindi", "Marathi"],
@@ -279,7 +168,7 @@ def test_flatten_persona_metadata_surfaces_dynamically(organization, workspace):
     """
     from simulate.utils.eval_context import flatten_persona
 
-    persona = _make_persona(
+    persona = make_persona(
         organization,
         workspace,
         metadata={"region": "EMEA", "vip_tier": "gold", "tags": ["A", "B"]},
@@ -316,16 +205,14 @@ def test_resolver_flatten_persona_falls_back_to_simulator(
     """
     from simulate.utils.eval_context import flatten_persona_for_resolver
 
-    persona = _make_persona(organization, workspace, name="Alice")
-    simulator = SimulatorAgent.objects.create(
+    persona = make_persona(organization, workspace, name="Alice")
+    simulator = make_simulator_agent(
+        organization,
+        workspace,
         name="SimulatorBot",  # Persona.name should still win.
         prompt="You are helpful",
-        voice_provider="elevenlabs",
         voice_name="alloy",
-        model="gpt-4",
         initial_message="Hello",
-        organization=organization,
-        workspace=workspace,
     )
 
     flat = flatten_persona_for_resolver(persona, simulator)
@@ -347,15 +234,13 @@ def test_resolver_flatten_persona_no_persona_uses_simulator(
     """
     from simulate.utils.eval_context import flatten_persona_for_resolver
 
-    simulator = SimulatorAgent.objects.create(
+    simulator = make_simulator_agent(
+        organization,
+        workspace,
         name="Bot",
         prompt="You are helpful",
-        voice_provider="elevenlabs",
         voice_name="alloy",
-        model="gpt-4",
         initial_message="Hi",
-        organization=organization,
-        workspace=workspace,
     )
 
     flat = flatten_persona_for_resolver(None, simulator)
@@ -380,7 +265,7 @@ def test_context_map_surfaces_persona_and_legacy_simulator_fields(
     """
     from simulate.temporal.activities.xl import _build_simulation_context_map
 
-    persona = _make_persona(
+    persona = make_persona(
         organization,
         workspace,
         name="Alice",
@@ -509,33 +394,28 @@ def call_with_dataset_columns(db, organization, workspace, user):
     Returns a closure that takes a {column_name: cell_value} dict and yields
     (call_execution, columns_by_name).
     """
-    agent_def = _make_agent_definition(organization, workspace)
-    simulator = SimulatorAgent.objects.create(
-        name="Sim",
-        prompt="You are a simulator",
-        voice_provider="elevenlabs",
-        voice_name="marissa",
-        model="gpt-4",
-        organization=organization,
-        workspace=workspace,
-    )
+    agent_def = make_agent_definition(organization, workspace)
+    simulator = make_simulator_agent(organization, workspace)
 
     def _build(columns):
         column_specs = list(columns.items())
-        dataset, row, columns_by_name = _make_dataset_with_columns(
+        dataset, row, columns_by_name = make_dataset_with_columns(
             organization, workspace, user, column_specs
         )
-        scenario = _make_scenario(
+        scenario = make_scenario(
             organization, workspace, agent_def, dataset=dataset
         )
-        rt = _make_run_test(organization, workspace, agent_def, simulator, scenario)
-        te = TestExecution.objects.create(
-            run_test=rt,
-            status=TestExecution.ExecutionStatus.COMPLETED,
+        rt = make_run_test(
+            organization,
+            workspace,
+            agent_def,
             simulator_agent=simulator,
-            agent_definition=agent_def,
+            scenarios=[scenario],
         )
-        call = _make_call_execution(te, scenario, row_id=row.id)
+        te = make_test_execution(
+            rt, agent_definition=agent_def, simulator_agent=simulator
+        )
+        call = make_call_execution(te, scenario, row_id=row.id)
         return call, columns_by_name
 
     return _build

--- a/futureagi/simulate/tests/test_xl_eval_context.py
+++ b/futureagi/simulate/tests/test_xl_eval_context.py
@@ -1,25 +1,22 @@
-"""Tests for the eval context map and mapping resolver in xl.py.
+"""Tests for the eval context map and mapping resolver.
 
 Covers:
-- _resolve_persona_for_call: picks the Persona used for a given CallExecution.
-- _flatten_persona / _flatten_persona_for_resolver: build the persona.* namespace.
-- _build_simulation_context_map: full context map assembly.
+- resolve_persona_for_call: picks the Persona used for a given CallExecution.
+- flatten_persona / flatten_persona_for_resolver: build persona.* namespace.
+- _build_simulation_context_map: full context map assembly (xl.py).
 - _translate_mapping_value: resolver branches including scenario.<column_name>.
 """
 
 import pytest
 
 from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
-
-# These exercise the resolver against a real DB graph (Persona, Scenarios,
-# Dataset, CallExecution) — integration scope, not pure unit. Per the
-# project convention these live in @pytest.mark.integration.
-pytestmark = pytest.mark.integration
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from simulate.models import AgentDefinition, Persona, Scenarios
 from simulate.models.run_test import RunTest
 from simulate.models.simulator_agent import SimulatorAgent
 from simulate.models.test_execution import CallExecution, TestExecution
+
+pytestmark = pytest.mark.integration
 
 
 # ---------------------------------------------------------------------------
@@ -180,7 +177,7 @@ def persona_setup(db, organization, workspace, user):
 def test_resolve_persona_prefers_row_data_persona_id(
     persona_setup, organization, workspace
 ):
-    from simulate.temporal.activities.xl import _resolve_persona_for_call
+    from simulate.utils.eval_context import resolve_persona_for_call
 
     persona_a = _make_persona(organization, workspace, name="A")
     persona_b = _make_persona(organization, workspace, name="B")
@@ -190,7 +187,7 @@ def test_resolve_persona_prefers_row_data_persona_id(
         row_data={"persona": str(persona_b.id)},
     )
 
-    resolved = _resolve_persona_for_call(call)
+    resolved = resolve_persona_for_call(call)
 
     assert resolved is not None
     assert resolved.id == persona_b.id
@@ -200,7 +197,7 @@ def test_resolve_persona_prefers_row_data_persona_id(
 def test_resolve_persona_falls_back_to_first_in_metadata(
     persona_setup, organization, workspace
 ):
-    from simulate.temporal.activities.xl import _resolve_persona_for_call
+    from simulate.utils.eval_context import resolve_persona_for_call
 
     persona_a = _make_persona(organization, workspace, name="A")
     persona_b = _make_persona(organization, workspace, name="B")
@@ -210,7 +207,7 @@ def test_resolve_persona_falls_back_to_first_in_metadata(
         row_data={},
     )
 
-    resolved = _resolve_persona_for_call(call)
+    resolved = resolve_persona_for_call(call)
 
     assert resolved is not None
     assert resolved.id == persona_a.id
@@ -218,8 +215,189 @@ def test_resolve_persona_falls_back_to_first_in_metadata(
 
 @pytest.mark.django_db
 def test_resolve_persona_returns_none_when_no_persona_ids(persona_setup):
-    from simulate.temporal.activities.xl import _resolve_persona_for_call
+    from simulate.utils.eval_context import resolve_persona_for_call
 
     call = persona_setup(scenario_metadata={}, row_data={})
 
-    assert _resolve_persona_for_call(call) is None
+    assert resolve_persona_for_call(call) is None
+
+
+# ---------------------------------------------------------------------------
+# Task 1.2 — _flatten_persona / _flatten_persona_for_resolver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_user_facing_flatten_persona_excludes_simulator_fields(
+    organization, workspace
+):
+    """User-facing variant — Persona model only. SimulatorAgent fields are
+    deliberately absent so the eval-mapping dropdown never offers them.
+    """
+    from simulate.utils.eval_context import flatten_persona
+
+    persona = _make_persona(
+        organization,
+        workspace,
+        name="Alice",
+        gender=["female"],
+        age_group=["28-35"],
+        tone="casual",
+    )
+
+    flat = flatten_persona(persona)
+
+    assert flat["persona.name"] == "Alice"
+    assert flat["persona.gender"] == "female"
+    assert flat["persona.age_group"] == "28-35"
+    assert flat["persona.tone"] == "casual"
+    # SimulatorAgent-only fields must NOT appear in the user-facing variant.
+    assert "persona.voice_name" not in flat
+    assert "persona.prompt" not in flat
+    assert "persona.initial_message" not in flat
+
+
+@pytest.mark.django_db
+def test_flatten_persona_multi_value_list_joins_with_comma(organization, workspace):
+    from simulate.utils.eval_context import flatten_persona
+
+    persona = _make_persona(
+        organization,
+        workspace,
+        languages=["English", "Hindi", "Marathi"],
+    )
+
+    flat = flatten_persona(persona)
+
+    assert flat["persona.languages"] == "English, Hindi, Marathi"
+
+
+@pytest.mark.django_db
+def test_flatten_persona_metadata_surfaces_dynamically(organization, workspace):
+    """Persona.metadata is a free-form dict — each key must surface under
+    persona.metadata.<key>, with the same flattening rules.
+    """
+    from simulate.utils.eval_context import flatten_persona
+
+    persona = _make_persona(
+        organization,
+        workspace,
+        metadata={"region": "EMEA", "vip_tier": "gold", "tags": ["A", "B"]},
+    )
+
+    flat = flatten_persona(persona)
+
+    assert flat["persona.metadata.region"] == "EMEA"
+    assert flat["persona.metadata.vip_tier"] == "gold"
+    assert flat["persona.metadata.tags"] == "A, B"
+
+
+@pytest.mark.django_db
+def test_flatten_persona_none_returns_empty_strings(organization, workspace):
+    """When no Persona is bound, every persona.<scalar> key is "" and no
+    JSONField/metadata keys are present.
+    """
+    from simulate.utils.eval_context import flatten_persona
+
+    flat = flatten_persona(None)
+
+    assert flat["persona.name"] == ""
+    assert flat["persona.gender"] == ""
+    assert flat["persona.tone"] == ""
+    assert "persona.metadata.region" not in flat
+
+
+@pytest.mark.django_db
+def test_resolver_flatten_persona_falls_back_to_simulator(
+    organization, workspace
+):
+    """The resolver variant adds a SimulatorAgent fallback for legacy
+    persona.<sim_field> mappings. Persona model still wins on conflicts.
+    """
+    from simulate.utils.eval_context import flatten_persona_for_resolver
+
+    persona = _make_persona(organization, workspace, name="Alice")
+    simulator = SimulatorAgent.objects.create(
+        name="SimulatorBot",  # Persona.name should still win.
+        prompt="You are helpful",
+        voice_provider="elevenlabs",
+        voice_name="alloy",
+        model="gpt-4",
+        initial_message="Hello",
+        organization=organization,
+        workspace=workspace,
+    )
+
+    flat = flatten_persona_for_resolver(persona, simulator)
+
+    # Persona wins the name collision.
+    assert flat["persona.name"] == "Alice"
+    # SimulatorAgent fills in the rest under persona.*.
+    assert flat["persona.prompt"] == "You are helpful"
+    assert flat["persona.voice_name"] == "alloy"
+    assert flat["persona.initial_message"] == "Hello"
+
+
+@pytest.mark.django_db
+def test_resolver_flatten_persona_no_persona_uses_simulator(
+    organization, workspace
+):
+    """If no Persona is bound, the resolver variant returns SimulatorAgent
+    fields under persona.* — keeping legacy eval-config mappings alive.
+    """
+    from simulate.utils.eval_context import flatten_persona_for_resolver
+
+    simulator = SimulatorAgent.objects.create(
+        name="Bot",
+        prompt="You are helpful",
+        voice_provider="elevenlabs",
+        voice_name="alloy",
+        model="gpt-4",
+        initial_message="Hi",
+        organization=organization,
+        workspace=workspace,
+    )
+
+    flat = flatten_persona_for_resolver(None, simulator)
+
+    assert flat["persona.name"] == "Bot"
+    assert flat["persona.prompt"] == "You are helpful"
+    assert flat["persona.voice_name"] == "alloy"
+
+
+# ---------------------------------------------------------------------------
+# Task 1.2 — integration: _build_simulation_context_map surfaces persona.*
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_context_map_surfaces_persona_and_legacy_simulator_fields(
+    persona_setup, organization, workspace
+):
+    """End-to-end: Persona attributes resolve under persona.*, and legacy
+    persona.<sim_field> keys (prompt, voice_name, initial_message) keep
+    resolving via the SimulatorAgent fallback in the resolver variant.
+    """
+    from simulate.temporal.activities.xl import _build_simulation_context_map
+
+    persona = _make_persona(
+        organization,
+        workspace,
+        name="Alice",
+        gender=["female"],
+        age_group=["28-35"],
+    )
+    call = persona_setup(
+        scenario_metadata={"persona_ids": [str(persona.id)]},
+        row_data={"persona": str(persona.id)},
+    )
+
+    ctx = _build_simulation_context_map(call, agent_version=None)
+
+    # Persona model fields.
+    assert ctx["persona.name"] == "Alice"
+    assert ctx["persona.gender"] == "female"
+    assert ctx["persona.age_group"] == "28-35"
+    # SimulatorAgent fallback fields under the same namespace (legacy compat).
+    assert ctx["persona.voice_name"] == "marissa"
+    assert ctx["persona.prompt"] == "You are a simulator"

--- a/futureagi/simulate/tests/test_xl_eval_context.py
+++ b/futureagi/simulate/tests/test_xl_eval_context.py
@@ -495,3 +495,139 @@ def test_context_map_scenario_metadata_jsonfield_flattening(persona_setup):
 
     assert ctx["scenario.metadata.tags"] == "urgent, billing"
     assert ctx["scenario.metadata.single_tag"] == "solo"
+
+
+# ---------------------------------------------------------------------------
+# Task 1.4 — resolve_scenario_column_by_name + scenario.<col> resolver branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def call_with_dataset_columns(db, organization, workspace, user):
+    """Bootstrap a CallExecution backed by a Dataset with named columns.
+
+    Returns a closure that takes a {column_name: cell_value} dict and yields
+    (call_execution, columns_by_name).
+    """
+    agent_def = _make_agent_definition(organization, workspace)
+    simulator = SimulatorAgent.objects.create(
+        name="Sim",
+        prompt="You are a simulator",
+        voice_provider="elevenlabs",
+        voice_name="marissa",
+        model="gpt-4",
+        organization=organization,
+        workspace=workspace,
+    )
+
+    def _build(columns):
+        column_specs = list(columns.items())
+        dataset, row, columns_by_name = _make_dataset_with_columns(
+            organization, workspace, user, column_specs
+        )
+        scenario = _make_scenario(
+            organization, workspace, agent_def, dataset=dataset
+        )
+        rt = _make_run_test(organization, workspace, agent_def, simulator, scenario)
+        te = TestExecution.objects.create(
+            run_test=rt,
+            status=TestExecution.ExecutionStatus.COMPLETED,
+            simulator_agent=simulator,
+            agent_definition=agent_def,
+        )
+        call = _make_call_execution(te, scenario, row_id=row.id)
+        return call, columns_by_name
+
+    return _build
+
+
+@pytest.mark.django_db
+def test_resolve_scenario_column_by_name_returns_cell_value(call_with_dataset_columns):
+    from simulate.utils.eval_context import resolve_scenario_column_by_name
+
+    call, _ = call_with_dataset_columns({"outcome": "resolved successfully"})
+
+    assert resolve_scenario_column_by_name(call, "outcome") == "resolved successfully"
+
+
+@pytest.mark.django_db
+def test_resolve_scenario_column_by_name_returns_empty_for_unknown_column(
+    call_with_dataset_columns,
+):
+    from simulate.utils.eval_context import resolve_scenario_column_by_name
+
+    call, _ = call_with_dataset_columns({"outcome": "..."})
+
+    assert resolve_scenario_column_by_name(call, "does_not_exist") == ""
+
+
+@pytest.mark.django_db
+def test_resolve_scenario_column_by_name_returns_empty_when_no_row_id(persona_setup):
+    from simulate.utils.eval_context import resolve_scenario_column_by_name
+
+    call = persona_setup(scenario_metadata={}, row_data={})
+
+    assert resolve_scenario_column_by_name(call, "outcome") == ""
+
+
+@pytest.mark.django_db
+def test_resolve_scenario_column_first_by_created_at_on_name_collision(
+    db, organization, workspace, user, call_with_dataset_columns
+):
+    """Two columns with the same name in one dataset — first by created_at
+    wins (rest are logged but ignored).
+    """
+    from simulate.utils.eval_context import resolve_scenario_column_by_name
+
+    call, columns_by_name = call_with_dataset_columns({"outcome": "first value"})
+    first_col = columns_by_name["outcome"]
+
+    # Create a second column with the same name on the same dataset.
+    Column.objects.create(
+        dataset=first_col.dataset,
+        name="outcome",
+        data_type="text",
+        source=SourceChoices.OTHERS.value,
+    )
+
+    # first_col was created earlier — should win.
+    assert resolve_scenario_column_by_name(call, "outcome") == "first value"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_run_single_evaluation_resolves_scenario_dotted_column_name(
+    call_with_dataset_columns, organization, workspace, user
+):
+    """End-to-end: an eval mapped to scenario.<col> resolves the cell value
+    via the new branch in _run_single_evaluation. run_eval_func is mocked so
+    we observe what `mappings` the underlying eval received.
+    """
+    from unittest.mock import patch
+
+    from model_hub.models.evals_metric import EvalTemplate
+    from simulate.models.eval_config import SimulateEvalConfig
+    from simulate.temporal.activities.xl import _run_single_evaluation
+
+    call, _ = call_with_dataset_columns({"outcome": "resolved successfully"})
+
+    eval_template = EvalTemplate.objects.create(
+        name="test template",
+        config={"prompt": "evaluate this"},
+        organization=organization,
+    )
+    eval_config = SimulateEvalConfig.objects.create(
+        eval_template=eval_template,
+        name="test eval",
+        run_test=call.test_execution.run_test,
+        mapping={"target": "scenario.outcome"},
+        config={},
+    )
+
+    with patch(
+        "model_hub.views.utils.evals.run_eval_func",
+        return_value={"output": True, "reason": "", "output_type": "boolean"},
+    ) as mock_run:
+        _run_single_evaluation(eval_config, call, {"transcript": "..."})
+
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs["mappings"]["target"] == "resolved successfully"

--- a/futureagi/simulate/utils/eval_context.py
+++ b/futureagi/simulate/utils/eval_context.py
@@ -158,7 +158,14 @@ def resolve_persona_for_call(call_execution):
     2. First Persona referenced by scenario.metadata.persona_ids
        (ordered by created_at — stable across runs).
     3. None — `persona.*` keys resolve to "".
+
+    Invalid UUIDs in either source resolve to None instead of raising;
+    callers (eval resolver, serializer) treat that as "no persona bound".
     """
+    import uuid as _uuid
+
+    from django.core.exceptions import ValidationError
+
     from simulate.models import Persona
 
     metadata = call_execution.call_metadata or {}
@@ -169,7 +176,7 @@ def resolve_persona_for_call(call_execution):
             return Persona.no_workspace_objects.get(
                 id=row_persona_id, deleted=False
             )
-        except (Persona.DoesNotExist, ValueError):
+        except (Persona.DoesNotExist, ValueError, ValidationError):
             pass
 
     scenario = getattr(call_execution, "scenario", None)
@@ -179,13 +186,19 @@ def resolve_persona_for_call(call_execution):
     persona_ids = scenario_meta.get("persona_ids") or []
     if not persona_ids:
         return None
-    try:
-        return (
-            Persona.no_workspace_objects.filter(
-                id__in=persona_ids, deleted=False
-            )
-            .order_by("created_at")
-            .first()
-        )
-    except ValueError:
+
+    valid_ids = []
+    for pid in persona_ids:
+        try:
+            _uuid.UUID(str(pid))
+            valid_ids.append(pid)
+        except (ValueError, TypeError):
+            continue
+    if not valid_ids:
         return None
+
+    return (
+        Persona.no_workspace_objects.filter(id__in=valid_ids, deleted=False)
+        .order_by("created_at")
+        .first()
+    )

--- a/futureagi/simulate/utils/eval_context.py
+++ b/futureagi/simulate/utils/eval_context.py
@@ -1,0 +1,141 @@
+"""Eval mapping context helpers.
+
+Shared between the Temporal `run_simulate_evaluations` activity (which
+resolves eval-config mapping values at run time) and the call-detail API
+serializer (which surfaces the same vocabulary to the frontend dropdown).
+"""
+
+import json
+
+# Persona model fields exposed under persona.* via flatten_persona.
+PERSONA_LIST_FIELDS = (
+    "gender", "age_group", "occupation", "location", "personality",
+    "communication_style", "languages", "accent", "conversation_speed",
+    "finished_speaking_sensitivity", "interrupt_sensitivity", "keywords",
+)
+PERSONA_SCALAR_FIELDS = (
+    "name", "description", "tone", "verbosity", "punctuation",
+    "emoji_usage", "slang_usage", "typos_frequency", "regional_mix",
+    "simulation_type", "additional_instruction",
+)
+
+# (SimulatorAgent attr, persona.<suffix>). "description" maps from
+# SimulatorAgent.prompt — preserves the legacy persona_description alias.
+SIMULATOR_FALLBACK_FIELDS = (
+    ("name", "name"),
+    ("prompt", "prompt"),
+    ("prompt", "description"),
+    ("voice_provider", "voice_provider"),
+    ("voice_name", "voice_name"),
+    ("model", "model"),
+    ("llm_temperature", "llm_temperature"),
+    ("conversation_speed", "conversation_speed"),
+    ("interrupt_sensitivity", "interrupt_sensitivity"),
+    ("finished_speaking_sensitivity", "finished_speaking_sensitivity"),
+    ("max_call_duration_in_minutes", "max_call_duration_in_minutes"),
+    ("initial_message_delay", "initial_message_delay"),
+    ("initial_message", "initial_message"),
+)
+
+
+def flatten_jsonfield_value(value):
+    """Flatten a JSONField value for eval consumption.
+
+    None/"" → "". Empty list → "". Single-element list unwrapped. Multi-element
+    list comma-joined. Dict JSON-stringified. Scalar str()'d.
+    """
+    if value is None or value == "":
+        return ""
+    if isinstance(value, list):
+        if not value:
+            return ""
+        if len(value) == 1:
+            return "" if value[0] is None else str(value[0])
+        return ", ".join("" if v is None else str(v) for v in value)
+    if isinstance(value, dict):
+        return json.dumps(value)
+    return str(value)
+
+
+def flatten_persona(persona):
+    """Build persona.* from the Persona model only — drives the user-facing
+    eval-mapping dropdown. SimulatorAgent fields are excluded here on purpose.
+    """
+    flat = {}
+    for field in PERSONA_LIST_FIELDS:
+        raw = getattr(persona, field, None) if persona else None
+        flat[f"persona.{field}"] = flatten_jsonfield_value(raw)
+    for field in PERSONA_SCALAR_FIELDS:
+        raw = getattr(persona, field, None) if persona else None
+        flat[f"persona.{field}"] = "" if raw is None else str(raw)
+
+    persona_metadata = getattr(persona, "metadata", None) if persona else None
+    if isinstance(persona_metadata, dict):
+        for meta_key, meta_value in persona_metadata.items():
+            flat[f"persona.metadata.{meta_key}"] = flatten_jsonfield_value(
+                meta_value
+            )
+
+    return flat
+
+
+def flatten_persona_for_resolver(persona, simulator_agent):
+    """Same as flatten_persona but adds SimulatorAgent fallback so legacy
+    eval-config mappings like persona.prompt keep resolving. Persona wins
+    on conflicts.
+    """
+    flat = flatten_persona(persona)
+
+    if simulator_agent is None:
+        return flat
+
+    for sim_attr, key in SIMULATOR_FALLBACK_FIELDS:
+        target = f"persona.{key}"
+        if flat.get(target):
+            continue
+        value = getattr(simulator_agent, sim_attr, None)
+        flat[target] = "" if value is None else str(value)
+
+    return flat
+
+
+def resolve_persona_for_call(call_execution):
+    """Pick the Persona used for this specific call.
+
+    Priority:
+    1. call_metadata.row_data.persona (UUID) — baked into the dataset row
+       at execution time by temporal/activities/test_execution.py.
+    2. First Persona referenced by scenario.metadata.persona_ids
+       (ordered by created_at — stable across runs).
+    3. None — `persona.*` keys resolve to "".
+    """
+    from simulate.models import Persona
+
+    metadata = call_execution.call_metadata or {}
+    row_data = metadata.get("row_data") or {}
+    row_persona_id = row_data.get("persona")
+    if row_persona_id:
+        try:
+            return Persona.no_workspace_objects.get(
+                id=row_persona_id, deleted=False
+            )
+        except (Persona.DoesNotExist, ValueError):
+            pass
+
+    scenario = getattr(call_execution, "scenario", None)
+    if not scenario:
+        return None
+    scenario_meta = scenario.metadata or {}
+    persona_ids = scenario_meta.get("persona_ids") or []
+    if not persona_ids:
+        return None
+    try:
+        return (
+            Persona.no_workspace_objects.filter(
+                id__in=persona_ids, deleted=False
+            )
+            .order_by("created_at")
+            .first()
+        )
+    except ValueError:
+        return None

--- a/futureagi/simulate/utils/eval_context.py
+++ b/futureagi/simulate/utils/eval_context.py
@@ -99,6 +99,56 @@ def flatten_persona_for_resolver(persona, simulator_agent):
     return flat
 
 
+def resolve_scenario_column_by_name(call_execution, column_name):
+    """Look up Column.name within the call's scenario dataset, fetch the cell.
+
+    Returns the cell value string, or "" if any of:
+    - call has no row_id (chat scenarios, free-form runs)
+    - the scenario has no linked dataset
+    - the column name doesn't exist in that dataset
+    - the cell for (row_id, column) is missing
+
+    Column.name is not unique within a dataset (no DB constraint). First match
+    by Column.created_at wins; duplicates are logged for follow-up cleanup.
+    """
+    import structlog
+
+    from model_hub.models.develop_dataset import Cell, Column
+
+    logger = structlog.get_logger(__name__)
+
+    metadata = call_execution.call_metadata or {}
+    row_id = metadata.get("row_id")
+    if not row_id:
+        return ""
+
+    scenario = getattr(call_execution, "scenario", None)
+    dataset = scenario.dataset if scenario else None
+    if not dataset:
+        return ""
+
+    matching = list(
+        Column.objects.filter(
+            dataset=dataset, name=column_name, deleted=False
+        ).order_by("created_at")
+    )
+    if not matching:
+        return ""
+    if len(matching) > 1:
+        logger.warning(
+            "duplicate_column_names_in_dataset",
+            dataset_id=str(dataset.id),
+            column_name=column_name,
+            column_ids=[str(c.id) for c in matching],
+        )
+
+    try:
+        cell = Cell.objects.get(row_id=row_id, column=matching[0], deleted=False)
+        return cell.value
+    except Cell.DoesNotExist:
+        return ""
+
+
 def resolve_persona_for_call(call_execution):
     """Pick the Persona used for this specific call.
 


### PR DESCRIPTION
## Description

Phase 1 of the eval-mapping stabilization stack. Builds on PR #531 (`fix/th-4952-route-rerun-through-temporal`).

This PR makes the eval context map scenario-agnostic and adds the missing resolver branches so legacy "Column mapping mismatch" failures resolve cleanly going forward. Functional changes:

**1. Persona attributes surface under `persona.*`**
- `resolve_persona_for_call` picks the Persona used for a CallExecution (row_data.persona → first in scenario.metadata.persona_ids → None).
- `flatten_persona` exposes every Persona field (gender, age_group, occupation, tone, verbosity, languages, accent, etc.) plus `persona.metadata.<key>` for free-form custom attributes — drives the user-facing eval-mapping dropdown.
- `flatten_persona_for_resolver` adds a SimulatorAgent fallback so legacy mappings like `persona.prompt`, `persona.voice_name`, `persona.initial_message` keep resolving without listing those as new dropdown options.

**2. Scenarios metadata moves to `scenario.info.*`**
- `scenario.info.{name,description,type,source}` replaces the previous `scenario.{name,…}` keys (which silently shadowed bare `scenario.<col>` lookups). Underscore aliases (`scenario_info_*`) preserved for pre-2026-04-13 saved configs.
- `scenario.metadata.<key>` surfaces every user-supplied `Scenarios.metadata` key dynamically through the same JSONField flattener used for Persona. Internal-reference keys (`persona_ids`, `agent_definition_version_id`) are denylisted.

**3. `scenario.<column_name>` resolver branch**
- `resolve_scenario_column_by_name(call_execution, column_name)` joins `Column → Cell` within the call's specific scenario dataset. First-by-`created_at` on name collisions; warns when duplicates are found.
- `_run_single_evaluation` gets an `elif` branch that catches bare `scenario.<X>` mappings (excluding `scenario.info.<X>` / `scenario.metadata.<X>`) and routes them through the helper. The mismatch-prep loop also skips `scenario.*` so dotted values no longer try to validate as UUIDs.

**4. Shared utils module**
- New `simulate/utils/eval_context.py` holds `flatten_jsonfield_value`, `flatten_persona`, `flatten_persona_for_resolver`, `resolve_persona_for_call`, `resolve_scenario_column_by_name`. Phase 2's `CallExecutionDetailSerializer` will import `flatten_persona` from the same place.

**Scope notes**
- Legacy `simulate/services/test_executor.py:_run_single_simulate_evaluation` (used by chat-sim's initial test execution) is **not** updated. Voice-sim reruns bypass it via PR #531. Chat-sim's initial-run path needs a parallel update (or a migration to Temporal) in a follow-up.
- Legacy eval configs that used `scenario.{name,description,type,source}` (without `info.`) stop resolving — the frontend already emits `scenario.info.<X>` so new configs aren't affected; the Phase 3 data migration handles persisted legacy values.

Refs [TH-4952](https://linear.app/future-agi/issue/TH-4952). Stacked on PR #531. Phase 2 (frontend drops UUID translation + serializer exposure) and Phase 3 (data migration) follow.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Configuration change

## Checklist

### Code Quality

- [ ] I have run `make pre-commit-all` and fixed all issues
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (19/19 in `test_xl_eval_context.py`; 12/12 in adjacent `test_temporal_activities.py` evaluation suite)
- [ ] I have run `make test` successfully

### Django-Specific (if applicable)

- [x] No model changes — no new migrations
- [ ] I have run `python manage.py check` without errors
- [x] Database migrations are reversible (N/A)

### Documentation

- [x] Docstrings updated for the new utility helpers and the refactored context-map builder
- [x] N/A — no user-facing doc changes
- [ ] I have updated the CHANGELOG (if applicable)

### Security

- [x] My changes don't introduce security vulnerabilities (denylist filters `persona_ids` / `agent_definition_version_id` so internal references don't leak through `scenario.metadata.<key>`)
- [x] I have not committed any secrets or credentials
- [ ] I have run `make check-secrets` and addressed any issues

## Pre-commit Hooks

- [ ] ✅ Pre-commit hooks are installed (`make pre-commit-install`)
- [ ] ✅ All pre-commit checks pass (`make pre-commit-all`)

## Related Issues

Refs TH-4952. Stacked on `fix/th-4952-route-rerun-through-temporal` (PR #531).

## Screenshots (if applicable)

N/A — backend only. Frontend dropdown changes ship in Phase 2.

## Additional Notes

- Decision recorded in `~/.claude/plans/eval-mapping-stabilization.md`: `persona.*` is the user-facing namespace and is sourced strictly from the Persona model in the call-detail serializer (Phase 2). The runtime resolver here keeps a SimulatorAgent fallback solely for legacy back-compat — those keys are not surfaced in the frontend dropdown.
- Column-name collisions within a Dataset are not currently enforced at the schema level. First-by-`created_at` wins and a warning is logged. A `unique_together(dataset, name, deleted)` constraint is a candidate follow-up after Phase 3's data cleanup.