### PR TITLE
[TH-4996] Column order survives auto-refresh + display panel sync

### DIFF
--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -360,8 +360,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
   const onColumnMoved = useCallback(
     (params) => {
       if (!params.finished || !params.api || typeof onColumnsChange !== "function") return;
-      const newOrder = params.api
-        .getColumnState()
+      const newOrder = (params.api?.getColumnState() ?? [])
         .map((s) => s.colId)
         .filter((id) => id !== APP_CONSTANTS.AG_GRID_SELECTION_COLUMN);
 

--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -359,7 +359,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
   // Propagate reorder to parent so the View columns dropdown stays in sync.
   const onColumnMoved = useCallback(
     (params) => {
-      if (!params.finished || typeof onColumnsChange !== "function") return;
+      if (!params.finished || !params.api || typeof onColumnsChange !== "function") return;
       const newOrder = params.api
         .getColumnState()
         .map((s) => s.colId)

--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -286,28 +286,17 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
       if (c.groupBy === "Custom Columns") customCols.push(c);
     });
 
-    // Sort to follow columnVisibility — otherwise reorders snap back.
     const updated = callLogsColumnDefs
-      .map((col) => {
-        if (col.field && col.field in visMap) {
-          return { ...col, hide: !visMap[col.field] };
-        }
-        return col;
-      })
-      .map((d, i) => ({ d, i }))
+      .map((col) => ({
+        ...col,
+        ...(col.field &&
+          col.field in visMap && { hide: !visMap[col.field] }),
+      }))
       .sort((a, b) => {
-        const ai =
-          a.d.field && orderIndex.has(a.d.field)
-            ? orderIndex.get(a.d.field)
-            : Infinity;
-        const bi =
-          b.d.field && orderIndex.has(b.d.field)
-            ? orderIndex.get(b.d.field)
-            : Infinity;
-        if (ai === bi) return a.i - b.i;
+        const ai = orderIndex.get(a?.field) ?? Infinity;
+        const bi = orderIndex.get(b?.field) ?? Infinity;
         return ai - bi;
-      })
-      .map(({ d }) => d);
+      });
 
     // Add column defs for custom columns not already in the grid
     const existingFields = new Set(callLogsColumnDefs.map((c) => c.field));
@@ -387,7 +376,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
         next.length === cols.length &&
         next.every(
           (c, i) =>
-            (c.field || c.id) === (cols[i].field || cols[i].id),
+            (c?.field || c?.id) === (cols[i]?.field || cols[i]?.id),
         );
       if (!sameOrder) onColumnsChange(next);
     },

--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -359,8 +359,8 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
   // Propagate reorder to parent so the View columns dropdown stays in sync.
   const onColumnMoved = useCallback(
     (params) => {
-      if (!params.finished || !params.api || typeof onColumnsChange !== "function") return;
-      const newOrder = (params.api?.getColumnState() ?? [])
+      if (!params?.finished || !params?.api || typeof onColumnsChange !== "function") return;
+      const newOrder = (params?.api?.getColumnState() ?? [])
         .map((s) => s.colId)
         .filter((id) => id !== APP_CONSTANTS.AG_GRID_SELECTION_COLUMN);
 

--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -37,6 +37,7 @@ import PropTypes from "prop-types";
 import { ShowComponent } from "src/components/show";
 import { useShallowToggleAnnotationsStore } from "../store";
 import NoRowsOverlay from "src/sections/project-detail/CompareDrawer/NoRowsOverlay";
+import { APP_CONSTANTS } from "src/utils/constants";
 
 const CELL_HEIGHT_MAP = { Short: 40, Medium: 52, Large: 68, "Extra Large": 88 };
 
@@ -85,6 +86,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
     onSelectionMeta,
     cellHeight = "Short",
     columnVisibility,
+    onColumnsChange,
     hideDrawer = false,
     showErrors = false,
   },
@@ -274,19 +276,38 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
     if (!callLogsColumnDefs) return callLogsColumnDefs;
 
     const visMap = {};
+    const orderIndex = new Map();
     const customCols = [];
-    (columnVisibility || []).forEach((c) => {
-      if (c.field) visMap[c.field] = c.isVisible !== false;
+    (columnVisibility || []).forEach((c, i) => {
+      if (c.field) {
+        visMap[c.field] = c.isVisible !== false;
+        orderIndex.set(c.field, i);
+      }
       if (c.groupBy === "Custom Columns") customCols.push(c);
     });
 
-    // Toggle visibility on existing defs
-    const updated = callLogsColumnDefs.map((col) => {
-      if (col.field && col.field in visMap) {
-        return { ...col, hide: !visMap[col.field] };
-      }
-      return col;
-    });
+    // Sort to follow columnVisibility — otherwise reorders snap back.
+    const updated = callLogsColumnDefs
+      .map((col) => {
+        if (col.field && col.field in visMap) {
+          return { ...col, hide: !visMap[col.field] };
+        }
+        return col;
+      })
+      .map((d, i) => ({ d, i }))
+      .sort((a, b) => {
+        const ai =
+          a.d.field && orderIndex.has(a.d.field)
+            ? orderIndex.get(a.d.field)
+            : Infinity;
+        const bi =
+          b.d.field && orderIndex.has(b.d.field)
+            ? orderIndex.get(b.d.field)
+            : Infinity;
+        if (ai === bi) return a.i - b.i;
+        return ai - bi;
+      })
+      .map(({ d }) => d);
 
     // Add column defs for custom columns not already in the grid
     const existingFields = new Set(callLogsColumnDefs.map((c) => c.field));
@@ -346,6 +367,33 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
     };
   }, []);
 
