### PR TITLE
[TH-4190] Live Preview column key hover tooltip

### DIFF
--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -2,13 +2,10 @@
 import {
   Autocomplete,
   Box,
-  Button,
   Chip,
   CircularProgress,
   IconButton,
   InputAdornment,
-  MenuItem,
-  Select,
   Tab,
   Tabs,
   TextField,
@@ -55,6 +52,7 @@ import EvalResultDisplay from "./EvalResultDisplay";
 import SpanRowList from "./SpanRowList";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
+import CustomTooltip from "src/components/tooltip";
 
 const ROW_TYPE_OPTIONS = [
   { value: "Span", label: "Spans", icon: "solar:layers-outline" },
@@ -1567,11 +1565,13 @@ const TracingTestMode = React.forwardRef(
                         "&:hover": { backgroundColor: "action.hover" },
                       }}
                     >
-                      <Tooltip
+                      <CustomTooltip
+                        show
                         title={key}
                         placement="top-start"
                         enterDelay={300}
                         arrow
+                        size="small"
                       >
                         <Typography
                           variant="caption"
@@ -1585,7 +1585,7 @@ const TracingTestMode = React.forwardRef(
                         >
                           {key}
                         </Typography>
-                      </Tooltip>
+                      </CustomTooltip>
                       <DraggableColResizer
                         getCurrentWidth={() => keyColWidthRef.current}
                         onResize={setKeyColWidth}

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -1045,14 +1045,23 @@ const RowDetailTable = ({
                   "&:hover": { backgroundColor: "action.hover" },
                 }}
               >
-                <Typography
-                  variant="caption"
-                  fontWeight={500}
-                  noWrap
-                  sx={{ width: 130, flexShrink: 0, pt: 0.25 }}
+                <CustomTooltip
+                  title={key}
+                  show
+                  type="default"
+                  placement="top-start"
+                  arrow
+                  size="small"
                 >
-                  {key}
-                </Typography>
+                  <Typography
+                    variant="caption"
+                    fontWeight={500}
+                    noWrap
+                    sx={{ width: 130, flexShrink: 0, pt: 0.25 }}
+                  >
+                    {key}
+                  </Typography>
+                </CustomTooltip>
                 <Box sx={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
                   {isEmpty ? (
                     <Typography variant="caption" color="text.disabled">

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -1048,7 +1048,6 @@ const RowDetailTable = ({
                 <CustomTooltip
                   title={key}
                   show
-                  type="default"
                   placement="top-start"
                   arrow
                   size="small"


### PR DESCRIPTION
## Summary
- The standalone Live Preview on the Task create/update page was rendering column keys with `noWrap` truncation and no tooltip, so long span-attribute paths (e.g. `gen_ai.input.messages.3.message.role`) had no hover affordance. The eval-picker drawer already had this fix via `TracingTestMode`; mirror it on `TaskLivePreview`.
- Standardize both surfaces on `CustomTooltip` and drop a no-op `type="default"` prop plus three unused MUI imports (`Button`, `MenuItem`, `Select`) that lint was flagging in `TracingTestMode`.

Closes TH-4190

## Linear Ticket
[TH-4190](https://linear.app/future-agi/issue/TH-4190/show-full-variable-names-on-hover-in-variable-mapping)

## Files Changed
- `frontend/src/sections/tasks/components/TaskLivePreview.jsx` — wrap column-key `Typography` in `CustomTooltip`
- `frontend/src/sections/evals/components/TracingTestMode.jsx` — swap MUI `Tooltip` → `CustomTooltip` for column-key hover; drop unused imports

## Test plan
- [ ] On Task create/update page, hover any column key in the Live Preview table — full key shows in tooltip
- [ ] In the eval picker drawer (Tasks → Add evaluation), hover any column key — same tooltip behaviour
- [ ] Long span-attribute paths (e.g. `gen_ai.input.messages.3.message.role`) still truncate with ellipsis and reveal on hover
- [ ] No regression in the value-cell tooltip in `TracingTestMode` (still uses MUI `Tooltip`)