### PR TITLE
fix(evals): TH-5119 skip feedback RAG when no feedback rows exist

### DIFF
--- a/futureagi/agentic_eval/core/embeddings/embedding_manager.py
+++ b/futureagi/agentic_eval/core/embeddings/embedding_manager.py
@@ -244,10 +244,20 @@ class EmbeddingManager:
     def get_feedback_count(self, eval_id: str, organization_id: str = None, workspace_id: str = None) -> int:
         """Return the number of non-deleted feedback rows for a given eval_id."""
         try:
-            result = self.db_client.client.execute(
-                "SELECT COUNT(*) FROM feedbacks WHERE eval_id = %(eval_id)s AND deleted = 0",
-                {"eval_id": eval_id},
-            )
+            where = ["eval_id = %(eval_id)s", "deleted = 0"]
+            params = {"eval_id": eval_id}
+            if organization_id:
+                where.append(
+                    "arrayElement(metadata.value, indexOf(metadata.key, 'organization_id')) = %(organization_id)s"
+                )
+                params["organization_id"] = organization_id
+            if workspace_id:
+                where.append(
+                    "arrayElement(metadata.value, indexOf(metadata.key, 'workspace_id')) = %(workspace_id)s"
+                )
+                params["workspace_id"] = workspace_id
+            sql = f"SELECT COUNT(*) FROM feedbacks WHERE {' AND '.join(where)}"
+            result = self.db_client.client.execute(sql, params)
             return result[0][0] if result else 0
         except Exception as e:
             logger.warning("get_feedback_count failed", eval_id=eval_id, error=str(e))
@@ -913,6 +923,20 @@ class EmbeddingManager:
         # row_dict
         if filter_by is None:
             filter_by = {}
+
+        # Skip the embed loop when there are no rows to match against.
+        if table_name == FEEDBACK_TABLE_NAME and eval_id:
+            if self.get_feedback_count(
+                eval_id=str(eval_id),
+                organization_id=organization_id,
+                workspace_id=workspace_id,
+            ) == 0:
+                logger.info(
+                    "retrieve_avg_rag_based_examples skipped: no feedback rows",
+                    eval_id=str(eval_id),
+                )
+                return []
+
         self.input_types = self.inputs_type_list(inputs)
 
         results = {}


### PR DESCRIPTION
## Summary

`EmbeddingManager.retrieve_avg_rag_based_examples` embeds each input before hitting the vector store. On eval templates with zero feedback rows the embed work is wasted — for audio inputs that round trip is 5-10s and exceeds the gunicorn worker timeout (~30s).

Gate the per-input embed-and-search loop on a fast `get_feedback_count(eval_id) == 0` check. Returns `[]` early when the feedback table has no matching rows. Other `table_name` values (knowledge-base callers like `kb_indexer.py`) are unaffected.

Pushing the check into the helper also removes the need for duplicate guards at each caller.

## Screenshots:
Audio used for testing - 3:37 mins.

> NOTE: all this was performed on localhost. (the time mentioned below are approximate)

### Before:

#### System Agent Eval: (~ 1 min)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6ff6d767-755f-4db5-853d-c1c6caf3113f" />

#### User Agent Eval: (~ 2.2 min)
<img width="1920" height="1078" alt="image" src="https://github.com/user-attachments/assets/400714ea-c019-48ec-b5fb-2df0a02b0817" />

### After these PRs:

#### System Agent Eval: (~ 17 sec)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6724e6c3-eb49-48a0-aaaa-aad4fbc08743" />

#### User Agent Eval: (~19 sec)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/61751d5b-3dce-47e7-b76b-64ae47ef6f7f" />
