### PR TITLE
fix(evals): pass runtime_config.params into CustomCodeEval kwargs

### DIFF
--- a/futureagi/evaluations/engine/runner.py
+++ b/futureagi/evaluations/engine/runner.py
@@ -149,6 +149,12 @@ def run_eval(request: EvalRequest) -> EvalResult:
         if "max_tokens" in request.inputs:
             run_params.setdefault("max_tokens", request.inputs["max_tokens"])
 
+    if eval_type_id == "CustomCodeEval" and request.runtime_config:
+        _runtime_params = (request.runtime_config or {}).get("params") or {}
+        if isinstance(_runtime_params, dict):
+            for _k, _v in _runtime_params.items():
+                run_params.setdefault(_k, _v)
+
     # 3.5. Preprocess inputs (e.g., compute embeddings for CLIP/FID)
     from evaluations.engine.preprocessing import preprocess_inputs
 


### PR DESCRIPTION
## Why

`CustomCodeEval` templates skip `function_params_schema` normalization in `create_eval_instance` (their constructor only accepts `{"code": ...}`). Result: any params passed via SDK `eval_config={"params": {...}}` are silently dropped, and the inline `evaluate()` falls back to defaults. `answer_similarity` permanently runs `CosineSimilarity`; `trajectory_match` and `syntax_validation` have the same issue.

## What

Lift `runtime_config.params` into the run kwargs after `prepare_run_params`, gated on `eval_type_id == "CustomCodeEval"`. `setdefault` so caller-provided inputs win.

Single file, +6 / -0.

## Risk

Low. All 97 `CustomCodeEval` rows audited — 94 take `**kwargs` (extra kwargs land harmlessly), 2 are JS (run elsewhere), 1 is an inert placeholder. Other eval types untouched by the `if` clause.
