### PR TITLE
fix(evals): version URL sync + Show more on task errors

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/TaskLogsView.jsx
+++ b/frontend/src/sections/common/EvalsTasks/TaskLogsView.jsx
@@ -98,6 +98,8 @@ function formatDuration(startTime, endTime) {
 
 const ErrorGroupCard = ({ group, defaultExpanded = false }) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
+  const [showFullError, setShowFullError] = useState(false);
+  const hasMoreError = group.raw && group.raw !== group.normalized;
   // Every entry in this log is a real failure — there's no soft tier.
   // Kept as a const so the styling chain below can still parameterize
   // off it if we ever bring back severity tiers.
@@ -176,10 +178,30 @@ const ErrorGroupCard = ({ group, defaultExpanded = false }) => {
               fontSize: "12px",
               fontFamily: "monospace",
               wordBreak: "break-word",
+              whiteSpace: "pre-wrap",
               lineHeight: 1.5,
             }}
           >
-            {group.normalized}
+            {showFullError && hasMoreError ? group.raw : group.normalized}
+            {hasMoreError && (
+              <Typography
+                component="span"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowFullError((prev) => !prev);
+                }}
+                sx={{
+                  ml: 0.5,
+                  fontSize: "11px",
+                  color: "primary.main",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                  "&:hover": { textDecoration: "underline" },
+                }}
+              >
+                {showFullError ? "Show less" : "Show more"}
+              </Typography>
+            )}
           </Typography>
         </Box>
 
