### PR TITLE
fix: wire trace grid tag editing

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/Renderers/CustomTraceRenderer.jsx
+++ b/frontend/src/sections/projects/LLMTracing/Renderers/CustomTraceRenderer.jsx
@@ -16,6 +16,7 @@ import {
   TagsCell,
   ObservationLevelsCell,
 } from "./index";
+import { getTagCellTargetIds } from "./tagTargetIds";
 import { useNavigationHandlers } from "./useNavigationHandlers";
 
 const CustomTraceRenderer = (params) => {
@@ -74,7 +75,8 @@ const CustomTraceRenderer = (params) => {
   }
 
   if (RENDERER_CONFIG.tagColumns?.includes(colId)) {
-    return <TagsCell value={value} />;
+    const { traceId, spanId } = getTagCellTargetIds(data);
+    return <TagsCell value={value} traceId={traceId} spanId={spanId} />;
   }
 
   if (isEval && column?.outputType === "Pass/Fail") {

--- a/frontend/src/sections/projects/LLMTracing/Renderers/TagsCell.jsx
+++ b/frontend/src/sections/projects/LLMTracing/Renderers/TagsCell.jsx
@@ -1,58 +1,140 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import PropTypes from "prop-types";
 import { Box, Chip } from "@mui/material";
+import AddTagsPopover from "src/components/traceDetail/AddTagsPopover";
 import { normalizeTag } from "src/components/traceDetail/tagUtils";
 import TagChip from "src/components/traceDetail/TagChip";
 
 const MAX_VISIBLE = 2;
 
-const TagsCell = ({ value }) => {
-  if (!Array.isArray(value) || value.length === 0) return null;
+const TagsCell = ({ value, traceId, spanId }) => {
+  const tags = Array.isArray(value) ? value : [];
+  const canEdit = Boolean(traceId || spanId);
+  const [anchorEl, setAnchorEl] = useState(null);
 
-  const visible = value.slice(0, MAX_VISIBLE);
-  const overflowCount = value.length - MAX_VISIBLE;
+  const handleOpen = useCallback(
+    (event) => {
+      if (!canEdit) return;
+      event.stopPropagation();
+      setAnchorEl(event.currentTarget);
+    },
+    [canEdit],
+  );
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      handleOpen(event);
+    },
+    [handleOpen],
+  );
+
+  const handleClose = useCallback(() => {
+    setAnchorEl(null);
+  }, []);
+
+  if (tags.length === 0) {
+    if (!canEdit) return null;
+
+    return (
+      <>
+        <Box
+          role="button"
+          tabIndex={0}
+          onClick={handleOpen}
+          onKeyDown={handleKeyDown}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            px: 1.5,
+            height: "100%",
+            cursor: "pointer",
+          }}
+        >
+          <Chip
+            label="+ Tag"
+            size="small"
+            variant="outlined"
+            sx={{ height: 20, fontSize: 11, "& .MuiChip-label": { px: 0.75 } }}
+          />
+        </Box>
+        <AddTagsPopover
+          open={Boolean(anchorEl)}
+          anchorEl={anchorEl}
+          onClose={handleClose}
+          traceId={traceId}
+          spanId={spanId}
+          currentTags={tags}
+        />
+      </>
+    );
+  }
+
+  const visible = tags.slice(0, MAX_VISIBLE);
+  const overflowCount = tags.length - MAX_VISIBLE;
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        alignItems: "center",
-        gap: 0.5,
-        px: 1.5,
-        overflow: "hidden",
-        height: "100%",
-      }}
-    >
-      {visible.map((rawTag, idx) => {
-        const tag = normalizeTag(rawTag);
-        return (
-          <TagChip
-            key={`${tag.name}-${idx}`}
-            name={tag.name}
-            color={tag.color}
+    <>
+      <Box
+        role={canEdit ? "button" : undefined}
+        tabIndex={canEdit ? 0 : undefined}
+        onClick={handleOpen}
+        onKeyDown={canEdit ? handleKeyDown : undefined}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 0.5,
+          px: 1.5,
+          overflow: "hidden",
+          height: "100%",
+          cursor: canEdit ? "pointer" : "default",
+        }}
+      >
+        {visible.map((rawTag, idx) => {
+          const tag = normalizeTag(rawTag);
+          return (
+            <TagChip
+              key={`${tag.name}-${idx}`}
+              name={tag.name}
+              color={tag.color}
+              size="small"
+            />
+          );
+        })}
+        {overflowCount > 0 && (
+          <Chip
+            label={`+${overflowCount}`}
             size="small"
-            readOnly
+            onClick={handleOpen}
+            sx={{
+              height: 20,
+              fontSize: 11,
+              "& .MuiChip-label": { px: 0.75 },
+              bgcolor: "action.hover",
+              cursor: canEdit ? "pointer" : "default",
+            }}
           />
-        );
-      })}
-      {overflowCount > 0 && (
-        <Chip
-          label={`+${overflowCount}`}
-          size="small"
-          sx={{
-            height: 20,
-            fontSize: 11,
-            "& .MuiChip-label": { px: 0.75 },
-            bgcolor: "action.hover",
-          }}
+        )}
+      </Box>
+      {canEdit && (
+        <AddTagsPopover
+          open={Boolean(anchorEl)}
+          anchorEl={anchorEl}
+          onClose={handleClose}
+          traceId={traceId}
+          spanId={spanId}
+          currentTags={tags}
         />
       )}
