### PR TITLE
fix(oss): add model_hub/tracer deps to demo-reseed migration (fixes fresh-DB crash loop)

### DIFF
--- a/futureagi/accounts/migrations/0020_reseed_broken_demo_data.py
+++ b/futureagi/accounts/migrations/0020_reseed_broken_demo_data.py
@@ -123,6 +123,13 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("accounts", "0019_merge_20260407_1927"),
+        # This data migration reads model_hub (Dataset/Row/Cell/Column) and
+        # tracer (Project) via apps.get_model(), so those apps must be migrated
+        # first. Without these deps a fresh database can apply this migration
+        # before them, raising "No installed app with label 'model_hub'" and
+        # crash-looping the backend on first boot.
+        ("model_hub", "0100_merge_20260521_0749"),
+        ("tracer", "0077_merge_20260514_1559"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary

`accounts/migrations/0020_reseed_broken_demo_data.py` is a `RunPython` data
migration that reads `model_hub` (`Dataset`/`Row`/`Cell`/`Column`) and `tracer`
(`Project`) via `apps.get_model(...)`, but it only declared a dependency on
`accounts.0019`. On a **fresh database** Django can order it before the
`model_hub`/`tracer` migrations, so those apps aren't in the historical app
registry yet → `LookupError: No installed app with label 'model_hub'` → the
migration step fails → the backend entrypoint exits 1 → crash loop. This blocks
**every fresh self-host / OSS `./bin/install`** and is currently live in the
published image.

This PR adds the missing `model_hub` and `tracer` migration dependencies so they
migrate first. On a fresh DB there are no broken demo datasets, so the migration
then no-ops cleanly. No behavior change on existing databases.

It went unnoticed because Cloud and internal environments migrated incrementally
(so `model_hub` already existed when `0020` ran); the bug only surfaces on an
empty DB, which is exactly the new-user path.

## Linked issues

<!-- No tracked issue — found during OSS self-host verification. Add one if you track these. -->
Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Reproduced and verified end-to-end on a clean OSS checkout (no `ee/`) against an
empty database.

**Reproduced the failure (before fix):**
- `git clone` + `./bin/install` with the published image → backend crash-looped
  (13 restarts) with `LookupError: No installed app with label 'model_hub'` at
  `accounts.0020`; the healthcheck kept the frontend gated and `bin/install`
  aborted with "docker compose up failed after 3 attempts."

**Verified the fix:**
- Rebuilt the backend from source with this change, `docker compose down -v`,
  then `docker compose up` on a fresh DB.
- Migration log: `Applying accounts.0020_reseed_broken_demo_data... No broken
  demo datasets found — nothing to do.`
- Backend reached **healthy with 0 restarts**; `/health/` → 200; an EE-only
  route (`/falcon-ai/...`) correctly degrades to **402** (not 500); the SPA
  loads; JWT login (`POST /accounts/token/`) with a seeded admin → 200.

> Note: a clean-room OSS boot CI job (builds without `ee/`, boots an empty DB,
> asserts `/health/`) is what catches this class of regression going forward —
> tracked in a separate PR.

## Screenshots / recordings (if UI)

N/A — backend-only migration change.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works <!-- data migration verified by fresh-DB boot above; clean-room boot test (separate PR) guards the class -->
- [ ] `make check-all` / `yarn check-all` passes locally <!-- run before merge -->
- [ ] I've updated the documentation where relevant <!-- N/A -->
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) <!-- handle as needed -->