@@ -317,6 +339,7 @@ ErrorGroupCard.propTypes = {
     severity: PropTypes.oneOf(["error"]).isRequired,
     hints: PropTypes.arrayOf(PropTypes.string),
     normalized: PropTypes.string.isRequired,
+    raw: PropTypes.string,
     count: PropTypes.number.isRequired,
     examples: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,

--- a/frontend/src/sections/common/EvalsTasks/classifyTaskError.js
+++ b/frontend/src/sections/common/EvalsTasks/classifyTaskError.js
@@ -428,6 +428,7 @@ export function enrichErrorGroup(group) {
     // grouping. Fall back to the classifier's normalize() if the backend
     // returned an empty normalized field.
     normalized: group?.normalized || classified.normalized,
+    raw: sample || classified.raw,
     count: group?.count || 0,
     // ErrorGroupCard expects an array — we only get one sample per
     // group from the backend (cheap enough to render verbatim).

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -280,8 +280,9 @@ const EvalDetailPage = () => {
         setViewingVersion(null);
         setSearchParams(
           (prev) => {
-            prev.delete("v");
-            return prev;
+            const next = new URLSearchParams(prev);
+            next.delete("v");
+            return next;
           },
           { replace: true },
         );
@@ -372,7 +373,16 @@ const EvalDetailPage = () => {
       isPopulatingRef.current = true;
       setViewingVersion(versionToLoad);
       setSearchParams(
-        { v: versionToLoad.version_number ?? versionToLoad.versionNumber },
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set(
+            "v",
+            String(
+              versionToLoad.version_number ?? versionToLoad.versionNumber,
+            ),
+          );
+          return next;
+        },
         { replace: true },
       );
       const config =
@@ -496,6 +506,30 @@ const EvalDetailPage = () => {
   const initialLoadDone = useRef(false);
   useEffect(() => {
     if (evalData && !viewingVersion) {
+
+      const isCustom = evalData.owner !== "system";
+      const urlVersion = searchParams.get("v");
+      if (urlVersion && !initialLoadDone.current) {
+        if (!versionsData) return;
+        const match = (versionsData?.versions || []).find(
+          (ver) =>
+            String(ver.version_number ?? ver.versionNumber) ===
+            String(urlVersion),
+        );
+        if (match) {
+          initialLoadDone.current = true;
+          handleVersionSelect(match);
+          return;
+        }
+      }
+      if (isCustom && !urlVersion && !initialLoadDone.current) {
+        if (!versionsData) return;
+        if (defaultVersion) {
+          initialLoadDone.current = true;
+          handleVersionSelect(defaultVersion);
+          return;
+        }
+      }
       // On initial load, always populate. On subsequent refetches, only populate
       // if the user hasn't made edits (isDirty).
       if (!initialLoadDone.current || !isDirty) {
@@ -600,7 +634,7 @@ const EvalDetailPage = () => {
         }, 100);
       }
     }
-  }, [evalData]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [evalData, versionsData, defaultVersion]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const evalType = evalData?.eval_type || "llm";
   const isSystemEval = evalData?.owner === "system";
@@ -780,7 +814,14 @@ const EvalDetailPage = () => {
       if (newVersion?.version_number ?? newVersion?.versionNumber) {
         setViewingVersion({ ...newVersion, config_snapshot: configSnapshot });
         setSearchParams(
-          { v: newVersion.version_number ?? newVersion.versionNumber },
+          (prev) => {
+            const next = new URLSearchParams(prev);
+            next.set(
+              "v",
+              String(newVersion.version_number ?? newVersion.versionNumber),
+            );
+            return next;
+          },
           { replace: true },
         );
         // Switch to versions tab and highlight the new version

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -20,6 +20,7 @@ import React, {
   useState,
 } from "react";
 import { useSnackbar } from "notistack";
+import { useSearchParams } from "react-router-dom";
 import { CreditExhaustionBanner } from "src/components/CreditExhaustionBanner";
 import Iconify from "src/components/iconify";
 import SvgColor from "src/components/svg-color";
@@ -664,7 +665,25 @@ const TestPlayground = React.forwardRef(
     const [hoveredVersionId, setHoveredVersionId] = useState(null);
     const [menuVersion, setMenuVersion] = useState(null);
     const [selectedVersionId, setSelectedVersionId] = useState(null);
+    const [searchParams] = useSearchParams();
 
+    const urlVersionParam = searchParams.get("v");
+    useEffect(() => {
+      const list = versionsData?.versions || [];
+      if (!list.length) return;
+      if (urlVersionParam) {
+        const match = list.find(
+      ver =>
+            String(ver.version_number ?? ver.versionNumber) ===
+            String(urlVersionParam),
+        );
+        if (match && match.id !== selectedVersionId) {
+          setSelectedVersionId(match.id);
+        }
+      } else if (selectedVersionId) {
+        setSelectedVersionId(null);
+      }
+    }, [urlVersionParam, versionsData]);
     const handleVersionMenuOpen = useCallback((e, version) => {
       e.stopPropagation();
       setVersionMenuAnchor(e.currentTarget);


### PR DESCRIPTION
## Summary
- Custom evals open on their **default version** instead of the latest config; system evals and URL-pinned versions are unaffected.
- Refreshing or sharing a URL with `?v=N` restores that version (`EvalDetailPage` + `TestPlayground` both sync from the param).
- `?v=` mutations no longer wipe other query params (e.g. `?tab=`) — switched to the merge-with-prev pattern.
- Task error groups in `TaskLogsView` keep the 160-char `normalized` summary as the primary label and add an inline **Show more / Show less** toggle that expands to the full `raw` sample. `enrichErrorGroup` now exposes `raw` on the group.

## Test plan
- [x] Open a **custom** eval — page loads on its default version, URL gets `?v=<default>`, timeline highlights it.
- [ ] Open a **system** eval — loads as before (no `?v=` injected, latest config shown).
- [x] Visit `/.../evals/<id>?v=2` directly — page loads on V2 and the V2 row is highlighted in the TestPlayground timeline.
- [x] Visit `/.../evals/<id>?tab=versions&v=2` — both `?tab=versions` and `?v=2` survive after the version is loaded.
- [x] Switch versions in the timeline — `?v=` updates while `?tab=` (if present) is preserved.
- [x] Deselect a version (click selected row) — `?v=` is removed; other params remain.
- [x] Save a new version — URL switches to the new version number; other params remain.
- [x] Custom eval with no versions yet — falls through to populating from `evalData` (no infinite spinner / blank state).
- [x] Task with a long unclassified error — only the 160-char normalized line shows by default; **Show more** expands to the full text, **Show less** collapses; clicking the toggle does not also toggle the row's expand/collapse.
- [x] Task error whose raw and normalized strings are identical — **Show more** is not rendered.

Closes TH-5571,TH-5103