### PR TITLE
fix(oss): move billing enums to tfc and guard dataset creation paths

### DIFF
--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -64,16 +64,14 @@ from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.pagination import ExtendedPageNumberPagination
 from tfc.utils.parse_errors import parse_serialized_errors
 
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
 try:
     from ee.usage.models.usage import (
-        APICallStatusChoices,
-        APICallTypeChoices,
         OrganizationSubscription,
         SubscriptionTierChoices,
     )
 except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
     OrganizationSubscription = None
     SubscriptionTierChoices = None
 try:

--- a/futureagi/ai_tools/tools/prompts/run_prompt.py
+++ b/futureagi/ai_tools/tools/prompts/run_prompt.py
@@ -60,10 +60,10 @@ class RunPromptTool(BaseTool):
         from model_hub.utils.column_utils import is_json_response_format
         from model_hub.utils.utils import remove_empty_text_from_messages
         from model_hub.views.prompt_template import replace_variables
+        from tfc.constants.api_calls import APICallTypeChoices
         try:
-            from ee.usage.utils.usage_entries import APICallTypeChoices, log_and_deduct_cost_for_api_request
+            from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
         except ImportError:
-            APICallTypeChoices = None
             log_and_deduct_cost_for_api_request = None
 
         template_obj, err = resolve_prompt_template(

--- a/futureagi/model_hub/services/dataset_service.py
+++ b/futureagi/model_hub/services/dataset_service.py
@@ -27,15 +27,14 @@ class ServiceError:
 def _check_resource_limit(organization, workspace, api_call_type, config=None):
     """Check resource limits. Returns True if allowed, False if limit reached."""
     try:
-        try:
-            from ee.usage.models import APICallStatusChoices, APICallTypeChoices
-        except ImportError:
-            APICallStatusChoices = None
-            APICallTypeChoices = None
+        from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
         try:
             from ee.usage.utils import log_and_deduct_cost_for_resource_request
         except ImportError:
             log_and_deduct_cost_for_resource_request = None
+
+        if log_and_deduct_cost_for_resource_request is None:
+            return True
 
         call_log = log_and_deduct_cost_for_resource_request(
             organization,

--- a/futureagi/model_hub/tasks/develop_dataset.py
+++ b/futureagi/model_hub/tasks/develop_dataset.py
@@ -51,11 +51,7 @@ from tfc.temporal import temporal_activity
 from tfc.utils.storage import (
     delete_compare_folder,
 )
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
@@ -364,10 +360,7 @@ def create_synthetic_dataset(
         if not request_uuid:
             request_uuid = task_manager.start_task(str(dataset_id))
 
-        try:
-            from ee.usage.models.usage import APICallTypeChoices
-        except ImportError:
-            APICallTypeChoices = None
+        from tfc.constants.api_calls import APICallTypeChoices
         try:
             from ee.usage.schemas.event_types import BillingEventType
         except ImportError:
@@ -377,11 +370,12 @@ def create_synthetic_dataset(
         except ImportError:
             check_usage = None
 
-        _usage_check = check_usage(
-            str(organization.id), BillingEventType.SYNTHETIC_DATA_GENERATION
-        )
-        if not _usage_check.allowed:
-            raise ValueError(_usage_check.reason or "Usage limit exceeded")
+        if check_usage is not None and BillingEventType is not None:
+            _usage_check = check_usage(
+                str(organization.id), BillingEventType.SYNTHETIC_DATA_GENERATION
+            )
+            if not _usage_check.allowed:
+                raise ValueError(_usage_check.reason or "Usage limit exceeded")
 
         agent = SyntheticDataAgent(dataset_id=dataset_id, request_uuid=request_uuid)
 
@@ -446,7 +440,7 @@ def create_synthetic_dataset(
         tik_total_tokens = 0
         for col in synthetic_df.columns:
             for value in synthetic_df[col]:
-                tik_total_tokens += count_text_tokens(str(value))
+                tik_total_tokens += (count_text_tokens(str(value)) if count_text_tokens else 0)
 
         rows = list(Row.objects.filter(dataset=dataset))
 
@@ -513,21 +507,22 @@ def create_synthetic_dataset(
                 "input_tokens": int(tik_total_tokens),
             }
 
-            api_call_log_row = log_and_deduct_cost_for_api_request(
-                organization,
-                api_call_type,
-                config=api_call_config,
-                source="synthetic_dataset",
-                workspace=dataset.workspace,
-            )
-
-            if not api_call_log_row:
-                raise ValueError(
-                    "API call not allowed : Error validating the api call."
+            if log_and_deduct_cost_for_api_request is not None:
+                api_call_log_row = log_and_deduct_cost_for_api_request(
+                    organization,
+                    api_call_type,
+                    config=api_call_config,
+                    source="synthetic_dataset",
+                    workspace=dataset.workspace,
                 )
 
-            if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-                raise ValueError("API call not allowed : ", api_call_log_row.status)
+                if not api_call_log_row:
+                    raise ValueError(
+                        "API call not allowed : Error validating the api call."
+                    )
+
+                if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
+                    raise ValueError("API call not allowed : ", api_call_log_row.status)
 
             # Dual-write: emit usage event for new billing system (cost-based)
             try:
@@ -547,9 +542,12 @@ def create_synthetic_dataset(
                 actual_cost = getattr(agent, "cost", {}).get("total_cost", 0)
                 if not actual_cost and hasattr(agent, "llm"):
                     actual_cost = getattr(agent.llm, "cost", {}).get("total_cost", 0)
-                credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+                credits = 0
+                if BillingConfig is not None:
+                    credits = BillingConfig.get().calculate_ai_credits(actual_cost)
 
-                emit(
+                if emit is not None and UsageEvent is not None:
+                    emit(
                     UsageEvent(
                         org_id=str(organization.id),
                         event_type=api_call_type,

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -42,12 +42,12 @@ from tfc.utils.distributed_locks import distributed_lock_manager
 from tfc.utils.distributed_state import evaluation_tracker
 from tfc.utils.error_codes import get_error_for_api_status
 from tracer.models.observation_span import EvalLogger
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
 try:
-    from ee.usage.models.usage import APICallLog, APICallStatusChoices, APICallTypeChoices
+    from ee.usage.models.usage import APICallLog
 except ImportError:
     APICallLog = None
-    APICallStatusChoices = None
-    APICallTypeChoices = None
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 except ImportError:

--- a/futureagi/model_hub/tests/test_background_helpers.py
+++ b/futureagi/model_hub/tests/test_background_helpers.py
@@ -433,7 +433,7 @@ class TestCreateKnowledgeBaseEntitlements:
         mock_kb_filter,
         mock_user_get,
     ):
-        from ee.usage.models.usage import APICallStatusChoices
+        from tfc.constants.api_calls import APICallStatusChoices
         from model_hub.views.develop_dataset import CreateKnowledgeBaseView
 
         view = CreateKnowledgeBaseView()

--- a/futureagi/model_hub/tests/test_user_evaluation_tasks.py
+++ b/futureagi/model_hub/tests/test_user_evaluation_tasks.py
@@ -459,10 +459,7 @@ class TestProcessSingleErrorLocalization:
         """Test successful error localization processing."""
         from model_hub.models.error_localizer_model import ErrorLocalizerStatus
         from model_hub.tasks.user_evaluation import process_single_error_localization
-        try:
-            from ee.usage.models.usage import APICallStatusChoices
-        except ImportError:
-            APICallStatusChoices = None
+        from tfc.constants.api_calls import APICallStatusChoices
 
         mock_check_usage.return_value = MagicMock(allowed=True)
 

--- a/futureagi/model_hub/utils/async_generate_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_generate_prompt_runner.py
@@ -12,14 +12,11 @@ except ImportError:
     PromptGenerator = _ee_stub("PromptGenerator")
 
 logger = structlog.get_logger(__name__)
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
 try:
-    from ee.usage.models.usage import APICallStatusChoices
+    from ee.usage.utils.usage_entries import count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallStatusChoices = None
-try:
-    from ee.usage.utils.usage_entries import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
-except ImportError:
-    APICallTypeChoices = None
     count_text_tokens = None
     log_and_deduct_cost_for_api_request = None
 

--- a/futureagi/model_hub/utils/async_improve_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_improve_prompt_runner.py
@@ -12,14 +12,11 @@ except ImportError:
     PromptGenerator = _ee_stub("PromptGenerator")
 
 logger = structlog.get_logger(__name__)
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
 try:
-    from ee.usage.models.usage import APICallStatusChoices
+    from ee.usage.utils.usage_entries import count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallStatusChoices = None
-try:
-    from ee.usage.utils.usage_entries import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
-except ImportError:
-    APICallTypeChoices = None
     count_text_tokens = None
     log_and_deduct_cost_for_api_request = None
 

--- a/futureagi/model_hub/utils/async_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_prompt_runner.py
@@ -11,10 +11,11 @@ from model_hub.services.derived_variable_service import (
     extract_derived_variables_from_output,
 )
 from model_hub.utils.column_utils import is_json_response_format
+from tfc.constants.api_calls import APICallTypeChoices
+
 try:
-    from ee.usage.utils.usage_entries import APICallTypeChoices, log_and_deduct_cost_for_api_request
+    from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallTypeChoices = None
     log_and_deduct_cost_for_api_request = None
 
 

--- a/futureagi/model_hub/utils/auto_annotate.py
+++ b/futureagi/model_hub/utils/auto_annotate.py
@@ -31,10 +31,7 @@ from model_hub.models.develop_annotations import Annotations, AnnotationsLabels
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from tfc.temporal import temporal_activity
 from tfc.utils.error_codes import get_error_message
-try:
-    from ee.usage.models.usage import APICallTypeChoices
-except ImportError:
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_tiktoken_tokens, log_and_deduct_cost_for_api_request
 except ImportError:

--- a/futureagi/model_hub/utils/composite_execution.py
+++ b/futureagi/model_hub/utils/composite_execution.py
@@ -197,11 +197,11 @@ def _log_composite_usage(
     """
     try:
         from sdk.utils.helpers import _get_api_call_type
+        from tfc.constants.api_calls import APICallStatusChoices
         try:
-            from ee.usage.models.usage import APICallLog, APICallStatusChoices, APICallType
+            from ee.usage.models.usage import APICallLog, APICallType
         except ImportError:
             APICallLog = None
-            APICallStatusChoices = None
             APICallType = None
 
         api_call_type_name = _get_api_call_type(model)

--- a/futureagi/model_hub/utils/eval_list.py
+++ b/futureagi/model_hub/utils/eval_list.py
@@ -20,10 +20,7 @@ from agentic_eval.core_evals.fi_evals.eval_type import (
 )
 from model_hub.models.choices import EvalOutputType, EvalTemplateType, OwnerChoices
 from model_hub.types import EvalListFilters, ThirtyDayDataPoint
-try:
-    from ee.usage.models.usage import APICallStatusChoices
-except ImportError:
-    APICallStatusChoices = None
+from tfc.constants.api_calls import APICallStatusChoices
 
 if TYPE_CHECKING:
     from model_hub.models.evals_metric import EvalTemplate

--- a/futureagi/model_hub/views/datasets/add_rows/existing_dataset.py
+++ b/futureagi/model_hub/views/datasets/add_rows/existing_dataset.py
@@ -12,11 +12,7 @@ from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from model_hub.models.experiments import ExperimentDatasetTable
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.general_methods import GeneralMethods
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
@@ -86,19 +82,20 @@ class AddRowsFromExistingView(APIView):
             new_rows_count = Row.objects.filter(
                 dataset=source_dataset, deleted=False
             ).count()
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                getattr(request, "organization", None) or request.user.organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": new_rows_count + existing_rows_count},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    getattr(request, "organization", None) or request.user.organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": new_rows_count + existing_rows_count},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
             # --- Row Limit Check End ---
 
             missing_columns = Column.objects.filter(

--- a/futureagi/model_hub/views/datasets/add_rows/huggingface.py
+++ b/futureagi/model_hub/views/datasets/add_rows/huggingface.py
@@ -19,11 +19,7 @@ from model_hub.views.datasets.create.huggingface import CreateDatasetFromHugging
 from model_hub.views.utils.hugginface import process_huggingface_dataset
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.general_methods import GeneralMethods
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
@@ -102,19 +98,20 @@ class AddRowsFromHuggingFaceView(APIView):
                 dataset=dataset, deleted=False
             ).count()
             prospective_total = existing_rows_count + new_rows_count
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": prospective_total},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": prospective_total},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
             # --- Row Limit Check End ---
 
             # data.reset_index()

--- a/futureagi/model_hub/views/datasets/create/dataset_from_experiment.py
+++ b/futureagi/model_hub/views/datasets/create/dataset_from_experiment.py
@@ -21,11 +21,7 @@ from model_hub.views.utils.utils import get_recommendations, update_column_id
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.parse_errors import parse_serialized_errors
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_resource_request
 except ImportError:
@@ -61,22 +57,23 @@ class CreateDatasetFromExpView(APIView):
             if not new_dataset_name:
                 new_dataset_name = experiment_dataset.name
 
-            call_log_row_entry = log_and_deduct_cost_for_resource_request(
-                organization=getattr(request, "organization", None)
-                or request.user.organization,
-                api_call_type=APICallTypeChoices.DATASET_ADD.value,
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row_entry is None
-                or call_log_row_entry.status
-                == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(
-                    get_error_message("DATASET_CREATE_LIMIT_REACHED")
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row_entry = log_and_deduct_cost_for_resource_request(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                    api_call_type=APICallTypeChoices.DATASET_ADD.value,
+                    workspace=request.workspace,
                 )
-            call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
-            call_log_row_entry.save()
+                if (
+                    call_log_row_entry is None
+                    or call_log_row_entry.status
+                    == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(
+                        get_error_message("DATASET_CREATE_LIMIT_REACHED")
+                    )
+                call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
+                call_log_row_entry.save()
 
             from model_hub.validators.dataset_validators import (
                 validate_dataset_name_unique,

--- a/futureagi/model_hub/views/datasets/create/empty_dataset.py
+++ b/futureagi/model_hub/views/datasets/create/empty_dataset.py
@@ -21,11 +21,7 @@ from model_hub.validators.dataset_validators import (
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.parse_errors import parse_serialized_errors
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_resource_request
 except ImportError:
@@ -39,22 +35,23 @@ class CreateEmptyDatasetView(APIView):
 
     def post(self, request, *args, **kwargs):
         try:
-            call_log_row_entry = log_and_deduct_cost_for_resource_request(
-                organization=getattr(request, "organization", None)
-                or request.user.organization,
-                api_call_type=APICallTypeChoices.DATASET_ADD.value,
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row_entry is None
-                or call_log_row_entry.status
-                == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(
-                    get_error_message("DATASET_CREATE_LIMIT_REACHED")
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row_entry = log_and_deduct_cost_for_resource_request(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                    api_call_type=APICallTypeChoices.DATASET_ADD.value,
+                    workspace=request.workspace,
                 )
-            call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
-            call_log_row_entry.save()
+                if (
+                    call_log_row_entry is None
+                    or call_log_row_entry.status
+                    == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(
+                        get_error_message("DATASET_CREATE_LIMIT_REACHED")
+                    )
+                call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
+                call_log_row_entry.save()
 
             dataset_name = request.data.get("new_dataset_name")
             model_type = request.data.get("model_type")

--- a/futureagi/model_hub/views/datasets/create/file_upload.py
+++ b/futureagi/model_hub/views/datasets/create/file_upload.py
@@ -48,11 +48,7 @@ from tfc.utils.storage_client import (
     extract_object_key,
     get_storage_client,
 )
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
@@ -127,15 +123,16 @@ def upload_file_to_minio(file_obj, object_key, org_id=None):
                 except ImportError:
                     emit = None
 
-                emit(
-                    UsageEvent(
-                        org_id=str(org_id),
-                        event_type=BillingEventType.OBSERVE_ADD,
-                        amount=len(file_content),
-                        properties={"source": "dataset_file"},
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                    emit(
+                        UsageEvent(
+                            org_id=str(org_id),
+                            event_type=BillingEventType.OBSERVE_ADD,
+                            amount=len(file_content),
+                            properties={"source": "dataset_file"},
+                        )
                     )
-                )
-            except ImportError:
+            except (ImportError, TypeError):
                 pass
 
         url = get_object_url(bucket_name, object_key)
@@ -940,24 +937,25 @@ class CreateDatasetFromLocalFileView(CreateAPIView):
                     return self._gm.bad_request(str(validation_err.detail[0]))
 
             # Check usage limits
-            call_log_row_entry = log_and_deduct_cost_for_resource_request(
-                organization=getattr(request, "organization", None)
-                or request.user.organization,
-                api_call_type=APICallTypeChoices.DATASET_ADD.value,
-                sdk_source=True if source == DatasetSourceChoices.SDK.value else False,
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row_entry is None
-                or call_log_row_entry.status
-                == APICallStatusChoices.RESOURCE_LIMIT.value
-                and source != DatasetSourceChoices.SDK.value
-            ):
-                return self._gm.too_many_requests(
-                    get_error_message("DATASET_CREATE_LIMIT_REACHED")
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row_entry = log_and_deduct_cost_for_resource_request(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                    api_call_type=APICallTypeChoices.DATASET_ADD.value,
+                    sdk_source=True if source == DatasetSourceChoices.SDK.value else False,
+                    workspace=request.workspace,
                 )
-            call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
-            call_log_row_entry.save()
+                if (
+                    call_log_row_entry is None
+                    or call_log_row_entry.status
+                    == APICallStatusChoices.RESOURCE_LIMIT.value
+                    and source != DatasetSourceChoices.SDK.value
+                ):
+                    return self._gm.too_many_requests(
+                        get_error_message("DATASET_CREATE_LIMIT_REACHED")
+                    )
+                call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
+                call_log_row_entry.save()
 
             # Validate inputs
             from model_hub.validators.dataset_validators import (
@@ -981,19 +979,20 @@ class CreateDatasetFromLocalFileView(CreateAPIView):
                 return self._gm.bad_request(error)
 
             rows_in_dataset = data.shape[0]
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                getattr(request, "organization", None) or request.user.organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": rows_in_dataset},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    getattr(request, "organization", None) or request.user.organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": rows_in_dataset},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
 
             # Upload file to Minio immediately
             _org = getattr(request, "organization", None) or request.user.organization

--- a/futureagi/model_hub/views/datasets/create/huggingface.py
+++ b/futureagi/model_hub/views/datasets/create/huggingface.py
@@ -36,11 +36,7 @@ from tfc.settings.settings import HUGGINGFACE_API_TOKEN
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.parse_errors import parse_serialized_errors
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
@@ -136,22 +132,23 @@ class CreateDatasetFromHuggingFaceView(CreateAPIView):
 
     def post(self, request, *args, **kwargs):
         try:
-            call_log_row_entry = log_and_deduct_cost_for_resource_request(
-                organization=getattr(request, "organization", None)
-                or request.user.organization,
-                api_call_type=APICallTypeChoices.DATASET_ADD.value,
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row_entry is None
-                or call_log_row_entry.status
-                == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(
-                    get_error_message("DATASET_CREATE_LIMIT_REACHED")
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row_entry = log_and_deduct_cost_for_resource_request(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                    api_call_type=APICallTypeChoices.DATASET_ADD.value,
+                    workspace=request.workspace,
                 )
-            call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
-            call_log_row_entry.save()
+                if (
+                    call_log_row_entry is None
+                    or call_log_row_entry.status
+                    == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(
+                        get_error_message("DATASET_CREATE_LIMIT_REACHED")
+                    )
+                call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
+                call_log_row_entry.save()
 
             form = UploadFileForm(request.POST, request.FILES)
             new_dataset_name = form.data.get("name")
@@ -215,20 +212,21 @@ class CreateDatasetFromHuggingFaceView(CreateAPIView):
                     rows_in_dataset = (
                         int(num_rows) if num_rows else int(dataset_info.get("num_rows"))
                     )
-                    call_log_row = log_and_deduct_cost_for_resource_request(
-                        organization,
-                        api_call_type=APICallTypeChoices.ROW_ADD.value,
-                        config={"total_rows": rows_in_dataset},
-                        workspace=request.workspace,
-                    )
-                    if (
-                        call_log_row is None
-                        or call_log_row.status
-                        == APICallStatusChoices.RESOURCE_LIMIT.value
-                    ):
-                        return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-                    call_log_row.status = APICallStatusChoices.SUCCESS.value
-                    call_log_row.save()
+                    if log_and_deduct_cost_for_resource_request is not None:
+                        call_log_row = log_and_deduct_cost_for_resource_request(
+                            organization,
+                            api_call_type=APICallTypeChoices.ROW_ADD.value,
+                            config={"total_rows": rows_in_dataset},
+                            workspace=request.workspace,
+                        )
+                        if (
+                            call_log_row is None
+                            or call_log_row.status
+                            == APICallStatusChoices.RESOURCE_LIMIT.value
+                        ):
+                            return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                        call_log_row.status = APICallStatusChoices.SUCCESS.value
+                        call_log_row.save()
 
                     try:
                         first_row = load_hf_dataset_with_retries(

--- a/futureagi/model_hub/views/datasets/create/synthetic.py
+++ b/futureagi/model_hub/views/datasets/create/synthetic.py
@@ -26,11 +26,7 @@ from model_hub.views.utils.synthetic_data import determine_data_type_syn_data
 from tfc.utils.error_codes import get_error_message
 from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.parse_errors import parse_serialized_errors
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
@@ -54,30 +50,40 @@ class CreateSyntheticDataset(APIView):
                 org = (
                     getattr(request, "organization", None) or request.user.organization
                 )
-                feat_check = Entitlements.check_feature(
-                    str(org.id), "has_synthetic_data"
-                )
-                if not feat_check.allowed:
-                    return self._gm.forbidden_response(feat_check.reason)
+                if Entitlements is not None:
+                    feat_check = Entitlements.check_feature(
+                        str(org.id), "has_synthetic_data"
+                    )
+                    if not feat_check.allowed:
+                        return self._gm.forbidden_response(feat_check.reason)
             except ImportError:
                 pass
 
-            call_log_row_entry = log_and_deduct_cost_for_resource_request(
-                organization=getattr(request, "organization", None)
-                or request.user.organization,
-                api_call_type=APICallTypeChoices.DATASET_ADD.value,
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row_entry is None
-                or call_log_row_entry.status
-                == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(
-                    get_error_message("DATASET_CREATE_LIMIT_REACHED")
+            # SyntheticDataAgent requires the ee module
+            try:
+                from ee.agenthub.synthetic_data_agent.synthetic_data_agent import SyntheticDataAgent  # noqa: F401
+            except ImportError:
+                return self._gm.forbidden_response(
+                    "Synthetic data generation is not available on your plan."
                 )
-            call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
-            call_log_row_entry.save()
+
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row_entry = log_and_deduct_cost_for_resource_request(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                    api_call_type=APICallTypeChoices.DATASET_ADD.value,
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row_entry is None
+                    or call_log_row_entry.status
+                    == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(
+                        get_error_message("DATASET_CREATE_LIMIT_REACHED")
+                    )
+                call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
+                call_log_row_entry.save()
 
             serializer = SyntheticDatasetCreationSerializer(data=request.data)
 
@@ -110,19 +116,20 @@ class CreateSyntheticDataset(APIView):
                     return self._gm.bad_request(get_error_message("10_ROWS_REQUIRED"))
 
                 # ------------------- Added Row Check -------------------
-                call_log_row = log_and_deduct_cost_for_resource_request(
-                    organization,
-                    api_call_type=APICallTypeChoices.ROW_ADD.value,
-                    config={"total_rows": validated_data["num_rows"]},
-                    workspace=request.workspace,
-                )
-                if (
-                    call_log_row is None
-                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-                ):
-                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-                call_log_row.status = APICallStatusChoices.SUCCESS.value
-                call_log_row.save()
+                if log_and_deduct_cost_for_resource_request is not None:
+                    call_log_row = log_and_deduct_cost_for_resource_request(
+                        organization,
+                        api_call_type=APICallTypeChoices.ROW_ADD.value,
+                        config={"total_rows": validated_data["num_rows"]},
+                        workspace=request.workspace,
+                    )
+                    if (
+                        call_log_row is None
+                        or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                    ):
+                        return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                    call_log_row.status = APICallStatusChoices.SUCCESS.value
+                    call_log_row.save()
                 # dataset = Dataset.objects.create(name=dataset_name)
                 dataset_serializer = DatasetSerializer(
                     data={
@@ -393,19 +400,20 @@ class UpdateSyntheticDatasetConfigView(APIView):
                 return self._gm.bad_request(get_error_message("10_ROWS_REQUIRED"))
 
             # Check row limit
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                getattr(request, "organization", None) or request.user.organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": validated_data["num_rows"]},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    getattr(request, "organization", None) or request.user.organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": validated_data["num_rows"]},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
 
             # Update the dataset name if it changed
             new_dataset_name = validated_data["dataset"]["name"]

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -193,11 +193,7 @@ from tfc.utils.storage import (
     upload_file_to_s3,
     upload_image_to_s3,
 )
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import ROW_LIMIT_REACHED_MESSAGE, log_and_deduct_cost_for_resource_request
 except ImportError:
@@ -492,19 +488,20 @@ class AddRowsFromFile(CreateAPIView):
             ).count()
             # total_rows_allowed = get_number_of_rows_allowed(organization)
 
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": existing_rows_count + new_rows_count},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": existing_rows_count + new_rows_count},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
             # --- Row Limit Check End ---
 
             data = data.reset_index(drop=True)
@@ -661,22 +658,23 @@ class CloneDatasetView(APIView):
 
     def post(self, request, dataset_id, *args, **kwargs):
         try:
-            call_log_row_entry = log_and_deduct_cost_for_resource_request(
-                organization=getattr(request, "organization", None)
-                or request.user.organization,
-                api_call_type=APICallTypeChoices.DATASET_ADD.value,
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row_entry is None
-                or call_log_row_entry.status
-                == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(
-                    get_error_message("DATASET_CREATE_LIMIT_REACHED")
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row_entry = log_and_deduct_cost_for_resource_request(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                    api_call_type=APICallTypeChoices.DATASET_ADD.value,
+                    workspace=request.workspace,
                 )
-            call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
-            call_log_row_entry.save()
+                if (
+                    call_log_row_entry is None
+                    or call_log_row_entry.status
+                    == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(
+                        get_error_message("DATASET_CREATE_LIMIT_REACHED")
+                    )
+                call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
+                call_log_row_entry.save()
             # Get the source dataset (org-scoped)
             source_dataset = get_object_or_404(
                 Dataset,
@@ -705,19 +703,20 @@ class CloneDatasetView(APIView):
             row_count = Row.objects.filter(
                 dataset=source_dataset, deleted=False
             ).count()
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                getattr(request, "organization", None) or request.user.organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": row_count},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    getattr(request, "organization", None) or request.user.organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": row_count},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
 
             if source_dataset.dataset_config.get("eval_recommendations", None) is None:
                 get_recommendations(source_dataset)
@@ -834,22 +833,23 @@ class AddAsNewDataset(APIView):
     def post(self, request, *args, **kwargs):
         try:
             dataset_id = request.data.get("dataset_id")
-            call_log_row_entry = log_and_deduct_cost_for_resource_request(
-                organization=getattr(request, "organization", None)
-                or request.user.organization,
-                api_call_type=APICallTypeChoices.DATASET_ADD.value,
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row_entry is None
-                or call_log_row_entry.status
-                == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(
-                    get_error_message("DATASET_CREATE_LIMIT_REACHED")
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row_entry = log_and_deduct_cost_for_resource_request(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                    api_call_type=APICallTypeChoices.DATASET_ADD.value,
+                    workspace=request.workspace,
                 )
-            call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
-            call_log_row_entry.save()
+                if (
+                    call_log_row_entry is None
+                    or call_log_row_entry.status
+                    == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(
+                        get_error_message("DATASET_CREATE_LIMIT_REACHED")
+                    )
+                call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
+                call_log_row_entry.save()
             # Get the source dataset (org-scoped)
             _org = getattr(request, "organization", None) or request.user.organization
             source_dataset = Dataset.objects.filter(
@@ -893,19 +893,20 @@ class AddAsNewDataset(APIView):
                 row_count = Row.objects.filter(
                     dataset=source_dataset, deleted=False
                 ).count()
-                call_log_row = log_and_deduct_cost_for_resource_request(
-                    getattr(request, "organization", None) or request.user.organization,
-                    api_call_type=APICallTypeChoices.ROW_ADD.value,
-                    config={"total_rows": row_count},
-                    workspace=request.workspace,
-                )
-                if (
-                    call_log_row is None
-                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-                ):
-                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-                call_log_row.status = APICallStatusChoices.SUCCESS.value
-                call_log_row.save()
+                if log_and_deduct_cost_for_resource_request is not None:
+                    call_log_row = log_and_deduct_cost_for_resource_request(
+                        getattr(request, "organization", None) or request.user.organization,
+                        api_call_type=APICallTypeChoices.ROW_ADD.value,
+                        config={"total_rows": row_count},
+                        workspace=request.workspace,
+                    )
+                    if (
+                        call_log_row is None
+                        or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                    ):
+                        return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                    call_log_row.status = APICallStatusChoices.SUCCESS.value
+                    call_log_row.save()
             # ---------------------------------------------------------
 
             # Create new dataset
@@ -4083,19 +4084,20 @@ class AddEmptyRowsView(APIView):
                 dataset=dataset, deleted=False
             ).count()
             prospective_total = existing_rows_count + num_rows
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": prospective_total},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": prospective_total},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
 
             # Get all columns for this dataset
             columns = Column.objects.filter(dataset=dataset, deleted=False).exclude(
@@ -4173,19 +4175,20 @@ class AddSDKRowsView(APIView):
             existing_rows_count = Row.objects.filter(
                 dataset=dataset, deleted=False
             ).count()
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                getattr(request, "organization", None) or request.user.organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": existing_rows_count},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    getattr(request, "organization", None) or request.user.organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": existing_rows_count},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
             # --- Row Limit Check End ---
 
             apiKeys = OrgApiKey.objects.filter(
@@ -4273,20 +4276,21 @@ class ManuallyCreateDatasetView(APIView):
             number_of_rows = int(request.data.get("number_of_rows", 1))
             number_of_columns = int(request.data.get("number_of_columns", 1))
 
-            call_log_row_entry = log_and_deduct_cost_for_resource_request(
-                getattr(request, "organization", None) or request.user.organization,
-                api_call_type=APICallTypeChoices.DATASET_ADD.value,
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row_entry is None
-                or call_log_row_entry.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(
-                    get_error_message("DATASET_CREATE_LIMIT_REACHED")
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row_entry = log_and_deduct_cost_for_resource_request(
+                    getattr(request, "organization", None) or request.user.organization,
+                    api_call_type=APICallTypeChoices.DATASET_ADD.value,
+                    workspace=request.workspace,
                 )
-            call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
-            call_log_row_entry.save()
+                if (
+                    call_log_row_entry is None
+                    or call_log_row_entry.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(
+                        get_error_message("DATASET_CREATE_LIMIT_REACHED")
+                    )
+                call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
+                call_log_row_entry.save()
 
             if not dataset_name:
                 return self._gm.bad_request(get_error_message("MISSING_DATASET_NAME"))
@@ -4325,19 +4329,20 @@ class ManuallyCreateDatasetView(APIView):
                 getattr(request, "organization", None) or request.user.organization
             )
 
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": number_of_rows},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": number_of_rows},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
 
             # Create dataset
             dataset = Dataset.objects.create(
@@ -4441,19 +4446,20 @@ class AddDataRowsView(APIView):
             new_rows_count = len(rows)
             prospective_total = existing_rows_count + new_rows_count
 
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": prospective_total},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": prospective_total},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
 
             # Get valid columns for this dataset
             columns = Column.objects.filter(dataset=dataset, deleted=False).exclude(
@@ -11060,20 +11066,21 @@ class DuplicateRowsView(APIView):
                     id__in=row_ids, dataset=dataset, deleted=False
                 )
 
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                organization=getattr(request, "organization", None)
-                or request.user.organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": source_rows.count() * num_copies},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": source_rows.count() * num_copies},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
             source_cells = Cell.objects.filter(
                 row__in=source_rows, deleted=False
             ).select_related("column")
@@ -11149,22 +11156,23 @@ class DuplicateDatasetView(APIView):
                     get_error_message("MISSING_NEW_DATASET_NAME")
                 )
 
-            call_log_row_entry = log_and_deduct_cost_for_resource_request(
-                organization=getattr(request, "organization", None)
-                or request.user.organization,
-                api_call_type=APICallTypeChoices.DATASET_ADD.value,
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row_entry is None
-                or call_log_row_entry.status
-                == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(
-                    get_error_message("DATASET_CREATE_LIMIT_REACHED")
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row_entry = log_and_deduct_cost_for_resource_request(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                    api_call_type=APICallTypeChoices.DATASET_ADD.value,
+                    workspace=request.workspace,
                 )
-            call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
-            call_log_row_entry.save()
+                if (
+                    call_log_row_entry is None
+                    or call_log_row_entry.status
+                    == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(
+                        get_error_message("DATASET_CREATE_LIMIT_REACHED")
+                    )
+                call_log_row_entry.status = APICallStatusChoices.SUCCESS.value
+                call_log_row_entry.save()
 
             # Get source dataset and verify it exists
             source_dataset = get_object_or_404(Dataset, id=dataset_id, deleted=False)
@@ -11251,20 +11259,21 @@ class DuplicateDatasetView(APIView):
             new_rows = []
             new_cells = []
 
-            call_log_row = log_and_deduct_cost_for_resource_request(
-                organization=getattr(request, "organization", None)
-                or request.user.organization,
-                api_call_type=APICallTypeChoices.ROW_ADD.value,
-                config={"total_rows": source_rows.count()},
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-            ):
-                return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
-            call_log_row.status = APICallStatusChoices.SUCCESS.value
-            call_log_row.save()
+            if log_and_deduct_cost_for_resource_request is not None:
+                call_log_row = log_and_deduct_cost_for_resource_request(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization,
+                    api_call_type=APICallTypeChoices.ROW_ADD.value,
+                    config={"total_rows": source_rows.count()},
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                ):
+                    return self._gm.too_many_requests(ROW_LIMIT_REACHED_MESSAGE)
+                call_log_row.status = APICallStatusChoices.SUCCESS.value
+                call_log_row.save()
             # Process in batches of 1000 rows
             batch_size = 1000
             for i in range(0, source_rows.count(), batch_size):
@@ -14121,36 +14130,39 @@ class CreateKnowledgeBaseView(APIView):
                 kb_count = KnowledgeBaseFile.objects.filter(
                     organization=org, deleted=False
                 ).count()
-                ent_check = Entitlements.can_create(
+                if Entitlements is not None:
+                    ent_check = Entitlements.can_create(
                     str(org.id), "knowledge_bases", kb_count
                 )
                 if not ent_check.allowed:
                     return self._gm.forbidden_response(ent_check.reason)
 
-                feat_check = Entitlements.check_feature(
-                    str(org.id), "has_knowledge_base"
-                )
-                if not feat_check.allowed:
-                    return self._gm.forbidden_response(feat_check.reason)
+                if Entitlements is not None:
+                    feat_check = Entitlements.check_feature(
+                        str(org.id), "has_knowledge_base"
+                    )
+                    if not feat_check.allowed:
+                        return self._gm.forbidden_response(feat_check.reason)
                 entitlements_checked = True
             except ImportError:
                 pass
 
             if not entitlements_checked:
-                call_log_row = log_and_deduct_cost_for_resource_request(
-                    organization=org,
-                    api_call_type=APICallTypeChoices.KNOWLEDGE_BASE.value,
-                    workspace=request.workspace,
-                )
-                if (
-                    call_log_row is None
-                    or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-                ):
-                    return self._gm.too_many_requests(
-                        get_error_message("KB_CREATION_LIMIT_REACHED")
+                if log_and_deduct_cost_for_resource_request is not None:
+                    call_log_row = log_and_deduct_cost_for_resource_request(
+                        organization=org,
+                        api_call_type=APICallTypeChoices.KNOWLEDGE_BASE.value,
+                        workspace=request.workspace,
                     )
-                call_log_row.status = APICallStatusChoices.SUCCESS.value
-                call_log_row.save()
+                    if (
+                        call_log_row is None
+                        or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+                    ):
+                        return self._gm.too_many_requests(
+                            get_error_message("KB_CREATION_LIMIT_REACHED")
+                        )
+                    call_log_row.status = APICallStatusChoices.SUCCESS.value
+                    call_log_row.save()
 
             # Validate ALL files FIRST (before creating KB)
             # Uses is_file_readable for full validation (password check, content parsing)
@@ -14257,11 +14269,12 @@ class CreateKnowledgeBaseView(APIView):
                 except ImportError:
                     Entitlements = None
 
-                feat_check = Entitlements.check_feature(
-                    str(org.id), "has_knowledge_base"
-                )
-                if not feat_check.allowed:
-                    return self._gm.forbidden_response(feat_check.reason)
+                if Entitlements is not None:
+                    feat_check = Entitlements.check_feature(
+                        str(org.id), "has_knowledge_base"
+                    )
+                    if not feat_check.allowed:
+                        return self._gm.forbidden_response(feat_check.reason)
             except ImportError:
                 pass
 

--- a/futureagi/model_hub/views/develop_optimiser.py
+++ b/futureagi/model_hub/views/develop_optimiser.py
@@ -45,10 +45,7 @@ from model_hub.models.run_prompt import RunPrompter
 from model_hub.serializers.develop_optimisation import OptimizationDetailSerializer
 from model_hub.views.eval_runner import EvaluationRunner
 from model_hub.views.prompt_template import replace_ids_with_column_name
-try:
-    from ee.usage.models.usage import APICallTypeChoices
-except ImportError:
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_tiktoken_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
@@ -157,11 +154,11 @@ class DevelopOptimizer:
     def _update_api_call_log_row(self):
         try:
             # get the optimisation object by id
+            from tfc.constants.api_calls import APICallStatusChoices
             try:
-                from ee.usage.models.usage import APICallLog, APICallStatusChoices
+                from ee.usage.models.usage import APICallLog
             except ImportError:
                 APICallLog = None
-                APICallStatusChoices = None
             try:
                 from ee.usage.utils.usage_entries import refund_cost_for_api_call
             except ImportError:

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -72,11 +72,7 @@ from tfc.utils.error_codes import (
 from tfc.utils.functions import get_eval_stats
 from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.parse_errors import parse_serialized_errors
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_tiktoken_tokens, log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 except ImportError:

--- a/futureagi/model_hub/views/prompt_template.py
+++ b/futureagi/model_hub/views/prompt_template.py
@@ -159,14 +159,11 @@ def _safe_background_task(func, *args, **kwargs):
     return wrapped
 
 
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
 try:
-    from ee.usage.models.usage import APICallStatusChoices
+    from ee.usage.utils.usage_entries import count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallStatusChoices = None
-try:
-    from ee.usage.utils.usage_entries import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
-except ImportError:
-    APICallTypeChoices = None
     count_text_tokens = None
     log_and_deduct_cost_for_api_request = None
 

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -82,11 +82,7 @@ from tfc.utils.storage import (
     convert_image_from_url_to_base64,
     detect_audio_format,
 )
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -72,11 +72,12 @@ from tracer.models.observation_span import EvalLogger
 from tracer.utils.filters import apply_created_at_filters
 from tracer.utils.graphs import GraphEngine
 
+from tfc.constants.api_calls import APICallStatusChoices
+
 try:
-    from ee.usage.models.usage import APICallLog, APICallStatusChoices
+    from ee.usage.models.usage import APICallLog
 except ImportError:
     APICallLog = None
-    APICallStatusChoices = None
 
 
 def apply_filters(row_data, filters):
@@ -956,15 +957,18 @@ class GetEvalTemplateNameView(APIView):
 
     def post(self, request):
         try:
-            logs = APICallLog.objects.filter(
-                organization=getattr(request, "organization", None)
-                or request.user.organization
-            )
-            log_ids = [
-                log.source_id
-                for log in logs
-                if log.source_id is not None and log.source_id != ""
-            ]
+            if APICallLog is None:
+                log_ids = []
+            else:
+                logs = APICallLog.objects.filter(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization
+                )
+                log_ids = [
+                    log.source_id
+                    for log in logs
+                    if log.source_id is not None and log.source_id != ""
+                ]
             eval_ids = EvalTemplate.objects.filter(
                 organization=getattr(request, "organization", None)
                 or request.user.organization,

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -23,10 +23,7 @@ from sdk.utils.helpers import _get_api_call_type
 from tfc.middleware.workspace_context import get_current_organization
 from tfc.temporal import temporal_activity
 from tfc.utils.error_codes import get_specific_error_message
-try:
-    from ee.usage.models.usage import APICallStatusChoices
-except ImportError:
-    APICallStatusChoices = None
+from tfc.constants.api_calls import APICallStatusChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:

--- a/futureagi/model_hub/views/utils/utils.py
+++ b/futureagi/model_hub/views/utils/utils.py
@@ -279,7 +279,10 @@ def validate_file_url(
 
 
 def get_recommendations(new_dataset):
-    recommendations = EvalRecommender(dataset_id=new_dataset.id).recommend_evals()
+    try:
+        recommendations = EvalRecommender(dataset_id=new_dataset.id).recommend_evals()
+    except Exception:
+        recommendations = {}
     recommend_evals = recommendations.get("recommended_evals", [])
     (
         recommend_evals.append("Deterministic Evals")

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -10,10 +10,7 @@ from model_hub.models.evaluation import Evaluation, StatusChoices
 from model_hub.tasks.user_evaluation import trigger_error_localization_for_standalone
 from sdk.utils.helpers import _get_api_call_type
 from tracer.utils.inline_evals import trigger_inline_eval
-try:
-    from ee.usage.models.usage import APICallStatusChoices
-except ImportError:
-    APICallStatusChoices = None
+from tfc.constants.api_calls import APICallStatusChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:

--- a/futureagi/sdk/utils/helpers.py
+++ b/futureagi/sdk/utils/helpers.py
@@ -2,26 +2,18 @@ import structlog
 
 logger = structlog.get_logger(__name__)
 from model_hub.models.choices import ModelChoices
-try:
-    from ee.usage.models.usage import APICallTypeChoices
-except ImportError:
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallTypeChoices
 
-if APICallTypeChoices is not None:
-    model_to_api_call_type = {
-        ModelChoices.TURING_LARGE: APICallTypeChoices.TURING_LARGE_EVALUATOR.value,
-        ModelChoices.TURING_SMALL: APICallTypeChoices.TURING_SMALL_EVALUATOR.value,
-        ModelChoices.TURING_FLASH: APICallTypeChoices.TURING_FLASH_EVALUATOR.value,
-        ModelChoices.PROTECT_FLASH: APICallTypeChoices.PROTECT_FLASH_EVALUATOR.value,
-        ModelChoices.PROTECT: APICallTypeChoices.PROTECT_EVALUATOR.value,
-    }
-else:
-    model_to_api_call_type = {}
+model_to_api_call_type = {
+    ModelChoices.TURING_LARGE: APICallTypeChoices.TURING_LARGE_EVALUATOR.value,
+    ModelChoices.TURING_SMALL: APICallTypeChoices.TURING_SMALL_EVALUATOR.value,
+    ModelChoices.TURING_FLASH: APICallTypeChoices.TURING_FLASH_EVALUATOR.value,
+    ModelChoices.PROTECT_FLASH: APICallTypeChoices.PROTECT_FLASH_EVALUATOR.value,
+    ModelChoices.PROTECT: APICallTypeChoices.PROTECT_EVALUATOR.value,
+}
 
 
 def _get_api_call_type(model: str):
-    if APICallTypeChoices is None:
-        return None
     try:
         if not model:
             return APICallTypeChoices.TURING_LARGE_EVALUATOR.value

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -111,10 +111,11 @@ from tfc.temporal.drop_in import temporal_activity
 
 # Note: run_eval_summary_task imported lazily to avoid circular imports
 from tfc.utils.error_codes import get_specific_error_message
+from tfc.constants.api_calls import APICallStatusChoices
+
 try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallType
+    from ee.usage.models.usage import APICallType
 except ImportError:
-    APICallStatusChoices = None
     APICallType = None
 try:
     from ee.usage.services.metering import check_usage

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -1257,10 +1257,7 @@ def _run_tool_evaluation_standalone(call_execution, test_execution):
     from simulate.models import AgentDefinition
     from tfc.utils.error_codes import get_specific_error_message
     from tracer.models.observability_provider import ProviderChoices
-    try:
-        from ee.usage.models.usage import APICallStatusChoices
-    except ImportError:
-        APICallStatusChoices = None
+    from tfc.constants.api_calls import APICallStatusChoices
     try:
         from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
     except ImportError:

--- a/futureagi/sockets/prompt_stream_consumer.py
+++ b/futureagi/sockets/prompt_stream_consumer.py
@@ -30,11 +30,7 @@ from model_hub.utils.websocket_direct_manager import WebSocketDirectManager
 from model_hub.views.prompt_template import (
     replace_ids_with_column_name_async,
 )
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:

--- a/futureagi/tfc/constants/api_calls.py
+++ b/futureagi/tfc/constants/api_calls.py
@@ -1,0 +1,73 @@
+"""API call type and status enums shared across OSS and EE.
+
+These enums are the canonical definitions. The EE module re-exports them
+from here so that OSS code never needs to import from ee.usage.models.
+"""
+
+from django.db import models
+
+
+class APICallTypeChoices(models.TextChoices):
+    PROMPT_BENCH = "prompt_bench", "Prompt Bench"
+    DATASET_PROTECT = "dataset_protect", "Dataset Protect"
+    DATASET_PROTECT_FLASH = "dataset_protect_flash", "Dataset Protect Flash"
+
+    # Evaluation
+    TURING_LARGE_EVALUATOR = "turing_large_evaluator", "Turing Large Evaluator"
+    TURING_SMALL_EVALUATOR = "turing_small_evaluator", "Turing Small Evaluator"
+    TURING_FLASH_EVALUATOR = "turing_flash_evaluator", "Turing Flash Evaluator"
+    PROTECT_EVALUATOR = "protect_evaluator", "Protect Evaluator"
+    PROTECT_FLASH_EVALUATOR = "protect_flash_evaluator", "Protect Flash Evaluator"
+    CODE_EVALUATOR = "code_evaluator", "Code Evaluator"
+
+    USER_ADD = "user_add", "User Add"
+    OBSERVE_ADD = "observe_add", "Observe Add"
+    PROTOTYPE_ADD = "prototype_add", "Prototype Add"
+    DATASET_ADD = "dataset_add", "Dataset Add"
+    ROW_ADD = "row_add", "Row Add"
+
+    KNOWLEDGE_BASE = "knowledge_base", "Knowledge Base"
+
+    SYNTHETIC_DATA_GENERATION = "synthetic_data_generation", "Synthetic Data Generation"
+
+    ERROR_LOCALIZER = "error_localizer", "Error Localizer"
+
+    AUTO_ANNOTATION = "auto_annotation", "Auto Annotation"
+
+    # Do not use these, use the above evaluator choices instead
+    DATASET_EVALUATION = "dataset_evaluation", "Dataset Evaluation"
+    EXPERIMENT_EVALUATION = "experiment_evaluation", "Experiment Evaluation"
+    OPTIMISATION_EVALUATION = "optimisation_evaluation", "Optimisation Evaluation"
+    EVAL_EXPLANATION = "eval_explanation", "Eval Explanation"
+
+    DATASET_RUN_PROMPT = "dataset_run_prompt", "Dataset Run Prompt"
+    DATASET_OPTIMIZATION = "dataset_optimization", "Dataset Optimization"
+    DATASET_EXPERIMENT = "dataset_experiment", "Dataset Experiment"
+
+    VOICE_CALL = "voice_call", "Voice Call"
+    TEXT_CALL = "text_call", "Text Call"
+
+    WALLET_REFUND = "wallet_refund", "Wallet Refund"
+    WALLET_REFILL = "wallet_refill", "Wallet Refill"
+    WALLET_AUTO_RECHARGE = "wallet_auto_recharge", "Wallet Auto Recharge"
+    WALLET_ADD_FUNDS = "wallet_add_funds", "Wallet Add Funds"
+
+    TRACE_ERROR_ANALYSIS = "trace_error_analysis", "Trace Error Analysis"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]
+
+
+class APICallStatusChoices(models.TextChoices):
+    SUCCESS = "success", "Success"
+    ERROR = "error", "Error"
+    NOT_STARTED = "not_started", "Not Started"
+    RATE_LIMITED = "rate_limited", "Rate Limited"
+    PROCESSING = "processing", "Processing"
+    INSUFFICIENT_CREDITS = "insufficient_credits", "Insufficient Credits"
+    RESOURCE_LIMIT = "resource_limit", "Resource Limit"
+
+    @classmethod
+    def get_choices(cls):
+        return [(tag.value, tag.name.replace("_", " ").title()) for tag in cls]

--- a/futureagi/tfc/utils/functions.py
+++ b/futureagi/tfc/utils/functions.py
@@ -14,10 +14,7 @@ from model_hub.models.develop_dataset import Cell, Column
 from model_hub.models.evals_metric import UserEvalMetric
 from model_hub.utils.SQL_queries import SQLQueryHandler
 from tfc.utils.clickhouse import ClickHouseClientSingleton
-try:
-    from ee.usage.models.usage import APICallStatusChoices
-except ImportError:
-    APICallStatusChoices = None
+from tfc.constants.api_calls import APICallStatusChoices
 
 
 def add_one_day_in_date(date_str):

--- a/futureagi/tfc/utils/storage.py
+++ b/futureagi/tfc/utils/storage.py
@@ -441,7 +441,8 @@ def upload_document_to_s3(
                 except ImportError:
                     emit = None
 
-                emit(
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                    emit(
                     UsageEvent(
                         org_id=str(org_id),
                         event_type=BillingEventType.OBSERVE_ADD,
@@ -563,7 +564,8 @@ def upload_image_to_s3(
             except ImportError:
                 emit = None
 
-            emit(
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                emit(
                 UsageEvent(
                     org_id=str(org_id),
                     event_type=BillingEventType.OBSERVE_ADD,
@@ -782,7 +784,8 @@ def upload_audio_to_s3_duration(
                 except ImportError:
                     emit = None
 
-                emit(
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                    emit(
                     UsageEvent(
                         org_id=str(org_id),
                         event_type=BillingEventType.OBSERVE_ADD,
@@ -1145,7 +1148,8 @@ def upload_file_to_s3(
             except ImportError:
                 emit = None
 
-            emit(
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                emit(
                 UsageEvent(
                     org_id=str(org_id),
                     event_type=BillingEventType.KB_STORAGE,
@@ -1694,7 +1698,8 @@ def upload_audio_to_s3(
             except ImportError:
                 emit = None
 
-            emit(
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                emit(
                 UsageEvent(
                     org_id=str(org_id),
                     event_type=BillingEventType.OBSERVE_ADD,
@@ -1885,7 +1890,8 @@ def upload_video_to_s3(
                     except ImportError:
                         emit = None
 
-                    emit(
+                    if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                        emit(
                         UsageEvent(
                             org_id=str(org_id),
                             event_type=BillingEventType.OBSERVE_ADD,
@@ -1912,7 +1918,8 @@ def upload_video_to_s3(
                     except ImportError:
                         emit = None
 
-                    emit(
+                    if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                        emit(
                         UsageEvent(
                             org_id=str(org_id),
                             event_type=BillingEventType.OBSERVE_ADD,
@@ -1936,7 +1943,8 @@ def upload_video_to_s3(
                 except ImportError:
                     emit = None
 
-                emit(
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                    emit(
                     UsageEvent(
                         org_id=str(org_id),
                         event_type=BillingEventType.OBSERVE_ADD,

--- a/futureagi/tracer/tasks.py
+++ b/futureagi/tracer/tasks.py
@@ -58,11 +58,7 @@ from tracer.tasks import *  # noqa: F401, F403
 from tracer.utils.external_eval import run_external_eval_config
 from tracer.utils.helper import get_default_project_session_config
 from tracer.utils.otel import SpanAttributes, convert_otel_span_to_observation_span
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 except ImportError:

--- a/futureagi/tracer/tasks/error_analysis.py
+++ b/futureagi/tracer/tasks/error_analysis.py
@@ -46,11 +46,7 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
     from tracer.models.trace_error_analysis import TraceErrorAnalysis
     from tracer.queries.error_analysis import TraceErrorAnalysisDB
     from tracer.queries.helpers import get_default_workspace_for_project
-    try:
-        from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-    except ImportError:
-        APICallStatusChoices = None
-        APICallTypeChoices = None
+    from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
     try:
         from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
     except ImportError:

--- a/futureagi/tracer/tests/conftest.py
+++ b/futureagi/tracer/tests/conftest.py
@@ -364,7 +364,7 @@ def stub_cost_log(monkeypatch):
     expects: ``.status``, mutable ``.config``, ``.log_id``, and ``.save()``.
     """
     try:
-        from ee.usage.models.usage import APICallStatusChoices
+        from tfc.constants.api_calls import APICallStatusChoices
         processing_status = APICallStatusChoices.PROCESSING.value
     except ImportError:
         processing_status = "processing"

--- a/futureagi/tracer/tests/test_datetime_filters.py
+++ b/futureagi/tracer/tests/test_datetime_filters.py
@@ -11,11 +11,12 @@ import pytest
 from django.utils import timezone
 
 from tracer.utils.filters import apply_created_at_filters
+from tfc.constants.api_calls import APICallStatusChoices
+
 try:
-    from ee.usage.models.usage import APICallLog, APICallStatusChoices
+    from ee.usage.models.usage import APICallLog
 except ImportError:
     APICallLog = None
-    APICallStatusChoices = None
 
 
 def _make_datetime_filter(filter_op, filter_value, column_id="created_at"):

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -24,10 +24,7 @@ from tracer.models.trace import Trace
 from tracer.models.trace_session import TraceSession
 from tracer.utils.helper import FieldConfig, get_default_trace_config
 from tracer.views.project import get_default_project_version_config
-try:
-    from ee.usage.models.usage import APICallStatusChoices
-except ImportError:
-    APICallStatusChoices = None
+from tfc.constants.api_calls import APICallStatusChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:

--- a/futureagi/tracer/utils/external_eval.py
+++ b/futureagi/tracer/utils/external_eval.py
@@ -12,10 +12,7 @@ from tracer.models.external_eval_config import (
     PlatformChoices,
     StatusChoices,
 )
-try:
-    from ee.usage.models.usage import APICallStatusChoices
-except ImportError:
-    APICallStatusChoices = None
+from tfc.constants.api_calls import APICallStatusChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:

--- a/futureagi/tracer/utils/otel.py
+++ b/futureagi/tracer/utils/otel.py
@@ -35,11 +35,7 @@ from tracer.utils.semantic_conventions import (
     detect_semconv,
     get_attribute,
 )
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_resource_request
 except ImportError:

--- a/futureagi/tracer/views/dataset.py
+++ b/futureagi/tracer/views/dataset.py
@@ -280,7 +280,7 @@ def create_new_dataset(new_dataset_name, organization, user_id):
     ).exists():
         raise ValueError(get_error_message("DATASET_EXIST_IN_ORG"))
 
-    if not check_if_dataset_creation_is_allowed(organization):
+    if check_if_dataset_creation_is_allowed is not None and not check_if_dataset_creation_is_allowed(organization):
         raise ValueError(get_error_message("DATASET_CREATE_LIMIT_REACHED"))
 
     dataset_id = uuid.uuid4()


### PR DESCRIPTION
## Summary

Moves `APICallStatusChoices` and `APICallTypeChoices` from `ee.usage.models.usage` to `tfc/constants/api_calls.py` so OSS installs without `ee/` don't crash on `None` enum dereferences. Adds null guards on all dataset and row creation paths so billing checks are skipped gracefully in OSS.

**Changes:**
- New file `tfc/constants/api_calls.py` — canonical enum definitions (single source of truth)
- 33 files — enum imports changed from `ee.usage.models` → `tfc.constants.api_calls`, removed `try/except` + `= None` fallbacks
- 7 dataset/row creation view files — `if log_and_deduct_cost_for_resource_request is not None:` guards on DATASET_ADD and ROW_ADD blocks
- `tracer/views/dataset.py` — null guard on `check_if_dataset_creation_is_allowed`
- `separate_evals.py` — null guard on `APICallLog` for eval template names endpoint

**Depends on:** `future-agi/ee` branch `fix/dataset-billing-new-system` (re-exports enums from `tfc.constants.api_calls`). Deploy OSS first.

## Linked issues

Closes #180

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- OSS mode: dataset creation (file upload, empty, HuggingFace, clone, duplicate, merge) — all return 2xx
- OSS mode: row add paths — all return 2xx
- EE mode: billing checks still run, no behavioral change
- `python3 -m py_compile` passes on all 42 changed files
- the tested flows include:
- dataset creation : through empty dataset
- file upload
- hugging face experiment
- synthetic data
- clone dataset
- duplicate
- merged
- manually 
- row creation : using file upload
- hugging face

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)