### PR TITLE
feat(simulate,eval-picker): persona_profile + scenario_metadata fields; drop scenario-column UUID translation

### DIFF
--- a/frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx
+++ b/frontend/src/sections/evals/components/CreateSimulationPreviewMode.jsx
@@ -16,7 +16,6 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import Iconify from "src/components/iconify";
@@ -63,6 +62,36 @@ const COMMON_RUNTIME_LEAVES = [
   "stereo_recording_url",
 ];
 
+// Persona model fields the call-detail serializer surfaces under
+// persona_profile.<key>. Seeded with RUNTIME_PLACEHOLDER in preview so the
+// dropdown vocabulary is consistent with SimulationTestMode — actual values
+// resolve at simulation run time from the bound Persona model.
+const PERSONA_PROFILE_LEAVES = [
+  "name",
+  "description",
+  "gender",
+  "age_group",
+  "occupation",
+  "location",
+  "personality",
+  "communication_style",
+  "languages",
+  "accent",
+  "tone",
+  "verbosity",
+  "punctuation",
+  "emoji_usage",
+  "slang_usage",
+  "typos_frequency",
+  "regional_mix",
+  "conversation_speed",
+  "finished_speaking_sensitivity",
+  "interrupt_sensitivity",
+  "keywords",
+  "simulation_type",
+  "additional_instruction",
+];
+
 const PRIORITY_PREFIXES = [
   "call.transcript",
   "call.summary",
@@ -74,8 +103,8 @@ const PRIORITY_PREFIXES = [
   "call.customer_recording",
   "call.agent_prompt",
   "call.",
-  "scenario.columns.",
   "scenario.info.",
+  "scenario.metadata.",
   "scenario.",
   "simulation.",
   "agent.",
@@ -175,16 +204,11 @@ const CreateSimulationPreviewMode = React.forwardRef(
     const [tableSearch, setTableSearch] = useState("");
     const [expandedCols, setExpandedCols] = useState({});
 
-    // Track displayKey -> UUID for scenario columns. The backend
-    // resolver only accepts column UUIDs, so the saved eval mapping
-    // must persist UUIDs even though the dropdown shows the friendly
-    // `scenario_<name>` label.
-    const scenarioKeyMap = useRef({});
-
     // Build the nested vocabulary dict from the preview data. Real
     // values fill in what the user already chose in the form (agent,
-    // persona, scenario, prompt); placeholder strings seed the runtime
-    // keys so they render in the panel and are pickable in the dropdown.
+    // scenario, prompt); placeholder strings seed the runtime keys
+    // (persona.*, call.*, scenario columns) so they render in the panel
+    // and remain pickable in the dropdown.
     const callDetail = useMemo(() => {
       const ctx = previewData || {};
       const flat = {
@@ -192,10 +216,9 @@ const CreateSimulationPreviewMode = React.forwardRef(
         agent: {},
         persona: {},
         prompt: {},
-        scenario: { info: {}, columns: {} },
+        scenario: { info: {}, metadata: {} },
         call: {},
       };
-      scenarioKeyMap.current = {};
 
       const isText = ctx.sim_call_type === "text" || ctx.simCallType === "text";
 
@@ -224,16 +247,13 @@ const CreateSimulationPreviewMode = React.forwardRef(
         if (snap.description) flat.agent.description = snap.description;
       }
 
-      // ── Persona (simulator agent) ──
-      const persona = ctx.simulator_agent;
-      if (persona) {
-        if (persona.name) flat.persona.name = persona.name;
-        if (persona.prompt) flat.persona.prompt = persona.prompt;
-        if (persona.description) flat.persona.description = persona.description;
-        if (persona.voice_name) flat.persona.voice_name = persona.voice_name;
-        if (persona.model) flat.persona.model = persona.model;
-        if (persona.initial_message)
-          flat.persona.initial_message = persona.initial_message;
+      // Persona attributes (Persona model fields, not SimulatorAgent). At
+      // form-time the bound Persona is not yet resolved (selection happens
+      // via scenario.metadata.persona_ids or per-row row_data.persona at
+      // run time) — seed placeholders so the dropdown still surfaces the
+      // vocabulary.
+      for (const leaf of PERSONA_PROFILE_LEAVES) {
+        flat.persona[leaf] = RUNTIME_PLACEHOLDER;
       }
 
       // ── Prompt template (prompt-type sims) ──
@@ -255,15 +275,15 @@ const CreateSimulationPreviewMode = React.forwardRef(
         if (scenarioRow.source) flat.scenario.info.source = scenarioRow.source;
       }
 
-      // ── Scenario columns (per-row dataset cells) ──
-      // Shape: { <uuid>: { name, type } }. Display path is
-      // `scenario.columns.<name>`; persisted mapping value is the UUID.
+      // Scenario columns surface as `scenario.<column_name>` — backend
+      // resolver matches Column.name within the call's dataset (TH-4952).
+      // `info` and `metadata` are reserved sub-keys (backend resolver
+      // skips them before column lookup, see xl.py:683).
       const scenarioColumns = ctx.scenario_columns || {};
-      for (const [uuid, col] of Object.entries(scenarioColumns)) {
+      for (const col of Object.values(scenarioColumns)) {
         const colName = col?.name;
-        if (!colName) continue;
-        flat.scenario.columns[colName] = RUNTIME_PLACEHOLDER;
-        scenarioKeyMap.current[`scenario.columns.${colName}`] = uuid;
+        if (!colName || colName === "info" || colName === "metadata") continue;
+        flat.scenario[colName] = RUNTIME_PLACEHOLDER;
       }
 
       // ── Runtime vocabulary nested under `call.*` — always rendered
@@ -322,15 +342,7 @@ const CreateSimulationPreviewMode = React.forwardRef(
       });
     }, [variables, fieldNames]);
 
-    // Translate display keys → persistence keys (scenario UUIDs) before
-    // emitting to the parent. Same contract as SimulationTestMode.
-    const persistedMapping = useMemo(() => {
-      const out = {};
-      for (const [variable, field] of Object.entries(mapping)) {
-        out[variable] = scenarioKeyMap.current[field] || field;
-      }
-      return out;
-    }, [mapping, callDetail]);
+    const persistedMapping = useMemo(() => ({ ...mapping }), [mapping]);
 
     const isReady = useMemo(
       () => variables.length > 0 && variables.every((v) => !!mapping[v]),

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -75,8 +75,8 @@ const PRIORITY_PREFIXES = [
   "call.agent_prompt",
   "call.", // remaining call-level leaves
   "eval_", // resolved eval results (still flat)
-  "scenario.columns.",
   "scenario.info.",
+  "scenario.metadata.",
   "scenario.",
   "simulation.",
   "agent.",
@@ -249,18 +249,12 @@ const SimulationTestMode = React.forwardRef(
     const [tableSearch, setTableSearch] = useState("");
     const [expandedCols, setExpandedCols] = useState({});
 
-    // Variable mapping (stores display keys internally; scenario fields are
-    // translated to their UUID via scenarioKeyMap when emitted to the parent).
     // Seeded from `initialMapping` when editing an existing eval (TH-4302).
     const [mapping, setMapping] = useState(
       initialMapping && typeof initialMapping === "object"
         ? { ...initialMapping }
         : {},
     );
-    // displayKey ("scenario_<col_name>") -> scenario column UUID. The backend
-    // resolver at run time only accepts scenario column UUIDs, not names, so
-    // we persist the UUID while the dropdown still shows the friendly label.
-    const scenarioKeyMap = useRef({});
 
     // Eval result
     const [, setIsRunning] = useState(false);
@@ -436,6 +430,8 @@ const SimulationTestMode = React.forwardRef(
             "customer_call_id",
             "eval_outputs",
             "scenario_columns",
+            "persona_profile",
+            "scenario_metadata",
             "eval_metrics",
             "is_snapshot",
             "snapshot_timestamp",
@@ -477,7 +473,7 @@ const SimulationTestMode = React.forwardRef(
             simulation: {},
             agent: {},
             persona: {},
-            scenario: { info: {}, columns: {} },
+            scenario: { info: {}, metadata: {} },
             call: {},
           };
 
@@ -499,19 +495,6 @@ const SimulationTestMode = React.forwardRef(
               if (ad.description) flat.agent.description = ad.description;
             }
 
-            const persona = runTestContext.simulator_agent_detail;
-            if (persona) {
-              if (persona.name) flat.persona.name = persona.name;
-              if (persona.prompt) flat.persona.prompt = persona.prompt;
-              if (persona.description)
-                flat.persona.description = persona.description;
-              if (persona.voice_name)
-                flat.persona.voice_name = persona.voice_name;
-              if (persona.model) flat.persona.model = persona.model;
-              if (persona.initial_message)
-                flat.persona.initial_message = persona.initial_message;
-            }
-
             const promptTemplate = runTestContext.prompt_template_detail;
             if (promptTemplate) {
               flat.prompt = {};
@@ -521,17 +504,50 @@ const SimulationTestMode = React.forwardRef(
             }
           }
 
-          // -- Scenario columns: display key `scenario.columns.<name>`,
-          // persisted mapping value is the column UUID (backend resolver
-          // accepts UUIDs, not names).
+          // Scenario columns surface as `scenario.<column_name>` — backend
+          // resolver matches Column.name within the call's dataset (TH-4952).
+          // `info` and `metadata` are reserved sub-keys (backend resolver
+          // skips them before column lookup, see xl.py:683) so columns with
+          // those names cannot be addressed via the eval-mapping dropdown.
           const sc = callData.scenario_columns;
-          scenarioKeyMap.current = {};
           if (sc && typeof sc === "object") {
-            for (const [uuid, col] of Object.entries(sc)) {
-              if (col?.column_name && col?.value !== undefined) {
-                flat.scenario.columns[col.column_name] = col.value;
-                scenarioKeyMap.current[`scenario.columns.${col.column_name}`] =
-                  uuid;
+            for (const col of Object.values(sc)) {
+              if (
+                col?.column_name &&
+                col?.value !== undefined &&
+                col.column_name !== "info" &&
+                col.column_name !== "metadata"
+              ) {
+                flat.scenario[col.column_name] = col.value;
+              }
+            }
+          }
+
+          // Persona attributes (Persona model fields + Persona.metadata) —
+          // sourced from the new `persona_profile` field on CallExecutionDetailSerializer.
+          const personaProfile = callData.persona_profile;
+          if (personaProfile && typeof personaProfile === "object") {
+            for (const [key, value] of Object.entries(personaProfile)) {
+              if (key === "metadata" && value && typeof value === "object") {
+                for (const [metaKey, metaValue] of Object.entries(value)) {
+                  if (metaValue !== "" && metaValue != null) {
+                    flat.persona.metadata = flat.persona.metadata || {};
+                    flat.persona.metadata[metaKey] = metaValue;
+                  }
+                }
+              } else if (value !== "" && value != null) {
+                flat.persona[key] = value;
+              }
+            }
+          }
+
+          // Free-form Scenarios.metadata sub-keys — sourced from the new
+          // `scenario_metadata` field (internal keys already denylisted server-side).
+          const scenarioMeta = callData.scenario_metadata;
+          if (scenarioMeta && typeof scenarioMeta === "object") {
+            for (const [key, value] of Object.entries(scenarioMeta)) {
+              if (value !== "" && value != null) {
+                flat.scenario.metadata[key] = value;
               }
             }
           }
@@ -806,17 +822,7 @@ const SimulationTestMode = React.forwardRef(
       [selectedRunTestId, variables, mapping],
     );
 
-    // Translate scenario display keys → UUIDs before handing mapping to
-    // the parent. The backend resolver matches on column UUID, so without
-    // this, saved evals that reference scenario columns fail at run time
-    // with "Column mapping mismatch".
-    const persistedMapping = useMemo(() => {
-      const out = {};
-      for (const [variable, field] of Object.entries(mapping)) {
-        out[variable] = scenarioKeyMap.current[field] || field;
-      }
-      return out;
-    }, [mapping, callDetail]);
+    const persistedMapping = useMemo(() => ({ ...mapping }), [mapping]);
 
     useEffect(() => {
       onReadyChange?.(isReady, persistedMapping);

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -173,6 +173,14 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
     # Dynamic scenario columns - these will be populated based on scenarios
     scenario_columns = serializers.SerializerMethodField()
 
+    # Persona profile attributes (gender, age_group, etc.) + free-form
+    # persona.metadata sub-keys. Frontend flattener emits flat.persona.<X>
+    # / flat.persona.metadata.<X> from these.
+    persona_profile = serializers.SerializerMethodField()
+
+    # Free-form Scenarios.metadata sub-keys (with internal references denylisted).
+    scenario_metadata = serializers.SerializerMethodField()
+
     # Graph-related field
     scenario_id = serializers.SerializerMethodField()
 
@@ -229,6 +237,8 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
             "eval_outputs",
             "eval_metrics",
             "scenario_columns",
+            "persona_profile",
+            "scenario_metadata",
             "ended_reason",
             "simulator_agent_name",
             "simulator_agent_id",
@@ -681,6 +691,54 @@ class CallExecutionDetailSerializer(serializers.ModelSerializer):
             scenario_data = {}
 
         return scenario_data
+
+    def get_persona_profile(self, obj):
+        """Persona attributes + Persona.metadata for the user-facing eval
+        mapping dropdown. Persona model fields only — SimulatorAgent fields
+        are deliberately excluded (legacy `persona.<sim_field>` mappings
+        still resolve at runtime via the eval-context resolver, but the
+        dropdown source must never list them).
+        """
+        if isinstance(obj, dict):
+            return {}
+        from simulate.utils.eval_context import (
+            flatten_persona,
+            resolve_persona_for_call,
+        )
+
+        persona = resolve_persona_for_call(obj)
+        if persona is None:
+            return {}
+
+        flat = flatten_persona(persona)
+        out = {}
+        for key, value in flat.items():
+            if not key.startswith("persona."):
+                continue
+            suffix = key[len("persona.") :]
+            if suffix.startswith("metadata."):
+                out.setdefault("metadata", {})[suffix[len("metadata.") :]] = value
+            else:
+                out[suffix] = value
+        return out
+
+    def get_scenario_metadata(self, obj):
+        """Free-form Scenarios.metadata sub-keys, with internal reference keys
+        denylisted (matches the eval context map's _SCENARIO_METADATA_DENYLIST).
+        """
+        if isinstance(obj, dict):
+            return {}
+        scenario = getattr(obj, "scenario", None)
+        if not scenario or not scenario.metadata:
+            return {}
+        from simulate.utils.eval_context import flatten_jsonfield_value
+
+        denylist = {"persona_ids", "agent_definition_version_id"}
+        return {
+            key: flatten_jsonfield_value(value)
+            for key, value in scenario.metadata.items()
+            if key not in denylist
+        }
 
     def get_scenario_id(self, obj):
         """Get scenario ID"""

--- a/futureagi/simulate/tests/test_call_detail_serializer.py
+++ b/futureagi/simulate/tests/test_call_detail_serializer.py
@@ -9,52 +9,18 @@ CreateSimulationPreviewMode.jsx.
 
 import pytest
 
-from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
-from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
-from simulate.models import AgentDefinition, Persona, Scenarios
-from simulate.models.run_test import RunTest
-from simulate.models.simulator_agent import SimulatorAgent
-from simulate.models.test_execution import CallExecution, TestExecution
 from simulate.serializers.test_execution import CallExecutionDetailSerializer
+from simulate.tests.factories import (
+    make_agent_definition,
+    make_call_execution,
+    make_persona,
+    make_run_test,
+    make_scenario,
+    make_simulator_agent,
+    make_test_execution,
+)
 
 pytestmark = pytest.mark.integration
-
-
-def _make_persona(organization, workspace, **overrides):
-    defaults = dict(
-        name="Test Persona",
-        organization=organization,
-        workspace=workspace,
-        persona_type=Persona.PersonaType.WORKSPACE,
-    )
-    defaults.update(overrides)
-    return Persona.objects.create(**defaults)
-
-
-def _make_agent_definition(organization, workspace):
-    return AgentDefinition.objects.create(
-        agent_name="Test Agent",
-        agent_type=AgentDefinition.AgentTypeChoices.VOICE,
-        inbound=True,
-        description="Test agent",
-        organization=organization,
-        workspace=workspace,
-        languages=["en"],
-    )
-
-
-def _make_simulator(organization, workspace, **overrides):
-    defaults = dict(
-        name="Sim",
-        prompt="You are a simulator",
-        voice_provider="elevenlabs",
-        voice_name="marissa",
-        model="gpt-4",
-        organization=organization,
-        workspace=workspace,
-    )
-    defaults.update(overrides)
-    return SimulatorAgent.objects.create(**defaults)
 
 
 def _make_call(
@@ -65,61 +31,42 @@ def _make_call(
     scenario_metadata=None,
     simulator=None,
 ):
-    """Bootstrap a CallExecution with optional persona / scenario.metadata wiring."""
-    agent_def = _make_agent_definition(organization, workspace)
-    simulator = simulator or _make_simulator(organization, workspace)
+    """Bootstrap a CallExecution with optional persona / scenario.metadata wiring.
+
+    Composes primitives from `simulate.tests.factories` — kept here (not in
+    the shared factories module) because the persona-resolution wiring is
+    specific to this suite's contract assertions.
+    """
+    agent_def = make_agent_definition(organization, workspace)
+    simulator = simulator or make_simulator_agent(organization, workspace)
 
     metadata = scenario_metadata or {}
     if persona is not None and "persona_ids" not in metadata:
         metadata["persona_ids"] = [str(persona.id)]
 
-    scenario = Scenarios.objects.create(
-        name="Test Scenario",
-        description="d",
-        source="s",
-        scenario_type=Scenarios.ScenarioTypes.DATASET,
-        organization=organization,
-        workspace=workspace,
-        agent_definition=agent_def,
-        status=StatusType.COMPLETED.value,
-        metadata=metadata,
+    scenario = make_scenario(
+        organization, workspace, agent_def, metadata=metadata
     )
-
-    rt = RunTest.objects.create(
-        name="rt",
-        description="d",
-        agent_definition=agent_def,
+    rt = make_run_test(
+        organization,
+        workspace,
+        agent_def,
         simulator_agent=simulator,
-        organization=organization,
-        workspace=workspace,
+        scenarios=[scenario],
     )
-    rt.scenarios.add(scenario)
-
-    te = TestExecution.objects.create(
-        run_test=rt,
-        status=TestExecution.ExecutionStatus.COMPLETED,
-        simulator_agent=simulator,
-        agent_definition=agent_def,
+    te = make_test_execution(
+        rt, agent_definition=agent_def, simulator_agent=simulator
     )
 
-    call_metadata = {}
-    if persona is not None:
-        call_metadata["row_data"] = {"persona": str(persona.id)}
-
-    return CallExecution.objects.create(
-        test_execution=te,
-        scenario=scenario,
-        phone_number="+1234567890",
-        status=CallExecution.CallStatus.COMPLETED,
-        call_metadata=call_metadata,
-    )
+    row_data = {"persona": str(persona.id)} if persona is not None else None
+    return make_call_execution(te, scenario, row_data=row_data)
 
 
 @pytest.mark.django_db
 def test_persona_profile_exposes_persona_model_attributes(
     organization, workspace
 ):
-    persona = _make_persona(
+    persona = make_persona(
         organization,
         workspace,
         name="Alice",
@@ -149,8 +96,8 @@ def test_persona_profile_excludes_simulator_fields(organization, workspace):
     still resolve at runtime via the eval-context resolver — but the
     dropdown source must never list them.
     """
-    persona = _make_persona(organization, workspace, name="Alice")
-    simulator = _make_simulator(
+    persona = make_persona(organization, workspace, name="Alice")
+    simulator = make_simulator_agent(
         organization, workspace, voice_name="alloy", prompt="You are helpful"
     )
     call = _make_call(
@@ -170,7 +117,7 @@ def test_persona_profile_excludes_simulator_fields(organization, workspace):
 def test_persona_profile_empty_when_no_persona_bound(organization, workspace):
     """If the scenario has no persona_ids and no row_data.persona, the
     profile is an empty dict (no SimulatorAgent stand-in)."""
-    simulator = _make_simulator(organization, workspace, voice_name="alloy")
+    simulator = make_simulator_agent(organization, workspace, voice_name="alloy")
     call = _make_call(organization, workspace, simulator=simulator)
 
     data = CallExecutionDetailSerializer(call).data
@@ -185,7 +132,7 @@ def test_persona_profile_nests_metadata_under_metadata_key(
     """Persona.metadata sub-keys should land under persona_profile["metadata"]
     so the frontend flattener can emit flat.persona.metadata.<key>.
     """
-    persona = _make_persona(
+    persona = make_persona(
         organization,
         workspace,
         metadata={"region": "EMEA", "vip_tier": "gold"},
@@ -200,7 +147,7 @@ def test_persona_profile_nests_metadata_under_metadata_key(
 
 @pytest.mark.django_db
 def test_persona_profile_multi_value_list_joined(organization, workspace):
-    persona = _make_persona(
+    persona = make_persona(
         organization,
         workspace,
         languages=["English", "Hindi", "Marathi"],

--- a/futureagi/simulate/tests/test_call_detail_serializer.py
+++ b/futureagi/simulate/tests/test_call_detail_serializer.py
@@ -1,0 +1,271 @@
+"""Integration tests for CallExecutionDetailSerializer's persona_profile and
+scenario_metadata fields.
+
+These fields drive the eval-mapping dropdown on the frontend — the dropdown
+auto-derives options from the serialized call-detail payload, so the shape
+asserted here is the contract with SimulationTestMode.jsx /
+CreateSimulationPreviewMode.jsx.
+"""
+
+import pytest
+
+from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from simulate.models import AgentDefinition, Persona, Scenarios
+from simulate.models.run_test import RunTest
+from simulate.models.simulator_agent import SimulatorAgent
+from simulate.models.test_execution import CallExecution, TestExecution
+from simulate.serializers.test_execution import CallExecutionDetailSerializer
+
+pytestmark = pytest.mark.integration
+
+
+def _make_persona(organization, workspace, **overrides):
+    defaults = dict(
+        name="Test Persona",
+        organization=organization,
+        workspace=workspace,
+        persona_type=Persona.PersonaType.WORKSPACE,
+    )
+    defaults.update(overrides)
+    return Persona.objects.create(**defaults)
+
+
+def _make_agent_definition(organization, workspace):
+    return AgentDefinition.objects.create(
+        agent_name="Test Agent",
+        agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+        inbound=True,
+        description="Test agent",
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+def _make_simulator(organization, workspace, **overrides):
+    defaults = dict(
+        name="Sim",
+        prompt="You are a simulator",
+        voice_provider="elevenlabs",
+        voice_name="marissa",
+        model="gpt-4",
+        organization=organization,
+        workspace=workspace,
+    )
+    defaults.update(overrides)
+    return SimulatorAgent.objects.create(**defaults)
+
+
+def _make_call(
+    organization,
+    workspace,
+    *,
+    persona=None,
+    scenario_metadata=None,
+    simulator=None,
+):
+    """Bootstrap a CallExecution with optional persona / scenario.metadata wiring."""
+    agent_def = _make_agent_definition(organization, workspace)
+    simulator = simulator or _make_simulator(organization, workspace)
+
+    metadata = scenario_metadata or {}
+    if persona is not None and "persona_ids" not in metadata:
+        metadata["persona_ids"] = [str(persona.id)]
+
+    scenario = Scenarios.objects.create(
+        name="Test Scenario",
+        description="d",
+        source="s",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=organization,
+        workspace=workspace,
+        agent_definition=agent_def,
+        status=StatusType.COMPLETED.value,
+        metadata=metadata,
+    )
+
+    rt = RunTest.objects.create(
+        name="rt",
+        description="d",
+        agent_definition=agent_def,
+        simulator_agent=simulator,
+        organization=organization,
+        workspace=workspace,
+    )
+    rt.scenarios.add(scenario)
+
+    te = TestExecution.objects.create(
+        run_test=rt,
+        status=TestExecution.ExecutionStatus.COMPLETED,
+        simulator_agent=simulator,
+        agent_definition=agent_def,
+    )
+
+    call_metadata = {}
+    if persona is not None:
+        call_metadata["row_data"] = {"persona": str(persona.id)}
+
+    return CallExecution.objects.create(
+        test_execution=te,
+        scenario=scenario,
+        phone_number="+1234567890",
+        status=CallExecution.CallStatus.COMPLETED,
+        call_metadata=call_metadata,
+    )
+
+
+@pytest.mark.django_db
+def test_persona_profile_exposes_persona_model_attributes(
+    organization, workspace
+):
+    persona = _make_persona(
+        organization,
+        workspace,
+        name="Alice",
+        gender=["female"],
+        age_group=["28-35"],
+        occupation=["Software Engineer"],
+        tone="casual",
+        verbosity="brief",
+    )
+    call = _make_call(organization, workspace, persona=persona)
+
+    data = CallExecutionDetailSerializer(call).data
+
+    profile = data["persona_profile"]
+    assert profile["name"] == "Alice"
+    assert profile["gender"] == "female"
+    assert profile["age_group"] == "28-35"
+    assert profile["occupation"] == "Software Engineer"
+    assert profile["tone"] == "casual"
+    assert profile["verbosity"] == "brief"
+
+
+@pytest.mark.django_db
+def test_persona_profile_excludes_simulator_fields(organization, workspace):
+    """SimulatorAgent fields must NOT show up in the user-facing persona profile,
+    even when a SimulatorAgent is bound. Legacy persona.<sim_field> mappings
+    still resolve at runtime via the eval-context resolver — but the
+    dropdown source must never list them.
+    """
+    persona = _make_persona(organization, workspace, name="Alice")
+    simulator = _make_simulator(
+        organization, workspace, voice_name="alloy", prompt="You are helpful"
+    )
+    call = _make_call(
+        organization, workspace, persona=persona, simulator=simulator
+    )
+
+    data = CallExecutionDetailSerializer(call).data
+
+    profile = data["persona_profile"]
+    assert profile["name"] == "Alice"
+    assert "voice_name" not in profile
+    assert "prompt" not in profile
+    assert "initial_message" not in profile
+
+
+@pytest.mark.django_db
+def test_persona_profile_empty_when_no_persona_bound(organization, workspace):
+    """If the scenario has no persona_ids and no row_data.persona, the
+    profile is an empty dict (no SimulatorAgent stand-in)."""
+    simulator = _make_simulator(organization, workspace, voice_name="alloy")
+    call = _make_call(organization, workspace, simulator=simulator)
+
+    data = CallExecutionDetailSerializer(call).data
+
+    assert data["persona_profile"] == {}
+
+
+@pytest.mark.django_db
+def test_persona_profile_nests_metadata_under_metadata_key(
+    organization, workspace
+):
+    """Persona.metadata sub-keys should land under persona_profile["metadata"]
+    so the frontend flattener can emit flat.persona.metadata.<key>.
+    """
+    persona = _make_persona(
+        organization,
+        workspace,
+        metadata={"region": "EMEA", "vip_tier": "gold"},
+    )
+    call = _make_call(organization, workspace, persona=persona)
+
+    data = CallExecutionDetailSerializer(call).data
+
+    assert data["persona_profile"]["metadata"]["region"] == "EMEA"
+    assert data["persona_profile"]["metadata"]["vip_tier"] == "gold"
+
+
+@pytest.mark.django_db
+def test_persona_profile_multi_value_list_joined(organization, workspace):
+    persona = _make_persona(
+        organization,
+        workspace,
+        languages=["English", "Hindi", "Marathi"],
+    )
+    call = _make_call(organization, workspace, persona=persona)
+
+    data = CallExecutionDetailSerializer(call).data
+
+    assert data["persona_profile"]["languages"] == "English, Hindi, Marathi"
+
+
+@pytest.mark.django_db
+def test_scenario_metadata_exposes_user_keys(organization, workspace):
+    call = _make_call(
+        organization,
+        workspace,
+        scenario_metadata={
+            "custom_instruction": "Be empathetic.",
+            "campaign_id": "Q2-launch",
+        },
+    )
+
+    data = CallExecutionDetailSerializer(call).data
+
+    metadata = data["scenario_metadata"]
+    assert metadata["custom_instruction"] == "Be empathetic."
+    assert metadata["campaign_id"] == "Q2-launch"
+
+
+@pytest.mark.django_db
+def test_scenario_metadata_filters_internal_reference_keys(
+    organization, workspace
+):
+    """persona_ids and agent_definition_version_id must NOT leak via the
+    serializer — same denylist as the eval context map.
+    """
+    call = _make_call(
+        organization,
+        workspace,
+        scenario_metadata={
+            "custom_instruction": "..",
+            "persona_ids": ["aaa-bbb"],
+            "agent_definition_version_id": "ccc-ddd",
+        },
+    )
+
+    data = CallExecutionDetailSerializer(call).data
+
+    assert "persona_ids" not in data["scenario_metadata"]
+    assert "agent_definition_version_id" not in data["scenario_metadata"]
+    assert data["scenario_metadata"]["custom_instruction"] == ".."
+
+
+@pytest.mark.django_db
+def test_scenario_metadata_jsonfield_values_flattened(organization, workspace):
+    call = _make_call(
+        organization,
+        workspace,
+        scenario_metadata={
+            "tags": ["urgent", "billing"],
+            "single_tag": ["solo"],
+        },
+    )
+
+    data = CallExecutionDetailSerializer(call).data
+
+    assert data["scenario_metadata"]["tags"] == "urgent, billing"
+    assert data["scenario_metadata"]["single_tag"] == "solo"

--- a/futureagi/simulate/utils/eval_context.py
+++ b/futureagi/simulate/utils/eval_context.py
@@ -158,7 +158,14 @@ def resolve_persona_for_call(call_execution):
     2. First Persona referenced by scenario.metadata.persona_ids
        (ordered by created_at — stable across runs).
     3. None — `persona.*` keys resolve to "".
+
+    Invalid UUIDs in either source resolve to None instead of raising;
+    callers (eval resolver, serializer) treat that as "no persona bound".
     """
+    import uuid as _uuid
+
+    from django.core.exceptions import ValidationError
+
     from simulate.models import Persona
 
     metadata = call_execution.call_metadata or {}
@@ -169,7 +176,7 @@ def resolve_persona_for_call(call_execution):
             return Persona.no_workspace_objects.get(
                 id=row_persona_id, deleted=False
             )
-        except (Persona.DoesNotExist, ValueError):
+        except (Persona.DoesNotExist, ValueError, ValidationError):
             pass
 
     scenario = getattr(call_execution, "scenario", None)
@@ -179,13 +186,19 @@ def resolve_persona_for_call(call_execution):
     persona_ids = scenario_meta.get("persona_ids") or []
     if not persona_ids:
         return None
-    try:
-        return (
-            Persona.no_workspace_objects.filter(
-                id__in=persona_ids, deleted=False
-            )
-            .order_by("created_at")
-            .first()
-        )
-    except ValueError:
+
+    valid_ids = []
+    for pid in persona_ids:
+        try:
+            _uuid.UUID(str(pid))
+            valid_ids.append(pid)
+        except (ValueError, TypeError):
+            continue
+    if not valid_ids:
         return None
+
+    return (
+        Persona.no_workspace_objects.filter(id__in=valid_ids, deleted=False)
+        .order_by("created_at")
+        .first()
+    )


### PR DESCRIPTION
## Summary

**Phase 2** of the TH-4952 eval-mapping stabilization stack — exposes the new vocabulary on the API and removes the legacy UUID translation in the frontend eval picker. Stacked on PR #536.

Two changes:

1. **`CallExecutionDetailSerializer`** gains two `SerializerMethodField`s that drive the user-facing eval-mapping dropdown:
   - `persona_profile`: every Persona model attribute (`gender`, `age_group`, `occupation`, `tone`, `verbosity`, `languages`, `accent`, etc.) flat-keyed, plus nested `persona_profile["metadata"][<key>]` for free-form `Persona.metadata`. SimulatorAgent fields are deliberately omitted — legacy `persona.<sim_field>` mappings still resolve at runtime via the eval-context resolver, but the dropdown source must never list them. `{}` when no Persona is bound.
   - `scenario_metadata`: free-form `Scenarios.metadata` sub-keys with internal reference keys (`persona_ids`, `agent_definition_version_id`) denylisted to prevent schema leakage into eval prompts.

   Both methods delegate to helpers in `simulate/utils/eval_context.py` so the user-facing dropdown vocabulary and the eval-context resolver share a single source of truth. Defensive hardening on `resolve_persona_for_call`: catches `ValidationError` and pre-filters non-UUID strings from `persona_ids`.

2. **`SimulationTestMode.jsx` + `CreateSimulationPreviewMode.jsx`** stop maintaining the display-key → scenario-column-UUID `scenarioKeyMap` ref. The backend resolver (`resolve_scenario_column_by_name`, Phase 1) matches by `Column.name` within the call's dataset, so the persisted mapping value is now the same dotted key the dropdown displays. Persona dropdown vocabulary now sources from `persona_profile`; scenario sub-keys from `scenario_metadata`. Reserved sub-keys `info` and `metadata` are guarded against collision with columns of those names.

## Linked issues

Refs TH-4952.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- 8 new integration tests in `simulate/tests/test_call_detail_serializer.py` — cover Persona/Simulator split, no-persona empty dict, metadata nesting, multi-value list flattening, scenario_metadata denylist, JSONField flattening. 8/8 pass.
- 19 existing Phase 1 tests in `simulate/tests/test_xl_eval_context.py` still pass (27/27 combined).
- Frontend: `npx eslint` on both touched files — 0 errors (only pre-existing warnings). 32/32 tests pass under `src/sections/evals` + `src/sections/common/EvalPicker` (including the `onReadyChange` prop-wiring regression guard from TH-5013).
- AST-verified that `CallExecutionInput.eval_config_ids` and `RunSimulateEvaluationsInput.eval_config_ids` accept the value shapes used by the resolver.

Manual end-to-end testing is deferred to **after Phase 3 data migration** so the full converged behavior (new + legacy + migrated evals) can be exercised at once. Manual checklist tracked separately.

## Surprises (please read before approving)

- **Legacy UUID-keyed mappings:** pre-TH-4952 evals stored mapping values as scenario-column UUIDs. After this PR those UUIDs no longer match any dropdown vocabulary key, so editing a legacy eval shows variables as unmapped in the picker UI. **Eval runs still work** — the Phase 1 resolver retains the legacy UUID code path. Phase 3 will run a data migration to convert UUIDs → dotted keys.
- **Reserved sub-keys `info` and `metadata`:** scenario columns named `info` or `metadata` are skipped on write to avoid colliding with the reserved `scenario.info.*` / `scenario.metadata.*` namespace (enforced server-side at `xl.py:683-689`).
- **Preview-mode persona vocabulary:** at form-time the bound Persona isn't resolved yet (selection happens at run time via `scenario.metadata.persona_ids` / per-row `row_data.persona`). The 24 Persona model fields are seeded with `RUNTIME_PLACEHOLDER` so the dropdown vocabulary matches `SimulationTestMode`.

## Screenshots / recordings (if UI)

Deferred to end-of-stack manual testing.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)