### PR TITLE
Adding Aggregation APIS

### DIFF
--- a/futureagi/tracer/tests/test_eval_task_aggregations.py
+++ b/futureagi/tracer/tests/test_eval_task_aggregations.py
@@ -1,0 +1,469 @@
+"""
+Tests for the new ``eval_aggregation`` / ``span_aggregation`` modes on
+``EvalTaskView.get_usage`` — see ``tracer/views/eval_task.py``.
+
+Both modes short-circuit ``get_usage`` and return *only* the aggregated
+payload (no ``stats`` / ``chart`` / ``logs``). Soft-deleted and error rows
+are excluded from rollups. Span aggregation ignores session/trace-target
+rows (``observation_span_id IS NULL``) and picks the latest run when the
+same ``(span, eval_config)`` repeats.
+"""
+
+import pytest  # noqa: E402
+
+# Break the import cycle (see test_eval_logger_schema.py for the
+# canonical comment).
+import model_hub.tasks  # noqa: F401
+from model_hub.models.evals_metric import EvalTemplate  # noqa: E402
+from tracer.models.custom_eval_config import CustomEvalConfig  # noqa: E402
+from tracer.models.eval_task import (  # noqa: E402
+    EvalTask,
+    EvalTaskStatus,
+    RunType,
+)
+from tracer.models.observation_span import (  # noqa: E402
+    EvalLogger,
+    EvalTargetType,
+)
+
+USAGE_URL = "/tracer/eval-task/get_usage/"
+
+
+# ── Test scaffolding ───────────────────────────────────────────────────
+
+
+def _template(*, organization, workspace, output_type_normalized, name=None):
+    return EvalTemplate.objects.create(
+        name=name or f"Template ({output_type_normalized})",
+        description="",
+        organization=organization,
+        workspace=workspace,
+        output_type_normalized=output_type_normalized,
+        config={
+            "output": {
+                "pass_fail": "Pass/Fail",
+                "percentage": "score",
+                "deterministic": "choices",
+            }[output_type_normalized]
+        },
+    )
+
+
+def _config(*, project, template, name):
+    return CustomEvalConfig.objects.create(
+        name=name,
+        project=project,
+        eval_template=template,
+        config={},
+        mapping={},
+        filters={},
+    )
+
+
+def _task(*, project, name="Agg task"):
+    return EvalTask.objects.create(
+        project=project,
+        name=name,
+        filters={},
+        sampling_rate=100,
+        run_type=RunType.CONTINUOUS,
+        status=EvalTaskStatus.PENDING,
+        spans_limit=100,
+    )
+
+
+def _row(*, span, cfg, task, **kwargs):
+    return EvalLogger.objects.create(
+        target_type=EvalTargetType.SPAN,
+        observation_span=span,
+        trace=span.trace,
+        custom_eval_config=cfg,
+        eval_task_id=str(task.id),
+        **kwargs,
+    )
+
+
+# ── eval_aggregation ───────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestEvalAggregation:
+    def _get(self, auth_client, task, **extra):
+        return auth_client.get(
+            USAGE_URL,
+            {"eval_task_id": str(task.id), "eval_aggregation": "true", **extra},
+        )
+
+    def test_percentage_eval_returns_avg_output_float(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="percentage",
+        )
+        cfg = _config(project=project, template=tpl, name="Faithfulness")
+        task = _task(project=project)
+        for v in (0.4, 0.6, 0.8):
+            _row(span=observation_span, cfg=cfg, task=task, output_float=v)
+
+        body = self._get(auth_client, task).json()["result"]
+        agg = body["eval_aggregation"]["Faithfulness"]
+        assert agg["output_type"] == "percentage"
+        assert agg["aggregated_score"] == pytest.approx(0.6)
+        assert "stats" not in body and "chart" not in body and "logs" not in body
+
+    def test_pass_fail_eval_returns_pass_rate_0_to_100(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="pass_fail",
+        )
+        cfg = _config(project=project, template=tpl, name="Toxicity Check")
+        task = _task(project=project)
+        for v in (True, True, True, False):
+            _row(span=observation_span, cfg=cfg, task=task, output_bool=v)
+
+        agg = self._get(auth_client, task).json()["result"]["eval_aggregation"][
+            "Toxicity Check"
+        ]
+        assert agg["output_type"] == "pass_fail"
+        assert agg["aggregated_score"] == 75.0
+
+    def test_deterministic_eval_returns_per_choice_percentages(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="deterministic",
+        )
+        cfg = _config(project=project, template=tpl, name="Sentiment")
+        task = _task(project=project)
+        # 4 rows: A, B, AC, A → A in 3/4, B in 1/4, C in 1/4
+        for lst in (["A"], ["B"], ["A", "C"], ["A"]):
+            _row(span=observation_span, cfg=cfg, task=task, output_str_list=lst)
+
+        agg = self._get(auth_client, task).json()["result"]["eval_aggregation"][
+            "Sentiment"
+        ]
+        assert agg["output_type"] == "deterministic"
+        assert agg["aggregated_score"] == {
+            "A": 75.0,
+            "B": 25.0,
+            "C": 25.0,
+        }
+
+    def test_multiple_eval_types_in_one_task(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl_p = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="percentage",
+            name="t-pct",
+        )
+        tpl_b = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="pass_fail",
+            name="t-pf",
+        )
+        tpl_d = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="deterministic",
+            name="t-det",
+        )
+        cfg_p = _config(project=project, template=tpl_p, name="Faithfulness")
+        cfg_b = _config(project=project, template=tpl_b, name="Toxicity")
+        cfg_d = _config(project=project, template=tpl_d, name="Sentiment")
+        task = _task(project=project)
+        _row(span=observation_span, cfg=cfg_p, task=task, output_float=0.5)
+        _row(span=observation_span, cfg=cfg_b, task=task, output_bool=True)
+        _row(span=observation_span, cfg=cfg_d, task=task, output_str_list=["pos"])
+
+        agg = self._get(auth_client, task).json()["result"]["eval_aggregation"]
+        assert set(agg.keys()) == {"Faithfulness", "Toxicity", "Sentiment"}
+        assert agg["Faithfulness"]["aggregated_score"] == pytest.approx(0.5)
+        assert agg["Toxicity"]["aggregated_score"] == 100.0
+        assert agg["Sentiment"]["aggregated_score"] == {"pos": 100.0}
+
+    def test_empty_task_returns_empty_dict(self, auth_client, project):
+        task = _task(project=project)
+        agg = self._get(auth_client, task).json()["result"]["eval_aggregation"]
+        assert agg == {}
+
+    def test_error_rows_are_excluded(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="percentage",
+        )
+        cfg = _config(project=project, template=tpl, name="Faithfulness")
+        task = _task(project=project)
+        _row(span=observation_span, cfg=cfg, task=task, output_float=0.5)
+        _row(span=observation_span, cfg=cfg, task=task, output_float=0.5)
+        # Adding an error row with a spurious output_float must not shift
+        # the mean — the row is excluded entirely.
+        _row(
+            span=observation_span,
+            cfg=cfg,
+            task=task,
+            error=True,
+            error_message="boom",
+            output_float=1.0,
+        )
+
+        agg = self._get(auth_client, task).json()["result"]["eval_aggregation"][
+            "Faithfulness"
+        ]
+        assert agg["aggregated_score"] == pytest.approx(0.5)
+
+    def test_soft_deleted_rows_are_excluded(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="pass_fail",
+        )
+        cfg = _config(project=project, template=tpl, name="Toxicity")
+        task = _task(project=project)
+        _row(span=observation_span, cfg=cfg, task=task, output_bool=True)
+        _row(span=observation_span, cfg=cfg, task=task, output_bool=True)
+        # A soft-deleted False row would drop pass-rate to 66% if counted;
+        # excluding it keeps it at 100%.
+        _row(
+            span=observation_span,
+            cfg=cfg,
+            task=task,
+            output_bool=False,
+            deleted=True,
+        )
+
+        agg = self._get(auth_client, task).json()["result"]["eval_aggregation"][
+            "Toxicity"
+        ]
+        assert agg["aggregated_score"] == 100.0
+
+    def test_eval_id_filter_narrows_to_one_config(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="percentage",
+        )
+        cfg_a = _config(project=project, template=tpl, name="A")
+        cfg_b = _config(project=project, template=tpl, name="B")
+        task = _task(project=project)
+        _row(span=observation_span, cfg=cfg_a, task=task, output_float=0.1)
+        _row(span=observation_span, cfg=cfg_b, task=task, output_float=0.9)
+
+        agg = self._get(auth_client, task, eval_id=str(cfg_a.id)).json()["result"][
+            "eval_aggregation"
+        ]
+        assert list(agg.keys()) == ["A"]
+
+
+# ── span_aggregation ───────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestSpanAggregation:
+    def _get(self, auth_client, task, **extra):
+        return auth_client.get(
+            USAGE_URL,
+            {"eval_task_id": str(task.id), "span_aggregation": "true", **extra},
+        )
+
+    def test_returns_raw_value_per_eval_per_span(
+        self,
+        auth_client,
+        project,
+        organization,
+        workspace,
+        observation_span,
+        child_span,
+    ):
+        tpl_p = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="percentage",
+            name="t-pct",
+        )
+        tpl_d = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="deterministic",
+            name="t-det",
+        )
+        cfg_p = _config(project=project, template=tpl_p, name="Faithfulness")
+        cfg_d = _config(project=project, template=tpl_d, name="Sentiment")
+        task = _task(project=project)
+        _row(span=observation_span, cfg=cfg_p, task=task, output_float=0.82)
+        _row(
+            span=observation_span,
+            cfg=cfg_d,
+            task=task,
+            output_str_list=["positive"],
+        )
+        _row(span=child_span, cfg=cfg_p, task=task, output_float=0.31)
+
+        body = self._get(auth_client, task).json()["result"]
+        sa = body["span_aggregation"]
+        assert set(sa.keys()) == {
+            str(observation_span.id),
+            str(child_span.id),
+        }
+        assert sa[str(observation_span.id)]["Faithfulness"]["value"] == 0.82
+        assert sa[str(observation_span.id)]["Sentiment"]["value"] == ["positive"]
+        assert sa[str(child_span.id)]["Faithfulness"]["value"] == 0.31
+        assert "stats" not in body and "logs" not in body
+
+    def test_session_target_rows_are_skipped(
+        self,
+        auth_client,
+        observe_project,
+        trace_session,
+        organization,
+        workspace,
+        observation_span,
+        project,
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="pass_fail",
+        )
+        cfg_obs = _config(project=observe_project, template=tpl, name="ObsEval")
+        cfg_span = _config(project=project, template=tpl, name="SpanEval")
+        task = _task(project=project)
+        # One session-target row (no observation_span) — must be skipped.
+        EvalLogger.objects.create(
+            target_type=EvalTargetType.SESSION,
+            observation_span=None,
+            trace=None,
+            trace_session=trace_session,
+            custom_eval_config=cfg_obs,
+            eval_task_id=str(task.id),
+            output_bool=True,
+        )
+        # One span-target row — must appear.
+        _row(span=observation_span, cfg=cfg_span, task=task, output_bool=True)
+
+        sa = self._get(auth_client, task).json()["result"]["span_aggregation"]
+        assert list(sa.keys()) == [str(observation_span.id)]
+        assert sa[str(observation_span.id)]["SpanEval"]["value"] is True
+
+    def test_latest_wins_when_same_span_eval_pair_has_multiple_rows(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="percentage",
+        )
+        cfg = _config(project=project, template=tpl, name="Faithfulness")
+        task = _task(project=project)
+        older = _row(span=observation_span, cfg=cfg, task=task, output_float=0.1)
+        newer = _row(span=observation_span, cfg=cfg, task=task, output_float=0.9)
+        # bump `older` further into the past so created_at ordering is
+        # deterministic regardless of intra-test timing.
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        EvalLogger.objects.filter(id=older.id).update(
+            created_at=timezone.now() - timedelta(hours=2)
+        )
+        EvalLogger.objects.filter(id=newer.id).update(created_at=timezone.now())
+
+        sa = self._get(auth_client, task).json()["result"]["span_aggregation"]
+        assert sa[str(observation_span.id)]["Faithfulness"]["value"] == pytest.approx(
+            0.9
+        )
+
+    def test_soft_deleted_rows_are_excluded(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="pass_fail",
+        )
+        cfg = _config(project=project, template=tpl, name="Toxicity")
+        task = _task(project=project)
+        _row(
+            span=observation_span,
+            cfg=cfg,
+            task=task,
+            output_bool=False,
+            deleted=True,
+        )
+
+        sa = self._get(auth_client, task).json()["result"]["span_aggregation"]
+        assert sa == {}
+
+
+# ── Both flags / legacy preservation ───────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestAggregationFlagsCombined:
+    def test_both_flags_return_both_top_level_keys(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="pass_fail",
+        )
+        cfg = _config(project=project, template=tpl, name="Toxicity")
+        task = _task(project=project)
+        _row(span=observation_span, cfg=cfg, task=task, output_bool=True)
+
+        body = auth_client.get(
+            USAGE_URL,
+            {
+                "eval_task_id": str(task.id),
+                "eval_aggregation": "true",
+                "span_aggregation": "true",
+            },
+        ).json()["result"]
+
+        assert "eval_aggregation" in body and "span_aggregation" in body
+        assert "stats" not in body and "chart" not in body and "logs" not in body
+
+    def test_flags_absent_returns_legacy_shape(
+        self, auth_client, project, organization, workspace, observation_span
+    ):
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="pass_fail",
+        )
+        cfg = _config(project=project, template=tpl, name="Toxicity")
+        task = _task(project=project)
+        _row(span=observation_span, cfg=cfg, task=task, output_bool=True)
+
+        body = auth_client.get(
+            USAGE_URL,
+            {"eval_task_id": str(task.id), "page": 1, "page_size": 25, "period": "30d"},
+        ).json()["result"]
+
+        # Legacy shape pinned — must keep top-level keys the FE consumes.
+        assert "stats" in body and "chart" in body and "logs" in body
+        assert "eval_aggregation" not in body
+        assert "span_aggregation" not in body

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -1,13 +1,13 @@
 import json
 import traceback
 import uuid as uuid_module
