### PR TITLE
fix(oss): add null guards for ee functions in eval and prompt paths

### DIFF
--- a/futureagi/agentic_eval/core_evals/run_prompt/litellm_response.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/litellm_response.py
@@ -319,7 +319,7 @@ class RunPrompt:
 
         # Token usage: prompt (text) via tiktoken helper, completion (audio) via 32 tokens/sec
         try:
-            prompt_tokens = count_tiktoken_tokens(input_text)
+            prompt_tokens = (count_tiktoken_tokens(input_text) if count_tiktoken_tokens else 0)
         except Exception:
             prompt_tokens = None
         completion_tokens = int(duration_seconds * 32) if duration_seconds else None
@@ -966,8 +966,8 @@ class RunPrompt:
                 completion_text = response_content
 
                 # Use tiktoken for accurate token counting (handles both text and images)
-                estimated_prompt_tokens = count_tiktoken_tokens(prompt_text, image_urls)
-                estimated_completion_tokens = count_tiktoken_tokens(completion_text)
+                estimated_prompt_tokens = (count_tiktoken_tokens(prompt_text, image_urls) if count_tiktoken_tokens else 0)
+                estimated_completion_tokens = (count_tiktoken_tokens(completion_text) if count_tiktoken_tokens else 0)
                 total_tokens = estimated_prompt_tokens + estimated_completion_tokens
 
                 # Use calculate_total_cost with custom model pricing as fallback

--- a/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/handlers/custom_model_handler.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/handlers/custom_model_handler.py
@@ -157,8 +157,8 @@ class CustomModelHandler(BaseModelHandler):
         )
 
         # Count tokens
