### PR TITLE
fix(agentcc): add streaming fallback before SSE commit

### DIFF
--- a/agentcc-gateway/internal/server/handlers.go
+++ b/agentcc-gateway/internal/server/handlers.go
@@ -395,7 +395,7 @@ func (h *Handlers) resolveOrgProvider(orgID string, orgCfg *tenant.OrgConfig, mo
 			continue
 		}
 		for _, m := range pcfg.Models {
-			if m == model {
+			if orgModelMatches(m, model, providerID) {
 				p, err := h.orgProviderCache.GetOrCreateWithTenantConfig(orgID, providerID, pcfg.APIKey, pcfg)
 				if err != nil {
 					slog.Warn("failed to create org provider for model",
@@ -407,6 +407,38 @@ func (h *Handlers) resolveOrgProvider(orgID string, orgCfg *tenant.OrgConfig, mo
 		}
 	}
 	return nil, ""
+}
+
+func (h *Handlers) effectiveFailover(orgCfg *tenant.OrgConfig) *routing.Failover {
+	if orgCfg != nil && orgCfg.Routing != nil && (orgCfg.Routing.FallbackEnabled || (orgCfg.Routing.Failover != nil && orgCfg.Routing.Failover.Enabled)) {
+		foCfg := h.buildOrgFailoverConfig(orgCfg.Routing)
+		var retryer *routing.Retryer
+		if orgCfg.Routing.Retry != nil && orgCfg.Routing.Retry.Enabled {
+			retryer = routing.NewRetryer(h.buildOrgRetryConfig(orgCfg.Routing.Retry))
+		}
+		return routing.NewFailover(foCfg, h.registry.Router(), retryer, nil)
+	}
+	return h.failover.Load()
+}
+
+func (h *Handlers) resolveFallbackProvider(orgID string, orgCfg *tenant.OrgConfig, rc *models.RequestContext, fallbackModel string) (providers.Provider, string, string, bool) {
+	if orgProvider, orgProviderID := h.resolveOrgProvider(orgID, orgCfg, fallbackModel); orgProvider != nil {
+		return orgProvider, orgProviderID, fallbackModel, true
+	}
+
+	fbResult, fbErr := h.registry.ResolveWithRouting(fallbackModel)
+	if fbErr != nil {
+		return nil, "", fallbackModel, false
+	}
+	fbProvider := fbResult.Provider
+	if shouldApplyOrgProviderOverride(rc) {
+		fbProvider = h.applyOrgProviderOverride(orgID, orgCfg, fbResult.Provider.ID(), fbResult.Provider)
+	}
+	resolvedModel := fallbackModel
+	if fbResult.ModelOverride != "" {
+		resolvedModel = fbResult.ModelOverride
+	}
+	return fbProvider, fbResult.Provider.ID(), resolvedModel, true
 }
 
 // applyOrgRoutingOverrides applies per-org routing config to the request context.
@@ -1056,7 +1088,7 @@ func (h *Handlers) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Stream {
-		h.handleStream(ctx, w, rc, provider)
+		h.handleStream(ctx, w, rc, provider, orgCfg)
 	} else {
 		h.handleNonStream(ctx, w, rc, provider, orgCfg)
 	}
@@ -1210,17 +1242,7 @@ func (h *Handlers) resolveProvider(ctx context.Context, rc *models.RequestContex
 
 func (h *Handlers) handleNonStream(ctx context.Context, w http.ResponseWriter, rc *models.RequestContext, provider providers.Provider, orgCfg *tenant.OrgConfig) {
 	// Determine effective failover: org routing config takes priority over global.
-	var effectiveFailover *routing.Failover
-	if orgCfg != nil && orgCfg.Routing != nil && (orgCfg.Routing.FallbackEnabled || (orgCfg.Routing.Failover != nil && orgCfg.Routing.Failover.Enabled)) {
-		foCfg := h.buildOrgFailoverConfig(orgCfg.Routing)
-		var retryer *routing.Retryer
-		if orgCfg.Routing.Retry != nil && orgCfg.Routing.Retry.Enabled {
-			retryer = routing.NewRetryer(h.buildOrgRetryConfig(orgCfg.Routing.Retry))
-		}
-		effectiveFailover = routing.NewFailover(foCfg, h.registry.Router(), retryer, nil)
-	} else if fo := h.failover.Load(); fo != nil {
-		effectiveFailover = fo
-	}
+	effectiveFailover := h.effectiveFailover(orgCfg)
 
 	if effectiveFailover != nil && effectiveFailover.IsEnabled() && h.registry.Router() != nil && h.registry.Router().HasTargets(rc.Model) {
 		h.handleNonStreamWithFailover(ctx, w, rc, effectiveFailover, orgCfg)
@@ -1251,47 +1273,13 @@ func (h *Handlers) handleNonStream(ctx context.Context, w http.ResponseWriter, r
 		}
 
 		for _, fbModel := range modelChain {
-			var fbProvider providers.Provider
-			var fbProviderID string
-
-			if orgCfg != nil && orgID != "" && h.orgProviderCache != nil {
-				for pid, pcfg := range orgCfg.Providers {
-					if pcfg == nil || !pcfg.Enabled || !pcfg.HasCredentials() {
-						continue
-					}
-					for _, m := range pcfg.Models {
-						if orgModelMatches(m, fbModel, pid) {
-							op, opErr := h.orgProviderCache.GetOrCreateWithTenantConfig(orgID, pid, pcfg.APIKey, pcfg)
-							if opErr == nil {
-								fbProvider = op
-								fbProviderID = pid
-							}
-							break
-						}
-					}
-					if fbProvider != nil {
-						break
-					}
-				}
-			}
-
-			if fbProvider == nil {
-				fbResult, fbErr := h.registry.ResolveWithRouting(fbModel)
-				if fbErr != nil {
-					continue
-				}
-				fbProvider = fbResult.Provider
-				if shouldApplyOrgProviderOverride(rc) {
-					fbProvider = h.applyOrgProviderOverride(orgID, orgCfg, fbResult.Provider.ID(), fbResult.Provider)
-				}
-				fbProviderID = fbResult.Provider.ID()
-				if fbResult.ModelOverride != "" {
-					fbModel = fbResult.ModelOverride
-				}
+			fbProvider, fbProviderID, resolvedModel, ok := h.resolveFallbackProvider(orgID, orgCfg, rc, fbModel)
+			if !ok {
+				continue
 			}
 
 			rc.Provider = fbProviderID
-			rc.Request.Model = fbModel
+			rc.Request.Model = resolvedModel
 
 			fbResp, fbCallErr := fbProvider.ChatCompletion(ctx, rc.Request)
 			if fbCallErr == nil {
@@ -1299,7 +1287,7 @@ func (h *Handlers) handleNonStream(ctx context.Context, w http.ResponseWriter, r
 				rc.ResolvedModel = fbResp.Model
 				rc.Flags.FallbackUsed = true
 				rc.Metadata["original_model"] = originalModel
-				rc.Metadata["fallback_model"] = fbModel
+				rc.Metadata["fallback_model"] = resolvedModel
 				return nil
 			}
 		}
@@ -1370,47 +1358,13 @@ func (h *Handlers) handleNonStreamWithFailover(ctx context.Context, w http.Respo
 
 			for _, fbModel := range modelChain {
 				// Resolve fallback model: check org providers first, then global registry.
-				var fbProvider providers.Provider
-				var fbProviderID string
-
-				if orgCfg != nil && orgID != "" && h.orgProviderCache != nil {
-					for pid, pcfg := range orgCfg.Providers {
-						if pcfg == nil || !pcfg.Enabled || !pcfg.HasCredentials() {
-							continue
-						}
-						for _, m := range pcfg.Models {
-							if orgModelMatches(m, fbModel, pid) {
-								op, opErr := h.orgProviderCache.GetOrCreateWithTenantConfig(orgID, pid, pcfg.APIKey, pcfg)
-								if opErr == nil {
-									fbProvider = op
-									fbProviderID = pid
-								}
-								break
-							}
-						}
-						if fbProvider != nil {
-							break
-						}
-					}
-				}
-
-				if fbProvider == nil {
-					fbResult, fbErr := h.registry.ResolveWithRouting(fbModel)
-					if fbErr != nil {
-						continue
-					}
-					fbProvider = fbResult.Provider
-					if shouldApplyOrgProviderOverride(rc) {
-						fbProvider = h.applyOrgProviderOverride(orgID, orgCfg, fbResult.Provider.ID(), fbResult.Provider)
-					}
-					fbProviderID = fbResult.Provider.ID()
-					if fbResult.ModelOverride != "" {
-						fbModel = fbResult.ModelOverride
-					}
+				fbProvider, fbProviderID, resolvedModel, ok := h.resolveFallbackProvider(orgID, orgCfg, rc, fbModel)
+				if !ok {
+					continue
 				}
 
 				rc.Provider = fbProviderID
-				rc.Request.Model = fbModel
+				rc.Request.Model = resolvedModel
 
 				fbResp, fbCallErr := fbProvider.ChatCompletion(ctx, rc.Request)
 				if fbCallErr == nil {
@@ -1418,7 +1372,7 @@ func (h *Handlers) handleNonStreamWithFailover(ctx context.Context, w http.Respo
 					rc.ResolvedModel = fbResp.Model
 					rc.Flags.FallbackUsed = true
 					rc.Metadata["original_model"] = originalModel
-					rc.Metadata["fallback_model"] = fbModel
+					rc.Metadata["fallback_model"] = resolvedModel
 					return nil
 				}
 			}
@@ -1454,25 +1408,130 @@ func (h *Handlers) handleNonStreamWithFailover(ctx context.Context, w http.Respo
 	json.NewEncoder(w).Encode(rc.Response)
 }
 
-func (h *Handlers) handleStream(ctx context.Context, w http.ResponseWriter, rc *models.RequestContext, provider providers.Provider) {
+func (h *Handlers) handleStream(ctx context.Context, w http.ResponseWriter, rc *models.RequestContext, provider providers.Provider, orgCfg *tenant.OrgConfig) {
 	sseWriter := streaming.NewSSEWriter(w)
 	if sseWriter == nil {
 		models.WriteError(w, models.ErrInternal("streaming not supported by server"))
 		return
 	}
 
-	// For streaming, we call the provider directly (pre/post plugins run but provider is streaming).
 	var chunks <-chan models.StreamChunk
 	var errCh <-chan error
+	var firstChunk *models.StreamChunk
+	var upstreamStreamCancel context.CancelFunc
+	defer func() {
+		if upstreamStreamCancel != nil {
+			upstreamStreamCancel()
+		}
+	}()
+	effectiveFailover := h.effectiveFailover(orgCfg)
 
-	providerCall := func(ctx context.Context, rc *models.RequestContext) error {
-		chunks, errCh = provider.StreamChatCompletion(ctx, rc.Request)
+	openStream := func(callCtx context.Context, callProvider providers.Provider) error {
+		attemptCtx, attemptCancel := context.WithCancel(callCtx)
+		candidateChunks, candidateErrCh := callProvider.StreamChatCompletion(attemptCtx, rc.Request)
+		if candidateChunks == nil {
+			attemptCancel()
+			return models.ErrUpstreamProvider(http.StatusBadGateway, "upstream provider returned no stream")
+		}
+
+		chunk, err := waitForFirstStreamChunk(attemptCtx, candidateChunks, candidateErrCh)
+		if err != nil {
+			cancelAndDrainStream(attemptCancel, candidateChunks)
+			return err
+		}
+
+		if upstreamStreamCancel != nil {
+			cancelAndDrainStream(upstreamStreamCancel, chunks)
+		}
+		upstreamStreamCancel = attemptCancel
+		chunks = candidateChunks
+		errCh = candidateErrCh
+		firstChunk = chunk
 		return nil
 	}
 
-	// Run pre-plugins, initiate streaming, then post-plugins will run after.
+	providerCall := func(ctx context.Context, rc *models.RequestContext) error {
+		originalModel := rc.Request.Model
+		orgID := rc.Metadata["org_id"]
+
+		tryModelFallbacks := func(firstErr error) error {
+			if effectiveFailover == nil || !effectiveFailover.ShouldFailover(firstErr) {
+				return firstErr
+			}
+
+			var modelChain []string
+			if len(rc.OrgModelFallbacks) > 0 {
+				modelChain = rc.OrgModelFallbacks[originalModel]
+			} else if mf := h.modelFallbacks.Load(); mf != nil {
+				modelChain = mf.GetChain(originalModel)
+			}
+
+			for _, fbModel := range modelChain {
+				fallbackModel := fbModel
+				fbProvider, fbProviderID, resolvedModel, ok := h.resolveFallbackProvider(orgID, orgCfg, rc, fallbackModel)
+				if !ok {
+					continue
+				}
+
+				rc.Provider = fbProviderID
+				rc.Request.Model = resolvedModel
+				if err := openStream(ctx, fbProvider); err == nil {
+					rc.Flags.FallbackUsed = true
+					rc.Metadata["original_model"] = originalModel
+					rc.Metadata["fallback_model"] = resolvedModel
+					return nil
+				}
+			}
+
+			rc.Request.Model = originalModel
+			return firstErr
+		}
+
+		if effectiveFailover != nil && effectiveFailover.IsEnabled() && h.registry.Router() != nil && h.registry.Router().HasTargets(rc.Model) {
+			result, err := effectiveFailover.Execute(ctx, rc.Model, func(callCtx context.Context, providerID string, modelOverride string) error {
+				p, ok := h.registry.GetProvider(providerID)
+				if !ok {
+					return models.ErrUpstreamProvider(http.StatusBadGateway, fmt.Sprintf("provider %q not found", providerID))
+				}
+				if shouldApplyOrgProviderOverride(rc) {
+					p = h.applyOrgProviderOverride(orgID, orgCfg, providerID, p)
+				}
+				if modelOverride != "" {
+					rc.Request.Model = modelOverride
+				} else {
+					rc.Request.Model = originalModel
+				}
+				return openStream(callCtx, p)
+			})
+			if err != nil {
+				return tryModelFallbacks(err)
+			}
+			if result != nil {
+				rc.Provider = result.ProviderID
+				if result.ModelOverride != "" {
+					rc.Request.Model = result.ModelOverride
+				}
+				if result.FallbackUsed {
+					rc.Flags.FallbackUsed = true
+					rc.Metadata["original_provider"] = result.OriginalProvider
+					rc.Metadata["fallback_provider"] = result.ProviderID
+				}
+				if result.StrategyName != "" {
+					rc.Metadata["routing_strategy"] = result.StrategyName
+				}
+			}
+			return nil
+		}
+
+		if err := openStream(ctx, provider); err != nil {
+			return tryModelFallbacks(err)
+		}
+		return nil
+	}
+
+	// Run pre-plugins before opening the upstream stream.
 	if err := h.engine.Process(ctx, rc, providerCall); err != nil {
-		models.WriteError(w, models.ErrInternal(err.Error()))
+		models.WriteErrorFromError(w, err)
 		return
 	}
 
@@ -1544,6 +1603,42 @@ func (h *Handlers) handleStream(ctx context.Context, w http.ResponseWriter, rc *
 	}
 
 	for {
+		if firstChunk != nil {
+			chunk := *firstChunk
+			firstChunk = nil
+			if streamID == "" && chunk.ID != "" {
+				streamID = chunk.ID
+			}
+			if streamCreated == 0 && chunk.Created != 0 {
+				streamCreated = chunk.Created
+			}
+			if len(chunk.Choices) > 0 && rc.ResolvedModel == "" {
+				rc.ResolvedModel = chunk.Model
+			}
+			if chunk.Usage != nil {
+				lastUsage = chunk.Usage
+			}
+
+			if streamChecker != nil {
+				if res := streamChecker.ProcessChunk(streamCtx, chunk); res.Blocked {
+					rc.Flags.GuardrailTriggered = true
+					sseWriter.WriteError(models.ErrGuardrailBlocked("stream_blocked", res.Message))
+					finalizeStream(false)
+					return
+				}
+			}
+
+			if err := sseWriter.WriteChunk(chunk); err != nil {
+				slog.Warn("error writing stream chunk",
+					"request_id", rc.RequestID,
+					"error", err,
+				)
+				finalizeStream(false)
+				return
+			}
+			continue
+		}
+
 		select {
 		case chunk, ok := <-chunks:
 			if !ok {
@@ -1665,6 +1760,41 @@ func (h *Handlers) buildStreamingMetadataChunk(rc *models.RequestContext, stream
 		}
 	}
 	return chunk
+}
+
+func waitForFirstStreamChunk(ctx context.Context, chunks <-chan models.StreamChunk, errCh <-chan error) (*models.StreamChunk, error) {
+	for {
+		select {
+		case chunk, ok := <-chunks:
+			if !ok {
+				return nil, models.ErrUpstreamProvider(http.StatusBadGateway, "upstream stream closed before sending any chunks")
+			}
+			return &chunk, nil
+		case err, ok := <-errCh:
+			if !ok {
+				errCh = nil
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func cancelAndDrainStream(cancel context.CancelFunc, chunks <-chan models.StreamChunk) {
+	if cancel != nil {
+		cancel()
+	}
+	if chunks == nil {
+		return
+	}
+	go func() {
+		for range chunks {
+		}
+	}()
 }
 
 func (h *Handlers) setAgentccHeaders(w http.ResponseWriter, rc *models.RequestContext) {

--- a/agentcc-gateway/internal/server/handlers_stream_retry_test.go
+++ b/agentcc-gateway/internal/server/handlers_stream_retry_test.go
@@ -1,0 +1,520 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/futureagi/agentcc-gateway/internal/config"
+	"github.com/futureagi/agentcc-gateway/internal/models"
+	"github.com/futureagi/agentcc-gateway/internal/pipeline"
+	"github.com/futureagi/agentcc-gateway/internal/providers"
+	"github.com/futureagi/agentcc-gateway/internal/routing"
+	"github.com/futureagi/agentcc-gateway/internal/tenant"
+)
+
+func startEmptyStreamOpenAI(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/chat/completions" && r.Method == "POST":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		case r.URL.Path == "/v1/models" && r.Method == "GET":
+			json.NewEncoder(w).Encode(models.ModelListResponse{
+				Object: "list",
+				Data:   []models.ModelObject{{ID: "gpt-4o", Object: "model", OwnedBy: "openai"}},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func newStreamingFailoverHandler(t *testing.T, firstURL string, secondURL string) (*Handlers, providers.Provider) {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	cfg.Providers["first"] = config.ProviderConfig{BaseURL: firstURL, APIFormat: "openai", Models: []string{"gpt-4o"}}
+	cfg.Providers["second"] = config.ProviderConfig{BaseURL: secondURL, APIFormat: "openai", Models: []string{"gpt-4o"}}
+	cfg.Routing.DefaultStrategy = "round-robin"
+	cfg.Routing.Targets = map[string][]config.RoutingTargetConfig{
+		"gpt-4o": {
+			{Provider: "first", Weight: 1},
+			{Provider: "second", Weight: 1},
+		},
+	}
+	cfg.Routing.Failover = config.FailoverConfig{
+		Enabled:       true,
+		MaxAttempts:   2,
+		OnStatusCodes: []int{http.StatusBadGateway, http.StatusTooManyRequests},
+	}
+
+	registry, err := providers.NewRegistry(cfg)
+	if err != nil {
+		t.Fatalf("creating registry: %v", err)
+	}
+	firstProvider, ok := registry.GetProvider("first")
+	if !ok {
+		t.Fatal("first provider not registered")
+	}
+
+	h := &Handlers{registry: registry, engine: pipeline.NewEngine()}
+	h.failover.Store(routing.NewFailover(cfg.Routing.Failover, registry.Router(), nil, nil))
+	return h, firstProvider
+}
+
+func newStreamingModelFallbackHandler(t *testing.T, primaryURL string, fallbackURL string) (*Handlers, providers.Provider) {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	cfg.Providers["primary"] = config.ProviderConfig{BaseURL: primaryURL, APIFormat: "openai", Models: []string{"primary-model"}}
+	cfg.Providers["fallback"] = config.ProviderConfig{BaseURL: fallbackURL, APIFormat: "openai", Models: []string{"fallback-model"}}
+	cfg.Routing.Failover = config.FailoverConfig{
+		Enabled:       true,
+		MaxAttempts:   2,
+		OnStatusCodes: []int{http.StatusTooManyRequests, http.StatusBadGateway},
+	}
+	cfg.Routing.ModelFallbacks = map[string][]string{
+		"primary-model": {"fallback-model"},
+	}
+
+	registry, err := providers.NewRegistry(cfg)
+	if err != nil {
+		t.Fatalf("creating registry: %v", err)
+	}
+	primaryProvider, ok := registry.GetProvider("primary")
+	if !ok {
+		t.Fatal("primary provider not registered")
+	}
+
+	h := &Handlers{registry: registry, engine: pipeline.NewEngine()}
+	h.failover.Store(routing.NewFailover(cfg.Routing.Failover, registry.Router(), nil, nil))
+	h.modelFallbacks.Store(routing.NewModelFallbacks(cfg.Routing.ModelFallbacks))
+	return h, primaryProvider
+}
+
+func TestHandleStreamFailoverOnEmptyStreamBeforeHeaders(t *testing.T) {
+	empty := startEmptyStreamOpenAI(t)
+	defer empty.Close()
+	good := startMockOpenAI(t)
+	defer good.Close()
+
+	h, firstProvider := newStreamingFailoverHandler(t, empty.URL, good.URL)
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+	rc.RequestID = "req-stream-failover"
+	rc.Model = "gpt-4o"
+	rc.Provider = "first"
+	rc.RequestHeaders = http.Header{}
+	rc.Request = &models.ChatCompletionRequest{
+		Model:    "gpt-4o",
+		Stream:   true,
+		Messages: []models.Message{{Role: "user", Content: json.RawMessage(`"hello"`)}},
+	}
+
+	w := httptest.NewRecorder()
+	h.handleStream(context.Background(), w, rc, firstProvider, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. Body: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("x-agentcc-provider"); got != "second" {
+		t.Fatalf("x-agentcc-provider = %q, want second", got)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Hello! How can I help you?") {
+		t.Fatalf("stream body did not include fallback provider content: %s", body)
+	}
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("stream body missing [DONE]: %s", body)
+	}
+	if strings.Contains(body, "provider_502") || strings.Contains(body, "upstream stream closed") {
+		t.Fatalf("client saw pre-header empty-stream error instead of failover: %s", body)
+	}
+}
+
+func TestWaitForFirstStreamChunkTreatsClosedStreamAsBadGateway(t *testing.T) {
+	chunks := make(chan models.StreamChunk)
+	errs := make(chan error)
+	close(chunks)
+	close(errs)
+
+	chunk, err := waitForFirstStreamChunk(context.Background(), chunks, errs)
+	if err == nil {
+		t.Fatal("expected error for closed empty stream")
+	}
+	if chunk != nil {
+		t.Fatalf("chunk = %+v, want nil", chunk)
+	}
+	if !strings.Contains(err.Error(), "provider_502") {
+		t.Fatalf("error = %v, want provider_502", err)
+	}
+}
+
+func TestWaitForFirstStreamChunkReturnsFirstChunk(t *testing.T) {
+	chunks := make(chan models.StreamChunk, 1)
+	errs := make(chan error)
+	content := "hello"
+	chunks <- models.StreamChunk{ID: "chunk-1", Choices: []models.StreamChoice{{Delta: models.Delta{Content: &content}}}}
+
+	chunk, err := waitForFirstStreamChunk(context.Background(), chunks, errs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if chunk == nil || chunk.ID != "chunk-1" {
+		t.Fatalf("chunk = %+v, want chunk-1", chunk)
+	}
+}
+
+func TestWaitForFirstStreamChunkReturnsErrorBeforeChunk(t *testing.T) {
+	chunks := make(chan models.StreamChunk)
+	errs := make(chan error, 1)
+	errs <- models.ErrTooManyRequests("rate limited")
+
+	chunk, err := waitForFirstStreamChunk(context.Background(), chunks, errs)
+	if err == nil {
+		t.Fatal("expected error before first chunk")
+	}
+	if chunk != nil {
+		t.Fatalf("chunk = %+v, want nil", chunk)
+	}
+	if !strings.Contains(err.Error(), "rate_limit_exceeded") {
+		t.Fatalf("error = %v, want rate_limit_exceeded", err)
+	}
+}
+
+func TestWaitForFirstStreamChunkReturnsContextCancellation(t *testing.T) {
+	chunks := make(chan models.StreamChunk)
+	errs := make(chan error)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	chunk, err := waitForFirstStreamChunk(ctx, chunks, errs)
+	if err == nil {
+		t.Fatal("expected context cancellation")
+	}
+	if chunk != nil {
+		t.Fatalf("chunk = %+v, want nil", chunk)
+	}
+	if err != context.Canceled {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestOpenAIProviderEmptySSEProducesClosedChunkChannel(t *testing.T) {
+	upstream := startEmptyStreamOpenAI(t)
+	defer upstream.Close()
+	cfg := config.ProviderConfig{BaseURL: upstream.URL, APIFormat: "openai", Models: []string{"gpt-4o"}}
+	registryCfg := config.DefaultConfig()
+	registryCfg.Providers["openai"] = cfg
+	registry, err := providers.NewRegistry(registryCfg)
+	if err != nil {
+		t.Fatalf("creating registry: %v", err)
+	}
+	p, ok := registry.GetProvider("openai")
+	if !ok {
+		t.Fatal("openai provider not registered")
+	}
+
+	req := &models.ChatCompletionRequest{Model: "gpt-4o", Stream: true, Messages: []models.Message{{Role: "user", Content: json.RawMessage(`"hi"`)}}}
+	chunks, errCh := p.StreamChatCompletion(context.Background(), req)
+	chunk, firstErr := waitForFirstStreamChunk(context.Background(), chunks, errCh)
+	if firstErr == nil || chunk != nil {
+		t.Fatalf("chunk=%+v err=%v, want empty stream error", chunk, firstErr)
+	}
+	if !strings.Contains(firstErr.Error(), "upstream stream closed before sending any chunks") {
+		t.Fatalf("error = %v", firstErr)
+	}
+}
+
+func TestHandleStreamNoFailoverReturnsJSONBeforeSSEHeaders(t *testing.T) {
+	empty := startEmptyStreamOpenAI(t)
+	defer empty.Close()
+	cfg := config.DefaultConfig()
+	cfg.Providers["openai"] = config.ProviderConfig{BaseURL: empty.URL, APIFormat: "openai", Models: []string{"gpt-4o"}}
+	registry, err := providers.NewRegistry(cfg)
+	if err != nil {
+		t.Fatalf("creating registry: %v", err)
+	}
+	provider, ok := registry.GetProvider("openai")
+	if !ok {
+		t.Fatal("openai provider not registered")
+	}
+	h := &Handlers{registry: registry, engine: pipeline.NewEngine()}
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+	rc.RequestID = "req-stream-empty"
+	rc.Model = "gpt-4o"
+	rc.Provider = "openai"
+	rc.RequestHeaders = http.Header{}
+	rc.Request = &models.ChatCompletionRequest{Model: "gpt-4o", Stream: true, Messages: []models.Message{{Role: "user", Content: json.RawMessage(`"hello"`)}}}
+
+	w := httptest.NewRecorder()
+	h.handleStream(context.Background(), w, rc, provider, nil)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502. Body: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	if bytes.Contains(w.Body.Bytes(), []byte("data: [DONE]")) {
+		t.Fatalf("empty stream should not be finalized as SSE success: %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "upstream stream closed before sending any chunks") {
+		t.Fatalf("body missing empty stream explanation: %s", w.Body.String())
+	}
+}
+
+func TestHandleStreamPropagatesFirstProviderHTTPErrorToFailover(t *testing.T) {
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/chat/completions" && r.Method == "POST":
+			w.WriteHeader(http.StatusTooManyRequests)
+			fmt.Fprint(w, `{"error":{"message":"rate limited","type":"rate_limit_error","code":"rate_limit_exceeded"}}`)
+		case r.URL.Path == "/v1/models" && r.Method == "GET":
+			json.NewEncoder(w).Encode(models.ModelListResponse{Object: "list", Data: []models.ModelObject{{ID: "gpt-4o", Object: "model", OwnedBy: "openai"}}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer first.Close()
+	good := startMockOpenAI(t)
+	defer good.Close()
+
+	h, firstProvider := newStreamingFailoverHandler(t, first.URL, good.URL)
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+	rc.RequestID = "req-stream-429-failover"
+	rc.Model = "gpt-4o"
+	rc.Provider = "first"
+	rc.RequestHeaders = http.Header{}
+	rc.Request = &models.ChatCompletionRequest{Model: "gpt-4o", Stream: true, Messages: []models.Message{{Role: "user", Content: json.RawMessage(`"hello"`)}}}
+
+	w := httptest.NewRecorder()
+	h.handleStream(context.Background(), w, rc, firstProvider, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. Body: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("x-agentcc-provider"); got != "second" {
+		t.Fatalf("x-agentcc-provider = %q, want second", got)
+	}
+}
+
+func TestHandleStreamFailoverUsesOrgProviderOverride(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/chat/completions" && r.Method == "POST":
+			if got := r.Header.Get("Authorization"); got != "Bearer org-key" {
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprintf(w, `{"error":{"message":"wrong key %s","type":"auth_error","code":"invalid_key"}}`, got)
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(w, "data: {\"id\":\"org-override\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"org override ok\"},\"finish_reason\":null}]}\n\n")
+			fmt.Fprint(w, "data: [DONE]\n\n")
+		case r.URL.Path == "/v1/models" && r.Method == "GET":
+			json.NewEncoder(w).Encode(models.ModelListResponse{Object: "list", Data: []models.ModelObject{{ID: "gpt-4o", Object: "model", OwnedBy: "openai"}}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer upstream.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Providers["first"] = config.ProviderConfig{BaseURL: upstream.URL, APIKey: "base-key", APIFormat: "openai", Models: []string{"gpt-4o"}}
+	cfg.Providers["second"] = config.ProviderConfig{BaseURL: upstream.URL, APIKey: "base-key", APIFormat: "openai", Models: []string{"gpt-4o"}}
+	cfg.Routing.DefaultStrategy = "round-robin"
+	cfg.Routing.Targets = map[string][]config.RoutingTargetConfig{
+		"gpt-4o": {{Provider: "first", Weight: 1}, {Provider: "second", Weight: 1}},
+	}
+
+	registry, err := providers.NewRegistry(cfg)
+	if err != nil {
+		t.Fatalf("creating registry: %v", err)
+	}
+	firstProvider, ok := registry.GetProvider("first")
+	if !ok {
+		t.Fatal("first provider not registered")
+	}
+
+	h := &Handlers{
+		registry:         registry,
+		engine:           pipeline.NewEngine(),
+		orgProviderCache: providers.NewOrgProviderCache(cfg.Providers),
+	}
+	orgCfg := &tenant.OrgConfig{
+		Providers: map[string]*tenant.ProviderConfig{
+			"first": {APIKey: "org-key", Enabled: true, Models: []string{"gpt-4o"}},
+		},
+		Routing: &tenant.RoutingConfig{Failover: &tenant.FailoverConfig{Enabled: true, MaxAttempts: 1, OnStatusCodes: []int{http.StatusBadGateway}}},
+	}
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+	rc.RequestID = "req-stream-org-override"
+	rc.Model = "gpt-4o"
+	rc.Provider = "first"
+	rc.RequestHeaders = http.Header{}
+	rc.Metadata["org_id"] = "org-1"
+	rc.Request = &models.ChatCompletionRequest{Model: "gpt-4o", Stream: true, Messages: []models.Message{{Role: "user", Content: json.RawMessage(`"hello"`)}}}
+
+	w := httptest.NewRecorder()
+	h.handleStream(context.Background(), w, rc, firstProvider, orgCfg)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. Body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "org override ok") {
+		t.Fatalf("body did not use org provider credentials: %s", w.Body.String())
+	}
+}
+
+func TestHandleStreamUsesModelFallbackChainBeforeHeaders(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/chat/completions" && r.Method == "POST":
+			w.WriteHeader(http.StatusTooManyRequests)
+			fmt.Fprint(w, `{"error":{"message":"rate limited","type":"rate_limit_error","code":"rate_limit_exceeded"}}`)
+		case r.URL.Path == "/v1/models" && r.Method == "GET":
+			json.NewEncoder(w).Encode(models.ModelListResponse{Object: "list", Data: []models.ModelObject{{ID: "primary-model", Object: "model", OwnedBy: "openai"}}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer primary.Close()
+	fallback := startMockOpenAI(t)
+	defer fallback.Close()
+
+	h, primaryProvider := newStreamingModelFallbackHandler(t, primary.URL, fallback.URL)
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+	rc.RequestID = "req-stream-model-fallback"
+	rc.Model = "primary-model"
+	rc.Provider = "primary"
+	rc.RequestHeaders = http.Header{}
+	rc.Request = &models.ChatCompletionRequest{
+		Model:    "primary-model",
+		Stream:   true,
+		Messages: []models.Message{{Role: "user", Content: json.RawMessage(`"hello"`)}},
+	}
+
+	w := httptest.NewRecorder()
+	h.handleStream(context.Background(), w, rc, primaryProvider, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. Body: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("x-agentcc-provider"); got != "fallback" {
+		t.Fatalf("x-agentcc-provider = %q, want fallback", got)
+	}
+	if rc.Request.Model != "fallback-model" {
+		t.Fatalf("request model = %q, want fallback-model", rc.Request.Model)
+	}
+	if !rc.Flags.FallbackUsed {
+		t.Fatal("FallbackUsed = false, want true")
+	}
+	if rc.Metadata["original_model"] != "primary-model" {
+		t.Fatalf("original_model metadata = %q, want primary-model", rc.Metadata["original_model"])
+	}
+	if rc.Metadata["fallback_model"] != "fallback-model" {
+		t.Fatalf("fallback_model metadata = %q, want fallback-model", rc.Metadata["fallback_model"])
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Hello! How can I help you?") {
+		t.Fatalf("stream body did not include fallback model content: %s", body)
+	}
+	if strings.Contains(body, "rate_limit_exceeded") {
+		t.Fatalf("client saw primary model error instead of fallback stream: %s", body)
+	}
+}
+
+func TestHandleStreamUsesModelFallbackAfterProviderFailoverExhausted(t *testing.T) {
+	primaryA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/chat/completions" && r.Method == "POST":
+			w.WriteHeader(http.StatusTooManyRequests)
+			fmt.Fprint(w, `{"error":{"message":"rate limited a","type":"rate_limit_error","code":"rate_limit_exceeded"}}`)
+		case r.URL.Path == "/v1/models" && r.Method == "GET":
+			json.NewEncoder(w).Encode(models.ModelListResponse{Object: "list", Data: []models.ModelObject{{ID: "primary-model", Object: "model", OwnedBy: "openai"}}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer primaryA.Close()
+	primaryB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/chat/completions" && r.Method == "POST":
+			w.WriteHeader(http.StatusTooManyRequests)
+			fmt.Fprint(w, `{"error":{"message":"rate limited b","type":"rate_limit_error","code":"rate_limit_exceeded"}}`)
+		case r.URL.Path == "/v1/models" && r.Method == "GET":
+			json.NewEncoder(w).Encode(models.ModelListResponse{Object: "list", Data: []models.ModelObject{{ID: "primary-model", Object: "model", OwnedBy: "openai"}}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer primaryB.Close()
+	fallback := startMockOpenAI(t)
+	defer fallback.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Providers["primary-a"] = config.ProviderConfig{BaseURL: primaryA.URL, APIFormat: "openai", Models: []string{"primary-model"}}
+	cfg.Providers["primary-b"] = config.ProviderConfig{BaseURL: primaryB.URL, APIFormat: "openai", Models: []string{"primary-model"}}
+	cfg.Providers["fallback"] = config.ProviderConfig{BaseURL: fallback.URL, APIFormat: "openai", Models: []string{"fallback-model"}}
+	cfg.Routing.DefaultStrategy = "round-robin"
+	cfg.Routing.Targets = map[string][]config.RoutingTargetConfig{
+		"primary-model": {
+			{Provider: "primary-a", Weight: 1},
+			{Provider: "primary-b", Weight: 1},
+		},
+	}
+	cfg.Routing.Failover = config.FailoverConfig{Enabled: true, MaxAttempts: 2, OnStatusCodes: []int{http.StatusTooManyRequests}}
+	cfg.Routing.ModelFallbacks = map[string][]string{"primary-model": {"fallback-model"}}
+
+	registry, err := providers.NewRegistry(cfg)
+	if err != nil {
+		t.Fatalf("creating registry: %v", err)
+	}
+	primaryProvider, ok := registry.GetProvider("primary-a")
+	if !ok {
+		t.Fatal("primary-a provider not registered")
+	}
+	h := &Handlers{registry: registry, engine: pipeline.NewEngine()}
+	h.failover.Store(routing.NewFailover(cfg.Routing.Failover, registry.Router(), nil, nil))
+	h.modelFallbacks.Store(routing.NewModelFallbacks(cfg.Routing.ModelFallbacks))
+
+	rc := models.AcquireRequestContext()
+	defer rc.Release()
+	rc.RequestID = "req-stream-failover-exhausted-model-fallback"
+	rc.Model = "primary-model"
+	rc.Provider = "primary-a"
+	rc.RequestHeaders = http.Header{}
+	rc.Request = &models.ChatCompletionRequest{
+		Model:    "primary-model",
+		Stream:   true,
+		Messages: []models.Message{{Role: "user", Content: json.RawMessage(`"hello"`)}},
+	}
+
+	w := httptest.NewRecorder()
+	h.handleStream(context.Background(), w, rc, primaryProvider, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. Body: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("x-agentcc-provider"); got != "fallback" {
+		t.Fatalf("x-agentcc-provider = %q, want fallback", got)
+	}
+	if rc.Metadata["original_model"] != "primary-model" || rc.Metadata["fallback_model"] != "fallback-model" {
+		t.Fatalf("fallback metadata = original:%q fallback:%q", rc.Metadata["original_model"], rc.Metadata["fallback_model"])
+	}
+	if !strings.Contains(w.Body.String(), "Hello! How can I help you?") {
+		t.Fatalf("stream body did not include model fallback content: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes AgentCC streaming correctness for TH-5326's silent upstream-empty-stream failure mode. The gateway now probes the upstream stream before committing SSE headers, so an upstream HTTP 200 stream that closes before producing any chunks is treated as a transient upstream failure instead of a successful empty completion. That error remains pre-header, allowing configured provider failover and model fallback chains to recover before the client sees the stream.

This intentionally covers the gateway-boundary part of the RCA. Eval-side retry/backoff work is tracked separately in `future-agi/ee#63`, and token-aware upstream pacing / force-finalize semantics remain separate RCA tracks.

## Linked issues

Related to TH-5326

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `go test ./internal/server -run 'TestHandleStream|TestWaitForFirstStreamChunk|TestOpenAIProviderEmptySSE' -count=1`
- `go test ./internal/streaming -count=1`
- LSP diagnostics on:
  - `agentcc-gateway/internal/server/handlers.go`
  - `agentcc-gateway/internal/server/handlers_stream_retry_test.go`
- Live gateway smoke tests against `localhost:8090`:
  - non-streaming `claude-haiku-4-5` returned HTTP 200 via `anthropic`
  - streaming `claude-haiku-4-5` returned SSE content chunks, usage/metadata chunk, and `[DONE]`
  - bad OpenAI key fallback test returned HTTP 200 SSE via Anthropic fallback with `x-agentcc-fallback-used: true`

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
