### PR TITLE
feat(filters): make text-type filters case-insensitive (TH-4993)

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -670,6 +670,7 @@ class ClickHouseFilterBuilder:
             exists_predicate,
             filter_op,
             normalized_value,
+            case_insensitive=(normalized_filter_type == "text"),
         )
         if not inner_predicate:
             return None
@@ -744,9 +745,24 @@ class ClickHouseFilterBuilder:
         exists_predicate: str,
         filter_op: str,
         normalized_value: Any,
+        case_insensitive: bool = False,
     ) -> Optional[str]:
-        """Emit the row-level predicate; negation ops require key present."""
+        """Emit the row-level predicate; negation ops require key present.
+
+        ``case_insensitive`` is set for text-typed span attributes (TH-4993):
+        equality/in collapse both sides via ``lower(...)``; LIKE-family ops
+        switch to ``ILIKE``.
+        """
         column_access = f"{map_column}['{attribute_key}']"
+        eq_lhs = f"lower({column_access})" if case_insensitive else column_access
+        like_op = "ILIKE" if case_insensitive else "LIKE"
+        not_like_op = "NOT ILIKE" if case_insensitive else "NOT LIKE"
+
+        def fold_case(value: Any) -> Any:
+            """Lowercase string values when the column is case-insensitive."""
+            if not case_insensitive:
+                return value
+            return value.lower() if isinstance(value, str) else value
 
         if filter_op == "is_null":
             return f"NOT {exists_predicate}"
@@ -755,38 +771,38 @@ class ClickHouseFilterBuilder:
 
         if filter_op == "equals":
             param = self._next_param("attr")
-            self._params[param] = normalized_value
-            return f"{exists_predicate} AND {column_access} = %({param})s"
+            self._params[param] = fold_case(normalized_value)
+            return f"{exists_predicate} AND {eq_lhs} = %({param})s"
         if filter_op == "not_equals":
             param = self._next_param("attr")
-            self._params[param] = normalized_value
-            return f"{exists_predicate} AND {column_access} != %({param})s"
+            self._params[param] = fold_case(normalized_value)
+            return f"{exists_predicate} AND {eq_lhs} != %({param})s"
 
         if filter_op == "in":
             param = self._next_param("attr")
-            self._params[param] = tuple(normalized_value)
-            return f"{exists_predicate} AND {column_access} IN %({param})s"
+            self._params[param] = tuple(fold_case(v) for v in normalized_value)
+            return f"{exists_predicate} AND {eq_lhs} IN %({param})s"
         if filter_op == "not_in":
             param = self._next_param("attr")
-            self._params[param] = tuple(normalized_value)
-            return f"{exists_predicate} AND {column_access} NOT IN %({param})s"
+            self._params[param] = tuple(fold_case(v) for v in normalized_value)
+            return f"{exists_predicate} AND {eq_lhs} NOT IN %({param})s"
 
         if filter_op == "contains":
             param = self._next_param("attr")
             self._params[param] = f"%{normalized_value}%"
-            return f"{exists_predicate} AND {column_access} LIKE %({param})s"
+            return f"{exists_predicate} AND {column_access} {like_op} %({param})s"
         if filter_op == "not_contains":
             param = self._next_param("attr")
             self._params[param] = f"%{normalized_value}%"
-            return f"{exists_predicate} AND {column_access} NOT LIKE %({param})s"
+            return f"{exists_predicate} AND {column_access} {not_like_op} %({param})s"
         if filter_op == "starts_with":
             param = self._next_param("attr")
             self._params[param] = f"{normalized_value}%"
-            return f"{exists_predicate} AND {column_access} LIKE %({param})s"
+            return f"{exists_predicate} AND {column_access} {like_op} %({param})s"
         if filter_op == "ends_with":
             param = self._next_param("attr")
             self._params[param] = f"%{normalized_value}"
-            return f"{exists_predicate} AND {column_access} LIKE %({param})s"
+            return f"{exists_predicate} AND {column_access} {like_op} %({param})s"
 
         if filter_op == "between":
             param_lo = self._next_param("lo")