-from collections import defaultdict
+from collections import Counter, defaultdict
 from datetime import datetime, timedelta
 from random import sample
 
 import structlog
 from django.db import models, transaction
-from django.db.models import Count, F, Func, Max, Q, Value
+from django.db.models import Avg, Count, F, Func, Max, Q, Value
 from django.utils import timezone
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -36,7 +36,6 @@ class _RegexpReplace(Func):
 
 # Re-exported for back-compat; canonical definition lives in `tracer.utils.eval`.
 from tracer.utils.eval import _walk_dotted_path  # noqa: E402, F401
-
 
 # Per-variable size cap to keep the panel payload bounded — a single
 # log row that maps a giant JSON document into the eval would otherwise
@@ -103,6 +102,139 @@ def _resolve_input_variables(custom_eval_config, obs_span):
             continue
         resolved[var_name] = value
     return resolved
+
+
+def _truthy(v):
+    """Match common DRF bool query-param conventions."""
+    return str(v).lower() in ("true", "1", "yes")
+
+
+def _compute_eval_aggregation(base_qs):
+    """Per-eval-config rollup for one eval task.
+
+    Returns a dict keyed by ``CustomEvalConfig.name`` so the FE can render
+    one row per configured eval. Value shape:
+
+        {"id": str, "name": str, "output_type": str, "aggregated_score": ...}
+
+    ``aggregated_score`` depends on the eval's ``output_type_normalized``:
+      * ``percentage``    → ``Avg(output_float)``, rounded to 4 dp.
+      * ``pass_fail``     → pass-rate as 0–100 pct, 2 dp (matches the
+        ``pass_rate`` field on the legacy ``get_usage`` shape).
+      * ``deterministic`` → ``{choice: pct}`` dict, 2 dp. Only choices that
+        actually appeared in the data are included.
+
+    The deterministic branch iterates rows in Python because PostgreSQL
+    JSONB array unnesting isn't expressible cleanly through the ORM and
+    the row count per (eval_task × eval_config) is bounded.
+    """
+    # Imported lazily to avoid the module-import cycle bite (tracer.views
+    # → tracer.models pulls things that import this view at import time).
+    from tracer.models.custom_eval_config import CustomEvalConfig
+
+    config_ids = list(
+        base_qs.values_list("custom_eval_config_id", flat=True).distinct()
+    )
+    configs = CustomEvalConfig.objects.filter(id__in=config_ids).select_related(
+        "eval_template"
+    )
+
+    result = {}
+    for cfg in configs:
+        output_type = (
+            cfg.eval_template.output_type_normalized
+            if cfg.eval_template
+            else "pass_fail"
+        )
+        rows = base_qs.filter(custom_eval_config_id=cfg.id, error=False)
+
+        aggregated_score = None
+        if output_type == "percentage":
+            avg = (
+                rows.exclude(output_float__isnull=True)
+                .aggregate(avg=Avg("output_float"))
+                .get("avg")
+            )
+            aggregated_score = round(avg, 4) if avg is not None else None
+        elif output_type == "pass_fail":
+            bool_rows = rows.exclude(output_bool__isnull=True)
+            total = bool_rows.count()
+            passed = bool_rows.filter(output_bool=True).count()
+            aggregated_score = round(passed / total * 100, 2) if total else None
+        elif output_type == "deterministic":
+            counter = Counter()
+            tally = 0
+            for lst in rows.values_list("output_str_list", flat=True):
+                if not lst:
+                    continue
+                tally += 1
+                # One count per choice per row — a multi-choice row that
+                # picks {"A","B"} contributes 1 to each, not 2 to one.
+                counter.update(set(lst))
+            aggregated_score = (
+                {c: round(n / tally * 100, 2) for c, n in counter.items()}
+                if tally
+                else {}
+            )
+
+        result[cfg.name] = {
+            "id": str(cfg.id),
+            "name": cfg.name,
+            "output_type": output_type,
+            "aggregated_score": aggregated_score,
+        }
+    return result
+
+
+def _compute_span_aggregation(base_qs):
+    """Per-span pivot of raw eval values for one eval task.
+
+    Returns ``{span_id → {eval_name → {id, name, output_type, value}}}``.
+    ``value`` is the raw column read for the eval's output type — no
+    averaging. Session/trace-target rows (``observation_span_id IS NULL``)
+    are filtered out.
+
+    When the same ``(span, eval_config)`` has multiple rows (re-runs),
+    the latest by ``created_at`` wins via the ORDER BY + first-seen set.
+    """
+    qs = (
+        base_qs.filter(observation_span_id__isnull=False, error=False)
+        .select_related("custom_eval_config__eval_template")
+        .order_by("observation_span_id", "custom_eval_config_id", "-created_at")
+    )
+
+    result = defaultdict(dict)
+    seen = set()
+    for log in qs.iterator(chunk_size=1000):
+        key = (log.observation_span_id, log.custom_eval_config_id)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        cfg = log.custom_eval_config
+        if cfg is None:
+            continue
+        output_type = (
+            cfg.eval_template.output_type_normalized
+            if cfg.eval_template
+            else "pass_fail"
+        )
+        if output_type == "percentage":
+            value = log.output_float
+        elif output_type == "pass_fail":
+            value = log.output_bool
+        elif output_type == "deterministic":
+            value = log.output_str_list
+        else:
+            value = None
+
+        result[str(log.observation_span_id)][cfg.name] = {
+            "id": str(cfg.id),
+            "name": cfg.name,
+            "output_type": output_type,
+            "value": value,
+        }
+    return dict(result)
 
 
 logger = structlog.get_logger(__name__)
