### PR TITLE
feat(eval): add backfill command for EvalLogger dual format and corre…

### DIFF
--- a/futureagi/tracer/management/commands/backfill_eval_logger_dual_format.py
+++ b/futureagi/tracer/management/commands/backfill_eval_logger_dual_format.py
@@ -1,0 +1,213 @@
+"""
+Backfill EvalLogger rows whose categorical/numeric result was written into
+``output_str`` only (the broken dispatch path) so that ``output_float`` and
+``output_str_list`` are re-populated for FE readers that still consume the
+typed columns.
+
+The row-level routing logic lives in
+:func:`tracer.utils.eval._dual_write_eval_value` — this command parses the
+existing ``output_str`` back into a Python value and feeds it through that
+same helper, then applies the result with idempotent gating:
+
+  * ``output_float`` is only set when ``config["output"] == "score"`` AND it
+    is currently NULL.
+  * ``output_str_list`` is only set when ``config["output"] == "choices"`` AND
+    it is currently empty; any already-populated list is deduped in place per
+    the universal "no element repeated" rule.
+  * ``output_bool`` is never touched.
+  * Rows for any other ``output`` type are skipped.
+
+Inherits the helper's full list handling automatically:
+  * score + list / list-of-{score: …} dicts → averaged into output_float.
+  * choices + list / list-of-{choice|choices} dicts → flattened + deduped into
+    output_str_list.
+
+Usage:
+    python manage.py backfill_eval_logger_dual_format --dry-run
+    python manage.py backfill_eval_logger_dual_format
+    python manage.py backfill_eval_logger_dual_format --limit 100
+    python manage.py backfill_eval_logger_dual_format --eval-task-id <uuid>
+    python manage.py backfill_eval_logger_dual_format --since 2026-05-01
+"""
+
+import ast
+import json
+from datetime import datetime, time
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from tracer.models.observation_span import EvalLogger
+from tracer.utils.eval import _dedupe_preserve_order, _dual_write_eval_value
+
+SENTINEL_STRINGS = {"", "ERROR", "Passed", "Failed"}
+
+
+def _parse_output_str(raw):
+    """Best-effort parse of an ``output_str`` payload.
+
+    Returns the parsed value (dict / list / scalar) on success, or the raw
+    string if neither JSON nor Python repr could decode it. The caller
+    inspects the type to decide how to feed it into the helper.
+    """
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        pass
+    try:
+        return ast.literal_eval(raw)
+    except (TypeError, ValueError, SyntaxError):
+        pass
+    return raw
+
+
+def _config_output_for(row):
+    """Read ``eval_template.config["output"]`` for the row's eval."""
+    try:
+        return row.custom_eval_config.eval_template.config.get("output", "score")
+    except (AttributeError, TypeError):
+        return None
+
+
+class Command(BaseCommand):
+    help = (
+        "Re-populate EvalLogger.output_float / output_str_list from output_str "
+        "for score / choices evals affected by the dispatch-path regression."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would change without writing.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=0,
+            help="Maximum number of rows to process (0 = no limit).",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=1000,
+            help="Bulk-update batch size.",
+        )
+        parser.add_argument(
+            "--eval-task-id",
+            type=str,
+            default=None,
+            help="Restrict to one eval_task_id (for testing on a single task).",
+        )
+        parser.add_argument(
+            "--since",
+            type=str,
+            default=None,
+            help="Only consider rows created on/after this date (YYYY-MM-DD).",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        limit = options["limit"]
+        batch_size = options["batch_size"]
+        eval_task_id = options.get("eval_task_id")
+        since = options.get("since")
+
+        qs = (
+            EvalLogger.objects.select_related("custom_eval_config__eval_template")
+            .filter(error=False)
+            .exclude(output_str__in=SENTINEL_STRINGS)
+            .exclude(output_str__isnull=True)
+            .order_by("id")
+        )
+        if eval_task_id:
+            qs = qs.filter(eval_task_id=eval_task_id)
+        if since:
+            since_dt = timezone.make_aware(
+                datetime.combine(
+                    datetime.strptime(since, "%Y-%m-%d").date(),
+                    time.min,
+                )
+            )
+            qs = qs.filter(created_at__gte=since_dt)
+        if limit:
+            qs = qs[:limit]
+
+        scanned = 0
+        updated = 0
+        skipped_other_output = 0
+        skipped_unchanged = 0
+        batch = []
+
+        for row in qs.iterator(chunk_size=batch_size):
+            scanned += 1
+            config_output = _config_output_for(row)
+            if config_output not in ("score", "choices"):
+                skipped_other_output += 1
+                continue
+
+            parsed = _parse_output_str(row.output_str)
+            # Helper expects the actual value; for unparseable input fall back
+            # to the raw string so the helper's str-branch still applies.
+            value = (
+                parsed
+                if isinstance(parsed, (dict, list, int, float, bool, str))
+                else row.output_str
+            )
+
+            proposed = {}
+            _dual_write_eval_value(value, config_output, proposed)
+
+            changed = False
+
+            # output_float: write only when missing AND helper produced one.
+            if (
+                config_output == "score"
+                and "output_float" in proposed
+                and row.output_float is None
+            ):
+                row.output_float = proposed["output_float"]
+                changed = True
+
+            # output_str_list: write only when empty; otherwise dedupe in place.
+            if config_output == "choices":
+                if not row.output_str_list and "output_str_list" in proposed:
+                    row.output_str_list = proposed["output_str_list"]
+                    changed = True
+                elif row.output_str_list:
+                    deduped = _dedupe_preserve_order(row.output_str_list)
+                    if deduped != list(row.output_str_list):
+                        row.output_str_list = deduped
+                        changed = True
+
+            # output_str: normalize to the helper's preferred form (JSON for
+            # dict/list, raw string for plain text). Only when it differs.
+            if "output_str" in proposed and row.output_str != proposed["output_str"]:
+                row.output_str = proposed["output_str"]
+                changed = True
+
+            if changed:
+                updated += 1
+                batch.append(row)
+            else:
+                skipped_unchanged += 1
+
+            if not dry_run and len(batch) >= batch_size:
+                EvalLogger.objects.bulk_update(
+                    batch, ["output_float", "output_str_list", "output_str"]
+                )
+                batch.clear()
+
+        if not dry_run and batch:
+            EvalLogger.objects.bulk_update(
+                batch, ["output_float", "output_str_list", "output_str"]
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"scanned={scanned} updated={updated} "
+                f"skipped_other_output={skipped_other_output} "
+                f"skipped_unchanged={skipped_unchanged} "
+                f"dry_run={dry_run}"
+            )
+        )

