### PR TITLE
[TH-5429] Fix unresponsive page after Start from Scratch in template flow

### DIFF
--- a/frontend/src/sections/workbench-v2/components/CreateNewPrompt.jsx
+++ b/frontend/src/sections/workbench-v2/components/CreateNewPrompt.jsx
@@ -100,6 +100,7 @@ export default function CreateNewPrompt({ open, onClose, isLoading }) {
         },
       );
       onClose();
+      setSelectTemplateDrawerOpen(false);
     },
   });
 

--- a/frontend/src/sections/workbench/ChoosePromptTemplateDrawer.jsx
+++ b/frontend/src/sections/workbench/ChoosePromptTemplateDrawer.jsx
@@ -534,9 +534,16 @@ export const ChoosePromptTemplateDrawer = ({ open, onClose, importMode }) => {
                       }}
                     >
                       <EmptyLayout
-                        title={"Create new template"}
-                        description="Craft a prompt, customize it to your needs, and save it as a 
-                      reusable template."
+                        title={
+                          importMode
+                            ? "No templates available"
+                            : "Create new template"
+                        }
+                        description={
+                          importMode
+                            ? "You don't have any templates yet. Create one from the prompts page to import it here."
+                            : "Craft a prompt, customize it to your needs, and save it as a reusable template."
+                        }
                         icon={"/assets/icons/ic_scratch.svg"}
                         linkText={"Check docs"}
                         link="https://docs.futureagi.com/docs/prompt"
@@ -544,13 +551,15 @@ export const ChoosePromptTemplateDrawer = ({ open, onClose, importMode }) => {
                           height: "80%",
                         }}
                         action={
-                          <Button
-                            onClick={() => setNewPromptModal(true)}
-                            variant="contained"
-                            color="primary"
-                          >
-                            Create prompt
-                          </Button>
+                          importMode ? null : (
+                            <Button
+                              onClick={() => setNewPromptModal(true)}
+                              variant="contained"
+                              color="primary"
+                            >
+                              Create prompt
+                            </Button>
+                          )
                         }
                       />
                     </Box>


### PR DESCRIPTION
## Summary
- Close the `ChoosePromptTemplateDrawer` alongside the `CreateNewPrompt` dialog when a draft is created, so the drawer's modal backdrop doesn't linger over the newly navigated prompt page and block clicks.
- In `importMode` (drawer opened from inside an existing prompt via `Playground`/`CompareInputs`), hide the empty-state "Create prompt" CTA because `CreateNewPrompt` isn't mounted on the `CreatePrompt` route — clicking it was a no-op. Show a plain "No templates available" message instead.

Closes TH-5429

## Linear Ticket
[TH-5429](https://linear.app/future-agi/issue/TH-5429/page-becomes-unresponsive-after-start-from-scratch)

## Files Changed
- `frontend/src/sections/workbench-v2/components/CreateNewPrompt.jsx`
- `frontend/src/sections/workbench/ChoosePromptTemplateDrawer.jsx`

## Test plan
- [ ] Prompts → Templates → Create Prompt → Start from Scratch: navigates to new prompt page and the page is fully interactive (drawer + backdrop gone).
- [ ] Same flow with "Write with AI / gen_ai" option: drawer closes on navigation.
- [ ] "Start with Template" option still keeps the drawer open as before.
- [ ] Inside an existing prompt (Playground) → Import Templates: empty state shows "No templates available" without a Create prompt button.
- [ ] FolderListView empty state still shows the "Create prompt" CTA and it opens the dialog normally.