### PR TITLE
[TH-5076] Disable save/test buttons when instructions lack template variables

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -23,6 +23,7 @@ import React, {
 import { useWatch } from "react-hook-form";
 import Iconify from "src/components/iconify";
 import { ShowComponent } from "src/components/show/ShowComponent";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import TaskFilterBar from "src/sections/tasks/components/TaskFilterBar";
 import { buildApiFilterArray } from "src/sections/tasks/components/TaskLivePreview";
@@ -622,10 +623,16 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   // `source === "composite"` means this drawer was opened from a composite's
   // child picker with no dataset bound — there's no variable mapping to
   // complete here, so don't gate saving on `sourceReady`.
+  const needsTemplateVariable =
+    evalType !== "code" &&
+    !hasDataInjection &&
+    !/\{\{\s*[^{}]+?\s*\}\}/.test(instructions);
+
   const canSave = isComposite
     ? !!name.trim() && selectedChildren.length > 0
     : name.trim() &&
       (evalType === "code" ? code.trim() : instructions.trim()) &&
+      !needsTemplateVariable &&
       (source === "composite" || sourceReady || hasDataInjection);
 
   // Variables from instructions
@@ -1282,40 +1289,63 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         <ShowComponent
           condition={!hasDataInjection }
         >
-          <Button
-            variant="outlined"
+          <CustomTooltip
+            show={needsTemplateVariable}
+            title="Instructions must contain at least one template variable (e.g. {{input}})"
+            arrow
             size="small"
-            onClick={handleTestEvaluation}
-            disabled={
-              isTesting ||
-              (!sourceReady && !hasDataInjection) ||
-              !draftId ||
-              isComposite ||
-              source === "workbench"
-            }
-            startIcon={
-              isTesting ? (
-                <CircularProgress size={14} />
-              ) : (
-                <Iconify icon="mdi:play-circle-outline" width={16} />
-              )
-            }
-            sx={{ textTransform: "none" }}
+            type="black"
+            placement="top"
           >
-            {isTesting ? "Testing..." : "Test Evaluation"}
-          </Button>
+            <span>
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={handleTestEvaluation}
+                disabled={
+                  isTesting ||
+                  needsTemplateVariable ||
+                  (!sourceReady && !hasDataInjection) ||
+                  !draftId ||
+                  isComposite ||
+                  source === "workbench"
+                }
+                startIcon={
+                  isTesting ? (
+                    <CircularProgress size={14} />
+                  ) : (
+                    <Iconify icon="mdi:play-circle-outline" width={16} />
+                  )
+                }
+                sx={{ textTransform: "none" }}
+              >
+                {isTesting ? "Testing..." : "Test Evaluation"}
+              </Button>
+            </span>
+          </CustomTooltip>
         </ShowComponent>
 
-        <LoadingButton
-          variant="contained"
+        <CustomTooltip
+          show={needsTemplateVariable}
+          title="Instructions must contain at least one template variable (e.g. {{input}})"
+          arrow
           size="small"
-          loading={isSaving}
-          disabled={!canSave}
-          onClick={isComposite ? handleSaveAndAddComposite : handleSaveAndAdd}
-          sx={{ textTransform: "none" }}
+          type="black"
+          placement="top"
         >
-          {isComposite ? "Create & Configure" : "Save & Add Evaluation"}
-        </LoadingButton>
+          <span>
+            <LoadingButton
+              variant="contained"
+              size="small"
+              loading={isSaving}
+              disabled={!canSave}
+              onClick={isComposite ? handleSaveAndAddComposite : handleSaveAndAdd}
+              sx={{ textTransform: "none" }}
+            >
+              {isComposite ? "Create & Configure" : "Save & Add Evaluation"}
+            </LoadingButton>
+          </span>
+        </CustomTooltip>
       </Box>
     </Box>
   );

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -382,12 +382,15 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
       next.instructions = "Instructions are required";
     } else if (instructions.trim().length < 10) {
       next.instructions = "Instructions must be at least 10 characters.";
-    } else if (
-      !hasDataInjection &&
-      !/\{\{\s*[^{}]+?\s*\}\}/.test(instructions)
-    ) {
-      next.instructions =
-        "Instructions must contain at least one template variable (e.g. {{input}})";
+    } else if (!hasDataInjection) {
+      const hasVar =
+        templateFormat === "jinja"
+          ? extractJinjaVariables(instructions).length > 0
+          : /\{\{\s*[^{}]+?\s*\}\}/.test(instructions);
+      if (!hasVar) {
+        const dialect = templateFormat === "jinja" ? "Jinja" : "Mustache";
+        next.instructions = `Instructions must contain at least one ${dialect} variable (e.g. {{input}})`;
+      }
     }
 
     if (!sourceReady && source !== "composite" && !hasDataInjection) {
@@ -623,17 +626,42 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   // `source === "composite"` means this drawer was opened from a composite's
   // child picker with no dataset bound — there's no variable mapping to
   // complete here, so don't gate saving on `sourceReady`.
+  const hasTemplateVariable =
+    templateFormat === "jinja"
+      ? extractJinjaVariables(instructions).length > 0
+      : /\{\{\s*[^{}]+?\s*\}\}/.test(instructions);
+
   const needsTemplateVariable =
-    evalType !== "code" &&
-    !hasDataInjection &&
-    !/\{\{\s*[^{}]+?\s*\}\}/.test(instructions);
+    evalType !== "code" && !hasDataInjection && !hasTemplateVariable;
 
   const canSave = isComposite
     ? !!name.trim() && selectedChildren.length > 0
     : name.trim() &&
-      (evalType === "code" ? code.trim() : instructions.trim()) &&
-      !needsTemplateVariable &&
+      (evalType === "code"
+        ? code.trim()
+        : instructions.trim() && !needsTemplateVariable) &&
       (source === "composite" || sourceReady || hasDataInjection);
+
+  const getDisabledReason = () => {
+    if (!name.trim()) return "Name is required";
+    if (isComposite) {
+      if (selectedChildren.length === 0) {
+        return "Select at least one child evaluation";
+      }
+      return null;
+    }
+    if (evalType === "code") {
+      if (!code.trim()) return "Code is required";
+      return null;
+    }
+    if (!instructions.trim()) return "Instructions are required";
+    if (needsTemplateVariable) {
+      const dialect = templateFormat === "jinja" ? "Jinja" : "Mustache";
+      return `Instructions must contain at least one ${dialect} variable (e.g. {{input}})`;
+    }
+    return null;
+  };
+  const disabledReason = getDisabledReason();
 
   // Variables from instructions
   const variables = useMemo(() => {
@@ -1290,8 +1318,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
           condition={!hasDataInjection }
         >
           <CustomTooltip
-            show={needsTemplateVariable}
-            title="Instructions must contain at least one template variable (e.g. {{input}})"
+            show={!!disabledReason}
+            title={disabledReason || ""}
             arrow
             size="small"
             type="black"
@@ -1304,7 +1332,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
                 onClick={handleTestEvaluation}
                 disabled={
                   isTesting ||
-                  needsTemplateVariable ||
+                  !!disabledReason ||
                   (!sourceReady && !hasDataInjection) ||
                   !draftId ||
                   isComposite ||
@@ -1326,8 +1354,8 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         </ShowComponent>
 
         <CustomTooltip
-          show={needsTemplateVariable}
-          title="Instructions must contain at least one template variable (e.g. {{input}})"
+          show={!!disabledReason}
+          title={disabledReason || ""}
           arrow
           size="small"
           type="black"

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -1928,22 +1928,37 @@ const EvalDetailPage = () => {
                     </CustomTooltip>
                   )}
                   {!isSystemEval && isComposite && (
-                    <Button
-                      variant="contained"
+                    <CustomTooltip
+                      show={compositeChildren.length === 0}
+                      title="Select at least one child evaluation"
+                      arrow
                       size="small"
-                      onClick={handleSaveComposite}
-                      disabled={isSaving || !isDirty}
-                      startIcon={
-                        isSaving ? (
-                          <CircularProgress size={14} />
-                        ) : (
-                          <Iconify icon="mdi:content-save-outline" width={16} />
-                        )
-                      }
-                      sx={{ textTransform: "none" }}
+                      type="black"
+                      placement="top"
                     >
-                      {isSaving ? "Saving..." : "Save Changes"}
-                    </Button>
+                      <span>
+                        <Button
+                          variant="contained"
+                          size="small"
+                          onClick={handleSaveComposite}
+                          disabled={
+                            isSaving ||
+                            !isDirty ||
+                            compositeChildren.length === 0
+                          }
+                          startIcon={
+                            isSaving ? (
+                              <CircularProgress size={14} />
+                            ) : (
+                              <Iconify icon="mdi:content-save-outline" width={16} />
+                            )
+                          }
+                          sx={{ textTransform: "none" }}
+                        >
+                          {isSaving ? "Saving..." : "Save Changes"}
+                        </Button>
+                      </span>
+                    </CustomTooltip>
                   )}
                 </Box>
               </Box>

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -601,11 +601,22 @@ const EvalDetailPage = () => {
     Array.isArray(contextOptions) &&
     contextOptions.some((o) => o && o !== "variables_only");
 
+  const hasTemplateVariable =
+    templateFormat === "jinja"
+      ? extractJinjaVariables(instructions).length > 0
+      : /\{\{\s*[^{}]+?\s*\}\}/.test(instructions);
+
   const needsTemplateVariable =
     evalType !== "code" &&
     !hasDataInjection &&
     !isComposite &&
-    !/\{\{\s*[^{}]+?\s*\}\}/.test(instructions);
+    !hasTemplateVariable;
+
+  const variableTooltip = !instructions?.trim()
+    ? "Instructions are required"
+    : needsTemplateVariable
+      ? `Instructions must contain at least one ${templateFormat === "jinja" ? "Jinja" : "Mustache"} variable (e.g. {{input}})`
+      : "";
 
   // Fetch composite detail (children, weights) when viewing a composite
   const { data: compositeDetail } = useCompositeDetail(evalId, isComposite);
@@ -1854,11 +1865,10 @@ const EvalDetailPage = () => {
 
                   <Tooltip
                     title={
-                      needsTemplateVariable
-                        ? "Instructions must contain at least one template variable (e.g. {{input}})"
-                        : !isPlaygroundReady && !isTesting
-                          ? "Map all required keys before running"
-                          : ""
+                      variableTooltip ||
+                      (!isPlaygroundReady && !isTesting
+                        ? "Map all required keys before running"
+                        : "")
                     }
                     placement="top"
                   >
@@ -1890,8 +1900,8 @@ const EvalDetailPage = () => {
                   </Tooltip>
                   {!isSystemEval && !isComposite && (
                     <CustomTooltip
-                      show={needsTemplateVariable}
-                      title="Instructions must contain at least one template variable (e.g. {{input}})"
+                      show={!!variableTooltip}
+                      title={variableTooltip}
                       arrow
                       size="small"
                       type="black"

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -29,6 +29,7 @@ import { useSearchParams } from "react-router-dom";
 import { useSnackbar } from "notistack";
 import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 import Iconify from "src/components/iconify";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import axios, { endpoints } from "src/utils/axios";
 
 import { useEvalDetail, useUpdateEval } from "../hooks/useEvalDetail";
@@ -594,6 +595,17 @@ const EvalDetailPage = () => {
 
   const evalType = evalData?.eval_type || "llm";
   const isSystemEval = evalData?.owner === "system";
+
+  const hasDataInjection =
+    evalType === "agent" &&
+    Array.isArray(contextOptions) &&
+    contextOptions.some((o) => o && o !== "variables_only");
+
+  const needsTemplateVariable =
+    evalType !== "code" &&
+    !hasDataInjection &&
+    !isComposite &&
+    !/\{\{\s*[^{}]+?\s*\}\}/.test(instructions);
 
   // Fetch composite detail (children, weights) when viewing a composite
   const { data: compositeDetail } = useCompositeDetail(evalId, isComposite);
@@ -1842,9 +1854,11 @@ const EvalDetailPage = () => {
 
                   <Tooltip
                     title={
-                      !isPlaygroundReady && !isTesting
-                        ? "Map all required keys before running"
-                        : ""
+                      needsTemplateVariable
+                        ? "Instructions must contain at least one template variable (e.g. {{input}})"
+                        : !isPlaygroundReady && !isTesting
+                          ? "Map all required keys before running"
+                          : ""
                     }
                     placement="top"
                   >
@@ -1853,7 +1867,7 @@ const EvalDetailPage = () => {
                         variant={isComposite ? "contained" : "outlined"}
                         size="small"
                         onClick={handleTestEvaluation}
-                        disabled={isTesting || !isPlaygroundReady}
+                        disabled={isTesting || !isPlaygroundReady || needsTemplateVariable}
                         startIcon={
                           isTesting ? (
                             <CircularProgress size={14} />
@@ -1875,22 +1889,33 @@ const EvalDetailPage = () => {
                     </span>
                   </Tooltip>
                   {!isSystemEval && !isComposite && (
-                    <Button
-                      variant="contained"
+                    <CustomTooltip
+                      show={needsTemplateVariable}
+                      title="Instructions must contain at least one template variable (e.g. {{input}})"
+                      arrow
                       size="small"
-                      onClick={handleSaveVersion}
-                      disabled={isSaving || !isDirty}
-                      startIcon={
-                        isSaving ? (
-                          <CircularProgress size={14} />
-                        ) : (
-                          <Iconify icon="mdi:content-save-outline" width={16} />
-                        )
-                      }
-                      sx={{ textTransform: "none" }}
+                      type="black"
+                      placement="top"
                     >
-                      {isSaving ? "Saving..." : "Save Version"}
-                    </Button>
+                      <span>
+                        <Button
+                          variant="contained"
+                          size="small"
+                          onClick={handleSaveVersion}
+                          disabled={isSaving || !isDirty || needsTemplateVariable}
+                          startIcon={
+                            isSaving ? (
+                              <CircularProgress size={14} />
+                            ) : (
+                              <Iconify icon="mdi:content-save-outline" width={16} />
+                            )
+                          }
+                          sx={{ textTransform: "none" }}
+                        >
+                          {isSaving ? "Saving..." : "Save Version"}
+                        </Button>
+                      </span>
+                    </CustomTooltip>
                   )}
                   {!isSystemEval && isComposite && (
                     <Button


### PR DESCRIPTION
## Summary
- When creating an eval without data injection, the "Save & Add Evaluation" and "Test Evaluation" buttons were enabled even when instructions contained no template variables (e.g. `{{input}}`). Clicking save would fail with a validation error.
- Added `needsTemplateVariable` check to `canSave` so both buttons stay disabled until instructions contain at least one `{{variable}}` (unless data injection is enabled or eval type is code).
- Both buttons now show a `CustomTooltip` explaining the requirement when disabled for this reason.

Fixes TH-5076

## Linear Ticket
[TH-5076](https://linear.app/future-agi/issue/TH-5076/shows-active-submit-button-without-context-and-variable-fails-later)

## Files Changed
- `frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx`

## Test plan
- [ ] Create new LLM eval → type instructions without any `{{variables}}` → both buttons should be disabled with tooltip
- [ ] Add a `{{input}}` variable → buttons should enable
- [ ] Create code eval → buttons should work normally (no template variable required)
- [ ] Create eval with data injection enabled → buttons should work without template variables
- [ ] Composite eval creation unaffected