### PR TITLE
[TH-4468] Align Span / Sessions / Users grid theme with TraceGrid

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { Box } from "@mui/material";
+import { Box, useTheme } from "@mui/material";
 import { AgGridReact } from "ag-grid-react";
 import "src/styles/clean-data-table.css";
 import PropTypes from "prop-types";
@@ -197,6 +197,7 @@ const SpanGrid = React.forwardRef(
       }));
 
     const agTheme = useAgTheme();
+    const theme = useTheme();
     const { observeId } = useParams();
     const { setSpanDetailDrawerOpen } = useLLMTracingStoreShallow((state) => ({
       setSpanDetailDrawerOpen: state.setSpanDetailDrawerOpen,
@@ -574,9 +575,15 @@ const SpanGrid = React.forwardRef(
           rowHeight={userTraceRowHeightMapping[cellHeight]?.height ?? 40}
           theme={agTheme.withParams({
             columnBorder: false,
-            headerColumnBorder: { width: 0 },
+            headerColumnBorder: false,
             wrapperBorder: { width: 0 },
             wrapperBorderRadius: 0,
+            rowBorder: { width: 1, color: "rgba(0,0,0,0.06)" },
+            headerFontSize: "13px",
+            headerFontWeight: theme.typography.fontWeightMedium,
+            headerBackgroundColor: "transparent",
+            headerTextColor: theme.palette.text.primary,
+            rowHoverColor: "rgba(120,87,252,0.04)",
           })}
           ref={gridRef}
           columnDefs={columnDefs}

--- a/frontend/src/sections/projects/SessionsView/Session-grid.jsx
+++ b/frontend/src/sections/projects/SessionsView/Session-grid.jsx
@@ -24,13 +24,19 @@ import { canonicalizeApiFilterColumnIds } from "src/utils/filter-column-ids";
 import { useSessionsGridStoreShallow } from "./ReplaySessions/store";
 import { APP_CONSTANTS } from "src/utils/constants";
 
-const SESSION_GRID_THEME_PARAMS = {
+const getSessionGridThemeParams = (theme) => ({
   columnBorder: false,
   rowVerticalPaddingScale: 2.6,
-  headerColumnBorder: { width: 0 },
+  headerColumnBorder: false,
   wrapperBorder: { width: 0 },
   wrapperBorderRadius: 0,
-};
+  rowBorder: { width: 1, color: "rgba(0,0,0,0.06)" },
+  headerFontSize: "13px",
+  headerFontWeight: theme.typography.fontWeightMedium,
+  headerBackgroundColor: "transparent",
+  headerTextColor: theme.palette.text.primary,
+  rowHoverColor: "rgba(120,87,252,0.04)",
+});
 
 const DATASET_ROWS_LIMIT = 30;
 
@@ -68,7 +74,7 @@ const SessionGrid = React.forwardRef(
     const [open, setOpen] = useState(false);
     const [currentRowData, setCurrentRowData] = useState(null);
     const theme = useTheme();
-    const agTheme = useAgThemeWith(SESSION_GRID_THEME_PARAMS);
+    const agTheme = useAgThemeWith(getSessionGridThemeParams(theme));
     const handleDrawerClose = () => {
       setOpen(false);
     };

--- a/frontend/src/sections/projects/UsersView/UsersGrid.jsx
+++ b/frontend/src/sections/projects/UsersView/UsersGrid.jsx
@@ -17,17 +17,18 @@ import { getRandomId } from "src/utils/utils";
 import NoRowsOverlay from "src/sections/project-detail/CompareDrawer/NoRowsOverlay";
 import { APP_CONSTANTS } from "src/utils/constants";
 
-const USERS_GRID_THEME_PARAMS = {
+const getUsersGridThemeParams = (theme) => ({
   columnBorder: false,
-  headerColumnBorder: { width: 0 },
+  headerColumnBorder: false,
   wrapperBorder: { width: 0 },
   wrapperBorderRadius: 0,
   rowBorder: { width: 1, color: "rgba(0,0,0,0.06)" },
   headerFontSize: "13px",
-  headerFontWeight: 500,
+  headerFontWeight: theme.typography.fontWeightMedium,
   headerBackgroundColor: "transparent",
+  headerTextColor: theme.palette.text.primary,
   rowHoverColor: "rgba(120,87,252,0.04)",
-};
+});
 
 const UsersGrid = React.memo(
   ({
@@ -38,7 +39,7 @@ const UsersGrid = React.memo(
     cellHeight,
   }) => {
     const theme = useTheme();
-    const agTheme = useAgThemeWith(USERS_GRID_THEME_PARAMS);
+    const agTheme = useAgThemeWith(getUsersGridThemeParams(theme));
     const gridApiRef = useRef(null);
     const {
       setGridApi,


### PR DESCRIPTION
## Summary
The Trace tab in LLM Tracing has visible row dividers, header background, branded purple hover, and properly-colored header text. The **Spans**, **Sessions**, and **Users** grids were each missing some subset of those AG Grid theme params — most visibly the header text color, which made the column names hard to read in dark mode (the literal ticket title).

This PR adds the missing params so all four grids look consistent.

## Changes (per file)

**`SpanGrid.jsx`** — was missing 6 params
- Imported `useTheme`
- Added inline to `agTheme.withParams({...})`: `rowBorder`, `headerFontSize`, `headerFontWeight` (→ `theme.typography.fontWeightMedium`), `headerBackgroundColor: "transparent"`, `headerTextColor: theme.palette.text.primary`, `rowHoverColor`
- Normalized `headerColumnBorder: { width: 0 }` → `headerColumnBorder: false` to match TraceGrid

**`Session-grid.jsx`** — was missing 5 params (kept the unique `rowVerticalPaddingScale: 2.6`)
- Renamed `SESSION_GRID_THEME_PARAMS` (object) → `getSessionGridThemeParams(theme)` (function) so theme tokens can be referenced while keeping all styling co-located at the top of the file
- Added the same 5 params + `headerTextColor`
- Normalized `headerColumnBorder` to `false`

**`UsersGrid.jsx`** — was missing only `headerTextColor`
- Same rename pattern as Sessions (`USERS_GRID_THEME_PARAMS` → `getUsersGridThemeParams(theme)`)
- Added `headerTextColor: theme.palette.text.primary`
- Normalized `headerColumnBorder` to `false`

## Design notes
- `rowHoverColor: "rgba(120,87,252,0.04)"` stays hardcoded — matches all 5 AG grids in the app (Trace, Span, CallLogs, Session, Users). Dark-mode `theme.palette.primary.main` is `#FAFAFA`, not the brand purple, so we can't pull from theme without losing the branded hover.
- `headerFontSize: "13px"` stays hardcoded — no MUI typography token equals 13px (caption=12, body2=14).
- Only `headerFontWeight` was theme-ified (`theme.typography.fontWeightMedium` === 500).
- `useAgThemeWith(...)`'s internal `useMemo` is bypassed when params are theme-dependent — kept the hook call for minimal diff.

## Test plan
- [ ] Observe → LLM Tracing → toggle Trace ↔ Spans tab: headers, row dividers, and hover tint should look identical
- [ ] Same project in light & dark mode
- [ ] Sessions tab (Observe → Sessions): rows visibly separated, header text readable
- [ ] Users tab: header text readable
- [ ] Composite / agent / simulator project types: no regression in CallLogsGrid (untouched)