### PR TITLE
fix(evals): mark missing-attribute eval rows as skipped, not failed

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/VoiceRightPanel.jsx
@@ -251,6 +251,7 @@ const VoiceRightPanel = ({
         score_items: scoreItems,
         explanation: e?.reason || e?.explanation,
         error: e?.error === true,
+        skipped: e?.skipped === true,
         // Error localization fields — pulled from whatever key the
         // backend used. Makes the shared EvalsTabView render the
         // dropdown / "Run" UX for failed voice evals.

--- a/frontend/src/components/traceDetail/EvalsTabView.jsx
+++ b/frontend/src/components/traceDetail/EvalsTabView.jsx
@@ -113,22 +113,30 @@ export function scoreColor(score) {
 /** Single eval row with collapsible explanation + optional "View span" */
 const EvalTableRow = ({ ev, onSelectSpan, showSpanColumn, onFixWithFalcon }) => {
   const [expanded, setExpanded] = useState(false);
-  const hasError = ev?.error === true;
-  const sc = hasError
+  const isSkipped = ev?.skipped === true;
+  const hasError = ev?.error === true && !isSkipped;
+  const sc = isSkipped
     ? {
-        bg: (theme) => alpha(theme.palette.error.main, 0.08),
-        text: "error.main",
+        bg: (theme) => alpha(theme.palette.text.disabled, 0.08),
+        text: "text.disabled",
       }
-    : scoreColor(ev.score);
+    : hasError
+      ? {
+          bg: (theme) => alpha(theme.palette.error.main, 0.08),
+          text: "error.main",
+        }
+      : scoreColor(ev.score);
   const evalName = ev.eval_name || ev.eval_config_id || "Eval";
   const explanation = ev.explanation || ev.eval_explanation;
-  const scoreLabel = hasError
-    ? "Error"
-    : ev.score_label != null
-      ? ev.score_label
-      : ev.score != null
-        ? `${ev.score}%`
-        : "—";
+  const scoreLabel = isSkipped
+    ? "Skipped"
+    : hasError
+      ? "Error"
+      : ev.score_label != null
+        ? ev.score_label
+        : ev.score != null
+          ? `${ev.score}%`
+          : "—";
 
   // Error localization visibility — surfaced for every eval that has
   // enough identifiers to drive either the cell-based or trace-based

--- a/futureagi/ai_tools/tools/tracing/get_eval_task_logs.py
+++ b/futureagi/ai_tools/tools/tracing/get_eval_task_logs.py
@@ -49,11 +49,18 @@ class GetEvalTaskLogsTool(BaseTool):
             eval_task_id=str(params.eval_task_id), deleted=False
         ).aggregate(
             errors_count=Count("id", filter=Q(error=True)),
-            success_count=Count("id", filter=Q(error=False)),
+            success_count=Count(
+                "id", filter=Q(error=False, skipped_reason__isnull=True)
+            ),
+            skipped_count=Count("id", filter=Q(skipped_reason__isnull=False)),
             errors_message=ArrayAgg("eval_explanation", filter=Q(error=True)),
         )
 
-        total_count = log_stats["errors_count"] + log_stats["success_count"]
+        total_count = (
+            log_stats["errors_count"]
+            + log_stats["success_count"]
+            + log_stats["skipped_count"]
+        )
         errors = log_stats["errors_message"] or []
 
         info = key_value_block(

--- a/futureagi/tracer/migrations/0078_evallogger_skipped_reason.py
+++ b/futureagi/tracer/migrations/0078_evallogger_skipped_reason.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tracer", "0077_merge_20260514_1559"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evallogger",
+            name="skipped_reason",
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/futureagi/tracer/migrations/0079_backfill_skipped_reason.py
+++ b/futureagi/tracer/migrations/0079_backfill_skipped_reason.py
@@ -1,0 +1,44 @@
+import re
+
+from django.db import migrations
+
+ATTR_RE = re.compile(r"Required attribute '([^']+)'")
+LEGACY_PREFIX = "Error during evaluation: Required attribute "
+
+
+def backfill(apps, schema_editor):
+    """Re-categorise rows that recorded a missing-attribute skip as an error.
+
+    These rows were written by the eval pipeline when a mapped span attribute
+    was absent (the eval never ran). They are recoded to the skip shape so
+    existing dashboards stop showing them as failures without re-running evals.
+    """
+    EvalLogger = apps.get_model("tracer", "EvalLogger")
+    rows = list(
+        EvalLogger.objects.filter(
+            error=True, error_message__startswith=LEGACY_PREFIX
+        )
+    )
+    for row in rows:
+        match = ATTR_RE.search(row.error_message or "")
+        attribute = match.group(1) if match else "unknown"
+        row.skipped_reason = f"missing_required_attribute: {attribute}"
+        row.error = False
+        row.error_message = None
+        row.output_str = None
+    if rows:
+        EvalLogger.objects.bulk_update(
+            rows,
+            ["skipped_reason", "error", "error_message", "output_str"],
+            batch_size=500,
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tracer", "0078_evallogger_skipped_reason"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill, migrations.RunPython.noop),
+    ]

--- a/futureagi/tracer/models/observation_span.py
+++ b/futureagi/tracer/models/observation_span.py
@@ -332,6 +332,10 @@ class EvalLogger(BaseModel):
     )
     error = models.BooleanField(default=False)
     error_message = models.TextField(null=True, blank=True)
+    # Set when the eval was skipped rather than run — e.g. a mapped span
+    # attribute was absent. Distinct from `error` so read paths render
+    # "Skipped" and drop these rows from failure-rate metrics.
+    skipped_reason = models.TextField(null=True, blank=True)
 
     def __str__(self):
         return f"Eval Log {self.id}"

--- a/futureagi/tracer/tests/test_process_mapping.py
+++ b/futureagi/tracer/tests/test_process_mapping.py
@@ -4,7 +4,7 @@ import uuid
 
 import pytest
 
-from tracer.utils.eval import _process_mapping
+from tracer.utils.eval import EvalSkippedMissingAttribute, _process_mapping
 
 
 @pytest.fixture
@@ -89,12 +89,18 @@ def test_provider_transcript_alias_resolves(_span_with_attrs, missing_eval_templ
     assert out == {"text": "hello world"}
 
 
-def test_missing_attribute_raises(_span_with_attrs, missing_eval_template_id):
+def test_missing_attribute_raises_typed_skip(
+    _span_with_attrs, missing_eval_template_id
+):
     span = _span_with_attrs({"unrelated": "value"})
-    with pytest.raises(ValueError, match="Required attribute 'input'"):
+    # Subclasses ValueError so legacy `except ValueError` handlers still catch
+    # it, while carrying the structured skip reason the eval logger persists.
+    with pytest.raises(ValueError, match="Required attribute 'input'") as exc:
         _process_mapping(
             {"prompt": "input"}, span, eval_template_id=missing_eval_template_id
         )
+    assert isinstance(exc.value, EvalSkippedMissingAttribute)
+    assert exc.value.skipped_reason == "missing_required_attribute: input"
 
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -419,6 +419,21 @@ def build_session_context(session) -> dict | None:
         return None
 
 
+class EvalSkippedMissingAttribute(ValueError):
+    """A mapped span attribute the eval needs is absent, so the eval is skipped.
+
+    There was no input to evaluate — this is a skip, not a failure. Subclasses
+    ValueError so existing ``except ValueError`` handlers still catch it, while
+    carrying the structured reason the eval logger persists.
+    """
+
+    def __init__(self, attribute: str, key: str, span_id):
+        self.skipped_reason = f"missing_required_attribute: {attribute}"
+        super().__init__(
+            f"Required attribute '{attribute}' for key '{key}' not found for span {span_id}"
+        )
+
+
 def _process_mapping(
     mapping: dict | None, span: ObservationSpan, eval_template_id: int
 ) -> dict:
@@ -514,12 +529,11 @@ def _process_mapping(
             # what dataset/playground do when a column cell is empty.
             parsed_mapping[key] = ""
         else:
-            logger.error(
-                f"Required attribute '{attribute}' for key '{key}' not found for span {span.id}"
+            logger.info(
+                f"Skipping eval for span {span.id}: required attribute "
+                f"'{attribute}' (key '{key}') not present"
             )
-            raise ValueError(
-                f"Required attribute '{attribute}' for key '{key}' not found for span {span.id}"
-            )
+            raise EvalSkippedMissingAttribute(attribute, key, span.id)
 
     return parsed_mapping
 
@@ -1697,22 +1711,31 @@ def _create_error_eval_logger(
     observation_span: ObservationSpan,
     custom_eval_config: CustomEvalConfig,
     eval_task_id: str,
-    error_message: str,
+    error: Exception,
 ):
     """
-    Create an error eval logger for the given observation span, custom eval config, and eval task id.
+    Persist the outcome when an eval could not run for an observation span.
+
+    A missing required span attribute is a skip — the eval never ran because
+    there was no input — so the row is written with ``skipped_reason`` set and
+    ``error=False``. Read paths key off ``skipped_reason`` to render "Skipped"
+    and exclude these rows from failure-rate metrics. Genuine failures keep the
+    ``error=True`` / ``output_str="ERROR"`` shape.
     """
+    skipped_reason = getattr(error, "skipped_reason", None)
+    message = str(error)
     EvalLogger.objects.create(
         trace=observation_span.trace,
         observation_span=observation_span,
-        output_metadata={"error": error_message},
-        eval_explanation=f"Error during evaluation: {error_message}",
-        results_explanation={"reason": error_message},
+        output_metadata=None if skipped_reason else {"error": message},
+        eval_explanation=None if skipped_reason else f"Error during evaluation: {message}",
+        results_explanation={} if skipped_reason else {"reason": message},
         eval_task_id=eval_task_id,
         custom_eval_config=custom_eval_config,
-        error=True,
-        error_message=f"Error during evaluation: {error_message}",
-        output_str="ERROR",
+        error=skipped_reason is None,
+        error_message=None if skipped_reason else f"Error during evaluation: {message}",
+        output_str=None if skipped_reason else "ERROR",
+        skipped_reason=skipped_reason,
     )
 
 
@@ -1774,7 +1797,7 @@ def evaluate_observation_span(
         return True
     except ValueError as e:
         logger.error(f"Error during evaluation in evaluate_observation_span: {e}")
-        _create_error_eval_logger(observation_span, custom_eval_config, None, str(e))
+        _create_error_eval_logger(observation_span, custom_eval_config, None, e)
         return False
 
     except Exception as e:
@@ -1938,7 +1961,7 @@ def evaluate_observation_span_observe(
                     f"Error during updating failed spans in exception handling evaluate_observation_span_observe: {e}"
                 )
         _create_error_eval_logger(
-            observation_span, custom_eval_config, eval_task_id, str(e)
+            observation_span, custom_eval_config, eval_task_id, e
         )
 
         return False

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -434,7 +434,13 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             # Pass/fail counts — cheap aggregate, two indexed COUNTs.
             counts = EvalLogger.objects.filter(eval_task_id=eval_task_id).aggregate(
                 errors_count=Count("id", filter=Q(error=True)),
-                success_count=Count("id", filter=Q(error=False)),
+                success_count=Count(
+                    "id", filter=Q(error=False, skipped_reason__isnull=True)
+                ),
+                # Skipped: the eval never ran (e.g. a mapped span attribute
+                # was absent). Counted separately so it stays out of the
+                # success and failure tallies.
+                skipped_count=Count("id", filter=Q(skipped_reason__isnull=False)),
                 # Partial-input warnings live in
                 # output_metadata.warnings as a JSON array. has_key on
                 # the JSONField gives us a cheap "any warnings?" filter
@@ -534,13 +540,18 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
                 reverse=True,
             )[: self._WARNING_GROUPS_LIMIT]
 
-            total_count = counts["errors_count"] + counts["success_count"]
+            total_count = (
+                counts["errors_count"]
+                + counts["success_count"]
+                + counts["skipped_count"]
+            )
 
             result = {
                 "start_time": eval_task.start_time,
                 "end_time": eval_task.end_time,
                 "errors_count": counts["errors_count"],
                 "success_count": counts["success_count"],
+                "skipped_count": counts["skipped_count"],
                 "warnings_count": counts["warnings_count"],
                 "total_count": total_count,
                 "error_groups": error_groups,

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -3795,6 +3795,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                     "output_type": output_type,
                     "reason": log.eval_explanation,
                     "error": log.error,
+                    "skipped": log.skipped_reason is not None,
                 }
                 if log.output_str_list:
                     # Legacy categorical eval — pre-agent-evaluator path


### PR DESCRIPTION
## Summary

When a span lacks the attribute an eval's mapping points at (e.g. a voicemail / customer-busy call with no transcript), the eval never runs — there is no input to evaluate. Today that row is recorded as a generic error and rendered "Fail"/"Error", which also inflates the failure rate. This records that case as a first-class **skip** instead: it renders "Skipped" and is excluded from the failure-rate denominator. A genuine eval failure (e.g. an LLM timeout) is still recorded and shown as **Error** — real failures are never hidden.

This is a leaner re-take of the same ticket: one mechanism, two migrations, no ClickHouse/LLM-grid changes (see Scope).

## Fix

- `_process_mapping` raises a typed `EvalSkippedMissingAttribute` (a `ValueError` subclass, so existing `except ValueError` handlers still catch it) carrying a structured `skipped_reason`.
- `_create_error_eval_logger` writes skip rows with `error=False` + `skipped_reason`; genuine failures keep the `error=True` / `output_str="ERROR"` shape.
- `EvalLogger` gains a nullable `skipped_reason` column (`0079`); `0080` backfills existing mislabeled rows in one bulk update.
- `voice_call_detail` emits `skipped`; the voice eval table renders "Skipped".
- Eval-task aggregates (`get_eval_task_logs`, eval-task summary) exclude skips from success/error and report `skipped_count`, so they no longer count toward the failure rate.

## Scope (deliberately minimal)

- **In:** the Postgres read path + the eval-task metric. The metric aggregates `EvalLogger` via the ORM, so it is correct on prod regardless of the read backend.
- **Out — ClickHouse read path:** where voice list/detail are served from ClickHouse, the CH query builders + the CH `tracer_eval_logger` schema/CDC would need the same `skipped_reason` handling. Called out as a follow-up rather than bundled here — happy to add it in this PR if we want it prod-complete for CH-served voice reads.
- **Out — LLM-tracing grid / trace-detail tab:** the ticket is voice-specific.

## Linked issues

Closes TH-4910

## Test plan

- [x] `_process_mapping` raises the typed skip exception carrying `skipped_reason` (assertion folded into `test_process_mapping.py`, no new file)
- [x] Verified on a local stack against a real voicemail trace via `voice_call_detail`: the no-transcript skip flips **Error → Skipped**, a genuine LLM-timeout failure stays **Error**, and skipped rows drop out of the failure-rate denominator (errors fall, `skipped_count` rises).
- [ ] CI green
