### PR TITLE
[TH-5564] Enforce required-key mapping for agent evals with data injection

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1672,6 +1672,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     onClearResult={handleClearTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
                     onReadyChange={handleSourceReadyChange}
+                    hasDataInjection={hasDataInjection}
                     errorLocalizerEnabled={errorLocalizerEnabled}
                     initialMapping={evalData?.mapping}
                     {...compositeSourceModeProps}
@@ -1715,6 +1716,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                     onClearResult={handleClearTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
                     onReadyChange={handleSourceReadyChange}
+                    hasDataInjection={hasDataInjection}
                     initialProjectId={sourceId}
                     initialRowType={sourceRowType}
                     initialMapping={evalData?.mapping}
@@ -1865,7 +1867,6 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
             settings only. */}
         {source !== "composite" &&
           !sourceReady &&
-          !hasDataInjection &&
           !testError &&
           !testPassed && (
             <Typography
@@ -1938,7 +1939,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   : "Your Mustache template has no variables. Add a {{variable}} placeholder (e.g. {{input}}) so test input can be passed in.";
             }
 
-            if (!testDisabled && !sourceReady && !hasDataInjection) {
+            if (!testDisabled && !sourceReady) {
               testDisabled = true;
               testDisabledReason = "Map all variables before running a test.";
             }
@@ -2028,14 +2029,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                 : `Your Mustache template has no variables. Add a {{variable}} placeholder (e.g. {{input}}) before ${actionLabel}.`;
           }
 
-          // Non-composite flows additionally require the full source config
-          // (name / output type / etc.) to be valid.
-          if (
-            !addDisabled &&
-            source !== "composite" &&
-            !sourceReady &&
-            !hasDataInjection
-          ) {
+          if (!addDisabled && source !== "composite" && !sourceReady) {
             addDisabled = true;
             addDisabledReason = `Map all variables before ${actionLabel}.`;
           }

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -390,7 +390,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         "Instructions must contain at least one template variable (e.g. {{input}})";
     }
 
-    if (!sourceReady && source !== "composite" && !hasDataInjection) {
+    if (!sourceReady && source !== "composite") {
       next.mapping = "Map all variables before saving";
     }
 
@@ -627,7 +627,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
     ? !!name.trim() && selectedChildren.length > 0
     : name.trim() &&
       (evalType === "code" ? code.trim() : instructions.trim()) &&
-      (source === "composite" || sourceReady || hasDataInjection);
+      (source === "composite" || sourceReady);
 
   // Variables from instructions
   const variables = useMemo(() => {
@@ -1158,6 +1158,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     onTestResult={handleTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
                     onReadyChange={handleSourceReadyChange}
+                    hasDataInjection={hasDataInjection}
                     initialProjectId={sourceId}
                     initialRowType={sourceRowType}
                     isComposite={isComposite}
@@ -1173,6 +1174,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                     onTestResult={handleTestResult}
                     onColumnsLoaded={handleColumnsLoaded}
                     onReadyChange={handleSourceReadyChange}
+                    hasDataInjection={hasDataInjection}
                     onRowTypeChange={handleSourceRowTypeChange}
                     isComposite={isComposite}
                     compositeAdhocConfig={compositeAdhocConfig}
@@ -1268,7 +1270,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
             </Typography>
           </Box>
         )}
-        {!sourceReady && !hasDataInjection && !testError && !testPassed && (
+        {!sourceReady && !testError && !testPassed && (
           <Typography
             variant="caption"
             color="text.disabled"
@@ -1286,7 +1288,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
             onClick={handleTestEvaluation}
             disabled={
               isTesting ||
-              (!sourceReady && !hasDataInjection) ||
+              !sourceReady ||
               !draftId ||
               isComposite ||
               source === "workbench"

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -231,6 +231,8 @@ const TracingTestMode = React.forwardRef(
       // Signals to EvalPickerConfigFull that all variables are mapped so
       // it can enable the Test Evaluation / Add Evaluation buttons.
       onReadyChange,
+      // When true, runtime context comes from data injection — no sample row needed.
+      hasDataInjection = false,
       // Optional: pre-select project + row type and hide the project picker
       // and the row type toggle. Used by the task flow's Add Evaluation
       // drawer so the user sees the exact same data their task will run on.
@@ -916,20 +918,16 @@ const TracingTestMode = React.forwardRef(
       });
     }, [variables, fieldNames]);
 
-    // Signal ready state to parent: ready when every template variable
-    // has a non-empty mapped field AND we have a current row to test
-    // against. This enables the Test Evaluation / Add Evaluation buttons
-    // in EvalPickerConfigFull.
+    // Mapping is always required; a sample row only when not using data injection.
     useEffect(() => {
       if (!onReadyChange) return;
-      // Evals with zero variables (e.g. some code evals) are always ready
-      // as long as we have a loaded row to run against.
       const allMapped =
         variables.length === 0 ||
         variables.every((v) => mapping[v] && String(mapping[v]).length > 0);
       const hasRow = !!currentRow;
-      onReadyChange(allMapped && hasRow, mapping);
-    }, [variables, mapping, currentRow, onReadyChange]);
+      const ready = hasDataInjection ? allMapped : allMapped && hasRow;
+      onReadyChange(ready, mapping);
+    }, [variables, mapping, currentRow, hasDataInjection, onReadyChange]);
 
     // ── Run test ──
     const handleRunTest = useCallback(async () => {
@@ -1920,6 +1918,7 @@ TracingTestMode.propTypes = {
   onColumnsLoaded: PropTypes.func,
   onClearResult: PropTypes.func,
   onReadyChange: PropTypes.func,
+  hasDataInjection: PropTypes.bool,
   initialProjectId: PropTypes.string,
   initialRowType: PropTypes.string,
   initialMapping: PropTypes.object,


### PR DESCRIPTION
## Summary
- The "Add Evaluation" button was enabled for agent evals attached to a Task even when required template variables (`required_keys` from the eval template) were left unmapped. The eval would save with an incomplete mapping and every backend run failed with `Missing required input(s) for eval: <key>`.
- Root cause: `sourceReady = allMapped && hasRow` conflated mapping-completeness and sample-row availability into a single boolean. The picker's `!sourceReady && !hasDataInjection` bypass was meant to skip the row half for agent evals using data injection (e.g. `span_context`), but it silently bypassed the mapping half as well — letting agent + Task/Tracing flows save with no mapping at all.
- Fix: pushed the `hasDataInjection` decision into `TracingTestMode` so readiness becomes `hasDataInjection ? allMapped : allMapped && hasRow`. Mapping is now always required; sample row is only required when not using data injection. The pickers simplify to plain `!sourceReady` gating. Applied symmetrically to `EvalPickerConfigFull` (Tasks/Evals attach flow) and `EvalPickerCreateNew` (Create New Eval flow).
- Covers both system evals (where `variables = required_keys`) and user-authored evals (where `variables` are live-parsed from `{{var}}` placeholders) — same gate, same backend contract.

Fixes TH-5564

## Linear Ticket
[TH-5564](https://linear.app/future-agi/issue/TH-5564/creating-eval-fails-when-required-field-mappings-are-dropped)

## Files Changed
- `frontend/src/sections/evals/components/TracingTestMode.jsx` — new `hasDataInjection` prop; readiness check uses it to gate the row requirement
- `frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx` — pass `hasDataInjection` to both `TracingTestMode` mounts; drop the `&& !hasDataInjection` bypass from the Add/Test gates + hint text
- `frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx` — symmetric port (Create-Eval entry point had the same bug at 4 gates + 2 mounts)

## Test plan
- [ ] Tasks → New Task → pick `conversation_hallucination` (or any `eval_type: "agent"` template) → leave variables unmapped → **Add button is disabled** with tooltip "Map all variables before adding this evaluation."
- [ ] Map only one of two required keys → still disabled
- [ ] Map all required keys → button enables, eval saves, backend runs succeed (no "Missing required input(s)" errors)
- [ ] Non-agent evals (LLM / code / function) on Dataset / Experiment / Workbench sources — unchanged behavior, mapping still required as before
- [ ] Create Eval flow (the picker's "Create New Eval" variant) — same checks as above for agent evals authored with `{{conversation}}` / `{{context}}` placeholders