### PR TITLE
Fix/composite eval v1 empty snapshot

### DIFF
--- a/futureagi/model_hub/migrations/0101_backfill_composite_v1_config_snapshots.py
+++ b/futureagi/model_hub/migrations/0101_backfill_composite_v1_config_snapshots.py
@@ -1,0 +1,87 @@
+"""Backfill empty config_snapshot on composite eval V1 versions.
+
+When a composite eval was first created, V1 was stored with
+config_snapshot={}.  This migration populates those empty snapshots
+from the live CompositeEvalChild rows and parent aggregation settings
+so that version-switching in the UI works correctly.
+
+Strictly additive — only touches versions where config_snapshot is
+empty ({}).  Idempotent and safe to re-run.
+"""
+
+from django.db import migrations
+
+
+def backfill_composite_v1_snapshots(apps, schema_editor):
+    EvalTemplate = apps.get_model("model_hub", "EvalTemplate")
+    EvalTemplateVersion = apps.get_model("model_hub", "EvalTemplateVersion")
+    CompositeEvalChild = apps.get_model("model_hub", "CompositeEvalChild")
+
+    # Find all composite templates
+    composite_ids = list(
+        EvalTemplate.objects.filter(
+            template_type="composite",
+            deleted=False,
+        ).values_list("id", flat=True)
+    )
+
+    if not composite_ids:
+        return
+
+    # Find versions with empty config_snapshot
+    empty_versions = EvalTemplateVersion.objects.filter(
+        eval_template_id__in=composite_ids,
+        config_snapshot={},
+        deleted=False,
+    )
+
+    updated = 0
+    for version in empty_versions:
+        parent = EvalTemplate.objects.get(id=version.eval_template_id)
+        links = (
+            CompositeEvalChild.objects.filter(parent=parent, deleted=False)
+            .select_related("child")
+            .order_by("order")
+        )
+        if not links.exists():
+            continue
+
+        version.config_snapshot = {
+            "aggregation_enabled": parent.aggregation_enabled,
+            "aggregation_function": parent.aggregation_function,
+            "composite_child_axis": parent.composite_child_axis or "",
+            "children": [
+                {
+                    "child_id": str(link.child_id),
+                    "child_name": link.child.name,
+                    "order": link.order,
+                    "weight": link.weight,
+                    "config": link.config or {},
+                    "pinned_version_id": (
+                        str(link.pinned_version_id)
+                        if link.pinned_version_id
+                        else None
+                    ),
+                }
+                for link in links
+            ],
+        }
+        version.save(update_fields=["config_snapshot"])
+        updated += 1
+
+    if updated:
+        print(f"\n  Backfilled {updated} composite eval version(s) with empty config_snapshot.")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("model_hub", "0100_merge_20260521_0749"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_composite_v1_snapshots,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -3035,11 +3035,38 @@ class CompositeEvalCreateView(APIView):
             from model_hub.models.evals_metric import EvalTemplateVersion
 
             workspace = getattr(request, "workspace", None)
+            # Build the same config_snapshot that PATCH uses so V1
+            # captures children, weights, and aggregation settings.
+            links = list(
+                CompositeEvalChild.objects.filter(parent=parent, deleted=False)
+                .select_related("child")
+                .order_by("order")
+            )
+            config_snapshot = {
+                "aggregation_enabled": parent.aggregation_enabled,
+                "aggregation_function": parent.aggregation_function,
+                "composite_child_axis": parent.composite_child_axis or "",
+                "children": [
+                    {
+                        "child_id": str(link.child_id),
+                        "child_name": link.child.name,
+                        "order": link.order,
+                        "weight": link.weight,
+                        "config": link.config or {},
+                        "pinned_version_id": (
+                            str(link.pinned_version_id)
+                            if link.pinned_version_id
+                            else None
+                        ),
+                    }
+                    for link in links
+                ],
+            }
             try:
                 EvalTemplateVersion.objects.create_version(
                     eval_template=parent,
                     prompt_messages=[],
-                    config_snapshot={},
+                    config_snapshot=config_snapshot,
                     criteria=req.description or "",
                     model="",
                     user=request.user,


### PR DESCRIPTION
## Summary

When a composite eval was created, V1 was stored with an empty:

```json
"config_snapshot": {}
```

The PATCH (update) endpoint already built a full snapshot with children, weights, and aggregation settings for V2+, but the POST (create) endpoint was passing `{}` instead.

As a result, switching to V1 in the version selector showed incorrect weights — the UI would fall back to the current/latest `CompositeEvalChild` values instead of the original V1 state.

This PR fixes the create endpoint to build a proper snapshot for V1 and adds a data migration to backfill existing composite eval versions that currently have empty snapshots.

## Linked issues

Closes TH-5234

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

1. Created a composite eval with two children and custom weights
2. Verified V1's `config_snapshot` now contains:
   - children
   - correct weights
   - aggregation settings
3. Updated weights and saved — V2 created with updated snapshot values
4. Switched back to V1 in the version selector
5. Verified V1 shows the original weights instead of V2's updated values
6. Ran the backfill migration locally
7. Confirmed empty snapshots were populated for existing composite evals without modifying versions that already had snapshot data

**Before fix:**

```json
"config_snapshot": {}
```

returned for V1 from:

```text
GET /eval-templates/{id}/versions/
```

**After fix:**

V1 now returns the full snapshot structure matching the PATCH endpoint format.

## Backfill behavior

For existing composite evals where V2+ was already created before this fix, the original V1 weights are unrecoverable because the underlying `CompositeEvalChild` rows were already overwritten.

The migration backfills V1 using the current child configuration and weights. This is not historically perfect, but it is still significantly better than an empty snapshot that causes V1 to incorrectly inherit newer version weights at render time.

## Screenshots / recordings (if UI)

N/A — backend-only change. Frontend version switching already correctly reads from:

```text
config_snapshot.children[].weight
```

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)