### PR TITLE
Fix/redirecting issue on url share

### DIFF
--- a/frontend/src/auth/guard/auth-guard.jsx
+++ b/frontend/src/auth/guard/auth-guard.jsx
@@ -56,6 +56,7 @@ function Container({ children }) {
     const refreshToken = queryParams.get("refresh_token");
     const isNewOAuthUser = queryParams.get("is_new_user") === "true";
     const returnTo = localStorage.getItem("redirectUrl");
+    
 
     if (!authenticated) {
       if (sso_token) {
@@ -191,6 +192,7 @@ function Container({ children }) {
         router.replace("/dashboard/get-started");
       }
       localStorage.setItem("initial-render", "done");
+      localStorage.removeItem("redirectUrl");
     }
   }, [postLoginPath, user, router]);
 

--- a/frontend/src/hooks/useDeploymentMode.js
+++ b/frontend/src/hooks/useDeploymentMode.js
@@ -34,5 +34,9 @@ export function useDeploymentMode() {
 
 export function usePostLoginPath() {
   const { isOSS } = useDeploymentMode();
+
+
+ const returnTo = localStorage.getItem("redirectUrl");
+  if (returnTo) return returnTo;
   return isOSS ? paths.dashboard.develop : paths.dashboard.falconAI;
 }

--- a/frontend/src/sections/auth/jwt/jwt-login-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-login-view.jsx
@@ -55,6 +55,13 @@ export default function JwtLoginView() {
   const [errorMsg, setErrorMsg] = useState("");
   const [searchParams] = useSearchParams();
   const returnTo = searchParams.get("returnTo");
+  // Persist returnTo on a login action so it survives flows that drop the
+  // URL param (OAuth round-trip, login → setup-org).
+  const persistReturnTo = () => {
+    if (returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")) {
+      localStorage.setItem("redirectUrl", returnTo);
+    }
+  };
   const password = useBoolean();
   const navigate = useNavigate();
   const { search } = useLocation();
@@ -186,6 +193,7 @@ export default function JwtLoginView() {
   } = methods;
 
   const onSubmit = handleSubmit(async (data) => {
+    persistReturnTo();
     if (GOOGLE_SITE_KEY && !executeRecaptcha) {
       enqueueSnackbar({
         message: "reCAPTCHA not ready. Please try again",
@@ -233,7 +241,9 @@ export default function JwtLoginView() {
           localStorage.setItem("signupProvider", "email");
           navigate(paths.auth.jwt.setup_org);
         } else {
+          if (returnTo) localStorage.setItem("initial-render", "done");
           router.push(returnTo || postLoginPath);
+          localStorage.removeItem("redirectUrl");
         }
       }
     } catch (error) {
@@ -330,6 +340,7 @@ export default function JwtLoginView() {
 
   const handlePasskeyLogin = async () => {
     try {
+      persistReturnTo();
       setPasskeyLoading(true);
       // Get authentication options from server
       const optionsRes = await axiosInstance.post(
@@ -353,7 +364,9 @@ export default function JwtLoginView() {
 
       if (verifyRes.status === 200) {
         await login(verifyRes);
+        if (returnTo) localStorage.setItem("initial-render", "done");
         router.push(returnTo || postLoginPath);
+        localStorage.removeItem("redirectUrl");
       }
     } catch (error) {
       if (error?.name === "NotAllowedError") {
@@ -373,11 +386,13 @@ export default function JwtLoginView() {
   };
 
   const handleSsoLogin = () => {
+    persistReturnTo();  
     // Navigate to SSO login page
     navigate(paths.auth.jwt.sso);
   };
 
   const handleServiceProvider = async (provider) => {
+    persistReturnTo();
     trackEvent(Events.ssoLoginClicked, {
       [PropertyName.mode]: provider,
     });

--- a/frontend/src/sections/auth/jwt/jwt-register-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-register-view.jsx
@@ -90,7 +90,17 @@ export default function JwtRegisterView() {
     locallyExtractUtmParams();
   }, [locallyExtractUtmParams]);
 
+  // Persist returnTo on an auth action so it survives flows that drop the
+  // URL param (OAuth / SSO round-trip, register → setup-org).
+  const persistReturnTo = () => {
+    const returnTo = new URLSearchParams(search).get("returnTo");
+    if (returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")) {
+      localStorage.setItem("redirectUrl", returnTo);
+    }
+  };
+
   const handleSsoLogin = () => {
+    persistReturnTo();
     // Navigate to SSO login page
     navigate(paths.auth.jwt.sso);
   };
@@ -110,6 +120,7 @@ export default function JwtRegisterView() {
   const email = watch("email");
 
   const handleSignup = async (data) => {
+    persistReturnTo();
     const token = GOOGLE_SITE_KEY ? await executeRecaptcha("signup") : "";
     setErrorMsg("");
     try {
@@ -181,6 +192,7 @@ export default function JwtRegisterView() {
   };
 
   const handleLogin = async (data) => {
+    persistReturnTo();
     const token = GOOGLE_SITE_KEY ? await executeRecaptcha("login") : "";
 
     trackEvent(Events.loginClicked, {
@@ -237,6 +249,7 @@ export default function JwtRegisterView() {
   });
 
   const handleServiceProvider = async (provider) => {
+    persistReturnTo();
     try {
       const response = await axios.get(endpoints.auth.service(provider));
       logger.debug("Service provider response:", {

--- a/frontend/src/sections/auth/jwt/setup-org.jsx
+++ b/frontend/src/sections/auth/jwt/setup-org.jsx
@@ -238,6 +238,12 @@ const SetupOrganization = ({ getStarted = false }) => {
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const activeStep = parseInt(searchParams.get("step") || "0", 10);
+  // Where to land once org setup finishes — honor an internal `returnTo`
+  // persisted in localStorage over the default dashboard page.
+  const returnTo = (() => {
+    const rt = localStorage.getItem("redirectUrl");
+    return rt && rt.startsWith("/") && !rt.startsWith("//") ? rt : null;
+  })();
 
   const setActiveStep = useCallback(
     (newStep) => {
@@ -326,7 +332,11 @@ const SetupOrganization = ({ getStarted = false }) => {
       } else {
         // Non-owners (invited users) should go straight to dashboard
         // They're already part of an org, no need for additional onboarding
-        window.location.href = paths.dashboard.develop;
+        if (returnTo) {
+          localStorage.setItem("initial-render", "done");
+          localStorage.removeItem("redirectUrl");
+        }
+        window.location.href = returnTo || paths.dashboard.develop;
       }
     },
     onError: (error) => {
@@ -498,7 +508,11 @@ const SetupOrganization = ({ getStarted = false }) => {
 
       if (!getStarted) {
         // After creating org during onboarding, redirect to get-started
-        window.location.href = paths.dashboard.getstarted;
+        if (returnTo) {
+          localStorage.setItem("initial-render", "done");
+          localStorage.removeItem("redirectUrl");
+        }
+        window.location.href = returnTo || paths.dashboard.getstarted;
       }
     },
 

--- a/frontend/src/sections/auth/jwt/two-factor-verify-view.jsx
+++ b/frontend/src/sections/auth/jwt/two-factor-verify-view.jsx
@@ -122,7 +122,9 @@ export default function TwoFactorVerifyView() {
     // login() expects a response-shaped object with { status, data }
     await login({ status: 200, data });
 
+    localStorage.setItem("initial-render", "done");
     router.push(postLoginPath);
+    localStorage.removeItem("redirectUrl");
   };
 
   // --------------- TOTP verification ---------------


### PR DESCRIPTION
Post-login/signup always landed on the default page (Falcon AI / Develop),
ignoring an explicit `returnTo`. The URL param is dropped across the OAuth
provider round-trip and the register → setup-org hand-off, so it never
reached the final landing redirect.

Persist `returnTo` to localStorage (`redirectUrl`) on every auth action —
email/passkey login, signup, SSO, and all OAuth providers — and consume it
at the post-login / post-onboarding landing: usePostLoginPath, the auth
guard's initial-render effect, and setup-org (owner + non-owner). The value
is cleared once used so it can't leak into a later session.