### PR TITLE
[TH-5339] fix(tasks): render span-attribute filter chip from columnId/filterConfig

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
+++ b/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
@@ -5,7 +5,6 @@ import {
   Chip,
   IconButton,
   Popover,
-  Tooltip,
   Typography,
 } from "@mui/material";
 import { formatDistanceToNow } from "date-fns";
@@ -214,10 +213,19 @@ const buildFilterChips = (filtersApplied) => {
   }
   if (filtersApplied.spanAttributesFilters?.length) {
     filtersApplied.spanAttributesFilters.forEach((f) => {
-      const key = f.key || f.field || f.name;
-      const op = f.operator || f.op || "=";
-      const val = f.value ?? "";
-      chips.push(`${key} ${op} ${val}`);
+      const key = f.columnId || f.column_id;
+      if (!key) return;
+      const op =
+        f.filterConfig?.filterOp || f.filter_config?.filter_op || "equals";
+      const rawVal =
+        f.filterConfig?.filterValue ?? f.filter_config?.filter_value;
+      const val = Array.isArray(rawVal) ? rawVal.join(", ") : (rawVal ?? "");
+      const isValuelessOp = op === "is_null" || op === "is_not_null";
+      chips.push(
+        isValuelessOp
+          ? `${key} ${op.replace(/_/g, " ")}`
+          : `${key} ${op} ${val}`,
+      );
     });
   }
   if (filtersApplied.project_id) {


### PR DESCRIPTION
## Summary
- `buildFilterChips` in `TaskListView.jsx` was reading a flat filter shape (`f.key`, `f.operator`, `f.value`) that never matched the actual API payload, so every span-attribute filter row rendered as `undefined =` on `/dashboard/tasks`.
- Read the nested shape — `columnId` + `filterConfig.filterOp` / `filterConfig.filterValue` — with snake_case fallbacks so the chip survives the axios interceptor being scoped down.
- Handle array `filterValue` for `in` / `not_in` ops (joined by `, `).
- Hide the trailing value for `is_null` / `is_not_null` so chips read like `"llm.provider is null"`, not `"llm.provider is_null "`.
- Drop unused `Tooltip` import while here.

Flagged by @atharva-bhange in [this Slack message](https://futureagi.slack.com/archives/C07JYLG0XMX/p1779180834347459?thread_ts=1779179241.751999&cid=C07JYLG0XMX): *"iska undefined wali chiz dekhlena"*.

Closes TH-5339

## Linear Ticket
[TH-5339](https://linear.app/future-agi/issue/TH-5339/bugfix-tasks-list-span-attribute-filter-chip-shows-undefined)

## Related PR
[#493](https://github.com/future-agi/future-agi/pull/493) (TH-5230) — touches the same file (`TaskListView.jsx`, `HoverChipList` hover/popover persistence). Good to merge alongside this PR; minor textual rebase only since the changes are in different functions (`HoverChipList` vs `buildFilterChips`).

## Root cause
`buildFilterChips` was introduced in core-frontend commit `6b9241791` ("wip: evals revamp + observe + on-demand error localization", 2026-04-13). The author guessed the filter shape (`f.key || f.field || f.name`, `f.operator || f.op`, `f.value`) without referencing the actual API response. The span-attribute branch has never produced a correct chip since the day it landed — the previous version of the function just said `"1 attr filter(s)"`.

Confirmed via runtime debug log of `filtersApplied` — span-attribute rows arrive as:
```js
{
  columnId: "llm.provider",
  filterConfig: { filterOp: "is_null", filterValue: "" }
}
```

The function is private to `TaskListView` (only `FilterSummary` calls it), no test coverage, no other consumers of the broken string format — scope is local.

## Files Changed
- `frontend/src/sections/common/EvalsTasks/TaskListView.jsx`

## Test plan
- [x] Open `/dashboard/tasks` for a project with span-attribute filters → chip shows `<columnId> <op> <value>`, no `undefined`.
- [x] Filter with `filter_op: "is_null"` → chip reads `"llm.provider is null"` (no trailing value).
- [x] Filter with `filter_op: "in"` and array `filter_value` → values joined by `, `.
- [x] Date / Type / Project chips unchanged.
- [x] Hover popover still lists all chips correctly.