### PR TITLE
Add onboarding activation contract serializers

### DIFF
--- a/futureagi/accounts/serializers/onboarding.py
+++ b/futureagi/accounts/serializers/onboarding.py
@@ -1,0 +1,450 @@
+from rest_framework import serializers
+
+from accounts.services.onboarding.constants import (
+    ACTION_KINDS,
+    ACTIVATION_SCHEMA_VERSION,
+    ACTIVATION_STAGES,
+    AVAILABLE_PATH_STATUSES,
+    EMAIL_CONTEXT_STATUSES,
+    HOME_MODES,
+    LIFECYCLE_SUPPRESSION_REASONS,
+    ONBOARDING_GOALS,
+    PRODUCT_PATHS,
+    PROGRESS_STATES,
+    ROUTE_UNAVAILABLE_REASONS,
+    SAMPLE_PROJECT_STATUSES,
+    canonical_goal,
+    canonical_path,
+    choices,
+)
+
+
+class ActivationAnalyticsSerializer(serializers.Serializer):
+    event_name = serializers.CharField()
+    source = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    target_path = serializers.ChoiceField(
+        choices=choices(PRODUCT_PATHS),
+        required=False,
+        allow_null=True,
+    )
+
+
+class ActivationActionSerializer(serializers.Serializer):
+    id = serializers.CharField()
+    kind = serializers.ChoiceField(choices=choices(ACTION_KINDS))
+    title = serializers.CharField()
+    description = serializers.CharField()
+    href = serializers.CharField(allow_blank=True, allow_null=True)
+    cta_label = serializers.CharField()
+    estimated_minutes = serializers.IntegerField(
+        min_value=1,
+        required=False,
+        allow_null=True,
+    )
+    priority = serializers.IntegerField()
+    blocked = serializers.BooleanField()
+    blocked_reason = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    requires_permission = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    completion_event = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    is_sample = serializers.BooleanField(default=False)
+    route_available = serializers.BooleanField()
+    fallback_href = serializers.CharField()
+    analytics = ActivationAnalyticsSerializer()
+
+    def validate(self, attrs):
+        if not attrs["blocked"] and not attrs.get("href"):
+            raise serializers.ValidationError(
+                "Unblocked actions must include an internal href."
+            )
+        if attrs["blocked"] and not attrs.get("blocked_reason"):
+            raise serializers.ValidationError(
+                "Blocked actions must include a blocked_reason."
+            )
+        if not attrs.get("fallback_href"):
+            raise serializers.ValidationError("Actions must include a fallback_href.")
+        if attrs["is_sample"] and attrs.get("completion_event"):
+            completion_event = attrs["completion_event"]
+            if "sample" not in completion_event:
+                raise serializers.ValidationError(
+                    "Sample actions cannot use real activation completion events."
+                )
+        return attrs
+
+
+class ActivationProgressSerializer(serializers.Serializer):
+    build = serializers.ChoiceField(choices=choices(PROGRESS_STATES))
+    test = serializers.ChoiceField(choices=choices(PROGRESS_STATES))
+    observe = serializers.ChoiceField(choices=choices(PROGRESS_STATES))
+    ship = serializers.ChoiceField(choices=choices(PROGRESS_STATES))
+    improve = serializers.ChoiceField(choices=choices(PROGRESS_STATES))
+
+
+class ActivationSignalsSerializer(serializers.Serializer):
+    provider_keys = serializers.IntegerField(min_value=0, default=0)
+    datasets = serializers.IntegerField(min_value=0, default=0)
+    evals = serializers.IntegerField(min_value=0, default=0)
+    eval_runs = serializers.IntegerField(min_value=0, default=0)
+    prompt_templates = serializers.IntegerField(min_value=0, default=0)
+    prompt_versions = serializers.IntegerField(min_value=0, default=0)
+    prompt_comparisons = serializers.IntegerField(min_value=0, default=0)
+    agents = serializers.IntegerField(min_value=0, default=0)
+    agent_prototype_runs = serializers.IntegerField(min_value=0, default=0)
+    observe_projects = serializers.IntegerField(min_value=0, default=0)
+    traces = serializers.IntegerField(min_value=0, default=0)
+    trace_reviews = serializers.IntegerField(min_value=0, default=0)
+    gateway_keys = serializers.IntegerField(min_value=0, default=0)
+    gateway_requests = serializers.IntegerField(min_value=0, default=0)
+    gateway_policies = serializers.IntegerField(min_value=0, default=0)
+    voice_agents = serializers.IntegerField(min_value=0, default=0)
+    voice_simulations = serializers.IntegerField(min_value=0, default=0)
+    voice_calls = serializers.IntegerField(min_value=0, default=0)
+    voice_reviews = serializers.IntegerField(min_value=0, default=0)
+    team_invites = serializers.IntegerField(min_value=0, default=0)
+    dashboards = serializers.IntegerField(min_value=0, default=0)
+    alerts = serializers.IntegerField(min_value=0, default=0)
+    first_trace_id = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    first_observe_id = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+
+
+class AvailablePathSerializer(serializers.Serializer):
+    id = serializers.ChoiceField(choices=choices(PRODUCT_PATHS))
+    label = serializers.CharField()
+    description = serializers.CharField()
+    status = serializers.ChoiceField(choices=choices(AVAILABLE_PATH_STATUSES))
+    href = serializers.CharField()
+    is_available = serializers.BooleanField()
+    blocked_reason = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    requires_permission = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    first_action_id = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+
+
+class SampleProjectStateSerializer(serializers.Serializer):
+    available = serializers.BooleanField()
+    created = serializers.BooleanField()
+    status = serializers.ChoiceField(choices=choices(SAMPLE_PROJECT_STATUSES))
+    href = serializers.CharField(allow_blank=True, allow_null=True)
+    version = serializers.CharField(allow_blank=True, allow_null=True)
+    is_hidden = serializers.BooleanField()
+    hidden_reason = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    entry_routes = serializers.ListField(child=serializers.CharField())
+    missing_artifacts = serializers.ListField(child=serializers.CharField())
+    last_opened_at = serializers.DateTimeField(required=False, allow_null=True)
+
+    def validate(self, attrs):
+        status = attrs["status"]
+        if attrs["created"] and status not in {
+            "ready",
+            "partial",
+            "stale_manifest",
+            "repair_required",
+        }:
+            raise serializers.ValidationError(
+                "Created samples must be ready, partial, stale, or repairable."
+            )
+        if status == "partial" and not attrs["missing_artifacts"]:
+            raise serializers.ValidationError(
+                "Partial samples must list missing_artifacts."
+            )
+        if status == "ready" and not attrs["entry_routes"]:
+            raise serializers.ValidationError("Ready samples must list entry_routes.")
+        return attrs
+
+
+class LifecycleEligibilitySerializer(serializers.Serializer):
+    eligible = serializers.BooleanField()
+    suppressed = serializers.BooleanField()
+    suppression_reason = serializers.ChoiceField(
+        choices=choices(LIFECYCLE_SUPPRESSION_REASONS),
+        required=False,
+        allow_null=True,
+    )
+    next_email_key = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    next_email_after = serializers.DateTimeField(required=False, allow_null=True)
+    digest_eligible = serializers.BooleanField()
+    last_email_sent_at = serializers.DateTimeField(required=False, allow_null=True)
+    frequency_cap_remaining = serializers.IntegerField(min_value=0)
+    dry_run_only = serializers.BooleanField(default=True)
+
+    def validate(self, attrs):
+        if attrs["suppressed"] and not attrs.get("suppression_reason"):
+            raise serializers.ValidationError(
+                "Suppressed lifecycle decisions must include suppression_reason."
+            )
+        return attrs
+
+
+class ActivationPermissionsSerializer(serializers.Serializer):
+    role = serializers.CharField(allow_blank=True, allow_null=True)
+    can_read = serializers.BooleanField()
+    can_write = serializers.BooleanField()
+    can_manage_workspace = serializers.BooleanField()
+    missing_permissions = serializers.ListField(child=serializers.CharField())
+    request_access_href = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    permission_limited = serializers.BooleanField()
+
+
+class RouteAvailabilityEntrySerializer(serializers.Serializer):
+    href = serializers.CharField()
+    is_available = serializers.BooleanField()
+    reason = serializers.ChoiceField(
+        choices=choices(ROUTE_UNAVAILABLE_REASONS),
+        required=False,
+        allow_null=True,
+    )
+
+    def validate(self, attrs):
+        if not attrs["is_available"] and not attrs.get("reason"):
+            raise serializers.ValidationError(
+                "Unavailable routes must include a reason."
+            )
+        return attrs
+
+
+class RouteAvailabilitySerializer(serializers.Serializer):
+    def to_internal_value(self, data):
+        if not isinstance(data, dict):
+            raise serializers.ValidationError("Expected a route availability map.")
+
+        errors = {}
+        validated = {}
+        for route_key, route_value in data.items():
+            serializer = RouteAvailabilityEntrySerializer(data=route_value)
+            if serializer.is_valid():
+                validated[route_key] = serializer.validated_data
+            else:
+                errors[route_key] = serializer.errors
+
+        if errors:
+            raise serializers.ValidationError(errors)
+        return validated
+
+    def to_representation(self, instance):
+        return instance
+
+
+class ActivationEmailContextSerializer(serializers.Serializer):
+    campaign_key = serializers.CharField()
+    email_key = serializers.CharField()
+    target_stage = serializers.ChoiceField(choices=choices(ACTIVATION_STAGES))
+    target_event = serializers.CharField()
+    target_route = serializers.CharField()
+    context_status = serializers.ChoiceField(choices=choices(EMAIL_CONTEXT_STATUSES))
+    stale_reason = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
+    resolved_href = serializers.CharField()
+
+
+class ActivationMeaningfulEventSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    occurred_at = serializers.DateTimeField()
+    is_sample = serializers.BooleanField(default=False)
+    path = serializers.ChoiceField(
+        choices=choices(PRODUCT_PATHS),
+        required=False,
+        allow_null=True,
+    )
+    metadata = serializers.DictField(required=False)
+
+
+class ActivationDiagnosticsSuppressedActionSerializer(serializers.Serializer):
+    id = serializers.CharField()
+    reason = serializers.CharField()
+
+
+class ActivationDiagnosticsSerializer(serializers.Serializer):
+    resolver_version = serializers.CharField()
+    decision_reason = serializers.CharField()
+    matched_rule = serializers.CharField()
+    candidate_actions = serializers.ListField(child=serializers.CharField())
+    suppressed_actions = ActivationDiagnosticsSuppressedActionSerializer(many=True)
+    evaluated_at = serializers.DateTimeField()
+
+
+class ActivationStateResponseSerializer(serializers.Serializer):
+    schema_version = serializers.CharField()
+    request_id = serializers.CharField()
+    server_time = serializers.DateTimeField()
+    workspace_id = serializers.CharField(allow_null=True)
+    organization_id = serializers.CharField(allow_null=True)
+    user_id = serializers.CharField()
+    goal = serializers.ChoiceField(
+        choices=choices(ONBOARDING_GOALS),
+        allow_null=True,
+    )
+    persona = serializers.CharField(allow_blank=True, allow_null=True)
+    primary_path = serializers.ChoiceField(
+        choices=choices(PRODUCT_PATHS),
+        allow_null=True,
+    )
+    stage = serializers.ChoiceField(choices=choices(ACTIVATION_STAGES))
+    home_mode = serializers.ChoiceField(choices=choices(HOME_MODES))
+    is_activated = serializers.BooleanField()
+    activated_at = serializers.DateTimeField(allow_null=True)
+    recommended_action = ActivationActionSerializer(allow_null=True)
+    fallback_action = ActivationActionSerializer()
+    progress = ActivationProgressSerializer()
+    signals = ActivationSignalsSerializer()
+    available_paths = AvailablePathSerializer(many=True)
+    sample_project = SampleProjectStateSerializer()
+    email_eligibility = LifecycleEligibilitySerializer()
+    permissions = ActivationPermissionsSerializer()
+    feature_flags = serializers.DictField(child=serializers.BooleanField())
+    route_availability = RouteAvailabilitySerializer()
+    email_context = ActivationEmailContextSerializer(allow_null=True)
+    last_meaningful_event = ActivationMeaningfulEventSerializer(allow_null=True)
+    diagnostics = ActivationDiagnosticsSerializer(allow_null=True)
+    warnings = serializers.ListField(child=serializers.CharField())
+
+    def validate_schema_version(self, value):
+        if value != ACTIVATION_SCHEMA_VERSION:
+            raise serializers.ValidationError("Unsupported activation schema version.")
+        return value
+
+    def validate(self, attrs):
+        stage = attrs["stage"]
+        recommended_action = attrs.get("recommended_action")
+        fallback_action = attrs["fallback_action"]
+
+        if stage not in {"workspace_missing"} and recommended_action is None:
+            raise serializers.ValidationError(
+                "Renderable activation states require a recommended_action."
+            )
+        if (
+            recommended_action
+            and recommended_action["id"] == fallback_action["id"]
+            and stage != "feature_disabled"
+        ):
+            raise serializers.ValidationError(
+                "Primary and fallback actions must be distinct."
+            )
+
+        last_event = attrs.get("last_meaningful_event")
+        if attrs["is_activated"] and last_event and last_event.get("is_sample"):
+            raise serializers.ValidationError(
+                "Sample-only events cannot activate a workspace."
+            )
+
+        permissions = attrs["permissions"]
+        if (
+            recommended_action
+            and not permissions["can_write"]
+            and recommended_action.get("requires_permission")
+            and recommended_action["kind"]
+            not in {"request_access", "review", "fallback"}
+        ):
+            raise serializers.ValidationError(
+                "Users without write permission cannot receive write-only CTAs."
+            )
+
+        available_hrefs = {
+            route["href"] for route in attrs["route_availability"].values()
+        }
+        if (
+            recommended_action
+            and recommended_action["route_available"]
+            and recommended_action.get("href")
+            and recommended_action["href"] not in available_hrefs
+        ):
+            raise serializers.ValidationError(
+                "Recommended action href must appear in route_availability."
+            )
+        if fallback_action["fallback_href"] not in available_hrefs:
+            raise serializers.ValidationError(
+                "Fallback action fallback_href must appear in route_availability."
+            )
+
+        return attrs
+
+
+class ActivationGoalRequestSerializer(serializers.Serializer):
+    goal = serializers.CharField()
+    persona = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    source = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    campaign_key = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    reason = serializers.ChoiceField(
+        choices=choices(
+            (
+                "first_selection",
+                "path_change",
+                "email_link",
+                "manual_switch",
+            )
+        ),
+        required=False,
+        allow_null=True,
+    )
+
+    def validate_goal(self, value):
+        canonical = canonical_goal(value)
+        if canonical not in ONBOARDING_GOALS:
+            raise serializers.ValidationError("Unsupported goal value.")
+        return canonical
+
+
+class SampleProjectRequestSerializer(serializers.Serializer):
+    path = serializers.CharField()
+    manifest_id = serializers.CharField()
+    manifest_version = serializers.CharField()
+    source = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    reason = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    open_after_create = serializers.BooleanField(default=False)
+
+    def validate_path(self, value):
+        canonical = canonical_path(value)
+        if canonical not in PRODUCT_PATHS:
+            raise serializers.ValidationError("Unsupported sample project path.")
+        return canonical
+
+
+class SampleProjectResponseSerializer(serializers.Serializer):
+    sample_project = SampleProjectStateSerializer()
+    activation_state = ActivationStateResponseSerializer()

