### PR TITLE
fix(oss): add null guards for ee functions in tfc, fix downstream scope leaks

### DIFF
--- a/futureagi/accounts/aws_marketplace_utils.py
+++ b/futureagi/accounts/aws_marketplace_utils.py
@@ -77,7 +77,8 @@ def create_organization_for_aws_customer(aws_customer, customer_aws_account_id):
     aws_customer.organization = organization
     aws_customer.save()
 
-    create_organization_subscription_if_not_exists(organization)
+    if create_organization_subscription_if_not_exists is not None:
+        create_organization_subscription_if_not_exists(organization)
 
 
 def create_onboarding_token(aws_customer, customer_identifier, product_code):
@@ -223,6 +224,9 @@ def _get_tier_mapping():
     Get the mapping between AWS dimensions and subscription tiers
     """
 
+    if SubscriptionTierChoices is None:
+        return {}
+
     tier_map = {
         "enterprise_plan": SubscriptionTierChoices.CUSTOM.value,
         "pro_plan": SubscriptionTierChoices.BUSINESS.value,
@@ -287,6 +291,10 @@ def _update_organization_subscription(aws_customer, tier_name, expiration_date):
     Update or create organization subscription with the specified tier
     """
     try:
+        if SubscriptionTier is None or OrganizationSubscription is None:
+            logger.warning("EE billing models not available, skipping subscription update.")
+            return
+
         subscription_tier = SubscriptionTier.objects.get(name=tier_name)
 
         OrganizationSubscription.objects.update_or_create(

--- a/futureagi/ai_tools/tools/prompts/run_prompt.py
+++ b/futureagi/ai_tools/tools/prompts/run_prompt.py
@@ -224,11 +224,11 @@ class RunPromptTool(BaseTool):
 
                 if check_usage is not None:
                     usage_check = check_usage(
-                    str(context.organization.id),
-                    BillingEventType.AI_PROMPT_CREATION,
-                )
-                if not usage_check.allowed:
-                    raise ValueError(usage_check.reason or "Usage limit exceeded")
+                        str(context.organization.id),
+                        BillingEventType.AI_PROMPT_CREATION,
+                    )
+                    if not usage_check.allowed:
+                        raise ValueError(usage_check.reason or "Usage limit exceeded")
             except ImportError:
                 pass
 

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -1100,6 +1100,7 @@ def process_single_error_localization(task_id):
                 raise ValueError(usage_check.reason or "Usage limit exceeded")
 
         # Log and deduct cost for error localization