@@ -824,11 +840,15 @@ class ClickHouseFilterBuilder:
 
         raise ValueError(f"Unhandled filter_op {filter_op!r}")
 
-    # Columns whose stored values vary in case across ingest paths — OTel
-    # writes lowercase ('ok'/'error'/'unset'), older provider integrations
-    # wrote uppercase, and the TraceFilterPanel's static enum choices send
-    # uppercase labels. Matches must be case-insensitive on both sides.
-    _CASE_INSENSITIVE_COLUMNS = {"status", "observation_type"}
+
+    _CASE_INSENSITIVE_COLUMNS = {
+        "status",
+        "observation_type",
+        "name",
+        "trace_name",
+        "model",
+        "provider",
+    }
 
     _NULLABLE_UUID_COLUMNS = frozenset({
         "end_user_id",
@@ -845,7 +865,7 @@ class ClickHouseFilterBuilder:
     ) -> Optional[str]:
         """Build a condition for a direct column reference."""
         param = self._next_param("col")
-        ci = column in self._CASE_INSENSITIVE_COLUMNS
+        case_insensitive = column in self._CASE_INSENSITIVE_COLUMNS
 
         if filter_op == "is_null":
             if column in self._NULLABLE_UUID_COLUMNS:
@@ -857,16 +877,20 @@ class ClickHouseFilterBuilder:
             return f"({column} IS NOT NULL AND {column} != '')"
         elif filter_op == "contains":
             self._params[param] = f"%{filter_value}%"
-            return f"{column} LIKE %({param})s"
+            like_op = "ILIKE" if case_insensitive else "LIKE"
+            return f"{column} {like_op} %({param})s"
         elif filter_op == "not_contains":
             self._params[param] = f"%{filter_value}%"
-            return f"{column} NOT LIKE %({param})s"
+            like_op = "NOT ILIKE" if case_insensitive else "NOT LIKE"
+            return f"{column} {like_op} %({param})s"
         elif filter_op == "starts_with":
             self._params[param] = f"{filter_value}%"
-            return f"{column} LIKE %({param})s"
+            like_op = "ILIKE" if case_insensitive else "LIKE"
+            return f"{column} {like_op} %({param})s"
         elif filter_op == "ends_with":
             self._params[param] = f"%{filter_value}"
-            return f"{column} LIKE %({param})s"
+            like_op = "ILIKE" if case_insensitive else "LIKE"
+            return f"{column} {like_op} %({param})s"
         elif filter_op == "between" and isinstance(filter_value, list):
             p_lo = self._next_param("lo")
             p_hi = self._next_param("hi")
@@ -887,7 +911,7 @@ class ClickHouseFilterBuilder:
             # value IN [] matches nothing.
             if not values:
                 return "0 = 1"
-            if ci:
+            if case_insensitive:
                 values = [str(v).lower() for v in values]
                 self._params[param] = tuple(values)
                 return f"lower({column}) IN %({param})s"
@@ -900,7 +924,7 @@ class ClickHouseFilterBuilder:
             # value NOT IN [] should not restrict results.
             if not values:
                 return "1 = 1"
-            if ci:
+            if case_insensitive:
                 values = [str(v).lower() for v in values]
                 self._params[param] = tuple(values)
                 return f"lower({column}) NOT IN %({param})s"
@@ -910,7 +934,11 @@ class ClickHouseFilterBuilder:
             op = self._sql_op(filter_op)
             if op is None:
                 return "0 = 1"
-            if ci and op in ("=", "!=") and isinstance(filter_value, str):
+            if (
+                case_insensitive
+                and op in ("=", "!=")
+                and isinstance(filter_value, str)
+            ):
                 self._params[param] = filter_value.lower()
                 return f"lower({column}) {op} %({param})s"
             self._params[param] = filter_value

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -15,6 +15,7 @@ from tracer.utils.constants import (
     NO_VALUE_OPS,
     RANGE_OPS,
     SPAN_ATTR_ALLOWED_OPS,
+    FilterType,
 )
 
 from tracer.utils.filter_operators import normalize_filter_op
@@ -39,9 +40,9 @@ def _coerce_strict_bool(v: Any) -> int:
 
 
 _SPAN_ATTR_TYPE_META: Dict[str, Tuple[str, Callable[[Any], Any]]] = {
-    "text":    ("span_attr_str",  lambda v: v if isinstance(v, str) else str(v)),
-    "number":  ("span_attr_num",  lambda v: float(v)),
-    "boolean": ("span_attr_bool", _coerce_strict_bool),
+    FilterType.TEXT.value:    ("span_attr_str",  lambda v: v if isinstance(v, str) else str(v)),
+    FilterType.NUMBER.value:  ("span_attr_num",  lambda v: float(v)),
+    FilterType.BOOLEAN.value: ("span_attr_bool", _coerce_strict_bool),
 }
 
 class ClickHouseFilterBuilder:
@@ -670,7 +671,7 @@ class ClickHouseFilterBuilder:
             exists_predicate,
             filter_op,
             normalized_value,
-            case_insensitive=(normalized_filter_type == "text"),
+            case_insensitive=(normalized_filter_type == FilterType.TEXT.value),
         )
         if not inner_predicate:
             return None
