### PR TITLE
feat(evals): lock composite child picker and polish eval UI

### DIFF
--- a/frontend/src/components/traceDetail/EvalsTabView.jsx
+++ b/frontend/src/components/traceDetail/EvalsTabView.jsx
@@ -584,34 +584,46 @@ const EvalsTabView = ({
           />
         </Box>
         <Box
-          onClick={() =>
-            enqueueSnackbar("Add Evals — coming soon", { variant: "info" })
-          }
           sx={{
             display: "inline-flex",
             alignItems: "center",
             gap: 0.5,
             px: 1,
             py: 0.35,
-            border: "1px solid",
+            border: "1px dashed",
             borderColor: "divider",
             borderRadius: "4px",
-            cursor: "pointer",
             bgcolor: "background.paper",
             flexShrink: 0,
-            "&:hover": { bgcolor: "action.hover" },
+            opacity: 0.7,
           }}
         >
           <Iconify
             icon="mdi:plus-circle-outline"
             width={13}
-            color="text.secondary"
+            color="text.disabled"
           />
           <Typography
-            sx={{ fontSize: 11, fontWeight: 500, color: "text.secondary" }}
+            sx={{ fontSize: 11, fontWeight: 500, color: "text.disabled" }}
           >
             Add Evals
           </Typography>
+          <Box
+            sx={{
+              px: 0.6,
+              py: 0.1,
+              borderRadius: "3px",
+              bgcolor: (theme) => alpha(theme.palette.success.main, 0.16),
+              color: "success.dark",
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 0.2,
+              lineHeight: 1.5,
+              whiteSpace: "nowrap",
+            }}
+          >
+            Coming soon
+          </Box>
         </Box>
       </Box>
 

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1139,12 +1139,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             setEvalName(raw);
             setIsDirty(true);
           }}
-          inputProps={{ maxLength: 50 }}
           error={!isEditMode && evalName.length > 50}
           helperText={
             isEditMode
               ? undefined
-              : evalName.length >= 50
+              : evalName.length > 50
                 ? "Name can't be longer than 50 characters"
                 : `Lowercase letters, numbers, hyphens and underscores only · ${evalName.length}/50`
           }
@@ -1476,7 +1475,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     Code evaluator returns a score between 0 and 1. Set a pass
                     threshold below.
                   </Typography>
-                  <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+                  <Typography typography="s1"  sx={{ mb: 0.5,color:"text.primary" }}>
                     Pass Threshold
                   </Typography>
                   <Typography

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1139,11 +1139,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             setEvalName(raw);
             setIsDirty(true);
           }}
-          error={!isEditMode && evalName.length > 50}
+          error={!isEditMode && evalName.length > 51}
           helperText={
             isEditMode
               ? undefined
-              : evalName.length > 50
+              : evalName.length > 51
                 ? "Name can't be longer than 50 characters"
                 : `Lowercase letters, numbers, hyphens and underscores only · ${evalName.length}/50`
           }

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1121,7 +1121,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
 
       {/* ── Eval Name ── */}
       <Box sx={{ py: 1.5, flexShrink: 0 }}>
-        <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+        <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
           Name<span style={{ color: "#d32f2f" }}>*</span>
         </Typography>
         <TextField