@@ -479,6 +611,38 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             # passes this when the user picks one from the dropdown.
             eval_id_filter = self.request.query_params.get("eval_id")
 
+            # ── Aggregation short-circuit ──
+            # When either flag is set, return ONLY the aggregated payload.
+            # Soft-deleted rows are excluded (intentional departure from the
+            # legacy path) so rollups reflect the user's current view of
+            # the data. ``period`` is not applied — these are task-wide.
+            eval_aggregation = _truthy(
+                self.request.query_params.get("eval_aggregation")
+            )
+            span_aggregation = _truthy(
+                self.request.query_params.get("span_aggregation")
+            )
+            if eval_aggregation or span_aggregation:
+                agg_base_qs = EvalLogger.objects.filter(
+                    eval_task_id=str(eval_task_id),
+                    deleted=False,
+                )
+                if eval_id_filter:
+                    agg_base_qs = agg_base_qs.filter(
+                        custom_eval_config_id=eval_id_filter
+                    )
+
+                agg_response = {"eval_task_id": str(eval_task_id)}
+                if eval_aggregation:
+                    agg_response["eval_aggregation"] = _compute_eval_aggregation(
+                        agg_base_qs
+                    )
+                if span_aggregation:
+                    agg_response["span_aggregation"] = _compute_span_aggregation(
+                        agg_base_qs
+                    )
+                return self._gm.success_response(agg_response)
+
             period_delta = self._USAGE_PERIOD_MAP.get(period, timedelta(days=30))
             end_date = timezone.now()
             start_date = end_date - period_delta