--- a/futureagi/accounts/services/onboarding/__init__.py
+++ b/futureagi/accounts/services/onboarding/__init__.py
@@ -1,0 +1,1 @@
+"""Onboarding activation contract helpers."""

--- a/futureagi/accounts/services/onboarding/constants.py
+++ b/futureagi/accounts/services/onboarding/constants.py
@@ -1,0 +1,206 @@
+ACTIVATION_SCHEMA_VERSION = "activation-state-2026-05-26.v1"
+
+ONBOARDING_GOALS = (
+    "improve_prompts",
+    "build_ai_agent",
+    "monitor_production_ai_app",
+    "control_model_traffic",
+    "evaluate_quality",
+    "connect_voice_ai_agent",
+    "explore_sample_data",
+)
+
+ONBOARDING_GOAL_ALIASES = {
+    "test_and_improve_prompts": "improve_prompts",
+    "build_or_prototype_agent": "build_ai_agent",
+    "route_llm_traffic_safely": "control_model_traffic",
+    "evaluate_quality_on_data_or_traces": "evaluate_quality",
+}
+
+PRODUCT_PATHS = (
+    "prompt",
+    "agent",
+    "observe",
+    "gateway",
+    "voice",
+    "evals",
+    "dashboards",
+    "sample",
+)
+
+PRODUCT_PATH_ALIASES = {
+    "prompts": "prompt",
+    "workbench": "prompt",
+    "agents": "agent",
+    "simulate_agent": "agent",
+    "observability": "observe",
+    "traces": "observe",
+    "model_gateway": "gateway",
+    "voice_ai": "voice",
+    "eval": "evals",
+    "evaluations": "evals",
+    "dashboard": "dashboards",
+    "sample_project": "sample",
+}
+
+ACTIVATION_STAGES = (
+    "feature_disabled",
+    "workspace_missing",
+    "permission_limited",
+    "choose_goal",
+    "selected_path_unavailable",
+    "activated",
+    "daily_review",
+    "start_prompt",
+    "run_prompt_test",
+    "save_prompt_version",
+    "compare_prompt_versions",
+    "prompt_next_loop",
+    "create_agent",
+    "run_agent_scenario",
+    "review_agent_trace",
+    "save_agent_eval",
+    "agent_create_eval",
+    "connect_observability",
+    "waiting_for_first_trace",
+    "waiting_for_first_trace_sample_available",
+    "review_first_trace",
+    "create_trace_evaluator",
+    "create_trace_dashboard",
+    "create_trace_alert",
+    "configure_gateway_provider",
+    "create_gateway_key",
+    "run_gateway_request",
+    "review_gateway_log",
+    "fix_gateway_failure",
+    "add_gateway_policy",
+    "create_voice_agent",
+    "run_voice_test_call",
+    "review_voice_call",
+    "add_voice_success_criteria",
+    "voice_monitor_calls",
+    "create_eval_dataset",
+    "add_eval_scorer",
+    "run_eval",
+    "review_eval_failures",
+    "eval_next_loop",
+    "open_sample_project",
+    "review_sample_signal",
+    "connect_real_data",
+)
+
+HOME_MODES = (
+    "first_run",
+    "daily_quality",
+    "fallback",
+)
+
+ACTION_KINDS = (
+    "choose_goal",
+    "setup",
+    "send_signal",
+    "review",
+    "improve",
+    "sample_project",
+    "request_access",
+    "fallback",
+    "daily_quality",
+    "adjacent_loop",
+)
+
+PROGRESS_KEYS = (
+    "build",
+    "test",
+    "observe",
+    "ship",
+    "improve",
+)
+
+PROGRESS_STATES = (
+    "not_started",
+    "available",
+    "selected",
+    "in_progress",
+    "blocked",
+    "complete",
+    "sample_only",
+)
+
+SAMPLE_PROJECT_STATUSES = (
+    "unavailable",
+    "available",
+    "creating",
+    "ready",
+    "partial",
+    "hidden",
+    "stale_manifest",
+    "repair_required",
+)
+
+LIFECYCLE_ELIGIBILITY_STATES = (
+    "eligible",
+    "suppressed",
+    "skipped",
+    "error",
+)
+
+LIFECYCLE_SUPPRESSION_REASONS = (
+    "activated",
+    "target_event_complete",
+    "frequency_cap",
+    "workspace_suppressed",
+    "user_unsubscribed",
+    "sample_hidden",
+    "route_unavailable",
+    "permission_limited",
+    "feature_disabled",
+    "recent_goal_change",
+    "manual_pause",
+)
+
+ROUTE_AVAILABILITY_STATES = (
+    "available",
+    "unavailable",
+)
+
+ROUTE_UNAVAILABLE_REASONS = (
+    "feature_disabled",
+    "missing_id",
+    "missing_permission",
+    "plan_blocked",
+    "route_not_implemented",
+    "sample_artifact_missing",
+    "target_event_complete",
+    "workspace_missing",
+)
+
+EMAIL_CONTEXT_STATUSES = (
+    "current",
+    "stale",
+    "expired",
+    "invalid",
+    "complete",
+    "route_unavailable",
+)
+
+AVAILABLE_PATH_STATUSES = (
+    "available",
+    "selected",
+    "in_progress",
+    "blocked",
+    "complete",
+    "sample_only",
+    "hidden",
+)
+
+
+def choices(values):
+    return tuple((value, value) for value in values)
+
+
+def canonical_goal(value):
+    return ONBOARDING_GOAL_ALIASES.get(value, value)
+
+
+def canonical_path(value):
+    return PRODUCT_PATH_ALIASES.get(value, value)

