### PR TITLE
fix(evals): voice-call eval-task scope parity with list_voice_calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,15 @@
 ---
 
 <!--
-  [MARKETING] hero-demo.gif
-  What:    8–12 second product loop. Suggested flow:
-             1. Open a trace → expand a span
-             2. Click "Run Eval" → score appears
-             3. Navigate to Simulate → a voice agent conversation plays
-             4. Navigate to Gateway → cost + guardrail dashboard
-  Size:    1600 × 900, GIF ≤ 4 MB (use `gifski` to compress).
-  Fallback: hero-demo.png (first frame) for users who disable GIFs.
-  Why here: carries the "what is this?" answer in 3 seconds; biggest
-            single lift on time-on-page across flagship OSS READMEs.
+  [MARKETING] hero-demo (YouTube)
+  GitHub markdown does not render inline <iframe>/<video>, so we use a
+  clickable YouTube thumbnail that opens the video in a new tab.
+  Video: https://www.youtube.com/watch?v=Mdpn8ekFwQ0
 -->
 <div align="center">
-  <img alt="Future AGI — trace an agent, run evals, simulate, and guardrail in one platform" src="frontend/public/assets/readme/self-host.gif" width="720">
+  <a href="https://www.youtube.com/watch?v=Mdpn8ekFwQ0&t=1s">
+    <img alt="Future AGI — trace an agent, run evals, simulate, and guardrail in one platform (watch on YouTube)" src="https://img.youtube.com/vi/Mdpn8ekFwQ0/maxresdefault.jpg" width="720">
+  </a>
 </div>
 
 ---

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -387,8 +387,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         evalData?.config?.run_config ||
         evalData?.config?.runConfig ||
         {};
-        
-     const normalizedRunConfig = {
+
+      const normalizedRunConfig = {
         ...rawRunConfig,
         agent_mode:
           rawRunConfig.agent_mode ??
@@ -529,13 +529,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           setContextOptions(["variables_only"]);
         }
       } else if (source === "task") {
-      const seeded = contextOptionsForRowType(sourceRowType);
+        const seeded = contextOptionsForRowType(sourceRowType);
         if (seeded) setContextOptions(seeded);
       }
       setErrorLocalizerEnabled(
         config.error_localizer_enabled ??
-          fullEval.error_localizer_enabled ??
-          false,
+        fullEval.error_localizer_enabled ??
+        false,
       );
 
       // Edit mode: keep the saved name. Create mode: generate a unique name
@@ -555,8 +555,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           .replace(/[^a-z0-9_-]/g, "");
         const sourceSlug = SOURCE_NAME_SLUGS[source] || "";
         const stamp = format(new Date(), "dd_MMM_yyyy_HH_mm").toLowerCase();
+        const suffix = [sourceSlug, stamp].filter(Boolean).join("_");
+        const maxBaseLen = Math.max(0, 50 - suffix.length - (suffix ? 1 : 0));
+        const truncatedBase = sanitized.slice(0, maxBaseLen).replace(/_+$/, "");
         setEvalName(
-          [sanitized, sourceSlug, stamp].filter(Boolean).join("_"),
+          [truncatedBase, sourceSlug, stamp].filter(Boolean).join("_"),
         );
       }
 
@@ -627,8 +630,8 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         setUseInternet(fullEval.config?.check_internet ?? false);
         setErrorLocalizerEnabled(
           fullEval.error_localizer_enabled ??
-            fullEval.config?.error_localizer_enabled ??
-            false,
+          fullEval.config?.error_localizer_enabled ??
+          false,
         );
         setIsDirty(false);
         return;
@@ -834,13 +837,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
         );
         return;
       }
-    if (evalType === "llm" && !hasValidPromptMessages) {
-      const errorMessage = "Prompt message is required";
-      setPromptMessageError(errorMessage);
-      enqueueSnackbar(errorMessage, { variant: "error" });
-      return;
+      if (evalType === "llm" && !hasValidPromptMessages) {
+        const errorMessage = "Prompt message is required";
+        setPromptMessageError(errorMessage);
+        enqueueSnackbar(errorMessage, { variant: "error" });
+        return;
+      }
     }
-  }
 
     if (source === "task" && onFiltersChange) {
       onFiltersChange(localFilterForm.getValues("filters") || []);
@@ -1151,7 +1154,16 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             setEvalName(raw);
             setIsDirty(true);
           }}
-          inputProps={{ maxLength: 60 }}
+          inputProps={{ maxLength: 50 }}
+          error={!isEditMode && evalName.length >= 50}
+          helperText={
+            isEditMode
+              ? undefined
+              : evalName.length >= 50
+                ? "Name can't be longer than 50 characters"
+                : `Use lowercase letters, numbers, hyphens (-) and underscores (_) only. ${evalName.length}/50`
+          }
+          FormHelperTextProps={{ sx: { fontSize: "11px", mt: 0.25, mx: 0 } }}
           sx={{ "& .MuiInputBase-root": { fontSize: "13px", height: 34 } }}
         />
       </Box>
