### PR TITLE
feat(billing): attach token usage to AI credit events + cover span/trace/session evals

### DIFF
--- a/futureagi/agentic_eval/core/llm/llm.py
+++ b/futureagi/agentic_eval/core/llm/llm.py
@@ -537,11 +537,17 @@ class LLM:
                 )
 
     def _update_cost(self, response: Any = None) -> None:
-        """Update cost statistics. Prioritizes response-level cost from litellm,
-        falls back to calculate_total_cost from token counts."""
+        """
+        Update cost statistics.
+        """
+        catalog = calculate_total_cost(self.model_name, self.token_usage)
+
+        if catalog.get("pricing_source") != "default":
+            self.cost.update(catalog)
+            return
+
         response_cost = 0.0
         if response is not None:
-            # litellm ModelResponse stores cost in _hidden_params
             hidden = getattr(response, "_hidden_params", None)
             if hidden and isinstance(hidden, dict):
                 response_cost = hidden.get("response_cost", 0) or 0
@@ -549,7 +555,7 @@ class LLM:
         if response_cost > 0:
             self.cost["total_cost"] = self.cost.get("total_cost", 0) + response_cost
         else:
-            self.cost.update(calculate_total_cost(self.model_name, self.token_usage))
+            self.cost.update(catalog)
 
     def _set_last_finish_reason_from_response(self, response: Any) -> None:
         self.last_finish_reason = None

--- a/futureagi/model_hub/tasks/develop_dataset.py
+++ b/futureagi/model_hub/tasks/develop_dataset.py
@@ -543,6 +543,10 @@ def create_synthetic_dataset(
                     from ee.usage.services.emitter import emit
                 except ImportError:
                     emit = None
+                try:
+                    from ee.usage.utils.event_properties import llm_usage_properties
+                except ImportError:
+                    llm_usage_properties = lambda obj: {}
 
                 actual_cost = getattr(agent, "cost", {}).get("total_cost", 0)
                 if not actual_cost and hasattr(agent, "llm"):
@@ -558,6 +562,7 @@ def create_synthetic_dataset(
                             "source": "synthetic_dataset",
                             "source_id": str(dataset.id),
                             "raw_cost_usd": str(actual_cost),
+                            **llm_usage_properties(agent),
                         },
                     )
                 )

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -1169,10 +1169,20 @@ def process_single_error_localization(task_id):
                 from ee.usage.services.emitter import emit
             except ImportError:
                 emit = None
+            try:
+                from ee.usage.utils.event_properties import llm_usage_properties
+            except ImportError:
+                llm_usage_properties = lambda obj: {}
 
             actual_cost = getattr(localizer, "cost", {}).get("total_cost", 0)
             if not actual_cost and hasattr(localizer, "llm"):
                 actual_cost = getattr(localizer.llm, "cost", {}).get("total_cost", 0)
+            if not actual_cost:
+                error_agent = getattr(localizer, "error_agent", None)
+                error_llm = getattr(error_agent, "llm", None)
+                actual_cost = getattr(error_llm, "cost", {}).get(
+                    "total_cost", 0
+                )
             credits = BillingConfig.get().calculate_ai_credits(actual_cost)
 
             emit(
@@ -1184,6 +1194,9 @@ def process_single_error_localization(task_id):
                         "source": "error_localizer",
                         "source_id": str(task.id),
                         "raw_cost_usd": str(actual_cost),
+                        **llm_usage_properties(
+                            getattr(localizer, "error_agent", None)
+                        ),
                     },
                 )
             )

--- a/futureagi/model_hub/tests/test_prompt_usage_events_api.py
+++ b/futureagi/model_hub/tests/test_prompt_usage_events_api.py
@@ -1,0 +1,89 @@
+import logging
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ee.usage.models.usage import APICallStatusChoices
+
+
+logger = logging.getLogger("tests.usage_events")
+
+
+@pytest.mark.django_db
+def test_generate_prompt_api_emits_token_usage_properties(auth_client):
+    call_log = SimpleNamespace(
+        status=APICallStatusChoices.PROCESSING.value,
+        log_id=uuid.uuid4(),
+    )
+
+    with (
+        patch(
+            "model_hub.views.prompt_template.log_and_deduct_cost_for_api_request",
+            return_value=call_log,
+        ) as mock_log_cost,
+        patch("model_hub.views.prompt_template.submit_with_retry") as mock_submit,
+        patch("ee.usage.services.emitter.emit") as mock_emit,
+    ):
+        response = auth_client.post(
+            "/model-hub/prompt-templates/generate-prompt/",
+            {"statement": "Write a concise bug triage prompt for a JSON API."},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.content
+        mock_log_cost.assert_called_once()
+        mock_submit.assert_called_once()
+        mock_emit.assert_called_once()
+
+        event = mock_emit.call_args.args[0]
+        logger.info("captured_prompt_usage_event %s", event.model_dump(mode="json"))
+
+    props = event.properties
+    assert event.event_type == "ai_prompt_creation"
+    assert props["source"] == "run_prompt_gen"
+    assert props["source_id"] == str(call_log.log_id)
+    assert props["prompt_tokens"] > 0
+    assert props["total_tokens"] == props["prompt_tokens"]
+
+
+@pytest.mark.django_db
+def test_improve_prompt_api_emits_token_usage_properties(auth_client):
+    call_log = SimpleNamespace(
+        status=APICallStatusChoices.PROCESSING.value,
+        log_id=uuid.uuid4(),
+    )
+
+    with (
+        patch("tfc.ee_gating.check_ee_feature"),
+        patch(
+            "model_hub.views.prompt_template.log_and_deduct_cost_for_api_request",
+            return_value=call_log,
+        ) as mock_log_cost,
+        patch("model_hub.views.prompt_template.submit_with_retry") as mock_submit,
+        patch("ee.usage.services.emitter.emit") as mock_emit,
+    ):
+        response = auth_client.post(
+            "/model-hub/prompt-templates/improve-prompt/",
+            {
+                "existing_prompt": "Summarize this support ticket: {{ticket}}",
+                "improvement_requirements": "Make the output include severity and next action.",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.content
+        mock_log_cost.assert_called_once()
+        mock_submit.assert_called_once()
+        mock_emit.assert_called_once()
+
+        event = mock_emit.call_args.args[0]
+        logger.info("captured_prompt_usage_event %s", event.model_dump(mode="json"))
+
+    props = event.properties
+    assert event.event_type == "ai_prompt_improvement"
+    assert props["source"] == "run_prompt_improve"
+    assert props["source_id"] == str(call_log.log_id)
+    assert props["prompt_tokens"] > 0
+    assert props["total_tokens"] == props["prompt_tokens"]

--- a/futureagi/model_hub/utils/async_generate_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_generate_prompt_runner.py
@@ -117,6 +117,10 @@ async def generate_prompt_async(
                 from ee.usage.services.emitter import emit
             except ImportError:
                 emit = None
+            try:
+                from ee.usage.utils.event_properties import llm_usage_properties
+            except ImportError:
+                llm_usage_properties = lambda obj: {}
 
             actual_cost = 0
             if hasattr(prompt_generator, "llm") and prompt_generator.llm:
@@ -134,6 +138,7 @@ async def generate_prompt_async(
                         "source": "run_prompt_gen",
                         "source_id": str(generation_id),
                         "raw_cost_usd": str(actual_cost),
+                        **llm_usage_properties(prompt_generator),
                     },
                 )
             )

--- a/futureagi/model_hub/utils/async_improve_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_improve_prompt_runner.py
@@ -125,6 +125,10 @@ async def improve_prompt_async(
                 from ee.usage.services.emitter import emit
             except ImportError:
                 emit = None
+            try:
+                from ee.usage.utils.event_properties import llm_usage_properties
+            except ImportError:
+                llm_usage_properties = lambda obj: {}
 
             actual_cost = 0
             if hasattr(prompt_generator, "llm") and prompt_generator.llm:
@@ -142,6 +146,7 @@ async def improve_prompt_async(
                         "source": "run_prompt_improve",
                         "source_id": str(improve_id),
                         "raw_cost_usd": str(actual_cost),
+                        **llm_usage_properties(prompt_generator),
                     },
                 )
             )

--- a/futureagi/model_hub/utils/auto_annotate.py
+++ b/futureagi/model_hub/utils/auto_annotate.py
@@ -300,6 +300,12 @@ class AutoAnnotation:
                             from ee.usage.services.emitter import emit
                         except ImportError:
                             emit = None
+                        try:
+                            from ee.usage.utils.event_properties import (
+                                llm_usage_properties,
+                            )
+                        except ImportError:
+                            llm_usage_properties = lambda obj: {}
 
                         actual_cost = 0
                         if hasattr(agent, "llm") and agent.llm:
@@ -318,6 +324,7 @@ class AutoAnnotation:
                                     "annotation_id": str(self.annotation.id),
                                     "row_id": str(row.id),
                                     "raw_cost_usd": str(actual_cost),
+                                    **llm_usage_properties(agent),
                                 },
                             )
                         )

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1101,12 +1101,17 @@ class EvaluationRunner:
                     from ee.usage.services.emitter import emit
                 except ImportError:
                     emit = None
+                try:
+                    from ee.usage.utils.event_properties import token_usage_properties
+                except ImportError:
+                    token_usage_properties = lambda token_usage: {}
 
                 billing_config = BillingConfig.get()
                 eval_cost = getattr(eval_instance, "cost", {})
                 llm_cost = eval_cost.get("total_cost", 0)
                 per_run_fee = billing_config.get_eval_per_run_fee()
                 actual_cost = llm_cost + per_run_fee
+                _token_usage = getattr(eval_instance, "token_usage", {})
 
                 # Also compute fallback cost for comparison logging
                 _fallback_cost = 0
@@ -1115,7 +1120,6 @@ class EvaluationRunner:
                         calculate_total_cost,
                     )
 
-                    _token_usage = getattr(eval_instance, "token_usage", {})
                     _model = self.user_eval_metric.model or "unknown"
                     _fallback = calculate_total_cost(_model, _token_usage)
                     _fallback_cost = _fallback.get("total_cost", 0)
@@ -1170,6 +1174,7 @@ class EvaluationRunner:
                                 )
                             ),
                             "raw_cost_usd": str(actual_cost),
+                            **token_usage_properties(_token_usage),
                         },
                     )
                 )

