### PR TITLE
fix(eval-task): cascade soft-delete to eval results + exclude them from ClickHouse queries

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/DeleteConfirmation.jsx
+++ b/frontend/src/sections/common/EvalsTasks/DeleteConfirmation.jsx
@@ -31,7 +31,11 @@ const DeleteConfirmation = ({
     };
   }, [open]);
 
-  const confirmationMessage = `Are you sure you want to delete  ${deleteCount > 1 ? `the selected ${deleteCount} tasks?` : `this task?`} `;
+  const confirmationMessage = `Are you sure you want to delete ${
+    deleteCount > 1 ? `the selected ${deleteCount} tasks` : `this task`
+  }? All evaluation results for ${
+    deleteCount > 1 ? "them" : "it"
+  } will also be deleted.`;
 
   return (
     <Dialog

--- a/futureagi/tracer/services/clickhouse/query_builders/eval_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/eval_metrics.py
@@ -211,6 +211,7 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
         FROM {self.RAW_TABLE} FINAL
         WHERE project_id = %(project_id)s
           AND _peerdb_is_deleted = 0
+          AND (deleted = 0 OR deleted IS NULL)
           AND custom_eval_config_id = toUUID(%(eval_config_id)s)
           AND created_at >= %(start_date)s
           AND created_at < %(end_date)s
@@ -260,6 +261,7 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
         FROM {self.RAW_TABLE} FINAL
         WHERE project_id = %(project_id)s
           AND _peerdb_is_deleted = 0
+          AND (deleted = 0 OR deleted IS NULL)
           AND custom_eval_config_id = toUUID(%(eval_config_id)s)
           AND created_at >= %(start_date)s
           AND created_at < %(end_date)s
@@ -310,6 +312,7 @@ class EvalMetricsQueryBuilder(BaseQueryBuilder):
         FROM {self.RAW_TABLE} FINAL
         WHERE project_id = %(project_id)s
           AND _peerdb_is_deleted = 0
+          AND (deleted = 0 OR deleted IS NULL)
           AND custom_eval_config_id = toUUID(%(eval_config_id)s)
           AND created_at >= %(start_date)s
           AND created_at < %(end_date)s

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -1092,6 +1092,7 @@ class ClickHouseFilterBuilder:
                 f"SELECT {inner_col} FROM tracer_eval_logger FINAL "
                 f"WHERE custom_eval_config_id IN %({param_cfg})s "
                 f"AND _peerdb_is_deleted = 0 "
+                f"AND (deleted = 0 OR deleted IS NULL) "
                 f"{error_clause} "
                 f"AND {match_condition}"
                 f")"
@@ -1552,7 +1553,8 @@ class ClickHouseFilterBuilder:
             "trace_id IN ("
             "SELECT DISTINCT toString(el.trace_id) FROM tracer_eval_logger AS el FINAL "
             f"INNER JOIN {self.table} AS sp ON sp.trace_id = toString(el.trace_id) "
-            "WHERE el._peerdb_is_deleted = 0 AND el.trace_id IS NOT NULL "
+            "WHERE el._peerdb_is_deleted = 0 AND (el.deleted = 0 OR el.deleted IS NULL) "
+            "AND el.trace_id IS NOT NULL "
             "AND sp._peerdb_is_deleted = 0 "
             "AND sp.project_id = %(project_id)s)"
         )

--- a/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/monitor_metrics.py
@@ -738,6 +738,7 @@ class MonitorMetricsQueryBuilder(BaseQueryBuilder):
         return (
             f"WHERE custom_eval_config_id = toUUID(%(eval_config_id)s) "
             f"AND _peerdb_is_deleted = 0 "
+            f"AND (deleted = 0 OR deleted IS NULL) "
             f"AND observation_span_id IN ("
             f"  SELECT id FROM {SPANS_TABLE} "
             f"  WHERE project_id = %(project_id)s "

--- a/futureagi/tracer/services/clickhouse/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/span_list.py
@@ -255,6 +255,7 @@ class SpanListQueryBuilder(BaseQueryBuilder):
             ) AS str_lists
         FROM {self.EVAL_TABLE} FINAL
         WHERE _peerdb_is_deleted = 0
