### PR TITLE
fix: surface prompt commit action

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/promptActions/MoreActions.jsx
+++ b/frontend/src/sections/workbench/createPrompt/promptActions/MoreActions.jsx
@@ -11,7 +11,6 @@ import {
 } from "@mui/material";
 import CustomTooltip from "src/components/tooltip";
 import SvgColor from "src/components/svg-color";
-import { ShowComponent } from "src/components/show";
 import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
 
 export default function MoreActions({
@@ -24,15 +23,12 @@ export default function MoreActions({
   Events,
   PropertyName,
   id,
-  isAnyPromptDraft,
   selectedVersions,
-  setSaveCommitOpen,
   theme,
   isAddingDraft,
   addToCompare,
   userRole,
 }) {
-  const disableCommit = isAnyPromptDraft || selectedVersions.length > 1;
   return (
     <Box
       sx={{
@@ -186,70 +182,6 @@ export default function MoreActions({
             </span>
           </CustomTooltip>
 
-          <ShowComponent
-            condition={RolePermission.PROMPTS[PERMISSIONS.UPDATE][userRole]}
-          >
-            <CustomTooltip
-              show
-              title={
-                disableCommit
-                  ? "Please run the prompt before saving and committing"
-                  : "Save your prompt changes with a clear message, so every update becomes a trackable version."
-              }
-              arrow
-              size="small"
-              type="black"
-              slotProps={{
-                tooltip: {
-                  sx: {
-                    maxWidth: "200px !important",
-                  },
-                },
-              }}
-            >
-              <span
-                style={{
-                  display: "inline-block",
-                }}
-              >
-                <Button
-                  sx={{
-                    borderRadius: "4px",
-                    backgroundColor: "background.paper",
-                    border: "1px solid",
-                    borderColor: "divider",
-                    height: "30px",
-                    whiteSpace: "nowrap",
-                    "&:hover": {
-                      backgroundColor: `${theme.palette.background.neutral} !important`,
-                    },
-                  }}
-                  disabled={
-                    disableCommit ||
-                    currentTab === "Evaluation" ||
-                    currentTab === "Metrics"
-                  }
-                  onClick={() => {
-                    setSaveCommitOpen(true);
-                    trackEvent(Events.promptVersionHistoryClicked, {
-                      [PropertyName.promptId]: id,
-                    });
-                  }}
-                  startIcon={
-                    <SvgColor
-                      sx={{ width: "20px", height: "20px" }}
-                      src="/assets/icons/ic_commit.svg"
-                    />
-                  }
-                >
-                  <Typography variant="s1" fontWeight={"fontWeightMedium"}>
-                    Commit
-                  </Typography>
-                </Button>
-              </span>
-            </CustomTooltip>
-          </ShowComponent>
-
           <CustomTooltip
             show
             title="Compare prompts side-by-side by tweaking words, model settings, and other parameters "
@@ -348,9 +280,7 @@ MoreActions.propTypes = {
   Events: PropTypes.object.isRequired,
   PropertyName: PropTypes.object.isRequired,
   id: PropTypes.string.isRequired,
-  isAnyPromptDraft: PropTypes.bool.isRequired,
   selectedVersions: PropTypes.array.isRequired,
-  setSaveCommitOpen: PropTypes.func.isRequired,
   theme: PropTypes.object.isRequired,
   isAddingDraft: PropTypes.bool.isRequired,
   addToCompare: PropTypes.func.isRequired,

--- a/frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx
+++ b/frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx
@@ -309,6 +309,7 @@ const PromptActions = () => {
     () => !!selectedVersions?.some((version) => version?.isDraft),
     [selectedVersions],
   );
+  const disableCommit = isAnyPromptDraft || selectedVersions.length > 1;
 
   // const selectedVersion = useMemo(() => {
   //   return versions?.find(
@@ -532,6 +533,61 @@ const PromptActions = () => {
         <Box display="flex" gap={theme.spacing(1.5)} alignItems={"flex-start"}>
           {/* Hide More Actions, Variables, and Run Prompt on Simulation tab */}
           <ShowComponent condition={currentTab !== "Simulation"}>
+            <ShowComponent
+              condition={RolePermission.PROMPTS[PERMISSIONS.UPDATE][userRole]}
+            >
+              <CustomTooltip
+                show
+                title={
+                  disableCommit
+                    ? "Please run the prompt before saving and committing"
+                    : "Save your prompt changes with a clear message, so every update becomes a trackable version."
+                }
+                arrow
+                size="small"
+                type="black"
+                slotProps={{
+                  tooltip: {
+                    sx: {
+                      maxWidth: "200px !important",
+                    },
+                  },
+                }}
+              >
+                <span style={{ display: "inline-block" }}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    sx={{
+                      borderRadius: "4px",
+                      height: "30px",
+                      whiteSpace: "nowrap",
+                    }}
+                    disabled={
+                      disableCommit ||
+                      currentTab === "Evaluation" ||
+                      currentTab === "Metrics"
+                    }
+                    onClick={() => {
+                      setSaveCommitOpen(true);
+                      trackEvent(Events.promptVersionHistoryClicked, {
+                        [PropertyName.promptId]: id,
+                      });
+                    }}
+                    startIcon={
+                      <SvgColor
+                        sx={{ width: "20px", height: "20px" }}
+                        src="/assets/icons/ic_commit.svg"
+                      />
+                    }
+                  >
+                    <Typography variant="s1" fontWeight={"fontWeightMedium"}>
+                      Commit
+                    </Typography>
+                  </Button>
+                </span>
+              </CustomTooltip>
+            </ShowComponent>
             <MoreActions
               isMoreOpen={isMoreOpen}
               setMoreOpen={setMoreOpen}
@@ -542,9 +598,7 @@ const PromptActions = () => {
               Events={Events}
               PropertyName={PropertyName}
               id={id}
-              isAnyPromptDraft={isAnyPromptDraft}
               selectedVersions={selectedVersions}
-              setSaveCommitOpen={setSaveCommitOpen}
               theme={theme}
               isAddingDraft={isAddingDraft}
               addToCompare={addToCompare}

--- a/frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx
+++ b/frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx
@@ -570,7 +570,7 @@ const PromptActions = () => {
                     }
                     onClick={() => {
                       setSaveCommitOpen(true);
-                      trackEvent(Events.promptVersionHistoryClicked, {
+                      trackEvent(Events.promptCommitClicked, {
                         [PropertyName.promptId]: id,
                       });
                     }}

--- a/frontend/src/sections/workbench/createPrompt/promptActions/SaveAndCommit.jsx
+++ b/frontend/src/sections/workbench/createPrompt/promptActions/SaveAndCommit.jsx
@@ -9,7 +9,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { enqueueSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
@@ -24,6 +24,7 @@ import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
 
 const SaveAndCommit = ({ open, onClose, data, promptName }) => {
   const { id } = useParams();
+  const queryClient = useQueryClient();
   const [messageType, setMessageType] = useState(null);
 
   const {
@@ -83,6 +84,12 @@ const SaveAndCommit = ({ open, onClose, data, promptName }) => {
       );
       trackEvent(Events.promptCommitClicked, {
         [PropertyName.promptId]: id,
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["prompt-versions", id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["prompt-latest-version", id],
       });
       handleOnClose();
     },


### PR DESCRIPTION
Closes #580

## Summary
- Move the prompt Commit action out of the More menu and into the main workbench action bar.
- Keep History and Compare in the More menu so Commit remains directly discoverable.
- Invalidate prompt version and latest-version queries after a successful commit so the workbench refreshes committed prompt state without a manual reload.

## Impact
This makes the save/commit path visible from the prompt workbench and refreshes prompt data after commit, reducing the need to manually refresh after saving prompt changes.

## Validation
- `frontend/node_modules/.bin/eslint.cmd src/sections/workbench/createPrompt/promptActions/SaveAndCommit.jsx src/sections/workbench/createPrompt/promptActions/MoreActions.jsx src/sections/workbench/createPrompt/promptActions/PromptActions.jsx` - passed
- `git diff --check` - passed