--- a/futureagi/tracer/tests/test_backfill_eval_logger_dual_format.py
+++ b/futureagi/tracer/tests/test_backfill_eval_logger_dual_format.py
@@ -1,0 +1,268 @@
+"""
+Tests for the ``backfill_eval_logger_dual_format`` management command.
+
+Verifies the same gating rules as the write-side helper:
+  * ``score`` rows: re-populate ``output_float`` from ``output_str`` dict;
+    never touch ``output_str_list``.
+  * ``choices`` rows: re-populate ``output_str_list`` from the dict /
+    plain-string ``output_str``; never touch ``output_float``.
+  * ``Pass/Fail`` and other ``output`` types are untouched.
+  * Re-running the command is a no-op.
+"""
+
+import json
+
+import pytest  # noqa: E402
+from django.core.management import call_command  # noqa: E402
+
+# Break the import cycle (see test_eval_logger_schema.py for the canonical
+# comment).
+import model_hub.tasks  # noqa: F401
+from model_hub.models.evals_metric import EvalTemplate  # noqa: E402
+from tracer.models.custom_eval_config import CustomEvalConfig  # noqa: E402
+from tracer.models.observation_span import (  # noqa: E402
+    EvalLogger,
+    EvalTargetType,
+)
+
+
+def _make_config(project, organization, workspace, output_type):
+    template = EvalTemplate.objects.create(
+        name=f"Template ({output_type})",
+        description="",
+        organization=organization,
+        workspace=workspace,
+        config={"output": output_type},
+    )
+    return CustomEvalConfig.objects.create(
+        name=f"Eval ({output_type})",
+        project=project,
+        eval_template=template,
+        config={},
+        mapping={},
+        filters={},
+    )
+
+
+def _make_row(observation_span, custom_eval_config, **kwargs):
+    return EvalLogger.objects.create(
+        target_type=EvalTargetType.SPAN,
+        observation_span=observation_span,
+        trace=observation_span.trace,
+        custom_eval_config=custom_eval_config,
+        **kwargs,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestBackfillEvalLoggerDualFormat:
+    def test_score_dict_python_repr_populates_output_float_and_rewrites_json(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "score")
+        # Simulate the buggy on-disk shape: str(dict) → single quotes.
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str=str({"score": 0.7, "choice": "Choice 1"}),
+        )
+
+        call_command("backfill_eval_logger_dual_format")
+
+        row.refresh_from_db()
+        assert row.output_float == 0.7
+        assert row.output_str_list == []  # gated: score rows do not write list
+        # The on-disk form is normalised to JSON.
+        assert json.loads(row.output_str) == {"score": 0.7, "choice": "Choice 1"}
+
+    def test_choices_dict_populates_output_str_list_not_float(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "choices")
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str=json.dumps({"score": 0.7, "choice": "Choice 1"}),
+        )
+
+        call_command("backfill_eval_logger_dual_format")
+
+        row.refresh_from_db()
+        assert row.output_str_list == ["Choice 1"]
+        assert row.output_float is None  # gated: choices rows do not write float
+
+    def test_choices_multi_choice_list_populated(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "choices")
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str=json.dumps({"score": 1.0, "choices": ["A", "B"]}),
+        )
+
+        call_command("backfill_eval_logger_dual_format")
+
+        row.refresh_from_db()
+        assert row.output_str_list == ["A", "B"]
+        assert row.output_float is None
+
+    def test_choices_plain_string_populates_output_str_list(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "choices")
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str="Choice 1",
+        )
+
+        call_command("backfill_eval_logger_dual_format")
+
+        row.refresh_from_db()
+        assert row.output_str_list == ["Choice 1"]
+        assert row.output_str == "Choice 1"  # plain string left as-is
+        assert row.output_float is None
+
+    def test_passfail_row_is_untouched(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "Pass/Fail")
+        row = _make_row(observation_span, cfg, output_bool=True, output_str="")
+
+        call_command("backfill_eval_logger_dual_format")
+
+        row.refresh_from_db()
+        assert row.output_bool is True
+        assert row.output_float is None
+        assert row.output_str_list == []
+        assert row.output_str == ""
+
+    def test_error_sentinel_rows_are_skipped(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "score")
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str="ERROR",
+            error=True,
+            error_message="something failed",
+        )
+
+        call_command("backfill_eval_logger_dual_format")
+
+        row.refresh_from_db()
+        assert row.output_str == "ERROR"
+        assert row.output_float is None
+
+    def test_dry_run_does_not_modify_rows(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "score")
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str=str({"score": 0.7, "choice": "Choice 1"}),
+        )
+        before = row.output_str
+
+        call_command("backfill_eval_logger_dual_format", "--dry-run")
+
+        row.refresh_from_db()
+        assert row.output_float is None
+        assert row.output_str == before
+
+    def test_rerun_is_idempotent(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "choices")
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str=json.dumps({"score": 0.7, "choice": "Choice 1"}),
+        )
+
+        call_command("backfill_eval_logger_dual_format")
+        row.refresh_from_db()
+        list_after_first = row.output_str_list
+        str_after_first = row.output_str
+
+        call_command("backfill_eval_logger_dual_format")
+        row.refresh_from_db()
+        assert row.output_str_list == list_after_first
+        assert row.output_str == str_after_first
+
+    # ── Backfill mirrors the helper's new list handling ────────────────
+
+    def test_score_list_in_output_str_averages_into_output_float(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "score")
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str=json.dumps([0.4, 0.6, 0.8]),
+        )
+
+        call_command("backfill_eval_logger_dual_format")
+
+        row.refresh_from_db()
+        assert row.output_float == pytest.approx(0.6)
+        assert row.output_str_list == []  # gated: score never writes list
+
+    def test_score_list_of_score_dicts_averages_into_output_float(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "score")
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str=json.dumps(
+                [
+                    {"score": 0.4, "choice": "A"},
+                    {"score": 0.8, "choice": "B"},
+                ]
+            ),
+        )
+
+        call_command("backfill_eval_logger_dual_format")
+
+        row.refresh_from_db()
+        assert row.output_float == pytest.approx(0.6)
+        assert row.output_str_list == []
+
+    def test_choices_list_of_dicts_flattens_and_dedupes(
+        self, observation_span, project, organization, workspace
+    ):
+        cfg = _make_config(project, organization, workspace, "choices")
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str=json.dumps([{"choice": "A"}, {"choice": "B"}, {"choice": "A"}]),
+        )
+
+        call_command("backfill_eval_logger_dual_format")
+
+        row.refresh_from_db()
+        assert row.output_str_list == ["A", "B"]
+        assert row.output_float is None
+
+    def test_choices_existing_output_str_list_is_deduped_in_place(
+        self, observation_span, project, organization, workspace
+    ):
+        """Rows written by the old buggy dispatch could have duplicate choices
+        already sitting in output_str_list; the backfill cleans those up."""
+        cfg = _make_config(project, organization, workspace, "choices")
+        row = _make_row(
+            observation_span,
+            cfg,
+            output_str=json.dumps({"choices": ["A", "B", "A"]}),
+            output_str_list=["A", "B", "A"],
+        )
+
+        call_command("backfill_eval_logger_dual_format")
+
+        row.refresh_from_db()
+        assert row.output_str_list == ["A", "B"]

