### PR TITLE
Fix/dataset pre fetching issue

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -300,8 +300,8 @@ const getDataSource = (
           if (!isLastPage) {
             const totalPages = totalRows
               ? Math.ceil(totalRows / DATASET_ROWS_LIMIT)
-              : Infinity;
-              
+              : pageNumber + 1;
+
             [pageNumber + 1, pageNumber + 2]
               .filter((page) => page < totalPages)
               .forEach((page) => {
@@ -925,6 +925,27 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
     const search = useDevelopSearchStore.getState().search;
     const validFilters = filters.filter(validateFilter).map(transformFilter);
 
+    const maxActivePage = activePages.length
+      ? Math.max(...activePages)
+      : currentPage;
+    const totalRowCount =
+      gridApiRef?.current?.api?.getGridOption("context")?.totalRowCount;
+    const lastPage = totalRowCount
+      ? Math.ceil(totalRowCount / DATASET_ROWS_LIMIT) - 1
+      : maxActivePage;
+    const endPage = Math.min(maxActivePage + 2, lastPage);
+    for (let p = Math.max(0, currentPage - 1); p <= endPage; p++) {
+      const { queryKey } = getDatasetQueryOptions(
+        dataset,
+        p,
+        validFilters,
+        sort,
+        search,
+        {},
+      );
+      queryClient.invalidateQueries({ queryKey });
+    }
+
     // Process pages in batches of 3 to avoid overwhelming the server
     const totalPages = pagesToRefresh.length;
 
@@ -1217,6 +1238,7 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
                   pagination={false}
                   cacheBlockSize={DATASET_ROWS_LIMIT}
                   rowBuffer={10}
+                  maxBlocksInCache={50}
                   suppressServerSideFullWidthLoadingRow={true}
                   serverSideInitialRowCount={DATASET_ROWS_LIMIT}
                   statusBar={statusBar}
@@ -1312,7 +1334,7 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
                     gridApiRef,
                     updateProcessingSyntheticData,
                   }}
-                  blockLoadDebounceMillis={100}
+                  blockLoadDebounceMillis={300}
                 />
               </>
             ) : (

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -519,7 +519,7 @@ const getAverageColumnConfig = (columns, tableRows) => {
     },
   ];
 };
-const DATASET_ROWS_LIMIT = 30;
+const DATASET_ROWS_LIMIT = 50;
 const BATCH_SIZE = 3;
 
 const DevelopDataV2 = ({ datasetId, viewOptions }) => {
@@ -1284,7 +1284,7 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
                     gridApiRef,
                     updateProcessingSyntheticData,
                   }}
-                  blockLoadDebounceMillis={300}
+                  blockLoadDebounceMillis={100}
                 />
               </>
             ) : (

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -216,9 +216,18 @@ const getDataSource = (
           validFilters,
           sort,
           search,
-          { enabled: true, staleTime: 0, pageSize: DATASET_ROWS_LIMIT },
+          { enabled: true, staleTime: 5 * 1000, pageSize: DATASET_ROWS_LIMIT },
         );
-        const data = await queryClient.fetchQuery({ ...queryOptions });
+      
+        // If this page is already in the cache and has not been marked
+        // changed, reuse it instantly; otherwise fetch it from the server.
+        const cachedState = queryClient.getQueryState(queryOptions.queryKey);
+        const servedFromCache =
+          cachedState?.data !== undefined && !cachedState.isInvalidated;
+        const data = servedFromCache
+          ? cachedState.data
+          : await queryClient.fetchQuery({ ...queryOptions });
+      
         const processingData = data?.data?.result?.isProcessingData;
 
         useProcessingStore.getState().setIsProcessingData(processingData);
@@ -280,17 +289,37 @@ const getDataSource = (
             rowCount: lastRow,
           });
 
-          // Prefetch next page so scroll feels instant
+          // Prefetch the next two pages so scrolling stays ahead of the
+          // network and never shows the 2-3s block loader. Pages past the
+          // end of the dataset are skipped — e.g. on the second-to-last
+          // page only the last page is prefetched, not a non-existent one.
+          // A prefetched page is reused only while it is still fresh when
+          // getRows consumes it — that is why this and the fetchQuery
+          // above use staleTime 5s; with staleTime 0 the page is stale on
+          // arrival and getRows fetches it again, wasting the prefetch.
           if (!isLastPage) {
-            const nextPageOptions = getDatasetQueryOptions(
-              datasetId,
-              pageNumber + 1,
-              validFilters,
-              sort,
-              search,
-              { enabled: true, staleTime: 0, pageSize: DATASET_ROWS_LIMIT },
-            );
-            queryClient.prefetchQuery({ ...nextPageOptions });
+            const totalPages = totalRows
+              ? Math.ceil(totalRows / DATASET_ROWS_LIMIT)
+              : Infinity;
+              
+            [pageNumber + 1, pageNumber + 2]
+              .filter((page) => page < totalPages)
+              .forEach((page) => {
+                queryClient.prefetchQuery(
+                  getDatasetQueryOptions(
+                    datasetId,
+                    page,
+                    validFilters,
+                    sort,
+                    search,
+                    {
+                      enabled: true,
+                      staleTime: 5 * 1000,
+                      pageSize: DATASET_ROWS_LIMIT,
+                    },
+                  ),
+                );
+              });
           }
         }
       } catch (e) {
@@ -519,7 +548,7 @@ const getAverageColumnConfig = (columns, tableRows) => {
     },
   ];
 };
-const DATASET_ROWS_LIMIT = 50;
+const DATASET_ROWS_LIMIT = 30;
 const BATCH_SIZE = 3;
 
 const DevelopDataV2 = ({ datasetId, viewOptions }) => {
@@ -1188,7 +1217,6 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
                   pagination={false}
                   cacheBlockSize={DATASET_ROWS_LIMIT}
                   rowBuffer={10}
-                  maxBlocksInCache={5}
                   suppressServerSideFullWidthLoadingRow={true}
                   serverSideInitialRowCount={DATASET_ROWS_LIMIT}
                   statusBar={statusBar}


### PR DESCRIPTION
## Summary
- Scrolling the develop Datasets grid showed a 2-3s loader on every new
  block because each page was fetched on demand with `staleTime: 0`.
- `getRows` now prefetches the next two pages and reuses cached pages
  directly, so scrolling stays ahead of the network. Column-run polling
  still refetches because it invalidates those pages — and now invalidates
  the full prefetch window (not just AG Grid's loaded blocks) so prefetched
  pages can't render stale during a column run / synthetic-fill.
- `maxBlocksInCache={50}` keeps AG Grid's in-memory blocks bounded
  (~1,500 rows of look-back) so they don't accumulate without limit on
  large datasets.

## Test plan
- [x] Open a dataset and scroll down — new pages appear with no 2-3s loader.
- [x] On the second-to-last page, no request fires for a page past the end.
- [x] Run a prompt/eval on a column — rows still update live while it runs.
- [x] Scroll forward two pages while a column run is active — cell values stay live, not snapshot-frozen.
- [x] Scroll back up to earlier pages — still instant, no refetch.

Closes TH-4768