### PR TITLE
fix(frontend): poll eval-task list while tasks are pending or running

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
@@ -253,6 +253,7 @@ const EditTaskDrawerV2Content = ({
       queryClient.invalidateQueries({
         queryKey: ["taskDetails", taskDetails?.id],
       });
+      queryClient.invalidateQueries({ queryKey: ["eval-tasks"] });
       enqueueSnackbar(data?.data?.result?.message || "Task updated", {
         variant: "success",
       });

--- a/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
+++ b/frontend/src/sections/common/EvalsTasks/TaskListView.jsx
@@ -249,6 +249,24 @@ FilterSummary.propTypes = {
   filtersApplied: PropTypes.object,
 };
 
+const INFLIGHT_STATUSES = ["pending", "running"];
+
+function getEvalTaskListItems(data) {
+  return (
+    data?.table ||
+    data?.tasks ||
+    data?.results ||
+    data?.data ||
+    (Array.isArray(data) ? data : [])
+  );
+}
+
+function hasInflightEvalTasks(data) {
+  return getEvalTaskListItems(data).some((row) =>
+    INFLIGHT_STATUSES.includes(row?.status),
+  );
+}
+
 // ── Main Component ──
 
 const TaskListView = ({
@@ -312,17 +330,12 @@ const TaskListView = ({
       return resp?.result;
     },
     keepPreviousData: true,
+    refetchInterval: (query) =>
+      hasInflightEvalTasks(query.state.data) ? 5000 : false,
+    refetchIntervalInBackground: false,
   });
 
-  const items = useMemo(
-    () =>
-      data?.table ||
-      data?.tasks ||
-      data?.results ||
-      data?.data ||
-      (Array.isArray(data) ? data : []),
-    [data],
-  );
+  const items = useMemo(() => getEvalTaskListItems(data), [data]);
   const total =
     data?.metadata?.total_count ||
     data?.total ||


### PR DESCRIPTION
## Summary
Fixes stale status cells on the eval-task list (#514). Rows stayed at their initial `pending` / `running` state until a hard refresh or pagination changed the query key.
- Poll the `eval-tasks` list every 5s while any visible row is `pending` or `running` (same pattern as `TaskLogsView`)
- Stop polling when all visible rows are terminal
- Pause polling when the tab is in the background
- Invalidate `["eval-tasks"]` after saving a task in `EditTaskDrawerV2`
Closes #514
## Test plan
- [ ] Open `/dashboard/tasks` with a `pending` or `running` task; status updates within ~5s without refresh
- [ ] When all visible rows are terminal, polling stops (no extra network requests)
- [ ] Edit task in drawer → list updates without manual refresh
- [ ] Tab in background → polling pauses
- [ ] Pagination / search / sort still work