### PR TITLE
fix(eval-picker): unwrap dataset cell wrapper when cell_value is null (TH-4979)

### DIFF
--- a/frontend/src/sections/evals/components/DatasetTestMode.jsx
+++ b/frontend/src/sections/evals/components/DatasetTestMode.jsx
@@ -34,6 +34,7 @@ import EvalResultDisplay from "./EvalResultDisplay";
 import { buildCompositeRuntimeConfig } from "../Helpers/compositeRuntimeConfig";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
+import { unwrapCellValue } from "./datasetCellValue";
 
 const DATASET_PAGE_SIZE = 25;
 
@@ -349,7 +350,10 @@ function renderTreeNode(node, onSelect) {
             color: hasKids ? "text.primary" : "text.secondary",
             py: 0.15,
           }}
-          onClick={(e) => { e.stopPropagation(); onSelect(node.path); }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect(node.path);
+          }}
         >
           {node.label}
         </Typography>
@@ -378,19 +382,25 @@ function ColumnTreeSelect({
     if (!typing || !value) return tree;
     const q = value.toLowerCase();
     const filterNodes = (nodes) =>
-      nodes.map((node) => {
-        if (node.path.toLowerCase().startsWith(q)) return node;
-        const kids = filterNodes(node.children);
-        if (kids.length) return { ...node, children: kids };
-        return null;
-      }).filter(Boolean);
+      nodes
+        .map((node) => {
+          if (node.path.toLowerCase().startsWith(q)) return node;
+          const kids = filterNodes(node.children);
+          if (kids.length) return { ...node, children: kids };
+          return null;
+        })
+        .filter(Boolean);
     return filterNodes(tree);
   }, [tree, value, typing]);
 
   // Collect all node IDs for default expansion
   const allIds = useMemo(() => {
     const ids = [];
-    const walk = (nodes) => nodes.forEach((n) => { ids.push(n.id); walk(n.children); });
+    const walk = (nodes) =>
+      nodes.forEach((n) => {
+        ids.push(n.id);
+        walk(n.children);
+      });
     walk(filtered);
     return ids;
   }, [filtered]);
@@ -436,7 +446,10 @@ function ColumnTreeSelect({
                 icon={open ? "mdi:chevron-up" : "mdi:chevron-down"}
                 width={16}
                 sx={{ color: "text.disabled", cursor: "pointer" }}
-                onClick={() => { setOpen((p) => !p); setTyping(false); }}
+                onClick={() => {
+                  setOpen((p) => !p);
+                  setTyping(false);
+                }}
               />
             )}
           </InputAdornment>
