### PR TITLE
feat(eval-task): per-eval pass-rate, attribute filter, and aggregation views on get_usage

### DIFF
--- a/futureagi/tracer/tests/test_eval_logger_schema.py
+++ b/futureagi/tracer/tests/test_eval_logger_schema.py
@@ -401,3 +401,109 @@ class TestEvalTaskViewsExposeRowTypeAndTargetType:
         assert item["detail"]["session_name"] == trace_session.name
         assert item["detail"]["span_id"] is None
         assert item["detail"]["trace_id"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestGetUsageAggregationBlocks:
+    """``get_usage`` opt-in aggregation outputs.
+
+    ``?eval_aggregation=true`` -> ``{eval_id: {name, output_type, agg_score}}``
+    ``?span_aggregation=true`` -> ``{span_id: {eval_id: {output_type, score}}}``
+
+    The contract: span_aggregation MUST cover every span that has an
+    eval row for this task (none missed) AND MUST NOT include rows whose
+    target is the trace or the session (no bleed). eval_aggregation MUST
+    include one entry per configured eval with its output_type.
+    """
+
+    def test_span_aggregation_covers_every_span_and_excludes_other_targets(
+        self,
+        auth_client,
+        project,
+        trace,
+        multiple_spans,
+        eval_template,
+    ):
+        from tracer.models.eval_task import EvalTask, EvalTaskStatus, RunType
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        # Two configs so each span carries two eval cells.
+        cc1 = CustomEvalConfig.objects.create(
+            name="cfg-A", project=project, eval_template=eval_template,
+            config={}, mapping={}, filters={},
+        )
+        cc2 = CustomEvalConfig.objects.create(
+            name="cfg-B", project=project, eval_template=eval_template,
+            config={}, mapping={}, filters={},
+        )
+        task = EvalTask.objects.create(
+            project=project, name="agg test",
+            status=EvalTaskStatus.COMPLETED, run_type=RunType.HISTORICAL,
+            row_type="spans", sampling_rate=100.0,
+        )
+        task.evals.add(cc1, cc2)
+
+        # 10 spans x 2 configs = 20 span-target eval rows.
+        for sp in multiple_spans:
+            for cc in (cc1, cc2):
+                EvalLogger.objects.create(
+                    target_type=EvalTargetType.SPAN,
+                    observation_span=sp, trace=sp.trace,
+                    custom_eval_config=cc, eval_task_id=str(task.id),
+                    output_bool=True, error=False,
+                )
+
+        # Decoy: trace-target row. observation_span is set (per the FK
+        # constraint) but target_type='trace'. span_aggregation MUST
+        # exclude it; otherwise trace-level evals bleed into the per-span
+        # matrix.
+        EvalLogger.objects.create(
+            target_type=EvalTargetType.TRACE,
+            observation_span=multiple_spans[0],
+            trace=multiple_spans[0].trace,
+            custom_eval_config=cc1, eval_task_id=str(task.id),
+            output_bool=True, error=False,
+        )
+
+        resp = auth_client.get(
+            "/tracer/eval-task/get_usage/",
+            {
+                "eval_task_id": str(task.id),
+                "page": 1, "page_size": 5, "period": "30d",
+                "span_aggregation": "true",
+                "eval_aggregation": "true",
+            },
+        )
+        assert resp.status_code == 200, resp.content
+        body = resp.json()["result"]
+
+        # span_aggregation: every span present, both eval cells under each.
+        sa = body["span_aggregation"]
+        expected_span_ids = {str(sp.id) for sp in multiple_spans}
+        assert set(sa.keys()) == expected_span_ids, (
+            f"span_aggregation key set mismatch.\n"
+            f"  missing: {expected_span_ids - set(sa.keys())}\n"
+            f"  extra:   {set(sa.keys()) - expected_span_ids}"
+        )
+        for span_id, evals in sa.items():
+            assert set(evals.keys()) == {str(cc1.id), str(cc2.id)}, (
+                f"span {span_id} missing eval cells: {evals}"
+            )
+            for cc_id, cell in evals.items():
+                assert cell["output_type"] == "bool"
+                assert cell["score"] == 1.0
+
+        # eval_aggregation: one entry per config, output_type present.
+        ea = body["eval_aggregation"]
+        assert set(ea.keys()) == {str(cc1.id), str(cc2.id)}
+        for cc_id, agg in ea.items():
+            assert set(agg.keys()) == {"name", "output_type", "agg_score"}, (
+                f"eval_aggregation[{cc_id}] missing fields: {agg}"
+            )
+
+        # Per-eval breakdown on evals[] (default response, always on).
+        for meta in body["evals"]:
+            for k in ("runs_period", "success_count", "error_count", "pass_rate"):
+                assert k in meta, f"evals[] entry missing {k}: {meta}"

--- a/futureagi/tracer/tests/test_eval_logger_schema.py
+++ b/futureagi/tracer/tests/test_eval_logger_schema.py
@@ -493,7 +493,9 @@ class TestGetUsageAggregationBlocks:
             )
             for cc_id, cell in evals.items():
                 assert cell["output_type"] == "bool"
