### PR TITLE
[TH-5336] fix(error-feed): stamp module=project on voice drawer payload

### DIFF
--- a/frontend/src/pages/dashboard/error-feed/components/TracesTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/TracesTab.jsx
@@ -339,11 +339,7 @@ export default function TracesTab({ error }) {
                       project_id: projectId,
                       module: "project",
                     }
-                  : {
-                      trace_id: drawerTraceId,
-                      project_id: projectId,
-                      module: "project",
-                    }
+                  : { trace_id: drawerTraceId, project_id: projectId }
               }
               onClose={() => setDrawerTraceId(null)}
               onPrev={handlePrev}

--- a/frontend/src/pages/dashboard/error-feed/components/TracesTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/TracesTab.jsx
@@ -334,8 +334,16 @@ export default function TracesTab({ error }) {
             <VoiceDetailDrawerV2
               data={
                 voiceCallData
-                  ? { ...voiceCallData, project_id: projectId }
-                  : { trace_id: drawerTraceId, project_id: projectId }
+                  ? {
+                      ...voiceCallData,
+                      project_id: projectId,
+                      module: "project",
+                    }
+                  : {
+                      trace_id: drawerTraceId,
+                      project_id: projectId,
+                      module: "project",
+                    }
               }
               onClose={() => setDrawerTraceId(null)}
               onPrev={handlePrev}


### PR DESCRIPTION
## Summary
- Add `module: "project"` to the data passed into `VoiceDetailDrawerV2` from error-feed's `TracesTab`, matching the convention used by `VoiceFullPage`, `VoiceCallsGrid`, `SharedVoiceView`, and `LLMTracingView`.
- Fixes "No recording found — silence-timed-out" rendering for every voice trace opened from the error-feed Traces tab, even when `voice_call_detail` returned valid recording URLs.
- Also restores tag-chip fetch (`CallDetailsBar`) and `vapi_call_id` log-filter (`VoiceLogsView`) which were silently degraded by the same missing stamp.

Mudflap-demo blocker — flagged in the [#frontmen thread](https://futureagi.slack.com/archives/C07JYLG0XMX/p1779186025192379).

Closes TH-5336

## Linear Ticket
[TH-5336](https://linear.app/future-agi/issue/TH-5336/bugfix-voice-recording-missing-in-error-feed-traces-tab-drawer)

## Video added in ticket  [TH-5336](https://linear.app/future-agi/issue/TH-5336/bugfix-voice-recording-missing-in-error-feed-traces-tab-drawer)

## Root cause
`AudioPlayerCustom` branches on `data.module === "project"` to pick between two historical voice-payload shapes:
- Project shape (`voice_call_detail`): singular `data.recording` + `data.recordingAvailable`
- Other shape (simulate test-execution): plural `data.recordings` + `data.audioUrl`

The error-feed `TracesTab.jsx` integration (added in `09fe1f840`, 2026-05-06) missed the stamp — error-feed voice payloads fell into the non-project branch, looked for `data.recordings`, and rendered the empty state. The same `module === "project"` gate is also relied on by `CallDetailsBar` (trace-tags fallback) and `VoiceLogsView` (`vapi_call_id` log filter).

## Files Changed
- `frontend/src/pages/dashboard/error-feed/components/TracesTab.jsx` — 1 file, +10/-2

## Test plan
- [x] in error feed trace detail drawer with recording url -- recordings render
- [x] trace detail drawer for chat still works -- regression test 
- [x] trace detail drawer for voice still works -- regression test