### PR TITLE
[TH-5085] Fix users page showing two loaders on initial mount

### DIFF
--- a/frontend/src/sections/projects/UsersView/UsersView.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersView.jsx
@@ -9,7 +9,7 @@ import React, {
   useState,
 } from "react";
 import PropTypes from "prop-types";
-import { Box, CircularProgress, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { useParams, useLocation, useNavigate } from "react-router";
 import { Helmet } from "react-helmet-async";
 import { formatDate } from "src/utils/report-utils";
@@ -766,8 +766,6 @@ const UsersView = ({
     searchState === "searching" ||
     hasActiveFilter;
 
-  const shouldShowLoading = isLoading && hasData === null;
-
   return (
     <>
       {!observeId && (
@@ -909,20 +907,6 @@ const UsersView = ({
           pt: 1,
         }}
       >
-        {/* Loading spinner */}
-        {shouldShowLoading && (
-          <Box
-            sx={{
-              flex: 1,
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-            }}
-          >
-            <CircularProgress />
-          </Box>
-        )}
-
         {/* Empty state */}
         {shouldShowEmptyLayout && (
           <Box


### PR DESCRIPTION
## Summary
- Users page showed two stacked loaders on initial mount: a standalone `CircularProgress` spinner AND the AG Grid below it (with its own loading overlay)
- Root cause: both `shouldShowLoading` and `shouldShowGrid` evaluated `true` simultaneously during initial mount because `searchState` starts as `"loading"` (not `"empty"`)
- The grid is always rendered and AG Grid handles its own loading state, so the standalone spinner was redundant. Removed it along with the unused `CircularProgress` import

Fixes TH-5085

## Linear Ticket
[TH-5085](https://linear.app/future-agi/issue/TH-5085/user-page-shows-two-loaders-second-one-loads-no-content)

## Files Changed
- `frontend/src/sections/projects/UsersView/UsersView.jsx`

## Test plan
- [ ] Open `/dashboard/observe/:projectId/users` — only one loader visible during fetch, then data appears
- [ ] Open `/dashboard/users` (cross-project) — same behavior
- [ ] Apply filters / search — loading transitions still work
- [ ] Empty state still renders when no users exist