### PR TITLE
Fix/eval template delete cleanup

### DIFF
--- a/frontend/src/sections/evals/components/BulkDeleteDialog.jsx
+++ b/frontend/src/sections/evals/components/BulkDeleteDialog.jsx
@@ -17,6 +17,9 @@ const BulkDeleteDialog = ({ open, count, onConfirm, onCancel, isLoading }) => (
       <DialogContentText>
         This action cannot be undone. System evaluations will not be deleted.
       </DialogContentText>
+      <DialogContentText sx={{ mt: 1, fontSize: "0.8rem", color: "text.secondary" }}>
+        This will also remove evaluation results from linked datasets.
+      </DialogContentText>
     </DialogContent>
     <DialogActions>
       <Button onClick={onCancel} disabled={isLoading}>

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -1569,12 +1569,99 @@ class EvalTemplateBulkDeleteView(APIView):
                 getattr(request, "organization", None) or request.user.organization
             )
 
-            deleted_count = EvalTemplate.objects.filter(
-                id__in=req.template_ids,
-                organization=organization,
-                owner=OwnerChoices.USER.value,
-                deleted=False,
-            ).update(deleted=True)
+            from model_hub.models.develop_dataset import Cell, Column, Dataset
+
+            with transaction.atomic():
+                deleted_count = EvalTemplate.objects.filter(
+                    id__in=req.template_ids,
+                    organization=organization,
+                    owner=OwnerChoices.USER.value,
+                    deleted=False,
+                ).update(deleted=True, deleted_at=timezone.now())
+
+                # Fetch all UserEvalMetrics bound to these templates
+                metrics = list(
+                    UserEvalMetric.objects.filter(
+                        template_id__in=req.template_ids,
+                        deleted=False,
+                    ).values_list("id", "dataset_id")
+                )
+
+                if metrics:
+                    metric_ids = {str(m[0]) for m in metrics}
+                    dataset_ids = {m[1] for m in metrics}
+
+                    # Find eval result columns scoped by dataset (indexed)
+                    eval_cols = list(
+                        Column.objects.filter(
+                            dataset_id__in=dataset_ids,
+                            source=SourceChoices.EVALUATION.value,
+                            source_id__in=metric_ids,
+                            deleted=False,
+                        ).values_list("id", "dataset_id", flat=False)
+                    )
+
+                    # Build set of eval column IDs for dependent column lookup
+                    eval_col_ids = {row[0] for row in eval_cols}
+                    all_col_ids = set(eval_col_ids)
+
+                    # Find dependent columns (reason, tags) scoped by dataset
+                    if eval_col_ids:
+                        eval_col_suffixes = {
+                            f"{ecid}-sourceid-" for ecid in
+                            (str(eid) for eid in eval_col_ids)
+                        }
+                        dep_cols = list(
+                            Column.objects.filter(
+                                dataset_id__in=dataset_ids,
+                                source__in=[
+                                    SourceChoices.EVALUATION_REASON.value,
+                                    SourceChoices.EVALUATION_TAGS.value,
+                                ],
+                                deleted=False,
+                            ).values_list("id", "source_id")
+                        )
+                        for col_id, source_id in dep_cols:
+                            if source_id and any(
+                                sfx in source_id for sfx in eval_col_suffixes
+                            ):
+                                all_col_ids.add(col_id)
+
+                    if all_col_ids:
+                        # Bulk soft-delete cells
+                        Cell.objects.filter(
+                            column_id__in=all_col_ids, deleted=False
+                        ).update(deleted=True)
+
+                        # Bulk soft-delete columns
+                        Column.objects.filter(
+                            id__in=all_col_ids
+                        ).update(deleted=True)
+
+                        # Fix column_order per affected dataset
+                        col_id_strs = {str(c) for c in all_col_ids}
+                        affected_datasets = list(
+                            Dataset.objects.filter(id__in=dataset_ids)
+                        )
+                        datasets_to_update = []
+                        for ds in affected_datasets:
+                            if ds.column_order:
+                                new_order = [
+                                    c for c in ds.column_order
+                                    if c not in col_id_strs
+                                ]
+                                if len(new_order) != len(ds.column_order):
+                                    ds.column_order = new_order
+                                    datasets_to_update.append(ds)
+                        if datasets_to_update:
+                            Dataset.objects.bulk_update(
+                                datasets_to_update, ["column_order"]
+                            )
+
+                    # Soft-delete the metrics themselves
+                    UserEvalMetric.objects.filter(
+                        id__in=[m[0] for m in metrics]
+                    ).update(deleted=True, deleted_at=timezone.now())
 
             response = BulkDeleteResponse(deleted_count=deleted_count)
             return self._gm.success_response(response.model_dump())

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -1633,12 +1633,12 @@ class EvalTemplateBulkDeleteView(APIView):
                         # Bulk soft-delete cells
                         Cell.objects.filter(
                             column_id__in=all_col_ids, deleted=False
-                        ).update(deleted=True)
+                        ).update(deleted=True, deleted_at=timezone.now())
 
                         # Bulk soft-delete columns
                         Column.objects.filter(
                             id__in=all_col_ids
-                        ).update(deleted=True)
+                        ).update(deleted=True, deleted_at=timezone.now())
 
                         # Fix column_order per affected dataset
                         col_id_strs = {str(c) for c in all_col_ids}

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -1580,9 +1580,11 @@ class EvalTemplateBulkDeleteView(APIView):
                 ).update(deleted=True, deleted_at=timezone.now())
 
                 # Fetch all UserEvalMetrics bound to these templates
+                # Scoped to the requesting org to prevent cross-tenant cascade
                 metrics = list(
                     UserEvalMetric.objects.filter(
                         template_id__in=req.template_ids,
+                        organization=organization,
                         deleted=False,
                     ).values_list("id", "dataset_id")
                 )


### PR DESCRIPTION
## Summary

Includes eval config (model, output type, params) in the baseline column auto-populate response during experiment creation.

Without this, the frontend couldn't pre-fill eval settings when adding evals to an experiment with a baseline — users had to manually re-configure each eval.

This change returns the baseline eval configuration as part of the auto-populate API response so the UI can initialize eval settings automatically.

**2 files changed:**
- `EvaluationStepExperimentCreation.jsx` (+4)
- `eval_list.py` (+1)

## Linked issues

Closes #TH-5299

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Created experiment with baseline
- Added eval to experiment
- Verified eval config auto-populates from baseline settings

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)