+  // Propagate reorder to parent so the View columns dropdown stays in sync.
+  const onColumnMoved = useCallback(
+    (params) => {
+      if (!params.finished || typeof onColumnsChange !== "function") return;
+      const newOrder = params.api
+        .getColumnState()
+        .map((s) => s.colId)
+        .filter((id) => id !== APP_CONSTANTS.AG_GRID_SELECTION_COLUMN);
+
+      const cols = columnVisibility || [];
+      const byColId = new Map(cols.map((c) => [c.field || c.id, c]));
+      const reordered = newOrder.map((id) => byColId.get(id)).filter(Boolean);
+      const matched = new Set(newOrder);
+      const unmatched = cols.filter((c) => !matched.has(c.field || c.id));
+      const next = [...reordered, ...unmatched];
+
+      const sameOrder =
+        next.length === cols.length &&
+        next.every(
+          (c, i) =>
+            (c.field || c.id) === (cols[i].field || cols[i].id),
+        );
+      if (!sameOrder) onColumnsChange(next);
+    },
+    [columnVisibility, onColumnsChange],
+  );
+
   return (
     <Box sx={{ height: "78vh", display: "flex" }}>
       <Box
@@ -383,6 +431,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
             })}
             rowHeight={CELL_HEIGHT_MAP[cellHeight] || 40}
             columnDefs={effectiveDefs}
+            onColumnMoved={onColumnMoved}
             defaultColDef={defaultColDef}
             rowData={rows}
             suppressServerSideFullWidthLoadingRow={true}
@@ -557,6 +606,7 @@ CallLogsGrid.propTypes = {
   onSelectionMeta: PropTypes.func,
   cellHeight: PropTypes.string,
   columnVisibility: PropTypes.array,
+  onColumnsChange: PropTypes.func,
   hideDrawer: PropTypes.bool,
   showErrors: PropTypes.bool,
 };

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -4548,6 +4548,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                 enabled={projectSource === PROJECT_SOURCE.SIMULATOR}
                 cellHeight={cellHeight}
                 columnVisibility={columns["primary-trace"]}
