### PR TITLE
fix(billing): emit usage events for voice recording rehost

### DIFF
--- a/futureagi/simulate/temporal/utils/async_storage.py
+++ b/futureagi/simulate/temporal/utils/async_storage.py
@@ -7,8 +7,6 @@ in high-concurrency scenarios.
 Uses httpx for async HTTP operations (already available in the project).
 """
 
-import uuid
-
 import httpx
 import structlog
 
@@ -89,6 +87,61 @@ async def download_audio_from_url_async(
     raise last_error or httpx.HTTPError(f"Failed to download {audio_url}")
 
 
+async def _convert_audio_url_to_s3_async_with_size(
+    call_id: str,
+    audio_url: str,
+    url_type: str = "audio",
+) -> tuple[str, int]:
+    """Internal worker that does the download + upload and reports size.
+
+    Returns (s3_url_or_original_on_failure, bytes_uploaded_to_s3). The
+    bytes count is 0 when the source URL was already on S3 or the upload
+    did not succeed; callers can use that to decide whether to bill.
+    """
+    if not audio_url:
+        return audio_url, 0
+
+    # Check if already an S3 URL
+    if "amazonaws.com" in str(audio_url) or "minio" in str(audio_url):
+        logger.info(f"{url_type} URL is already S3: {audio_url}")
+        return audio_url, 0
+
+    try:
+        logger.info(f"Converting {url_type} URL to S3: {audio_url}")
+
+        # Async download
+        audio_bytes = await download_audio_from_url_async(audio_url)
+
+        # S3 upload (still sync - minio client doesn't have async support)
+        # We use run_in_executor for just the upload, which is faster than download
+        import asyncio
+
+        # Use get_running_loop() to get the loop with the worker's large thread pool
+        # (set in worker.py via loop.set_default_executor)
+        loop = asyncio.get_running_loop()
+
+        def do_upload():
+            from tfc.utils.storage import upload_audio_to_s3
+
+            # Deterministic key per (call_id, url_type) so retries overwrite
+            # the same object instead of creating orphans. Required for
+            # idempotent rehost.
+            object_key = f"call-recordings/{call_id}/{url_type}.mp3"
+            audio_data = {"bytes": audio_bytes}
+            return upload_audio_to_s3(audio_data, object_key=object_key)
+
+        # Run upload in thread pool (small operation compared to download)
+        s3_url = await loop.run_in_executor(None, do_upload)
+
+        logger.info(f"Successfully converted {url_type} URL to S3: {s3_url}")
+        return s3_url, len(audio_bytes)
+
+    except Exception as e:
+        logger.error(f"Error converting {url_type} URL to S3: {e}")
+        # Return original URL on failure
+        return audio_url, 0
+
+
 async def convert_audio_url_to_s3_async(
     call_id: str,
     audio_url: str,
@@ -110,42 +163,23 @@ async def convert_audio_url_to_s3_async(
     Returns:
         str: S3 URL or original URL if conversion fails
     """
-    if not audio_url:
-        return audio_url
+    s3_url, _ = await _convert_audio_url_to_s3_async_with_size(
+        call_id, audio_url, url_type
+    )
+    return s3_url
 
-    # Check if already an S3 URL
-    if "amazonaws.com" in str(audio_url) or "minio" in str(audio_url):
-        logger.info(f"{url_type} URL is already S3: {audio_url}")
-        return audio_url
 
-    try:
-        logger.info(f"Converting {url_type} URL to S3: {audio_url}")
+async def convert_audio_url_to_s3_async_with_size(
+    call_id: str,
+    audio_url: str,
+    url_type: str = "audio",
+) -> tuple[str, int]:
+    """Like `convert_audio_url_to_s3_async` but also reports uploaded bytes.
 
-        # Async download
-        audio_bytes = await download_audio_from_url_async(audio_url)
-
-        # S3 upload (still sync - minio client doesn't have async support)
-        # We use run_in_executor for just the upload, which is faster than download
-        import asyncio
-
-        # Use get_running_loop() to get the loop with the worker's large thread pool
-        # (set in worker.py via loop.set_default_executor)
-        loop = asyncio.get_running_loop()
-
-        def do_upload():
-            from tfc.utils.storage import upload_audio_to_s3
-
-            object_key = f"call-recordings/{call_id}/{uuid.uuid4()}.mp3"
-            audio_data = {"bytes": audio_bytes}
-            return upload_audio_to_s3(audio_data, object_key=object_key)
-
-        # Run upload in thread pool (small operation compared to download)
-        s3_url = await loop.run_in_executor(None, do_upload)
-
-        logger.info(f"Successfully converted {url_type} URL to S3: {s3_url}")
-        return s3_url
-
-    except Exception as e:
-        logger.error(f"Error converting {url_type} URL to S3: {e}")
-        # Return original URL on failure
-        return audio_url
+    Returns (s3_url_or_original_on_failure, bytes_uploaded). The bytes
+    value is 0 when nothing was uploaded (already-on-S3 / failure), so
+    billing call sites can sum it directly without re-checking the URL.
+    """
+    return await _convert_audio_url_to_s3_async_with_size(
+        call_id, audio_url, url_type
+    )

