### PR TITLE
fix(observe): TH-4054 save view button visibility + tab name truncation

### DIFF
--- a/frontend/src/components/imagine/ImagineTab.jsx
+++ b/frontend/src/components/imagine/ImagineTab.jsx
@@ -115,16 +115,11 @@ export default function ImagineTab({
   const suggestedName = useMemo(() => {
     const titles = widgets.map((w) => w.title).filter(Boolean);
     if (titles.length) {
-      const combined = titles.slice(0, 3).join(", ");
-      return combined.length > 40 ? combined.slice(0, 37) + "..." : combined;
+      return titles.slice(0, 3).join(", ");
     }
     const messages = useFalconStore.getState().messages;
     const firstUserMsg = messages.find((m) => m.role === "user")?.content;
-    if (firstUserMsg) {
-      return firstUserMsg.length > 40
-        ? firstUserMsg.slice(0, 37) + "..."
-        : firstUserMsg;
-    }
+    if (firstUserMsg) return firstUserMsg;
     return `Imagine View — ${new Date().toLocaleDateString()}`;
   }, [widgets]);
 
@@ -263,11 +258,14 @@ export default function ImagineTab({
             py: 0.25,
             borderRadius: "4px",
             border: "1px solid",
-            borderColor: "divider",
+            borderColor: "border.hover",
             fontSize: 11,
             fontWeight: 500,
             color: widgets.length ? "text.primary" : "text.disabled",
-            "&:hover": { bgcolor: "action.hover" },
+            "&:hover": {
+              bgcolor: "action.hover",
+              borderColor: "border.active",
+            },
           }}
         >
           <Iconify icon="mdi:content-save-outline" width={14} />
@@ -478,17 +476,20 @@ export default function ImagineTab({
               textTransform: "none",
               fontSize: 12,
               fontWeight: 500,
+              fontFamily: "'IBM Plex Sans', sans-serif",
               borderRadius: "2px",
               px: 2,
               py: 0.25,
-              bgcolor: saveName.trim() ? "primary.main" : "action.disabled",
-              color: "white",
-              "&:hover": {
-                bgcolor: saveName.trim() ? "primary.dark" : "action.disabled",
-              },
+              ...(saveName.trim()
+                ? {}
+                : {
+                    bgcolor: "text.disabled",
+                    color: "background.paper",
+                    "&:hover": { bgcolor: "text.disabled" },
+                  }),
               "&.Mui-disabled": {
-                bgcolor: "action.disabled",
-                color: "text.disabled",
+                bgcolor: "text.disabled",
+                color: "background.paper",
               },
             }}
           >

--- a/frontend/src/components/observe-tabs/CustomViewTab.jsx
+++ b/frontend/src/components/observe-tabs/CustomViewTab.jsx
@@ -58,8 +58,8 @@ const CustomViewTab = ({
 
   return (
     <CustomTooltip
-      show={!!shortcut}
-      title={`${view.name} (${shortcut})`}
+      show
+      title={shortcut ? `${view.name} (${shortcut})` : view.name}
       placement="bottom"
       arrow
       size="small"
@@ -118,6 +118,9 @@ const CustomViewTab = ({
               fontFamily: "'IBM Plex Sans', sans-serif",
               color: "text.primary",
               whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              maxWidth: 200,
               lineHeight: "20px",
             }}
           >

--- a/frontend/src/components/traceDetail/DrawerToolbar.jsx
+++ b/frontend/src/components/traceDetail/DrawerToolbar.jsx
@@ -96,6 +96,9 @@ const TabPill = ({
           fontWeight: isActive ? 600 : 400,
           color: isActive ? "primary.main" : "text.secondary",
           whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          maxWidth: 200,
         }}
       >
         {label}
@@ -121,11 +124,12 @@ const TabPill = ({
     </Box>
   );
 
-  if (!tooltip) return pill;
+  const effectiveTooltip = tooltip || (!isDefault ? label : undefined);
+  if (!effectiveTooltip) return pill;
   return (
     <CustomTooltip
       show
-      title={tooltip}
+      title={effectiveTooltip}
       placement="bottom"
       arrow
       size="small"

--- a/frontend/src/components/traceDetail/SaveViewDialog.jsx
+++ b/frontend/src/components/traceDetail/SaveViewDialog.jsx
@@ -161,12 +161,16 @@ const SaveViewPopover = ({ anchorEl, open, onClose, onSave, isLoading }) => {
             fontSize: 12,
             fontWeight: 500,
             fontFamily: "'IBM Plex Sans', sans-serif",
-            bgcolor: name.trim() ? "#573FCC" : "text.disabled",
-            color: "background.paper",
             borderRadius: "2px",
             px: 2,
             py: 0.25,
-            "&:hover": { bgcolor: name.trim() ? "#4530a8" : "text.disabled" },
+            ...(name.trim()
+              ? {}
+              : {
+                  bgcolor: "text.disabled",
+                  color: "background.paper",
+                  "&:hover": { bgcolor: "text.disabled" },
+                }),
             "&.Mui-disabled": {
               bgcolor: "text.disabled",
               color: "background.paper",


### PR DESCRIPTION
## Summary
- Fixes [TH-4054](https://linear.app/future-agi/issue/TH-4054/saving-a-view-fails-and-button-is-hard-to-see). Save view itself is working — verified locally (see ticket comment).
- **Button color** — Save view buttons (Imagine toolbar pill + SaveViewDialog primary action + Imagine popover Save) had low-contrast dark-theme styling. Toolbar pill now uses `border.hover`/`border.active` instead of the near-invisible `divider`; the popover Save buttons now let MUI's default contained palette show through when a name is typed (spread pattern), instead of `inherit`-ing the popover background.
- **Default view name truncation** — `ImagineTab.suggestedName` was hard-truncating to 37 chars + a literal `"..."` suffix, so the *persisted* view name carried the ellipsis. Dropped the truncation so the full title list is saved; visual ellipsis now lives in CSS on the tab pill (`CustomViewTab` + `DrawerToolbar.TabPill` get `maxWidth: 200`, `overflow: hidden`, `textOverflow: ellipsis`) with the full name shown via tooltip on hover.

## Test plan
- [ ] Open a trace detail drawer in dark theme, open the Imagine canvas — Save View pill at top-right should have a visible outline against the dark surface (border noticeably stronger on hover).
- [ ] Click Save View on the Imagine canvas, type a name — the Save button in the popover should be a solid primary-colored button while the name is non-empty (not blending into the popover background).
- [ ] Same check for the `+` "Create new view" popover (`SaveViewDialog`) on the trace list page / trace detail drawer.
- [ ] Build an Imagine view with 3 widgets that have long titles, click Save — input pre-fills with the *full* joined title list (no `...` suffix). Save and confirm the saved tab visually ellipsizes at ~200px width, hover the tab to see the full name in a tooltip.