+          AND (deleted = 0 OR deleted IS NULL)
           AND observation_span_id IN %(span_ids)s
           AND custom_eval_config_id IN %(eval_config_ids)s
         GROUP BY observation_span_id, custom_eval_config_id

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -439,6 +439,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             ) AS str_lists
         FROM {self.EVAL_TABLE} FINAL
         WHERE _peerdb_is_deleted = 0
+          AND (deleted = 0 OR deleted IS NULL)
           AND trace_id IN %(trace_ids)s
           AND custom_eval_config_id IN %(eval_config_ids)s
         GROUP BY trace_id, custom_eval_config_id

--- a/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/voice_call_list.py
@@ -251,6 +251,7 @@ class VoiceCallListQueryBuilder(BaseQueryBuilder):
             ) AS str_lists
         FROM {self.EVAL_TABLE} FINAL
         WHERE _peerdb_is_deleted = 0
+          AND (deleted = 0 OR deleted IS NULL)
           AND trace_id IN %(trace_ids)s
           AND custom_eval_config_id IN %(eval_config_ids)s
         GROUP BY trace_id, custom_eval_config_id

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -265,6 +265,7 @@ class AnalyticsQueryService:
             SELECT DISTINCT toString(custom_eval_config_id) AS config_id
             FROM tracer_eval_logger FINAL
             WHERE _peerdb_is_deleted = 0
