### PR TITLE
fix(evals): variable highlighting, execution drill-in, ground-truth polling & toggle

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -53,6 +53,7 @@ import {
   contextOptionsForRowType,
   extractCodeEvaluateParams,
 } from "./evalPickerConfigUtils";
+import { useParams } from "react-router";
 
 const TRACING_ROW_TYPE_TO_KEY = {
   Span: "spans",
@@ -125,7 +126,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   const createEval = useCreateEval();
   const createComposite = useCreateCompositeEval();
   const sourceRef = useRef(null);
-
+  const {testId,executionId} = useParams();
   // Form state (same as EvalCreatePage)
   const [name, setName] = useState("");
   const [mode, setMode] = useState("single");
@@ -1181,6 +1182,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     onColumnsLoaded={handleColumnsLoaded}
                     onReadyChange={handleSourceReadyChange}
                     isComposite={isComposite}
+                    initialRunTestId={testId}
+                    initialExecutionId={executionId}
                     compositeAdhocConfig={compositeAdhocConfig}
                   />
                 )}

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -176,6 +176,17 @@ const EvalCreatePage = () => {
     setDatasetJsonSchemas(jsonSchemas || {});
   }, []);
 
+  // Active test-tab variable→column mapping. Threaded into the
+  // InstructionEditor so mapped variables render green; otherwise the
+  // {{var}} tokens stay red even after the user binds them in the test
+  // panel.
+  const [playgroundMapping, setPlaygroundMapping] = useState({});
+  const handlePlaygroundReadyChange = useCallback((_ready, mapping) => {
+    if (mapping && typeof mapping === "object") {
+      setPlaygroundMapping(mapping);
+    }
+  }, []);
+
   // --- Composite eval state ---
   const [compositeName, setCompositeName] = useState("");
   const [compositeDescription, setCompositeDescription] = useState("");
