### PR TITLE
fix(ui): improve secondary text contrast across creation & test-detail screens

### DIFF
--- a/frontend/src/components/ConfigureApiKeysModal/ConfigureKeysModal.jsx
+++ b/frontend/src/components/ConfigureApiKeysModal/ConfigureKeysModal.jsx
@@ -48,7 +48,7 @@ export default function ConfigureKeysModal({ open, onClose, selectedModel }) {
             Configure API keys
           </Typography>
           <Typography
-            color={"text.disabled"}
+            color={"text.secondary"}
             variant="s1"
             fontWeight={"fontWeightBold"}
           >

--- a/frontend/src/components/GraphBuilder/ConfigForms/ConfigureConversationNode.jsx
+++ b/frontend/src/components/GraphBuilder/ConfigForms/ConfigureConversationNode.jsx
@@ -76,7 +76,7 @@ const ConfigureConversationNode = ({ node, onChange }) => {
             <Typography typography="s1" fontWeight="fontWeightMedium">
               Enable Global Node
             </Typography>
-            <Typography typography="s1" color="text.disabled">
+            <Typography typography="s1" color="text.secondary">
               Make this node available from any point in the conversation
             </Typography>
           </Box>

--- a/frontend/src/components/GraphBuilder/GraphBuilderLeftBar.jsx
+++ b/frontend/src/components/GraphBuilder/GraphBuilderLeftBar.jsx
@@ -23,7 +23,7 @@ const GraphBuilderLeftBar = ({ onSave, saveLoading, agentType }) => {
         <Typography typography="m3" fontWeight="fontWeightMedium">
           Basic Information
         </Typography>
-        <Typography typography="s2_1" color="text.disabled">
+        <Typography typography="s2_1" color="text.secondary">
           Configure the basic settings for your agent
         </Typography>
       </Box>
@@ -115,7 +115,7 @@ const GraphBuilderLeftBar = ({ onSave, saveLoading, agentType }) => {
                 <Typography typography="s2" fontWeight="fontWeightMedium">
                   {name}
                 </Typography>
-                <Typography typography="s3" color="text.disabled">
+                <Typography typography="s3" color="text.secondary">
                   {description}
                 </Typography>
               </Box>

--- a/frontend/src/components/LandingPageCard/LandingPageCard.jsx
+++ b/frontend/src/components/LandingPageCard/LandingPageCard.jsx
@@ -65,7 +65,7 @@ const LandingPageCard = ({
           <Typography
             variant="s1"
             fontWeight={"fontWeightRegular"}
-            color="text.disabled"
+            color="text.secondary"
           >
             {description}
           </Typography>

--- a/frontend/src/components/ModalWrapper/ModalWrapper.jsx
+++ b/frontend/src/components/ModalWrapper/ModalWrapper.jsx
@@ -78,7 +78,7 @@ export default function ModalWrapper({
         {subTitle && (
           <Typography
             variant="s1"
-            color={"text.disabled"}
+            color={"text.secondary"}
             fontWeight={"fontWeightRegular"}
           >
             {subTitle}

--- a/frontend/src/components/PromptCards/UploadMedia/UploadMedia.jsx
+++ b/frontend/src/components/PromptCards/UploadMedia/UploadMedia.jsx
@@ -70,7 +70,7 @@ const UploadMediaChild = ({ control, type, onClose, onSubmit, isPending }) => {
           >
             {TitleMap[type]}
           </Typography>
-          <Typography variant="s1" color="text.disabled">
+          <Typography variant="s1" color="text.secondary">
             {DescriptionMap[type]}
           </Typography>
         </Box>

--- a/frontend/src/components/VariableDrawer/EmptyVariable.jsx
+++ b/frontend/src/components/VariableDrawer/EmptyVariable.jsx
@@ -38,7 +38,7 @@ const EmptyVariable = () => {
       <Typography
         variant="m3"
         fontWeight="fontWeightMedium"
-        color="text.disabled"
+        color="text.secondary"
         sx={{ width: "386px", textAlign: "center" }}
       >
         Create variables within the prompt using double curly braces {"{{}}"} to

--- a/frontend/src/components/custom-audio/CancelUploadDialog.jsx
+++ b/frontend/src/components/custom-audio/CancelUploadDialog.jsx
@@ -55,7 +55,7 @@ const CancelUploadDialog = ({ open, onClose, onConfirmCancel }) => {
       >
         <Typography
           fontSize="14px"
-          color="text.disabled"
+          color="text.secondary"
           sx={{
             pr: 4,
             pl: 2,

--- a/frontend/src/components/custom-audio/UnsupportedFileDialog.jsx
+++ b/frontend/src/components/custom-audio/UnsupportedFileDialog.jsx
@@ -54,7 +54,7 @@ const UnsupportedFileDialog = ({ open, onClose, onUpload }) => {
       >
         <Typography
           fontSize="14px"
-          color="text.disabled"
+          color="text.secondary"
           sx={{
             pr: 4,
             pl: 2,

--- a/frontend/src/components/custom-model-dropdown/KeysDrawer.jsx
+++ b/frontend/src/components/custom-model-dropdown/KeysDrawer.jsx
@@ -177,7 +177,7 @@ const KeyConfigDrawerChild = ({
             <Typography
               typography="s1"
               fontWeight={"fontWeightRegular"}
-              color="text.disabled"
+              color="text.secondary"
             >
               Configure your LLM API keys to run evals and prompts, All keys are
               encrypted and securely stored.

--- a/frontend/src/components/custom-model-options/PromptModalWrapper.jsx
+++ b/frontend/src/components/custom-model-options/PromptModalWrapper.jsx
@@ -67,7 +67,7 @@ export default function PromptModalWrapper({
         {subTitle && (
           <Typography
             variant="s2"
-            color={"text.disabled"}
+            color={"text.secondary"}
             fontWeight={"fontWeightRegular"}
           >
             {subTitle}

--- a/frontend/src/components/custom-model-tools/ShowModelTools.jsx
+++ b/frontend/src/components/custom-model-tools/ShowModelTools.jsx
@@ -91,7 +91,7 @@ const ShowModelToolsChild = ({ onClose, handleApply, tools }) => {
           <Typography
             variant="s1"
             fontWeight={"fontWeightRegular"}
-            color="text.disabled"
+            color="text.secondary"
           >
             Explore all actions taken and their outcomes during the tool run.
           </Typography>

--- a/frontend/src/components/feed/Thread.jsx
+++ b/frontend/src/components/feed/Thread.jsx
@@ -52,7 +52,7 @@ export default function Thread({ data = [], sx }) {
               {item?.subtitle ? (
                 <Typography
                   typography={"s2"}
-                  color={"text.disabled"}
+                  color={"text.secondary"}
                   fontWeight={"fontWeightRegular"}
                 >
                   {item?.subtitle}

--- a/frontend/src/components/imagine/WidgetCanvas.jsx
+++ b/frontend/src/components/imagine/WidgetCanvas.jsx
@@ -74,7 +74,7 @@ export default function WidgetCanvas({
           </Typography>
           <Typography
             fontSize={12}
-            color="text.disabled"
+            color="text.secondary"
             textAlign="center"
             maxWidth={320}
           >

--- a/frontend/src/components/run-tests/CreateRunTestPage.jsx
+++ b/frontend/src/components/run-tests/CreateRunTestPage.jsx
@@ -2234,7 +2234,7 @@ const CreateRunTestPage = ({ open, onClose }) => {
                             ? "text.primary"
                             : index <= activeStep
                               ? "primary.main"
-                              : "text.disabled"
+                              : "text.secondary"
                         }
                         sx={{
                           textAlign: "center",

--- a/frontend/src/components/scenarios/ScenarioGraphBuilder.jsx
+++ b/frontend/src/components/scenarios/ScenarioGraphBuilder.jsx
@@ -35,7 +35,7 @@ const ScenarioGraphBuilder = () => {
         <Typography typography="s1" fontWeight="fontWeightSemiBold">
           Graph Builder
         </Typography>
-        <Typography typography="s2" color="text.disabled">
+        <Typography typography="s2" color="text.secondary">
           Use our visual graph builder to create conversation flows
         </Typography>
       </Box>

--- a/frontend/src/components/traceDetailDrawer/AnnotationSidebarContent.jsx
+++ b/frontend/src/components/traceDetailDrawer/AnnotationSidebarContent.jsx
@@ -311,7 +311,7 @@ export default function AnnotationSidebarContent({
             </Typography>
             <Typography
               variant="caption"
-              color="text.disabled"
+              color="text.secondary"
               textAlign="center"
             >
               This item is not part of any annotation queue assigned to you.

--- a/frontend/src/components/traceDetailDrawer/dialogue-boxes/view-details.jsx
+++ b/frontend/src/components/traceDetailDrawer/dialogue-boxes/view-details.jsx
@@ -122,7 +122,7 @@ const ViewDetailsModal = ({ open, onClose, selectedViewDetail, title }) => {
             </Typography>
             <Typography
               fontSize={typographyTheme.caption.fontSize}
-              color="text.disabled"
+              color="text.secondary"
             >
               This evaluation hasn&apos;t produced a result for this span yet,
               or the previous result was removed.

--- a/frontend/src/pages/dashboard/error-feed/ErrorFeedView.jsx
+++ b/frontend/src/pages/dashboard/error-feed/ErrorFeedView.jsx
@@ -85,7 +85,7 @@ export default function ErrorFeedView() {
           </Stack>
           <Typography
             typography="s2"
-            color="text.disabled"
+            color="text.secondary"
             fontWeight="fontWeightRegular"
           >
             Track, triage, and resolve AI errors — hallucinations, eval

--- a/frontend/src/pages/dashboard/error-feed/components/ErrorFeedTable.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorFeedTable.jsx
@@ -237,7 +237,7 @@ function EmptyState({ filtered }) {
               ? "No errors match your filters"
               : "No errors — everything looks good!"}
           </Typography>
-          <Typography typography="s2" color="text.disabled">
+          <Typography typography="s2" color="text.secondary">
             {filtered
               ? "Try adjusting your search or filter criteria."
               : "Errors captured by Future AGI will appear here."}

--- a/frontend/src/pages/dashboard/error-feed/components/ErrorMetadataPanel.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorMetadataPanel.jsx
@@ -894,7 +894,7 @@ function LinearTeamPicker({ open, onClose, clusterId, traceId }) {
             <Typography fontSize="14px" fontWeight={700} color="text.primary">
               Create Linear Issue
             </Typography>
-            <Typography fontSize="11px" color="text.disabled">
+            <Typography fontSize="11px" color="text.secondary">
               Select a team to create the issue in.
             </Typography>
           </Stack>

--- a/frontend/src/pages/dashboard/models/ConfigureDatasetModal.jsx
+++ b/frontend/src/pages/dashboard/models/ConfigureDatasetModal.jsx
@@ -29,7 +29,7 @@ const ConfigureDatasetModal = ({ open, onClose }) => {
         <Typography variant="h5">Configure Dataset</Typography>
         <Typography
           variant="body1"
-          color="text.disabled"
+          color="text.secondary"
         >{`You haven't configured a dataset`}</Typography>
         <Box sx={{ display: "flex", justifyContent: "end" }}>
           <Button

--- a/frontend/src/pages/dashboard/models/ConfigureMetricModal.jsx
+++ b/frontend/src/pages/dashboard/models/ConfigureMetricModal.jsx
@@ -29,7 +29,7 @@ const ConfigureMetricModal = ({ open, onClose }) => {
         <Typography variant="h5">Define Metric</Typography>
         <Typography
           variant="body1"
-          color="text.disabled"
+          color="text.secondary"
         >{`You haven't defined a metric`}</Typography>
         <Box sx={{ display: "flex", justifyContent: "end" }}>
           <Button

--- a/frontend/src/pages/dashboard/scenarios/SimulationScenarioEmptyScreen.jsx
+++ b/frontend/src/pages/dashboard/scenarios/SimulationScenarioEmptyScreen.jsx
@@ -192,7 +192,7 @@ const SimulationScenarioEmptyScreen = () => {
               <Typography
                 variant="s1"
                 fontWeight={"fontWeightMedium"}
-                color="text.disabled"
+                color="text.secondary"
               >
                 For more instructions, check out our{" "}
                 <Link

--- a/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
+++ b/frontend/src/sections/agent-playground/AgentBuilder/RunAgentPanel/NodeOutputDetail.jsx
@@ -418,7 +418,7 @@ export default function NodeOutputDetail({ executionId, nodeExecutionId }) {
           bgcolor: "background.paper",
         }}
       >
-        <Typography typography="s2" color="text.disabled">
+        <Typography typography="s2" color="text.secondary">
           Select a node to view details
         </Typography>
       </Box>

--- a/frontend/src/sections/agent-playground/Executions/ExecutionDetailView.jsx
+++ b/frontend/src/sections/agent-playground/Executions/ExecutionDetailView.jsx
@@ -121,7 +121,7 @@ export default function ExecutionDetailView({ graphId, executionId }) {
           justifyContent: "center",
         }}
       >
-        <Typography typography="s2" color="text.disabled">
+        <Typography typography="s2" color="text.secondary">
           Select an execution to view details
         </Typography>
       </Box>

--- a/frontend/src/sections/agent-playground/Executions/Executions.jsx
+++ b/frontend/src/sections/agent-playground/Executions/Executions.jsx
@@ -65,7 +65,7 @@ export default function Executions() {
         <Typography typography="m3" color="text.disabled">
           No executions yet
         </Typography>
-        <Typography typography="s2" color="text.disabled">
+        <Typography typography="s2" color="text.secondary">
           Run your workflow from the Agent Builder to see results here
         </Typography>
       </Box>

--- a/frontend/src/sections/agents/AgentConfiguration/AgentConfigurationView.jsx
+++ b/frontend/src/sections/agents/AgentConfiguration/AgentConfigurationView.jsx
@@ -95,7 +95,7 @@ const AgentConfigurationView = () => {
               </Typography>
               <Typography
                 typography="s2_1"
-                color="text.disabled"
+                color="text.secondary"
                 fontWeight={"fontWeightRegular"}
               >
                 A configuration that specifies how your AI agent behaves during

--- a/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
+++ b/frontend/src/sections/agents/AgentConfiguration/EditAgentDetails.jsx
@@ -1013,7 +1013,7 @@ const EditAgentDetails = ({
             </CustomTooltip>
             <Typography
               typography="s2"
-              color="text.disabled"
+              color="text.secondary"
               sx={{ marginLeft: 1 }}
               fontWeight="500"
             >

--- a/frontend/src/sections/agents/CreateAgentScenarioHelp.jsx
+++ b/frontend/src/sections/agents/CreateAgentScenarioHelp.jsx
@@ -76,7 +76,7 @@ function HelpCard({ title, description, imageSrc }) {
         <Typography
           typography={"s1"}
           fontWeight={"fontWeightRegular"}
-          color={"text.disabled"}
+          color={"text.secondary"}
         >
           {description}
         </Typography>
@@ -136,7 +136,7 @@ export default function CreateAgentScenarioHelp({ open, onClose }) {
           </Typography>
           <Typography
             typography={"s1_2"}
-            color={"text.disabled"}
+            color={"text.secondary"}
             fontWeight={"fontWeightRegular"}
           >
             Use your agent definition to create scenarios and run tests

--- a/frontend/src/sections/agents/CreateNewAgent/AgentBasicInfoStep/AgentBasicInfoStep.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentBasicInfoStep/AgentBasicInfoStep.jsx
@@ -37,7 +37,7 @@ const AgentBasicInfo = ({ control }) => {
         <Typography
           typography="s1"
           fontWeight="fontWeightRegular"
-          color="text.disabled"
+          color="text.secondary"
         >
           Set up the basic details for your agent that you want run simulation
           for

--- a/frontend/src/sections/agents/CreateNewAgent/AgentBehaviourStep/AgentBehaviourStep.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentBehaviourStep/AgentBehaviourStep.jsx
@@ -38,7 +38,7 @@ const AgentBehaviourStep = ({ control }) => {
         <Typography
           typography="s1"
           fontWeight="fontWeightRegular"
-          color="text.disabled"
+          color="text.secondary"
         >
           Define how your agent thinks, responds, and handles interactions.
         </Typography>
@@ -84,7 +84,7 @@ const AgentBehaviourStep = ({ control }) => {
             </Link>
           </Box>
 
-          <Typography variant="body2" color="text.primary">
+          <Typography variant="body2" color="text.secondary">
             Provide domain-specific information to help agent behaviour as per
             your business use-case
           </Typography>

--- a/frontend/src/sections/agents/CreateNewAgent/AgentBehaviourStep/AgentBehaviourStepRightSection.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentBehaviourStep/AgentBehaviourStepRightSection.jsx
@@ -232,7 +232,7 @@ const AgentBehaviourStepRightSection = ({ control }) => {
         <Typography typography="m3" fontWeight="fontWeightMedium">
           Summary
         </Typography>
-        <Typography typography="s1" color="text.disabled">
+        <Typography typography="s1" color="text.secondary">
           Review your configuration before creating the agent
         </Typography>
       </Box>

--- a/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentConfigurationStep.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentConfigurationStep.jsx
@@ -41,7 +41,7 @@ const AgentConfigurationStep = ({ control, getValues }) => {
         <Typography
           typography="s1"
           fontWeight="fontWeightRegular"
-          color="text.disabled"
+          color="text.secondary"
         >
           Configure specific settings and provider details
         </Typography>

--- a/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentConfigurationStep/AgentVoiceForm.jsx
@@ -810,7 +810,7 @@ export default function AgentVoiceForm() {
                 <Typography
                   typography="s2_1"
                   fontWeight={"fontWeightRegular"}
-                  color={"text.primary"}
+                  color={"text.secondary"}
                 >
                   {inbound
                     ? INBOUND_OUTBOUND_COPY.inbound.description

--- a/frontend/src/sections/agents/CreateNewAgent/AgentVideoPlayerModal.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentVideoPlayerModal.jsx
@@ -52,7 +52,7 @@ const AgentVideoPlayerModal = ({ open, onClose, content }) => {
             <Typography
               typography="m3"
               fontWeight="fontWeightRegular"
-              color="text.disabled"
+              color="text.secondary"
             >
               {subtitle}
             </Typography>

--- a/frontend/src/sections/agents/CreateNewAgentCards.jsx
+++ b/frontend/src/sections/agents/CreateNewAgentCards.jsx
@@ -65,7 +65,7 @@ const CreateNewAgentCards = ({ title, subtitle, children }) => {
           <Typography
             variant="s2_1"
             fontWeight="fontWeightRegular"
-            color="text.disabled"
+            color="text.secondary"
           >
             {subtitle}
           </Typography>

--- a/frontend/src/sections/agents/VersionManagement/AddNewVersionDrawer.jsx
+++ b/frontend/src/sections/agents/VersionManagement/AddNewVersionDrawer.jsx
@@ -125,7 +125,7 @@ const AddNewVersionDrawer = ({ open, onClose, latestVersion }) => {
             </Typography> */}
             <Typography
               typography="s2_1"
-              color="text.disabled"
+              color="text.secondary"
               fontWeight={"fontWeightRegular"}
             >
               Edit this configuration to create as a new version{" "}

--- a/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
+++ b/frontend/src/sections/annotations/queues/annotate/annotate-workspace-view.jsx
@@ -1566,7 +1566,7 @@ export default function AnnotateWorkspaceView() {
               <Typography variant="subtitle1" color="text.secondary">
                 Assigned to {assignedToName || "another annotator"}
               </Typography>
-              <Typography variant="body2" color="text.disabled">
+              <Typography variant="body2" color="text.secondary">
                 This item is assigned to someone else. You cannot annotate it.
               </Typography>
               <Button

--- a/frontend/src/sections/annotations/queues/create-queue-drawer.jsx
+++ b/frontend/src/sections/annotations/queues/create-queue-drawer.jsx
@@ -384,7 +384,7 @@ export default function CreateQueueDrawer({
                           >
                             Auto-assign items to all annotators
                           </Typography>
-                          <Typography variant="caption" color="text.disabled">
+                          <Typography variant="caption" color="text.secondary">
                             When on, all annotators are assigned to every item
                             and anyone can annotate any item
                           </Typography>
@@ -491,7 +491,7 @@ export default function CreateQueueDrawer({
                 {!advancedOpen && (
                   <Typography
                     variant="caption"
-                    color="text.disabled"
+                    color="text.secondary"
                     sx={{ ml: 0.5 }}
                   >
                     Assignment strategy, reservation timeout, review

--- a/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
+++ b/frontend/src/sections/annotations/queues/view/queue-settings-tab.jsx
@@ -408,7 +408,7 @@ export default function QueueSettingsTab({ queue, queueId, creatorId }) {
                         >
                           Auto-assign items to all annotator members
                         </Typography>
-                        <Typography variant="caption" color="text.disabled">
+                        <Typography variant="caption" color="text.secondary">
                           When on, all members with the Annotator role are
                           assigned to every item and can annotate any item
                         </Typography>

--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -1870,7 +1870,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           !testPassed && (
             <Typography
               variant="caption"
-              color="text.disabled"
+              color="text.secondary"
               sx={{ mr: "auto", fontSize: "11px" }}
             >
               Map all variables to enable testing & adding

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -1274,7 +1274,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
         {!sourceReady && !hasDataInjection && !testError && !testPassed && (
           <Typography
             variant="caption"
-            color="text.disabled"
+            color="text.secondary"
             sx={{ mr: "auto", fontSize: "11px" }}
           >
             Map all variables to enable{" "}

--- a/frontend/src/sections/common/EvalsTasks/DeleteConfirmation.jsx
+++ b/frontend/src/sections/common/EvalsTasks/DeleteConfirmation.jsx
@@ -80,7 +80,7 @@ const DeleteConfirmation = ({
       </DialogTitle>
 
       <DialogContent>
-        <Typography color="text.disabled">{confirmationMessage}</Typography>
+        <Typography color="text.secondary">{confirmationMessage}</Typography>
       </DialogContent>
 
       <DialogActions>

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/EvaluationTest/EvaluationTest.jsx
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/EvaluationTest/EvaluationTest.jsx
@@ -40,7 +40,7 @@ const EvaluationTest = () => {
             color="text.disabled"
             width={18}
           />
-          <Typography fontSize="13px" color="text.disabled">
+          <Typography fontSize="13px" color="text.secondary">
             Run a sample evals to see how it works
           </Typography>
         </Box>

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/NewTaskDrawerV2.jsx
@@ -532,7 +532,7 @@ const NewTaskDrawerV2 = ({
                       {!isProjectSelected && (
                         <Typography
                           variant="caption"
-                          color="text.disabled"
+                          color="text.secondary"
                           sx={{ fontSize: "12px" }}
                         >
                           Select a project first to add evaluations.

--- a/frontend/src/sections/common/EvaluationDrawer/ConfirmRunEvaluations.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/ConfirmRunEvaluations.jsx
@@ -74,7 +74,7 @@ const ConfirmRunEvaluations = ({
             <Iconify icon="line-md:close" color="text.primary" />
           </IconButton>
         </Box>
-        <Typography variant="body2" color="text.disabled">
+        <Typography variant="body2" color="text.secondary">
           This will overwrite previous evaluation results.
         </Typography>
       </DialogTitle>

--- a/frontend/src/sections/common/EvaluationDrawer/CreateEvaluationGroupDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/CreateEvaluationGroupDrawer.jsx
@@ -75,7 +75,7 @@ const EvalCard = ({ name, description, onRemove }) => {
       <Typography
         typography={"s2"}
         fontWeight={"fontWeightRegular"}
-        color={"text.disabled"}
+        color={"text.secondary"}
       >
         {description}
       </Typography>

--- a/frontend/src/sections/common/EvaluationDrawer/CustomEvalsForm.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/CustomEvalsForm.jsx
@@ -1319,7 +1319,7 @@ const CustomEvalsFormChild = ({
                 <Typography
                   typography={"s2"}
                   sx={{ mt: -1 }}
-                  color={"text.disabled"}
+                  color={"text.secondary"}
                   fontStyle={"italic"}
                 >
                   <Typography

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationTest.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationTest.jsx
@@ -111,7 +111,7 @@ const EvaluationTest = ({ onClose, testingEvalData, testingEvalLoading }) => {
           <Typography fontWeight={600} fontSize={16} color={"text.primary"}>
             Test Eval
           </Typography>
-          <Typography fontWeight={400} fontSize={14} color={"text.disabled"}>
+          <Typography fontWeight={400} fontSize={14} color={"text.secondary"}>
             Test runs on the first 3 rows of a dataset
           </Typography>
         </Box>

--- a/frontend/src/sections/common/SliderRow/SliderRow.jsx
+++ b/frontend/src/sections/common/SliderRow/SliderRow.jsx
@@ -73,7 +73,7 @@ const SliderRow = ({
       <Typography
         typography="s1"
         fontWeight="fontWeightRegular"
-        color="text.disabled"
+        color="text.secondary"
       >
         {description}
       </Typography>
@@ -107,7 +107,7 @@ const SliderRow = ({
               <Typography
                 fontWeight="fontWeightRegular"
                 typography="s2_1"
-                color="text.disabled"
+                color="text.secondary"
               >
                 {rest.minDescription}
               </Typography>
@@ -124,7 +124,7 @@ const SliderRow = ({
               <Typography
                 fontWeight="fontWeightRegular"
                 typography="s2_1"
-                color="text.disabled"
+                color="text.secondary"
               >
                 {rest.maxDescription}
               </Typography>

--- a/frontend/src/sections/common/TemplateAccordion.jsx
+++ b/frontend/src/sections/common/TemplateAccordion.jsx
@@ -127,7 +127,7 @@ const TemplateRow = ({ template, idx, count, isOutlined }) => {
         <Typography
           sx={{ paddingLeft: 5 }}
           variant="caption"
-          color="text.disabled"
+          color="text.secondary"
         >
           Best template out of the {count}
         </Typography>

--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -1215,7 +1215,7 @@ export default function DashboardDetailView() {
             <Typography variant="h6" color="text.secondary">
               No widgets yet
             </Typography>
-            <Typography variant="body2" color="text.disabled">
+            <Typography variant="body2" color="text.secondary">
               Add your first widget to start visualizing data
             </Typography>
             <Button

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -3216,7 +3216,7 @@ export default function WidgetEditorView() {
                     alignItems: "center",
                   }}
                 >
-                  <Typography variant="body2" color="text.disabled">
+                  <Typography variant="body2" color="text.secondary">
                     Fill in the required fields to see preview
                   </Typography>
                 </Box>
@@ -3907,7 +3907,7 @@ export default function WidgetEditorView() {
                     )}
                   </Box>
                 ) : (
-                  <Typography variant="body2" color="text.disabled">
+                  <Typography variant="body2" color="text.secondary">
                     Fill in the required fields to see preview
                   </Typography>
                 )}
@@ -5773,7 +5773,7 @@ export default function WidgetEditorView() {
               {isPie || isTable || isMetricCard ? (
                 <Typography
                   variant="body2"
-                  color="text.disabled"
+                  color="text.secondary"
                   sx={{ fontStyle: "italic", textAlign: "center", mt: 4 }}
                 >
                   {isPie
@@ -5972,7 +5972,7 @@ export default function WidgetEditorView() {
                     {previewSeries.length === 0 && (
                       <Typography
                         variant="body2"
-                        color="text.disabled"
+                        color="text.secondary"
                         sx={{ fontStyle: "italic" }}
                       >
                         Add metrics to see axis assignments

--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImage.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImage.jsx
@@ -209,7 +209,7 @@ const EditImage = ({
                   >
                     No image added
                   </Typography>
-                  <Typography variant="caption" color="text.disabled">
+                  <Typography variant="caption" color="text.secondary">
                     Click to upload an image
                   </Typography>
                 </Box>

--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImageZoom.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImageZoom.jsx
@@ -282,7 +282,7 @@ const EditImageZoom = ({
                       >
                         No image added
                       </Typography>
-                      <Typography variant="body2" color="text.disabled">
+                      <Typography variant="body2" color="text.secondary">
                         Click to upload an image
                       </Typography>
                     </Box>

--- a/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImages.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DoubleClickEditCell/EditImages.jsx
@@ -382,7 +382,7 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
                   >
                     No images added
                   </Typography>
-                  <Typography variant="body2" color="text.disabled">
+                  <Typography variant="body2" color="text.secondary">
                     Click or drag images here to upload
                   </Typography>
                 </Box>
@@ -432,7 +432,7 @@ const EditImages = ({ params, onClose, onCellValueChanged }) => {
                 {imageUrls.length} image{imageUrls.length !== 1 ? "s" : ""}
               </Typography>
               {imageUrls.length > 1 && (
-                <Typography variant="caption" color="text.disabled">
+                <Typography variant="caption" color="text.secondary">
                   Drag to reorder
                 </Typography>
               )}

--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/NoResultsUI.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/NoResultsUI.jsx
@@ -36,7 +36,7 @@ export default function NoResultsUI({
         {description && (
           <Typography
             variant="s1"
-            color="text.disabled"
+            color="text.secondary"
             fontWeight="fontWeightRegular"
           >
             {description}

--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -1377,7 +1377,7 @@ const DatasetTestMode = React.forwardRef(
               >
                 No rows in this dataset
               </Typography>
-              <Typography variant="caption" color="text.disabled">
+              <Typography variant="caption" color="text.secondary">
                 Add rows to the dataset before running a test
               </Typography>
             </Box>
@@ -1573,7 +1573,7 @@ const DatasetTestMode = React.forwardRef(
               {filteredCells.length === 0 && (
                 <Typography
                   variant="caption"
-                  color="text.disabled"
+                  color="text.secondary"
                   sx={{ py: 2, textAlign: "center", display: "block" }}
                 >
                   No columns match your search

--- a/frontend/src/sections/evals/components/EvalGroundTruthTab.jsx
+++ b/frontend/src/sections/evals/components/EvalGroundTruthTab.jsx
@@ -950,7 +950,7 @@ const EmptyState = ({ onUpload }) => (
       Upload annotated data to calibrate evaluations with human-scored reference
       examples.
     </Typography>
-    <Typography variant="caption" color="text.disabled">
+    <Typography variant="caption" color="text.secondary">
       Click anywhere to upload
     </Typography>
   </Box>

--- a/frontend/src/sections/evals/components/FewShotExamples.jsx
+++ b/frontend/src/sections/evals/components/FewShotExamples.jsx
@@ -125,7 +125,7 @@ const FewShotExamples = ({
       {selectedDatasets.length > 0 && (
         <Typography
           variant="caption"
-          color="text.disabled"
+          color="text.secondary"
           sx={{ mt: 0.5, display: "block" }}
         >
           Rows from selected datasets will be used as few-shot examples at

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -1197,7 +1197,7 @@ const SimulationTestMode = React.forwardRef(
             <Typography variant="body2" fontWeight={600} color="text.secondary">
               This simulation has no data
             </Typography>
-            <Typography variant="caption" color="text.disabled">
+            <Typography variant="caption" color="text.secondary">
               Run the simulation first to generate call data for testing
             </Typography>
           </Box>
@@ -1228,7 +1228,7 @@ const SimulationTestMode = React.forwardRef(
             <Typography variant="body2" fontWeight={600} color="text.secondary">
               No calls in this simulation
             </Typography>
-            <Typography variant="caption" color="text.disabled">
+            <Typography variant="caption" color="text.secondary">
               Add calls to the simulation before running a test
             </Typography>
           </Box>

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -37,7 +37,6 @@ import SimulationTestMode from "./SimulationTestMode";
 import {
   useEvalVersions,
   useSetDefaultVersion,
-  useRestoreVersion,
 } from "../hooks/useEvalVersions";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import EvalResultDisplay from "./EvalResultDisplay";
@@ -643,7 +642,6 @@ const TestPlayground = React.forwardRef(
     const [activeTab, setActiveTab] = useState("Custom");
     const { data: versionsData } = useEvalVersions(templateId);
     const setDefaultVersion = useSetDefaultVersion(templateId);
-    const restoreVersion = useRestoreVersion(templateId);
     const { enqueueSnackbar } = useSnackbar();
     const [isRunning, setIsRunning] = useState(false);
     const [result, setResult] = useState(null);
@@ -713,28 +711,16 @@ const TestPlayground = React.forwardRef(
       handleVersionMenuClose,
     ]);
 
-    const handleRestore = useCallback(async () => {
+    const handleRestore = useCallback(() => {
       if (!menuVersion) return;
-      try {
-        const restored = await restoreVersion.mutateAsync(menuVersion.id);
-        enqueueSnackbar(
-          `Restored V${menuVersion.version_number} as new V${restored?.version_number || ""}`,
-          { variant: "success" },
-        );
-      } catch {
-        enqueueSnackbar("Failed to restore version", { variant: "error" });
-      }
+      setSelectedVersionId(menuVersion.id);
+      onVersionSelect?.(menuVersion);
+      enqueueSnackbar(
+        `Loaded V${menuVersion.version_number} config — edit and save to create a new version`,
+        { variant: "info" },
+      );
       handleVersionMenuClose();
-    }, [menuVersion, restoreVersion, enqueueSnackbar, handleVersionMenuClose]);
-
-    const handleViewConfig = useCallback(
-      (version) => {
-        setSelectedVersionId(version.id);
-        onVersionSelect?.(version);
-        handleVersionMenuClose();
-      },
-      [onVersionSelect, handleVersionMenuClose],
-    );
+    }, [menuVersion, onVersionSelect, enqueueSnackbar, handleVersionMenuClose]);
 
     const handleVersionClick = useCallback(
       (version) => {
@@ -1843,19 +1829,6 @@ const TestPlayground = React.forwardRef(
                     },
                   }}
                 >
-                  <MenuItem
-                    onClick={() => {
-                      handleViewConfig(menuVersion);
-                    }}
-                    sx={{ fontSize: "13px", gap: 1, py: 1 }}
-                  >
-                    <Iconify
-                      icon="solar:eye-bold"
-                      width={16}
-                      sx={{ color: "text.secondary" }}
-                    />
-                    View Config
-                  </MenuItem>
                   {!menuVersion?.is_default && (
                     <MenuItem
                       onClick={handleSetDefault}

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -1529,7 +1529,7 @@ const TestPlayground = React.forwardRef(
             {!templateId ? (
               <Typography
                 variant="body2"
-                color="text.disabled"
+                color="text.secondary"
                 sx={{ mt: 4, textAlign: "center" }}
               >
                 Save the evaluation first to create versions.
@@ -1537,7 +1537,7 @@ const TestPlayground = React.forwardRef(
             ) : !versionsData?.versions?.length ? (
               <Typography
                 variant="body2"
-                color="text.disabled"
+                color="text.secondary"
                 sx={{ mt: 4, textAlign: "center" }}
               >
                 No versions yet. Click &ldquo;Save Version&rdquo; to create one.

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -1719,7 +1719,7 @@ const TracingTestMode = React.forwardRef(
             <Typography variant="body2" fontWeight={600} color="text.secondary">
               No {rowType.toLowerCase()} data found
             </Typography>
-            <Typography variant="caption" color="text.disabled">
+            <Typography variant="caption" color="text.secondary">
               Add {rowType.toLowerCase()} to this project before running a test
             </Typography>
           </Box>

--- a/frontend/src/sections/gateway/fallbacks/FallbacksSection.jsx
+++ b/frontend/src/sections/gateway/fallbacks/FallbacksSection.jsx
@@ -560,7 +560,7 @@ const FallbacksSection = () => {
               </Typography>
               <Typography
                 variant="body2"
-                color="text.disabled"
+                color="text.secondary"
                 textAlign="center"
                 maxWidth={460}
               >

--- a/frontend/src/sections/get-started/GetStartedDemoVideo.jsx
+++ b/frontend/src/sections/get-started/GetStartedDemoVideo.jsx
@@ -53,7 +53,7 @@ const GetStartedDemoVideo = ({
               <Typography
                 variant="s2"
                 fontWeight={"fontWeightRegular"}
-                color="text.disabled"
+                color="text.secondary"
               >
                 {headingDescription}
               </Typography>

--- a/frontend/src/sections/get-started/setup-steps/InitialSetup.jsx
+++ b/frontend/src/sections/get-started/setup-steps/InitialSetup.jsx
@@ -50,7 +50,7 @@ const InitialSetup = ({ currentLabel, setCurrentLabel, data }) => {
         <Typography
           variant="s2"
           fontWeight={"fontWeightRegular"}
-          color="text.disabled"
+          color="text.secondary"
         >
           Help you guide through the key features and functionalities
         </Typography>

--- a/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/CreateDatasetLinks.jsx
+++ b/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/CreateDatasetLinks.jsx
@@ -51,7 +51,7 @@ const CreateDatasetLinks = ({
               <Typography
                 variant="s2"
                 fontWeight={"fontWeightMedium"}
-                color="text.disabled"
+                color="text.secondary"
               >
                 {item}
               </Typography>

--- a/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/HeaderContent.jsx
+++ b/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/HeaderContent.jsx
@@ -15,7 +15,7 @@ const HeaderContent = ({ title, description }) => {
       <Typography
         variant="s2"
         fontWeight={"fontWeightRegular"}
-        color="text.disabled"
+        color="text.secondary"
       >
         {description}
       </Typography>

--- a/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/VideoContent.jsx
+++ b/frontend/src/sections/get-started/setup-steps/InitialSetupOptions/VideoContent.jsx
@@ -68,7 +68,7 @@ const VideoContent = ({
           <Typography
             variant="s2"
             fontWeight={"fontWeightRegular"}
-            color="text.disabled"
+            color="text.secondary"
           >
             {description}
           </Typography>

--- a/frontend/src/sections/get-started/try-out-features/FeatureCard.jsx
+++ b/frontend/src/sections/get-started/try-out-features/FeatureCard.jsx
@@ -70,7 +70,7 @@ const FeatureCard = ({
           <Typography
             variant="s1"
             fontWeight={"fontWeightRegular"}
-            color="text.disabled"
+            color="text.secondary"
           >
             {description}
           </Typography>

--- a/frontend/src/sections/huggingface/HuggingDetailForm.jsx
+++ b/frontend/src/sections/huggingface/HuggingDetailForm.jsx
@@ -186,7 +186,7 @@ const HuggingDetailForm = ({
               required
             />
             <Typography
-              color="text.disabled"
+              color="text.secondary"
               variant="s3"
               fontWeight="fontWeightMedium"
               sx={{ mt: 0, mb: 2 }}
@@ -209,7 +209,7 @@ const HuggingDetailForm = ({
             required
           />
           <Typography
-            color="text.disabled"
+            color="text.secondary"
             variant="s3"
             fontWeight="fontWeightMedium"
             sx={{ mt: 0, mb: 2 }}
@@ -231,7 +231,7 @@ const HuggingDetailForm = ({
             required
           />
           <Typography
-            color="text.disabled"
+            color="text.secondary"
             variant="s3"
             fontWeight="fontWeightMedium"
             sx={{ mt: 0, mb: 2 }}
@@ -264,7 +264,7 @@ const HuggingDetailForm = ({
             required
           />
           <Typography
-            color="text.disabled"
+            color="text.secondary"
             variant="s3"
             fontWeight="fontWeightMedium"
             sx={{ mt: 0, mb: 2 }}

--- a/frontend/src/sections/knowledge-base/CreateKnowledgeBase/SdkInfoDialog.jsx
+++ b/frontend/src/sections/knowledge-base/CreateKnowledgeBase/SdkInfoDialog.jsx
@@ -62,7 +62,7 @@ export default function SdkInfoDialog({ open, onClose, onSubmit }) {
           </Stack>
           <Typography
             variant="s1"
-            color={"text.disabled"}
+            color={"text.secondary"}
             fontWeight={"fontWeightRegular"}
           >
             Attachments larger than 5 MB should be used using SDK. For this use

--- a/frontend/src/sections/knowledge-base/help/HelpKnowledgeBase.jsx
+++ b/frontend/src/sections/knowledge-base/help/HelpKnowledgeBase.jsx
@@ -145,7 +145,7 @@ const HelpKnowledgeBase = ({ helpIcon = false, onCreateKnowledge }) => {
             // @ts-ignore
             variant="s1"
             fontWeight={"fontWeightMedium"}
-            color="text.disabled"
+            color="text.secondary"
           >
             For more instructions, check out our{" "}
             <Link

--- a/frontend/src/sections/knowledge-base/sheet-view/confirm-delete.jsx
+++ b/frontend/src/sections/knowledge-base/sheet-view/confirm-delete.jsx
@@ -148,7 +148,7 @@ export default function ConfirmDelete({
             </Typography>
             <Typography
               variant="s1"
-              color={"text.disabled"}
+              color={"text.secondary"}
               fontWeight={"fontWeightRegular"}
             >
               {confirmationMessage}

--- a/frontend/src/sections/persona/PersonaCreateEdit/LanguageSelector.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/LanguageSelector.jsx
@@ -57,7 +57,7 @@ const LanguageSelector = ({ multiple = true }) => {
           <Typography
             typography="s1"
             fontWeight="fontWeightRegular"
-            color="text.disabled"
+            color="text.secondary"
           >
             Enable your persona to communicate in multiple languages during
             calls

--- a/frontend/src/sections/persona/PersonaCreateEdit/OptionSelectors.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/OptionSelectors.jsx
@@ -74,7 +74,7 @@ const OptionSelectors = ({
         <Typography
           typography="s1"
           fontWeight="fontWeightRegular"
-          color="text.disabled"
+          color="text.secondary"
         >
           {description}
         </Typography>

--- a/frontend/src/sections/persona/PersonaCreateEdit/PersonaAddCustomProperties.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/PersonaAddCustomProperties.jsx
@@ -31,7 +31,7 @@ const PersonaAddCustomProperties = () => {
         </CustomPersonaAccordionHeader>
         <CustomPersonaAccordionContent>
           <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-            <Typography variant="s1_2" fontWeight="fontWeightMedium">
+            <Typography variant="s1_2" color="text.secondary" fontWeight="fontWeightMedium">
               Define keys and values
             </Typography>
             {fields.map((field, index) => (

--- a/frontend/src/sections/persona/PersonaCreateEdit/PersonaConversationSetting.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/PersonaConversationSetting.jsx
@@ -84,7 +84,7 @@ const PersonaConversationSetting = ({
                     <Typography
                       typography="s1"
                       fontWeight="fontWeightRegular"
-                      color="text.disabled"
+                      color="text.secondary"
                     >
                       To test how your agent interprets and responds in
                       real-world conditions

--- a/frontend/src/sections/persona/PersonaCreateEdit/PersonaCreateEditDrawer.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/PersonaCreateEditDrawer.jsx
@@ -48,7 +48,7 @@ const PersonaCreateEditDrawer = ({
                 Create Persona
               </Typography>
               <Typography
-                color={"text.disabled"}
+                color={"text.secondary"}
                 variant="s1"
                 fontWeight={"fontWeightRegular"}
               >

--- a/frontend/src/sections/persona/PersonaCreateEdit/PersonaCreateEditForm.jsx
+++ b/frontend/src/sections/persona/PersonaCreateEdit/PersonaCreateEditForm.jsx
@@ -142,7 +142,7 @@ const PersonaCreateEditForm = ({
           <Typography
             typography="s1"
             fontWeight="fontWeightRegular"
-            color="text.disabled"
+            color="text.secondary"
           >
             Create custom personas for more realistic scenario
           </Typography>

--- a/frontend/src/sections/project-detail/ConfigureProject.jsx
+++ b/frontend/src/sections/project-detail/ConfigureProject.jsx
@@ -230,7 +230,7 @@ const ConfigureProject = ({ open, onClose, id, refreshGrid, module }) => {
                         fontSize={"12px"}
                         typography={"s2_1"}
                         fontWeight={"fontWeightRegular"}
-                        color={"text.disabled"}
+                        color={"text.secondary"}
                       >
                         Defines the percentage of data processed for agent
                         compass

--- a/frontend/src/sections/project-detail/DeleteRuns.jsx
+++ b/frontend/src/sections/project-detail/DeleteRuns.jsx
@@ -104,7 +104,7 @@ const DeleteRuns = ({ open, onClose, selectedRows, refreshGrid }) => {
         <Typography
           mb={theme.spacing(1)}
           fontWeight={400}
-          color="text.disabled"
+          color="text.secondary"
           fontSize={14}
         >
           Are you sure you want to delete the following run

--- a/frontend/src/sections/project/NewProject/InstructionTitle.jsx
+++ b/frontend/src/sections/project/NewProject/InstructionTitle.jsx
@@ -22,7 +22,7 @@ const InstructionTitle = ({ title, description, urltext, url, onUrlClick }) => {
       <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
         <Typography
           variant="s1"
-          color="text.disabled"
+          color="text.secondary"
           fontWeight={"fontWeightRegular"}
         >
           {description}

--- a/frontend/src/sections/project/ProjectFtux.jsx
+++ b/frontend/src/sections/project/ProjectFtux.jsx
@@ -41,7 +41,7 @@ const ProjectFtux = () => {
           Welcome to {isObserve ? `Observe` : `Prototype`}
         </Typography>
         <Box sx={{ height: "5px" }} />
-        <Typography fontSize="14px" color="text.disabled">
+        <Typography fontSize="14px" color="text.secondary">
           Create a project to experiment on your model
         </Typography>
         <Box sx={{ height: "20px" }} />

--- a/frontend/src/sections/project/ProjectWrapperView.jsx
+++ b/frontend/src/sections/project/ProjectWrapperView.jsx
@@ -348,7 +348,7 @@ const ProjectWrapperView = () => {
             onClose={() => setDeleteModalOpen(false)}
             title="Delete Project"
             content={
-              <Typography color="text.disabled">
+              <Typography color="text.secondary">
                 Are you sure you want to delete{" "}
                 {selectedRowsData.length === 1
                   ? "this project?"

--- a/frontend/src/sections/projects/MonitorsView/DeleteConfirmation.jsx
+++ b/frontend/src/sections/projects/MonitorsView/DeleteConfirmation.jsx
@@ -74,7 +74,7 @@ const DeleteConfirmation = ({ open, onClose, onConfirm }) => {
         <Typography
           variant="s1"
           fontWeight={"fontWeightRegular"}
-          color="text.disabled"
+          color="text.secondary"
         >
           Are you sure you want to delete these Alerts?
         </Typography>

--- a/frontend/src/sections/projects/MonitorsView/DuplicateMonitor.jsx
+++ b/frontend/src/sections/projects/MonitorsView/DuplicateMonitor.jsx
@@ -69,7 +69,7 @@ const DuplicateMonitor = ({
           <Typography
             variant="s1"
             fontWeight={"fontWeightRegular"}
-            color="text.disabled"
+            color="text.secondary"
           >
             Create a new for the alert that you want to duplicate
           </Typography>

--- a/frontend/src/sections/projects/MonitorsView/ManageMonitorSettings.jsx
+++ b/frontend/src/sections/projects/MonitorsView/ManageMonitorSettings.jsx
@@ -219,7 +219,7 @@ const ManageMonitorSettings = ({
       </Typography>
       <Typography
         variant="s2"
-        color="text.disabled"
+        color="text.secondary"
         fontWeight={"fontWeightRegular"}
       >
         Create alerts to get notifications

--- a/frontend/src/sections/projects/MonitorsView/MonitorGraph.jsx
+++ b/frontend/src/sections/projects/MonitorsView/MonitorGraph.jsx
@@ -70,7 +70,7 @@ const MonitorGraph = ({ selectedMetric, control, metricList }) => {
           <Typography
             variant="s1"
             fontWeight={"fontWeightRegular"}
-            color="text.disabled"
+            color="text.secondary"
             sx={{
               width: "207px",
               textAlign: "center",

--- a/frontend/src/sections/projects/MonitorsView/MonitorsView.jsx
+++ b/frontend/src/sections/projects/MonitorsView/MonitorsView.jsx
@@ -327,7 +327,7 @@ const MonitorsView = () => {
               }}
             >
               <Typography
-                color="text.disabled"
+                color="text.secondary"
                 typography="m3"
                 fontWeight="fontWeightSemiBold"
                 sx={{ marginBottom: theme.spacing(2) }}

--- a/frontend/src/sections/projects/MonitorsView/UnsavedChangesDialog.jsx
+++ b/frontend/src/sections/projects/MonitorsView/UnsavedChangesDialog.jsx
@@ -82,7 +82,7 @@ const UnsavedChangesDialog = ({
         <Typography
           variant="s1"
           fontWeight={"fontWeightRegular"}
-          color="text.disabled"
+          color="text.secondary"
         >
           {message}
         </Typography>

--- a/frontend/src/sections/projects/SessionsView/ReplaySessions/AddedEvaluations.jsx
+++ b/frontend/src/sections/projects/SessionsView/ReplaySessions/AddedEvaluations.jsx
@@ -63,7 +63,7 @@ export default function AddedEvaluations({
         <Collapse in={!collapsed}>
           <Typography
             typography={"s2_1"}
-            color={"text.disabled"}
+            color={"text.secondary"}
             sx={{
               mr: 5,
               maxWidth: "97%",

--- a/frontend/src/sections/projects/SessionsView/ReplaySessions/CreateScenariosForm.jsx
+++ b/frontend/src/sections/projects/SessionsView/ReplaySessions/CreateScenariosForm.jsx
@@ -420,7 +420,7 @@ const ScenarioDetails = () => {
         <Collapse in={!collapsed}>
           <Typography
             typography={"s2_1"}
-            color={"text.disabled"}
+            color={"text.secondary"}
             sx={{
               mr: 5,
               maxWidth: "97%",

--- a/frontend/src/sections/projects/SessionsView/ReplaySessions/Loading.jsx
+++ b/frontend/src/sections/projects/SessionsView/ReplaySessions/Loading.jsx
@@ -37,7 +37,7 @@ export default function Loading({ title, description }) {
         <ShowComponent condition={description}>
           <Typography
             typography={"s2_1"}
-            color={"text.disabled"}
+            color={"text.secondary"}
             sx={{
               textAlign: "center",
             }}

--- a/frontend/src/sections/projects/TracesDrawer/SessionEvalsList.jsx
+++ b/frontend/src/sections/projects/TracesDrawer/SessionEvalsList.jsx
@@ -126,7 +126,7 @@ const SessionEvalsList = ({ sessionId }) => {
         <Typography variant="body2" color="text.secondary">
           No session-level evaluations yet.
         </Typography>
-        <Typography variant="caption" color="text.disabled" textAlign="center">
+        <Typography variant="caption" color="text.secondary" textAlign="center">
           Configure a task with row type{" "}
           <Box component="span" sx={{ fontWeight: 600 }}>
             Sessions

--- a/frontend/src/sections/prompt/NewPrompt/ImprovePrompt/ImprovePrompt.jsx
+++ b/frontend/src/sections/prompt/NewPrompt/ImprovePrompt/ImprovePrompt.jsx
@@ -264,7 +264,7 @@ const ImprovePromptDrawer = (props) => {
         </Typography>
         <Box sx={{ display: "flex", gap: 0.8, alignItems: "center" }}>
           {/* <Iconify icon="solar:info-circle-bold" color="#637381" width="15px" /> */}
-          <Typography variant="caption" color="text.disabled">
+          <Typography variant="caption" color="text.secondary">
             Enhance your prompt with nuanced refinements for more precise and
             effective results.
           </Typography>

--- a/frontend/src/sections/prompt/NewPrompt/PromptGenerate/Workbench.jsx
+++ b/frontend/src/sections/prompt/NewPrompt/PromptGenerate/Workbench.jsx
@@ -71,7 +71,7 @@ const Workbench = ({
           mb: 3,
         }}
       >
-        <Typography fontSize="12px" color="text.disabled">
+        <Typography fontSize="12px" color="text.secondary">
           Test, Evaluate, and refine your prompts before running them on the
           full dataset, ensuring optimal results
         </Typography>

--- a/frontend/src/sections/prompt/PromptDrawer/GeneratePrompt.jsx
+++ b/frontend/src/sections/prompt/PromptDrawer/GeneratePrompt.jsx
@@ -299,7 +299,7 @@ const GeneratePrompt = (props) => {
           {/* sub title */}
           <Box sx={{ display: "flex", gap: 0.6, alignItems: "center" }}>
             {/* <Iconify icon="solar:info-circle-bold" color="#637381" width="15px" /> */}
-            <Typography color={"text.disabled"} variant="caption">
+            <Typography color={"text.secondary"} variant="caption">
               You can generate a structured prompt by sharing basic details
               about your task
             </Typography>

--- a/frontend/src/sections/scenarios/CreateScenarioHeader.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioHeader.jsx
@@ -25,7 +25,7 @@ const CreateScenarioHeader = ({
           <Collapse in={!!rightSection}>{rightSection}</Collapse>
         </Stack>
         <Box display="flex" alignItems="center" gap="4px">
-          <Typography typography="s2_1" color="text.disabled">
+          <Typography typography="s2_1" color="text.secondary">
             {description}
           </Typography>
           {docLink && (

--- a/frontend/src/sections/scenarios/CustomInstruction.jsx
+++ b/frontend/src/sections/scenarios/CustomInstruction.jsx
@@ -43,7 +43,7 @@ export default function CustomInstruction({ control }) {
           <Typography
             typography={"s2_1"}
             fontWeight={"fontWeightRegular"}
-            color={"text.primary"}
+            color={"text.secondary"}
           >
             Create scenarios based on how your agent is defined
           </Typography>

--- a/frontend/src/sections/scenarios/PersonaSection.jsx
+++ b/frontend/src/sections/scenarios/PersonaSection.jsx
@@ -88,7 +88,7 @@ const PersonaSection = ({ control, description = "" }) => {
           <Typography
             typography="s2_1"
             fontWeight="fontWeightRegular"
-            color="text.disabled"
+            color="text.secondary"
           >
             Auto-adds all active personas to your scenarios
           </Typography>

--- a/frontend/src/sections/scenarios/scenario-detail/AddColumnScenario.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/AddColumnScenario.jsx
@@ -176,7 +176,7 @@ const AddColumnScenario = ({ open, onClose, datasetId, scenarioId }) => {
             <Typography
               variant="s1"
               fontWeight={"fontWeightRegular"}
-              color={"text.disabled"}
+              color={"text.secondary"}
             >
               Define the column name, type, and description (max 10 columns)
             </Typography>

--- a/frontend/src/sections/settings/EELicenses/EELicensesPage.jsx
+++ b/frontend/src/sections/settings/EELicenses/EELicensesPage.jsx
@@ -363,7 +363,7 @@ export default function EELicensesPage() {
           <Typography variant="subtitle1" color="text.secondary">
             No licenses yet
           </Typography>
-          <Typography variant="body2" color="text.disabled" mb={2}>
+          <Typography variant="body2" color="text.secondary" mb={2}>
             Generate a license key to unlock EE features on your self-hosted
             instance.
           </Typography>

--- a/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
@@ -216,7 +216,7 @@ function StatCard({ icon, label, value, subtitle, color, tooltip }) {
             <Typography
               variant="caption"
               display="block"
-              color="text.disabled"
+              color="text.secondary"
               noWrap
             >
               {subtitle}
@@ -993,7 +993,7 @@ export default function UsageSummaryV2() {
           <Typography variant="h6" color="text.secondary" gutterBottom>
             No usage data yet
           </Typography>
-          <Typography variant="body2" color="text.disabled">
+          <Typography variant="body2" color="text.secondary">
             Start using FutureAGI features and your usage will appear here.
           </Typography>
         </Paper>

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -722,7 +722,7 @@ const TaskConfigPanel = ({
           {!isProjectSelected && (
             <Typography
               variant="caption"
-              color="text.disabled"
+              color="text.secondary"
               sx={{ fontSize: "11px", display: "block", fontStyle: "italic" }}
             >
               Select a project to configure filters, scheduling, and

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -1166,7 +1166,7 @@ const VariableMappingView = ({
         </Typography>
         <Typography
           variant="caption"
-          color="text.disabled"
+          color="text.secondary"
           sx={{ display: "block", fontSize: "10px" }}
         >
           Configured mapping for each eval against the current row&apos;s fields

--- a/frontend/src/sections/tasks/components/TaskSchedulingSection.jsx
+++ b/frontend/src/sections/tasks/components/TaskSchedulingSection.jsx
@@ -400,7 +400,7 @@ const SamplingRateField = ({ control }) => {
 
       <Typography
         variant="caption"
-        color="text.disabled"
+        color="text.secondary"
         sx={{ fontSize: "11px", display: "block", mt: 0.25 }}
       >
         {samplingHelperText(numValue)}

--- a/frontend/src/sections/test-detail/CreateEditOptimization/CreateEditOptimizationForm.jsx
+++ b/frontend/src/sections/test-detail/CreateEditOptimization/CreateEditOptimizationForm.jsx
@@ -262,7 +262,7 @@ const CreateEditOptimizationForm = ({ onClose, defaultValues, onSuccess }) => {
             <Typography
               variant="s3"
               fontWeight={"fontWeightRegular"}
-              color={"text.disabled"}
+              color={"text.secondary"}
             >
               These are the recommended parameters which give a good balance
               between speed and quality of the prompt optimization run

--- a/frontend/src/sections/test-detail/CreateEditOptimization/ShareComponents.jsx
+++ b/frontend/src/sections/test-detail/CreateEditOptimization/ShareComponents.jsx
@@ -8,7 +8,7 @@ export const FieldWrapper = ({ children, helperText }) => {
       <Typography
         typography="s3"
         fontWeight="fontWeightMedium"
-        color="text.disabled"
+        color="text.secondary"
       >
         {helperText}
       </Typography>

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/SuggestionCard.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/SuggestionCard.jsx
@@ -71,7 +71,7 @@ const SuggestionCard = ({
                 />
               </ShowComponent>
             </Box>
-            <Typography variant="s2" color="text.disabled">
+            <Typography variant="s2" color="text.secondary">
               <TruncateText>{description}</TruncateText>
             </Typography>
           </Box>

--- a/frontend/src/sections/test-detail/OptimizeAgentDrawer.jsx/OptimizingAgentSteps.jsx
+++ b/frontend/src/sections/test-detail/OptimizeAgentDrawer.jsx/OptimizingAgentSteps.jsx
@@ -182,7 +182,7 @@ const OptimizingAgentSteps = ({ status, optimizationId }) => {
                     >
                       <Typography
                         variant="body2"
-                        color="text.disabled"
+                        color="text.secondary"
                         fontSize="14px"
                       >
                         {description}

--- a/frontend/src/sections/test-detail/OptimizeAgentDrawer.jsx/OptmizationLoaderComponent.jsx
+++ b/frontend/src/sections/test-detail/OptimizeAgentDrawer.jsx/OptmizationLoaderComponent.jsx
@@ -57,6 +57,7 @@ const OptmizationLoaderComponent = ({
             <Typography
               variant="s1"
               fontWeight="fontWeightRegular"
+              color="text.secondary"
               sx={{ width: "250px" }}
             >
               We are optimizing your agent’s issues, this might take some time.

--- a/frontend/src/sections/test-detail/PerformanceMetrics/EvaluationMetrics.jsx
+++ b/frontend/src/sections/test-detail/PerformanceMetrics/EvaluationMetrics.jsx
@@ -106,7 +106,7 @@ export default function EvaluationMetrics({
         >
           <Typography
             typography={"s2"}
-            color={"text.disabled"}
+            color={"text.secondary"}
             fontWeight={"fontWeightRegular"}
           >
             Evaluation results will appear shortly

--- a/frontend/src/sections/test-detail/PerformanceMetrics/EvaluationMetrics.jsx
+++ b/frontend/src/sections/test-detail/PerformanceMetrics/EvaluationMetrics.jsx
@@ -122,7 +122,7 @@ export default function EvaluationMetrics({
         >
           <Typography
             typography={"body1"}
-            color={"text.disabled"}
+            color={"text.secondary"}
             fontWeight={"fontWeightRegular"}
           >
             No evaluation metrics added

--- a/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSystemMetrics.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/TestDetailSystemMetrics.jsx
@@ -186,7 +186,7 @@ const TestDetailSystemMetrics = ({ latencies }) => {
         <Typography typography="s1_2" fontWeight="fontWeightMedium">
           System Metrics
         </Typography>
-        <Typography typography="s1" color="text.disabled">
+        <Typography typography="s1" color="text.secondary">
           Average latency metrics of the call
         </Typography>
       </Box>

--- a/frontend/src/sections/test-detail/components/MetadataItem.jsx
+++ b/frontend/src/sections/test-detail/components/MetadataItem.jsx
@@ -61,7 +61,7 @@ const MetadataItem = ({
         {iconSrc && <SvgColor sx={{ width: 20, ...iconSx }} src={iconSrc} />}
         <Typography
           typography="s2_1"
-          color="text.disabled"
+          color="text.secondary"
           fontWeight="fontWeightRegular"
           sx={{ ...sx }}
         >

--- a/frontend/src/sections/test/TestEvaluationPage.jsx
+++ b/frontend/src/sections/test/TestEvaluationPage.jsx
@@ -277,7 +277,7 @@ const TestEvaluationPage = ({
             <Typography fontSize={15} fontWeight={600} mb={0.5}>
               No evaluations added
             </Typography>
-            <Typography fontSize={12} color="text.disabled" mb={2}>
+            <Typography fontSize={12} color="text.secondary" mb={2}>
               Add evaluations to measure test quality
             </Typography>
             <Button

--- a/frontend/src/sections/workbench/ChoosePromptTemplateDrawer.jsx
+++ b/frontend/src/sections/workbench/ChoosePromptTemplateDrawer.jsx
@@ -97,7 +97,7 @@ const TemplateCard = ({ name, description, createdBy, onClick }) => {
         <Typography
           typography={"s2"}
           fontWeight={"fontWeightRegular"}
-          color={"text.disabled"}
+          color={"text.secondary"}
           sx={{
             overflowWrap: "break-word",
             wordBreak: "break-word",
@@ -319,7 +319,7 @@ export const ChoosePromptTemplateDrawer = ({ open, onClose, importMode }) => {
           </Typography>
           <Typography
             typography="s2"
-            color="text.disabled"
+            color="text.secondary"
             fontWeight={"fontWeightRegular"}
           >
             Browse and discover curated prompt templates for writing,

--- a/frontend/src/sections/workbench/LoadingTemplate.jsx
+++ b/frontend/src/sections/workbench/LoadingTemplate.jsx
@@ -36,7 +36,7 @@ export default function LoadingTemplate({ sx }) {
         </Typography>
         <Typography
           typography={"s2"}
-          color={"text.disabled"}
+          color={"text.secondary"}
           fontWeight={"fontWeightMedium"}
         >
           We are loading your template...

--- a/frontend/src/sections/workbench/SelectedPromptTemplateDrawer.jsx
+++ b/frontend/src/sections/workbench/SelectedPromptTemplateDrawer.jsx
@@ -270,7 +270,7 @@ export const SelectedPromptTemplateDrawer = ({
               </Typography>
               <Typography
                 typography="s2"
-                color="text.disabled"
+                color="text.secondary"
                 fontWeight={"fontWeightRegular"}
               >
                 Generate engaging blog posts on any topic with SEO optimization

--- a/frontend/src/sections/workbench/createPrompt/Evaluation/AddEvalsComparison.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Evaluation/AddEvalsComparison.jsx
@@ -67,7 +67,7 @@ const AddEvalsComparisonChild = ({
             <Typography
               typography="s1"
               fontWeight={"fontWeightRegular"}
-              color="text.disabled"
+              color="text.secondary"
             >
               {description}
             </Typography>

--- a/frontend/src/sections/workbench/createPrompt/Playground/OutputSection/DefaultOutput.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Playground/OutputSection/DefaultOutput.jsx
@@ -37,7 +37,7 @@ const DefaultOutput = () => {
             <Typography
               typography="m3"
               fontWeight={"fontWeightRegular"}
-              color="text.disabled"
+              color="text.secondary"
               fontFamily={"Inter, sans-serif"}
             >
               {item}

--- a/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationPage.jsx
+++ b/frontend/src/sections/workbench/createPrompt/Simulate/SimulationDetailView/SimulationEvaluationPage.jsx
@@ -188,7 +188,7 @@ const SimulationEvaluationPage = ({
             <Typography fontSize={15} fontWeight={600} mb={0.5}>
               No evaluations added
             </Typography>
-            <Typography fontSize={12} color="text.disabled" mb={2}>
+            <Typography fontSize={12} color="text.secondary" mb={2}>
               Add evaluations to measure simulation quality
             </Typography>
             <Button

--- a/frontend/src/sections/workbench/createPrompt/VersionHistory/EmptyVersions.jsx
+++ b/frontend/src/sections/workbench/createPrompt/VersionHistory/EmptyVersions.jsx
@@ -38,7 +38,7 @@ const EmptyVersions = ({ activeTab }) => {
       <Typography
         variant="m3"
         fontWeight="fontWeightMedium"
-        color="text.disabled"
+        color="text.secondary"
         sx={{ width: "300px", textAlign: "center" }}
       >
         {activeTab === "commit_history"

--- a/frontend/src/sections/workbench/createPrompt/VersionHistory/VersionHistoryDrawer.jsx
+++ b/frontend/src/sections/workbench/createPrompt/VersionHistory/VersionHistoryDrawer.jsx
@@ -102,7 +102,7 @@ const VersionHistoryChild = ({ onClose }) => {
         <Typography
           typography="s1"
           fontWeight={"fontWeightRegular"}
-          color="text.disabled"
+          color="text.secondary"
         >
           Access the history of prompts along with variables, tags, and model
           versions.

--- a/frontend/src/sections/workbench/workbenchDetailView/help/InfoWorkbenchModal.jsx
+++ b/frontend/src/sections/workbench/workbenchDetailView/help/InfoWorkbenchModal.jsx
@@ -165,7 +165,7 @@ const InfoWorkbenchModal = ({ open, onClose }) => {
                 // @ts-ignore
                 variant="s1"
                 fontWeight={"fontWeightMedium"}
-                color="text.disabled"
+                color="text.secondary"
               >
                 For more instructions, checkout our{" "}
                 <Link


### PR DESCRIPTION
## Summary

Descriptive and helper text in several screens was rendered with `text.disabled`, making it hard to read against the background. This PR swaps those to `text.secondary` (and bumps a few `text.primary` descriptions down to `text.secondary` for consistent hierarchy).

## Changes

- **Agents (Create New Agent):** subtitles/descriptions in Basic Info, Behaviour (+ right section), Configuration, Voice form, and agent cards
- **Persona (Create/Edit):** language selector, option selectors, custom properties, conversation settings, drawer, and form descriptions
- **Scenarios:** create header and custom instruction copy
- **Test detail:** optimization form, share components, optimizing steps, optimization loader, evaluation metrics empty state, and metadata item
- **Eval picker:** "map all variables" hint
- **Run tests:** stepper label color
- **Error feed:** page subtitle

No logic changes — styling/color only.

## Test plan

- [x] Open each affected screen and confirm description/helper text is legible in both light and dark mode
- [x] Verify no layout shifts or regressions in the stepper, drawers, and forms

Closes  TH-4492, TH-5154