+              AND (deleted = 0 OR deleted IS NULL)
               AND trace_id IN (
                   SELECT DISTINCT trace_id
                   FROM spans

--- a/futureagi/tracer/tests/test_eval_task.py
+++ b/futureagi/tracer/tests/test_eval_task.py
@@ -9,7 +9,8 @@ import uuid
 import pytest
 from rest_framework import status
 
-from tracer.models.eval_task import EvalTask, EvalTaskStatus
+from tracer.models.eval_task import EvalTask, EvalTaskLogger, EvalTaskStatus
+from tracer.models.observation_span import EvalLogger
 
 
 def get_result(response):
@@ -264,6 +265,148 @@ class TestEvalTaskDeleteAPI:
         task2.refresh_from_db()
         assert task1.status == EvalTaskStatus.DELETED
         assert task2.status == EvalTaskStatus.DELETED
+
+    def test_bulk_delete_cascades_soft_delete(
+        self, auth_client, eval_task, trace, observation_span
+    ):
+        """Bulk delete soft-deletes each task's loggers and eval results."""
+        task_logger = EvalTaskLogger.objects.create(
+            eval_task=eval_task,
+            status=EvalTaskStatus.PENDING,
+        )
+        eval_logger = EvalLogger.objects.create(
+            trace=trace,
+            observation_span=observation_span,
+            eval_task_id=str(eval_task.id),
+        )
+
+        response = auth_client.post(
+            "/tracer/eval-task/mark_eval_tasks_deleted/",
+            {"eval_task_ids": [str(eval_task.id)]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        eval_task.refresh_from_db()
+        assert eval_task.status == EvalTaskStatus.DELETED
+        assert eval_task.deleted is True
+
+        task_logger = EvalTaskLogger.all_objects.get(id=task_logger.id)
+        assert task_logger.deleted is True
+        assert task_logger.deleted_at is not None
+
+        eval_logger = EvalLogger.all_objects.get(id=eval_logger.id)
+        assert eval_logger.deleted is True
+        assert eval_logger.deleted_at is not None
+
+    def test_bulk_delete_leaves_other_tasks_results(
+        self, auth_client, project, eval_task, trace, observation_span
+    ):
+        """Bulk-deleting one task must not touch another task's eval results."""
+        other_task = EvalTask.objects.create(
+            project=project,
+            name="Other Task",
+            status=EvalTaskStatus.PENDING,
+        )
+        other_logger = EvalLogger.objects.create(
+            trace=trace,
+            observation_span=observation_span,
+            eval_task_id=str(other_task.id),
+        )
+
+        response = auth_client.post(
+            "/tracer/eval-task/mark_eval_tasks_deleted/",
+            {"eval_task_ids": [str(eval_task.id)]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        other_logger.refresh_from_db()
+        assert other_logger.deleted is False
+
+    def test_bulk_delete_rejects_running_tasks(self, auth_client, project):
+        """Running tasks cannot be bulk-deleted; they must be paused first."""
+        running_task = EvalTask.objects.create(
+            project=project,
+            name="Running Task",
+            status=EvalTaskStatus.RUNNING,
+        )
+
+        response = auth_client.post(
+            "/tracer/eval-task/mark_eval_tasks_deleted/",
+            {"eval_task_ids": [str(running_task.id)]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        running_task.refresh_from_db()
+        assert running_task.status == EvalTaskStatus.RUNNING
+        assert running_task.deleted is False
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestEvalTaskDestroyAPI:
+    """Tests for DELETE /tracer/eval-task/{id}/ (single REST delete)."""
+
+    def test_destroy_eval_task_unauthenticated(self, api_client, eval_task):
+        """Unauthenticated requests should be rejected."""
+        response = api_client.delete(f"/tracer/eval-task/{eval_task.id}/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_destroy_eval_task_cascades_soft_delete(
+        self, auth_client, eval_task, trace, observation_span
+    ):
+        """DELETE on a single eval task soft-deletes its loggers and results."""
+        task_logger = EvalTaskLogger.objects.create(
+            eval_task=eval_task,
+            status=EvalTaskStatus.PENDING,
+        )
+        eval_logger = EvalLogger.objects.create(
+            trace=trace,
+            observation_span=observation_span,
+            eval_task_id=str(eval_task.id),
+        )
+
+        response = auth_client.delete(f"/tracer/eval-task/{eval_task.id}/")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        # The task itself is soft-deleted (filtered out of the default manager).
+        assert not EvalTask.objects.filter(id=eval_task.id).exists()
+        eval_task.refresh_from_db()
+        assert eval_task.deleted is True
+        assert eval_task.deleted_at is not None
+
+        # Loggers and eval results cascade to soft-deleted (use all_objects
+        # since the default manager hides deleted rows).
+        task_logger = EvalTaskLogger.all_objects.get(id=task_logger.id)
+        assert task_logger.deleted is True
+        assert task_logger.deleted_at is not None
+
+        eval_logger = EvalLogger.all_objects.get(id=eval_logger.id)
+        assert eval_logger.deleted is True
+        assert eval_logger.deleted_at is not None
+
+    def test_destroy_eval_task_leaves_other_tasks_results(
+        self, auth_client, project, eval_task, trace, observation_span
+    ):
+        """Deleting one task must not touch another task's eval results."""
+        other_task = EvalTask.objects.create(
+            project=project,
+            name="Other Task",
+            status=EvalTaskStatus.PENDING,
+        )
+        other_logger = EvalLogger.objects.create(
+            trace=trace,
+            observation_span=observation_span,
+            eval_task_id=str(other_task.id),
+        )
+
+        response = auth_client.delete(f"/tracer/eval-task/{eval_task.id}/")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        other_logger.refresh_from_db()
+        assert other_logger.deleted is False
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -158,6 +158,18 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
 
         return queryset
 
+    def perform_destroy(self, instance):
+        # Cascade soft-delete to the task's loggers and eval results so they
+        # don't outlive the deleted task (mirrors mark_eval_tasks_deleted).
+        now = timezone.now()
+        EvalTaskLogger.objects.filter(eval_task_id=instance.id).update(
+            deleted=True, deleted_at=now
+        )
+        EvalLogger.objects.filter(eval_task_id=instance.id).update(
+            deleted=True, deleted_at=now
+        )
+        instance.delete()
+
     def create(self, request, *args, **kwargs):
         try:
             data = request.data

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -2044,6 +2044,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
             "FROM tracer_eval_logger FINAL "
             "WHERE _peerdb_is_deleted = 0 "
+            "AND (deleted = 0 OR deleted IS NULL) "
             "AND dictGet('trace_dict', 'project_id', "
             "trace_id) = toUUID(%(pid)s)",
             {"pid": str(project_id)},

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -824,6 +824,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             FROM tracer_eval_logger FINAL
             WHERE trace_id = %(trace_id)s
               AND _peerdb_is_deleted = 0
+              AND (deleted = 0 OR deleted IS NULL)
             """
             eval_result = analytics.execute_ch_query(
                 eval_query, {"trace_id": str(trace_id)}, timeout_ms=30000
@@ -4083,6 +4084,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 any(output_str_list) AS output_str_list
             FROM tracer_eval_logger FINAL
             WHERE _peerdb_is_deleted = 0
+              AND (deleted = 0 OR deleted IS NULL)
               AND trace_id = %(trace_id)s
               AND custom_eval_config_id IN %(eval_config_ids)s
             GROUP BY trace_id, custom_eval_config_id
@@ -4937,6 +4939,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
                 "FROM tracer_eval_logger FINAL "
                 "WHERE _peerdb_is_deleted = 0 "
+                "AND (deleted = 0 OR deleted IS NULL) "
                 "AND dictGet('trace_dict', 'project_id', "
                 "trace_id) = toUUID(%(pid)s)",
                 {"pid": str(project_id)},
@@ -5209,6 +5212,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
             "FROM tracer_eval_logger FINAL "
             "WHERE _peerdb_is_deleted = 0 "
+            "AND (deleted = 0 OR deleted IS NULL) "
             "AND dictGet('trace_dict', 'project_id', "
             "trace_id) = toUUID(%(pid)s)",
             {"pid": str(project_id)},
@@ -5504,6 +5508,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
             "FROM tracer_eval_logger FINAL "
             "WHERE _peerdb_is_deleted = 0 "
+            "AND (deleted = 0 OR deleted IS NULL) "
             "AND dictGet('trace_dict', 'project_id', "
             "trace_id) = toUUID(%(pid)s)",
             {"pid": project_id},

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -553,6 +553,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                 WHERE trace_id IN %(trace_ids)s
                   AND custom_eval_config_id IN %(config_ids)s
                   AND _peerdb_is_deleted = 0
+                  AND (deleted = 0 OR deleted IS NULL)
                   AND output_str != 'ERROR'
                   AND (error = 0 OR error IS NULL)
                 GROUP BY trace_id, custom_eval_config_id


### PR DESCRIPTION
## Problem
Deleting an eval task left its evaluation results behind and still showing in the UI:

1. **Single delete** (`DELETE /tracer/eval-task/{id}/`) used DRF's default `destroy()`, which only soft-deleted the `EvalTask` itself — its `EvalTaskLogger` and `EvalLogger` (results) rows were orphaned. (The bulk `mark_eval_tasks_deleted` already cascaded.)
2. **ClickHouse eval queries** filtered only on `_peerdb_is_deleted = 0` (PeerDB's *hard*-delete marker). Soft deletes are PG `UPDATE deleted=true`, which CDC replicates as `deleted=1` while `_peerdb_is_deleted` stays `0`. So soft-deleted eval results **leaked** into eval column discovery, scores, metric charts, monitors, and eval filters.

## Changes
**Commit 1 — delete cascade + FE copy + tests**
- `EvalTaskView.perform_destroy` now cascades the soft-delete to `EvalTaskLogger` and `EvalLogger`, matching the bulk path.
- Delete confirmation modal copy now warns that all evaluation results will be deleted.
- Tests added for the cascade on both single and bulk delete paths.

**Commit 2 — ClickHouse soft-delete filter**
- Added `AND (deleted = 0 OR deleted IS NULL)` alongside the existing `_peerdb_is_deleted = 0` on every CH read of `tracer_eval_logger` (kept the hard-delete guard). 16 query sites across query builders (`trace_list`, `span_list`, `eval_metrics`, `monitor_metrics`, `voice_call_list`, `filters`), `query_service`, and views (`trace`, `trace_session`, `observation_span`).
- Verified the target CH table has the `deleted` column; matches the predicate already used in the sites that filtered correctly.
- PG/ORM eval reads already exclude soft deletes via `BaseModelManager`, so they're unchanged.

## Verification
- Local CH: a deleted task's config went from **10 → 0** rows under the new filter; a non-deleted task's config still returns its rows (no regression).
- `tracer/tests/test_eval_task.py`: **38 passed**.

## Affected UI surfaces to QA
Traces (list/detail, eval columns, eval-value & has-eval filters), Spans (list/observe), Sessions (detail), Voice calls (list/detail), eval metric charts (`get_graph_methods`), eval names dropdown (`get_eval_names`), and monitor/alert eval graphs.

## Follow-up (out of scope)
`futureagi/tracer/socket.py` has **Postgres** raw-SQL `tracer_eval_logger` queries with no `deleted` guard (bypasses the ORM manager) — same class of leak on the PG side, worth a separate fix.