### PR TITLE
fix(evals): tag PDF-accepting evals so the PDF picker chip populates (TH-5162)

### DIFF
--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 10
+SYSTEM_EVALS_VERSION = 11
 
 # Postgres advisory-lock key. Serialises concurrent seed_evals() calls
 # across pods so the bulk_create path can't race on new eval_ids. Any
@@ -223,6 +223,18 @@ def seed_evals(dry_run=False, force=False, verbose=False):
     return created_count, updated_count, skipped_count
 
 
+def _eval_accepts_pdf(config):
+    """True when any of the eval's params accepts a PDF input. The picker
+    filters on eval_tags, so this is what fills the PDF filter chip."""
+    param_modalities = (config or {}).get("param_modalities") or {}
+    for modalities in param_modalities.values():
+        if isinstance(modalities, (list, tuple)) and any(
+            str(m).upper() == "PDF" for m in modalities
+        ):
+            return True
+    return False
+
+
 def _yaml_to_template_fields(eval_def):
     """Convert a YAML eval definition dict into EvalTemplate field values."""
     from model_hub.models.choices import OwnerChoices
@@ -259,6 +271,10 @@ def _yaml_to_template_fields(eval_def):
     allow_edit = permissions.get("allow_edit", False)  # System evals default to no edit
     allow_copy = permissions.get("allow_copy", True)  # But copy is allowed
 
+    eval_tags = list(eval_def.get("eval_tags", []) or [])
+    if _eval_accepts_pdf(config) and "PDF" not in eval_tags:
+        eval_tags.append("PDF")
+
     # Output type mapping
     output = config.get("output", "Pass/Fail")
     output_type_normalized = eval_def.get("output_type_normalized")
@@ -277,7 +293,7 @@ def _yaml_to_template_fields(eval_def):
         "name": eval_def["name"],
         "description": eval_def.get("description", ""),
         "criteria": eval_def.get("criteria", ""),
-        "eval_tags": eval_def.get("eval_tags", []),
+        "eval_tags": eval_tags,
         "config": config,
         "choices": eval_def.get("choices"),
         "multi_choice": eval_def.get("multi_choice", False),

--- a/futureagi/model_hub/tests/test_seed_system_evals_modality_tags.py
+++ b/futureagi/model_hub/tests/test_seed_system_evals_modality_tags.py
@@ -1,0 +1,71 @@
+"""Seeder tags an eval "PDF" when it accepts a PDF input
+(config.param_modalities), and only PDF."""
+
+from model_hub.management.commands.seed_system_evals import (
+    _eval_accepts_pdf,
+    _yaml_to_template_fields,
+)
+
+
+def test_accepts_pdf_when_a_param_lists_pdf():
+    assert _eval_accepts_pdf({"param_modalities": {"input": ["TEXT", "PDF"]}}) is True
+
+
+def test_accepts_pdf_is_case_insensitive():
+    assert _eval_accepts_pdf({"param_modalities": {"input": ["pdf"]}}) is True
+
+
+def test_accepts_pdf_checks_all_params():
+    config = {"param_modalities": {"input": ["TEXT"], "context": ["PDF"]}}
+    assert _eval_accepts_pdf(config) is True
+
+
+def test_not_pdf_when_no_pdf_modality():
+    config = {"param_modalities": {"input": ["TEXT", "AUDIO", "IMAGE", "JSON"]}}
+    assert _eval_accepts_pdf(config) is False
+
+
+def test_not_pdf_when_missing_or_empty():
+    assert _eval_accepts_pdf({}) is False
+    assert _eval_accepts_pdf(None) is False
+    assert _eval_accepts_pdf({"param_modalities": {}}) is False
+    assert _eval_accepts_pdf({"param_modalities": {"input": None}}) is False
+
+
+def test_yaml_fields_add_pdf_tag_and_preserve_existing():
+    eval_def = {
+        "eval_id": 999001,
+        "name": "th5162_pdf_eval",
+        "_track": "agent",
+        "eval_tags": ["Data Leakage", "Safety"],
+        "config": {"param_modalities": {"input": ["TEXT", "PDF"]}},
+    }
+    tags = _yaml_to_template_fields(eval_def)["eval_tags"]
+    assert "PDF" in tags
+    assert "Data Leakage" in tags and "Safety" in tags
+
+
+def test_yaml_fields_only_touch_pdf_never_other_modalities():
+    # Accepts TEXT/AUDIO/IMAGE but NOT PDF → no tag should be added at all.
+    eval_def = {
+        "eval_id": 999002,
+        "name": "th5162_non_pdf_eval",
+        "_track": "agent",
+        "eval_tags": ["Safety"],
+        "config": {"param_modalities": {"input": ["TEXT", "AUDIO", "IMAGE"]}},
+    }
+    tags = _yaml_to_template_fields(eval_def)["eval_tags"]
+    assert tags == ["Safety"]
+    assert "Text" not in tags and "Audio" not in tags and "Image" not in tags
+
+
+def test_yaml_fields_dedupe_when_already_pdf_tagged():
+    eval_def = {
+        "eval_id": 999003,
+        "name": "th5162_already_pdf",
+        "_track": "agent",
+        "eval_tags": ["PDF"],
+        "config": {"param_modalities": {"input": ["PDF"]}},
+    }
+    tags = _yaml_to_template_fields(eval_def)["eval_tags"]
+    assert tags.count("PDF") == 1


### PR DESCRIPTION
## Problem
The "Select Evaluation" picker filters evals by `eval_tags`. No eval was tagged `PDF`, so the **PDF** filter chip showed "No evaluations found" — even though many evals accept a PDF input, already declared in each eval's `config.param_modalities`.

## Fix
- `seed_system_evals.py`: tag an eval `PDF` at seed time when any of its params accepts a PDF input (`_eval_accepts_pdf`). **Only the PDF chip is affected** — every other tag is left exactly as curated.
- Bumped `SYSTEM_EVALS_VERSION` (10 → 11) so existing deployments re-seed and pick up the tag.
- No frontend change — the picker already filters on `eval_tags`.

## Verification
- Re-seeded against a real system-eval DB: PDF-tagged evals **0 → 20**; Text / Audio / Image unchanged (12 / 9 / 8).
- Live picker: the PDF chip now lists **1–20 of 20** (ocr_evaluation, pii, toxicity, summary_quality, …).
- 8 unit tests on `_eval_accepts_pdf` / `_yaml_to_template_fields`, including a guard that *only* `PDF` is added (text/audio/image never tagged).

## Screenshots
Before: PDF → "No evaluations found".  After: PDF → 1–20 of 20.
<img width="3024" height="1964" alt="Screenshot 2026-05-29 at 3 57 04 PM" src="https://github.com/user-attachments/assets/bdf2f54f-362d-4bf6-bb48-193664922ba1" />

## Out of scope
- Other modality chips (Text / Audio / Image) and the category chips — left untouched per scope.
- The **Finance** chip is empty and is not a modality, so there is no `param_modalities` signal to auto-fill it — needs a separate product decision (remove the chip vs. hand-curate finance evals).

Closes TH-5162