### PR TITLE
fix(evals): restore is_empty_value in dataset eval runner [TH-5515]

### DIFF
--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1924,6 +1924,13 @@ class EvaluationRunner:
                 "custom_eval", False
             )
 
+        # Emptiness rules live in the shared validator so dataset,
+        # playground, tracing, and SDK paths apply the same logic.
+        from model_hub.utils.eval_input_validation import (
+            is_empty_value,
+            validate_eval_inputs,
+        )
+
         # Validate mapped required/optional keys only. Skip for user-built
         # custom evals so empty cells flow through to the eval (the template
         # can define explicit handling, e.g. a "No Input" choice). This keeps
@@ -1950,14 +1957,10 @@ class EvaluationRunner:
                     )
                 # Map back from key to row value via the ordered lists.
                 value = mapping[required_field.index(key)]
-                if _is_empty_value(value):
+                if is_empty_value(value):
                     raise ValueError(
                         f"No input received for '{key}'. Please check your input."
                     )
-
-        # Emptiness rules live in the shared validator so dataset,
-        # playground, tracing, and SDK paths apply the same logic.
-        from model_hub.utils.eval_input_validation import validate_eval_inputs
 
         values_for_validation = {
             key: mapping[required_field.index(key)]


### PR DESCRIPTION
## Issue (urgent — affects prod)

All **system evals on the dataset path** crash with:

> Evaluation failed. Please contact Future AGI support.

User-built **custom evals work** — only system evals are broken. The user-facing message hides:

```
NameError: name '_is_empty_value' is not defined
  at model_hub/views/eval_runner.py:1953
```

The exception bubbles to the upstream handler which wraps it as `FAILED_TO_PROCESS_EVALUATION`, producing the generic user-facing string.

## Root cause

Commit `8eb886c8` (`TH-5107`, "fix(evals): unify partial-input handling across all eval execution paths", 2026-05-19) refactored the empty-check logic:

- Removed the local nested helper `def _is_empty_value(value):` inside `EvaluationRunner._run_evaluation`
- Re-exported it as `is_empty_value` from `model_hub/utils/eval_input_validation`
- Imported and used the new function in most places

But **one call site at line 1953 was missed** — it still references the removed local symbol.

## Why only system evals are affected

Line 1953 sits inside a gate at line 1934:

```python
if keys_to_check and not is_user_custom_eval:   # ← gate
    ...
    if _is_empty_value(value):                  # ← line 1953, NameError
```

`is_user_custom_eval` comes from `eval_template.config.get("custom_eval", False)`:

- **System evals** (seeded from YAML, no `custom_eval` flag) → `False` → enter the block → crash.
- **User custom evals** (`custom_eval=True` in template config) → block skipped → no crash.

Matches the reported symptom exactly.

## Fix

Two minimal changes:

1. Rename the call at line 1953 from `_is_empty_value` to `is_empty_value` (the shared module's name).
2. Lift the inline `from model_hub.utils.eval_input_validation import …` block up so the import sits **before** the gated block, ensuring `is_empty_value` is defined when line 1953 runs.

No behaviour change — restores the pre-TH-5107 functionality for the dataset path.

## Linear

- Closes [TH-5515](https://linear.app/future-agi/issue/TH-5515) (urgent prod report from @dileep)
- Closes [TH-5516](https://linear.app/future-agi/issue/TH-5516) (Sentry auto-created)
- Regression introduced by [TH-5107](https://linear.app/future-agi/issue/TH-5107)

## Test plan

- [ ] Run a system eval against a dataset on dev (post-merge) — confirm it executes and returns a result instead of "Evaluation failed."
- [ ] Run a user-built custom eval against the same dataset — confirm no regression.
- [ ] Confirm `model_hub.views.eval_runner` no longer surfaces `NameError: name '_is_empty_value' is not defined` in Sentry.

## Companion PR

A separate PR with the same fix will be opened against `dev` so the regression doesn't re-land via the next merge train.