### PR TITLE
fix(usage): polish UsageSummaryV2 formatting, legend, and period caption

### DIFF
--- a/frontend/src/sections/settings/UsageSummaryV2/UsageChart.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageChart.jsx
@@ -7,7 +7,7 @@ import { useMemo } from "react";
 import PropTypes from "prop-types";
 import { useQuery } from "@tanstack/react-query";
 import { useTheme } from "@mui/material/styles";
-import { Box, Typography, Skeleton } from "@mui/material";
+import { Box, Typography, Skeleton, Stack } from "@mui/material";
 import ApexChart from "react-apexcharts";
 
 import axios, { endpoints } from "src/utils/axios";
@@ -38,6 +38,21 @@ export default function UsageChart({
     select: (res) => res.data?.result?.series || [],
     enabled: !!dimension,
   });
+
+  const yAxisFormatter = useMemo(
+    () => (val) => {
+      if (val == null) return "";
+      if (val >= 1e6) return `${(val / 1e6).toFixed(1)}M`;
+      if (val >= 1e3) return `${(val / 1e3).toFixed(1)}K`;
+      if (val === 0) return "0";
+      const abs = Math.abs(val);
+      if (abs < 0.001) return val.toFixed(4);
+      if (abs < 0.01) return val.toFixed(3);
+      if (abs < 0.1) return val.toFixed(2);
+      return val.toFixed(1);
+    },
+    [],
+  );
 
   const chartOptions = useMemo(
     () => ({
@@ -71,17 +86,7 @@ export default function UsageChart({
       yaxis: {
         labels: {
           style: { colors: theme.palette.text.secondary, fontSize: "11px" },
-          formatter: (val) => {
-            if (val == null) return "";
-            if (val >= 1e6) return `${(val / 1e6).toFixed(1)}M`;
-            if (val >= 1e3) return `${(val / 1e3).toFixed(1)}K`;
-            if (val === 0) return "0";
-            const abs = Math.abs(val);
-            if (abs < 0.001) return val.toFixed(4);
-            if (abs < 0.01) return val.toFixed(3);
-            if (abs < 0.1) return val.toFixed(2);
-            return val.toFixed(1);
-          },
+          formatter: yAxisFormatter,
         },
       },
       grid: {
@@ -104,22 +109,12 @@ export default function UsageChart({
                   y: freeAllowance,
                   borderColor: theme.palette.warning.main,
                   strokeDashArray: 4,
-                  label: {
-                    text: `Free tier: ${freeAllowance.toLocaleString()} ${displayUnit}`,
-                    position: "front",
-                    style: {
-                      color: theme.palette.warning.contrastText,
-                      background: theme.palette.warning.main,
-                      fontSize: "11px",
-                      padding: { left: 6, right: 6, top: 2, bottom: 2 },
-                    },
-                  },
                 },
               ],
             }
           : {},
     }),
-    [theme, freeAllowance, displayUnit],
+    [theme, freeAllowance, displayUnit, yAxisFormatter],
   );
   const chartSeries = useMemo(
     () => [
@@ -158,14 +153,51 @@ export default function UsageChart({
     );
   }
 
+  /** @type {any} */
+  const apexOptions = chartOptions;
+
   return (
     <Box>
       <ApexChart
         type="area"
         series={chartSeries}
-        options={chartOptions}
+        options={apexOptions}
         height={250}
       />
+      <Stack
+        direction="row"
+        spacing={2.5}
+        alignItems="center"
+        sx={{ mt: 1, pl: 1 }}
+      >
+        <Stack direction="row" spacing={0.75} alignItems="center">
+          <Box
+            sx={{
+              width: 18,
+              height: 2,
+              borderRadius: 1,
+              bgcolor: theme.palette.primary.main,
+            }}
+          />
+          <Typography variant="caption" color="text.secondary">
+            Daily usage
+          </Typography>
+        </Stack>
+        {freeAllowance > 0 && (
+          <Stack direction="row" spacing={0.75} alignItems="center">
+            <Box
+              sx={{
+                width: 18,
+                height: 0,
+                borderTop: `2px dashed ${theme.palette.warning.main}`,
+              }}
+            />
+            <Typography variant="caption" color="text.secondary">
+              Free tier ({freeAllowance.toLocaleString()} {displayUnit})
+            </Typography>
+          </Stack>
+        )}
+      </Stack>
     </Box>
   );
 }

--- a/frontend/src/sections/settings/UsageSummaryV2/UsageChart.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageChart.jsx
@@ -39,20 +39,38 @@ export default function UsageChart({
     enabled: !!dimension,
   });
 
-  const yAxisFormatter = useMemo(
-    () => (val) => {
+  const maxUsage = useMemo(
+    () =>
+      Math.max(
+        0,
+        ...(seriesData || []).map(
+          (/** @type {{ usage: number }} */ d) => d.usage,
+        ),
+      ),
+    [seriesData],
+  );
+
+  const yAxisFormatter = useMemo(() => {
+    let divisor = 1;
+    let suffix = "";
+    if (maxUsage >= 1e6) {
+      divisor = 1e6;
+      suffix = "M";
+    } else if (maxUsage >= 1e3) {
+      divisor = 1e3;
+      suffix = "K";
+    }
+    return (val) => {
       if (val == null) return "";
-      if (val >= 1e6) return `${(val / 1e6).toFixed(1)}M`;
-      if (val >= 1e3) return `${(val / 1e3).toFixed(1)}K`;
       if (val === 0) return "0";
+      if (suffix) return `${(val / divisor).toFixed(1)}${suffix}`;
       const abs = Math.abs(val);
       if (abs < 0.001) return val.toFixed(4);
       if (abs < 0.01) return val.toFixed(3);
       if (abs < 0.1) return val.toFixed(2);
       return val.toFixed(1);
-    },
-    [],
-  );
+    };
+  }, [maxUsage]);
 
   const chartOptions = useMemo(
     () => ({

--- a/frontend/src/sections/settings/UsageSummaryV2/UsageChart.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageChart.jsx
@@ -72,9 +72,15 @@ export default function UsageChart({
         labels: {
           style: { colors: theme.palette.text.secondary, fontSize: "11px" },
           formatter: (val) => {
+            if (val == null) return "";
             if (val >= 1e6) return `${(val / 1e6).toFixed(1)}M`;
             if (val >= 1e3) return `${(val / 1e3).toFixed(1)}K`;
-            return val?.toFixed(1);
+            if (val === 0) return "0";
+            const abs = Math.abs(val);
+            if (abs < 0.001) return val.toFixed(4);
+            if (abs < 0.01) return val.toFixed(3);
+            if (abs < 0.1) return val.toFixed(2);
+            return val.toFixed(1);
           },
         },
       },
@@ -115,7 +121,6 @@ export default function UsageChart({
     }),
     [theme, freeAllowance, displayUnit],
   );
-
   const chartSeries = useMemo(
     () => [
       {

--- a/frontend/src/sections/settings/UsageSummaryV2/UsageChart.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageChart.jsx
@@ -177,6 +177,7 @@ export default function UsageChart({
   return (
     <Box>
       <ApexChart
+        key={`${dimension}-${displayUnit}`}
         type="area"
         series={chartSeries}
         options={apexOptions}

--- a/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
@@ -71,6 +71,8 @@ function formatUsage(value, unit) {
   if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M ${unit}`;
   if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K ${unit}`;
   if (Number.isInteger(value)) return `${value.toLocaleString()} ${unit}`;
+  if (value < 0.1) return `${value.toFixed(3)} ${unit}`;
+  if (value < 1) return `${value.toFixed(2)} ${unit}`;
   return `${value.toFixed(1)} ${unit}`;
 }
 
@@ -245,7 +247,7 @@ StatCard.propTypes = {
 
 // ── Dimension Product Card ────────────────────────────────────────────────
 
-function DimensionCard({ dim }) {
+function DimensionCard({ dim, periodCaption }) {
   const theme = useTheme();
   const [expanded, setExpanded] = useState(false);
   const config = DIMENSION_CONFIG[dim.key] || {};
@@ -311,7 +313,10 @@ function DimensionCard({ dim }) {
                 )}
                 {dim.free_allowance > 0 && !isOverFree && (
                   <Typography variant="caption" color="text.secondary">
-                    {usagePct.toFixed(0)}% of free tier used
+                    {usagePct > 0 && usagePct < 1
+                      ? `${usagePct.toFixed(2)}`
+                      : usagePct.toFixed(0)}
+                    % of free tier used
                   </Typography>
                 )}
               </Stack>
@@ -323,7 +328,7 @@ function DimensionCard({ dim }) {
               {fCurrency(dim.estimated_cost)}
             </Typography>
             <Typography variant="caption" color="text.secondary">
-              month to date
+              {periodCaption}
             </Typography>
           </Stack>
         </Stack>
@@ -461,6 +466,7 @@ const dimensionPropType = PropTypes.shape({
 
 DimensionCard.propTypes = {
   dim: dimensionPropType.isRequired,
+  periodCaption: PropTypes.string.isRequired,
 };
 
 // ── Legend ─────────────────────────────────────────────────────────────────
@@ -563,6 +569,11 @@ const TIME_RANGES = [
   { value: "6", label: "6M" },
   { value: "12", label: "12M" },
 ];
+
+function getPeriodCaption(rangeValue) {
+  if (rangeValue === "current") return "month to date";
+  return `last ${rangeValue} months`;
+}
 
 function getPeriodRange(rangeValue) {
   const now = new Date();
@@ -904,7 +915,11 @@ export default function UsageSummaryV2() {
 
       <Stack spacing={2}>
         {overview?.dimensions?.map((dim) => (
-          <DimensionCard key={dim.key} dim={dim} />
+          <DimensionCard
+            key={dim.key}
+            dim={dim}
+            periodCaption={getPeriodCaption(timeRange)}
+          />
         ))}
       </Stack>
 

--- a/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
@@ -28,7 +28,7 @@ import {
 } from "@mui/material";
 import Iconify from "src/components/iconify";
 import axios, { endpoints } from "src/utils/axios";
-import { fCurrency } from "src/utils/format-number";
+import { fCurrency, fUsage } from "src/utils/format-number";
 import UsageChart from "./UsageChart";
 import WorkspaceBreakdown from "./WorkspaceBreakdown";
 
@@ -64,16 +64,17 @@ const DIMENSION_CONFIG = {
   },
 };
 
-function formatUsage(value, unit) {
-  if (value == null) return `0 ${unit}`;
-  if (value === 0) return `0 ${unit}`;
-  if (value >= 1e9) return `${(value / 1e9).toFixed(1)}B ${unit}`;
-  if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M ${unit}`;
-  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K ${unit}`;
-  if (Number.isInteger(value)) return `${value.toLocaleString()} ${unit}`;
-  if (value < 0.1) return `${value.toFixed(3)} ${unit}`;
-  if (value < 1) return `${value.toFixed(2)} ${unit}`;
-  return `${value.toFixed(1)} ${unit}`;
+function getSingularUnit(unit) {
+  if (!unit) return "unit";
+  if (/^[A-Z]+$/.test(unit)) return unit;
+  return unit.endsWith("s") ? unit.slice(0, -1) : unit;
+}
+
+function formatTierRate(rateStr) {
+  if (rateStr == null) return "$0";
+  const num = parseFloat(String(rateStr).replace(/[^0-9.-]/g, ""));
+  if (!Number.isFinite(num) || num === 0) return "$0";
+  return fCurrency(num, true);
 }
 
 // ── Usage Gauge (multi-segment bar) ───────────────────────────────────────
@@ -353,10 +354,10 @@ function DimensionCard({ dim, periodCaption }) {
               component="span"
               sx={{ fontWeight: 600, color: "text.primary" }}
             >
-              {formatUsage(dim.current_usage, dim.display_unit)}
+              {fUsage(dim.current_usage, dim.display_unit)}
             </Box>
             {dim.free_allowance > 0 && (
-              <> of {formatUsage(dim.free_allowance, dim.display_unit)} free</>
+              <> of {fUsage(dim.free_allowance, dim.display_unit)} free</>
             )}
           </Typography>
           {dim.projected_usage > dim.current_usage && (
@@ -367,7 +368,7 @@ function DimensionCard({ dim, periodCaption }) {
                 sx={{ color: "text.disabled" }}
               />
               <Typography variant="caption" color="text.disabled">
-                ~{formatUsage(dim.projected_usage, dim.display_unit)} projected
+                ~{fUsage(dim.projected_usage, dim.display_unit)} projected
               </Typography>
             </Stack>
           )}
@@ -411,12 +412,49 @@ function DimensionCard({ dim, periodCaption }) {
                   borderColor: "divider",
                 }}
               >
+                <Box
+                  sx={{
+                    display: "grid",
+                    gridTemplateColumns: "1fr 120px 140px 100px",
+                    columnGap: 2,
+                    pb: 0.75,
+                    mb: 0.25,
+                    borderBottom: "1px solid",
+                    borderColor: "divider",
+                  }}
+                >
+                  <Typography variant="overline" color="text.secondary">
+                    {`Range${dim.display_unit ? ` (${dim.display_unit})` : ""}`}
+                  </Typography>
+                  <Typography
+                    variant="overline"
+                    color="text.secondary"
+                    textAlign="right"
+                  >
+                    Used
+                  </Typography>
+                  <Typography
+                    variant="overline"
+                    color="text.secondary"
+                    textAlign="right"
+                  >
+                    Rate
+                  </Typography>
+                  <Typography
+                    variant="overline"
+                    color="text.secondary"
+                    textAlign="right"
+                  >
+                    Cost
+                  </Typography>
+                </Box>
                 {dim.tier_breakdown.map((tier, i) => (
-                  <Stack
+                  <Box
                     key={i}
-                    direction="row"
-                    justifyContent="space-between"
                     sx={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr 120px 140px 100px",
+                      columnGap: 2,
                       py: 0.75,
                       borderBottom:
                         i < dim.tier_breakdown.length - 1
@@ -428,15 +466,28 @@ function DimensionCard({ dim, periodCaption }) {
                     <Typography variant="caption" color="text.secondary">
                       {tier.range}
                     </Typography>
-                    <Stack direction="row" spacing={2}>
-                      <Typography variant="caption" color="text.secondary">
-                        {tier.rate}/unit
-                      </Typography>
-                      <Typography variant="caption" fontWeight={600}>
-                        {fCurrency(tier.cost)}
-                      </Typography>
-                    </Stack>
-                  </Stack>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ textAlign: "right" }}
+                    >
+                      {fUsage(tier.usage, dim.display_unit)}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ textAlign: "right" }}
+                    >
+                      {formatTierRate(tier.rate)}/{getSingularUnit(dim.display_unit)}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      fontWeight={600}
+                      sx={{ textAlign: "right" }}
+                    >
+                      {fCurrency(tier.cost, true)}
+                    </Typography>
+                  </Box>
                 ))}
               </Box>
             </Collapse>
@@ -1029,7 +1080,7 @@ function DimensionDetail({ dimensions, period, periodEnd }) {
           </Typography>
           <Stack direction="row" spacing={1} alignItems="center">
             <Typography variant="caption" color="text.disabled">
-              {formatUsage(selected.current_usage, selected.display_unit)} total
+              {fUsage(selected.current_usage, selected.display_unit)} total
             </Typography>
           </Stack>
         </Stack>

--- a/frontend/src/sections/settings/UsageSummaryV2/WorkspaceBreakdown.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/WorkspaceBreakdown.jsx
@@ -21,13 +21,7 @@ import {
 import { useState } from "react";
 
 import axios, { endpoints } from "src/utils/axios";
-
-function formatUsageCompact(value, _unit) {
-  if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M`;
-  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
-  if (Number.isInteger(value)) return value.toLocaleString();
-  return value.toFixed(1);
-}
+import { fUsage } from "src/utils/format-number";
 
 WorkspaceBreakdown.propTypes = {
   dimension: PropTypes.string.isRequired,
@@ -138,7 +132,7 @@ export default function WorkspaceBreakdown({
               </TableCell>
               <TableCell align="right">
                 <Typography variant="body2">
-                  {formatUsageCompact(w.usage, displayUnit)}
+                  {fUsage(w.usage)}
                 </Typography>
               </TableCell>
               <TableCell align="right">
@@ -158,7 +152,7 @@ export default function WorkspaceBreakdown({
             </TableCell>
             <TableCell align="right">
               <Typography variant="subtitle2">
-                {formatUsageCompact(totalUsage, displayUnit)}
+                {fUsage(totalUsage)}
               </Typography>
             </TableCell>
             <TableCell align="right">

--- a/frontend/src/utils/format-number.js
+++ b/frontend/src/utils/format-number.js
@@ -6,65 +6,55 @@ export function fNumber(number) {
   return numeral(number).format();
 }
 export function fCurrency(number, showThreeDecimals = false) {
-  // Return empty string if input is null or undefined
-  if (number === null || number === undefined) return "";
-
-  // Convert string inputs to numbers
+  if (number == null) return "";
   if (typeof number === "string") number = parseFloat(number);
+  if (!Number.isFinite(number) || number === 0) return "$0";
 
-  // If number is exactly 0, return "$0"
-  if (number === 0) return "$0";
-
-  // If number is a whole integer, return formatted string with no decimals
-  if (Number.isInteger(number)) return numeral(number).format("$0,0");
-
-  // Treat near-zero values as zero (use smaller threshold when showing extra decimals)
-  if (Math.abs(number) < (showThreeDecimals ? 0.0000001 : 0.000001))
-    return "$0";
-
-  // If showThreeDecimals flag is false, use default 2 decimal formatting
-  if (!showThreeDecimals) {
-    const format = number ? numeral(number).format("$0,0.00") : "";
-    return result(format, ".00"); // Remove unnecessary trailing zeros if needed
-  }
-
-  // -----------------------------
-  // For showThreeDecimals = true
-  // -----------------------------
-
-  // Work with absolute value to calculate magnitude
   const absNumber = Math.abs(number);
+  if (absNumber < (showThreeDecimals ? 0.0000001 : 0.000001)) return "$0";
 
-  // Calculate order of magnitude (log10) of the number
-  // Example: 123 -> 2, 0.00456 -> -3
-  const orderOfMagnitude = Math.floor(Math.log10(absNumber));
-
-  let decimalPlaces;
-
-  // Determine number of decimal places based on magnitude
-  if (orderOfMagnitude >= 0) {
-    // Numbers >= 1 → show up to 3 decimal places
-    decimalPlaces = 3;
+  let decimals;
+  if (Number.isInteger(number)) {
+    decimals = 0;
+  } else if (!showThreeDecimals) {
+    decimals = 2;
+  } else if (absNumber >= 1) {
+    decimals = 3;
   } else {
-    // Numbers < 1 → show enough decimals to capture first 3 significant digits
-    // Cap at 7 decimal places to support micro-pricing (e.g., $0.000002/token)
-    decimalPlaces = Math.min(7, -orderOfMagnitude + 2);
+    // Capture first 3 significant digits for sub-1 values, capped at 7
+    // to support micro-pricing like $0.000002/token.
+    decimals = Math.min(7, -Math.floor(Math.log10(absNumber)) + 2);
   }
 
-  // Build a numeral.js format string with the calculated decimal places
-  const formatString = "$0,0." + "0".repeat(decimalPlaces);
+  let formatted = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  }).format(number);
 
-  // Format the number
-  let formatted = numeral(number).format(formatString);
-
-  // Remove unnecessary trailing zeros after significant decimals
-  formatted = formatted.replace(/(\.\d*?[1-9])0+$/g, "$1");
-
-  // Remove .0 if the number has no meaningful decimals
-  formatted = formatted.replace(/\.0+$/g, "");
-
-  // Return the formatted currency string
+  if (decimals > 0) {
+    formatted = formatted.replace(/(\.\d*?[1-9])0+$/g, "$1");
+    formatted = formatted.replace(/\.0+$/g, "");
+  }
   return formatted;
+}
+
+
+export function fUsage(value, unit) {
+  const suffix = unit ? ` ${unit}` : "";
+  if (value == null || value === 0) return `0${suffix}`;
+  if (value >= 1e9) return `${(value / 1e9).toFixed(1)}B${suffix}`;
+  if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M${suffix}`;
+  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K${suffix}`;
+  if (Number.isInteger(value)) return `${value.toLocaleString()}${suffix}`;
+  if (value < 1) {
+  
+    const order = Math.floor(Math.log10(Math.abs(value)));
+    const decimals = Math.min(6, Math.max(2, -order + 1));
+    return `${Number(value.toFixed(decimals))}${suffix}`;
+  }
+  return `${value.toFixed(1)}${suffix}`;
 }
 
 export function fPercent(number) {


### PR DESCRIPTION
## Summary

- Show real values for sub-1 usage and sub-cent costs: new `fUsage` helper formats small values with enough significant digits, `fCurrency` switches to `Intl.NumberFormat` and picks decimal places by magnitude, and the "% of free tier used" caption renders 2 decimals when below 1%.
- Replace the clipped free-tier annotation chip inside `UsageChart` with a proper legend below the chart (Daily usage swatch + Free tier dashed line with allowance and unit), and harden the y-axis formatter for sub-1 values.
- `DimensionCard` period caption now reflects the selected time range ("month to date" vs "last N months") instead of being hard-coded.
- Tier breakdown table gains a header row (Range / Used / Rate / Cost) on a 4-column grid, uses `fUsage` for the Used column, singularises the rate unit (e.g. `$0.000002/token`), and shows tier rate/cost via `fCurrency(_, true)` so micro-pricing isn't rounded to `$0`.
- Consolidates duplicate `formatUsage` / `formatUsageCompact` in [UsageSummaryV2.jsx](frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx) and [WorkspaceBreakdown.jsx](frontend/src/sections/settings/UsageSummaryV2/WorkspaceBreakdown.jsx) into a single `fUsage` export in [format-number.js](frontend/src/utils/format-number.js).

## Test plan

- [ ] Settings → Usage page loads without runtime errors and the chart renders.
- [ ] A dimension whose `current_usage` is `< 1` (e.g. 0.42 spans) shows a real number, not `0`, in the product card and the workspace breakdown table.
- [ ] A dimension whose `estimated_cost` is sub-cent (e.g. `$0.000002`) shows the actual amount in the tier breakdown's Rate and Cost columns, not `$0`.
- [ ] When usage is `> 0` but under 1% of free tier, the "% of free tier used" caption shows two decimals (e.g. `0.42%`), and renders a whole-number percent for values `>= 1%`.
- [ ] Switch the time range selector between "Current", "3M", "6M", "12M" — the product card sub-caption under the cost flips between "month to date" and "last N months" accordingly.
- [ ] On the chart card, the orange free-tier label is no longer rendered as a clipped chip on the plot; instead a legend row below the chart shows a primary swatch for "Daily usage" and a dashed swatch for "Free tier (`<allowance>` `<unit>`)".
- [ ] Legend hides the Free tier entry when `freeAllowance === 0`.
- [ ] Y-axis labels on the chart show `1.2M` / `3.4K` for large values, `0.5` for mid values, and finer decimals (`0.001`–`0.0001`) for sub-1 values without throwing on null.
- [ ] Expand a dimension's tier breakdown: header row `Range (<unit>) / Used / Rate / Cost` is visible, columns align under it, Rate reads e.g. `$0.000002/token` (singular unit), and Cost matches `fCurrency` formatting.
- [ ] Workspace breakdown table totals and per-row usage match `fUsage` output (no `NaN`, no `undefined`).
- [ ] `grep -R "formatUsage\b\|formatUsageCompact" frontend/src` returns no matches (helper fully migrated to `fUsage`).
- [ ] `npm run lint` (or repo equivalent) passes with no new warnings on the touched files.

Closes TH-5517,TH-5563,TH-5557,TH-5552,TH-5513,TH-5518