### PR TITLE
fix(evals): serialise seed_evals with advisory lock (TH-5501)

### DIFF
--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -27,6 +27,11 @@ logger = structlog.get_logger(__name__)
 # Bump this when system evals change. Seeder skips if DB is already at this version.
 SYSTEM_EVALS_VERSION = 10
 
+# Postgres advisory-lock key. Serialises concurrent seed_evals() calls
+# across pods so the bulk_create path can't race on new eval_ids. Any
+# stable 64-bit constant works; this one is arbitrary.
+_SEED_EVALS_LOCK_KEY = 0x5EED_E7A1
+
 SYSTEM_EVALS_DIR = Path(__file__).resolve().parent.parent.parent / "system_evals"
 CATALOG_YAML = (
     Path(__file__).resolve().parent.parent.parent.parent
@@ -86,83 +91,95 @@ def seed_evals(dry_run=False, force=False, verbose=False):
     """
     Core seeding logic. Called by the management command and by apps.py on startup.
 
+    Wrapped in a transaction-scoped advisory lock so concurrent pod startups
+    can't race on bulk_create for newly-added eval_ids (TH-5501).
+
     Returns (created, updated, skipped) counts.
     """
     from django.core.cache import cache
+    from django.db import connection
 
     from model_hub.models.choices import OwnerChoices
     from model_hub.models.evals_metric import EvalTemplate
 
-    # Version check — skip if already up to date
-    if not force:
-        cached_version = cache.get("system_evals_version", 0)
-        if cached_version >= SYSTEM_EVALS_VERSION:
-            if verbose:
-                logger.info("system_evals_up_to_date", version=SYSTEM_EVALS_VERSION)
+    with transaction.atomic():
+        # Serialise concurrent seeders. pg_advisory_xact_lock releases at
+        # COMMIT/ROLLBACK, so a killed pod can't leave an orphan lock.
+        with connection.cursor() as cur:
+            cur.execute(
+                "SELECT pg_advisory_xact_lock(%s)", [_SEED_EVALS_LOCK_KEY]
+            )
+
+        # Re-check version cache INSIDE the lock — another pod may have
+        # finished seeding while we were waiting for the lock.
+        if not force:
+            cached_version = cache.get("system_evals_version", 0)
+            if cached_version >= SYSTEM_EVALS_VERSION:
+                if verbose:
+                    logger.info("system_evals_up_to_date", version=SYSTEM_EVALS_VERSION)
+                return 0, 0, 0
+
+        yaml_evals = load_yaml_evals()
+        if not yaml_evals:
+            logger.warning("no_yaml_evals_found", dir=str(SYSTEM_EVALS_DIR))
             return 0, 0, 0
 
-    yaml_evals = load_yaml_evals()
-    if not yaml_evals:
-        logger.warning("no_yaml_evals_found", dir=str(SYSTEM_EVALS_DIR))
-        return 0, 0, 0
+        # Build lookup of existing templates by eval_id
+        existing_by_eval_id = {
+            t.eval_id: t
+            for t in EvalTemplate.no_workspace_objects.filter(
+                eval_id__in=[e["eval_id"] for e in yaml_evals]
+            )
+        }
 
-    # Build lookup of existing templates by eval_id
-    existing_by_eval_id = {
-        t.eval_id: t
-        for t in EvalTemplate.no_workspace_objects.filter(
-            eval_id__in=[e["eval_id"] for e in yaml_evals]
-        )
-    }
+        created_count = 0
+        updated_count = 0
+        skipped_count = 0
 
-    created_count = 0
-    updated_count = 0
-    skipped_count = 0
+        to_create = []
+        to_update = []
 
-    to_create = []
-    to_update = []
+        for eval_def in yaml_evals:
+            eval_id = eval_def["eval_id"]
+            name = eval_def["name"]
 
-    for eval_def in yaml_evals:
-        eval_id = eval_def["eval_id"]
-        name = eval_def["name"]
+            # Build the template fields from YAML
+            fields = _yaml_to_template_fields(eval_def)
 
-        # Build the template fields from YAML
-        fields = _yaml_to_template_fields(eval_def)
+            if eval_id in existing_by_eval_id:
+                # Update existing
+                existing = existing_by_eval_id[eval_id]
+                changed = False
+                for field_name, value in fields.items():
+                    if getattr(existing, field_name, None) != value:
+                        setattr(existing, field_name, value)
+                        changed = True
 
-        if eval_id in existing_by_eval_id:
-            # Update existing
-            existing = existing_by_eval_id[eval_id]
-            changed = False
-            for field_name, value in fields.items():
-                if getattr(existing, field_name, None) != value:
-                    setattr(existing, field_name, value)
-                    changed = True
-
-            if changed:
-                to_update.append(existing)
-                updated_count += 1
-                if verbose:
-                    logger.info("eval_updated", name=name, eval_id=eval_id)
+                if changed:
+                    to_update.append(existing)
+                    updated_count += 1
+                    if verbose:
+                        logger.info("eval_updated", name=name, eval_id=eval_id)
+                else:
+                    skipped_count += 1
+                    if verbose:
+                        logger.info("eval_unchanged", name=name, eval_id=eval_id)
             else:
-                skipped_count += 1
+                # Create new
+                to_create.append(EvalTemplate(**fields))
+                created_count += 1
                 if verbose:
-                    logger.info("eval_unchanged", name=name, eval_id=eval_id)
-        else:
-            # Create new
-            to_create.append(EvalTemplate(**fields))
-            created_count += 1
-            if verbose:
-                logger.info("eval_created", name=name, eval_id=eval_id)
+                    logger.info("eval_created", name=name, eval_id=eval_id)
 
-    if dry_run:
-        logger.info(
-            "dry_run_summary",
-            would_create=created_count,
-            would_update=updated_count,
-            unchanged=skipped_count,
-        )
-        return created_count, updated_count, skipped_count
+        if dry_run:
+            logger.info(
+                "dry_run_summary",
+                would_create=created_count,
+                would_update=updated_count,
+                unchanged=skipped_count,
+            )
+            return created_count, updated_count, skipped_count
 
-    with transaction.atomic():
         if to_create:
             EvalTemplate.no_workspace_objects.bulk_create(
                 to_create, ignore_conflicts=True
@@ -188,11 +205,11 @@ def seed_evals(dry_run=False, force=False, verbose=False):
             ]
             EvalTemplate.no_workspace_objects.bulk_update(to_update, update_fields)
 
-    # Update version cache
-    try:
-        cache.set("system_evals_version", SYSTEM_EVALS_VERSION, timeout=None)
-    except Exception:
-        pass  # Cache unavailable — seeder still works, just re-runs next time
+        # Update version cache
+        try:
+            cache.set("system_evals_version", SYSTEM_EVALS_VERSION, timeout=None)
+        except Exception:
+            pass  # Cache unavailable — seeder still works, just re-runs next time
 
     logger.info(
         "system_evals_seeded",


### PR DESCRIPTION
## What this fixes

Newly-added system evals get duplicated in `model_hub_evaltemplate` on the deploy that first introduces them. Confirmed:

- `conversation_hallucination` (eval_id 200) on Dev RDS: 3 rows within 144ms
- `dead_air_detection` (eval_id 201) on staging EC2: 4 rows within 185ms

## Root cause

`AppConfig.ready()` calls `seed_evals()` on every Django process startup. On a k8s rolling deploy, ~28-30 pods (backend, temporal workers, etc.) enter `seed_evals()` concurrently. `model_hub_evaltemplate` has no unique index on `eval_id`, so `bulk_create(ignore_conflicts=True)` is a no-op and every concurrent INSERT succeeds for new eval_ids.

## Fix

Wrap `seed_evals()` in a transaction-scoped Postgres advisory lock (`pg_advisory_xact_lock`). One pod cluster-wide does the work at a time; others wait briefly then hit the version-cache skip (re-checked inside the lock).

- Single file change: `model_hub/management/commands/seed_system_evals.py`
- No migration, no schema change, no Helm / CI changes
- Lock auto-releases at COMMIT/ROLLBACK, no orphan-lock risk

## Tests

End-to-end on local docker (Postgres + Redis + backend container):

| Test | Branch | Concurrent pods | New eval YAML | Rows created |
|---|---|---|---|---|
| Reproduce race | `dev` | 6 `--force` | `eval_id=999` | **6 dupes** |
| Verify fix | this PR | 6 `--force` | `eval_id=999` | **1 row** |
| Idempotency on existing evals | this PR | 4 `--force` | none | 0 created, 155 unchanged |

In the fix run, Pod-2 acquired the lock first, created the new row, set Redis to v=11. Pods 1, 3, 4, 5, 6 each acquired the lock in turn, saw `cached_version=11 >= 11` from the re-check inside the lock, and returned (0, 0, 0).

## Linear

https://linear.app/future-agi/issue/TH-5501