### PR TITLE
fix: dataset row deletion payload keys + persona text clamp

### DIFF
--- a/frontend/src/sections/persona/PersonaInfo/PersonaBasicInfo.jsx
+++ b/frontend/src/sections/persona/PersonaInfo/PersonaBasicInfo.jsx
@@ -59,7 +59,6 @@ const PersonaBasicInfo = ({ persona }) => {
             sx={{
               display: "-webkit-box",
               WebkitBoxOrient: "vertical",
-              WebkitLineClamp: 2,
               overflow: "hidden",
               textOverflow: "ellipsis",
             }}

--- a/frontend/src/sections/scenarios/scenario-detail/ScenarioDetailSelectionView.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/ScenarioDetailSelectionView.jsx
@@ -58,9 +58,9 @@ const ScenarioDetailSelectionView = ({ dataset }) => {
   const { mutate: onDeleteDatasetRow, isPending: isDeleting } = useMutation({
     mutationFn: () => {
       const selectedIds = toggledNodes;
-
+      
       return axios.delete(endpoints.develop.deleteDatasetRow(dataset), {
-        data: { rowIds: selectedIds, selectedAllRows: selectAll },
+        data: { row_ids: selectedIds, selected_all_rows: selectAll },
       });
     },
     onSuccess: () => {


### PR DESCRIPTION
## Test plan

**Dataset row deletion** (snake_case payload keys)
- [x] Select one or more rows → delete → those rows are removed (no MISSING_ROW_IDS error)
- [x] "Select all" → delete → every row in the dataset is removed
- [x] "Select all", deselect a few → delete → only the kept rows remain
- [x] Delete with nothing selected → action disabled / no request fired
- [x] Grid refreshes and row count updates after deletion
- [x] Request body sends `row_ids` and `selected_all_rows` (snake_case)

**Persona basic info** (removed WebkitLineClamp: 2)
- [x] Persona with long text → renders in full, no 2-line truncation

Closes TH-5356,TH-5358

