### PR TITLE
fix: add raw JSON editor for dataset cells

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/JsonCellEditor.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/JsonCellEditor.jsx
@@ -10,6 +10,7 @@ import PropTypes from "prop-types";
 import { defineDataType, JsonViewer } from "@textea/json-viewer";
 import { Box, Button, Stack, TextField, useTheme } from "@mui/material";
 import { Icon } from "@iconify/react";
+import EditJson from "./EditJson";
 
 const MiniImageRender = ({ value }) => (
   <img
@@ -81,11 +82,12 @@ const JsonCellEditor = forwardRef((props, ref) => {
   const [addPath, setAddPath] = useState([]);
   const [newKey, setNewKey] = useState("");
   const [newValue, setNewValue] = useState("");
+  const [rawMode, setRawMode] = useState(false);
   const originalValueRef = useRef(JSON.stringify(initialValue));
   const [keyExistsError, setKeyExistsError] = useState(false);
 
-  const triggerValueChange = () => {
-    const jsonString = JSON.stringify(value);
+  const triggerValueChange = (nextValue = value) => {
+    const jsonString = JSON.stringify(nextValue);
 
     if (
       jsonString !== originalValueRef.current &&
@@ -116,6 +118,10 @@ const JsonCellEditor = forwardRef((props, ref) => {
 
   useEffect(() => {
     const handleKeyDown = (e) => {
+      if (rawMode) {
+        return;
+      }
+
       if (e.key === "Enter" && !e.shiftKey) {
         props.api.stopEditing();
       }
@@ -129,7 +135,7 @@ const JsonCellEditor = forwardRef((props, ref) => {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [props?.api, showAddField]); // Add showAddField to dependencies
+  }, [props?.api, showAddField, rawMode]); // Add showAddField to dependencies
 
   useImperativeHandle(ref, () => ({
     getValue: () => {
@@ -224,6 +230,11 @@ const JsonCellEditor = forwardRef((props, ref) => {
     });
   };
 
+  const handleRawJsonSave = ({ newValue }) => {
+    setValue(newValue);
+    triggerValueChange(newValue);
+  };
+
   return (
     <div
       style={{
@@ -295,46 +306,54 @@ const JsonCellEditor = forwardRef((props, ref) => {
         </div>
       )}
 
-      <Box
-        sx={{
-          resize: "both",
-          overflow: "auto",
-          minHeight: "180px",
-          maxHeight: "500px",
-          width: "412px",
-          scrollbarWidth: "none",
-          msOverflowStyle: "none",
-          "&::-webkit-scrollbar": {
-            display: "none",
-          },
-        }}
-      >
-        <JsonViewer
-          value={value}
-          theme={theme.palette.mode}
-          displayDataTypes={false}
-          displaySize={false}
-          indentWidth={2}
-          rootName={false}
-          editable={true}
-          enableAdd={(path, currentValue) =>
-            typeof currentValue === "object" && currentValue !== null
-          }
-          enableDelete={() => true}
-          onDelete={handleRemoveElement}
-          onAdd={handleInlineAdd}
-          onChange={handleValueChange}
-          valueTypes={[imageType]}
+      {rawMode ? (
+        <EditJson
+          params={{ ...props, value: JSON.stringify(value, null, 2) }}
+          onClose={() => setRawMode(false)}
+          onCellValueChanged={handleRawJsonSave}
+        />
+      ) : (
+        <Box
           sx={{
-            fontSize: "14px",
-            "& .jv-edit-input": {
-              border: "1px solid var(--border-default)",
-              borderRadius: "4px",
-              padding: "2px 4px",
+            resize: "both",
+            overflow: "auto",
+            minHeight: "180px",
+            maxHeight: "500px",
+            width: "412px",
+            scrollbarWidth: "none",
+            msOverflowStyle: "none",
+            "&::-webkit-scrollbar": {
+              display: "none",
             },
           }}
-        />
-      </Box>
+        >
+          <JsonViewer
+            value={value}
+            theme={theme.palette.mode}
+            displayDataTypes={false}
+            displaySize={false}
+            indentWidth={2}
+            rootName={false}
+            editable={true}
+            enableAdd={(path, currentValue) =>
+              typeof currentValue === "object" && currentValue !== null
+            }
+            enableDelete={() => true}
+            onDelete={handleRemoveElement}
+            onAdd={handleInlineAdd}
+            onChange={handleValueChange}
+            valueTypes={[imageType]}
+            sx={{
+              fontSize: "14px",
+              "& .jv-edit-input": {
+                border: "1px solid var(--border-default)",
+                borderRadius: "4px",
+                padding: "2px 4px",
+              },
+            }}
+          />
+        </Box>
+      )}
 
       <div style={{ marginTop: "12px", textAlign: "right" }}>
         <Stack
@@ -343,13 +362,39 @@ const JsonCellEditor = forwardRef((props, ref) => {
           justifyContent="flex-start"
           sx={{ mt: 1.5 }}
         >
+          {!rawMode && (
+            <Button
+              variant="outlined"
+              size="small"
+              color="primary"
+              startIcon={
+                <Icon
+                  icon="mdi:check-bold"
+                  style={{
+                    width: 16,
+                    height: 16,
+                    color: "inherit",
+                  }}
+                />
+              }
+              onClick={() => triggerValueChange()}
+              sx={{
+                fontSize: "12px",
+                fontWeight: 500,
+                p: theme.spacing(2),
+                whiteSpace: "nowrap",
+              }}
+            >
+              Apply Changes
+            </Button>
+          )}
           <Button
             variant="outlined"
             size="small"
             color="primary"
             startIcon={
               <Icon
-                icon="mdi:check-bold"
+                icon={rawMode ? "mdi:file-tree" : "mdi:code-json"}
                 style={{
                   width: 16,
                   height: 16,
@@ -357,7 +402,7 @@ const JsonCellEditor = forwardRef((props, ref) => {
                 }}
               />
             }
-            onClick={triggerValueChange}
+            onClick={() => setRawMode((current) => !current)}
             sx={{
               fontSize: "12px",
               fontWeight: 500,
@@ -365,7 +410,7 @@ const JsonCellEditor = forwardRef((props, ref) => {
               whiteSpace: "nowrap",
             }}
           >
-            Apply Changes
+            {rawMode ? "View JSON Tree" : "Edit Raw JSON"}
           </Button>
         </Stack>
       </div>


### PR DESCRIPTION
## Summary

- Adds a raw JSON editing mode to JSON dataset cells by wiring the existing `EditJson` editor into `JsonCellEditor`.
- Keeps the existing visual JSON tree editor and AG Grid cell update flow for normal edits.
- Prevents the JSON cell editor's Enter shortcut from closing the cell while raw mode is active, so multi-line Monaco editing works.

## Linked issues

Closes #515

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only
- [ ] Chore / refactor (no user-visible change)
- [ ] Performance improvement
- [ ] Test-only change

## How was this tested?

- Verified the GitHub compare contains one changed file: `frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/JsonCellEditor.jsx`.
- Manually reviewed the raw-editor save path to ensure it still calls `colDef.cellEditorParams.onCellValueChanged` with the existing `cellValueChanged`/`source: edit` params.
- Attempted `corepack yarn install --frozen-lockfile --ignore-scripts --network-timeout 600000`; dependency install timed out in this Windows environment before runnable bins were linked.
- Attempted a focused Prettier check via `npm exec --yes --package=prettier@3.3.0`; npm failed locally with `ECOMPROMISED Lock compromised`.

## Screenshots / recordings (if UI)

Not captured locally because frontend dependencies did not finish installing in this environment.

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA