### PR TITLE
feat: add PhoneticSimilarity comparator

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/grounded_evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/grounded_evaluator.py
@@ -1,5 +1,3 @@
-
-
 import time
 
 from agentic_eval.core_evals.fi_metrics.metric_type import MetricType
@@ -13,6 +11,7 @@ from .similarity import (
     JaccardSimilarity,
     JaroWincklerSimilarity,
     NormalisedLevenshteinSimilarity,
+    PhoneticSimilarity,
     SorensenDiceSimilarity,
 )
 
@@ -65,6 +64,8 @@ class GroundedEvaluator(BaseEvaluator):
                 self._comparator = SorensenDiceSimilarity()
             elif comparator_str == "cosinesimilarity":
                 self._comparator = CosineSimilarity()
+            elif comparator_str == "phoneticsimilarity":
+                self._comparator = PhoneticSimilarity()
             else:
                 raise ValueError(f"Invalid comparator: {comparator_str}")
         if failure_threshold is not None and isinstance(failure_threshold, dict):
@@ -76,7 +77,11 @@ class GroundedEvaluator(BaseEvaluator):
 
     def _process_kwargs(self, required_args, **kwargs):
         required_args_map = {
-            key: "\n".join(kwargs[key]) if key == "context" and isinstance(kwargs[key], list) else kwargs[key]
+            key: (
+                "\n".join(kwargs[key])
+                if key == "context" and isinstance(kwargs[key], list)
+                else kwargs[key]
+            )
             for key in required_args
         }
         if len(required_args_map) == 2:
@@ -97,9 +102,12 @@ class GroundedEvaluator(BaseEvaluator):
             config["failure_threshold"] = self._failure_threshold
         return config
 
-
     def is_failure(self, score) -> bool | None:
-        return bool(score < self._failure_threshold) if self._failure_threshold is not None else None
+        return (
+            bool(score < self._failure_threshold)
+            if self._failure_threshold is not None
+            else None
+        )
 
     def _evaluate(self, **kwargs) -> EvalResult:
         """
@@ -114,7 +122,11 @@ class GroundedEvaluator(BaseEvaluator):
             string1, string2 = self._process_kwargs(self.required_args, **kwargs)
             # Calculate the similarity score using the comparator
             similarity_score = self._comparator.compare(string1, string2)
-            metrics.append(EvalResultMetric(id=MetricType.SIMILARITY_SCORE.value, value=similarity_score))
+            metrics.append(
+                EvalResultMetric(
+                    id=MetricType.SIMILARITY_SCORE.value, value=similarity_score
+                )
+            )
             if self._failure_threshold is None:
                 explanation = f"Successfully calculated similarity score of {similarity_score} using {self.display_name}"
             elif bool(similarity_score < self._failure_threshold):
@@ -142,4 +154,3 @@ class GroundedEvaluator(BaseEvaluator):
             datapoint_field_annotations=None,
         )
         return eval_result
-

--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
@@ -8,6 +8,7 @@ class Comparator(ABC):
     def compare(self, string1, string2):
         pass
 
+
 class CosineSimilarity(Comparator):
     def compare(self, string1, string2):
         # Tokenize and create a combined set of unique words
@@ -15,7 +16,7 @@ class CosineSimilarity(Comparator):
         # Vectorize the strings
         vector1 = self._vectorize(string1, combined_set)
         vector2 = self._vectorize(string2, combined_set)
-        dot_product = sum(p*q for p, q in zip(vector1, vector2, strict=False))
+        dot_product = sum(p * q for p, q in zip(vector1, vector2, strict=False))
         magnitude_vec1 = math.sqrt(sum([val**2 for val in vector1]))
         magnitude_vec2 = math.sqrt(sum([val**2 for val in vector2]))
         if magnitude_vec1 * magnitude_vec2 == 0:
@@ -33,7 +34,7 @@ class CosineSimilarity(Comparator):
         Returns:
             list: A list of lowercased words from the string.
         """
-        return re.findall(r'\b\w+\b', string.lower())
+        return re.findall(r"\b\w+\b", string.lower())
 
     def _create_combined_set(self, string1, string2):
         return set(self._tokenize(string1)).union(set(self._tokenize(string2)))
@@ -43,12 +44,16 @@ class CosineSimilarity(Comparator):
         vector = [tokenized.count(word) for word in combined_set]
         return vector
 
+
 class NormalisedLevenshteinSimilarity(Comparator):
     def compare(self, string1, string2):
         return 1 - self._normalised_levenshtein_distance(string1, string2)
 
     def _normalised_levenshtein_distance(self, str1, str2):
         m, n = len(str1), len(str2)
+        # ZeroDivisionError
+        if not str1 and not str2:
+            return 0.0
         # Create a matrix to store the distances
         dp = [[0] * (n + 1) for _ in range(m + 1)]
         # Initialize the first row and first column
@@ -62,12 +67,12 @@ class NormalisedLevenshteinSimilarity(Comparator):
                 if str1[i - 1] == str2[j - 1]:
                     dp[i][j] = dp[i - 1][j - 1]
                 else:
-                    dp[i][j] = 1 + min(dp[i - 1][j], dp[i]
-                                    [j - 1], dp[i - 1][j - 1])
-        if (len(str1) >= len(str2)):
+                    dp[i][j] = 1 + min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+        if len(str1) >= len(str2):
             return dp[m][n] / len(str1)
         else:
             return dp[m][n] / len(str2)
+
 
 class JaroWincklerSimilarity(Comparator):
     def compare(self, string1, string2):
@@ -103,20 +108,98 @@ class JaroWincklerSimilarity(Comparator):
         t //= 2
         return (match / len1 + match / len2 + (match - t) / match) / 3.0
 
+
 class JaccardSimilarity(Comparator):
     def compare(self, string1, string2):
         return self._jaccard_similarity(string1, string2)
 
     def _jaccard_similarity(self, str1, str2):
-        str1_tokens = set(str1.split())
-        str2_tokens = set(str2.split())
-        return len(str1_tokens.intersection(str2_tokens)) / len(str1_tokens.union(str2_tokens))
+        str1_tokens = set(str1.lower().split())
+        str2_tokens = set(str2.lower().split())
+        return len(str1_tokens.intersection(str2_tokens)) / len(
+            str1_tokens.union(str2_tokens)
+        )
+
 
 class SorensenDiceSimilarity(Comparator):
     def compare(self, string1, string2):
         return self._sorensen_dice_similarity(string1, string2)
 
     def _sorensen_dice_similarity(self, str1, str2):
-        str1_tokens = set(str1.split())
-        str2_tokens = set(str2.split())
-        return 2 * len(str1_tokens.intersection(str2_tokens)) / (len(str1_tokens) + len(str2_tokens))
+        str1_tokens = set(str1.lower().split())
+        str2_tokens = set(str2.lower().split())
+        return (
+            2
+            * len(str1_tokens.intersection(str2_tokens))
+            / (len(str1_tokens) + len(str2_tokens))
+        )
+
+
+class PhoneticSimilarity(Comparator):
+    """
+    Compares string similarity based on how words sound phonetically.
+    Useful for evaluation paths prone to transcription or speech abnormalities.
+    """
+
+    SOUNDEX_MAP = {
+        "B": "1",
+        "F": "1",
+        "P": "1",
+        "V": "1",
+        "C": "2",
+        "G": "2",
+        "J": "2",
+        "K": "2",
+        "Q": "2",
+        "S": "2",
+        "X": "2",
+        "Z": "2",
+        "D": "3",
+        "T": "3",
+        "L": "4",
+        "M": "5",
+        "N": "5",
+        "R": "6",
+    }
+
+    def _get_soundex_code(self, word: str) -> str:
+        word = word.upper()
+        if not word or not word[0].isalpha():
+            return "0000"
+
+        first_letter = word[0]
+        first_code = self.SOUNDEX_MAP.get(first_letter, "")
+
+        encoded_tail = []
+        for char in word[1:]:
+            code = self.SOUNDEX_MAP.get(char, "")
+            if not code:
+                continue
+            # Skip if same as previous code OR matches first letter's code on first entry
+            if encoded_tail and encoded_tail[-1] == code:
+                continue
+            if not encoded_tail and code == first_code:
+                continue
+            encoded_tail.append(code)
+
+        soundex = (first_letter + "".join(encoded_tail) + "000")[:4]
+        return soundex
+
+    def _tokenize(self, string: str) -> list[str]:
+        return re.findall(r"\b\w+\b", string.lower())
+
+    def _to_soundex_tokens(self, string: str) -> list[str]:
+        return [self._get_soundex_code(token) for token in self._tokenize(string)]
+
+    def compare(self, string1: str, string2: str) -> float:
+        tokens1 = self._to_soundex_tokens(string1)
+        tokens2 = self._to_soundex_tokens(string2)
+
+        if not tokens1 and not tokens2:
+            return 1.0
+        if not tokens1 or not tokens2:
+            return 0.0
+
+        # Token-level comparison: match each token in tokens1 to best in tokens2
+        matches = sum(1 for t in tokens1 if t in set(tokens2))
+        return matches / max(len(tokens1), len(tokens2))

--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
@@ -51,9 +51,6 @@ class NormalisedLevenshteinSimilarity(Comparator):
 
     def _normalised_levenshtein_distance(self, str1, str2):
         m, n = len(str1), len(str2)
-        # ZeroDivisionError
-        if not str1 and not str2:
-            return 0.0
         # Create a matrix to store the distances
         dp = [[0] * (n + 1) for _ in range(m + 1)]
         # Initialize the first row and first column
