### PR TITLE
chore(oss): self-serve hardening — CI boot gate, admin seed, healthcheck, docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,16 @@ RECAPTCHA_ENABLED=false
 
 # Future AGI Cloud (optional, leave blank for fully offline).
 FUTURE_AGI_CLOUD_API_KEY=
+
+# ---- First-run admin (optional) ----
+# Set all three and `docker compose up` creates this login on first boot
+# (idempotent — re-running never duplicates it). Leave blank to create the
+# account yourself with:
+#   docker exec -it futureagi-backend-1 python manage.py create_user
+FAGI_ADMIN_EMAIL=
+FAGI_ADMIN_NAME=
+FAGI_ADMIN_PASSWORD=
+
+# Allow any email domain for signup (OSS default: true). Set false to require
+# work-email addresses, as the hosted SaaS does.
+ALLOW_ANY_EMAIL=true

--- a/.github/workflows/oss-boot-test.yml
+++ b/.github/workflows/oss-boot-test.yml
@@ -1,0 +1,138 @@
+# ============================================================================
+# OSS clean-room boot test
+#
+# Proves a *fresh public clone boots*: builds the backend from Dockerfile.oss
+# with the Enterprise (`ee/`) code absent — exactly what a community user gets —
+# then brings up the light stack and asserts the app actually works.
+#
+# This is the regression gate behind the "git clone && ./bin/install" promise.
+# It catches the class of bug that has repeatedly broken self-host: an
+# unguarded `from ee...` import or a missing `DeploymentMode` None-check that
+# only fails when `ee/` isn't present (it always is in the dev monorepo).
+#
+# Why build only the backend: it's the EE-coupled image, and the same tag
+# (futureagi/future-agi:latest) is used by both `backend` and `worker`. The
+# other services pull published images.
+# ============================================================================
+name: OSS clean-room boot
+
+on:
+  pull_request:
+    paths:
+      - "futureagi/**"
+      - "docker-compose.yml"
+      - ".env.example"
+      - ".github/workflows/oss-boot-test.yml"
+  push:
+    branches: [main, dev]
+    paths:
+      - "futureagi/**"
+      - "docker-compose.yml"
+      - ".env.example"
+      - ".github/workflows/oss-boot-test.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: oss-boot-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  boot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Guarantee clean-room (no EE code)
+        run: |
+          # ee/ is gitignored so checkout never includes it; remove defensively
+          # in case a future change accidentally tracks it.
+          rm -rf futureagi/ee
+          if [ -d futureagi/ee ]; then
+            echo "::error::futureagi/ee still present — not a clean OSS tree"; exit 1
+          fi
+          echo "clean-room OK: futureagi/ee absent"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build OSS backend image (ee/ absent)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./futureagi
+          file: ./futureagi/Dockerfile.oss
+          tags: futureagi/future-agi:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Boot the light stack (with admin auto-seed)
+        run: |
+          # Minimal .env: exercise the FAGI_ADMIN_* auto-seed path too.
+          cat > .env <<'EOF'
+          FAGI_ADMIN_EMAIL=ci-admin@example.com
+          FAGI_ADMIN_NAME=CI Admin
+          FAGI_ADMIN_PASSWORD=ci-test-password-123
+          ALLOW_ANY_EMAIL=true
+          EOF
+          # `up frontend` pulls in backend + its datastores via depends_on, but
+          # leaves the heavy serving/code-executor leaves down to fit the runner.
+          # No `pull` — that would clobber our locally built backend image.
+          docker compose up -d frontend
+
+      - name: Wait for backend health
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:8000/health/ >/dev/null 2>&1; then
+              echo "backend healthy after ~$((i * 10))s"; exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::backend did not pass /health/ within 10 minutes"; exit 1
+
+      - name: Assert health, EE stub (402 not 500), and frontend
+        run: |
+          set -x
+          health=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/health/)
+          [ "$health" = "200" ] || { echo "::error::/health/ expected 200, got $health"; exit 1; }
+
+          # An EE-only route must degrade to the 402 upgrade stub, never 500.
+          stub=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/falcon-ai/anything)
+          [ "$stub" = "402" ] || { echo "::error::EE stub expected 402, got $stub (an unguarded ee path?)"; exit 1; }
+
+          # Frontend only starts once the backend is healthy, so give nginx a
+          # moment to come up before asserting.
+          front=000
+          for i in $(seq 1 12); do
+            front=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/ || echo 000)
+            [ "$front" = "200" ] && break
+            sleep 5
+          done
+          [ "$front" = "200" ] || { echo "::error::frontend expected 200, got $front"; exit 1; }
+
+      - name: Assert no unguarded EE imports leaked into boot
+        run: |
+          logs=$(docker compose logs backend --no-color)
+          if echo "$logs" | grep -qE "No module named '?ee'?|ModuleNotFoundError: No module named .ee"; then
+            echo "::error::backend log shows a missing-ee import — an EE guard is missing"
+            echo "$logs" | grep -nE "No module named|ModuleNotFoundError" | head
+            exit 1
+          fi
+          echo "OK: no missing-ee imports in backend boot"
+
+      - name: Assert admin was auto-seeded
+        run: |
+          if ! docker compose logs backend --no-color | grep -q "ensure_admin: created admin"; then
+            echo "::error::admin auto-seed did not run"
+            docker compose logs backend --no-color | grep -i ensure_admin || true
+            exit 1
+          fi
+          echo "OK: admin account auto-seeded from FAGI_ADMIN_*"
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose logs --no-color | tail -n 400
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,12 @@
 # not just your changes, making it slow and pointless.
 [ -f "$(git rev-parse --git-path MERGE_HEAD 2>/dev/null)" ] && exit 0
 
