### PR TITLE
fix: correct usage billing display

### DIFF
--- a/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
@@ -77,6 +77,60 @@ function formatTierRate(rateStr) {
   return fCurrency(num, true);
 }
 
+const DISCRETE_UNITS = new Set(["events", "requests", "hits", "tokens"]);
+
+function isDiscreteUnit(unit) {
+  return DISCRETE_UNITS.has(unit);
+}
+
+function normalizeUsageValue(value, unit) {
+  const numericValue = Number(value || 0);
+  if (!Number.isFinite(numericValue)) return 0;
+  return isDiscreteUnit(unit) ? Math.round(numericValue) : numericValue;
+}
+
+function formatUsageNumber(value, unit, { exact = false } = {}) {
+  const normalizedValue = normalizeUsageValue(value, unit);
+  if (normalizedValue === 0) return "0";
+
+  if (exact) {
+    return normalizedValue.toLocaleString(undefined, {
+      maximumFractionDigits: isDiscreteUnit(unit) ? 0 : 4,
+    });
+  }
+
+  if (normalizedValue >= 1e9) return `${(normalizedValue / 1e9).toFixed(1)}B`;
+  if (normalizedValue >= 1e6) return `${(normalizedValue / 1e6).toFixed(1)}M`;
+  if (normalizedValue >= 1e3) return `${(normalizedValue / 1e3).toFixed(1)}K`;
+  if (Number.isInteger(normalizedValue))
+    return normalizedValue.toLocaleString();
+  return normalizedValue.toFixed(1);
+}
+
+function formatUsage(value, unit, options) {
+  return `${formatUsageNumber(value, unit, options)} ${unit}`;
+}
+
+function parseTierRate(rate) {
+  const rateText = String(rate || "")
+    .split("/")[0]
+    .replace(/[$,\s]/g, "");
+  const parsedRate = Number(rateText);
+  return Number.isFinite(parsedRate) ? parsedRate : 0;
+}
+
+function getFirstPaidTierRate(tierBreakdown = []) {
+  return (
+    tierBreakdown
+      .map((tier) => parseTierRate(tier.rate))
+      .find((rate) => rate > 0) || 0
+  );
+}
+
+function getPeriodAllowance(freeAllowance, periodMonthCount) {
+  return (freeAllowance || 0) * periodMonthCount;
+}
+
 // ── Usage Gauge (multi-segment bar) ───────────────────────────────────────
 
 function UsageGauge({ current, projected, freeAllowance, color }) {
@@ -248,14 +302,35 @@ StatCard.propTypes = {
 
 // ── Dimension Product Card ────────────────────────────────────────────────
 
-function DimensionCard({ dim, periodCaption }) {
+function DimensionCard({ dim, periodCaption, periodMonthCount }) {
   const theme = useTheme();
   const [expanded, setExpanded] = useState(false);
   const config = DIMENSION_CONFIG[dim.key] || {};
   const color = config.color || theme.palette.primary.main;
+  const periodFreeAllowance = getPeriodAllowance(
+    dim.free_allowance,
+    periodMonthCount,
+  );
+  const currentUsage = normalizeUsageValue(dim.current_usage, dim.display_unit);
+  const projectedUsage = normalizeUsageValue(
+    dim.projected_usage,
+    dim.display_unit,
+  );
+  const freeAllowance = normalizeUsageValue(
+    periodFreeAllowance,
+    dim.display_unit,
+  );
+  const showExactCurrentUsage = isDiscreteUnit(dim.display_unit);
+  const displayedCurrentUsage = showExactCurrentUsage
+    ? dim.current_usage_raw ?? dim.current_usage
+    : dim.current_usage;
+  const billableUsage = Math.max(
+    0,
+    normalizeUsageValue(displayedCurrentUsage, dim.display_unit) -
+      freeAllowance,
+  );
 
-  const usagePct =
-    dim.free_allowance > 0 ? (dim.current_usage / dim.free_allowance) * 100 : 0;
+  const usagePct = freeAllowance > 0 ? (currentUsage / freeAllowance) * 100 : 0;
   const isOverFree = usagePct > 100;
 
   return (
@@ -336,9 +411,9 @@ function DimensionCard({ dim, periodCaption }) {
 
         {/* Usage gauge */}
         <UsageGauge
-          current={dim.current_usage || 0}
-          projected={dim.projected_usage || 0}
-          freeAllowance={dim.free_allowance || 0}
+          current={currentUsage}
+          projected={projectedUsage}
+          freeAllowance={freeAllowance}
           color={color}
         />
 
@@ -354,13 +429,36 @@ function DimensionCard({ dim, periodCaption }) {
               component="span"
               sx={{ fontWeight: 600, color: "text.primary" }}
             >
-              {fUsage(dim.current_usage, dim.display_unit)}
+              {formatUsage(displayedCurrentUsage, dim.display_unit, {
+                exact: showExactCurrentUsage,
+              })}
             </Box>
-            {dim.free_allowance > 0 && (
-              <> of {fUsage(dim.free_allowance, dim.display_unit)} free</>
+            {freeAllowance > 0 && billableUsage <= 0 && (
+              <>
+                {" "}
+                of{" "}
+                {formatUsage(freeAllowance, dim.display_unit, {
+                  exact: showExactCurrentUsage,
+                })}{" "}
+                free
+              </>
+            )}
+            {freeAllowance > 0 && billableUsage > 0 && (
+              <>
+                {" "}
+                (
+                {formatUsageNumber(freeAllowance, dim.display_unit, {
+                  exact: true,
+                })}{" "}
+                free +{" "}
+                {formatUsageNumber(billableUsage, dim.display_unit, {
+                  exact: true,
+                })}{" "}
+                billed)
+              </>
             )}
           </Typography>
-          {dim.projected_usage > dim.current_usage && (
+          {projectedUsage > currentUsage && (
             <Stack direction="row" spacing={0.5} alignItems="center">
               <Iconify
                 icon="mdi:trending-up"
@@ -368,7 +466,7 @@ function DimensionCard({ dim, periodCaption }) {
                 sx={{ color: "text.disabled" }}
               />
               <Typography variant="caption" color="text.disabled">
-                ~{fUsage(dim.projected_usage, dim.display_unit)} projected
+                ~{formatUsage(projectedUsage, dim.display_unit)} projected
               </Typography>
             </Stack>
           )}
@@ -478,7 +576,8 @@ function DimensionCard({ dim, periodCaption }) {
                       color="text.secondary"
                       sx={{ textAlign: "right" }}
                     >
-                      {formatTierRate(tier.rate)}/{getSingularUnit(dim.display_unit)}
+                      {formatTierRate(tier.rate)}/
+                      {getSingularUnit(dim.display_unit)}
                     </Typography>
                     <Typography
                       variant="caption"
@@ -502,6 +601,7 @@ const dimensionPropType = PropTypes.shape({
   key: PropTypes.string,
   display_name: PropTypes.string,
   current_usage: PropTypes.number,
+  current_usage_raw: PropTypes.number,
   projected_usage: PropTypes.number,
   free_allowance: PropTypes.number,
   estimated_cost: PropTypes.number,
@@ -518,6 +618,7 @@ const dimensionPropType = PropTypes.shape({
 DimensionCard.propTypes = {
   dim: dimensionPropType.isRequired,
   periodCaption: PropTypes.string.isRequired,
+  periodMonthCount: PropTypes.number.isRequired,
 };
 
 // ── Legend ─────────────────────────────────────────────────────────────────
@@ -638,6 +739,12 @@ function getPeriodRange(rangeValue) {
   };
 }
 
+function getPeriodMonthCount(rangeValue) {
+  if (rangeValue === "current") return 1;
+  const months = parseInt(rangeValue, 10);
+  return Number.isFinite(months) ? months : 1;
+}
+
 // ── Main Component ────────────────────────────────────────────────────────
 
 export default function UsageSummaryV2() {
@@ -647,6 +754,10 @@ export default function UsageSummaryV2() {
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const periodParams = useMemo(() => getPeriodRange(timeRange), [timeRange]);
+  const periodMonthCount = useMemo(
+    () => getPeriodMonthCount(timeRange),
+    [timeRange],
+  );
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);
@@ -699,19 +810,17 @@ export default function UsageSummaryV2() {
 
   const freeTierSavings = useMemo(() => {
     if (!overview?.dimensions) return 0;
-    // Sum what free usage would have cost at tier-1 rates
     return overview.dimensions.reduce((sum, dim) => {
+      const paidTierRate = getFirstPaidTierRate(dim.tier_breakdown);
+      if (!paidTierRate) return sum;
+
       const freeUsed = Math.min(
         dim.current_usage || 0,
-        dim.free_allowance || 0,
+        getPeriodAllowance(dim.free_allowance, periodMonthCount),
       );
-      if (freeUsed > 0 && dim.tier_breakdown?.[0]?.rate) {
-        const rateStr = dim.tier_breakdown[0].rate.replace(/[^0-9.]/g, "");
-        return sum + freeUsed * parseFloat(rateStr || "0");
-      }
-      return sum;
+      return freeUsed > 0 ? sum + freeUsed * paidTierRate : sum;
     }, 0);
-  }, [overview]);
+  }, [overview, periodMonthCount]);
 
   const activeDimensions = useMemo(() => {
     if (!overview?.dimensions) return 0;
@@ -970,6 +1079,7 @@ export default function UsageSummaryV2() {
             key={dim.key}
             dim={dim}
             periodCaption={getPeriodCaption(timeRange)}
+            periodMonthCount={periodMonthCount}
           />
         ))}
       </Stack>

--- a/frontend/src/sections/settings/UsageSummaryV2/__tests__/UsageSummaryV2.test.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/__tests__/UsageSummaryV2.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "src/utils/test-utils";
+import { render, screen, userEvent } from "src/utils/test-utils";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mockGet = vi.fn();
@@ -20,6 +20,7 @@ vi.mock("src/utils/axios", () => ({
 
 vi.mock("src/utils/format-number", () => ({
   fCurrency: (val) => `$${Number(val || 0).toFixed(2)}`,
+  fUsage: (val, unit) => `${Number(val || 0).toLocaleString()} ${unit}`,
 }));
 
 vi.mock("react-apexcharts", () => ({
@@ -48,18 +49,22 @@ const BASE_OVERVIEW = {
   dimensions: [],
 };
 
+function mockUsageOverview(overview) {
+  mockGet.mockImplementation((url) => {
+    if (url === "/usage/v2/usage-overview/") {
+      return Promise.resolve({ data: { result: overview } });
+    }
+    if (url === "/usage/v2/notifications/") {
+      return Promise.resolve({ data: { result: { banners: [] } } });
+    }
+    return Promise.resolve({ data: { result: {} } });
+  });
+}
+
 describe("UsageSummaryV2", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGet.mockImplementation((url) => {
-      if (url === "/usage/v2/usage-overview/") {
-        return Promise.resolve({ data: { result: BASE_OVERVIEW } });
-      }
-      if (url === "/usage/v2/notifications/") {
-        return Promise.resolve({ data: { result: { banners: [] } } });
-      }
-      return Promise.resolve({ data: { result: {} } });
-    });
+    mockUsageOverview(BASE_OVERVIEW);
   });
 
   it("should be importable", async () => {
@@ -73,6 +78,177 @@ describe("UsageSummaryV2", () => {
 
     expect(await screen.findByText("Usage & Billing")).toBeInTheDocument();
     expect(screen.queryByText(/days left/i)).not.toBeInTheDocument();
+  });
+
+  it("shows exact discrete usage and billable amount on dimension cards", async () => {
+    const { default: UsageSummaryV2 } = await import("../UsageSummaryV2");
+    mockUsageOverview({
+      ...BASE_OVERVIEW,
+      dimensions: [
+        {
+          key: "tracing_events",
+          display_name: "Tracing Events",
+          display_unit: "events",
+          current_usage: 30531,
+          current_usage_raw: 30531,
+          free_allowance: 10000,
+          projected_usage: 30531,
+          estimated_cost: 13.14,
+          tier_breakdown: [
+            { range: "0 to 10,000 events", rate: "$0.00", cost: 0 },
+            { range: "Above 10,000 events", rate: "$0.00064", cost: 13.14 },
+          ],
+        },
+      ],
+    });
+
+    renderWithQuery(<UsageSummaryV2 />);
+
+    expect(await screen.findByText("30,531 events")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (content) =>
+          content.includes("10,000 free") && content.includes("20,531 billed"),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("rounds projected usage for all discrete units", async () => {
+    const { default: UsageSummaryV2 } = await import("../UsageSummaryV2");
+    mockUsageOverview({
+      ...BASE_OVERVIEW,
+      dimensions: [
+        {
+          key: "tracing_events",
+          display_name: "Tracing Events",
+          display_unit: "events",
+          current_usage: 700,
+          current_usage_raw: 700,
+          free_allowance: 10000,
+          projected_usage: 704.4,
+          estimated_cost: 0,
+          tier_breakdown: [
+            { range: "0 to 10,000 events", rate: "$0.00", cost: 0 },
+          ],
+        },
+        {
+          key: "gateway_requests",
+          display_name: "Gateway Requests",
+          display_unit: "requests",
+          current_usage: 100,
+          current_usage_raw: 100,
+          free_allowance: 0,
+          projected_usage: 101.6,
+          estimated_cost: 0,
+          tier_breakdown: [],
+        },
+        {
+          key: "gateway_cache_hits",
+          display_name: "Gateway Cache Hits",
+          display_unit: "hits",
+          current_usage: 200,
+          current_usage_raw: 200,
+          free_allowance: 0,
+          projected_usage: 200.5,
+          estimated_cost: 0,
+          tier_breakdown: [],
+        },
+        {
+          key: "text_sim_tokens",
+          display_name: "Text Simulation",
+          display_unit: "tokens",
+          current_usage: 990,
+          current_usage_raw: 990,
+          free_allowance: 0,
+          projected_usage: 999.4,
+          estimated_cost: 0,
+          tier_breakdown: [],
+        },
+      ],
+    });
+
+    renderWithQuery(<UsageSummaryV2 />);
+
+    expect(
+      await screen.findByText(/~704 events projected/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/~102 requests projected/)).toBeInTheDocument();
+    expect(screen.getByText(/~201 hits projected/)).toBeInTheDocument();
+    expect(screen.getByText(/~999 tokens projected/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/704\.4 events projected/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/101\.6 requests projected/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/200\.5 hits projected/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/999\.4 tokens projected/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not display raw storage bytes as GB", async () => {
+    const { default: UsageSummaryV2 } = await import("../UsageSummaryV2");
+    mockUsageOverview({
+      ...BASE_OVERVIEW,
+      dimensions: [
+        {
+          key: "storage",
+          display_name: "Storage",
+          display_unit: "GB",
+          current_usage: 0.0853,
+          current_usage_raw: 91583729,
+          free_allowance: 50,
+          projected_usage: 0.1,
+          estimated_cost: 0,
+          tier_breakdown: [{ range: "0 to 50 GB", rate: "$0.00", cost: 0 }],
+        },
+      ],
+    });
+
+    renderWithQuery(<UsageSummaryV2 />);
+
+    expect(await screen.findByText("0.1 GB")).toBeInTheDocument();
+    expect(screen.queryByText(/91\.6M GB/)).not.toBeInTheDocument();
+  });
+
+  it("scales free tier savings with the selected period", async () => {
+    const { default: UsageSummaryV2 } = await import("../UsageSummaryV2");
+    mockUsageOverview({
+      ...BASE_OVERVIEW,
+      dimensions: [
+        {
+          key: "tracing_events",
+          display_name: "Tracing Events",
+          display_unit: "events",
+          current_usage: 150000,
+          current_usage_raw: 150000,
+          free_allowance: 10000,
+          projected_usage: 150000,
+          estimated_cost: 0,
+          tier_breakdown: [
+            { range: "0 to 10,000 events", rate: "$0.00", cost: 0 },
+            { range: "Above 10,000 events", rate: "$0.00064", cost: 12.8 },
+          ],
+        },
+      ],
+    });
+
+    renderWithQuery(<UsageSummaryV2 />);
+
+    expect(await screen.findByText("$6.40")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "3M" }));
+
+    expect(await screen.findByText("$19.20")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "6M" }));
+
+    expect(await screen.findByText("$38.40")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "12M" }));
+
+    expect(await screen.findByText("$76.80")).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes usage and billing display issues on the pricing page. Discrete projected usage now rounds to whole counts, exact and billable usage are visible for count-based dimensions, storage avoids displaying raw bytes as GB, and free tier savings recalculates for MTD, 3M, 6M, and 12M views.

## Linked issues

Closes TH-5526
Closes TH-5538
Closes TH-5545
Closes TH-5556

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only
- [ ] Chore / refactor (no user-visible change)
- [ ] Performance improvement
- [ ] Test-only change

## How was this tested?

- `./node_modules/.bin/vitest run src/sections/settings/UsageSummaryV2/__tests__/UsageSummaryV2.test.jsx`
- `git diff --check -- frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx frontend/src/sections/settings/UsageSummaryV2/__tests__/UsageSummaryV2.test.jsx`

## Screenshots / recordings (if UI)

Not added. Covered by focused component tests for the affected pricing card states.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the CLA
