### PR TITLE
Enabling list voice call to handle errors as well

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
@@ -217,17 +217,38 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
             "eval_config_ids": tuple(self.eval_config_ids),
         }
 
+        # Include errored rows but compute aggregates only over successful
+        # rows (error = 0). ``success_count`` / ``error_count`` let the
+        # pivot surface an explicit error state on the UI when every eval
+        # row for a (trace, config) pair errored.
+        # Column order must match what ``pivot_eval_results`` expects:
+        # trace_id, eval_config_id, avg_score, pass_rate, success_count,
+        # error_count, eval_count, str_lists.
         query = f"""
         SELECT
             trace_id,
             toString(custom_eval_config_id) AS eval_config_id,
-            -- ifNotFinite(, NULL): avg over an all-NULL group returns NaN, which
-            -- json.dumps(allow_nan=False) rejects. NULL serializes as null.
-            ifNotFinite(avg(output_float), NULL) AS avg_score,
-            ifNotFinite(avg(CASE WHEN output_bool = 1 THEN 100.0 ELSE 0.0 END), NULL)
-                AS pass_rate,
+            -- ifNotFinite(, NULL): avgIf over an all-NULL group returns NaN,
+            -- which json.dumps(allow_nan=False) rejects. NULL serializes as null.
+            ifNotFinite(avgIf(
+                output_float,
+                error = 0 AND ifNull(output_str, '') != 'ERROR'
+            ), NULL) AS avg_score,
+            ifNotFinite(avgIf(
+                CASE WHEN output_bool = 1 THEN 100.0 ELSE 0.0 END,
+                error = 0 AND ifNull(output_str, '') != 'ERROR'
+            ), NULL) AS pass_rate,
+            countIf(
+                error = 0 AND ifNull(output_str, '') != 'ERROR'
+            ) AS success_count,
+            countIf(
+                error = 1 OR ifNull(output_str, '') = 'ERROR'
+            ) AS error_count,
             count() AS eval_count,
-            any(output_str_list) AS output_str_list
+            groupArrayIf(
+                output_str_list,
+                error = 0 AND ifNull(output_str, '') != 'ERROR'
+            ) AS str_lists
         FROM {self.EVAL_TABLE} FINAL
         WHERE _peerdb_is_deleted = 0
           AND trace_id IN %(trace_ids)s

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -103,7 +103,9 @@ class TestClickHouseSchema:
         assert "allow_nullable_key = 1" in CDC_EVAL_LOGGER
 
         # New TRACE_SESSION_DICT exists and points at the trace_session table
-        assert "CREATE DICTIONARY IF NOT EXISTS trace_session_dict" in TRACE_SESSION_DICT
+        assert (
+            "CREATE DICTIONARY IF NOT EXISTS trace_session_dict" in TRACE_SESSION_DICT
+        )
         assert "trace_session" in TRACE_SESSION_DICT
         assert "project_id UUID" in TRACE_SESSION_DICT
 
@@ -996,9 +998,7 @@ class TestClickHouseFilterBuilder:
         assert "output_float IS NOT NULL" in where
 
     @pytest.mark.django_db
-    def test_translate_pass_fail_eval_filter_uses_output_bool(
-        self, custom_eval_config
-    ):
+    def test_translate_pass_fail_eval_filter_uses_output_bool(self, custom_eval_config):
         """Pass/fail evals must use output_bool, not stale mixed fields."""
         from tracer.services.clickhouse.query_builders.filters import (
             ClickHouseFilterBuilder,
@@ -5227,7 +5227,7 @@ class TestVoiceCallListQueryBuilder:
         )
         query, params = builder.build_eval_query(["trace-1", "trace-2"])
         assert "tracer_eval_logger" in query
-        assert "avg(output_float)" in query
+        assert "avgIf" in query
         assert params["trace_ids"] == ("trace-1", "trace-2")
         assert params["eval_config_ids"] == ("eval-1", "eval-2")
 
@@ -5244,6 +5244,118 @@ class TestVoiceCallListQueryBuilder:
         query, params = builder.build_eval_query([])
         assert query == ""
         assert params == {}
+
+    def test_eval_query_filters_errored_rows(self):
+        """Eval query should exclude errored rows from score aggregation."""
+        from tracer.services.clickhouse.query_builders.voice_call_list import (
+            VoiceCallListQueryBuilder,
+        )
+
+        builder = VoiceCallListQueryBuilder(
+            project_id="proj-1",
+            eval_config_ids=["eval-1"],
+        )
+        query, _ = builder.build_eval_query(["trace-1"])
+        assert "error = 0" in query
+        assert "success_count" in query
+        assert "error_count" in query
+
+    def test_eval_query_returns_8_columns(self):
+        """Eval query should return all 8 columns expected by pivot_eval_results."""
+        from tracer.services.clickhouse.query_builders.voice_call_list import (
+            VoiceCallListQueryBuilder,
+        )
+
+        builder = VoiceCallListQueryBuilder(
+            project_id="proj-1",
+            eval_config_ids=["eval-1"],
+        )
+        query, _ = builder.build_eval_query(["trace-1"])
+        for col_name in [
+            "avg_score",
+            "pass_rate",
+            "success_count",
+            "error_count",
+            "eval_count",
+            "str_lists",
+        ]:
+            assert col_name in query, f"Missing column: {col_name}"
+
+    def test_pivot_eval_results_all_errored(self):
+        """When all evals errored, pivot should return error marker."""
+        from tracer.services.clickhouse.query_builders.trace_list import (
+            TraceListQueryBuilder,
+        )
+
+        rows = [
+            ("t1", "cfg-1", None, None, 0, 3, 3, []),
+        ]
+        columns = [
+            "trace_id",
+            "eval_config_id",
+            "avg_score",
+            "pass_rate",
+            "success_count",
+            "error_count",
+            "eval_count",
+            "str_lists",
+        ]
+        result = TraceListQueryBuilder.pivot_eval_results(rows, columns)
+        assert result["t1"]["cfg-1"] == {"error": True}
+
+    def test_pivot_eval_results_partial_errors(self):
+        """When some evals succeed and some error, should return scores not error."""
+        from tracer.services.clickhouse.query_builders.trace_list import (
+            TraceListQueryBuilder,
+        )
+
+        rows = [
+            ("t1", "cfg-1", 0.75, None, 2, 1, 3, []),
+        ]
+        columns = [
+            "trace_id",
+            "eval_config_id",
+            "avg_score",
+            "pass_rate",
+            "success_count",
+            "error_count",
+            "eval_count",
+            "str_lists",
+        ]
+        result = TraceListQueryBuilder.pivot_eval_results(rows, columns)
+        assert result["t1"]["cfg-1"]["avg_score"] == 75.0
+        assert "error" not in result["t1"]["cfg-1"]
+
+    def test_pivot_eval_results_error_with_dict_rows(self):
+        """Error detection should work with dict-style rows from CH client."""
+        from tracer.services.clickhouse.query_builders.trace_list import (
+            TraceListQueryBuilder,
+        )
+
+        rows = [
+            {
+                "trace_id": "t1",
+                "eval_config_id": "cfg-1",
+                "avg_score": None,
+                "pass_rate": None,
+                "success_count": 0,
+                "error_count": 5,
+                "eval_count": 5,
+                "str_lists": [],
+            }
+        ]
+        columns = [
+            "trace_id",
+            "eval_config_id",
+            "avg_score",
+            "pass_rate",
+            "success_count",
+            "error_count",
+            "eval_count",
+            "str_lists",
+        ]
+        result = TraceListQueryBuilder.pivot_eval_results(rows, columns)
+        assert result["t1"]["cfg-1"] == {"error": True}
 
     def test_annotation_query(self):
         """Phase 3 annotation query should filter by trace_ids and label_ids."""

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -13,6 +13,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.db import models
 from django.db.models import (
     Avg,
+    BooleanField,
     Case,
     CharField,
     Count,
@@ -1224,7 +1225,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
 
             metric_subquery = (
                 EvalLogger.objects.filter(
-                    trace_id=OuterRef("id"), custom_eval_config_id=config.id
+                    trace_id=OuterRef("id"),
+                    custom_eval_config_id=config.id,
+                    error=False,
                 )
                 .values("custom_eval_config_id")
                 .annotate(
@@ -1248,6 +1251,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 trace_id=OuterRef("id"),
                 custom_eval_config_id=config.id,
                 output_str_list__isnull=False,
+                error=False,
             ).values("output_str_list")[:1]
 
             base_query = base_query.annotate(
@@ -1327,7 +1331,27 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     f"metric_reason_{config.id}": Subquery(
                         metric_subquery.values("eval_explanation")
                     ),
-                    f"error_{config.id}": Subquery(metric_subquery.values("error")),
+                    f"error_{config.id}": Case(
+                        When(
+                            ~Exists(
+                                EvalLogger.objects.filter(
+                                    trace_id=OuterRef("id"),
+                                    custom_eval_config_id=config.id,
+                                    error=False,
+                                )
+                            )
+                            & Exists(
+                                EvalLogger.objects.filter(
+                                    trace_id=OuterRef("id"),
+                                    custom_eval_config_id=config.id,
+                                    error=True,
+                                )
+                            ),
+                            then=Value(True),
+                        ),
+                        default=Value(False),
+                        output_field=BooleanField(),
+                    ),
                 }
             )
         return eval_configs, base_query
@@ -5265,6 +5289,11 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                         ) or {}
                         output_type = eval_template_config.get("output", "score")
                         metric_entry = {"name": metric_name, "output_type": output_type}
+                        # All eval rows errored — surface error to frontend
+                        if isinstance(scores, dict) and scores.get("error"):
+                            metric_entry["error"] = True
+                            metrics[config_id] = metric_entry
+                            continue
                         if isinstance(scores, dict):
                             if scores.get("per_choice"):
                                 metric_entry["output"] = [


### PR DESCRIPTION
## Summary

When an eval errors (`EvalLogger.error = True`) for a span-eval combo, the voice call list APIs were not surfacing `error: true` to the frontend. This caused two problems:

1. **ClickHouse path**: Errored eval rows were included in score averages (polluting results), and fully-errored evals showed as blank instead of an explicit "Error" state.
2. **PostgreSQL path**: The error annotation used a single-row `Subquery` instead of an aggregate check, and errored rows were not excluded from `Avg()` aggregation.

The frontend already has renderers (`EvalCellRenderer`, `EvaluationCell`) that display red "Error" badges when they receive `error: true` — but the backend was never sending it for voice calls.

## What changed and why

### 1. ClickHouse eval query (`voice_call_list.py`)
- **What**: Replaced `avg()` with `avgIf(..., error = 0)` to exclude errored rows from score aggregation. Added `success_count` and `error_count` columns. Changed `any(output_str_list)` to `groupArrayIf(..., error = 0) AS str_lists`.
- **Why**: The query now produces the same 8-column result set as `TraceListQueryBuilder.build_eval_query` (the trace list reference implementation). Previously it returned 6 columns with different names, causing `pivot_eval_results` to misinterpret positional indices — so the `success_count == 0 and error_count > 0` error detection never fired.

### 2. ClickHouse inline eval assembly (`trace.py` — `_list_voice_calls_clickhouse`)
- **What**: Added an early check for `scores.get("error")` before the existing score-processing branches, setting `metric_entry["error"] = True`.
- **Why**: When `pivot_eval_results` returns `{"error": True}` for a fully-errored (trace, config) pair, this ensures the frontend receives `error: true` at the top level of the metric entry (which `EvalCellRenderer` checks via `evalData?.error`).

### 3. PostgreSQL eval aggregation (`trace.py` — `get_eval_configs`)
- **What**: Added `error=False` filter to `metric_subquery` and `str_list_subquery`. Replaced the `error_{config.id}` single-row `Subquery` with a `Case/When/Exists` aggregate check (true only when ALL eval rows have errored AND at least one exists).
- **Why**: Previously, errored rows with non-null output values polluted `Avg()` scores, and the error flag picked one arbitrary row's state instead of computing aggregate error status.

### 4. Import addition (`trace.py`)
- Added `BooleanField` to Django model imports (needed for the new `error_{config.id}` `Case` annotation's `output_field`).

## Test scenarios covered

| Scenario | What it verifies |
|----------|-----------------|
| Eval query filters errored rows | CH query contains `error = 0` condition, `success_count`, and `error_count` columns |
| Eval query returns 8 columns | All 8 columns expected by `pivot_eval_results` are present: `avg_score`, `pass_rate`, `success_count`, `error_count`, `eval_count`, `str_lists` |
| All evals errored (tuple rows) | When `success_count=0` and `error_count>0`, `pivot_eval_results` returns `{"error": True}` |
| Partial errors (tuple rows) | When some evals succeed and some error, returns normal scores with no error flag |
| All evals errored (dict rows) | Same as all-errored but with dict-style rows (the format returned by the ClickHouse client) |

## List of test cases

**Updated:**
- `TestVoiceCallListQueryBuilder::test_eval_query` — assertion changed from `avg(output_float)` to `avgIf` to match the new error-filtered query

**Added:**
- `TestVoiceCallListQueryBuilder::test_eval_query_filters_errored_rows`
- `TestVoiceCallListQueryBuilder::test_eval_query_returns_8_columns`
- `TestVoiceCallListQueryBuilder::test_pivot_eval_results_all_errored`
- `TestVoiceCallListQueryBuilder::test_pivot_eval_results_partial_errors`
- `TestVoiceCallListQueryBuilder::test_pivot_eval_results_error_with_dict_rows`

## How was this tested?


# All voice call query builder tests (61 passed)
python -m pytest tracer/tests/test_clickhouse.py -k "TestVoiceCallListQueryBuilder" -v

<img width="1512" height="982" alt="Screenshot 2026-05-19 at 7 40 38 PM" src="https://github.com/user-attachments/assets/76c1ce4c-20f4-4c68-857c-c9f4e3bf1b5e" />

# All pivot_eval_results tests (9 passed)
python -m pytest tracer/tests/test_clickhouse.py -k "test_pivot_eval_results" -v

<img width="1391" height="312" alt="Screenshot 2026-05-19 at 7 41 42 PM" src="https://github.com/user-attachments/assets/7ac36e99-8a11-4181-84dc-1c3ab38d7430" />


# All clickhouse unit tests (419 passed, 8 pre-existing DB-dependent errors unrelated to this PR)
python -m pytest tracer/tests/test_clickhouse.py -v

# All tracer unit tests (876 passed)
python -m pytest tracer/tests/ -m "unit" --ignore=tracer/tests/test_datetime_filters.py


## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

##Linear
Fixes TH-5341

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] No hardcoded secrets, URLs, or PII
- [x] No frontend changes needed — existing `EvalCellRenderer` and `EvaluationCell` already handle `error: true`