### PR TITLE
feat(eval-clustering): fix_layer + severity for eval clusters (cheap-LLM meta)

### DIFF
--- a/futureagi/tracer/queries/eval_clustering.py
+++ b/futureagi/tracer/queries/eval_clustering.py
@@ -26,7 +26,7 @@ from tracer.models.trace_error_analysis import (
     FeedIssueStatus,
     TraceErrorGroup,
 )
-from tracer.types.eval_cluster_types import ClusterableEvalResult
+from tracer.types.eval_cluster_types import ClusterableEvalResult, EvalClusterMeta
 
 logger = structlog.get_logger(__name__)
 
@@ -232,16 +232,19 @@ def _extract_title(explanation: str) -> str:
     return first_line[:200] if first_line else text[:200]
 
 
-def _eval_cluster_title(eval_name: str, reasoning: str) -> str:
-    """Sentry-style cluster title via the cheap-LLM EE helper, with a
-    deterministic fallback.
+def _eval_cluster_meta(eval_name: str, reasoning: str) -> EvalClusterMeta:
+    """Title + fix_layer + severity for an eval cluster via the cheap-LLM
+    EE helper, with deterministic fallback.
 
-    EE absent (OSS) or any LLM failure → the first-sentence extraction.
-    A title is low-stakes; it must never break cluster creation.
+    EE absent (OSS) or any LLM failure → first-sentence title, null
+    fix_layer, null severity (caller defaults priority). Each field
+    degrades independently; metadata is best-effort and must never break
+    cluster creation.
     """
+    fallback = EvalClusterMeta(title=_extract_title(reasoning))
     try:
         from ee.agenthub.trace_scanner.eval_cluster_title import (
-            generate_eval_cluster_title,
+            generate_eval_cluster_meta,
         )
     except ImportError:
         if settings.DEBUG:
@@ -249,15 +252,21 @@ def _eval_cluster_title(eval_name: str, reasoning: str) -> str:
                 "Could not import ee.agenthub.trace_scanner.eval_cluster_title",
                 exc_info=True,
             )
-        return _extract_title(reasoning)
+        return fallback
 
     try:
-        title = generate_eval_cluster_title(eval_name, reasoning)
+        meta = generate_eval_cluster_meta(eval_name, reasoning)
     except Exception:
-        logger.warning("eval_cluster_title_llm_failed", exc_info=True)
-        title = None
+        logger.warning("eval_cluster_meta_llm_failed", exc_info=True)
+        meta = None
 
-    return title or _extract_title(reasoning)
+    if not meta:
+        return fallback
+    return EvalClusterMeta(
+        title=meta.title or _extract_title(reasoning),
+        fix_layer=meta.fix_layer,
+        severity=meta.severity,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +297,10 @@ def create_cluster(
         ).hexdigest()[:8]
         cluster_id = f"E-{h2.upper()}"
 
-    title = _eval_cluster_title(result.eval_name, result.explanation)
+    meta = _eval_cluster_meta(result.eval_name, result.explanation)
+    # Lazy import avoids a query-module import cycle; severity_to_priority
+    # returns "medium" when severity is None (the fallback default).
+    from tracer.queries.feed import severity_to_priority
 
     cluster = TraceErrorGroup.objects.create(
         project_id=project_id,
@@ -296,11 +308,12 @@ def create_cluster(
         source=ClusterSource.EVAL,
         issue_group=result.eval_name,
         issue_category=None,
-        fix_layer=None,
-        title=title,
+        fix_layer=meta.fix_layer,
+        title=meta.title,
         combined_description=result.explanation,
         combined_impact=_score_to_impact(result.score),
         status=FeedIssueStatus.ESCALATING,
+        priority=severity_to_priority(meta.severity),
         error_type=result.eval_name,
         eval_config_id=result.eval_config_id,
         total_events=1,
@@ -344,7 +357,9 @@ def create_cluster(
         "eval_cluster_created",
         cluster_id=cluster_id,
         eval_name=result.eval_name,
-        title=title[:80],
+        title=(meta.title or "")[:80],
+        fix_layer=meta.fix_layer,
+        severity=meta.severity,
     )
     return cluster_id
 

--- a/futureagi/tracer/queries/tests/test_eval_cluster_title.py
+++ b/futureagi/tracer/queries/tests/test_eval_cluster_title.py
@@ -1,63 +1,75 @@
 """
-_eval_cluster_title gating + fallback contract.
+_eval_cluster_meta gating + fallback contract.
 
-The cheap-LLM title is EE-only and best-effort. The load-bearing
-guarantee is that cluster creation NEVER breaks on its account:
+The cheap-LLM metadata (title / fix_layer / severity) is EE-only and
+best-effort. The load-bearing guarantee: cluster creation NEVER breaks
+on its account, and every field degrades independently.
 
