### PR TITLE
fix: bump CH timeout to 15s for custom_attribute filter_values

### DIFF
--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -2099,7 +2099,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                 result = analytics.execute_ch_query(
                     sql,
                     {"project_ids": project_ids, "attr_key": metric_name},
-                    timeout_ms=5000,
+                    timeout_ms=15000,
                 )
                 values = [
                     {"value": row["val"], "label": row["val"]} for row in result.data


### PR DESCRIPTION
## Summary

`/tracer/dashboard/filter_values/` was returning intermittent 400s on the `custom_attribute` branch (e.g. `ended_reason` on mudflap voice projects) because the ClickHouse `DISTINCT span_attr_str[key]` scan hit the 5 s client-side ceiling. Raising `timeout_ms` from 5000 → 15000 on that single `execute_ch_query` call.

## Linked issues

Fixed TH-5464

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] No hardcoded secrets, URLs, or PII