--- a/futureagi/tracer/tasks/recordings_rehost.py
+++ b/futureagi/tracer/tasks/recordings_rehost.py
@@ -13,12 +13,16 @@ via `transaction.on_commit` after each upsert.
 import asyncio
 
 import structlog
+from django.db import transaction
 
-from simulate.temporal.utils.async_storage import convert_audio_url_to_s3_async
+from simulate.temporal.utils.async_storage import (
+    convert_audio_url_to_s3_async_with_size,
+)
 from tfc.temporal import temporal_activity
 from tracer.models.observability_provider import ProviderChoices
 from tracer.models.observation_span import ObservationSpan
 from tracer.utils.otel import ConversationAttributes
+from tracer.utils.usage_emit import emit_span_ingestion_usage
 
 logger = structlog.get_logger(__name__)
 
@@ -83,7 +87,7 @@ def rehost_external_recordings(span_id: str) -> None:
     """Re-host external provider recording URLs (Vapi/Retell) on FAGI S3.
 
     Hands each non-S3 `conversation.recording.*` URL to
-    `convert_audio_url_to_s3_async` (downloads run concurrently) and
+    `convert_audio_url_to_s3_async_with_size` (downloads run concurrently) and
     overwrites the key with the durable S3 URL. The helper returns the
     input URL unchanged on download failure, so the key falls back to the
     provider URL and a future tick can pick it up.
@@ -101,47 +105,95 @@ def rehost_external_recordings(span_id: str) -> None:
     if not keys:
         return
 
+    # Billing marker — url_types we've already emitted OBSERVE_ADD for on
+    # this span. Survives `_update_observation_span` overwriting
+    # span_attributes back to provider URLs, so subsequent polls of the
+    # same call don't re-bill the same audio.
+    already_billed = set((span.metadata or {}).get("rehost_billed_url_types", []))
+
     attrs = dict(span.span_attributes or {})
     jobs = [
         (key, attrs[key], url_type)
         for key, url_type in keys
-        if attrs.get(key) and not is_already_s3_url(attrs[key])
+        if attrs.get(key)
+        and not is_already_s3_url(attrs[key])
+        and url_type not in already_billed
     ]
     if not jobs:
         return
 
     call_id = _resolve_call_id(span)
 
-    async def _rehost_all() -> list[str]:
+    async def _rehost_all() -> list[tuple[str, int]]:
         return await asyncio.gather(
             *(
-                convert_audio_url_to_s3_async(call_id, url, url_type)
+                convert_audio_url_to_s3_async_with_size(call_id, url, url_type)
                 for _, url, url_type in jobs
             )
         )
 
     results = asyncio.run(_rehost_all())
 
-    changed = False
-    for (key, original_url, url_type), s3_url in zip(jobs, results):
+    successful: list[tuple[str, str, str, int]] = []  # (key, url_type, s3_url, size)
+    for (key, original_url, url_type), (s3_url, size) in zip(jobs, results):
         if s3_url and s3_url != original_url:
-            attrs[key] = s3_url
-            changed = True
+            successful.append((key, url_type, s3_url, size))
             logger.info(
                 "rehost_external_recordings: uploaded to S3",
                 call_id=call_id,
                 url_type=url_type,
                 s3_url=s3_url,
+                bytes=size,
             )
 
-    if not changed:
+    if not successful:
         return
 
-    span.span_attributes = attrs
-    span.save(update_fields=["span_attributes"])
+    # Re-check the marker under a row lock so concurrent activities for
+    # the same span (e.g., overlapping poll + webhook) can't both bill
+    # the same url_types. S3 uploads above are idempotent thanks to
+    # deterministic object keys, so they are safe to do without a lock.
+    with transaction.atomic():
+        locked = (
+            ObservationSpan.objects.select_for_update().filter(id=span_id).first()
+        )
+        if not locked:
+            return
+
+        current_billed = set(
+            (locked.metadata or {}).get("rehost_billed_url_types", [])
+        )
+        to_bill_types = {ut for (_, ut, _, _) in successful if ut not in current_billed}
+        bytes_to_bill = sum(
+            size for (_, ut, _, size) in successful if ut in to_bill_types
+        )
+
+        new_attrs = dict(locked.span_attributes or {})
+        for (key, _, s3_url, _) in successful:
+            new_attrs[key] = s3_url
+
+        md = dict(locked.metadata or {})
+        md["rehost_billed_url_types"] = sorted(current_billed | to_bill_types)
+
+        locked.span_attributes = new_attrs
+        locked.metadata = md
+        locked.save(update_fields=["span_attributes", "metadata"])
+
+        org_id = locked.project.organization_id
+
     logger.info(
         "rehost_external_recordings: persisted recordings",
         span_id=span_id,
         provider=span.provider,
         call_id=call_id,
+        uploaded_bytes=bytes_to_bill,
     )
+
+    if bytes_to_bill:
+        emit_span_ingestion_usage(
+            organization_id=org_id,
+            num_traces=0,
+            num_spans=0,
+            payload_bytes=bytes_to_bill,
+            source="voice_recording_rehost",
+        )

--- a/futureagi/tracer/tests/test_observability_recordings_rehost.py
+++ b/futureagi/tracer/tests/test_observability_recordings_rehost.py
@@ -72,10 +72,10 @@ class TestRehostExternalRecordings:
         )
 
         async def _fake_convert(call_id, url, url_type):
-            return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3"
+            return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3", 1024
 
         with patch(
-            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async_with_size",
             new=AsyncMock(side_effect=_fake_convert),
         ):
             rehost_external_recordings(span_id=str(span.id))
@@ -104,10 +104,10 @@ class TestRehostExternalRecordings:
         )
 
         async def _fake_convert(call_id, url, url_type):
-            return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3"
+            return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3", 1024
 
         with patch(
-            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async_with_size",
             new=AsyncMock(side_effect=_fake_convert),
         ):
             rehost_external_recordings(span_id=str(span.id))
@@ -136,7 +136,7 @@ class TestRehostExternalRecordings:
         )
 
         with patch(
-            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async_with_size",
             new=AsyncMock(),
         ) as mock_convert:
             rehost_external_recordings(span_id=str(span.id))
@@ -162,11 +162,11 @@ class TestRehostExternalRecordings:
         async def _flaky_convert(call_id, url, url_type):
             # Combined succeeds, stereo fails (helper returns input on failure).
             if url_type == "stereo":
-                return url
-            return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3"
+                return url, 0
+            return f"https://fagi.s3.amazonaws.com/{call_id}/{url_type}.mp3", 1024
 
         with patch(
-            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async_with_size",
             new=AsyncMock(side_effect=_flaky_convert),
         ):
             rehost_external_recordings(span_id=str(span.id))
@@ -187,7 +187,7 @@ class TestRehostExternalRecordings:
         )
 
         with patch(
-            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async_with_size",
             new=AsyncMock(),
         ) as mock_convert:
             rehost_external_recordings(span_id=str(span.id))
@@ -204,7 +204,7 @@ class TestRehostExternalRecordings:
         )
 
         with patch(
-            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async_with_size",
             new=AsyncMock(),
         ) as mock_convert:
             rehost_external_recordings(span_id=str(span.id))
@@ -213,7 +213,7 @@ class TestRehostExternalRecordings:
 
     def test_missing_span_logs_and_returns(self):
         with patch(
-            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async",
+            "tracer.tasks.recordings_rehost.convert_audio_url_to_s3_async_with_size",
             new=AsyncMock(),
         ) as mock_convert:
             rehost_external_recordings(span_id=str(uuid.uuid4()))

--- a/futureagi/tracer/utils/observability_provider.py
+++ b/futureagi/tracer/utils/observability_provider.py
@@ -240,7 +240,15 @@ def _create_observation_span(project, provider, normalized_data, metadata):
 
 def _update_observation_span(existing_span, normalized_data):
     """Updates an existing ObservationSpan and its associated Trace."""
-    attributes = normalized_data.get("span_attributes", {})
+    attributes = dict(normalized_data.get("span_attributes", {}))
+
+    # Preserve recording URLs we've already rehosted to S3 — the provider
+    # response only contains its own (expiring) URLs, so a wholesale
+    # overwrite would otherwise drop the durable S3 links the rehost task
+    # wrote on a previous poll.
+    for k, v in (existing_span.span_attributes or {}).items():
+        if isinstance(v, str) and ("amazonaws.com" in v or "minio" in v):
+            attributes[k] = v
 
     existing_span.start_time = normalized_data.get("start_time")
     existing_span.end_time = normalized_data.get("end_time")

--- a/futureagi/tracer/utils/usage_emit.py
+++ b/futureagi/tracer/utils/usage_emit.py
@@ -38,13 +38,16 @@ def emit_span_ingestion_usage(
                 )
             )
 
-        if num_spans:
+        if payload_bytes:
+            props = {"source": source}
+            if num_spans:
+                props["spans"] = num_spans
             emit(
                 UsageEvent(
                     org_id=org_id_str,
                     event_type=BillingEventType.OBSERVE_ADD,
-                    amount=payload_bytes or 0,
-                    properties={"source": source, "spans": num_spans},
+                    amount=payload_bytes,
+                    properties=props,
                 )
             )
     except Exception:


### PR DESCRIPTION
## Summary
- `rehost_external_recordings` was uploading vapi/retell audio MP3s to our S3 but **never emitting `OBSERVE_ADD`**. The JSON-metadata fix in #537 only covered ~1-5% of byte volume; the actual MB-per-call audio (95%+) was un-metered. This PR plugs that.
- Wires the rehost path through the shared `emit_span_ingestion_usage` helper with `source="voice_recording_rehost"`.
- Idempotency at the producer side: deterministic S3 keys + per-`(span, url_type)` marker in `metadata.rehost_billed_url_types` + `select_for_update` row lock on the save+marker step. Retries and concurrent activities (poll + webhook race for the same span) bill at-most-once.
- Side-channel data-loss fix: `_update_observation_span` now preserves `span_attribute` values already pointing at S3 across subsequent polls, so the wholesale overwrite no longer drops rehost links and the UI doesn't fall back to expiring provider URLs.

## Backward compat
- `convert_audio_url_to_s3_async` keeps its `-> str` signature. The 4 call sites in `ee/voice/services/vapi_service.py` (CallExecutionWorkflow's `extract_and_persist_recordings`) are untouched.
- New sibling `convert_audio_url_to_s3_async_with_size` returns `(url, bytes)` and is only imported by `recordings_rehost.py`.
- S3 key shape changed across both wrappers (`{call_id}/{url_type}.mp3` instead of `{call_id}/{uuid}.mp3`). Existing recordings with uuid-style keys remain accessible via the URLs already persisted in PG — they aren't moved.

## Out of scope (follow-ups)
- April + May backfill — separate one-off S3-walk script that lists `call-recordings/` by `LastModified`, maps `call_id → org`, and writes additive `UsageSummary` deltas (with `--update-redis` for May; April needs a billing decision since the period is closed).
- Exactly-once delivery — the commit-to-emit window can still under-bill on a process crash. Outbox pattern would close it; not in this hotfix.

## Test plan
- [ ] Trigger a Vapi call through the simulator, watch `usage:events` Redis stream for both `tracing_event` and `observe_add` (the latter with `source=voice_recording_rehost` once rehost completes)
- [ ] Confirm `UsageSummary` row for `dimension=storage` includes the audio bytes after the consumer flush
- [ ] Force a Temporal retry of `rehost_external_recordings` (e.g., raise mid-activity) — confirm only one emit fires across attempts and no orphan S3 objects accumulate
- [ ] After a poll arrives for an already-rehosted call, confirm `span.span_attributes` still holds the S3 URL (not the provider URL) and no second `observe_add` fires
- [ ] Existing CallExecutionWorkflow path: confirm vapi recordings still land on S3 and `result.recording_url` still receives a plain string

🤖 Generated with [Claude Code](https://claude.com/claude-code)