@@ -749,7 +750,7 @@ class ClickHouseFilterBuilder:
     ) -> Optional[str]:
         """Emit the row-level predicate; negation ops require key present.
 
-        ``case_insensitive`` is set for text-typed span attributes (TH-4993):
+        ``case_insensitive`` is set for text-typed span attributes:
         equality/in collapse both sides via ``lower(...)``; LIKE-family ops
         switch to ``ILIKE``.
         """

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -488,7 +488,7 @@ class TestClickHouseFilterBuilder:
 
         where, params = builder.translate(filters)
 
-        assert "name IN" in where
+        assert "lower(name) IN" in where
         assert "span_attr_" not in where
         assert "trace_id IN" not in where
         assert tuple(params.values()) == (("response",),)
@@ -517,7 +517,7 @@ class TestClickHouseFilterBuilder:
         where, params = builder.translate(filters)
 
         assert "trace_id IN" in where
-        assert "name IN" in where
+        assert "lower(name) IN" in where
         assert "span_attr_" not in where
         assert "parent_span_id" not in where
         assert tuple(params.values()) == (("response",),)
@@ -546,7 +546,7 @@ class TestClickHouseFilterBuilder:
         where, params = builder.translate(filters)
 
         assert "trace_id IN" in where
-        assert "name IN" in where
+        assert "lower(name) IN" in where
         assert "parent_span_id IS NULL OR parent_span_id = ''" in where
         assert tuple(params.values()) == (("root trace",),)
 
@@ -4556,7 +4556,7 @@ class TestFilterBuilderEdgeCases:
         assert "!=" in where
 
     def test_not_contains_filter(self):
-        """not_contains should produce NOT LIKE."""
+        """not_contains should produce NOT ILIKE (case-insensitive)."""
         from tracer.services.clickhouse.query_builders.filters import (
             ClickHouseFilterBuilder,
         )
@@ -4574,7 +4574,7 @@ class TestFilterBuilderEdgeCases:
             }
         ]
         where, _ = builder.translate(filters)
-        assert "NOT LIKE" in where
+        assert "NOT ILIKE" in where
 
     def test_starts_with_filter(self):
         """starts_with should produce LIKE with trailing %."""
@@ -4700,7 +4700,7 @@ class TestFilterBuilderEdgeCases:
         assert "<=" in where
 
     def test_span_attr_not_contains(self):
-        """SPAN_ATTRIBUTE not_contains should produce NOT LIKE."""
+        """SPAN_ATTRIBUTE not_contains should produce NOT ILIKE (case-insensitive)."""
         from tracer.services.clickhouse.query_builders.filters import (
             ClickHouseFilterBuilder,
         )
@@ -4718,7 +4718,7 @@ class TestFilterBuilderEdgeCases:
             }
         ]
         where, _ = builder.translate(filters)
-        assert "NOT LIKE" in where
+        assert "NOT ILIKE" in where
         assert "span_attr_str" in where
 
     def test_span_attr_between(self):
