### PR TITLE
fix(evals): render Error badge for errored eval rows

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -244,6 +244,7 @@ const VoiceRightPanel = ({
         score,
         score_label: scoreLabel,
         explanation: e?.reason || e?.explanation,
+        error: e?.error === true,
         // Error localization fields — pulled from whatever key the
         // backend used. Makes the shared EvalsTabView render the
         // dropdown / "Run" UX for failed voice evals.

--- a/frontend/src/components/traceDetail/EvalsTabView.jsx
+++ b/frontend/src/components/traceDetail/EvalsTabView.jsx
@@ -60,6 +60,10 @@ export function collectAllEvalsFromEntry(entry) {
         spanId: s.id || spanId,
         spanName: s.name || "unnamed",
         spanType: s.observation_type || "unknown",
+        // Trace API writes "ERROR" into `result` instead of a dedicated error
+        // field (voice API uses `error: true`). Unify both into `error` so the
+        // shared EvalTableRow renderer only checks one signal.
+        error: ev?.error === true || ev?.result === "ERROR",
       });
     }
     if (e?.children?.length) {
@@ -96,11 +100,18 @@ export function scoreColor(score) {
 /** Single eval row with collapsible explanation + optional "View span" */
 const EvalTableRow = ({ ev, onSelectSpan, showSpanColumn, onFixWithFalcon }) => {
   const [expanded, setExpanded] = useState(false);
-  const sc = scoreColor(ev.score);
+  const hasError = ev?.error === true;
+  const sc = hasError
+    ? {
+        bg: (theme) => alpha(theme.palette.error.main, 0.08),
+        text: "error.main",
+      }
+    : scoreColor(ev.score);
   const evalName = ev.eval_name || ev.eval_config_id || "Eval";
   const explanation = ev.explanation || ev.eval_explanation;
-  const scoreLabel =
-    ev.score_label != null
+  const scoreLabel = hasError
+    ? "Error"
+    : ev.score_label != null
       ? ev.score_label
       : ev.score != null
         ? `${ev.score}%`


### PR DESCRIPTION
## Summary
Errored evals in the trace + voice drawer Evals tab rendered as `—` or `0%`, with no signal that the eval actually errored. Now renders a red `Error` chip.

## Why two paths
Backend surfaces eval errors differently per endpoint:
- **Voice** (`voice_call_detail`): `eval_outputs[id].error: true/false`
- **Trace** (`tracer/trace/{id}/`): `eval_scores[].result: "ERROR"` (no dedicated error field)

Unify both into a single `error` boolean on the canonical `EvalRow`, then short-circuit `EvalTableRow`.

## Changes
- `VoiceRightPanel.normalizedEvals` — pass `error: e?.error === true` through.
- `collectAllEvalsFromEntry` — compute `error: ev.error === true || ev.result === "ERROR"`.
- `EvalTableRow` — `hasError` short-circuit → red palette + literal `"Error"` text.

Matches the convention already used by the spans-list grid (`EvaluationCell.jsx`, `value.error === true`).

## Test plan
- [ ] Voice trace with `error: true` eval → red `Error` chip.
- [ ] Voice trace with `error: false, score: 0.8` → `80%` green (unchanged).
- [ ] Voice trace with `error: null, output: null` → `—` gray (unchanged).
- [ ] Trace with `result: "ERROR"` eval → red `Error` chip, error explanation visible on expand.
- [ ] Trace with `result: true, score: 100` → `100%` green (unchanged).

## Known follow-up
Summary counts (`totalPass` / `totalFail` / `passRate`) still bucket errored rows into "fail" when the backend writes a stale `score: 0` alongside `result: "ERROR"`. Visual chip is correct; only the `N/M passed` header is slightly off for trace-path errors. Not in scope here.