@@ -473,21 +486,40 @@ function ColumnTreeSelect({
           placement="bottom-start"
           style={{ zIndex: 1301, width: anchorRef.current?.offsetWidth || 240 }}
         >
-          <ClickAwayListener onClickAway={(e) => {
-            // Don't close if clicking the input field itself
-            if (anchorRef.current?.contains(e.target)) return;
-            setOpen(false);
-            setTyping(false);
-          }}>
+          <ClickAwayListener
+            onClickAway={(e) => {
+              // Don't close if clicking the input field itself
+              if (anchorRef.current?.contains(e.target)) return;
+              setOpen(false);
+              setTyping(false);
+            }}
+          >
             <Paper
               elevation={8}
-              sx={{ mt: 0.5, borderRadius: "8px", border: "1px solid", borderColor: "divider" }}
+              sx={{
+                mt: 0.5,
+                borderRadius: "8px",
+                border: "1px solid",
+                borderColor: "divider",
+              }}
             >
               <Box sx={{ maxHeight: 260, overflow: "auto", py: 0.5 }}>
                 <TreeView
                   defaultExpanded={allIds}
-                  defaultCollapseIcon={<Iconify icon="mdi:chevron-down" width={14} sx={{ color: "text.disabled" }} />}
-                  defaultExpandIcon={<Iconify icon="mdi:chevron-right" width={14} sx={{ color: "text.disabled" }} />}
+                  defaultCollapseIcon={
+                    <Iconify
+                      icon="mdi:chevron-down"
+                      width={14}
+                      sx={{ color: "text.disabled" }}
+                    />
+                  }
+                  defaultExpandIcon={
+                    <Iconify
+                      icon="mdi:chevron-right"
+                      width={14}
+                      sx={{ color: "text.disabled" }}
+                    />
+                  }
                   sx={{
                     "& .MuiTreeItem-content": { py: 0.1, borderRadius: "4px" },
                     "& .MuiTreeItem-content:hover": { bgcolor: "action.hover" },
@@ -509,7 +541,12 @@ function extractKeysFromValue(raw) {
   let parsed = null;
   if (raw && typeof raw === "object") parsed = raw;
   else if (typeof raw === "string" && raw.trim()) {
-    try { const p = JSON.parse(raw); if (p && typeof p === "object") parsed = p; } catch { /* not JSON */ }
+    try {
+      const p = JSON.parse(raw);
+      if (p && typeof p === "object") parsed = p;
+    } catch {
+      /* not JSON */
+    }
   }
   if (!parsed) return [];
   const keys = [];
@@ -542,14 +579,24 @@ function resolveNestedValue(raw, jsonPath) {
   let parsed = null;
   if (raw && typeof raw === "object") parsed = raw;
   else if (typeof raw === "string") {
-    try { parsed = JSON.parse(raw); } catch { return raw; }
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return raw;
+    }
   }
   if (!parsed) return raw;
   const parts = jsonPath.split(/[.[\]]/).filter(Boolean);
   let cur = parsed;
   for (const p of parts) {
     if (cur == null) return undefined;
-    cur = /^\d+$/.test(p) ? (Array.isArray(cur) ? cur[parseInt(p, 10)] : undefined) : (typeof cur === "object" ? cur[p] : undefined);
+    cur = /^\d+$/.test(p)
+      ? Array.isArray(cur)
+        ? cur[parseInt(p, 10)]
+        : undefined
+      : typeof cur === "object"
+        ? cur[p]
+        : undefined;
   }
   return cur;
 }
@@ -764,7 +811,7 @@ const DatasetTestMode = React.forwardRef(
         )
         .map((col) => {
           const cell = currentRow[col.id];
-          const value = cell?.cell_value ?? cell ?? "";
+          const value = unwrapCellValue(cell);
           // Don't pre-stringify objects/arrays — coercing them via
           // String(value) produces the literal text "[object Object]"
           // which then fails the downstream JSON.parse check, falls
@@ -849,7 +896,9 @@ const DatasetTestMode = React.forwardRef(
         // Collect sub-paths from backend schema + runtime cell values
         const schemaPaths = jsonSchemas?.[c.id]?.keys || [];
         const cell = currentRow?.[c.id];
-        const runtimePaths = cell ? extractKeysFromValue(cell?.cell_value ?? cell) : [];
+        const runtimePaths = cell
+          ? extractKeysFromValue(unwrapCellValue(cell))
+          : [];
         const allPaths = new Set([...schemaPaths, ...runtimePaths]);
         allPaths.forEach((path) => {
           // Bracket paths: "col[0]" not "col.[0]"
@@ -859,14 +908,25 @@ const DatasetTestMode = React.forwardRef(
       });
       if (!extraColumns?.length) return { columnNames: names, nameToId: n2id };
       const extras = (extraColumns || [])
-        .map((col) => (typeof col === "string" ? col : col.headerName || col.field || col.name || col.label || ""))
+        .map((col) =>
+          typeof col === "string"
+            ? col
+            : col.headerName || col.field || col.name || col.label || "",
+        )
         .filter(Boolean);
       const extraSet = new Set(extras);
       return {
         columnNames: [...extras, ...names.filter((n) => !extraSet.has(n))],
         nameToId: n2id,
       };
-    }, [columns, sourceColumns, extraColumns, isWorkbenchMode, jsonSchemas, currentRow]);
+    }, [
+      columns,
+      sourceColumns,
+      extraColumns,
+      isWorkbenchMode,
+      jsonSchemas,
+      currentRow,
+    ]);
 
     // Workbench mode: map display name → field identifier (e.g. "model_output" → "output_prompt")
     const sourceNameToField = useMemo(() => {
@@ -894,7 +954,9 @@ const DatasetTestMode = React.forwardRef(
         idToName[c.id] = c.name;
         // Reverse-map nested IDs: "uuid.path" → "col.path"
         const paths = jsonSchemas?.[c.id]?.keys || [];
-        paths.forEach((p) => { idToName[`${c.id}.${p}`] = `${c.name}.${p}`; });
+        paths.forEach((p) => {
+          idToName[`${c.id}.${p}`] = `${c.name}.${p}`;
+        });
       });
       setMapping((prev) => {
         const next = { ...prev };
@@ -902,8 +964,13 @@ const DatasetTestMode = React.forwardRef(
         Object.keys(next).forEach((variable) => {
           const val = next[variable];
           if (!val) return;
-          if (idToName[val]) { next[variable] = idToName[val]; changed = true; }
-          else if (extraFieldToName[val]) { next[variable] = extraFieldToName[val]; changed = true; }
+          if (idToName[val]) {
+            next[variable] = idToName[val];
+            changed = true;
+          } else if (extraFieldToName[val]) {
+            next[variable] = extraFieldToName[val];
+            changed = true;
+          }
         });
         if (changed) uuidResolutionDone.current = true;
         return changed ? next : prev;
@@ -918,7 +985,8 @@ const DatasetTestMode = React.forwardRef(
         const pruned = {};
         let changed = false;
         Object.keys(prev).forEach((k) => {
-          if (varSet.has(k)) pruned[k] = prev[k]; else changed = true;
+          if (varSet.has(k)) pruned[k] = prev[k];
+          else changed = true;
         });
         return changed ? pruned : prev;
       });
@@ -1023,16 +1091,23 @@ const DatasetTestMode = React.forwardRef(
               const col = columns.find((c) => c.name === baseName);
               if (col) {
                 const cell = currentRow[col.id];
-                let cellValue = cell?.cell_value ?? cell ?? "";
+                let cellValue = unwrapCellValue(cell);
                 if (jsonPath) {
                   const resolved = resolveNestedValue(cellValue, jsonPath);
                   if (resolved !== undefined && resolved !== null) {
-                    cellValue = typeof resolved === "object" ? JSON.stringify(resolved) : String(resolved);
+                    cellValue =
+                      typeof resolved === "object"
+                        ? JSON.stringify(resolved)
+                        : String(resolved);
                   }
                 }
                 evalMapping[variable] = cellValue;
                 const dt = col.data_type || "text";
-                inputDataTypes[variable] = ["image", "images"].includes(dt) ? "image" : dt === "audio" ? "audio" : "text";
+                inputDataTypes[variable] = ["image", "images"].includes(dt)
+                  ? "image"
+                  : dt === "audio"
+                    ? "audio"
+                    : "text";
               }
             }
           }
@@ -1045,7 +1120,7 @@ const DatasetTestMode = React.forwardRef(
               )
               .forEach((col) => {
                 const cell = currentRow[col.id];
-                const val = cell?.cell_value ?? cell ?? "";
+                const val = unwrapCellValue(cell);
                 const valStr =
                   typeof val === "object" ? JSON.stringify(val) : String(val);
                 rowContext[col.name] = valStr;
@@ -1086,14 +1161,17 @@ const DatasetTestMode = React.forwardRef(
                   }),
                 },
               }
-            : await axios.post(endpoints.develop.eval.executeCompositeEval(tid), {
-                mapping: evalMapping,
-                model,
-                config: compositeConfig,
-                error_localizer: errorLocalizerEnabled,
-                input_data_types: inputDataTypes,
-                row_context: rowContext,
-              })
+            : await axios.post(
+                endpoints.develop.eval.executeCompositeEval(tid),
+                {
+                  mapping: evalMapping,
+                  model,
+                  config: compositeConfig,
+                  error_localizer: errorLocalizerEnabled,
+                  input_data_types: inputDataTypes,
+                  row_context: rowContext,
+                },
+              )
           : await axios.post(endpoints.develop.eval.evalPlayground, {
               template_id: tid,
               model,
@@ -1109,13 +1187,21 @@ const DatasetTestMode = React.forwardRef(
                 // context toggles are enabled.
                 ...(() => {
                   const flags = {};
-                  if (contextOptions.includes("dataset_row")) flags.full_row = true;
-                  if (contextOptions.includes("full_row")) flags.full_row = true;
-                  if (contextOptions.includes("span_context")) flags.span_context = true;
-                  if (contextOptions.includes("trace_context")) flags.trace_context = true;
-                  if (contextOptions.includes("session_context")) flags.session_context = true;
-                  if (contextOptions.includes("call_context")) flags.call_context = true;
-                  return Object.keys(flags).length > 0 ? { data_injection: flags } : {};
+                  if (contextOptions.includes("dataset_row"))
+                    flags.full_row = true;
+                  if (contextOptions.includes("full_row"))
+                    flags.full_row = true;
+                  if (contextOptions.includes("span_context"))
+                    flags.span_context = true;
+                  if (contextOptions.includes("trace_context"))
+                    flags.trace_context = true;
+                  if (contextOptions.includes("session_context"))
+                    flags.session_context = true;
+                  if (contextOptions.includes("call_context"))
+                    flags.call_context = true;
+                  return Object.keys(flags).length > 0
+                    ? { data_injection: flags }
+                    : {};
                 })(),
               },
               input_data_types: inputDataTypes,
@@ -1195,22 +1281,42 @@ const DatasetTestMode = React.forwardRef(
       } else {
         Object.entries(mapping).forEach(([variable, colName]) => {
           if (!colName) return;
-          if (extraNameToField[colName]) { m[variable] = extraNameToField[colName]; return; }
-          if (nameToId[colName]) { m[variable] = nameToId[colName]; return; }
+          if (extraNameToField[colName]) {
+            m[variable] = extraNameToField[colName];
+            return;
+          }
+          if (nameToId[colName]) {
+            m[variable] = nameToId[colName];
+            return;
+          }
           // freeSolo: "col.typed_path" → "uuid.typed_path"
           const dot = colName.indexOf(".");
           const bracket = colName.indexOf("[");
-          const split = dot > 0 && (bracket < 0 || dot < bracket) ? dot : bracket > 0 ? bracket : -1;
+          const split =
+            dot > 0 && (bracket < 0 || dot < bracket)
+              ? dot
+              : bracket > 0
+                ? bracket
+                : -1;
           if (split > 0) {
             const base = colName.substring(0, split);
             const baseId = nameToId[base];
-            if (baseId) { m[variable] = `${baseId}${colName.substring(split)}`; return; }
+            if (baseId) {
+              m[variable] = `${baseId}${colName.substring(split)}`;
+              return;
+            }
           }
           m[variable] = colName;
         });
       }
       return m;
-    }, [mapping, nameToId, isWorkbenchMode, sourceNameToField, extraNameToField]);
+    }, [
+      mapping,
+      nameToId,
+      isWorkbenchMode,
+      sourceNameToField,
+      extraNameToField,
+    ]);
     const isReady = (!!selectedDatasetId || isWorkbenchMode) && allMapped;
 
     useEffect(() => {
@@ -1600,10 +1706,7 @@ const DatasetTestMode = React.forwardRef(
                 fontWeight={600}
               >
                 Variable Mapping
-                <Box
-                  component="span"
-                  sx={{ color: "error.main", ml: 0.25 }}
-                >
+                <Box component="span" sx={{ color: "error.main", ml: 0.25 }}>
                   *
                 </Box>
               </Typography>

--- a/frontend/src/sections/evals/components/datasetCellValue.js
+++ b/frontend/src/sections/evals/components/datasetCellValue.js
@@ -1,0 +1,6 @@
+export const unwrapCellValue = (cell) => {
+  if (cell && typeof cell === "object" && "cell_id" in cell) {
+    return cell.cell_value ?? "";
+  }
+  return cell ?? "";
+};

--- a/frontend/src/sections/evals/components/datasetCellValue.test.js
+++ b/frontend/src/sections/evals/components/datasetCellValue.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { unwrapCellValue } from "./datasetCellValue";
+
+describe("unwrapCellValue", () => {
+  it("returns blank for a wrapper whose cell_value is null (the empty-cell leak)", () => {
+    const wrapper = {
+      cell_id: "abc",
+      cell_value: null,
+      metadata: {},
+      status: "empty",
+    };
+    expect(unwrapCellValue(wrapper)).toBe("");
+  });
+
+  it("returns blank for a wrapper whose cell_value is undefined", () => {
+    expect(unwrapCellValue({ cell_id: "abc" })).toBe("");
+  });
+
+  it("returns the inner value when the wrapper has a cell_value", () => {
+    expect(unwrapCellValue({ cell_id: "abc", cell_value: "hello" })).toBe(
+      "hello",
+    );
+  });
+
+  it("preserves falsy-but-present inner values (0, false, empty string)", () => {
+    expect(unwrapCellValue({ cell_id: "abc", cell_value: 0 })).toBe(0);
+    expect(unwrapCellValue({ cell_id: "abc", cell_value: false })).toBe(false);
+    expect(unwrapCellValue({ cell_id: "abc", cell_value: "" })).toBe("");
+  });
+
+  it("returns an object cell_value (nested JSON) unchanged", () => {
+    const nested = { foo: "bar" };
+    expect(unwrapCellValue({ cell_id: "abc", cell_value: nested })).toBe(
+      nested,
+    );
+  });
+
+  it("passes through legacy non-wrapper values as-is", () => {
+    expect(unwrapCellValue("raw string")).toBe("raw string");
+    expect(unwrapCellValue(42)).toBe(42);
+  });
+
+  it("does not treat a plain object without cell_id as a wrapper", () => {
+    const plain = { cell_value: "x", foo: 1 };
+    expect(unwrapCellValue(plain)).toBe(plain);
+  });
+
+  it("returns blank for null/undefined input", () => {
+    expect(unwrapCellValue(null)).toBe("");
+    expect(unwrapCellValue(undefined)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
Empty dataset cells (`cell_value: null`) were leaking the wrapper object into the eval mapping preview as an `Object (10 keys)` tree instead of rendering blank. Root cause: `cell?.cell_value ?? cell ?? ""` falls through to the whole wrapper when `cell_value` is `null`.

- Add `unwrapCellValue()` helper in `datasetCellValue.js` (treats null `cell_value` as blank; only falls back to `cell` for non-wrapper legacy values).
- Route the 4 cell-reading sites in `DatasetTestMode.jsx` through it.
- Unit tests in `datasetCellValue.test.js` (8 cases) — `vitest run` 8/8.

## Notes
This is the **`fix/nightly-dev-27-05`-targeted** version of the same fix, raised per the move to consolidate branches onto the nightly integration branch. The `dev`-targeted twin (with before/after screenshots + Yash's sign-off) is #488. Re-applied surgically onto nightly's `DatasetTestMode.jsx` so nightly-specific code (CustomTooltip / loading-state on `ColumnTreeSelect`) is untouched.

## Test plan
- [x] `vitest run datasetCellValue.test.js` → 8/8
- [x] No `cell?.cell_value ?? cell` leak patterns remain in `DatasetTestMode.jsx`
- [ ] Empty cell renders blank in Eval Variable Mapping (verified visually on #488)

Closes TH-4979.