### PR TITLE
[TH-5357] feat(error-feed): show call recording on Overview for simulator projects

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/TranscriptView.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/TranscriptView.jsx
@@ -488,7 +488,7 @@ const FILTERS = [
   { id: "user", label: "Customer" },
 ];
 
-const TranscriptView = ({ transcript, onAnnotate }) => {
+const TranscriptView = ({ transcript, onAnnotate, embedded = false }) => {
   const colors = useSpeakerColors();
 
   const seekTo = useVoiceAudioStore((s) => s.seekTo);
@@ -566,23 +566,50 @@ const TranscriptView = ({ transcript, onAnnotate }) => {
     return () => document.removeEventListener("keydown", onKey);
   }, [filteredTurns.length]);
 
-  // Scroll focused row into view (j/k nav overrides autoScroll — it's an
-  // explicit navigation action)
+  // Scrolls a row into view *inside the list container only* using
+  // `listRef.scrollTo` — never `scrollIntoView`, which walks up scrollable
+  // ancestors and pulls the host page along when embedded.
   const rowRefs = useRef([]);
   const listRef = useRef(null);
+  const scrollRowIntoView = useCallback(
+    ({ idx, block = "center", behavior = "smooth" }) => {
+      const rowEl = rowRefs.current[idx];
+      if (!rowEl) return;
+      // Drawer keeps the original scrollIntoView behavior. Embedded mode
+      // scopes the scroll to the list container so it can never walk up
+      // and pull the host page along with it.
+      if (!embedded) {
+        rowEl.scrollIntoView({ block, behavior });
+        return;
+      }
+      const listEl = listRef.current;
+      if (!listEl) return;
+      const rowRect = rowEl.getBoundingClientRect();
+      const listRect = listEl.getBoundingClientRect();
+      const rowTop = rowRect.top - listRect.top + listEl.scrollTop;
+      const rowBottom = rowTop + rowRect.height;
+      const viewTop = listEl.scrollTop;
+      const viewBottom = viewTop + listEl.clientHeight;
+      let target;
+      if (block === "nearest") {
+        if (rowTop >= viewTop && rowBottom <= viewBottom) return;
+        target = rowTop < viewTop ? rowTop : rowBottom - listEl.clientHeight;
+      } else {
+        target = rowTop - listEl.clientHeight / 2 + rowRect.height / 2;
+      }
+      listEl.scrollTo({ top: Math.max(0, target), behavior });
+    },
+    [embedded],
+  );
+
+  // j/k nav — overrides autoScroll (explicit user action)
   useEffect(() => {
     if (focusIdx >= 0) {
-      rowRefs.current[focusIdx]?.scrollIntoView({
-        block: "nearest",
-        behavior: "smooth",
-      });
+      scrollRowIntoView({ idx: focusIdx, block: "nearest" });
     }
-  }, [focusIdx]);
+  }, [focusIdx, scrollRowIntoView]);
 
-  // Auto-scroll to playing row — debounced so that rapid playingIdx churn
-  // (e.g. the currentTime poller nudging by fractions of a second) does not
-  // trigger a scrollIntoView on every frame. We only actually scroll once
-  // the value has been stable for ~250ms, which matches how a human reads.
+  // Playback follow — debounced 250ms against currentTime poller churn.
   const lastScrolledIdxRef = useRef(-1);
   useEffect(() => {
     if (!autoScroll) return;
@@ -591,23 +618,18 @@ const TranscriptView = ({ transcript, onAnnotate }) => {
     const handle = setTimeout(() => {
       if (lastScrolledIdxRef.current === playingIdx) return;
       lastScrolledIdxRef.current = playingIdx;
-      rowRefs.current[playingIdx]?.scrollIntoView({
-        block: "center",
-        behavior: "smooth",
-      });
+      scrollRowIntoView({ idx: playingIdx, block: "center" });
     }, 250);
     return () => clearTimeout(handle);
-  }, [playingIdx, autoScroll]);
+  }, [playingIdx, autoScroll, scrollRowIntoView]);
 
