### PR TITLE
fix: run AI filter from Apply

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -1835,6 +1835,14 @@ const TraceFilterPanel = ({
     }
   }, [aiQuery, aiParseQuery, observeId, source, properties, onApply, onClose]);
 
+  const handlePrimaryApply = useCallback(() => {
+    if (showAi && aiQuery.trim()) {
+      void handleAiFilter();
+      return;
+    }
+    handleApply();
+  }, [aiQuery, handleAiFilter, handleApply, showAi]);
+
   return (
     <Popover
       open={open}
@@ -2002,7 +2010,7 @@ const TraceFilterPanel = ({
                 <Button
                   size="small"
                   variant="contained"
-                  onClick={handleApply}
+                  onClick={handlePrimaryApply}
                   sx={{
                     textTransform: "none",
                     fontSize: 12,
@@ -2062,7 +2070,7 @@ const TraceFilterPanel = ({
               <Button
                 size="small"
                 variant="contained"
-                onClick={handleApply}
+                onClick={handlePrimaryApply}
                 sx={{ textTransform: "none", fontSize: 12, px: 2 }}
               >
                 Apply

--- a/frontend/src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "src/utils/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
+  default as TraceFilterPanel,
   buildTraceFilterProperties,
   getTraceFilterFields,
   normalizeFilterRowOperator,
@@ -8,6 +11,89 @@ import {
   getPickerOptionSearchText,
   getPickerOptionSecondaryLabel,
 } from "../filterValuePickerUtils";
+
+const parseQueryMock = vi.fn();
+
+vi.mock("src/hooks/use-ai-filter", () => ({
+  useAIFilter: () => ({
+    parseQuery: parseQueryMock,
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("src/hooks/useDashboards", () => ({
+  useDashboardFilterValues: () => ({
+    data: [],
+    isLoading: false,
+  }),
+}));
+
+describe("TraceFilterPanel AI actions", () => {
+  beforeEach(() => {
+    parseQueryMock.mockReset();
+  });
+
+  it("runs the AI filter when Apply is clicked with an AI query", async () => {
+    parseQueryMock.mockResolvedValue([
+      { field: "status", operator: "equals", value: "ERROR" },
+    ]);
+    const onApply = vi.fn();
+    const onClose = vi.fn();
+    const anchorEl = document.createElement("button");
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    document.body.appendChild(anchorEl);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TraceFilterPanel
+          anchorEl={anchorEl}
+          open
+          onClose={onClose}
+          onApply={onApply}
+          currentFilters={[]}
+          properties={[
+            {
+              id: "status",
+              name: "Status",
+              category: "system",
+              type: "string",
+            },
+          ]}
+          showQueryTab={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/Ask AI/i), {
+      target: { value: "show errors" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(parseQueryMock).toHaveBeenCalledWith("show errors", {
+        smart: true,
+        projectId: undefined,
+        source: "traces",
+      });
+    });
+    expect(onApply).toHaveBeenCalledWith([
+      {
+        field: "status",
+        fieldCategory: "system",
+        fieldType: "string",
+        apiColType: undefined,
+        operator: "equals",
+        value: ["ERROR"],
+      },
+    ]);
+    expect(onClose).toHaveBeenCalled();
+
+    document.body.removeChild(anchorEl);
+  });
+});
 
 describe("getTraceFilterFields (TH-4571)", () => {
   it("prepends Trace ID when tab is 'trace'", () => {


### PR DESCRIPTION
## Summary
- route the panel Apply button through the AI filter flow when an AI query is present
- preserve the existing structured Apply behavior when the AI query is empty
- add regression coverage for applying an AI query from the panel button

Fixes #577

## Tests
- ./node_modules/.bin/vitest run src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
- npm run lint (passes with existing warnings)
- ./node_modules/.bin/prettier --check src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
- git diff --check
- npm audit signatures