### PR TITLE
[TH-5419] Clear popover-cleared filters from localStorage

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -2095,6 +2095,27 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     ? `user-filters-${userIdForUserMode}`
     : `observe-filters-${observeId}`;
 
+  // User-initiated clears (popover "Clear all" / chip-strip "Clear all").
+  // Wipes the localStorage entry too — without this the saved filter
+  // resurrects on the next project mount because the load effect for
+  // `filtersStorageKey` restores any non-empty extraFilters it finds.
+  const clearPrimaryExtraFilters = useCallback(() => {
+    setExtraFilters([]);
+    try {
+      localStorage.removeItem(filtersStorageKey);
+    } catch {
+      /* noop */
+    }
+  }, [setExtraFilters, filtersStorageKey]);
+  const clearCompareExtraFilters = useCallback(() => {
+    setCompareExtraFilters([]);
+    try {
+      localStorage.removeItem(filtersStorageKey);
+    } catch {
+      /* noop */
+    }
+  }, [setCompareExtraFilters, filtersStorageKey]);
+
   // Pending custom cols, queued until the backend returns real columns so
   // the grid doesn't render with only-custom-col headers mid-load. One ref
   // per grid instance — a shared ref would race across the 4 mounted grids.
@@ -3439,11 +3460,13 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                 setIsPrimaryFilterOpen(!isPrimaryFilterOpen);
               }}
               onApplyExtraFilters={setExtraFilters}
+              onClearExtraFilters={clearPrimaryExtraFilters}
               graphFilters={extraFilters}
               isFilterOpen={isPrimaryFilterOpen}
               externalFilterAnchor={externalFilterAnchor}
               filterTarget={filterTarget}
               onApplyCompareExtraFilters={setCompareExtraFilters}
+              onClearCompareExtraFilters={clearCompareExtraFilters}
               filters={
                 selectedTab === "trace"
                   ? primaryTraceFilters

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -2101,19 +2101,11 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   // `filtersStorageKey` restores any non-empty extraFilters it finds.
   const clearPrimaryExtraFilters = useCallback(() => {
     setExtraFilters([]);
-    try {
-      localStorage.removeItem(filtersStorageKey);
-    } catch {
-      /* noop */
-    }
+    localStorage.removeItem(filtersStorageKey);
   }, [setExtraFilters, filtersStorageKey]);
   const clearCompareExtraFilters = useCallback(() => {
     setCompareExtraFilters([]);
-    try {
-      localStorage.removeItem(filtersStorageKey);
-    } catch {
-      /* noop */
-    }
+    localStorage.removeItem(filtersStorageKey);
   }, [setCompareExtraFilters, filtersStorageKey]);
 
   // Pending custom cols, queued until the backend returns real columns so

--- a/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
+++ b/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
@@ -59,6 +59,10 @@ const ObserveToolbar = ({
   filterDefinition,
   defaultFilter,
   onApplyExtraFilters,
+  // Called when the panel's Clear all (or empty Apply) resets extraFilters
+  // — owns the localStorage cleanup parent state can't reach from here.
+  onClearExtraFilters,
+  onClearCompareExtraFilters,
   // Filter fields override (for sessions/users)
   filterFields,
   // LLM Tracing tab ("trace" | "spans") — when set, TraceFilterPanel
@@ -423,8 +427,14 @@ const ObserveToolbar = ({
             onApply={(newFilters) => {
               setPanelFilters(newFilters);
               if (!newFilters || newFilters.length === 0) {
-                if (filterTarget === "compare" && onApplyCompareExtraFilters) {
-                  onApplyCompareExtraFilters([]);
+                if (filterTarget === "compare") {
+                  if (onClearCompareExtraFilters) {
+                    onClearCompareExtraFilters();
+                  } else {
+                    onApplyCompareExtraFilters?.([]);
+                  }
+                } else if (onClearExtraFilters) {
+                  onClearExtraFilters();
                 } else {
                   onApplyExtraFilters?.([]);
                 }
@@ -677,6 +687,8 @@ ObserveToolbar.propTypes = {
   excludeSimulationCalls: PropTypes.bool,
   onToggleSimulationCalls: PropTypes.func,
   onApplyExtraFilters: PropTypes.func,
+  onClearExtraFilters: PropTypes.func,
+  onClearCompareExtraFilters: PropTypes.func,
   filterFields: PropTypes.array,
   tab: PropTypes.oneOf(["trace", "spans"]),
   graphFilters: PropTypes.array,


### PR DESCRIPTION
## Summary
- Clicking **Clear all** inside the filter popover only reset in-memory `extraFilters`. The saved entry under `filtersStorageKey` was left intact, so the hydrate effect on the next project mount restored the cleared filter and made it look active again.
- Adds explicit `clearPrimaryExtraFilters` / `clearCompareExtraFilters` handlers in `LLMTracingView` that pair the state reset with `localStorage.removeItem(filtersStorageKey)`. Wires them through `ObserveToolbar` so the panel's empty-Apply branch invokes them instead of the silent `setExtraFilters([])`.
- Works for both the Observe project page (`/dashboard/observe/:projectId`) and the cross-project user detail page (`/dashboard/users/:userId?userTab=traces`) — same component, same storage key resolution.

Fixes TH-5419

## Linear Ticket
[TH-5419](https://linear.app/future-agi/issue/TH-5419/cleared-project-filter-reappears-after-returning)

## Why the chip-strip clear wasn't enough
The chip-strip's **Clear all** already wipes localStorage (line 2953-2961). The filter popover's **Clear all** routes through `TraceFilterPanel.handleClear` → `ObserveToolbar.onApply(null)` → `setExtraFilters([])`, which is a state-only path and doesn't know about persistence.

## Why not just `localStorage.removeItem` inside `setExtraFilters` wrapper
Several internal sites set `extraFilters` to `[]` for reasons that aren't user-initiated clears (saved-view → default-tab transitions at line 1740, applying a saved view's empty extraFilters at line 1976, single-chip removal that happens to empty the list at line 2951). An unconditional cleanup in the wrapper would nuke the saved entry on those flows too. Explicit "user wants to clear" callbacks keep the semantic clean.

## Files Changed
- `frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx` — new `clearPrimaryExtraFilters` / `clearCompareExtraFilters` callbacks; passed to `<ObserveToolbar>`.
- `frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx` — accept the two new optional props + prop-types; use them on the empty-Apply branch with the existing `onApplyExtraFilters?.([])` as fallback.

## Test plan
- [ ] On a project page, apply a filter, click chip-strip **Save** → confirm `observe-filters-<projectId>` is in localStorage.
- [ ] Open the filter popover → click **Clear all** → leave the project → return → filter is gone, and the localStorage entry is removed.
- [ ] Repeat the same on the cross-project user detail page (`/dashboard/users/:userId?userTab=traces`) → confirm `user-filters-<userId>` gets removed.
- [ ] Compare mode: with filters on both primary and compare graphs, popover-clear from the compare graph clears localStorage and doesn't leak into the primary state.
- [ ] Saved-view switching (default → custom view → default) still works — `clearPrimaryExtraFilters` isn't called on those transitions, only on the popover/chip-strip clear paths.
- [ ] Chip-strip **Clear all** unchanged (already worked).