+# lint-staged is contributor tooling — you only need it to contribute, not to
+# run the app. If it isn't installed, skip cleanly instead of blocking the
+# commit. Run `yarn install` from the repo root to enable formatting on commit.
+if [ ! -x node_modules/.bin/lint-staged ]; then
+  echo "⏭  lint-staged not installed — skipping pre-commit formatting (run 'yarn install' to enable)."
+  exit 0
+fi
+
 npx --no-install lint-staged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,22 +47,34 @@ docker compose up -d
 
 The backend will be at `http://localhost:8000`, the frontend at `http://localhost:3031`.
 
-### 3. Install git hooks
+### 3. Install git hooks (optional)
+
+Git hooks are **contributor tooling only** — you don't need them to run or
+self-host Future AGI (the Docker stack never touches them). They just format
+and lint your changes before they leave your machine.
 
 ```bash
-# From repo root — installs husky hooks and lint-staged tooling.
+# From repo root — installs husky hooks + lint-staged (frontend formatting).
 yarn install
 
-# For Python hooks (black, isort, mypy, Django system checks):
+# Optional: Python checks (black, isort, mypy, Django system checks).
 cd futureagi && make pre-commit-install
 ```
 
-On every commit, `lint-staged` auto-formats and lints the staged files:
+What runs:
 
-- `frontend/src/**` → ESLint + Prettier
-- `futureagi/**/*.py` → `black`, `isort`, `mypy` (via pre-commit)
+- **pre-commit** → `lint-staged` on staged `frontend/src/**` files (ESLint + Prettier).
+- **pre-commit (Python)** → `black`, `isort`, `mypy` on staged `futureagi/**/*.py` —
+  only if you ran `make pre-commit-install` above. Not part of `lint-staged`.
+- **pre-push** → branch-name validation (skipped automatically on `main`/`dev`).
 
