### PR TITLE
[TH-4895] hide Fix with Falcon on passed evals (re-apply to nightly-dev)

### DIFF
--- a/frontend/src/components/traceDetail/EvalsTabView.jsx
+++ b/frontend/src/components/traceDetail/EvalsTabView.jsx
@@ -74,6 +74,16 @@ export function collectAllEvalsFromEntry(entry) {
   return rows;
 }
 
+// `score >= 50` matches the summary's totalPass threshold. Some evals
+// (label-based pass/fail) may come through with no numeric score — fall back
+// to the textual label so we still hide Fix on those. Anything else (null
+// score, arbitrary label) is treated as not-passed and keeps the button.
+const isPassedEval = (ev) => {
+  if (ev?.score != null) return ev.score >= 50;
+  const label = (ev?.score_label || "").trim().toLowerCase();
+  return label === "pass" || label === "passed" || label === "true";
+};
+
 /** Score → colored background + text — traffic-light pattern */
 export function scoreColor(score) {
   if (score == null)
@@ -327,43 +337,43 @@ const EvalTableRow = ({ ev, onSelectSpan, showSpanColumn, onFixWithFalcon }) => 
             />
           )}
 
-          {/* Fix with Falcon — always shown whenever the row is expanded,
-              regardless of whether there's an explanation or error
-              localization data, so users can always escalate a failing
-              eval for a proposed fix. */}
-          <Box
-            onClick={(e) => {
-              e.stopPropagation();
-              if (onFixWithFalcon) {
-                onFixWithFalcon({ level: "eval", ev });
-              } else {
-                defaultFixNotice();
-              }
-            }}
-            sx={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 0.5,
-              px: 0.75,
-              py: 0.25,
-              alignSelf: "flex-start",
-              border: "1px solid",
-              borderColor: (theme) => alpha(theme.palette.primary.main, 0.4),
-              borderRadius: "4px",
-              cursor: "pointer",
-              bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
-              "&:hover": {
-                bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
-              },
-            }}
-          >
-            <Iconify icon="mdi:creation" width={12} color="primary.main" />
-            <Typography
-              sx={{ fontSize: 10, fontWeight: 600, color: "primary.main" }}
+          {/* Fix with Falcon — hidden for passed evals (nothing to fix);
+              shown for failed and unscored rows whenever expanded. */}
+          {!isPassedEval(ev) && (
+            <Box
+              onClick={(e) => {
+                e.stopPropagation();
+                if (onFixWithFalcon) {
+                  onFixWithFalcon({ level: "eval", ev });
+                } else {
+                  defaultFixNotice();
+                }
+              }}
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.5,
+                px: 0.75,
+                py: 0.25,
+                alignSelf: "flex-start",
+                border: "1px solid",
+                borderColor: (theme) => alpha(theme.palette.primary.main, 0.4),
+                borderRadius: "4px",
+                cursor: "pointer",
+                bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
+                "&:hover": {
+                  bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+                },
+              }}
             >
-              Fix with Falcon
-            </Typography>
-          </Box>
+              <Iconify icon="mdi:creation" width={12} color="primary.main" />
+              <Typography
+                sx={{ fontSize: 10, fontWeight: 600, color: "primary.main" }}
+              >
+                Fix with Falcon
+              </Typography>
+            </Box>
+          )}
         </Box>
       )}
     </>
@@ -497,46 +507,51 @@ const EvalsTabView = ({
           </Box>
         </Box>
 
-        <Box
-          onClick={() => {
-            if (onFixWithFalcon) {
-              const failing = list.filter(
-                (e) => e.score != null && e.score < 50,
-              );
-              onFixWithFalcon({
-                level: "span",
-                failingEvals: failing,
-                allEvals: list,
-              });
-            } else {
-              defaultFixNotice();
-            }
-          }}
-          sx={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 0.5,
-            mt: 1,
-            px: 1,
-            py: 0.35,
-            border: "1px solid",
-            borderColor: (theme) => alpha(theme.palette.primary.main, 0.4),
-            borderRadius: "6px",
-            cursor: "pointer",
-            bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
-            "&:hover": {
-              bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
-              borderColor: (theme) => alpha(theme.palette.primary.main, 0.5),
-            },
-          }}
-        >
-          <Iconify icon="mdi:creation" width={14} color="primary.main" />
-          <Typography
-            sx={{ fontSize: 11, fontWeight: 600, color: "primary.main" }}
+        {/* Summary-bar Fix with Falcon — hidden when every eval passed
+            (nothing failing to escalate). Uses isPassedEval so unscored /
+            label-based non-passes also keep the button visible (e.g. an
+            eval with score=null and no Pass label still shows up as
+            non-passing in the "X/N passed" text). */}
+        {list.some((e) => !isPassedEval(e)) && (
+          <Box
+            onClick={() => {
+              if (onFixWithFalcon) {
+                const failing = list.filter((e) => !isPassedEval(e));
+                onFixWithFalcon({
+                  level: "span",
+                  failingEvals: failing,
+                  allEvals: list,
+                });
+              } else {
+                defaultFixNotice();
+              }
+            }}
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.5,
+              mt: 1,
+              px: 1,
+              py: 0.35,
+              border: "1px solid",
+              borderColor: (theme) => alpha(theme.palette.primary.main, 0.4),
+              borderRadius: "6px",
+              cursor: "pointer",
+              bgcolor: (theme) => alpha(theme.palette.primary.main, 0.06),
+              "&:hover": {
+                bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+                borderColor: (theme) => alpha(theme.palette.primary.main, 0.5),
+              },
+            }}
           >
-            Fix with Falcon
-          </Typography>
-        </Box>
+            <Iconify icon="mdi:creation" width={14} color="primary.main" />
+            <Typography
+              sx={{ fontSize: 11, fontWeight: 600, color: "primary.main" }}
+            >
+              Fix with Falcon
+            </Typography>
+          </Box>
+        )}
       </Box>
 
       {/* Search + Add Evals */}


### PR DESCRIPTION
Cherry-pick of #449 onto `nightly-dev` (per Sarthak's note about `dev` being unstable today).

Same diff as the original PR — see #449 for the full summary, root cause, and test plan.

Fixes TH-4895.