--- a/futureagi/tracer/tests/test_eval_dual_write.py
+++ b/futureagi/tracer/tests/test_eval_dual_write.py
@@ -1,0 +1,295 @@
+"""
+Unit tests for :func:`tracer.utils.eval._dual_write_eval_value`.
+
+The helper is the only place in ``tracer/utils/eval.py`` allowed to assign
+``output_float`` / ``output_str_list`` on ``logger_kwargs``; every assertion
+here is keyed on the stored ``config_output`` so the gating contract is
+exercised directly.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+# Break the import cycle (tracer.utils.eval_tasks -> tracer.utils.eval ->
+# model_hub.tasks.__init__ -> tracer.utils.eval_tasks) by importing the
+# package first. See test_eval_logger_schema.py for the canonical comment.
+import model_hub.tasks  # noqa: F401
+from tracer.utils.eval import _dual_write_eval_value  # noqa: E402
+
+EVAL_PY = (Path(__file__).resolve().parent.parent / "utils" / "eval.py").read_text()
+
+
+# ── score output_type ────────────────────────────────────────────────────
+
+
+def test_score_dict_routes_to_output_float_and_json_output_str():
+    kw = {}
+    _dual_write_eval_value({"score": 0.7, "choice": "Choice 1"}, "score", kw)
+    assert json.loads(kw["output_str"]) == {"score": 0.7, "choice": "Choice 1"}
+    assert kw["output_float"] == 0.7
+    assert "output_str_list" not in kw
+
+
+def test_score_plain_float_routes_to_output_float():
+    kw = {}
+    _dual_write_eval_value(0.7, "score", kw)
+    assert kw["output_float"] == 0.7
+    assert "output_str_list" not in kw
+    assert "output_str" not in kw
+
+
+def test_score_zero_is_a_real_value():
+    """``score == 0`` must populate output_float (truthiness pitfall)."""
+    kw = {}
+    _dual_write_eval_value(0, "score", kw)
+    assert kw["output_float"] == 0.0
+
+
+def test_score_dict_with_choice_does_not_set_output_str_list():
+    """Score-output evals never write output_str_list even if dict has 'choice'."""
+    kw = {}
+    _dual_write_eval_value({"score": 0.4, "choice": "Bad"}, "score", kw)
+    assert "output_str_list" not in kw
+
+
+def test_score_list_averages_into_output_float():
+    """A list arriving on the score path is collapsed to its mean — score evals
+    always render a single scalar from output_float, never a list."""
+    kw = {}
+    _dual_write_eval_value([0.4, 0.6, 0.8], "score", kw)
+    assert kw["output_float"] == pytest.approx(0.6)
+    assert "output_str_list" not in kw
+    assert json.loads(kw["output_str"]) == [0.4, 0.6, 0.8]
+
+
+def test_score_list_with_non_numeric_elements_is_filtered_before_averaging():
+    kw = {}
+    _dual_write_eval_value([0.2, "skip", 0.8, None], "score", kw)
+    assert kw["output_float"] == pytest.approx(0.5)
+    assert "output_str_list" not in kw
+
+
+def test_score_empty_list_does_not_set_output_float():
+    kw = {}
+    _dual_write_eval_value([], "score", kw)
+    assert "output_float" not in kw
+    assert "output_str_list" not in kw
+    assert json.loads(kw["output_str"]) == []
+
+
+def test_score_list_of_bools_does_not_count_them_as_numeric():
+    """``bool`` is a subclass of int; exclude bools from the mean so we don't
+    accidentally average them to 0.5."""
+    kw = {}
+    _dual_write_eval_value([True, False], "score", kw)
+    assert "output_float" not in kw
+
+
+def test_score_list_of_dicts_extracts_score_field_and_averages():
+    """Choices-promoted score evals can yield per-item dicts; pull each item's
+    'score' and average those."""
+    kw = {}
+    _dual_write_eval_value(
+        [
+            {"score": 0.4, "choice": "A"},
+            {"score": 0.6, "choice": "B"},
+            {"score": 0.8, "choice": "C"},
+        ],
+        "score",
+        kw,
+    )
+    assert kw["output_float"] == pytest.approx(0.6)
+    assert "output_str_list" not in kw
+    assert json.loads(kw["output_str"]) == [
+        {"score": 0.4, "choice": "A"},
+        {"score": 0.6, "choice": "B"},
+        {"score": 0.8, "choice": "C"},
+    ]
+
+
+def test_score_list_mixes_numbers_and_dicts():
+    kw = {}
+    _dual_write_eval_value([0.4, {"score": 0.8}], "score", kw)
+    assert kw["output_float"] == pytest.approx(0.6)
+
+
+def test_score_list_of_dicts_skips_items_with_missing_or_non_numeric_score():
+    kw = {}
+    _dual_write_eval_value(
+        [{"score": 0.5}, {"choice": "no-score-here"}, {"score": "x"}],
+        "score",
+        kw,
+    )
+    assert kw["output_float"] == pytest.approx(0.5)
+
+
+# ── choices output_type ──────────────────────────────────────────────────
+
+
+def test_choices_dict_single_choice_routes_to_list_not_float():
+    kw = {}
+    _dual_write_eval_value({"score": 0.7, "choice": "Choice 1"}, "choices", kw)
+    assert json.loads(kw["output_str"]) == {"score": 0.7, "choice": "Choice 1"}
+    assert kw["output_str_list"] == ["Choice 1"]
+    assert "output_float" not in kw
+
+
+def test_choices_dict_multi_choice_routes_to_list():
+    kw = {}
+    _dual_write_eval_value({"score": 1.0, "choices": ["A", "B"]}, "choices", kw)
+    assert kw["output_str_list"] == ["A", "B"]
+    assert "output_float" not in kw
+
+
+def test_choices_plain_string_dual_writes_to_str_and_list():
+    """Prebuilt tune/choices eval: format_eval_value returns a raw choice str."""
+    kw = {}
+    _dual_write_eval_value("Choice 1", "choices", kw)
+    assert kw["output_str"] == "Choice 1"
+    assert kw["output_str_list"] == ["Choice 1"]
+
+
+def test_choices_plain_list_routes_to_list():
+    kw = {}
+    _dual_write_eval_value(["A", "B"], "choices", kw)
+    assert kw["output_str_list"] == ["A", "B"]
+    assert "output_str" not in kw  # plain string lists don't touch output_str
+
+
+def test_choices_plain_list_dedupes_repeated_strings():
+    kw = {}
+    _dual_write_eval_value(["A", "B", "A", "C", "B"], "choices", kw)
+    assert kw["output_str_list"] == ["A", "B", "C"]
+
+
+def test_choices_dict_multi_choice_dedupes_repeated_values():
+    kw = {}
+    _dual_write_eval_value({"choices": ["A", "B", "A"]}, "choices", kw)
+    assert kw["output_str_list"] == ["A", "B"]
+
+
+def test_choices_list_of_dicts_with_choice_flattens_and_dedupes():
+    kw = {}
+    _dual_write_eval_value(
+        [{"choice": "A"}, {"choice": "B"}, {"choice": "A"}],
+        "choices",
+        kw,
+    )
+    assert kw["output_str_list"] == ["A", "B"]
+    # Raw payloads kept in output_str for inspection.
+    assert json.loads(kw["output_str"]) == [
+        {"choice": "A"},
+        {"choice": "B"},
+        {"choice": "A"},
+    ]
+
+
+def test_choices_list_of_dicts_with_choices_field_flattens_and_dedupes():
+    kw = {}
+    _dual_write_eval_value(
+        [{"choices": ["A", "B"]}, {"choices": ["B", "C"]}],
+        "choices",
+        kw,
+    )
+    assert kw["output_str_list"] == ["A", "B", "C"]
+
+
+def test_choices_list_mixes_strings_and_dicts():
+    kw = {}
+    _dual_write_eval_value(
+        ["A", {"choice": "B"}, {"choices": ["A", "C"]}, "C"],
+        "choices",
+        kw,
+    )
+    assert kw["output_str_list"] == ["A", "B", "C"]
+    # Has at least one dict element → raw list also dumped to output_str.
+    assert "output_str" in kw
+
+
+# ── Pass/Fail, reason, numeric, other output_types ───────────────────────
+
+
+def test_passfail_passed_routes_to_output_bool():
+    kw = {}
+    _dual_write_eval_value("Passed", "Pass/Fail", kw)
+    assert kw["output_bool"] is True
+    assert "output_float" not in kw
+    assert "output_str_list" not in kw
+
+
+def test_passfail_failed_routes_to_output_bool():
+    kw = {}
+    _dual_write_eval_value("Failed", "Pass/Fail", kw)
+    assert kw["output_bool"] is False
+
+
+def test_reason_plain_string_does_not_set_output_str_list():
+    kw = {}
+    _dual_write_eval_value("Why this scored low", "reason", kw)
+    assert kw["output_str"] == "Why this scored low"
+    assert "output_str_list" not in kw
+    assert "output_float" not in kw
+
+
+def test_numeric_plain_float_preserves_today_behavior():
+    """``numeric`` is NOT in the dual-write gate; preserve today's dispatch."""
+    kw = {}
+    _dual_write_eval_value(5.0, "numeric", kw)
+    assert kw["output_float"] == 5.0
+    assert "output_str_list" not in kw
+
+
+# ── Bool-vs-int ordering ─────────────────────────────────────────────────
+
+
+def test_bool_takes_precedence_over_int_for_any_output_type():
+    """bool is a subclass of int; output_bool wins regardless of config."""
+    for cfg in ("score", "choices", "Pass/Fail", "reason", "numeric"):
+        kw = {}
+        _dual_write_eval_value(True, cfg, kw)
+        assert kw["output_bool"] is True, cfg
+        assert "output_float" not in kw, cfg
+
+
+# ── Source-level regression guards ───────────────────────────────────────
+
+
+def test_helper_is_called_from_exactly_seven_dispatch_sites():
+    """Pins call-site count so future edits cannot drop a dispatcher silently."""
+    calls = re.findall(r"_dual_write_eval_value\(", EVAL_PY)
+    # 1 helper definition + 7 call sites = 8 occurrences total.
+    assert (
+        len(calls) == 8
+    ), f"Expected 1 def + 7 calls of _dual_write_eval_value, found {len(calls)}"
+
+
+def test_typed_columns_only_assigned_inside_helper():
+    """``output_float`` / ``output_str_list`` must never be assigned outside
+    the dual-write helper — that's the only place gating rules are enforced."""
+    # Locate the helper body.
+    start_match = re.search(r"^def _dual_write_eval_value\(", EVAL_PY, re.MULTILINE)
+    assert start_match, "_dual_write_eval_value definition not found"
+    after_def = EVAL_PY[start_match.end() :]
+    next_def = re.search(r"^def [_A-Za-z]", after_def, re.MULTILINE)
+    assert next_def, "could not locate end of _dual_write_eval_value"
+    helper_body = after_def[: next_def.start()]
+    rest_of_file = EVAL_PY[: start_match.start()] + after_def[next_def.start() :]
+
+    typed_assignments = re.findall(
+        r'logger_kwargs\["output_(?:float|str_list)"\]\s*=', rest_of_file
+    )
+    assert not typed_assignments, (
+        f"Inline assignments outside helper found: {typed_assignments}. "
+        "All output_float / output_str_list writes must go through "
+        "_dual_write_eval_value to honour the score/choices gating."
+    )
+    # Sanity: the helper itself does assign them.
+    assert re.search(
+        r'logger_kwargs\["output_float"\]\s*=', helper_body
+    ), "helper should assign output_float internally"
+    assert re.search(
+        r'logger_kwargs\["output_str_list"\]\s*=', helper_body
+    ), "helper should assign output_str_list internally"

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -24,6 +24,7 @@ from tracer.models.trace import Trace
 from tracer.models.trace_session import TraceSession
 from tracer.utils.helper import FieldConfig, get_default_trace_config
 from tracer.views.project import get_default_project_version_config
