### PR TITLE
fix(evals): prevent stale data and disable variable mapping while columns load across all three test modes

### DIFF
--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -12,6 +12,7 @@ import {
   Tab,
   Tabs,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { TreeView, TreeItem } from "@mui/lab";
@@ -359,7 +360,14 @@ function renderTreeNode(node, onSelect) {
   );
 }
 
-function ColumnTreeSelect({ columnNames, value, onChange, isUnmapped }) {
+function ColumnTreeSelect({
+  columnNames,
+  value,
+  onChange,
+  isUnmapped,
+  disabled = false,
+  disabledTooltip = "",
+}) {
   const [open, setOpen] = useState(false);
   const [typing, setTyping] = useState(false);
   const anchorRef = useRef(null);
@@ -393,46 +401,65 @@ function ColumnTreeSelect({ columnNames, value, onChange, isUnmapped }) {
     setTyping(false);
   };
 
-  return (
-    <Box sx={{ flex: 1 }}>
-      <TextField
-        ref={anchorRef}
-        size="small"
-        fullWidth
-        value={value}
-        placeholder="Select column"
-        onFocus={() => setOpen(true)}
-        onChange={(e) => {
-          setTyping(true);
-          onChange(e.target.value);
-          if (!open) setOpen(true);
-        }}
-        autoComplete="off"
-        inputProps={{
-          autoComplete: "off",
-          autoCorrect: "off",
-          spellCheck: false,
-        }}
-        InputProps={{
-          sx: { fontSize: "12px", fontFamily: "monospace", height: 30, py: 0 },
-          endAdornment: (
-            <InputAdornment position="end">
+  const textField = (
+    <TextField
+      ref={anchorRef}
+      size="small"
+      fullWidth
+      value={value}
+      placeholder={disabled ? "Loading columns..." : "Select column"}
+      disabled={disabled}
+      onFocus={() => {
+        if (disabled) return;
+        setOpen(true);
+      }}
+      onChange={(e) => {
+        if (disabled) return;
+        setTyping(true);
+        onChange(e.target.value);
+        if (!open) setOpen(true);
+      }}
+      autoComplete="off"
+      inputProps={{
+        autoComplete: "off",
+        autoCorrect: "off",
+        spellCheck: false,
+      }}
+      InputProps={{
+        sx: { fontSize: "12px", fontFamily: "monospace", height: 30, py: 0 },
+        endAdornment: (
+          <InputAdornment position="end">
+            {disabled ? (
+              <CircularProgress size={14} />
+            ) : (
               <Iconify
                 icon={open ? "mdi:chevron-up" : "mdi:chevron-down"}
                 width={16}
                 sx={{ color: "text.disabled", cursor: "pointer" }}
                 onClick={() => { setOpen((p) => !p); setTyping(false); }}
               />
-            </InputAdornment>
-          ),
-        }}
-        sx={{
-          ...(isUnmapped && {
-            "& .MuiOutlinedInput-notchedOutline": { borderColor: "warning.main" },
-          }),
-        }}
-      />
-      {open && filtered.length > 0 && (
+            )}
+          </InputAdornment>
+        ),
+      }}
+      sx={{
+        ...(isUnmapped && {
+          "& .MuiOutlinedInput-notchedOutline": { borderColor: "warning.main" },
+        }),
+      }}
+    />
+  );
+
+  return (
+    <Box sx={{ flex: 1 }}>
+      {disabled && disabledTooltip ? (
+        <Tooltip title={disabledTooltip} placement="top" arrow>
+          <Box>{textField}</Box>
+        </Tooltip>
+      ) : (
+        textField
+      )}
+      {!disabled && open && filtered.length > 0 && (
         <Popper
           open
           anchorEl={anchorRef.current}
@@ -1222,6 +1249,8 @@ const DatasetTestMode = React.forwardRef(
               onChange={(_, newValue) => {
                 setSelectedDataset(newValue);
                 setSelectedDatasetId(newValue?.id || "");
+                setMapping({});
+                setColumns([]);
               }}
               onInputChange={(_, newInput, reason) => {
                 if (reason === "input") setDatasetSearch(newInput);
@@ -1629,6 +1658,8 @@ const DatasetTestMode = React.forwardRef(
                       }))
                     }
                     isUnmapped={isUnmapped}
+                    disabled={!isWorkbenchMode && loadingData}
+                    disabledTooltip="Columns are being fetched"
                   />
                 </Box>
               );

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -12,9 +12,9 @@ import {
   Tab,
   Tabs,
   TextField,
-  Tooltip,
   Typography,
 } from "@mui/material";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import { TreeView, TreeItem } from "@mui/lab";
 import PropTypes from "prop-types";
 import React, {
@@ -453,9 +453,16 @@ function ColumnTreeSelect({
   return (
     <Box sx={{ flex: 1 }}>
       {disabled && disabledTooltip ? (
-        <Tooltip title={disabledTooltip} placement="top" arrow>
+        <CustomTooltip
+          show
+          type="black"
+          size="small"
+          title={disabledTooltip}
+          placement="top"
+          arrow
+        >
           <Box>{textField}</Box>
-        </Tooltip>
+        </CustomTooltip>
       ) : (
         textField
       )}

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -26,6 +26,7 @@ import axios, { endpoints } from "src/utils/axios";
 import { canonicalEntries, canonicalKeys } from "src/utils/utils";
 import CustomAudioPlayer from "src/components/custom-audio/CustomAudioPlayer";
 import { AudioPlaybackProvider } from "src/components/custom-audio/context-provider/AudioPlaybackContext";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import DraggableColResizer from "src/components/draggable-col-resizer";
 import { JsonValueTree } from "./DatasetTestMode";
 import { buildCompositeRuntimeConfig } from "../Helpers/compositeRuntimeConfig";
@@ -1655,44 +1656,11 @@ const SimulationTestMode = React.forwardRef(
               Variable Mapping
             </Typography>
             <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
-              {variables.map((variable) => (
-                <Box
-                  key={variable}
-                  sx={{ display: "flex", alignItems: "center", gap: 1 }}
-                >
-                  <Box
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 0.5,
-                      px: 1,
-                      py: 0.25,
-                      borderRadius: "4px",
-                      border: "1px solid",
-                      borderColor: "divider",
-                      minWidth: 120,
-                    }}
-                  >
-                    <Iconify
-                      icon="mdi:code-braces"
-                      width={14}
-                      sx={{ color: "text.secondary" }}
-                    />
-                    <Typography
-                      variant="caption"
-                      fontWeight={600}
-                      sx={{ fontSize: "12px" }}
-                    >
-                      {variable}
-                    </Typography>
-                  </Box>
-                  <Iconify
-                    icon="mdi:arrow-right"
-                    width={14}
-                    sx={{ color: "text.disabled" }}
-                  />
+              {variables.map((variable) => {
+                const autocomplete = (
                   <Autocomplete
                     size="small"
+                    disabled={isMappingPending}
                     options={
                       mapping[variable] &&
                       !fieldNames.includes(mapping[variable])
@@ -1716,7 +1684,11 @@ const SimulationTestMode = React.forwardRef(
                     renderInput={(params) => (
                       <TextField
                         {...params}
-                        placeholder="Search field..."
+                        placeholder={
+                          isMappingPending
+                            ? "Loading columns..."
+                            : "Search field..."
+                        }
                         InputProps={{
                           ...params.InputProps,
                           sx: {
@@ -1726,6 +1698,13 @@ const SimulationTestMode = React.forwardRef(
                             height: 28,
                             py: 0,
                           },
+                          endAdornment: isMappingPending ? (
+                            <InputAdornment position="end">
+                              <CircularProgress size={14} />
+                            </InputAdornment>
+                          ) : (
+                            params.InputProps.endAdornment
+                          ),
                         }}
                       />
                     )}
@@ -1757,8 +1736,60 @@ const SimulationTestMode = React.forwardRef(
                       );
                     }}
                   />
-                </Box>
-              ))}
+                );
+                return (
+                  <Box
+                    key={variable}
+                    sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                  >
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.5,
+                        px: 1,
+                        py: 0.25,
+                        borderRadius: "4px",
+                        border: "1px solid",
+                        borderColor: "divider",
+                        minWidth: 120,
+                      }}
+                    >
+                      <Iconify
+                        icon="mdi:code-braces"
+                        width={14}
+                        sx={{ color: "text.secondary" }}
+                      />
+                      <Typography
+                        variant="caption"
+                        fontWeight={600}
+                        sx={{ fontSize: "12px" }}
+                      >
+                        {variable}
+                      </Typography>
+                    </Box>
+                    <Iconify
+                      icon="mdi:arrow-right"
+                      width={14}
+                      sx={{ color: "text.disabled" }}
+                    />
+                    {isMappingPending ? (
+                      <CustomTooltip
+                        show
+                        type="black"
+                        size="small"
+                        title="Columns are being fetched"
+                        placement="top"
+                        arrow
+                      >
+                        <Box sx={{ flex: 1 }}>{autocomplete}</Box>
+                      </CustomTooltip>
+                    ) : (
+                      autocomplete
+                    )}
+                  </Box>
+                );
+              })}
             </Box>
           </Box>
         )}

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -327,9 +327,10 @@ const SimulationTestMode = React.forwardRef(
         setSelectedExecutionId("");
         setRunTestContext(null);
         setExecutionsFetched(false);
-        return;
+        return undefined;
       }
       setExecutionsFetched(false);
+      let cancelled = false;
       const fetchAll = async () => {
         try {
           // Fetch detail (agent def, scenarios, persona, evals) and executions in parallel
@@ -342,6 +343,7 @@ const SimulationTestMode = React.forwardRef(
               params: { page: 1, limit: 100 },
             }),
           ]);
+          if (cancelled) return;
           // Detail: flat serializer data
           setRunTestContext(detailRes.data || null);
           // Executions: paginated {results: [...]}
@@ -352,12 +354,16 @@ const SimulationTestMode = React.forwardRef(
             setSelectedExecutionId(items[0].id || "");
           }
         } catch {
+          if (cancelled) return;
           setExecutions([]);
           setRunTestContext(null);
           setExecutionsFetched(true);
         }
       };
       fetchAll();
+      return () => {
+        cancelled = true;
+      };
     }, [selectedRunTestId]);
 
     // 3. Fetch call executions for the selected execution
@@ -368,32 +374,40 @@ const SimulationTestMode = React.forwardRef(
         setCurrentCallIndex(0);
         setCallDetail(null);
         setLastFetchedCallsKey(null);
-        return;
+        return undefined;
       }
       // Flip loading synchronously so the spinner shows as soon as the
       // user picks a run. Empty-state visibility comes from the
       // render-time `isPendingCallsFetch` comparison.
       setLoadingCalls(true);
+      let cancelled = false;
       const fetchCalls = async () => {
         try {
           const { data } = await axios.get(
             endpoints.testExecutions.list(selectedExecutionId),
             { params: { page: 1, limit: 50 } },
           );
+          if (cancelled) return;
           const items = data?.results || [];
           const total = data?.count || items.length;
           setCalls(items);
           setTotalCalls(total);
           setCurrentCallIndex(0);
         } catch {
+          if (cancelled) return;
           setCalls([]);
           setTotalCalls(0);
         } finally {
-          setLoadingCalls(false);
-          setLastFetchedCallsKey(selectedExecutionId);
+          if (!cancelled) {
+            setLoadingCalls(false);
+            setLastFetchedCallsKey(selectedExecutionId);
+          }
         }
       };
       fetchCalls();
+      return () => {
+        cancelled = true;
+      };
     }, [selectedExecutionId]);
 
     // Current call
