### PR TITLE
fix(evals): restore is_empty_value in dataset eval runner [TH-5515]

### DIFF
--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1920,6 +1920,13 @@ class EvaluationRunner:
                 "custom_eval", False
             )
 
+        # Emptiness rules live in the shared validator so dataset,
+        # playground, tracing, and SDK paths apply the same logic.
+        from model_hub.utils.eval_input_validation import (
+            is_empty_value,
+            validate_eval_inputs,
+        )
+
         # Validate mapped required/optional keys only. Skip for user-built
         # custom evals so empty cells flow through to the eval (the template
         # can define explicit handling, e.g. a "No Input" choice). This keeps
@@ -1946,14 +1953,10 @@ class EvaluationRunner:
                     )
                 # Map back from key to row value via the ordered lists.
                 value = mapping[required_field.index(key)]
-                if _is_empty_value(value):
+                if is_empty_value(value):
                     raise ValueError(
                         f"No input received for '{key}'. Please check your input."
                     )
-
-        # Emptiness rules live in the shared validator so dataset,
-        # playground, tracing, and SDK paths apply the same logic.
-        from model_hub.utils.eval_input_validation import validate_eval_inputs
 
         values_for_validation = {
             key: mapping[required_field.index(key)]


### PR DESCRIPTION
## Issue (urgent — affects prod, same fix going to main in #632)

All **system evals on the dataset path** crash with:

> Evaluation failed. Please contact Future AGI support.

User-built **custom evals work** — only system evals are broken. The user-facing message hides:

```
NameError: name '_is_empty_value' is not defined
  at model_hub/views/eval_runner.py:1953
```

## Root cause

Commit `8eb886c8` (`TH-5107`, 2026-05-19) removed the local nested `def _is_empty_value` helper inside `EvaluationRunner._run_evaluation` and re-exported it from `model_hub/utils/eval_input_validation` as `is_empty_value`. One call site at line 1953 was missed and still references the removed symbol.

## Why only system evals are affected

Line 1953 is gated behind `if keys_to_check and not is_user_custom_eval:` (line 1934). System evals enter the block (`custom_eval=False`); user-built custom evals skip it (`custom_eval=True`).

## Fix

- Rename the call to `is_empty_value`
- Lift the existing inline import above the gated block so the symbol is defined when line 1953 runs

## Linear

- Closes [TH-5515](https://linear.app/future-agi/issue/TH-5515)
- Closes [TH-5516](https://linear.app/future-agi/issue/TH-5516)
- Regression from [TH-5107](https://linear.app/future-agi/issue/TH-5107)

## Companion PR

[#632](https://github.com/future-agi/future-agi/pull/632) carries the same change to `main` for the immediate prod hotfix. This PR keeps `dev` in sync so the regression doesn't reappear on the next merge train.

## Test plan

- [ ] Run a system eval against a dataset locally on this branch — confirm it executes successfully.
- [ ] Run a user-built custom eval against the same dataset — confirm no regression.