### PR TITLE
feat(eval-clustering): cheap-LLM Sentry-style titles for eval clusters

### DIFF
--- a/futureagi/tracer/queries/eval_clustering.py
+++ b/futureagi/tracer/queries/eval_clustering.py
@@ -13,6 +13,7 @@ import re
 from typing import List, Optional, Tuple
 
 import structlog
+from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 
@@ -231,6 +232,34 @@ def _extract_title(explanation: str) -> str:
     return first_line[:200] if first_line else text[:200]
 
 
+def _eval_cluster_title(eval_name: str, reasoning: str) -> str:
+    """Sentry-style cluster title via the cheap-LLM EE helper, with a
+    deterministic fallback.
+
+    EE absent (OSS) or any LLM failure → the first-sentence extraction.
+    A title is low-stakes; it must never break cluster creation.
+    """
+    try:
+        from ee.agenthub.trace_scanner.eval_cluster_title import (
+            generate_eval_cluster_title,
+        )
+    except ImportError:
+        if settings.DEBUG:
+            logger.warning(
+                "Could not import ee.agenthub.trace_scanner.eval_cluster_title",
+                exc_info=True,
+            )
+        return _extract_title(reasoning)
+
+    try:
+        title = generate_eval_cluster_title(eval_name, reasoning)
+    except Exception:
+        logger.warning("eval_cluster_title_llm_failed", exc_info=True)
+        title = None
+
+    return title or _extract_title(reasoning)
+
+
 # ---------------------------------------------------------------------------
 # Cluster creation
 # ---------------------------------------------------------------------------
@@ -259,7 +288,7 @@ def create_cluster(
         ).hexdigest()[:8]
         cluster_id = f"E-{h2.upper()}"
 
-    title = _extract_title(result.explanation)
+    title = _eval_cluster_title(result.eval_name, result.explanation)
 
     cluster = TraceErrorGroup.objects.create(
         project_id=project_id,

--- a/futureagi/tracer/queries/tests/test_eval_cluster_title.py
+++ b/futureagi/tracer/queries/tests/test_eval_cluster_title.py
@@ -1,0 +1,63 @@
+"""
+_eval_cluster_title gating + fallback contract.
+
+The cheap-LLM title is EE-only and best-effort. The load-bearing
+guarantee is that cluster creation NEVER breaks on its account:
+
+  * EE present + good title  -> use it
+  * EE present + None        -> deterministic _extract_title
+  * EE present + raises      -> deterministic _extract_title
+  * EE absent (OSS)          -> deterministic _extract_title
+
+The last is the OSS-safety contract: no ee module, no crash.
+"""
+
+import sys
+from unittest.mock import patch
+
+from tracer.queries.eval_clustering import _eval_cluster_title, _extract_title
+
+REASONING = (
+    "The verdict is Fail because the speech has an unnatural, robotic "
+    "rhythm and pacing throughout the call."
+)
+
+
+def test_uses_llm_title_when_available():
+    with patch(
+        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
+        return_value="Robotic, unnatural speech rhythm",
+    ):
+        assert (
+            _eval_cluster_title("prosody_and_intonation", REASONING)
+            == "Robotic, unnatural speech rhythm"
+        )
+
+
+def test_falls_back_when_llm_returns_none():
+    with patch(
+        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
+        return_value=None,
+    ):
+        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
+            REASONING
+        )
+
+
+def test_falls_back_when_llm_raises():
+    with patch(
+        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
+        side_effect=RuntimeError("gateway down"),
+    ):
+        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
+            REASONING
+        )
+
+
+def test_oss_safety_no_ee_module_no_crash():
+    # Setting the module to None in sys.modules makes `import` raise
+    # ImportError — simulates an OSS deployment with no ee package.
+    with patch.dict(sys.modules, {"ee.agenthub.trace_scanner.eval_cluster_title": None}):
+        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
+            REASONING
+        )


### PR DESCRIPTION
## Eval-cluster titles (quick-fix #1)

Eval-source error clusters (`source='eval'`) were titled with the first sentence of the raw evaluator reasoning — *"The verdict is Fail because the speech has an unnatural, robotic rhythm..."*. Unreadable in the feed.

`create_cluster` now generates a concise, **generalized** Sentry-style title via a gated cheap-LLM helper.

### Public side (this PR)
- `tracer/queries/eval_clustering.py`: `_eval_cluster_title()` — import-guards the EE helper; **EE absent (OSS) or any LLM failure → falls back to `_extract_title`**. Titling never breaks cluster creation.
- `tracer/queries/tests/test_eval_cluster_title.py`: gating/fallback contract — LLM-good, LLM-None→fallback, LLM-raises→fallback, **OSS no-ee-module-no-crash**. 4/4.

### EE side (separate, gitignored in this repo)
**future-agi/ee#64** — the helper (`TURING_FLASH`, mirrors scanner gateway + cost + OSS fallback; few-shot prompt that titles the *cluster pattern*, not trace-specific literals) + a one-shot post-deploy backfill (`source='eval'`, `--org/--workspace/--project`, batched, `--dry-run`). The import guard means this PR stands alone (falls back) until ee#64 merges.

### Verified e2e
- Helper: generalizes away trace literals (input with order #/dates → *"Agent misrepresents order shipping timeline against tracking data"*).
- **Create-time path**: real `create_cluster` → LLM title applied (vs raw extraction).
- Backfill: dry-run / real / `--org`/`--project` scoping / batched bulk_update; seed rows cleaned up.
- Gating: 4/4 unit tests.

### Scope notes
- Branch name mentions voice-evidence (#3) — **that's a separate follow-up**, not in this PR (blocked on account data). This PR is titles only.
- `tracer/utils/otel.py` (a pre-existing, unrelated working-tree change) deliberately excluded.