--- a/futureagi/accounts/tests/onboarding_fixtures.py
+++ b/futureagi/accounts/tests/onboarding_fixtures.py
@@ -1,0 +1,194 @@
+from copy import deepcopy
+
+from accounts.services.onboarding.constants import ACTIVATION_SCHEMA_VERSION
+
+
+def activation_action(**overrides):
+    action = {
+        "id": "create_observe_project",
+        "kind": "setup",
+        "title": "Connect observability",
+        "description": "Create an observability project and send one request.",
+        "href": "/dashboard/observe?setup=true&source=onboarding",
+        "cta_label": "Connect observability",
+        "estimated_minutes": 5,
+        "priority": 100,
+        "blocked": False,
+        "blocked_reason": None,
+        "requires_permission": "observe:write",
+        "completion_event": "observe_project_created",
+        "is_sample": False,
+        "route_available": True,
+        "fallback_href": "/dashboard/get-started",
+        "analytics": {
+            "event_name": "onboarding_recommended_action_clicked",
+            "source": "home",
+            "target_path": "observe",
+        },
+    }
+    action.update(overrides)
+    return action
+
+
+def fallback_action(**overrides):
+    action = activation_action(
+        id="open_get_started",
+        kind="fallback",
+        title="Open Get Started",
+        description="Use the existing setup checklist.",
+        href="/dashboard/get-started",
+        cta_label="Open Get Started",
+        estimated_minutes=None,
+        priority=10,
+        requires_permission=None,
+        completion_event=None,
+        route_available=True,
+        analytics={
+            "event_name": "onboarding_recommended_action_clicked",
+            "source": "fallback",
+            "target_path": None,
+        },
+    )
+    action.update(overrides)
+    return action
+
+
+def activation_state_payload(**overrides):
+    payload = {
+        "schema_version": ACTIVATION_SCHEMA_VERSION,
+        "request_id": "req_onboarding_contract",
+        "server_time": "2026-05-26T15:00:00Z",
+        "workspace_id": "wrk_contract",
+        "organization_id": "org_contract",
+        "user_id": "usr_contract",
+        "goal": "monitor_production_ai_app",
+        "persona": "developer",
+        "primary_path": "observe",
+        "stage": "connect_observability",
+        "home_mode": "first_run",
+        "is_activated": False,
+        "activated_at": None,
+        "recommended_action": activation_action(),
+        "fallback_action": fallback_action(),
+        "progress": {
+            "build": "selected",
+            "test": "available",
+            "observe": "not_started",
+            "ship": "available",
+            "improve": "available",
+        },
+        "signals": {
+            "provider_keys": 1,
+            "datasets": 0,
+            "evals": 0,
+            "eval_runs": 0,
+            "prompt_templates": 0,
+            "prompt_versions": 0,
+            "prompt_comparisons": 0,
+            "agents": 0,
+            "agent_prototype_runs": 0,
+            "observe_projects": 0,
+            "traces": 0,
+            "trace_reviews": 0,
+            "gateway_keys": 0,
+            "gateway_requests": 0,
+            "gateway_policies": 0,
+            "voice_agents": 0,
+            "voice_simulations": 0,
+            "voice_calls": 0,
+            "voice_reviews": 0,
+            "team_invites": 0,
+            "dashboards": 0,
+            "alerts": 0,
+            "first_trace_id": None,
+            "first_observe_id": None,
+        },
+        "available_paths": [
+            {
+                "id": "observe",
+                "label": "Monitor a production AI app",
+                "description": "Connect traces and inspect quality signals.",
+                "status": "selected",
+                "href": "/dashboard/home?path=observe",
+                "is_available": True,
+                "blocked_reason": None,
+                "requires_permission": "observe:write",
+                "first_action_id": "create_observe_project",
+            },
+            {
+                "id": "sample",
+                "label": "Explore with sample data",
+                "description": "Use a sample workspace while real data is pending.",
+                "status": "available",
+                "href": "/dashboard/home?path=sample",
+                "is_available": True,
+                "blocked_reason": None,
+                "requires_permission": None,
+                "first_action_id": "open_sample_project",
+            },
+        ],
+        "sample_project": {
+            "available": True,
+            "created": False,
+            "status": "available",
+            "href": "/dashboard/home?sample=true",
+            "version": "sample-observe-v1",
+            "is_hidden": False,
+            "hidden_reason": None,
+            "entry_routes": [],
+            "missing_artifacts": [],
+            "last_opened_at": None,
+        },
+        "email_eligibility": {
+            "eligible": True,
+            "suppressed": False,
+            "suppression_reason": None,
+            "next_email_key": "observe_connect_first",
+            "next_email_after": "2026-05-26T15:00:00Z",
+            "digest_eligible": False,
+            "last_email_sent_at": None,
+            "frequency_cap_remaining": 2,
+            "dry_run_only": True,
+        },
+        "permissions": {
+            "role": "admin",
+            "can_read": True,
+            "can_write": True,
+            "can_manage_workspace": True,
+            "missing_permissions": [],
+            "request_access_href": "/dashboard/settings/user-management",
+            "permission_limited": False,
+        },
+        "feature_flags": {
+            "onboarding_home_enabled": True,
+            "onboarding_observe_mvp_enabled": True,
+            "onboarding_sample_project_enabled": True,
+            "onboarding_lifecycle_dry_run_enabled": True,
+            "onboarding_lifecycle_send_enabled": False,
+            "daily_quality_home_enabled": False,
+            "activation_state_debug_enabled": False,
+        },
+        "route_availability": {
+            "home": {
+                "href": "/dashboard/home",
+                "is_available": True,
+                "reason": None,
+            },
+            "observe_setup": {
+                "href": "/dashboard/observe?setup=true&source=onboarding",
+                "is_available": True,
+                "reason": None,
+            },
+            "get_started": {
+                "href": "/dashboard/get-started",
+                "is_available": True,
+                "reason": None,
+            },
+        },
+        "email_context": None,
+        "last_meaningful_event": None,
+        "diagnostics": None,
+        "warnings": [],
+    }
+    payload.update(overrides)
+    return deepcopy(payload)