-  // When the transcript source changes (user jumped to a different
-  // recording), move the view to wherever the audio is now — but only if
-  // autoScroll is still active. If the user had already disabled autoScroll
-  // on the previous call, preserve that preference across the jump.
+  // Transcript source changed — jump within the list to the current row.
   useEffect(() => {
     lastScrolledIdxRef.current = -1;
     if (!autoScroll) return;
     if (playingIdx >= 0) {
-      rowRefs.current[playingIdx]?.scrollIntoView({
+      scrollRowIntoView({
+        idx: playingIdx,
         block: "center",
         behavior: "auto",
       });
@@ -615,14 +637,11 @@ const TranscriptView = ({ transcript, onAnnotate }) => {
     } else {
       listRef.current?.scrollTo?.({ top: 0, behavior: "auto" });
     }
-    // Intentionally depending on `transcript` identity, not playingIdx, so
-    // this fires exactly once per new call.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [transcript]);
 
-  // Detect user-initiated scroll intent. Using wheel/touch/keydown (rather
-  // than the scroll event) lets us distinguish manual scrolling from the
-  // programmatic scrollIntoView calls above without fragile flag passing.
+  // wheel/touch/keydown lets us distinguish manual scroll from the
+  // programmatic scrollRowIntoView calls above.
   const handleUserScrollIntent = useCallback(() => {
     setAutoScroll(false);
   }, []);
@@ -656,12 +675,9 @@ const TranscriptView = ({ transcript, onAnnotate }) => {
   const handleResumeFollow = useCallback(() => {
     setAutoScroll(true);
     if (playingIdx >= 0) {
-      rowRefs.current[playingIdx]?.scrollIntoView({
-        block: "center",
-        behavior: "smooth",
-      });
+      scrollRowIntoView({ idx: playingIdx, block: "center" });
     }
-  }, [playingIdx]);
+  }, [playingIdx, scrollRowIntoView]);
 
   const handleCopyTurn = useCallback((turn) => {
     const text = `[${formatClock(turn.start)}] ${turn.rawRole || turn.role}: ${turn.content}`;
@@ -896,6 +912,7 @@ const TranscriptView = ({ transcript, onAnnotate }) => {
 TranscriptView.propTypes = {
   transcript: PropTypes.array,
   onAnnotate: PropTypes.func,
+  embedded: PropTypes.bool,
 };
 
 export default TranscriptView;

--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceLeftPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceLeftPanel.jsx
@@ -34,7 +34,7 @@ const PATH_VIEW_MODE = {
  * a hidden container on non-transcript tabs) so seeking via click from
  * a path view keeps the audio player hydrated.
  */
-const VoiceLeftPanel = ({ data, scenarioId }) => {
+const VoiceLeftPanel = ({ data, scenarioId, embedded = false }) => {
   const isSimulate = data?.module === "simulate";
   const [currentTab, setCurrentTab] = useState(TABS.TRANSCRIPT);
 
@@ -87,24 +87,28 @@ const VoiceLeftPanel = ({ data, scenarioId }) => {
       }}
     >
       {/* Tabs at the top — no chrome above them so all four views get
-          the full panel height. */}
-      <Box sx={{ px: 1.25, flexShrink: 0 }}>
-        <CompactTabs
-          value={currentTab}
-          onChange={(_, value) => setCurrentTab(value)}
-          tabs={tabs}
-        />
-      </Box>
+          the full panel height. Hidden in `embedded` mode (e.g. error-feed
+          Overview) where the parent SectionCard already provides chrome. */}
+      {!embedded && (
+        <Box sx={{ px: 1.25, flexShrink: 0 }}>
+          <CompactTabs
+            value={currentTab}
+            onChange={(_, value) => setCurrentTab(value)}
+            tabs={tabs}
+          />
+        </Box>
+      )}
 
-      {/* Scrollable tab content */}
+      {/* Scrollable tab content. `embedded` callers drop internal padding so
+          the panel sits flush inside their own container. */}
       <Box
         sx={{
           flex: 1,
           minHeight: 0,
           overflow: "auto",
-          px: 1.25,
-          pt: 1,
-          pb: 1,
+          px: embedded ? 0 : 1.25,
+          pt: embedded ? 0 : 1,
+          pb: embedded ? 0 : 1,
           display: "flex",
           flexDirection: "column",
         }}
@@ -141,7 +145,9 @@ const VoiceLeftPanel = ({ data, scenarioId }) => {
                         }),
                   }}
                 >
-                  <ShowComponent condition={!!filteredTranscript?.length}>
+                  <ShowComponent
+                    condition={!!filteredTranscript?.length && !embedded}
+                  >
                     <Typography
                       sx={{
                         fontSize: 10,
@@ -184,6 +190,7 @@ const VoiceLeftPanel = ({ data, scenarioId }) => {
 VoiceLeftPanel.propTypes = {
   data: PropTypes.object.isRequired,
   scenarioId: PropTypes.string,
+  embedded: PropTypes.bool,
 };
 
 export default VoiceLeftPanel;

--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceLeftPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceLeftPanel.jsx
@@ -165,7 +165,10 @@ const VoiceLeftPanel = ({ data, scenarioId, embedded = false }) => {
                 </Box>
                 <ShowComponent condition={!!filteredTranscript?.length}>
                   <Box sx={{ flex: 1, minHeight: 0, display: "flex" }}>
-                    <TranscriptView transcript={filteredTranscript} />
+                    <TranscriptView
+                      transcript={filteredTranscript}
+                      embedded={embedded}
+                    />
                   </Box>
                 </ShowComponent>
               </Stack>

--- a/frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx
@@ -18,6 +18,9 @@ import Iconify from "src/components/iconify";
 import AgentGraph from "src/sections/projects/LLMTracing/GraphSection/AgentGraph";
 import { buildTraceGraph } from "src/components/traceDetail/buildTraceGraph";
 import { useGetTraceDetail } from "src/api/project/trace-detail";
+import { useGetProjectDetails } from "src/api/project/project-detail";
+import { PROJECT_SOURCE } from "src/utils/constants";
+import TraceVoicePanel from "./TraceVoicePanel";
 import {
   useErrorFeedDeepAnalysis,
   useErrorFeedOverview,
@@ -827,7 +830,7 @@ function PatternSummary({ summary, clusterId }) {
 
   return (
     <Box
-      sx={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 1 }}
+      sx={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 1, overflowX: "auto" }}
     >
       {slots.map((insight, i) => (
         <Box
@@ -924,6 +927,7 @@ function TraceAgentFlow({ traceId }) {
   );
 }
 TraceAgentFlow.propTypes = { traceId: PropTypes.string };
+
 
 // ── Trace evidence reel (fail / pass tabs) ───────────────────────────────────
 
@@ -1604,6 +1608,10 @@ export default function OverviewTab({ _error: currentError }) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const clusterId = currentError?.clusterId;
+  const projectId = currentError?.projectId;
+  const { data: projectDetail } = useGetProjectDetails(projectId, !!projectId);
+  const isVoiceProject =
+    projectDetail?.source === PROJECT_SOURCE.SIMULATOR;
   const { data: overview, isLoading: isOverviewLoading } =
     useErrorFeedOverview(clusterId);
   const traces = useMemo(
@@ -1888,13 +1896,16 @@ export default function OverviewTab({ _error: currentError }) {
               <PatternSummary summary={patternSummary} clusterId={clusterId} />
             </SectionCard>
 
-            {/* Agent Flow */}
             <SectionCard
-              title="Agent Flow"
-              icon="mdi:graph-outline"
+              title={isVoiceProject ? "Call Recording" : "Agent Flow"}
+              icon={isVoiceProject ? "mdi:phone-outline" : "mdi:graph-outline"}
               collapsible
             >
-              <TraceAgentFlow traceId={trace.id} />
+              {isVoiceProject ? (
+                <TraceVoicePanel traceId={trace.id} projectId={projectId} />
+              ) : (
+                <TraceAgentFlow traceId={trace.id} />
+              )}
             </SectionCard>
 
             {/* Trace Evidence — scanner clusters only (evals don't have scanner steps) */}

--- a/frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/OverviewTab.jsx
@@ -3,12 +3,9 @@ import ApexCharts from "apexcharts";
 import { format } from "date-fns";
 import {
   Box,
-  Button,
   Chip,
-  IconButton,
   Skeleton,
   Stack,
-  Tooltip,
   Typography,
   alpha,
   useTheme,
@@ -1961,5 +1958,6 @@ OverviewTab.propTypes = {
   _error: PropTypes.shape({
     clusterId: PropTypes.string,
     source: PropTypes.string,
+    projectId: PropTypes.string,
   }),
 };

--- a/frontend/src/pages/dashboard/error-feed/components/TraceVoicePanel.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/TraceVoicePanel.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Box, Typography } from "@mui/material";
+import { useVoiceCallDetail } from "src/sections/agents/helper";
+import VoiceLeftPanel from "src/components/VoiceDetailDrawerV2/VoiceLeftPanel";
+import TraceVoiceSkeleton from "./TraceVoiceSkeleton";
+
+function TraceVoicePanel({ traceId, projectId }) {
+  const {
+    data: voiceCallData,
+    isFetching,
+    error,
+  } = useVoiceCallDetail(traceId, !!traceId);
+
+  if (error) {
+    return (
+      <Typography
+        typography="caption"
+        color="error.main"
+        sx={{ py: 2, textAlign: "center", display: "block" }}
+      >
+        Failed to load voice call
+      </Typography>
+    );
+  }
+
+  if (isFetching && !voiceCallData) {
+    return <TraceVoiceSkeleton />;
+  }
+
+  if (!voiceCallData) {
+    return (
+      <Typography
+        typography="caption"
+        color="text.disabled"
+        sx={{ py: 2, textAlign: "center", display: "block" }}
+      >
+        No voice call data available for this trace
+      </Typography>
+    );
+  }
+
+  const data = { ...voiceCallData, project_id: projectId, module: "project" };
+
+  return (
+    <Box sx={{ minHeight: 400, display: "flex", flexDirection: "column" }}>
+      <VoiceLeftPanel data={data} embedded />
+    </Box>
+  );
+}
+
+TraceVoicePanel.propTypes = {
+  traceId: PropTypes.string,
+  projectId: PropTypes.string,
+};
+
+export default TraceVoicePanel;

--- a/frontend/src/pages/dashboard/error-feed/components/TraceVoicePanel.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/TraceVoicePanel.jsx
@@ -43,7 +43,13 @@ function TraceVoicePanel({ traceId, projectId }) {
   const data = { ...voiceCallData, project_id: projectId, module: "project" };
 
   return (
-    <Box sx={{ minHeight: 400, display: "flex", flexDirection: "column" }}>
+    <Box
+      sx={{
+        height: "clamp(420px, 70vh, 700px)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
       <VoiceLeftPanel data={data} embedded />
     </Box>
   );

--- a/frontend/src/pages/dashboard/error-feed/components/TraceVoiceSkeleton.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/TraceVoiceSkeleton.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Skeleton, Stack } from "@mui/material";
+
+const TraceVoiceSkeleton = () => (
+  <Stack gap={1} sx={{ p: 1 }}>
+    <Skeleton variant="rounded" width="40%" height={28} />
+    <Skeleton variant="rounded" width="100%" height={70} />
+    <Skeleton variant="rounded" width="100%" height={70} />
+    <Stack gap={0.5} sx={{ mt: 1 }}>
+      {[0, 1, 2, 3].map((i) => (
+        <Skeleton
+          key={i}
+          variant="text"
+          width={i % 2 ? "80%" : "60%"}
+          height={20}
+        />
+      ))}
+    </Stack>
+  </Stack>
+);
+
+export default TraceVoiceSkeleton;


### PR DESCRIPTION
## Summary
On `/dashboard/error-feed/:clusterId` Overview tab, swap the Agent Flow diagram for the shared `VoiceLeftPanel` when the cluster's project has `source === "simulator"`. Agent-flow stays unchanged for non-simulator projects.

Closes TH-5357

## Linear
[TH-5357](https://linear.app/future-agi/issue/TH-5357)

## Changes
- **`OverviewTab.jsx`** — fetch project details, compute `isVoiceProject`, conditionally swap the SectionCard body and title (`Agent Flow` ↔ `Call Recording`).
- **`TraceVoicePanel.jsx`** (new) — fetches voice call data via existing `useVoiceCallDetail` hook, renders `VoiceLeftPanel` in `embedded` mode with bounded height `clamp(420px, 70vh, 700px)` so the inner list is a real overflow scroll container at any viewport size.
- **`TraceVoiceSkeleton.jsx`** (new) — loading placeholder shaped like the actual panel.
- **`VoiceLeftPanel.jsx`** — new `embedded` prop (opt-in). When true: hides the top tab strip, drops internal padding, hides the inner "Recording" subheading, and forwards the flag to `TranscriptView`. All four existing call sites (voice drawer, shared view, full-page, annotate) keep the default and render unchanged.
- **`TranscriptView.jsx`** — `embedded` prop. When true, the scroll helper uses list-local `scrollTo` math (rowRect / listRect / scrollTop / clientHeight) so the scroll is scoped to the transcript list and never walks up to ancestors. When false, the original `scrollIntoView` path is preserved — drawer/shared/full-page UX untouched.

## Why two commits
1. `97265af07` — the feature itself (swap Agent Flow ↔ Call Recording, embedded VoiceLeftPanel).
2. `08e89083f` — scope the transcript auto-follow scroll to the list container so the host page doesn't get yanked when audio plays in the embedded view. Also bumps the panel to a `clamp()` height so the list is bounded and the wheel handler stops intercepting page-level scrolls.

Stamps `module: "project"` on the payload to route `AudioPlayerCustom` into the project-shape branch + lets `CallDetailsBar` fetch trace tags — matches the convention used by `VoiceFullPage` / `VoiceCallsGrid` / `SharedVoiceView` / `TracesTab` (per the TH-5336 fix).

## Test plan
- [ ] Open `/dashboard/error-feed/E-1EA48B77` (Brew Buddy 2, source=simulator) → Overview tab shows **Call Recording** card with the waveform + transcript instead of Agent Flow.
- [ ] Open a non-simulator cluster (any LLM/observe cluster) → still shows **Agent Flow** (regression check).
- [ ] In the Call Recording panel, hit Play → transcript follows the highlighted row inside its own scroll container; **host page does not move**.
- [ ] Wheel-scroll inside the transcript list → auto-follow disables, "Follow playback" pill appears, clicking it re-enables (existing UX).
- [ ] Switch traces in the "Traces affected" sidebar → recording panel refetches for the new trace.
- [ ] Cold-load shows skeleton, then panel; error case (block `voice_call_detail` in DevTools) shows "Failed to load voice call".
- [ ] Voice drawer (`/dashboard/observe/.../voice/<trace>`) — full regression: tab strip visible, padding intact, auto-follow scrolls the drawer transcript as before, no host-page movement (drawer is fixed-positioned anyway).
- [ ] Shared voice view (`/share/...`) — same flows work.
- [ ] Small laptop viewport (≤768px tall) — Call Recording card fits within the page, not dominating; transcript still scrollable inside.