-  * EE present + good title  -> use it
-  * EE present + None        -> deterministic _extract_title
-  * EE present + raises      -> deterministic _extract_title
-  * EE absent (OSS)          -> deterministic _extract_title
-
-The last is the OSS-safety contract: no ee module, no crash.
+  * EE present + full meta   -> use it
+  * EE present + None        -> deterministic title, null fix_layer/severity
+  * EE present + raises      -> same fallback
+  * EE absent (OSS)          -> same fallback   (no crash)
+  * EE present + partial     -> per-field fallback (title backfilled)
 """
 
 import sys
 from unittest.mock import patch
 
-from tracer.queries.eval_clustering import _eval_cluster_title, _extract_title
+from tracer.queries.eval_clustering import _eval_cluster_meta, _extract_title
+from tracer.types.eval_cluster_types import EvalClusterMeta
 
 REASONING = (
     "The verdict is Fail because the speech has an unnatural, robotic "
     "rhythm and pacing throughout the call."
 )
+_PATCH = "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_meta"
 
 
-def test_uses_llm_title_when_available():
+def test_uses_full_meta_when_available():
     with patch(
-        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
-        return_value="Robotic, unnatural speech rhythm",
+        _PATCH,
+        return_value=EvalClusterMeta(
+            title="Robotic, unnatural speech rhythm",
+            fix_layer="Prompt",
+            severity="high",
+        ),
     ):
-        assert (
-            _eval_cluster_title("prosody_and_intonation", REASONING)
-            == "Robotic, unnatural speech rhythm"
-        )
+        m = _eval_cluster_meta("prosody_and_intonation", REASONING)
+    assert m.title == "Robotic, unnatural speech rhythm"
+    assert m.fix_layer == "Prompt"
+    assert m.severity == "high"
 
 
-def test_falls_back_when_llm_returns_none():
+def test_partial_meta_backfills_title_only():
+    """Null title -> deterministic title; fix_layer/severity stay as given."""
     with patch(
-        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
-        return_value=None,
+        _PATCH,
+        return_value=EvalClusterMeta(
+            title=None, fix_layer="Guardrails", severity="critical"
+        ),
     ):
-        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
-            REASONING
-        )
+        m = _eval_cluster_meta("pii_leak", REASONING)
+    assert m.title == _extract_title(REASONING)
+    assert m.fix_layer == "Guardrails"
+    assert m.severity == "critical"
 
 
-def test_falls_back_when_llm_raises():
-    with patch(
-        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
-        side_effect=RuntimeError("gateway down"),
-    ):
-        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
-            REASONING
-        )
+def test_falls_back_when_meta_none():
+    with patch(_PATCH, return_value=None):
+        m = _eval_cluster_meta("prosody_and_intonation", REASONING)
+    assert m == EvalClusterMeta(title=_extract_title(REASONING))
+
+
+def test_falls_back_when_meta_raises():
+    with patch(_PATCH, side_effect=RuntimeError("gateway down")):
+        m = _eval_cluster_meta("prosody_and_intonation", REASONING)
+    assert m.title == _extract_title(REASONING)
+    assert m.fix_layer is None and m.severity is None
 
 
 def test_oss_safety_no_ee_module_no_crash():
-    # Setting the module to None in sys.modules makes `import` raise
-    # ImportError — simulates an OSS deployment with no ee package.
+    # Module set to None in sys.modules makes `import` raise ImportError —
+    # simulates an OSS deployment with no ee package.
     with patch.dict(sys.modules, {"ee.agenthub.trace_scanner.eval_cluster_title": None}):
-        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
-            REASONING
-        )
+        m = _eval_cluster_meta("prosody_and_intonation", REASONING)
+    assert m == EvalClusterMeta(title=_extract_title(REASONING))

--- a/futureagi/tracer/types/eval_cluster_types.py
+++ b/futureagi/tracer/types/eval_cluster_types.py
@@ -32,3 +32,14 @@ class EvalClusteringSummary:
     clustered: int = 0
     new_clusters: int = 0
     assigned: int = 0
+
+
+@dataclass
+class EvalClusterMeta:
+    """Cheap-LLM-derived metadata for an eval cluster. Any field may be
+    None — the caller falls back per field (title -> first-sentence,
+    severity -> default priority, fix_layer -> unset)."""
+
+    title: Optional[str] = None
+    fix_layer: Optional[str] = None  # Tools|Prompt|Orchestration|Guardrails
+    severity: Optional[str] = None  # critical|high|medium|low


### PR DESCRIPTION
Eval-source clusters showed **everything Medium / no Fix Layer** — `create_cluster` hardcoded `fix_layer=None` and never set `priority` (model default = medium).

`_eval_cluster_title` → **`_eval_cluster_meta`** returning the new **`EvalClusterMeta`** dataclass (`tracer/types/eval_cluster_types.py`, beside `ClusterableEvalResult`) — title + fix_layer + severity from one gated cheap-LLM call. `create_cluster` sets `fix_layer` and maps `severity → priority` via the existing `severity_to_priority` (lazy import, no cycle). **No raw dicts at any boundary.**

Gating unchanged: EE absent (OSS) or any LLM failure → deterministic first-sentence title, null fix_layer, default priority — **each field degrades independently**, never breaks cluster creation.

EE side (helper + backfill): future-agi/ee#65.

### Verified e2e
- Live meta: PII→Guardrails/critical, prosody→Prompt/low, hallucination→Prompt/high (differentiated, generalized).
- Real `create_cluster`: data-leak → title + Guardrails + **urgent**.
- Backfill: seed → dry-run → real → DB (title+fix_layer+priority all written).
- **Full pipeline**: injected failing EvalLogger → `cluster_eval_results` → auto-created cluster Orchestration/high. Cleaned up.
- Unit: **5/5** (incl. partial-meta per-field fallback + OSS no-ee-crash).

### Notes
- Branch name mentions voice-evidence (#3) — separate, not here.
- `tracer/utils/otel.py` (pre-existing unrelated change) excluded.
- Deferred refinements consolidated in **TH-5333**.