### PR TITLE
fix: populate config_snapshot on composite eval V1 creation

### DIFF
--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -3035,11 +3035,38 @@ class CompositeEvalCreateView(APIView):
             from model_hub.models.evals_metric import EvalTemplateVersion
 
             workspace = getattr(request, "workspace", None)
+            # Build the same config_snapshot that PATCH uses so V1
+            # captures children, weights, and aggregation settings.
+            links = list(
+                CompositeEvalChild.objects.filter(parent=parent, deleted=False)
+                .select_related("child")
+                .order_by("order")
+            )
+            config_snapshot = {
+                "aggregation_enabled": parent.aggregation_enabled,
+                "aggregation_function": parent.aggregation_function,
+                "composite_child_axis": parent.composite_child_axis or "",
+                "children": [
+                    {
+                        "child_id": str(link.child_id),
+                        "child_name": link.child.name,
+                        "order": link.order,
+                        "weight": link.weight,
+                        "config": link.config or {},
+                        "pinned_version_id": (
+                            str(link.pinned_version_id)
+                            if link.pinned_version_id
+                            else None
+                        ),
+                    }
+                    for link in links
+                ],
+            }
             try:
                 EvalTemplateVersion.objects.create_version(
                     eval_template=parent,
                     prompt_messages=[],
-                    config_snapshot={},
+                    config_snapshot=config_snapshot,
                     criteria=req.description or "",
                     model="",
                     user=request.user,


### PR DESCRIPTION
## Summary

When a composite eval is first created, the V1 version snapshot was stored with an empty:

```json
"config_snapshot": {}
```

This meant switching to V1 in the version selector showed no children, weights, or aggregation settings — because there was nothing in the snapshot to load.

The PATCH (update) endpoint already built a full snapshot with children, weights, aggregation settings, and pinned versions for subsequent versions, but the POST (create) endpoint was passing `{}` instead.

This PR builds the same snapshot structure on create so V1 correctly captures the initial state of the composite eval.

## Linked issues

Closes TH-5234

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

1. Created a composite eval with two children and custom weights (e.g. `5.0`, `4.0`)
2. Verified V1's `config_snapshot` now contains:
   - `children[]`
   - correct `weight`
   - `child_id`
   - `child_name`
   - `order`
   - `config`
   - `pinned_version_id`
3. Updated weights and saved → V2 created
4. Switched back to V1 in the version selector
5. Verified V1 shows the original weights instead of V2's updated values

**Before fix:**

```json
"config_snapshot": {}
```

returned for V1 from:

```text
GET /eval-templates/{id}/versions/
```

**After fix:**

V1 now returns the full snapshot structure matching the PATCH endpoint format.

## Screenshots / recordings (if UI)

N/A — backend-only change. Frontend version switching already correctly reads from:

```text
config_snapshot.children[].weight
```

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)