@@ -1464,7 +1464,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
               {/* Output Type (not applicable to composites) */}
               {isComposite ? null : evalType === "code" ? (
                 <Box>
-                  <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+                  <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
                     Scoring
                   </Typography>
                   <Typography
@@ -1475,7 +1475,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     Code evaluator returns a score between 0 and 1. Set a pass
                     threshold below.
                   </Typography>
-                  <Typography typography="s1"  sx={{ mb: 0.5,color:"text.primary" }}>
+                  <Typography variant="subtitle2"  sx={{ mb: 0.5,color:"text.primary" }}>
                     Pass Threshold
                   </Typography>
                   <Typography
@@ -1769,7 +1769,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
 
                 {source !== "composite" && visibleCodeParamEntries.length > 0 && (
                   <Box sx={{ mt: 2 }}>
-                    <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
+                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
                       Parameters
                     </Typography>
                     {visibleCodeParamEntries.map(([key, schema]) => (

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1140,13 +1140,13 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             setIsDirty(true);
           }}
           inputProps={{ maxLength: 50 }}
-          error={!isEditMode && evalName.length >= 50}
+          error={!isEditMode && evalName.length > 50}
           helperText={
             isEditMode
               ? undefined
               : evalName.length >= 50
                 ? "Name can't be longer than 50 characters"
-                : `Use lowercase letters, numbers, hyphens (-) and underscores (_) only. ${evalName.length}/50`
+                : `Lowercase letters, numbers, hyphens and underscores only · ${evalName.length}/50`
           }
           FormHelperTextProps={{ sx: { fontSize: "11px", mt: 0.25, mx: 0 } }}
           sx={{ "& .MuiInputBase-root": { fontSize: "13px", height: 34 } }}
@@ -1468,11 +1468,30 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
                     Scoring
                   </Typography>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ mb: 1.5, display: "block" }}
+                  >
+                    Code evaluator returns a score between 0 and 1. Set a pass
+                    threshold below.
+                  </Typography>
+                  <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+                    Pass Threshold
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ mb: 1, display: "block" }}
+                  >
+                    Scores at or above this threshold are considered a pass.
+                  </Typography>
                   <Box
                     sx={{
                       display: "flex",
                       alignItems: "center",
                       gap: 2,
+                      px: 1,
                     }}
                   >
                     <Typography variant="caption">0</Typography>

--- a/frontend/src/sections/common/EvalPicker/EvalPickerList.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerList.jsx
@@ -612,7 +612,7 @@ const EvalPickerList = ({ onSelectEval }) => {
                 : undefined
             }
           />
-          {!lockedFilters && (
+
             <Button
               size="small"
               variant="outlined"
@@ -629,12 +629,12 @@ const EvalPickerList = ({ onSelectEval }) => {
             >
               Filter{activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
             </Button>
-          )}
+  
         </Box>
       </Box>
 
       {/* Quick tag filters */}
-      {!lockedFilters && (
+    
         <Box
           sx={{
             display: "flex",
@@ -705,7 +705,6 @@ const EvalPickerList = ({ onSelectEval }) => {
             />
           ) : null}
         </Box>
-      )}
 
       {/* Scrollable Table */}
       <TableContainer sx={{ flex: 1, overflow: "auto", minHeight: 0 }}>
@@ -951,6 +950,7 @@ const EvalPickerList = ({ onSelectEval }) => {
         open={Boolean(filterAnchorEl)}
         onClose={() => setFilterAnchorEl(null)}
         currentFilters={filters}
+        lockedFilters={lockedFilters}
         onApply={(newFilters) => {
           setFilters(newFilters);
           setPage(0);

--- a/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.js
+++ b/frontend/src/sections/common/EvalPicker/hooks/useEvalPickerData.js
@@ -20,8 +20,9 @@ export function useEvalPickerData({
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(25);
   const [sorting, setSorting] = useState([{ id: "lastUpdated", desc: true }]);
-  const [filters, setFilters] = useState(null);
-
+  const [filters, setFilters] = useState(
+ null,
+  );
   const debouncedSearch = useDebounce(searchQuery.trim(), 500);
 
   const ownerFilter = filters?.owner || "all";
@@ -31,8 +32,10 @@ export function useEvalPickerData({
     if (filters?.output_type) f.output_type = filters.output_type;
     if (filters?.tags) f.tags = filters.tags;
     // Locked filters override and cannot be removed by the user.
-    if (lockedFilters?.eval_type) f.eval_type = lockedFilters.eval_type;
-    if (lockedFilters?.output_type) f.output_type = lockedFilters.output_type;
+    const lf  =lockedFilters;
+    if (lf?.eval_type) f.eval_type = lf.eval_type;
+    if (lf?.output_type) f.output_type = lf.output_type;
+    if (lf?.template_type) f.template_type = lf.template_type;
     return Object.keys(f).length > 0 ? f : null;
   }, [filters, lockedFilters]);
 
@@ -165,8 +168,10 @@ export function useEvalPickerData({
   const filteredItems = useMemo(() => {
     if (!isUsingOldEndpoint) return items;
     if (!filters && !lockedFilters) return items;
-    const evalTypes = lockedFilters?.eval_type || filters?.eval_type;
-    const outputTypes = lockedFilters?.output_type || filters?.output_type;
+    const lf = lockedFilters;
+    const evalTypes = lf?.eval_type || filters?.eval_type;
+    const outputTypes = lf?.output_type || filters?.output_type;
+    const templateTypes = lf?.template_type;
     const owner = filters?.owner;
     const templateType = filters?.template_type;
     const tags = filters?.tags;
@@ -176,6 +181,8 @@ export function useEvalPickerData({
       if (outputTypes?.length && !outputTypes.includes(it.outputType))
         return false;
       if (owner && owner !== "all" && it.owner !== owner) return false;
+      if (templateTypes?.length && !templateTypes.includes(it.templateType))
+        return false;
       if (templateType && it.templateType !== templateType) return false;
       if (tags?.length && !tags.some((t) => it.evalTemplateTags?.includes(t)))
         return false;

--- a/frontend/src/sections/evals/components/CompositeAxisTabs.jsx
+++ b/frontend/src/sections/evals/components/CompositeAxisTabs.jsx
@@ -29,17 +29,19 @@ export const COMPOSITE_AXIS_OPTIONS = [
 /**
  * Maps a composite_child_axis value to the filters the eval picker
  * should apply so that only children of the matching shape are shown.
+ * Every axis also locks template_type to "single" — a composite cannot
+ * contain another composite.
  */
 export function axisToLockedFilters(axis) {
   switch (axis) {
     case "pass_fail":
-      return { output_type: ["pass_fail"] };
+      return { output_type: ["pass_fail"], template_type: ["single"] };
     case "percentage":
-      return { output_type: ["percentage"] };
+      return { output_type: ["percentage"], template_type: ["single"] };
     case "choices":
-      return { output_type: ["deterministic"] };
+      return { output_type: ["deterministic"], template_type: ["single"] };
     case "code":
-      return { eval_type: ["code"] };
+      return { eval_type: ["code"], template_type: ["single"] };
     default:
       return null;
   }

--- a/frontend/src/sections/evals/components/EvalFilterPanel.jsx
+++ b/frontend/src/sections/evals/components/EvalFilterPanel.jsx
@@ -538,7 +538,7 @@ QueryInput.propTypes = {
 // ---------------------------------------------------------------------------
 // Single filter row (Basic mode)
 // ---------------------------------------------------------------------------
-function FilterRow({ filter, index, onChange, onRemove }) {
+function FilterRow({ filter, index, onChange, onRemove, availableFields }) {
   const fieldDef = FIELD_MAP[filter.field] || FILTER_FIELDS[0];
   const operators = getOperators(fieldDef.type);
 
@@ -557,7 +557,7 @@ function FilterRow({ filter, index, onChange, onRemove }) {
         }}
         sx={{ minWidth: 100, fontSize: "13px", height: 30 }}
       >
-        {FILTER_FIELDS.map((f) => (
+        {availableFields.map((f) => (
           <MenuItem key={f.value} value={f.value} sx={{ fontSize: "13px" }}>
             {f.label}
           </MenuItem>
@@ -685,6 +685,7 @@ FilterRow.propTypes = {
   index: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
+  availableFields: PropTypes.array.isRequired,
 };
 
 // ---------------------------------------------------------------------------
@@ -774,6 +775,7 @@ const EvalFilterPanel = ({
   onClose,
   onApply,
   currentFilters,
+  lockedFilters,
 }) => {
   const [activeTab, setActiveTab] = useState("basic");
   const [aiQuery, setAiQuery] = useState("");
@@ -782,6 +784,16 @@ const EvalFilterPanel = ({
     loading: aiLoading,
     error: aiError,
   } = useAIFilter(AI_FILTER_SCHEMA);
+
+  const lockedFields = useMemo(
+    () => Object.keys(lockedFilters || {}),
+    [lockedFilters],
+  );
+  const availableFields = useMemo(
+    () => FILTER_FIELDS.filter((f) => !lockedFields.includes(f.value)),
+    [lockedFields],
+  );
+
   // Build the UI rows from the API-shaped `currentFilters` object. Each
   // enum field collapses into a single row with an *array* value — the
   // enum FilterRow uses a multi-select Autocomplete and expects one row
@@ -796,6 +808,7 @@ const EvalFilterPanel = ({
         value: [...currentFilters.eval_type],
       });
     }
+
     if (currentFilters?.output_type?.length) {
       initial.push({
         field: "output_type",
@@ -831,10 +844,11 @@ const EvalFilterPanel = ({
         value: currentFilters.search,
       });
     }
-    return initial.length > 0
-      ? initial
+    const visible = initial.filter((r) => !lockedFields.includes(r.field));
+    return visible.length > 0
+      ? visible
       : [{ field: "name", operator: "contains", value: "" }];
-  }, [currentFilters]);
+  }, [currentFilters, lockedFields]);
 
   const [rows, setRows] = useState(buildInitialRows);
 
@@ -1055,6 +1069,7 @@ const EvalFilterPanel = ({
                   index={i}
                   onChange={handleUpdateRow}
                   onRemove={handleRemoveRow}
+                  availableFields={availableFields}
                 />
               ))}
             </Stack>
@@ -1125,6 +1140,7 @@ EvalFilterPanel.propTypes = {
   onClose: PropTypes.func.isRequired,
   onApply: PropTypes.func.isRequired,
   currentFilters: PropTypes.object,
+  lockedFilters: PropTypes.object,
 };
 
 export default EvalFilterPanel;

--- a/frontend/src/sections/evals/components/EvalUsageTab.jsx
+++ b/frontend/src/sections/evals/components/EvalUsageTab.jsx
@@ -626,7 +626,7 @@ const EvalUsageTab = ({
               />
             </Box>
           </Box>
-          <Box sx={{ flex: 1, minHeight: 0 }}>
+          <Box sx={{ flex: 1,overflowY: "auto", minHeight: 0 }}>
             <DataTable
               columns={columns}
               data={filteredLogs}

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -1633,7 +1633,7 @@ const TestPlayground = React.forwardRef(
                                 fontWeight: 600,
                                 fontFamily: "'IBM Plex Sans', sans-serif",
                                 color: isSelected
-                                  ? "common.white"
+                                  ? "primary.contrastText"
                                   : isDefault
                                     ? "info.main"
                                     : "text.primary",


### PR DESCRIPTION
## Summary

- **Composite child picker locked to single evals** — `axisToLockedFilters`
  now also locks `template_type` to `single` for every axis, and
  `useEvalPickerData` applies the lock in both the API query and the
  old-endpoint client-side filter. Composite evals cannot contain other
  composites, so they no longer appear as selectable children.
- **Filter panel respects locked fields** — `EvalFilterPanel` hides any
  locked field from the field dropdown instead of hiding the whole panel,
  so the remaining filters stay usable. `EvalPickerList` keeps the Filter
  button and tag chips visible when filters are locked and passes
  `lockedFilters` through.
- **Coming soon badge** — the Add Evals control in the trace evals tab
  fired an info snackbar for an unbuilt feature; it is now a static,
  non-interactive label with a green Coming soon badge.
- **Code-eval scoring copy** — added the missing scoring description and
  Pass Threshold heading to `EvalPickerConfigFull` so it matches
  `EvalCreatePage`.
- **Eval name helper text** — improved readability (dropped cluttered
  inline symbols, separated the character counter with a middot).
- **Eval usage table** — the logs table is now vertically scrollable
  instead of overflowing the panel.

## Test plan

- [x] Composite Pass/Fail axis → child picker shows only single,
      non-composite evals; no composite rows
- [x] Composite Code axis → only code evals listed
- [x] Filter dropdown in the locked picker omits the locked field
      (Output Type / Eval Type / Type) but other filters still work
- [x] Normal eval picker (no lock) → all fields and composite evals still
      shown
- [x] Trace evals tab → Add Evals shows a Coming soon badge, no snackbar
- [x] Create/edit a code eval → scoring + Pass Threshold descriptions
      render in EvalPickerConfigFull, matching EvalCreatePage
- [x] Eval name field → helper text is readable, counter updates
- [x] Eval usage tab → long log lists scroll within the panel

Closes  TH-5266,TH-5262,TH-5198,TH-5189,TH-5082,TH-5069