+                onColumnsChange={(next) =>
+                  setColumns((prev) => ({ ...prev, "primary-trace": next }))
+                }
                 showErrors={showErrors}
                 params={{
                   project_id: observeId,
@@ -4587,6 +4590,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
                 enabled={projectSource === PROJECT_SOURCE.SIMULATOR}
                 cellHeight={cellHeight}
                 columnVisibility={columns["compare-trace"]}
+                onColumnsChange={(next) =>
+                  setColumns((prev) => ({ ...prev, "compare-trace": next }))
+                }
                 showErrors={showErrors}
                 hideDrawer
                 params={{

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -37,7 +37,6 @@ import IPOPTooltipComponent from "./Renderers/IPOPTooltipComponent";
 import { RENDERER_CONFIG } from "./Renderers/common";
 import { NameCell } from "./Renderers";
 import IPOPCell from "./Renderers/IPOPCell";
-import _ from "lodash";
 import { isCellValueEmpty } from "src/components/table/utils";
 import { APP_CONSTANTS } from "src/utils/constants";
 import { useShallowToggleAnnotationsStore } from "../../agents/store";
@@ -239,7 +238,6 @@ const SpanGrid = React.forwardRef(
       () => ({
         filter: false,
         resizable: true,
-        suppressMovable: true,
         suppressHeaderMenuButton: true,
         suppressHeaderFilterButton: true,
         suppressHeaderContextMenu: true,
@@ -388,32 +386,33 @@ const SpanGrid = React.forwardRef(
                 const dedupedPending = pending.filter(
                   (c) => !existingIds.has(c.id),
                 );
-                // Strip isVisible from the diff so saved-view hide maps
-                // don't keep retriggering the merge on every fetch.
-                const stripVis = (cols) =>
-                  (cols || []).map(({ isVisible, ...rest }) => rest);
-                const backendChanged = !_.isEqual(
-                  stripVis(newCols),
-                  stripVis(currentNonCustom),
-                );
+                // Diff by ID set — order isn't a schema change (TH-4996).
+                const newIds = new Set(newCols.map((c) => c.id));
+                const currentIdSet = new Set(currentNonCustom.map((c) => c.id));
+                const idSetChanged =
+                  newIds.size !== currentIdSet.size ||
+                  [...newIds].some((id) => !currentIdSet.has(id));
                 const hasPending = dedupedPending.length > 0;
-                if (backendChanged || hasPending) {
+                if (idSetChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
-                  // Preserve existing isVisible so saved-view hide intent
-                  // survives backend col changes.
-                  const finalNonCustom = backendChanged
-                    ? newCols.map((nc) => {
-                        const existing = currentNonCustom.find(
-                          (c) => c.id === nc.id,
-                        );
-                        return existing
-                          ? { ...nc, isVisible: existing.isVisible }
-                          : nc;
-                      })
-                    : currentNonCustom;
+                  let finalNonCustom;
+                  if (idSetChanged) {
+                    const newById = new Map(newCols.map((nc) => [nc.id, nc]));
+                    const seen = new Set();
+                    const kept = currentNonCustom
+                      .filter((cc) => newById.has(cc.id))
+                      .map((cc) => {
+                        seen.add(cc.id);
+                        return { ...newById.get(cc.id), isVisible: cc.isVisible };
+                      });
+                    const added = newCols.filter((nc) => !seen.has(nc.id));
+                    finalNonCustom = [...kept, ...added];
+                  } else {
+                    finalNonCustom = currentNonCustom;
+                  }
                   setColumns(
                     allCustom.length > 0
                       ? [...finalNonCustom, ...allCustom]
@@ -467,6 +466,27 @@ const SpanGrid = React.forwardRef(
         hasEvalFilter,
         enabled,
       ],
+    );
+
+    // Propagate drag-reorder to parent so the View columns dropdown stays in sync.
+    const onColumnMoved = useCallback(
+      (params) => {
+        if (!params.finished) return;
+        const newOrder = params.api
+          .getColumnState()
+          .map((s) => s.colId)
+          .filter((id) => id !== APP_CONSTANTS.AG_GRID_SELECTION_COLUMN);
+        const byId = new Map((columns || []).map((c) => [c.id, c]));
+        const reordered = newOrder.map((id) => byId.get(id)).filter(Boolean);
+        const matched = new Set(newOrder);
+        const unmatched = (columns || []).filter((c) => !matched.has(c.id));
+        const next = [...reordered, ...unmatched];
+        const changed =
+          next.length !== (columns || []).length ||
+          next.some((c, i) => c.id !== columns[i]?.id);
+        if (changed) setColumns(next);
+      },
+      [columns, setColumns],
     );
 
     const onSelectionChanged = useCallback((params) => {
@@ -560,6 +580,7 @@ const SpanGrid = React.forwardRef(
           })}
           ref={gridRef}
           columnDefs={columnDefs}
+          onColumnMoved={onColumnMoved}
           defaultColDef={defaultColDef}
           rowSelection={{ mode: "multiRow" }}
           pagination={false}

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -30,7 +30,6 @@ import { objectCamelToSnake } from "src/utils/utils";
 import { canonicalizeApiFilterColumnIds } from "src/utils/filter-column-ids";
 import LLMTracingTraceDetailDrawer from "./LLMTracingTraceDetailDrawer";
 import { useLLMTracingStoreShallow, useTraceGridStore } from "./states";
-import _ from "lodash";
 import { APP_CONSTANTS } from "src/utils/constants";
 import { useReplaySessionsStoreShallow } from "../SessionsView/ReplaySessions/store";
 import { REPLAY_MODULES } from "../SessionsView/ReplaySessions/configurations";
@@ -232,35 +231,33 @@ const TraceGrid = React.forwardRef(
                 const dedupedPending = pending.filter(
                   (c) => !existingIds.has(c.id),
                 );
-                // Strip isVisible from the diff so saved-view hide maps
-                // don't keep retriggering the merge on every fetch. The
-                // hasPending clause ensures a saved-view switch with same
-                // backend cols still drains the pending customs.
-                const stripVis = (cols) =>
-                  (cols || []).map(({ isVisible, ...rest }) => rest);
-                const backendChanged = !_.isEqual(
-                  stripVis(newCols),
-                  stripVis(currentNonCustom),
-                );
+                // Diff by ID set — order isn't a schema change (TH-4996).
+                const newIds = new Set(newCols.map((c) => c.id));
+                const currentIdSet = new Set(currentNonCustom.map((c) => c.id));
+                const idSetChanged =
+                  newIds.size !== currentIdSet.size ||
+                  [...newIds].some((id) => !currentIdSet.has(id));
                 const hasPending = dedupedPending.length > 0;
-                if (backendChanged || hasPending) {
+                if (idSetChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
-                  // Preserve existing isVisible so saved-view hide intent
-                  // survives backend col changes. Pending-only path reuses
-                  // currentNonCustom to keep column identity stable.
-                  const finalNonCustom = backendChanged
-                    ? newCols.map((nc) => {
-                        const existing = currentNonCustom.find(
-                          (c) => c.id === nc.id,
-                        );
-                        return existing
-                          ? { ...nc, isVisible: existing.isVisible }
-                          : nc;
-                      })
-                    : currentNonCustom;
+                  let finalNonCustom;
+                  if (idSetChanged) {
+                    const newById = new Map(newCols.map((nc) => [nc.id, nc]));
+                    const seen = new Set();
+                    const kept = currentNonCustom
+                      .filter((cc) => newById.has(cc.id))
+                      .map((cc) => {
+                        seen.add(cc.id);
+                        return { ...newById.get(cc.id), isVisible: cc.isVisible };
+                      });
+                    const added = newCols.filter((nc) => !seen.has(nc.id));
+                    finalNonCustom = [...kept, ...added];
+                  } else {
+                    finalNonCustom = currentNonCustom;
+                  }
                   setColumns(
                     allCustom.length > 0
                       ? [...finalNonCustom, ...allCustom]

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -8,7 +8,6 @@ import React, {
   useEffect,
   useCallback,
 } from "react";
-import _ from "lodash";
 import PropTypes from "prop-types";
 import { getRandomId } from "src/utils/utils";
 import TotalRowsStatusBar from "src/sections/develop-detail/Common/TotalRowsStatusBar";
@@ -250,18 +249,35 @@ const SessionGrid = React.forwardRef(
                 const dedupedPending = pending.filter(
                   (c) => !existingIds.has(c.id),
                 );
-                const backendChanged = !_.isEqual(newCols, currentNonCustom);
+                // Diff by ID set — order isn't a schema change (TH-4996).
+                const newIds = new Set(newCols.map((c) => c.id));
+                const currentIdSet = new Set(currentNonCustom.map((c) => c.id));
+                const idSetChanged =
+                  newIds.size !== currentIdSet.size ||
+                  [...newIds].some((id) => !currentIdSet.has(id));
                 // hasPending ensures same-tab saved-view clicks still drain
                 // queued customs even when backend cols match.
                 const hasPending = dedupedPending.length > 0;
-                if (backendChanged || hasPending) {
+                if (idSetChanged || hasPending) {
                   const allCustom = [...existingCustom, ...dedupedPending];
                   if (pending.length > 0 && pendingCustomColumnsRef) {
                     pendingCustomColumnsRef.current = [];
                   }
-                  const finalNonCustom = backendChanged
-                    ? newCols
-                    : currentNonCustom;
+                  let finalNonCustom;
+                  if (idSetChanged) {
+                    const newById = new Map(newCols.map((nc) => [nc.id, nc]));
+                    const seen = new Set();
+                    const kept = currentNonCustom
+                      .filter((cc) => newById.has(cc.id))
+                      .map((cc) => {
+                        seen.add(cc.id);
+                        return newById.get(cc.id);
+                      });
+                    const added = newCols.filter((nc) => !seen.has(nc.id));
+                    finalNonCustom = [...kept, ...added];
+                  } else {
+                    finalNonCustom = currentNonCustom;
+                  }
                   setColumns(
                     allCustom.length > 0
                       ? [...finalNonCustom, ...allCustom]

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -249,7 +249,6 @@ const SessionGrid = React.forwardRef(
                 const dedupedPending = pending.filter(
                   (c) => !existingIds.has(c.id),
                 );
-                // Diff by ID set — order isn't a schema change (TH-4996).
                 const newIds = new Set(newCols.map((c) => c.id));
                 const currentIdSet = new Set(currentNonCustom.map((c) => c.id));
                 const idSetChanged =


### PR DESCRIPTION
## Summary
- Dragging a column to a new position in the Observe **Trace**, **Spans**, or **Sessions** tabs used to silently snap back to backend order on the next 10s auto-refresh tick. The per-fetch reconcile in each grid's `getRows` used `_.isEqual(newCols, currentNonCustom)` which is order-sensitive — every user reorder tripped `backendChanged=true`, then the merge rebuilt the column array iterating `newCols.map(...)` in backend order.
- Voice/simulator (**CallLogsGrid**) had a second, distinct bug: it had no `onColumnMoved` handler at all, so reorders never reached parent state and the "View columns" display panel stayed in original order. **SpanGrid had the same gap** — `onColumnMoved` missing — caught on the second review pass.

Fixes TH-4996

## Linear Ticket
[TH-4996](https://linear.app/future-agi/issue/TH-4996/any-changes-in-columns-re-changes-on-auto-refresh)

## Files Changed

### Auto-refresh reset (3 grids)
- `frontend/src/sections/projects/LLMTracing/TraceGrid.jsx` — ID-set diff replaces order-sensitive `_.isEqual`; reconcile preserves user order, carries `isVisible` forward, appends new IDs at end, drops removed IDs. Lodash import removed.
- `frontend/src/sections/projects/LLMTracing/SpanGrid.jsx` — same fix. Lodash import removed.
- `frontend/src/sections/projects/SessionsView/Session-grid.jsx` — same fix. Lodash import removed.

### Display-panel sync (2 files)
- `frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx` — new optional `onColumnsChange` prop; `onColumnMoved` callback (uses `c.field || c.id` since voice cols carry both shapes); `effectiveDefs` `useMemo` now sorts by `columnVisibility` order so AG Grid doesn't snap drags back. New import: `APP_CONSTANTS`.
- `frontend/src/sections/projects/LLMTracing/SpanGrid.jsx` — new `onColumnMoved` callback (mirrors TraceGrid's pattern) wired to the AgGridReact.
- `frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx` — both `<CallLogsGrid>` instantiations (primary + compare) pass `onColumnsChange={(next) => setColumns((prev) => ({ ...prev, "<key>": next }))}`.

### Intentionally untouched
- `UsersGrid.jsx` — initialises columns once via `useEffect(() => setColumns(transformed), [])`; `getRows` never touches columns. No bug present.

## Test plan
- [ ] Observe → Trace tab → Auto refresh ON → drag a column → wait 10s → position holds.
- [ ] Observe → Trace tab → switch to **Spans** view → drag column → position holds AND View columns dropdown shows the new order.
- [ ] Observe → **Sessions** tab → drag column → position holds across auto-refresh.
- [ ] Voice/simulator project → **CallLogs** view → drag column → table updates AND View columns dropdown reflects the new order.
- [ ] Add or remove a column on the backend (e.g. create a new annotation type that surfaces as a column) → new column appears at the **end** of the user's order, not at backend's preferred position.
- [ ] Users tab → no regression (was already correct).