--- a/futureagi/model_hub/views/prompt_template.py
+++ b/futureagi/model_hub/views/prompt_template.py
@@ -2649,6 +2649,10 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                     from ee.usage.services.emitter import emit
                 except ImportError:
                     emit = None
+                try:
+                    from ee.usage.utils.event_properties import token_usage_properties
+                except ImportError:
+                    token_usage_properties = lambda token_usage: {}
 
                 emit(
                     UsageEvent(
@@ -2657,6 +2661,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                         properties={
                             "source": "prompt_template",
                             "source_id": str(eval_template.id),
+                            **token_usage_properties(metadata.get("usage", {})),
                         },
                     )
                 )
@@ -3231,6 +3236,10 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                     from ee.usage.services.emitter import emit
                 except ImportError:
                     emit = None
+                try:
+                    from ee.usage.utils.event_properties import token_usage_properties
+                except ImportError:
+                    token_usage_properties = lambda token_usage: {}
 
                 _org = (
                     getattr(request, "organization", None) or request.user.organization
@@ -3242,6 +3251,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                         properties={
                             "source": "run_prompt_gen",
                             "source_id": str(call_log_row.log_id),
+                            **token_usage_properties(config),
                         },
                     )
                 )
@@ -3353,6 +3363,10 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                     from ee.usage.services.emitter import emit
                 except ImportError:
                     emit = None
+                try:
+                    from ee.usage.utils.event_properties import token_usage_properties
+                except ImportError:
+                    token_usage_properties = lambda token_usage: {}
 
                 _org = (
                     getattr(request, "organization", None) or request.user.organization
@@ -3364,6 +3378,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                         properties={
                             "source": "run_prompt_improve",
                             "source_id": str(call_log_row.log_id),
+                            **token_usage_properties(config),
                         },
                     )
                 )

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -421,12 +421,17 @@ def run_eval_func(
                 from ee.usage.services.emitter import emit
             except ImportError:
                 emit = None
+            try:
+                from ee.usage.utils.event_properties import token_usage_properties
+            except ImportError:
+                token_usage_properties = lambda token_usage: {}
 
             billing_config = BillingConfig.get()
             eval_cost = getattr(eval_instance, "cost", {})
             llm_cost = eval_cost.get("total_cost", 0)
             per_run_fee = billing_config.get_eval_per_run_fee()
             actual_cost = llm_cost + per_run_fee
+            _token_usage = getattr(eval_instance, "token_usage", {})
 
             # Fallback cost for comparison logging
             _fallback_cost = 0
@@ -435,7 +440,6 @@ def run_eval_func(
                     calculate_total_cost,
                 )
 
-                _token_usage = getattr(eval_instance, "token_usage", {})
                 _fallback = calculate_total_cost(model or "unknown", _token_usage)
                 _fallback_cost = _fallback.get("total_cost", 0)
             except Exception:
@@ -463,6 +467,7 @@ def run_eval_func(
                         "source": source,
                         "source_id": str(template.id),
                         "raw_cost_usd": str(actual_cost),
+                        **token_usage_properties(_token_usage),
                     },
                 )
             )

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -298,9 +298,14 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
             from ee.usage.services.emitter import emit
         except ImportError:
             emit = None
+        try:
+            from ee.usage.utils.event_properties import token_usage_properties
+        except ImportError:
+            token_usage_properties = lambda token_usage: {}
 
         billing_config = BillingConfig.get()
         eval_cost = result.cost or {}
+        token_usage = result.token_usage or {}
         llm_cost = eval_cost.get("total_cost", 0)
         per_run_fee = billing_config.get_eval_per_run_fee()
         actual_cost = llm_cost + per_run_fee
@@ -317,6 +322,7 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
                     "source_id": str(eval_template.id),
                     "raw_cost_usd": str(actual_cost),
                     "log_id": str(api_call_log_row.log_id),
+                    **token_usage_properties(token_usage),
                 },
             )
         )
@@ -547,19 +553,27 @@ def _run_protect(
                 from ee.usage.services.emitter import emit
             except ImportError:
                 emit = None
+            try:
+                from ee.usage.utils.event_properties import token_usage_properties
+            except ImportError:
+                token_usage_properties = lambda token_usage: {}
 
             billing_config = BillingConfig.get()
             token_usage = (result.metadata or {}).get("token_usage", {})
             from agentic_eval.core_evals.fi_utils.token_count_helper import (
                 calculate_total_cost,
             )
+
             # Resolve model alias for pricing lookup
             if protect_flash:
                 protect_model = "protect_flash"
             else:
                 try:
                     from ee.protect.helper import ProtectHelper
-                    protect_model = ProtectHelper.resolve_alias(eval_template.name, is_flash=False)
+
+                    protect_model = ProtectHelper.resolve_alias(
+                        eval_template.name, is_flash=False
+                    )
                 except ImportError:
                     protect_model = f"protect_{eval_template.name}"
             cost_info = calculate_total_cost(protect_model, token_usage)
@@ -579,6 +593,7 @@ def _run_protect(
                         "source": "standalone_v2",
                         "source_id": str(eval_template.id),
                         "raw_cost_usd": str(actual_cost),
+                        **token_usage_properties(token_usage),
                     },
                 )
             )

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -316,20 +316,21 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
             credits = billing_config.calculate_ai_credits(actual_cost)
 
             api_call_type = _get_api_call_type(model)
-            emit(
-                UsageEvent(
-                    org_id=str(user.organization.id),
-                    event_type=api_call_type,
-                    amount=credits,
-                    properties={
-                        "source": "standalone_v2",
-                        "source_id": str(eval_template.id),
-                        "raw_cost_usd": str(actual_cost),
-                        "log_id": str(api_call_log_row.log_id),
-                        **token_usage_properties(token_usage),
-                    },
+            if emit is not None and UsageEvent is not None:
+                emit(
+                    UsageEvent(
+                        org_id=str(user.organization.id),
+                        event_type=api_call_type,
+                        amount=credits,
+                        properties={
+                            "source": "standalone_v2",
+                            "source_id": str(eval_template.id),
+                            "raw_cost_usd": str(actual_cost),
+                            "log_id": str(api_call_log_row.log_id) if api_call_log_row else None,
+                            **token_usage_properties(token_usage),
+                        },
+                    )
                 )
-            )
 
     except Exception:
         pass  # Metering failure must not break the action
@@ -593,21 +594,22 @@ def _run_protect(
                 actual_cost = llm_cost + per_run_fee
                 credits = billing_config.calculate_ai_credits(actual_cost)
 
-                emit(
-                    UsageEvent(
-                        org_id=str(user.organization.id),
-                        event_type=_get_api_call_type(
-                            "protect_flash" if protect_flash else "protect"
-                        ),
-                        amount=credits,
-                        properties={
-                            "source": "standalone_v2",
-                            "source_id": str(eval_template.id),
-                            "raw_cost_usd": str(actual_cost),
-                            **token_usage_properties(token_usage),
-                        },
+                if emit is not None and UsageEvent is not None:
+                    emit(
+                        UsageEvent(
+                            org_id=str(user.organization.id),
+                            event_type=_get_api_call_type(
+                                "protect_flash" if protect_flash else "protect"
+                            ),
+                            amount=credits,
+                            properties={
+                                "source": "standalone_v2",
+                                "source_id": str(eval_template.id),
+                                "raw_cost_usd": str(actual_cost),
+                                **token_usage_properties(token_usage),
+                            },
+                        )
                     )
-                )
 
         except Exception:
             pass

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -1573,6 +1573,10 @@ def _run_tool_evaluation_standalone(call_execution, test_execution):
                         from ee.usage.services.emitter import emit
                     except ImportError:
                         emit = None
+                    try:
+                        from ee.usage.utils.event_properties import llm_usage_properties
+                    except ImportError:
+                        llm_usage_properties = lambda obj: {}
 
                     actual_cost = 0
                     if hasattr(agent, "llm") and agent.llm:
@@ -1590,6 +1594,7 @@ def _run_tool_evaluation_standalone(call_execution, test_execution):
                                 "source": "simulate_tool_evaluation",
                                 "source_id": str(test_execution.id),
                                 "raw_cost_usd": str(actual_cost),
+                                **llm_usage_properties(agent),
                             },
                         )
                     )

--- a/futureagi/tfc/templates/admin/usage/custom_pricing.html
+++ b/futureagi/tfc/templates/admin/usage/custom_pricing.html
@@ -83,9 +83,12 @@
         <input type="date" id="contract-end-date">
       </div>
       <div class="cp-field">
-        <label>Subscription Start Date</label>
+        <label>Subscription Start Date <span style="font-weight:400;color:var(--body-quiet-color,#666)">(only for backdated contracts)</span></label>
         <input type="date" id="start-date">
       </div>
+    </div>
+    <div style="margin-top:8px; font-size:0.8em; color:var(--body-quiet-color,#666); line-height:1.5">
+      <strong>Note:</strong> Metered usage is always anchored to the 1st of next month. Set <em>Subscription Start Date</em> only if the customer has already paid out-of-band for a past period — Stripe will anchor the platform-fee renewal to the next anniversary instead of charging immediately.
     </div>
     <div id="per-charge-preview" style="margin-top:8px; font-size:0.85em; color:var(--body-quiet-color,#666);">
       Per-charge amount: $0.00
@@ -95,6 +98,9 @@
   <!-- Entitlements -->
   <div class="cp-section" id="ent-section" style="display:none">
     <h3>Entitlement Overrides</h3>
+    <div style="font-size:0.8em; color:var(--body-quiet-color,#666); margin-bottom:8px; line-height:1.5">
+      <strong>Skip <code>free_*</code> entries.</strong> Free allowances are auto-derived from the leading <code>$0</code> band of each pricing tier below — any <code>free_*</code> entitlement you add here will be overwritten on save.
+    </div>
     <table class="cp-table" id="ent-table">
       <thead><tr><th>Feature</th><th>Value</th><th></th></tr></thead>
       <tbody id="ent-body"></tbody>
@@ -117,6 +123,10 @@
   <!-- Pricing Tiers -->
   <div class="cp-section" id="pricing-section" style="display:none">
     <h3>Custom Pricing Tiers</h3>