-        estimated_prompt_tokens = count_tiktoken_tokens(prompt_text, image_urls)
-        estimated_completion_tokens = count_tiktoken_tokens(completion_text)
+        estimated_prompt_tokens = (count_tiktoken_tokens(prompt_text, image_urls) if count_tiktoken_tokens else 0)
+        estimated_completion_tokens = (count_tiktoken_tokens(completion_text) if count_tiktoken_tokens else 0)
 
         # Prepare usage payload for cost calculation
         token_usage = {

--- a/futureagi/ai_tools/tools/prompts/run_prompt.py
+++ b/futureagi/ai_tools/tools/prompts/run_prompt.py
@@ -60,10 +60,10 @@ class RunPromptTool(BaseTool):
         from model_hub.utils.column_utils import is_json_response_format
         from model_hub.utils.utils import remove_empty_text_from_messages
         from model_hub.views.prompt_template import replace_variables
+        from tfc.constants.api_calls import APICallTypeChoices
         try:
-            from ee.usage.utils.usage_entries import APICallTypeChoices, log_and_deduct_cost_for_api_request
+            from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
         except ImportError:
-            APICallTypeChoices = None
             log_and_deduct_cost_for_api_request = None
 
         template_obj, err = resolve_prompt_template(
@@ -222,7 +222,8 @@ class RunPromptTool(BaseTool):
                 from ee.usage.schemas.event_types import BillingEventType
                 from ee.usage.services.metering import check_usage
 
-                usage_check = check_usage(
+                if check_usage is not None:
+                    usage_check = check_usage(
                     str(context.organization.id),
                     BillingEventType.AI_PROMPT_CREATION,
                 )
@@ -265,7 +266,8 @@ class RunPromptTool(BaseTool):
             # Log usage and deduct cost (skipped when ee is absent).
             if log_and_deduct_cost_for_api_request is not None:
                 try:
-                    log_and_deduct_cost_for_api_request(
+                    if log_and_deduct_cost_for_api_request is not None:
+                        log_and_deduct_cost_for_api_request(
                         context.organization,
                         APICallTypeChoices.PROMPT_BENCH.value,
                         config=token_config,
@@ -280,7 +282,10 @@ class RunPromptTool(BaseTool):
                 from ee.usage.schemas.events import UsageEvent
                 from ee.usage.services.emitter import emit
 
-                emit(
+                if emit is not None and UsageEvent is not None:
+
+
+                    emit(
                     UsageEvent(
                         org_id=str(context.organization.id),
                         event_type=APICallTypeChoices.PROMPT_BENCH.value,

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -42,12 +42,12 @@ from tfc.utils.distributed_locks import distributed_lock_manager
 from tfc.utils.distributed_state import evaluation_tracker
 from tfc.utils.error_codes import get_error_for_api_status
 from tracer.models.observation_span import EvalLogger
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
 try:
-    from ee.usage.models.usage import APICallLog, APICallStatusChoices, APICallTypeChoices
+    from ee.usage.models.usage import APICallLog
 except ImportError:
     APICallLog = None
-    APICallStatusChoices = None
-    APICallTypeChoices = None
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 except ImportError:
@@ -181,10 +181,20 @@ def process_single_evaluation(user_eval_metric):
         if is_oss():
             user_eval_metric.status = StatusType.FAILED.value
             user_eval_metric.save(update_fields=["status"])
-            raise ValueError(
+            _err_msg = (
                 "Agent evaluations are not available on your plan. "
                 "Use LLM-as-a-Judge or Code evaluations instead."
             )
+            # Mark cells as error so the UI doesn't stay stuck on loading
+            class _ErrInfo:
+                error_code = "ENTITLEMENT_DENIED"
+                reason = _err_msg
+                dimension = ""
+                current_usage = 0
+                limit = 0
+                upgrade_cta = None
+            _mark_cells_usage_limit_error(user_eval_metric, _ErrInfo())
+            raise ValueError(_err_msg)
 
     try:
         from ee.usage.services.metering import check_usage
@@ -1090,27 +1100,28 @@ def process_single_error_localization(task_id):
                 raise ValueError(usage_check.reason or "Usage limit exceeded")
 
         # Log and deduct cost for error localization
-        api_call_log_row = log_and_deduct_cost_for_api_request(
-            organization=task.organization,
-            api_call_type=APICallTypeChoices.ERROR_LOCALIZER.value,
-            workspace=task.workspace,
-            source="error_localizer",
-            source_id=str(task.id),
-            config={
-                "reference_id": str(task.source_id),
-                "error_localizer_task_id": str(task.id),
-            },
-        )
+        if log_and_deduct_cost_for_api_request is not None:
+            api_call_log_row = log_and_deduct_cost_for_api_request(
+                organization=task.organization,
+                api_call_type=APICallTypeChoices.ERROR_LOCALIZER.value,
+                workspace=task.workspace,
+                source="error_localizer",
+                source_id=str(task.id),
+                config={
+                    "reference_id": str(task.source_id),
+                    "error_localizer_task_id": str(task.id),
+                },
+            )
 
-        if not api_call_log_row:
-            logger.error("API call not allowed : Error validating the api call.")
-            task.mark_as_failed("API call not allowed : Error validating the api call.")
-            raise ValueError("API call not allowed : Error validating the api call.")
+            if not api_call_log_row:
+                logger.error("API call not allowed : Error validating the api call.")
+                task.mark_as_failed("API call not allowed : Error validating the api call.")
+                raise ValueError("API call not allowed : Error validating the api call.")
 
-        if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-            error_message = get_error_for_api_status(api_call_log_row.status)
-            task.mark_as_failed(error_message)
-            return
+            if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
+                error_message = get_error_for_api_status(api_call_log_row.status)
+                task.mark_as_failed(error_message)
+                return
 
         try:
             localizer = ErrorLocalizer(
@@ -1134,7 +1145,8 @@ def process_single_error_localization(task_id):
                 f"Error in process_single_error_localization: {str(e)}\n{traceback.format_exc()}"
             )
             task.mark_as_failed(str(e))
-            refund_cost_for_api_call(api_call_log_row)
+            if refund_cost_for_api_call is not None:
+                refund_cost_for_api_call(api_call_log_row)
             return
 
         # Check if we got valid results
@@ -1143,7 +1155,8 @@ def process_single_error_localization(task_id):
                 f"Error localization returned empty results for cell {task.source_id}"
             )
             task.mark_as_skipped("Error localization returned empty results")
-            refund_cost_for_api_call(api_call_log_row)
+            if refund_cost_for_api_call is not None:
+                refund_cost_for_api_call(api_call_log_row)
             return
 
         # Update the task with the results
@@ -1173,9 +1186,11 @@ def process_single_error_localization(task_id):
             actual_cost = getattr(localizer, "cost", {}).get("total_cost", 0)
             if not actual_cost and hasattr(localizer, "llm"):
                 actual_cost = getattr(localizer.llm, "cost", {}).get("total_cost", 0)
-            credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+            if BillingConfig is not None:
+                credits = BillingConfig.get().calculate_ai_credits(actual_cost)
 
-            emit(
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                emit(
                 UsageEvent(
                     org_id=str(task.organization.id),
                     event_type=BillingEventType.ERROR_LOCALIZER,
@@ -1212,7 +1227,8 @@ def process_single_error_localization(task_id):
                 metadata = task.metadata
                 if metadata.get("log_id", None):
                     try:
-                        log = APICallLog.objects.get(log_id=metadata.get("log_id"))
+                        if APICallLog is not None:
+                            log = APICallLog.objects.get(log_id=metadata.get("log_id"))
                         config = json.loads(log.config)
                         config["error_localizer"] = {
                             "error_analysis": error_analysis,
@@ -1226,7 +1242,8 @@ def process_single_error_localization(task_id):
                         logger.info("Log doesn't exist.")
             except Exception as e:
                 logger.error(f"Error in updating cell metadata: {str(e)}")
-                refund_cost_for_api_call(api_call_log_row)
+                if refund_cost_for_api_call is not None:
+                    refund_cost_for_api_call(api_call_log_row)
                 task.mark_as_failed(str(e))
 
         elif task.source == ErrorLocalizerSource.OBSERVE:
@@ -1248,7 +1265,8 @@ def process_single_error_localization(task_id):
                 metadata = task.metadata
                 if metadata.get("log_id", None):
                     try:
-                        log = APICallLog.objects.get(log_id=metadata.get("log_id"))
+                        if APICallLog is not None:
+                            log = APICallLog.objects.get(log_id=metadata.get("log_id"))
                         config = json.loads(log.config)
                         config["error_localizer"] = {
                             "error_analysis": error_analysis,
@@ -1263,12 +1281,14 @@ def process_single_error_localization(task_id):
 
             except Exception as e:
                 logger.error(f"Error in updating span metadata: {str(e)}")
-                refund_cost_for_api_call(api_call_log_row)
+                if refund_cost_for_api_call is not None:
+                    refund_cost_for_api_call(api_call_log_row)
                 task.mark_as_failed(str(e))
 
         elif task.source == ErrorLocalizerSource.PLAYGROUND:
             try:
-                eval_logger = APICallLog.objects.get(log_id=task.source_id)
+                if APICallLog is not None:
+                    eval_logger = APICallLog.objects.get(log_id=task.source_id)
                 config = json.loads(eval_logger.config) or {}
                 config["error_localizer"] = {
                     "error_analysis": error_analysis,
@@ -1280,7 +1300,8 @@ def process_single_error_localization(task_id):
                 eval_logger.save(update_fields=["config"])
             except Exception as e:
                 logger.exception(f"Error in updating log config: {str(e)}")
-                refund_cost_for_api_call(api_call_log_row)
+                if refund_cost_for_api_call is not None:
+                    refund_cost_for_api_call(api_call_log_row)
                 task.mark_as_failed(str(e))
     finally:
         close_old_connections()

--- a/futureagi/model_hub/utils/async_generate_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_generate_prompt_runner.py
@@ -12,14 +12,11 @@ except ImportError:
     PromptGenerator = _ee_stub("PromptGenerator")
 
 logger = structlog.get_logger(__name__)
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
 try:
-    from ee.usage.models.usage import APICallStatusChoices
+    from ee.usage.utils.usage_entries import count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallStatusChoices = None
-try:
-    from ee.usage.utils.usage_entries import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
-except ImportError:
-    APICallTypeChoices = None
     count_text_tokens = None
     log_and_deduct_cost_for_api_request = None
 
@@ -52,40 +49,43 @@ async def generate_prompt_async(
         except ImportError:
             check_usage = None
 
-        usage_check = await database_sync_to_async(check_usage)(
-            str(organization_id), BillingEventType.AI_PROMPT_CREATION
-        )
-        if not usage_check.allowed:
-            await ws_manager.send_generate_prompt_error_message(
-                generation_id=generation_id,
-                error=usage_check.reason or "Usage limit exceeded",
+        if check_usage is not None and BillingEventType is not None:
+            usage_check = await database_sync_to_async(check_usage)(
+                str(organization_id), BillingEventType.AI_PROMPT_CREATION
             )
-            return
+            if not usage_check.allowed:
+                await ws_manager.send_generate_prompt_error_message(
+                    generation_id=generation_id,
+                    error=usage_check.reason or "Usage limit exceeded",
+                )
+                return
 
         prompt_generator = PromptGenerator()
         prompt_generator.organization_id = organization_id
 
         # Create a call_log_row for tracking
-        config = {"input_tokens": count_text_tokens(description)}
-        call_log_row = await database_sync_to_async(
-            log_and_deduct_cost_for_api_request
-        )(
-            organization,
-            APICallTypeChoices.PROMPT_BENCH.value,
-            config=config,
-            source="run_prompt_gen",
-            workspace=workspace,
-        )
-
-        if (
-            call_log_row is None
-            or call_log_row.status != APICallStatusChoices.PROCESSING.value
-        ):
-            await ws_manager.send_generate_prompt_error_message(
-                generation_id=generation_id,
-                error="Insufficient credits",
+        call_log_row = None
+        config = {"input_tokens": (count_text_tokens(description) if count_text_tokens else 0)}
+        if log_and_deduct_cost_for_api_request is not None:
+            call_log_row = await database_sync_to_async(
+                log_and_deduct_cost_for_api_request
+            )(
+                organization,
+                APICallTypeChoices.PROMPT_BENCH.value,
+                config=config,
+                source="run_prompt_gen",
+                workspace=workspace,
             )
-            return
+
+            if (
+                call_log_row is None
+                or call_log_row.status != APICallStatusChoices.PROCESSING.value
+            ):
+                await ws_manager.send_generate_prompt_error_message(
+                    generation_id=generation_id,
+                    error="Insufficient credits",
+                )
+                return
 
         # Run the generate_prompt process with WebSocket manager
         # Use async version when ws_manager is provided (WebSocket context)
@@ -123,9 +123,14 @@ async def generate_prompt_async(
                 actual_cost = getattr(prompt_generator.llm, "cost", {}).get(
                     "total_cost", 0
                 )
-            credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+            if BillingConfig is not None:
 
-            emit(
+                credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+
+                emit(
                 UsageEvent(
                     org_id=str(organization_id),
                     event_type=BillingEventType.AI_PROMPT_CREATION,

--- a/futureagi/model_hub/utils/async_improve_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_improve_prompt_runner.py
@@ -12,14 +12,11 @@ except ImportError:
     PromptGenerator = _ee_stub("PromptGenerator")
 
 logger = structlog.get_logger(__name__)
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
 try:
-    from ee.usage.models.usage import APICallStatusChoices
+    from ee.usage.utils.usage_entries import count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallStatusChoices = None
-try:
-    from ee.usage.utils.usage_entries import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
-except ImportError:
-    APICallTypeChoices = None
     count_text_tokens = None
     log_and_deduct_cost_for_api_request = None
 
@@ -54,42 +51,45 @@ async def improve_prompt_async(
         except ImportError:
             check_usage = None
 
-        usage_check = await database_sync_to_async(check_usage)(
-            str(organization_id), BillingEventType.AI_PROMPT_IMPROVEMENT
-        )
-        if not usage_check.allowed:
-            await ws_manager.send_improve_prompt_error_message(
-                improve_id=improve_id,
-                error=usage_check.reason or "Usage limit exceeded",
+        if check_usage is not None and BillingEventType is not None:
+            usage_check = await database_sync_to_async(check_usage)(
+                str(organization_id), BillingEventType.AI_PROMPT_IMPROVEMENT
             )
-            return
+            if not usage_check.allowed:
+                await ws_manager.send_improve_prompt_error_message(
+                    improve_id=improve_id,
+                    error=usage_check.reason or "Usage limit exceeded",
+                )
+                return
 
         prompt_generator = PromptGenerator()
         prompt_generator.organization_id = organization_id
 
         # Create a call_log_row for tracking
+        call_log_row = None
         config = {
-            "input_tokens": count_text_tokens(
-                original_prompt + (improvement_suggestions or "")
+            "input_tokens": (count_text_tokens(
+                original_prompt + (improvement_suggestions or "")) if count_text_tokens else 0
             )
         }
-        call_log_row = await database_sync_to_async(
-            log_and_deduct_cost_for_api_request
-        )(
-            organization,
-            APICallTypeChoices.PROMPT_BENCH.value,
-            config=config,
-            source="run_prompt_improve",
-            workspace=workspace,
-        )
+        if log_and_deduct_cost_for_api_request is not None:
+            call_log_row = await database_sync_to_async(
+                log_and_deduct_cost_for_api_request
+            )(
+                organization,
+                APICallTypeChoices.PROMPT_BENCH.value,
+                config=config,
+                source="run_prompt_improve",
+                workspace=workspace,
+            )
 
-        if (
-            call_log_row is None
-            or call_log_row.status != APICallStatusChoices.PROCESSING.value
-        ):
-            await ws_manager.send_improve_prompt_error_message(
-                improve_id=improve_id,
-                error="Insufficient credits",
+            if (
+                call_log_row is None
+                or call_log_row.status != APICallStatusChoices.PROCESSING.value
+            ):
+                await ws_manager.send_improve_prompt_error_message(
+                    improve_id=improve_id,
+                    error="Insufficient credits",
             )
             return
 
@@ -131,9 +131,14 @@ async def improve_prompt_async(
                 actual_cost = getattr(prompt_generator.llm, "cost", {}).get(
                     "total_cost", 0
                 )
-            credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+            if BillingConfig is not None:
 
-            emit(
+                credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+
+                emit(
                 UsageEvent(
                     org_id=str(organization_id),
                     event_type=BillingEventType.AI_PROMPT_IMPROVEMENT,

--- a/futureagi/model_hub/utils/async_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_prompt_runner.py
@@ -11,10 +11,11 @@ from model_hub.services.derived_variable_service import (
     extract_derived_variables_from_output,
 )
 from model_hub.utils.column_utils import is_json_response_format
+from tfc.constants.api_calls import APICallTypeChoices
+
 try:
-    from ee.usage.utils.usage_entries import APICallTypeChoices, log_and_deduct_cost_for_api_request
+    from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallTypeChoices = None
     log_and_deduct_cost_for_api_request = None
 
 
@@ -136,13 +137,14 @@ async def run_template_async(
                     token_config = metadata.get("usage", {})
 
                     # Wrap the synchronous DB call
-                    await database_sync_to_async(log_and_deduct_cost_for_api_request)(
-                        organization,
-                        APICallTypeChoices.PROMPT_BENCH.value,
-                        config=token_config,
-                        source="run_prompt_gen",
-                        workspace=workspace,
-                    )
+                    if log_and_deduct_cost_for_api_request is not None:
+                        await database_sync_to_async(log_and_deduct_cost_for_api_request)(
+                            organization,
+                            APICallTypeChoices.PROMPT_BENCH.value,
+                            config=token_config,
+                            source="run_prompt_gen",
+                            workspace=workspace,
+                        )
 
                     # Dual-write: emit usage event for new billing system
                     try:
@@ -155,8 +157,9 @@ async def run_template_async(
                         except ImportError:
                             emit = None
 
-                        emit(
-                            UsageEvent(
+                        if emit is not None and UsageEvent is not None:
+                            emit(
+                                UsageEvent(
                                 org_id=str(organization.id),
                                 event_type=APICallTypeChoices.PROMPT_BENCH.value,
                                 properties={

--- a/futureagi/model_hub/utils/auto_annotate.py
+++ b/futureagi/model_hub/utils/auto_annotate.py
@@ -31,10 +31,7 @@ from model_hub.models.develop_annotations import Annotations, AnnotationsLabels
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from tfc.temporal import temporal_activity
 from tfc.utils.error_codes import get_error_message
-try:
-    from ee.usage.models.usage import APICallTypeChoices
-except ImportError:
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_tiktoken_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
@@ -188,9 +185,10 @@ class AutoAnnotation:
             except ImportError:
                 check_usage = None
 
-            usage_check = check_usage(str(org.id), BillingEventType.AUTO_ANNOTATION)
-            if not usage_check.allowed:
-                raise ValueError(usage_check.reason or "Usage limit exceeded")
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(str(org.id), BillingEventType.AUTO_ANNOTATION)
+                if not usage_check.allowed:
+                    raise ValueError(usage_check.reason or "Usage limit exceeded")
 
             for _index, row in enumerate(rows):
                 if (
@@ -223,13 +221,14 @@ class AutoAnnotation:
                         inputs, input_type, strict=False
                     ):
                         if input_type_item == "image":
-                            tokens = count_tiktoken_tokens("", input_item)
+                            tokens = (count_tiktoken_tokens("", input_item) if count_tiktoken_tokens else 0)
                         else:
-                            tokens = count_tiktoken_tokens(input_item)
+                            tokens = (count_tiktoken_tokens(input_item) if count_tiktoken_tokens else 0)
                         api_call_type = APICallTypeChoices.AUTO_ANNOTATION.value
                         config = {}
                         config["input_tokens"] = tokens
-                        log_and_deduct_cost_for_api_request(
+                        if log_and_deduct_cost_for_api_request is not None:
+                            log_and_deduct_cost_for_api_request(
                             org,
                             api_call_type,
                             config,
@@ -306,9 +305,14 @@ class AutoAnnotation:
                             actual_cost = getattr(agent.llm, "cost", {}).get(
                                 "total_cost", 0
                             )
-                        credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+                        if BillingConfig is not None:
 
-                        emit(
+                            credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+
+                        if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+
+                            emit(
                             UsageEvent(
                                 org_id=str(org.id),
                                 event_type=BillingEventType.AUTO_ANNOTATION,

--- a/futureagi/model_hub/utils/composite_execution.py
+++ b/futureagi/model_hub/utils/composite_execution.py
@@ -210,15 +210,16 @@ def _log_composite_usage(
     """
     try:
         from sdk.utils.helpers import _get_api_call_type
+        from tfc.constants.api_calls import APICallStatusChoices
         try:
-            from ee.usage.models.usage import APICallLog, APICallStatusChoices, APICallType
+            from ee.usage.models.usage import APICallLog, APICallType
         except ImportError:
             APICallLog = None
-            APICallStatusChoices = None
             APICallType = None
 
         api_call_type_name = _get_api_call_type(model)
-        api_call_type_obj = APICallType.objects.get(name=api_call_type_name)
+        if APICallType is not None:
+            api_call_type_obj = APICallType.objects.get(name=api_call_type_name)
 
         completed = sum(1 for cr in child_results if cr.status == "completed")
         failed = sum(1 for cr in child_results if cr.status == "failed")
@@ -269,6 +270,9 @@ def _log_composite_usage(
 
         # Pass dict directly — config is a JSONField, so Django handles
         # serialization. Using json.dumps() here would double-encode.
+        if APICallLog is None:
+            return None
+
         log_row = APICallLog.objects.create(
             api_call_type=api_call_type_obj,
             organization=org,

--- a/futureagi/model_hub/views/develop_optimiser.py
+++ b/futureagi/model_hub/views/develop_optimiser.py
@@ -45,10 +45,7 @@ from model_hub.models.run_prompt import RunPrompter
 from model_hub.serializers.develop_optimisation import OptimizationDetailSerializer
 from model_hub.views.eval_runner import EvaluationRunner
 from model_hub.views.prompt_template import replace_ids_with_column_name
-try:
-    from ee.usage.models.usage import APICallTypeChoices
-except ImportError:
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_tiktoken_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
@@ -101,9 +98,9 @@ class DevelopOptimizer:
                     cell_values_strings.append("")
 
             input_words_string = " ".join(cell_values_strings)
-            opt_column_token_count = count_tiktoken_tokens(
+            opt_column_token_count = (count_tiktoken_tokens(
                 input_words_string, input_image_urls=cell_values_image_urls
-            )
+            ) if count_tiktoken_tokens else 0)
 
             # print("optimisation token_count : ", opt_column_token_count)
             reference_id = str(self.optimize_dataset.id)
@@ -115,7 +112,8 @@ class DevelopOptimizer:
             }
             organization = column.dataset.organization
             api_call_type = APICallTypeChoices.DATASET_OPTIMIZATION.value
-            log_and_deduct_cost_for_api_request(
+            if log_and_deduct_cost_for_api_request is not None:
+                log_and_deduct_cost_for_api_request(
                 organization,
                 api_call_type,
                 config,
@@ -136,7 +134,8 @@ class DevelopOptimizer:
                 except ImportError:
                     emit = None
 
-                emit(
+                if emit is not None and UsageEvent is not None:
+                    emit(
                     UsageEvent(
                         org_id=str(organization.id),
                         event_type=api_call_type,
@@ -157,11 +156,11 @@ class DevelopOptimizer:
     def _update_api_call_log_row(self):
         try:
             # get the optimisation object by id
+            from tfc.constants.api_calls import APICallStatusChoices
             try:
-                from ee.usage.models.usage import APICallLog, APICallStatusChoices
+                from ee.usage.models.usage import APICallLog
             except ImportError:
                 APICallLog = None
-                APICallStatusChoices = None
             try:
                 from ee.usage.utils.usage_entries import refund_cost_for_api_call
             except ImportError:
@@ -170,7 +169,8 @@ class DevelopOptimizer:
             optimizer_row = OptimizationDataset.objects.get(id=self.optimize_dataset.id)
             optimisation_id = str(optimizer_row.id)
             # get the api call log row by reference id
-            api_call_log_row = APICallLog.objects.filter(
+            if APICallLog is not None:
+                api_call_log_row = APICallLog.objects.filter(
                 reference_id=optimisation_id, deleted=False
             ).first()
             if optimizer_row.status == StatusType.FAILED.value:
@@ -179,7 +179,8 @@ class DevelopOptimizer:
                 api_call_log_row.status = APICallStatusChoices.ERROR.value
                 api_call_log_row.save()
                 refund_config = {"reference_id": str(optimizer_row.id)}
-                refund_cost_for_api_call(api_call_log_row, config=refund_config)
+                if refund_cost_for_api_call is not None:
+                    refund_cost_for_api_call(api_call_log_row, config=refund_config)
             else:
                 # update the api call log row
                 api_call_log_row.status = APICallStatusChoices.SUCCESS.value

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -72,11 +72,7 @@ from tfc.utils.error_codes import (
 from tfc.utils.functions import get_eval_stats
 from tfc.utils.general_methods import GeneralMethods
 from tfc.utils.parse_errors import parse_serialized_errors
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import count_tiktoken_tokens, log_and_deduct_cost_for_api_request, refund_cost_for_api_call
 except ImportError:
@@ -1055,37 +1051,33 @@ class EvaluationRunner:
                     )
             value = self.format_output(response, row)
 
-            config_dict = json.loads(api_call_log_row.config)
-            output_payload = {
-                "output": value,
-                "reason": (
-                    response["reason"] if "reason" in response.keys() else None
-                ),
-            }
-            # Propagate partial-input warnings into the API call log so the
-            # eval tasks log and eval usage views (which read APICallLog)
-            # can surface the warning alongside the eval's output.
-            if response.get("warnings"):
-                output_payload["warnings"] = response["warnings"]
-            config_dict.update({"output": output_payload})
-            input_types = {}
-            for key, mapping_value in mappings.items():
-                # Extract base column ID to look up data type
-                base_col_id, _ = (
-                    _extract_column_id_and_path(str(mapping_value))
-                    if mapping_value
-                    else (None, None)
-                )
-                data_type = col_map.get(str(base_col_id)) if base_col_id else None
-                input_types[key] = (
-                    data_type if data_type in ["image", "images", "audio"] else "text"
-                )
-            config_dict.update({"input_data_types": input_types})
-            # logger.info(f' ----- INSIDE EvaluationRunner : function _process_eval_result | config_dict : {config_dict} -----')
-            api_call_log_row.config = json.dumps(config_dict)
-            api_call_log_row.save()
+            if api_call_log_row is not None:
+                config_dict = json.loads(api_call_log_row.config)
+                output_payload = {
+                    "output": value,
+                    "reason": (
+                        response["reason"] if "reason" in response.keys() else None
+                    ),
+                }
+                if response.get("warnings"):
+                    output_payload["warnings"] = response["warnings"]
+                config_dict.update({"output": output_payload})
+                input_types = {}
+                for key, mapping_value in mappings.items():
+                    base_col_id, _ = (
+                        _extract_column_id_and_path(str(mapping_value))
+                        if mapping_value
+                        else (None, None)
+                    )
+                    data_type = col_map.get(str(base_col_id)) if base_col_id else None
+                    input_types[key] = (
+                        data_type if data_type in ["image", "images", "audio"] else "text"
+                    )
+                config_dict.update({"input_data_types": input_types})
+                api_call_log_row.config = json.dumps(config_dict)
+                api_call_log_row.save()
 
-            self._handle_api_call_status(api_call_log_row, CellStatus.PASS.value)
+                self._handle_api_call_status(api_call_log_row, CellStatus.PASS.value)
 
             # Post-eval cost-based usage emit
             try:
@@ -1102,7 +1094,8 @@ class EvaluationRunner:
                 except ImportError:
                     emit = None
 
-                billing_config = BillingConfig.get()
+                if BillingConfig is not None:
+                    billing_config = BillingConfig.get()
                 eval_cost = getattr(eval_instance, "cost", {})
                 llm_cost = eval_cost.get("total_cost", 0)
                 per_run_fee = billing_config.get_eval_per_run_fee()
@@ -1151,10 +1144,12 @@ class EvaluationRunner:
                 _is_code_eval = getattr(self.eval_template, "eval_type", "") == "code"
                 eval_event_type = (
                     BillingEventType.CODE_EVALUATOR.value
-                    if _is_code_eval
+                    if _is_code_eval and BillingEventType is not None
                     else _get_api_call_type(self.user_eval_metric.model)
                 )
-                emit(
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+                    emit(
                     UsageEvent(
                         org_id=emit_org_id,
                         event_type=eval_event_type,
@@ -1201,7 +1196,7 @@ class EvaluationRunner:
                         eval_result=value,
                         response=response,
                         cell=cell,
-                        log_id=str(api_call_log_row.log_id),
+                        log_id=str(api_call_log_row.log_id) if api_call_log_row else None,
                     )
 
         except Exception as e:
@@ -1301,6 +1296,9 @@ class EvaluationRunner:
                 }
             )
 
+        if log_and_deduct_cost_for_api_request is None:
+            return None
+
         api_call_log_row = log_and_deduct_cost_for_api_request(
             org if org else self.user_eval_metric.organization,
             api_call_type,
@@ -1322,7 +1320,6 @@ class EvaluationRunner:
             raise ValueError("API call not allowed : Error validating the api call.")
 
         if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-            # Use the dedicated function to get the appropriate error message for this status
             error_message = get_error_for_api_status(api_call_log_row.status)
             raise ValueError(error_message)
 
@@ -1950,6 +1947,7 @@ class EvaluationRunner:
                     )
                 # Map back from key to row value via the ordered lists.
                 value = mapping[required_field.index(key)]
+                from model_hub.utils.eval_input_validation import is_empty_value as _is_empty_value
                 if _is_empty_value(value):
                     raise ValueError(
                         f"No input received for '{key}'. Please check your input."
@@ -2284,9 +2282,9 @@ class EvaluationRunner:
         except Exception:
             logger.error(f"unable to retrieve rule prompt for column id : {column_id}")
 
-        input_token_count = count_tiktoken_tokens(
+        input_token_count = (count_tiktoken_tokens(
             input_words_string, cell_values_image_urls
-        )
+        ) if count_tiktoken_tokens else 0)
         return input_token_count
 
     def _resolve_version(self):
@@ -2649,7 +2647,8 @@ class EvaluationRunner:
                 api_call_log_row.save(update_fields=["status"])
 
                 refund_config = {"evaluation_id": str(self.user_eval_metric_id)}
-                refund_cost_for_api_call(api_call_log_row, config=refund_config)
+                if refund_cost_for_api_call is not None:
+                    refund_cost_for_api_call(api_call_log_row, config=refund_config)
             except Exception as e:
                 logger.error(f"Error refunding cost for api call: {str(e)}")
         elif value == CellStatus.PASS.value and api_call_log_row:
@@ -3100,11 +3099,12 @@ class EvaluationRunner:
                 getattr(self.user_eval_metric, "model", None)
                 or ModelChoices.TURING_LARGE.value
             )
-            usage_check = check_usage(org_id, api_call_type)
-            if not usage_check.allowed:
-                self.user_eval_metric.status = StatusType.FAILED.value
-                self.user_eval_metric.save(update_fields=["status"])
-                raise ValueError(usage_check.reason or "Usage limit exceeded")
+            if check_usage is not None:
+                usage_check = check_usage(org_id, api_call_type)
+                if not usage_check.allowed:
+                    self.user_eval_metric.status = StatusType.FAILED.value
+                    self.user_eval_metric.save(update_fields=["status"])
+                    raise ValueError(usage_check.reason or "Usage limit exceeded")
 
             self.update_cell(row_ids=row_ids)
             logger.info(

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1094,11 +1094,12 @@ class EvaluationRunner:
                 except ImportError:
                     emit = None
 
+                billing_config = None
                 if BillingConfig is not None:
                     billing_config = BillingConfig.get()
                 eval_cost = getattr(eval_instance, "cost", {})
                 llm_cost = eval_cost.get("total_cost", 0)
-                per_run_fee = billing_config.get_eval_per_run_fee()
+                per_run_fee = billing_config.get_eval_per_run_fee() if billing_config else 0
                 actual_cost = llm_cost + per_run_fee
 
                 # Also compute fallback cost for comparison logging
@@ -1126,7 +1127,7 @@ class EvaluationRunner:
                     token_usage=getattr(eval_instance, "token_usage", {}),
                 )
 
-                credits = billing_config.calculate_ai_credits(actual_cost)
+                credits = billing_config.calculate_ai_credits(actual_cost) if billing_config else 0
                 emit_org_id = str(
                     self.organization_id
                     or (

--- a/futureagi/model_hub/views/prompt_template.py
+++ b/futureagi/model_hub/views/prompt_template.py
@@ -159,14 +159,11 @@ def _safe_background_task(func, *args, **kwargs):
     return wrapped
 
 
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+
 try:
-    from ee.usage.models.usage import APICallStatusChoices
+    from ee.usage.utils.usage_entries import count_text_tokens, log_and_deduct_cost_for_api_request
 except ImportError:
-    APICallStatusChoices = None
-try:
-    from ee.usage.utils.usage_entries import APICallTypeChoices, count_text_tokens, log_and_deduct_cost_for_api_request
-except ImportError:
-    APICallTypeChoices = None
     count_text_tokens = None
     log_and_deduct_cost_for_api_request = None
 
@@ -1912,7 +1909,8 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                         }
                         # print("token config is here:",token_config)
                         if organization:
-                            log_and_deduct_cost_for_api_request(
+                            if log_and_deduct_cost_for_api_request is not None:
+                                log_and_deduct_cost_for_api_request(
                                 organization,
                                 APICallTypeChoices.PROMPT_BENCH.value,
                                 config=token_config,
@@ -1933,7 +1931,10 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                                 except ImportError:
                                     emit = None
 
-                                emit(
+                                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+
+                                    emit(
                                     UsageEvent(
                                         org_id=str(organization.id),
                                         event_type=APICallTypeChoices.PROMPT_BENCH.value,
@@ -2564,7 +2565,8 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 }
             )
             org = Organization.objects.get(id=organization_id)
-            api_call_log_row = log_and_deduct_cost_for_api_request(
+            if log_and_deduct_cost_for_api_request is not None:
+                api_call_log_row = log_and_deduct_cost_for_api_request(
                 organization=org,
                 api_call_type=APICallTypeChoices.DATASET_EVALUATION.value,
                 source="prompt_template",
@@ -2650,7 +2652,10 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 except ImportError:
                     emit = None
 
-                emit(
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+
+                    emit(
                     UsageEvent(
                         org_id=str(org.id),
                         event_type=BillingEventType.EVAL_EXPLANATION,
@@ -3203,8 +3208,9 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
             if not statement:
                 return self._gm.bad_request(get_error_message("MISSING_STATEMENT"))
 
-            config = {"input_tokens": count_text_tokens(statement)}
-            call_log_row = log_and_deduct_cost_for_api_request(
+            config = {"input_tokens": (count_text_tokens(statement) if count_text_tokens else 0)}
+            if log_and_deduct_cost_for_api_request is not None:
+                call_log_row = log_and_deduct_cost_for_api_request(
                 getattr(request, "organization", None) or request.user.organization,
                 APICallTypeChoices.PROMPT_BENCH.value,
                 config=config,
@@ -3235,7 +3241,9 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 _org = (
                     getattr(request, "organization", None) or request.user.organization
                 )
-                emit(
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+                    emit(
                     UsageEvent(
                         org_id=str(_org.id),
                         event_type=BillingEventType.AI_PROMPT_CREATION,
@@ -3322,11 +3330,12 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 )
 
             config = {
-                "input_tokens": count_text_tokens(
+                "input_tokens": (count_text_tokens(
                     existing_prompt + improvement_requirements
-                )
+                ) if count_text_tokens else 0)
             }
-            call_log_row = log_and_deduct_cost_for_api_request(
+            if log_and_deduct_cost_for_api_request is not None:
+                call_log_row = log_and_deduct_cost_for_api_request(
                 getattr(request, "organization", None) or request.user.organization,
                 APICallTypeChoices.PROMPT_BENCH.value,
                 config=config,
@@ -3357,7 +3366,9 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 _org = (
                     getattr(request, "organization", None) or request.user.organization
                 )
-                emit(
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+                    emit(
                     UsageEvent(
                         org_id=str(_org.id),
                         event_type=BillingEventType.AI_PROMPT_IMPROVEMENT,

--- a/futureagi/model_hub/views/prompt_template.py
+++ b/futureagi/model_hub/views/prompt_template.py
@@ -2565,23 +2565,24 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 }
             )
             org = Organization.objects.get(id=organization_id)
+            api_call_log_row = None
             if log_and_deduct_cost_for_api_request is not None:
                 api_call_log_row = log_and_deduct_cost_for_api_request(
-                organization=org,
-                api_call_type=APICallTypeChoices.DATASET_EVALUATION.value,
-                source="prompt_template",
-                source_id=eval_template.id,
-                config=source_config,
-                workspace=evaluation.prompt_template.workspace,
-            )
-
-            if not api_call_log_row:
-                raise ValueError(
-                    "API call not allowed : Error validating the api call."
+                    organization=org,
+                    api_call_type=APICallTypeChoices.DATASET_EVALUATION.value,
+                    source="prompt_template",
+                    source_id=eval_template.id,
+                    config=source_config,
+                    workspace=evaluation.prompt_template.workspace,
                 )
 
-            if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-                raise ValueError("API call not allowed : ", api_call_log_row.status)
+                if not api_call_log_row:
+                    raise ValueError(
+                        "API call not allowed : Error validating the api call."
+                    )
+
+                if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
+                    raise ValueError("API call not allowed : ", api_call_log_row.status)
             # Apply the shared empty-input rules so prompt-template evals
             # behave the same as dataset/playground/tracing/SDK paths.
             from model_hub.utils.eval_input_validation import (
@@ -3209,19 +3210,20 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 return self._gm.bad_request(get_error_message("MISSING_STATEMENT"))
 
             config = {"input_tokens": (count_text_tokens(statement) if count_text_tokens else 0)}
+            call_log_row = None
             if log_and_deduct_cost_for_api_request is not None:
                 call_log_row = log_and_deduct_cost_for_api_request(
-                getattr(request, "organization", None) or request.user.organization,
-                APICallTypeChoices.PROMPT_BENCH.value,
-                config=config,
-                source="run_prompt_gen",
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status != APICallStatusChoices.PROCESSING.value
-            ):
-                return self._gm.bad_request(get_error_message("INSUFFICIENT_CREDITS"))
+                    getattr(request, "organization", None) or request.user.organization,
+                    APICallTypeChoices.PROMPT_BENCH.value,
+                    config=config,
+                    source="run_prompt_gen",
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status != APICallStatusChoices.PROCESSING.value
+                ):
+                    return self._gm.bad_request(get_error_message("INSUFFICIENT_CREDITS"))
 
             # Dual-write: emit usage event for new billing system
             try:
@@ -3334,19 +3336,20 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                     existing_prompt + improvement_requirements
                 ) if count_text_tokens else 0)
             }
+            call_log_row = None
             if log_and_deduct_cost_for_api_request is not None:
                 call_log_row = log_and_deduct_cost_for_api_request(
-                getattr(request, "organization", None) or request.user.organization,
-                APICallTypeChoices.PROMPT_BENCH.value,
-                config=config,
-                source="run_prompt_improve",
-                workspace=request.workspace,
-            )
-            if (
-                call_log_row is None
-                or call_log_row.status != APICallStatusChoices.PROCESSING.value
-            ):
-                return self._gm.bad_request(get_error_message("INSUFFICIENT_CREDITS"))
+                    getattr(request, "organization", None) or request.user.organization,
+                    APICallTypeChoices.PROMPT_BENCH.value,
+                    config=config,
+                    source="run_prompt_improve",
+                    workspace=request.workspace,
+                )
+                if (
+                    call_log_row is None
+                    or call_log_row.status != APICallStatusChoices.PROCESSING.value
+                ):
+                    return self._gm.bad_request(get_error_message("INSUFFICIENT_CREDITS"))
 
             # Dual-write: emit usage event for new billing system
             try:

--- a/futureagi/model_hub/views/run_prompt.py
+++ b/futureagi/model_hub/views/run_prompt.py
@@ -82,11 +82,7 @@ from tfc.utils.storage import (
     convert_image_from_url_to_base64,
     detect_audio_format,
 )
-try:
-    from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-except ImportError:
-    APICallStatusChoices = None
-    APICallTypeChoices = None
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
@@ -1117,56 +1113,56 @@ class RunPrompts:
                     run_prompt_id=str(self.run_prompt_id),
                     row_id=row_id,
                 )
-                try:
-                    api_call_config = {"reference_id": str(self.run_prompt_id)}
-                    api_call_log_row = log_and_deduct_cost_for_api_request(
-                        self.run_prompt_model.organization,
-                        APICallTypeChoices.DATASET_RUN_PROMPT.value,
-                        config=api_call_config,
-                        workspace=row.dataset.workspace,
-                    )
-                    logger.info(
-                        "RunPrompts_process_row_api_call_logged",
-                        run_prompt_id=str(self.run_prompt_id),
-                        row_id=row_id,
-                        api_call_log_row_id=(
-                            str(api_call_log_row.id) if api_call_log_row else None
-                        ),
-                    )
-                except Exception as api_err:
-                    logger.error(
-                        "RunPrompts_process_row_api_call_validation_error",
-                        run_prompt_id=str(self.run_prompt_id),
-                        row_id=row_id,
-                        error=str(api_err),
-                    )
-                    raise ValueError("Error in API call validation")  # noqa: B904
-                if not api_call_log_row:
-                    logger.error(
-                        "RunPrompts_process_row_api_call_log_row_none",
-                        run_prompt_id=str(self.run_prompt_id),
-                        row_id=row_id,
-                    )
-                    raise ValueError("Error in API call validation")
-                elif api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-                    error_message = get_error_for_api_status(api_call_log_row.status)
-                    logger.error(
-                        "RunPrompts_process_row_api_call_status_invalid",
-                        run_prompt_id=str(self.run_prompt_id),
-                        row_id=row_id,
-                        status=api_call_log_row.status,
-                        error_message=error_message,
-                    )
-                    raise ValueError(error_message)
-                elif api_call_log_row.status == APICallStatusChoices.PROCESSING.value:
-                    # by default set the status to success since we are not deducting cost
-                    api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-                    api_call_log_row.save()
-                    logger.info(
-                        "RunPrompts_process_row_api_call_status_set_success",
-                        run_prompt_id=str(self.run_prompt_id),
-                        row_id=row_id,
-                    )
+                if log_and_deduct_cost_for_api_request is not None:
+                    try:
+                        api_call_config = {"reference_id": str(self.run_prompt_id)}
+                        api_call_log_row = log_and_deduct_cost_for_api_request(
+                            self.run_prompt_model.organization,
+                            APICallTypeChoices.DATASET_RUN_PROMPT.value,
+                            config=api_call_config,
+                            workspace=row.dataset.workspace,
+                        )
+                        logger.info(
+                            "RunPrompts_process_row_api_call_logged",
+                            run_prompt_id=str(self.run_prompt_id),
+                            row_id=row_id,
+                            api_call_log_row_id=(
+                                str(api_call_log_row.id) if api_call_log_row else None
+                            ),
+                        )
+                    except Exception as api_err:
+                        logger.error(
+                            "RunPrompts_process_row_api_call_validation_error",
+                            run_prompt_id=str(self.run_prompt_id),
+                            row_id=row_id,
+                            error=str(api_err),
+                        )
+                        raise ValueError("Error in API call validation")  # noqa: B904
+                    if not api_call_log_row:
+                        logger.error(
+                            "RunPrompts_process_row_api_call_log_row_none",
+                            run_prompt_id=str(self.run_prompt_id),
+                            row_id=row_id,
+                        )
+                        raise ValueError("Error in API call validation")
+                    elif api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
+                        error_message = get_error_for_api_status(api_call_log_row.status)
+                        logger.error(
+                            "RunPrompts_process_row_api_call_status_invalid",
+                            run_prompt_id=str(self.run_prompt_id),
+                            row_id=row_id,
+                            status=api_call_log_row.status,
+                            error_message=error_message,
+                        )
+                        raise ValueError(error_message)
+                    elif api_call_log_row.status == APICallStatusChoices.PROCESSING.value:
+                        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+                        api_call_log_row.save()
+                        logger.info(
+                            "RunPrompts_process_row_api_call_status_set_success",
+                            run_prompt_id=str(self.run_prompt_id),
+                            row_id=row_id,
+                        )
 
                 # Dual-write: emit usage event for new billing system
                 try:
@@ -1179,7 +1175,10 @@ class RunPrompts:
                     except ImportError:
                         emit = None
 
-                    emit(
+                    if emit is not None and UsageEvent is not None:
+
+
+                        emit(
                         UsageEvent(
                             org_id=str(self.run_prompt_model.organization.id),
                             event_type=APICallTypeChoices.DATASET_RUN_PROMPT.value,

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -72,11 +72,12 @@ from tracer.models.observation_span import EvalLogger
 from tracer.utils.filters import apply_created_at_filters
 from tracer.utils.graphs import GraphEngine
 
+from tfc.constants.api_calls import APICallStatusChoices
+
 try:
-    from ee.usage.models.usage import APICallLog, APICallStatusChoices
+    from ee.usage.models.usage import APICallLog
 except ImportError:
     APICallLog = None
-    APICallStatusChoices = None
 
 
 def apply_filters(row_data, filters):
@@ -289,6 +290,10 @@ class GetAPICallLogDetailsView(APIView):
 
     def get(self, request, *args, **kwargs):
         try:
+            if APICallLog is None:
+                return self._gm.success_response([])
+            if APICallLog is None:
+                return self._gm.success_response([])
             eval_template_id = request.query_params.get(
                 "eval_template_id", None
             ) or request.query_params.get("evalTemplateId", None)
@@ -438,6 +443,8 @@ class GetAPICallLogView(APIView):
         try:
             log_id = request.query_params.get("log_id", None)
             try:
+                if APICallLog is None:
+                    return self._gm.success_response([])
                 log_row = APICallLog.objects.get(log_id=log_id)
             except APICallLog.DoesNotExist:
                 return self._gm.bad_request(
@@ -584,6 +591,8 @@ class GetAPICallLogView(APIView):
 
     def delete(self, request, *args, **kwargs):
         try:
+            if APICallLog is None:
+                return self._gm.success_response([])
             log_ids = request.data.get("log_ids", [])
             if not log_ids:
                 return self._gm.bad_request(get_error_message("LOG_ID_REQUIRED"))
@@ -898,6 +907,8 @@ class EvalMetricView(APIView):
 
     def get(self, request, *args, **kwargs):
         try:
+            if APICallLog is None:
+                return self._gm.success_response([])
             eval_template_id = request.query_params.get("eval_template_id", None)
             filters_param = request.query_params.get("filters", "[]")
 
@@ -927,6 +938,8 @@ class EvalMetricView(APIView):
 
     def post(self, request, *args, **kwargs):
         try:
+            if APICallLog is None:
+                return self._gm.success_response([])
             eval_template_id = request.data.get("eval_template_id", None)
             filters = request.data.get("filters", [])
 
@@ -956,15 +969,18 @@ class GetEvalTemplateNameView(APIView):
 
     def post(self, request):
         try:
-            logs = APICallLog.objects.filter(
-                organization=getattr(request, "organization", None)
-                or request.user.organization
-            )
-            log_ids = [
-                log.source_id
-                for log in logs
-                if log.source_id is not None and log.source_id != ""
-            ]
+            if APICallLog is None:
+                log_ids = []
+            else:
+                logs = APICallLog.objects.filter(
+                    organization=getattr(request, "organization", None)
+                    or request.user.organization
+                )
+                log_ids = [
+                    log.source_id
+                    for log in logs
+                    if log.source_id is not None and log.source_id != ""
+                ]
             eval_ids = EvalTemplate.objects.filter(
                 organization=getattr(request, "organization", None)
                 or request.user.organization,
@@ -1125,6 +1141,8 @@ class GetEvalTemplates(APIView):
 
     def post(self, request, *args, **kwargs):
         try:
+            if APICallLog is None:
+                return self._gm.success_response([])
             page_size = request.data.get("page_size", 10)
             current_page = request.data.get("current_page_index", 0)
             search_text = request.data.get("search_text", "")
@@ -1198,7 +1216,10 @@ class GetEvalTemplates(APIView):
                 total_rows = row[4]
 
             # Fetch logs ONLY for paginated templates (not all templates)
-            logs = APICallLog.objects.filter(
+            if APICallLog is None:
+                logs = []
+            else:
+                logs = APICallLog.objects.filter(
                 organization=getattr(request, "organization", None)
                 or request.user.organization,
                 deleted=False,
@@ -4381,6 +4402,10 @@ class EvalUsageStatsView(APIView):
 
     def get(self, request, template_id, *args, **kwargs):
         try:
+            if APICallLog is None:
+                return self._gm.success_response([])
+            if APICallLog is None:
+                return self._gm.success_response([])
             try:
                 template = EvalTemplate.no_workspace_objects.get(
                     id=template_id, deleted=False
@@ -4784,6 +4809,8 @@ class EvalFeedbackListView(APIView):
             )
 
             try:
+                if APICallLog is None:
+                    return self._gm.success_response([])
                 EvalTemplate.no_workspace_objects.get(id=template_id, deleted=False)
             except EvalTemplate.DoesNotExist:
                 return self._gm.not_found("Eval template not found.")
@@ -5693,6 +5720,8 @@ class EvalPlayGroundFeedbackAPIView(APIView):
             explanation = validated_data.get("explanation", None)
 
             try:
+                if APICallLog is None:
+                    return self._gm.success_response([])
                 log = APICallLog.objects.get(log_id=log_id)
                 config = json.loads(log.config)
                 required_keys = config.get("required_keys", [])
@@ -5971,9 +6000,10 @@ class DeleteEvalTemplateView(APIView):
                 ExternalEvalConfig.objects.filter(eval_template=eval_template).update(
                     deleted=True, deleted_at=timezone.now()
                 )
-                APICallLog.objects.filter(source_id=eval_template_id).update(
-                    deleted=True, deleted_at=timezone.now()
-                )
+                if APICallLog is not None:
+                    APICallLog.objects.filter(source_id=eval_template_id).update(
+                        deleted=True, deleted_at=timezone.now()
+                    )
                 EvalLogger.objects.filter(
                     custom_eval_config__eval_template=eval_template
                 ).update(deleted=True, deleted_at=timezone.now())

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -292,8 +292,6 @@ class GetAPICallLogDetailsView(APIView):
         try:
             if APICallLog is None:
                 return self._gm.success_response([])
-            if APICallLog is None:
-                return self._gm.success_response([])
             eval_template_id = request.query_params.get(
                 "eval_template_id", None
             ) or request.query_params.get("evalTemplateId", None)
@@ -4402,8 +4400,6 @@ class EvalUsageStatsView(APIView):
 
     def get(self, request, template_id, *args, **kwargs):
         try:
-            if APICallLog is None:
-                return self._gm.success_response([])
             if APICallLog is None:
                 return self._gm.success_response([])
             try:

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -23,10 +23,7 @@ from sdk.utils.helpers import _get_api_call_type
 from tfc.middleware.workspace_context import get_current_organization
 from tfc.temporal import temporal_activity
 from tfc.utils.error_codes import get_specific_error_message
-try:
-    from ee.usage.models.usage import APICallStatusChoices
-except ImportError:
-    APICallStatusChoices = None
+from tfc.constants.api_calls import APICallStatusChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
@@ -224,7 +221,7 @@ def run_eval_func(
         _is_code_eval = getattr(template, "eval_type", "") == "code"
         api_call_type = (
             BillingEventType.CODE_EVALUATOR.value
-            if _is_code_eval
+            if _is_code_eval and BillingEventType is not None
             else _get_api_call_type(model)
         )
 
@@ -241,7 +238,10 @@ def run_eval_func(
         if check_usage is not None:
             usage_check = check_usage(str(org.id), api_call_type)
             if not usage_check.allowed:
-                raise UsageLimitExceeded(usage_check)
+                if UsageLimitExceeded is not None:
+                    raise UsageLimitExceeded(usage_check)
+                else:
+                    raise ValueError(str(usage_check))
 
         if log_and_deduct_cost_for_api_request is not None:
             api_call_log_row = log_and_deduct_cost_for_api_request(
@@ -422,7 +422,9 @@ def run_eval_func(
             except ImportError:
                 emit = None
 
-            billing_config = BillingConfig.get()
+            billing_config = None
+            if BillingConfig is not None:
+                billing_config = BillingConfig.get()
             eval_cost = getattr(eval_instance, "cost", {})
             llm_cost = eval_cost.get("total_cost", 0)
             per_run_fee = billing_config.get_eval_per_run_fee()
@@ -452,9 +454,12 @@ def run_eval_func(
                 token_usage=getattr(eval_instance, "token_usage", {}),
             )
 
-            credits = billing_config.calculate_ai_credits(actual_cost)
+            credits = billing_config.calculate_ai_credits(actual_cost) if billing_config else 0
 
-            emit(
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+
+                emit(
                 UsageEvent(
                     org_id=str(org.id),
                     event_type=api_call_type,

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -427,7 +427,7 @@ def run_eval_func(
                 billing_config = BillingConfig.get()
             eval_cost = getattr(eval_instance, "cost", {})
             llm_cost = eval_cost.get("total_cost", 0)
-            per_run_fee = billing_config.get_eval_per_run_fee()
+            per_run_fee = billing_config.get_eval_per_run_fee() if billing_config else 0
             actual_cost = llm_cost + per_run_fee
 
             # Fallback cost for comparison logging

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -10,10 +10,7 @@ from model_hub.models.evaluation import Evaluation, StatusChoices
 from model_hub.tasks.user_evaluation import trigger_error_localization_for_standalone
 from sdk.utils.helpers import _get_api_call_type
 from tracer.utils.inline_evals import trigger_inline_eval
-try:
-    from ee.usage.models.usage import APICallStatusChoices
-except ImportError:
-    APICallStatusChoices = None
+from tfc.constants.api_calls import APICallStatusChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
@@ -51,7 +48,8 @@ def _log_and_deduct_cost_for_standalone_eval(
     except ImportError:
         check_usage = None
 
-    usage_check = check_usage(str(user.organization.id), api_call_type)
+    if check_usage is not None:
+        usage_check = check_usage(str(user.organization.id), api_call_type)
     if not usage_check.allowed:
         raise ValueError(usage_check.reason or "Usage limit exceeded")
 
@@ -60,7 +58,8 @@ def _log_and_deduct_cost_for_standalone_eval(
     if kb_id:
         log_config.update({"kb_id": str(kb_id)})
 
-    api_call_log_row = log_and_deduct_cost_for_api_request(
+    if log_and_deduct_cost_for_api_request is not None:
+        api_call_log_row = log_and_deduct_cost_for_api_request(
         organization=user.organization,
         api_call_type=api_call_type,
         source="standalone_v2",
@@ -299,7 +298,8 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
         except ImportError:
             emit = None
 
-        billing_config = BillingConfig.get()
+        if BillingConfig is not None:
+            billing_config = BillingConfig.get()
         eval_cost = result.cost or {}
         llm_cost = eval_cost.get("total_cost", 0)
         per_run_fee = billing_config.get_eval_per_run_fee()
@@ -307,7 +307,9 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
         credits = billing_config.calculate_ai_credits(actual_cost)
 
         api_call_type = _get_api_call_type(model)
-        emit(
+        if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+            emit(
             UsageEvent(
                 org_id=str(user.organization.id),
                 event_type=api_call_type,
@@ -548,7 +550,8 @@ def _run_protect(
             except ImportError:
                 emit = None
 
-            billing_config = BillingConfig.get()
+            if BillingConfig is not None:
+                billing_config = BillingConfig.get()
             token_usage = (result.metadata or {}).get("token_usage", {})
             from agentic_eval.core_evals.fi_utils.token_count_helper import (
                 calculate_total_cost,
@@ -568,7 +571,10 @@ def _run_protect(
             actual_cost = llm_cost + per_run_fee
             credits = billing_config.calculate_ai_credits(actual_cost)
 
-            emit(
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+
+                emit(
                 UsageEvent(
                     org_id=str(user.organization.id),
                     event_type=_get_api_call_type(

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -50,29 +50,30 @@ def _log_and_deduct_cost_for_standalone_eval(
 
     if check_usage is not None:
         usage_check = check_usage(str(user.organization.id), api_call_type)
-    if not usage_check.allowed:
-        raise ValueError(usage_check.reason or "Usage limit exceeded")
+        if not usage_check.allowed:
+            raise ValueError(usage_check.reason or "Usage limit exceeded")
 
     if model:
         log_config.update({"model": str(model)})
     if kb_id:
         log_config.update({"kb_id": str(kb_id)})
 
+    api_call_log_row = None
     if log_and_deduct_cost_for_api_request is not None:
         api_call_log_row = log_and_deduct_cost_for_api_request(
-        organization=user.organization,
-        api_call_type=api_call_type,
-        source="standalone_v2",
-        source_id=eval_template.id,
-        config=log_config,
-        workspace=workspace,
-    )
+            organization=user.organization,
+            api_call_type=api_call_type,
+            source="standalone_v2",
+            source_id=eval_template.id,
+            config=log_config,
+            workspace=workspace,
+        )
 
-    if not api_call_log_row:
-        raise ValueError("API call not allowed : Error validating the api call.")
+        if not api_call_log_row:
+            raise ValueError("API call not allowed : Error validating the api call.")
 
-    if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-        raise ValueError(f"API call not allowed: {api_call_log_row.status}")
+        if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
+            raise ValueError(f"API call not allowed: {api_call_log_row.status}")
 
     # NOTE: No pre-eval UsageEvent emission. The cost isn't known until the
     # eval finishes, and UsageEvent.amount defaults to 1 — emitting here
@@ -269,16 +270,17 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
         output_payload["warnings"] = [partial_input_warning]
         eval_result["warnings"] = [partial_input_warning]
 
-    config_dict = json.loads(api_call_log_row.config)
-    config_dict.update(
-        {
-            "input": eval_result.get("data", {}),
-            "output": output_payload,
-        }
-    )
-    api_call_log_row.config = json.dumps(config_dict)
-    api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-    api_call_log_row.save()
+    if api_call_log_row is not None:
+        config_dict = json.loads(api_call_log_row.config)
+        config_dict.update(
+            {
+                "input": eval_result.get("data", {}),
+                "output": output_payload,
+            }
+        )
+        api_call_log_row.config = json.dumps(config_dict)
+        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+        api_call_log_row.save()
 
     # Dual-write: emit cost-based usage event for new billing system.
     # The pre-eval emit in _log_and_deduct_cost_for_standalone_eval has no
@@ -298,30 +300,32 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
         except ImportError:
             emit = None
 
+        billing_config = None
         if BillingConfig is not None:
             billing_config = BillingConfig.get()
-        eval_cost = result.cost or {}
-        llm_cost = eval_cost.get("total_cost", 0)
-        per_run_fee = billing_config.get_eval_per_run_fee()
-        actual_cost = llm_cost + per_run_fee
-        credits = billing_config.calculate_ai_credits(actual_cost)
 
-        api_call_type = _get_api_call_type(model)
-        if emit is not None and UsageEvent is not None and BillingEventType is not None:
+        if billing_config is not None:
+            eval_cost = result.cost or {}
+            llm_cost = eval_cost.get("total_cost", 0)
+            per_run_fee = billing_config.get_eval_per_run_fee()
+            actual_cost = llm_cost + per_run_fee
+            credits = billing_config.calculate_ai_credits(actual_cost)
 
-            emit(
-            UsageEvent(
-                org_id=str(user.organization.id),
-                event_type=api_call_type,
-                amount=credits,
-                properties={
-                    "source": "standalone_v2",
-                    "source_id": str(eval_template.id),
-                    "raw_cost_usd": str(actual_cost),
-                    "log_id": str(api_call_log_row.log_id),
-                },
-            )
-        )
+            api_call_type = _get_api_call_type(model)
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                emit(
+                    UsageEvent(
+                        org_id=str(user.organization.id),
+                        event_type=api_call_type,
+                        amount=credits,
+                        properties={
+                            "source": "standalone_v2",
+                            "source_id": str(eval_template.id),
+                            "raw_cost_usd": str(actual_cost),
+                            "log_id": str(api_call_log_row.log_id) if api_call_log_row else None,
+                        },
+                    )
+                )
     except Exception:
         pass  # Metering failure must not break the action
 
@@ -500,15 +504,16 @@ def _run_protect(
         except Exception as e:
             logger.exception(f"Protect Eval | Failed: user: {user.id}, error: {e}")
 
-            api_call_log_row.status = APICallStatusChoices.ERROR.value
-            config_dict = json.loads(api_call_log_row.config)
-            config_dict.update(
-                {
-                    "output": {"output": None, "reason": str(e)},
-                }
-            )
-            api_call_log_row.config = json.dumps(config_dict)
-            api_call_log_row.save()
+            if api_call_log_row is not None:
+                api_call_log_row.status = APICallStatusChoices.ERROR.value
+                config_dict = json.loads(api_call_log_row.config)
+                config_dict.update(
+                    {
+                        "output": {"output": None, "reason": str(e)},
+                    }
+                )
+                api_call_log_row.config = json.dumps(config_dict)
+                api_call_log_row.save()
 
             raise StandaloneEvaluationError(e)  # noqa: B904
 
@@ -521,19 +526,20 @@ def _run_protect(
             "eval_id": sdk_uuid,
         }
 
-        config_dict = json.loads(api_call_log_row.config)
-        config_dict.update(
-            {
-                "input": result.data or {},
-                "output": {
-                    "output": formatted["output"],
-                    "reason": formatted["reason"],
-                },
-            }
-        )
-        api_call_log_row.config = json.dumps(config_dict)
-        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-        api_call_log_row.save()
+        if api_call_log_row is not None:
+            config_dict = json.loads(api_call_log_row.config)
+            config_dict.update(
+                {
+                    "input": result.data or {},
+                    "output": {
+                        "output": formatted["output"],
+                        "reason": formatted["reason"],
+                    },
+                }
+            )
+            api_call_log_row.config = json.dumps(config_dict)
+            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+            api_call_log_row.save()
 
         # Emit usage event with actual cost after eval completion
         try:
@@ -550,44 +556,45 @@ def _run_protect(
             except ImportError:
                 emit = None
 
+            billing_config = None
             if BillingConfig is not None:
                 billing_config = BillingConfig.get()
-            token_usage = (result.metadata or {}).get("token_usage", {})
-            from agentic_eval.core_evals.fi_utils.token_count_helper import (
-                calculate_total_cost,
-            )
-            # Resolve model alias for pricing lookup
-            if protect_flash:
-                protect_model = "protect_flash"
-            else:
-                try:
-                    from ee.protect.helper import ProtectHelper
-                    protect_model = ProtectHelper.resolve_alias(eval_template.name, is_flash=False)
-                except ImportError:
-                    protect_model = f"protect_{eval_template.name}"
-            cost_info = calculate_total_cost(protect_model, token_usage)
-            llm_cost = cost_info.get("total_cost", 0)
-            per_run_fee = billing_config.get_eval_per_run_fee()
-            actual_cost = llm_cost + per_run_fee
-            credits = billing_config.calculate_ai_credits(actual_cost)
 
-            if emit is not None and UsageEvent is not None and BillingEventType is not None:
-
-
-                emit(
-                UsageEvent(
-                    org_id=str(user.organization.id),
-                    event_type=_get_api_call_type(
-                        "protect_flash" if protect_flash else "protect"
-                    ),
-                    amount=credits,
-                    properties={
-                        "source": "standalone_v2",
-                        "source_id": str(eval_template.id),
-                        "raw_cost_usd": str(actual_cost),
-                    },
+            if billing_config is not None:
+                token_usage = (result.metadata or {}).get("token_usage", {})
+                from agentic_eval.core_evals.fi_utils.token_count_helper import (
+                    calculate_total_cost,
                 )
-            )
+                # Resolve model alias for pricing lookup
+                if protect_flash:
+                    protect_model = "protect_flash"
+                else:
+                    try:
+                        from ee.protect.helper import ProtectHelper
+                        protect_model = ProtectHelper.resolve_alias(eval_template.name, is_flash=False)
+                    except ImportError:
+                        protect_model = f"protect_{eval_template.name}"
+                cost_info = calculate_total_cost(protect_model, token_usage)
+                llm_cost = cost_info.get("total_cost", 0)
+                per_run_fee = billing_config.get_eval_per_run_fee()
+                actual_cost = llm_cost + per_run_fee
+                credits = billing_config.calculate_ai_credits(actual_cost)
+
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                    emit(
+                        UsageEvent(
+                            org_id=str(user.organization.id),
+                            event_type=_get_api_call_type(
+                                "protect_flash" if protect_flash else "protect"
+                            ),
+                            amount=credits,
+                            properties={
+                                "source": "standalone_v2",
+                                "source_id": str(eval_template.id),
+                                "raw_cost_usd": str(actual_cost),
+                            },
+                        )
+                    )
         except Exception:
             pass
 

--- a/futureagi/simulate/tasks/chat_sim.py
+++ b/futureagi/simulate/tasks/chat_sim.py
@@ -572,12 +572,13 @@ def run_single_prompt_chat(call_execution_id: str):
         except ImportError:
             check_usage = None
 
-        usage_check = check_usage(str(organization.id), BillingEventType.TEXT_CALL)
-        if not usage_check.allowed:
-            call_execution.status = CallExecution.CallStatus.FAILED
-            call_execution.ended_reason = usage_check.reason or "Usage limit exceeded"
-            call_execution.save(update_fields=["status", "ended_reason"])
-            return False
+        if check_usage is not None and BillingEventType is not None:
+            usage_check = check_usage(str(organization.id), BillingEventType.TEXT_CALL)
+            if not usage_check.allowed:
+                call_execution.status = CallExecution.CallStatus.FAILED
+                call_execution.ended_reason = usage_check.reason or "Usage limit exceeded"
+                call_execution.save(update_fields=["status", "ended_reason"])
+                return False
 
         logger.info(
             "prompt_chat_simulation_starting",

--- a/futureagi/tracer/tasks/error_analysis.py
+++ b/futureagi/tracer/tasks/error_analysis.py
@@ -46,11 +46,7 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
     from tracer.models.trace_error_analysis import TraceErrorAnalysis
     from tracer.queries.error_analysis import TraceErrorAnalysisDB
     from tracer.queries.helpers import get_default_workspace_for_project
-    try:
-        from ee.usage.models.usage import APICallStatusChoices, APICallTypeChoices
-    except ImportError:
-        APICallStatusChoices = None
-        APICallTypeChoices = None
+    from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
     try:
         from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request, refund_cost_for_api_call
     except ImportError:
@@ -91,17 +87,19 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
         except ImportError:
             check_usage = None
 
-        usage_check = check_usage(
-            str(organization.id), APICallTypeChoices.TRACE_ERROR_ANALYSIS.value
-        )
-        if not usage_check.allowed:
-            Trace.objects.filter(id=trace_id).update(
-                error_analysis_status=TraceErrorAnalysisStatus.FAILED
+        if check_usage is not None:
+            usage_check = check_usage(
+                str(organization.id), APICallTypeChoices.TRACE_ERROR_ANALYSIS.value
             )
-            raise ValueError(usage_check.reason or "Usage limit exceeded")
+            if not usage_check.allowed:
+                Trace.objects.filter(id=trace_id).update(
+                    error_analysis_status=TraceErrorAnalysisStatus.FAILED
+                )
+                raise ValueError(usage_check.reason or "Usage limit exceeded")
 
         # Log and deduct cost for the analysis upfront.
-        api_call_log_row = log_and_deduct_cost_for_api_request(
+        if log_and_deduct_cost_for_api_request is not None:
+            api_call_log_row = log_and_deduct_cost_for_api_request(
             organization=organization,
             api_call_type=APICallTypeChoices.TRACE_ERROR_ANALYSIS.value,
             source="trace_error_analysis",
@@ -170,9 +168,14 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
             actual_cost = getattr(agent, "cost", {}).get("total_cost", 0)
             if not actual_cost and hasattr(agent, "llm"):
                 actual_cost = getattr(agent.llm, "cost", {}).get("total_cost", 0)
-            credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+            if BillingConfig is not None:
 
-            emit(
+                credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+
+
+                emit(
                 UsageEvent(
                     org_id=str(organization.id),
                     event_type=BillingEventType.TRACE_ERROR_ANALYSIS,
@@ -196,7 +199,8 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
         # If something went wrong, refund the cost.
         if api_call_log_row:
             logger.info(f"Refunding cost for failed trace analysis {trace_id}.")
-            refund_cost_for_api_call(api_call_log_row, config={"error": str(e)})
+            if refund_cost_for_api_call is not None:
+                refund_cost_for_api_call(api_call_log_row, config={"error": str(e)})
             api_call_log_row.status = APICallStatusChoices.ERROR.value
             api_call_log_row.save(update_fields=["status"])
 

--- a/futureagi/tracer/tasks/error_analysis.py
+++ b/futureagi/tracer/tasks/error_analysis.py
@@ -100,25 +100,25 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
         # Log and deduct cost for the analysis upfront.
         if log_and_deduct_cost_for_api_request is not None:
             api_call_log_row = log_and_deduct_cost_for_api_request(
-            organization=organization,
-            api_call_type=APICallTypeChoices.TRACE_ERROR_ANALYSIS.value,
-            source="trace_error_analysis",
-            workspace=workspace,
-            source_id=str(trace_id),
-            config={
-                "trace_id": str(trace_id),
-                "project_id": str(trace.project.id),
-                "reference_id": str(trace.project.id),
-            },
-        )
-
-        if not api_call_log_row:
-            error_message = "Failed to create API call log for trace analysis."
-            logger.error(error_message)
-            Trace.objects.filter(id=trace_id).update(
-                error_analysis_status=TraceErrorAnalysisStatus.FAILED
+                organization=organization,
+                api_call_type=APICallTypeChoices.TRACE_ERROR_ANALYSIS.value,
+                source="trace_error_analysis",
+                workspace=workspace,
+                source_id=str(trace_id),
+                config={
+                    "trace_id": str(trace_id),
+                    "project_id": str(trace.project.id),
+                    "reference_id": str(trace.project.id),
+                },
             )
-            return {"success": False, "trace_id": trace_id, "error": error_message}
+
+            if not api_call_log_row:
+                error_message = "Failed to create API call log for trace analysis."
+                logger.error(error_message)
+                Trace.objects.filter(id=trace_id).update(
+                    error_analysis_status=TraceErrorAnalysisStatus.FAILED
+                )
+                return {"success": False, "trace_id": trace_id, "error": error_message}
 
         agent = TraceErrorAnalysisAgent(
             trace_id=str(trace_id),
@@ -143,8 +143,9 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
             error_analysis_db.ingest_trace_error_embeddings(trace_id)
 
         # Mark the API call as successful
-        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-        api_call_log_row.save(update_fields=["status"])
+        if api_call_log_row:
+            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+            api_call_log_row.save(update_fields=["status"])
 
         # Dual-write: emit usage event for new billing system (cost-based)
         try:
@@ -168,26 +169,25 @@ def analyze_single_trace(trace_id, task_id, ingest_embeddings: bool = True):
             actual_cost = getattr(agent, "cost", {}).get("total_cost", 0)
             if not actual_cost and hasattr(agent, "llm"):
                 actual_cost = getattr(agent.llm, "cost", {}).get("total_cost", 0)
-            if BillingConfig is not None:
 
+            credits = 0
+            if BillingConfig is not None:
                 credits = BillingConfig.get().calculate_ai_credits(actual_cost)
 
             if emit is not None and UsageEvent is not None and BillingEventType is not None:
-
-
                 emit(
-                UsageEvent(
-                    org_id=str(organization.id),
-                    event_type=BillingEventType.TRACE_ERROR_ANALYSIS,
-                    amount=credits,
-                    properties={
-                        "source": "trace_error_analysis",
-                        "source_id": str(trace_id),
-                        "errors_found": error_count,
-                        "raw_cost_usd": str(actual_cost),
-                    },
+                    UsageEvent(
+                        org_id=str(organization.id),
+                        event_type=BillingEventType.TRACE_ERROR_ANALYSIS,
+                        amount=credits,
+                        properties={
+                            "source": "trace_error_analysis",
+                            "source_id": str(trace_id),
+                            "errors_found": error_count,
+                            "raw_cost_usd": str(actual_cost),
+                        },
+                    )
                 )
-            )
         except Exception:
             pass
 

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -526,23 +526,24 @@ def _run_evaluation(
         org = observation_span.project.organization
         if check_usage is not None:
             usage_check = check_usage(str(org.id), api_call_type)
-        if not usage_check.allowed:
-            raise ValueError(usage_check.reason or "Usage limit exceeded")
+            if not usage_check.allowed:
+                raise ValueError(usage_check.reason or "Usage limit exceeded")
 
+        api_call_log_row = None
         if log_and_deduct_cost_for_api_request is not None:
             api_call_log_row = log_and_deduct_cost_for_api_request(
-            organization=org,
-            api_call_type=api_call_type,
-            source="tracer" if not feedback_id else "feedback",
-            source_id=eval_model.id,
-            config=source_config,
-            workspace=workspace,
-        )
-        if not api_call_log_row:
-            raise ValueError("API call not allowed : Error validating the api call.")
+                organization=org,
+                api_call_type=api_call_type,
+                source="tracer" if not feedback_id else "feedback",
+                source_id=eval_model.id,
+                config=source_config,
+                workspace=workspace,
+            )
+            if not api_call_log_row:
+                raise ValueError("API call not allowed : Error validating the api call.")
 
-        if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-            raise ValueError("API call not allowed : ", api_call_log_row.status)
+            if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
+                raise ValueError("API call not allowed : ", api_call_log_row.status)
 
         # Apply the same empty-input rules the dataset and playground
         # paths use, so eval tasks behave consistently with everywhere
@@ -576,19 +577,20 @@ def _run_evaluation(
             response["warnings"] = [partial_input_warning]
         value = runner.format_output(result_data=response, eval_template=eval_model)
 
-        config_dict = json.loads(api_call_log_row.config)
-        output_payload = {"output": value, "reason": response["reason"]}
-        if response.get("warnings"):
-            output_payload["warnings"] = response["warnings"]
-        config_dict.update(
-            {
-                "input": response["data"],
-                "output": output_payload,
-            }
-        )
-        api_call_log_row.config = json.dumps(config_dict)
-        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-        api_call_log_row.save()
+        if api_call_log_row is not None:
+            config_dict = json.loads(api_call_log_row.config)
+            output_payload = {"output": value, "reason": response["reason"]}
+            if response.get("warnings"):
+                output_payload["warnings"] = response["warnings"]
+            config_dict.update(
+                {
+                    "input": response["data"],
+                    "output": output_payload,
+                }
+            )
+            api_call_log_row.config = json.dumps(config_dict)
+            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+            api_call_log_row.save()
 
         # Dual-write: emit usage event for new billing system (cost-based)
         try:
@@ -606,28 +608,26 @@ def _run_evaluation(
                 emit = None
 
             actual_cost = getattr(eval_instance, "cost", {}).get("total_cost", 0)
+            credits = 0
             if BillingConfig is not None:
-
                 credits = BillingConfig.get().calculate_ai_credits(actual_cost)
 
             if emit is not None and UsageEvent is not None:
-
-
                 emit(
-                UsageEvent(
-                    org_id=str(observation_span.project.organization_id),
-                    event_type=api_call_type,
-                    amount=credits,
-                    properties={
-                        "source": "tracer" if not feedback_id else "feedback",
-                        "source_id": str(eval_model.id),
-                        "model": custom_eval_config.model if custom_eval_config else "",
-                        "workspace_id": str(workspace.id) if workspace else "",
-                        "log_id": str(api_call_log_row.log_id),
-                        "raw_cost_usd": str(actual_cost),
-                    },
+                    UsageEvent(
+                        org_id=str(observation_span.project.organization_id),
+                        event_type=api_call_type,
+                        amount=credits,
+                        properties={
+                            "source": "tracer" if not feedback_id else "feedback",
+                            "source_id": str(eval_model.id),
+                            "model": custom_eval_config.model if custom_eval_config else "",
+                            "workspace_id": str(workspace.id) if workspace else "",
+                            "log_id": str(api_call_log_row.log_id) if api_call_log_row else None,
+                            "raw_cost_usd": str(actual_cost),
+                        },
+                    )
                 )
-            )
         except Exception:
             pass  # Metering failure must not break eval
 
@@ -657,18 +657,19 @@ def _run_evaluation(
             "eval_task_id": eval_task_id,
             "custom_eval_config": custom_eval_config,
             "eval_type_id": eval_type_id,
-            "log_id": api_call_log_row.log_id,
+            "log_id": api_call_log_row.log_id if api_call_log_row else None,
         }
 
     except Exception as e:
         traceback.print_exc()
         error_message = str(e)
         try:
-            api_call_log_row.status = APICallStatusChoices.ERROR.value
-            current_config = json.loads(api_call_log_row.config)
-            current_config.update({"output": {"output": None, "reason": str(e)}})
-            api_call_log_row.config = json.dumps(current_config)
-            api_call_log_row.save()
+            if api_call_log_row is not None:
+                api_call_log_row.status = APICallStatusChoices.ERROR.value
+                current_config = json.loads(api_call_log_row.config)
+                current_config.update({"output": {"output": None, "reason": str(e)}})
+                api_call_log_row.config = json.dumps(current_config)
+                api_call_log_row.save()
         except Exception:
             pass
         logger_kwargs = {
@@ -1181,19 +1182,20 @@ def _execute_evaluation(
             is_active=True,
         )
 
+    api_call_log_row = None
     if log_and_deduct_cost_for_api_request is not None:
         api_call_log_row = log_and_deduct_cost_for_api_request(
-        organization=observation_span.project.organization,
-        api_call_type=api_call_type,
-        source="tracer" if not feedback_id else "feedback",
-        source_id=eval_model.id,
-        config=source_config,
-        workspace=workspace,
-    )
-    if not api_call_log_row:
-        raise ValueError("API call not allowed : Error validating the api call.")
-    if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-        raise ValueError("API call not allowed : ", api_call_log_row.status)
+            organization=observation_span.project.organization,
+            api_call_type=api_call_type,
+            source="tracer" if not feedback_id else "feedback",
+            source_id=eval_model.id,
+            config=source_config,
+            workspace=workspace,
+        )
+        if not api_call_log_row:
+            raise ValueError("API call not allowed : Error validating the api call.")
+        if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
+            raise ValueError("API call not allowed : ", api_call_log_row.status)
 
     # --- Build context for data_injection support ---
     _eval_inputs = dict(run_params or {})
@@ -1240,16 +1242,17 @@ def _execute_evaluation(
         # Build the output payload up front so the partial-input warning
         # rides on the single save below — avoids losing the warning if a
         # follow-up save were to fail (see _build_apicall_output).
-        config_dict = json.loads(api_call_log_row.config)
-        config_dict.update(
-            {
-                "input": result.data,
-                "output": _build_apicall_output(result, partial_input_warning),
-            }
-        )
-        api_call_log_row.config = json.dumps(config_dict)
-        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-        api_call_log_row.save()
+        if api_call_log_row is not None:
+            config_dict = json.loads(api_call_log_row.config)
+            config_dict.update(
+                {
+                    "input": result.data,
+                    "output": _build_apicall_output(result, partial_input_warning),
+                }
+            )
+            api_call_log_row.config = json.dumps(config_dict)
+            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+            api_call_log_row.save()
 
         # Parse metadata
         metadata = result.metadata
@@ -1288,18 +1291,19 @@ def _execute_evaluation(
             "eval_task_id": eval_task_id,
             "custom_eval_config": custom_eval_config,
             "eval_type_id": eval_type_id,
-            "log_id": api_call_log_row.log_id,
+            "log_id": api_call_log_row.log_id if api_call_log_row else None,
         }
 
     except Exception as e:
         traceback.print_exc()
         error_message = str(e)
         try:
-            api_call_log_row.status = APICallStatusChoices.ERROR.value
-            current_config = json.loads(api_call_log_row.config)
-            current_config.update({"output": {"output": None, "reason": str(e)}})
-            api_call_log_row.config = json.dumps(current_config)
-            api_call_log_row.save()
+            if api_call_log_row is not None:
+                api_call_log_row.status = APICallStatusChoices.ERROR.value
+                current_config = json.loads(api_call_log_row.config)
+                current_config.update({"output": {"output": None, "reason": str(e)}})
+                api_call_log_row.config = json.dumps(current_config)
+                api_call_log_row.save()
         except Exception:
             pass
         logger_kwargs = {
@@ -2431,19 +2435,20 @@ def _execute_evaluation_for_trace(
         source_config["feedback_id"] = str(feedback_id)
 
     api_call_type = _get_api_call_type(custom_eval_config.model)
+    api_call_log_row = None
     if log_and_deduct_cost_for_api_request is not None:
         api_call_log_row = log_and_deduct_cost_for_api_request(
-        organization=trace.project.organization,
-        api_call_type=api_call_type,
-        source="tracer" if not feedback_id else "feedback",
-        source_id=eval_template.id,
-        config=source_config,
-        workspace=workspace,
-    )
-    if not api_call_log_row:
-        raise ValueError("API call not allowed : Error validating the api call.")
-    if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-        raise ValueError("API call not allowed : ", api_call_log_row.status)
+            organization=trace.project.organization,
+            api_call_type=api_call_type,
+            source="tracer" if not feedback_id else "feedback",
+            source_id=eval_template.id,
+            config=source_config,
+            workspace=workspace,
+        )
+        if not api_call_log_row:
+            raise ValueError("API call not allowed : Error validating the api call.")
+        if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
+            raise ValueError("API call not allowed : ", api_call_log_row.status)
 
     # --- Set workspace context for tools that need org-scoping ---
     # See _execute_evaluation_for_session for rationale; same applies here.
@@ -2499,16 +2504,17 @@ def _execute_evaluation_for_trace(
             )
         )
 
-        config_dict = json.loads(api_call_log_row.config)
-        config_dict.update(
-            {
-                "input": result.data,
-                "output": _build_apicall_output(result, partial_input_warning),
-            }
-        )
-        api_call_log_row.config = json.dumps(config_dict)
-        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-        api_call_log_row.save()
+        if api_call_log_row is not None:
+            config_dict = json.loads(api_call_log_row.config)
+            config_dict.update(
+                {
+                    "input": result.data,
+                    "output": _build_apicall_output(result, partial_input_warning),
+                }
+            )
+            api_call_log_row.config = json.dumps(config_dict)
+            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+            api_call_log_row.save()
 
         metadata = result.metadata
         if isinstance(metadata, str):
@@ -2551,13 +2557,14 @@ def _execute_evaluation_for_trace(
         traceback.print_exc()
         error_message = str(e)
         try:
-            api_call_log_row.status = APICallStatusChoices.ERROR.value
-            current_config = json.loads(api_call_log_row.config)
-            current_config.update(
-                {"output": {"output": None, "reason": str(e)}}
-            )
-            api_call_log_row.config = json.dumps(current_config)
-            api_call_log_row.save()
+            if api_call_log_row is not None:
+                api_call_log_row.status = APICallStatusChoices.ERROR.value
+                current_config = json.loads(api_call_log_row.config)
+                current_config.update(
+                    {"output": {"output": None, "reason": str(e)}}
+                )
+                api_call_log_row.config = json.dumps(current_config)
+                api_call_log_row.save()
         except Exception:
             pass
         logger_kwargs = {
@@ -2657,19 +2664,20 @@ def _execute_evaluation_for_session(
         source_config["feedback_id"] = str(feedback_id)
 
     api_call_type = _get_api_call_type(custom_eval_config.model)
+    api_call_log_row = None
     if log_and_deduct_cost_for_api_request is not None:
         api_call_log_row = log_and_deduct_cost_for_api_request(
-        organization=trace_session.project.organization,
-        api_call_type=api_call_type,
-        source="tracer" if not feedback_id else "feedback",
-        source_id=eval_template.id,
-        config=source_config,
-        workspace=workspace,
-    )
-    if not api_call_log_row:
-        raise ValueError("API call not allowed : Error validating the api call.")
-    if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-        raise ValueError("API call not allowed : ", api_call_log_row.status)
+            organization=trace_session.project.organization,
+            api_call_type=api_call_type,
+            source="tracer" if not feedback_id else "feedback",
+            source_id=eval_template.id,
+            config=source_config,
+            workspace=workspace,
+        )
+        if not api_call_log_row:
+            raise ValueError("API call not allowed : Error validating the api call.")
+        if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
+            raise ValueError("API call not allowed : ", api_call_log_row.status)
 
     # --- Set workspace context for tools that need org-scoping ---
     # The explore_trace tool's live DB actions (list_trace_spans, span_detail)
@@ -2725,16 +2733,17 @@ def _execute_evaluation_for_session(
             )
         )
 
-        config_dict = json.loads(api_call_log_row.config)
-        config_dict.update(
-            {
-                "input": result.data,
-                "output": _build_apicall_output(result, partial_input_warning),
-            }
-        )
-        api_call_log_row.config = json.dumps(config_dict)
-        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-        api_call_log_row.save()
+        if api_call_log_row is not None:
+            config_dict = json.loads(api_call_log_row.config)
+            config_dict.update(
+                {
+                    "input": result.data,
+                    "output": _build_apicall_output(result, partial_input_warning),
+                }
+            )
+            api_call_log_row.config = json.dumps(config_dict)
+            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+            api_call_log_row.save()
 
         metadata = result.metadata
         if isinstance(metadata, str):
@@ -2777,13 +2786,14 @@ def _execute_evaluation_for_session(
         traceback.print_exc()
         error_message = str(e)
         try:
-            api_call_log_row.status = APICallStatusChoices.ERROR.value
-            current_config = json.loads(api_call_log_row.config)
-            current_config.update(
-                {"output": {"output": None, "reason": str(e)}}
-            )
-            api_call_log_row.config = json.dumps(current_config)
-            api_call_log_row.save()
+            if api_call_log_row is not None:
+                api_call_log_row.status = APICallStatusChoices.ERROR.value
+                current_config = json.loads(api_call_log_row.config)
+                current_config.update(
+                    {"output": {"output": None, "reason": str(e)}}
+                )
+                api_call_log_row.config = json.dumps(current_config)
+                api_call_log_row.save()
         except Exception:
             pass
         logger_kwargs = {

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -24,10 +24,7 @@ from tracer.models.trace import Trace
 from tracer.models.trace_session import TraceSession
 from tracer.utils.helper import FieldConfig, get_default_trace_config
 from tracer.views.project import get_default_project_version_config
-try:
-    from ee.usage.models.usage import APICallStatusChoices
-except ImportError:
-    APICallStatusChoices = None
+from tfc.constants.api_calls import APICallStatusChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
@@ -527,11 +524,13 @@ def _run_evaluation(
             check_usage = None
 
         org = observation_span.project.organization
-        usage_check = check_usage(str(org.id), api_call_type)
+        if check_usage is not None:
+            usage_check = check_usage(str(org.id), api_call_type)
         if not usage_check.allowed:
             raise ValueError(usage_check.reason or "Usage limit exceeded")
 
-        api_call_log_row = log_and_deduct_cost_for_api_request(
+        if log_and_deduct_cost_for_api_request is not None:
+            api_call_log_row = log_and_deduct_cost_for_api_request(
             organization=org,
             api_call_type=api_call_type,
             source="tracer" if not feedback_id else "feedback",
@@ -607,9 +606,14 @@ def _run_evaluation(
                 emit = None
 
             actual_cost = getattr(eval_instance, "cost", {}).get("total_cost", 0)
-            credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+            if BillingConfig is not None:
 
-            emit(
+                credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+
+            if emit is not None and UsageEvent is not None:
+
+
+                emit(
                 UsageEvent(
                     org_id=str(observation_span.project.organization_id),
                     event_type=api_call_type,
@@ -1177,7 +1181,8 @@ def _execute_evaluation(
             is_active=True,
         )
 
-    api_call_log_row = log_and_deduct_cost_for_api_request(
+    if log_and_deduct_cost_for_api_request is not None:
+        api_call_log_row = log_and_deduct_cost_for_api_request(
         organization=observation_span.project.organization,
         api_call_type=api_call_type,
         source="tracer" if not feedback_id else "feedback",
@@ -2426,7 +2431,8 @@ def _execute_evaluation_for_trace(
         source_config["feedback_id"] = str(feedback_id)
 
     api_call_type = _get_api_call_type(custom_eval_config.model)
-    api_call_log_row = log_and_deduct_cost_for_api_request(
+    if log_and_deduct_cost_for_api_request is not None:
+        api_call_log_row = log_and_deduct_cost_for_api_request(
         organization=trace.project.organization,
         api_call_type=api_call_type,
         source="tracer" if not feedback_id else "feedback",
@@ -2651,7 +2657,8 @@ def _execute_evaluation_for_session(
         source_config["feedback_id"] = str(feedback_id)
 
     api_call_type = _get_api_call_type(custom_eval_config.model)
-    api_call_log_row = log_and_deduct_cost_for_api_request(
+    if log_and_deduct_cost_for_api_request is not None:
+        api_call_log_row = log_and_deduct_cost_for_api_request(
         organization=trace_session.project.organization,
         api_call_type=api_call_type,
         source="tracer" if not feedback_id else "feedback",

--- a/futureagi/tracer/utils/external_eval.py
+++ b/futureagi/tracer/utils/external_eval.py
@@ -62,23 +62,24 @@ def _log_and_deduct_cost_for_external_eval(
 
     if check_usage is not None:
         usage_check = check_usage(str(config.organization.id), api_call_type)
-    if not usage_check.allowed:
-        raise ValueError(usage_check.reason or "Usage limit exceeded")
+        if not usage_check.allowed:
+            raise ValueError(usage_check.reason or "Usage limit exceeded")
 
+    api_call_log_row = None
     if log_and_deduct_cost_for_api_request is not None:
         api_call_log_row = log_and_deduct_cost_for_api_request(
-        organization=config.organization,
-        api_call_type=api_call_type,
-        source="tracer",
-        source_id=config.id,
-        config=log_config,
-        workspace=config.workspace,
-    )
-    if not api_call_log_row:
-        raise ValueError("API call not allowed : Error validating the api call.")
+            organization=config.organization,
+            api_call_type=api_call_type,
+            source="tracer",
+            source_id=config.id,
+            config=log_config,
+            workspace=config.workspace,
+        )
+        if not api_call_log_row:
+            raise ValueError("API call not allowed : Error validating the api call.")
 
-    if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
-        raise ValueError("API call not allowed : ", api_call_log_row.status)
+        if api_call_log_row.status != APICallStatusChoices.PROCESSING.value:
+            raise ValueError("API call not allowed : ", api_call_log_row.status)
 
     # Dual-write: emit usage event for new billing system
     try:

--- a/futureagi/tracer/utils/external_eval.py
+++ b/futureagi/tracer/utils/external_eval.py
@@ -12,10 +12,7 @@ from tracer.models.external_eval_config import (
     PlatformChoices,
     StatusChoices,
 )
-try:
-    from ee.usage.models.usage import APICallStatusChoices
-except ImportError:
-    APICallStatusChoices = None
+from tfc.constants.api_calls import APICallStatusChoices
 try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
@@ -63,11 +60,13 @@ def _log_and_deduct_cost_for_external_eval(
     except ImportError:
         check_usage = None
 
-    usage_check = check_usage(str(config.organization.id), api_call_type)
+    if check_usage is not None:
+        usage_check = check_usage(str(config.organization.id), api_call_type)
     if not usage_check.allowed:
         raise ValueError(usage_check.reason or "Usage limit exceeded")
 
-    api_call_log_row = log_and_deduct_cost_for_api_request(
+    if log_and_deduct_cost_for_api_request is not None:
+        api_call_log_row = log_and_deduct_cost_for_api_request(
         organization=config.organization,
         api_call_type=api_call_type,
         source="tracer",
@@ -92,7 +91,10 @@ def _log_and_deduct_cost_for_external_eval(
         except ImportError:
             emit = None
 
-        emit(
+        if emit is not None and UsageEvent is not None:
+
+
+            emit(
             UsageEvent(
                 org_id=str(config.organization.id),
                 event_type=api_call_type,


### PR DESCRIPTION
## Summary

Adds null guards for EE billing/metering functions across eval and prompt execution paths so OSS installs (without `ee/`) don't crash on `None` dereferences.

Adds guards for:

- `log_and_deduct_cost_for_api_request`
- `check_usage`
- `emit` / `UsageEvent` / `BillingEventType`
- `refund_cost_for_api_call`
- `count_tiktoken_tokens` / `count_text_tokens`
- `BillingConfig`
- `APICallLog` model access

Also:

- marks agent eval cells as `ERROR` with a clear message instead of leaving them stuck in `RUNNING`
- fixes a missing `_is_empty_value` import

**19 files changed** across eval runner, prompt template, run prompt, separate evals, external eval, auto annotate, prompt optimization, error analysis, SDK evaluations, and async prompt runners.

**Depends on:** #583 (enum move to `tfc.constants.api_calls`) being merged first.

## Linked issues

Closes #180

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- OSS mode: ran LLM-as-a-Judge eval on dataset rows — completed successfully
- OSS mode: ran prompt on dataset rows — completed successfully
- OSS mode: eval logs page loads without 500
- OSS mode: agent eval now shows error in cells instead of stuck loading state
- EE mode: all billing/metering functions still execute normally
- Ran:
  ```bash
  docker exec backend python -m pytest model_hub/tests/ -k "eval"
  ```
  Result:
  ```text
  309 passed, 0 failures
  ```

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)