-Branch names are validated on `git push`.
+The hooks are fully skippable when you need to bypass them:
+
+```bash
+git commit --no-verify     # skip the pre-commit hook for this commit
+git push --no-verify       # skip branch-name validation for this push
+HUSKY=0 git commit         # disable husky hooks entirely for the command
+```
 
 ### 4. Run tests
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -77,6 +77,18 @@ docker exec futureagi-backend-1 python manage.py create_user \
   --password yourpassword
 ```
 
+#### Auto-seed the admin on boot (no CLI)
+
+If you'd rather not run any command, set these in `.env` before `docker compose up`:
+
+```bash
+FAGI_ADMIN_EMAIL=you@example.com
+FAGI_ADMIN_NAME=Your Name
+FAGI_ADMIN_PASSWORD=at-least-8-chars
+```
+
+The backend creates this account on first boot. It's **idempotent** — restarting won't duplicate it, and it's a no-op if the account already exists. This is the same path `./bin/install` uses when you pass `FAGI_ADMIN_*` for an unattended install. By default the OSS stack accepts any email domain; set `ALLOW_ANY_EMAIL=false` to require work emails.
+
 > **Team invites and password resets require email (SMTP).** See the [Email configuration](#email-smtp) section below for setup. Mailgun offers a free tier (100 emails/day) that works well for small self-hosted deployments.
 
 To stop everything: `./bin/uninstall` (or `docker compose down`). Data persists in named volumes across restarts.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Go-based gateway with **~9.9 ns weighted routing**, **~29 k req/s on t3.xlarge**
 
 ---
 
-## 🚀 Quickstart (60 seconds)
+## 🚀 Quickstart (one command)
 
 Two ways, picked by how much you want to install:
 
@@ -134,7 +134,7 @@ cd future-agi
 .\bin\install.ps1
 ```
 
