### PR TITLE
fix(observe): structured composite eval rendering + TH-5228 evals tab empty fix

### DIFF
--- a/frontend/src/components/traceDetail/EvalsTabView.jsx
+++ b/frontend/src/components/traceDetail/EvalsTabView.jsx
@@ -6,6 +6,7 @@ import Markdown from "react-markdown";
 import Iconify from "src/components/iconify";
 import { enqueueSnackbar } from "notistack";
 import EvalErrorLocalization from "./EvalErrorLocalization";
+import CompositeResultView from "src/sections/evals/components/CompositeResultView";
 
 // Kept locally so callers that don't supply an onFixWithFalcon handler still
 // see the informational toast — preserves pre-integration behavior.
@@ -259,26 +260,35 @@ const EvalTableRow = ({ ev, onSelectSpan, showSpanColumn, onFixWithFalcon }) => 
             gap: 1,
           }}
         >
-          {explanation && (
-            <Box
-              sx={{
-                fontSize: 11,
-                color: "text.secondary",
-                lineHeight: 1.6,
-                "& p": { m: 0, mb: 0.5 },
-                "& ul, & ol": { m: 0, pl: 2 },
-                "& li": { mb: 0.25 },
-                "& strong": { fontWeight: 600, color: "text.primary" },
-                "& code": {
-                  bgcolor: (theme) => alpha(theme.palette.text.disabled, 0.15),
-                  px: 0.5,
-                  borderRadius: "2px",
-                  fontSize: 10,
-                },
-              }}
-            >
-              <Markdown>{explanation}</Markdown>
-            </Box>
+          {/* Composite eval result — render the shared per-child card view
+              the dataset experiment surface uses. The flattened ``explanation``
+              string for composite results has the form
+              ``[child_name] (score:..., weight:...)`` which collides with
+              markdown link syntax and renders as broken ``[]()`` artifacts. */}
+          {ev?.composite?.children?.length ? (
+            <CompositeResultView compositeResult={ev.composite} />
+          ) : (
+            explanation && (
+              <Box
+                sx={{
+                  fontSize: 11,
+                  color: "text.secondary",
+                  lineHeight: 1.6,
+                  "& p": { m: 0, mb: 0.5 },
+                  "& ul, & ol": { m: 0, pl: 2 },
+                  "& li": { mb: 0.25 },
+                  "& strong": { fontWeight: 600, color: "text.primary" },
+                  "& code": {
+                    bgcolor: (theme) => alpha(theme.palette.text.disabled, 0.15),
+                    px: 0.5,
+                    borderRadius: "2px",
+                    fontSize: 10,
+                  },
+                }}
+              >
+                <Markdown>{explanation}</Markdown>
+              </Box>
+            )
           )}
 
           {/* Error localization section — shows run-on-demand button when

--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx
@@ -133,19 +133,104 @@ const LogDrawerRight = ({
               borderRadius: "4px",
             }}
           >
-            <Typography fontWeight={400} fontSize={14} color="text.primary">
-              {typeof output.reason === "string" ? (
-                output?.reason?.trim() ? (
-                  <CellMarkdown spacing={0} text={output?.reason} />
+            {/*
+              Composite eval results carry a structured ``composite.children``
+              payload (BE: tracer/views/observation_span.py::get_evaluation_details).
+              When present we render per-child cards instead of markdown-parsing
+              the flattened ``output.reason`` string — the flattened form uses
+              [child_name] (score:..., weight:...) which collides with markdown
+              link syntax and renders as broken ``[]()`` artifacts.
+            */}
+            {output?.composite?.children?.length ? (
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                {output.composite.children.map((child) => {
+                  const isFailed = child.status === "failed";
+                  const passLabel =
+                    child.output === "Passed" || child.output === true;
+                  const failLabel =
+                    child.output === "Failed" || child.output === false;
+                  let chipColor = "default";
+                  if (isFailed) chipColor = "error";
+                  else if (passLabel) chipColor = "success";
+                  else if (failLabel) chipColor = "error";
+                  return (
+                    <Box
+                      key={child.child_id || child.order}
+                      sx={{
+                        border: `1px solid ${alpha(theme.palette.text.disabled, 0.2)}`,
+                        borderRadius: "4px",
+                        padding: "12px",
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          display: "flex",
+                          justifyContent: "space-between",
+                          alignItems: "center",
+                          mb: 0.5,
+                        }}
+                      >
+                        <Typography fontSize={13} fontWeight={600}>
+                          {child.child_name}
+                        </Typography>
+                        <Chip
+                          size="small"
+                          label={
+                            isFailed
+                              ? "failed"
+                              : String(child.output ?? child.status ?? "—")
+                          }
+                          color={chipColor}
+                          sx={{ textTransform: "capitalize" }}
+                        />
+                      </Box>
+                      <Typography
+                        fontSize={11}
+                        color="text.secondary"
+                        sx={{ mb: child.reason ? 1 : 0 }}
+                      >
+                        score:{" "}
+                        {typeof child.score === "number"
+                          ? child.score.toFixed(2)
+                          : "N/A"}{" "}
+                        · weight: {child.weight ?? 1.0}
+                      </Typography>
+                      {isFailed && child.error && (
+                        <Typography
+                          fontSize={12}
+                          color="error"
+                          sx={{ whiteSpace: "pre-wrap" }}
+                        >
+                          {child.error}
+                        </Typography>
+                      )}
+                      {!isFailed && child.reason && (
+                        <Typography
+                          fontSize={13}
+                          sx={{ whiteSpace: "pre-wrap" }}
+                        >
+                          {child.reason}
+                        </Typography>
+                      )}
+                    </Box>
+                  );
+                })}
+              </Box>
+            ) : (
+              <Typography fontWeight={400} fontSize={14} color="text.primary">
+                {typeof output.reason === "string" ? (
+                  output?.reason?.trim() ? (
+                    <CellMarkdown spacing={0} text={output?.reason} />
+                  ) : (
+                    "Unable to fetch Explanation"
+                  )
                 ) : (
-                  "Unable to fetch Explanation"
-                )
-              ) : (
-                output?.reason?.map((item, index) => (
-                  <CellMarkdown key={index} spacing={0} text={item} />
-                ))
-              )}
-            </Typography>
+                  output?.reason?.map((item, index) => (
+                    <CellMarkdown key={index} spacing={0} text={item} />
+                  ))
+                )}
+              </Typography>
+            )}
           </Box>
         </Box>
 

