### PR TITLE
[TH-5427] Always carry filter_value for is_null/is_not_null filter ops

### DIFF
--- a/frontend/src/components/ComplexFilter/common.js
+++ b/frontend/src/components/ComplexFilter/common.js
@@ -143,13 +143,15 @@ export const getComplexFilterValidation = (
         ),
     })
     .transform((val) => {
-      // For null operators, set filterValue to empty string even if it exists in old data
-      const isNullOperator =
-        val.filterConfig.filterOp === "is_null" ||
-        val.filterConfig.filterOp === "is_not_null";
+      const isNullOperator = NULL_OPERATORS.includes(val.filterConfig.filterOp);
 
       let finalFilters = {};
-      if (val.filterConfig.filterType === "number") {
+      if (isNullOperator) {
+        finalFilters = {
+          columnId: val.columnId,
+          filterConfig: { ...val.filterConfig, filterValue: "" },
+        };
+      } else if (val.filterConfig.filterType === "number") {
         let newFilterValues;
         if (["between", "not_in_between"].includes(val.filterConfig.filterOp)) {
           newFilterValues = val.filterConfig.filterValue.map((item) =>
@@ -183,10 +185,7 @@ export const getComplexFilterValidation = (
       } else {
         finalFilters = {
           columnId: val.columnId,
-          filterConfig: {
-            ...val.filterConfig,
-            ...(isNullOperator && { filterValue: "" }),
-          },
+          filterConfig: { ...val.filterConfig },
         };
       }
 

--- a/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
+++ b/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
@@ -17,6 +17,7 @@ import {
   startOfYesterday,
   sub,
 } from "date-fns";
+import { NULL_OPERATORS } from "src/components/ComplexFilter/common";
 import Iconify from "src/components/iconify";
 import DisplayPanel from "./DisplayPanel";
 import TraceFilterPanel from "./TraceFilterPanel";
@@ -453,7 +454,9 @@ const ObserveToolbar = ({
               const apiFilters = newFilters.map((f) => {
                 const filterOp = LEGACY_OP_ALIAS[f.operator] || f.operator;
                 const apiColType = f.apiColType || colTypeMap[f.fieldCategory];
-                let filterValue = f.value;
+                let filterValue = NULL_OPERATORS.includes(filterOp)
+                  ? ""
+                  : f.value;
                 if (Array.isArray(filterValue)) {
                   if (RANGE_OPS.has(filterOp)) {
                     // Coerce numeric range bounds.

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -39,6 +39,7 @@ import {
   isAudioUrlString,
   isRecordingObjectKey,
 } from "src/components/inline-audio/audio-detection";
+import { NULL_OPERATORS } from "src/components/ComplexFilter/common";
 
 // ───────────────────────────────────────────────────────────────
 // Helpers (ported from TracingTestMode)
@@ -56,6 +57,7 @@ const ID_COLUMNS = new Set(["trace_id", "span_id"]);
 
 const RANGE_OPS = new Set(["between", "not_between"]);
 const LIST_OPS = new Set(["in", "not_in"]);
+const NO_VALUE_OPS = new Set(NULL_OPERATORS);
 
 // Form rows from `TaskFilterBar.convertNewToOld` carry scalar `filterValue`
 // for single-value ops and arrays for `in`/`not_in`/`between`/`not_between`.
@@ -106,7 +108,9 @@ export function buildApiFilterArray(oldFormatFilters, startDate, endDate) {
         COL_TYPE_MAP[entry.fieldCategory] ||
         (entry.isAttribute ? "SPAN_ATTRIBUTE" : "SYSTEM_METRIC");
       let filterValue;
-      if (RANGE_OPS.has(entry.op)) {
+      if (NO_VALUE_OPS.has(entry.op)) {
+        filterValue = "";
+      } else if (RANGE_OPS.has(entry.op)) {
         filterValue = entry.value;
       } else if (LIST_OPS.has(entry.op)) {
         filterValue = entry.values;


### PR DESCRIPTION
## Summary

Dev backend's filter validator requires `filter_value` to be present in `filter_config` for every op. Three FE paths previously emitted null-op filters with the key either absent or set to a non-canonical placeholder (`[]`), causing `"Missing required filter config keys: filter_value"` 400s and silent payload inconsistencies across observe surfaces.

- **`src/components/ComplexFilter/common.js`** — Hoisted the `isNullOperator` check to the top of the zod transform. Previously only the text/boolean/array branch emitted `filterValue: ""`; the number and datetime branches ran `parseFloat(val.filterConfig.filterValue[0])` / `new Date(...filterValue[0])` unconditionally, which would have crashed once null-op filterValue became `null`. Now every filter_type for a null op emits `filter_value: ""` and skips the type-specific coercion entirely.
- **`src/sections/projects/LLMTracing/ObserveToolbar.jsx`** — The TraceFilterPanel → API mapper inherited the row's `value` (typically `[]` for string-type rows whose default op is the LIST op `in`). Forced `""` for null ops via `NULL_OPERATORS.includes(filterOp)`.
- **`src/sections/tasks/components/TaskLivePreview.jsx`** — `buildApiFilterArray` (shared by Tasks live preview, evals `TracingTestMode`, and EvalPicker) was conditionally omitting `filter_value` when undefined. Added a `NO_VALUE_OPS` branch that resolves to `""` so the key is always carried.

Closes TH-5427

## Linear Ticket

[TH-5427](https://linear.app/future-agi/issue/TH-5427/debug-reported-observe-filter-issue-from-screenshot)

## Files Changed

- `frontend/src/components/ComplexFilter/common.js`
- `frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx`
- `frontend/src/sections/tasks/components/TaskLivePreview.jsx`

## Test plan

- [ ] Voice calls grid (`list_voice_calls`): `is_null` / `is_not_null` on `ai_interruption_count` (number, SPAN_ATTRIBUTE) — no 400, payload carries `filter_value: ""`.
- [ ] Spans grid (`list_spans_observe`): `is_null` on a SYSTEM_METRIC text column — same.
- [ ] Sessions grid (`list_sessions`): `is_null` on a text column — same.
- [ ] Users page (`/tracer/users/`): `is_not_null` on `user_id` — same.
- [ ] Traces of session (`list_traces_of_session`): `is_null` on `model` (SYSTEM_METRIC text) — same.
- [ ] Tasks create page live preview: `gen_ai.conversation.id is_not_null` filter — fetches without 400.
- [ ] Regression — non-null ops (`equals`, `between`, `in`, etc.) continue to send the canonical payload across all the above surfaces.