### PR TITLE
fix: bill composite eval token costs

### DIFF
--- a/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
+++ b/futureagi/model_hub/tests/test_composite_wiring_phase_b.py
@@ -7,7 +7,9 @@ Covers:
 - `process_eval_batch_async_task` branching on `template_type`
 """
 
-from unittest.mock import patch
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -324,6 +326,98 @@ class TestExecuteCompositeChildrenSync:
         assert statuses == ["failed", "completed"]
         # Aggregate should still compute using the one completed child.
         assert outcome.aggregate_score == pytest.approx(0.8, abs=1e-6)
+
+    def test_composite_child_billing_uses_token_pricing_when_cost_is_zero(
+        self, composite_parent, organization, workspace, monkeypatch
+    ):
+        from ee.usage.services.config import BillingConfig
+        import model_hub.views.utils.evals as evals_module
+        from model_hub.views.utils.evals import run_eval_func
+        from tfc.constants.api_calls import APICallStatusChoices
+
+        child = CompositeEvalChild.objects.filter(parent=composite_parent).first().child
+        child.model = "turing_large"
+        child.save(update_fields=["model"])
+        captured = []
+
+        class FakeEvalInstance:
+            cost = {"total_cost": 0}
+            token_usage = {
+                "prompt_tokens": 1341,
+                "completion_tokens": 150,
+                "total_tokens": 1491,
+            }
+
+            def run(self, **_kwargs):
+                return SimpleNamespace(
+                    eval_results=[
+                        {
+                            "data": {"input": "hello"},
+                            "failure": None,
+                            "reason": "ok",
+                            "runtime": 0.01,
+                            "model": "turing_large",
+                            "metrics": None,
+                            "metadata": {},
+                        }
+                    ]
+                )
+
+        log_row = SimpleNamespace(
+            log_id="log-1",
+            config=json.dumps({}),
+            status=APICallStatusChoices.PROCESSING.value,
+            input_token_count=0,
+            save=MagicMock(),
+        )
+
+        monkeypatch.setattr(
+            evals_module,
+            "log_and_deduct_cost_for_api_request",
+            lambda **_kwargs: log_row,
+        )
+        monkeypatch.setattr(
+            "ee.usage.services.metering.check_usage",
+            lambda *_args, **_kwargs: SimpleNamespace(allowed=True),
+        )
+        monkeypatch.setattr(
+            "ee.usage.services.emitter.emit",
+            lambda event: captured.append(event),
+        )
+        monkeypatch.setattr(
+            "model_hub.views.utils.evals.EvaluationRunner._create_eval_instance",
+            lambda *_args, **_kwargs: FakeEvalInstance(),
+        )
+        monkeypatch.setattr(
+            "model_hub.views.utils.evals.EvaluationRunner.map_fields",
+            lambda *_args, **_kwargs: {"input": "hello"},
+        )
+        monkeypatch.setattr(
+            "model_hub.views.utils.evals.EvaluationRunner.format_output",
+            lambda *_args, **_kwargs: 0.7,
+        )
+
+        output = run_eval_func(
+            {"config": {}, "params": {}},
+            {"input": "hello"},
+            child,
+            organization,
+            model="turing_large",
+            workspace=workspace,
+            source="composite_eval",
+        )
+
+        assert output["output"] == 0.7
+        assert captured
+        event = captured[0]
+        assert event.properties["raw_cost_usd"] == "0.012001"
+        assert event.properties["llm_cost_usd"] == "0.011501"
+        assert event.properties["reported_llm_cost_usd"] == "0"
+        assert event.properties["llm_cost_source"] == "token_pricing"
+        assert event.properties["pricing_source"] == "available_models"
+        assert event.amount == pytest.approx(
+            BillingConfig.get().calculate_ai_credits(0.012001)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -2,6 +2,7 @@ import json
 import time
 import traceback
 import uuid
+from decimal import Decimal
 
 import structlog
 from django.db import close_old_connections
@@ -435,8 +436,11 @@ def run_eval_func(
             actual_cost = llm_cost + per_run_fee
             _token_usage = getattr(eval_instance, "token_usage", {})
 
-            # Fallback cost for comparison logging
+            # Fallback cost for comparison logging and composite eval billing.
+            # Composite children can return token usage with a zero `cost`;
+            # in that case, charge model token pricing plus the per-run fee.
             _fallback_cost = 0
+            _pricing_source = ""
             try:
                 from agentic_eval.core_evals.fi_utils.token_count_helper import (
                     calculate_total_cost,
@@ -444,17 +448,35 @@ def run_eval_func(
 
                 _fallback = calculate_total_cost(model or "unknown", _token_usage)
                 _fallback_cost = _fallback.get("total_cost", 0)
+                _pricing_source = _fallback.get("pricing_source", "")
             except Exception:
                 pass
+
+            is_composite_source = source in {
+                "composite_eval",
+                "composite_eval_adhoc",
+                "composite_eval_dataset",
+                "tracer_composite",
+            }
+            cost_properties = {}
+            if is_composite_source and not llm_cost and _fallback_cost:
+                actual_cost = Decimal(str(_fallback_cost)) + Decimal(str(per_run_fee))
+                cost_properties = {
+                    "llm_cost_usd": str(_fallback_cost),
+                    "reported_llm_cost_usd": str(llm_cost),
+                    "llm_cost_source": "token_pricing",
+                    "pricing_source": _pricing_source,
+                }
 
             logger.info(
                 "eval_cost_breakdown",
                 template=template.name,
                 model=model,
-                llm_cost=llm_cost,
+                llm_cost=cost_properties.get("llm_cost_usd", llm_cost),
                 per_run_fee=per_run_fee,
                 actual_cost=actual_cost,
                 fallback_calculated_cost=_fallback_cost,
+                llm_cost_source=cost_properties.get("llm_cost_source"),
                 token_usage=getattr(eval_instance, "token_usage", {}),
             )
 
@@ -472,6 +494,7 @@ def run_eval_func(
                         "source": source,
                         "source_id": str(template.id),
                         "raw_cost_usd": str(actual_cost),
+                        **cost_properties,
                         **token_usage_properties(_token_usage),
                     },
                 )


### PR DESCRIPTION
## Summary

Fixes composite eval child billing when the evaluator returns token usage but reports zero LLM cost. Composite execute paths now fall back to model token pricing for the LLM portion and still add the per-run fee, instead of charging only the per-run fee. The fix is scoped to composite sources and leaves the usage consumer unchanged.

## Linked issues

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `set -a && source .env.test && set +a && .venv/bin/pytest model_hub/tests/test_composite_wiring_phase_b.py::TestExecuteCompositeChildrenSync -v`
- `futureagi/.venv/bin/python -m compileall -q futureagi/model_hub/views/utils/evals.py futureagi/model_hub/tests/test_composite_wiring_phase_b.py`
- `git diff --check -- futureagi/model_hub/views/utils/evals.py futureagi/model_hub/tests/test_composite_wiring_phase_b.py`

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)