### PR TITLE
fix: wire tracing graph fullscreen controls

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
@@ -529,7 +529,7 @@ const buildFlowData = (graphData, direction = "LR", theme = null) => {
 // ---------------------------------------------------------------------------
 // Zoom controls — top-right, appear on hover
 // ---------------------------------------------------------------------------
-const ZoomControls = () => {
+const ZoomControls = ({ isFullscreen, onToggleFullscreen }) => {
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const btnSx = {
     p: 0.5,
@@ -558,6 +558,7 @@ const ZoomControls = () => {
     >
       <IconButton
         size="small"
+        title="Zoom in"
         onClick={() => zoomIn({ duration: 200 })}
         sx={btnSx}
       >
@@ -565,6 +566,7 @@ const ZoomControls = () => {
       </IconButton>
       <IconButton
         size="small"
+        title="Zoom out"
         onClick={() => zoomOut({ duration: 200 })}
         sx={btnSx}
       >
@@ -572,6 +574,7 @@ const ZoomControls = () => {
       </IconButton>
       <IconButton
         size="small"
+        title="Fit"
         onClick={() => fitView({ duration: 300, padding: 0.3 })}
         sx={btnSx}
       >
@@ -579,13 +582,22 @@ const ZoomControls = () => {
       </IconButton>
       <IconButton
         size="small"
-        onClick={() => fitView({ duration: 300, padding: 0.2 })}
+        title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+        onClick={onToggleFullscreen}
         sx={btnSx}
       >
-        <Iconify icon="mdi:fullscreen" width={14} />
+        <Iconify
+          icon={isFullscreen ? "mdi:fullscreen-exit" : "mdi:fullscreen"}
+          width={14}
+        />
       </IconButton>
     </Box>
   );
+};
+
+ZoomControls.propTypes = {
+  isFullscreen: PropTypes.bool.isRequired,
+  onToggleFullscreen: PropTypes.func.isRequired,
 };
 
 // ---------------------------------------------------------------------------
@@ -600,6 +612,7 @@ const AgentGraphInner = ({
 }) => {
   const theme = useTheme();
   const [isHovering, setIsHovering] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const { nodes: layoutNodes, edges: layoutEdges } = useMemo(
     () => buildFlowData(data, direction, theme),
     [data, direction, theme],
@@ -612,6 +625,19 @@ const AgentGraphInner = ({
     setNodes(layoutNodes);
     setEdges(layoutEdges);
   }, [layoutNodes, layoutEdges, setNodes, setEdges]);
+
+  useEffect(() => {
+    if (!isFullscreen) return undefined;
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        setIsFullscreen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isFullscreen]);
 
   if (isLoading) {
     return (
@@ -667,10 +693,13 @@ const AgentGraphInner = ({
   return (
     <Box
       sx={{
-        height: "100%",
+        height: isFullscreen ? "100vh" : "100%",
         minHeight: 120,
         width: "100%",
-        position: "relative",
+        position: isFullscreen ? "fixed" : "relative",
+        inset: isFullscreen ? 0 : "auto",
+        zIndex: isFullscreen ? (t) => t.zIndex.modal : "auto",
+        bgcolor: "background.paper",
       }}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
@@ -699,7 +728,14 @@ const AgentGraphInner = ({
         maxZoom={2}
         proOptions={{ hideAttribution: true }}
       >
-        {isHovering && <ZoomControls />}
+        {(isHovering || isFullscreen) && (
+          <ZoomControls
+            isFullscreen={isFullscreen}
+            onToggleFullscreen={() =>
+              setIsFullscreen((fullscreen) => !fullscreen)
+            }
+          />
+        )}
       </ReactFlow>
     </Box>
   );

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
@@ -405,6 +405,9 @@ const AgentPath = ({ data, isLoading, onNodeClick }) => {
   const theme = useTheme();
   const containerRef = useRef(null);
   const [containerWidth, setContainerWidth] = useState(900);
+  const [zoom, setZoom] = useState(1);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const layout = useMemo(() => computeSankeyLayout(data), [data]);
 
   useEffect(() => {
@@ -417,6 +420,19 @@ const AgentPath = ({ data, isLoading, onNodeClick }) => {
     observer.observe(containerRef.current);
     return () => observer.disconnect();
   }, []);
+
+  useEffect(() => {
+    if (!isFullscreen) return undefined;
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        setIsFullscreen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isFullscreen]);
 
   if (isLoading) {
     return (
@@ -450,8 +466,25 @@ const AgentPath = ({ data, isLoading, onNodeClick }) => {
     );
   }
 
+  const viewportHeight = typeof window === "undefined" ? 0 : window.innerHeight;
+  const chartHeight = isFullscreen ? Math.max(viewportHeight - 48, 240) : 200;
+  const chartWidth = Math.max(Math.round(containerWidth * zoom), 320);
+  const scaledChartHeight = Math.max(Math.round(chartHeight * zoom), 120);
+
   return (
-    <Box ref={containerRef} sx={{ position: "relative", mx: 2, my: 1 }}>
+    <Box
+      ref={containerRef}
+      sx={{
+        position: isFullscreen ? "fixed" : "relative",
+        inset: isFullscreen ? 0 : "auto",
+        zIndex: isFullscreen ? (t) => t.zIndex.modal : "auto",
+        mx: isFullscreen ? 0 : 2,
+        my: isFullscreen ? 0 : 1,
+        p: isFullscreen ? 2 : 0,
+        bgcolor: "background.paper",
+        overflow: "auto",
+      }}
+    >
       {/* Zoom controls, top right (matches AgentGraph) */}
       <Box
         sx={{
@@ -469,16 +502,39 @@ const AgentPath = ({ data, isLoading, onNodeClick }) => {
         }}
       >
         {[
-          { icon: "mdi:plus", label: "Zoom in" },
-          { icon: "mdi:minus", label: "Zoom out" },
-          { icon: "mdi:crosshairs-gps", label: "Fit" },
-          { icon: "mdi:fullscreen", label: "Fullscreen" },
-          { icon: "mdi:chevron-down", label: "Collapse" },
+          {
+            icon: "mdi:plus",
+            label: "Zoom in",
+            onClick: () =>
+              setZoom((currentZoom) => Math.min(2, currentZoom + 0.2)),
+          },
+          {
+            icon: "mdi:minus",
+            label: "Zoom out",
+            onClick: () =>
+              setZoom((currentZoom) => Math.max(0.6, currentZoom - 0.2)),
+          },
+          {
+            icon: "mdi:crosshairs-gps",
+            label: "Fit",
+            onClick: () => setZoom(1),
+          },
+          {
+            icon: isFullscreen ? "mdi:fullscreen-exit" : "mdi:fullscreen",
+            label: isFullscreen ? "Exit fullscreen" : "Fullscreen",
+            onClick: () => setIsFullscreen((fullscreen) => !fullscreen),
+          },
+          {
+            icon: isCollapsed ? "mdi:chevron-up" : "mdi:chevron-down",
+            label: isCollapsed ? "Expand" : "Collapse",
+            onClick: () => setIsCollapsed((collapsed) => !collapsed),
+          },
         ].map((btn) => (
           <IconButton
             key={btn.icon}
             size="small"
             title={btn.label}
+            onClick={btn.onClick}
             sx={{
               p: 0.5,
               borderRadius: 0,
@@ -493,13 +549,15 @@ const AgentPath = ({ data, isLoading, onNodeClick }) => {
         ))}
       </Box>
 
-      <SankeyChart
-        layout={layout}
-        width={containerWidth}
-        height={200}
-        onNodeClick={onNodeClick}
-        theme={theme}
-      />
+      {!isCollapsed && (
+        <SankeyChart
+          layout={layout}
+          width={chartWidth}
+          height={scaledChartHeight}
+          onNodeClick={onNodeClick}
+          theme={theme}
+        />
+      )}
     </Box>
   );
 };

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/fullscreen-controls.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/fullscreen-controls.test.jsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "src/utils/test-utils";
+
+import AgentPath from "../AgentPath";
+import AgentGraph from "../AgentGraph";
+
+const reactFlowControls = {
+  zoomIn: vi.fn(),
+  zoomOut: vi.fn(),
+  fitView: vi.fn(),
+};
+
+vi.mock("src/components/iconify", () => ({
+  default: ({ icon }) => <span data-testid="iconify" data-icon={icon} />,
+}));
+
+vi.mock("src/components/tooltip", () => ({
+  default: ({ children }) => children,
+}));
+
+vi.mock("@xyflow/react", () => ({
+  // eslint-disable-next-line react/prop-types
+  ReactFlowProvider: ({ children }) => <div>{children}</div>,
+  // eslint-disable-next-line react/prop-types
+  ReactFlow: ({ children, onNodeClick }) => (
+    <div
+      data-testid="react-flow"
+      onClick={() =>
+        onNodeClick?.(null, { data: { type: "agent", name: "Agent" } })
+      }
+    >
+      {children}
+    </div>
+  ),
+  useNodesState: (nodes) => [nodes, vi.fn(), vi.fn()],
+  useEdgesState: (edges) => [edges, vi.fn(), vi.fn()],
+  useReactFlow: () => reactFlowControls,
+  Handle: () => null,
+  Position: {
+    Left: "left",
+    Right: "right",
+    Top: "top",
+    Bottom: "bottom",
+  },
+  MarkerType: {
+    ArrowClosed: "arrowclosed",
+  },
+}));
+
+const graphData = {
+  nodes: [
+    { id: "start", type: "start", name: "Start", span_count: 1 },
+    { id: "agent", type: "agent", name: "Agent", span_count: 2 },
+    { id: "tool", type: "tool", name: "Tool", span_count: 1 },
+    { id: "end", type: "end", name: "End", span_count: 1 },
+  ],
+  edges: [
+    { source: "agent", target: "tool", transitionCount: 1 },
+    { source: "agent", target: "tool", transition_count: 1 },
+  ],
+};
+
+describe("tracing graph fullscreen controls", () => {
+  it("toggles AgentPath fullscreen and exits on Escape", () => {
+    render(<AgentPath data={graphData} isLoading={false} />);
+
+    fireEvent.click(screen.getByTitle("Fullscreen"));
+
+    expect(screen.getByTitle("Exit fullscreen")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(screen.getByTitle("Fullscreen")).toBeInTheDocument();
+  });
+
+  it("toggles AgentGraph fullscreen without replacing the existing fit control", () => {
+    render(<AgentGraph data={graphData} isLoading={false} isError={false} />);
+
+    fireEvent.mouseEnter(screen.getByTestId("react-flow").parentElement);
+    fireEvent.click(screen.getByTitle("Fit"));
+
+    expect(reactFlowControls.fitView).toHaveBeenCalledWith({
+      duration: 300,
+      padding: 0.3,
+    });
+
+    fireEvent.click(screen.getByTitle("Fullscreen"));
+
+    expect(screen.getByTitle("Exit fullscreen")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Wires the tracing graph fullscreen controls so the fullscreen icon now toggles a fixed, viewport-sized graph container instead of acting as a duplicate fit button. AgentGraph keeps its existing zoom in, zoom out, and fit handlers, while AgentPath now gives its toolbar working zoom, fit, fullscreen, and collapse actions. Both fullscreen variants can be exited with Escape and expose matching button titles/icons.

## Linked issues

Closes #517

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `npm run test:run -- src/sections/projects/LLMTracing/GraphSection/__tests__/fullscreen-controls.test.jsx`
- `npm run test:run -- src/sections/projects/LLMTracing`
- `./node_modules/.bin/eslint src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx src/sections/projects/LLMTracing/GraphSection/__tests__/fullscreen-controls.test.jsx`
- `npm audit signatures`

## Screenshots / recordings (if UI)

N/A; covered by component interaction tests.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] I have updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I have signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

Notes: I could not run `yarn check-all` because Yarn is not installed in this environment, so I ran the focused frontend lint and LLMTracing test suite above. The CLA checkbox is left unchecked for the bot-driven first-time contributor flow.