### PR TITLE
fix(evals): hide Error Localization toggle for code evals

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -844,23 +844,27 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                 <Tabs
                   value={evalType}
                   onChange={(_, val) => setEvalType(val)}
+                  variant="standard"
                   TabIndicatorProps={{ style: { display: "none" } }}
                   sx={{
-                    minHeight: 28,
+                    width: "fit-content",
+                    minHeight: 32,
                     "& .MuiTab-root": {
+                      height: 28,
                       minHeight: 28,
+                      maxHeight: 28,
                       px: 1.5,
                       py: 0,
                       mr: "0px !important",
                       textTransform: "none",
                       fontSize: "13px",
+                      lineHeight: "28px",
                       borderRadius: "6px",
                     },
                     border: "1px solid",
                     borderColor: "divider",
                     p: "2px",
                     borderRadius: "8px",
-                    width: "fit-content",
                     bgcolor: (theme) =>
                       theme.palette.mode === "dark"
                         ? "rgba(255,255,255,0.04)"

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -1563,7 +1563,7 @@ const EvalDetailPage = () => {
                   ))}
 
                 {/* Error Localization */}
-                {!isComposite && (
+                {!isComposite && evalType !== "code"  && (
                   <Box>
                     <FormControlLabel
                       control={

--- a/frontend/src/sections/evals/components/OutputTypeConfig.jsx
+++ b/frontend/src/sections/evals/components/OutputTypeConfig.jsx
@@ -110,8 +110,8 @@ const OutputTypeConfig = ({
               sx={{ color: "text.disabled", flexShrink: 0 }}
             />
             <Typography variant="caption" color="text.secondary">
-              Output type is fixed for system-level evaluations and can&apos;t
-              be changed.
+              Output type is fixed for this evaluation and can&apos;t be
+              changed.
             </Typography>
           </Box>
         )}

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -1256,7 +1256,10 @@ const TracingTestMode = React.forwardRef(
             </Typography>
             <Tabs
               value={rowType}
-              onChange={(_, val) => setRowType(val)}
+              onChange={(_, val) => {
+                setRowType(val);
+                setMapping({});
+              }}
               variant="standard"
               scrollButtons={false}
               TabIndicatorProps={{ style: { display: "none" } }}


### PR DESCRIPTION
## Summary
- The Error Localization toggle on the eval detail page was shown for every
  non-composite eval, including code evals.
- Error localization isn't applicable to code evals, so the toggle shouldn't
  appear for them.
- Restricted the section's condition to `!isComposite && evalType !== "code"`.

## Test plan
- [x] Open an LLM-as-a-Judge eval → Error Localization toggle is visible
- [x] Open an Agent eval → toggle is visible
- [x] Open a Code eval → toggle is hidden
- [x] Open a Composite eval → toggle is hidden (unchanged)
- [x] Open a code eval that previously had error localization enabled → toggle
      no longer renders, no console errors

Closes TH-4845,TH-5401