-    </Box>
+    </>
   );
 };
 
 TagsCell.propTypes = {
   value: PropTypes.array,
+  traceId: PropTypes.string,
+  spanId: PropTypes.string,
 };
 
 export default React.memo(TagsCell);

--- a/frontend/src/sections/projects/LLMTracing/Renderers/TagsCell.jsx
+++ b/frontend/src/sections/projects/LLMTracing/Renderers/TagsCell.jsx
@@ -99,6 +99,7 @@ const TagsCell = ({ value, traceId, spanId }) => {
               name={tag.name}
               color={tag.color}
               size="small"
+              readOnly
             />
           );
         })}

--- a/frontend/src/sections/projects/LLMTracing/Renderers/__tests__/CustomTraceRenderer.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/Renderers/__tests__/CustomTraceRenderer.test.jsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "src/utils/test-utils";
+import CustomTraceRenderer from "../CustomTraceRenderer";
+import { getTagCellTargetIds } from "../tagTargetIds";
+
+vi.mock("src/components/traceDetail/AddTagsPopover", () => ({
+  default: ({ open, spanId, traceId }) =>
+    open ? (
+      <div
+        data-span-id={spanId || ""}
+        data-testid="tags-popover"
+        data-trace-id={traceId || ""}
+      />
+    ) : null,
+}));
+
+const renderTagColumn = (data) =>
+  render(
+    <CustomTraceRenderer
+      colDef={{ col: { id: "tags", name: "Tags" } }}
+      data={data}
+      value={["release"]}
+    />,
+  );
+
+describe("getTagCellTargetIds", () => {
+  it("uses trace_id for trace rows", () => {
+    expect(getTagCellTargetIds({ trace_id: "trace-1" })).toEqual({
+      traceId: "trace-1",
+      spanId: undefined,
+    });
+  });
+
+  it("uses span_id when the row provides it explicitly", () => {
+    expect(
+      getTagCellTargetIds({ trace_id: "trace-1", span_id: "span-1" }),
+    ).toEqual({
+      traceId: "trace-1",
+      spanId: "span-1",
+    });
+  });
+
+  it("uses id as the span id when a span row also has a trace id", () => {
+    expect(getTagCellTargetIds({ trace_id: "trace-1", id: "span-1" })).toEqual({
+      traceId: "trace-1",
+      spanId: "span-1",
+    });
+  });
+
+  it("falls back to id as the trace id when no span identity is present", () => {
+    expect(getTagCellTargetIds({ id: "trace-1" })).toEqual({
+      traceId: "trace-1",
+      spanId: undefined,
+    });
+  });
+});
+
+describe("CustomTraceRenderer", () => {
+  it("threads trace row ids into editable tag cells", () => {
+    renderTagColumn({ trace_id: "trace-123", project_id: "project-1" });
+
+    fireEvent.click(screen.getByText("release"));
+
+    const popover = screen.getByTestId("tags-popover");
+    expect(popover).toHaveAttribute("data-trace-id", "trace-123");
+    expect(popover).toHaveAttribute("data-span-id", "");
+  });
+
+  it("threads span row ids into editable tag cells", () => {
+    renderTagColumn({
+      trace_id: "trace-123",
+      span_id: "span-456",
+      project_id: "project-1",
+    });
+
+    fireEvent.click(screen.getByText("release"));
+
+    const popover = screen.getByTestId("tags-popover");
+    expect(popover).toHaveAttribute("data-trace-id", "trace-123");
+    expect(popover).toHaveAttribute("data-span-id", "span-456");
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/Renderers/__tests__/TagsCell.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/Renderers/__tests__/TagsCell.test.jsx
@@ -14,6 +14,14 @@ vi.mock("src/components/traceDetail/AddTagsPopover", () => ({
     ) : null,
 }));
 
+vi.mock("src/components/traceDetail/TagChip", () => ({
+  default: ({ name, readOnly }) => (
+    <span data-read-only={String(readOnly)} data-testid={`tag-chip-${name}`}>
+      {name}
+    </span>
+  ),
+}));
+
 describe("TagsCell", () => {
   it("renders tag chips for an array of strings", () => {
     render(<TagsCell value={["production", "v2"]} />);
@@ -48,6 +56,15 @@ describe("TagsCell", () => {
     render(<TagsCell value={["solo"]} />);
     expect(screen.getByText("solo")).toBeInTheDocument();
     expect(screen.queryByText(/\+/)).not.toBeInTheDocument();
+  });
+
+  it("keeps grid chips read-only while the cell handles editing", () => {
+    render(<TagsCell traceId="trace-1" value={["production"]} />);
+
+    expect(screen.getByTestId("tag-chip-production")).toHaveAttribute(
+      "data-read-only",
+      "true",
+    );
   });
 
   it("opens the tag editor for a trace row when a visible tag is clicked", () => {

--- a/frontend/src/sections/projects/LLMTracing/Renderers/__tests__/TagsCell.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/Renderers/__tests__/TagsCell.test.jsx
@@ -1,6 +1,18 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "src/utils/test-utils";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "src/utils/test-utils";
 import TagsCell from "../TagsCell";
+
+vi.mock("src/components/traceDetail/AddTagsPopover", () => ({
+  default: ({ currentTags, open, spanId, traceId }) =>
+    open ? (
+      <div
+        data-current-tags={JSON.stringify(currentTags)}
+        data-span-id={spanId || ""}
+        data-testid="tags-popover"
+        data-trace-id={traceId || ""}
+      />
+    ) : null,
+}));
 
 describe("TagsCell", () => {
   it("renders tag chips for an array of strings", () => {
@@ -36,5 +48,39 @@ describe("TagsCell", () => {
     render(<TagsCell value={["solo"]} />);
     expect(screen.getByText("solo")).toBeInTheDocument();
     expect(screen.queryByText(/\+/)).not.toBeInTheDocument();
+  });
+
+  it("opens the tag editor for a trace row when a visible tag is clicked", () => {
+    render(<TagsCell traceId="trace-1" value={["production", "v2"]} />);
+
+    fireEvent.click(screen.getByText("production"));
+
+    const popover = screen.getByTestId("tags-popover");
+    expect(popover).toHaveAttribute("data-trace-id", "trace-1");
+    expect(popover).toHaveAttribute("data-span-id", "");
+    expect(popover).toHaveAttribute(
+      "data-current-tags",
+      JSON.stringify(["production", "v2"]),
+    );
+  });
+
+  it("opens the tag editor for a span row when the overflow chip is clicked", () => {
+    render(<TagsCell spanId="span-1" value={["a", "b", "c"]} />);
+
+    fireEvent.click(screen.getByText("+1"));
+
+    const popover = screen.getByTestId("tags-popover");
+    expect(popover).toHaveAttribute("data-trace-id", "");
+    expect(popover).toHaveAttribute("data-span-id", "span-1");
+  });
+
+  it("renders an add-tag action for empty editable rows", () => {
+    render(<TagsCell traceId="trace-empty" value={[]} />);
+
+    fireEvent.click(screen.getByText("+ Tag"));
+
+    const popover = screen.getByTestId("tags-popover");
+    expect(popover).toHaveAttribute("data-trace-id", "trace-empty");
+    expect(popover).toHaveAttribute("data-current-tags", JSON.stringify([]));
   });
 });

--- a/frontend/src/sections/projects/LLMTracing/Renderers/tagTargetIds.js
+++ b/frontend/src/sections/projects/LLMTracing/Renderers/tagTargetIds.js
@@ -1,0 +1,13 @@
+export const getTagCellTargetIds = (data = {}) => {
+  const explicitSpanId =
+    data?.span_id ?? data?.spanId ?? data?.observation_span_id;
+  const traceId = data?.trace_id ?? data?.traceId;
+  const rowId = data?.id;
+  const spanId =
+    explicitSpanId ?? (traceId && rowId && rowId !== traceId ? rowId : null);
+
+  return {
+    traceId: traceId ?? (!spanId ? rowId : null) ?? undefined,
+    spanId: spanId ?? undefined,
+  };
+};

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -111,12 +111,15 @@ const getSpanListColumnDefs = (col) => {
     },
     cellRendererSelector: (params) => {
       const value = params.value;
-      if (isCellValueEmpty(value)) {
+      const column = params?.colDef?.col;
+      const colId = column?.id;
+      if (
+        isCellValueEmpty(value) &&
+        !RENDERER_CONFIG.tagColumns?.includes(colId)
+      ) {
         // No renderer for empty values
         return null;
       }
-      const column = params?.colDef?.col;
-      const colId = column?.id;
 
       if (RENDERER_CONFIG.nameColumns.includes(colId)) {
         return {

--- a/frontend/src/sections/projects/LLMTracing/__tests__/tagColumnRenderers.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/tagColumnRenderers.test.jsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getTraceListColumnDefs } from "../common";
+import CustomTraceRenderer from "../Renderers/CustomTraceRenderer";
+
+describe("trace tag column renderers", () => {
+  it("keeps the custom renderer active for empty tag cells", () => {
+    const colDef = getTraceListColumnDefs({
+      id: "tags",
+      isVisible: true,
+      name: "Tags",
+    });
+
+    const renderer = colDef.cellRendererSelector({
+      colDef,
+      value: [],
+    });
+
+    expect(renderer).toEqual({ component: CustomTraceRenderer });
+  });
+
+  it("continues to skip renderers for empty non-tag cells", () => {
+    const colDef = getTraceListColumnDefs({
+      id: "trace_name",
+      isVisible: true,
+      name: "Trace Name",
+    });
+
+    expect(
+      colDef.cellRendererSelector({
+        colDef,
+        value: "",
+      }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/common.js
+++ b/frontend/src/sections/projects/LLMTracing/common.js
@@ -624,12 +624,15 @@ export const getTraceListColumnDefs = (col) => {
     },
     cellRendererSelector: (params) => {
       const value = params.value;
-      if (isCellValueEmpty(value)) {
+      const column = params?.colDef?.col;
+      const colId = column?.id;
+      if (
+        isCellValueEmpty(value) &&
+        !RENDERER_CONFIG.tagColumns?.includes(colId)
+      ) {
         // No renderer for empty values
         return null;
       }
-      const column = params?.colDef?.col;
-      const colId = column?.id;
 
       if (RENDERER_CONFIG.nameColumns.includes(colId)) {
         return {


### PR DESCRIPTION
## Summary
- wire `TagsCell` to the existing `AddTagsPopover` so tag chips and overflow chips open the editor
- add a `+ Tag` affordance for empty editable tag cells
- thread trace/span row ids into tag renderers for both trace and span grids
- keep empty non-tag cells on the existing no-renderer path

Fixes #516.

## Validation
- `npm run test:run -- src/sections/projects/LLMTracing/Renderers/__tests__/TagsCell.test.jsx src/sections/projects/LLMTracing/Renderers/__tests__/CustomTraceRenderer.test.jsx`
- `npm run test:run -- src/sections/projects/LLMTracing`
- `./node_modules/.bin/eslint src/sections/projects/LLMTracing/Renderers/TagsCell.jsx src/sections/projects/LLMTracing/Renderers/CustomTraceRenderer.jsx src/sections/projects/LLMTracing/Renderers/tagTargetIds.js src/sections/projects/LLMTracing/SpanGrid.jsx src/sections/projects/LLMTracing/common.js src/sections/projects/LLMTracing/Renderers/__tests__/TagsCell.test.jsx src/sections/projects/LLMTracing/Renderers/__tests__/CustomTraceRenderer.test.jsx src/sections/projects/LLMTracing/__tests__/tagColumnRenderers.test.jsx` (existing warnings only)
- `./node_modules/.bin/prettier --check ...`
- `git diff --check`
- `npm audit signatures`