### PR TITLE
seed system evals as LLM-as-a-Judge in OSS mode

### DIFF
--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -210,8 +210,15 @@ def _yaml_to_template_fields(eval_def):
     """Convert a YAML eval definition dict into EvalTemplate field values."""
     from model_hub.models.choices import OwnerChoices
 
+    from tfc.ee_gating import is_oss
+
     track = eval_def.get("_track", "agent")
-    eval_type_map = {"function": "code", "agent": "agent", "specialty": "agent"}
+    # In OSS, agent evals run as LLM-as-a-Judge (CustomPromptEvaluator)
+    # since AgentEvaluator requires the ee module.
+    if is_oss():
+        eval_type_map = {"function": "code", "agent": "llm", "specialty": "llm"}
+    else:
+        eval_type_map = {"function": "code", "agent": "agent", "specialty": "agent"}
 
     # Build config dict
     config = eval_def.get("config", {})
@@ -225,7 +232,10 @@ def _yaml_to_template_fields(eval_def):
     if track in ("agent", "specialty"):
         if "rule_prompt" not in config and eval_def.get("criteria"):
             config["rule_prompt"] = eval_def["criteria"]
-        config.setdefault("eval_type_id", "AgentEvaluator")
+        if is_oss():
+            config.setdefault("eval_type_id", "CustomPromptEvaluator")
+        else:
+            config.setdefault("eval_type_id", "AgentEvaluator")
 
     # Permissions
     permissions = eval_def.get("permissions", {})


### PR DESCRIPTION
## Summary

In OSS mode (no `ee/` plugin), all built-in system evals are currently seeded as `eval_type: agent` with `AgentEvaluator`, which depends on EE-only functionality. As a result, every eval fails in OSS with "Agent evaluations are not available on your plan", making system evals unusable outside EE.

This PR updates the eval seeder to detect OSS mode via `is_oss()` and seed system evals as `eval_type: llm` with `CustomPromptEvaluator` instead. The existing `rule_prompt` criteria from the YAML catalog work identically with `CustomPromptEvaluator` (single LLM call), so no catalog changes are required.

- New OSS installs automatically get `llm` system evals on first boot
- Existing OSS installs can migrate by running:

```bash
python manage.py seed_system_evals --force
```

EE environments remain unchanged and continue using `agent` + `AgentEvaluator`.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Ran `python manage.py seed_system_evals --force` in an OSS environment and confirmed evals were updated from `agent` → `llm`
- Verified API responses now return:
  - `eval_type: "llm"`
  - `config.eval_type_id: "CustomPromptEvaluator"`
- Confirmed EE environments are unaffected:
  - `is_oss()` returns `False`
  - Seeder continues using `agent` + `AgentEvaluator`

## Screenshots / recordings (if UI)

N/A — backend-only change with no UI modifications.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)