### PR TITLE
fix: use legacy_prompt_config in demo dataset seeder after field rename

### DIFF
--- a/futureagi/accounts/user_onboard.py
+++ b/futureagi/accounts/user_onboard.py
@@ -437,7 +437,7 @@ def upload_demo_dataset(organization_id, user_id):
             exp_dataset = ExperimentDatasetTable.objects.create(
                 status=StatusType.COMPLETED.value,
                 name="Response Generation-Generate Answer-1-o1-mini",
-                prompt_config=exp_pr_config,
+                legacy_prompt_config=exp_pr_config,
             )
             experiment.experiments_datasets.add(exp_dataset)
 


### PR DESCRIPTION
## Summary

Migration 0057 renamed `ExperimentDatasetTable.prompt_config` → `legacy_prompt_config` (keeping `db_column="prompt_config"`), but the demo dataset seeder in `accounts/user_onboard.py` was never updated. This causes `upload_demo_dataset()` to crash at `ExperimentDatasetTable.objects.create(prompt_config=...)` with `"The following fields do not exist in this model: prompt_config"`.

Because the crash happens inside a broad `try/except`, the dataset object is already committed to DB but all subsequent steps (column_order save, row creation, cell creation, image dataset) are silently skipped — leaving every new user with a blank demo dataset.

Fix: `prompt_config=` → `legacy_prompt_config=` (one line).

## Linked issues

Closes TH-4917

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

1. Signed up a new user locally (`tanmay@gggi.com`).
2. Checked temporal worker logs — confirmed the `"fields do not exist"` error is gone.
3. Verified via Django shell that `Demo-dataset` now has 50 rows, 13 columns, and populated cells.

## Screenshots / recordings (if UI)

N/A — backend-only change, no UI diff.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII