### PR TITLE
fix:hardcoded eval_type & length checking condition

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1139,11 +1139,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             setEvalName(raw);
             setIsDirty(true);
           }}
-          error={!isEditMode && evalName.length > 51}
+          error={!isEditMode && evalName.length >= 51}
           helperText={
             isEditMode
               ? undefined
-              : evalName.length > 51
+              : evalName.length >= 51
                 ? "Name can't be longer than 50 characters"
                 : `Lowercase letters, numbers, hyphens and underscores only · ${evalName.length}/50`
           }

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -261,7 +261,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       try {
         const data = await createEval.mutateAsync({
           is_draft: true,
-          eval_type: "agent",
+          // eval_type: "agent",
           output_type: "pass_fail",
           model: "turing_large",
           pass_threshold: 0.5,
@@ -276,6 +276,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   // Auto-save to draft
   const buildPayload = useCallback(
     () => ({
+      eval_type: evalType,
       instructions: evalType === "code" ? "" : instructions,
       code: evalType === "code" ? code : undefined,
       code_language: evalType === "code" ? codeLanguage : undefined,


### PR DESCRIPTION


## Summary
- Fixed `eval_type` being hardcoded to `"agent"` on draft create in [EvalPickerCreateNew.jsx](frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx), so LLM-as-a-Judge and Code evals were silently persisted as `agent` (TH-5215). Now `buildPayload()` carries the user-selected `evalType` on every auto-save.
- Tightened the name-length guard in [EvalPickerConfigFull.jsx](frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx) from `> 51` to `>= 51` so the "max 50 characters" error fires at the documented limit.

## Test plan
- [x] Open Create New Evaluation drawer, select **LLM-As-A-Judge**, save — confirm created template's `eval_type` is `llm`.
- [x] Repeat with **Code** tab — confirm `eval_type` is `code`.
- [x] Repeat with **Agent** tab — confirm `eval_type` is `agent` (regression check).
- [x] Switch tabs (Agent → LLM → Code) before saving and confirm the auto-save PATCH carries the latest `eval_type` each time.
- [x] In the config page name field, type a 50-char name — no error, helper shows `50/50`.
- [x] Type a 51-char name — error state shows with "Name can't be longer than 50 characters".
- [x] Edit-mode on an existing eval — length error stays suppressed.

Closes TH-5215