### PR TITLE
feat(evals): add dead_air_detection system code eval (TH-5461)

### DIFF
--- a/futureagi/evaluations/catalog/system_eval_code.py
+++ b/futureagi/evaluations/catalog/system_eval_code.py
@@ -614,6 +614,56 @@ def evaluate(real_images, fake_images, **kwargs):
 '''
 
 
+DEAD_AIR_DETECTION = '''def evaluate(input, output, expected, context, **kwargs):
+    """Detect dead air (silence) in an audio conversation.
+
+    Audio decoding + RMS / silence-gap computation runs in the API-server
+    preprocessor (librosa is not in the sandbox allowlist and the sandbox
+    has no network access). This body just reads pre-computed numbers and
+    applies user-tunable thresholds.
+
+    Kwargs from preprocessor:
+        _dead_air_percentage: float, % of audio below the silence threshold
+        _dead_air_max_gap_ms: float, longest single silent run in ms
+        _dead_air_duration_sec: float, total audio duration
+        _dead_air_error: str, populated if preprocessing failed
+
+    User-tunable kwargs (see eval template config):
+        dead_air_threshold: float, max acceptable % of dead air (default 20.0)
+        gap_threshold_ms: float, max acceptable single silence gap in ms (default 3000)
+    """
+    err = kwargs.get("_dead_air_error")
+    if err:
+        return {"score": 0.0, "reason": f"Dead air analysis unavailable: {err}"}
+
+    dead_air_pct = kwargs.get("_dead_air_percentage")
+    max_gap_ms = kwargs.get("_dead_air_max_gap_ms")
+    if dead_air_pct is None or max_gap_ms is None:
+        return {"score": 0.0, "reason": "Dead air analysis unavailable: preprocessing did not run"}
+
+    try:
+        dead_air_threshold = float(kwargs.get("dead_air_threshold", 20.0))
+    except (TypeError, ValueError):
+        dead_air_threshold = 20.0
+    try:
+        gap_threshold_ms = float(kwargs.get("gap_threshold_ms", 3000.0))
+    except (TypeError, ValueError):
+        gap_threshold_ms = 3000.0
+
+    dead_air_passed = dead_air_pct <= dead_air_threshold
+    gap_passed = max_gap_ms <= gap_threshold_ms
+    passed = dead_air_passed and gap_passed
+
+    reason = (
+        f"Dead air: {dead_air_pct:.1f}% "
+        f"({'pass' if dead_air_passed else 'fail'}, threshold {dead_air_threshold:.1f}%). "
+        f"Max silence gap: {max_gap_ms:.0f}ms "
+        f"({'pass' if gap_passed else 'fail'}, threshold {gap_threshold_ms:.0f}ms)."
+    )
+    return {"score": 1.0 if passed else 0.0, "reason": reason}
+'''
+
+
 # =============================================================================
 # Registry: eval_name → code string
 # =============================================================================
@@ -653,4 +703,5 @@ CODE_REGISTRY = {
     "answer_similarity": ANSWER_SIMILARITY,
     "clip_score": CLIP_SCORE,
     "fid_score": FID_SCORE,
+    "dead_air_detection": DEAD_AIR_DETECTION,
 }

--- a/futureagi/evaluations/engine/preprocessing.py
+++ b/futureagi/evaluations/engine/preprocessing.py
@@ -390,74 +390,47 @@ def _preprocess_ssim(inputs):
     return inputs
 
 
-def _resolve_audio_input_to_bytes(value):
-    """Resolve an audio input (URL / data URI / local path / bytes) to raw bytes.
-
-    Returns ``(bytes, source_kind)`` on success, or ``None`` if the input is
-    empty or unreachable. SSRF guard mirrors the image path.
-    """
-    if value is None or value == "":
-        return None
-    if isinstance(value, (bytes, bytearray)):
-        return bytes(value), "bytes"
-    if not isinstance(value, str):
-        return None
-    stripped = value.strip()
-    if not stripped:
-        return None
-    if stripped.startswith("data:"):
-        try:
-            header, payload = stripped.split(",", 1)
-        except ValueError:
-            return None
-        if ";base64" in header:
-            try:
-                return base64.b64decode(payload), "data_uri"
-            except Exception:
-                return None
-        return None
-    if stripped.startswith(("http://", "https://")):
-        fetched = _fetch_url_bytes(stripped)
-        if fetched is None:
-            return None
-        data, _ = fetched
-        return data, "url"
-    if os.path.isfile(stripped):
-        try:
-            with open(stripped, "rb") as f:
-                return f.read(), "path"
-        except Exception:
-            return None
-    return None
-
-
 @register_preprocessor("dead_air_detection")
 def _preprocess_dead_air_detection(inputs):
     """Compute silence statistics on the backend so the sandbox stays audio-free.
 
     librosa lives in the API image but is not in the sandbox allowlist, and
     the sandbox has no network access — so we resolve the audio URL here,
-    decode with librosa/soundfile, and pass the derived numbers to the
-    sandbox as ``_dead_air_*`` kwargs.
+    decode with librosa, and pass the derived numbers to the sandbox as
+    ``_dead_air_*`` kwargs.
+
+    `pad_silence=False` is critical here: the canonical loader will otherwise
+    pad short clips with synthetic silence to meet the STT min-duration, which
+    would inflate the dead-air metric we're trying to measure.
     """
     audio_value = inputs.get("input_audio")
     if audio_value is None or audio_value == "":
         inputs["_dead_air_error"] = "Missing input_audio"
         return inputs
 
-    fetched = _resolve_audio_input_to_bytes(audio_value)
-    if fetched is None:
-        inputs["_dead_air_error"] = "Could not load audio input (unsupported URL, fetch blocked, or empty)"
+    try:
+        from tfc.utils.storage import audio_bytes_from_url_or_base64
+    except ImportError as e:
+        logger.warning("dead_air_preprocess_import_failed", error=str(e))
+        inputs["_dead_air_error"] = f"Audio loader unavailable: {e}"
         return inputs
 
-    audio_bytes, _ = fetched
+    try:
+        audio_bytes = audio_bytes_from_url_or_base64(
+            audio_value,
+            min_duration_seconds=None,
+            pad_silence=False,
+        )
+    except Exception as e:
+        logger.warning("dead_air_preprocess_load_failed", error=str(e))
+        inputs["_dead_air_error"] = f"Could not load audio: {e}"
+        return inputs
 
     try:
         import io
         import librosa
-        import numpy as np
     except ImportError as e:
-        logger.warning("dead_air_preprocess_import_failed", error=str(e))
+        logger.warning("dead_air_preprocess_librosa_missing", error=str(e))
         inputs["_dead_air_error"] = f"Audio analysis unavailable: {e}"
         return inputs
 

--- a/futureagi/evaluations/engine/preprocessing.py
+++ b/futureagi/evaluations/engine/preprocessing.py
@@ -390,6 +390,131 @@ def _preprocess_ssim(inputs):
     return inputs
 
 
+def _resolve_audio_input_to_bytes(value):
+    """Resolve an audio input (URL / data URI / local path / bytes) to raw bytes.
+
+    Returns ``(bytes, source_kind)`` on success, or ``None`` if the input is
+    empty or unreachable. SSRF guard mirrors the image path.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value), "bytes"
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if stripped.startswith("data:"):
+        try:
+            header, payload = stripped.split(",", 1)
+        except ValueError:
+            return None
+        if ";base64" in header:
+            try:
+                return base64.b64decode(payload), "data_uri"
+            except Exception:
+                return None
+        return None
+    if stripped.startswith(("http://", "https://")):
+        fetched = _fetch_url_bytes(stripped)
+        if fetched is None:
+            return None
+        data, _ = fetched
+        return data, "url"
+    if os.path.isfile(stripped):
+        try:
+            with open(stripped, "rb") as f:
+                return f.read(), "path"
+        except Exception:
+            return None
+    return None
+
+
+@register_preprocessor("dead_air_detection")
+def _preprocess_dead_air_detection(inputs):
+    """Compute silence statistics on the backend so the sandbox stays audio-free.
+
+    librosa lives in the API image but is not in the sandbox allowlist, and
+    the sandbox has no network access — so we resolve the audio URL here,
+    decode with librosa/soundfile, and pass the derived numbers to the
+    sandbox as ``_dead_air_*`` kwargs.
+    """
+    audio_value = inputs.get("input_audio")
+    if audio_value is None or audio_value == "":
+        inputs["_dead_air_error"] = "Missing input_audio"
+        return inputs
+
+    fetched = _resolve_audio_input_to_bytes(audio_value)
+    if fetched is None:
+        inputs["_dead_air_error"] = "Could not load audio input (unsupported URL, fetch blocked, or empty)"
+        return inputs
+
+    audio_bytes, _ = fetched
+
+    try:
+        import io
+        import librosa
+        import numpy as np
+    except ImportError as e:
+        logger.warning("dead_air_preprocess_import_failed", error=str(e))
+        inputs["_dead_air_error"] = f"Audio analysis unavailable: {e}"
+        return inputs
+
+    try:
+        silence_threshold = float(inputs.get("silence_threshold", 0.01))
+    except (TypeError, ValueError):
+        silence_threshold = 0.01
+
+    try:
+        y, sr = librosa.load(io.BytesIO(audio_bytes), sr=None)
+    except Exception as e:
+        logger.warning("dead_air_preprocess_decode_failed", error=str(e))
+        inputs["_dead_air_error"] = f"Could not decode audio: {e}"
+        return inputs
+
+    duration = float(librosa.get_duration(y=y, sr=sr))
+    if duration <= 0:
+        inputs["_dead_air_error"] = "Audio has zero duration"
+        return inputs
+
+    frame_length = max(1, int(0.1 * sr))
+    hop_length = max(1, frame_length // 2)
+    rms = librosa.feature.rms(y=y, frame_length=frame_length, hop_length=hop_length)[0]
+
+    silent_frames = rms < silence_threshold
+    total_frames = len(rms)
+    dead_air_duration = float(silent_frames.sum()) * (hop_length / sr)
+    dead_air_percentage = (dead_air_duration / duration) * 100.0
+
+    gaps_ms = []
+    in_gap = False
+    gap_start = 0
+    for i, is_silent in enumerate(silent_frames):
+        if is_silent and not in_gap:
+            in_gap = True
+            gap_start = i
+        elif not is_silent and in_gap:
+            in_gap = False
+            gaps_ms.append((i - gap_start) * (hop_length / sr) * 1000.0)
+    if in_gap:
+        gaps_ms.append((total_frames - gap_start) * (hop_length / sr) * 1000.0)
+    max_gap_ms = float(max(gaps_ms)) if gaps_ms else 0.0
+
+    inputs["_dead_air_percentage"] = float(dead_air_percentage)
+    inputs["_dead_air_max_gap_ms"] = max_gap_ms
+    inputs["_dead_air_duration_sec"] = duration
+    inputs["_dead_air_silence_threshold"] = silence_threshold
+
+    logger.info(
+        "dead_air_preprocessed",
+        duration_sec=round(duration, 2),
+        dead_air_pct=round(dead_air_percentage, 2),
+        max_gap_ms=round(max_gap_ms, 0),
+    )
+    return inputs
+
+
 @register_preprocessor("meteor_score")
 def _preprocess_meteor(inputs):
     """Compute METEOR via NLTK on the backend, inject the score as a kwarg.

--- a/futureagi/evaluations/engine/tests/test_dead_air_preprocessing.py
+++ b/futureagi/evaluations/engine/tests/test_dead_air_preprocessing.py
@@ -1,18 +1,18 @@
 """
 Tests for the dead_air_detection preprocessor.
 
-The preprocessor decodes audio with librosa on the API server and injects
-``_dead_air_*`` kwargs into the sandbox payload. The sandbox body (in
-evaluations/catalog/system_eval_code.py) just reads those numbers and
-applies user-tunable pass/fail thresholds; that logic is trivial enough
-to verify by inspection so we focus tests on the decode/SSRF path here.
+The preprocessor uses ``audio_bytes_from_url_or_base64`` (the canonical
+audio loader in tfc/utils/storage.py) to resolve the input, then decodes
+with librosa and injects ``_dead_air_*`` kwargs for the sandbox body.
+The sandbox body itself is trivial threshold logic and is verified by
+inspection.
 """
 
 from __future__ import annotations
 
 import io
 import math
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -28,19 +28,17 @@ def test_missing_audio_returns_error():
     assert out["_dead_air_error"] == "Missing input_audio"
 
 
-def test_unresolvable_input_returns_error():
-    out = preprocess_inputs("dead_air_detection", {"input_audio": "not-a-url"})
-    assert "_dead_air_error" in out
-
-
-def test_blocked_host_never_fetches():
-    with patch("evaluations.engine.preprocessing.requests.get") as mock_get:
+def test_loader_failure_returns_error():
+    with patch(
+        "tfc.utils.storage.audio_bytes_from_url_or_base64",
+        side_effect=ValueError("not a valid audio source"),
+    ):
         out = preprocess_inputs(
             "dead_air_detection",
-            {"input_audio": "http://169.254.169.254/audio.wav"},
+            {"input_audio": "not-a-url"},
         )
-        mock_get.assert_not_called()
     assert "_dead_air_error" in out
+    assert "not a valid audio source" in out["_dead_air_error"]
 
 
 def _synth_wav_bytes(duration_sec=2.0, sr=8000, silence_segments=None):
@@ -59,26 +57,11 @@ def _synth_wav_bytes(duration_sec=2.0, sr=8000, silence_segments=None):
     return buf.getvalue()
 
 
-def _mock_audio_response(body):
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.headers = {"Content-Type": "audio/wav"}
-
-    def _iter(chunk_size=64 * 1024):
-        for i in range(0, len(body), chunk_size):
-            yield body[i:i + chunk_size]
-
-    resp.iter_content = _iter
-    resp.__enter__.return_value = resp
-    resp.__exit__.return_value = False
-    return resp
-
-
 def test_clean_audio_has_low_dead_air():
     body = _synth_wav_bytes(duration_sec=1.0, silence_segments=None)
     with patch(
-        "evaluations.engine.preprocessing.requests.get",
-        return_value=_mock_audio_response(body),
+        "tfc.utils.storage.audio_bytes_from_url_or_base64",
+        return_value=body,
     ):
         out = preprocess_inputs(
             "dead_air_detection",
@@ -95,8 +78,8 @@ def test_silent_audio_is_mostly_dead_air():
         silence_segments=[(0.0, 1.6)],
     )
     with patch(
-        "evaluations.engine.preprocessing.requests.get",
-        return_value=_mock_audio_response(body),
+        "tfc.utils.storage.audio_bytes_from_url_or_base64",
+        return_value=body,
     ):
         out = preprocess_inputs(
             "dead_air_detection",
@@ -105,3 +88,19 @@ def test_silent_audio_is_mostly_dead_air():
     assert "_dead_air_error" not in out
     assert out["_dead_air_percentage"] > 50.0
     assert out["_dead_air_max_gap_ms"] > 1000.0
+
+
+def test_loader_called_with_no_silence_padding():
+    """Padding short audio with synthetic silence would inflate the metric."""
+    body = _synth_wav_bytes(duration_sec=0.5)
+    with patch(
+        "tfc.utils.storage.audio_bytes_from_url_or_base64",
+        return_value=body,
+    ) as mock_loader:
+        preprocess_inputs(
+            "dead_air_detection",
+            {"input_audio": "https://example.com/short.wav"},
+        )
+    _, kwargs = mock_loader.call_args
+    assert kwargs.get("pad_silence") is False
+    assert kwargs.get("min_duration_seconds") is None

--- a/futureagi/evaluations/engine/tests/test_dead_air_preprocessing.py
+++ b/futureagi/evaluations/engine/tests/test_dead_air_preprocessing.py
@@ -1,0 +1,107 @@
+"""
+Tests for the dead_air_detection preprocessor.
+
+The preprocessor decodes audio with librosa on the API server and injects
+``_dead_air_*`` kwargs into the sandbox payload. The sandbox body (in
+evaluations/catalog/system_eval_code.py) just reads those numbers and
+applies user-tunable pass/fail thresholds; that logic is trivial enough
+to verify by inspection so we focus tests on the decode/SSRF path here.
+"""
+
+from __future__ import annotations
+
+import io
+import math
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from evaluations.engine.preprocessing import PREPROCESSORS, preprocess_inputs
+
+
+def test_dead_air_preprocessor_registered():
+    assert "dead_air_detection" in PREPROCESSORS
+
+
+def test_missing_audio_returns_error():
+    out = preprocess_inputs("dead_air_detection", {})
+    assert out["_dead_air_error"] == "Missing input_audio"
+
+
+def test_unresolvable_input_returns_error():
+    out = preprocess_inputs("dead_air_detection", {"input_audio": "not-a-url"})
+    assert "_dead_air_error" in out
+
+
+def test_blocked_host_never_fetches():
+    with patch("evaluations.engine.preprocessing.requests.get") as mock_get:
+        out = preprocess_inputs(
+            "dead_air_detection",
+            {"input_audio": "http://169.254.169.254/audio.wav"},
+        )
+        mock_get.assert_not_called()
+    assert "_dead_air_error" in out
+
+
+def _synth_wav_bytes(duration_sec=2.0, sr=8000, silence_segments=None):
+    try:
+        import numpy as np
+        import soundfile as sf
+    except ImportError:
+        pytest.skip("numpy/soundfile not installed")
+    n = int(duration_sec * sr)
+    t = np.linspace(0, duration_sec, n, endpoint=False)
+    y = 0.5 * np.sin(2 * math.pi * 440 * t).astype("float32")
+    for (s, e) in silence_segments or []:
+        y[int(s * sr):int(e * sr)] = 0.0
+    buf = io.BytesIO()
+    sf.write(buf, y, sr, format="WAV")
+    return buf.getvalue()
+
+
+def _mock_audio_response(body):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"Content-Type": "audio/wav"}
+
+    def _iter(chunk_size=64 * 1024):
+        for i in range(0, len(body), chunk_size):
+            yield body[i:i + chunk_size]
+
+    resp.iter_content = _iter
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def test_clean_audio_has_low_dead_air():
+    body = _synth_wav_bytes(duration_sec=1.0, silence_segments=None)
+    with patch(
+        "evaluations.engine.preprocessing.requests.get",
+        return_value=_mock_audio_response(body),
+    ):
+        out = preprocess_inputs(
+            "dead_air_detection",
+            {"input_audio": "https://example.com/clean.wav"},
+        )
+    assert "_dead_air_error" not in out
+    assert out["_dead_air_percentage"] < 5.0
+    assert out["_dead_air_max_gap_ms"] < 200.0
+
+
+def test_silent_audio_is_mostly_dead_air():
+    body = _synth_wav_bytes(
+        duration_sec=2.0,
+        silence_segments=[(0.0, 1.6)],
+    )
+    with patch(
+        "evaluations.engine.preprocessing.requests.get",
+        return_value=_mock_audio_response(body),
+    ):
+        out = preprocess_inputs(
+            "dead_air_detection",
+            {"input_audio": "https://example.com/silent.wav"},
+        )
+    assert "_dead_air_error" not in out
+    assert out["_dead_air_percentage"] > 50.0
+    assert out["_dead_air_max_gap_ms"] > 1000.0

--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 9
+SYSTEM_EVALS_VERSION = 10
 
 SYSTEM_EVALS_DIR = Path(__file__).resolve().parent.parent.parent / "system_evals"
 CATALOG_YAML = (

--- a/futureagi/model_hub/system_evals/function/dead_air_detection.yaml
+++ b/futureagi/model_hub/system_evals/function/dead_air_detection.yaml
@@ -16,16 +16,22 @@ config:
   - input_audio
   output: Pass/Fail
   eval_type_id: CustomCodeEval
-  config:
+  config: {}
+  function_params_schema:
     dead_air_threshold:
       type: number
       default: 20.0
+      minimum: 0
+      maximum: 100
     gap_threshold_ms:
       type: number
       default: 3000
+      minimum: 0
     silence_threshold:
       type: number
       default: 0.01
+      minimum: 0
+      maximum: 1
   config_params_desc:
     input_audio: The conversation audio to analyse (URL, data URI, or file path)
     dead_air_threshold: Maximum acceptable dead-air percentage (% of total audio duration)

--- a/futureagi/model_hub/system_evals/function/dead_air_detection.yaml
+++ b/futureagi/model_hub/system_evals/function/dead_air_detection.yaml
@@ -1,0 +1,63 @@
+eval_id: 201
+name: dead_air_detection
+description: Detects dead air (silence) in conversation audio using RMS energy analysis. Fails if either the total dead-air percentage or the longest single silence gap exceeds the configured threshold.
+criteria: Check whether the conversation audio stays below the configured dead-air budget (total silence %) and the single-gap budget (longest continuous silence in ms). Return Passed if both budgets hold; otherwise return Failed.
+eval_tags:
+- Audio
+- Voice
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+output_type_normalized: pass_fail
+pass_threshold: 0.5
+config:
+  required_keys:
+  - input_audio
+  output: Pass/Fail
+  eval_type_id: CustomCodeEval
+  config:
+    dead_air_threshold:
+      type: number
+      default: 20.0
+    gap_threshold_ms:
+      type: number
+      default: 3000
+    silence_threshold:
+      type: number
+      default: 0.01
+  config_params_desc:
+    input_audio: The conversation audio to analyse (URL, data URI, or file path)
+    dead_air_threshold: Maximum acceptable dead-air percentage (% of total audio duration)
+    gap_threshold_ms: Maximum acceptable single continuous silence gap (milliseconds)
+    silence_threshold: RMS energy below which a frame is treated as silent (0-1)
+  param_modalities:
+    input_audio:
+    - AUDIO
+  code: |
+    def evaluate(input, output, expected, context, **kwargs):
+        err = kwargs.get("_dead_air_error")
+        if err:
+            return {"score": 0.0, "reason": f"Dead air analysis unavailable: {err}"}
+        dead_air_pct = kwargs.get("_dead_air_percentage")
+        max_gap_ms = kwargs.get("_dead_air_max_gap_ms")
+        if dead_air_pct is None or max_gap_ms is None:
+            return {"score": 0.0, "reason": "Dead air analysis unavailable: preprocessing did not run"}
+        try:
+            dead_air_threshold = float(kwargs.get("dead_air_threshold", 20.0))
+        except (TypeError, ValueError):
+            dead_air_threshold = 20.0
+        try:
+            gap_threshold_ms = float(kwargs.get("gap_threshold_ms", 3000.0))
+        except (TypeError, ValueError):
+            gap_threshold_ms = 3000.0
+        dead_air_passed = dead_air_pct <= dead_air_threshold
+        gap_passed = max_gap_ms <= gap_threshold_ms
+        passed = dead_air_passed and gap_passed
+        reason = (
+            f"Dead air: {dead_air_pct:.1f}% "
+            f"({'pass' if dead_air_passed else 'fail'}, threshold {dead_air_threshold:.1f}%). "
+            f"Max silence gap: {max_gap_ms:.0f}ms "
+            f"({'pass' if gap_passed else 'fail'}, threshold {gap_threshold_ms:.0f}ms)."
+        )
+        return {"score": 1.0 if passed else 0.0, "reason": reason}


### PR DESCRIPTION
## Summary
- New system code eval `dead_air_detection` (eval_id 201) that flags conversations with too much silence.
- Audio decoding + RMS / silence-gap analysis runs in a backend preprocessor (`_preprocess_dead_air_detection`); librosa isn't in the sandbox allowlist and the sandbox has no network access, so the existing CLIP/FID/METEOR pattern of "compute server-side, hand the sandbox precomputed numbers" applies here too.
- Thresholds are user-tunable via `dead_air_threshold` (% of total audio, default 20), `gap_threshold_ms` (longest single gap, default 3000), and `silence_threshold` (RMS floor, default 0.01).

## Files
- `evaluations/engine/preprocessing.py` — `_preprocess_dead_air_detection` + `_resolve_audio_input_to_bytes` helper; reuses the SSRF-guarded fetch path.
- `evaluations/catalog/system_eval_code.py` — `DEAD_AIR_DETECTION` sandbox body + registry entry.
- `model_hub/system_evals/function/dead_air_detection.yaml` — eval template (`required_keys: [input_audio]`, `param_modalities: { input_audio: [AUDIO] }`, configurable thresholds).
- `model_hub/management/commands/seed_system_evals.py` — `SYSTEM_EVALS_VERSION` bumped to 10 so the new template seeds.
- `evaluations/engine/tests/test_dead_air_preprocessing.py` — registration, missing input, SSRF, synthesized clean vs silent WAV.

## Test plan
- [ ] `pytest evaluations/engine/tests/test_dead_air_preprocessing.py -q` passes locally
- [ ] `python manage.py seed_system_evals --dry-run` reports the new template as a create
- [ ] Run `seed_system_evals`; verify `EvalTemplate(name="dead_air_detection")` exists with `eval_type="code"` and `config.code` populated
- [ ] End-to-end: trigger the eval against a sample audio URL with normal speech (expect pass) and one with a long silent stretch (expect fail with reason naming the failing budget)
- [ ] Confirm UI shows audio uploader for `input_audio` and exposes the three configurable thresholds