@@ -7043,7 +7043,7 @@ class TestSpanAttrConditionContract:
                 "k", filter_type="text", filter_op="not_equals", filter_value="v"
             )
         )
-        assert "AND span_attr_str['k'] != " in where
+        assert "AND lower(span_attr_str['k']) != " in where
         assert "NOT mapContains" not in where
 
     def test_text_in(self):
@@ -7052,7 +7052,7 @@ class TestSpanAttrConditionContract:
                 "k", filter_type="text", filter_op="in", filter_value=["a", "b"]
             )
         )
-        assert "span_attr_str['k'] IN" in where
+        assert "lower(span_attr_str['k']) IN" in where
         assert ("a", "b") in params.values()
 
     def test_text_not_in_uses_exists_and(self):
@@ -7067,7 +7067,7 @@ class TestSpanAttrConditionContract:
             )
         )
         assert "mapContains(span_attr_str, 'ended_reason')" in where
-        assert "AND span_attr_str['ended_reason'] NOT IN" in where
+        assert "AND lower(span_attr_str['ended_reason']) NOT IN" in where
         assert "NOT mapContains" not in where
         assert ("voicemail", "assistant-ended-call") in params.values()
 
@@ -7086,7 +7086,7 @@ class TestSpanAttrConditionContract:
                 "k", filter_type="text", filter_op="not_contains", filter_value="abc"
             )
         )
-        assert "AND span_attr_str['k'] NOT LIKE" in where
+        assert "AND span_attr_str['k'] NOT ILIKE" in where
         assert "NOT mapContains" not in where
         assert "%abc%" in params.values()
 