@@ -114,10 +111,8 @@ class JaccardSimilarity(Comparator):
         return self._jaccard_similarity(string1, string2)
 
     def _jaccard_similarity(self, str1, str2):
-        str1_tokens = set(str1.lower().split())
-        str2_tokens = set(str2.lower().split())
-        if not str1_tokens and not str2_tokens:
-            return 1.0
+        str1_tokens = set(str1.split())
+        str2_tokens = set(str2.split())
         return len(str1_tokens.intersection(str2_tokens)) / len(
             str1_tokens.union(str2_tokens)
         )
@@ -128,10 +123,8 @@ class SorensenDiceSimilarity(Comparator):
         return self._sorensen_dice_similarity(string1, string2)
 
     def _sorensen_dice_similarity(self, str1, str2):
-        str1_tokens = set(str1.lower().split())
-        str2_tokens = set(str2.lower().split())
-        if not str1_tokens and not str2_tokens:
-            return 1.0
+        str1_tokens = set(str1.split())
+        str2_tokens = set(str2.split())
         return (
             2
             * len(str1_tokens.intersection(str2_tokens))

--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/similarity.py
@@ -116,6 +116,8 @@ class JaccardSimilarity(Comparator):
     def _jaccard_similarity(self, str1, str2):
         str1_tokens = set(str1.lower().split())
         str2_tokens = set(str2.lower().split())
+        if not str1_tokens and not str2_tokens:
+            return 1.0
         return len(str1_tokens.intersection(str2_tokens)) / len(
             str1_tokens.union(str2_tokens)
         )
@@ -128,6 +130,8 @@ class SorensenDiceSimilarity(Comparator):
     def _sorensen_dice_similarity(self, str1, str2):
         str1_tokens = set(str1.lower().split())
         str2_tokens = set(str2.lower().split())
+        if not str1_tokens and not str2_tokens:
+            return 1.0
         return (
             2
             * len(str1_tokens.intersection(str2_tokens))
@@ -192,14 +196,13 @@ class PhoneticSimilarity(Comparator):
         return [self._get_soundex_code(token) for token in self._tokenize(string)]
 
     def compare(self, string1: str, string2: str) -> float:
-        tokens1 = self._to_soundex_tokens(string1)
-        tokens2 = self._to_soundex_tokens(string2)
+        tokens1 = set(self._to_soundex_tokens(string1))
+        tokens2 = set(self._to_soundex_tokens(string2))
 
         if not tokens1 and not tokens2:
             return 1.0
         if not tokens1 or not tokens2:
             return 0.0
 
-        # Token-level comparison: match each token in tokens1 to best in tokens2
-        matches = sum(1 for t in tokens1 if t in set(tokens2))
-        return matches / max(len(tokens1), len(tokens2))
+        matches = len(tokens1.intersection(tokens2))
+        return matches / len(tokens1.union(tokens2))

--- a/futureagi/agentic_eval/core_evals/fi_evals/grounded/tests/test_phonetic_similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/grounded/tests/test_phonetic_similarity.py
@@ -1,0 +1,27 @@
+from agentic_eval.core_evals.fi_evals.grounded.similarity import PhoneticSimilarity
+
+p = PhoneticSimilarity()
+
+
+def test_identical_sound():
+    assert p.compare("Smith", "Smyth") == 1.0
+
+
+def test_totally_different():
+    assert p.compare("Smith", "Johnson") == 0.0
+
+
+def test_empty_strings():
+    assert p.compare("", "") == 1.0
+
+
+def test_one_empty():
+    assert p.compare("Smith", "") == 0.0
+
+
+def test_mixed_case():
+    assert p.compare("SMITH", "smith") == 1.0
+
+
+def test_multi_word():
+    assert p.compare("Robert Smith", "Rupert Smyth") == 1.0

--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 10
+SYSTEM_EVALS_VERSION = 11
 
 SYSTEM_EVALS_DIR = Path(__file__).resolve().parent.parent.parent / "system_evals"
 CATALOG_YAML = (
@@ -209,7 +209,6 @@ def seed_evals(dry_run=False, force=False, verbose=False):
 def _yaml_to_template_fields(eval_def):
     """Convert a YAML eval definition dict into EvalTemplate field values."""
     from model_hub.models.choices import OwnerChoices
-
     from tfc.ee_gating import is_oss
 
     track = eval_def.get("_track", "agent")

--- a/futureagi/model_hub/system_evals/function/answer_similarity.yaml
+++ b/futureagi/model_hub/system_evals/function/answer_similarity.yaml
@@ -43,11 +43,12 @@ config:
         expected_response = kwargs.get("expected_response", expected or "")
         comparator = kwargs.get("comparator", "CosineSimilarity")
         failure_threshold = float(kwargs.get("failure_threshold", 0.5))
-        response = str(response)
-        expected_response = str(expected_response)
-        if not response or not expected_response:
+        # Allow empty strings through so individual comparators can evaluate them
+        if response is None or expected_response is None:
             return {"score": 0.0, "reason": "Missing response or expected_response"}
 
+        response = str(response)
+        expected_response = str(expected_response)
         if comparator == "NormalisedLevenshteinSimilarity":
             # Normalized Levenshtein using SequenceMatcher as approximation
             score = difflib.SequenceMatcher(None, response, expected_response).ratio()

--- a/futureagi/model_hub/system_evals/function/answer_similarity.yaml
+++ b/futureagi/model_hub/system_evals/function/answer_similarity.yaml
@@ -35,6 +35,7 @@ config:
     - JaroWincklerSimilarity
     - JaccardSimilarity
     - SorensenDiceSimilarity
+    - PhoneticSimilarity
   code: |
     def evaluate(input, output, expected, context, **kwargs):
         import difflib
@@ -46,6 +47,7 @@ config:
         expected_response = str(expected_response)
         if not response or not expected_response:
             return {"score": 0.0, "reason": "Missing response or expected_response"}
+
         if comparator == "NormalisedLevenshteinSimilarity":
             # Normalized Levenshtein using SequenceMatcher as approximation
             score = difflib.SequenceMatcher(None, response, expected_response).ratio()
@@ -110,9 +112,45 @@ config:
             else:
                 intersection = set1 & set2
                 score = 2 * len(intersection) / (len(set1) + len(set2)) if (len(set1) + len(set2)) > 0 else 0.0
+        elif comparator == "PhoneticSimilarity":
+            import re
+
+            def soundex(word):
+                mapping = {
+                    'B':'1','F':'1','P':'1','V':'1',
+                    'C':'2','G':'2','J':'2','K':'2','Q':'2','S':'2','X':'2','Z':'2',
+                    'D':'3','T':'3','L':'4','M':'5','N':'5','R':'6'
+                }
+                word = word.upper()
+                if not word or not word[0].isalpha():
+                    return "0000"
+                first_letter = word[0]
+                first_code = mapping.get(first_letter, '')
+                encoded = []
+                for char in word[1:]:
+                    code = mapping.get(char, '')
+                    if not code:
+                        continue
+                    if encoded and encoded[-1] == code:
+                        continue
+                    if not encoded and code == first_code:
+                        continue
+                    encoded.append(code)
+                return (first_letter + ''.join(encoded) + '000')[:4]
+
+            tokens1 = set(soundex(w) for w in re.findall(r'\b\w+\b', response.lower()))
+            tokens2 = set(soundex(w) for w in re.findall(r'\b\w+\b', expected_response.lower()))
+
+            if not tokens1 and not tokens2:
+                score = 1.0
+            elif not tokens1 or not tokens2:
+                score = 0.0
+            else:
+                score = len(tokens1.intersection(tokens2)) / max(len(tokens1), len(tokens2))
         else:
             # Default: CosineSimilarity approximated via SequenceMatcher
             score = difflib.SequenceMatcher(None, response.lower(), expected_response.lower()).ratio()
+
         reason = f"{comparator} score: {score:.4f}"
         if score < failure_threshold:
             reason += f" (below threshold {failure_threshold})"

--- a/futureagi/model_hub/system_evals/function/answer_similarity.yaml
+++ b/futureagi/model_hub/system_evals/function/answer_similarity.yaml
@@ -146,7 +146,7 @@ config:
             elif not tokens1 or not tokens2:
                 score = 0.0
             else:
-                score = len(tokens1.intersection(tokens2)) / max(len(tokens1), len(tokens2))
+                score = len(tokens1.intersection(tokens2)) / len(tokens1.union(tokens2))
         else:
             # Default: CosineSimilarity approximated via SequenceMatcher
             score = difflib.SequenceMatcher(None, response.lower(), expected_response.lower()).ratio()


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->
Adds a PhoneticSimilarity comparator to the grounded evaluators that uses a pure Python Soundex implementation with no external dependencies. This enables phonetic matching for evaluation paths prone to transcription or speech errors (e.g. "Smith" vs "Smyth"). The comparator follows the existing Comparator interface and is registered in GroundedEvaluator alongside the other similarity functions.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #614 

## Type of change
- [ ] ✨ New feature (non-breaking change which adds functionality)


## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

Ran make test locally — 7677 tests collected, 4 pre-existing errors unrelated to this change
Manually verified phonetic matching: PhoneticSimilarity().compare("Smith", "Smyth") returns 1.0


## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist
No external dependencies added
Follows existing Comparator interface
make check-all — pre-commit hooks (black, isort, trailing whitespace) passed after auto-fix

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
