### PR TITLE
fix(evals): treat numeric score_label as passed in isPassedEval

### DIFF
--- a/frontend/src/components/traceDetail/EvalsTabView.jsx
+++ b/frontend/src/components/traceDetail/EvalsTabView.jsx
@@ -80,7 +80,10 @@ export function collectAllEvalsFromEntry(entry) {
 // score, arbitrary label) is treated as not-passed and keeps the button.
 const isPassedEval = (ev) => {
   if (ev?.score != null) return ev.score >= 50;
-  const label = (ev?.score_label || "").trim().toLowerCase();
+  const rawLabel = (ev?.score_label || "").trim();
+  const numericLabel = parseFloat(rawLabel.replace(/%$/, ""));
+  if (Number.isFinite(numericLabel)) return numericLabel >= 50;
+  const label = rawLabel.toLowerCase();
   return label === "pass" || label === "passed" || label === "true";
 };
 


### PR DESCRIPTION
Follow-up to #449/#662 — evals with score=null but a numeric score_label (e.g. "100%") were not recognized as passed, leaving the Fix with Falcon button on already-passing rows.

<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

<!-- What does this PR change and why? 2–5 sentences. -->

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

<!-- Commands run, manual test steps, screenshots for UI work. -->

## Screenshots / recordings (if UI)

<!-- Drag & drop images or GIFs here. Before / after is especially helpful. -->

## Checklist

- [ ] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [ ] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
