### PR TITLE
fix(eval-clustering): re-enable trigger with bounded, deduped, batched clustering (TH-4789)

### DIFF
--- a/futureagi/agentic_eval/core/embeddings/serving_client.py
+++ b/futureagi/agentic_eval/core/embeddings/serving_client.py
@@ -127,6 +127,36 @@ class ModelServingClient:
             logger.error(f"Text embedding failed: {e}")
             raise
 
+    def embed_text_batch(self, texts: list[str]) -> list[list[float]]:
+        """
+        Batch text embedding: send N texts in one request, get N vectors back.
+
+        Deliberately does NOT go through _make_request — that path unwraps
+        embeddings[0] for single-input convenience, which silently drops all
+        but the first vector for a batch. The /embed endpoint already returns
+        one vector per input in order, so we return it as-is.
+        """
+        if not texts:
+            return []
+        if not all(isinstance(t, str) for t in texts):
+            raise ValueError("All text inputs must be strings")
+
+        data = {"text": texts, "input_type": "text"}
+        response = self.session.post(
+            f"{self.base_url}/model/v1/embed", json=data, timeout=self.default_timeout
+        )
+        if response.status_code != 200:
+            response.raise_for_status()
+        embeddings = response.json().get("embeddings", [])
+        if len(embeddings) != len(texts):
+            # Contract violation — caller decides how to fall back rather
+            # than us silently returning misaligned vectors.
+            raise ValueError(
+                f"serving returned {len(embeddings)} embeddings for "
+                f"{len(texts)} texts"
+            )
+        return embeddings
+
     def embed_image(self, image: str | Image.Image | bytes, model_name: str = "image_embedding") -> list[float]:
         """
         ✅ IMPROVED: Get image embeddings from the serving service with better image handling.

--- a/futureagi/tfc/temporal/drop_in/decorator.py
+++ b/futureagi/tfc/temporal/drop_in/decorator.py
@@ -140,6 +140,9 @@ def temporal_activity(
                     args=args or (),
                     kwargs=kwargs or {},
                     queue=target_queue,
+                    task_id=options.get("task_id"),
+                    id_conflict_policy=options.get("id_conflict_policy"),
+                    start_delay=options.get("start_delay"),
                 )
                 log.info(
                     "apply_async_completed",

--- a/futureagi/tfc/temporal/drop_in/runner.py
+++ b/futureagi/tfc/temporal/drop_in/runner.py
@@ -28,6 +28,8 @@ def start_activity(
     kwargs: Optional[dict] = None,
     queue: str = "default",
     task_id: Optional[str] = None,
+    id_conflict_policy: Optional[Any] = None,
+    start_delay: Optional[Any] = None,
 ) -> str:
     """
     Start a Temporal activity (drop-in replacement for Celery's apply_async).
@@ -86,7 +88,13 @@ def start_activity(
                 future = executor.submit(
                     asyncio.run,
                     _start_activity_async(
-                        activity_name, args, kwargs, temporal_queue, task_id
+                        activity_name,
+                        args,
+                        kwargs,
+                        temporal_queue,
+                        task_id,
+                        id_conflict_policy,
+                        start_delay,
                     ),
                 )
                 result = future.result(timeout=30)  # 30 second timeout
@@ -101,7 +109,13 @@ def start_activity(
             # No running loop, create one - this is the normal case for sync Django views
             result = asyncio.run(
                 _start_activity_async(
-                    activity_name, args, kwargs, temporal_queue, task_id
+                    activity_name,
+                    args,
+                    kwargs,
+                    temporal_queue,
+                    task_id,
+                    id_conflict_policy,
+                    start_delay,
                 )
             )
             logger.info(
@@ -124,6 +138,8 @@ async def _start_activity_async(
     kwargs: dict,
     queue: str,
     task_id: str,
+    id_conflict_policy: Optional[Any] = None,
+    start_delay: Optional[Any] = None,
 ) -> str:
     """Async implementation of start_activity."""
     from temporalio.client import Client
@@ -178,6 +194,13 @@ async def _start_activity_async(
             queue=queue,
             activity_name=activity_name,
         )
+        # Only pass these when explicitly provided so every existing caller
+        # resolves to the exact same start_workflow call (zero blast radius).
+        _extra_start_kwargs: dict = {}
+        if id_conflict_policy is not None:
+            _extra_start_kwargs["id_conflict_policy"] = id_conflict_policy
+        if start_delay is not None:
+            _extra_start_kwargs["start_delay"] = start_delay
         handle = await client.start_workflow(
             TaskRunnerWorkflow.run,
             TaskRunnerInput(
@@ -192,6 +215,7 @@ async def _start_activity_async(
             execution_timeout=timedelta(hours=24),
             # Prevent single run from running forever - 13 hours max
             run_timeout=timedelta(hours=13),
+            **_extra_start_kwargs,
         )
 
         logger.info(

--- a/futureagi/tfc/temporal/drop_in/tests/test_dedup.py
+++ b/futureagi/tfc/temporal/drop_in/tests/test_dedup.py
@@ -1,0 +1,142 @@
+"""
+Per-project dedup wiring for the eval-clustering trigger.
+
+Real coalescing is Temporal-server behaviour (USE_EXISTING conflict
+policy), which a unit test can't exercise. What we *can* and must pin
+down is the wiring that makes the server coalesce:
+
+  * a deterministic per-project workflow id is used, and
+  * the conflict policy is forwarded to client.start_workflow when
+    provided, and
+  * the default path (no policy) is byte-identical to before — so every
+    existing .delay/.apply_async caller is unaffected.
+
+If those three hold, N rapid same-project triggers all hand Temporal the
+same workflow id + USE_EXISTING, which is exactly what collapses them to
+one in-flight run.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tfc.temporal.drop_in.runner import _start_activity_async
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _patched_client():
+    """Mock Temporal client whose start_workflow records its call."""
+    client = MagicMock()
+    client.namespace = "test-ns"
+    client.start_workflow = AsyncMock(return_value=MagicMock())
+    return client
+
+
+def _start(**kwargs):
+    """
+    Invoke _start_activity_async with internal deps patched, return the
+    kwargs that reached client.start_workflow.
+    """
+    client = _patched_client()
+    with patch(
+        "tfc.temporal.common.client.get_client", AsyncMock(return_value=client)
+    ), patch("tfc.temporal.drop_in.workflow.TaskRunnerWorkflow", MagicMock()), patch(
+        "tfc.temporal.drop_in.workflow.TaskRunnerInput", MagicMock()
+    ):
+        _run(
+            _start_activity_async(
+                "cluster_eval_results_task",
+                ("proj-1",),
+                {},
+                "agent_compass",
+                kwargs.get("task_id", "cluster_eval_results_task-abcd1234"),
+                **(
+                    {"id_conflict_policy": kwargs["id_conflict_policy"]}
+                    if "id_conflict_policy" in kwargs
+                    else {}
+                ),
+            )
+        )
+    assert client.start_workflow.await_count == 1
+    return client.start_workflow.await_args.kwargs
+
+
+def test_deterministic_workflow_id_from_task_id():
+    """A per-project task_id yields a deterministic workflow id."""
+    call = _start(task_id="eval-cluster-proj-1")
+    assert call["id"] == "task-eval-cluster-proj-1"
+
+
+def test_conflict_policy_forwarded_when_provided():
+    """id_conflict_policy reaches start_workflow when passed."""
+    sentinel = object()
+    call = _start(task_id="eval-cluster-proj-1", id_conflict_policy=sentinel)
+    assert call.get("id_conflict_policy") is sentinel
+
+
+def test_default_path_unchanged_no_conflict_policy():
+    """
+    Zero blast radius: with no policy, start_workflow is called WITHOUT
+    an id_conflict_policy kwarg — identical to pre-change behaviour for
+    every existing caller.
+    """
+    call = _start(task_id="cluster_eval_results_task-abcd1234")
+    assert "id_conflict_policy" not in call
+
+
+def test_rapid_same_project_calls_all_coalesceable():
+    """
+    The TH-4789 acceptance proxy: 100 rapid triggers for the same project
+    must all hand Temporal the *same* workflow id and USE_EXISTING, which
+    is precisely what makes the server collapse them to <=1 in-flight run.
+    """
+    from temporalio.common import WorkflowIDConflictPolicy
+
+    ids = set()
+    policies = set()
+    for _ in range(100):
+        call = _start(
+            task_id="eval-cluster-proj-1",
+            id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+        )
+        ids.add(call["id"])
+        policies.add(call.get("id_conflict_policy"))
+
+    assert ids == {"task-eval-cluster-proj-1"}
+    assert policies == {WorkflowIDConflictPolicy.USE_EXISTING}
+
+
+def test_apply_async_forwards_task_id_and_policy():
+    """
+    apply_async (what the re-enabled trigger calls) must forward task_id
+    + id_conflict_policy into start_activity, else the wiring above never
+    gets the deterministic id.
+    """
+    from tfc.temporal.drop_in.decorator import temporal_activity
+
+    @temporal_activity(queue="agent_compass")
+    def dummy_task(project_id):
+        return project_id
+
+    sentinel = object()
+    with patch(
+        "tfc.temporal.drop_in.runner.start_activity", return_value="wf-1"
+    ) as mock_start:
+        dummy_task.apply_async(
+            args=("proj-1",),
+            task_id="eval-cluster-proj-1",
+            id_conflict_policy=sentinel,
+        )
+
+    assert mock_start.call_count == 1
+    _, kw = mock_start.call_args
+    assert kw["task_id"] == "eval-cluster-proj-1"
+    assert kw["id_conflict_policy"] is sentinel
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/futureagi/tracer/queries/eval_clustering.py
+++ b/futureagi/tracer/queries/eval_clustering.py
@@ -38,13 +38,19 @@ COSINE_THRESHOLD = 0.45
 # ---------------------------------------------------------------------------
 
 
-def get_unclustered_eval_results(project_id: str) -> List[ClusterableEvalResult]:
+def get_unclustered_eval_results(
+    project_id: str, limit: Optional[int] = None
+) -> List[ClusterableEvalResult]:
     """
     Fetch EvalLogger rows that failed, have an explanation, and haven't
     been assigned to a cluster yet.
 
     "Failed" = output_bool is False OR output_float < 1.0.
     Skips rows with null eval_explanation (deterministic evals without reasoning).
+
+    ``limit`` bounds the returned batch (oldest-first). The caller drains a
+    large backlog over successive bounded runs so a single clustering
+    activity can never grow unbounded and time out.
     """
     # Already-clustered eval_logger IDs
     clustered_ids = set(
@@ -74,8 +80,10 @@ def get_unclustered_eval_results(project_id: str) -> List[ClusterableEvalResult]
         .order_by("created_at")
     )
 
-    results = []
-    for ev in evals:
+    results: List[ClusterableEvalResult] = []
+    # .iterator() so a huge backlog isn't all loaded into memory just to
+    # stop early once `limit` unclustered rows have been collected.
+    for ev in evals.iterator(chunk_size=2000):
         if ev.id in clustered_ids:
             continue
         results.append(
@@ -89,6 +97,8 @@ def get_unclustered_eval_results(project_id: str) -> List[ClusterableEvalResult]
                 score=ev.output_float,
             )
         )
+        if limit is not None and len(results) >= limit:
+            break
 
     return results
 
@@ -98,13 +108,48 @@ def get_unclustered_eval_results(project_id: str) -> List[ClusterableEvalResult]
 # ---------------------------------------------------------------------------
 
 
+_EMBED_BATCH_SIZE = 64
+
+
 def embed_texts(texts: List[str]) -> List[List[float]]:
-    """Embed a batch of texts using the model serving client."""
-    text_embed = model_manager.text_model
-    embeddings = []
-    for text in texts:
-        embedding = text_embed(text)
-        embeddings.append(embedding)
+    """Embed texts via the serving client in bounded batches.
+
+    Chunked rather than per-row or all-at-once: one request carries up to
+    _EMBED_BATCH_SIZE texts (the single-worker serving process does one
+    batched forward pass instead of N round-trips), and a failed chunk only
+    costs re-embedding that chunk on the next idempotent clustering sweep —
+    bounded blast radius, which is the fault-isolation the old per-row
+    enqueue was reaching for, without the fan-out that overran serving.
+    """
+    if not texts:
+        return []
+
+    try:
+        client = model_manager.serving_client
+    except Exception:
+        client = None
+
+    if client is None:
+        # Serving unavailable — preserve the previous per-item behaviour.
+        text_embed = model_manager.text_model
+        return [text_embed(t) for t in texts]
+
+    embeddings: List[List[float]] = []
+    for start in range(0, len(texts), _EMBED_BATCH_SIZE):
+        chunk = texts[start : start + _EMBED_BATCH_SIZE]
+        try:
+            embeddings.extend(client.embed_text_batch(chunk))
+        except Exception:
+            # One bad chunk must not fail the whole project sweep — fall
+            # back to per-item for this chunk only.
+            logger.warning(
+                "embed_batch_fallback_per_item",
+                chunk_start=start,
+                chunk_size=len(chunk),
+                exc_info=True,
+            )
+            text_embed = model_manager.text_model
+            embeddings.extend(text_embed(t) for t in chunk)
     return embeddings
 
 

--- a/futureagi/tracer/queries/feed.py
+++ b/futureagi/tracer/queries/feed.py
@@ -2152,6 +2152,11 @@ def _recommendation_title_from_category(category: Optional[str]) -> str:
     return parts[-1] if parts else category.strip()
 
 
+# Cap on probable root causes surfaced per cluster — keeps the card
+# readable. See the NOTE in _build_root_causes for the real upstream fix.
+_MAX_ROOT_CAUSES = 4
+
+
 def _build_root_causes(details: List[TraceErrorDetail]) -> List[RootCause]:
     """Flatten ``TraceErrorDetail.root_causes`` across every detail for a
     trace, dedupe, and produce a ranked ``RootCause`` list.
@@ -2161,9 +2166,18 @@ def _build_root_causes(details: List[TraceErrorDetail]) -> List[RootCause]:
     Title = first clause before the first period/comma; description = the
     full string (so the card renders a natural headline + body).
     """
-    seen: set = set()
-    result: List[RootCause] = []
-    rank = 1
+    # NOTE: this is a display-layer mitigation, not the real fix. Two
+    # upstream problems make this list explode and both should be fixed
+    # at the source, not here:
+    #   1. The analysis agent over-generates root causes per trace instead
+    #      of committing to the few that matter — needs a hard cap + ranking
+    #      instruction in the agent prompt.
+    #   2. Dedup below is exact-text only, so the same cause phrased
+    #      slightly differently across traces survives as N near-duplicates
+    #      — needs semantic dedup (same gap as cluster fragmentation).
+    # Until those land we frequency-rank (most recurrent cause first) and
+    # cap the list so the card stays readable.
+    counts: dict = {}
     for d in details:
         for raw in d.root_causes or []:
             if not raw:
@@ -2172,21 +2186,27 @@ def _build_root_causes(details: List[TraceErrorDetail]) -> List[RootCause]:
             if not text:
                 continue
             key = text.lower()
-            if key in seen:
-                continue
-            seen.add(key)
+            entry = counts.get(key)
+            if entry is None:
+                counts[key] = {"text": text, "count": 1}
+            else:
+                entry["count"] += 1
 
-            # Headline: first clause before . or ,
-            split_idx = min(
-                (i for i in (text.find("."), text.find(",")) if i > 0),
-                default=-1,
-            )
-            title = text[:split_idx].strip() if split_idx > 0 else text
-            if len(title) > 120:
-                title = title[:117].rstrip() + "..."
+    # Most-recurrent first; stable on first-seen order for ties.
+    ranked = sorted(counts.values(), key=lambda e: -e["count"])
 
-            result.append(RootCause(rank=rank, title=title, description=text))
-            rank += 1
+    result: List[RootCause] = []
+    for rank, entry in enumerate(ranked[:_MAX_ROOT_CAUSES], start=1):
+        text = entry["text"]
+        # Headline: first clause before . or ,
+        split_idx = min(
+            (i for i in (text.find("."), text.find(",")) if i > 0),
+            default=-1,
+        )
+        title = text[:split_idx].strip() if split_idx > 0 else text
+        if len(title) > 120:
+            title = title[:117].rstrip() + "..."
+        result.append(RootCause(rank=rank, title=title, description=text))
     return result
 
 

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -1556,19 +1556,28 @@ def evaluate_observation_span_observe(
                 eval_task_id,
             )
 
-        # DISABLED 2026-04-30 — per-row enqueue caused Aurora CPU saturation
-        # under load (incident: cron-driven historical EvalTask × N×M fan-out
-        # → 60+ cluster_eval_results_task/sec → embedding service connection
-        # resets → workflow pile-up). Re-enable only after per-project debounce
-        # is implemented (Temporal workflow ID dedup or Redis lock).
-        #
-        # try:
-        #     from tracer.tasks.eval_clustering import cluster_eval_results_task
-        #
-        #     project_id = str(observation_span.project_id)
-        #     cluster_eval_results_task.delay(project_id)
-        # except Exception:
-        #     logger.debug("eval_clustering_dispatch_skipped", exc_info=True)
+        # Re-enabled with per-project Temporal dedup. The original per-row
+        # enqueue caused embedding-service overload under backfill (N×M
+        # fan-out → many concurrent same-project clustering runs each
+        # re-embedding the whole unclustered backlog). A deterministic
+        # per-project workflow id + USE_EXISTING conflict policy collapses
+        # concurrent triggers for a project onto the single in-flight run;
+        # once it completes the next trigger starts a fresh run that
+        # re-sweeps whatever is still unclustered (cluster_eval_results is
+        # idempotent), so coalescing is safe and loses nothing.
+        try:
+            from temporalio.common import WorkflowIDConflictPolicy
+
+            from tracer.tasks.eval_clustering import cluster_eval_results_task
+
+            project_id = str(observation_span.project_id)
+            cluster_eval_results_task.apply_async(
+                args=(project_id,),
+                task_id=f"eval-cluster-{project_id}",
+                id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+            )
+        except Exception:
+            logger.debug("eval_clustering_dispatch_skipped", exc_info=True)
 
         return True
     except ValueError as e:

--- a/futureagi/tracer/utils/eval_clustering.py
+++ b/futureagi/tracer/utils/eval_clustering.py
@@ -5,6 +5,7 @@ Mirrors trace_scanner.cluster_issues() — orchestrates the embed → match → 
 pipeline for failing eval results.
 """
 
+import uuid
 from typing import List
 
 import structlog
@@ -20,15 +21,24 @@ from tracer.types.eval_cluster_types import EvalClusteringSummary
 
 logger = structlog.get_logger(__name__)
 
+# Max eval rows clustered per activity invocation. Bounds the work unit so
+# a backfilled project (tens of thousands of unclustered rows) can never
+# produce a single activity that exceeds its Temporal time limit and then
+# retry-loops forever. A larger backlog drains over successive bounded runs
+# (see the self-continuation at the end of cluster_eval_results).
+_CLUSTER_BATCH_LIMIT = 500
+
 
 def cluster_eval_results(project_id: str) -> EvalClusteringSummary:
     """
-    Cluster all unclustered failing eval results for a project.
+    Cluster a bounded batch of unclustered failing eval results for a project.
 
     Online incremental: embed each explanation → cosine match against
-    centroids (partitioned by eval name) → assign or create.
+    centroids (partitioned by eval name) → assign or create. If the batch
+    cap is hit, more rows remain, so a follow-up run is scheduled to keep
+    draining — bounded O(total / cap) runs instead of one unbounded one.
     """
-    results = get_unclustered_eval_results(project_id)
+    results = get_unclustered_eval_results(project_id, limit=_CLUSTER_BATCH_LIMIT)
     if not results:
         logger.info("no_unclustered_eval_results", project_id=project_id)
         return EvalClusteringSummary()
@@ -70,4 +80,53 @@ def cluster_eval_results(project_id: str) -> EvalClusteringSummary:
         new_clusters=summary.new_clusters,
         assigned=summary.assigned,
     )
+
+    # Continue draining only when the batch was full AND we made forward
+    # progress.
+    #
+    # The continuation must use a DISTINCT workflow id — not the fixed
+    # per-project id + USE_EXISTING. That id+policy is for coalescing the
+    # per-row trigger burst; reusing it here is fatal: this code runs
+    # inside the still-open parent workflow, so USE_EXISTING resolves the
+    # conflict against the running parent at request time, coalesces the
+    # follow-up into it, the parent completes, and the backlog never
+    # advances past one batch (start_delay defers execution, not conflict
+    # resolution). A distinct id always starts a fresh run. The chain stays
+    # bounded — exactly one continuation per completed run, strictly
+    # sequential per project.
+    #
+    # The progress guard prevents a hot loop: a full batch with zero
+    # clustered means a downstream dependency (embeddings / centroid store)
+    # is failing — re-triggering would spin with no effect, so stop and
+    # surface it instead.
+    if len(results) >= _CLUSTER_BATCH_LIMIT:
+        if summary.clustered > 0:
+            try:
+                from datetime import timedelta
+
+                from tracer.tasks.eval_clustering import cluster_eval_results_task
+
+                cluster_eval_results_task.apply_async(
+                    args=(project_id,),
+                    task_id=f"eval-cluster-{project_id}-cont-{uuid.uuid4().hex[:8]}",
+                    start_delay=timedelta(seconds=5),
+                )
+                logger.info(
+                    "eval_clustering_continuation_scheduled",
+                    project_id=project_id,
+                    drained=summary.clustered,
+                )
+            except Exception:
+                logger.debug(
+                    "eval_clustering_continuation_skipped",
+                    project_id=project_id,
+                    exc_info=True,
+                )
+        else:
+            logger.error(
+                "eval_clustering_stuck_no_progress",
+                project_id=project_id,
+                fetched=len(results),
+            )
+
     return summary

--- a/futureagi/tracer/utils/tests/test_eval_clustering_cap.py
+++ b/futureagi/tracer/utils/tests/test_eval_clustering_cap.py
@@ -1,0 +1,100 @@
+"""
+Bounded work unit + self-continuation for eval clustering.
+
+The work unit must be bounded: an unbounded backfill in one activity
+times out, retries once, times out again, and the backlog never drains
+(the exact incident TH-4789 exists to fix). These tests pin down:
+
+  * a full batch (== cap) schedules a follow-up run so the backlog
+    drains over successive bounded runs, and
+  * a partial batch (< cap) does NOT — no pointless re-trigger.
+
+The continuation must use the per-project task id + USE_EXISTING + a
+start_delay (so it isn't coalesced into the run that spawns it).
+"""
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from tracer.utils.eval_clustering import _CLUSTER_BATCH_LIMIT, cluster_eval_results
+
+
+class _FakeResult:
+    def __init__(self, i: int):
+        self.eval_logger_id = f"el-{i}"
+        self.eval_name = "prosody_and_intonation"
+
+    @property
+    def embedding_text(self) -> str:
+        return "robotic rhythm"
+
+
+def _run_with(n_results: int, cluster_raises: bool = False):
+    """Run cluster_eval_results with deps mocked, return the patched task."""
+    results = [_FakeResult(i) for i in range(n_results)]
+
+    task = MagicMock()
+    create = (
+        MagicMock(side_effect=RuntimeError("centroid store down"))
+        if cluster_raises
+        else MagicMock(return_value="E-X")
+    )
+    with patch(
+        "tracer.utils.eval_clustering.get_unclustered_eval_results",
+        return_value=results,
+    ), patch(
+        "tracer.utils.eval_clustering.embed_texts",
+        return_value=[[0.0] for _ in results],
+    ), patch(
+        "tracer.utils.eval_clustering.find_nearest_centroid", return_value=None
+    ), patch(
+        "tracer.utils.eval_clustering.create_cluster", create
+    ), patch(
+        "tracer.tasks.eval_clustering.cluster_eval_results_task", task
+    ):
+        cluster_eval_results("proj-1")
+    return task
+
+
+def test_full_batch_schedules_distinct_id_continuation():
+    """
+    Full batch + progress → exactly one follow-up, with a DISTINCT id and
+    NO conflict policy. Reusing the fixed id + USE_EXISTING here is the
+    bug found in e2e: it coalesces the follow-up into the still-open
+    parent and the backlog never drains past one batch.
+    """
+    task = _run_with(_CLUSTER_BATCH_LIMIT)
+
+    assert task.apply_async.call_count == 1
+    kw = task.apply_async.call_args.kwargs
+    assert kw["args"] == ("proj-1",)
+    assert kw["task_id"].startswith("eval-cluster-proj-1-cont-")
+    assert kw["task_id"] != "eval-cluster-proj-1"
+    assert "id_conflict_policy" not in kw  # must NOT coalesce into parent
+    assert isinstance(kw["start_delay"], timedelta)
+
+
+def test_two_runs_get_unique_continuation_ids():
+    """Chained continuations must not collide on workflow id."""
+    id1 = _run_with(_CLUSTER_BATCH_LIMIT).apply_async.call_args.kwargs["task_id"]
+    id2 = _run_with(_CLUSTER_BATCH_LIMIT).apply_async.call_args.kwargs["task_id"]
+    assert id1 != id2
+
+
+def test_full_batch_zero_progress_does_not_loop():
+    """
+    Full batch but every cluster op fails (downstream down) → progress is
+    0 → NO continuation. Guards against a hot retrigger loop.
+    """
+    task = _run_with(_CLUSTER_BATCH_LIMIT, cluster_raises=True)
+    task.apply_async.assert_not_called()
+
+
+def test_partial_batch_does_not_continue():
+    task = _run_with(_CLUSTER_BATCH_LIMIT - 1)
+    task.apply_async.assert_not_called()
+
+
+def test_empty_does_not_continue():
+    task = _run_with(0)
+    task.apply_async.assert_not_called()


### PR DESCRIPTION
## TH-4789 — re-enable eval-clustering trigger with per-project debounce

Re-enables the per-row eval-clustering trigger disabled 2026-04-30 after a historical backfill overran the embedding service (N×M fan-out → 60+ clustering tasks/sec → connection resets → workflow pile-up).

### Approach (not a Redis lock — Temporal-native)

| Concern | Fix |
|---|---|
| Per-row trigger burst | Deterministic per-project workflow id + `USE_EXISTING` → the burst coalesces into one in-flight run. Additive `id_conflict_policy`/`start_delay` plumbing through the shared `start_activity` runner; **defaults preserve every existing caller's path byte-for-byte** (zero blast radius). |
| Unbounded work unit | `cluster_eval_results` processes ≤ `_CLUSTER_BATCH_LIMIT` (500) oldest unclustered rows per activity → no single activity can grow until it times out and retry-loops forever. |
| Per-row embedding storm | `embed_texts` chunks at 64 and calls a batch-safe serving path (no single-item unwrap); a failed chunk falls back to per-item *for that chunk only* — bounded fault isolation. |
| Draining a large backlog | A full batch *with forward progress* schedules ONE follow-up with a **distinct** id. Backlog drains over bounded O(total/500) chained runs. Zero-progress guard prevents a hot retrigger loop when a downstream dep is down. |

### Bug found & fixed during e2e

The first continuation design (reused the fixed id + `USE_EXISTING`) was **deterministically broken**: the follow-up is dispatched from inside the still-open parent workflow, so `USE_EXISTING` coalesces it into the parent and the backlog never advances past one batch (`start_delay` defers execution, not conflict resolution). Fixed by using a distinct continuation id. Re-validated e2e: a backlog drains fully across distinct-id chained runs.

### Validation

- **10 unit tests** — dedup wiring contract (incl. 100-rapid-call coalesce proxy + zero-blast-radius default path), bounded continuation (distinct id, unique-per-run, progress-gated, no-loop-on-zero-progress).
- **e2e** — burst dedup (3 rapid → 1 Temporal execution), full backlog drains 60→0 across 6 distinct-id continuation executions, no timeout/retry-loop, batch path verified engaged (0 fallbacks).

### Scope notes

- **AC reading:** steady-state freshness (new evals cluster within ~one run) is met. A massive historical backfill drains over *bounded chained runs* (tens of minutes for tens of thousands of rows) — this is the intended safety (no stampede), not a regression. "Fresh within 2 min" = steady-state, not "drain 50k in 2 min".
- Bundles a small `feed._build_root_causes` cap (frequency-rank, top 4) — separate feed fix, intentionally carried on this branch.
- **Out of scope (separate work):** queue/worker rate cap (config, tied to serving scaling), scanner-side batching (same serving SPOF, flagged follow-up).
- `_CLUSTER_BATCH_LIMIT=500` is a reasonable default; tune with prod metrics (mechanism degrades gracefully if mis-sized — more, shorter runs).