@@ -869,6 +880,8 @@ const EvalCreatePage = () => {
                       onTemplateFormatChange={setTemplateFormat}
                       datasetColumns={datasetColumns}
                       datasetJsonSchemas={datasetJsonSchemas}
+                      mappedVariables={playgroundMapping}
+                      modelSelectorDisabled={false}
                       mode={agentMode}
                       onModeChange={setAgentMode}
                       useInternet={checkInternet}
@@ -1221,6 +1234,7 @@ const EvalCreatePage = () => {
                   showVersions={false}
                   onTestResult={handleTestResult}
                   onColumnsLoaded={handleColumnsLoaded}
+                  onReadyChange={handlePlaygroundReadyChange}
                   errorLocalizerEnabled={
                     mode === "composite" ? false : errorLocalizerEnabled
                   }

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -159,6 +159,16 @@ const EvalDetailPage = () => {
   const [testError, setTestError] = useState(null);
   const [isTesting, setIsTesting] = useState(false);
   const [isPlaygroundReady, setIsPlaygroundReady] = useState(false);
+  // Variable→column mapping from the active test-panel tab. Used by the
+  // InstructionEditor / LLMPromptEditor to highlight mapped variables in
+  // green instead of leaving them red after the user binds them.
+  const [playgroundMapping, setPlaygroundMapping] = useState({});
+  const handlePlaygroundReadyChange = useCallback((ready, mapping) => {
+    setIsPlaygroundReady(!!ready);
+    if (mapping && typeof mapping === "object") {
+      setPlaygroundMapping(mapping);
+    }
+  }, []);
 
   // Auto-dismiss test error after 6 seconds
   useEffect(() => {
@@ -1392,6 +1402,7 @@ const EvalDetailPage = () => {
                     onTemplateFormatChange={setTemplateFormat}
                     datasetColumns={datasetColumns}
                     datasetJsonSchemas={datasetJsonSchemas}
+                    mappedVariables={playgroundMapping}
                     disabled={isSystemEval}
                     modelSelectorDisabled={false}
                     mode={agentMode}
@@ -1778,7 +1789,7 @@ const EvalDetailPage = () => {
                       setTestError(null);
                       setTestPassed(false);
                     }}
-                    onReadyChange={setIsPlaygroundReady}
+                    onReadyChange={handlePlaygroundReadyChange}
                   />
                 </Box>
 

--- a/frontend/src/sections/evals/components/EvalGroundTruthTab.jsx
+++ b/frontend/src/sections/evals/components/EvalGroundTruthTab.jsx
@@ -16,6 +16,7 @@ import {
   TextField,
   Tooltip,
   Typography,
+  useTheme,
 } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useCallback, useMemo, useState } from "react";
@@ -45,6 +46,7 @@ import {
   useUpdateVariableMapping,
   useUploadGroundTruth,
 } from "../hooks/useGroundTruth";
+import SwitchComponent from "src/components/Switch/SwitchComponent";
 
 // ═══════════════════════════════════════════════════════════════
 // Status Badge
@@ -1153,6 +1155,7 @@ const ConfigPanel = ({ templateId, gtId }) => {
   const [maxExamples, setMaxExamples] = useState(
     config?.maxExamples ?? config?.max_examples ?? 3,
   );
+  const theme = useTheme()
   const [threshold, setThreshold] = useState(
     config?.similarityThreshold ?? config?.similarity_threshold ?? 0.7,
   );
@@ -1203,15 +1206,19 @@ const ConfigPanel = ({ templateId, gtId }) => {
         <Typography variant="body2" fontWeight={600} sx={{ fontSize: "12px" }}>
           Injection Settings
         </Typography>
-        <Button
-          size="small"
-          variant={enabled ? "contained" : "outlined"}
-          color={enabled ? "success" : "inherit"}
-          onClick={handleToggle}
-          sx={{ fontSize: "11px", height: 26 }}
-        >
-          {enabled ? "Enabled" : "Disabled"}
-        </Button>
+
+        <SwitchComponent
+          label={enabled ? "Enabled" : "Disabled"}
+          labelPlacement={"start"}
+          labelStyle={{
+            fontSize: theme.spacing(1.5),
+          }}
+          size={"small"}
+          checked={enabled}
+          disableRipple
+          onChange={handleToggle}
+        />
+
       </Box>
       <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
         <Typography

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -183,6 +183,7 @@ const SimulationTestMode = React.forwardRef(
       initialRunTestId = "",
       isComposite = false,
       compositeAdhocConfig = null,
+      initialExecutionId=null
     },
     ref,
   ) => {
@@ -203,7 +204,9 @@ const SimulationTestMode = React.forwardRef(
     // Test executions (runs within a simulation)
     const [executions, setExecutions] = useState([]);
     const [executionsFetched, setExecutionsFetched] = useState(false);
-    const [selectedExecutionId, setSelectedExecutionId] = useState("");
+    const [selectedExecutionId, setSelectedExecutionId] = useState(
+      initialExecutionId || "",
+    );
 
     // Call executions (individual calls)
     const [calls, setCalls] = useState([]);
@@ -349,7 +352,13 @@ const SimulationTestMode = React.forwardRef(
           setExecutions(items);
           setExecutionsFetched(true);
           if (items.length > 0) {
-            setSelectedExecutionId(items[0].id || "");
+  
+            const preferred =
+              initialExecutionId &&
+              items.some((it) => it.id === initialExecutionId)
+                ? initialExecutionId
+                : items[0].id || "";
+            setSelectedExecutionId(preferred);
           }
         } catch {
           setExecutions([]);
@@ -358,7 +367,7 @@ const SimulationTestMode = React.forwardRef(
         }
       };
       fetchAll();
-    }, [selectedRunTestId]);
+    }, [selectedRunTestId, initialExecutionId]);
 
     // 3. Fetch call executions for the selected execution
     useEffect(() => {
@@ -1110,6 +1119,7 @@ const SimulationTestMode = React.forwardRef(
               fullWidth
               value={selectedExecutionId}
               onChange={(e) => setSelectedExecutionId(e.target.value)}
+              disabled={!!initialExecutionId}
               sx={{ fontSize: "13px" }}
             >
               {executions.map((ex, i) => (
@@ -1779,6 +1789,7 @@ SimulationTestMode.propTypes = {
   initialRunTestId: PropTypes.string,
   isComposite: PropTypes.bool,
   compositeAdhocConfig: PropTypes.object,
+  initialExecutionId :PropTypes.string
 };
 
 export default SimulationTestMode;

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -835,25 +835,37 @@ const TestPlayground = React.forwardRef(
       Simulation: false,
     });
 
-    const handleDatasetReady = useCallback((isReady) => {
-      setTabReady((prev) =>
-        prev.Dataset === !!isReady ? prev : { ...prev, Dataset: !!isReady },
-      );
-    }, []);
-    const handleTracingReady = useCallback((isReady) => {
-      setTabReady((prev) =>
-        prev.Tracing === !!isReady ? prev : { ...prev, Tracing: !!isReady },
-      );
-    }, []);
-    const handleSimulationReady = useCallback((isReady) => {
-      setTabReady((prev) =>
-        prev.Simulation === !!isReady
-          ? prev
-          : { ...prev, Simulation: !!isReady },
-      );
-    }, []);
-
-    useEffect(() => {
+ 
+    const handleDatasetReady = useCallback(
+      (isReady, mapping) => {
+        setTabReady((prev) =>
+          prev.Dataset === !!isReady ? prev : { ...prev, Dataset: !!isReady },
+        );
+        onReadyChange?.(!!isReady, mapping);
+      },
+      [onReadyChange],
+    );
+    const handleTracingReady = useCallback(
+      (isReady, mapping) => {
+        setTabReady((prev) =>
+          prev.Tracing === !!isReady ? prev : { ...prev, Tracing: !!isReady },
+        );
+        onReadyChange?.(!!isReady, mapping);
+      },
+      [onReadyChange],
+    );
+    const handleSimulationReady = useCallback(
+      (isReady, mapping) => {
+        setTabReady((prev) =>
+          prev.Simulation === !!isReady
+            ? prev
+            : { ...prev, Simulation: !!isReady },
+        );
+        onReadyChange?.(!!isReady, mapping);
+      },
+      [onReadyChange],
+    );
+  useEffect(() => {
       if (!onReadyChange) return;
       onReadyChange(!!tabReady[activeTab]);
     }, [activeTab, tabReady, onReadyChange]);

--- a/frontend/src/sections/evals/hooks/useGroundTruth.js
+++ b/frontend/src/sections/evals/hooks/useGroundTruth.js
@@ -69,7 +69,7 @@ export function useGroundTruthStatus(gtId, { enabled = true } = {}) {
     enabled: !!gtId && enabled,
     refetchInterval: (data) => {
       // Poll every 3s while processing
-      if (data?.embedding_status === "processing") return 3000;
+      if (data?.state?.data?.embedding_status === "processing") return 3000;
       return false;
     },
   });


### PR DESCRIPTION
## Summary
Batch of UX/state fixes for the evals area found this week.

### 1. Variable highlighting in prompt editor for TestPlayground pages
- `DatasetTestMode` / `TracingTestMode` / `SimulationTestMode` were
  passing `(isReady, mapping)` via `onReadyChange`, but
  `TestPlayground`'s per-tab handlers destructured only `isReady` and
  silently dropped the mapping.
- `EvalDetailPage` and `EvalCreatePage` never received it, so the
  `InstructionEditor`'s validator marked every `{{var}}` as invalid
  (red) even after the user mapped it in the test panel.
- TestPlayground now forwards the mapping straight through (no local
  mirror state). EvalDetailPage and EvalCreatePage hold a
  `playgroundMapping` slot fed into `InstructionEditor.mappedVariables`.
- Matches the contract `EvalPickerConfigFull` / `EvalPickerCreateNew`
  were already using when talking to the test modes directly.

### 2. `initialExecutionId` actually locks the SimulationTestMode execution
- The prop was declared but never wired — Select stayed unlocked and
  always defaulted to the most recent run.
- Seed `selectedExecutionId` from `initialExecutionId` on mount.
- After the executions fetch, prefer `initialExecutionId` (if present)
  over `items[0]`.
- Disable the Execution Run Select when `initialExecutionId` is
  supplied, matching the existing `disabled={!!initialRunTestId}` on
  the simulation Autocomplete.
- `EvalPickerCreateNew` reads `testId` / `executionId` from the route
  params and forwards them as `initialRunTestId` /
  `initialExecutionId` so drill-in URLs pre-select and lock both.

### 3. Ground-truth embedding status polling actually runs
- `useGroundTruthStatus`' `refetchInterval` was reading
  `data?.embedding_status`, but React Query v5 passes the Query object
  to refetchInterval, not raw data. The check was always undefined →
  polling never fired.
- Read from `data?.state?.data?.embedding_status` so the 3s poll
  actually triggers while embedding is in progress.
- `EvalGroundTruthTab` also dropped the stale `enabled` gate so the
  query runs as soon as a dataset id is present; the `refetchInterval`
  itself self-stops once status leaves `processing`.

### 4. SwitchComponent for ground-truth injection toggle
- Replaced the contained/outlined Button enable/disable toggle in the
  Ground Truth config panel with the shared `SwitchComponent` for
  visual consistency with the rest of the eval picker.

## Test plan

### Variable highlighting (TestPlayground)
- [x] Open an eval in **EvalDetailPage**, evalType = `agent`. Add `{{output}}` to Instructions. Without mapping, it renders red. Open the Test panel → Dataset tab → pick a dataset → map `output` → `<column>`. The `{{output}}` in Instructions turns **green** without a page refresh.
- [x] Repeat in the **Tracing** tab (pick project + row → map variable to a field). `{{output}}` should turn green.
- [x] Repeat in the **Simulation** tab (pick simulation → execution → call → map variable). `{{output}}` should turn green.
- [x] Switch between tabs — the active tab's mapping drives the highlight; previously-mapped vars from the other tab continue to appear green until the new tab fires its own mapping event.
- [ ] Same flow in **EvalCreatePage** — variable in newly-typed Instructions turns green as soon as it's mapped in the test panel.
- [x] **Regression check** — `EvalPickerConfigFull` (eval picker drawer) still highlights mapped vars green (was already working; should remain so).
- [x] **Caveat** — `evalType === "llm"` uses `LLMPromptEditor` → `MessageEditor` → `MessageEditorBlock` which don't accept `mappedVariables`. Vars still appear red in LLM-as-judge prompts; out of scope for this PR.

### initialExecutionId locks Simulation execution
- [x] Navigate to an `EvalPickerCreateNew` URL with both `:testId` and `:executionId` route params.
- [ ] Simulation tab: the Simulation Autocomplete is locked to the route's test id, AND the Execution Run Select is locked to the route's execution id.
- [x] Without route params, both controls are editable as before (no regression).
- [x] When multiple executions exist and `initialExecutionId` is supplied, the matching execution is selected (not `items[0]`).
- [x] If the supplied `initialExecutionId` does NOT exist in the response, fall back to the most recent execution.

### Ground-truth embedding-status polling
- [x] In Ground Truth tab, click "Generate embeddings" on a dataset. The status chip changes from `Pending`/`Failed` to `Embedding...` (animated icon) within ~3s — no refresh needed.
- [x] The `embedded_row_count / total_rows` progress display updates live as the backend embeds rows.
- [x] Once embedding completes, the chip flips to `Ready` and polling stops (verify in Network tab — `groundTruthStatus` requests cease firing every 3s).
- [x] If status is already `completed` on mount, the query fires once and then stops (no infinite polling).

### SwitchComponent toggle
- [x] In Ground Truth → Config Panel, the "Injection Settings" row shows a Switch instead of a Button.
- [x] Toggle on/off and confirm `useUpdateGroundTruthConfig` mutation fires with the new enabled state.
- [x] Label reads "Enabled" / "Disabled" matching the switch state.


Closes  TH-5312,TH-5176,TH-5144,TH-5008