+
 try:
     from ee.usage.models.usage import APICallStatusChoices
 except ImportError:
@@ -39,6 +40,7 @@ OBSERVE = "observe"
 
 # Re-export for backward compat
 from tracer.utils.eval_helpers import resolve_eval_config_id  # noqa: F401, E402
+
 
 # Friendly eval-mapping shorthands used in saved configs. The user-
 # facing variable picker (voice projects in particular) lets people map
@@ -207,9 +209,7 @@ def build_trace_context(trace, *, anchor_span_id: str | None = None) -> dict:
     from tracer.models.observation_span import ObservationSpan
 
     try:
-        _agg = ObservationSpan.objects.filter(
-            trace=trace, deleted=False
-        ).aggregate(
+        _agg = ObservationSpan.objects.filter(trace=trace, deleted=False).aggregate(
             span_count=Count("id"),
             error_count=Count("id", filter=Q(status="ERROR")),
             total_tokens=Sum("total_tokens"),
@@ -286,9 +286,7 @@ def build_session_context(session) -> dict | None:
         per_trace = {
             row["trace_id"]: row
             for row in (
-                ObservationSpan.objects.filter(
-                    trace_id__in=trace_ids, deleted=False
-                )
+                ObservationSpan.objects.filter(trace_id__in=trace_ids, deleted=False)
                 .values("trace_id")
                 .annotate(
                     span_count=Count("id"),
@@ -303,11 +301,11 @@ def build_session_context(session) -> dict | None:
         # trace to bound payload size.
         spans_by_trace: dict = {}
         for s in (
-            ObservationSpan.objects.filter(
-                trace_id__in=trace_ids, deleted=False
-            )
+            ObservationSpan.objects.filter(trace_id__in=trace_ids, deleted=False)
             .order_by("start_time")
-            .values("id", "trace_id", "name", "observation_type", "status", "parent_span_id")
+            .values(
+                "id", "trace_id", "name", "observation_type", "status", "parent_span_id"
+            )
         ):
             bucket = spans_by_trace.setdefault(s["trace_id"], [])
             if len(bucket) >= 50:
@@ -356,9 +354,7 @@ def build_session_context(session) -> dict | None:
         return {
             "id": str(session.id),
             "name": session.name,
-            "project_id": (
-                str(session.project_id) if session.project_id else None
-            ),
+            "project_id": (str(session.project_id) if session.project_id else None),
             "bookmarked": session.bookmarked,
             "created_at": (
                 session.created_at.isoformat() if session.created_at else None
@@ -368,9 +364,7 @@ def build_session_context(session) -> dict | None:
             "error_count": sess_agg["error_count"] or 0,
             "total_tokens": sess_agg["total_tokens"] or 0,
             "total_cost": (
-                float(round(sess_agg["total_cost"], 6))
-                if sess_agg["total_cost"]
-                else 0
+                float(round(sess_agg["total_cost"], 6)) if sess_agg["total_cost"] else 0
             ),
             "start_time": str(start) if start else None,
             "end_time": str(end) if end else None,
@@ -422,9 +416,7 @@ def _process_mapping(
     try:
         given_eval_template = EvalTemplate.no_workspace_objects.get(id=eval_template_id)
         optional_keys = given_eval_template.config.get("optional_keys", [])
-        is_user_custom_eval = bool(
-            given_eval_template.config.get("custom_eval", False)
-        )
+        is_user_custom_eval = bool(given_eval_template.config.get("custom_eval", False))
         if len(optional_keys) > 0:
             for key in optional_keys:
                 if key in mapping and (mapping[key] is None or mapping[key] == ""):
@@ -477,6 +469,141 @@ def _process_mapping(
             )
 
     return parsed_mapping
+
+
+def _dedupe_preserve_order(items):
+    """Return ``items`` with duplicates removed, keeping first-seen order.
+
+    Used to guarantee ``EvalLogger.output_str_list`` never repeats a choice
+    when the upstream eval emits duplicates (per-item dicts, choices arrays,
+    plain string lists — all funnel through here).
+    """
+    seen = set()
+    out = []
+    for x in items:
+        if x in seen:
+            continue
+        seen.add(x)
+        out.append(x)
+    return out
+
+
+def _dual_write_eval_value(value, config_output, logger_kwargs):
+    """Populate ``logger_kwargs`` with one eval result, dual-writing both the
+    new (``output_str``) and legacy (``output_float`` / ``output_str_list``)
+    shapes so FE readers that still consume the typed columns keep working.
+
+    Gating (see the dual-write plan):
+      * ``output_float`` is (re-)populated only when ``config_output == "score"``.
+      * ``output_str_list`` is (re-)populated only when ``config_output == "choices"``.
+      * ``output_bool`` is never touched here; the bool / "Passed"/"Failed"
+        branches behave exactly as today's dispatch.
+      * Any other ``config_output`` (``Pass/Fail``, ``reason``, ``numeric``, …)
+        keeps today's isinstance-chain behaviour unchanged.
+
+    The dict shape ``{"score": …, "choice": …}`` / ``{"score": …, "choices": […]}``
+    comes from ``evaluations/engine/formatting.py``'s choices branch; we serialize
+    it as JSON into ``output_str`` for the new format.
+    """
+    if isinstance(value, bool):
+        logger_kwargs["output_bool"] = value
+        return
+    if value in ("Passed", "Failed"):
+        logger_kwargs["output_bool"] = value == "Passed"
+        return
+
+    if config_output == "score":
+        if isinstance(value, dict):
+            logger_kwargs["output_str"] = json.dumps(value)
+            score = value.get("score")
+            if isinstance(score, (int, float)) and not isinstance(score, bool):
+                logger_kwargs["output_float"] = float(score)
+        elif isinstance(value, (int, float)):
+            logger_kwargs["output_float"] = float(value)
+        elif isinstance(value, list):
+            # Score evals never store a list — collapse to the mean so the FE
+            # always reads a single scalar from output_float. Elements may be
+            # raw numbers or per-item dicts shaped like ``{"score": …, "choice": …}``
+            # from the choices-promoted code path; extract the score from each.
+            # Keep the original list in output_str so per-element values stay
+            # inspectable.
+            logger_kwargs["output_str"] = json.dumps(value)
+            numerics = []
+            for v in value:
+                if isinstance(v, bool):
+                    continue
+                if isinstance(v, (int, float)):
+                    numerics.append(v)
+                elif isinstance(v, dict):
+                    s = v.get("score")
+                    if isinstance(s, (int, float)) and not isinstance(s, bool):
+                        numerics.append(s)
+            if numerics:
+                logger_kwargs["output_float"] = sum(numerics) / len(numerics)
+        else:
+            logger_kwargs["output_str"] = str(value)
+        return
+
+    if config_output == "choices":
+        if isinstance(value, dict):
+            logger_kwargs["output_str"] = json.dumps(value)
+            choice = value.get("choice")
+            choices = value.get("choices")
+            if isinstance(choice, str):
+                logger_kwargs["output_str_list"] = [choice]
+            elif isinstance(choices, list):
+                logger_kwargs["output_str_list"] = _dedupe_preserve_order(choices)
+        elif isinstance(value, str):
+            logger_kwargs["output_str"] = value
+            logger_kwargs["output_str_list"] = [value]
+        elif isinstance(value, list):
+            # Two shapes can arrive here:
+            #   * Plain list of choice strings.
+            #   * List of per-item dicts shaped like ``{"choice": …}`` /
+            #     ``{"choices": [...]}`` (mirrors the dict branch above).
+            # Flatten + dedupe to a single ordered list either way. If any
+            # element is a dict, also dump the raw list to ``output_str`` so the
+            # per-item payloads stay inspectable.
+            if any(isinstance(v, dict) for v in value):
+                logger_kwargs["output_str"] = json.dumps(value)
+            collected = []
+            for v in value:
+                if isinstance(v, str):
+                    collected.append(v)
+                elif isinstance(v, dict):
+                    inner_choice = v.get("choice")
+                    inner_choices = v.get("choices")
+                    if isinstance(inner_choice, str):
+                        collected.append(inner_choice)
+                    elif isinstance(inner_choices, list):
+                        collected.extend(c for c in inner_choices if isinstance(c, str))
+            logger_kwargs["output_str_list"] = _dedupe_preserve_order(collected)
+        elif isinstance(value, (int, float)):
+            logger_kwargs["output_float"] = float(value)
+        else:
+            logger_kwargs["output_str"] = str(value)
+        return
+
+    # Other output types — preserve today's dispatch verbatim.
+    if isinstance(value, (int, float)):
+        logger_kwargs["output_float"] = float(value)
+    elif isinstance(value, list):
+        logger_kwargs["output_str_list"] = value
+    else:
+        logger_kwargs["output_str"] = str(value)
+
+
+def _eval_config_output(custom_eval_config):
+    """Read the stored ``output`` type from an eval template config.
+
+    Never use the runtime-promoted value (``format_eval_value`` internally
+    promotes ``score`` → ``choices`` when ``choice_scores`` exist); the gating
+    rules in :func:`_dual_write_eval_value` are keyed on the **stored** type.
+    """
+    try:
+        return custom_eval_config.eval_template.config.get("output", "score")
+    except (AttributeError, TypeError):
+        return "score"
 
 
 def _run_evaluation(
@@ -689,16 +816,9 @@ def _run_evaluation(
     # Determine the appropriate field based on value type
     if value != "ERROR":  # Only try to process value type if no error occurred
         logger_kwargs["value"] = value
-        if isinstance(value, bool):
-            logger_kwargs["output_bool"] = value
-        elif isinstance(value, float) or isinstance(value, int):
-            logger_kwargs["output_float"] = float(value)
-        elif value in ["Passed", "Failed"]:
-            logger_kwargs["output_bool"] = True if value == "Passed" else False
-        elif isinstance(value, list):
-            logger_kwargs["output_str_list"] = value
-        else:
-            logger_kwargs["output_str"] = str(value)
+        _dual_write_eval_value(
+            value, _eval_config_output(custom_eval_config), logger_kwargs
+        )
 
     return logger_kwargs
 
@@ -809,14 +929,9 @@ def _execute_composite_on_span(
 
     if value != "ERROR":
         logger_kwargs["value"] = value
-        if isinstance(value, bool):
-            logger_kwargs["output_bool"] = value
-        elif isinstance(value, float) or isinstance(value, int):
-            logger_kwargs["output_float"] = float(value)
-        elif isinstance(value, list):
-            logger_kwargs["output_str_list"] = value
-        else:
-            logger_kwargs["output_str"] = str(value)
+        _dual_write_eval_value(
+            value, _eval_config_output(custom_eval_config), logger_kwargs
+        )
 
     return logger_kwargs
 
@@ -858,7 +973,9 @@ def _execute_composite_on_trace(
         .order_by("order")
     )
     if not child_links:
-        raise ValueError(f"Composite {parent.id} has no children — cannot run on trace.")
+        raise ValueError(
+            f"Composite {parent.id} has no children — cannot run on trace."
+        )
 
     # Mirror the single-eval trace path: set the workspace ContextVar so child
     # evals' tools (explore_trace etc.) see the right org scope.
@@ -944,14 +1061,9 @@ def _execute_composite_on_trace(
         value = "ERROR"
 
     if value != "ERROR":
-        if isinstance(value, bool):
-            logger_kwargs["output_bool"] = value
-        elif isinstance(value, float) or isinstance(value, int):
-            logger_kwargs["output_float"] = float(value)
-        elif isinstance(value, list):
-            logger_kwargs["output_str_list"] = value
-        else:
-            logger_kwargs["output_str"] = str(value)
+        _dual_write_eval_value(
+            value, _eval_config_output(custom_eval_config), logger_kwargs
+        )
 
     return logger_kwargs
 
@@ -1080,14 +1192,9 @@ def _execute_composite_on_session(
         value = "ERROR"
 
     if value != "ERROR":
-        if isinstance(value, bool):
-            logger_kwargs["output_bool"] = value
-        elif isinstance(value, float) or isinstance(value, int):
-            logger_kwargs["output_float"] = float(value)
-        elif isinstance(value, list):
-            logger_kwargs["output_str_list"] = value
-        else:
-            logger_kwargs["output_str"] = str(value)
+        _dual_write_eval_value(
+            value, _eval_config_output(custom_eval_config), logger_kwargs
+        )
 
     return logger_kwargs
 
@@ -1193,7 +1300,9 @@ def _execute_evaluation(
     # --- Build context for data_injection support ---
     _eval_inputs = dict(run_params or {})
     _di = _di_normalize(
-        (custom_eval_config.config or {}).get("run_config", {}).get("data_injection", {})
+        (custom_eval_config.config or {})
+        .get("run_config", {})
+        .get("data_injection", {})
     )
     if _di["span_context"]:
         _eval_inputs["span_context"] = build_span_context(observation_span)
@@ -1319,16 +1428,9 @@ def _execute_evaluation(
     # Determine the appropriate field based on value type
     if value != "ERROR":
         logger_kwargs["value"] = value
-        if isinstance(value, bool):
-            logger_kwargs["output_bool"] = value
-        elif isinstance(value, float) or isinstance(value, int):
-            logger_kwargs["output_float"] = float(value)
-        elif value in ["Passed", "Failed"]:
-            logger_kwargs["output_bool"] = True if value == "Passed" else False
-        elif isinstance(value, list):
-            logger_kwargs["output_str_list"] = value
-        else:
-            logger_kwargs["output_str"] = str(value)
+        _dual_write_eval_value(
+            value, _eval_config_output(custom_eval_config), logger_kwargs
+        )
 
     # Persist EvalLogger result
     if logger_kwargs:
@@ -2248,13 +2350,9 @@ def _process_trace_mapping(
     is_user_custom_eval = False
 
     try:
-        given_eval_template = EvalTemplate.no_workspace_objects.get(
-            id=eval_template_id
-        )
+        given_eval_template = EvalTemplate.no_workspace_objects.get(id=eval_template_id)
         optional_keys = given_eval_template.config.get("optional_keys", []) or []
-        is_user_custom_eval = bool(
-            given_eval_template.config.get("custom_eval", False)
-        )
+        is_user_custom_eval = bool(given_eval_template.config.get("custom_eval", False))
         for key in optional_keys:
             if key in mapping and (mapping[key] is None or mapping[key] == ""):
                 mapping.pop(key)
@@ -2269,9 +2367,7 @@ def _process_trace_mapping(
             f"EvalTemplate {eval_template_id} not found while processing "
             f"trace mapping for trace {trace.id}"
         )
-        raise ValueError(
-            f"EvalTemplate {eval_template_id} not found"
-        )
+        raise ValueError(f"EvalTemplate {eval_template_id} not found")
 
     for key, attribute in mapping.items():
         value = _resolve_trace_path(trace, attribute) if attribute else _MISSING
@@ -2306,13 +2402,9 @@ def _process_session_mapping(
     is_user_custom_eval = False
 
     try:
-        given_eval_template = EvalTemplate.no_workspace_objects.get(
-            id=eval_template_id
-        )
+        given_eval_template = EvalTemplate.no_workspace_objects.get(id=eval_template_id)
         optional_keys = given_eval_template.config.get("optional_keys", []) or []
-        is_user_custom_eval = bool(
-            given_eval_template.config.get("custom_eval", False)
-        )
+        is_user_custom_eval = bool(given_eval_template.config.get("custom_eval", False))
         for key in optional_keys:
             if key in mapping and (mapping[key] is None or mapping[key] == ""):
                 mapping.pop(key)
@@ -2324,15 +2416,11 @@ def _process_session_mapping(
             f"EvalTemplate {eval_template_id} not found while processing "
             f"session mapping for session {trace_session.id}"
         )
-        raise ValueError(
-            f"EvalTemplate {eval_template_id} not found"
-        )
+        raise ValueError(f"EvalTemplate {eval_template_id} not found")
 
     for key, attribute in mapping.items():
         value = (
-            _resolve_session_path(trace_session, attribute)
-            if attribute
-            else _MISSING
+            _resolve_session_path(trace_session, attribute) if attribute else _MISSING
         )
         if value is _MISSING:
             if is_user_custom_eval:
@@ -2443,14 +2531,13 @@ def _execute_evaluation_for_trace(
     # See _execute_evaluation_for_session for rationale; same applies here.
     try:
         from tfc.middleware.workspace_context import set_workspace_context
+
         set_workspace_context(
             workspace=workspace,
             organization=trace.project.organization,
         )
     except Exception as _ctx_err:
-        logger.warning(
-            "Failed to set workspace context for trace eval: %s", _ctx_err
-        )
+        logger.warning("Failed to set workspace context for trace eval: %s", _ctx_err)
 
     # --- Build context for data_injection support (trace-scoped) ---
     # Mirrors the span-level _execute_evaluation block. At trace level, the
@@ -2464,7 +2551,9 @@ def _execute_evaluation_for_trace(
     #                     trace-scoped but the anchor span has rich detail.
     _eval_inputs = dict(run_params or {})
     _di = _di_normalize(
-        (custom_eval_config.config or {}).get("run_config", {}).get("data_injection", {})
+        (custom_eval_config.config or {})
+        .get("run_config", {})
+        .get("data_injection", {})
     )
     if _di["trace_context"]:
         _eval_inputs["trace_context"] = build_trace_context(trace)
@@ -2547,9 +2636,7 @@ def _execute_evaluation_for_trace(
         try:
             api_call_log_row.status = APICallStatusChoices.ERROR.value
             current_config = json.loads(api_call_log_row.config)
-            current_config.update(
-                {"output": {"output": None, "reason": str(e)}}
-            )
+            current_config.update({"output": {"output": None, "reason": str(e)}})
             api_call_log_row.config = json.dumps(current_config)
             api_call_log_row.save()
         except Exception:
@@ -2576,16 +2663,9 @@ def _execute_evaluation_for_trace(
         value = "ERROR"
 
     if value != "ERROR":
-        if isinstance(value, bool):
-            logger_kwargs["output_bool"] = value
-        elif isinstance(value, float) or isinstance(value, int):
-            logger_kwargs["output_float"] = float(value)
-        elif value in ["Passed", "Failed"]:
-            logger_kwargs["output_bool"] = True if value == "Passed" else False
-        elif isinstance(value, list):
-            logger_kwargs["output_str_list"] = value
-        else:
-            logger_kwargs["output_str"] = str(value)
+        _dual_write_eval_value(
+            value, _eval_config_output(custom_eval_config), logger_kwargs
+        )
 
     EvalLogger.objects.create(**logger_kwargs)
 
@@ -2672,14 +2752,13 @@ def _execute_evaluation_for_session(
     # individual trace spans during exploration.
     try:
         from tfc.middleware.workspace_context import set_workspace_context
+
         set_workspace_context(
             workspace=workspace,
             organization=trace_session.project.organization,
         )
     except Exception as _ctx_err:
-        logger.warning(
-            "Failed to set workspace context for session eval: %s", _ctx_err
-        )
+        logger.warning("Failed to set workspace context for session eval: %s", _ctx_err)
 
     # --- Build context for data_injection support (session-scoped) ---
     # Mirrors the span-level _execute_evaluation block. At session level, the
@@ -2694,7 +2773,9 @@ def _execute_evaluation_for_session(
     #   span_context    → not applicable at session-level.
     _eval_inputs = dict(run_params or {})
     _di = _di_normalize(
-        (custom_eval_config.config or {}).get("run_config", {}).get("data_injection", {})
+        (custom_eval_config.config or {})
+        .get("run_config", {})
+        .get("data_injection", {})
     )
     if _di["session_context"]:
         _session_ctx = build_session_context(trace_session)
@@ -2772,9 +2853,7 @@ def _execute_evaluation_for_session(
         try:
             api_call_log_row.status = APICallStatusChoices.ERROR.value
             current_config = json.loads(api_call_log_row.config)
-            current_config.update(
-                {"output": {"output": None, "reason": str(e)}}
-            )
+            current_config.update({"output": {"output": None, "reason": str(e)}})
             api_call_log_row.config = json.dumps(current_config)
             api_call_log_row.save()
         except Exception:
@@ -2801,16 +2880,9 @@ def _execute_evaluation_for_session(
         value = "ERROR"
 
     if value != "ERROR":
-        if isinstance(value, bool):
-            logger_kwargs["output_bool"] = value
-        elif isinstance(value, float) or isinstance(value, int):
-            logger_kwargs["output_float"] = float(value)
-        elif value in ["Passed", "Failed"]:
-            logger_kwargs["output_bool"] = True if value == "Passed" else False
-        elif isinstance(value, list):
-            logger_kwargs["output_str_list"] = value
-        else:
-            logger_kwargs["output_str"] = str(value)
+        _dual_write_eval_value(
+            value, _eval_config_output(custom_eval_config), logger_kwargs
+        )
 
     EvalLogger.objects.create(**logger_kwargs)
 
@@ -2890,9 +2962,7 @@ def evaluate_trace_observe(
     target_type='trace' EvalLogger row anchored to the trace's root span.
     """
     if not trace_id or not custom_eval_config_id:
-        raise ValueError(
-            "trace_id and custom_eval_config_id are required parameters"
-        )
+        raise ValueError("trace_id and custom_eval_config_id are required parameters")
 
     try:
         custom_eval_config = CustomEvalConfig.objects.get(id=custom_eval_config_id)
@@ -2996,9 +3066,7 @@ def evaluate_trace_observe(
         )
         return False
     except Exception as e:
-        logger.exception(
-            f"Exception during evaluation in evaluate_trace_observe: {e}"
-        )
+        logger.exception(f"Exception during evaluation in evaluate_trace_observe: {e}")
         return False
 
 
@@ -3021,9 +3089,7 @@ def evaluate_trace_session_observe(
     and the session FK populated.
     """
     if not session_id or not custom_eval_config_id:
-        raise ValueError(
-            "session_id and custom_eval_config_id are required parameters"
-        )
+        raise ValueError("session_id and custom_eval_config_id are required parameters")
 
     try:
         custom_eval_config = CustomEvalConfig.objects.get(id=custom_eval_config_id)
@@ -3067,9 +3133,7 @@ def evaluate_trace_session_observe(
         )
         return True
     except ValueError as e:
-        logger.error(
-            f"Error during evaluation in evaluate_trace_session_observe: {e}"
-        )
+        logger.error(f"Error during evaluation in evaluate_trace_session_observe: {e}")
         if eval_task_id:
             try:
                 with transaction.atomic():


### PR DESCRIPTION
## Summary

Fixes the categorical / numeric eval regression where new rows written by `EvalLogger` stopped populating `output_float` and `output_str_list`. After `format_eval_value()` was changed to return dicts like `{"score": 0.7, "choice": "Choice 1"}` (and plain choice strings for prebuilt tune/choices evals), the 7 inline `isinstance(value, …)` dispatch chains in `tracer/utils/eval.py` fell through to `else: output_str = str(value)`, so the FE renderer (which still reads `output_float` / `output_str_list`) blanked the cell.

This PR centralises dispatch in a single dual-write helper, replaces all 7 sites with one call, and ships a Django management command to backfill rows already corrupted by the regression. The new dict/string shape stays available in `output_str`; the old format gets re-populated alongside for backward compatibility.

## Linked issues

Closes #

##Linear
Fixes TH-5449

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## What changed

**`futureagi/tracer/utils/eval.py`** — added two private helpers near the top of the file:

- `_dedupe_preserve_order(items)` — used everywhere we write `output_str_list` so the same choice never repeats.
- `_dual_write_eval_value(value, config_output, logger_kwargs)` — the only place in the file that assigns `output_float` / `output_str_list`. Strictly gated by the **stored** `eval_template.config["output"]`:
  - `output_float` ← only when `config["output"] == "score"`
  - `output_str_list` ← only when `config["output"] == "choices"`
  - `output_bool` ← never modified
  - All other output types (`Pass/Fail`, `reason`, `numeric`, …) ← behaviour identical to today's dispatch

  Other behaviour: dict-shaped results are JSON-serialised into `output_str` (instead of today's `str(value)` Python-repr). Score-path lists are collapsed to a mean (the list items can be plain numbers or `{"score": …}` dicts; bools are excluded from the average). Choices-path lists flatten through both plain-string and `{"choice": …}`/`{"choices": [...]}` shapes and run through dedup.

  All 7 dispatch sites in `_run_evaluation`, `_execute_composite_on_span`, `_execute_composite_on_trace`, `_execute_composite_on_session`, `_execute_evaluation`, `_execute_evaluation_for_trace`, `_execute_evaluation_for_session` now collapse to a single `_dual_write_eval_value(value, config_output, logger_kwargs)` call. A small `_eval_config_output(custom_eval_config)` accessor reads the stored type (never the runtime-promoted value).

**`futureagi/tracer/management/commands/backfill_eval_logger_dual_format.py`** (new) — parses the existing `output_str` (tries `json.loads` then `ast.literal_eval` for historical Python-repr rows) and feeds the parsed value back through `_dual_write_eval_value`, so backfill logic can never drift from the write path. Applies the helper's output with idempotent gating:

- `output_float` only written when missing.
- `output_str_list` only written when empty; otherwise deduped in place (cleans pre-existing duplicates from the buggy writes).
- `output_str` normalized to the helper's preferred form (JSON for dicts/lists, raw text otherwise).
- `output_bool`, `Pass/Fail`, and unrelated output types untouched.

Flags: `--dry-run`, `--limit N`, `--batch-size N`, `--eval-task-id <uuid>`, `--since YYYY-MM-DD`. Re-running is a no-op.

**No frontend change. No model migration. `format_eval_value()` left alone — the dict shape is treated as load-bearing.**

## Why this approach

- **Strict gating on stored `config["output"]`.** `format_eval_value` internally promotes `score` evals to the choices branch when `choice_scores` exist, but our gating reads the *stored* output type. A score eval whose dict happens to carry a `"choice"` key still routes only `score` → `output_float`; a choices eval whose dict carries `"score"` still routes only `choice(s)` → `output_str_list`. No accidental cross-writes.
- **Single source of truth.** `output_float` / `output_str_list` are only ever assigned inside `_dual_write_eval_value` — guarded by a source-level grep regression test. The backfill imports the same helper, so any future write-side refinement applies to historical data the next time the backfill runs.
- **Safe to roll out.** Every reader of `output_str` was audited: sentinel-equality checks (`== "ERROR"` / `"Passed"` / `"Failed"`), truncated display, or opaque `ILIKE` substring matching. No reader parses `output_str` as either Python repr or JSON today, so switching dict serialization to `json.dumps` is invisible to current consumers and forwards-compatible for any future JSON-aware reader.

## Deploy order

1. Merge this PR — every newly written eval is now correctly dual-written.
2. In prod: `python manage.py backfill_eval_logger_dual_format --dry-run`, inspect counts.
3. `python manage.py backfill_eval_logger_dual_format` to apply.
4. Rerun — should report `updated=0` (idempotent).

## How was this tested?

Two new test modules. 39 tests in total — 27 pure-function helper tests (no DB) + 12 backfill integration tests. Every assertion is keyed on the stored `config_output` so the gating contract is exercised directly.

### `tracer/tests/test_eval_dual_write.py` — 27 helper tests

#### Score-path routing (11 tests)

| Test | Scenario covered |
|---|---|
| `test_score_dict_routes_to_output_float_and_json_output_str` | Dict `{score: 0.7, choice: "Choice 1"}` → JSON in `output_str`, `output_float = 0.7`, `output_str_list` not set |
| `test_score_plain_float_routes_to_output_float` | Plain float `0.7` → `output_float = 0.7`, `output_str_list` not set, `output_str` not set |
| `test_score_zero_is_a_real_value` | `score = 0` populates `output_float = 0.0` (truthiness pitfall) |
| `test_score_dict_with_choice_does_not_set_output_str_list` | Dict with `"choice"` on a score config still routes only `score` → `output_float`, never `output_str_list` |
| `test_score_list_averages_into_output_float` | Plain list `[0.4, 0.6, 0.8]` → averaged to `0.6` in `output_float`, raw list JSON-dumped to `output_str` |
| `test_score_list_with_non_numeric_elements_is_filtered_before_averaging` | `[0.2, "skip", 0.8, None]` → mean of numerics only (`0.5`) |
| `test_score_empty_list_does_not_set_output_float` | `[]` → `output_float` left unset (no division-by-zero), empty list still JSON-dumped to `output_str` |
| `test_score_list_of_bools_does_not_count_them_as_numeric` | `[True, False]` excluded from mean (`bool` is `int` subclass) |
| `test_score_list_of_dicts_extracts_score_field_and_averages` | List of `{"score": …, "choice": …}` dicts → extract each `score`, average |
| `test_score_list_mixes_numbers_and_dicts` | Mixed `[0.4, {"score": 0.8}]` → both contribute to the mean |
| `test_score_list_of_dicts_skips_items_with_missing_or_non_numeric_score` | Items lacking `score`, or with non-numeric `score`, silently skipped |

#### Choices-path routing (8 tests)

| Test | Scenario covered |
|---|---|
| `test_choices_dict_single_choice_routes_to_list_not_float` | Dict with `"choice"` → `output_str_list = [choice]`, JSON in `output_str`, `output_float` not set |
| `test_choices_dict_multi_choice_routes_to_list` | Dict with `"choices": ["A","B"]` → `output_str_list = ["A","B"]` |
| `test_choices_plain_string_dual_writes_to_str_and_list` | Prebuilt tune/choices output `"Choice 1"` → both `output_str = "Choice 1"` and `output_str_list = ["Choice 1"]` |
| `test_choices_plain_list_routes_to_list` | `["A","B"]` → `output_str_list = ["A","B"]`, `output_str` not set (plain string lists don't touch `output_str`) |
| `test_choices_plain_list_dedupes_repeated_strings` | `["A","B","A","C","B"]` → `["A","B","C"]` (preserves first-seen order) |
| `test_choices_dict_multi_choice_dedupes_repeated_values` | `{"choices": ["A","B","A"]}` → `["A","B"]` |
| `test_choices_list_of_dicts_with_choice_flattens_and_dedupes` | `[{"choice":"A"},{"choice":"B"},{"choice":"A"}]` → `["A","B"]`; raw list also JSON-dumped to `output_str` (has dicts) |
| `test_choices_list_of_dicts_with_choices_field_flattens_and_dedupes` | `[{"choices":["A","B"]},{"choices":["B","C"]}]` → `["A","B","C"]` |
| `test_choices_list_mixes_strings_and_dicts` | `["A",{"choice":"B"},{"choices":["A","C"]},"C"]` → `["A","B","C"]`, mixed shape triggers `output_str` dump |

#### Other output types — unchanged from today (4 tests)

| Test | Scenario covered |
|---|---|
| `test_passfail_passed_routes_to_output_bool` | `"Passed"` → `output_bool = True`; nothing else set |
| `test_passfail_failed_routes_to_output_bool` | `"Failed"` → `output_bool = False` |
| `test_reason_plain_string_does_not_set_output_str_list` | `reason`-output string → only `output_str`; `output_str_list` not touched |
| `test_numeric_plain_float_preserves_today_behavior` | `numeric`-output float → `output_float` set (today's path preserved) |

#### Type-precedence + source-level regression guards (4 tests)

| Test | Scenario covered |
|---|---|
| `test_bool_takes_precedence_over_int_for_any_output_type` | `True` for any `config_output` → `output_bool = True`, never `output_float` (bool-vs-int subclass pitfall) |
| `test_helper_is_called_from_exactly_seven_dispatch_sites` | Greps `eval.py` and asserts `_dual_write_eval_value(` appears exactly 8 times (1 def + 7 call sites). Pins the call-site count so future edits can't silently drop a dispatcher. |
| `test_typed_columns_only_assigned_inside_helper` | Greps `eval.py` and asserts every `logger_kwargs["output_float"] =` / `logger_kwargs["output_str_list"] =` lives **inside** `_dual_write_eval_value`. Guarantees gating cannot be bypassed by inline assignments. |

### `tracer/tests/test_backfill_eval_logger_dual_format.py` — 12 backfill integration tests

These create real `EvalLogger` rows in the test DB, invoke `call_command("backfill_eval_logger_dual_format")`, and assert on the row state.

#### Original buggy-shape recovery (4 tests)

| Test | Scenario covered |
|---|---|
| `test_score_dict_python_repr_populates_output_float_and_rewrites_json` | Row with `output_str = str({"score": 0.7, "choice": "Choice 1"})` (Python repr) on a score config → `output_float = 0.7`, `output_str` rewritten to valid JSON, `output_str_list == []` (gated) |
| `test_choices_dict_populates_output_str_list_not_float` | Row with JSON dict in `output_str` on a choices config → `output_str_list = ["Choice 1"]`, `output_float` stays NULL |
| `test_choices_multi_choice_list_populated` | Row with `{"choices": ["A","B"]}` → `output_str_list = ["A","B"]` |
| `test_choices_plain_string_populates_output_str_list` | Prebuilt tune/choices: `output_str = "Choice 1"` on a choices config → `output_str_list = ["Choice 1"]`, `output_str` left as the raw string |

#### Out-of-scope rows are skipped (2 tests)

| Test | Scenario covered |
|---|---|
| `test_passfail_row_is_untouched` | `Pass/Fail` config with `output_bool` already set → nothing changed |
| `test_error_sentinel_rows_are_skipped` | Row with `output_str = "ERROR"` and `error = True` → untouched |

#### Operational safety (2 tests)

| Test | Scenario covered |
|---|---|
| `test_dry_run_does_not_modify_rows` | `--dry-run` reports counts but writes nothing |
| `test_rerun_is_idempotent` | Running the command twice in succession produces zero changes on the second run |

#### Helper parity — list-averaging + flattening + dedup (4 tests)

| Test | Scenario covered |
|---|---|
| `test_score_list_in_output_str_averages_into_output_float` | Row with `output_str = json.dumps([0.4, 0.6, 0.8])` on a score config → `output_float = 0.6`, `output_str_list` stays `[]` |
| `test_score_list_of_score_dicts_averages_into_output_float` | Row with `output_str = json.dumps([{"score":0.4,...},{"score":0.8,...}])` → `output_float = 0.6` |
| `test_choices_list_of_dicts_flattens_and_dedupes` | Row with `output_str = json.dumps([{"choice":"A"},{"choice":"B"},{"choice":"A"}])` → `output_str_list = ["A","B"]` |
| `test_choices_existing_output_str_list_is_deduped_in_place` | Row already has `output_str_list = ["A","B","A"]` (from a historical buggy write) → backfill dedupes to `["A","B"]` |

### Regression sweep — 225 eval-touching tests all pass

In addition to the 39 new tests, the following pre-existing suites pass against the changed code:

- `test_eval_score_rendering.py` (26)
- `test_eval_logger_schema.py` (13)
- `test_eval_task_runtime.py` (39)
- `test_custom_eval_config.py`, `test_eval_attributes_list.py`, `test_eval_clustering_window.py`, `test_get_evaluation_details.py`, `test_has_eval_filter.py`, `test_eval_task.py` (108 combined)

### Commands to run the tests

All from `futureagi/`. **Activate the venv first** — `bin/test` exports env vars but resolves `pytest` from `\$PATH`, so without the venv it falls back to system Python which lacks project deps.

```bash
cd futureagi
source .venv/bin/activate
bin/test up                        # starts test docker stack (ports 15432 / 16379 / 18123 / 19005)
```

**Just the new tests (39):**

```bash
bin/test --no-services \
  tracer/tests/test_eval_dual_write.py \
  tracer/tests/test_backfill_eval_logger_dual_format.py
```

<img width="1512" height="982" alt="Screenshot 2026-05-22 at 8 53 26 PM" src="https://github.com/user-attachments/assets/3334ba38-3feb-446f-8771-722bbc26384d" />


**Pure-function helper only (27, no DB needed — fastest feedback):**

```bash
bin/test --no-services tracer/tests/test_eval_dual_write.py
```

<img width="1512" height="982" alt="Screenshot 2026-05-22 at 8 54 02 PM" src="https://github.com/user-attachments/assets/ce2fcc79-9d50-4558-8202-ed273148aeb8" />


**Full eval regression sweep (225):**

```bash
bin/test --no-services \
  tracer/tests/test_eval_dual_write.py \
  tracer/tests/test_backfill_eval_logger_dual_format.py \
  tracer/tests/test_eval_score_rendering.py \
  tracer/tests/test_eval_logger_schema.py \
  tracer/tests/test_eval_task_runtime.py \
  tracer/tests/test_custom_eval_config.py \
  tracer/tests/test_eval_attributes_list.py \
  tracer/tests/test_eval_clustering_window.py \
  tracer/tests/test_get_evaluation_details.py \
  tracer/tests/test_has_eval_filter.py \
  tracer/tests/test_eval_task.py
```

<img width="1512" height="982" alt="Screenshot 2026-05-22 at 8 58 39 PM" src="https://github.com/user-attachments/assets/65551f3b-3ba5-4382-b4f1-f59152969c19" />


**Single test, debugging:**

```bash
bin/test --no-services -k "test_score_list_of_dicts" tracer/tests/test_eval_dual_write.py -v
```

**Direct invocation if you'd rather not activate the venv:**

```bash
DJANGO_SETTINGS_MODULE=tfc.settings.test \
DATABASE_URL=postgres://test_user:test_password@localhost:15432/test_tfc \
REDIS_URL=redis://localhost:16379/0 \
TEST_CLICKHOUSE_HOST=localhost TEST_CLICKHOUSE_PORT=18123 \
MINIO_ENDPOINT=localhost:19005 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin \
DEBUG=1 TEST=1 \
.venv/bin/pytest --reuse-db -q \
  tracer/tests/test_eval_dual_write.py \
  tracer/tests/test_backfill_eval_logger_dual_format.py
```

**Tear down the test stack when done:**

```bash
bin/test down
```

## Will the migration script work if data is large

currently only 12k rows are there which needs to be updated so , script should run easily.

<img width="1512" height="982" alt="Screenshot 2026-05-25 at 5 53 46 PM" src="https://github.com/user-attachments/assets/f74da1c7-aea8-477b-b96c-50cf1c5dd21b" />

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [ ] \`make check-all\` passes locally
- [x] I've updated the documentation where relevant (command help / docstrings)
- [x] No hardcoded secrets, URLs, or PII