@@ -1624,27 +1636,27 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   source === "workbench" ||
                   source === "run-experiment" ||
                   source === "run-optimization") && (
-                  <DatasetTestMode
-                    ref={sourceRef}
-                    templateId={templateId}
-                    variables={variables}
-                    model={model}
-                    codeParams={codeParams}
-                    onTestResult={handleTestResult}
-                    onClearResult={handleClearTestResult}
-                    onColumnsLoaded={handleColumnsLoaded}
-                    initialDatasetId={sourceId}
-                    onReadyChange={handleSourceReadyChange}
-                    contextOptions={contextOptions}
-                    errorLocalizerEnabled={errorLocalizerEnabled}
-                    initialMapping={evalData?.mapping}
-                    {...compositeSourceModeProps}
-                    sourceColumns={
-                      source === "workbench" ? sourceColumns : null
-                    }
-                    extraColumns={extraColumns}
-                  />
-                )}
+                    <DatasetTestMode
+                      ref={sourceRef}
+                      templateId={templateId}
+                      variables={variables}
+                      model={model}
+                      codeParams={codeParams}
+                      onTestResult={handleTestResult}
+                      onClearResult={handleClearTestResult}
+                      onColumnsLoaded={handleColumnsLoaded}
+                      initialDatasetId={sourceId}
+                      onReadyChange={handleSourceReadyChange}
+                      contextOptions={contextOptions}
+                      errorLocalizerEnabled={errorLocalizerEnabled}
+                      initialMapping={evalData?.mapping}
+                      {...compositeSourceModeProps}
+                      sourceColumns={
+                        source === "workbench" ? sourceColumns : null
+                      }
+                      extraColumns={extraColumns}
+                    />
+                  )}
                 {source === "tracing" && (
                   <TracingTestMode
                     ref={sourceRef}
@@ -1924,7 +1936,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
 
           return (
             <ShowComponent
-              condition={!hasDataInjection }
+              condition={!hasDataInjection}
             >
               <CustomTooltip
                 show={testDisabled && !!testDisabledReason}

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -220,6 +220,23 @@ const EvalDetailPage = () => {
 
   // Version viewing state
   const [viewingVersion, setViewingVersion] = useState(null);
+
+  useEffect(() => {
+    if (!viewingVersion || !versionsData?.versions) return;
+    const fresh = versionsData.versions.find((v) => v.id === viewingVersion.id);
+    if (!fresh) return;
+    const freshFlag = fresh.is_default ?? fresh.isDefault ?? false;
+    const localFlag =
+      viewingVersion.is_default ?? viewingVersion.isDefault ?? false;
+    if (freshFlag !== localFlag) {
+      setViewingVersion((prev) =>
+        prev
+          ? { ...prev, is_default: freshFlag, isDefault: freshFlag }
+          : prev,
+      );
+    }
+  }, [versionsData, viewingVersion]);
+
   const defaultVersion = useMemo(() => {
     const list = versionsData?.versions || [];
     if (!list.length) return null;
@@ -1873,7 +1890,7 @@ const EvalDetailPage = () => {
                       variant="contained"
                       size="small"
                       onClick={handleSaveVersion}
-                      disabled={isSaving}
+                      disabled={isSaving || !isDirty}
                       startIcon={
                         isSaving ? (
                           <CircularProgress size={14} />

--- a/frontend/src/sections/evals/components/EvalUsageTab.jsx
+++ b/frontend/src/sections/evals/components/EvalUsageTab.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import {
   Box,
+  ButtonBase,
   Chip,
   IconButton,
   Skeleton,
@@ -409,7 +410,15 @@ const EvalUsageTab = ({
   }, [detailIndex, filteredLogs.length]);
 
   return (
-    <Box sx={{ display: "flex", height: "100%", minHeight: 0 }}>
+    <Box
+      sx={{
+        display: "flex",
+        height: "100%",
+        minHeight: 0,
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
       {/* ── Main content ── */}
       <Box
         sx={{
@@ -418,6 +427,7 @@ const EvalUsageTab = ({
           flexDirection: "column",
           minHeight: 0,
           minWidth: 0,
+          marginRight: detailIndex !== null ? "420px" : 0,
           transition: "margin-right 0.25s",
         }}
       >
@@ -596,14 +606,17 @@ const EvalUsageTab = ({
       >
         <Box
           sx={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+            bottom: 0,
             width: 420,
-            flexShrink: 0,
             borderLeft: "1px solid",
             borderColor: "divider",
             display: "flex",
             flexDirection: "column",
-            height: "100%",
             backgroundColor: "background.paper",
+            zIndex: 1,
           }}
         >
           {/* Header with prev/next */}
@@ -753,17 +766,17 @@ const DetailPanelContent = ({
         }}
       >
         {["formatted", "json"].map((m) => (
-          <Box
+          <ButtonBase
             key={m}
             onClick={() => setViewMode(m)}
+            disableRipple
             sx={{
               px: 1.5,
               py: 0.375,
               borderRadius: "5px",
               fontSize: "11px",
-              cursor: "pointer",
               fontWeight: viewMode === m ? 600 : 400,
-              color: viewMode === m ? "text.primary" : "text.disabled",
+              color: viewMode === m ? "text.primary" : "text.secondary",
               backgroundColor:
                 viewMode === m
                   ? (t) =>
@@ -771,10 +784,16 @@ const DetailPanelContent = ({
                         ? "rgba(255,255,255,0.08)"
                         : "action.hover"
                   : "transparent",
+              "&:hover": {
+                backgroundColor: (t) =>
+                  t.palette.mode === "dark"
+                    ? "rgba(255,255,255,0.04)"
+                    : "action.hover",
+              },
             }}
           >
             {m === "formatted" ? "Formatted" : "JSON"}
-          </Box>
+          </ButtonBase>
         ))}
       </Box>
 

--- a/frontend/src/sections/persona/PersonaDrawer.jsx
+++ b/frontend/src/sections/persona/PersonaDrawer.jsx
@@ -58,7 +58,7 @@ const PersonaListContent = ({
       >
         <Iconify icon="akar-icons:cross" />
       </IconButton>
-      <Box sx={{ flex: 1, overflow: "hidden", display: "flex", p: 2 }}>
+      <Box sx={{ flex: 1, minHeight: 0, p: 2, display: "flex", flexDirection: "column" }}>
         <PersonaListView
           onCreatePersona={onCreatePersona}
           selectedPersonas={selectedPersonas}

--- a/frontend/src/sections/persona/PersonaListView.jsx
+++ b/frontend/src/sections/persona/PersonaListView.jsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import { formatDistanceToNow } from "date-fns";
 import PropTypes from "prop-types";
-import { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { enqueueSnackbar } from "src/components/snackbar";
 import Iconify from "src/components/iconify";
 import FormSearchField from "src/components/FormSearchField/FormSearchField";
@@ -613,32 +613,39 @@ const PersonaListView = ({
             />
           );
         })}
-        <Box
-          sx={{
-            width: "1px",
-            height: 18,
-            bgcolor: "divider",
-            mx: 0.5,
-          }}
-        />
-        {SIMULATION_FILTERS.map((f) => {
-          const isActive = simulationFilter === f.value;
-          return (
-            <Chip
-              key={f.label}
-              icon={f.icon ? <Iconify icon={f.icon} width={14} /> : undefined}
-              label={f.label}
-              size="small"
-              variant={isActive ? "filled" : "outlined"}
-              color={isActive ? "primary" : "default"}
-              onClick={() => {
-                setSimulationFilter(f.value);
-                setPage(0);
+
+        {!(isSelectable && personaCreateEditType) && (
+          <>
+            <Box
+              sx={{
+                width: "1px",
+                height: 18,
+                bgcolor: "divider",
+                mx: 0.5,
               }}
-              sx={{ fontSize: "11px", height: 26, cursor: "pointer" }}
             />
-          );
-        })}
+            {SIMULATION_FILTERS.map((f) => {
+              const isActive = simulationFilter === f.value;
+              return (
+                <Chip
+                  key={f.label}
+                  icon={
+                    f.icon ? <Iconify icon={f.icon} width={14} /> : undefined
+                  }
+                  label={f.label}
+                  size="small"
+                  variant={isActive ? "filled" : "outlined"}
+                  color={isActive ? "primary" : "default"}
+                  onClick={() => {
+                    setSimulationFilter(f.value);
+                    setPage(0);
+                  }}
+                  sx={{ fontSize: "11px", height: 26, cursor: "pointer" }}
+                />
+              );
+            })}
+          </>
+        )}
       </Box>
 
       {/* Table */}

--- a/frontend/src/sections/test-detail/TestDetailConfigureEval.jsx
+++ b/frontend/src/sections/test-detail/TestDetailConfigureEval.jsx
@@ -19,7 +19,7 @@ import { AGENT_TYPES } from "../agents/constants";
 import { SourceType } from "../scenarios/common";
 
 const TestDetailConfigureEval = () => {
-  const { testId } = useParams();
+  const { testId, executionId } = useParams();
   const queryClient = useQueryClient();
 
   const { configureEval, setConfigureEval } = useTestDetailStoreShallow(
@@ -76,7 +76,12 @@ const TestDetailConfigureEval = () => {
   }, [agentType, sourceType, testData]);
 
   const { mutateAsync: updateEvalAsync } = useMutation({
-    mutationFn: ({ evalConfigId, payload }) =>
+    mutationFn: (
+      {
+        evalConfigId,
+        payload,
+      },
+    ) =>
       axios.post(
         endpoints.runTests.updateSimulateEval(testId, evalConfigId),
         payload,
@@ -95,8 +100,14 @@ const TestDetailConfigureEval = () => {
       try {
         await updateEvalAsync({
           evalConfigId: editingEvalItem.id,
-          payload,
+          payload: {
+            ...payload,
+            ...(executionId
+              ? { run: true, test_execution_id: executionId }
+              : {}),
+          },
         });
+
         enqueueSnackbar("Eval updated successfully", { variant: "success" });
         handleRefresh();
       } catch (error) {
@@ -106,7 +117,7 @@ const TestDetailConfigureEval = () => {
         throw error;
       }
     },
-    [testId, editingEvalItem, updateEvalAsync, handleRefresh],
+    [testId, executionId, editingEvalItem, updateEvalAsync, handleRefresh],
   );
 
   const onClose = useCallback(() => {

--- a/frontend/src/sections/test/TestEvaluationDrawer.jsx
+++ b/frontend/src/sections/test/TestEvaluationDrawer.jsx
@@ -137,7 +137,7 @@ const TestEvaluationDrawer = ({ executionIds, onSuccessOfAdditionOfEvals }) => {
       <Drawer
         anchor="right"
         open={openTestEvaluation}
-        variant="temporary"
+              variant="persistent"
         onClose={onCloseHandler}
         PaperProps={{
           sx: (theme) => ({

--- a/frontend/src/sections/test/TestEvaluationDrawer.jsx
+++ b/frontend/src/sections/test/TestEvaluationDrawer.jsx
@@ -137,7 +137,7 @@ const TestEvaluationDrawer = ({ executionIds, onSuccessOfAdditionOfEvals }) => {
       <Drawer
         anchor="right"
         open={openTestEvaluation}
-              variant="persistent"
+              variant={onSuccessOfAdditionOfEvals?"temporary":"persistent"}
         onClose={onCloseHandler}
         PaperProps={{
           sx: (theme) => ({

--- a/frontend/src/sections/test/TestEvaluationPage.jsx
+++ b/frontend/src/sections/test/TestEvaluationPage.jsx
@@ -372,7 +372,7 @@ const TestEvaluationPage = ({
             show={
               executionIds ? executionIds?.length === 0 : selectedCount === 0
             }
-            title="Please select at least one Test Run to run"
+            title="Please select at least one Test Run from grid to run evaluation"
             arrow
             placement="top"
             size="small"

--- a/frontend/src/sections/test/TestEvaluationPage.jsx
+++ b/frontend/src/sections/test/TestEvaluationPage.jsx
@@ -430,8 +430,8 @@ const TestEvaluationPage = ({
         open={openConfirmDialog}
         onClose={() => setOpenConfirmDialog(false)}
         onConfirm={() => {}}
-        title="Confirm Delete eval"
-        message="Are you sure you want to proceed?"
+        title="Delete Evaluation"
+        content="This will also remove all its results. This action cannot be undone."
         action={
           <LoadingButton
             variant="contained"

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationPage.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationPage.jsx
@@ -329,8 +329,8 @@ const SimulationEvaluationPage = ({
       <ConfirmDialog
         open={Boolean(openConfirmDialog)}
         onClose={() => setOpenConfirmDialog(false)}
-        title="Confirm Delete eval"
-        content="Are you sure you want to delete this evaluation?"
+        title="Delete Evaluation"
+        content="This will also remove all its results. This action cannot be undone."
         action={
           <LoadingButton
             variant="contained"

--- a/futureagi/tracer/queries/eval_clustering.py
+++ b/futureagi/tracer/queries/eval_clustering.py
@@ -13,6 +13,7 @@ import re
 from typing import List, Optional, Tuple
 
 import structlog
+from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 
@@ -231,6 +232,34 @@ def _extract_title(explanation: str) -> str:
     return first_line[:200] if first_line else text[:200]
 
 
+def _eval_cluster_title(eval_name: str, reasoning: str) -> str:
+    """Sentry-style cluster title via the cheap-LLM EE helper, with a
+    deterministic fallback.
+
+    EE absent (OSS) or any LLM failure → the first-sentence extraction.
+    A title is low-stakes; it must never break cluster creation.
+    """
+    try:
+        from ee.agenthub.trace_scanner.eval_cluster_title import (
+            generate_eval_cluster_title,
+        )
+    except ImportError:
+        if settings.DEBUG:
+            logger.warning(
+                "Could not import ee.agenthub.trace_scanner.eval_cluster_title",
+                exc_info=True,
+            )
+        return _extract_title(reasoning)
+
+    try:
+        title = generate_eval_cluster_title(eval_name, reasoning)
+    except Exception:
+        logger.warning("eval_cluster_title_llm_failed", exc_info=True)
+        title = None
+
+    return title or _extract_title(reasoning)
+
+
 # ---------------------------------------------------------------------------
 # Cluster creation
 # ---------------------------------------------------------------------------
@@ -259,7 +288,7 @@ def create_cluster(
         ).hexdigest()[:8]
         cluster_id = f"E-{h2.upper()}"
 
-    title = _extract_title(result.explanation)
+    title = _eval_cluster_title(result.eval_name, result.explanation)
 
     cluster = TraceErrorGroup.objects.create(
         project_id=project_id,

--- a/futureagi/tracer/queries/eval_clustering.py
+++ b/futureagi/tracer/queries/eval_clustering.py
@@ -26,7 +26,7 @@ from tracer.models.trace_error_analysis import (
     FeedIssueStatus,
     TraceErrorGroup,
 )
-from tracer.types.eval_cluster_types import ClusterableEvalResult
+from tracer.types.eval_cluster_types import ClusterableEvalResult, EvalClusterMeta
 
 logger = structlog.get_logger(__name__)
 
@@ -232,16 +232,19 @@ def _extract_title(explanation: str) -> str:
     return first_line[:200] if first_line else text[:200]
 
 
-def _eval_cluster_title(eval_name: str, reasoning: str) -> str:
-    """Sentry-style cluster title via the cheap-LLM EE helper, with a
-    deterministic fallback.
+def _eval_cluster_meta(eval_name: str, reasoning: str) -> EvalClusterMeta:
+    """Title + fix_layer + severity for an eval cluster via the cheap-LLM
+    EE helper, with deterministic fallback.
 
-    EE absent (OSS) or any LLM failure → the first-sentence extraction.
-    A title is low-stakes; it must never break cluster creation.
+    EE absent (OSS) or any LLM failure → first-sentence title, null
+    fix_layer, null severity (caller defaults priority). Each field
+    degrades independently; metadata is best-effort and must never break
+    cluster creation.
     """
+    fallback = EvalClusterMeta(title=_extract_title(reasoning))
     try:
         from ee.agenthub.trace_scanner.eval_cluster_title import (
-            generate_eval_cluster_title,
+            generate_eval_cluster_meta,
         )
     except ImportError:
         if settings.DEBUG:
@@ -249,15 +252,21 @@ def _eval_cluster_title(eval_name: str, reasoning: str) -> str:
                 "Could not import ee.agenthub.trace_scanner.eval_cluster_title",
                 exc_info=True,
             )
-        return _extract_title(reasoning)
+        return fallback
 
     try:
-        title = generate_eval_cluster_title(eval_name, reasoning)
+        meta = generate_eval_cluster_meta(eval_name, reasoning)
     except Exception:
-        logger.warning("eval_cluster_title_llm_failed", exc_info=True)
-        title = None
+        logger.warning("eval_cluster_meta_llm_failed", exc_info=True)
+        meta = None
 
-    return title or _extract_title(reasoning)
+    if not meta:
+        return fallback
+    return EvalClusterMeta(
+        title=meta.title or _extract_title(reasoning),
+        fix_layer=meta.fix_layer,
+        severity=meta.severity,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +297,10 @@ def create_cluster(
         ).hexdigest()[:8]
         cluster_id = f"E-{h2.upper()}"
 
-    title = _eval_cluster_title(result.eval_name, result.explanation)
+    meta = _eval_cluster_meta(result.eval_name, result.explanation)
+    # Lazy import avoids a query-module import cycle; severity_to_priority
+    # returns "medium" when severity is None (the fallback default).
+    from tracer.queries.feed import severity_to_priority
 
     cluster = TraceErrorGroup.objects.create(
         project_id=project_id,
@@ -296,11 +308,12 @@ def create_cluster(
         source=ClusterSource.EVAL,
         issue_group=result.eval_name,
         issue_category=None,
-        fix_layer=None,
-        title=title,
+        fix_layer=meta.fix_layer,
+        title=meta.title,
         combined_description=result.explanation,
         combined_impact=_score_to_impact(result.score),
         status=FeedIssueStatus.ESCALATING,
+        priority=severity_to_priority(meta.severity),
         error_type=result.eval_name,
         eval_config_id=result.eval_config_id,
         total_events=1,
@@ -344,7 +357,9 @@ def create_cluster(
         "eval_cluster_created",
         cluster_id=cluster_id,
         eval_name=result.eval_name,
-        title=title[:80],
+        title=(meta.title or "")[:80],
+        fix_layer=meta.fix_layer,
+        severity=meta.severity,
     )
     return cluster_id
 

--- a/futureagi/tracer/queries/tests/test_eval_cluster_title.py
+++ b/futureagi/tracer/queries/tests/test_eval_cluster_title.py
@@ -1,0 +1,63 @@
+"""
+_eval_cluster_title gating + fallback contract.
+
+The cheap-LLM title is EE-only and best-effort. The load-bearing
+guarantee is that cluster creation NEVER breaks on its account:
+
+  * EE present + good title  -> use it
+  * EE present + None        -> deterministic _extract_title
+  * EE present + raises      -> deterministic _extract_title
+  * EE absent (OSS)          -> deterministic _extract_title
+
+The last is the OSS-safety contract: no ee module, no crash.
+"""
+
+import sys
+from unittest.mock import patch
+
+from tracer.queries.eval_clustering import _eval_cluster_title, _extract_title
+
+REASONING = (
+    "The verdict is Fail because the speech has an unnatural, robotic "
+    "rhythm and pacing throughout the call."
+)
+
+
+def test_uses_llm_title_when_available():
+    with patch(
+        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
+        return_value="Robotic, unnatural speech rhythm",
+    ):
+        assert (
+            _eval_cluster_title("prosody_and_intonation", REASONING)
+            == "Robotic, unnatural speech rhythm"
+        )
+
+
+def test_falls_back_when_llm_returns_none():
+    with patch(
+        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
+        return_value=None,
+    ):
+        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
+            REASONING
+        )
+
+
+def test_falls_back_when_llm_raises():
+    with patch(
+        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
+        side_effect=RuntimeError("gateway down"),
+    ):
+        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
+            REASONING
+        )
+
+
+def test_oss_safety_no_ee_module_no_crash():
+    # Setting the module to None in sys.modules makes `import` raise
+    # ImportError — simulates an OSS deployment with no ee package.
+    with patch.dict(sys.modules, {"ee.agenthub.trace_scanner.eval_cluster_title": None}):
+        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
+            REASONING
+        )

--- a/futureagi/tracer/queries/tests/test_eval_cluster_title.py
+++ b/futureagi/tracer/queries/tests/test_eval_cluster_title.py
@@ -1,63 +1,75 @@
 """
-_eval_cluster_title gating + fallback contract.
+_eval_cluster_meta gating + fallback contract.
 
-The cheap-LLM title is EE-only and best-effort. The load-bearing
-guarantee is that cluster creation NEVER breaks on its account:
+The cheap-LLM metadata (title / fix_layer / severity) is EE-only and
+best-effort. The load-bearing guarantee: cluster creation NEVER breaks
+on its account, and every field degrades independently.
 
-  * EE present + good title  -> use it
-  * EE present + None        -> deterministic _extract_title
-  * EE present + raises      -> deterministic _extract_title
-  * EE absent (OSS)          -> deterministic _extract_title
-
-The last is the OSS-safety contract: no ee module, no crash.
+  * EE present + full meta   -> use it
+  * EE present + None        -> deterministic title, null fix_layer/severity
+  * EE present + raises      -> same fallback
+  * EE absent (OSS)          -> same fallback   (no crash)
+  * EE present + partial     -> per-field fallback (title backfilled)
 """
 
 import sys
 from unittest.mock import patch
 
-from tracer.queries.eval_clustering import _eval_cluster_title, _extract_title
+from tracer.queries.eval_clustering import _eval_cluster_meta, _extract_title
+from tracer.types.eval_cluster_types import EvalClusterMeta
 
 REASONING = (
     "The verdict is Fail because the speech has an unnatural, robotic "
     "rhythm and pacing throughout the call."
 )
+_PATCH = "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_meta"
 
 
-def test_uses_llm_title_when_available():
+def test_uses_full_meta_when_available():
     with patch(
-        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
-        return_value="Robotic, unnatural speech rhythm",
+        _PATCH,
+        return_value=EvalClusterMeta(
+            title="Robotic, unnatural speech rhythm",
+            fix_layer="Prompt",
+            severity="high",
+        ),
     ):
-        assert (
-            _eval_cluster_title("prosody_and_intonation", REASONING)
-            == "Robotic, unnatural speech rhythm"
-        )
+        m = _eval_cluster_meta("prosody_and_intonation", REASONING)
+    assert m.title == "Robotic, unnatural speech rhythm"
+    assert m.fix_layer == "Prompt"
+    assert m.severity == "high"
 
 
-def test_falls_back_when_llm_returns_none():
+def test_partial_meta_backfills_title_only():
+    """Null title -> deterministic title; fix_layer/severity stay as given."""
     with patch(
-        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
-        return_value=None,
+        _PATCH,
+        return_value=EvalClusterMeta(
+            title=None, fix_layer="Guardrails", severity="critical"
+        ),
     ):
-        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
-            REASONING
-        )
+        m = _eval_cluster_meta("pii_leak", REASONING)
+    assert m.title == _extract_title(REASONING)
+    assert m.fix_layer == "Guardrails"
+    assert m.severity == "critical"
 
 
-def test_falls_back_when_llm_raises():
-    with patch(
-        "ee.agenthub.trace_scanner.eval_cluster_title.generate_eval_cluster_title",
-        side_effect=RuntimeError("gateway down"),
-    ):
-        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
-            REASONING
-        )
+def test_falls_back_when_meta_none():
+    with patch(_PATCH, return_value=None):
+        m = _eval_cluster_meta("prosody_and_intonation", REASONING)
+    assert m == EvalClusterMeta(title=_extract_title(REASONING))
+
+
+def test_falls_back_when_meta_raises():
+    with patch(_PATCH, side_effect=RuntimeError("gateway down")):
+        m = _eval_cluster_meta("prosody_and_intonation", REASONING)
+    assert m.title == _extract_title(REASONING)
+    assert m.fix_layer is None and m.severity is None
 
 
 def test_oss_safety_no_ee_module_no_crash():
-    # Setting the module to None in sys.modules makes `import` raise
-    # ImportError — simulates an OSS deployment with no ee package.
+    # Module set to None in sys.modules makes `import` raise ImportError —
+    # simulates an OSS deployment with no ee package.
     with patch.dict(sys.modules, {"ee.agenthub.trace_scanner.eval_cluster_title": None}):
-        assert _eval_cluster_title("prosody_and_intonation", REASONING) == _extract_title(
-            REASONING
-        )
+        m = _eval_cluster_meta("prosody_and_intonation", REASONING)
+    assert m == EvalClusterMeta(title=_extract_title(REASONING))

--- a/futureagi/tracer/tests/test_eval_task_runtime.py
+++ b/futureagi/tracer/tests/test_eval_task_runtime.py
@@ -25,7 +25,8 @@ import model_hub.tasks  # noqa: F401, E402
 
 from tracer.models.custom_eval_config import CustomEvalConfig  # noqa: E402
 from tracer.models.eval_task import EvalTask, EvalTaskStatus, RunType  # noqa: E402
-from tracer.models.observation_span import EvalLogger  # noqa: E402
+from tracer.models.observation_span import EvalLogger, ObservationSpan  # noqa: E402
+from tracer.models.trace import Trace  # noqa: E402
 from tracer.utils.eval_tasks import process_eval_task  # noqa: E402
 
 
@@ -178,17 +179,84 @@ class TestProcessEvalTaskSpans:
 
 
 # ────────────────────────────────────────────────────────────────────────
-# Voice-call dispatch — literal alias of the spans pipeline. Any
-# observation_type narrowing is the caller's job via ``filters``.
+# Voice-call dispatch — root conversation spans only, windowed by
+# ``start_time``. Mirrors ``list_voice_calls`` so the eval covers exactly
+# the population the user sees in the voice-call list view.
 # ────────────────────────────────────────────────────────────────────────
 
 
 @pytest.fixture
-def voice_call_eval_task(db, populated_observe_project, eval_template):
-    """Historical voiceCalls eval task on the shared 12-span fixture."""
+def populated_voice_project(db, observe_project):
+    """Build a small voice-call graph for dispatcher tests.
+
+    Two traces:
+
+    * Trace A: ``conv_root`` (conversation, root) + ``conv_child``
+      (conversation, child of conv_root). Only conv_root qualifies.
+    * Trace B: ``llm_root`` (llm, root). Non-conversation; excluded.
+
+    Returns each span by name so tests can assert on ids without
+    re-querying. ``start_time`` is anchored so date-range tests can
+    bracket it.
+    """
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    anchor = timezone.now().replace(microsecond=0)
+    out = {"project": observe_project, "anchor": anchor}
+
+    trace_a = Trace.objects.create(
+        project=observe_project,
+        name="Trace A (conversation)",
+        input={"prompt": "a"},
+        output={"response": "a"},
+        metadata={},
+    )
+    trace_b = Trace.objects.create(
+        project=observe_project,
+        name="Trace B (llm)",
+        input={"prompt": "b"},
+        output={"response": "b"},
+        metadata={},
+    )
+
+    def _mk(span_id, trace, parent_span_id, obs_type, start):
+        span = ObservationSpan.objects.create(
+            id=span_id,
+            project=observe_project,
+            trace=trace,
+            parent_span_id=parent_span_id,
+            name=f"Span {span_id}",
+            observation_type=obs_type,
+            start_time=start,
+            end_time=start + timedelta(seconds=1),
+            input={"messages": [{"role": "user", "content": span_id}]},
+            output={"choices": [{"message": {"content": span_id}}]},
+            span_attributes={
+                "input": {"value": span_id},
+                "output": {"value": span_id},
+            },
+            model="gpt-4",
+            status="OK",
+        )
+        return span
+
+    out["conv_root"] = _mk("vc_conv_root", trace_a, None, "conversation", anchor)
+    out["conv_child"] = _mk(
+        "vc_conv_child", trace_a, "vc_conv_root", "conversation", anchor
+    )
+    out["llm_root"] = _mk("vc_llm_root", trace_b, None, "llm", anchor)
+
+    return out
+
+
+@pytest.fixture
+def voice_call_eval_task(db, populated_voice_project, eval_template):
+    """Historical voiceCalls eval task scoped to ``populated_voice_project``."""
     from tracer.models.eval_task import RowType
 
-    project = populated_observe_project["project"]
+    project = populated_voice_project["project"]
     config = CustomEvalConfig.objects.create(
         project=project,
         eval_template=eval_template,
@@ -215,40 +283,105 @@ def voice_call_eval_task(db, populated_observe_project, eval_template):
 @pytest.mark.api
 @pytest.mark.django_db
 class TestProcessEvalTaskVoiceCalls:
-    """Dispatcher must route voiceCalls through the spans flow.
+    """Dispatcher narrows voiceCalls to root conversation spans.
 
-    Regression net for the bug where ``row_type='voiceCalls'`` hit the
-    dispatcher's ``else`` branch (added in fb134ddf) and raised
-    ``ValueError`` — flipping every voiceCalls task in prod to FAILED.
+    Mirrors ``list_voice_calls`` (CH ``VoiceCallListQueryBuilder``):
+    ``parent_span_id IS NULL AND observation_type = 'conversation'``,
+    windowed by ``start_time``.
 
-    Behaviour pin: voiceCalls is a literal alias of spans at dispatch.
-    Any observation_type narrowing (e.g. limiting to conversation roots)
-    is the caller's responsibility via ``EvalTask.filters``.
+    Regression net for the earlier bug where ``row_type='voiceCalls'`` hit
+    the dispatcher's ``else`` branch (added in fb134ddf) and raised
+    ``ValueError`` — covered by the status-transitions test below.
     """
 
-    def test_dispatches_same_spans_as_spans_path(
+    def test_dispatches_only_conversation_root_spans(
         self,
-        populated_observe_project,
+        populated_voice_project,
         voice_call_eval_task,
         stub_run_eval,
         stub_cost_log,
         inline_temporal,
     ):
-        """voiceCalls fan-out matches the spans path on the same project."""
+        """Only spans where parent_span_id IS NULL AND observation_type='conversation' are evaluated."""
         task = voice_call_eval_task["task"]
 
         process_eval_task._original_func(str(task.id))
 
         rows = EvalLogger.objects.filter(eval_task_id=str(task.id), deleted=False)
-        # populated_observe_project has 2 sessions × 2 traces × 3 spans = 12
-        # spans × 1 eval -> 12 EvalLogger rows (no observation_type narrowing).
-        assert rows.count() == 12
-        expected_ids = {s.id for s in populated_observe_project["spans"]}
-        assert {r.observation_span_id for r in rows} == expected_ids
+        # Fixture has one conversation-root span (``conv_root``). The other
+        # roots are non-conversation; ``conv_child`` is conversation-typed
+        # but has a parent — neither qualifies.
+        assert rows.count() == 1
+        assert {r.observation_span_id for r in rows} == {
+            populated_voice_project["conv_root"].id
+        }
 
-    def test_status_transitions_match_spans_path(
+    def test_date_range_binds_to_start_time(
         self,
-        populated_observe_project,
+        populated_voice_project,
+        voice_call_eval_task,
+        stub_run_eval,
+        stub_cost_log,
+        inline_temporal,
+    ):
+        """``date_range`` filters voiceCalls on ``start_time`` (not ``created_at``).
+
+        Force a second conversation root whose ``start_time`` falls outside
+        the saved window. The dispatcher must dispatch only the in-window
+        span — even though both rows were ``created_at`` ~now.
+        """
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        project = populated_voice_project["project"]
+        anchor = populated_voice_project["anchor"]
+        # Past-window conversation root: start_time well before the window.
+        past_start = anchor - timedelta(days=30)
+        out_of_window = ObservationSpan.objects.create(
+            id="vc_conv_root_past",
+            project=project,
+            trace=Trace.objects.create(
+                project=project, name="Trace past", input={}, output={}, metadata={}
+            ),
+            parent_span_id=None,
+            name="Span past conversation",
+            observation_type="conversation",
+            start_time=past_start,
+            end_time=past_start + timedelta(seconds=1),
+            input={}, output={},
+            span_attributes={"input": {"value": "past"}, "output": {"value": "past"}},
+            model="gpt-4",
+            status="OK",
+        )
+
+        # Window covers only ``anchor`` (today's conv_root), not ``past_start``.
+        window_start = (anchor - timedelta(hours=1)).isoformat()
+        window_end = (anchor + timedelta(hours=1)).isoformat()
+        task = voice_call_eval_task["task"]
+        task.filters = {
+            "project_id": str(project.id),
+            "date_range": [window_start, window_end],
+        }
+        task.save(update_fields=["filters", "updated_at"])
+
+        process_eval_task._original_func(str(task.id))
+
+        dispatched = {
+            r.observation_span_id
+            for r in EvalLogger.objects.filter(
+                eval_task_id=str(task.id), deleted=False
+            )
+        }
+        # Only the in-window conversation root is dispatched. The past
+        # span is excluded by the start_time filter; the present non-
+        # conversation roots are excluded by observation_type narrowing.
+        assert dispatched == {populated_voice_project["conv_root"].id}
+        assert out_of_window.id not in dispatched
+
+    def test_status_transitions(
+        self,
+        populated_voice_project,
         voice_call_eval_task,
         stub_run_eval,
         stub_cost_log,

--- a/futureagi/tracer/types/eval_cluster_types.py
+++ b/futureagi/tracer/types/eval_cluster_types.py
@@ -32,3 +32,14 @@ class EvalClusteringSummary:
     clustered: int = 0
     new_clusters: int = 0
     assigned: int = 0
+
+
+@dataclass
+class EvalClusterMeta:
+    """Cheap-LLM-derived metadata for an eval cluster. Any field may be
+    None — the caller falls back per field (title -> first-sentence,
+    severity -> default priority, fix_layer -> unset)."""
+
+    title: Optional[str] = None
+    fix_layer: Optional[str] = None  # Tools|Prompt|Orchestration|Guardrails
+    severity: Optional[str] = None  # critical|high|medium|low

--- a/futureagi/tracer/utils/eval_tasks.py
+++ b/futureagi/tracer/utils/eval_tasks.py
@@ -133,10 +133,16 @@ def compute_drain_state(eval_task, eval_task_logger=None):
     }
 
 
-def parsing_evaltask_filters(filters: dict) -> Q:
+def parsing_evaltask_filters(filters: dict, *, time_field: str = "created_at") -> Q:
     """
     Parses the input filters dictionary and returns a single combined Q object
     for Django ORM filtering.
+
+    ``time_field`` controls which column ``date_range`` / ``created_at`` keys
+    bind to. Defaults to ``created_at`` (matches the historical spans/traces/
+    sessions and monitor callers); the voice-call dispatcher passes
+    ``start_time`` so the window matches what ``list_voice_calls`` returns
+    (call timing, not ingest time).
     """
     combined_q = Q()
 
@@ -167,9 +173,9 @@ def parsing_evaltask_filters(filters: dict) -> Q:
         elif key == "date_range":
             if isinstance(value, list) and len(value) == 2:
                 start_date, end_date = value
-                combined_q &= Q(created_at__range=[start_date, end_date])
+                combined_q &= Q(**{f"{time_field}__range": [start_date, end_date]})
         elif key == "created_at":
-            combined_q &= Q(created_at__gte=value)
+            combined_q &= Q(**{f"{time_field}__gte": value})
         elif key == "project_id":
             combined_q &= Q(project_id=value)
 
@@ -236,19 +242,17 @@ def process_eval_task(eval_task_id: str):
                 eval_task=eval_task, status=EvalTaskStatus.RUNNING, spanids_processed=[]
             )
 
-        filters = Q()
-        if eval_task.filters is not None:
-            filters = parsing_evaltask_filters(eval_task.filters)
-
         # Branch the candidate queryset and dispatch activity on
         # row_type. The rest of the function operates on ``entity_qs``
         # (a Django queryset of the entities we'll evaluate) and
-        # ``dispatch`` (the activity to fan out to). The span path stays
-        # the original behaviour. The ``spanids_processed`` JSONField
-        # stores the processed entity ids generically — its name is
-        # historical (it once held only span ids); a future rename to
+        # ``dispatch`` (the activity to fan out to). The ``spanids_processed``
+        # JSONField stores the processed entity ids generically — its name
+        # is historical (it once held only span ids); a future rename to
         # ``processed_target_ids`` is intentionally deferred so this PR
         # stays focused on dispatcher behaviour.
+        raw_filters = eval_task.filters or {}
+        filters = parsing_evaltask_filters(raw_filters)
+
         if eval_task.row_type == RowType.TRACES:
             # A trace is in scope iff at least one of its spans matches
             # the existing span-level filters.
@@ -277,11 +281,26 @@ def process_eval_task(eval_task_id: str):
             )
             entity_qs = TraceSession.objects.filter(id__in=matching_session_ids)
             dispatch = evaluate_trace_session_observe
-        elif eval_task.row_type in (RowType.SPANS, RowType.VOICE_CALLS):
-            # Voice calls share the spans dispatch — the picker layer
-            # already aliases voiceCalls→spans (observation_span.py:2890),
-            # and any conversation-type narrowing the user wants comes
-            # through ``filters`` like every other span query.
+        elif eval_task.row_type == RowType.VOICE_CALLS:
+            # A voice call is the root conversation span of a trace.
+            # Mirrors list_voice_calls (CH ``VoiceCallListQueryBuilder``)
+            # so the eval evaluates exactly the population the user sees
+            # in the voice-call list view:
+            #   * ``parent_span_id IS NULL`` + ``observation_type='conversation'``
+            #     — root conversation span only
+            #   * ``date_range`` binds to ``start_time`` (call timing), not
+            #     ``created_at`` (ingest time)
+            # See ``futureagi/tracer/services/clickhouse/query_builders/
+            # voice_call_list.py:120-124`` for the canonical CH query.
+            filters = parsing_evaltask_filters(raw_filters, time_field="start_time")
+            entity_qs = ObservationSpan.objects.filter(
+                filters,
+                parent_span_id__isnull=True,
+                observation_type="conversation",
+            )
+            dispatch = evaluate_observation_span_observe
+        elif eval_task.row_type == RowType.SPANS:
+            # Every span matching ``filters`` — no observation_type narrowing.
             entity_qs = ObservationSpan.objects.filter(filters)
             dispatch = evaluate_observation_span_observe
         else:


### PR DESCRIPTION
## Summary

- Voice-call eval tasks were evaluating a superset of what the voice-call list view shows. The dispatcher branched `RowType.VOICE_CALLS` through the spans path with no narrowing, so every span whose `span_attributes` matched the filter was dispatched — including non-root and non-conversation spans.
- Align the PG voice-call path with `list_voice_calls` (CH `VoiceCallListQueryBuilder`) semantics: narrow to `parent_span_id IS NULL AND observation_type='conversation'`, and bind `date_range` to `start_time` instead of `created_at`.
- `RowType.SPANS` behaviour is unchanged.

Paired with #549 (same branch, targeting `dev`).

## What changed

`futureagi/tracer/utils/eval_tasks.py`
- Split the SPANS/VOICE_CALLS dispatcher branch in `process_eval_task`. VOICE_CALLS now filters to root conversation spans and uses `start_time` for date_range.
- `parsing_evaltask_filters` takes a `time_field` kwarg (default `created_at`) so monitor and trace/session/spans callers stay on the historical column.

`futureagi/tracer/tests/test_eval_task_runtime.py`
- New `populated_voice_project` fixture (1 conversation root + child, 1 llm root).
- `TestProcessEvalTaskVoiceCalls` now pins: root-conversation narrowing, `start_time`-bound date_range, unchanged drain semantics.

## Repro / investigation

For prod task `f466cf5c-70ea-4bed-af4c-707c75c5642a` (filter: `ended_reason not_contains voicemail`):
- `list_voice_calls` API (CH path): **39 calls**.
- Eval task before fix (PG, no narrowing): **116 spans** processed.
- PG count after applying the new narrowing matches the conversation-root population.

Note: existing tasks stored with `row_type='spans'` on voice projects (e.g. those created via API without `row_type`, which defaults to `SPANS`) need a one-shot `UPDATE tracer_eval_task SET row_type='voiceCalls' WHERE id='...'` to pick up the new narrowing. This PR doesn't backfill that — flagged as an ops correction.

There's a separate, out-of-scope finding: the CH `span_attr_str` MV is missing `ended_reason` for ~77 of the 116 traces in this project, which makes `list_voice_calls` itself undercount against PG. That's a CH data-quality issue; tracking separately.

## Test plan

- [x] `uv run pytest tracer/tests/test_eval_task_runtime.py` — 40/40 passed locally
- [x] `uv run pytest tracer/tests/test_eval_task.py` — 32/32 passed locally
- [ ] On staging: create a voice-call eval task on a voice project, confirm the dispatched count matches the `list_voice_calls` count for the same filter.
- [ ] Spot-check a SPANS task on the same fixture data — count unchanged (no narrowing applied for `row_type='spans'`).