### PR TITLE
[TH-5129] Fix cell value alignment with header menu icon in sessions table

### DIFF
--- a/frontend/src/sections/projects/SessionsView/common.js
+++ b/frontend/src/sections/projects/SessionsView/common.js
@@ -32,7 +32,7 @@ export const getSessionListColumnDef = (col) => {
         originType: "Tracing",
       },
       cellStyle: {
-        paddingInline: 0,
+        paddingInline: "0 26px",
         justifyContent: "flex-end",
         display: "flex",
       },
@@ -67,7 +67,7 @@ export const getSessionListColumnDef = (col) => {
           ? "—"
           : params.value,
       cellStyle: {
-        paddingInline: 0,
+        paddingInline: "0 26px",
         justifyContent: "flex-end",
         display: "flex",
       },
@@ -86,7 +86,7 @@ export const getSessionListColumnDef = (col) => {
     filter: id === "duration" || id === "lastMessage" ? false : undefined,
     cellRenderer: SessionCellRenderer,
     cellStyle: {
-      paddingInline: 0,
+      paddingInline: "0 17px",
       justifyContent: "flex-end",
       display: "flex",
     },


### PR DESCRIPTION
## Summary
- Cell values in the sessions table were misaligned with the header's three-dot menu icon (⋮)
- Added right padding to cell styles: `17px` for regular columns, `26px` for grouped columns (custom columns, annotation metrics) to match the ⋮ icon position

Fixes TH-5129

## Linear Ticket
[TH-5129](https://linear.app/future-agi/issue/TH-5129/cell-value-alignment-issue)

## Files Changed
- `frontend/src/sections/projects/SessionsView/common.js`

## Test plan
- [ ] Sessions table — regular columns (Total Traces, Duration, etc.) values align with ⋮
- [ ] Sessions table — custom columns values align with ⋮
- [ ] Sessions table — annotation metrics columns values align with ⋮