### PR TITLE
[TH-5233] Task Usage table: clamp width so columns don't get cut off (re-apply to nightly-dev)

### DIFF
--- a/frontend/src/components/data-table/DataTable.jsx
+++ b/frontend/src/components/data-table/DataTable.jsx
@@ -117,7 +117,7 @@ export default function DataTable({
   }, [columnVisibility]);
 
   return (
-    <Box sx={{ flex: 1, minHeight: 0 }}>
+    <Box sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
       <DataGrid
         rows={data || []}
         columns={muiColumns}

--- a/frontend/src/sections/tasks/components/TaskUsageTab.jsx
+++ b/frontend/src/sections/tasks/components/TaskUsageTab.jsx
@@ -1226,7 +1226,7 @@ const TaskUsageTab = ({ taskId }) => {
               height. Without it the DataGrid renders every row at
               natural height and the table grows past the viewport,
               hiding the pagination footer and breaking internal scroll. */}
-          <Box sx={{ flex: 1, minHeight: 0, display: "flex" }}>
+          <Box sx={{ flex: 1, minHeight: 0, minWidth: 0, display: "flex" }}>
             <DataTable
               columns={columns}
               data={visibleLogs}


### PR DESCRIPTION
Cherry-pick of #494 onto `nightly-dev` (per Sarthak's note about `dev` being unstable today).

Same diff as the original PR — see #494 for the full summary, root cause, and test plan.

Closes TH-5233.