### PR TITLE
fix(evals): add numeric-aware dotted-key support to CustomPromptEvaluator (TH-5443)

### DIFF
--- a/futureagi/agentic_eval/core/utils/jinja_utils.py
+++ b/futureagi/agentic_eval/core/utils/jinja_utils.py
@@ -1,0 +1,35 @@
+"""Shared helpers for Jinja-based prompt rendering across evaluators."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def nest_dotted_value(container: dict, parts: list[str], value: Any) -> None:
+    """Nest ``value`` at ``parts`` path; numeric components become list indices."""
+    target: Any = container
+    for i, part in enumerate(parts[:-1]):
+        next_is_numeric = parts[i + 1].isdigit()
+        child_factory = list if next_is_numeric else dict
+        if isinstance(target, list):
+            idx = int(part)
+            while len(target) <= idx:
+                target.append(None)
+            if not isinstance(target[idx], child_factory):
+                target[idx] = child_factory()
+            target = target[idx]
+        else:
+            existing = target.get(part)
+            if not isinstance(existing, child_factory):
+                existing = child_factory()
+                target[part] = existing
+            target = existing
+
+    leaf = parts[-1]
+    if isinstance(target, list):
+        idx = int(leaf)
+        while len(target) <= idx:
+            target.append(None)
+        target[idx] = value
+    else:
+        target[leaf] = value

--- a/futureagi/agentic_eval/core/utils/jinja_utils.py
+++ b/futureagi/agentic_eval/core/utils/jinja_utils.py
@@ -6,25 +6,44 @@ from typing import Any
 
 
 def nest_dotted_value(container: dict, parts: list[str], value: Any) -> None:
-    """Nest ``value`` at ``parts`` path; numeric components become list indices."""
+    """Nest ``value`` at ``parts`` path; numeric components become list indices.
+
+    Jinja parses ``{{spans.0.kind}}`` as ``spans[0].kind``, so ``spans`` must
+    be a list. e.g. ``["spans", "0", "kind"], "X"`` → ``{"spans": [{"kind": "X"}]}``.
+    """
     target: Any = container
+
+    # Walk every component except the leaf. Each iteration descends one
+    # level, creating the right type of child container on the way down.
     for i, part in enumerate(parts[:-1]):
+        # The CHILD container's type is decided by the NEXT component
+        # (not the current one): numeric next → list, word next → dict.
+        # That's because the next component is what will index into the
+        # child we're about to create.
         next_is_numeric = parts[i + 1].isdigit()
         child_factory = list if next_is_numeric else dict
+
         if isinstance(target, list):
+            # In a list: `part` is the integer index of our slot.
             idx = int(part)
+            # Pad with None so out-of-order assignments work
+            # (e.g. spans.2 set before spans.0).
             while len(target) <= idx:
                 target.append(None)
+            # Create or replace the slot so it's the right kind.
             if not isinstance(target[idx], child_factory):
                 target[idx] = child_factory()
             target = target[idx]
         else:
+            # In a dict: `part` is the string key.
             existing = target.get(part)
             if not isinstance(existing, child_factory):
                 existing = child_factory()
                 target[part] = existing
             target = existing
 
+    # Drop `value` at the final position. Same dict-vs-list split as
+    # above — depends on what `target` ended up as after the walk.
     leaf = parts[-1]
     if isinstance(target, list):
         idx = int(leaf)

--- a/futureagi/agentic_eval/core/utils/tests/test_jinja_utils.py
+++ b/futureagi/agentic_eval/core/utils/tests/test_jinja_utils.py
@@ -1,0 +1,156 @@
+"""Tests for ``nest_dotted_value`` (TH-5443 regression coverage).
+
+The bug: ``required_keys`` like ``spans.0.gen_ai.span.kind`` were nested into
+a dict with the string key ``"0"``, but Jinja parses ``.0`` as list index 0
+and raised ``UndefinedError: dict object has no element 0``. The fix builds
+a list at the parent level whenever the next path component is numeric.
+
+These tests are pure (no Django, no IO) so they run fast and don't break
+when the surrounding eval pipeline changes.
+"""
+
+import pytest
+from jinja2 import Environment
+
+from agentic_eval.core.utils.jinja_utils import nest_dotted_value
+
+
+# ── Backward compatibility (the TH-4715 word-only path) ─────────────────
+
+
+def test_pure_dict_path_two_levels():
+    out = {}
+    nest_dotted_value(out, ["json_col", "field"], "X")
+    assert out == {"json_col": {"field": "X"}}
+
+
+def test_pure_dict_path_deep():
+    out = {}
+    nest_dotted_value(out, ["a", "b", "c", "d"], 42)
+    assert out == {"a": {"b": {"c": {"d": 42}}}}
+
+
+def test_pure_dict_preserves_existing_siblings():
+    out = {"json_col": {"existing": 1}}
+    nest_dotted_value(out, ["json_col", "field"], "X")
+    assert out == {"json_col": {"existing": 1, "field": "X"}}
+
+
+# ── The bug — numeric components become list indices ────────────────────
+
+
+def test_single_numeric_creates_list():
+    """The exact failure case from the bug report."""
+    out = {}
+    nest_dotted_value(out, ["spans", "0", "gen_ai", "span", "kind"], "AGENT")
+    assert out == {"spans": [{"gen_ai": {"span": {"kind": "AGENT"}}}]}
+
+
+def test_numeric_at_leaf_creates_list():
+    out = {}
+    nest_dotted_value(out, ["items", "0"], "first")
+    nest_dotted_value(out, ["items", "1"], "second")
+    assert out == {"items": ["first", "second"]}
+
+
+def test_out_of_order_indices_auto_grow():
+    out = {}
+    nest_dotted_value(out, ["spans", "2", "k"], "C")
+    nest_dotted_value(out, ["spans", "0", "k"], "A")
+    nest_dotted_value(out, ["spans", "1", "k"], "B")
+    assert out == {"spans": [{"k": "A"}, {"k": "B"}, {"k": "C"}]}
+
+
+def test_sparse_index_pads_with_none():
+    out = {}
+    nest_dotted_value(out, ["items", "3"], "fourth")
+    assert out == {"items": [None, None, None, "fourth"]}
+
+
+# ── Mixed dict + list nesting ───────────────────────────────────────────
+
+
+def test_dict_containing_list():
+    out = {}
+    nest_dotted_value(out, ["a", "b", "0", "c"], "X")
+    assert out == {"a": {"b": [{"c": "X"}]}}
+
+
+def test_list_containing_list():
+    out = {}
+    nest_dotted_value(out, ["matrix", "0", "1"], "X")
+    assert out == {"matrix": [[None, "X"]]}
+
+
+def test_multiple_keys_populate_same_list():
+    """Two required_keys with shared parent paths share the same list."""
+    out = {}
+    nest_dotted_value(out, ["spans", "0", "name"], "first_span")
+    nest_dotted_value(out, ["spans", "0", "kind"], "AGENT")
+    nest_dotted_value(out, ["spans", "1", "name"], "second_span")
+    assert out == {
+        "spans": [
+            {"name": "first_span", "kind": "AGENT"},
+            {"name": "second_span"},
+        ]
+    }
+
+
+# ── Wrong-typed existing children get replaced ──────────────────────────
+
+
+def test_wrong_typed_child_dict_replaced_with_list():
+    """Defensive: if an earlier call left a dict where a list now belongs, we replace it."""
+    out = {"spans": {}}
+    nest_dotted_value(out, ["spans", "0", "k"], "X")
+    assert out == {"spans": [{"k": "X"}]}
+
+
+def test_wrong_typed_child_list_replaced_with_dict():
+    out = {"obj": []}
+    nest_dotted_value(out, ["obj", "field"], "X")
+    assert out == {"obj": {"field": "X"}}
+
+
+# ── End-to-end: the renderer no longer raises ───────────────────────────
+
+
+def _render(template_str: str, **context) -> str:
+    """Render with Jinja the same way CustomPromptEvaluator/AgentEvaluator do."""
+    return Environment().from_string(template_str).render(**context)
+
+
+def test_jinja_renders_numeric_indexed_path():
+    """The actual user-visible bug fix: this used to raise UndefinedError."""
+    out = {}
+    nest_dotted_value(out, ["spans", "0", "gen_ai", "span", "kind"], "AGENT")
+    rendered = _render("kind: {{ spans.0.gen_ai.span.kind }}", **out)
+    assert rendered == "kind: AGENT"
+
+
+def test_jinja_renders_word_only_path():
+    """Regression: TH-4715's original use case still works."""
+    out = {}
+    nest_dotted_value(out, ["json_col", "field"], "value")
+    rendered = _render("{{ json_col.field }}", **out)
+    assert rendered == "value"
+
+
+def test_jinja_for_loop_over_populated_list():
+    """Multi-element list populated via the helper is iterable in Jinja."""
+    out = {}
+    nest_dotted_value(out, ["spans", "0", "kind"], "A")
+    nest_dotted_value(out, ["spans", "1", "kind"], "B")
+    nest_dotted_value(out, ["spans", "2", "kind"], "C")
+    rendered = _render(
+        "{% for s in spans %}[{{ s.kind }}]{% endfor %}", **out
+    )
+    assert rendered == "[A][B][C]"
+
+
+def test_jinja_bracket_access_also_works():
+    """spans[0] syntax (in addition to spans.0) resolves correctly."""
+    out = {}
+    nest_dotted_value(out, ["spans", "0", "kind"], "X")
+    rendered = _render("{{ spans[0].kind }}", **out)
+    assert rendered == "X"

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -7,6 +7,7 @@ import jinja2
 from jinja2 import Environment
 
 from agentic_eval.core.llm.llm import LLM