--- a/futureagi/tracer/tests/test_filter_case_insensitive.py
+++ b/futureagi/tracer/tests/test_filter_case_insensitive.py
@@ -1,0 +1,189 @@
+"""TH-4993 — text-type filters must match case-insensitively.
+
+Covers both SYSTEM_METRIC text columns (trace_name, name, model, provider)
+and SPAN_ATTRIBUTE filter_type="text". Non-text types (number, boolean,
+UUIDs) and non-CI columns (e.g. span_id) must stay literal.
+"""
+
+import pytest
+
+from tracer.services.clickhouse.query_builders.filters import (
+    ClickHouseFilterBuilder,
+)
+
+
+def _builder(mode: str = "span") -> ClickHouseFilterBuilder:
+    return ClickHouseFilterBuilder(table="spans", query_mode=mode)
+
+
+def _sm(col_id, op, value, ftype="text"):
+    return {
+        "column_id": col_id,
+        "filter_config": {
+            "col_type": "SYSTEM_METRIC",
+            "filter_type": ftype,
+            "filter_op": op,
+            "filter_value": value,
+        },
+    }
+
+
+def _attr(key, op, value, ftype="text"):
+    return {
+        "column_id": key,
+        "filter_config": {
+            "col_type": "SPAN_ATTRIBUTE",
+            "filter_type": ftype,
+            "filter_op": op,
+            "filter_value": value,
+        },
+    }
+
+
+@pytest.mark.unit
+class TestSystemMetricTextCaseInsensitive:
+    """trace_name / name / model / provider — TH-4993 ticket scope."""
+
+    @pytest.mark.parametrize("col", ["trace_name", "name", "model", "provider"])
+    def test_contains_uses_ilike(self, col):
+        where, params = _builder().translate([_sm(col, "contains", "FooBar")])
+        assert f"{col} ILIKE" in where
+        assert params["col_1"] == "%FooBar%"
+
+    @pytest.mark.parametrize("col", ["trace_name", "name", "model", "provider"])
+    def test_not_contains_uses_not_ilike(self, col):
+        where, params = _builder().translate([_sm(col, "not_contains", "Foo")])
+        assert f"{col} NOT ILIKE" in where
+        assert params["col_1"] == "%Foo%"
+
+    @pytest.mark.parametrize("col", ["trace_name", "name", "model", "provider"])
+    def test_starts_with_uses_ilike(self, col):
+        where, _ = _builder().translate([_sm(col, "starts_with", "Foo")])
+        assert f"{col} ILIKE" in where
+
+    @pytest.mark.parametrize("col", ["trace_name", "name", "model", "provider"])
+    def test_ends_with_uses_ilike(self, col):
+        where, _ = _builder().translate([_sm(col, "ends_with", "Bar")])
+        assert f"{col} ILIKE" in where
+
+    @pytest.mark.parametrize("col", ["trace_name", "name", "model", "provider"])
+    def test_equals_lowers_both_sides(self, col):
+        where, params = _builder().translate([_sm(col, "equals", "FooBar")])
+        assert f"lower({col}) =" in where
+        assert params["col_1"] == "foobar"
+
+    @pytest.mark.parametrize("col", ["trace_name", "name", "model", "provider"])
+    def test_not_equals_lowers_both_sides(self, col):
+        where, params = _builder().translate([_sm(col, "not_equals", "FooBar")])
+        assert f"lower({col}) !=" in where
+        assert params["col_1"] == "foobar"
+
+    @pytest.mark.parametrize("col", ["trace_name", "name", "model", "provider"])
+    def test_in_lowers_values(self, col):
+        where, params = _builder().translate(
+            [_sm(col, "in", ["GPT-4", "Claude"])]
+        )
+        assert f"lower({col}) IN" in where
+        assert params["col_1"] == ("gpt-4", "claude")
+
+    @pytest.mark.parametrize("col", ["trace_name", "name", "model", "provider"])
+    def test_not_in_lowers_values(self, col):
+        where, params = _builder().translate(
+            [_sm(col, "not_in", ["GPT-4", "Claude"])]
+        )
+        assert f"lower({col}) NOT IN" in where
+        assert params["col_1"] == ("gpt-4", "claude")
+
+    def test_status_remains_case_insensitive(self):
+        """status was already CI before TH-4993; behavior must be preserved."""
+        where, params = _builder().translate([_sm("status", "equals", "ERROR")])
+        assert "lower(status) =" in where
+        assert params["col_1"] == "error"
+
+    def test_trace_mode_wraps_in_subquery_with_ilike(self):
+        where, params = _builder("trace").translate(
+            [_sm("trace_name", "contains", "Foo")]
+        )
+        # Trace-list mode wraps the predicate in `trace_id IN (SELECT ...)`,
+        # the ILIKE belongs inside that wrap.
+        assert "trace_id IN (SELECT trace_id FROM spans" in where
+        assert "trace_name ILIKE" in where
+
+    def test_span_id_not_case_folded(self):
+        """UUID-shaped columns must not be lowercased."""
+        where, _ = _builder().translate([_sm("span_id", "equals", "ABC")])
+        assert "lower(" not in where
+
+
+@pytest.mark.unit
+class TestSpanAttributeTextCaseInsensitive:
+    """SPAN_ATTRIBUTE filter_type='text' — TH-4993 (broad scope)."""
+
+    def test_equals_lowers_both_sides(self):
+        where, params = _builder().translate([_attr("mykey", "equals", "Hello")])
+        assert "lower(span_attr_str['mykey']) =" in where
+        assert params["attr_1"] == "hello"
+
+    def test_not_equals_lowers_both_sides(self):
+        where, params = _builder().translate(
+            [_attr("mykey", "not_equals", "Hello")]
+        )
+        assert "lower(span_attr_str['mykey']) !=" in where
+        assert params["attr_1"] == "hello"
+
+    def test_in_lowers_values(self):
+        where, params = _builder().translate(
+            [_attr("mykey", "in", ["Hello", "World"])]
+        )
+        assert "lower(span_attr_str['mykey']) IN" in where
+        assert params["attr_1"] == ("hello", "world")
+
+    def test_not_in_lowers_values(self):
+        where, params = _builder().translate(
+            [_attr("mykey", "not_in", ["Hello", "World"])]
+        )
+        assert "lower(span_attr_str['mykey']) NOT IN" in where
+        assert params["attr_1"] == ("hello", "world")
+
+    def test_contains_uses_ilike(self):
+        where, params = _builder().translate(
+            [_attr("mykey", "contains", "Hello")]
+        )
+        assert "span_attr_str['mykey'] ILIKE" in where
+        assert params["attr_1"] == "%Hello%"
+
+    def test_not_contains_uses_not_ilike(self):
+        where, params = _builder().translate(
+            [_attr("mykey", "not_contains", "Hello")]
+        )
+        assert "span_attr_str['mykey'] NOT ILIKE" in where
+        assert params["attr_1"] == "%Hello%"
+
+    def test_starts_with_uses_ilike(self):
+        where, _ = _builder().translate(
+            [_attr("mykey", "starts_with", "Hel")]
+        )
+        assert "span_attr_str['mykey'] ILIKE" in where
+
+    def test_ends_with_uses_ilike(self):
+        where, _ = _builder().translate([_attr("mykey", "ends_with", "lo")])
+        assert "span_attr_str['mykey'] ILIKE" in where
+
+    def test_exists_predicate_still_present(self):
+        """Case-insensitive predicate must still guard with mapContains."""
+        where, _ = _builder().translate([_attr("mykey", "equals", "X")])
+        assert "mapContains(span_attr_str, 'mykey')" in where
+
+    def test_number_attr_not_case_folded(self):
+        where, _ = _builder().translate(
+            [_attr("mykey", "equals", 5, ftype="number")]
+        )
+        assert "lower(" not in where
+        assert "span_attr_num['mykey'] =" in where
+
+    def test_boolean_attr_not_case_folded(self):
+        where, _ = _builder().translate(
+            [_attr("mykey", "equals", True, ftype="boolean")]
+        )
+        assert "lower(" not in where
+        assert "span_attr_bool['mykey'] =" in where