+    <div style="font-size:0.8em; color:var(--body-quiet-color,#666); margin-bottom:8px; line-height:1.5">
+      <strong>Leading <code>$0</code> tier sets the free allowance.</strong> Per dimension, the first tier must be <code>tier_start=0, price_per_unit=0</code> with <code>tier_end</code> = quantity included free. Subsequent tiers stack on top with their own prices.<br>
+      Display unit is fixed by the dimension (e.g. <em>ai_credits</em> = credits) and not editable here.
+    </div>
     <table class="cp-table" id="pricing-table">
       <thead><tr><th>Dimension</th><th>Range</th><th>$/Unit</th><th></th></tr></thead>
       <tbody id="pricing-body"></tbody>
@@ -194,7 +204,8 @@ let localTiers = [];
     sel.appendChild(opt);
   });
   const fSel = document.getElementById("new-ent-feature");
-  FEATURE_KEYS.forEach(f => {
+  // Hide free_* keys — they're auto-derived from leading $0 pricing tier.
+  FEATURE_KEYS.filter(f => !f.startsWith("free_")).forEach(f => {
     const opt = document.createElement("option");
     opt.value = f;
     opt.textContent = f;
@@ -269,7 +280,10 @@ async function loadOrg() {
     }
     renderEntitlements();
 
-    // Load existing tiers into local state
+    // Load existing tiers into local state. display_unit comes back from
+    // the server (sourced from billing.yaml) so we keep it for UI display
+    // only; we never include it in POST/PUT payloads since the server
+    // re-derives it on save.
     localTiers = [];
     if (r.pricing) {
       r.pricing.forEach(p => {
@@ -316,6 +330,9 @@ function addEntitlementLocal() {
   const feature = document.getElementById("new-ent-feature").value;
   const raw = document.getElementById("new-ent-value").value.trim();
   if (!feature || !raw) return showMsg("Feature and value required", "error");
+  if (feature.startsWith("free_")) {
+    return showMsg("free_* entitlements are auto-derived from pricing tiers — set the leading $0 tier instead", "error");
+  }
 
   if (raw === "true") localEntitlements[feature] = true;
   else if (raw === "false") localEntitlements[feature] = false;
@@ -362,7 +379,8 @@ async function createCustomPlan() {
   const contractEnd = document.getElementById("contract-end-date").value || null;
   const startDate = document.getElementById("start-date").value || null;
 
-  // Group tiers by dimension
+  // Group tiers by dimension. display_unit is intentionally omitted —
+  // the server re-derives it from billing.yaml on save.
   const pricing = {};
   localTiers.forEach(t => {
     if (!pricing[t.dimension]) pricing[t.dimension] = [];
@@ -371,6 +389,13 @@ async function createCustomPlan() {
       tier_end: t.tier_end,
       price_per_unit: t.price_per_unit
     });
+  });
+
+  // Strip free_* entitlements client-side too — server auto-derives them,
+  // but stripping here keeps the network payload honest.
+  const cleanedEntitlements = {};
+  Object.entries(localEntitlements).forEach(([k, v]) => {
+    if (!k.startsWith("free_")) cleanedEntitlements[k] = v;
   });
 
   try {
@@ -382,7 +407,7 @@ async function createCustomPlan() {
         platform_fee_billing_cycle: billingCycle,
         contract_end_date: contractEnd,
         start_date: startDate,
-        entitlements: localEntitlements,
+        entitlements: cleanedEntitlements,
         pricing: pricing
       })
     });

--- a/futureagi/tfc/templates/admin/usage/generate_invoice.html
+++ b/futureagi/tfc/templates/admin/usage/generate_invoice.html
@@ -37,6 +37,9 @@
 
 <div class="gi-container">
   <h2>Generate Invoice</h2>
+  <div style="font-size:0.85em; color:var(--body-quiet-color,#666); margin-bottom:16px; line-height:1.5">
+    Works for any paid plan (PAYG / Boost / Scale / Enterprise / Custom). Free-plan orgs cannot be invoiced. The invoice bundles the platform fee for the selected period (advance, prorated if the plan started mid-month) with the prior period's usage (arrears) — matching how Stripe issues its monthly invoice.
+  </div>
   <div id="gi-message"></div>
   <div id="gi-loading">Processing...</div>
 
@@ -254,7 +257,9 @@ function renderPreview(data) {
 
   // Summary
   const summary = document.getElementById("preview-summary");
+  const planLabel = data.plan ? data.plan.charAt(0).toUpperCase() + data.plan.slice(1) : "-";
   summary.innerHTML = `
+    <div><strong>Plan:</strong> ${planLabel}</div>
     <div><strong>Usage Total:</strong> $${parseFloat(data.usage_total).toFixed(2)}</div>
     <div><strong>Platform Fee:</strong> $${parseFloat(data.platform_fee).toFixed(2)}</div>
     <div><strong>Credits Applied:</strong> -$${parseFloat(data.credits_applied).toFixed(2)}</div>

--- a/futureagi/tfc/temporal/billing/__init__.py
+++ b/futureagi/tfc/temporal/billing/__init__.py
@@ -1,4 +1,4 @@
-"""Temporal billing module — activities for Stripe usage reporting and dunning."""
+"""Temporal billing module — activities for dunning, invoice gen, monthly closing."""
 
 
 def get_activities():
@@ -6,12 +6,10 @@ def get_activities():
     from tfc.temporal.billing.activities import (
         generate_monthly_invoices_activity,
         monthly_closing_activity,
-        report_stripe_usage_activity,
         run_dunning_checks_activity,
     )
 
     return [
-        report_stripe_usage_activity,
         run_dunning_checks_activity,
         generate_monthly_invoices_activity,
         monthly_closing_activity,

--- a/futureagi/tfc/temporal/billing/activities.py
+++ b/futureagi/tfc/temporal/billing/activities.py
@@ -1,11 +1,7 @@
-"""Temporal activities for billing operations.
+"""Temporal activities for billing — dunning, invoice gen, monthly closing.
 
-Two scheduled activities:
-- report_stripe_usage_activity: hourly, reports pre-calculated usage costs to Stripe
-- run_dunning_checks_activity: daily, processes dunning steps for past_due orgs
-
-Pattern: @activity.defn (async) with close_old_connections + sync_to_async.
-Errors re-raised for Temporal retry.
+Stripe meter events fire at invoice-close (see invoice_generation.py);
+no hourly catch-up. Errors re-raise so Temporal applies its retry policy.
 """
 
 from asgiref.sync import sync_to_async
@@ -19,45 +15,7 @@ from tfc.temporal.billing.types import (
     MonthlyClosingOutput,
     MonthlyInvoiceInput,
     MonthlyInvoiceOutput,
-    StripeUsageReportInput,
-    StripeUsageReportOutput,
 )
-
-# ── Stripe Usage Reporting (hourly) ───────────────────────────────────────
-
-
-@activity.defn(name="report_stripe_usage_activity")
-async def report_stripe_usage_activity(
-    input: StripeUsageReportInput,
-) -> StripeUsageReportOutput:
-    """Report metered usage to Stripe for all paid orgs.
-
-    Re-raises on failure so Temporal applies retry policy.
-    """
-    close_old_connections()
-    try:
-        count = await sync_to_async(_report_stripe_usage_sync, thread_sensitive=False)(
-            input.period
-        )
-        activity.logger.info(f"Stripe usage reported: {count} records")
-        return StripeUsageReportOutput(records_reported=count, status="COMPLETED")
-    finally:
-        close_old_connections()
-
-
-def _report_stripe_usage_sync(period: str) -> int:
-    """Sync wrapper — calls existing report_all_usage_to_stripe."""
-    close_old_connections()
-    try:
-        try:
-            from ee.usage.tasks.stripe_reporting import report_all_usage_to_stripe
-        except ImportError:
-            report_all_usage_to_stripe = None
-
-        return report_all_usage_to_stripe()
-    finally:
-        close_old_connections()
-
 
 # ── Dunning Checks (daily) ────────────────────────────────────────────────
 
@@ -185,6 +143,7 @@ def _generate_monthly_invoices_sync(
             skip_stripe=False,
             skip_email=False,
             stdout=lambda msg: activity.logger.info(msg),
+            on_progress=activity.heartbeat,
         )
         return result.created, result.skipped, result.errors
     finally:
@@ -204,41 +163,51 @@ def _run_monthly_reset_sync(period: str) -> None:
         close_old_connections()
 
 
+def _next_period_str(period: str) -> str:
+    """``'2026-05' → '2026-06'``."""
+    y, m = int(period[:4]), int(period[5:7])
+    if m == 12:
+        return f"{y + 1}-01"
+    return f"{y}-{m + 1:02d}"
+
+
 @activity.defn(name="monthly_closing_activity")
 async def monthly_closing_activity(
     input: MonthlyClosingInput,
 ) -> MonthlyClosingOutput:
-    """Flush Redis usage to DB, then generate invoices for the same period.
-
-    Reset must precede invoice generation: the invoice-gen idempotency gate
-    skips orgs that already have an Invoice row for the period, so a retry
-    can't recover events still buffered in Redis at fire time.
-
-    ``input.period`` MUST be a non-empty ``YYYY-MM`` string, derived from
-    ``workflow.now()`` in ``MonthlyClosingWorkflow``. No wall-clock
-    fallback — see the workflow docstring for why.
+    """Reset then invoice. ``input.period`` is the period being closed
+    (arrears); we derive the period being billed (advance) by adding one
+    month. Reset must run first — BillingEngine reads the just-flushed
+    UsageSummary for the closed period as the arrears half of the new
+    invoice.
     """
     close_old_connections()
     try:
-        period = input.period
-        if not period or len(period) != 7 or period[4] != "-":
+        period_closed = input.period
+        if not period_closed or len(period_closed) != 7 or period_closed[4] != "-":
             raise ValueError(
-                f"monthly_closing_activity requires YYYY-MM period, got {period!r}"
+                f"monthly_closing_activity requires YYYY-MM period, got {period_closed!r}"
             )
-        activity.logger.info(f"monthly_closing_start period={period}")
+        period_billed = _next_period_str(period_closed)
+        activity.logger.info(
+            f"monthly_closing_start closed={period_closed} billed={period_billed}"
+        )
 
-        await sync_to_async(_run_monthly_reset_sync, thread_sensitive=False)(period)
+        await sync_to_async(_run_monthly_reset_sync, thread_sensitive=False)(
+            period_closed
+        )
 
         created, skipped, errors = await sync_to_async(
             _generate_monthly_invoices_sync, thread_sensitive=False
-        )(period, "")
+        )(period_billed, "")
         activity.logger.info(
-            f"monthly_closing_done period={period} "
+            f"monthly_closing_done closed={period_closed} billed={period_billed} "
             f"created={created} skipped={skipped} errors={errors}"
         )
 
         return MonthlyClosingOutput(
-            period=period,
+            period=period_billed,
+            closed_period=period_closed,
             invoices_created=created,
             invoices_skipped=skipped,
             errors=errors,

--- a/futureagi/tfc/temporal/billing/activities.py
+++ b/futureagi/tfc/temporal/billing/activities.py
@@ -4,6 +4,8 @@ Stripe meter events fire at invoice-close (see invoice_generation.py);
 no hourly catch-up. Errors re-raise so Temporal applies its retry policy.
 """
 
+from datetime import datetime
+
 from asgiref.sync import sync_to_async
 from django.db import close_old_connections
 from temporalio import activity
@@ -43,8 +45,6 @@ def _run_dunning_checks_sync() -> int:
     """Sync wrapper — processes all past_due orgs."""
     close_old_connections()
     try:
-        from datetime import datetime
-
         try:
             from ee.usage.models.usage import OrganizationSubscription
         except ImportError:
@@ -119,8 +119,6 @@ def _generate_monthly_invoices_sync(
     Delegates to ``InvoiceGenerationService`` so the CLI, Temporal schedule,
     and admin "Generate Invoice" page all share identical logic.
     """
-    from datetime import datetime
-
     try:
         from ee.usage.services.invoice_generation import InvoiceGenerationService
     except ImportError:
@@ -163,12 +161,17 @@ def _run_monthly_reset_sync(period: str) -> None:
         close_old_connections()
 
 
+def _parse_period(period: str) -> datetime:
+    """Parse a ``YYYY-MM`` period string into a ``datetime`` (day=1)."""
+    return datetime.strptime(period, "%Y-%m")
+
+
 def _next_period_str(period: str) -> str:
     """``'2026-05' → '2026-06'``."""
-    y, m = int(period[:4]), int(period[5:7])
-    if m == 12:
-        return f"{y + 1}-01"
-    return f"{y}-{m + 1:02d}"
+    d = _parse_period(period)
+    if d.month == 12:
+        return f"{d.year + 1}-01"
+    return f"{d.year}-{d.month + 1:02d}"
 
 
 @activity.defn(name="monthly_closing_activity")
@@ -184,7 +187,9 @@ async def monthly_closing_activity(
     close_old_connections()
     try:
         period_closed = input.period
-        if not period_closed or len(period_closed) != 7 or period_closed[4] != "-":
+        try:
+            _parse_period(period_closed or "")
+        except (TypeError, ValueError):
             raise ValueError(
                 f"monthly_closing_activity requires YYYY-MM period, got {period_closed!r}"
             )

--- a/futureagi/tfc/temporal/billing/types.py
+++ b/futureagi/tfc/temporal/billing/types.py
@@ -3,24 +3,7 @@
 Separated from activities to avoid Django imports in workflow sandbox.
 """
 
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Optional
-
-
-@dataclass
-class StripeUsageReportInput:
-    """Input for the hourly Stripe usage reporting activity."""
-
-    period: str = field(default_factory=lambda: datetime.utcnow().strftime("%Y-%m"))
-
-
-@dataclass
-class StripeUsageReportOutput:
-    """Output from the Stripe usage reporting activity."""
-
-    records_reported: int = 0
-    status: str = "COMPLETED"
+from dataclasses import dataclass
 
 
 @dataclass
@@ -58,12 +41,20 @@ class MonthlyInvoiceOutput:
 
 @dataclass
 class MonthlyClosingInput:
-    period: str = ""  # YYYY-MM. Empty = previous month from now.
+    period: str = ""  # YYYY-MM being CLOSED. Empty = previous month from now.
 
 
 @dataclass
 class MonthlyClosingOutput:
-    period: str = ""
+    """Output of the monthly closing activity.
+
+    The closing flushes Redis usage for ``closed_period`` and bills an
+    invoice for ``period`` (= closed_period + 1 month) — advance fee +
+    arrears usage. Both are surfaced so callers can't confuse them.
+    """
+
+    period: str = ""  # YYYY-MM billed (closed_period + 1).
+    closed_period: str = ""  # YYYY-MM whose Redis usage was flushed.
     invoices_created: int = 0
     invoices_skipped: int = 0
     errors: int = 0

--- a/futureagi/tfc/temporal/billing/workflows.py
+++ b/futureagi/tfc/temporal/billing/workflows.py
@@ -45,6 +45,8 @@ class MonthlyClosingWorkflow:
             "monthly_closing_activity",
             MonthlyClosingInput(period=period),
             start_to_close_timeout=timedelta(hours=2),
+            # Activity heartbeats per org; 5 min covers a slow Stripe RTT.
+            heartbeat_timeout=timedelta(minutes=5),
             retry_policy=CLOSING_RETRY_POLICY,
         )
 

--- a/futureagi/tfc/temporal/schedules/billing.py
+++ b/futureagi/tfc/temporal/schedules/billing.py
@@ -1,8 +1,9 @@
 """Billing Temporal activities and schedules.
 
-Budget catch-up workflow runs every 15 minutes to evaluate budgets
-that were missed by the consumer (e.g., consumer was down, budget created after threshold crossed).
-Hourly Stripe usage reporting + daily dunning checks. The consumer workflow runs as a long-lived workflow (not a schedule).
+Schedules: budget catch-up (15 min), dunning (daily), monthly closing
+(``0 0 1 * *``). Meter events fire at invoice-close inside the monthly
+closing activity — no hourly catch-up. The usage consumer is a separate
+long-lived workflow, not a schedule.
 """
 
 from datetime import datetime, timezone
@@ -83,13 +84,6 @@ BILLING_SCHEDULES: List[ScheduleConfig] = [
         interval_seconds=900,
         queue="default",
         description="Evaluate budgets missed by consumer (every 15 min)",
-    ),
-    ScheduleConfig(
-        schedule_id="stripe-usage-hourly",
-        activity_name="report_stripe_usage_activity",
-        interval_seconds=3600,
-        queue="default",
-        description="Report pre-calculated usage costs to Stripe (hourly)",
     ),
     ScheduleConfig(
         schedule_id="dunning-checks-daily",

--- a/futureagi/tfc/temporal/simulate/activities.py
+++ b/futureagi/tfc/temporal/simulate/activities.py
@@ -42,6 +42,10 @@ try:
     )
 except ImportError:
     PersonaConfigurator = _ee_stub("PersonaConfigurator")
+try:
+    from ee.usage.utils.event_properties import token_usage_properties
+except ImportError:
+    token_usage_properties = lambda token_usage: {}
 from agentic_eval.core.llm.llm import LLM
 from model_hub.models.choices import (
     CellStatus,
@@ -245,9 +249,7 @@ async def generate_synthetic_data_activity(
                         properties={
                             "source": "simulate_scenario_generation",
                             "raw_cost_usd": str(actual_cost),
-                            "total_tokens": agent.llm.token_usage.get(
-                                "total_tokens", 0
-                            ),
+                            **token_usage_properties(agent.llm.token_usage),
                         },
                     )
                 )
@@ -643,9 +645,7 @@ async def generate_column_data_activity(
                         properties={
                             "source": "simulate_column_generation",
                             "raw_cost_usd": str(actual_cost),
-                            "total_tokens": agent.llm.token_usage.get(
-                                "total_tokens", 0
-                            ),
+                            **token_usage_properties(agent.llm.token_usage),
                         },
                     )
                 )
@@ -1813,9 +1813,6 @@ def _create_dataset_scenario_sync(
                     emit = None
 
                 _total_cost = graph_generator.sda.llm.cost.get("total_cost", 0)
-                _total_tokens = graph_generator.sda.llm.token_usage.get(
-                    "total_tokens", 0
-                )
                 credits = BillingConfig.get().calculate_ai_credits(_total_cost)
                 emit(
                     UsageEvent(
@@ -1826,7 +1823,9 @@ def _create_dataset_scenario_sync(
                             "source": "simulate_dataset_scenario_creation",
                             "source_id": str(scenario_id),
                             "raw_cost_usd": str(_total_cost),
-                            "total_tokens": _total_tokens,
+                            **token_usage_properties(
+                                graph_generator.sda.llm.token_usage
+                            ),
                         },
                     )
                 )
@@ -2038,6 +2037,7 @@ def _create_script_scenario_sync(
                             "source": "simulate_dataset_scenario",
                             "source_id": scenario_id,
                             "raw_cost_usd": str(_cost),
+                            **token_usage_properties(enhanced_agent.llm.token_usage),
                         },
                     )
                 )
@@ -2583,6 +2583,7 @@ def _create_graph_scenario_sync(
                             "source": "simulate_script_scenario",
                             "source_id": scenario_id,
                             "raw_cost_usd": str(_cost),
+                            **token_usage_properties(enhanced_agent.llm.token_usage),
                         },
                     )
                 )
@@ -2991,9 +2992,6 @@ def _setup_graph_scenario_sync(
                     emit = None
 
                 _total_cost = graph_generator.sda.llm.cost.get("total_cost", 0)
-                _total_tokens = graph_generator.sda.llm.token_usage.get(
-                    "total_tokens", 0
-                )
                 credits = BillingConfig.get().calculate_ai_credits(_total_cost)
                 emit(
                     UsageEvent(
@@ -3004,7 +3002,9 @@ def _setup_graph_scenario_sync(
                             "source": "simulate_graph_scenario_setup",
                             "source_id": str(scenario_id),
                             "raw_cost_usd": str(_total_cost),
-                            "total_tokens": _total_tokens,
+                            **token_usage_properties(
+                                graph_generator.sda.llm.token_usage
+                            ),
                         },
                     )
                 )
@@ -3288,7 +3288,6 @@ def _extract_intents_sync(
                                 emit = None
 
                             _total_cost = llm.cost.get("total_cost", 0)
-                            _total_tokens = llm.token_usage.get("total_tokens", 0)
                             credits = BillingConfig.get().calculate_ai_credits(
                                 _total_cost
                             )
@@ -3301,7 +3300,7 @@ def _extract_intents_sync(
                                         "source": "simulate_extract_intents",
                                         "source_id": str(graph_id),
                                         "raw_cost_usd": str(_total_cost),
-                                        "total_tokens": _total_tokens,
+                                        **token_usage_properties(llm.token_usage),
                                     },
                                 )
                             )
@@ -3464,7 +3463,6 @@ def _process_branches_sync(
                     emit = None
 
                 _total_cost = agent.llm.cost.get("total_cost", 0)
-                _total_tokens = agent.llm.token_usage.get("total_tokens", 0)
                 credits = BillingConfig.get().calculate_ai_credits(_total_cost)
                 emit(
                     UsageEvent(
@@ -3475,7 +3473,7 @@ def _process_branches_sync(
                             "source": "simulate_process_branches",
                             "source_id": str(graph_id),
                             "raw_cost_usd": str(_total_cost),
-                            "total_tokens": _total_tokens,
+                            **token_usage_properties(agent.llm.token_usage),
                         },
                     )
                 )
@@ -3737,6 +3735,7 @@ def _generate_cases_for_intent_sync(
                                 "source": "simulate_generate_cases_intent",
                                 "source_id": str(intent_id),
                                 "raw_cost_usd": str(_cost),
+                                **token_usage_properties(agent.llm.token_usage),
                             },
                         )
                     )
@@ -4577,6 +4576,9 @@ def _process_single_branch_sync(
                             "source": "simulate_process_single_branch",
                             "source_id": str(graph_id),
                             "raw_cost_usd": str(_total_cost),
+                            **token_usage_properties(
+                                _branch_llm_cost.get("token_usage")
+                            ),
                         },
                     )
                 )

--- a/futureagi/tracer/tasks/error_analysis.py
+++ b/futureagi/tracer/tasks/error_analysis.py
@@ -166,6 +166,10 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
                 from ee.usage.services.emitter import emit
             except ImportError:
                 emit = None
+            try:
+                from ee.usage.utils.event_properties import llm_usage_properties
+            except ImportError:
+                llm_usage_properties = lambda obj: {}
 
             actual_cost = getattr(agent, "cost", {}).get("total_cost", 0)
             if not actual_cost and hasattr(agent, "llm"):
@@ -182,6 +186,7 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
                         "source_id": str(trace_id),
                         "errors_found": error_count,
                         "raw_cost_usd": str(actual_cost),
+                        **llm_usage_properties(agent),
                     },
                 )
             )

--- a/futureagi/tracer/tests/test_eval_credits_emit.py
+++ b/futureagi/tracer/tests/test_eval_credits_emit.py
@@ -1,0 +1,258 @@
+"""End-to-end coverage for ai_credits UsageEvent emission across eval paths.
+
+Asserts the new-billing-system dual-write fires for span-, trace-, and
+session-level evals with the right shape:
+    - event_type resolved from custom_eval_config.model
+    - amount = BillingConfig.calculate_ai_credits(actual_cost)
+    - properties.{source, source_id, raw_cost_usd, target_type}
+    - properties.{prompt_tokens, completion_tokens, total_tokens}
+
+These three paths used to charge legacy billing only; this verifies the
+new emit hits all of them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Break the tracer.utils.eval ↔ model_hub.tasks import cycle for test-time
+# imports — see test_eval_task_runtime.py for the rationale.
+import model_hub.tasks  # noqa: F401
+
+from evaluations.engine.runner import EvalResult
+
+
+PROMPT_TOKENS = 100
+COMPLETION_TOKENS = 50
+TOTAL_TOKENS = PROMPT_TOKENS + COMPLETION_TOKENS
+RAW_COST_USD = 0.12345
+
+
+def _build_result():
+    return EvalResult(
+        value=True,
+        data={"input": "x"},
+        reason="ok",
+        failure=None,
+        runtime=0.01,
+        model_used="turing_large",
+        metrics=None,
+        metadata={"stub": True},
+        output_type="Pass/Fail",
+        start_time=0.0,
+        end_time=0.01,
+        duration=0.01,
+        cost={"total_cost": RAW_COST_USD},
+        token_usage={
+            "prompt_tokens": PROMPT_TOKENS,
+            "completion_tokens": COMPLETION_TOKENS,
+            "total_tokens": TOTAL_TOKENS,
+        },
+    )
+
+
+@pytest.fixture
+def patched_run_eval(monkeypatch):
+    """Patch ``run_eval`` with a non-zero-cost EvalResult.
+
+    Stronger variant of conftest's ``stub_run_eval`` so we can assert
+    credits calculation produces a non-zero amount.
+    """
+
+    def _stub(_request):
+        return _build_result()
+
+    monkeypatch.setattr("evaluations.engine.run_eval", _stub, raising=False)
+    monkeypatch.setattr("evaluations.engine.runner.run_eval", _stub, raising=False)
+
+
+@pytest.fixture
+def captured_emit(monkeypatch):
+    """Capture every UsageEvent passed to ``ee.usage.services.emitter.emit``.
+
+    Mirrors the import path used inside the eval helpers (lazy import inside
+    the dual-write try-block), so patching the source module is enough.
+    """
+    captured: list = []
+
+    def _record(event):
+        captured.append(event)
+
+    monkeypatch.setattr("ee.usage.services.emitter.emit", _record)
+    return captured
+
+
+def _credit_event(captured):
+    """Pick the ai_credits emit, ignoring tracing/observe events fired elsewhere."""
+    from ee.usage.models.usage import APICallTypeChoices
+
+    credit_event_types = {
+        APICallTypeChoices.TURING_LARGE_EVALUATOR.value,
+        APICallTypeChoices.TURING_SMALL_EVALUATOR.value,
+        APICallTypeChoices.TURING_FLASH_EVALUATOR.value,
+        APICallTypeChoices.PROTECT_EVALUATOR.value,
+        APICallTypeChoices.PROTECT_FLASH_EVALUATOR.value,
+    }
+    matches = [e for e in captured if e.event_type in credit_event_types]
+    assert matches, f"No ai_credits event emitted. Captured: {[e.event_type for e in captured]}"
+    assert len(matches) == 1, f"Expected one ai_credits event, got {len(matches)}"
+    return matches[0]
+
+
+def _assert_token_properties(props):
+    assert props["prompt_tokens"] == PROMPT_TOKENS
+    assert props["completion_tokens"] == COMPLETION_TOKENS
+    assert props["total_tokens"] == TOTAL_TOKENS
+    assert props["raw_cost_usd"] == str(RAW_COST_USD)
+
+
+@pytest.mark.django_db
+def test_span_eval_emits_ai_credits_with_tokens(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    custom_eval_config,
+    patched_run_eval,
+    stub_cost_log,
+    captured_emit,
+):
+    from ee.usage.models.usage import APICallTypeChoices
+    from ee.usage.services.config import BillingConfig
+    from tracer.utils.eval import OBSERVE, _execute_evaluation
+
+    _execute_evaluation(
+        observation_span_id=observation_span.id,
+        custom_eval_config_id=custom_eval_config.id,
+        eval_task_id=None,
+        type=OBSERVE,
+        run_params={"input": "hello", "output": "world"},
+    )
+
+    event = _credit_event(captured_emit)
+    expected_credits = BillingConfig.get().calculate_ai_credits(RAW_COST_USD)
+
+    assert event.event_type == APICallTypeChoices.TURING_LARGE_EVALUATOR.value
+    assert event.org_id == str(organization.id)
+    assert event.amount == expected_credits
+    props = event.properties
+    assert props["source"] == "tracer"
+    assert props["source_id"] == str(custom_eval_config.eval_template.id)
+    assert props["target_type"] == "span"
+    _assert_token_properties(props)
+
+
+@pytest.mark.django_db
+def test_trace_eval_emits_ai_credits_with_tokens(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    custom_eval_config,
+    patched_run_eval,
+    stub_cost_log,
+    captured_emit,
+):
+    from ee.usage.models.usage import APICallTypeChoices
+    from ee.usage.services.config import BillingConfig
+    from tracer.utils.eval import _execute_evaluation_for_trace
+
+    _execute_evaluation_for_trace(
+        trace=trace,
+        anchor_span=observation_span,
+        custom_eval_config=custom_eval_config,
+        eval_task_id=None,
+        run_params={"input": "hello", "output": "world"},
+    )
+
+    event = _credit_event(captured_emit)
+    expected_credits = BillingConfig.get().calculate_ai_credits(RAW_COST_USD)
+
+    assert event.event_type == APICallTypeChoices.TURING_LARGE_EVALUATOR.value
+    assert event.org_id == str(organization.id)
+    assert event.amount == expected_credits
+    props = event.properties
+    assert props["source"] == "tracer"
+    assert props["source_id"] == str(custom_eval_config.eval_template.id)
+    assert props["target_type"] == "trace"
+    _assert_token_properties(props)
+
+
+@pytest.mark.django_db
+def test_session_eval_emits_ai_credits_with_tokens(
+    organization,
+    workspace,
+    observe_project,
+    trace_session,
+    custom_eval_config,
+    patched_run_eval,
+    stub_cost_log,
+    captured_emit,
+):
+    from ee.usage.models.usage import APICallTypeChoices
+    from ee.usage.services.config import BillingConfig
+    from tracer.utils.eval import _execute_evaluation_for_session
+
+    _execute_evaluation_for_session(
+        trace_session=trace_session,
+        custom_eval_config=custom_eval_config,
+        eval_task_id=None,
+        run_params={"input": "hello", "output": "world"},
+    )
+
+    event = _credit_event(captured_emit)
+    expected_credits = BillingConfig.get().calculate_ai_credits(RAW_COST_USD)
+
+    assert event.event_type == APICallTypeChoices.TURING_LARGE_EVALUATOR.value
+    assert event.org_id == str(organization.id)
+    assert event.amount == expected_credits
+    props = event.properties
+    assert props["source"] == "tracer"
+    assert props["source_id"] == str(custom_eval_config.eval_template.id)
+    assert props["target_type"] == "session"
+    _assert_token_properties(props)
+
+
+@pytest.mark.django_db
+def test_eval_failure_does_not_emit_ai_credits(
+    organization,
+    workspace,
+    project,
+    trace,
+    observation_span,
+    custom_eval_config,
+    stub_cost_log,
+    captured_emit,
+    monkeypatch,
+):
+    """If the eval engine raises, we mark the api_call_log as ERROR and the
+    dual-write emit must be skipped (no charge for a failed eval)."""
+    from tracer.utils.eval import OBSERVE, _execute_evaluation
+
+    def _boom(_request):
+        raise RuntimeError("engine_blew_up")
+
+    monkeypatch.setattr("evaluations.engine.run_eval", _boom, raising=False)
+    monkeypatch.setattr("evaluations.engine.runner.run_eval", _boom, raising=False)
+
+    _execute_evaluation(
+        observation_span_id=observation_span.id,
+        custom_eval_config_id=custom_eval_config.id,
+        eval_task_id=None,
+        type=OBSERVE,
+        run_params={"input": "hello", "output": "world"},
+    )
+
+    from ee.usage.models.usage import APICallTypeChoices
+
+    credit_event_types = {
+        APICallTypeChoices.TURING_LARGE_EVALUATOR.value,
+        APICallTypeChoices.TURING_SMALL_EVALUATOR.value,
+        APICallTypeChoices.TURING_FLASH_EVALUATOR.value,
+        APICallTypeChoices.PROTECT_EVALUATOR.value,
+        APICallTypeChoices.PROTECT_FLASH_EVALUATOR.value,
+    }
+    credit_events = [e for e in captured_emit if e.event_type in credit_event_types]
+    assert credit_events == []

--- a/futureagi/tracer/tests/test_eval_credits_emit.py
+++ b/futureagi/tracer/tests/test_eval_credits_emit.py
@@ -57,6 +57,10 @@ def patched_run_eval(monkeypatch):
 
     Stronger variant of conftest's ``stub_run_eval`` so we can assert
     credits calculation produces a non-zero amount.
+
+    Also zeroes ``BillingConfig.get_eval_per_run_fee`` so ``actual_cost`` in
+    ``_emit_eval_billing`` collapses to ``RAW_COST_USD`` and the assertions
+    below can compare against it directly.
     """
 
     def _stub(_request):
@@ -64,6 +68,10 @@ def patched_run_eval(monkeypatch):
 
     monkeypatch.setattr("evaluations.engine.run_eval", _stub, raising=False)
     monkeypatch.setattr("evaluations.engine.runner.run_eval", _stub, raising=False)
+
+    from ee.usage.services.config import BillingConfig
+
+    monkeypatch.setattr(BillingConfig, "get_eval_per_run_fee", lambda self: 0)
 
 
 @pytest.fixture

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -610,9 +610,12 @@ def _run_evaluation(
             except ImportError:
                 token_usage_properties = lambda token_usage: {}
 
-            actual_cost = getattr(eval_instance, "cost", {}).get("total_cost", 0)
+            billing_config = BillingConfig.get()
+            llm_cost = getattr(eval_instance, "cost", {}).get("total_cost", 0)
+            per_run_fee = billing_config.get_eval_per_run_fee()
+            actual_cost = llm_cost + per_run_fee
             _token_usage = getattr(eval_instance, "token_usage", {})
-            credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+            credits = billing_config.calculate_ai_credits(actual_cost)
 
             emit(
                 UsageEvent(
@@ -1271,9 +1274,12 @@ def _execute_evaluation(
             except ImportError:
                 token_usage_properties = lambda token_usage: {}
 
-            _actual_cost = (result.cost or {}).get("total_cost", 0)
+            billing_config = BillingConfig.get()
+            _llm_cost = (result.cost or {}).get("total_cost", 0)
+            _per_run_fee = billing_config.get_eval_per_run_fee()
+            _actual_cost = _llm_cost + _per_run_fee
             _token_usage = result.token_usage or {}
-            credits = BillingConfig.get().calculate_ai_credits(_actual_cost)
+            credits = billing_config.calculate_ai_credits(_actual_cost)
 
             emit(
                 UsageEvent(
@@ -2572,9 +2578,12 @@ def _execute_evaluation_for_trace(
             except ImportError:
                 token_usage_properties = lambda token_usage: {}
 
-            _actual_cost = (result.cost or {}).get("total_cost", 0)
+            billing_config = BillingConfig.get()
+            _llm_cost = (result.cost or {}).get("total_cost", 0)
+            _per_run_fee = billing_config.get_eval_per_run_fee()
+            _actual_cost = _llm_cost + _per_run_fee
             _token_usage = result.token_usage or {}
-            credits = BillingConfig.get().calculate_ai_credits(_actual_cost)
+            credits = billing_config.calculate_ai_credits(_actual_cost)
 
             emit(
                 UsageEvent(
@@ -2840,9 +2849,12 @@ def _execute_evaluation_for_session(
             except ImportError:
                 token_usage_properties = lambda token_usage: {}
 
-            _actual_cost = (result.cost or {}).get("total_cost", 0)
+            billing_config = BillingConfig.get()
+            _llm_cost = (result.cost or {}).get("total_cost", 0)
+            _per_run_fee = billing_config.get_eval_per_run_fee()
+            _actual_cost = _llm_cost + _per_run_fee
             _token_usage = result.token_usage or {}
-            credits = BillingConfig.get().calculate_ai_credits(_actual_cost)
+            credits = billing_config.calculate_ai_credits(_actual_cost)
 
             emit(
                 UsageEvent(

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -602,6 +602,68 @@ def _eval_config_output(custom_eval_config):
         return "score"
 
 
+def _emit_eval_billing(
+    org_id: str,
+    api_call_type,
+    source_id: str,
+    target_type: str,
+    result,
+    custom_eval_config,
+    ws_id: str | None,
+    api_call_log_row,
+    feedback_id=None,
+):
+    """Emit a UsageEvent for the new billing pipeline after a successful eval.
+
+    Centralizes the dual-write block used by span/trace/session eval paths.
+    Silently no-ops when ee billing modules are unavailable or on any error.
+    """
+    try:
+        from ee.usage.schemas.events import UsageEvent
+    except ImportError:
+        return
+    try:
+        from ee.usage.services.config import BillingConfig
+    except ImportError:
+        return
+    try:
+        from ee.usage.services.emitter import emit
+    except ImportError:
+        return
+    try:
+        from ee.usage.utils.event_properties import token_usage_properties
+    except ImportError:
+        token_usage_properties = lambda token_usage: {}
+
+    try:
+        billing_config = BillingConfig.get()
+        _llm_cost = (result.cost or {}).get("total_cost", 0)
+        _per_run_fee = billing_config.get_eval_per_run_fee()
+        _actual_cost = _llm_cost + _per_run_fee
+        _token_usage = result.token_usage or {}
+        credits = billing_config.calculate_ai_credits(_actual_cost)
+
+        emit(
+            UsageEvent(
+                org_id=org_id,
+                event_type=api_call_type,
+                amount=credits,
+                properties={
+                    "source": "tracer" if not feedback_id else "feedback",
+                    "source_id": source_id,
+                    "model": custom_eval_config.model or "",
+                    "workspace_id": ws_id or "",
+                    "log_id": str(api_call_log_row.log_id) if api_call_log_row else "",
+                    "raw_cost_usd": str(_actual_cost),
+                    "target_type": target_type,
+                    **token_usage_properties(_token_usage),
+                },
+            )
+        )
+    except Exception:
+        pass  # Metering failure must not break eval
+
+
 def _run_evaluation(
     run_params,
     eval_model,
@@ -1369,50 +1431,17 @@ def _execute_evaluation(
             api_call_log_row.save()
 
         # Dual-write: emit usage event for new billing system (cost-based)
-        try:
-            try:
-                from ee.usage.schemas.events import UsageEvent
-            except ImportError:
-                UsageEvent = None
-            try:
-                from ee.usage.services.config import BillingConfig
-            except ImportError:
-                BillingConfig = None
-            try:
-                from ee.usage.services.emitter import emit
-            except ImportError:
-                emit = None
-            try:
-                from ee.usage.utils.event_properties import token_usage_properties
-            except ImportError:
-                token_usage_properties = lambda token_usage: {}
-
-            billing_config = BillingConfig.get()
-            _llm_cost = (result.cost or {}).get("total_cost", 0)
-            _per_run_fee = billing_config.get_eval_per_run_fee()
-            _actual_cost = _llm_cost + _per_run_fee
-            _token_usage = result.token_usage or {}
-            credits = billing_config.calculate_ai_credits(_actual_cost)
-
-            emit(
-                UsageEvent(
-                    org_id=org_id,
-                    event_type=api_call_type,
-                    amount=credits,
-                    properties={
-                        "source": "tracer" if not feedback_id else "feedback",
-                        "source_id": str(eval_model.id),
-                        "model": custom_eval_config.model or "",
-                        "workspace_id": ws_id or "",
-                        "log_id": str(api_call_log_row.log_id),
-                        "raw_cost_usd": str(_actual_cost),
-                        "target_type": EvalTargetType.SPAN.value,
-                        **token_usage_properties(_token_usage),
-                    },
-                )
-            )
-        except Exception:
-            pass  # Metering failure must not break eval
+        _emit_eval_billing(
+            org_id=org_id,
+            api_call_type=api_call_type,
+            source_id=str(eval_model.id),
+            target_type=EvalTargetType.SPAN.value,
+            result=result,
+            custom_eval_config=custom_eval_config,
+            ws_id=ws_id,
+            api_call_log_row=api_call_log_row,
+            feedback_id=feedback_id,
+        )
 
         # Parse metadata
         metadata = result.metadata
@@ -2660,50 +2689,17 @@ def _execute_evaluation_for_trace(
             api_call_log_row.save()
 
         # Dual-write: emit usage event for new billing system (cost-based)
-        try:
-            try:
-                from ee.usage.schemas.events import UsageEvent
-            except ImportError:
-                UsageEvent = None
-            try:
-                from ee.usage.services.config import BillingConfig
-            except ImportError:
-                BillingConfig = None
-            try:
-                from ee.usage.services.emitter import emit
-            except ImportError:
-                emit = None
-            try:
-                from ee.usage.utils.event_properties import token_usage_properties
-            except ImportError:
-                token_usage_properties = lambda token_usage: {}
-
-            billing_config = BillingConfig.get()
-            _llm_cost = (result.cost or {}).get("total_cost", 0)
-            _per_run_fee = billing_config.get_eval_per_run_fee()
-            _actual_cost = _llm_cost + _per_run_fee
-            _token_usage = result.token_usage or {}
-            credits = billing_config.calculate_ai_credits(_actual_cost)
-
-            emit(
-                UsageEvent(
-                    org_id=org_id,
-                    event_type=api_call_type,
-                    amount=credits,
-                    properties={
-                        "source": "tracer" if not feedback_id else "feedback",
-                        "source_id": str(eval_template.id),
-                        "model": custom_eval_config.model or "",
-                        "workspace_id": ws_id or "",
-                        "log_id": str(api_call_log_row.log_id),
-                        "raw_cost_usd": str(_actual_cost),
-                        "target_type": EvalTargetType.TRACE.value,
-                        **token_usage_properties(_token_usage),
-                    },
-                )
-            )
-        except Exception:
-            pass  # Metering failure must not break eval
+        _emit_eval_billing(
+            org_id=org_id,
+            api_call_type=api_call_type,
+            source_id=str(eval_template.id),
+            target_type=EvalTargetType.TRACE.value,
+            result=result,
+            custom_eval_config=custom_eval_config,
+            ws_id=ws_id,
+            api_call_log_row=api_call_log_row,
+            feedback_id=feedback_id,
+        )
 
         metadata = result.metadata
         if isinstance(metadata, str):
@@ -2929,50 +2925,17 @@ def _execute_evaluation_for_session(
             api_call_log_row.save()
 
         # Dual-write: emit usage event for new billing system (cost-based)
-        try:
-            try:
-                from ee.usage.schemas.events import UsageEvent
-            except ImportError:
-                UsageEvent = None
-            try:
-                from ee.usage.services.config import BillingConfig
-            except ImportError:
-                BillingConfig = None
-            try:
-                from ee.usage.services.emitter import emit
-            except ImportError:
-                emit = None
-            try:
-                from ee.usage.utils.event_properties import token_usage_properties
-            except ImportError:
-                token_usage_properties = lambda token_usage: {}
-
-            billing_config = BillingConfig.get()
-            _llm_cost = (result.cost or {}).get("total_cost", 0)
-            _per_run_fee = billing_config.get_eval_per_run_fee()
-            _actual_cost = _llm_cost + _per_run_fee
-            _token_usage = result.token_usage or {}
-            credits = billing_config.calculate_ai_credits(_actual_cost)
-
-            emit(
-                UsageEvent(
-                    org_id=org_id,
-                    event_type=api_call_type,
-                    amount=credits,
-                    properties={
-                        "source": "tracer" if not feedback_id else "feedback",
-                        "source_id": str(eval_template.id),
-                        "model": custom_eval_config.model or "",
-                        "workspace_id": ws_id or "",
-                        "log_id": str(api_call_log_row.log_id),
-                        "raw_cost_usd": str(_actual_cost),
-                        "target_type": EvalTargetType.SESSION.value,
-                        **token_usage_properties(_token_usage),
-                    },
-                )
-            )
-        except Exception:
-            pass  # Metering failure must not break eval
+        _emit_eval_billing(
+            org_id=org_id,
+            api_call_type=api_call_type,
+            source_id=str(eval_template.id),
+            target_type=EvalTargetType.SESSION.value,
+            result=result,
+            custom_eval_config=custom_eval_config,
+            ws_id=ws_id,
+            api_call_log_row=api_call_log_row,
+            feedback_id=feedback_id,
+        )
 
         metadata = result.metadata
         if isinstance(metadata, str):

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -605,8 +605,13 @@ def _run_evaluation(
                 from ee.usage.services.emitter import emit
             except ImportError:
                 emit = None
+            try:
+                from ee.usage.utils.event_properties import token_usage_properties
+            except ImportError:
+                token_usage_properties = lambda token_usage: {}
 
             actual_cost = getattr(eval_instance, "cost", {}).get("total_cost", 0)
+            _token_usage = getattr(eval_instance, "token_usage", {})
             credits = BillingConfig.get().calculate_ai_credits(actual_cost)
 
             emit(
@@ -621,6 +626,7 @@ def _run_evaluation(
                         "workspace_id": str(workspace.id) if workspace else "",
                         "log_id": str(api_call_log_row.log_id),
                         "raw_cost_usd": str(actual_cost),
+                        **token_usage_properties(_token_usage),
                     },
                 )
             )
@@ -1245,6 +1251,49 @@ def _execute_evaluation(
         api_call_log_row.config = json.dumps(config_dict)
         api_call_log_row.status = APICallStatusChoices.SUCCESS.value
         api_call_log_row.save()
+
+        # Dual-write: emit usage event for new billing system (cost-based)
+        try:
+            try:
+                from ee.usage.schemas.events import UsageEvent
+            except ImportError:
+                UsageEvent = None
+            try:
+                from ee.usage.services.config import BillingConfig
+            except ImportError:
+                BillingConfig = None
+            try:
+                from ee.usage.services.emitter import emit
+            except ImportError:
+                emit = None
+            try:
+                from ee.usage.utils.event_properties import token_usage_properties
+            except ImportError:
+                token_usage_properties = lambda token_usage: {}
+
+            _actual_cost = (result.cost or {}).get("total_cost", 0)
+            _token_usage = result.token_usage or {}
+            credits = BillingConfig.get().calculate_ai_credits(_actual_cost)
+
+            emit(
+                UsageEvent(
+                    org_id=org_id,
+                    event_type=api_call_type,
+                    amount=credits,
+                    properties={
+                        "source": "tracer" if not feedback_id else "feedback",
+                        "source_id": str(eval_model.id),
+                        "model": custom_eval_config.model or "",
+                        "workspace_id": ws_id or "",
+                        "log_id": str(api_call_log_row.log_id),
+                        "raw_cost_usd": str(_actual_cost),
+                        "target_type": EvalTargetType.SPAN.value,
+                        **token_usage_properties(_token_usage),
+                    },
+                )
+            )
+        except Exception:
+            pass  # Metering failure must not break eval
 
         # Parse metadata
         metadata = result.metadata
@@ -2504,6 +2553,49 @@ def _execute_evaluation_for_trace(
         api_call_log_row.status = APICallStatusChoices.SUCCESS.value
         api_call_log_row.save()
 
+        # Dual-write: emit usage event for new billing system (cost-based)
+        try:
+            try:
+                from ee.usage.schemas.events import UsageEvent
+            except ImportError:
+                UsageEvent = None
+            try:
+                from ee.usage.services.config import BillingConfig
+            except ImportError:
+                BillingConfig = None
+            try:
+                from ee.usage.services.emitter import emit
+            except ImportError:
+                emit = None
+            try:
+                from ee.usage.utils.event_properties import token_usage_properties
+            except ImportError:
+                token_usage_properties = lambda token_usage: {}
+
+            _actual_cost = (result.cost or {}).get("total_cost", 0)
+            _token_usage = result.token_usage or {}
+            credits = BillingConfig.get().calculate_ai_credits(_actual_cost)
+
+            emit(
+                UsageEvent(
+                    org_id=org_id,
+                    event_type=api_call_type,
+                    amount=credits,
+                    properties={
+                        "source": "tracer" if not feedback_id else "feedback",
+                        "source_id": str(eval_template.id),
+                        "model": custom_eval_config.model or "",
+                        "workspace_id": ws_id or "",
+                        "log_id": str(api_call_log_row.log_id),
+                        "raw_cost_usd": str(_actual_cost),
+                        "target_type": EvalTargetType.TRACE.value,
+                        **token_usage_properties(_token_usage),
+                    },
+                )
+            )
+        except Exception:
+            pass  # Metering failure must not break eval
+
         metadata = result.metadata
         if isinstance(metadata, str):
             try:
@@ -2728,6 +2820,49 @@ def _execute_evaluation_for_session(
         api_call_log_row.config = json.dumps(config_dict)
         api_call_log_row.status = APICallStatusChoices.SUCCESS.value
         api_call_log_row.save()
+
+        # Dual-write: emit usage event for new billing system (cost-based)
+        try:
+            try:
+                from ee.usage.schemas.events import UsageEvent
+            except ImportError:
+                UsageEvent = None
+            try:
+                from ee.usage.services.config import BillingConfig
+            except ImportError:
+                BillingConfig = None
+            try:
+                from ee.usage.services.emitter import emit
+            except ImportError:
+                emit = None
+            try:
+                from ee.usage.utils.event_properties import token_usage_properties
+            except ImportError:
+                token_usage_properties = lambda token_usage: {}
+
+            _actual_cost = (result.cost or {}).get("total_cost", 0)
+            _token_usage = result.token_usage or {}
+            credits = BillingConfig.get().calculate_ai_credits(_actual_cost)
+
+            emit(
+                UsageEvent(
+                    org_id=org_id,
+                    event_type=api_call_type,
+                    amount=credits,
+                    properties={
+                        "source": "tracer" if not feedback_id else "feedback",
+                        "source_id": str(eval_template.id),
+                        "model": custom_eval_config.model or "",
+                        "workspace_id": ws_id or "",
+                        "log_id": str(api_call_log_row.log_id),
+                        "raw_cost_usd": str(_actual_cost),
+                        "target_type": EvalTargetType.SESSION.value,
+                        **token_usage_properties(_token_usage),
+                    },
+                )
+            )
+        except Exception:
+            pass  # Metering failure must not break eval
 
         metadata = result.metadata
         if isinstance(metadata, str):

--- a/futureagi/tracer/utils/external_eval.py
+++ b/futureagi/tracer/utils/external_eval.py
@@ -97,19 +97,17 @@ def _log_and_deduct_cost_for_external_eval(
             token_usage_properties = lambda token_usage: {}
 
         if emit is not None and UsageEvent is not None:
-
-
             emit(
-            UsageEvent(
-                org_id=str(config.organization.id),
-                event_type=api_call_type,
-                properties={
-                    "source": "tracer",
-                    "source_id": str(config.id),
-                    **token_usage_properties(log_config),
-                },
+                UsageEvent(
+                    org_id=str(config.organization.id),
+                    event_type=api_call_type,
+                    properties={
+                        "source": "tracer",
+                        "source_id": str(config.id),
+                        **token_usage_properties(log_config.get("token_usage", {})),
+                    },
+                )
             )
-        )
     except Exception:
         pass  # Metering failure must not break the action
 

--- a/futureagi/tracer/utils/external_eval.py
+++ b/futureagi/tracer/utils/external_eval.py
@@ -91,6 +91,10 @@ def _log_and_deduct_cost_for_external_eval(
             from ee.usage.services.emitter import emit
         except ImportError:
             emit = None
+        try:
+            from ee.usage.utils.event_properties import token_usage_properties
+        except ImportError:
+            token_usage_properties = lambda token_usage: {}
 
         emit(
             UsageEvent(
@@ -99,6 +103,7 @@ def _log_and_deduct_cost_for_external_eval(
                 properties={
                     "source": "tracer",
                     "source_id": str(config.id),
+                    **token_usage_properties(log_config),
                 },
             )
         )

--- a/futureagi/tracer/utils/trace_scanner.py
+++ b/futureagi/tracer/utils/trace_scanner.py
@@ -129,6 +129,10 @@ def _emit_scanner_billing(
             from ee.usage.services.emitter import emit
         except ImportError:
             emit = None
+        try:
+            from ee.usage.utils.event_properties import token_usage_properties
+        except ImportError:
+            token_usage_properties = lambda token_usage: {}
 
         project = Project.objects.select_related("organization").filter(
             id=project_id
@@ -149,6 +153,7 @@ def _emit_scanner_billing(
                     "issues_found": sum(len(r.issues) for r in results),
                     "raw_cost_usd": str(cost_usd),
                     "model": scanner.model_config.model_name,
+                    **token_usage_properties(getattr(scanner, "token_usage", {})),
                 },
             )
         )


### PR DESCRIPTION
## Description

Attach token usage (`prompt_tokens` / `completion_tokens` / `total_tokens`) to every `ai_credits` `UsageEvent` emit site in this repo, and close a span/trace/session eval billing gap in `tracer/utils/eval.py`.

**What changed**

- Thread `token_usage_properties()` through every cost-based `UsageEvent` emit (`sdk/utils/evaluations.py`, `model_hub/tasks/*`, `model_hub/utils/*`, `model_hub/views/*`, `tracer/utils/*`, `simulate/temporal/activities/xl.py`) so `prompt_tokens / completion_tokens / total_tokens` land on the billing event alongside `raw_cost_usd`.
- New helper `tracer/utils/eval.py::_emit_eval_billing()` centralizes the dual-write block used by span/trace/session paths.
  - `_execute_evaluation` (span path) — the pre-existing emit lived on dead-code `_run_evaluation`; the active path now emits with `target_type="span"`.
  - `_execute_evaluation_for_trace` / `_execute_evaluation_for_session` (added in `37730a20`, 2026-05-07) never wired the new `ai_credits` emit — they only called the legacy `log_and_deduct_cost_for_api_request`. Both now emit with `target_type="trace"` / `target_type="session"`.
- Temporal billing wiring is consolidated: monthly closing chains reset → invoice gen in a single activity. Stripe meter events fire at invoice-close (see `ee/usage/services/invoice_generation.py`), so the hourly `report_stripe_usage_activity` + `StripeUsageReportInput/Output` types are removed. `_next_period_str` / period-format validation now use `datetime.strptime("%Y-%m")` instead of string slicing.
- Restored `if emit is not None and UsageEvent is not None:` guards around the new emit blocks in `sdk/utils/evaluations.py` (`_run_eval`, `_run_protect`) so they no-op cleanly when ee modules are unavailable. `log_id` ternary preserved when `api_call_log_row is None`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) — trace/session evals were not emitting `ai_credits` events
- [x] New feature (non-breaking change which adds functionality) — token usage on every billing event
- [x] Configuration change — Temporal billing schedule consolidation

---

## Flows changed in this PR

### 1. Standalone eval (`_run_eval`) — token usage + guarded emit

- **What changed:** `sdk/utils/evaluations.py::_run_eval` reads `result.token_usage`, spreads `token_usage_properties(token_usage)` into the UsageEvent properties, and the emit is guarded by `if emit is not None and UsageEvent is not None`. `log_id` ternary restored.
- **Entry point:** `futureagi/sdk/utils/evaluations.py`

### 2. Protect eval (`_run_protect`) — token usage + guarded emit

- **What changed:** Same treatment in `_run_protect`. Cost lookup now resolves protect aliases via `ProtectHelper.resolve_alias` (with import fallback) before pricing.
- **Entry point:** `futureagi/sdk/utils/evaluations.py`

### 3. Span / trace / session evals (`tracer/utils/eval.py`)

- **What changed:** New `_emit_eval_billing()` helper centralizes the dual-write. `_execute_evaluation` (span), `_execute_evaluation_for_trace`, and `_execute_evaluation_for_session` all call it with the right `target_type`. Helper silently no-ops on ImportError or any exception (metering failure must not break eval).
- **Entry point:** `futureagi/tracer/utils/eval.py`

### 4. Prompt workbench generate / improve

- **What changed:** `model_hub/utils/async_generate_prompt_runner.py`, `async_improve_prompt_runner.py`, and the `model_hub/views/prompt_template.py` view emit `prompt_tokens / completion_tokens / total_tokens` alongside the existing cost.
- **Entry points:** `futureagi/model_hub/utils/async_*_prompt_runner.py`, `futureagi/model_hub/views/prompt_template.py`

### 5. Auto-annotate / dataset develop / error analysis / trace scanner

- **What changed:** All cost-emitting call sites in `model_hub/utils/auto_annotate.py`, `model_hub/tasks/develop_dataset.py`, `model_hub/tasks/user_evaluation.py`, `tracer/tasks/error_analysis.py`, `tracer/utils/trace_scanner.py`, and `simulate/temporal/activities/xl.py` now spread `llm_usage_properties(...)` / `token_usage_properties(...)` into UsageEvent properties.
- **Entry points:** as above

### 6. Temporal billing schedule consolidation

- **What changed:** `monthly_closing_activity` chains the monthly reset and invoice generation. `_next_period_str` derives the next YYYY-MM via `datetime.strptime`. The hourly Stripe usage reporting activity + its IO types are removed — Stripe meter events fire at invoice-close per `ee/usage/services/invoice_generation.py`.
- **Entry points:** `futureagi/tfc/temporal/billing/{__init__,activities,types,workflows}.py`, `futureagi/tfc/temporal/schedules/billing.py`

### 7. Admin templates

- **What changed:** `tfc/templates/admin/usage/custom_pricing.html` and `generate_invoice.html` updated to surface the new pricing / generation flows.
- **Entry points:** `futureagi/tfc/templates/admin/usage/*.html`

### 8. Eval runner cost path

- **What changed:** `model_hub/views/eval_runner.py` and `model_hub/views/utils/evals.py` thread token usage into their existing cost-event emits.
- **Entry points:** as above

### Existing flows that continue to work (covered, not behaviour-changed)

- Standalone eval LLM driver (`agentic_eval/core/llm/llm.py`) — token_usage already surfaces; tests assert no regression.
- External eval (`tracer/utils/external_eval.py`) — call-site cleanup only, no billing change.
- Simulate Temporal activity — additive token props on the existing emit.

---

## Test plan

### How to run locally

```bash
# from futureagi/
set -a && source .env.test && set +a

.venv/bin/python -m pytest \
  tracer/tests/test_eval_credits_emit.py \
  model_hub/tests/test_prompt_usage_events_api.py \
  -v --no-header
```

### Cases covered

**`tracer/tests/test_eval_credits_emit.py`** (4 tests, new) — verifies the new dual-write emit fires with the right shape for each anchor type.
- `test_span_eval_emits_ai_credits_with_tokens` — `_execute_evaluation(OBSERVE)` → one ai_credits event with `target_type="span"`, `event_type=TURING_LARGE_EVALUATOR`, `prompt/completion/total_tokens` from `result.token_usage`, `raw_cost_usd` = `llm_cost + per_run_fee`.
- `test_trace_eval_emits_ai_credits_with_tokens` — same assertions via `_execute_evaluation_for_trace`, `target_type="trace"`.
- `test_session_eval_emits_ai_credits_with_tokens` — same via `_execute_evaluation_for_session`, `target_type="session"`.
- `test_eval_failure_does_not_emit_ai_credits` — guard against billing on failed evals.

**`model_hub/tests/test_prompt_usage_events_api.py`** (2 tests, new) — prompt workbench emit shape.
- `test_generate_prompt_api_emits_token_usage_properties` — generate-prompt API path emits with `prompt_tokens / completion_tokens / total_tokens` keys.
- `test_improve_prompt_api_emits_token_usage_properties` — same for improve-prompt path.

---

## Test pass output

```
tracer/tests/test_eval_credits_emit.py::test_span_eval_emits_ai_credits_with_tokens                    PASSED
tracer/tests/test_eval_credits_emit.py::test_trace_eval_emits_ai_credits_with_tokens                   PASSED
tracer/tests/test_eval_credits_emit.py::test_session_eval_emits_ai_credits_with_tokens                 PASSED
tracer/tests/test_eval_credits_emit.py::test_eval_failure_does_not_emit_ai_credits                     PASSED
model_hub/tests/test_prompt_usage_events_api.py::test_generate_prompt_api_emits_token_usage_properties PASSED
model_hub/tests/test_prompt_usage_events_api.py::test_improve_prompt_api_emits_token_usage_properties  PASSED

============================== 6 passed in 8.45s ===============================
```

<img width="1066" height="219" alt="image" src="https://github.com/user-attachments/assets/875b249f-70f2-4b0d-8b40-8cd0e610c61a" />

---

## Resolved review comments

- `sdk/utils/evaluations.py:319` — restored `if emit is not None and UsageEvent is not None:` guard before `emit(UsageEvent(...))`.
- `sdk/utils/evaluations.py:596` — same in `_run_protect`.
- `sdk/utils/evaluations.py:328` — restored `if api_call_log_row else None` ternary for `log_id`.
- `tfc/temporal/billing/activities.py:168` — `_next_period_str` now uses `datetime.strptime("%Y-%m")` instead of `int(period[:4])` / `int(period[5:7])` slicing.
- `tfc/temporal/billing/activities.py:187` — period format validation uses `datetime.strptime` (raises `ValueError` on malformed input) instead of `len(...) != 7 or period[4] != "-"`.
- `tfc/temporal/billing/{__init__.py, activities.py}` — removal of `report_stripe_usage_activity` + `StripeUsageReportInput/Output` is intentional. Stripe meter events fire at invoice-close (`ee/usage/services/invoice_generation.py::InvoiceGenerationService._report_to_stripe`) — there is no hourly catch-up. Top-of-file docstring documents this.
- `model_hub/tasks/user_evaluation.py:1186` (import-from-ee pattern) — left as is; matches the existing `emit / UsageEvent / BillingConfig` try/except pattern directly above. Open to refactoring under a separate convention if preferred.
- `tracer/utils/eval.py::_emit_eval_billing` — helper returns early on any ee ImportError and wraps the body in `try/except Exception: pass` so metering failure cannot break eval.

## Linked issues

Closes #

## Checklist

- [x] Tests added / updated
- [x] No hardcoded secrets, URLs, or PII
- [x] Review comments #2 / #3 / #4 / #7 / #8 addressed in code; #1 / #5 / #6 / #9 addressed in description
