### PR TITLE
fix(eval-clustering): bound clustering to last 60 days of eval failures

### DIFF
--- a/futureagi/tracer/queries/eval_clustering.py
+++ b/futureagi/tracer/queries/eval_clustering.py
@@ -10,6 +10,7 @@ within the same eval, never across different evals.
 
 import hashlib
 import re
+from datetime import timedelta
 from typing import List, Optional, Tuple
 
 import structlog
@@ -33,6 +34,10 @@ logger = structlog.get_logger(__name__)
 CENTROIDS_TABLE = "cluster_centroids"  # shared with scanner — different family values
 COSINE_THRESHOLD = 0.45
 
+# Only cluster recent eval failures — old results aren't actionable and
+# bound the per-run work unit.
+_CLUSTER_WINDOW_DAYS = 60
+
 
 # ---------------------------------------------------------------------------
 # Fetch unclustered failing eval results
@@ -48,6 +53,7 @@ def get_unclustered_eval_results(
 
     "Failed" = output_bool is False OR output_float < 1.0.
     Skips rows with null eval_explanation (deterministic evals without reasoning).
+    Only the last _CLUSTER_WINDOW_DAYS of results are considered.
 
     ``limit`` bounds the returned batch (oldest-first). The caller drains a
     large backlog over successive bounded runs so a single clustering
@@ -71,6 +77,7 @@ def get_unclustered_eval_results(
             trace__project_id=project_id,
             target_type="span",
             custom_eval_config__isnull=False,
+            created_at__gte=timezone.now() - timedelta(days=_CLUSTER_WINDOW_DAYS),
         )
         .filter(
             Q(output_bool=False) | Q(output_float__lt=1.0),

--- a/futureagi/tracer/tests/test_eval_clustering_window.py
+++ b/futureagi/tracer/tests/test_eval_clustering_window.py
@@ -1,0 +1,83 @@
+"""
+Tests for the recency window on eval clustering.
+
+get_unclustered_eval_results must only return eval failures from the last
+_CLUSTER_WINDOW_DAYS — old failures aren't actionable and an unbounded
+history is what let the clustering work unit balloon.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from tracer.models.observation_span import EvalLogger
+from tracer.queries.eval_clustering import (
+    _CLUSTER_WINDOW_DAYS,
+    get_unclustered_eval_results,
+)
+
+
+def _make_failing_eval(trace, span, cfg, explanation, age_days):
+    """Create a failing span eval and backdate created_at by age_days.
+
+    created_at is auto_now_add, so it must be set via a direct UPDATE.
+    """
+    ev = EvalLogger.objects.create(
+        trace=trace,
+        observation_span=span,
+        custom_eval_config=cfg,
+        target_type="span",
+        output_bool=False,
+        eval_explanation=explanation,
+    )
+    EvalLogger.objects.filter(pk=ev.pk).update(
+        created_at=timezone.now() - timedelta(days=age_days)
+    )
+    return ev
+
+
+@pytest.mark.django_db
+def test_window_excludes_old_includes_recent(
+    project, trace, observation_span, custom_eval_config
+):
+    old_exp = "old failing eval - outside the window"
+    new_exp = "recent failing eval - inside the window"
+
+    _make_failing_eval(
+        trace, observation_span, custom_eval_config,
+        old_exp, age_days=_CLUSTER_WINDOW_DAYS + 30,
+    )
+    _make_failing_eval(
+        trace, observation_span, custom_eval_config,
+        new_exp, age_days=1,
+    )
+
+    explanations = {
+        r.explanation for r in get_unclustered_eval_results(str(project.id))
+    }
+
+    assert new_exp in explanations, "recent failure must be clustered"
+    assert old_exp not in explanations, "stale failure must be excluded"
+
+
+@pytest.mark.django_db
+def test_boundary_just_inside_window_is_included(
+    project, trace, observation_span, custom_eval_config
+):
+    exp = "failure just inside the window boundary"
+    _make_failing_eval(
+        trace, observation_span, custom_eval_config,
+        exp, age_days=_CLUSTER_WINDOW_DAYS - 1,
+    )
+
+    explanations = {
+        r.explanation for r in get_unclustered_eval_results(str(project.id))
+    }
+    assert exp in explanations
+
+
+@pytest.mark.unit
+def test_window_constant_unchanged():
+    """Guards against an accidental edit to the recency window."""
+    assert _CLUSTER_WINDOW_DAYS == 60


### PR DESCRIPTION
## What
`get_unclustered_eval_results` now only considers `EvalLogger` rows from the last **60 days** (`_CLUSTER_WINDOW_DAYS`).

## Why
- Old eval failures aren't actionable — the agent/prompt has moved on; nobody fixes a 4-month-old failure from the feed.
- Unbounded history is what let the clustering work unit balloon (the TH-4789 incident class). The `limit`/bounded-iterator from TH-4789 caps a single run; this caps the *total* candidate set.
- Tighter than, and consistent with, the existing ~90-day effective ceiling (60 ⊂ 90 — no behavior conflict, just a smaller, fresher work unit).

## Scope
One filter + one named constant + docstring. No change to clustering math, embeddings, or the title/meta path.