@@ -659,9 +823,7 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
 
             paginator = ExtendedPageNumberPagination()
             paginator.page_size = page_size
-            logs_page = paginator.paginate_queryset(
-                logs_qs, self.request, view=self
-            )
+            logs_page = paginator.paginate_queryset(logs_qs, self.request, view=self)
 
             log_items = []
             for log in logs_page:

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -13,6 +13,8 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
 
+from model_hub.models.evals_metric import EvalTemplate
+
 
 class _RegexpReplace(Func):
     """
@@ -219,11 +221,11 @@ def _compute_span_aggregation(base_qs):
             if cfg.eval_template
             else "pass_fail"
         )
-        if output_type == "percentage":
+        if output_type == EvalTemplate.OutputTypeNormalized.PERCENTAGE:
             value = log.output_float
-        elif output_type == "pass_fail":
+        elif output_type == EvalTemplate.OutputTypeNormalized.PASS_FAIL:
             value = log.output_bool
-        elif output_type == "deterministic":
+        elif output_type == EvalTemplate.OutputTypeNormalized.DETERMINISTIC:
             value = log.output_str_list
         else:
             value = None


### PR DESCRIPTION
## Summary

Adds two new boolean query params (`eval_aggregation`, `span_aggregation`) to the existing `EvalTaskView.get_usage` endpoint so the UI can surface two summary views the current shape doesn't have:

1. **Eval-level rollup** — for each `CustomEvalConfig` that ran in the task, a single scalar that captures how the eval performed across all of its runs (pass rate, average score, per-choice proportions).
2. **Span-level pivot** — for each span the task evaluated, the raw result of every eval that touched it.

When either flag is true, `get_usage` short-circuits and returns *only* the aggregated payload — no `stats`, `chart`, or paginated `logs`. Soft-deleted and error rows are excluded from rollups; the legacy response shape is preserved when both flags are absent.

## Linked issues

Fixes **TH-5466**

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

## What changed

### `futureagi/tracer/views/eval_task.py`

Three new module-level private helpers (above the viewset class, next to `_resolve_input_variables`):

| Helper | Purpose |
|---|---|
| `_truthy(v)` | Parses common DRF bool query-param conventions (`true` / `1` / `yes`). |
| `_compute_eval_aggregation(base_qs)` | Per-eval-config rollup. Returns `{eval_name → {id, name, output_type, aggregated_score}}`. |
| `_compute_span_aggregation(base_qs)` | Per-span pivot. Returns `{span_id → {eval_name → {id, name, output_type, value}}}`. |

`get_usage` itself gains a short-circuit block immediately after `eval_id_filter` is parsed — if either flag is set, it builds a `base_qs` filtered by `eval_task_id`, `deleted=False`, and optionally `eval_id`, populates the aggregated keys, and returns. The rest of the legacy code (stats, chart, pagination, per-row log assembly) is not executed.

### Response shapes

**`eval_aggregation=true`** — key is `CustomEvalConfig.name`:

```jsonc
{
  "eval_task_id": "<uuid>",
  "eval_aggregation": {
    "Faithfulness": {
      "id": "<uuid>", "name": "Faithfulness",
      "output_type": "percentage",
      "aggregated_score": 0.7421                // Avg(output_float), 4dp
    },
    "Toxicity Check": {
      "id": "<uuid>", "name": "Toxicity Check",
      "output_type": "pass_fail",
      "aggregated_score": 87.5                  // pass rate 0–100, 2dp
    },
    "Sentiment": {
      "id": "<uuid>", "name": "Sentiment",
      "output_type": "deterministic",
      "aggregated_score": { "positive": 62.5, "neutral": 25.0, "negative": 12.5 }
    }
  }
}
```

**`span_aggregation=true`** — outer key is `observation_span_id`, inner key is `CustomEvalConfig.name`:

```jsonc
{
  "eval_task_id": "<uuid>",
  "span_aggregation": {
    "<span_id_1>": {
      "Faithfulness":   { "id": "...", "name": "Faithfulness",   "output_type": "percentage",    "value": 0.82 },
      "Toxicity Check": { "id": "...", "name": "Toxicity Check", "output_type": "pass_fail",     "value": true },
      "Sentiment":      { "id": "...", "name": "Sentiment",      "output_type": "deterministic", "value": ["positive"] }
    },
    "<span_id_2>": { ... }
  }
}
```

**Both flags true** → returns one payload containing both top-level keys; the legacy keys (`stats`, `chart`, `logs`) remain absent.

### Behaviour rules

1. **Soft-deleted rows excluded.** `.filter(deleted=False)` applied to `base_qs` once. Deliberate departure from legacy `get_usage`, which keeps soft-deleted rows for parity with `get_eval_task_logs`. Rationale: aggregated rollups should reflect the user's current view of the data.
2. **Error rows excluded** from numeric aggregates and from the span pivot.
3. **`eval_id` filter honoured**; **`period` ignored**. Aggregations are task-wide summaries.
4. **Span pivot ignores session/trace-target rows** (`observation_span_id IS NULL`).
5. **Latest-wins for duplicate `(span, eval)` pairs** via `ORDER BY observation_span_id, custom_eval_config_id, -created_at` + first-seen set. Rare but happens with re-runs.
6. **Empty results respond 200** with empty dicts, never an error.

### Per-output-type semantics

| `output_type_normalized` | Column read | Aggregated value |
|---|---|---|
| `percentage`     | `output_float`    | `Avg(output_float)` over non-error rows where `output_float IS NOT NULL`, rounded to 4 dp |
| `pass_fail`      | `output_bool`     | `count(output_bool=True) / count(output_bool IS NOT NULL) × 100`, 2 dp |
| `deterministic`  | `output_str_list` | `{choice: pct}` where `pct = (rows containing choice / non-empty rows) × 100`, 2 dp. Each choice counted once per row even when multi-choice. Only choices that actually appeared are included. |

The deterministic branch uses Python iteration deliberately: PostgreSQL JSONB array unnesting isn't expressible cleanly through the ORM, row count per (eval_task × eval_config) is bounded, and per-row scan is cheap.

**No FE change. No model migration. No new dependencies.**

## How was this tested?

One new test module, **14 tests total**, exercised through the DRF client against `/tracer/eval-task/get_usage/`. All assertions read the same wrapped response shape (`response.json()["result"]`) as the existing endpoint tests.

### `tracer/tests/test_eval_task_aggregations.py` — 14 tests

#### `TestEvalAggregation` — 8 tests

| Test | Scenario covered |
|---|---|
| `test_percentage_eval_returns_avg_output_float` | Task with one `percentage` eval, 3 non-error rows (`0.4`, `0.6`, `0.8`) → `aggregated_score = 0.6`. Also asserts the legacy `stats`/`chart`/`logs` keys are absent. |
| `test_pass_fail_eval_returns_pass_rate_0_to_100` | One `pass_fail` eval, 4 rows (3 True, 1 False) → `aggregated_score = 75.0` |
| `test_deterministic_eval_returns_per_choice_percentages` | One `deterministic` eval, 4 rows (`["A"]`, `["B"]`, `["A","C"]`, `["A"]`) → `{"A": 75.0, "B": 25.0, "C": 25.0}` |
| `test_multiple_eval_types_in_one_task` | Task with `percentage` + `pass_fail` + `deterministic` evals in the same task → response has all 3 entries with the right scalar / dict shape per type |
| `test_empty_task_returns_empty_dict` | Task with zero rows → `eval_aggregation == {}` (200, not an error) |
| `test_error_rows_are_excluded` | Adding an `error=True` row with a spurious `output_float=1.0` does not shift the mean of the non-error rows |
| `test_soft_deleted_rows_are_excluded` | Adding a `deleted=True` row that would otherwise drop pass-rate from 100% to 66% does not affect the result |
| `test_eval_id_filter_narrows_to_one_config` | With `eval_id=<cfg_a>` set, only `cfg_a`'s entry appears in the response — `cfg_b` (also on the task) is filtered out |

#### `TestSpanAggregation` — 4 tests

| Test | Scenario covered |
|---|---|
| `test_returns_raw_value_per_eval_per_span` | Two spans × two evals (one `percentage`, one `deterministic`) → outer keys are both span IDs; each inner dict has the raw column value per eval (no averaging). Legacy `stats`/`logs` keys absent. |
| `test_session_target_rows_are_skipped` | A `target_type=SESSION` row (with `observation_span IS NULL`) on the same task does NOT appear in the response keys; the span-target row does. |
| `test_latest_wins_when_same_span_eval_pair_has_multiple_rows` | Two rows for the same `(span, eval_config)` with `created_at` 2 hours apart → response shows the **newer** row's `value`. |
| `test_soft_deleted_rows_are_excluded` | A single `deleted=True` row on a span → `span_aggregation == {}` (the span doesn't appear because its only row is filtered) |

#### `TestAggregationFlagsCombined` — 2 tests

| Test | Scenario covered |
|---|---|
| `test_both_flags_return_both_top_level_keys` | `?eval_aggregation=true&span_aggregation=true` → response has both top-level keys; `stats`/`chart`/`logs` absent |
| `test_flags_absent_returns_legacy_shape` | No aggregation flags → response is the legacy shape (`stats`, `chart`, `logs` present; `eval_aggregation`, `span_aggregation` absent). Regression-pinned so the new code path can't silently swallow the legacy callers. |

### Regression sweep — 186 pre-existing eval-touching tests still pass

| File | Tests |
|---|---|
| `test_eval_task.py` | 38 |
| `test_eval_task_runtime.py` | 39 |
| `test_eval_logger_schema.py` | 13 |
| `test_eval_score_rendering.py` | 26 |
| `test_custom_eval_config.py` | 19 |
| `test_eval_attributes_list.py` | 13 |
| `test_eval_clustering_window.py` | 3 |
| `test_get_evaluation_details.py` | 14 |
| `test_has_eval_filter.py` | 21 |

Combined: **200 / 200 passing** (14 new + 186 regression).

### Commands to run the tests

All from `futureagi/`. **Activate the venv first** — `bin/test` exports env vars but resolves `pytest` from `$PATH`, so without the venv it falls back to system Python which lacks project deps.

```bash
cd futureagi
source .venv/bin/activate
bin/test up                            # starts test docker stack (ports 15432 / 16379 / 18123 / 19005)
```

**Just the new aggregation tests (14):**

```bash
bin/test --no-services tracer/tests/test_eval_task_aggregations.py
```

<img width="1512" height="982" alt="Screenshot 2026-05-22 at 11 01 10 PM" src="https://github.com/user-attachments/assets/eb8d9914-e0e8-4479-87b7-ee474853a846" />


**Pre-existing eval-touching tests — regression sweep (186):**

```bash
bin/test --no-services \
  tracer/tests/test_eval_task.py \
  tracer/tests/test_eval_task_runtime.py \
  tracer/tests/test_eval_logger_schema.py \
  tracer/tests/test_eval_score_rendering.py \
  tracer/tests/test_custom_eval_config.py \
  tracer/tests/test_eval_attributes_list.py \
  tracer/tests/test_eval_clustering_window.py \
  tracer/tests/test_get_evaluation_details.py \
  tracer/tests/test_has_eval_filter.py
```

<img width="1512" height="982" alt="Screenshot 2026-05-22 at 11 03 28 PM" src="https://github.com/user-attachments/assets/66759ae4-b036-4ac4-acf5-1c930dd021a0" />



**New + pre-existing — full sweep (200):**

```bash
bin/test --no-services \
  tracer/tests/test_eval_task_aggregations.py \
  tracer/tests/test_eval_task.py \
  tracer/tests/test_eval_task_runtime.py \
  tracer/tests/test_eval_logger_schema.py \
  tracer/tests/test_eval_score_rendering.py \
  tracer/tests/test_custom_eval_config.py \
  tracer/tests/test_eval_attributes_list.py \
  tracer/tests/test_eval_clustering_window.py \
  tracer/tests/test_get_evaluation_details.py \
  tracer/tests/test_has_eval_filter.py
```

<img width="1512" height="982" alt="Screenshot 2026-05-22 at 11 05 17 PM" src="https://github.com/user-attachments/assets/0e90a4f1-1789-4b37-9c24-6ac9bc088c51" />


**Single test, debugging:**



```bash
bin/test --no-services -k "test_deterministic_eval_returns_per_choice" tracer/tests/test_eval_task_aggregations.py -v
```

**Stop the test stack when done:**

```bash
bin/test down
```

**Manual smoke test against a local backend:**

```bash
curl 'http://localhost:8001/tracer/eval-task/get_usage/?eval_task_id=<id>&eval_aggregation=true'
curl 'http://localhost:8001/tracer/eval-task/get_usage/?eval_task_id=<id>&span_aggregation=true'
curl 'http://localhost:8001/tracer/eval-task/get_usage/?eval_task_id=<id>&eval_aggregation=true&span_aggregation=true'
curl 'http://localhost:8001/tracer/eval-task/get_usage/?eval_task_id=<id>'               # legacy shape unchanged
```

### Expected results

| Command | Tests | Time |
|---|---|---|
| New only | `14 passed` | ~9 s |
| Pre-existing sweep | `186 passed` | ~65 s |
| Full sweep | `200 passed` | ~70 s |

## Risks / called-out decisions

- **Keying by name** (per the design ask). `CustomEvalConfig.name` is not guaranteed unique within a project; if two configs in the same task share a name one will silently overwrite the other in the response dict. Acceptable given current product constraints; revisit if uniqueness assumptions change.
- **Choice keyspace** for `deterministic` evals comes from observed data, not the template's declared `choice_scores`. A choice configured on the template that never appeared in any row will be absent from the response — by design (self-describing).
- **No period scoping** on aggregations. If product later wants period-scoped rollups, it's an additive param (`agg_period=...`).
- **Latest-wins** for `(span, eval)` duplicates. If product wants a list of all runs per pair instead, the helper switches `value` to a list and drops the `seen` set.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my feature works
- [ ] `make check-all` passes locally
- [x] I've updated the documentation where relevant (helper docstrings)
- [x] No hardcoded secrets, URLs, or PII