--- a/futureagi/tracer/utils/constants.py
+++ b/futureagi/tracer/utils/constants.py
@@ -374,22 +374,31 @@ PortkeyInstrumentor().instrument(tracer_provider=tracer_provider)
 }
 
 
+from enum import Enum
+
+
+class FilterType(Enum):
+    TEXT = "text"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+
+
 # SPAN_ATTRIBUTE filter vocabulary shared by the CH builder and the Django ORM
 # validator. Single source of truth for allowed filter ops per type.
 SPAN_ATTR_ALLOWED_OPS: dict[str, set[str]] = {
-    "text": {
+    FilterType.TEXT.value: {
         "equals", "not_equals", "in", "not_in",
         "contains", "not_contains", "starts_with", "ends_with",
         "is_null", "is_not_null",
     },
-    "number": {
+    FilterType.NUMBER.value: {
         "equals", "not_equals",
         "greater_than", "greater_than_or_equal",
         "less_than", "less_than_or_equal",
         "between", "not_between",
         "is_null", "is_not_null",
     },
-    "boolean": {
+    FilterType.BOOLEAN.value: {
         "equals", "not_equals", "is_null", "is_not_null",
     },
 }


### PR DESCRIPTION
## Summary

Text filters in Observe now match regardless of case. In the ClickHouse filter builder, LIKE-family ops (`contains` / `not_contains` / `starts_with` / `ends_with`) emit `ILIKE` and equality / `in` / `not_in` collapse both sides via `lower(...)` for SYSTEM_METRIC text columns (`name`, `trace_name`, `model`, `provider`) and for SPAN_ATTRIBUTE `filter_type="text"`. Numeric, boolean, and UUID-shaped columns are unchanged. Brings trace/span name behaviour in line with what users expect when filtering by display value.

## Linked issues

Closes [TH-4993](https://linear.app/future-agi/issue/TH-4993/make-trace-and-span-name-operators-case-insensitive)

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- New unit suite `futureagi/tracer/tests/test_filter_case_insensitive.py` — 46 tests covering every string op (equals, not_equals, in, not_in, contains, not_contains, starts_with, ends_with) for the four SYSTEM_METRIC text columns and SPAN_ATTRIBUTE text type, plus negative coverage that number/boolean/UUID columns are not case-folded and that the trace-mode `trace_id IN (...)` wrap still works.
- Existing filter suites still green: `test_metric_filters_comprehensive`, `test_filter_engine_parity`, `test_normalize_filter_params`, `test_user_id_filter` — 192 tests pass locally.


## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] \`make check-all\` / \`yarn check-all\` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA