### PR TITLE
fix(migrations): declare model_hub and tracer deps on accounts.0020

### DIFF
--- a/futureagi/accounts/migrations/0020_reseed_broken_demo_data.py
+++ b/futureagi/accounts/migrations/0020_reseed_broken_demo_data.py
@@ -123,6 +123,8 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("accounts", "0019_merge_20260407_1927"),
+        ("model_hub", "0100_merge_20260521_0749"),
+        ("tracer", "0077_merge_20260514_1559"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary

- `accounts/0020_reseed_broken_demo_data` calls `apps.get_model(\"model_hub\", ...)` and `apps.get_model(\"tracer\", ...)` inside RunPython, but only declares an `accounts` migration as a dependency. Django's state-apps registry for RunPython only contains apps reachable through the dependency graph, so the lookups fail with `LookupError: No installed app with label 'model_hub'`.
- This blocks every later migration in the chain, so `bin/install` cannot complete on a fresh clone — and the install script's later \`create_user\` step then reports \`relation \"saml_meta\" does not exist\` (because the saml migrations never ran either).
- Fix: add explicit dependencies on the latest \`model_hub\` and \`tracer\` migrations. The function itself is already idempotent — on a fresh install with no demo data it finds nothing and exits cleanly, so the extra deps are harmless beyond unblocking the chain.

## Repro (before fix)

\`\`\`
$ ./bin/install -y
…
==> Waiting for backend to become healthy
  ! Backend did not pass /health/ within 10 minutes.

$ docker compose logs backend | tail
…  File \"/app/backend/accounts/migrations/0020_reseed_broken_demo_data.py\", line 18, in reseed_broken_demo_data
    Dataset = apps.get_model(\"model_hub\", \"Dataset\")
  LookupError: No installed app with label 'model_hub'.
\`\`\`

Bug was introduced by 71305a9 (\"add data migration to reseed broken demo datasets\").

## Test plan

- [x] On a fresh clone with no \`.env\`, \`./bin/install -y\` fails at migrations (reproduced).
- [x] With this patch, \`docker compose restart backend\` lets the migration chain complete; \`/health/\` returns 200.
- [x] \`python manage.py create_user --email … --name … --password …\` succeeds; \`User.objects.filter(email=…).first()\` returns an active user.
- [x] Frontend serves at the configured \`FRONTEND_PORT\` and returns 200.
- [x] Migration is still idempotent on a fresh install (no demo data) — function exits at the \"nothing to do\" branch.