-Open [http://localhost:3000](http://localhost:3000).
+The installer pulls images and starts ~12 services. **First boot takes a few minutes** (image download + database migrations) and wants **~8 GB of free RAM**. When it's ready, open [http://localhost:3000](http://localhost:3000).
 <sub>For production, use `./deploy/setup.sh` to generate required secrets and pin the image version.</sub>
 
 </td>

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ cd future-agi
 .\bin\install.ps1
 ```
 
-The installer pulls images and starts ~12 services. **First boot takes a few minutes** (image download + database migrations) and wants **~8 GB of free RAM**. When it's ready, open [http://localhost:3000](http://localhost:3000).
+The installer pulls images, starts ~12 services, and **prompts you to create your first admin account (email + password)**. **First boot takes a few minutes** (image download + database migrations) and wants **~8 GB of free RAM**. When it's ready, sign in with that account at [http://localhost:3000](http://localhost:3000).
+<sub>Not using the installer? Set `FAGI_ADMIN_EMAIL` and `FAGI_ADMIN_PASSWORD` in `.env` **before** `docker compose up` and the admin is created on first boot — there's no default login. See [INSTALLATION.md](INSTALLATION.md#create-your-first-account).</sub>
 <sub>For production, use `./deploy/setup.sh` to generate required secrets and pin the image version.</sub>
 
 </td>

--- a/deploy/docker-compose.production.yml
+++ b/deploy/docker-compose.production.yml
@@ -6,6 +6,11 @@ services:
   backend:
     environment:
       ENV_TYPE: production
+      # OSS root sets ALLOW_ANY_EMAIL=true by default for self-host
+      # friendliness; production should require work-email signups. Operator
+      # can flip back via ALLOW_ANY_EMAIL=true in .env if a specific
+      # deployment genuinely needs personal-email accounts.
+      ALLOW_ANY_EMAIL: ${ALLOW_ANY_EMAIL:-false}
       SECRET_KEY: ${SECRET_KEY:?must be set for production}
       AGENTCC_INTERNAL_API_KEY: ${AGENTCC_INTERNAL_API_KEY:?must be set for production}
       AGENTCC_ADMIN_TOKEN: ${AGENTCC_ADMIN_TOKEN:?must be set for production}
@@ -19,6 +24,9 @@ services:
   worker:
     environment:
       ENV_TYPE: production
+      # Same OSS-default override as the backend — kept in sync so all
+      # services sharing the &backend-env anchor land on the same value.
+      ALLOW_ANY_EMAIL: ${ALLOW_ANY_EMAIL:-false}
       SECRET_KEY: ${SECRET_KEY:?must be set for production}
       AGENTCC_INTERNAL_API_KEY: ${AGENTCC_INTERNAL_API_KEY:?must be set for production}
       AGENTCC_ADMIN_TOKEN: ${AGENTCC_ADMIN_TOKEN:?must be set for production}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,8 @@ x-backend-env: &backend-env
 
   # Accounts: OSS self-host allows any email domain for signup / admin seeding.
   # The hosted SaaS gates this to work emails; self-hosters use whatever they
-  # have. Set ALLOW_ANY_EMAIL=false in .env to require work emails.
+  # have. The production overlay (deploy/docker-compose.production.yml) flips
+  # this default to false so EE/prod requires work emails by default.
   ALLOW_ANY_EMAIL: ${ALLOW_ANY_EMAIL:-true}
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,11 @@ x-backend-env: &backend-env
   FUTURE_AGI_CLOUD_API_KEY: ${FUTURE_AGI_CLOUD_API_KEY:-}
   FUTURE_AGI_CLOUD_API_URL: ${FUTURE_AGI_CLOUD_API_URL:-https://api.futureagi.com}
 
+  # Accounts: OSS self-host allows any email domain for signup / admin seeding.
+  # The hosted SaaS gates this to work emails; self-hosters use whatever they
+  # have. Set ALLOW_ANY_EMAIL=false in .env to require work emails.
+  ALLOW_ANY_EMAIL: ${ALLOW_ANY_EMAIL:-true}
+
 
 services:
   # ==========================================================================
@@ -177,6 +182,11 @@ services:
       GRANIAN_THREADS: ${GRANIAN_THREADS:-2}
       ENABLE_HTTP: ${ENABLE_HTTP:-true}
       ENABLE_GRPC: ${ENABLE_GRPC:-true}
+      # First-run admin seed (idempotent). Set all three in .env and the
+      # backend creates this login on boot — no installer or CLI needed.
+      FAGI_ADMIN_EMAIL: ${FAGI_ADMIN_EMAIL:-}
+      FAGI_ADMIN_NAME: ${FAGI_ADMIN_NAME:-}
+      FAGI_ADMIN_PASSWORD: ${FAGI_ADMIN_PASSWORD:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,11 @@ services:
       # deployment (e.g. https://api.example.com for split-domain).
       VITE_HOST_API: ${VITE_HOST_API:-}
     depends_on:
-      - backend
+      # Wait for the backend to pass its healthcheck so the SPA never loads
+      # against an API that's still migrating (the "frontend startup errors"
+      # first-run symptom).
+      backend:
+        condition: service_healthy
     restart: unless-stopped
 
   backend:
@@ -200,6 +204,15 @@ services:
         condition: service_healthy
       agentcc-gateway:
         condition: service_started
+    healthcheck:
+      # /health/ is an anonymous 200 served by Granian on port 80 inside the
+      # container. start_period is generous: on first boot the backend waits
+      # on Temporal, then runs migrations + collectstatic before serving.
+      test: ["CMD-SHELL", "curl -fsS http://localhost:80/health/ || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 180s
     restart: unless-stopped
 
   worker:

--- a/futureagi/accounts/management/commands/ensure_admin.py
+++ b/futureagi/accounts/management/commands/ensure_admin.py
@@ -1,0 +1,91 @@
+import os
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = (
+        "Idempotently seed the first admin account from FAGI_ADMIN_* env vars "
+        "(or --email/--name/--password). Safe to run on every boot: it does "
+        "nothing if the account already exists or if no credentials are "
+        "configured, and never raises in a way that would block startup. "
+        "The container entrypoint calls this so a plain `docker compose up` "
+        "yields a usable login without running the installer."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--email", help="Admin email (default: $FAGI_ADMIN_EMAIL)"
+        )
+        parser.add_argument(
+            "--name", help="Full name (default: $FAGI_ADMIN_NAME, else 'Admin')"
+        )
+        parser.add_argument(
+            "--password", help="Password (default: $FAGI_ADMIN_PASSWORD)"
+        )
+
+    def handle(self, *args, **options):
+        email = (
+            options.get("email") or os.getenv("FAGI_ADMIN_EMAIL") or ""
+        ).strip().lower()
+        name = (options.get("name") or os.getenv("FAGI_ADMIN_NAME") or "").strip()
+        password = options.get("password") or os.getenv("FAGI_ADMIN_PASSWORD") or ""
+
+        # No credentials configured: this is the normal case when the operator
+        # creates the account some other way. Quietly no-op so boot continues.
+        if not email or not password:
+            self.stdout.write(
+                "ensure_admin: FAGI_ADMIN_EMAIL / FAGI_ADMIN_PASSWORD not set — "
+                "skipping admin seed (create one later with "
+                "`python manage.py create_user`)."
+            )
+            return
+
+        if len(password) < 8:
+            self.stderr.write(
+                "ensure_admin: FAGI_ADMIN_PASSWORD must be at least 8 characters "
+                "— skipping admin seed."
+            )
+            return
+
+        if not name:
+            name = "Admin"
+
+        User = get_user_model()
+        if User.objects.filter(email__iexact=email).exists():
+            self.stdout.write(
+                f"ensure_admin: account '{email}' already exists — nothing to do."
+            )
+            return
+
+        # Import here so a missing/half-built app never breaks `manage.py` itself.
+        from accounts.utils import first_signup
+
+        try:
+            user = first_signup(
+                {
+                    "email": email,
+                    "full_name": name,
+                    "password": password,
+                    "allow_email": True,
+                }
+            )
+        except Exception as exc:  # noqa: BLE001 — seed must never block boot
+            msg = str(exc)
+            self.stderr.write(f"ensure_admin: could not create admin '{email}': {msg}")
+            if "work email" in msg.lower():
+                self.stderr.write(
+                    "  Personal email domains are rejected unless "
+                    "ALLOW_ANY_EMAIL=true (the default in the OSS compose). "
+                    "Set ALLOW_ANY_EMAIL=true and restart the backend."
+                )
+            self.stderr.write(
+                "  Create the account manually instead: "
+                "`python manage.py create_user`."
+            )
+            return
+
+        self.stdout.write(
+            self.style.SUCCESS(f"ensure_admin: created admin account '{user.email}'.")
+        )

--- a/futureagi/entrypoint.sh
+++ b/futureagi/entrypoint.sh
@@ -248,6 +248,15 @@ else
     echo "FAST_STARTUP mode: skipping DB checks, migrations, and static collection"
 fi
 
+# Seed the first admin account from FAGI_ADMIN_* (backend only; idempotent and
+# best-effort — never blocks boot). Lets a plain `docker compose up` produce a
+# usable login without running bin/install. No-ops if the account exists or the
+# env vars are unset; ensure_admin handles both cases internally.
+if [ "$SERVICE_TYPE" = "backend" ] && [ -n "${FAGI_ADMIN_EMAIL:-}" ] && [ -n "${FAGI_ADMIN_PASSWORD:-}" ]; then
+    echo "Seeding first admin account from FAGI_ADMIN_* env (idempotent)..."
+    python manage.py ensure_admin || echo "WARNING: admin seed failed (non-fatal), continuing startup..."
+fi
+
 python manage.py register_temporal_schedules || echo "WARNING: Temporal schedule registration failed (non-fatal), continuing startup..."
 
 # Start the appropriate service based on SERVICE_TYPE

--- a/futureagi/entrypoint.sh
+++ b/futureagi/entrypoint.sh
@@ -339,6 +339,14 @@ case "$SERVICE_TYPE" in
         fi
         ;;
 
+    # -----------------------------------------------------------------------
+    # LEGACY (Celery). The "worker", "beat", and "flower" service types below
+    # are the old Celery-based execution path. Background work now runs on
+    # Temporal — see the "temporal-worker" case. The OSS docker-compose only
+    # uses SERVICE_TYPE=backend and SERVICE_TYPE=temporal-worker, so these
+    # Celery branches are NOT exercised by a default self-host. They are kept
+    # for backward compatibility only; prefer temporal-worker for new setups.
+    # -----------------------------------------------------------------------
     "worker")
         echo "Starting Celery worker for queue(s): $CELERY_QUEUE..."
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Repo-level tooling for Future AGI (hooks + formatters). App code lives in frontend/ and futureagi/.",
   "scripts": {
-    "prepare": "husky",
+    "prepare": "husky || true",
     "lint-staged": "lint-staged"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Hardens the OSS self-host path so a new user's `git clone → ./bin/install → localhost:3000` works smoothly and stays working. Six small, related commits:

1. **CI clean-room OSS boot test** — builds the backend without `ee/`, boots the light stack on an empty database, and asserts `/health/` 200, EE-stub routes → 402 (not 500), and no missing-`ee` imports. This is the regression gate that would have caught the recent `accounts.0020` migration crash before it shipped.
2. **Idempotent admin auto-seed** (`ensure_admin` command + entrypoint hook + `FAGI_ADMIN_*` passthrough in compose). Plus `ALLOW_ANY_EMAIL=true` as the OSS default so `first_signup` no longer rejects personal-email admins (a silent trap that blocks Gmail users today).
3. **Backend healthcheck + frontend gated on `service_healthy`** — fixes the "frontend stuck loading" first-run symptom where the SPA loaded before the API was ready.
4. `LEGACY` banner above the Celery `worker`/`beat`/`flower` branches in `entrypoint.sh` (Temporal is the live path).
5. Husky hooks made optional, skippable, and accurately documented; fixes a stale claim that lint-staged ran `black/isort/mypy`.
6. Honest README first-boot expectations — replaces "Quickstart (60 seconds)" with realistic ~12 services / few minutes / ~8 GB RAM.

No new user-visible features; this is infrastructure + UX hardening + a regression gate. The migration bug (`accounts.0020`) that hit the published image is fixed *separately* on `nightly-dev` — this PR is what *gates* the next one.

## Linked issues

<!-- No tracked issue — surfaced making the OSS self-host actually self-serve. Add one if your team tracks these. -->
Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [x] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

<!-- Primarily chore. Has bug-fix aspects (ALLOW_ANY_EMAIL personal-email trap, frontend-loading race) and a test-only piece (the CI boot gate). -->

## How was this tested?

End-to-end on a fresh public-style OSS clone (no `ee/`), multiple ways:

**Backend boot + EE-stub correctness** (this is what the new CI gate also asserts):
- Built the backend from this branch with `Dockerfile.oss` against an empty database.
- All 12 light-stack services come up healthy.
- `curl /health/` → **200**, `curl /falcon-ai/anything` → **402** (not 500), frontend → **200**.
- Backend logs free of `No module named 'ee'` / unguarded EE import errors.

**#3 admin auto-seed:**
- With `FAGI_ADMIN_*` set in `.env`, backend logs show `ensure_admin: created admin account 'verify-admin@example.com'.`
- Re-boot is a no-op (`account 'X' already exists — nothing to do.`).
- `POST /accounts/token/` with the seeded creds returns **200** (JWT).
- Unset env vars → command prints a friendly skip and boot continues normally.

**#5 healthcheck:**
- `docker compose ps` shows backend `(healthy)` only once `/health/` responds; frontend stays `created` until then, then starts. Verified compose ordering by inspecting `up -d` output.

**#1 CI clean-room boot workflow:**
- YAML validates (`ruby -ryaml`).
- Build step mirrors the proven `release-backend.yml` (`context: ./futureagi`, `file: ./futureagi/Dockerfile.oss`).
- *Caveat:* not yet executed in CI — the first PR run is the real proof. Local equivalent (`rm -rf futureagi/ee` + build + boot + curl assertions) passes.

**#9 hooks:**
- `bash -n .husky/pre-commit` and `package.json` JSON parse both pass.

## Screenshots / recordings (if UI)

N/A — backend / infra / docs.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works  <!-- `.github/workflows/oss-boot-test.yml` is the integration test for the whole branch's effect -->
- [ ] `make check-all` / `yarn check-all` passes locally  <!-- run before merge -->
- [x] I've updated the documentation where relevant  <!-- README, INSTALLATION.md, CONTRIBUTING.md, .env.example -->
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla) <!-- handle as needed -->
