### PR TITLE
fix(evals): TH-5569 introduce MediaNotAccessibleError typed exception

### DIFF
--- a/futureagi/agentic_eval/core/utils/llm_payloads.py
+++ b/futureagi/agentic_eval/core/utils/llm_payloads.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 import requests
 
 from agentic_eval.core.utils.model_config import LiteLlmProvider
+from agentic_eval.core_evals.fi_utils.exceptions import MediaNotAccessibleError
 from tfc.utils.storage import download_image_from_url
 
 ContentBlock = Dict[str, Any]
@@ -441,8 +442,8 @@ def build_media_content_block(
                     img_bytes = download_image_from_url(img_str)
                     mime = mimetypes.guess_type(img_str)[0] or "image/jpeg"
                     url = f"data:{mime};base64,{base64.b64encode(img_bytes).decode('utf-8')}"
-                except Exception:
-                    url = img_str
+                except Exception as e:
+                    raise MediaNotAccessibleError(key=key) from e
             else:
                 url = standardize_to_data_uri(img, "image/jpeg")
             tag = f"{key}_{img_num}" if len(image_inputs) > 1 else key
@@ -463,7 +464,10 @@ def build_media_content_block(
         elif val_str.startswith(("http://", "https://")):
             from agentic_eval.core.llm.audio_utils import download_audio_url_to_base64
 
-            b64_data, audio_fmt = download_audio_url_to_base64(val_str)
+            try:
+                b64_data, audio_fmt = download_audio_url_to_base64(val_str)
+            except Exception as e:
+                raise MediaNotAccessibleError(key=key) from e
             data_uri = f"data:audio/{audio_fmt};base64,{b64_data}"
         else:
             data_uri = standardize_to_data_uri(value, "audio/mp3")
@@ -568,11 +572,7 @@ def detect_and_build_media_blocks(
             elif str(media_type).lower() == "file":
                 val = remaining.get(key, "") if isinstance(remaining, dict) else ""
                 if isinstance(val, str) and val.startswith(("http://", "https://")):
-                    raise ValueError(
-                        f"Media file is not accessible for '{key}'. "
-                        f"The file could not be downloaded — please ensure "
-                        f"the URL is valid and accessible."
-                    )
+                    raise MediaNotAccessibleError(key=key)
 
     # Build content blocks from detected types
     media_blocks: List[ContentBlock] = []

--- a/futureagi/agentic_eval/core_evals/fi_utils/exceptions.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/exceptions.py
@@ -22,3 +22,14 @@ class NoFiApiKeyException(CustomException):
 class NoOpenAiApiKeyException(CustomException):
     def __init__(self, message: str = "Please set an Open API key."):
         super().__init__(message)
+
+
+class MediaNotAccessibleError(ValueError):
+    """Raised when a media URL passed as eval input cannot be fetched."""
+
+    def __init__(self, key: str | None = None):
+        suffix = f" for '{key}'" if key else ""
+        super().__init__(
+            f"Media file is not accessible{suffix}. "
+            f"Please ensure the URL is valid and reachable."
+        )


### PR DESCRIPTION
## Summary

Add `MediaNotAccessibleError(ValueError)` and raise it from the two places that silently failed when a media URL was unreachable:

- `build_media_content_block` image branch: previously fell back to the bare URL, which then propagated to the LLM as a broken reference.
- `detect_and_build_media_blocks` Stage 2 file path: was a bare `ValueError`, fingerprinted as a generic backend error in Sentry.

Subclasses `ValueError` so existing catch-alls keep matching; the ee-side consumer (paired PR) catches it before the generic handler and surfaces an actionable "check the URL" message to the user.

Single file, +11 / -5.

## Screenshots:
### Valid Image URL:
<img width="2194" height="2130" alt="image" src="https://github.com/user-attachments/assets/77857456-3298-4fce-912a-77fc688402c2" />

### Invalid Audio URL:
<img width="2192" height="2124" alt="image" src="https://github.com/user-attachments/assets/2df63209-9d12-49bc-a624-f669a27f1c76" />