--- a/futureagi/accounts/tests/test_onboarding_serializers.py
+++ b/futureagi/accounts/tests/test_onboarding_serializers.py
@@ -1,0 +1,162 @@
+from copy import deepcopy
+
+from accounts.serializers.onboarding import (
+    ActivationGoalRequestSerializer,
+    ActivationStateResponseSerializer,
+    SampleProjectRequestSerializer,
+    SampleProjectStateSerializer,
+)
+from accounts.services.onboarding.constants import (
+    ACTIVATION_STAGES,
+    ONBOARDING_GOALS,
+    PRODUCT_PATHS,
+    canonical_goal,
+    canonical_path,
+)
+from accounts.tests.onboarding_fixtures import (
+    activation_action,
+    activation_state_payload,
+)
+
+
+def test_onboarding_constants_include_release_0_contract_values():
+    assert "monitor_production_ai_app" in ONBOARDING_GOALS
+    assert "connect_voice_ai_agent" in ONBOARDING_GOALS
+    assert "gateway" in PRODUCT_PATHS
+    assert "voice" in PRODUCT_PATHS
+    assert "review_first_trace" in ACTIVATION_STAGES
+    assert "run_gateway_request" in ACTIVATION_STAGES
+    assert "voice_monitor_calls" in ACTIVATION_STAGES
+    assert canonical_goal("test_and_improve_prompts") == "improve_prompts"
+    assert canonical_path("evaluations") == "evals"
+
+
+def test_activation_state_response_serializer_accepts_observe_first_run_fixture():
+    serializer = ActivationStateResponseSerializer(data=activation_state_payload())
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["stage"] == "connect_observability"
+    assert serializer.validated_data["recommended_action"]["id"] == (
+        "create_observe_project"
+    )
+
+
+def test_activation_state_response_rejects_unknown_stage():
+    payload = activation_state_payload(stage="unknown_stage")
+    serializer = ActivationStateResponseSerializer(data=payload)
+
+    assert not serializer.is_valid()
+    assert "stage" in serializer.errors
+
+
+def test_activation_state_response_requires_all_progress_keys():
+    payload = activation_state_payload()
+    del payload["progress"]["observe"]
+    serializer = ActivationStateResponseSerializer(data=payload)
+
+    assert not serializer.is_valid()
+    assert "observe" in serializer.errors["progress"]
+
+
+def test_activation_state_response_rejects_unavailable_action_route():
+    payload = activation_state_payload()
+    payload["route_availability"].pop("observe_setup")
+    serializer = ActivationStateResponseSerializer(data=payload)
+
+    assert not serializer.is_valid()
+    assert "Recommended action href must appear" in str(serializer.errors)
+
+
+def test_activation_state_response_rejects_sample_only_activation():
+    payload = activation_state_payload(
+        is_activated=True,
+        activated_at="2026-05-26T15:05:00Z",
+        last_meaningful_event={
+            "name": "sample_trace_reviewed",
+            "occurred_at": "2026-05-26T15:04:00Z",
+            "is_sample": True,
+            "path": "sample",
+        },
+    )
+    serializer = ActivationStateResponseSerializer(data=payload)
+
+    assert not serializer.is_valid()
+    assert "Sample-only events cannot activate" in str(serializer.errors)
+
+
+def test_activation_state_response_rejects_write_cta_for_read_only_user():
+    payload = activation_state_payload()
+    payload["permissions"]["can_write"] = False
+    payload["permissions"]["permission_limited"] = True
+    payload["permissions"]["missing_permissions"] = ["observe:write"]
+    serializer = ActivationStateResponseSerializer(data=payload)
+
+    assert not serializer.is_valid()
+    assert "write-only CTAs" in str(serializer.errors)
+
+
+def test_action_serializer_rejects_sample_action_with_real_completion_event():
+    payload = activation_state_payload(
+        recommended_action=activation_action(
+            id="open_sample_project",
+            kind="sample_project",
+            href="/dashboard/home?sample=true",
+            completion_event="trace_reviewed",
+            is_sample=True,
+        )
+    )
+    payload["route_availability"]["sample"] = {
+        "href": "/dashboard/home?sample=true",
+        "is_available": True,
+        "reason": None,
+    }
+    serializer = ActivationStateResponseSerializer(data=payload)
+
+    assert not serializer.is_valid()
+    assert "Sample actions cannot use real activation" in str(serializer.errors)
+
+
+def test_sample_project_state_requires_ready_entry_routes():
+    sample = deepcopy(activation_state_payload()["sample_project"])
+    sample.update({"created": True, "status": "ready"})
+    serializer = SampleProjectStateSerializer(data=sample)
+
+    assert not serializer.is_valid()
+    assert "Ready samples must list entry_routes" in str(serializer.errors)
+
+
+def test_goal_request_accepts_alias_and_emits_canonical_goal():
+    serializer = ActivationGoalRequestSerializer(
+        data={
+            "goal": "route_llm_traffic_safely",
+            "persona": "platform_engineer",
+            "source": "goal_picker",
+            "reason": "first_selection",
+        }
+    )
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["goal"] == "control_model_traffic"
+
+
+def test_goal_request_rejects_unknown_goal():
+    serializer = ActivationGoalRequestSerializer(data={"goal": "ship_magic"})
+
+    assert not serializer.is_valid()
+    assert "goal" in serializer.errors
+
+
+def test_sample_project_request_accepts_path_alias():
+    serializer = SampleProjectRequestSerializer(
+        data={
+            "path": "observability",
+            "manifest_id": "futureagi_sample_ai_support_workspace",
+            "manifest_version": "2026-05-26.1",
+            "source": "onboarding_home",
+            "reason": "waiting_for_first_trace",
+            "open_after_create": True,
+        }
+    )
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["path"] == "observe"


### PR DESCRIPTION
## Summary
- add canonical onboarding activation constants for goals, paths, stages, action kinds, progress, sample states, lifecycle suppression, and route availability
- add DRF serializers for the activation-state response, actions, progress, signals, path options, sample state, lifecycle eligibility, permissions, route availability, email context, diagnostics, goal requests, and sample project requests
- add backend fixtures and serializer tests covering canonical aliases, invalid stages, missing progress keys, sample-only activation, permission-limited CTAs, route availability, and sample request validation

## Scope
This is additive contract work only. It does not add URLs, migrations, resolver queries, persistence, sample project creation, lifecycle jobs, frontend UI, or post-login behavior changes.

## Validation
- uv run ruff check accounts/serializers/onboarding.py accounts/services/onboarding/constants.py accounts/tests/onboarding_fixtures.py accounts/tests/test_onboarding_serializers.py
- uv run pytest accounts/tests/test_contract_serializers.py accounts/tests/test_workspace_contract_serializers.py accounts/tests/test_onboarding_serializers.py
- git diff --check
- staged restricted-term scan

## Notes
The first pytest attempt exposed a broken local Django package install missing a standard contrib module. Reinstalling Django with a fresh package download repaired the local virtualenv; the targeted tests then passed.