### PR TITLE
Add CSV export API and reduce code duplication

### DIFF
--- a/frontend/src/sections/projects/ObserveHeader.jsx
+++ b/frontend/src/sections/projects/ObserveHeader.jsx
@@ -62,6 +62,7 @@ const ObserveHeader = ({
   filterSpan,
   selectedTab,
   filterSession,
+  filterUsers,
   refreshData,
   resetFilters,
 }) => {
@@ -225,11 +226,13 @@ const ObserveHeader = ({
       if (text === "Sessions") {
         url = endpoints.project.projectSessionListExport;
         filters = filterSession;
+      } else if (text === "Users") {
+        url = endpoints.project.getUsersForObserveExport;
+        filters = filterUsers;
       } else if (selectedTab === "spans") {
         url = endpoints.project.getSpansForObserveExport;
         filters = filterSpan;
       } else {
-        // Default to trace export
         url = endpoints.project.getTraceForObserveExport;
         filters = filterTrace || [];
       }
@@ -248,11 +251,13 @@ const ObserveHeader = ({
       const fileSuffix =
         text === "Sessions"
           ? "sessions"
-          : selectedTab === "trace"
-            ? "traces"
-            : selectedTab === "spans"
-              ? "spans"
-              : "data";
+          : text === "Users"
+            ? "users"
+            : selectedTab === "trace"
+              ? "traces"
+              : selectedTab === "spans"
+                ? "spans"
+                : "data";
 
       enqueueSnackbar(
         `${fileSuffix.charAt(0).toUpperCase() + fileSuffix.slice(1)} downloaded successfully`,
@@ -670,6 +675,7 @@ ObserveHeader.propTypes = {
   filterSpan: PropTypes.array,
   selectedTab: PropTypes.string,
   filterSession: PropTypes.array,
+  filterUsers: PropTypes.array,
   refreshData: PropTypes.func,
   resetFilters: PropTypes.func,
 };

--- a/frontend/src/sections/projects/ObservePage.jsx
+++ b/frontend/src/sections/projects/ObservePage.jsx
@@ -400,6 +400,7 @@ const ObservePage = React.memo(() => {
           filterSpan={headerConfig.filterSpan}
           selectedTab={headerConfig.selectedTab}
           filterSession={headerConfig.filterSession}
+          filterUsers={headerConfig.filterUsers}
           refreshData={headerConfig.refreshData}
           resetFilters={headerConfig.resetFilters}
         />

--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -214,14 +214,6 @@ const UsersView = ({
     }
   }, [gridApi]);
 
-  useEffect(() => {
-    setHeaderConfig((prev) => ({
-      ...prev,
-      text: "Users",
-      refreshData: refreshUsers,
-    }));
-  }, [refreshUsers, setHeaderConfig]);
-
   // --- Filter & date state ---
   const defaultDateFilter = useMemo(() => getDefaultDateRange(), []);
 
@@ -309,6 +301,15 @@ const UsersView = ({
   useEffect(() => {
     useUsersStore.setState({ filters: finalFilters });
   }, [finalFilters]);
+
+  useEffect(() => {
+    setHeaderConfig((prev) => ({
+      ...prev,
+      text: "Users",
+      filterUsers: finalFilters,
+      refreshData: refreshUsers,
+    }));
+  }, [refreshUsers, finalFilters, setHeaderConfig]);
 
   // Saved-view api — populates a ref the parent UsersPageTabBar drives.
   const getConfig = useCallback(() => {

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1069,6 +1069,7 @@ export const endpoints = {
     getSpansForObserveProject: () =>
       `/tracer/observation-span/list_spans_observe/`,
     getSpansForObserveExport: `/tracer/observation-span/get_spans_export_data/`,
+    getUsersForObserveExport: `/tracer/users/export/`,
     getTraceProperties: `/tracer/trace/get_properties/`,
     getTraceEvals: () => `/tracer/trace/get_eval_names/`,
     getTraceErrorAnalysis: (id) => `/tracer/trace-error-analysis/${id}/`,

--- a/futureagi/tracer/tests/test_users_export.py
+++ b/futureagi/tracer/tests/test_users_export.py
@@ -1,0 +1,294 @@
+import json
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+from rest_framework.views import APIView
+
+from accounts.models import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.ai_model import AIModel
+from tfc.constants.roles import OrganizationRoles
+from tfc.middleware.workspace_context import set_workspace_context
+from tracer.models.project import Project
+from tracer.utils.helper import get_default_project_version_config
+
+User = get_user_model()
+
+
+def _row(
+    user_id="user1",
+    total_cost=10.50,
+    total_tokens=1000,
+    input_tokens=400,
+    output_tokens=600,
+    num_traces=5,
+    num_sessions=2,
+    avg_session_duration=300.0,
+    avg_trace_latency=150.0,
+    num_llm_calls=10,
+    num_guardrails_triggered=1,
+    activated_at="2024-01-01",
+    last_active="2024-01-15",
+    num_active_days=10,
+    num_traces_with_errors=0,
+    bool_eval_pass_rate=0.85,
+    avg_output_float=4.2,
+    project_id="00000000-0000-0000-0000-000000000000",
+    count=2,
+    user_id_type="email",
+    user_id_hash="hash123",
+    end_user_id="end-user-1",
+):
+    """Build a result tuple in the exact shape get_spans_by_end_users returns.
+
+    Tuple indices match the unpacking inside `users_row_to_dict` (and
+    historically `UsersView.get`): position 18 carries the total count.
+    """
+    return (
+        user_id,
+        total_cost,
+        total_tokens,
+        input_tokens,
+        output_tokens,
+        num_traces,
+        num_sessions,
+        avg_session_duration,
+        avg_trace_latency,
+        num_llm_calls,
+        num_guardrails_triggered,
+        activated_at,
+        last_active,
+        num_active_days,
+        num_traces_with_errors,
+        bool_eval_pass_rate,
+        avg_output_float,
+        project_id,
+        count,
+        user_id_type,
+        user_id_hash,
+        end_user_id,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.core_backend
+class TestUsersExportAPI(APITestCase):
+    """Tests for the new UsersExportView CSV endpoint.
+
+    Mirrors the auth + workspace-injection harness used by TestUsersViewAPI
+    so request.user.organization.id and request.workspace.id are populated
+    when UsersExportView.get runs.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            email="export-test@example.com",
+            name="Export Test User",
+            password="testpass123",
+        )
+        self.organization = Organization.objects.create(name="Export Test Org")
+        self.user.organization = self.organization
+        self.user.organization_role = OrganizationRoles.OWNER
+        self.user.save()
+
+        self.workspace = Workspace.objects.create(
+            name="Export Test Workspace",
+            organization=self.organization,
+            is_default=True,
+            created_by=self.user,
+        )
+        set_workspace_context(workspace=self.workspace, organization=self.organization)
+        self.client.force_authenticate(user=self.user)
+
+        # Inject request.workspace before the view runs. WorkspaceMiddleware
+        # would normally do this; in tests we patch APIView.initial to match
+        # the pattern used by TestUsersViewAPI.
+        self.original_initial = APIView.initial
+        workspace = self.workspace
+
+        def initial_with_workspace(view_self, request, *args, **view_kwargs):
+            request.workspace = workspace
+            return self.original_initial(view_self, request, *args, **view_kwargs)
+
+        self.workspace_patcher = patch.object(
+            APIView, "initial", initial_with_workspace
+        )
+        self.workspace_patcher.start()
+
+        self.test_project = Project.objects.create(
+            name="Export Test Project",
+            organization=self.organization,
+            model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+            trace_type="observe",
+            config=get_default_project_version_config(),
+        )
+        self.test_project_id = str(self.test_project.id)
+        self.url = "/tracer/users/export/"
+
+    def tearDown(self):
+        self.workspace_patcher.stop()
+        super().tearDown()
+
+    # ------------------------------------------------------------------
+    # Happy path
+    # ------------------------------------------------------------------
+
+    @patch("model_hub.utils.SQL_queries.SQLQueryHandler.get_spans_by_end_users")
+    def test_export_returns_csv_with_headers_and_rows(self, mock_get_spans):
+        mock_get_spans.return_value = [
+            _row(user_id="user-a", total_cost=1.234567, total_tokens=100),
+            _row(user_id="user-b", total_cost=2.5, total_tokens=200),
+        ]
+
+        response = self.client.get(self.url, {"project_id": self.test_project_id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response["Content-Type"].startswith("text/csv"))
+        self.assertIn("attachment;", response["Content-Disposition"])
+
+        body = response.content.decode("utf-8")
+        lines = [line for line in body.splitlines() if line]
+        self.assertEqual(len(lines), 3, "expected header + 2 data rows")
+
+        # Header order is the contract the frontend relies on.
+        expected_header = (
+            "User ID,User ID Type,User ID Hash,First Active,Last Active,"
+            "No. of Traces,No. of Sessions,Avg Session Duration (s),"
+            "Total Tokens,Total Cost ($),Avg Latency / Trace (ms),"
+            "No. of LLM Calls,Guardrails Triggered,Evals Pass Rate (%),"
+            "Input Tokens,Output Tokens"
+        )
+        self.assertEqual(lines[0], expected_header)
+        self.assertTrue(lines[1].startswith("user-a,"))
+        self.assertTrue(lines[2].startswith("user-b,"))
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+
+    def test_export_requires_authentication(self):
+        # Drop credentials and confirm the IsAuthenticated guard fires.
+        self.client.force_authenticate(user=None)
+        response = self.client.get(self.url)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
+
+    # ------------------------------------------------------------------
+    # Shared-helper wiring: filters, sort, pagination
+    # ------------------------------------------------------------------
+
+    @patch("model_hub.utils.SQL_queries.SQLQueryHandler.get_spans_by_end_users")
+    def test_export_passes_filters_and_sort_to_sql_handler(self, mock_get_spans):
+        mock_get_spans.return_value = []
+        filters = [
+            {
+                "column_id": "created_at",
+                "filter_config": {
+                    "filter_type": "datetime",
+                    "filter_op": "between",
+                    "filter_value": [
+                        "2026-02-24T08:48:10.685Z",
+                        "2026-05-25T08:48:10.685Z",
+                    ],
+                },
+            }
+        ]
+        sort_params = {"column_id": "total_cost", "direction": "desc"}
+
+        response = self.client.get(
+            self.url,
+            {
+                "project_id": self.test_project_id,
+                "filters": json.dumps(filters),
+                "sort_params": json.dumps(sort_params),
+                "search": " alice ",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        kwargs = mock_get_spans.call_args.kwargs
+        self.assertEqual(kwargs["filters"], filters)
+        self.assertEqual(kwargs["sort_by"], "total_cost")
+        self.assertEqual(kwargs["sort_order"], "DESC")
+        self.assertEqual(kwargs["search_name"], "alice")
+        self.assertEqual(kwargs["project_id"], self.test_project_id)
+
+    @patch("model_hub.utils.SQL_queries.SQLQueryHandler.get_spans_by_end_users")
+    def test_export_skips_pagination(self, mock_get_spans):
+        """Export must fetch every matching row, not a single page."""
+        mock_get_spans.return_value = []
+        self.client.get(
+            self.url,
+            {
+                "project_id": self.test_project_id,
+                # Pagination params on the URL should be ignored.
+                "page_size": 5,
+                "current_page_index": 3,
+            },
+        )
+        kwargs = mock_get_spans.call_args.kwargs
+        self.assertIsNone(kwargs["limit"])
+        self.assertIsNone(kwargs["offset"])
+
+    # ------------------------------------------------------------------
+    # Cell formatting
+    # ------------------------------------------------------------------
+
+    @patch("model_hub.utils.SQL_queries.SQLQueryHandler.get_spans_by_end_users")
+    def test_export_formats_datetime_and_none_cells(self, mock_get_spans):
+        # last_active=None must come out as empty, activated_at=datetime must
+        # be ISO-formatted (not the repr Python prints by default).
+        activated = datetime(2026, 5, 25, 14, 21, 35)
+        mock_get_spans.return_value = [
+            _row(
+                user_id="dt-user",
+                activated_at=activated,
+                last_active=None,
+                num_llm_calls=42,
+            )
+        ]
+
+        response = self.client.get(self.url, {"project_id": self.test_project_id})
+        body = response.content.decode("utf-8")
+        # Locate the data row (not header).
+        data_row = body.splitlines()[1]
+        cells = data_row.split(",")
+
+        # Header position: First Active is index 3, Last Active index 4,
+        # No. of LLM Calls is index 11.
+        self.assertEqual(cells[3], activated.isoformat())
+        self.assertEqual(cells[4], "")
+        self.assertEqual(cells[11], "42")
+
+    # ------------------------------------------------------------------
+    # Filename composition
+    # ------------------------------------------------------------------
+
+    @patch("model_hub.utils.SQL_queries.SQLQueryHandler.get_spans_by_end_users")
+    def test_export_filename_includes_project_id(self, mock_get_spans):
+        mock_get_spans.return_value = []
+        response = self.client.get(self.url, {"project_id": self.test_project_id})
+        self.assertIn(f"users_{self.test_project_id}_", response["Content-Disposition"])
+
+    @patch("model_hub.utils.SQL_queries.SQLQueryHandler.get_spans_by_end_users")
+    def test_export_filename_defaults_to_all_when_no_project(self, mock_get_spans):
+        mock_get_spans.return_value = []
+        response = self.client.get(self.url)
+        self.assertIn("users_all_", response["Content-Disposition"])
+
+    # ------------------------------------------------------------------
+    # Failure mode
+    # ------------------------------------------------------------------
+
+    @patch("model_hub.utils.SQL_queries.SQLQueryHandler.get_spans_by_end_users")
+    def test_export_returns_400_when_sql_handler_raises(self, mock_get_spans):
+        mock_get_spans.side_effect = RuntimeError("boom")
+        response = self.client.get(self.url, {"project_id": self.test_project_id})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/futureagi/tracer/urls.py
+++ b/futureagi/tracer/urls.py
@@ -44,7 +44,12 @@ from tracer.views.project_version import ProjectVersionView
 from tracer.views.replay_session import ReplaySessionView
 from tracer.views.saved_view import SavedViewViewSet
 from tracer.views.shared_link import SharedLinkViewSet, resolve_shared_link
-from tracer.views.trace import GetUserCodeExampleView, TraceView, UsersView
+from tracer.views.trace import (
+    GetUserCodeExampleView,
+    TraceView,
+    UsersExportView,
+    UsersView,
+)
 from tracer.views.trace_session import TraceSessionView
 
 router = DefaultRouter()
@@ -96,6 +101,7 @@ urlpatterns = [
     ),
     path("shared/<str:token>/", resolve_shared_link, name="resolve-shared-link"),
     path("users/", UsersView.as_view(), name="users"),
+    path("users/export/", UsersExportView.as_view(), name="users-export"),
     path("users/get_code_example/", GetUserCodeExampleView.as_view(), name="users"),
     # Deprecated — replaced by /feed/ endpoints (TH-3816 Phase 5)
     # path(

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -1090,8 +1090,13 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         # 'choice': 'never'}") when output_float/output_str_list are empty.
         # Keyed by (trace_id, config_id); only the most recent row per pair.
         _str_lookup_configs = [
-            c for c in eval_configs
-            if ((getattr(getattr(c, "eval_template", None), "config", None) or {}).get("output"))
+            c
+            for c in eval_configs
+            if (
+                (getattr(getattr(c, "eval_template", None), "config", None) or {}).get(
+                    "output"
+                )
+            )
             in (EvalOutputType.CHOICES.value, EvalOutputType.SCORE.value)
         ]
         output_str_map: dict[tuple, "EvalLogger"] = {}
@@ -1218,11 +1223,18 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                         else None
                     )
                     log = output_str_map.get((trace.id, config.id))
-                    if log and log.output_str and tpl_output in (
-                        EvalOutputType.CHOICES.value, EvalOutputType.SCORE.value,
+                    if (
+                        log
+                        and log.output_str
+                        and tpl_output
+                        in (
+                            EvalOutputType.CHOICES.value,
+                            EvalOutputType.SCORE.value,
+                        )
                     ):
                         try:
                             import ast as _ast_mod
+
                             parsed = _ast_mod.literal_eval(log.output_str)
                         except (ValueError, SyntaxError):
                             parsed = None
@@ -1231,7 +1243,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                                 choice = parsed.get("choice")
                                 if choice:
                                     metric_entry["output"] = [choice]
-                                    metric_entry["output_type"] = EvalOutputType.CHOICES.value
+                                    metric_entry["output_type"] = (
+                                        EvalOutputType.CHOICES.value
+                                    )
                                     # Mirror as top-level `score` so the
                                     # drawer's `e?.score ?? e?.output ?? e?.value`
                                     # lookup hits a string and renders verbatim
@@ -1246,7 +1260,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                                     metric_entry["output"] = round(
                                         float(score_val) * 100, 2
                                     )
-                                    metric_entry["output_type"] = EvalOutputType.SCORE.value
+                                    metric_entry["output_type"] = (
+                                        EvalOutputType.SCORE.value
+                                    )
 
                 metrics[str(config.id)] = metric_entry
             if metrics:
@@ -3799,14 +3815,22 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 if log.output_str_list:
                     # Legacy categorical eval — pre-agent-evaluator path
                     metric_entry["output"] = log.output_str_list
-                elif output_type == EvalOutputType.PASS_FAIL.value and log.output_bool is not None:
+                elif (
+                    output_type == EvalOutputType.PASS_FAIL.value
+                    and log.output_bool is not None
+                ):
                     metric_entry["output"] = "Pass" if log.output_bool else "Fail"
                 elif log.output_float is not None:
                     # Score evals on the legacy storage path.
                     metric_entry["output"] = round(log.output_float * 100, 2)
-                elif output_type in (
-                    EvalOutputType.CHOICES.value, EvalOutputType.SCORE.value,
-                ) and log.output_str:
+                elif (
+                    output_type
+                    in (
+                        EvalOutputType.CHOICES.value,
+                        EvalOutputType.SCORE.value,
+                    )
+                    and log.output_str
+                ):
                     # New agent-evaluator path: output_str holds a Python dict
                     # literal like "{'score': 0.0, 'choice': 'never'}". For
                     # choices evals, use `choice`; for score evals, use `score`.
@@ -3815,6 +3839,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     # verbatim without a frontend change.
                     try:
                         import ast as _ast_mod
+
                         parsed = _ast_mod.literal_eval(log.output_str)
                     except (ValueError, SyntaxError):
                         parsed = None
@@ -5955,6 +5980,157 @@ class UsersView(APIView):
         except Exception as e:
             logger.exception(f"ERROR {e}")
             return self._gm.bad_request(f"error fetching users: {str(e)}")
+
+
+class UsersExportView(APIView):
+    """Export the Users tab as a CSV.
+
+    Mirrors the parsing and filtering of `UsersView` but ignores pagination so
+    every matching row is written to the response. Columns match the static
+    set the frontend shows in its column-visibility menu (visible + hidden).
+    """
+
+    permission_classes = [IsAuthenticated]
+    _gm = GeneralMethods()
+
+    EXPORT_COLUMNS = [
+        ("User ID", "user_id"),
+        ("User ID Type", "user_id_type"),
+        ("User ID Hash", "user_id_hash"),
+        ("First Active", "activated_at"),
+        ("Last Active", "last_active"),
+        ("No. of Traces", "num_traces"),
+        ("No. of Sessions", "num_sessions"),
+        ("Avg Session Duration (s)", "avg_session_duration"),
+        ("Total Tokens", "total_tokens"),
+        ("Total Cost ($)", "total_cost"),
+        ("Avg Latency / Trace (ms)", "avg_trace_latency"),
+        ("No. of LLM Calls", "num_llm_calls"),
+        ("Guardrails Triggered", "num_guardrails_triggered"),
+        ("Evals Pass Rate (%)", "bool_eval_pass_rate"),
+        ("Input Tokens", "input_tokens"),
+        ("Output Tokens", "output_tokens"),
+    ]
+
+    COLUMN_MAPPING = {
+        "user_id": "user_id",
+        "activated_at": "created_at",
+        "avg_trace_latency": "avg_latency_trace",
+        "total_cost": "total_cost",
+        "total_tokens": "total_tokens",
+        "input_tokens": "input_tokens",
+        "output_tokens": "output_tokens",
+        "num_traces": "num_traces",
+        "num_sessions": "COALESCE(fo.num_sessions, 0)",
+        "avg_session_duration": "avg_session_duration_seconds",
+        "num_llm_calls": "num_llm_calls",
+        "num_guardrails_triggered": "num_guardrails_triggered",
+        "last_active": "la.last_active",
+        "num_active_days": "num_active_days",
+        "num_traces_with_errors": "num_traces_with_errors",
+        "bool_eval_pass_rate": "bool_eval_pass_rate",
+        "avg_output_float": "avg_output_float",
+        "user_id_hash": "user_id_hash",
+        "user_id_type": "user_id_type",
+    }
+
+    def get(self, request, *args, **kwargs):
+        try:
+            project_id = request.query_params.get("project_id") or None
+            search = request.query_params.get("search", "")
+            search_name = search.strip() if search else None
+            organization_id = request.user.organization.id
+
+            sort_params = request.query_params.get("sort_params", [])
+            filters = request.query_params.get("filters", [])
+
+            if isinstance(sort_params, str):
+                try:
+                    sort_params = json.loads(sort_params)
+                except (ValueError, TypeError):
+                    sort_params = []
+
+            if isinstance(filters, str):
+                try:
+                    filters = json.loads(filters)
+                except (ValueError, TypeError):
+                    filters = []
+
+            column = None
+            sort_order = None
+            if isinstance(sort_params, dict) and sort_params:
+                column = self.COLUMN_MAPPING.get(sort_params.get("column_id"))
+                direction = sort_params.get("direction", "asc")
+                sort_order = "DESC" if direction == "desc" else "ASC"
+
+            query_params = {
+                "org_id": organization_id,
+                "project_id": project_id,
+                "search_name": search_name,
+                # limit=offset=None makes get_spans_by_end_users skip LIMIT/OFFSET,
+                # returning every matching row for the export.
+                "limit": None,
+                "offset": None,
+                "filters": filters,
+                "column_map": self.COLUMN_MAPPING,
+                "workspace_id": request.workspace.id,
+            }
+            if column and sort_order:
+                query_params["sort_by"] = column
+                query_params["sort_order"] = sort_order
+
+            results = SQLQueryHandler.get_spans_by_end_users(**query_params)
+
+            filename = (
+                f"users_{project_id or 'all'}_"
+                f"{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}.csv"
+            )
+            response = HttpResponse(content_type="text/csv")
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
+
+            headers = [h for h, _ in self.EXPORT_COLUMNS]
+            writer = csv.writer(response)
+            writer.writerow(headers)
+
+            for result in results:
+                row = {
+                    "user_id": result[0],
+                    "total_cost": round(result[1], 6) if result[1] else 0,
+                    "total_tokens": result[2],
+                    "input_tokens": result[3],
+                    "output_tokens": result[4],
+                    "num_traces": result[5],
+                    "num_sessions": result[6],
+                    "avg_session_duration": result[7],
+                    "avg_trace_latency": result[8],
+                    "num_llm_calls": result[9],
+                    "num_guardrails_triggered": result[10],
+                    "activated_at": result[11],
+                    "last_active": result[12],
+                    "bool_eval_pass_rate": result[15],
+                    "user_id_type": result[19],
+                    "user_id_hash": result[20],
+                }
+                writer.writerow(
+                    [
+                        self._format_cell(row.get(field))
+                        for _, field in self.EXPORT_COLUMNS
+                    ]
+                )
+
+            return response
+
+        except Exception as e:
+            logger.exception(f"ERROR {e}")
+            return self._gm.bad_request(f"error exporting users: {str(e)}")
+
+    @staticmethod
+    def _format_cell(value):
+        if value is None:
+            return ""
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return value
 
 
 class GetUserCodeExampleView(APIView):

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -5753,127 +5753,129 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             return self._gm.bad_request("Failed to compute agent graph")
 
 
+# NOTE: num_sessions is computed in the SQL as COALESCE(fo.num_sessions, 0).
+# Filtering with "equals 0" must match NULL session aggregates (no sessions),
+# so we coalesce in the filter expression as well.
+USERS_COLUMN_MAPPING = {
+    "user_id": "user_id",
+    "activated_at": "created_at",
+    "avg_trace_latency": "avg_latency_trace",
+    "total_cost": "total_cost",
+    "total_tokens": "total_tokens",
+    "input_tokens": "input_tokens",
+    "output_tokens": "output_tokens",
+    "num_traces": "num_traces",
+    "num_sessions": "COALESCE(fo.num_sessions, 0)",
+    "avg_session_duration": "avg_session_duration_seconds",
+    "num_llm_calls": "num_llm_calls",
+    "num_guardrails_triggered": "num_guardrails_triggered",
+    "last_active": "la.last_active",
+    "num_active_days": "num_active_days",
+    "num_traces_with_errors": "num_traces_with_errors",
+    "bool_eval_pass_rate": "bool_eval_pass_rate",
+    "avg_output_float": "avg_output_float",
+    "user_id_hash": "user_id_hash",
+    "user_id_type": "user_id_type",
+}
+
+
+def _parse_json_query_param(raw, default):
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (ValueError, TypeError):
+            return default
+    return raw if raw else default
+
+
+def _resolve_users_sort(sort_params):
+    if not (isinstance(sort_params, dict) and sort_params):
+        return None, None
+    column = USERS_COLUMN_MAPPING.get(sort_params.get("column_id"))
+    direction = sort_params.get("direction", "asc")
+    return column, ("DESC" if direction == "desc" else "ASC")
+
+
+def build_users_query_params(request, *, limit, offset):
+    """Build the kwargs dict passed to SQLQueryHandler.get_spans_by_end_users.
+
+    Shared by the paginated users view and the CSV export view — both parse
+    the same request shape; only `limit`/`offset` differ (export passes None
+    to fetch every row).
+    """
+    sort_params = _parse_json_query_param(
+        request.query_params.get("sort_params", []), []
+    )
+    filters = _parse_json_query_param(request.query_params.get("filters", []), [])
+    sort_column, sort_order = _resolve_users_sort(sort_params)
+    search = request.query_params.get("search", "")
+    query_params = {
+        "org_id": request.user.organization.id,
+        "project_id": request.query_params.get("project_id") or None,
+        "search_name": search.strip() if search else None,
+        "limit": limit,
+        "offset": offset,
+        "filters": filters,
+        "column_map": USERS_COLUMN_MAPPING,
+        "workspace_id": request.workspace.id,
+    }
+    if sort_column and sort_order:
+        query_params["sort_by"] = sort_column
+        query_params["sort_order"] = sort_order
+    return query_params
+
+
+def users_row_to_dict(result):
+    """Map a get_spans_by_end_users result tuple to the API row shape."""
+    return {
+        "user_id": result[0],
+        "total_cost": round(result[1], 6) if result[1] else 0,
+        "total_tokens": result[2],
+        "input_tokens": result[3],
+        "output_tokens": result[4],
+        "num_traces": result[5],
+        "num_sessions": result[6],
+        "avg_session_duration": result[7],
+        "avg_trace_latency": result[8],
+        "num_llm_calls": result[9],
+        "num_guardrails_triggered": result[10],
+        "activated_at": result[11],
+        "last_active": result[12],
+        "num_active_days": result[13],
+        "num_traces_with_errors": result[14],
+        "bool_eval_pass_rate": result[15],
+        "avg_output_float": result[16],
+        "project_id": result[17],
+        "user_id_type": result[19],
+        "user_id_hash": result[20],
+        "end_user_id": result[21],
+    }
+
+
 class UsersView(APIView):
     permission_classes = [IsAuthenticated]
     _gm = GeneralMethods()
 
     def get(self, request, *args, **kwargs):
-        """
-        List traces filtered by project ID with optimized queries.
-        """
+        """List end users for a project with optimized queries."""
         try:
-            project_id = request.query_params.get("project_id") or None
-            search = request.query_params.get("search", "")
-            page_size = int(request.query_params.get("page_size", 30))
-            current_page = int(request.query_params.get("current_page_index", 0))
-            search_name = search.strip() if search else None
-            organization_id = request.user.organization.id
-            limit = page_size
-            offset = current_page * page_size
-            sort_params = request.query_params.get("sort_params", [])
-            filters = request.query_params.get("filters", [])
-
-            # Convert string parameters to appropriate types
             try:
-                page_size = int(page_size)
-                current_page = int(current_page)
+                page_size = int(request.query_params.get("page_size", 30))
+                current_page = int(request.query_params.get("current_page_index", 0))
             except (ValueError, TypeError):
                 page_size = 10
                 current_page = 0
 
-            # Parse sort_params and filters if they're strings
-            if isinstance(sort_params, str):
-                try:
-                    sort_params = json.loads(sort_params)
-                except (ValueError, TypeError):
-                    sort_params = []
-
-            if isinstance(filters, str):
-                try:
-                    filters = json.loads(filters)
-                except (ValueError, TypeError):
-                    filters = []
-
-            column_mapping = {
-                "user_id": "user_id",
-                "activated_at": "created_at",
-                "avg_trace_latency": "avg_latency_trace",
-                "total_cost": "total_cost",
-                "total_tokens": "total_tokens",
-                "input_tokens": "input_tokens",
-                "output_tokens": "output_tokens",
-                "num_traces": "num_traces",
-                # NOTE: num_sessions is computed in the SQL as COALESCE(fo.num_sessions, 0).
-                # Filtering with "equals 0" must match NULL session aggregates (no sessions),
-                # so we coalesce in the filter expression as well.
-                "num_sessions": "COALESCE(fo.num_sessions, 0)",
-                "avg_session_duration": "avg_session_duration_seconds",
-                "num_llm_calls": "num_llm_calls",
-                "num_guardrails_triggered": "num_guardrails_triggered",
-                "last_active": "la.last_active",
-                "num_active_days": "num_active_days",
-                "num_traces_with_errors": "num_traces_with_errors",
-                "bool_eval_pass_rate": "bool_eval_pass_rate",
-                "avg_output_float": "avg_output_float",
-                "user_id_hash": "user_id_hash",
-                "user_id_type": "user_id_type",
-            }
-
-            column = None
-            sort_order = None
-            if isinstance(sort_params, dict) and sort_params:
-                column = sort_params.get("column_id")
-                column = column_mapping.get(column, None)
-                direction = sort_params.get("direction", "asc")
-                if direction == "desc":
-                    sort_order = "DESC"
-                else:
-                    sort_order = "ASC"
-
-            query_params = {
-                "org_id": organization_id,
-                "project_id": project_id,
-                "search_name": search_name,
-                "limit": limit,
-                "offset": offset,
-                "filters": filters,
-                "column_map": column_mapping,
-                "workspace_id": request.workspace.id,
-            }
-
-            if column and sort_order:
-                query_params["sort_by"] = column
-                query_params["sort_order"] = sort_order
+            query_params = build_users_query_params(
+                request, limit=page_size, offset=current_page * page_size
+            )
+            project_id = query_params["project_id"]
 
             results = SQLQueryHandler.get_spans_by_end_users(**query_params)
             output = []
             count = 0
             for result in results:
-                output.append(
-                    {
-                        "user_id": result[0],
-                        "total_cost": round(result[1], 6) if result[1] else 0,
-                        "total_tokens": result[2],
-                        "input_tokens": result[3],
-                        "output_tokens": result[4],
-                        "num_traces": result[5],
-                        "num_sessions": result[6],
-                        "avg_session_duration": result[7],
-                        "avg_trace_latency": result[8],
-                        "num_llm_calls": result[9],
-                        "num_guardrails_triggered": result[10],
-                        "activated_at": result[11],
-                        "last_active": result[12],
-                        "num_active_days": result[13],
-                        "num_traces_with_errors": result[14],
-                        "bool_eval_pass_rate": result[15],
-                        "avg_output_float": result[16],
-                        "project_id": result[17],
-                        "user_id_type": result[19],
-                        "user_id_hash": result[20],
-                        "end_user_id": result[21],
-                    }
-                )
+                output.append(users_row_to_dict(result))
                 count = result[18]
 
             # Enrich with aggregated span attributes from ClickHouse
@@ -5985,9 +5987,11 @@ class UsersView(APIView):
 class UsersExportView(APIView):
     """Export the Users tab as a CSV.
 
-    Mirrors the parsing and filtering of `UsersView` but ignores pagination so
-    every matching row is written to the response. Columns match the static
-    set the frontend shows in its column-visibility menu (visible + hidden).
+    Reuses `build_users_query_params` and `users_row_to_dict` from the module
+    helpers so request parsing and the result-tuple mapping stay in one place.
+    Pagination is intentionally skipped (limit=offset=None) so every matching
+    row is exported. Columns match the static set the frontend shows in its
+    column-visibility menu (visible + hidden).
     """
 
     permission_classes = [IsAuthenticated]
@@ -6012,105 +6016,22 @@ class UsersExportView(APIView):
         ("Output Tokens", "output_tokens"),
     ]
 
-    COLUMN_MAPPING = {
-        "user_id": "user_id",
-        "activated_at": "created_at",
-        "avg_trace_latency": "avg_latency_trace",
-        "total_cost": "total_cost",
-        "total_tokens": "total_tokens",
-        "input_tokens": "input_tokens",
-        "output_tokens": "output_tokens",
-        "num_traces": "num_traces",
-        "num_sessions": "COALESCE(fo.num_sessions, 0)",
-        "avg_session_duration": "avg_session_duration_seconds",
-        "num_llm_calls": "num_llm_calls",
-        "num_guardrails_triggered": "num_guardrails_triggered",
-        "last_active": "la.last_active",
-        "num_active_days": "num_active_days",
-        "num_traces_with_errors": "num_traces_with_errors",
-        "bool_eval_pass_rate": "bool_eval_pass_rate",
-        "avg_output_float": "avg_output_float",
-        "user_id_hash": "user_id_hash",
-        "user_id_type": "user_id_type",
-    }
-
     def get(self, request, *args, **kwargs):
         try:
-            project_id = request.query_params.get("project_id") or None
-            search = request.query_params.get("search", "")
-            search_name = search.strip() if search else None
-            organization_id = request.user.organization.id
-
-            sort_params = request.query_params.get("sort_params", [])
-            filters = request.query_params.get("filters", [])
-
-            if isinstance(sort_params, str):
-                try:
-                    sort_params = json.loads(sort_params)
-                except (ValueError, TypeError):
-                    sort_params = []
-
-            if isinstance(filters, str):
-                try:
-                    filters = json.loads(filters)
-                except (ValueError, TypeError):
-                    filters = []
-
-            column = None
-            sort_order = None
-            if isinstance(sort_params, dict) and sort_params:
-                column = self.COLUMN_MAPPING.get(sort_params.get("column_id"))
-                direction = sort_params.get("direction", "asc")
-                sort_order = "DESC" if direction == "desc" else "ASC"
-
-            query_params = {
-                "org_id": organization_id,
-                "project_id": project_id,
-                "search_name": search_name,
-                # limit=offset=None makes get_spans_by_end_users skip LIMIT/OFFSET,
-                # returning every matching row for the export.
-                "limit": None,
-                "offset": None,
-                "filters": filters,
-                "column_map": self.COLUMN_MAPPING,
-                "workspace_id": request.workspace.id,
-            }
-            if column and sort_order:
-                query_params["sort_by"] = column
-                query_params["sort_order"] = sort_order
-
+            query_params = build_users_query_params(request, limit=None, offset=None)
             results = SQLQueryHandler.get_spans_by_end_users(**query_params)
 
             filename = (
-                f"users_{project_id or 'all'}_"
+                f"users_{query_params['project_id'] or 'all'}_"
                 f"{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}.csv"
             )
             response = HttpResponse(content_type="text/csv")
             response["Content-Disposition"] = f'attachment; filename="{filename}"'
 
-            headers = [h for h, _ in self.EXPORT_COLUMNS]
             writer = csv.writer(response)
-            writer.writerow(headers)
-
+            writer.writerow([header for header, _ in self.EXPORT_COLUMNS])
             for result in results:
-                row = {
-                    "user_id": result[0],
-                    "total_cost": round(result[1], 6) if result[1] else 0,
-                    "total_tokens": result[2],
-                    "input_tokens": result[3],
-                    "output_tokens": result[4],
-                    "num_traces": result[5],
-                    "num_sessions": result[6],
-                    "avg_session_duration": result[7],
-                    "avg_trace_latency": result[8],
-                    "num_llm_calls": result[9],
-                    "num_guardrails_triggered": result[10],
-                    "activated_at": result[11],
-                    "last_active": result[12],
-                    "bool_eval_pass_rate": result[15],
-                    "user_id_type": result[19],
-                    "user_id_hash": result[20],
-                }
+                row = users_row_to_dict(result)
                 writer.writerow(
                     [
                         self._format_cell(row.get(field))


### PR DESCRIPTION
## 1. What changes are being made

**New endpoint:** `GET /tracer/users/export/`

Returns a `text/csv` attachment with every row matching the same project / search / filter / sort the Users tab uses, across every column the column-visibility menu exposes (visible + hidden). Pagination params on the URL are intentionally ignored so the full dataset is exported in one response.

**Refactor:** `UsersView` and `UsersExportView` now share three module-level helpers in `futureagi/tracer/views/trace.py`:

| Helper | Purpose |
| --- | --- |
| `USERS_COLUMN_MAPPING` | Single source of truth for sortable columns → SQL expressions (incl. the `COALESCE(fo.num_sessions, 0)` note for the `equals 0` filter case) |
| `build_users_query_params(request, *, limit, offset)` | Parses `project_id` / `search` / `filters` / `sort_params` from a DRF request and assembles the kwargs dict for `SQLQueryHandler.get_spans_by_end_users`. Caller controls pagination via `limit`/`offset` (export passes `None` to fetch every row) |
| `users_row_to_dict(result)` | Maps the SQL result tuple to the 21-field API row shape |

**Files touched**

- `futureagi/tracer/views/trace.py` — added helpers + `UsersExportView`, shrunk `UsersView.get` to ~30 lines by delegating to the helpers
- `futureagi/tracer/urls.py` — registered `path("users/export/", UsersExportView.as_view(), name="users-export")`
- `futureagi/tracer/tests/test_users_export.py` — new test module (8 tests)

## 2. Why these changes are being made

- The Users tab currently has no export path — the download button in the Observe header was falling through to the trace-export endpoint, which returns trace rows, not user aggregates.
- A dedicated `/tracer/users/export/` lets the frontend wire the download button to a CSV that matches exactly what the user sees (including hidden columns), without piggy-backing on the trace exporter.
- The first cut of `UsersExportView` duplicated `UsersView`'s column mapping, request parsing, sort resolution, query-params dict, and result-tuple unpacking — five places where the two views could drift. Lifting those into shared helpers means adding a new sortable column or a new field is now a one-place edit and both endpoints see it. `UsersExportView` shrunk from ~150 to ~70 lines as a side effect.
- Pagination support inside `get_spans_by_end_users` already short-circuits the `LIMIT/OFFSET` clause when `limit`/`offset` are `None` (`SQL_queries.py:1218`), so the export reuses the existing query path — no new SQL.

## 3. Test cases added and scenarios covered

New file: `futureagi/tracer/tests/test_users_export.py` → `TestUsersExportAPI` (`APITestCase`, mirrors the auth + workspace-injection harness used by `TestUsersViewAPI`).

| # | Test | Scenario covered |
| --- | --- | --- |
| 1 | `test_export_returns_csv_with_headers_and_rows` | Happy path: 200, `Content-Type: text/csv`, `Content-Disposition: attachment`, exact header order (the contract the frontend relies on), correct row count |
| 2 | `test_export_requires_authentication` | `IsAuthenticated` guard — drops credentials and asserts 401/403 |
| 3 | `test_export_passes_filters_and_sort_to_sql_handler` | Proves `build_users_query_params` correctly parses the production-shape `datetime/between` filter (the one used by the date-range filter on the screenshot), the `sort_params` JSON, and trims whitespace on `search` — and passes them verbatim to `SQLQueryHandler.get_spans_by_end_users` |
| 4 | `test_export_skips_pagination` | Verifies `limit=None, offset=None` even when `page_size`/`current_page_index` are present in the URL — full export, not a single page |
| 5 | `test_export_formats_datetime_and_none_cells` | `_format_cell` emits ISO-formatted datetimes (not Python's `repr`) and turns `None` into empty cells, instead of the literal string "None" |
| 6 | `test_export_filename_includes_project_id` | Filename pattern `users_<project_id>_<utc-timestamp>.csv` when a project is scoped |
| 7 | `test_export_filename_defaults_to_all_when_no_project` | Filename falls back to `users_all_<utc-timestamp>.csv` when called without `project_id` |
| 8 | `test_export_returns_400_when_sql_handler_raises` | Failure-mode contract — SQL exception is caught by the view and returned as 400, not a 500 |

`SQLQueryHandler.get_spans_by_end_users` is mocked so the suite exercises the controller in isolation and runs in ~5s with no fixtures beyond user/org/workspace/project.

## 4. Commands to run new and existing tests

All commands run from `futureagi/` (the backend root):

```bash
# Run just the new file (8 tests, ~5s)
bin/test tracer/tests/test_users_export.py

# Regression: run the existing UsersView suite (34 tests) — these exercise
# the same helpers the refactor extracted, so they catch any drift
bin/test tracer/tests/test_endusers.py

# Both together (recommended before merging — 42 tests, ~12s)
bin/test tracer/tests/test_endusers.py tracer/tests/test_users_export.py

# A single test by name
bin/test tracer/tests/test_users_export.py::TestUsersExportAPI::test_export_returns_csv_with_headers_and_rows

# Filter by keyword
bin/test tracer/tests/test_users_export.py -k "filename"

# Skip docker-service bootstrap on reruns (faster after first run)
bin/test --no-services tracer/tests/test_users_export.py

# Watch mode — reruns on file change
bin/test watch tracer/tests/test_users_export.py
```
##Linear 
Fix TH-5145


##Video and Screenshots

https://github.com/user-attachments/assets/6c743818-63ce-4f7b-9012-32a697ca86ac


  bin/test tracer/tests/test_users_export.py - command to run new tests
  
<img width="1512" height="982" alt="Screenshot 2026-05-26 at 7 36 18 PM" src="https://github.com/user-attachments/assets/e44d10be-3537-4576-a467-3839dba0a39e" />


 # Run new + regression in one command (42 tests total)
  bin/test tracer/tests/test_endusers.py tracer/tests/test_users_export.py

<img width="1512" height="982" alt="Screenshot 2026-05-26 at 7 41 29 PM" src="https://github.com/user-attachments/assets/cbe09f26-2808-4399-90e0-4d622263c1e2" />



> Note: `bin/test -k UsersExport` (repo-wide keyword match) currently fails at collection time because of unrelated import errors in `falcon_ai`, `tfc/utils/tests/test_slack`, and `tracer/tests/test_linear_issue_view` — none of which are touched by this PR. Prefer the explicit file-path commands above.

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧹 Chore / refactor (no user-visible change) — `UsersView` shares helpers with `UsersExportView`

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the feature works (8 new tests, all passing)
- [x] No hardcoded secrets, URLs, or PII
