### PR TITLE
fix: enable model selector on system LLM evals

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1429,6 +1429,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     datasetColumns={datasetColumns}
                     datasetJsonSchemas={datasetJsonSchemas}
                     disabled={isInstructionsReadOnly}
+                    modelSelectorDisabled={false}
                   />
                   <FewShotExamples
                     selectedDatasets={fewShotExamples}

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -1444,6 +1444,7 @@ const EvalDetailPage = () => {
                       datasetColumns={datasetColumns}
                       datasetJsonSchemas={datasetJsonSchemas}
                       disabled={isSystemEval}
+                      modelSelectorDisabled={false}
                     />
                     <FewShotExamples
                       selectedDatasets={fewShotExamples}

--- a/frontend/src/sections/evals/components/LLMPromptEditor.jsx
+++ b/frontend/src/sections/evals/components/LLMPromptEditor.jsx
@@ -29,6 +29,7 @@ const LLMPromptEditor = ({
   datasetColumns = [],
   datasetJsonSchemas = {},
   disabled = false,
+  modelSelectorDisabled,
   // Optional model selector — forwarded to MessageEditor's top bar so
   // the model picker and template format picker share the same row.
   model,
@@ -353,6 +354,7 @@ const LLMPromptEditor = ({
         datasetColumns={datasetColumns}
         datasetJsonSchemas={datasetJsonSchemas}
         disabled={disabled}
+        modelSelectorDisabled={modelSelectorDisabled}
       />
     </Box>
   );
@@ -366,6 +368,7 @@ LLMPromptEditor.propTypes = {
   model: PropTypes.string,
   onModelChange: PropTypes.func,
   disabled: PropTypes.bool,
+  modelSelectorDisabled: PropTypes.bool,
 };
 
 export default LLMPromptEditor;

--- a/frontend/src/sections/evals/components/MessageEditor.jsx
+++ b/frontend/src/sections/evals/components/MessageEditor.jsx
@@ -57,6 +57,7 @@ const MessageEditor = ({
   datasetColumns = [],
   datasetJsonSchemas = {},
   disabled = false,
+  modelSelectorDisabled,
   // Optional model selector — when provided, renders inline in the top
   // bar alongside the template format picker so LLM-as-a-judge has the
   // same top-bar layout as the agent InstructionEditor.
@@ -201,7 +202,7 @@ const MessageEditor = ({
                 onModelChange={onModelChange}
                 showMode={false}
                 showPlus={false}
-                disabled={disabled}
+                disabled={modelSelectorDisabled ?? disabled}
               />
             </Box>
           ) : (
@@ -411,6 +412,7 @@ MessageEditor.propTypes = {
   datasetColumns: PropTypes.array,
   datasetJsonSchemas: PropTypes.object,
   disabled: PropTypes.bool,
+  modelSelectorDisabled: PropTypes.bool,
 };
 
 export default MessageEditor;


### PR DESCRIPTION
## Summary

After #587 converted system evals from `agent` to `llm` type in OSS, the model selector dropdown became disabled on system LLM evals. This happened because `LLMPromptEditor` passes `disabled={isInstructionsReadOnly}` straight through to `ModelSelector` — locking both the prompt text and the model picker. The agent path (`InstructionEditor`) already had a `modelSelectorDisabled={false}` override for this, but the LLM path never needed it until now since no system eval was ever `llm` type before.

This PR threads a `modelSelectorDisabled` prop through `LLMPromptEditor` → `MessageEditor` → `ModelSelector`, matching the existing pattern in `InstructionEditor`. Both `EvalPickerConfigFull` and `EvalDetailPage` pass `modelSelectorDisabled={false}` so system LLM evals have read-only instructions but an editable model picker.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Open a system eval (e.g. Toxicity) on a dataset → model dropdown is now clickable and changeable
- User-created evals — no change in behavior
- Agent evals (EE) — no change, `InstructionEditor` already had this override

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)