### PR TITLE
Add onboarding current-flow analytics

### DIFF
--- a/frontend/src/auth/guard/auth-guard.jsx
+++ b/frontend/src/auth/guard/auth-guard.jsx
@@ -14,6 +14,11 @@ import { trackRedditSignup } from "src/utils/redditAds";
 import { trackTwitterSignup } from "src/utils/twitterAds";
 import { ROLES } from "src/utils/rolePermissionMapping";
 import { usePostLoginPath } from "src/hooks/useDeploymentMode";
+import { Events } from "src/utils/Mixpanel";
+import {
+  buildCurrentFlowContext,
+  trackCurrentFlow,
+} from "src/utils/analytics/currentFlow";
 
 // ----------------------------------------------------------------------
 
@@ -56,7 +61,6 @@ function Container({ children }) {
     const refreshToken = queryParams.get("refresh_token");
     const isNewOAuthUser = queryParams.get("is_new_user") === "true";
     const returnTo = localStorage.getItem("redirectUrl");
-
 
     if (!authenticated) {
       if (sso_token) {
@@ -112,6 +116,30 @@ function Container({ children }) {
     // Skip redirect logic for standalone pages (e.g. MCP OAuth consent)
     if (window.location.pathname.startsWith("/mcp/")) return;
     if (!user) return;
+    const trackPostLoginDecision = (decisionBranch, targetRoute) => {
+      trackCurrentFlow(
+        Events.currentFlowPostLoginDecisionResolved,
+        {
+          ...buildCurrentFlowContext({
+            user,
+            route: window.location.pathname,
+            postLoginPath,
+          }),
+          event_source: "auth_guard",
+          decision_branch: decisionBranch,
+          target_route: targetRoute,
+        },
+        {
+          onceKeyParts: [
+            "postLoginDecision",
+            user?.default_workspace_id,
+            user?.id,
+            decisionBranch,
+          ],
+        },
+      );
+    };
+
     const isNewOAuthSignup = localStorage.getItem("isNewOAuthSignup") === "1";
     if (isNewOAuthSignup) {
       const stampedAt = Number(localStorage.getItem("isNewOAuthSignupAt") || 0);
@@ -144,6 +172,7 @@ function Container({ children }) {
     // New user to platform (requires_org_setup) — redirect to org-setup
     // flow and, for OAuth/SSO paths, fire ad-platform signup conversions.
     if (user?.requires_org_setup) {
+      trackPostLoginDecision("requires_org_setup", paths.auth.jwt.org_removed);
       // Default to "oauth" so SSO / deep-link / unknown paths are still
       // counted. "email" is excluded because the register view fires it
       // directly at API-success time.
@@ -176,7 +205,10 @@ function Container({ children }) {
     }
 
     // Onboarding not finished — let the setup-org effect below handle routing.
-    if (!user?.onboarding_completed) return;
+    if (!user?.onboarding_completed) {
+      trackPostLoginDecision("onboarding_incomplete", window.location.pathname);
+      return;
+    }
 
     const initial = localStorage.getItem("initial-render");
 
@@ -184,8 +216,13 @@ function Container({ children }) {
       // If user has an organization_role, they're already part of an org (invited or owner)
       // Skip onboarding and go straight to dashboard
       if (user?.organization_role) {
+        trackPostLoginDecision("organization_role_post_login", postLoginPath);
         router.replace(postLoginPath);
       } else {
+        trackPostLoginDecision(
+          "no_org_role_get_started",
+          "/dashboard/get-started",
+        );
         router.replace("/dashboard/get-started");
       }
       localStorage.setItem("initial-render", "done");

--- a/frontend/src/routes/sections/dashboard.jsx
+++ b/frontend/src/routes/sections/dashboard.jsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import { Navigate, Outlet, useLocation, useParams } from "react-router-dom";
 
 import { AuthGuard } from "src/auth/guard";
+import { useAuthContext } from "src/auth/hooks";
 import DashboardLayout from "src/layouts/dashboard";
 
 import { LoadingScreen } from "src/components/loading-screen";
@@ -13,6 +14,11 @@ import WorkspaceRoleProtection from "../components/workspace-role-protection";
 import { GatewayProvider } from "src/sections/gateway/context/GatewayContext";
 import GatewayGuard from "src/sections/gateway/components/GatewayGuard";
 import lazyWithRetry from "src/utils/lazyWithRetry";
+import {
+  buildCurrentFlowContext,
+  isProductRoute,
+  trackCurrentFlow,
+} from "src/utils/analytics/currentFlow";
 // Lazy load all route components (with retry for chunk errors after deploys)
 const DevKeysPage = lazyWithRetry(
   () => import("src/pages/dashboard/keys/dev-keys"),
@@ -434,6 +440,7 @@ const ErrorBoundaryTest = () => {
 
 const DashboardRoutes = () => {
   const location = useLocation();
+  const { user } = useAuthContext();
 
   React.useEffect(() => {
     const { eventName, extras = {} } = getPageViewEvent(
@@ -441,7 +448,43 @@ const DashboardRoutes = () => {
       location.search,
     ) || { eventName: Events.pageView, extras: {} };
     trackEvent(eventName, { path: location.pathname, ...extras });
-  }, [location]);
+    if (!user) return;
+
+    const context = buildCurrentFlowContext({
+      user,
+      route: location.pathname,
+    });
+
+    trackCurrentFlow(
+      Events.currentFlowFirstLandingViewed,
+      {
+        ...context,
+        event_source: "dashboard_routes",
+        query_present: Boolean(location.search),
+      },
+      {
+        onceKeyParts: ["firstLanding", user?.default_workspace_id, user?.id],
+      },
+    );
+
+    if (isProductRoute(location.pathname)) {
+      trackCurrentFlow(
+        Events.currentFlowFirstProductRouteOpened,
+        {
+          ...context,
+          event_source: "dashboard_routes",
+          query_present: Boolean(location.search),
+        },
+        {
+          onceKeyParts: [
+            "firstProductRoute",
+            user?.default_workspace_id,
+            user?.id,
+          ],
+        },
+      );
+    }
+  }, [location, user]);
 
   return (
     <AuthGuard>

--- a/frontend/src/sections/falcon-ai/FalconAIFullPage.jsx
+++ b/frontend/src/sections/falcon-ai/FalconAIFullPage.jsx
@@ -1,6 +1,12 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import Box from "@mui/material/Box";
+import { useAuthContext } from "src/auth/hooks";
+import { Events } from "src/utils/Mixpanel";
+import {
+  buildCurrentFlowContext,
+  trackCurrentFlow,
+} from "src/utils/analytics/currentFlow";
 import useFalconStore from "./store/useFalconStore";
 import useFalconSocket from "./hooks/useFalconSocket";
 import { useFalconContext } from "./hooks/useFalconContext";
@@ -20,6 +26,7 @@ import CustomizePanel from "./components/CustomizePanel";
 export default function FalconAIFullPage() {
   const { conversationId: urlConversationId } = useParams();
   const navigate = useNavigate();
+  const { user } = useAuthContext();
 
   const currentConversationId = useFalconStore((s) => s.currentConversationId);
   const setCurrentConversation = useFalconStore(
@@ -55,6 +62,21 @@ export default function FalconAIFullPage() {
   useEffect(() => {
     loadSkillsAndConnectors();
   }, [loadSkillsAndConnectors]);
+
+  useEffect(() => {
+    if (!user) return;
+    trackCurrentFlow(
+      Events.currentFlowFalconViewed,
+      {
+        ...buildCurrentFlowContext({ user }),
+        event_source: "falcon_full_page",
+        has_conversation_id: Boolean(urlConversationId),
+      },
+      {
+        onceKeyParts: ["falconViewed", user?.default_workspace_id, user?.id],
+      },
+    );
+  }, [urlConversationId, user]);
 
   // Sync URL ↔ store (one-way: URL wins on mount, store wins after)
   const initializedRef = useRef(false);
@@ -114,6 +136,41 @@ export default function FalconAIFullPage() {
       // Capture attached files before clearing
       const attachedFiles = useFalconStore.getState().attachedFiles;
       const fileIds = attachedFiles.map((f) => f.id);
+      const contextProperties = buildCurrentFlowContext({ user });
+
+      trackCurrentFlow(
+        Events.currentFlowFalconMessageSent,
+        {
+          ...contextProperties,
+          event_source: "falcon_full_page",
+          conversation_id: convId,
+          had_existing_conversation: Boolean(currentConversationId),
+          attached_file_count: fileIds.length,
+        },
+        {
+          onceKeyParts: [
+            "falconMessageSent",
+            user?.default_workspace_id,
+            user?.id,
+          ],
+        },
+      );
+      trackCurrentFlow(
+        Events.currentFlowFirstValueCandidate,
+        {
+          ...contextProperties,
+          event_source: "falcon_full_page",
+          candidate_type: "falcon_first_message",
+          conversation_id: convId,
+        },
+        {
+          onceKeyParts: [
+            "firstValueCandidate",
+            user?.default_workspace_id,
+            user?.id,
+          ],
+        },
+      );
 
       const userMsg = {
         id: `user-${Date.now()}`,
@@ -149,10 +206,12 @@ export default function FalconAIFullPage() {
     [
       currentConversationId,
       context,
+      user,
       setCurrentConversation,
       addMessage,
       setStreaming,
       sendChat,
+      navigate,
     ],
   );
 

--- a/frontend/src/sections/get-started/GetStartedView.jsx
+++ b/frontend/src/sections/get-started/GetStartedView.jsx
@@ -1,5 +1,5 @@
 import Box from "@mui/material/Box/Box";
-import React, { Suspense, useState } from "react";
+import React, { Suspense, useEffect, useState } from "react";
 import GetStartedHeaderView from "./GetStartedHeaderView";
 import SetupStepsView from "./setup-steps/SetupStepsView";
 import { useAuthContext } from "src/auth/hooks";
@@ -10,6 +10,11 @@ import { menuesConstant } from "./constant";
 import { useSearchParams } from "src/routes/hooks";
 import { ShowComponent } from "src/components/show";
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
+import {
+  buildCurrentFlowContext,
+  getFirstIncompleteStep,
+  trackCurrentFlow,
+} from "src/utils/analytics/currentFlow";
 const TryOutFeatures = React.lazy(
   () => import("./try-out-features/TryOutFeatures"),
 );
@@ -21,7 +26,7 @@ const GetStartedView = () => {
     tab: "addKeys",
   });
   const [_showDemoModal, setShowDemoModal] = useState(false);
-  const { user: _user } = useAuthContext();
+  const { user } = useAuthContext();
   const { contactUs: _contactUs, getStartedVideo: _getStartedVideo } =
     getStartedPage;
 
@@ -42,6 +47,25 @@ const GetStartedView = () => {
       }
     }
     trackEvent(Events.demoVideoPageLoaded, { [PropertyName.status]: "Loaded" });
+    trackCurrentFlow(
+      Events.currentFlowGetStartedTabsLoaded,
+      {
+        ...buildCurrentFlowContext({ user }),
+        event_source: "get_started_view",
+        first_incomplete_step: getFirstIncompleteStep(label),
+        completed_step_count: label
+          ? Object.values(label).filter(Boolean).length
+          : undefined,
+        total_step_count: label ? Object.keys(label).length : undefined,
+      },
+      {
+        onceKeyParts: [
+          "getStartedTabsLoaded",
+          user?.default_workspace_id,
+          user?.id,
+        ],
+      },
+    );
     return label;
   };
 
@@ -59,6 +83,25 @@ const GetStartedView = () => {
   const setCurrentLabel = (label) => {
     setQueryParamState({ tab: label });
   };
+
+  useEffect(() => {
+    if (!user) return;
+    trackCurrentFlow(
+      Events.currentFlowGetStartedViewed,
+      {
+        ...buildCurrentFlowContext({ user }),
+        event_source: "get_started_view",
+        selected_tab: currentLabel.tab,
+      },
+      {
+        onceKeyParts: [
+          "getStartedViewed",
+          user?.default_workspace_id,
+          user?.id,
+        ],
+      },
+    );
+  }, [currentLabel.tab, user]);
 
   return (
     <Box

--- a/frontend/src/sections/get-started/setup-steps/InitialSetup.jsx
+++ b/frontend/src/sections/get-started/setup-steps/InitialSetup.jsx
@@ -4,6 +4,12 @@ import PropTypes from "prop-types";
 import React, { useMemo } from "react";
 import { useAuthContext } from "src/auth/hooks";
 import SvgColor from "src/components/svg-color";
+import { Events } from "src/utils/Mixpanel";
+import {
+  buildCurrentFlowContext,
+  normalizeGetStartedStep,
+  trackCurrentFlow,
+} from "src/utils/analytics/currentFlow";
 import { menuesConstant } from "./../constant";
 
 const InitialSetup = ({ currentLabel, setCurrentLabel, data }) => {
@@ -26,6 +32,14 @@ const InitialSetup = ({ currentLabel, setCurrentLabel, data }) => {
   }, [currentLabel, data, keySelector, menusList]);
 
   const handleMenuClick = (selected) => {
+    trackCurrentFlow(Events.currentFlowGetStartedStepSelected, {
+      ...buildCurrentFlowContext({ user }),
+      event_source: "get_started_initial_setup",
+      selected_step: normalizeGetStartedStep(selected.label),
+      selected_step_status: selected.status,
+      previous_step: normalizeGetStartedStep(currentLabel),
+      is_step_complete: Boolean(data?.[keySelector[selected.label]]),
+    });
     setCurrentLabel(selected.label);
   };
 

--- a/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/BottomAction.jsx
+++ b/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/BottomAction.jsx
@@ -2,27 +2,40 @@ import { Box, Button, Divider } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useMemo } from "react";
 import { useNavigate } from "react-router";
+import { useAuthContext } from "src/auth/hooks";
+import { Events } from "src/utils/Mixpanel";
+import {
+  buildCurrentFlowContext,
+  isProductRoute,
+  normalizeGetStartedStep,
+  trackCurrentFlow,
+} from "src/utils/analytics/currentFlow";
 
 const BottomAction = ({ currentLabel, setCurrentLabel }) => {
   const navigate = useNavigate();
+  const { user } = useAuthContext();
   const currentAction = useMemo(() => {
     const option = {};
     switch (currentLabel) {
       case "addKeys":
         option.buttonText = "Next";
         option.buttonAction = () => setCurrentLabel("createFirstDataset");
+        option.targetStep = "createFirstDataset";
         break;
       case "SetupObsabilityInApplication":
         option.buttonText = "Go to observe";
         option.buttonAction = () => navigate("/dashboard/observe");
+        option.targetRoute = "/dashboard/observe";
         break;
       case "RunFirstExperiment":
         option.buttonText = "Go to experiments";
         option.buttonAction = () => navigate("/dashboard/prototype");
+        option.targetRoute = "/dashboard/prototype";
         break;
       case "inviteTeamMembers":
         option.buttonText = "Complete the setup";
         option.buttonAction = () => setCurrentLabel("completed");
+        option.targetStep = "completed";
         break;
       default:
         option.buttonText = "";
@@ -30,6 +43,41 @@ const BottomAction = ({ currentLabel, setCurrentLabel }) => {
     }
     return option;
   }, [currentLabel, navigate, setCurrentLabel]);
+
+  const handlePrimaryClick = () => {
+    const context = buildCurrentFlowContext({ user });
+    trackCurrentFlow(Events.currentFlowGetStartedPrimaryClicked, {
+      ...context,
+      event_source: "get_started_bottom_action",
+      selected_step: normalizeGetStartedStep(currentLabel),
+      button_text: currentAction.buttonText,
+      target_route: currentAction.targetRoute,
+      target_step: normalizeGetStartedStep(currentAction.targetStep),
+    });
+    if (
+      currentAction.targetRoute &&
+      isProductRoute(currentAction.targetRoute)
+    ) {
+      trackCurrentFlow(
+        Events.currentFlowFirstValueCandidate,
+        {
+          ...context,
+          event_source: "get_started_bottom_action",
+          selected_step: normalizeGetStartedStep(currentLabel),
+          candidate_type: "get_started_primary_route",
+          target_route: currentAction.targetRoute,
+        },
+        {
+          onceKeyParts: [
+            "firstValueCandidate",
+            user?.default_workspace_id,
+            user?.id,
+          ],
+        },
+      );
+    }
+    currentAction.buttonAction();
+  };
 
   return (
     <Box sx={{ bgcolor: "white.100" }}>
@@ -47,7 +95,7 @@ const BottomAction = ({ currentLabel, setCurrentLabel }) => {
         <Button
           color="primary"
           variant="contained"
-          onClick={currentAction.buttonAction}
+          onClick={handlePrimaryClick}
           sx={{ minWidth: "120px", height: "38px", padding: "8px 24px" }}
         >
           {currentAction?.buttonText}

--- a/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/CreateDatasetLinks.jsx
+++ b/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/CreateDatasetLinks.jsx
@@ -2,18 +2,59 @@ import { Box, Button, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import GetStartedDemoVideo from "../../GetStartedDemoVideo";
+import { useAuthContext } from "src/auth/hooks";
+import { Events } from "src/utils/Mixpanel";
+import {
+  buildCurrentFlowContext,
+  isProductRoute,
+  normalizeGetStartedStep,
+  trackCurrentFlow,
+} from "src/utils/analytics/currentFlow";
 
 const CreateDatasetLinks = ({
   links = [],
   heading,
   descriptions,
   buttonTitle,
+  targetRoute,
   buttonAction = () => {},
 }) => {
   const [showDemoModal, setShowDemoModal] = useState(null);
+  const { user } = useAuthContext();
 
   const handleClose = () => {
     setShowDemoModal(null);
+  };
+
+  const handlePrimaryClick = () => {
+    const context = buildCurrentFlowContext({ user });
+    trackCurrentFlow(Events.currentFlowGetStartedPrimaryClicked, {
+      ...context,
+      event_source: "get_started_dataset_links",
+      selected_step: normalizeGetStartedStep(heading),
+      button_text: buttonTitle,
+      target_route: targetRoute,
+    });
+    if (targetRoute && isProductRoute(targetRoute)) {
+      trackCurrentFlow(
+        Events.currentFlowFirstValueCandidate,
+        {
+          ...context,
+          event_source: "get_started_dataset_links",
+          selected_step: normalizeGetStartedStep(heading),
+          candidate_type: "get_started_primary_route",
+          target_route: targetRoute,
+        },
+        {
+          onceKeyParts: [
+            "firstValueCandidate",
+            user?.default_workspace_id,
+            user?.id,
+          ],
+        },
+      );
+    }
+    buttonAction();
   };
 
   return (
@@ -87,7 +128,7 @@ const CreateDatasetLinks = ({
           color="primary"
           variant="contained"
           sx={{ maxWidth: "max-content", height: "38px", padding: "8px 24px" }}
-          onClick={buttonAction}
+          onClick={handlePrimaryClick}
         >
           {buttonTitle}
         </Button>
@@ -136,5 +177,6 @@ CreateDatasetLinks.propTypes = {
   heading: PropTypes.string,
   descriptions: PropTypes.array,
   buttonTitle: PropTypes.string,
+  targetRoute: PropTypes.string,
   buttonAction: PropTypes.func,
 };

--- a/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/CreateFirstDataset.jsx
+++ b/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/CreateFirstDataset.jsx
@@ -75,6 +75,7 @@ const CreateFirstDataset = ({ setCurrentLabel }) => {
           heading="Create your first dataset"
           descriptions={descriptions}
           buttonTitle="Create Dataset"
+          targetRoute="/dashboard/develop"
           buttonAction={() => navigate("/dashboard/develop")}
         />
       </Box>

--- a/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/CreateFirstEvaluation.jsx
+++ b/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/CreateFirstEvaluation.jsx
@@ -77,6 +77,7 @@ const CreateFirstEvaluation = ({ setCurrentLabel }) => {
           heading="Set Up Your First Evaluation"
           descriptions={descriptions}
           buttonTitle="Create evaluation"
+          targetRoute="/dashboard/evaluations"
           buttonAction={() => navigate("/dashboard/evaluations")}
         />
       </Box>

--- a/frontend/src/sections/get-started/try-out-features/FeatureCard.jsx
+++ b/frontend/src/sections/get-started/try-out-features/FeatureCard.jsx
@@ -9,7 +9,14 @@ import {
 import PropTypes from "prop-types";
 import React from "react";
 import { useNavigate } from "react-router";
+import { useAuthContext } from "src/auth/hooks";
 import Image from "src/components/image";
+import { Events } from "src/utils/Mixpanel";
+import {
+  buildCurrentFlowContext,
+  getRouteFamily,
+  trackCurrentFlow,
+} from "src/utils/analytics/currentFlow";
 
 const FeatureCard = ({
   title = "",
@@ -21,8 +28,40 @@ const FeatureCard = ({
   actionLink,
 }) => {
   const navigate = useNavigate();
+  const { user } = useAuthContext();
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
+
+  const handleFeatureClick = () => {
+    const context = buildCurrentFlowContext({ user });
+    trackCurrentFlow(Events.currentFlowTryFeatureClicked, {
+      ...context,
+      event_source: "get_started_feature_card",
+      feature_title: title,
+      button_text: buttonTitle,
+      target_route: actionLink,
+      target_route_family: getRouteFamily(actionLink),
+    });
+    trackCurrentFlow(
+      Events.currentFlowFirstValueCandidate,
+      {
+        ...context,
+        event_source: "get_started_feature_card",
+        candidate_type: "try_feature_card",
+        feature_title: title,
+        target_route: actionLink,
+        target_route_family: getRouteFamily(actionLink),
+      },
+      {
+        onceKeyParts: [
+          "firstValueCandidate",
+          user?.default_workspace_id,
+          user?.id,
+        ],
+      },
+    );
+    navigate(actionLink);
+  };
 
   return (
     <Box
@@ -105,7 +144,7 @@ const FeatureCard = ({
             <Button
               color="primary"
               variant="contained"
-              onClick={() => navigate(actionLink)}
+              onClick={handleFeatureClick}
               sx={{ height: "38px", padding: "8px 24px" }}
             >
               <Typography

--- a/frontend/src/utils/Mixpanel/EventNames.js
+++ b/frontend/src/utils/Mixpanel/EventNames.js
@@ -19,6 +19,19 @@ export const Events = {
   sendPasswordClicked: "Send_password_clicked",
   setupOrganizationClicked: "Set_up_organization_clicked",
   demoVideoPageLoaded: "Demo_video_page_loaded",
+  currentFlowPostLoginDecisionResolved:
+    "current_flow_post_login_decision_resolved",
+  currentFlowFirstLandingViewed: "current_flow_first_landing_viewed",
+  currentFlowFirstProductRouteOpened: "current_flow_first_product_route_opened",
+  currentFlowGetStartedViewed: "current_flow_get_started_viewed",
+  currentFlowGetStartedTabsLoaded: "current_flow_get_started_tabs_loaded",
+  currentFlowGetStartedStepSelected: "current_flow_get_started_step_selected",
+  currentFlowGetStartedPrimaryClicked:
+    "current_flow_get_started_primary_clicked",
+  currentFlowTryFeatureClicked: "current_flow_try_feature_clicked",
+  currentFlowFalconViewed: "current_flow_falcon_viewed",
+  currentFlowFalconMessageSent: "current_flow_falcon_message_sent",
+  currentFlowFirstValueCandidate: "current_flow_first_value_candidate",
   ssoSignupClicked: "SSO_signup_clicked",
 
   createOrganizationSetup: "Create Organization Clicked",

--- a/frontend/src/utils/analytics/currentFlow.js
+++ b/frontend/src/utils/analytics/currentFlow.js
@@ -1,0 +1,135 @@
+import { trackEvent } from "src/utils/Mixpanel";
+import { trackPostHogEvent } from "src/utils/PostHog";
+
+const BLOCKED_PROPERTY_KEYS = new Set([
+  "email",
+  "message",
+  "message_text",
+  "prompt",
+  "prompt_text",
+  "trace_payload",
+  "model_response",
+  "api_key",
+  "provider_key",
+  "secret",
+]);
+
+const PRODUCT_ROUTE_PREFIXES = [
+  ["/dashboard/develop", "dataset"],
+  ["/dashboard/prompt", "prompt"],
+  ["/dashboard/workbench", "prompt"],
+  ["/dashboard/prototype", "experiment"],
+  ["/dashboard/agents", "agent"],
+  ["/dashboard/simulate", "agent"],
+  ["/dashboard/observe", "observe"],
+  ["/dashboard/gateway", "gateway"],
+  ["/dashboard/evaluations", "evals"],
+  ["/dashboard/error-feed", "observe"],
+  ["/dashboard/dashboards", "dashboards"],
+  ["/dashboard/annotation", "annotation"],
+  ["/dashboard/settings", "settings"],
+  ["/dashboard/keys", "settings"],
+];
+
+export const normalizeCurrentFlowProperties = (properties = {}) =>
+  Object.entries(properties).reduce((result, [key, value]) => {
+    if (value === undefined || BLOCKED_PROPERTY_KEYS.has(key)) {
+      return result;
+    }
+    result[key] = value;
+    return result;
+  }, {});
+
+export const markOncePerWorkspaceSession = (keyParts = []) => {
+  if (typeof window === "undefined" || !window.sessionStorage) return true;
+
+  const key = ["currentFlow", ...keyParts.map((part) => part ?? "unknown")]
+    .join(":")
+    .replace(/\s+/g, "_");
+
+  try {
+    if (window.sessionStorage.getItem(key)) return false;
+    window.sessionStorage.setItem(key, "1");
+    return true;
+  } catch {
+    return true;
+  }
+};
+
+export const getRouteFamily = (pathname = "") => {
+  if (pathname.startsWith("/dashboard/falcon-ai")) return "falcon";
+  if (pathname.startsWith("/dashboard/get-started")) return "get_started";
+  if (pathname === "/dashboard" || pathname === "/dashboard/") {
+    return "dashboard";
+  }
+
+  const route = PRODUCT_ROUTE_PREFIXES.find(([prefix]) =>
+    pathname.startsWith(prefix),
+  );
+
+  return route?.[1] || "other";
+};
+
+export const isOnboardingRoute = (pathname = "") =>
+  pathname.startsWith("/dashboard/get-started");
+
+export const isProductRoute = (pathname = "") => {
+  const family = getRouteFamily(pathname);
+  return !["falcon", "get_started", "dashboard", "other"].includes(family);
+};
+
+export const normalizeGetStartedStep = (label) => {
+  if (!label) return null;
+  return String(label)
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
+};
+
+export const getFirstIncompleteStep = (firstChecks = {}) => {
+  const entry = Object.entries(firstChecks).find(([, value]) => !value);
+  return entry?.[0] || null;
+};
+
+export const buildCurrentFlowContext = ({
+  user,
+  route,
+  postLoginPath,
+  deploymentMode,
+} = {}) => {
+  const currentRoute =
+    route ||
+    (typeof window !== "undefined" ? window.location.pathname : undefined);
+
+  return normalizeCurrentFlowProperties({
+    workspace_id: user?.default_workspace_id,
+    organization_id: user?.organization?.id,
+    user_id: user?.id,
+    route: currentRoute,
+    route_family: currentRoute ? getRouteFamily(currentRoute) : undefined,
+    deployment_mode: deploymentMode,
+    post_login_path: postLoginPath,
+    is_invited_user: Boolean(user?.invited_by || user?.invite_id),
+    organization_role: user?.organization_role ?? user?.organizationRole,
+    workspace_role: user?.default_workspace_role,
+    onboarding_completed: user?.onboarding_completed,
+    requires_org_setup: user?.requires_org_setup,
+  });
+};
+
+export const trackCurrentFlow = (eventName, properties = {}, options = {}) => {
+  if (!eventName) return false;
+
+  if (
+    options.onceKeyParts &&
+    !markOncePerWorkspaceSession(options.onceKeyParts)
+  ) {
+    return false;
+  }
+
+  const safeProperties = normalizeCurrentFlowProperties(properties);
+  trackEvent(eventName, safeProperties);
+  trackPostHogEvent(eventName, safeProperties);
+  return true;
+};

--- a/frontend/src/utils/analytics/currentFlow.test.js
+++ b/frontend/src/utils/analytics/currentFlow.test.js
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildCurrentFlowContext,
+  getFirstIncompleteStep,
+  getRouteFamily,
+  isOnboardingRoute,
+  isProductRoute,
+  markOncePerWorkspaceSession,
+  normalizeCurrentFlowProperties,
+  normalizeGetStartedStep,
+  trackCurrentFlow,
+} from "./currentFlow";
+
+import { trackEvent } from "src/utils/Mixpanel";
+import { trackPostHogEvent } from "src/utils/PostHog";
+
+vi.mock("src/utils/Mixpanel", () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("src/utils/PostHog", () => ({
+  trackPostHogEvent: vi.fn(),
+}));
+
+describe("current flow analytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+  });
+
+  it("removes undefined and unsafe content properties", () => {
+    expect(
+      normalizeCurrentFlowProperties({
+        workspace_id: "workspace-1",
+        route: undefined,
+        email: "user@example.com",
+        prompt_text: "hidden",
+        message_text: "hidden",
+        api_key: "hidden",
+      }),
+    ).toEqual({ workspace_id: "workspace-1" });
+  });
+
+  it("tracks to Mixpanel and PostHog with safe properties", () => {
+    const tracked = trackCurrentFlow("current_flow_test", {
+      workspace_id: "workspace-1",
+      message_text: "hidden",
+      route: "/dashboard/get-started",
+    });
+
+    expect(tracked).toBe(true);
+    expect(trackEvent).toHaveBeenCalledWith("current_flow_test", {
+      workspace_id: "workspace-1",
+      route: "/dashboard/get-started",
+    });
+    expect(trackPostHogEvent).toHaveBeenCalledWith("current_flow_test", {
+      workspace_id: "workspace-1",
+      route: "/dashboard/get-started",
+    });
+  });
+
+  it("dedupes once-per-session events", () => {
+    expect(markOncePerWorkspaceSession(["landing", "workspace-1"])).toBe(true);
+    expect(markOncePerWorkspaceSession(["landing", "workspace-1"])).toBe(false);
+  });
+
+  it("skips duplicate once-per-session tracking", () => {
+    const options = { onceKeyParts: ["event", "workspace-1"] };
+
+    expect(trackCurrentFlow("current_flow_test", {}, options)).toBe(true);
+    expect(trackCurrentFlow("current_flow_test", {}, options)).toBe(false);
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(trackPostHogEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("classifies route families", () => {
+    expect(getRouteFamily("/dashboard/falcon-ai")).toBe("falcon");
+    expect(getRouteFamily("/dashboard/get-started")).toBe("get_started");
+    expect(getRouteFamily("/dashboard/prompt/add/123")).toBe("prompt");
+    expect(getRouteFamily("/dashboard/agents")).toBe("agent");
+    expect(getRouteFamily("/dashboard/gateway/logs")).toBe("gateway");
+    expect(getRouteFamily("/dashboard/evaluations")).toBe("evals");
+  });
+
+  it("separates onboarding and product routes", () => {
+    expect(isOnboardingRoute("/dashboard/get-started")).toBe(true);
+    expect(isProductRoute("/dashboard/get-started")).toBe(false);
+    expect(isProductRoute("/dashboard/falcon-ai")).toBe(false);
+    expect(isProductRoute("/dashboard/observe")).toBe(true);
+  });
+
+  it("normalizes Get Started step labels", () => {
+    expect(normalizeGetStartedStep("SetupObsabilityInApplication")).toBe(
+      "setup_obsability_in_application",
+    );
+    expect(normalizeGetStartedStep("create first dataset")).toBe(
+      "create_first_dataset",
+    );
+  });
+
+  it("finds the first incomplete first-check step", () => {
+    expect(
+      getFirstIncompleteStep({
+        keys: true,
+        dataset: false,
+        evals: false,
+      }),
+    ).toBe("dataset");
+    expect(getFirstIncompleteStep({ keys: true })).toBe(null);
+  });
+
+  it("builds a safe user context", () => {
+    expect(
+      buildCurrentFlowContext({
+        route: "/dashboard/observe",
+        postLoginPath: "/dashboard/falcon-ai",
+        deploymentMode: "cloud",
+        user: {
+          id: "user-1",
+          email: "user@example.com",
+          default_workspace_id: "workspace-1",
+          default_workspace_role: "workspace_admin",
+          organization_role: "Owner",
+          onboarding_completed: true,
+          requires_org_setup: false,
+          organization: { id: "org-1", name: "Org" },
+        },
+      }),
+    ).toEqual({
+      workspace_id: "workspace-1",
+      organization_id: "org-1",
+      user_id: "user-1",
+      route: "/dashboard/observe",
+      route_family: "observe",
+      deployment_mode: "cloud",
+      post_login_path: "/dashboard/falcon-ai",
+      is_invited_user: false,
+      organization_role: "Owner",
+      workspace_role: "workspace_admin",
+      onboarding_completed: true,
+      requires_org_setup: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add current-flow analytics helpers for onboarding-safe event properties and session-level de-duping
- track post-login routing decisions, first dashboard landing, first product route, Get Started actions, feature-card clicks, and Falcon message starts
- cover the new analytics helper with focused unit tests

## Validation
- yarn --cwd frontend test:run currentFlow
- targeted ESLint on changed frontend files
- git diff --check
- compile-only Vite build with the existing config and the lint checker removed in-process

## Notes
The normal frontend build still runs the repository-wide ESLint checker and is blocked by existing lint errors in untouched files, mostly prop validation errors outside this change set. The compile-only Vite build completed successfully.