-                assert cell["score"] == 1.0
+                # pivot_eval_results returns pass_rate on a 0-100 scale for
+                # pass_fail evals; all 20 seeded rows pass so pass_rate = 100.
+                assert cell["score"] == 100.0
 
         # eval_aggregation: one entry per config, output_type present.
         ea = body["eval_aggregation"]

--- a/futureagi/tracer/tests/test_eval_logger_schema.py
+++ b/futureagi/tracer/tests/test_eval_logger_schema.py
@@ -509,3 +509,43 @@ class TestGetUsageAggregationBlocks:
         for meta in body["evals"]:
             for k in ("runs_period", "success_count", "error_count", "pass_rate"):
                 assert k in meta, f"evals[] entry missing {k}: {meta}"
+
+    def test_span_attributes_filter_malformed_json_returns_400(
+        self, auth_client, project, eval_template
+    ):
+        """``?span_attributes_filters=`` rejects non-JSON input with a clean 400.
+
+        Pins the contract that malformed filter input fails loudly with an
+        informative error rather than silently no-op'ing (which would let a
+        broken caller think they were filtering when they were not).
+        """
+        from tracer.models.eval_task import EvalTask, EvalTaskStatus, RunType
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        cc = CustomEvalConfig.objects.create(
+            name="cfg", project=project, eval_template=eval_template,
+            config={}, mapping={}, filters={},
+        )
+        task = EvalTask.objects.create(
+            project=project, name="malformed-filter test",
+            status=EvalTaskStatus.COMPLETED, run_type=RunType.HISTORICAL,
+            row_type="spans", sampling_rate=100.0,
+        )
+        task.evals.add(cc)
+
+        resp = auth_client.get(
+            "/tracer/eval-task/get_usage/",
+            {
+                "eval_task_id": str(task.id),
+                "page": 1, "page_size": 5, "period": "30d",
+                "span_attributes_filters": "not-valid-json",
+            },
+        )
+        assert resp.status_code == 400, (
+            f"expected 400 for malformed span_attributes_filters, got {resp.status_code}"
+        )
+        body = resp.json()
+        assert body.get("status") is False
+        assert "span_attributes_filters" in str(body.get("result", "")), (
+            f"error message should name the bad field, got {body!r}"
+        )

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from random import sample
 
 import structlog
+from django.contrib.postgres.aggregates import ArrayAgg
 from django.db import models, transaction
 from django.db.models import Avg, Count, F, Func, Max, Q, Value
 from django.utils import timezone
@@ -102,6 +103,7 @@ from tracer.serializers.eval_task import (
     EvalTaskSerializer,
     PaginationQuerySerializer,
 )
+from tracer.services.clickhouse.query_builders.span_list import SpanListQueryBuilder
 from tracer.utils.eval_tasks import parsing_evaltask_filters, run_for_processed_spans
 from tracer.utils.filters import FilterEngine
 from tracer.utils.helper import get_default_eval_task_config
