### PR TITLE
fix(annotate): stop inline-annotator Save button stretching

### DIFF
--- a/frontend/src/components/InlineAnnotator/InlineAnnotator.jsx
+++ b/frontend/src/components/InlineAnnotator/InlineAnnotator.jsx
@@ -377,11 +377,10 @@ const InlineAnnotator = forwardRef(function InlineAnnotator(
           onChange={(e) => setNotes(e.target.value)}
         />
 
-        <Stack direction="row" spacing={1}>
+        <Stack direction="row" justifyContent={"flex-end"} spacing={1}>
           <Button
             variant="contained"
             size="small"
-            fullWidth
             onClick={handleSubmit}
             disabled={isSaving || !hasValues}
             startIcon={


### PR DESCRIPTION
## Summary
- In the Session History inline annotator, the Save button rendered edge-to-edge while Cancel hugged the right edge — caused by `fullWidth` on Save inside a `direction="row"` Stack.
- Dropped `fullWidth` on Save and added `justifyContent="flex-end"` so both buttons size naturally and align to the right of the action row.

Closes TH-5067

## Linear Ticket
[TH-5067 — annotation button of Save is streched out to max](https://linear.app/future-agi/issue/TH-5067/annotation-button-of-save-is-streched-out-to-max)

## Files Changed
- `frontend/src/components/InlineAnnotator/InlineAnnotator.jsx`

## Test plan
- [ ] Open a project → Traces drawer → Session History tab → Annotate panel — confirm Save + Cancel sit side-by-side at the right edge, neither stretched.
- [ ] Narrow the drawer/window — buttons stay side-by-side, no overlap with the Notes textarea above.
- [ ] Save still submits and Cancel still closes the annotator with no behavioural change.