### PR TITLE
fix(evals): TH-5219 clamp out-of-range CustomPromptEvaluator scores to [0, 1]

### DIFF
--- a/futureagi/agentic_eval/core/utils/score.py
+++ b/futureagi/agentic_eval/core/utils/score.py
@@ -1,0 +1,39 @@
+"""Helpers for LLM-judge score handling.
+
+Used by CustomPromptEvaluator and AgentEvaluator only. Function /
+deterministic / code / similarity evaluators compute their own scores
+deterministically and must NEVER call into this module.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def clamp_unit_score(raw: Any) -> Any:
+    """Clamp an LLM-judge score into [0, 1].
+
+    None is preserved. Non-numeric values are returned unchanged so the
+    caller decides how to handle them. Booleans are coerced via float()
+    (True -> 1.0, False -> 0.0). A warning is logged on every clamp.
+    """
+    if raw is None:
+        return None
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return raw
+    if v < 0.0 or v > 1.0:
+        logger.warning(
+            "eval_score_out_of_range_clamped",
+            raw_value=v,
+            clamped_to=max(0.0, min(1.0, v)),
+        )
+    return max(0.0, min(1.0, v))
+
+
+__all__ = ["clamp_unit_score"]

--- a/futureagi/agentic_eval/core/utils/tests/test_cpe_clamp.py
+++ b/futureagi/agentic_eval/core/utils/tests/test_cpe_clamp.py
@@ -1,0 +1,98 @@
+"""Integration tests for the score clamp wiring inside CustomPromptEvaluator._evaluate.
+
+These mirror the AgentEvaluator clamp tests in
+`ee/evals/llm/agent_evaluator/tests/test_evaluator_failure_paths.py`.
+
+Lives under `agentic_eval/core/utils/tests/` (not the CPE tests dir) because
+CPE's own tests dir does not currently collect under the project pytest config.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from jinja2 import Environment
+from structlog.testing import capture_logs
+
+from agentic_eval.core_evals.fi_evals.llm.custom_prompt_evaluator.evaluator import (
+    CustomPromptEvaluator,
+)
+from agentic_eval.core_evals.fi_utils.utils import PreserveUndefined
+
+
+def _make_cpe(output_type, choices=None, choice_scores=None):
+    """Construct a CPE without running LLM.__init__."""
+    ev = CustomPromptEvaluator.__new__(CustomPromptEvaluator)
+    ev.rule_prompt = "evaluate the input"
+    ev.system_prompt = None
+    ev._output_type = output_type
+    ev._model = "stub-model"
+    ev._choices = choices or []
+    ev._multi_choice = False
+    ev._choice_scores = choice_scores
+    ev._few_shot_examples = None
+    ev._messages = None
+    ev.provider = "openai"
+    ev._is_turing = False
+    ev.system_template_value = ""
+    ev.temperature = 0.0
+    ev.max_tokens = 256
+    ev.knowledge_base_id = None
+    ev.check_internet = False
+    ev.template_format = "mustache"
+    ev.token_usage = {"completion_tokens": 0, "prompt_tokens": 0, "total_tokens": 0}
+    ev.cost = {"total_cost": 0.0, "prompt_cost": 0.0, "completion_cost": 0.0}
+    ev.env = Environment(
+        variable_start_string="{{",
+        variable_end_string="}}",
+        undefined=PreserveUndefined,
+    )
+    return ev
+
+
+def _patched_evaluate(ev, llm_response_json: str):
+    """Run ev._evaluate with the LLM call patched to return llm_response_json."""
+    with patch.object(ev, "call_llm", return_value=llm_response_json):
+        return ev._evaluate()
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (0.5, 0.5),
+        (3.5, 1.0),
+        (-0.1, 0.0),
+        (7, 1.0),
+    ],
+)
+def test_cpe_evaluate_clamps_score(raw, expected):
+    ev = _make_cpe(output_type="score")
+    result = _patched_evaluate(ev, f'{{"result": {raw}, "explanation": "x"}}')
+    assert result["data"]["result"] == expected
+
+
+def test_cpe_evaluate_clamps_numeric():
+    ev = _make_cpe(output_type="numeric")
+    result = _patched_evaluate(ev, '{"result": 4.2, "explanation": "x"}')
+    assert result["data"]["result"] == 1.0
+
+
+@pytest.mark.parametrize("label", ["Pass", "Fail"])
+def test_cpe_evaluate_passfail_not_clamped(label):
+    ev = _make_cpe(output_type="Pass/Fail")
+    result = _patched_evaluate(ev, f'{{"result": "{label}", "explanation": "x"}}')
+    assert result["data"]["result"] == label
+
+
+@pytest.mark.parametrize("label", ["1", "10", "joy"])
+def test_cpe_evaluate_choices_labels_not_clamped(label):
+    ev = _make_cpe(output_type="choices", choices=["1", "10", "joy"])
+    result = _patched_evaluate(ev, f'{{"result": "{label}", "explanation": "x"}}')
+    assert result["data"]["result"] == label
+
+
+def test_cpe_out_of_range_emits_warning():
+    ev = _make_cpe(output_type="score")
+    with capture_logs() as captured:
+        _patched_evaluate(ev, '{"result": 3.5, "explanation": "x"}')
+    events = [e["event"] for e in captured]
+    assert "eval_score_out_of_range_clamped" in events