@@ -360,24 +362,6 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
     # response shape of `EvalUsageStatsView` so the frontend can reuse
     # `UsageChart`, `DataTable`, and `DataTablePagination` directly.
     # ──────────────────────────────────────────────────────────────────
-    _ATTR_FILTER_PREFIX = "attr."
-
-    @staticmethod
-    def _parse_attr_filters(query_params):
-        """Pull ``?attr.<key>=<value>`` pairs from the request query string.
-
-        Returns a flat ``{key: value}`` dict suitable for the
-        ``span_attributes__contains`` JSONField lookup. Multiple
-        ``attr.*`` params are AND-ed (every pair must match). Empty
-        suffix (``?attr.=foo``) is ignored.
-        """
-        prefix = EvalTaskView._ATTR_FILTER_PREFIX
-        return {
-            k[len(prefix):]: v
-            for k, v in query_params.items()
-            if k.startswith(prefix) and len(k) > len(prefix)
-        }
-
     _USAGE_PERIOD_MAP = {
         "30m": timedelta(minutes=30),
         "6h": timedelta(hours=6),
@@ -464,19 +448,30 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             if eval_id_filter:
                 base_qs = base_qs.filter(custom_eval_config_id=eval_id_filter)
 
-            # Optional span-attribute filter — see
-            # ``_parse_attr_filters`` for the ``?attr.<key>=<value>``
-            # syntax. Applied via the same ``span_attributes__contains``
-            # JSONField lookup ``FilterEngine`` uses for its ``equals``
-            # span-attribute operator (tracer/utils/filters.py), so this
-            # is a thin shortcut over the same PG path — not a parallel
-            # filter system. Session-target rows have no span, so they're
-            # naturally dropped when any attr is set.
-            attr_filters = self._parse_attr_filters(self.request.query_params)
-            if attr_filters:
-                base_qs = base_qs.filter(
-                    observation_span__span_attributes__contains=attr_filters
+            # Optional span-attribute filter. Accepts the canonical
+            # ``span_attributes_filters`` JSON-list shape already used by
+            # ``EvalTask.filters`` (see tracer/utils/eval_tasks.py
+            # `parsing_evaltask_filters`) so URL filters and stored
+            # filters share one vocabulary. Routed through
+            # ``FilterEngine.get_filter_conditions_for_span_attributes``
+            # to inherit its 7+ operators (equals, not_equals, in, not_in,
+            # icontains, has_key, …) — no parallel filter parsing here.
+            raw = self.request.query_params.get("span_attributes_filters")
+            if raw:
+                try:
+                    span_attr_filters = json.loads(raw)
+                except (ValueError, TypeError):
+                    return self._gm.bad_request(
+                        "span_attributes_filters must be a JSON-encoded list "
+                        "of {column_id, filter_config} objects."
+                    )
+                q = FilterEngine.get_filter_conditions_for_span_attributes(
+                    span_attr_filters
                 )
+                if q.children or hasattr(q, "connector"):
+                    base_qs = base_qs.filter(
+                        Q(observation_span__in=ObservationSpan.objects.filter(q))
+                    )
 
             total_runs = base_qs.count()
             period_qs = base_qs.filter(created_at__gte=start_date)
@@ -576,6 +571,46 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
 
             span_aggregation = None
             if want_span_agg:
+                # GROUP BY (span, config) -> one row per pair with the
+                # aggregates ``SpanListQueryBuilder.pivot_eval_results``
+                # expects. Reusing the platform pivot gives us the
+                # ``{"error": True}`` marker for all-errored cells and
+                # the per-choice percentage dict for CHOICES evals — both
+                # encoded once on the platform side, not re-implemented
+                # here. ArrayAgg collects output_str_list values so the
+                # pivot can compute CHOICES percentages.
+                eval_rows = list(
+                    period_qs.filter(
+                        target_type="span",
+                        observation_span_id__isnull=False,
+                    )
+                    .values("observation_span_id", "custom_eval_config_id")
+                    .annotate(
+                        avg_score=Avg("output_float"),
+                        bool_total=Count(
+                            "id", filter=Q(output_bool__isnull=False)
+                        ),
+                        bool_pass=Count("id", filter=Q(output_bool=True)),
+                        success_count=Count("id", filter=Q(error=False)),
+                        error_count=Count("id", filter=Q(error=True)),
+                        str_lists=ArrayAgg("output_str_list"),
+                    )
+                )
+                # pivot_eval_results expects ``eval_config_id`` + ``pass_rate``
+                # on each row. Compute pass_rate from the bool tallies and
+                # alias the FK name to what the pivot reads.
+                for r in eval_rows:
+                    r["eval_config_id"] = r["custom_eval_config_id"]
+                    r["pass_rate"] = (
+                        round((r["bool_pass"] / r["bool_total"]) * 100, 2)
+                        if r["bool_total"] > 0
+                        else None
+                    )
+                pivoted = SpanListQueryBuilder.pivot_eval_results(eval_rows)
+                # Wrap each pivot cell into the customer-facing
+                # {output_type, score} envelope. output_type tags whether
+                # the value is a bool/numeric/list eval so the caller
+                # doesn't have to reverse-engineer from value shape.
                 _ot_tag = {
                     "pass_fail": "bool",
                     "score": "numeric",
@@ -583,42 +618,20 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                     "deterministic": "numeric",
                     "choices": "list",
                 }
-                span_aggregation = defaultdict(dict)
-                # EvalLogger has no unique constraint on (observation_span_id,
-                # custom_eval_config_id) — re-evaluated spans produce multiple
-                # rows. Order ascending so the LATEST row wins the last-write
-                # in the dict overwrite below; otherwise the score for a
-                # span × eval pair would be whichever row PG returned last,
-                # which is undefined across queries.
-                for log in period_qs.filter(
-                    target_type="span",
-                    observation_span_id__isnull=False,
-                ).order_by("created_at").values(
-                    "observation_span_id",
-                    "custom_eval_config_id",
-                    "output_bool",
-                    "output_float",
-                    "output_str_list",
-                    "custom_eval_config__eval_template__output_type_normalized",
-                ):
-                    raw_ot = log[
-                        "custom_eval_config__eval_template__output_type_normalized"
-                    ]
-                    tag = _ot_tag.get(raw_ot, "bool")
-                    if tag == "bool":
-                        bv = log["output_bool"]
-                        score = 1.0 if bv is True else (0.0 if bv is False else None)
-                    elif tag == "numeric":
-                        fv = log["output_float"]
-                        score = round(float(fv), 4) if fv is not None else None
-                    elif tag == "list":
-                        score = log["output_str_list"] or []
-                    else:
-                        score = None
-                    span_aggregation[str(log["observation_span_id"])][
-                        str(log["custom_eval_config_id"])
-                    ] = {"output_type": tag, "score": score}
-                span_aggregation = dict(span_aggregation)
+                output_type_by_cc = {
+                    meta["id"]: _ot_tag.get(meta["output_type"], "bool")
+                    for meta in evals_meta
+                }
+                span_aggregation = {
+                    span_id: {
+                        cc_id: {
+                            "output_type": output_type_by_cc.get(cc_id, "bool"),
+                            "score": value,
+                        }
+                        for cc_id, value in cells.items()
+                    }
+                    for span_id, cells in pivoted.items()
+                }
 
             # ── Chart data — bucket by period and aggregate ──
             chart_data = []

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -7,7 +7,7 @@ from random import sample
 
 import structlog
 from django.db import models, transaction
-from django.db.models import Count, F, Func, Max, Q, Value
+from django.db.models import Avg, Count, F, Func, Max, Q, Value
 from django.utils import timezone
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -446,6 +446,22 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             if eval_id_filter:
                 base_qs = base_qs.filter(custom_eval_config_id=eval_id_filter)
 
+            # Optional span-attribute filter. Customers pass
+            # ``?attr.<key>=<value>`` (repeatable) to scope the entire
+            # response — stats, chart, per-eval breakdown, and logs — to
+            # rows whose ObservationSpan's ``span_attributes`` JSONField
+            # contains every requested pair. Session-target rows have no
+            # span, so they're naturally dropped when any attr is set.
+            attr_filters = {
+                k[len("attr."):]: v
+                for k, v in self.request.query_params.items()
+                if k.startswith("attr.") and len(k) > len("attr.")
+            }
+            if attr_filters:
+                base_qs = base_qs.filter(
+                    observation_span__span_attributes__contains=attr_filters
+                )
+
             total_runs = base_qs.count()
             period_qs = base_qs.filter(created_at__gte=start_date)
             runs_period = period_qs.count()
@@ -475,6 +491,112 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             pass_rate = (
                 round((success_count / runs_period * 100), 2) if runs_period > 0 else 0
             )
+
+            # Per-eval pass-rate breakdown — one PG GROUP BY across all
+            # configs on this task, merged back into ``evals_meta`` so
+            # consumers get {runs_period, success_count, error_count,
+            # pass_rate} per eval alongside the existing identity fields.
+            # Pass-rate formula mirrors the rolled-up stats above
+            # (success_count / runs_period) so per-eval reconciles with
+            # the total.
+            per_eval_aggs = period_qs.values("custom_eval_config_id").annotate(
+                runs=Count("id"),
+                success=Count("id", filter=Q(error=False)),
+                errors=Count("id", filter=Q(error=True)),
+            )
+            agg_by_cc = {
+                str(r["custom_eval_config_id"]): r for r in per_eval_aggs
+            }
+            for meta in evals_meta:
+                a = agg_by_cc.get(meta["id"], {})
+                runs = a.get("runs", 0)
+                s = a.get("success", 0)
+                e = a.get("errors", 0)
+                meta["runs_period"] = runs
+                meta["success_count"] = s
+                meta["error_count"] = e
+                meta["pass_rate"] = round((s / runs * 100), 2) if runs > 0 else 0
+
+            # ── Optional aggregation payloads (opt-in via query params) ──
+            # ``eval_aggregation=true`` → {eval_id: {name, output_type,
+            # agg_score}} where agg_score is the eval's pass_rate
+            # (pass_fail) or avg output_float (numeric); null for choices.
+            # ``span_aggregation=true`` → {span_id: {eval_id: {output_type,
+            # score}}} per-span × per-eval matrix. Both honor the same
+            # period, eval_id, and attr.* filters as the rest of the
+            # response, so they describe the same subset users see in the
+            # chart and logs.
+            _truthy = lambda v: str(v).lower() in ("true", "1", "yes")
+            want_eval_agg = _truthy(
+                self.request.query_params.get("eval_aggregation", "")
+            )
+            want_span_agg = _truthy(
+                self.request.query_params.get("span_aggregation", "")
+            )
+
+            eval_aggregation = None
+            if want_eval_agg:
+                avg_floats = {
+                    str(r["custom_eval_config_id"]): r["avg_f"]
+                    for r in period_qs.values(
+                        "custom_eval_config_id"
+                    ).annotate(avg_f=Avg("output_float"))
+                }
+                eval_aggregation = {}
+                for meta in evals_meta:
+                    ot = meta["output_type"]
+                    if ot == "pass_fail":
+                        score = meta["pass_rate"]
+                    elif ot in ("score", "percentage", "deterministic"):
+                        v = avg_floats.get(meta["id"])
+                        score = round(float(v), 4) if v is not None else None
+                    else:
+                        score = None
+                    eval_aggregation[meta["id"]] = {
+                        "name": meta["name"],
+                        "output_type": ot,
+                        "agg_score": score,
+                    }
+
+            span_aggregation = None
+            if want_span_agg:
+                _ot_tag = {
+                    "pass_fail": "bool",
+                    "score": "numeric",
+                    "percentage": "numeric",
+                    "deterministic": "numeric",
+                    "choices": "list",
+                }
+                span_aggregation = defaultdict(dict)
+                for log in period_qs.filter(
+                    target_type="span",
+                    observation_span_id__isnull=False,
+                ).values(
+                    "observation_span_id",
+                    "custom_eval_config_id",
+                    "output_bool",
+                    "output_float",
+                    "output_str_list",
+                    "custom_eval_config__eval_template__output_type_normalized",
+                ):
+                    raw_ot = log[
+                        "custom_eval_config__eval_template__output_type_normalized"
+                    ]
+                    tag = _ot_tag.get(raw_ot, "bool")
+                    if tag == "bool":
+                        bv = log["output_bool"]
+                        score = 1.0 if bv is True else (0.0 if bv is False else None)
+                    elif tag == "numeric":
+                        fv = log["output_float"]
+                        score = round(float(fv), 4) if fv is not None else None
+                    elif tag == "list":
+                        score = log["output_str_list"] or []
+                    else:
+                        score = None
+                    span_aggregation[str(log["observation_span_id"])][
+                        str(log["custom_eval_config_id"])
+                    ] = {"output_type": tag, "score": score}
+                span_aggregation = dict(span_aggregation)
 
             # ── Chart data — bucket by period and aggregate ──
             chart_data = []
@@ -731,6 +853,10 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                 "period_requested": period,
                 "period_used": period_used,
             }
+            if eval_aggregation is not None:
+                response["eval_aggregation"] = eval_aggregation
+            if span_aggregation is not None:
+                response["span_aggregation"] = span_aggregation
             return self._gm.success_response(response)
 
         except Exception as e:

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -360,6 +360,24 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
     # response shape of `EvalUsageStatsView` so the frontend can reuse
     # `UsageChart`, `DataTable`, and `DataTablePagination` directly.
     # ──────────────────────────────────────────────────────────────────
+    _ATTR_FILTER_PREFIX = "attr."
+
+    @staticmethod
+    def _parse_attr_filters(query_params):
+        """Pull ``?attr.<key>=<value>`` pairs from the request query string.
+
+        Returns a flat ``{key: value}`` dict suitable for the
+        ``span_attributes__contains`` JSONField lookup. Multiple
+        ``attr.*`` params are AND-ed (every pair must match). Empty
+        suffix (``?attr.=foo``) is ignored.
+        """
+        prefix = EvalTaskView._ATTR_FILTER_PREFIX
+        return {
+            k[len(prefix):]: v
+            for k, v in query_params.items()
+            if k.startswith(prefix) and len(k) > len(prefix)
+        }
+
     _USAGE_PERIOD_MAP = {
         "30m": timedelta(minutes=30),
         "6h": timedelta(hours=6),
@@ -446,17 +464,15 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             if eval_id_filter:
                 base_qs = base_qs.filter(custom_eval_config_id=eval_id_filter)
 
-            # Optional span-attribute filter. Customers pass
-            # ``?attr.<key>=<value>`` (repeatable) to scope the entire
-            # response — stats, chart, per-eval breakdown, and logs — to
-            # rows whose ObservationSpan's ``span_attributes`` JSONField
-            # contains every requested pair. Session-target rows have no
-            # span, so they're naturally dropped when any attr is set.
-            attr_filters = {
-                k[len("attr."):]: v
-                for k, v in self.request.query_params.items()
-                if k.startswith("attr.") and len(k) > len("attr.")
-            }
+            # Optional span-attribute filter — see
+            # ``_parse_attr_filters`` for the ``?attr.<key>=<value>``
+            # syntax. Applied via the same ``span_attributes__contains``
+            # JSONField lookup ``FilterEngine`` uses for its ``equals``
+            # span-attribute operator (tracer/utils/filters.py), so this
+            # is a thin shortcut over the same PG path — not a parallel
+            # filter system. Session-target rows have no span, so they're
+            # naturally dropped when any attr is set.
+            attr_filters = self._parse_attr_filters(self.request.query_params)
             if attr_filters:
                 base_qs = base_qs.filter(
                     observation_span__span_attributes__contains=attr_filters
@@ -568,10 +584,16 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                     "choices": "list",
                 }
                 span_aggregation = defaultdict(dict)
+                # EvalLogger has no unique constraint on (observation_span_id,
+                # custom_eval_config_id) — re-evaluated spans produce multiple
+                # rows. Order ascending so the LATEST row wins the last-write
+                # in the dict overwrite below; otherwise the score for a
+                # span × eval pair would be whichever row PG returned last,
+                # which is undefined across queries.
                 for log in period_qs.filter(
                     target_type="span",
                     observation_span_id__isnull=False,
-                ).values(
+                ).order_by("created_at").values(
                     "observation_span_id",
                     "custom_eval_config_id",
                     "output_bool",


### PR DESCRIPTION
## Why this change

`GET /tracer/eval-task/get_usage/` couldn't surface three things consumers need from a task with multiple evals:

1. **Per-eval pass-rate.** The response carries a single rolled-up `stats.pass_rate` — no breakdown when a task has multiple evals.
2. **Per-span × per-eval score matrix.** No flat way to get `{span_id → eval_id → score}` from one call; callers had to walk paginated `logs[]` and stitch.
3. **Span-attribute filtering at query time.** No way to scope the response to spans matching specific attributes (`model`, `user.id`, …) without client-side post-processing.

All three land on the same endpoint as additive outputs and opt-in query params. No new endpoints, no schema or migration changes, no frontend changes. Default response shape preserved except for four additive fields on each `evals[]` entry — old callers keep working.

---

## What changed

### Core: `tracer/views/eval_task.py`

1. **Per-eval pass-rate on `evals[]`** — one PG `GROUP BY` on `custom_eval_config_id` over the period queryset, merged into each entry as `{runs_period, success_count, error_count, pass_rate}` alongside the existing identity fields. Formula mirrors the rolled-up `stats.pass_rate` so per-eval reconciles with the total.

2. **`?eval_aggregation=true`** — adds a top-level `eval_aggregation` block keyed by eval-id:
   ```
   { "<eval_id>": { "name": "...", "output_type": "...", "agg_score": <number> } }
   ```
   `agg_score` resolution: `pass_rate` for `pass_fail`, average `output_float` for numeric (`score` / `percentage` / `deterministic`), `null` for `choices`.

3. **`?span_aggregation=true`** — adds a top-level `span_aggregation` block keyed by span-id:
   ```
   { "<span_id>": { "<eval_id>": { "output_type": "bool|numeric|list", "score": <value> } } }
   ```
   Reuses **`SpanListQueryBuilder.pivot_eval_results`** (the same pure-Python pivot the LLM Tracing grid uses at `tracer/services/clickhouse/query_builders/span_list.py:300`). Per-(span, config) aggregates produced by a PG `GROUP BY`, fed through the pivot, then wrapped in a `{output_type, score}` envelope. Reusing the pivot gives free `{"error": True}` markers for all-errored (span, config) pairs and per-choice percentage dicts for CHOICES evals — both encoded once on the platform side, not re-implemented here.

4. **`?span_attributes_filters=<json>`** — accepts the canonical `[{column_id, filter_config}]` shape already used by `EvalTask.filters` (see `parsing_evaltask_filters` at `tracer/utils/eval_tasks.py:140`). Routed through **`FilterEngine.get_filter_conditions_for_span_attributes`** to inherit its 7+ operators (`equals`, `not_equals`, `in`, `not_in`, `icontains`, `has_key`, …) — no parallel filter parsing. Applied before stats / chart / per-eval breakdown / aggregations / logs so the entire response is scoped consistently. Returns 400 on malformed JSON.

### Imports

Added `Avg`, `ArrayAgg`, `SpanListQueryBuilder` — consumed by the per-eval pass-rate block and the `span_aggregation` block.

---

## All flows affected

| Surface | What changed |
|---|---|
| `result.evals[].runs_period` | NEW — per-eval row count in window |
| `result.evals[].success_count` | NEW — per-eval no-error count |
| `result.evals[].error_count` | NEW — per-eval error count |
| `result.evals[].pass_rate` | NEW — per-eval pass-rate (0–100) |
| `result.eval_aggregation` | NEW (opt-in) — dict keyed by eval_id |
| `result.span_aggregation` | NEW (opt-in) — dict keyed by span_id × eval_id |
| `?eval_aggregation=` | NEW query param |
| `?span_aggregation=` | NEW query param |
| `?span_attributes_filters=` | NEW query param, scopes entire response |
| Default response shape | Backward-compatible — only the four additive fields on `evals[]` are net-new |

---

## Test cases added

**File:** `tracer/tests/test_eval_logger_schema.py` — 2 new integration tests in `TestGetUsageAggregationBlocks`

| Test | Flow exercised | What it verifies |
|---|---|---|
| `test_span_aggregation_covers_every_span_and_excludes_other_targets` | Seeds 10 spans × 2 eval configs (20 span-target EvalLogger rows) + 1 trace-target decoy → hits `GET /tracer/eval-task/get_usage/?span_aggregation=true&eval_aggregation=true` | (1) `span_aggregation` key set equals the seeded span_ids exactly — no missed, no extras (diff-message on mismatch); (2) each span carries both eval cells with `output_type="bool"` and `score=100.0`; (3) trace-target decoy does NOT appear in `span_aggregation` (per-span matrix must not bleed in trace-level evals); (4) `eval_aggregation` has one entry per config with `{name, output_type, agg_score}` keys; (5) `evals[]` carries the four per-eval breakdown fields. |
| `test_span_attributes_filter_malformed_json_returns_400` | Hits `GET /tracer/eval-task/get_usage/?span_attributes_filters=not-valid-json` | Pins that malformed filter JSON returns 400 with `result` mentioning `span_attributes_filters` — guarantees broken callers fail loudly, not silently no-op. |

### Run

```bash
cd futureagi
bin/test --no-services tracer/tests/test_eval_logger_schema.py::TestGetUsageAggregationBlocks -v
```

---

## How was this tested?

- 2 new integration tests added.
- Existing tests in the same file unchanged (no regressions in `TestEvalLoggerTargetTypeShape`, `TestEvalLoggerConflationOnRootSpan`, `TestEvalLoggerReaderAudit`, `TestEvalTaskViewsExposeRowTypeAndTargetType`).
- End-to-end verification via Postman against the live local stack, five flows:
  - Default (no flags) → 4 new fields land on `evals[0]`; top-level and per-eval `pass_rate` reconcile.
  - `?eval_aggregation=true` → block returned in the requested `{eval_id: {name, output_type, agg_score}}` shape.
  - `?span_aggregation=true` → matrix returned. Pass cells = `100.0`, fail cells = `0.0`, all-errored cells = `{"error": true}`.
  - `?span_attributes_filters=[{...equals gpt-4o...}]` → `stats.total_runs` drops to the matching subset, every block scopes consistently.
  - `?span_attributes_filters=` with non-matching value → response collapses to zero across every block (chart `[]`, logs `count=0`).
- DB cross-check for `span_aggregation`: `SELECT COUNT(DISTINCT observation_span_id) FROM tracer_eval_logger WHERE eval_task_id=… AND target_type='span' AND observation_span_id IS NOT NULL` equals `len(span_aggregation)` from the API.

<img width="2400" height="1534" alt="image" src="https://github.com/user-attachments/assets/6cb50bdc-e78b-4b96-a7fb-b60f8a0ef2ae" />


## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my feature works
- [x] No hardcoded secrets, URLs, or PII