+from agentic_eval.core.utils.jinja_utils import nest_dotted_value
 from agentic_eval.core.utils.json_utils import extract_dict_from_string
 from agentic_eval.core.utils.llm_payloads import detect_and_build_media_blocks
 from agentic_eval.core.utils.model_config import ModelConfigs
@@ -22,7 +23,6 @@ from agentic_eval.core_evals.fi_evals.eval_type import LlmEvalTypeId
 # values let huge transcripts/raw_logs flow in fully, at the cost of higher
 # TPM/cost per eval. Tuned for the 200K-window judge models. See TH-4905.
 _MAX_CONTEXT_CHARS = 200000
-
 
 class CustomPromptEvaluator(LLM):
     """
@@ -250,6 +250,12 @@ class CustomPromptEvaluator(LLM):
                     prompt_to_render = prompt_to_render.replace(
                         "{{ " + stripped + " }}", replacement
                     )
+                elif "." in stripped and stripped in safe_context:
+                    # Jinja parses dots as nested access; numeric segments
+                    # become list indices.
+                    parts = stripped.split(".")
+                    value = safe_context.pop(stripped)
+                    nest_dotted_value(safe_context, parts, value)
 
             # In Jinja mode, parse JSON strings to native objects right
             # before rendering so {% for %} loops work correctly.


### PR DESCRIPTION
## Summary

Companion to [ee#74](https://github.com/future-agi/ee/pull/74). This PR adds dotted-key variable support to the **runtime** CustomPromptEvaluator (LLM-as-judge) and makes it numeric-index aware from the start, plus introduces a shared helper module both evaluators import from.

## Context

CustomPromptEvaluator exists in two places:
- `agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py` ← runtime copy (this PR)
- `ee/evals/llm/custom_prompt_evaluator/evaluator.py` ← stale, not loaded by the registry

The registry imports from `agentic_eval/...` (see `agentic_eval/core_evals/fi_evals/__init__.py:111`). TH-4715 added dotted-key support, but it landed on the **stale ee/ copy** — so dotted refs in LLM-judge rule_prompts have never actually worked at runtime.

## Fix

- New shared module `agentic_eval/core/utils/jinja_utils.py` with `nest_dotted_value(container, parts, value)`. Imported by **both** AgentEvaluator (ee#74) and CustomPromptEvaluator (this PR) so there is exactly one implementation.
- A new `elif "." in stripped` branch in `_render_prompt`'s spaced/dotted handler that calls the helper.

The helper builds:
- A **list** at the parent level when the next component is purely numeric (so `spans.0.gen_ai.span.kind` produces `spans = [{...}]`).
- A dict otherwise (existing `json_col.field` semantics preserved exactly).
- Lists auto-grow with `None` placeholders so out-of-order assignments work.

**Note**: this PR does NOT include `_AUTO_CONTEXT_ROOTS` skip logic. CustomPromptEvaluator has no auto-context binding (the FE doesn't expose `{{row.X}}` / `{{span.X}}` style refs for LLM-judge templates), so the skip would protect nothing here. AgentEvaluator keeps its `_AUTO_CONTEXT_ROOTS` skip (in ee#74) because it does have auto-context binding.

## Tests

16 unit tests added at `agentic_eval/core/utils/tests/test_jinja_utils.py`:

- Backward compatibility (word-only dotted paths produce identical structures to `setdefault`)
- The original bug case (`spans.0.gen_ai.span.kind`)
- Out-of-order numeric indices auto-grow
- Sparse list growth
- Mixed dict + list nesting
- Wrong-typed existing children replaced
- End-to-end Jinja rendering (the regression test — asserts the rendered output, not just the data structure)

All 16 pass in 0.06s. Verified that reverting `nest_dotted_value` to the old `setdefault(part, {})` implementation causes 13 of 16 tests to fail with the exact diff: `{'spans': {'0': ...}} != {'spans': [...]}`.

## Verification

Smoke-tested via repl AND end-to-end via `POST /model-hub/eval-playground/` with the failing payload from the bug report:

```json
{
  "template_id": "013f3aa2-d265-4263-a54a-c5daf9faf82a",
  "model": "turing_large",
  "config": {
    "run_config": {"data_injection": {"trace_context": true}},
    "mapping": {"spans.0.gen_ai.span.kind": "AGENT"}
  },
  "trace_id": "42528faa-017c-4ca1-ac6a-37d766a04c8f"
}
```

Before: `Error running evaluation: dict object has no element 0` → 400.
After: 200 with eval result.

## Linear

https://linear.app/future-agi/issue/TH-5443

## Companion PR

[ee#74 — AgentEvaluator side](https://github.com/future-agi/ee/pull/74). Both should land together; ee#74 imports from the shared `agentic_eval/core/utils/jinja_utils.py` introduced here.

## Before:
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/a0a289a5-c8ed-49d0-a3b6-c8b1f313ee34" />

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/4f06d700-c567-43c8-b457-a36284775488" />

## After:
<img width="1920" height="1080" alt="Screenshot 2026-05-21 at 7 02 14 PM" src="https://github.com/user-attachments/assets/c772eadb-daac-4fee-89c2-5394325182c9" />

<img width="1920" height="1080" alt="Screenshot 2026-05-21 at 7 03 44 PM" src="https://github.com/user-attachments/assets/2cbc0826-e1e4-44df-b355-f2ab13cccbae" />

<img width="1920" height="1079" alt="Screenshot 2026-05-21 at 7 05 24 PM" src="https://github.com/user-attachments/assets/cafd6c5f-c5fa-4752-a53e-85c4ae1101ac" />
