### PR TITLE
fix(temporal): bump drop-in schedule_to_start_timeout default to 12h

### DIFF
--- a/futureagi/tfc/temporal/drop_in/workflow.py
+++ b/futureagi/tfc/temporal/drop_in/workflow.py
@@ -25,7 +25,7 @@ class TaskRunnerInput:
     time_limit: Optional[int] = None  # Override default timeout
     max_retries: Optional[int] = None
     retry_delay: Optional[int] = None
-    schedule_to_start_timeout: Optional[int] = None  # Seconds; defaults to 6h
+    schedule_to_start_timeout: Optional[int] = None  # Seconds; defaults to 12h
 
 
 @dataclass
@@ -85,6 +85,9 @@ class TaskRunnerWorkflow:
         try:
             # Get timeout from activity metadata or use default
             time_limit = input.time_limit or 3600 * 12  # 12 hours default
+            schedule_to_start_seconds = (
+                input.schedule_to_start_timeout or 3600 * 12
+            )  # 12 hours default
 
             retry_policy = _resolve_retry_policy(input)
 
@@ -96,7 +99,9 @@ class TaskRunnerWorkflow:
                     "kwargs": input.kwargs,
                 },
                 start_to_close_timeout=timedelta(seconds=time_limit),
-                schedule_to_start_timeout=timedelta(minutes=5),
+                schedule_to_start_timeout=timedelta(
+                    seconds=schedule_to_start_seconds
+                ),
                 heartbeat_timeout=timedelta(minutes=5),
                 retry_policy=retry_policy,
                 versioning_intent=VersioningIntent.DEFAULT,


### PR DESCRIPTION
## Problem

`TaskRunnerWorkflow` (the drop-in Celery-style activity dispatcher) hardcoded `schedule_to_start_timeout=timedelta(minutes=5)` for every activity it scheduled. On a queue-saturating fan-out — voiceCalls eval fanning out 50 spans × 18 configs = 900 activities into `tasks_s` — ~200 activities sat in the queue longer than 5 minutes and Temporal closed them as:

```
ACTIVITY_TASK_TIMED_OUT (SCHEDULE_TO_START)
  → WORKFLOW_EXECUTION_FAILED (RETRY_STATE_NON_RETRYABLE_FAILURE)
```

The activity body never ran, so no `EvalLogger` row and no `failed_spans` entry were written. The rows just vanished from the user's report.

## Change

Single file: `futureagi/tfc/temporal/drop_in/workflow.py`.

- Replace `timedelta(minutes=5)` with `input.schedule_to_start_timeout or 3600 * 12`, mirroring the existing `input.time_limit or 3600 * 12` pattern two lines above.
- Fix the lying docstring on `TaskRunnerInput.schedule_to_start_timeout` (claimed 6h default, was actually applying 5min hardcoded).

The `TaskRunnerInput.schedule_to_start_timeout` field already existed — it was dead until this PR. No caller currently sets it, so today everything resolves to the 12h fallback. If a future caller wants per-activity override, the field is now wired.

## What does NOT change

- `start_to_close_timeout` semantics, default, or value
- `heartbeat_timeout` (still 5 min)
- `retry_policy`, `versioning_intent`
- Workflow outer bounds: `execution_timeout=24h`, `run_timeout=13h`
- The 30-min drain-stall watchdog (`_DRAIN_STALL_SECONDS`) still bounds eval-task progress, so the stuck-workflow trade-off is acceptable.

## Verification

Verified live against a running eval on the local dev stack after restarting Temporal workers. From a real `evaluate_observation_span_observe` `ActivityTaskScheduled` event in Temporal history:

```
activityType:           evaluate_observation_span_observe
taskQueue:              tasks_s
scheduleToStartTimeout: 43200s   ← 12h ✓ (was 300s before this PR)
startToCloseTimeout:    43200s   ← unchanged
heartbeatTimeout:       300s     ← unchanged
```

The workflow also completed end-to-end (11 events: schedule → start → activity-schedule → activity-start → activity-complete → workflow-complete), confirming nothing else regressed.

## Out of scope

- Parent orchestrator workflow with bounded concurrency for eval-task fan-outs
- App-side error rows on workflow failure
- Worker autoscaling

Those are the real fix; this PR is a band-aid that stops the silent row loss while they're being designed.