### PR TITLE
fix(evals): rerun on eval edit, drawer variant gating, dialog & tooltip copy

### DIFF
--- a/frontend/src/sections/test-detail/TestDetailConfigureEval.jsx
+++ b/frontend/src/sections/test-detail/TestDetailConfigureEval.jsx
@@ -19,7 +19,7 @@ import { AGENT_TYPES } from "../agents/constants";
 import { SourceType } from "../scenarios/common";
 
 const TestDetailConfigureEval = () => {
-  const { testId } = useParams();
+  const { testId, executionId } = useParams();
   const queryClient = useQueryClient();
 
   const { configureEval, setConfigureEval } = useTestDetailStoreShallow(
@@ -76,7 +76,12 @@ const TestDetailConfigureEval = () => {
   }, [agentType, sourceType, testData]);
 
   const { mutateAsync: updateEvalAsync } = useMutation({
-    mutationFn: ({ evalConfigId, payload }) =>
+    mutationFn: (
+      {
+        evalConfigId,
+        payload,
+      },
+    ) =>
       axios.post(
         endpoints.runTests.updateSimulateEval(testId, evalConfigId),
         payload,
@@ -95,8 +100,14 @@ const TestDetailConfigureEval = () => {
       try {
         await updateEvalAsync({
           evalConfigId: editingEvalItem.id,
-          payload,
+          payload: {
+            ...payload,
+            ...(executionId
+              ? { run: true, test_execution_id: executionId }
+              : {}),
+          },
         });
+
         enqueueSnackbar("Eval updated successfully", { variant: "success" });
         handleRefresh();
       } catch (error) {
@@ -106,7 +117,7 @@ const TestDetailConfigureEval = () => {
         throw error;
       }
     },
-    [testId, editingEvalItem, updateEvalAsync, handleRefresh],
+    [testId, executionId, editingEvalItem, updateEvalAsync, handleRefresh],
   );
 
   const onClose = useCallback(() => {

--- a/frontend/src/sections/test/TestEvaluationDrawer.jsx
+++ b/frontend/src/sections/test/TestEvaluationDrawer.jsx
@@ -137,7 +137,7 @@ const TestEvaluationDrawer = ({ executionIds, onSuccessOfAdditionOfEvals }) => {
       <Drawer
         anchor="right"
         open={openTestEvaluation}
-        variant="temporary"
+              variant="persistent"
         onClose={onCloseHandler}
         PaperProps={{
           sx: (theme) => ({

--- a/frontend/src/sections/test/TestEvaluationDrawer.jsx
+++ b/frontend/src/sections/test/TestEvaluationDrawer.jsx
@@ -137,7 +137,7 @@ const TestEvaluationDrawer = ({ executionIds, onSuccessOfAdditionOfEvals }) => {
       <Drawer
         anchor="right"
         open={openTestEvaluation}
-              variant="persistent"
+              variant={onSuccessOfAdditionOfEvals?"temporary":"persistent"}
         onClose={onCloseHandler}
         PaperProps={{
           sx: (theme) => ({

--- a/frontend/src/sections/test/TestEvaluationPage.jsx
+++ b/frontend/src/sections/test/TestEvaluationPage.jsx
@@ -372,7 +372,7 @@ const TestEvaluationPage = ({
             show={
               executionIds ? executionIds?.length === 0 : selectedCount === 0
             }
-            title="Please select at least one Test Run to run"
+            title="Please select at least one Test Run from grid to run evaluation"
             arrow
             placement="top"
             size="small"

--- a/frontend/src/sections/test/TestEvaluationPage.jsx
+++ b/frontend/src/sections/test/TestEvaluationPage.jsx
@@ -430,8 +430,8 @@ const TestEvaluationPage = ({
         open={openConfirmDialog}
         onClose={() => setOpenConfirmDialog(false)}
         onConfirm={() => {}}
-        title="Confirm Delete eval"
-        message="Are you sure you want to proceed?"
+        title="Delete Evaluation"
+        content="This will also remove all its results. This action cannot be undone."
         action={
           <LoadingButton
             variant="contained"

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationPage.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationPage.jsx
@@ -329,8 +329,8 @@ const SimulationEvaluationPage = ({
       <ConfirmDialog
         open={Boolean(openConfirmDialog)}
         onClose={() => setOpenConfirmDialog(false)}
-        title="Confirm Delete eval"
-        content="Are you sure you want to delete this evaluation?"
+        title="Delete Evaluation"
+        content="This will also remove all its results. This action cannot be undone."
         action={
           <LoadingButton
             variant="contained"


### PR DESCRIPTION
## Summary

- **Rerun on eval edit**: editing an existing eval from a test-execution context now triggers a rerun on the current execution. `run: true` and `test_execution_id` were being passed alongside `payload` in the mutation args, but the mutation only forwards `payload` as the request body, so they were silently dropped. Moved them into `payload` so they actually reach `/simulate/run-tests/{id}/eval-configs/{evalId}/update/`. (`TestDetailConfigureEval`)
- **Drawer variant gating**: `TestEvaluationDrawer` now uses `persistent` for the new flow (drawer stays open while interacting with the grid behind it) and falls back to `temporary` for legacy callers that pass `onSuccessOfAdditionOfEvals` (click-outside dismisses, preserving prior behavior).
- **Delete-eval dialog**: `ConfirmDialog` only renders the `content` prop, but the caller was passing `message=...`, so the warning body never showed. Switched to `content`, retitled to "Delete Evaluation", and reworded to "This will also remove all its results. This action cannot be undone." Applied to both `TestEvaluationPage` and `SimulationEvaluationPage` for consistency.
- **Run-evaluations tooltip**: reworded the disabled-button tooltip to specify the grid as the selection source.

## Test plan
- [x] On a test-execution detail page, edit an existing eval → DevTools shows the POST body includes `run: true` and `test_execution_id`; eval reruns on the current execution
- [x] Legacy flow (caller passes `onSuccessOfAdditionOfEvals`): open the evaluation drawer → clicking outside dismisses it
- [x] New flow: open the evaluation drawer → it stays open while interacting with the grid behind it
- [x] Click delete on an eval in `TestEvaluationPage` → title reads "Delete Evaluation"; body shows "This will also remove all its results. This action cannot be undone."
- [x] Same check on the Simulation evaluation page
- [x] Hover the Run Evaluations button with no rows selected → tooltip clearly indicates selecting from the grid



Closes TH-5302,TH-5236
