### PR TITLE
feat(model_config): add Gemini 3.5 Flash on Vertex AI

### DIFF
--- a/futureagi/agentic_eval/core/utils/model_config.py
+++ b/futureagi/agentic_eval/core/utils/model_config.py
@@ -119,6 +119,13 @@ class ModelConfigs:
         supports_pdf=True,
     )
 
+    VERTEX_GEMINI_3_5_FLASH: Final[ModelConfig] = ModelConfig(
+        provider=LiteLlmProvider.VERTEX_AI.value,
+        model_name="vertex_ai/gemini-3.5-flash",
+        temperature=0.2,
+        max_tokens=8100,
+    )
+
     CLAUDE_4_5_SONNET_BEDROCK_ARN: Final[ModelConfig] = ModelConfig(
         provider=LiteLlmProvider.AWS_BEDROCK_ANTHROPIC.value,
         model_name=os.environ.get("BEDROCK_SONNET_ARN", ""),


### PR DESCRIPTION
Adds a `VERTEX_GEMINI_3_5_FLASH` entry to `ModelConfigs` so the registry covers the latest Gemini Flash tier alongside 2.5 / 3.1.

`max_tokens=8100` reflects the model's actual output cap (Gemini Flash tops out around 8k regardless of what the request asks for) — the 50k value used elsewhere in this file is the legacy default for Claude/long-context models and not appropriate here.

Single-file, additive, no behavior change for any existing caller.