+        api_call_log_row = None
         if log_and_deduct_cost_for_api_request is not None:
             api_call_log_row = log_and_deduct_cost_for_api_request(
                 organization=task.organization,
@@ -1161,8 +1162,9 @@ def process_single_error_localization(task_id):
 
         # Update the task with the results
         task.mark_as_completed(error_analysis, selected_input_key)
-        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-        api_call_log_row.save(update_fields=["status"])
+        if api_call_log_row is not None:
+            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+            api_call_log_row.save(update_fields=["status"])
 
         # Dual-write: emit usage event for new billing system (cost-based)
         try:

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -1231,16 +1231,16 @@ def process_single_error_localization(task_id):
                     try:
                         if APICallLog is not None:
                             log = APICallLog.objects.get(log_id=metadata.get("log_id"))
-                        config = json.loads(log.config)
-                        config["error_localizer"] = {
-                            "error_analysis": error_analysis,
-                            "selected_input_key": selected_input_key,
-                            "input_types": task.input_types,
-                            "input_data": task.input_data,
-                        }
-                        log.config = json.dumps(config)
-                        log.save(update_fields=["config"])
-                    except APICallLog.DoesNotExist:
+                            config = json.loads(log.config)
+                            config["error_localizer"] = {
+                                "error_analysis": error_analysis,
+                                "selected_input_key": selected_input_key,
+                                "input_types": task.input_types,
+                                "input_data": task.input_data,
+                            }
+                            log.config = json.dumps(config)
+                            log.save(update_fields=["config"])
+                    except (APICallLog.DoesNotExist if APICallLog else Exception):
                         logger.info("Log doesn't exist.")
             except Exception as e:
                 logger.error(f"Error in updating cell metadata: {str(e)}")
@@ -1269,16 +1269,16 @@ def process_single_error_localization(task_id):
                     try:
                         if APICallLog is not None:
                             log = APICallLog.objects.get(log_id=metadata.get("log_id"))
-                        config = json.loads(log.config)
-                        config["error_localizer"] = {
-                            "error_analysis": error_analysis,
-                            "selected_input_key": selected_input_key,
-                            "input_types": task.input_types,
-                            "input_data": task.input_data,
-                        }
-                        log.config = json.dumps(config)
-                        log.save(update_fields=["config"])
-                    except APICallLog.DoesNotExist:
+                            config = json.loads(log.config)
+                            config["error_localizer"] = {
+                                "error_analysis": error_analysis,
+                                "selected_input_key": selected_input_key,
+                                "input_types": task.input_types,
+                                "input_data": task.input_data,
+                            }
+                            log.config = json.dumps(config)
+                            log.save(update_fields=["config"])
+                    except (APICallLog.DoesNotExist if APICallLog else Exception):
                         logger.info("Log doesn't exist.")
 
             except Exception as e:
@@ -1291,15 +1291,15 @@ def process_single_error_localization(task_id):
             try:
                 if APICallLog is not None:
                     eval_logger = APICallLog.objects.get(log_id=task.source_id)
-                config = json.loads(eval_logger.config) or {}
-                config["error_localizer"] = {
-                    "error_analysis": error_analysis,
-                    "selected_input_key": selected_input_key,
-                    "input_types": task.input_types,
-                    "input_data": task.input_data,
-                }
-                eval_logger.config = json.dumps(config)
-                eval_logger.save(update_fields=["config"])
+                    config = json.loads(eval_logger.config) or {}
+                    config["error_localizer"] = {
+                        "error_analysis": error_analysis,
+                        "selected_input_key": selected_input_key,
+                        "input_types": task.input_types,
+                        "input_data": task.input_data,
+                    }
+                    eval_logger.config = json.dumps(config)
+                    eval_logger.save(update_fields=["config"])
             except Exception as e:
                 logger.exception(f"Error in updating log config: {str(e)}")
                 if refund_cost_for_api_call is not None:

--- a/futureagi/model_hub/utils/async_generate_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_generate_prompt_runner.py
@@ -124,24 +124,21 @@ async def generate_prompt_async(
                     "total_cost", 0
                 )
             if BillingConfig is not None:
-
                 credits = BillingConfig.get().calculate_ai_credits(actual_cost)
 
-            if emit is not None and UsageEvent is not None and BillingEventType is not None:
-
-
-                emit(
-                UsageEvent(
-                    org_id=str(organization_id),
-                    event_type=BillingEventType.AI_PROMPT_CREATION,
-                    amount=credits,
-                    properties={
-                        "source": "run_prompt_gen",
-                        "source_id": str(generation_id),
-                        "raw_cost_usd": str(actual_cost),
-                    },
-                )
-            )
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                    emit(
+                        UsageEvent(
+                            org_id=str(organization_id),
+                            event_type=BillingEventType.AI_PROMPT_CREATION,
+                            amount=credits,
+                            properties={
+                                "source": "run_prompt_gen",
+                                "source_id": str(generation_id),
+                                "raw_cost_usd": str(actual_cost),
+                            },
+                        )
+                    )
         except Exception:
             pass
 

--- a/futureagi/model_hub/utils/async_improve_prompt_runner.py
+++ b/futureagi/model_hub/utils/async_improve_prompt_runner.py
@@ -132,24 +132,21 @@ async def improve_prompt_async(
                     "total_cost", 0
                 )
             if BillingConfig is not None:
-
                 credits = BillingConfig.get().calculate_ai_credits(actual_cost)
 
-            if emit is not None and UsageEvent is not None and BillingEventType is not None:
-
-
-                emit(
-                UsageEvent(
-                    org_id=str(organization_id),
-                    event_type=BillingEventType.AI_PROMPT_IMPROVEMENT,
-                    amount=credits,
-                    properties={
-                        "source": "run_prompt_improve",
-                        "source_id": str(improve_id),
-                        "raw_cost_usd": str(actual_cost),
-                    },
-                )
-            )
+                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                    emit(
+                        UsageEvent(
+                            org_id=str(organization_id),
+                            event_type=BillingEventType.AI_PROMPT_IMPROVEMENT,
+                            amount=credits,
+                            properties={
+                                "source": "run_prompt_improve",
+                                "source_id": str(improve_id),
+                                "raw_cost_usd": str(actual_cost),
+                            },
+                        )
+                    )
         except Exception:
             pass
 

--- a/futureagi/model_hub/views/develop_optimiser.py
+++ b/futureagi/model_hub/views/develop_optimiser.py
@@ -173,18 +173,19 @@ class DevelopOptimizer:
                 api_call_log_row = APICallLog.objects.filter(
                     reference_id=optimisation_id, deleted=False
                 ).first()
-                if optimizer_row.status == StatusType.FAILED.value:
-                    # refund the cost
-                    # update the api call log row
-                    api_call_log_row.status = APICallStatusChoices.ERROR.value
-                    api_call_log_row.save()
-                    refund_config = {"reference_id": str(optimizer_row.id)}
-                    if refund_cost_for_api_call is not None:
-                        refund_cost_for_api_call(api_call_log_row, config=refund_config)
-                else:
-                    # update the api call log row
-                    api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-                    api_call_log_row.save()
+                if api_call_log_row is not None:
+                    if optimizer_row.status == StatusType.FAILED.value:
+                        # refund the cost
+                        # update the api call log row
+                        api_call_log_row.status = APICallStatusChoices.ERROR.value
+                        api_call_log_row.save()
+                        refund_config = {"reference_id": str(optimizer_row.id)}
+                        if refund_cost_for_api_call is not None:
+                            refund_cost_for_api_call(api_call_log_row, config=refund_config)
+                    else:
+                        # update the api call log row
+                        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+                        api_call_log_row.save()
 
         except Exception as e:
             logger.exception(f"error in refunding cost : {e}")

--- a/futureagi/model_hub/views/develop_optimiser.py
+++ b/futureagi/model_hub/views/develop_optimiser.py
@@ -171,20 +171,20 @@ class DevelopOptimizer:
             # get the api call log row by reference id
             if APICallLog is not None:
                 api_call_log_row = APICallLog.objects.filter(
-                reference_id=optimisation_id, deleted=False
-            ).first()
-            if optimizer_row.status == StatusType.FAILED.value:
-                # refund the cost
-                # update the api call log row
-                api_call_log_row.status = APICallStatusChoices.ERROR.value
-                api_call_log_row.save()
-                refund_config = {"reference_id": str(optimizer_row.id)}
-                if refund_cost_for_api_call is not None:
-                    refund_cost_for_api_call(api_call_log_row, config=refund_config)
-            else:
-                # update the api call log row
-                api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-                api_call_log_row.save()
+                    reference_id=optimisation_id, deleted=False
+                ).first()
+                if optimizer_row.status == StatusType.FAILED.value:
+                    # refund the cost
+                    # update the api call log row
+                    api_call_log_row.status = APICallStatusChoices.ERROR.value
+                    api_call_log_row.save()
+                    refund_config = {"reference_id": str(optimizer_row.id)}
+                    if refund_cost_for_api_call is not None:
+                        refund_cost_for_api_call(api_call_log_row, config=refund_config)
+                else:
+                    # update the api call log row
+                    api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+                    api_call_log_row.save()
 
         except Exception as e:
             logger.exception(f"error in refunding cost : {e}")

--- a/futureagi/model_hub/views/prompt_template.py
+++ b/futureagi/model_hub/views/prompt_template.py
@@ -2627,16 +2627,17 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 result_data=response, eval_template=eval_template
             )
 
-            config_dict = json.loads(api_call_log_row.config)
-            config_dict.update(
-                {"output": {"output": value, "reason": response["reason"]}}
-            )
-            api_call_log_row.input_token_count = (
-                metadata.get("usage", {}).get("prompt_tokens") or 0
-            )
-            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-            api_call_log_row.config = json.dumps(config_dict)
-            api_call_log_row.save()
+            if api_call_log_row is not None:
+                config_dict = json.loads(api_call_log_row.config)
+                config_dict.update(
+                    {"output": {"output": value, "reason": response["reason"]}}
+                )
+                api_call_log_row.input_token_count = (
+                    metadata.get("usage", {}).get("prompt_tokens") or 0
+                )
+                api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+                api_call_log_row.config = json.dumps(config_dict)
+                api_call_log_row.save()
 
             # Dual-write: emit usage event for new billing system
             try:
@@ -2673,11 +2674,12 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
 
         except Exception as e:
             try:
-                api_call_log_row.status = APICallStatusChoices.ERROR.value
-                config_dict = json.loads(api_call_log_row.config)
-                config_dict.update({"output": {"output": None, "reason": str(e)}})
-                api_call_log_row.config = json.dumps(config_dict)
-                api_call_log_row.save()
+                if api_call_log_row is not None:
+                    api_call_log_row.status = APICallStatusChoices.ERROR.value
+                    config_dict = json.loads(api_call_log_row.config)
+                    config_dict.update({"output": {"output": None, "reason": str(e)}})
+                    api_call_log_row.config = json.dumps(config_dict)
+                    api_call_log_row.save()
             except Exception:
                 pass
             logger.exception(f"{e} error")
@@ -3251,7 +3253,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                         event_type=BillingEventType.AI_PROMPT_CREATION,
                         properties={
                             "source": "run_prompt_gen",
-                            "source_id": str(call_log_row.log_id),
+                            "source_id": str(call_log_row.log_id) if call_log_row else None,
                         },
                     )
                 )
@@ -3377,7 +3379,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                         event_type=BillingEventType.AI_PROMPT_IMPROVEMENT,
                         properties={
                             "source": "run_prompt_improve",
-                            "source_id": str(call_log_row.log_id),
+                            "source_id": str(call_log_row.log_id) if call_log_row else None,
                         },
                     )
                 )

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -599,38 +599,39 @@ def process_eval_for_single_row(
 
         value = runner.format_output(response)
 
-        config_dict = json.loads(api_call_log_row.config)
+        if api_call_log_row is not None:
+            config_dict = json.loads(api_call_log_row.config)
 
-        if (
-            eval_template
-            and eval_template.config.get("eval_type_id") == "DeterministicEvaluator"
-        ):
-            metadata_json = eval_result.eval_results[0].get("metadata", "{}")
-            json.loads(metadata_json)
-            config_dict.update(
-                {"output": {"output": value, "reason": response["reason"]}}
-            )
+            if (
+                eval_template
+                and eval_template.config.get("eval_type_id") == "DeterministicEvaluator"
+            ):
+                metadata_json = eval_result.eval_results[0].get("metadata", "{}")
+                json.loads(metadata_json)
+                config_dict.update(
+                    {"output": {"output": value, "reason": response["reason"]}}
+                )
 
-        else:
-            config_dict.update(
-                {"output": {"output": value, "reason": response["reason"]}}
-            )
-
-        input_types = {}
-        for key, mapping_value in mappings.items():
-            # Extract base column ID to look up data type
-            if isinstance(mapping_value, uuid.UUID):
-                base_col_id = str(mapping_value)
-            elif isinstance(mapping_value, str) and mapping_value:
-                base_col_id, _ = _extract_column_id_and_path(mapping_value)
             else:
-                base_col_id = None
-            data_type = col_map.get(str(base_col_id)) if base_col_id else None
-            input_types[key] = data_type if data_type in ["image", "audio"] else "text"
-        config_dict.update({"input_data_types": input_types})
-        api_call_log_row.config = json.dumps(config_dict, default=str)
-        api_call_log_row.status = APICallStatusChoices.SUCCESS.value
-        api_call_log_row.save()
+                config_dict.update(
+                    {"output": {"output": value, "reason": response["reason"]}}
+                )
+
+            input_types = {}
+            for key, mapping_value in mappings.items():
+                # Extract base column ID to look up data type
+                if isinstance(mapping_value, uuid.UUID):
+                    base_col_id = str(mapping_value)
+                elif isinstance(mapping_value, str) and mapping_value:
+                    base_col_id, _ = _extract_column_id_and_path(mapping_value)
+                else:
+                    base_col_id = None
+                data_type = col_map.get(str(base_col_id)) if base_col_id else None
+                input_types[key] = data_type if data_type in ["image", "audio"] else "text"
+            config_dict.update({"input_data_types": input_types})
+            api_call_log_row.config = json.dumps(config_dict, default=str)
+            api_call_log_row.status = APICallStatusChoices.SUCCESS.value
+            api_call_log_row.save()
 
         output = {}
         for index, key in enumerate(required_field):
@@ -650,11 +651,12 @@ def process_eval_for_single_row(
         return output
     except Exception as e:
         try:
-            api_call_log_row.status = APICallStatusChoices.ERROR.value
-            current_config = json.loads(api_call_log_row.config)
-            current_config.update({"output": {"output": None, "reason": str(e)}})
-            api_call_log_row.config = json.dumps(current_config, default=str)
-            api_call_log_row.save()
+            if api_call_log_row is not None:
+                api_call_log_row.status = APICallStatusChoices.ERROR.value
+                current_config = json.loads(api_call_log_row.config)
+                current_config.update({"output": {"output": None, "reason": str(e)}})
+                api_call_log_row.config = json.dumps(current_config, default=str)
+                api_call_log_row.save()
         except Exception:
             pass
         traceback.print_exc()

--- a/futureagi/sdk/utils/evaluations.py
+++ b/futureagi/sdk/utils/evaluations.py
@@ -288,6 +288,10 @@ def _run_eval(eval_template, inputs, model, user, workspace, eval_config=None):
     # emit SDK/API-key evals never produce a billable UsageEvent. (TH-3402)
     try:
         try:
+            from ee.usage.schemas.event_types import BillingEventType
+        except ImportError:
+            BillingEventType = None
+        try:
             from ee.usage.schemas.events import UsageEvent
         except ImportError:
             UsageEvent = None
@@ -543,6 +547,10 @@ def _run_protect(
 
         # Emit usage event with actual cost after eval completion
         try:
+            try:
+                from ee.usage.schemas.event_types import BillingEventType
+            except ImportError:
+                BillingEventType = None
             try:
                 from ee.usage.schemas.events import UsageEvent
             except ImportError:

--- a/futureagi/tfc/temporal/billing/activities.py
+++ b/futureagi/tfc/temporal/billing/activities.py
@@ -54,7 +54,9 @@ def _report_stripe_usage_sync(period: str) -> int:
         except ImportError:
             report_all_usage_to_stripe = None
 
-        return report_all_usage_to_stripe()
+        if report_all_usage_to_stripe is not None:
+            return report_all_usage_to_stripe()
+        return 0
     finally:
         close_old_connections()
 
@@ -95,6 +97,9 @@ def _run_dunning_checks_sync() -> int:
             from ee.usage.services.dunning import DunningService
         except ImportError:
             DunningService = None
+
+        if OrganizationSubscription is None or DunningService is None:
+            return 0
 
         past_due_subs = OrganizationSubscription.objects.filter(
             status="past_due", deleted=False
@@ -177,6 +182,9 @@ def _generate_monthly_invoices_sync(
                 period = f"{now.year - 1}-12"
             else:
                 period = f"{now.year}-{now.month - 1:02d}"
+
+        if InvoiceGenerationService is None:
+            return 0, 0, 0
 
         result = InvoiceGenerationService.run_for_period(
             period=period,

--- a/futureagi/tfc/temporal/schedules/billing.py
+++ b/futureagi/tfc/temporal/schedules/billing.py
@@ -44,6 +44,9 @@ def evaluate_budgets_catchup_activity():
         evaluate_budgets_catchup = None
         evaluate_total_spend_budget = None
 
+    if UsageBudget is None or evaluate_budgets_catchup is None or evaluate_total_spend_budget is None:
+        return 0
+
     period = datetime.now(tz=timezone.utc).strftime("%Y-%m")
 
     active_budgets = (

--- a/futureagi/tfc/temporal/schedules/retention.py
+++ b/futureagi/tfc/temporal/schedules/retention.py
@@ -15,6 +15,10 @@ def soft_delete_expired_data_activity():
     except ImportError:
         soft_delete_expired_data = None
 
+    if soft_delete_expired_data is None:
+        logger.info("soft_delete_activity_skipped", reason="ee module not available")
+        return {}
+
     result = soft_delete_expired_data()
     total = sum(sum(counts.values()) for counts in result.values())
     logger.info(
@@ -31,6 +35,10 @@ def hard_delete_expired_data_activity():
         from ee.usage.tasks.retention import hard_delete_expired_data
     except ImportError:
         hard_delete_expired_data = None
+
+    if hard_delete_expired_data is None:
+        logger.info("hard_delete_activity_skipped", reason="ee module not available")
+        return {}
 
     result = hard_delete_expired_data()
     total = sum(result.values())

--- a/futureagi/tfc/temporal/simulate/activities.py
+++ b/futureagi/tfc/temporal/simulate/activities.py
@@ -182,14 +182,15 @@ async def generate_synthetic_data_activity(
             except ImportError:
                 check_usage = None
 
-            usage_check = check_usage(
-                input.organization_id, BillingEventType.SYNTHETIC_DATA_GENERATION
-            )
-            if not usage_check.allowed:
-                return GenerateSyntheticDataOutput(
-                    status="FAILED",
-                    error=usage_check.reason or "Usage limit exceeded",
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(
+                    input.organization_id, BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
+                if not usage_check.allowed:
+                    return GenerateSyntheticDataOutput(
+                        status="FAILED",
+                        error=usage_check.reason or "Usage limit exceeded",
+                    )
         else:
             logger.warning(
                 "usage_check_skipped_no_org_id",
@@ -236,21 +237,23 @@ async def generate_synthetic_data_activity(
                     emit = None
 
                 actual_cost = agent.llm.cost.get("total_cost", 0)
-                credits = BillingConfig.get().calculate_ai_credits(actual_cost)
-                emit(
-                    UsageEvent(
-                        org_id=input.organization_id,
-                        event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
-                        amount=credits,
-                        properties={
-                            "source": "simulate_scenario_generation",
-                            "raw_cost_usd": str(actual_cost),
-                            "total_tokens": agent.llm.token_usage.get(
-                                "total_tokens", 0
-                            ),
-                        },
-                    )
-                )
+                if BillingConfig is not None:
+                    credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+                    if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                        emit(
+                            UsageEvent(
+                                org_id=input.organization_id,
+                                event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
+                                amount=credits,
+                                properties={
+                                    "source": "simulate_scenario_generation",
+                                    "raw_cost_usd": str(actual_cost),
+                                    "total_tokens": agent.llm.token_usage.get(
+                                        "total_tokens", 0
+                                    ),
+                                },
+                            )
+                        )
             except Exception:
                 pass
 
@@ -579,14 +582,15 @@ async def generate_column_data_activity(
             except ImportError:
                 check_usage = None
 
-            usage_check = check_usage(
-                input.organization_id, BillingEventType.SYNTHETIC_DATA_GENERATION
-            )
-            if not usage_check.allowed:
-                return GenerateColumnDataOutput(
-                    status="FAILED",
-                    error=usage_check.reason or "Usage limit exceeded",
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(
+                    input.organization_id, BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
+                if not usage_check.allowed:
+                    return GenerateColumnDataOutput(
+                        status="FAILED",
+                        error=usage_check.reason or "Usage limit exceeded",
+                    )
         else:
             logger.warning(
                 "usage_check_skipped_no_org_id",
@@ -634,21 +638,23 @@ async def generate_column_data_activity(
                     emit = None
 
                 actual_cost = agent.llm.cost.get("total_cost", 0)
-                credits = BillingConfig.get().calculate_ai_credits(actual_cost)
-                emit(
-                    UsageEvent(
-                        org_id=input.organization_id,
-                        event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
-                        amount=credits,
-                        properties={
-                            "source": "simulate_column_generation",
-                            "raw_cost_usd": str(actual_cost),
-                            "total_tokens": agent.llm.token_usage.get(
-                                "total_tokens", 0
-                            ),
-                        },
-                    )
-                )
+                if BillingConfig is not None:
+                    credits = BillingConfig.get().calculate_ai_credits(actual_cost)
+                    if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                        emit(
+                            UsageEvent(
+                                org_id=input.organization_id,
+                                event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
+                                amount=credits,
+                                properties={
+                                    "source": "simulate_column_generation",
+                                    "raw_cost_usd": str(actual_cost),
+                                    "total_tokens": agent.llm.token_usage.get(
+                                        "total_tokens", 0
+                                    ),
+                                },
+                            )
+                        )
             except Exception:
                 pass
 
@@ -820,14 +826,15 @@ async def add_scenario_columns_activity(
             _close_check()
             _asc_scenario = Scenarios.objects.get(id=input.scenario_id)
             _asc_org_id = str(_asc_scenario.organization.id)
-            usage_check = check_usage(
-                _asc_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
-            )
-            if not usage_check.allowed:
-                raise ApplicationError(
-                    usage_check.reason or "Usage limit exceeded",
-                    non_retryable=True,
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(
+                    _asc_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
+                if not usage_check.allowed:
+                    raise ApplicationError(
+                        usage_check.reason or "Usage limit exceeded",
+                        non_retryable=True,
+                    )
         except ApplicationError:
             raise
         except Exception:
@@ -1223,14 +1230,15 @@ def _create_dataset_scenario_sync(
                 check_usage = None
 
             _cds_org_id = str(scenario.organization.id)
-            usage_check = check_usage(
-                _cds_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
-            )
-            if not usage_check.allowed:
-                raise ApplicationError(
-                    usage_check.reason or "Usage limit exceeded",
-                    non_retryable=True,
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(
+                    _cds_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
+                if not usage_check.allowed:
+                    raise ApplicationError(
+                        usage_check.reason or "Usage limit exceeded",
+                        non_retryable=True,
+                    )
         except ApplicationError:
             raise
         except Exception:
@@ -1816,20 +1824,22 @@ def _create_dataset_scenario_sync(
                 _total_tokens = graph_generator.sda.llm.token_usage.get(
                     "total_tokens", 0
                 )
-                credits = BillingConfig.get().calculate_ai_credits(_total_cost)
-                emit(
-                    UsageEvent(
-                        org_id=_cds_org_id,
-                        event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
-                        amount=credits,
-                        properties={
-                            "source": "simulate_dataset_scenario_creation",
-                            "source_id": str(scenario_id),
-                            "raw_cost_usd": str(_total_cost),
-                            "total_tokens": _total_tokens,
-                        },
-                    )
-                )
+                if BillingConfig is not None:
+                    credits = BillingConfig.get().calculate_ai_credits(_total_cost)
+                    if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                        emit(
+                            UsageEvent(
+                                org_id=_cds_org_id,
+                                event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
+                                amount=credits,
+                                properties={
+                                    "source": "simulate_dataset_scenario_creation",
+                                    "source_id": str(scenario_id),
+                                    "raw_cost_usd": str(_total_cost),
+                                    "total_tokens": _total_tokens,
+                                },
+                            )
+                        )
         except Exception:
             pass
 
@@ -1942,14 +1952,15 @@ def _create_script_scenario_sync(
                 check_usage = None
 
             _org_id = str(scenario.organization.id)
-            usage_check = check_usage(
-                _org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
-            )
-            if not usage_check.allowed:
-                raise ApplicationError(
-                    usage_check.reason or "Usage limit exceeded",
-                    non_retryable=True,
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(
+                    _org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
+                if not usage_check.allowed:
+                    raise ApplicationError(
+                        usage_check.reason or "Usage limit exceeded",
+                        non_retryable=True,
+                    )
         except ApplicationError:
             raise
         except Exception:
@@ -2029,18 +2040,19 @@ def _create_script_scenario_sync(
                     emit = None
 
                 _cost = enhanced_agent.llm.cost.get("total_cost", 0)
-                emit(
-                    UsageEvent(
-                        org_id=_org_id,
-                        event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
-                        amount=BillingConfig.get().calculate_ai_credits(_cost),
-                        properties={
-                            "source": "simulate_dataset_scenario",
-                            "source_id": scenario_id,
-                            "raw_cost_usd": str(_cost),
-                        },
+                if BillingConfig is not None and emit is not None and UsageEvent is not None and BillingEventType is not None:
+                    emit(
+                        UsageEvent(
+                            org_id=_org_id,
+                            event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
+                            amount=BillingConfig.get().calculate_ai_credits(_cost),
+                            properties={
+                                "source": "simulate_dataset_scenario",
+                                "source_id": scenario_id,
+                                "raw_cost_usd": str(_cost),
+                            },
+                        )
                     )
-                )
         except Exception:
             pass
 
@@ -2354,14 +2366,15 @@ def _create_graph_scenario_sync(
                 check_usage = None
 
             _org_id = str(scenario.organization.id)
-            usage_check = check_usage(
-                _org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
-            )
-            if not usage_check.allowed:
-                raise ApplicationError(
-                    usage_check.reason or "Usage limit exceeded",
-                    non_retryable=True,
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(
+                    _org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
+                if not usage_check.allowed:
+                    raise ApplicationError(
+                        usage_check.reason or "Usage limit exceeded",
+                        non_retryable=True,
+                    )
         except ApplicationError:
             raise
         except Exception:
@@ -2574,18 +2587,19 @@ def _create_graph_scenario_sync(
                     emit = None
 
                 _cost = enhanced_agent.llm.cost.get("total_cost", 0)
-                emit(
-                    UsageEvent(
-                        org_id=_org_id,
-                        event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
-                        amount=BillingConfig.get().calculate_ai_credits(_cost),
-                        properties={
-                            "source": "simulate_script_scenario",
-                            "source_id": scenario_id,
-                            "raw_cost_usd": str(_cost),
-                        },
+                if BillingConfig is not None and emit is not None and UsageEvent is not None and BillingEventType is not None:
+                    emit(
+                        UsageEvent(
+                            org_id=_org_id,
+                            event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
+                            amount=BillingConfig.get().calculate_ai_credits(_cost),
+                            properties={
+                                "source": "simulate_script_scenario",
+                                "source_id": scenario_id,
+                                "raw_cost_usd": str(_cost),
+                            },
+                        )
                     )
-                )
         except Exception:
             pass
 
@@ -2767,14 +2781,15 @@ def _setup_graph_scenario_sync(
                 check_usage = None
 
             _sgs_org_id = str(scenario.organization.id)
-            usage_check = check_usage(
-                _sgs_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
-            )
-            if not usage_check.allowed:
-                raise ApplicationError(
-                    usage_check.reason or "Usage limit exceeded",
-                    non_retryable=True,
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(
+                    _sgs_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
+                if not usage_check.allowed:
+                    raise ApplicationError(
+                        usage_check.reason or "Usage limit exceeded",
+                        non_retryable=True,
+                    )
         except ApplicationError:
             raise
         except Exception:
@@ -2994,20 +3009,22 @@ def _setup_graph_scenario_sync(
                 _total_tokens = graph_generator.sda.llm.token_usage.get(
                     "total_tokens", 0
                 )
-                credits = BillingConfig.get().calculate_ai_credits(_total_cost)
-                emit(
-                    UsageEvent(
-                        org_id=_sgs_org_id,
-                        event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
-                        amount=credits,
-                        properties={
-                            "source": "simulate_graph_scenario_setup",
-                            "source_id": str(scenario_id),
-                            "raw_cost_usd": str(_total_cost),
-                            "total_tokens": _total_tokens,
-                        },
-                    )
-                )
+                if BillingConfig is not None:
+                    credits = BillingConfig.get().calculate_ai_credits(_total_cost)
+                    if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                        emit(
+                            UsageEvent(
+                                org_id=_sgs_org_id,
+                                event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
+                                amount=credits,
+                                properties={
+                                    "source": "simulate_graph_scenario_setup",
+                                    "source_id": str(scenario_id),
+                                    "raw_cost_usd": str(_total_cost),
+                                    "total_tokens": _total_tokens,
+                                },
+                            )
+                        )
         except Exception:
             pass
 
@@ -3132,14 +3149,15 @@ def _extract_intents_sync(
 
             _ei_graph = ScenarioGraph.objects.get(id=graph_id)
             _ei_org_id = str(_ei_graph.organization.id)
-            usage_check = check_usage(
-                _ei_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
-            )
-            if not usage_check.allowed:
-                raise ApplicationError(
-                    usage_check.reason or "Usage limit exceeded",
-                    non_retryable=True,
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(
+                    _ei_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
+                if not usage_check.allowed:
+                    raise ApplicationError(
+                        usage_check.reason or "Usage limit exceeded",
+                        non_retryable=True,
+                    )
         except ApplicationError:
             raise
         except Exception:
@@ -3289,22 +3307,24 @@ def _extract_intents_sync(
 
                             _total_cost = llm.cost.get("total_cost", 0)
                             _total_tokens = llm.token_usage.get("total_tokens", 0)
-                            credits = BillingConfig.get().calculate_ai_credits(
-                                _total_cost
-                            )
-                            emit(
-                                UsageEvent(
-                                    org_id=_ei_org_id,
-                                    event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
-                                    amount=credits,
-                                    properties={
-                                        "source": "simulate_extract_intents",
-                                        "source_id": str(graph_id),
-                                        "raw_cost_usd": str(_total_cost),
-                                        "total_tokens": _total_tokens,
-                                    },
+                            if BillingConfig is not None:
+                                credits = BillingConfig.get().calculate_ai_credits(
+                                    _total_cost
                                 )
-                            )
+                                if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                                    emit(
+                                        UsageEvent(
+                                            org_id=_ei_org_id,
+                                            event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
+                                            amount=credits,
+                                            properties={
+                                                "source": "simulate_extract_intents",
+                                                "source_id": str(graph_id),
+                                                "raw_cost_usd": str(_total_cost),
+                                                "total_tokens": _total_tokens,
+                                            },
+                                        )
+                                    )
                     except Exception:
                         pass
                     try:
@@ -3417,14 +3437,15 @@ def _process_branches_sync(
 
             _pb_graph = ScenarioGraph.objects.get(id=graph_id)
             _pb_org_id = str(_pb_graph.organization.id)
-            usage_check = check_usage(
-                _pb_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
-            )
-            if not usage_check.allowed:
-                raise ApplicationError(
-                    usage_check.reason or "Usage limit exceeded",
-                    non_retryable=True,
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(
+                    _pb_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
+                if not usage_check.allowed:
+                    raise ApplicationError(
+                        usage_check.reason or "Usage limit exceeded",
+                        non_retryable=True,
+                    )
         except ApplicationError:
             raise
         except Exception:
@@ -3465,20 +3486,22 @@ def _process_branches_sync(
 
                 _total_cost = agent.llm.cost.get("total_cost", 0)
                 _total_tokens = agent.llm.token_usage.get("total_tokens", 0)
-                credits = BillingConfig.get().calculate_ai_credits(_total_cost)
-                emit(
-                    UsageEvent(
-                        org_id=_pb_org_id,
-                        event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
-                        amount=credits,
-                        properties={
-                            "source": "simulate_process_branches",
-                            "source_id": str(graph_id),
-                            "raw_cost_usd": str(_total_cost),
-                            "total_tokens": _total_tokens,
-                        },
-                    )
-                )
+                if BillingConfig is not None:
+                    credits = BillingConfig.get().calculate_ai_credits(_total_cost)
+                    if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                        emit(
+                            UsageEvent(
+                                org_id=_pb_org_id,
+                                event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
+                                amount=credits,
+                                properties={
+                                    "source": "simulate_process_branches",
+                                    "source_id": str(graph_id),
+                                    "raw_cost_usd": str(_total_cost),
+                                    "total_tokens": _total_tokens,
+                                },
+                            )
+                        )
         except Exception:
             pass
 
@@ -3638,7 +3661,7 @@ def _generate_cases_for_intent_sync(
                 check_usage = None
 
             _gc_org_id = agent_context.get("organization_id") if agent_context else None
-            if _gc_org_id:
+            if _gc_org_id and check_usage is not None and BillingEventType is not None:
                 usage_check = check_usage(
                     str(_gc_org_id), BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
@@ -3728,18 +3751,19 @@ def _generate_cases_for_intent_sync(
                         emit = None
 
                     _cost = agent.llm.cost.get("total_cost", 0)
-                    emit(
-                        UsageEvent(
-                            org_id=str(_gc_org_id),
-                            event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
-                            amount=BillingConfig.get().calculate_ai_credits(_cost),
-                            properties={
-                                "source": "simulate_generate_cases_intent",
-                                "source_id": str(intent_id),
-                                "raw_cost_usd": str(_cost),
-                            },
+                    if BillingConfig is not None and emit is not None and UsageEvent is not None and BillingEventType is not None:
+                        emit(
+                            UsageEvent(
+                                org_id=str(_gc_org_id),
+                                event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
+                                amount=BillingConfig.get().calculate_ai_credits(_cost),
+                                properties={
+                                    "source": "simulate_generate_cases_intent",
+                                    "source_id": str(intent_id),
+                                    "raw_cost_usd": str(_cost),
+                                },
+                            )
                         )
-                    )
             except Exception:
                 pass
 
@@ -4243,7 +4267,7 @@ async def create_graph_scenario_activity(
             id=input.scenario_id
         )
         org_id = str(scenario.dataset.organization.id) if scenario.dataset else None
-        if org_id:
+        if org_id and check_usage is not None and BillingEventType is not None:
             usage_check = check_usage(
                 org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
             )
@@ -4519,14 +4543,15 @@ def _process_single_branch_sync(
                 except ImportError:
                     check_usage = None
 
-                usage_check = check_usage(
-                    str(_psb_org_id), BillingEventType.SYNTHETIC_DATA_GENERATION
-                )
-                if not usage_check.allowed:
-                    raise ApplicationError(
-                        usage_check.reason or "Usage limit exceeded",
-                        non_retryable=True,
+                if check_usage is not None and BillingEventType is not None:
+                    usage_check = check_usage(
+                        str(_psb_org_id), BillingEventType.SYNTHETIC_DATA_GENERATION
                     )
+                    if not usage_check.allowed:
+                        raise ApplicationError(
+                            usage_check.reason or "Usage limit exceeded",
+                            non_retryable=True,
+                        )
         except ApplicationError:
             raise
         except Exception:
@@ -4567,19 +4592,21 @@ def _process_single_branch_sync(
                     emit = None
 
                 _total_cost = _branch_llm_cost.get("total_cost", 0)
-                credits = BillingConfig.get().calculate_ai_credits(_total_cost)
-                emit(
-                    UsageEvent(
-                        org_id=str(_psb_org_id),
-                        event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
-                        amount=credits,
-                        properties={
-                            "source": "simulate_process_single_branch",
-                            "source_id": str(graph_id),
-                            "raw_cost_usd": str(_total_cost),
-                        },
-                    )
-                )
+                if BillingConfig is not None:
+                    credits = BillingConfig.get().calculate_ai_credits(_total_cost)
+                    if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                        emit(
+                            UsageEvent(
+                                org_id=str(_psb_org_id),
+                                event_type=BillingEventType.SYNTHETIC_DATA_GENERATION,
+                                amount=credits,
+                                properties={
+                                    "source": "simulate_process_single_branch",
+                                    "source_id": str(graph_id),
+                                    "raw_cost_usd": str(_total_cost),
+                                },
+                            )
+                        )
         except Exception:
             pass
 
@@ -5074,14 +5101,15 @@ def _prepare_scenario_sync(
 
             _ps_scenario = Scenarios.objects.get(id=scenario_id)
             _ps_org_id = str(_ps_scenario.organization.id)
-            usage_check = check_usage(
-                _ps_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
-            )
-            if not usage_check.allowed:
-                raise ApplicationError(
-                    usage_check.reason or "Usage limit exceeded",
-                    non_retryable=True,
+            if check_usage is not None and BillingEventType is not None:
+                usage_check = check_usage(
+                    _ps_org_id, BillingEventType.SYNTHETIC_DATA_GENERATION
                 )
+                if not usage_check.allowed:
+                    raise ApplicationError(
+                        usage_check.reason or "Usage limit exceeded",
+                        non_retryable=True,
+                    )
         except ApplicationError:
             raise
         except Exception:

--- a/futureagi/tracer/services/grpc.py
+++ b/futureagi/tracer/services/grpc.py
@@ -70,13 +70,14 @@ class ObservationSpanService(generics.GenericService, TraceServiceServicer):
                 except ImportError:
                     RateLimiter = None
 
-                rl_result = await sync_to_async(RateLimiter.check)(
-                    str(organization_id), "ingestion"
-                )
-                if not rl_result.allowed:
-                    await context.abort(
-                        grpc.StatusCode.RESOURCE_EXHAUSTED, rl_result.reason
+                if RateLimiter is not None:
+                    rl_result = await sync_to_async(RateLimiter.check)(
+                        str(organization_id), "ingestion"
                     )
+                    if not rl_result.allowed:
+                        await context.abort(
+                            grpc.StatusCode.RESOURCE_EXHAUSTED, rl_result.reason
+                        )
             except ImportError:
                 pass
 

--- a/futureagi/tracer/tasks/dataset.py
+++ b/futureagi/tracer/tasks/dataset.py
@@ -276,18 +276,19 @@ def process_spans_chunk_task(span_ids, dataset_id, column_span_mapping_data):
 
             dataset = Database.objects.only("organization_id").get(id=dataset_id)
             data_size = sum(len(str(c.value or "").encode()) for c in cells_to_create)
-            emit(
-                UsageEvent(
-                    org_id=str(dataset.organization_id),
-                    event_type="dataset_row_from_spans",
-                    amount=data_size,
-                    properties={
-                        "source": "dataset_from_spans",
-                        "source_id": str(dataset_id),
-                        "rows_created": len(created_rows),
-                    },
+            if emit is not None and UsageEvent is not None:
+                emit(
+                    UsageEvent(
+                        org_id=str(dataset.organization_id),
+                        event_type="dataset_row_from_spans",
+                        amount=data_size,
+                        properties={
+                            "source": "dataset_from_spans",
+                            "source_id": str(dataset_id),
+                            "rows_created": len(created_rows),
+                        },
+                    )
                 )
-            )
         except Exception:
             logger.debug(
                 "emit_dataset_storage_event_failed", dataset_id=str(dataset_id)

--- a/futureagi/tracer/utils/otel.py
+++ b/futureagi/tracer/utils/otel.py
@@ -1072,6 +1072,7 @@ def _deduct_project_creation_cost(
         else APICallTypeChoices.OBSERVE_ADD.value
     )
 
+    call_log_row = None
     if log_and_deduct_cost_for_resource_request is not None:
         call_log_row = log_and_deduct_cost_for_resource_request(
             organization,
@@ -1086,7 +1087,7 @@ def _deduct_project_creation_cost(
         ):
             raise ResourceLimitError(
                 "Trace creation not allowed due to plan limits or insufficient credits."
-        )
+            )
 
     return call_log_row
 

--- a/futureagi/tracer/utils/otel.py
+++ b/futureagi/tracer/utils/otel.py
@@ -1072,19 +1072,20 @@ def _deduct_project_creation_cost(
         else APICallTypeChoices.OBSERVE_ADD.value
     )
 
-    call_log_row = log_and_deduct_cost_for_resource_request(
-        organization,
-        call_type,
-        config={"existing": existing, "project_id": project_id},
-        workspace=workspace,
-    )
+    if log_and_deduct_cost_for_resource_request is not None:
+        call_log_row = log_and_deduct_cost_for_resource_request(
+            organization,
+            call_type,
+            config={"existing": existing, "project_id": project_id},
+            workspace=workspace,
+        )
 
-    if (
-        call_log_row is None
-        or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
-    ):
-        raise ResourceLimitError(
-            "Trace creation not allowed due to plan limits or insufficient credits."
+        if (
+            call_log_row is None
+            or call_log_row.status == APICallStatusChoices.RESOURCE_LIMIT.value
+        ):
+            raise ResourceLimitError(
+                "Trace creation not allowed due to plan limits or insufficient credits."
         )
 
     return call_log_row

--- a/futureagi/tracer/utils/trace_ingestion.py
+++ b/futureagi/tracer/utils/trace_ingestion.py
@@ -691,7 +691,7 @@ def bulk_create_observation_span_task(
             except ImportError:
                 DeploymentMode = None
 
-            if not DeploymentMode.is_oss():
+            if DeploymentMode is not None and not DeploymentMode.is_oss():
                 try:
                     from ee.usage.schemas.event_types import BillingEventType
                 except ImportError:
@@ -701,16 +701,17 @@ def bulk_create_observation_span_task(
                 except ImportError:
                     check_usage = None
 
-                usage_check = check_usage(
-                    str(organization_id), BillingEventType.TRACING_EVENT
-                )
-                if not usage_check.allowed:
-                    logger.warning(
-                        "trace_ingestion_blocked_free_tier",
-                        org_id=str(organization_id),
-                        reason=usage_check.reason,
+                if check_usage is not None and BillingEventType is not None:
+                    usage_check = check_usage(
+                        str(organization_id), BillingEventType.TRACING_EVENT
                     )
-                    return
+                    if not usage_check.allowed:
+                        logger.warning(
+                            "trace_ingestion_blocked_free_tier",
+                            org_id=str(organization_id),
+                            reason=usage_check.reason,
+                        )
+                        return
         except Exception:
             pass  # Fail open — don't break ingestion on metering errors
 

--- a/futureagi/tracer/utils/trace_scanner.py
+++ b/futureagi/tracer/utils/trace_scanner.py
@@ -136,22 +136,25 @@ def _emit_scanner_billing(
         if not project or not project.organization:
             return
 
-        credits = BillingConfig.get().calculate_ai_credits(cost_usd)
-        emit(
-            UsageEvent(
-                org_id=str(project.organization.id),
-                event_type=BillingEventType.TRACE_ERROR_ANALYSIS,
-                amount=credits,
-                properties={
-                    "source": "trace_scanner",
-                    "source_id": str(project_id),
-                    "traces_scanned": len(results),
-                    "issues_found": sum(len(r.issues) for r in results),
-                    "raw_cost_usd": str(cost_usd),
-                    "model": scanner.model_config.model_name,
-                },
-            )
-        )
+        if BillingConfig is not None:
+            credits = BillingConfig.get().calculate_ai_credits(cost_usd)
+
+            if emit is not None and UsageEvent is not None and BillingEventType is not None:
+                emit(
+                    UsageEvent(
+                        org_id=str(project.organization.id),
+                        event_type=BillingEventType.TRACE_ERROR_ANALYSIS,
+                        amount=credits,
+                        properties={
+                            "source": "trace_scanner",
+                            "source_id": str(project_id),
+                            "traces_scanned": len(results),
+                            "issues_found": sum(len(r.issues) for r in results),
+                            "raw_cost_usd": str(cost_usd),
+                            "model": scanner.model_config.model_name,
+                        },
+                    )
+                )
     except Exception:
         logger.exception("scanner_billing_emit_failed", project_id=project_id)
 

--- a/futureagi/tracer/views/otlp.py
+++ b/futureagi/tracer/views/otlp.py
@@ -111,11 +111,12 @@ class OTLPTraceView(APIView):
                 except ImportError:
                     RateLimiter = None
 
-                rl_result = RateLimiter.check(organization_id, "ingestion")
-                if not rl_result.allowed:
-                    response = self._error_response(request, rl_result.reason, 429)
-                    response["Retry-After"] = str(rl_result.retry_after)
-                    return response
+                if RateLimiter is not None:
+                    rl_result = RateLimiter.check(organization_id, "ingestion")
+                    if not rl_result.allowed:
+                        response = self._error_response(request, rl_result.reason, 429)
+                        response["Retry-After"] = str(rl_result.retry_after)
+                        return response
             except ImportError:
                 pass
 


### PR DESCRIPTION
## Summary

Extends #631's OSS null-guard work to `accounts/` and `tfc/temporal/`, and fixes scope leaks where variables assigned inside guards were later used outside them.

Prevents 16 hard crashes (`NameError`, `TypeError`, `AttributeError`) in OSS mode across synthetic data generation, billing crons, error localization, SDK evals, playground evals, and AgentCC.

### Key changes

- Added:
  - 13 `check_usage()` guards
  - 10 `BillingConfig.get()` / `emit()` guards
  in:
  ```text
  tfc/temporal/simulate/activities.py
  ```

- Added billing, retention, and budget cron guards in:
  ```text
  tfc/temporal/billing/
  tfc/temporal/schedules/
  ```

- Added AWS Marketplace model guards in:
  ```text
  accounts/aws_marketplace_utils.py
  ```

- Fixed missing import:
  ```python
  BillingEventType
  ```
  in:
  ```text
  sdk/utils/evaluations.py
  ```

- Fixed scope leaks where guarded variables were referenced outside their guard blocks across 8 files:
  - `usage_check`
  - `api_call_log_row`
  - `credits`
  - `log`
  - `eval_logger`

## Linked issues

Extends #631

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- All modified files pass:
  ```python
  ast.parse
  ```
  — no syntax errors

- Grep-audited all guarded variables for downstream scope leaks

- Traced each fix to the product flow it protects

## Screenshots / recordings (if UI)

<img width="1494" height="1794" alt="image" src="https://github.com/user-attachments/assets/76476496-8583-46d5-844d-9bbd4977355b" />

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)