--- a/futureagi/agentic_eval/core/utils/tests/test_score.py
+++ b/futureagi/agentic_eval/core/utils/tests/test_score.py
@@ -1,0 +1,54 @@
+import pytest
+from structlog.testing import capture_logs
+
+from agentic_eval.core.utils.score import clamp_unit_score
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # in-range pass-through
+        (0.0, 0.0),
+        (0.5, 0.5),
+        (1.0, 1.0),
+        # clamp upper bound
+        (1.5, 1.0),
+        (float("inf"), 1.0),
+        # clamp lower bound
+        (-0.5, 0.0),
+        (float("-inf"), 0.0),
+        # integer coerced and clamped
+        (7, 1.0),
+        # string-numeric parsed and clamped
+        ("3.5", 1.0),
+    ],
+)
+def test_clamp_numeric_inputs(raw, expected):
+    assert clamp_unit_score(raw) == expected
+
+
+def test_unparseable_string_passes_through():
+    assert clamp_unit_score("abc") == "abc"
+
+
+def test_none_returns_none():
+    assert clamp_unit_score(None) is None
+
+
+def test_non_numeric_object_passes_through():
+    obj = {"k": "v"}
+    assert clamp_unit_score(obj) is obj
+
+
+def test_out_of_range_emits_warning_event():
+    with capture_logs() as captured:
+        clamp_unit_score(3.5)
+    events = [e["event"] for e in captured]
+    assert "eval_score_out_of_range_clamped" in events
+
+
+def test_in_range_does_not_emit_warning():
+    with capture_logs() as captured:
+        clamp_unit_score(0.5)
+    events = [e["event"] for e in captured]
+    assert "eval_score_out_of_range_clamped" not in events

--- a/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/llm/custom_prompt_evaluator/evaluator.py
@@ -11,6 +11,7 @@ from agentic_eval.core.utils.jinja_utils import nest_dotted_value
 from agentic_eval.core.utils.json_utils import extract_dict_from_string
 from agentic_eval.core.utils.llm_payloads import detect_and_build_media_blocks
 from agentic_eval.core.utils.model_config import ModelConfigs
+from agentic_eval.core.utils.score import clamp_unit_score
 from agentic_eval.core_evals.fi_utils.evals_result import EvalResult
 import structlog
 
@@ -521,16 +522,20 @@ class CustomPromptEvaluator(LLM):
             # "data": chat_history,
         })
 
+        result_value = chat_completion_response_json["result"]
+        if self._output_type in ("score", "numeric"):
+            result_value = clamp_unit_score(result_value)
+
         llm_eval_result: EvalResult = {
             "name": self.name,
             "display_name": self.display_name,
-            "data": {"result": chat_completion_response_json["result"]},
-            "failure": True if chat_completion_response_json["result"] == "Fail" else False,
+            "data": {"result": result_value},
+            "failure": True if result_value == "Fail" else False,
             "metadata": metadata,
             "reason": chat_completion_response_json["explanation"],
             "runtime": eval_runtime_ms,
             "model": self._model,
-            "metrics": [{"id": "custom_eval_score", "value": chat_completion_response_json.get("result", 0.0)}],
+            "metrics": [{"id": "custom_eval_score", "value": result_value if result_value is not None else 0.0}],
             "datapoint_field_annotations": None,
         }
 


### PR DESCRIPTION
## Summary

Weaker judges occasionally return values outside the requested range — e.g. `3.5` or `7` when the criterion phrases the scale as 1-10. The raw value previously surfaced unchanged.

- New helper `agentic_eval/core/utils/score.py` :: `clamp_unit_score` coerces values into `[0, 1]`. `None` is preserved; non-numeric values pass through unchanged so unparseable judge output isn't silently coerced to `0.0`.
- `CustomPromptEvaluator` applies the clamp only when `output_type in ('score', 'numeric')`. Pass/Fail and choices labels (including numeric-shaped ones like `"1"` / `"10"`) are never coerced.
- A warning is logged on every clamp so out-of-range judge behaviour stays observable.

## Tests

**Helper unit tests** — `agentic_eval/core/utils/tests/test_score.py`:
- In-range pass-through; above-1 / below-0 / `±inf` clamping; integer + string-numeric coercion.
- Unparseable strings and non-numeric objects pass through unchanged.
- `None` preserved.
- Log-assertion: `eval_score_out_of_range_clamped` fires on clamp, not on in-range values.

**CPE integration tests** — `agentic_eval/core/utils/tests/test_cpe_clamp.py`:
- `_evaluate` clamps score / numeric outputs end-to-end (LLM response mocked, real parsing path).
- Pass/Fail values pass through unchanged.
- Choices labels (`"1"`, `"10"`, text labels) pass through unchanged.
- Log-assertion: warning fires through the full `_evaluate` path.

## Verification

```bash
docker exec backend bash -c "cd /app/backend && DJANGO_SETTINGS_MODULE=tfc.settings.settings python -m pytest --tb=short -p no:cacheprovider -p no:logging -s agentic_eval/core/utils/tests/test_score.py agentic_eval/core/utils/tests/test_cpe_clamp.py"
```

 ## Screenshots
### Tests passing locally:
<img width="756" height="280" alt="image" src="https://github.com/user-attachments/assets/bab2650e-8230-4227-b15f-60229efc40f7" />

### FE - sanity check:
<img width="1615" height="1068" alt="image" src="https://github.com/user-attachments/assets/bf8cf23e-8a80-4d80-810e-d58ea6f96b92" />
<img width="1617" height="1067" alt="image" src="https://github.com/user-attachments/assets/f6af1e86-85b4-4253-b8e3-1e632081a84f" />
<img width="1609" height="1055" alt="image" src="https://github.com/user-attachments/assets/ba3bb817-cf11-472c-9e81-a9212980d67e" />
