### PR TITLE
Exclude session-target rows and add date range filtering for evaluation

### DIFF
--- a/futureagi/tracer/tests/test_eval_task_aggregations.py
+++ b/futureagi/tracer/tests/test_eval_task_aggregations.py
@@ -9,7 +9,10 @@ rows (``observation_span_id IS NULL``) and picks the latest run when the
 same ``(span, eval_config)`` repeats.
 """
 
+from datetime import timedelta
+
 import pytest  # noqa: E402
+from django.utils import timezone
 
 # Break the import cycle (see test_eval_logger_schema.py for the
 # canonical comment).
@@ -24,6 +27,7 @@ from tracer.models.eval_task import (  # noqa: E402
 from tracer.models.observation_span import (  # noqa: E402
     EvalLogger,
     EvalTargetType,
+    ObservationSpan,
 )
 
 USAGE_URL = "/tracer/eval-task/get_usage/"
@@ -272,6 +276,42 @@ class TestEvalAggregation:
         ]
         assert list(agg.keys()) == ["A"]
 
+    def test_session_target_rows_are_excluded(
+        self,
+        auth_client,
+        project,
+        observe_project,
+        trace_session,
+        organization,
+        workspace,
+        observation_span,
+    ):
+        # Session-target rows (no observation_span) must be dropped from
+        # eval_aggregation. A False session row would tank pass-rate from
+        # 100% to 50% if counted — assertion below pins it at 100%.
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="pass_fail",
+        )
+        cfg_session = _config(project=observe_project, template=tpl, name="SessionEval")
+        cfg_span = _config(project=project, template=tpl, name="SpanEval")
+        task = _task(project=project)
+        EvalLogger.objects.create(
+            target_type=EvalTargetType.SESSION,
+            observation_span=None,
+            trace=None,
+            trace_session=trace_session,
+            custom_eval_config=cfg_session,
+            eval_task_id=str(task.id),
+            output_bool=False,
+        )
+        _row(span=observation_span, cfg=cfg_span, task=task, output_bool=True)
+
+        agg = self._get(auth_client, task).json()["result"]["eval_aggregation"]
+        assert set(agg.keys()) == {"SpanEval"}
+        assert agg["SpanEval"]["aggregated_score"] == 100.0
+
 
 # ── span_aggregation ───────────────────────────────────────────────────
 
@@ -467,3 +507,170 @@ class TestAggregationFlagsCombined:
         assert "stats" in body and "chart" in body and "logs" in body
         assert "eval_aggregation" not in body
         assert "span_aggregation" not in body
+
+
+# ── start_date / end_date date range filter ────────────────────────────
+
+
+def _set_span_created_at(span, when):
+    """Override ``created_at`` (auto_now_add) for a span via ``.update()``."""
+    ObservationSpan.objects.filter(id=span.id).update(created_at=when)
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.django_db
+class TestAggregationDateRange:
+    """``start_date`` / ``end_date`` filter both aggregations by the span's
+    own ``created_at`` (not the EvalLogger's). When neither is given, every
+    span linked to the task is included; otherwise the range bounds the
+    set of qualifying spans inclusively."""
+
+    def _get(self, auth_client, task, **extra):
+        return auth_client.get(
+            USAGE_URL,
+            {"eval_task_id": str(task.id), "eval_aggregation": "true", **extra},
+        )
+
+    def _setup_two_spans(
+        self, project, organization, workspace, observation_span, child_span
+    ):
+        # observation_span = 10 days ago, child_span = 1 day ago.
+        now = timezone.now()
+        _set_span_created_at(observation_span, now - timedelta(days=10))
+        _set_span_created_at(child_span, now - timedelta(days=1))
+
+        tpl = _template(
+            organization=organization,
+            workspace=workspace,
+            output_type_normalized="pass_fail",
+        )
+        cfg = _config(project=project, template=tpl, name="Toxicity")
+        task = _task(project=project)
+        # old span passes, recent span fails — pass rate diverges per range.
+        _row(span=observation_span, cfg=cfg, task=task, output_bool=True)
+        _row(span=child_span, cfg=cfg, task=task, output_bool=False)
+        return task, cfg
+
+    def test_no_date_range_includes_all_spans(
+        self,
+        auth_client,
+        project,
+        organization,
+        workspace,
+        observation_span,
+        child_span,
+    ):
+        task, _ = self._setup_two_spans(
+            project, organization, workspace, observation_span, child_span
+        )
+        agg = self._get(auth_client, task).json()["result"]["eval_aggregation"][
+            "Toxicity"
+        ]
+        # 1 pass + 1 fail = 50%.
+        assert agg["aggregated_score"] == 50.0
+
+    def test_start_date_excludes_older_spans(
+        self,
+        auth_client,
+        project,
+        organization,
+        workspace,
+        observation_span,
+        child_span,
+    ):
+        task, _ = self._setup_two_spans(
+            project, organization, workspace, observation_span, child_span
+        )
+        # 5 days ago: keeps child_span (1d), drops observation_span (10d).
+        start = (timezone.now() - timedelta(days=5)).isoformat()
+        agg = self._get(auth_client, task, start_date=start).json()["result"][
+            "eval_aggregation"
+        ]["Toxicity"]
+        # Only the failing recent span survives → 0%.
+        assert agg["aggregated_score"] == 0.0
+
+    def test_end_date_excludes_newer_spans(
+        self,
+        auth_client,
+        project,
+        organization,
+        workspace,
+        observation_span,
+        child_span,
+    ):
+        task, _ = self._setup_two_spans(
+            project, organization, workspace, observation_span, child_span
+        )
+        # 5 days ago: keeps observation_span (10d), drops child_span (1d).
+        end = (timezone.now() - timedelta(days=5)).isoformat()
+        agg = self._get(auth_client, task, end_date=end).json()["result"][
+            "eval_aggregation"
+        ]["Toxicity"]
+        # Only the passing older span survives → 100%.
+        assert agg["aggregated_score"] == 100.0
+
+    def test_both_bounds_keep_only_in_range_spans(
+        self,
+        auth_client,
+        project,
+        organization,
+        workspace,
+        observation_span,
+        child_span,
+    ):
+        task, _ = self._setup_two_spans(
+            project, organization, workspace, observation_span, child_span
+        )
+        # Window 15..7 days ago → only observation_span (10d) qualifies.
+        start = (timezone.now() - timedelta(days=15)).isoformat()
+        end = (timezone.now() - timedelta(days=7)).isoformat()
+        agg = self._get(auth_client, task, start_date=start, end_date=end).json()[
+            "result"
+        ]["eval_aggregation"]["Toxicity"]
+        assert agg["aggregated_score"] == 100.0
+
+    def test_range_excluding_all_returns_empty_rollup(
+        self,
+        auth_client,
+        project,
+        organization,
+        workspace,
+        observation_span,
+        child_span,
+    ):
+        task, _ = self._setup_two_spans(
+            project, organization, workspace, observation_span, child_span
+        )
+        # 100 years ago → no span qualifies; rollup omits the config.
+        start = (timezone.now() - timedelta(days=36500)).isoformat()
+        end = (timezone.now() - timedelta(days=36000)).isoformat()
+        agg = self._get(auth_client, task, start_date=start, end_date=end).json()[
+            "result"
+        ]["eval_aggregation"]
+        assert agg == {}
+
+    def test_range_filters_span_aggregation_too(
+        self,
+        auth_client,
+        project,
+        organization,
+        workspace,
+        observation_span,
+        child_span,
+    ):
+        # Same range mechanic must apply when only span_aggregation is set.
+        task, _ = self._setup_two_spans(
+            project, organization, workspace, observation_span, child_span
+        )
+        start = (timezone.now() - timedelta(days=5)).isoformat()
+        sa = auth_client.get(
+            USAGE_URL,
+            {
+                "eval_task_id": str(task.id),
+                "span_aggregation": "true",
+                "start_date": start,
+            },
+        ).json()["result"]["span_aggregation"]
+        # Only the recent (child) span survives the window.
+        assert list(sa.keys()) == [str(child_span.id)]

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -618,6 +618,14 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             # Soft-deleted rows are excluded (intentional departure from the
             # legacy path) so rollups reflect the user's current view of
             # the data. ``period`` is not applied — these are task-wide.
+            #
+            # Spans-only semantics: session-target rows (``observation_span_id
+            # IS NULL``) are excluded from both aggregations so the row set
+            # is consistent whether or not a date range is supplied.
+            #
+            # Optional ``start_date`` / ``end_date`` (ISO-8601) scope the
+            # rollup to spans whose ``observation_span.created_at`` falls
+            # in the range.
             eval_aggregation = _truthy(
                 self.request.query_params.get("eval_aggregation")
             )
@@ -628,10 +636,26 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                 agg_base_qs = EvalLogger.objects.filter(
                     eval_task_id=str(eval_task_id),
                     deleted=False,
+                    observation_span_id__isnull=False,
                 )
                 if eval_id_filter:
                     agg_base_qs = agg_base_qs.filter(
                         custom_eval_config_id=eval_id_filter
+                    )
+
+                start_date_str = self.request.query_params.get("start_date")
+                end_date_str = self.request.query_params.get("end_date")
+                if start_date_str:
+                    agg_base_qs = agg_base_qs.filter(
+                        observation_span__created_at__gte=datetime.fromisoformat(
+                            start_date_str
+                        )
+                    )
+                if end_date_str:
+                    agg_base_qs = agg_base_qs.filter(
+                        observation_span__created_at__lte=datetime.fromisoformat(
+                            end_date_str
+                        )
                     )
 
                 agg_response = {"eval_task_id": str(eval_task_id)}


### PR DESCRIPTION
## Summary

Adds `start_date` and `end_date` query parameters to `GET /tracer/eval-task/get_usage/` when `eval_aggregation` and/or `span_aggregation` is set, so callers can scope rollups to spans created in a specific window. Both bounds are optional and ISO-8601 — when neither is supplied, every span linked to the eval task is included (no behavioural change for existing callers).

Also tightens `eval_aggregation` to always exclude session-target eval runs (rows where `observation_span_id IS NULL`). Previously these were included by default and silently dropped only when a date range was supplied (because the filter joins through `observation_span` with an INNER JOIN). Making the exclusion explicit and unconditional means both aggregations now agree on the same row set regardless of whether a date range is given.

## Linked issues

Closes #

## Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📖 Documentation only (mdx doc updated alongside the code change)

## What changed

**Backend** — `futureagi/tracer/views/eval_task.py`

- Aggregation short-circuit base queryset now adds `observation_span_id__isnull=False`, so session-target rows are excluded from both `_compute_eval_aggregation` and `_compute_span_aggregation` — always, regardless of date range.
- New `start_date` / `end_date` query params (ISO-8601) are parsed via `datetime.fromisoformat` and applied as `observation_span__created_at__gte` / `__lte` filters. Filtering is on the span's `created_at`, **not** the EvalLogger's — the intent is "which spans were collected in this window," independent of when evals ran on them. The `observation_span.created_at` is indexed (`tracer_observation_span` composite indexes on `(project, created_at)` and `(trace, created_at)`).
- Only the aggregation path is affected. The non-aggregation path (`stats` / `chart` / paginated `logs`) still uses the existing `period` enum — no change there.

**Docs** — `docs/src/pages/docs/api/eval-tasks/eval-task-aggregations.mdx`

- Added `start_date` / `end_date` to the API playground param list and the `Query parameters` section, with descriptions calling out that the bounds are inclusive and operate on the span's creation time.
- Updated the `<Note>` block to (a) make explicit that both aggregations are spans-only — session-target eval runs are excluded regardless of whether a date range is supplied, and (b) explain that the date range filters on `observation_span.created_at`, so the rollup only includes those spans that were created in the supplied window.

## Tests added

`futureagi/tracer/tests/test_eval_task_aggregations.py`

**New test in `TestEvalAggregation`:**

- `test_session_target_rows_are_excluded` — creates a session-target eval row (with `output_bool=False`) alongside a span-target row (with `output_bool=True`) for the same `eval_task_id`, then asserts the rollup contains only the `SpanEval` config and reports a pass rate of 100% (not 50%). This pins the new always-on exclusion.

**New `TestAggregationDateRange` class (6 tests):**

Uses two spans with overridden `created_at` (10 days ago and 1 day ago) and asserts each scenario from the API perspective:

| Test | Scenario covered |
|---|---|
| `test_no_date_range_includes_all_spans` | No `start_date` / `end_date` → both spans counted (1 pass + 1 fail = 50%). Locks in the "default = everything" contract. |
| `test_start_date_excludes_older_spans` | `start_date = now - 5d` → only the 1-day-old span survives. |
| `test_end_date_excludes_newer_spans` | `end_date = now - 5d` → only the 10-day-old span survives. |
| `test_both_bounds_keep_only_in_range_spans` | Window 15..7 days ago → only the 10-day-old span qualifies. |
| `test_range_excluding_all_returns_empty_rollup` | Range that matches no spans → aggregation map is `{}` (config drops out entirely when no rows survive). |
| `test_range_filters_span_aggregation_too` | Same range mechanic applied to `span_aggregation=true` — confirms the filter is on the shared `agg_base_qs`, not just the eval-aggregation branch. |

## How was this tested?

All 21 tests in the file pass against a fresh test DB:

```bash
cd futureagi
bin/test --no-services tracer/tests/test_eval_task_aggregations.py -v
# ... 21 passed in 16.05s
```

## Commands to run the tests

**Just the affected file (recommended — quick feedback loop, ~16s):**

```bash
cd futureagi
bin/test tracer/tests/test_eval_task_aggregations.py
# or, if test services are already up:
bin/test --no-services tracer/tests/test_eval_task_aggregations.py
```

**Just the new tests added in this PR:**

```bash
cd futureagi
bin/test tracer/tests/test_eval_task_aggregations.py -k "TestAggregationDateRange or test_session_target_rows_are_excluded"
```

**All previously existing tests in this file (regression coverage):**

```bash
cd futureagi
bin/test tracer/tests/test_eval_task_aggregations.py -k "not TestAggregationDateRange and not test_session_target_rows_are_excluded"
```

**Broader scope (everything tagged integration for the tracer app):**

```bash
cd futureagi
bin/test app tracer
```

##Linear
Fixes TH-5568


## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII