### PR TITLE
fix(auth): reject revoked and expired API keys

### DIFF
--- a/agentcc-gateway/internal/auth/keystore.go
+++ b/agentcc-gateway/internal/auth/keystore.go
@@ -211,7 +211,7 @@ func (ks *KeyStore) Authenticate(rawKey string) *APIKey {
 	key, ok := ks.byHash[hash]
 	ks.mu.RUnlock()
 
-	if !ok {
+	if !ok || !key.IsActive() {
 		return nil
 	}
 	// Best-effort last-used timestamp — atomic pointer swap, no write lock needed.

--- a/agentcc-gateway/internal/auth/keystore_test.go
+++ b/agentcc-gateway/internal/auth/keystore_test.go
@@ -103,6 +103,37 @@ func TestAuthenticate_SetsLastUsedAt(t *testing.T) {
 	}
 }
 
+func TestAuthenticate_RevokedKeyFails(t *testing.T) {
+	ks := NewKeyStore(authCfg())
+
+	key, rawKey := ks.Create("revoked", "alice", nil, nil, nil)
+
+	if !ks.Revoke(key.ID) {
+		t.Fatal("expected revoke to succeed")
+	}
+
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected revoked key authentication to fail")
+	}
+}
+
+func TestAuthenticate_ExpiredKeyFails(t *testing.T) {
+	expires := time.Now().Add(-1 * time.Hour)
+
+	cfg := authCfg(config.AuthKeyConfig{
+		Name:      "expired",
+		Key:       "expired-secret",
+		Owner:     "alice",
+		ExpiresAt: expires.Format(time.RFC3339),
+	})
+
+	ks := NewKeyStore(cfg)
+
+	if got := ks.Authenticate("expired-secret"); got != nil {
+		t.Fatal("expected expired key authentication to fail")
+	}
+}
+
 // ---------- CanAccessModel ----------
 
 func TestCanAccessModel_NoRestrictions(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes an authentication issue where revoked or expired API keys could still be authenticated successfully.

`Authenticate()` now validates that a key is active before returning it. Added unit tests to verify revoked and expired keys are correctly rejected.

## Linked issues

Closes #

## Type of change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

* Added unit tests for:

  * revoked API key authentication failure
  * expired API key authentication failure
* Existing authentication tests continue to pass