--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx
@@ -16,6 +16,7 @@ import {
 import { ShowComponent } from "src/components/show";
 import ErrorLocalizeCard from "src/sections/common/ErrorLocalizeCard";
 import CellMarkdown from "src/sections/common/CellMarkdown";
+import CompositeResultView from "src/sections/evals/components/CompositeResultView";
 import JsonCodeView from "src/components/code/json-code-view";
 import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 import { useAuthContext } from "src/auth/hooks";
@@ -142,147 +143,10 @@ const LogDrawerRight = ({
               link syntax and renders as broken ``[]()`` artifacts.
             */}
             {output?.composite?.children?.length ? (
-              (() => {
-                // Compute whether to expose weight at all — if every child
-                // carries the same weight, the value is informationally
-                // useless to an end user and we suppress it. When weights
-                // differ, surface each child's share as a % so a non-
-                // technical reader sees "this metric counts more than that
-                // one" rather than the raw float.
-                const totalWeight = output.composite.children.reduce(
-                  (acc, c) => acc + (typeof c.weight === "number" ? c.weight : 0),
-                  0,
-                );
-                const uniqueWeights = new Set(
-                  output.composite.children.map((c) =>
-                    typeof c.weight === "number" ? c.weight : null,
-                  ),
-                );
-                const showWeight = uniqueWeights.size > 1 && totalWeight > 0;
-
-                return (
-                  <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
-                    {output.composite.children.map((child) => {
-                      const isFailed = child.status === "failed";
-                      const passLabel =
-                        child.output === "Passed" || child.output === true;
-                      const failLabel =
-                        child.output === "Failed" || child.output === false;
-                      let chipColor = "default";
-                      if (isFailed) chipColor = "error";
-                      else if (passLabel) chipColor = "success";
-                      else if (failLabel) chipColor = "error";
-
-                      // Score shown as 0–100% so end users see one consistent
-                      // scale across Pass/Fail (0 or 100), score (raw %), and
-                      // choices (mapped %). Raw float stays in the chip below
-                      // for power users via the `output` label.
-                      const scorePct =
-                        typeof child.score === "number"
-                          ? Math.round(child.score * 100)
-                          : null;
-                      const weightPct =
-                        showWeight && typeof child.weight === "number"
-                          ? Math.round((child.weight / totalWeight) * 100)
-                          : null;
-
-                      return (
-                        <Box
-                          key={child.child_id || child.order}
-                          sx={{
-                            border: `1px solid ${alpha(theme.palette.text.disabled, 0.2)}`,
-                            borderRadius: "6px",
-                            padding: "12px 14px",
-                          }}
-                        >
-                          <Box
-                            sx={{
-                              display: "flex",
-                              justifyContent: "space-between",
-                              alignItems: "center",
-                              gap: 1,
-                              mb: child.reason || child.error ? 1 : 0,
-                            }}
-                          >
-                            <Box
-                              sx={{
-                                display: "flex",
-                                alignItems: "center",
-                                gap: 1,
-                                flex: 1,
-                                minWidth: 0,
-                              }}
-                            >
-                              <Typography
-                                fontSize={13}
-                                fontWeight={600}
-                                sx={{
-                                  overflow: "hidden",
-                                  textOverflow: "ellipsis",
-                                  whiteSpace: "nowrap",
-                                }}
-                              >
-                                {child.child_name}
-                              </Typography>
-                              {weightPct != null && (
-                                <Chip
-                                  size="small"
-                                  variant="outlined"
-                                  label={`counts ${weightPct}%`}
-                                  sx={{
-                                    height: 18,
-                                    fontSize: 10,
-                                    color: "text.secondary",
-                                    borderColor: (t) =>
-                                      alpha(t.palette.text.disabled, 0.4),
-                                  }}
-                                />
-                              )}
-                            </Box>
-                            <Chip
-                              size="small"
-                              label={
-                                isFailed
-                                  ? "error"
-                                  : passLabel
-                                    ? "Passed"
-                                    : failLabel
-                                      ? "Failed"
-                                      : scorePct != null
-                                        ? `${scorePct}%`
-                                        : String(child.status ?? "—")
-                              }
-                              color={chipColor}
-                              sx={{ textTransform: "capitalize" }}
-                            />
-                          </Box>
-                          {isFailed && child.error && (
-                            <Typography
-                              fontSize={12}
-                              color="error"
-                              sx={{ whiteSpace: "pre-wrap" }}
-                            >
-                              {child.error}
-                            </Typography>
-                          )}
-                          {!isFailed && child.reason && (
-                            <Typography
-                              fontSize={13}
-                              sx={{
-                                whiteSpace: "pre-wrap",
-                                color: "text.secondary",
-                                lineHeight: 1.55,
-                              }}
-                            >
-                              {child.reason}
-                            </Typography>
-                          )}
-                        </Box>
-                      );
-                    })}
-                  </Box>
-                );
-              })()
+              // Reuse the shared CompositeResultView (same component the
+              // dataset experiment surface uses) so per-child eval cards
+              // look identical across every consumer.
+              <CompositeResultView compositeResult={output.composite} />
             ) : (
               <Typography fontWeight={400} fontSize={14} color="text.primary">
                 {typeof output.reason === "string" ? (

--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx
@@ -142,80 +142,147 @@ const LogDrawerRight = ({
               link syntax and renders as broken ``[]()`` artifacts.
             */}
             {output?.composite?.children?.length ? (
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
-                {output.composite.children.map((child) => {
-                  const isFailed = child.status === "failed";
-                  const passLabel =
-                    child.output === "Passed" || child.output === true;
-                  const failLabel =
-                    child.output === "Failed" || child.output === false;
-                  let chipColor = "default";
-                  if (isFailed) chipColor = "error";
-                  else if (passLabel) chipColor = "success";
-                  else if (failLabel) chipColor = "error";
-                  return (
-                    <Box
-                      key={child.child_id || child.order}
-                      sx={{
-                        border: `1px solid ${alpha(theme.palette.text.disabled, 0.2)}`,
-                        borderRadius: "4px",
-                        padding: "12px",
-                      }}
-                    >
-                      <Box
-                        sx={{
-                          display: "flex",
-                          justifyContent: "space-between",
-                          alignItems: "center",
-                          mb: 0.5,
-                        }}
-                      >
-                        <Typography fontSize={13} fontWeight={600}>
-                          {child.child_name}
-                        </Typography>
-                        <Chip
-                          size="small"
-                          label={
-                            isFailed
-                              ? "failed"
-                              : String(child.output ?? child.status ?? "—")
-                          }
-                          color={chipColor}
-                          sx={{ textTransform: "capitalize" }}
-                        />
-                      </Box>
-                      <Typography
-                        fontSize={11}
-                        color="text.secondary"
-                        sx={{ mb: child.reason ? 1 : 0 }}
-                      >
-                        score:{" "}
-                        {typeof child.score === "number"
-                          ? child.score.toFixed(2)
-                          : "N/A"}{" "}
-                        · weight: {child.weight ?? 1.0}
-                      </Typography>
-                      {isFailed && child.error && (
-                        <Typography
-                          fontSize={12}
-                          color="error"
-                          sx={{ whiteSpace: "pre-wrap" }}
+              (() => {
+                // Compute whether to expose weight at all — if every child
+                // carries the same weight, the value is informationally
+                // useless to an end user and we suppress it. When weights
+                // differ, surface each child's share as a % so a non-
+                // technical reader sees "this metric counts more than that
+                // one" rather than the raw float.
+                const totalWeight = output.composite.children.reduce(
+                  (acc, c) => acc + (typeof c.weight === "number" ? c.weight : 0),
+                  0,
+                );
+                const uniqueWeights = new Set(
+                  output.composite.children.map((c) =>
+                    typeof c.weight === "number" ? c.weight : null,
+                  ),
+                );
+                const showWeight = uniqueWeights.size > 1 && totalWeight > 0;
+
+                return (
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                    {output.composite.children.map((child) => {
+                      const isFailed = child.status === "failed";
+                      const passLabel =
+                        child.output === "Passed" || child.output === true;
+                      const failLabel =
+                        child.output === "Failed" || child.output === false;
+                      let chipColor = "default";
+                      if (isFailed) chipColor = "error";
+                      else if (passLabel) chipColor = "success";
+                      else if (failLabel) chipColor = "error";
+
+                      // Score shown as 0–100% so end users see one consistent
+                      // scale across Pass/Fail (0 or 100), score (raw %), and
+                      // choices (mapped %). Raw float stays in the chip below
+                      // for power users via the `output` label.
+                      const scorePct =
+                        typeof child.score === "number"
+                          ? Math.round(child.score * 100)
+                          : null;
+                      const weightPct =
+                        showWeight && typeof child.weight === "number"
+                          ? Math.round((child.weight / totalWeight) * 100)
+                          : null;
+
+                      return (
+                        <Box
+                          key={child.child_id || child.order}
+                          sx={{
+                            border: `1px solid ${alpha(theme.palette.text.disabled, 0.2)}`,
+                            borderRadius: "6px",
+                            padding: "12px 14px",
+                          }}
                         >
-                          {child.error}
-                        </Typography>
-                      )}
-                      {!isFailed && child.reason && (
-                        <Typography
-                          fontSize={13}
-                          sx={{ whiteSpace: "pre-wrap" }}
-                        >
-                          {child.reason}
-                        </Typography>
-                      )}
-                    </Box>
-                  );
-                })}
-              </Box>
+                          <Box
+                            sx={{
+                              display: "flex",
+                              justifyContent: "space-between",
+                              alignItems: "center",
+                              gap: 1,
+                              mb: child.reason || child.error ? 1 : 0,
+                            }}
+                          >
+                            <Box
+                              sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 1,
+                                flex: 1,
+                                minWidth: 0,
+                              }}
+                            >
+                              <Typography
+                                fontSize={13}
+                                fontWeight={600}
+                                sx={{
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                {child.child_name}
+                              </Typography>
+                              {weightPct != null && (
+                                <Chip
+                                  size="small"
+                                  variant="outlined"
+                                  label={`counts ${weightPct}%`}
+                                  sx={{
+                                    height: 18,
+                                    fontSize: 10,
+                                    color: "text.secondary",
+                                    borderColor: (t) =>
+                                      alpha(t.palette.text.disabled, 0.4),
+                                  }}
+                                />
+                              )}
+                            </Box>
+                            <Chip
+                              size="small"
+                              label={
+                                isFailed
+                                  ? "error"
+                                  : passLabel
+                                    ? "Passed"
+                                    : failLabel
+                                      ? "Failed"
+                                      : scorePct != null
+                                        ? `${scorePct}%`
+                                        : String(child.status ?? "—")
+                              }
+                              color={chipColor}
+                              sx={{ textTransform: "capitalize" }}
+                            />
+                          </Box>
+                          {isFailed && child.error && (
+                            <Typography
+                              fontSize={12}
+                              color="error"
+                              sx={{ whiteSpace: "pre-wrap" }}
+                            >
+                              {child.error}
+                            </Typography>
+                          )}
+                          {!isFailed && child.reason && (
+                            <Typography
+                              fontSize={13}
+                              sx={{
+                                whiteSpace: "pre-wrap",
+                                color: "text.secondary",
+                                lineHeight: 1.55,
+                              }}
+                            >
+                              {child.reason}
+                            </Typography>
+                          )}
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                );
+              })()
             ) : (
               <Typography fontWeight={400} fontSize={14} color="text.primary">
                 {typeof output.reason === "string" ? (

--- a/frontend/src/sections/tasks/components/TaskUsageTab.jsx
+++ b/frontend/src/sections/tasks/components/TaskUsageTab.jsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import CellMarkdown from "src/sections/common/CellMarkdown";
+import CompositeResultView from "src/sections/evals/components/CompositeResultView";
 import PropTypes from "prop-types";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { alpha } from "@mui/material/styles";
@@ -786,6 +787,23 @@ const DetailPanelContent = ({ row, isDark }) => {
                   `reason` is set on both. */}
               {row.status === "error" ? (
                 <ErrorDetails rawError={detail.error_message || row.reason} />
+              ) : row?.composite?.children?.length ? (
+                // Composite eval result — render the shared per-child card
+                // view (same component the dataset experiment surface uses).
+                // The flattened ``row.reason`` for composite evals has the
+                // form ``[child_name] (score:..., weight:...)`` which collides
+                // with markdown link syntax and renders as broken ``[]()``
+                // artifacts when piped through CellMarkdown.
+                <>
+                  <Typography
+                    variant="caption"
+                    fontWeight={600}
+                    sx={{ mt: 1.5, mb: 0.5 }}
+                  >
+                    Per-child Results
+                  </Typography>
+                  <CompositeResultView compositeResult={row.composite} />
+                </>
               ) : (
                 row.reason && (
                   <>

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -496,6 +496,24 @@ class GetAPICallLogView(APIView):
             if "required_keys" in values:
                 required_keys = values.get("required_keys", [])
 
+            # Composite eval results carry per-child structured data under
+            # ``config.children`` (see model_hub/utils/composite_execution.py).
+            # Attach it onto ``output.composite`` so the FE's LogDrawerRight
+            # can render per-child cards instead of markdown-parsing the
+            # flattened ``[child_name] (score:..., weight:...)`` summary
+            # string (which collides with markdown link syntax).
+            output_payload = config.get("output", {}) or {}
+            if config.get("composite") and config.get("children"):
+                if not isinstance(output_payload, dict):
+                    output_payload = {"output": output_payload}
+                output_payload["composite"] = {
+                    "composite_id": config.get("reference_id"),
+                    "aggregation_function": config.get("aggregation_function"),
+                    "aggregation_enabled": config.get("aggregation_enabled"),
+                    "aggregate_pass": (output_payload or {}).get("aggregate_pass"),
+                    "children": config.get("children"),
+                }
+
             row_data.update(
                 {
                     "log_id": log_row.log_id,
@@ -504,7 +522,7 @@ class GetAPICallLogView(APIView):
                     "source": log_source,
                     "required_keys": required_keys,
                     "values": config.get("mappings", {}),
-                    "output": config.get("output", {}),
+                    "output": output_payload,
                     "input_data_types": config.get("input_data_types", {}),
                 }
             )

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -642,6 +642,39 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
 
                 reason = log.eval_explanation or log.error_message or ""
 
+                # Composite eval result — pull the per-child structured
+                # payload from output_metadata so the FE can render the
+                # shared CompositeResultView component instead of markdown-
+                # parsing the flattened summary string. The flattened
+                # ``[child] (score:..., weight:...)`` form collides with
+                # markdown link syntax and renders as broken ``[]()``
+                # artifacts in the task usage drawer.
+                composite_payload = None
+                meta = log.output_metadata if isinstance(log.output_metadata, dict) else None
+                if meta and meta.get("composite_id"):
+                    children_list = meta.get("children") or []
+                    completed_children = sum(
+                        1 for c in children_list if (c or {}).get("status") == "completed"
+                    )
+                    failed_children = sum(
+                        1 for c in children_list if (c or {}).get("status") == "failed"
+                    )
+                    composite_payload = {
+                        "composite_id": meta.get("composite_id"),
+                        "aggregation_function": meta.get("aggregation_function"),
+                        "aggregation_enabled": meta.get("aggregation_enabled"),
+                        "aggregate_pass": meta.get("aggregate_pass"),
+                        "aggregate_score": (
+                            float(log.output_float)
+                            if log.output_float is not None
+                            else None
+                        ),
+                        "children": children_list,
+                        "total_children": len(children_list),
+                        "completed_children": completed_children,
+                        "failed_children": failed_children,
+                    }
+
                 log_items.append(
                     {
                         "id": str(log.id),
@@ -649,6 +682,7 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                         "result": result_label,
                         "score": score,
                         "reason": reason,
+                        "composite": composite_payload,
                         "status": status,
                         "source": "eval_task",
                         "created_at": (

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -3174,6 +3174,24 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 "input_types": output_metadata.get("input_types"),
                 "score": evaluation_result,
                 "explanation": evaluation_explanation,
+                # Composite payload — only populated for composite eval results.
+                # Lets the FE render per-child cards instead of markdown-parsing
+                # the flattened ``eval_explanation`` string.
+                "composite": (
+                    {
+                        "composite_id": output_metadata.get("composite_id"),
+                        "aggregation_function": output_metadata.get(
+                            "aggregation_function"
+                        ),
+                        "aggregation_enabled": output_metadata.get(
+                            "aggregation_enabled"
+                        ),
+                        "aggregate_pass": output_metadata.get("aggregate_pass"),
+                        "children": output_metadata.get("children"),
+                    }
+                    if output_metadata.get("composite_id")
+                    else None
+                ),
             }
         )
 
@@ -3261,6 +3279,24 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 "input_types": output_metadata.get("input_types", None),
                 "score": evaluation_result,
                 "explanation": evaluation_explanation,
+                # Composite payload — only populated for composite eval results.
+                # Lets the FE render per-child cards instead of markdown-parsing
+                # the flattened ``eval_explanation`` string.
+                "composite": (
+                    {
+                        "composite_id": output_metadata.get("composite_id"),
+                        "aggregation_function": output_metadata.get(
+                            "aggregation_function"
+                        ),
+                        "aggregation_enabled": output_metadata.get(
+                            "aggregation_enabled"
+                        ),
+                        "aggregate_pass": output_metadata.get("aggregate_pass"),
+                        "children": output_metadata.get("children"),
+                    }
+                    if output_metadata.get("composite_id")
+                    else None
+                ),
             }
 
             return self._gm.success_response(result)
@@ -4057,7 +4093,101 @@ def get_observation_spans(filters):
     # Process orphaned spans
     response_data.extend(_process_orphaned_spans(base_filters))
 
+    # TH-5228: attach eval_scores onto every entry in the tree. The CH path
+    # for trace detail (tracer/views/trace.py::_retrieve_clickhouse) already
+    # decorates each entry with `eval_scores`; the PG path was only setting
+    # `total_evals_count`, so the FE's Evals tab (which reads `eval_scores`)
+    # showed empty for every trace when CH wasn't available. Use a batched
+    # query keyed by trace_id to avoid N+1.
+    if trace_id:
+        try:
+            _attach_eval_scores_to_tree(response_data, trace_id=trace_id)
+        except Exception as exc:
+            logger.warning(
+                f"Failed to attach eval_scores to PG span tree: {exc}"
+            )
+
     return response_data
+
+
+def _attach_eval_scores_to_tree(response_data, trace_id):
+    """Decorate each entry in a span tree with `eval_scores` (PG path).
+
+    Mirrors the shape produced by `tracer/views/trace.py::_retrieve_clickhouse`
+    so the FE consumer (EvalsTabView.collectAllEvalsFromEntry) sees identical
+    data regardless of which backend served the trace detail.
+
+    One batched query against ``EvalLogger`` for the whole trace, joined to
+    ``CustomEvalConfig`` + ``EvalTemplate`` for the per-eval display name and
+    output_type. The result is pivoted into a per-span map and applied
+    recursively to every entry under ``response_data``.
+    """
+    if not response_data or not trace_id:
+        return
+
+    eval_loggers = (
+        EvalLogger.objects.filter(trace_id=trace_id, deleted=False)
+        .select_related("custom_eval_config__eval_template")
+    )
+
+    eval_map = {}
+    for el in eval_loggers:
+        span_id = (
+            str(el.observation_span_id) if el.observation_span_id else None
+        )
+        if not span_id:
+            continue
+
+        # Mirror the CH score derivation: prefer float, fall back to bool.
+        if el.output_float is not None and el.output_float != 0:
+            score = round(float(el.output_float) * 100, 2)
+        elif el.output_bool is not None:
+            score = 100 if el.output_bool else 0
+        else:
+            score = None
+
+        cec = el.custom_eval_config
+        eval_template = cec.eval_template if cec and cec.eval_template_id else None
+
+        eval_map.setdefault(span_id, []).append(
+            {
+                "eval_config_id": str(cec.id) if cec else None,
+                "eval_name": (
+                    (cec.name if cec and cec.name else None)
+                    or (eval_template.name if eval_template else None)
+                    or (str(cec.id) if cec else "")
+                ),
+                "output_type": (
+                    getattr(eval_template, "output_type_normalized", None)
+                    if eval_template
+                    else None
+                ),
+                "score": score,
+                "result": (
+                    el.output_str
+                    if el.output_str
+                    else (el.output_bool if el.output_bool is not None else None)
+                ),
+                "explanation": el.eval_explanation or None,
+                # Identifiers the FE uses for the per-eval drill-down and
+                # error-localizer overlay. Match CH retrieve shape where it
+                # already exposes these (see trace.py CH path for parity).
+                "eval_log_id": str(el.id),
+                "observation_span_id": span_id,
+                "custom_eval_config_id": str(cec.id) if cec else None,
+            }
+        )
+
+    def _walk(entries):
+        for entry in entries:
+            span = entry.get("observation_span") or {}
+            sid = str(span.get("id")) if span.get("id") else None
+            entry["eval_scores"] = eval_map.get(sid, []) if sid else []
+            children = entry.get("children", [])
+            if children:
+                _walk(children)
+
+    _walk(response_data)
 
 
 def fetch_children_span_ids(root_span: ObservationSpan):

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -4093,12 +4093,14 @@ def get_observation_spans(filters):
     # Process orphaned spans
     response_data.extend(_process_orphaned_spans(base_filters))
 
-    # TH-5228: attach eval_scores onto every entry in the tree. The CH path
-    # for trace detail (tracer/views/trace.py::_retrieve_clickhouse) already
-    # decorates each entry with `eval_scores`; the PG path was only setting
-    # `total_evals_count`, so the FE's Evals tab (which reads `eval_scores`)
-    # showed empty for every trace when CH wasn't available. Use a batched
-    # query keyed by trace_id to avoid N+1.
+    # TH-5228: attach eval_scores onto every entry in the tree. The CH trace
+    # detail path (tracer/views/trace.py::_retrieve_clickhouse) already
+    # decorates each entry with `eval_scores`; the PG path (used in local
+    # dev where ClickHouse host is not configured, and as the prod fallback
+    # when CH is unhealthy) only set `total_evals_count`. FE consumers
+    # (EvalsTabView.collectAllEvalsFromEntry) read the list, so the trace
+    # drawer's Evals tab rendered empty for every trace whenever the PG path
+    # served the request. One batched query keyed by trace_id, no N+1.
     if trace_id:
         try:
             _attach_eval_scores_to_tree(response_data, trace_id=trace_id)
@@ -4111,16 +4113,17 @@ def get_observation_spans(filters):
 
 
 def _attach_eval_scores_to_tree(response_data, trace_id):
-    """Decorate each entry in a span tree with `eval_scores` (PG path).
+    """Decorate each entry in a PG-served span tree with `eval_scores`.
 
     Mirrors the shape produced by `tracer/views/trace.py::_retrieve_clickhouse`
     so the FE consumer (EvalsTabView.collectAllEvalsFromEntry) sees identical
     data regardless of which backend served the trace detail.
 
-    One batched query against ``EvalLogger`` for the whole trace, joined to
-    ``CustomEvalConfig`` + ``EvalTemplate`` for the per-eval display name and
-    output_type. The result is pivoted into a per-span map and applied
-    recursively to every entry under ``response_data``.
+    Composite eval results carry per-child structured data under
+    ``EvalLogger.output_metadata.children``; this is shaped to match the
+    FE's shared ``CompositeResultView`` component so the trace drawer
+    renders per-child cards instead of markdown-parsing the flattened
+    ``[child] (score:..., weight:...)`` summary string.
     """
     if not response_data or not trace_id:
         return
@@ -4149,6 +4152,30 @@ def _attach_eval_scores_to_tree(response_data, trace_id):
         cec = el.custom_eval_config
         eval_template = cec.eval_template if cec and cec.eval_template_id else None
 
+        composite_payload = None
+        meta = el.output_metadata if isinstance(el.output_metadata, dict) else None
+        if meta and meta.get("composite_id"):
+            children_list = meta.get("children") or []
+            completed_children = sum(
+                1 for c in children_list if (c or {}).get("status") == "completed"
+            )
+            failed_children = sum(
+                1 for c in children_list if (c or {}).get("status") == "failed"
+            )
+            composite_payload = {
+                "composite_id": meta.get("composite_id"),
+                "aggregation_function": meta.get("aggregation_function"),
+                "aggregation_enabled": meta.get("aggregation_enabled"),
+                "aggregate_pass": meta.get("aggregate_pass"),
+                "aggregate_score": (
+                    float(el.output_float) if el.output_float is not None else None
+                ),
+                "children": children_list,
+                "total_children": len(children_list),
+                "completed_children": completed_children,
+                "failed_children": failed_children,
+            }
+
         eval_map.setdefault(span_id, []).append(
             {
                 "eval_config_id": str(cec.id) if cec else None,
@@ -4169,9 +4196,7 @@ def _attach_eval_scores_to_tree(response_data, trace_id):
                     else (el.output_bool if el.output_bool is not None else None)
                 ),
                 "explanation": el.eval_explanation or None,
-                # Identifiers the FE uses for the per-eval drill-down and
-                # error-localizer overlay. Match CH retrieve shape where it
-                # already exposes these (see trace.py CH path for parity).
+                "composite": composite_payload,
                 "eval_log_id": str(el.id),
                 "observation_span_id": span_id,
                 "custom_eval_config_id": str(cec.id) if cec else None,

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -817,7 +817,8 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 output_float,
                 output_bool,
                 output_str,
-                eval_explanation
+                eval_explanation,
+                output_metadata
             FROM tracer_eval_logger FINAL
             WHERE trace_id = %(trace_id)s
               AND _peerdb_is_deleted = 0
@@ -876,6 +877,50 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
 
                 explanation = row.get("eval_explanation", "")
 
+                # Composite eval payload. ``output_metadata`` is stored as
+                # a String in CH (jsonb on PG), so parse it before reading
+                # ``children``. Shape matches what the FE's
+                # ``CompositeResultView`` component expects so the trace
+                # drawer's Evals tab renders per-child cards instead of
+                # markdown-parsing the flattened
+                # ``[child] (score:..., weight:...)`` summary string.
+                composite_payload = None
+                meta_raw = row.get("output_metadata")
+                meta = None
+                if meta_raw:
+                    if isinstance(meta_raw, dict):
+                        meta = meta_raw
+                    elif isinstance(meta_raw, str):
+                        try:
+                            meta = json.loads(meta_raw)
+                        except (ValueError, TypeError):
+                            meta = None
+                if meta and meta.get("composite_id"):
+                    children_list = meta.get("children") or []
+                    completed_children = sum(
+                        1
+                        for c in children_list
+                        if (c or {}).get("status") == "completed"
+                    )
+                    failed_children = sum(
+                        1
+                        for c in children_list
+                        if (c or {}).get("status") == "failed"
+                    )
+                    composite_payload = {
+                        "composite_id": meta.get("composite_id"),
+                        "aggregation_function": meta.get("aggregation_function"),
+                        "aggregation_enabled": meta.get("aggregation_enabled"),
+                        "aggregate_pass": meta.get("aggregate_pass"),
+                        "aggregate_score": (
+                            float(output_float) if output_float is not None else None
+                        ),
+                        "children": children_list,
+                        "total_children": len(children_list),
+                        "completed_children": completed_children,
+                        "failed_children": failed_children,
+                    }
+
                 eval_map[sid].append(
                     {
                         "eval_config_id": cid,
@@ -885,6 +930,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                         "result": output_str
                         or (output_bool if output_bool is not None else None),
                         "explanation": explanation if explanation else None,
+                        "composite": composite_payload,
                     }
                 )
         except Exception as e:


### PR DESCRIPTION
## Summary

Two user-visible composite-eval rendering bugs on the observe surfaces, plus the TH-5228 root cause (evals tab empty on trace drawer when PG serves the request).

### What was broken

**Trace detail drawer → Evals sub-tab** and **Tasks → Usage detail panel** both rendered composite eval explanations through markdown. The flattened summary text from the backend (``[child_name] (score:..., weight:...)`` followed by the reason) collided with markdown link syntax and rendered as broken ``[]()`` artifacts in both surfaces.

Separately, TH-5228 — the trace drawer's Evals sub-tab was empty for every trace whenever the PG trace-detail path served the request (local dev where CH host is not configured; prod CH-failure fallback). The CH path already attached ``eval_scores`` onto each span entry; the PG path only set ``total_evals_count``.

### What this PR does

**BE — expose composite payload on every endpoint that feeds the affected surfaces**

- ``tracer/views/eval_task.py::get_usage`` — attaches ``row.composite`` (composite_id, aggregation_function, aggregate_score, children, per-status counts) pulled from ``EvalLogger.output_metadata``.
- ``tracer/views/observation_span.py`` — new ``_attach_eval_scores_to_tree`` helper. PG trace-detail path now decorates each entry with ``eval_scores`` matching the CH path's shape. Each entry also carries ``composite`` when applicable.
- ``tracer/views/trace.py::_retrieve_clickhouse`` — adds ``output_metadata`` to the CH eval query and parses the composite payload onto each eval entry, so the trace drawer behaves identically on either backend.
- ``tracer/views/observation_span.py::get_evaluation_details`` (CH + PG paths) and ``model_hub/views/separate_evals.py::GetAPICallLogView`` — defensive composite passthrough for any other consumer.

**FE — render the existing shared CompositeResultView when the payload is present**

The component is already used on the dataset experiment surface (``ViewDetailsModal.jsx``, ``EvalResultDisplay.jsx``, ``EvalsOutput.jsx``). Reusing it means the per-child cards look identical across every consumer.

- ``frontend/src/components/traceDetail/EvalsTabView.jsx`` — trace drawer Evals tab.
- ``frontend/src/sections/tasks/components/TaskUsageTab.jsx`` — task usage detail panel.
- ``frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx`` — eval task logs detail (defensive).

Single-eval (non-composite) results fall back to the existing markdown render — that path is unchanged.

## Files changed

- ``futureagi/tracer/views/observation_span.py``
- ``futureagi/tracer/views/trace.py``
- ``futureagi/tracer/views/eval_task.py``
- ``futureagi/model_hub/views/separate_evals.py``
- ``frontend/src/components/traceDetail/EvalsTabView.jsx``
- ``frontend/src/sections/tasks/components/TaskUsageTab.jsx``
- ``frontend/src/sections/evals/EvalDetails/EvalsLog/LogDrawerRight.jsx``

## Linked

Closes [TH-5228](https://linear.app/future-agi/issue/TH-5228) (the trace drawer's Evals tab being empty when the PG path served the request).

## Verification

Tested end-to-end against the local docker stack on trace ``d1d6121f-2bfb-49e6-b051-de566aa05494``:

- 7 ``EvalLogger`` rows in the DB.
- ``get_observation_spans`` now returns 7 ``eval_scores`` across the tree (3 on root span + 2+2 on children) — matches the DB.
- Each composite eval entry carries a ``composite`` sub-object with ``children``, ``aggregate_score``, and per-status counts.
- ``CompositeResultView`` renders per-child cards (name, score chip, status, reason in plain text) instead of the broken markdown.

## Test plan

- [ ] Open ``/dashboard/observe/<project>/llm-tracing?tab=traces`` → click any trace row → Evals sub-tab in right drawer. Evals should populate; composite evals should expand to per-child cards instead of the ``[span_quality_check] (score:..., weight:...)`` raw text.
- [ ] Open ``/dashboard/tasks/<id>`` → Usage tab → click any row → detail side panel. Composite evals should render per-child cards under "Per-child Results"; single evals should render their reason text as before.
- [ ] Single (non-composite) evals on both surfaces continue to render reason text via markdown (unchanged).

## Notes

- PG fallback code on ``get_observation_spans`` runs only when CH is unavailable. Local dev always uses PG (CH host is not configured); prod uses CH but falls back to PG on CH errors. Keeping the PG attachment ensures the Evals tab keeps working in both environments.
- All changes are additive on the wire — non-composite responses unchanged; existing consumers that don't read ``composite`` continue to see the same shape.