@@ -403,7 +417,7 @@ const SimulationTestMode = React.forwardRef(
     useEffect(() => {
       if (!currentCall) {
         setCallDetail(null);
-        return;
+        return undefined;
       }
 
       const cacheKey = currentCall.id || "";
@@ -411,9 +425,10 @@ const SimulationTestMode = React.forwardRef(
       if (cached) {
         setCallDetail(cached.detail);
         setLoadingDetail(false);
-        return;
+        return undefined;
       }
 
+      let cancelled = false;
       const fetchDetail = async () => {
         setLoadingDetail(true);
         try {
@@ -423,6 +438,7 @@ const SimulationTestMode = React.forwardRef(
             const { data } = await axios.get(
               endpoints.runTests.callExecutionDetail(callId),
             );
+            if (cancelled) return;
             callData = data || currentCall;
           }
 
@@ -675,17 +691,22 @@ const SimulationTestMode = React.forwardRef(
             flat[k] = v;
           }
 
+          if (cancelled) return;
           if (cacheKey) {
             detailCacheRef.current.set(cacheKey, { detail: flat });
           }
           setCallDetail(flat);
         } catch {
+          if (cancelled) return;
           setCallDetail(currentCall);
         } finally {
-          setLoadingDetail(false);
+          if (!cancelled) setLoadingDetail(false);
         }
       };
       fetchDetail();
+      return () => {
+        cancelled = true;
+      };
     }, [currentCall, runTestContext]);
 
     // Field names for variable mapping. Expand nested object keys into
@@ -1008,7 +1029,20 @@ const SimulationTestMode = React.forwardRef(
             options={runTests}
             getOptionLabel={getRunTestLabel}
             value={runTests.find((rt) => rt.id === selectedRunTestId) || null}
-            onChange={(_, val) => setSelectedRunTestId(val?.id || "")}
+            onChange={(_, val) => {
+              setSelectedRunTestId(val?.id || "");
+              setMapping({});
+              setRunTestContext(null);
+              setExecutions([]);
+              setExecutionsFetched(false);
+              setSelectedExecutionId("");
+              setCalls([]);
+              setTotalCalls(0);
+              setCurrentCallIndex(0);
+              setCallDetail(null);
+              setLastFetchedCallsKey(null);
+              detailCacheRef.current.clear();
+            }}
             loading={loadingRunTests || loadingMoreRunTests}
             disabled={!!initialRunTestId}
             openOnFocus
@@ -1109,7 +1143,13 @@ const SimulationTestMode = React.forwardRef(
               size="small"
               fullWidth
               value={selectedExecutionId}
-              onChange={(e) => setSelectedExecutionId(e.target.value)}
+              onChange={(e) => {
+                setSelectedExecutionId(e.target.value);
+                setCalls([]);
+                setTotalCalls(0);
+                setCurrentCallIndex(0);
+                setCallDetail(null);
+              }}
               sx={{ fontSize: "13px" }}
             >
               {executions.map((ex, i) => (

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -1179,7 +1179,15 @@ const TracingTestMode = React.forwardRef(
               options={projects}
               getOptionLabel={(opt) => opt?.name || opt?.id || ""}
               value={projects.find((p) => p.id === selectedProjectId) || null}
-              onChange={(_, val) => setSelectedProjectId(val?.id || "")}
+              onChange={(_, val) => {
+
+                setSelectedProjectId(val?.id || "")
+                setMapping({});
+                setColumns([]);
+
+              }
+
+              }
               loading={loadingProjects}
               openOnFocus
               renderInput={(params) => (
@@ -1717,70 +1725,44 @@ const TracingTestMode = React.forwardRef(
         )}
 
         {/* Variable mapping */}
-        {variables.length > 0 && (
-          <Box>
-            <Typography
-              variant="caption"
-              fontWeight={600}
-              sx={{ mb: 0.5, display: "block" }}
-            >
-              Variable Mapping
-            </Typography>
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
-              {variables.map((variable) => (
-                <Box
-                  key={variable}
-                  sx={{ display: "flex", alignItems: "center", gap: 1 }}
-                >
-                  <Box
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 0.5,
-                      px: 1,
-                      py: 0.25,
-                      borderRadius: "4px",
-                      border: "1px solid",
-                      borderColor: "divider",
-                      minWidth: 120,
-                    }}
-                  >
-                    <Iconify
-                      icon="mdi:code-braces"
-                      width={14}
-                      sx={{ color: "text.secondary" }}
-                    />
-                    <Typography
-                      variant="caption"
-                      fontWeight={600}
-                      sx={{ fontSize: "12px" }}
-                    >
-                      {variable}
-                    </Typography>
-                  </Box>
-                  <Iconify
-                    icon="mdi:arrow-right"
-                    width={14}
-                    sx={{ color: "text.disabled" }}
-                  />
-                  <Autocomplete
-                    size="small"
-                    freeSolo={allowCustomFieldPath}
-                    options={
-                      mapping[variable] &&
-                      !fieldNames.includes(mapping[variable])
-                        ? [mapping[variable], ...fieldNames]
-                        : fieldNames
-                    }
-                    value={mapping[variable] || null}
-                    onChange={(_, val) =>
-                      setMapping((prev) => ({
-                        ...prev,
-                        [variable]: val || "",
-                      }))
-                    }
-                    {...(allowCustomFieldPath
-                      ? {
+        {variables.length > 0 && (() => {
+          const isFetchingColumns =
+            !!selectedProjectId &&
+            (loading || isPendingNewFetch || loadingDetail);
+          const mappingDisabledTooltip = isFetchingColumns
+            ? "Columns are being fetched"
+            : "";
+          return (
+            <Box>
+              <Typography
+                variant="caption"
+                fontWeight={600}
+                sx={{ mb: 0.5, display: "block" }}
+              >
+                Variable Mapping
+              </Typography>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+                {variables.map((variable) => {
+                  const autocomplete = (
+                    <Autocomplete
+                      size="small"
+                      freeSolo={allowCustomFieldPath}
+                      disabled={isFetchingColumns}
+                      options={
+                        mapping[variable] &&
+                          !fieldNames.includes(mapping[variable])
+                          ? [mapping[variable], ...fieldNames]
+                          : fieldNames
+                      }
+                      value={mapping[variable] || null}
+                      onChange={(_, val) =>
+                        setMapping((prev) => ({
+                          ...prev,
+                          [variable]: val || "",
+                        }))
+                      }
+                      {...(allowCustomFieldPath
+                        ? {
                           inputValue: mapping[variable] || "",
                           onInputChange: (_, val, reason) => {
                             if (reason === "reset") return;
@@ -1790,67 +1772,126 @@ const TracingTestMode = React.forwardRef(
                             }));
                           },
                         }
-                      : {})}
-                    openOnFocus
-                    autoHighlight
-                    selectOnFocus
-                    handleHomeEndKeys
-                    isOptionEqualToValue={(opt, val) => opt === val}
-                    sx={{ flex: 1 }}
-                    ListboxProps={{ style: { maxHeight: 260 } }}
-                    renderInput={(params) => (
-                      <TextField
-                        {...params}
-                        placeholder={
-                          allowCustomFieldPath
-                            ? "Search or type a path (e.g. attributes.input.value)"
-                            : "Search column..."
-                        }
-                        InputProps={{
-                          ...params.InputProps,
-                          sx: {
-                            ...params.InputProps.sx,
-                            fontSize: "12px",
-                            fontFamily: "monospace",
-                            height: 28,
-                            py: 0,
-                          },
-                        }}
-                      />
-                    )}
-                    renderOption={(props, col) => {
-                      const { key, ...rest } = props;
-                      return (
-                        <Box
-                          component="li"
-                          key={key}
-                          {...rest}
-                          title={col}
-                          sx={{
-                            ...rest.sx,
-                            fontSize: "12px",
-                            fontFamily: "monospace",
-                            pl: col.includes(".")
-                              ? `${12 + (col.split(".").length - 1) * 12}px`
-                              : undefined,
-                            color: col.includes(".")
-                              ? "primary.main"
-                              : "text.primary",
-                            whiteSpace: "nowrap",
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
+                        : {})}
+                      openOnFocus
+                      autoHighlight
+                      selectOnFocus
+                      handleHomeEndKeys
+                      isOptionEqualToValue={(opt, val) => opt === val}
+                      sx={{ flex: 1 }}
+                      ListboxProps={{ style: { maxHeight: 260 } }}
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          placeholder={
+                            isFetchingColumns
+                              ? "Loading columns..."
+                              : allowCustomFieldPath
+                                ? "Search or type a path (e.g. attributes.input.value)"
+                                : "Search column..."
+                          }
+                          InputProps={{
+                            ...params.InputProps,
+                            sx: {
+                              ...params.InputProps.sx,
+                              fontSize: "12px",
+                              fontFamily: "monospace",
+                              height: 28,
+                              py: 0,
+                            },
+                            endAdornment: isFetchingColumns ? (
+                              <InputAdornment position="end">
+                                <CircularProgress size={14} />
+                              </InputAdornment>
+                            ) : (
+                              params.InputProps.endAdornment
+                            ),
                           }}
+                        />
+                      )}
+                      renderOption={(props, col) => {
+                        const { key, ...rest } = props;
+                        return (
+                          <Box
+                            component="li"
+                            key={key}
+                            {...rest}
+                            title={col}
+                            sx={{
+                              ...rest.sx,
+                              fontSize: "12px",
+                              fontFamily: "monospace",
+                              pl: col.includes(".")
+                                ? `${12 + (col.split(".").length - 1) * 12}px`
+                                : undefined,
+                              color: col.includes(".")
+                                ? "primary.main"
+                                : "text.primary",
+                              whiteSpace: "nowrap",
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                            }}
+                          >
+                            {col}
+                          </Box>
+                        );
+                      }}
+                    />
+                  );
+                  return (
+                    <Box
+                      key={variable}
+                      sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                    >
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 0.5,
+                          px: 1,
+                          py: 0.25,
+                          borderRadius: "4px",
+                          border: "1px solid",
+                          borderColor: "divider",
+                          minWidth: 120,
+                        }}
+                      >
+                        <Iconify
+                          icon="mdi:code-braces"
+                          width={14}
+                          sx={{ color: "text.secondary" }}
+                        />
+                        <Typography
+                          variant="caption"
+                          fontWeight={600}
+                          sx={{ fontSize: "12px" }}
                         >
-                          {col}
-                        </Box>
-                      );
-                    }}
-                  />
-                </Box>
-              ))}
+                          {variable}
+                        </Typography>
+                      </Box>
+                      <Iconify
+                        icon="mdi:arrow-right"
+                        width={14}
+                        sx={{ color: "text.disabled" }}
+                      />
+                      {isFetchingColumns ? (
+                        <Tooltip
+                          title={mappingDisabledTooltip}
+                          placement="top"
+                          arrow
+                        >
+                          <Box sx={{ flex: 1 }}>{autocomplete}</Box>
+                        </Tooltip>
+                      ) : (
+                        autocomplete
+                      )}
+                    </Box>
+                  );
+                })}
+              </Box>
             </Box>
-          </Box>
-        )}
+          );
+        })()}
 
         {/* Result */}
         {result && (

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -47,6 +47,7 @@ import {
   isRecordingObjectKey,
 } from "src/components/inline-audio/audio-detection";
 import { useForm, useWatch } from "react-hook-form";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import TaskFilterBar from "src/sections/tasks/components/TaskFilterBar";
 import { buildApiFilterArray } from "src/sections/tasks/components/TaskLivePreview";
 import { JsonValueTree } from "./DatasetTestMode";
@@ -1875,13 +1876,16 @@ const TracingTestMode = React.forwardRef(
                         sx={{ color: "text.disabled" }}
                       />
                       {isFetchingColumns ? (
-                        <Tooltip
+                        <CustomTooltip
+                          show
+                          type="black"
+                          size="small"
                           title={mappingDisabledTooltip}
                           placement="top"
                           arrow
                         >
                           <Box sx={{ flex: 1 }}>{autocomplete}</Box>
-                        </Tooltip>
+                        </CustomTooltip>
                       ) : (
                         autocomplete
                       )}


### PR DESCRIPTION
## Summary
The Dataset, Tracing, and Simulation test panels in the eval picker had
two recurring bugs:

1. **Stale data leaks on selector change** — switching dataset / project /
   simulation / execution-run could leave the previous selection's rows,
   call detail, or variable mapping visible until the new fetch resolved.
   Late-arriving responses from the previous selection could also
   overwrite the new selection's state.

2. **Variable mapping was interactive before columns existed** — users
   could open the mapping dropdown and pick or type a field while the
   underlying column list was still being fetched, leading to broken
   mappings or empty option lists with no indication why.

## Changes

### DatasetTestMode
- Reset `mapping` and `columns` when dataset is switched.
- `ColumnTreeSelect` now accepts `disabled` + `disabledTooltip` props; the
  parent passes `disabled={!isWorkbenchMode && loadingData}` so the
  dropdown disables, the placeholder reads "Loading columns...", and a
  spinner shows in the end adornment.
- Disabled state wrapped in `CustomTooltip` ("Columns are being fetched").

### TracingTestMode
- Reset `mapping` and `columns` when project is switched.
- Mapping Autocomplete disables while
  `selectedProjectId && (loading || isPendingNewFetch || loadingDetail)`,
  with the same placeholder / spinner / CustomTooltip treatment.

### SimulationTestMode
- Add request cancellation (cancelled flag + cleanup) to all three async
  effects: run-test detail+executions, calls list, call detail. Late
  responses no-op instead of stomping on newer state.
- Reset full state slice in the simulation/execution onChange handlers
  (executions, calls, currentCallIndex, callDetail, mapping,
  lastFetchedCallsKey, runTestContext, executionsFetched).
- Clear `detailCacheRef` when switching simulations.
- Wire the existing `isMappingPending` flag into the variable-mapping
  Autocomplete (it was previously only powering the skeleton table).
  Adds the same disabled + placeholder + spinner + CustomTooltip
  treatment as the other two modes.
- Widen `useState<null>` for `lastFetchedCallsKey` to `string | null`
  via JSDoc cast so the new `setLastFetchedCallsKey(executionId)` call
  type-checks.

### Shared
- Swap MUI `Tooltip` → `CustomTooltip` (type="black", size="small") for
  the disabled-state tooltip in all three modes so they match the rest
  of the eval picker.

## Test plan
- [x] **Dataset mode**: open eval picker → dataset tab → pick a dataset → confirm the mapping dropdown is disabled, shows "Loading columns…" placeholder and a spinner adornment while the dataset detail loads. Hover the disabled dropdown → tooltip "Columns are being fetched" appears.
- [x] **Dataset mode**: with a dataset selected and rows loaded, switch to a different dataset → the previous dataset's column rows and mapping vanish immediately (no stale flash) and the new dataset's columns load cleanly.
- [x] **Tracing mode**: open eval picker → tracing tab → pick a project → mapping dropdown disables until the row list and span detail finish. Switching row type (Span / Trace / Session) re-disables the mapping while the new data loads.
- [x] **Tracing mode**: switch projects rapidly → no stale rows from the previous project leak into the new project's view.
- [x] **Simulation mode**: open eval picker → simulation tab → pick a simulation → mapping dropdown shows the "Loading columns…" placeholder + spinner + tooltip during the run-test detail + executions + calls + call-detail fetch chain.
- [x] **Simulation mode (race repro)**: pick Simulation A, immediately pick Simulation B before A finishes loading → confirm Sim B's executions / calls / call detail are shown; Sim A's late response does NOT overwrite Sim B's data (this was the primary bug).
- [x] **Simulation mode**: switch execution runs within a simulation → previous run's calls and call detail clear immediately (no flash of the old run's transcript / recordings).
- [x] **Simulation mode (edit existing eval)**: open an eval that already has a saved mapping in simulation mode → mapping field shows the saved value once columns load (auto-map / id-resolution still works after the cache clear on sim switch).
- [x] **Edit mode (all three)**: re-open the picker for an eval that already has a mapping → previously saved mapping renders correctly once data loads; disabled-state placeholder doesn't replace the saved value.
- [x] **Cancellation**: with browser devtools throttling at "Slow 3G", switch selections fast and confirm no console errors from setState-on-unmounted or duplicate state updates.


Closes TH-5507
