### PR TITLE
fix(error-feed): TH-5332 — simplify Overview tab on Error Feed

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -131,6 +131,9 @@ services:
     image: futureagi/future-agi:dev
     volumes:
       - ./futureagi:/app/backend
+      # Host repo's .tmp/ exposed inside container so replicate-locally can
+      # drop snapshot dirs directly without a `docker cp` round-trip.
+      - ./.tmp:/app/.tmp
     environment:
       FAST_STARTUP: "true"
 

--- a/frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx
@@ -805,7 +805,8 @@ function PatternSummary({ summary, clusterId }) {
 
   if (!insights.length) {
     // Cluster ID prefix is canonical: E-* = eval-source, S-* = scanner-source.
-    const isEvalCluster = typeof clusterId === "string" && clusterId.startsWith("E-");
+    const isEvalCluster =
+      typeof clusterId === "string" && clusterId.startsWith("E-");
     const message = isEvalCluster
       ? "No eval scores aggregated yet — this cluster's evaluations are still landing."
       : "Not enough data yet — waiting for more scanner results.";
@@ -1206,7 +1207,7 @@ function RootCauses({ causes }) {
 
   return (
     <Stack gap={0.75}>
-      {causes.map((c) => {
+      {causes.slice(0, 3).map((c) => {
         // Backend splits title vs description at first period/comma. When
         // the agent produces a short single-clause string with no internal
         // punctuation, both fields end up identical — skip the description
@@ -1293,10 +1294,9 @@ function RecSectionLabel({ icon, label }) {
 }
 RecSectionLabel.propTypes = { icon: PropTypes.string, label: PropTypes.string };
 
-function RecommendationCard({ rec, rootCauses, isDark }) {
+function RecommendationCard({ rec, isDark }) {
   const [expanded, setExpanded] = useState(false);
   const pm = PRIORITY_META[rec.priority] || PRIORITY_META.medium;
-  const linkedCause = rootCauses?.find((c) => c.rank === rec.rootCauseLink);
 
   return (
     <Box
@@ -1374,7 +1374,8 @@ function RecommendationCard({ rec, rootCauses, isDark }) {
         />
       </Stack>
 
-      {/* Expanded body */}
+      {/* Expanded body — only Immediate Fix; other sub-fields are intentionally
+          omitted per the Error Feed simplification. */}
       {expanded && (
         <Box
           sx={{
@@ -1385,152 +1386,31 @@ function RecommendationCard({ rec, rootCauses, isDark }) {
             pb: 1.5,
           }}
         >
-          <Stack gap={1.5}>
-            {/* Description */}
-            <Box>
-              <RecSectionLabel
-                icon="mdi:text-box-outline"
-                label="Description"
-              />
+          <Box>
+            <RecSectionLabel icon="mdi:wrench-outline" label="Immediate Fix" />
+            <Box
+              sx={{
+                px: 1.25,
+                py: 1,
+                borderRadius: "6px",
+                bgcolor: isDark ? alpha("#fff", 0.04) : alpha("#000", 0.03),
+                border: "1px solid",
+                borderColor: "divider",
+              }}
+            >
               <Typography
                 fontSize="11.5px"
                 color="text.primary"
-                sx={{ lineHeight: 1.65 }}
-              >
-                {rec.description}
-              </Typography>
-            </Box>
-
-            {/* Immediate Fix */}
-            <Box>
-              <RecSectionLabel
-                icon="mdi:wrench-outline"
-                label="Immediate Fix"
-              />
-              <Box
                 sx={{
-                  px: 1.25,
-                  py: 1,
-                  borderRadius: "6px",
-                  bgcolor: isDark ? alpha("#fff", 0.04) : alpha("#000", 0.03),
-                  border: "1px solid",
-                  borderColor: "divider",
+                  lineHeight: 1.65,
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
                 }}
               >
-                <Typography
-                  fontSize="11.5px"
-                  color="text.primary"
-                  sx={{
-                    lineHeight: 1.65,
-                    whiteSpace: "pre-wrap",
-                    wordBreak: "break-word",
-                  }}
-                >
-                  {rec.immediateFix}
-                </Typography>
-              </Box>
+                {rec.immediateFix}
+              </Typography>
             </Box>
-
-            {/* Insights */}
-            {rec.insights && (
-              <Box>
-                <RecSectionLabel
-                  icon="mdi:lightbulb-outline"
-                  label="Insights"
-                />
-                <Typography
-                  fontSize="11.5px"
-                  color="text.primary"
-                  sx={{ lineHeight: 1.65 }}
-                >
-                  {rec.insights}
-                </Typography>
-              </Box>
-            )}
-
-            {/* Evidence */}
-            {rec.evidence?.length > 0 && (
-              <Box>
-                <RecSectionLabel icon="mdi:magnify" label="Evidence" />
-                <Stack gap={0.55}>
-                  {rec.evidence.map((e, i) => (
-                    <Stack
-                      key={i}
-                      direction="row"
-                      alignItems="flex-start"
-                      gap={0.75}
-                    >
-                      <Box
-                        sx={{
-                          width: 4,
-                          height: 4,
-                          borderRadius: "50%",
-                          bgcolor: "text.disabled",
-                          mt: "6px",
-                          flexShrink: 0,
-                        }}
-                      />
-                      <Typography
-                        fontSize="11px"
-                        color="text.primary"
-                        sx={{ lineHeight: 1.6 }}
-                      >
-                        {e}
-                      </Typography>
-                    </Stack>
-                  ))}
-                </Stack>
-              </Box>
-            )}
-
-            {/* Root Cause link */}
-            {linkedCause && (
-              <Box>
-                <RecSectionLabel icon="mdi:magnify-scan" label="Root Cause" />
-                <Stack
-                  direction="row"
-                  alignItems="flex-start"
-                  gap={0.75}
-                  sx={{
-                    px: 1.25,
-                    py: 0.9,
-                    borderRadius: "6px",
-                    bgcolor: isDark
-                      ? alpha("#fff", 0.03)
-                      : alpha("#000", 0.025),
-                    border: "1px solid",
-                    borderColor: "divider",
-                  }}
-                >
-                  <Typography
-                    fontSize="10px"
-                    fontWeight={700}
-                    color="text.disabled"
-                    sx={{ flexShrink: 0, mt: "1px" }}
-                  >
-                    #{linkedCause.rank}
-                  </Typography>
-                  <Stack gap={0.2} minWidth={0}>
-                    <Typography
-                      fontSize="11.5px"
-                      fontWeight={600}
-                      color="text.primary"
-                      noWrap
-                    >
-                      {linkedCause.title}
-                    </Typography>
-                    <Typography
-                      fontSize="11px"
-                      color="text.secondary"
-                      sx={{ lineHeight: 1.55 }}
-                    >
-                      {linkedCause.description}
-                    </Typography>
-                  </Stack>
-                </Stack>
-              </Box>
-            )}
-          </Stack>
+          </Box>
         </Box>
       )}
     </Box>
@@ -1538,30 +1418,23 @@ function RecommendationCard({ rec, rootCauses, isDark }) {
 }
 RecommendationCard.propTypes = {
   rec: PropTypes.object.isRequired,
-  rootCauses: PropTypes.array,
   isDark: PropTypes.bool,
 };
 
-function Recommendations({ recs, rootCauses }) {
+function Recommendations({ recs }) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   if (!recs?.length) return null;
   return (
     <Stack gap={0.75}>
       {recs.map((rec) => (
-        <RecommendationCard
-          key={rec.id}
-          rec={rec}
-          rootCauses={rootCauses}
-          isDark={isDark}
-        />
+        <RecommendationCard key={rec.id} rec={rec} isDark={isDark} />
       ))}
     </Stack>
   );
 }
 Recommendations.propTypes = {
   recs: PropTypes.array,
-  rootCauses: PropTypes.array,
 };
 
 // ── Deep analysis revealed section ───────────────────────────────────────────
@@ -1585,7 +1458,7 @@ function DeepAnalysisResults({ rootCauses, recommendations }) {
           title="Recommendations & Fixes"
           icon="mdi:lightbulb-on-outline"
         >
-          <Recommendations recs={recommendations} rootCauses={rootCauses} />
+          <Recommendations recs={recommendations} />
         </SectionCard>
       )}
     </Stack>
@@ -1640,6 +1513,22 @@ export default function OverviewTab({ _error: currentError }) {
 
   const eventsOverTime = overview?.eventsOverTime ?? null;
   const patternSummary = overview?.patternSummary ?? null;
+
+  // Voice/Vapi projects swap the events chart for the trace recording
+  // (a graph is less useful than listening to the actual failing call).
+  // Detected via backend's project_source on the cluster row.
+  const isVoiceProject = currentError?.projectSource === "simulator";
+  const { data: representativeTraceDetail } = useGetTraceDetail(
+    isVoiceProject ? trace?.id : null,
+  );
+  const recordingUrl =
+    representativeTraceDetail?.metadata?.recording_url ||
+    representativeTraceDetail?.metadata?.recordingUrl ||
+    representativeTraceDetail?.metadata?.recording?.mono?.combined_url ||
+    representativeTraceDetail?.metadata?.recording?.mono?.combinedUrl ||
+    representativeTraceDetail?.metadata?.stereo_recording_url ||
+    representativeTraceDetail?.metadata?.stereoRecordingUrl ||
+    null;
 
   // Deep analysis is driven by the backend root-cause query for the
   // currently-selected trace. When status flips to ``done`` we smooth-
@@ -1705,7 +1594,8 @@ export default function OverviewTab({ _error: currentError }) {
           overflow: "hidden",
         }}
       >
-        {/* Events/Users chart — flat (no own border) */}
+        {/* Events/Users chart (default) — swapped for the trace recording
+            when the project is a Vapi/simulator project. */}
         <Box
           sx={{
             flexShrink: 0,
@@ -1713,12 +1603,41 @@ export default function OverviewTab({ _error: currentError }) {
             borderColor: "divider",
           }}
         >
-          <EventsUsersChart
-            flat
-            data={eventsOverTime}
-            deployMarkers={[]}
-            loading={isOverviewLoading && !overview}
-          />
+          {isVoiceProject ? (
+            <Box sx={{ px: 1.5, py: 1.25, minHeight: 80 }}>
+              <Typography
+                fontSize="11px"
+                fontWeight={600}
+                color="text.secondary"
+                sx={{
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                  mb: 0.75,
+                }}
+              >
+                Trace recording
+              </Typography>
+              {recordingUrl ? (
+                <audio
+                  src={recordingUrl}
+                  controls
+                  preload="metadata"
+                  style={{ width: "100%" }}
+                />
+              ) : (
+                <Typography fontSize="11px" color="text.disabled">
+                  No recording available for the selected trace.
+                </Typography>
+              )}
+            </Box>
+          ) : (
+            <EventsUsersChart
+              flat
+              data={eventsOverTime}
+              deployMarkers={[]}
+              loading={isOverviewLoading && !overview}
+            />
+          )}
         </Box>
 
         {/* Traces heading */}
@@ -1950,5 +1869,6 @@ OverviewTab.propTypes = {
   _error: PropTypes.shape({
     clusterId: PropTypes.string,
     source: PropTypes.string,
+    projectSource: PropTypes.string,
   }),
 };

--- a/futureagi/tracer/queries/feed.py
+++ b/futureagi/tracer/queries/feed.py
@@ -301,6 +301,7 @@ def _row_from_cluster(
         assignees=assignees,
         project=cluster.project.name if cluster.project_id else None,
         project_id=str(cluster.project_id) if cluster.project_id else None,
+        project_source=cluster.project.source if cluster.project_id else None,
         trace_id=latest_trace_id,
         external_issue_url=cluster.external_issue_url,
         external_issue_id=cluster.external_issue_id,

--- a/futureagi/tracer/serializers/feed.py
+++ b/futureagi/tracer/serializers/feed.py
@@ -104,6 +104,7 @@ class FeedListRowSerializer(serializers.Serializer):
     model_version = serializers.CharField(allow_null=True)
     project = serializers.CharField(allow_null=True)
     project_id = serializers.CharField(allow_null=True)
+    project_source = serializers.CharField(allow_null=True)
     environment = serializers.CharField(allow_null=True)
     eval_score = serializers.FloatField(allow_null=True)
     trace_id = serializers.CharField(allow_null=True)

--- a/futureagi/tracer/types/feed_types.py
+++ b/futureagi/tracer/types/feed_types.py
@@ -60,6 +60,7 @@ class FeedListRow:
     model_version: Optional[str] = None
     project: Optional[str] = None
     project_id: Optional[str] = None
+    project_source: Optional[str] = None
     environment: Optional[str] = None
     eval_score: Optional[float] = None
     trace_id: Optional[str] = None


### PR DESCRIPTION
## Summary

Three surgical changes to the Error Feed Overview tab + a small dev-env mount.

- **RootCauses** — cap the rendered list at top 3 (`causes.slice(0, 3)`).
- **RecommendationCard** — when expanded, render only **Immediate Fix**. Description, Insights, Evidence, and the linked Root Cause chip are intentionally removed.
- **EventsUsersChart** — for Vapi/simulator projects, swap the events chart for a native `<audio>` player of the representative trace recording. Non-Vapi projects keep the chart unchanged.

Voice-project detection is sourced from a new `project_source` field on the Feed list/detail row. Reads `Project.source` verbatim — no new model, no migration.

`docker-compose.dev.yml` gets a small dev-only quality-of-life change: `./.tmp:/app/.tmp` is bind-mounted into `backend`, so snapshot dirs are visible inside the container without a `docker cp` round-trip.

## Surfaces

- `frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx` (+30 / -141)
- `futureagi/tracer/types/feed_types.py` (+1)
- `futureagi/tracer/serializers/feed.py` (+1)
- `futureagi/tracer/queries/feed.py` (+1)
- `docker-compose.dev.yml` (+3, dev overlay only)

## Test plan

- [ ] Local: open an Error Feed cluster on a Vapi/simulator-source project — verify the recording player renders in place of the chart.
- [ ] Local: open an Error Feed cluster on a non-Vapi project — verify the chart still renders.
- [ ] Local: trigger Deep Analysis on a cluster with more than 3 root causes — verify only top 3 render.
- [ ] Local: expand a Recommendation card — verify Immediate Fix is the only sub-section shown.
- [ ] Local: verify the cluster list/detail responses include `project_source` and the value is `null` for legacy/no-project rows.

## Notes

- Visual BEFORE captured against a real Vapi customer cluster (8 root causes, 3 recommendations, all sub-fields populated) and confirmed the spec maps to actual production-rendered state.
- AFTER visual verification will land on staging post-merge — local seeding of the Error-Feed cluster + deep-analysis chain isn't trivial enough to be worth blocking on for a UI-only change.