### PR TITLE
[TH-5132] Fix autosize columns for simulator projects (CallLogsGrid)

### DIFF
--- a/frontend/src/sections/agents/helper.jsx
+++ b/frontend/src/sections/agents/helper.jsx
@@ -629,6 +629,7 @@ export const getCallLogsColumnDefs = (
       field: "status",
       flex: 0,
       minWidth: 100,
+      width: 140,
       cellRenderer: CallLogsCellRenderer,
     },
     {

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -991,14 +991,20 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   }, [observeId]);
 
   const handleAutoSize = () => {
+    const isSimulator = projectSource === PROJECT_SOURCE.SIMULATOR;
+
     const gridRef =
-      selectedGraph === "primary"
-        ? selectedTab === "trace"
-          ? primaryTraceGridRef
-          : primarySpanGridRef
-        : selectedTab === "trace"
-          ? compareTraceGridRef
-          : compareSpanGridRef;
+      isSimulator && selectedTab === "trace"
+        ? selectedGraph === "primary"
+          ? primaryCallLogsGridRef
+          : compareCallLogsGridRef
+        : selectedGraph === "primary"
+          ? selectedTab === "trace"
+            ? primaryTraceGridRef
+            : primarySpanGridRef
+          : selectedTab === "trace"
+            ? compareTraceGridRef
+            : compareSpanGridRef;
 
     if (!gridRef.current?.api) return;
 


### PR DESCRIPTION
## Summary
- "Autosize columns" in Display dropdown did nothing on simulator projects — `handleAutoSize` only checked trace/span grid refs, never `primaryCallLogsGridRef` which is what simulator projects render
- Added simulator branch to ref selection so CallLogsGrid gets the correct grid API
- Fixed `isAnimationFrameQueueEmpty` guard — deprecated in AG Grid 35 (stubbed to `0`, not a function), was throwing TypeError and silently aborting
- Autosize state now carries over on tab/view switches instead of resetting — switching tabs re-applies autosize to the new grid
- Reduced default Status column width from 180px to 140px for a tighter initial layout

Fixes TH-5132

## Linear Ticket
[TH-5132](https://linear.app/future-agi/issue/TH-5132/whats-the-use-of-autosizze-columns-its-doing-nothing)

## Files Changed
- `frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx`
- `frontend/src/sections/agents/helper.jsx`

## Test plan
- [ ] Open a simulator project → Tracing → click "Autosize columns" → columns should resize to content
- [ ] Click "Reset columns" → columns should restore via sizeColumnsToFit
- [ ] Switch to a saved view tab with autosize active → new grid should also be autosized
- [ ] Normal trace/span projects should still work as before