### PR TITLE
[TH-5584] Call ID column respects width — truncate at boundary instead of clamping to 130px

### DIFF
--- a/frontend/src/sections/agents/CallLogs/CallLogsCellRenderer.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsCellRenderer.jsx
@@ -17,6 +17,26 @@ const CallLogsCellRenderer = (props) => {
       ? format(createdAt, "MM/dd/yyyy, hh:mmaaa")
       : rowData?.created_at?.split("T")[0] ?? "-";
 
+  // Bypass the outer flex wrapper for id/phone columns — match the IPOPCell
+  // structure (a single `.ipop-cell` div directly in the AG cell) so the
+  // text truncates at the column boundary instead of extending past it.
+  if (
+    columnId === "call_id" ||
+    columnId === "assistant_phone_number" ||
+    columnId === "phone_number"
+  ) {
+    return (
+      <CustomTooltip size="small" show={!!value} arrow title={value}>
+        <Box
+          className="ipop-cell"
+          sx={{ px: 1.5, color: "text.secondary" }}
+        >
+          {value || "-"}
+        </Box>
+      </CustomTooltip>
+    );
+  }
+
   let content;
 
   if (columnId === "call_summary") {
@@ -178,22 +198,6 @@ const CallLogsCellRenderer = (props) => {
       <Typography variant="body2" sx={{ fontSize: 13 }}>
         {formatted}
       </Typography>
-    );
-  } else if (
-    columnId === "call_id" ||
-    columnId === "assistant_phone_number" ||
-    columnId === "phone_number"
-  ) {
-    content = (
-      <CustomTooltip show={!!value} arrow title={value}>
-        <Typography
-          variant="body2"
-          noWrap
-          sx={{ fontSize: 13, maxWidth: 130, color: "text.secondary" }}
-        >
-          {value || "-"}
-        </Typography>
-      </CustomTooltip>
     );
   } else if (columnId === "turn_count") {
     const n = value != null && value !== "" ? Number(value) : NaN;


### PR DESCRIPTION
## Summary
In CallLogs grid (Observe → simulator / voice projects), the **Call ID** column was clamping text to `maxWidth: 130px` regardless of column width — widening the column never revealed more of the UUID.

Root cause: the Typography for `call_id` / `assistant_phone_number` / `phone_number` had a hardcoded `maxWidth: 130` (CallLogsCellRenderer.jsx, old line 192).

## Fix
Pulled the three columns into an **early return** at the top of `CallLogsCellRenderer`, bypassing the renderer's outer flex wrapper Box and rendering directly as a `<Box className="ipop-cell">` — the same structural pattern `IPOPCell` uses in `SpanGrid` / `TraceGrid`.

The `.ipop-cell` CSS (`clean-data-table.css:33-41`) handles all four behaviors needed:
- `width: 100%` — fills the column
- `overflow: hidden` — clips overflow + (per CSS flex spec) makes the flex-child's auto min-width = 0 so the box can actually shrink
- `text-overflow: ellipsis` — ellipsizes
- `white-space: nowrap` — single-line

Vertical centering comes from the AG cell's `defaultColDef.cellStyle` in `CallLogsGrid.jsx` (`display: flex, alignItems: center`), which centers any block child automatically — so my Box stays plain block (no `display: flex` on it, which would have broken `text-overflow`).

`px: 1.5` keeps horizontal padding consistent with the other column types.

## Test plan
- [ ] Observe → simulator/voice project → resize Call ID column wider — text reveals more of the UUID, no clamp
- [ ] Resize narrower — ellipsizes exactly at the column edge, no overflow into the next column
- [ ] Same for the two phone-number columns
- [ ] Cell-height variants (Medium / Large / Extra Large) — text stays vertically centered (AG cell's flex centering does this)
- [ ] Empty value still shows `-` and no tooltip
- [ ] Non-empty value still shows the full ID in the tooltip