### PR TITLE
fix: include eval config in baseline column auto-populate response

### DIFF
--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/EvaluationStepExperimentCreation.jsx
@@ -74,6 +74,10 @@ const EvaluationStepExperimentCreation = ({
       const apiEvals = userEvalList.map((item) => ({
         ...item,
         evalId: item.id,
+        config: item.config || {
+          ...item.params,
+          mapping: item.mapping || {},
+        },
       }));
       replaceEvals([...apiEvals, ...manualEvals]);
       userChangedColumnRef.current = false;

--- a/futureagi/model_hub/utils/eval_list.py
+++ b/futureagi/model_hub/utils/eval_list.py
@@ -270,6 +270,7 @@ def build_user_eval_list_items(
             "eval_required_keys": (template.config or {}).get("required_keys", []),
             "eval_template_tags": template.eval_tags,
             "description": template.description,
+            "config": user_eval.config or {},
             "model": run_config.get("model")
             or (user_eval.config or {}).get("config", {}).get("model", ""),
             "column_id": column_map.get(str(user_eval.id)),


### PR DESCRIPTION
## Summary

Includes eval config (model, output type, params) in the baseline column auto-populate response during experiment creation.

Without this, the frontend couldn't pre-fill eval settings when adding evals to an experiment with a baseline — users had to manually re-configure each eval.

This change returns the baseline eval configuration as part of the auto-populate API response so the UI can initialize eval settings automatically.

**2 files changed:**
- `EvaluationStepExperimentCreation.jsx` (+4)
- `eval_list.py` (+1)

## Linked issues

Closes #TH-4806

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Created experiment with baseline
- Added eval to experiment
- Verified eval config auto-populates from baseline settings

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)