### PR TITLE
Sentry overhaul: noise/PII reduction, alerting & last-2-months bug sweep (tested, dev-based)

### DIFF
--- a/frontend/src/auth/context/jwt/auth-provider.jsx
+++ b/frontend/src/auth/context/jwt/auth-provider.jsx
@@ -251,7 +251,7 @@ export function AuthProvider({ children }) {
 
       return response.data; // Return response so calling function can use it
     } catch (error) {
-      logger.error("Registration Error:", error);
+      if ((error?.statusCode >= 400 && error?.statusCode < 500) || error?.name === "NotAllowedError") { logger.info("Registration Error (expected)", error); } else { logger.error("Registration Error:", error); }
       throw error; // Ensure errors are caught by caller
     }
   }, []);
@@ -264,7 +264,7 @@ export function AuthProvider({ children }) {
 
       return response.data; // Return response so calling function can use it
     } catch (error) {
-      logger.error("Registration Error:", error);
+      if ((error?.statusCode >= 400 && error?.statusCode < 500) || error?.name === "NotAllowedError") { logger.info("Registration Error (expected)", error); } else { logger.error("Registration Error:", error); }
       throw error; // Ensure errors are caught by caller
     }
   }, []);

--- a/frontend/src/components/CallLogsDetailDrawer/CallDetailLogs/CallDetailLogGrid.jsx
+++ b/frontend/src/components/CallLogsDetailDrawer/CallDetailLogs/CallDetailLogGrid.jsx
@@ -181,7 +181,7 @@ const CallDetailLogGrid = forwardRef(
               rowCount: lastRow,
             });
           } catch (error) {
-            logger.error("Error fetching call detail logs:", error);
+            logger.warn("Error fetching call detail logs:", error);
             // Show the error overlay
             params.success({
               rowData: [],

--- a/frontend/src/components/traceDetailDrawer/AnnotateDrawer.jsx
+++ b/frontend/src/components/traceDetailDrawer/AnnotateDrawer.jsx
@@ -232,12 +232,12 @@ const AnnotateDrawer = ({
   const updatedSpanId =
     listSpanId ?? (selectedNode ? selectedNode?.id : voiceObserveSpanId);
   const { data: spanAnnotationData, isPending } = useQuery({
-    queryKey: ["span-annotation", updatedSpanId, [user.id], "contains"],
+    queryKey: ["span-annotation", updatedSpanId, [user?.id], "contains"],
     queryFn: () => {
       return axios.get(endpoints.project.getAnnotationsForSpanId(), {
         params: {
           observation_span_id: updatedSpanId,
-          annotators: JSON.stringify([user.id]),
+          annotators: JSON.stringify([user?.id]),
           exclude_annotators: JSON.stringify([]),
         },
       });

--- a/frontend/src/components/websocket/use-socket.jsx
+++ b/frontend/src/components/websocket/use-socket.jsx
@@ -16,6 +16,7 @@ export const WebSocketContext = createContext();
 
 const RECONNECT_INTERVAL = 5000;
 const MAX_RECONNECT_DELAY = 30000; // 30 seconds max delay
+const MAX_RECONNECT_ATTEMPTS = 10; // Give up after this many consecutive failures
 const HEARTBEAT_INTERVAL = 10000;
 
 export const WebSocketProvider = ({ children }) => {
@@ -102,6 +103,18 @@ export const WebSocketProvider = ({ children }) => {
       socketRef.current?.readyState === WebSocket.OPEN ||
       socketRef.current?.readyState === WebSocket.CONNECTING
     ) {
+      return;
+    }
+
+    // Reconnection permanently exhausted — stop retrying. The single actionable
+    // exception is emitted from errorHandler once this cap is reached; here we
+    // just stop the loop so transient drops don't retry forever.
+    if (reconnectAttempts.current >= MAX_RECONNECT_ATTEMPTS) {
+      logger.addBreadcrumb({
+        category: "websocket",
+        level: "warning",
+        message: `WebSocket reconnection exhausted after ${reconnectAttempts.current} attempts`,
+      });
       return;
     }
 
@@ -193,7 +206,20 @@ export const WebSocketProvider = ({ children }) => {
       );
       wsError.name = "WebSocketError";
 
-      logger.error("WebSocket error:", wsError, errorContext);
+      // Transient WS drops (network blips, navigation, token expiry, proxy
+      // idle-timeout) are routine and must NOT create Sentry issues. Record a
+      // breadcrumb for context and only capture an exception once reconnection
+      // is permanently exhausted (the final attempt).
+      if (reconnectAttempts.current >= MAX_RECONNECT_ATTEMPTS) {
+        logger.error("WebSocket error:", wsError, errorContext);
+      } else {
+        logger.addBreadcrumb({
+          category: "websocket",
+          level: "warning",
+          message: wsError.message,
+          data: errorContext,
+        });
+      }
       setError("WebSocket connection error");
       setIsConnected(false);
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -86,6 +86,21 @@ const SENTRY_IGNORE_ERRORS = [
   "Failed to load Stripe.js",
   "Failed to get pricing card details",
   "Failed to update a ServiceWorker",
+  // SW update() rejects with these when the worker is redundant or the
+  // registration is gone (FRONTEND-194 / FRONTEND-1BF). Not actionable.
+  "newestWorker is null",
+  "Cannot update a null/nonexistent service worker registration",
+  // Background request hit a 401 with no refresh token: the refresh helper
+  // throws this and the user is logged out as expected (FRONTEND-1D9 / 1D7).
+  "No refresh token",
+  // Vite dev-server only: when the dep-optimizer re-bundles .vite/deps and
+  // forces a reload, a transformed chunk can transiently inject the same
+  // top-level declaration twice, throwing e.g. "Identifier 'PROJECT_SOURCE'
+  // has already been declared". These are caught by React's dev
+  // invokeguardedcallback with no stacktrace, so the .vite/deps frame filter
+  // in beforeSend below never matches them. A real prod build fails at build
+  // time, so this message never originates from a shipped bundle.
+  "has already been declared",
 ];
 
 Sentry.init({
@@ -131,6 +146,18 @@ Sentry.init({
       ),
     );
     if (fromViteDeps) return null;
+    // Drop errors originating entirely inside the Mixpanel/rrweb session
+    // recorder. These surface as generic "reading 'logs'" TypeErrors thrown
+    // from third-party recorder internals (no app frames) and are not
+    // actionable application bugs.
+    const fromSessionRecorder = event?.exception?.values?.some((value) =>
+      value?.stacktrace?.frames?.some((frame) =>
+        /recording-registry\.js|session-recording\.js|rrweb-compiled\.js/.test(
+          frame?.filename || "",
+        ),
+      ),
+    );
+    if (fromSessionRecorder) return null;
     return event;
   },
 });
@@ -171,9 +198,16 @@ if (CURRENT_ENVIRONMENT !== "local" && "serviceWorker" in navigator) {
         setInterval(() => {
           // Transient CDN/network failures fetching service-worker.js are
           // non-fatal; swallow so they don't surface as unhandled rejections.
-          registration.update().catch((err) => {
-            logger.debug("ServiceWorker update check failed:", err);
-          });
+          // Guard against a missing registration and a synchronous throw:
+          // some browsers (Safari) throw InvalidStateError synchronously from
+          // update() when the worker is redundant, which .catch() can't cover.
+          try {
+            registration?.update().catch((err) => {
+              logger.debug("ServiceWorker update check failed:", err);
+            });
+          } catch (err) {
+            logger.debug("ServiceWorker update check threw:", err);
+          }
         }, 5 * 60 * 1000);
         // When a new SW is found, activate it immediately
         registration.addEventListener("updatefound", () => {
@@ -192,7 +226,10 @@ if (CURRENT_ENVIRONMENT !== "local" && "serviceWorker" in navigator) {
         });
       })
       .catch((error) => {
-        logger.error("ServiceWorker registration failed:", error);
+        // SW registration/install failures (extension-wrapped "Rejected",
+        // transient install errors) are non-actionable. Record a breadcrumb
+        // instead of a Sentry error (FRONTEND-1DQ / FRONTEND-13X).
+        logger.warn("ServiceWorker registration failed:", error);
       });
   });
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -80,6 +80,12 @@ const SENTRY_IGNORE_ERRORS = [
   "TypeError: cancelled",
   "AbortError",
   "Non-Error promise rejection captured",
+  // Transient third-party / backend load failures: surfaced to the user via
+  // snackbars but not actionable as Sentry issues (adblock/HTTP for Stripe.js,
+  // a backend 500 for pricing-card-details, transient CDN fetch on SW update).
+  "Failed to load Stripe.js",
+  "Failed to get pricing card details",
+  "Failed to update a ServiceWorker",
 ];
 
 Sentry.init({
@@ -90,7 +96,15 @@ Sentry.init({
   environment: CURRENT_ENVIRONMENT || "development",
   release: import.meta.env.VITE_APP_VERSION || undefined,
   integrations: [
-    Sentry.browserTracingIntegration(),
+    Sentry.browserTracingIntegration({
+      // Don't instrument third-party marketing/analytics beacons (Google Ads,
+      // GTM, GA, Reddit/Twitter pixels) — their repeated conversion pings get
+      // flagged as N+1 API-call perf issues even though they aren't app fetches.
+      shouldCreateSpanForRequest: (url) =>
+        !/(?:googleadservices|googletagmanager|google-analytics|doubleclick|googlesyndication|redditstatic|reddit\.com|ads-twitter|t\.co|analytics\.twitter)\.com/i.test(
+          url,
+        ),
+    }),
     // Mask text and media in session replays so we never stream customer
     // content (prompts, PII, uploads) to a third party.
     Sentry.replayIntegration({ maskAllText: true, blockAllMedia: true }),
@@ -105,6 +119,20 @@ Sentry.init({
   // Ignore noise injected by browser extensions / third-party scripts.
   denyUrls: [/extensions\//i, /^chrome:\/\//i, /^moz-extension:\/\//i],
   tracePropagationTargets: [HOST_API],
+  // Drop Vite dev-server dep-optimizer artifacts: when Vite re-bundles
+  // .vite/deps it forces a reload, and an in-flight dep chunk can transiently
+  // be null (e.g. "Cannot read properties of null (reading 'useContext')").
+  // These frames only exist under /node_modules/.vite/deps/* in dev, never in a
+  // production build, so genuine production errors stay reported.
+  beforeSend(event) {
+    const fromViteDeps = event?.exception?.values?.some((value) =>
+      value?.stacktrace?.frames?.some((frame) =>
+        frame?.filename?.includes("/.vite/deps/"),
+      ),
+    );
+    if (fromViteDeps) return null;
+    return event;
+  },
 });
 
 // Initialize PostHog (autocapture, session replay, web vitals)
@@ -140,7 +168,13 @@ if (CURRENT_ENVIRONMENT !== "local" && "serviceWorker" in navigator) {
           registration.scope,
         );
         // Check for updates every 5 minutes
-        setInterval(() => registration.update(), 5 * 60 * 1000);
+        setInterval(() => {
+          // Transient CDN/network failures fetching service-worker.js are
+          // non-fatal; swallow so they don't surface as unhandled rejections.
+          registration.update().catch((err) => {
+            logger.debug("ServiceWorker update check failed:", err);
+          });
+        }, 5 * 60 * 1000);
         // When a new SW is found, activate it immediately
         registration.addEventListener("updatefound", () => {
           const newWorker = registration.installing;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -52,19 +52,58 @@ import { initGoogleAds } from "./utils/googleAds";
 import { initReddit } from "./utils/redditAds";
 import { initTwitter } from "./utils/twitterAds";
 
+const IS_PRODUCTION = CURRENT_ENVIRONMENT === "production";
+const DEFAULT_TRACES_SAMPLE_RATE = IS_PRODUCTION ? 0.1 : 1.0;
+const tracesSampleRateEnv = import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE;
+const configuredTracesSampleRate = Number(
+  tracesSampleRateEnv === "" ? undefined : tracesSampleRateEnv,
+);
+const sentryTracesSampleRate = Number.isFinite(configuredTracesSampleRate)
+  ? configuredTracesSampleRate
+  : DEFAULT_TRACES_SAMPLE_RATE;
+
+// Browser/extension/network errors that are never actionable. Dropping them
+// keeps the issue stream focused on real application bugs.
+const SENTRY_IGNORE_ERRORS = [
+  // Benign ResizeObserver loop notifications fired by many UI libraries
+  "ResizeObserver loop limit exceeded",
+  "ResizeObserver loop completed with undelivered notifications",
+  // Stale chunk after a deploy - the app reloads to recover
+  "Loading chunk",
+  "Loading CSS chunk",
+  "Failed to fetch dynamically imported module",
+  "Importing a module script failed",
+  // User connectivity / aborted navigations, not app faults
+  "NetworkError when attempting to fetch resource",
+  "Network request failed",
+  "Failed to fetch",
+  "TypeError: cancelled",
+  "AbortError",
+  "Non-Error promise rejection captured",
+];
+
 Sentry.init({
   dsn: SENTRY_DSN,
-  sendDefaultPii: true,
-  environment:
-    CURRENT_ENVIRONMENT === "production" ? "production" : "development",
+  // Do not attach IP/user PII automatically; user context is set explicitly
+  // (and scrubbed) by the logger where it is actually needed.
+  sendDefaultPii: false,
+  environment: CURRENT_ENVIRONMENT || "development",
+  release: import.meta.env.VITE_APP_VERSION || undefined,
   integrations: [
     Sentry.browserTracingIntegration(),
-    Sentry.replayIntegration({ maskAllText: false, blockAllMedia: false }),
+    // Mask text and media in session replays so we never stream customer
+    // content (prompts, PII, uploads) to a third party.
+    Sentry.replayIntegration({ maskAllText: true, blockAllMedia: true }),
   ],
-  tracesSampleRate: 1.0,
+  // 100% tracing in production is expensive and noisy; sample at 10% there and
+  // keep full fidelity in lower environments. Override via VITE_SENTRY_TRACES_SAMPLE_RATE.
+  tracesSampleRate: sentryTracesSampleRate,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   enabled: CURRENT_ENVIRONMENT !== "local",
+  ignoreErrors: SENTRY_IGNORE_ERRORS,
+  // Ignore noise injected by browser extensions / third-party scripts.
+  denyUrls: [/extensions\//i, /^chrome:\/\//i, /^moz-extension:\/\//i],
   tracePropagationTargets: [HOST_API],
 });
 

--- a/frontend/src/routes/hooks/use-url-state.js
+++ b/frontend/src/routes/hooks/use-url-state.js
@@ -30,6 +30,19 @@ export function useUrlState(key, defaultValue) {
   // Flag to track if the URL change was triggered internally
   const isInternalUpdate = useRef(false);
 
+  // Keep the latest setSearchParams / defaultValue in refs so setValue and
+  // removeValue below can stay referentially stable across renders.
+  // react-router recreates setSearchParams whenever the URL (searchParams)
+  // changes; if setValue/removeValue depended on it directly, their identity
+  // would churn on every URL write. Consumers that list these setters in an
+  // effect dependency array (e.g. TraceDetailDrawerChild's setAnalysisExists
+  // effect) would then re-run on every write, calling the setter again and
+  // looping until React throws "Maximum update depth exceeded".
+  const setSearchParamsRef = useRef(setSearchParams);
+  setSearchParamsRef.current = setSearchParams;
+  const defaultValueRef = useRef(defaultValue);
+  defaultValueRef.current = defaultValue;
+
   // Update both state and URL.
   // Reads from `window.location.search` rather than the functional
   // setSearchParams form because react-router's prev arg in the functional
@@ -50,9 +63,9 @@ export function useUrlState(key, defaultValue) {
 
       const newSearchParams = new URLSearchParams(window.location.search);
       newSearchParams.set(key, stringifyUrlValue(nextValue));
-      setSearchParams(newSearchParams, { replace: options.replace });
+      setSearchParamsRef.current(newSearchParams, { replace: options.replace });
     },
-    [key, setSearchParams],
+    [key],
   );
 
   const removeValue = useCallback(
@@ -61,12 +74,12 @@ export function useUrlState(key, defaultValue) {
 
       const newSearchParams = new URLSearchParams(window.location.search);
       newSearchParams.delete(key);
-      setSearchParams(newSearchParams, { replace: options.replace });
+      setSearchParamsRef.current(newSearchParams, { replace: options.replace });
 
-      valueRef.current = defaultValue;
-      setStateValue(defaultValue);
+      valueRef.current = defaultValueRef.current;
+      setStateValue(defaultValueRef.current);
     },
-    [key, setSearchParams, defaultValue],
+    [key],
   );
 
   // Handle external URL changes (like browser back/forward)

--- a/frontend/src/sections/auth/jwt/jwt-login-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-login-view.jsx
@@ -330,7 +330,7 @@ export default function JwtLoginView() {
           );
         }
       }
-      logger.error("Login attempt failed", error);
+      if ((error?.statusCode >= 400 && error?.statusCode < 500) || error?.name === "NotAllowedError") { logger.info("Login attempt failed (expected)", error); } else { logger.error("Login attempt failed", error); }
     }
   });
 
@@ -377,7 +377,7 @@ export default function JwtLoginView() {
           { variant: "error" },
         );
       }
-      logger.error("Passkey login failed", error);
+      if ((error?.statusCode >= 400 && error?.statusCode < 500) || error?.name === "NotAllowedError") { logger.info("Passkey login failed (expected)", error); } else { logger.error("Passkey login failed", error); }
     } finally {
       setPasskeyLoading(false);
     }
@@ -421,7 +421,7 @@ export default function JwtLoginView() {
         });
       }
     } catch (error) {
-      logger.error("Error during social login:", error);
+      if ((error?.statusCode >= 400 && error?.statusCode < 500) || error?.name === "NotAllowedError") { logger.info("Error during social login (expected)", error); } else { logger.error("Error during social login:", error); }
       if (error.response?.status === 302 && error.response?.headers?.reason) {
         enqueueSnackbar(error.response.headers.reason, { variant: "error" });
       } else {

--- a/frontend/src/sections/auth/jwt/jwt-register-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-register-view.jsx
@@ -180,7 +180,7 @@ export default function JwtRegisterView() {
       setLoading(false);
     } catch (error) {
       setLoading(false);
-      logger.error("Registration Error:", error);
+      if ((error?.statusCode >= 400 && error?.statusCode < 500) || error?.name === "NotAllowedError") { logger.info("Registration Error (expected)", error); } else { logger.error("Registration Error:", error); }
       setErrorMsg(
         typeof error === "string"
           ? error
@@ -231,7 +231,7 @@ export default function JwtRegisterView() {
             : error?.detail || error?.result?.error,
         );
       }
-      logger.error("Login failed", error);
+      if ((error?.statusCode >= 400 && error?.statusCode < 500) || error?.name === "NotAllowedError") { logger.info("Login failed (expected)", error); } else { logger.error("Login failed", error); }
     } finally {
       setLoading(false);
     }
@@ -268,7 +268,7 @@ export default function JwtRegisterView() {
         });
       }
     } catch (error) {
-      logger.error("Error during social login:", error);
+      if ((error?.statusCode >= 400 && error?.statusCode < 500) || error?.name === "NotAllowedError") { logger.info("Error during social login (expected)", error); } else { logger.error("Error during social login:", error); }
       if (error.response?.status === 302 && error.response?.headers?.reason) {
         enqueueSnackbar(error.response.headers.reason, { variant: "error" });
       } else {

--- a/frontend/src/sections/common/DevelopCellRenderer/AnnotationCellRenderer/renderAnnotationValue.jsx
+++ b/frontend/src/sections/common/DevelopCellRenderer/AnnotationCellRenderer/renderAnnotationValue.jsx
@@ -13,7 +13,8 @@ export const parseAnnotationValue = (value) => {
 };
 
 const renderChips = (items, theme) =>
-  items.map((item) => (
+  Array.isArray(items)
+    ? items.map((item) => (
     <Chip
       key={item}
       label={item}
@@ -25,7 +26,8 @@ const renderChips = (items, theme) =>
         fontWeight: 400,
       }}
     />
-  ));
+      ))
+    : null;
 
 export const renderAnnotationValue = (value, theme) => {
   const parsed = parseAnnotationValue(value);

--- a/frontend/src/sections/common/EvalsTasks/EvalsGrid.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EvalsGrid.jsx
@@ -178,7 +178,7 @@ const EvalsGrid = forwardRef(
             gridRef?.current?.api?.applyServerSideTransaction(transaction);
           }
         } catch (e) {
-          logger.error("Failed to refresh eval tasks rows", e);
+          logger.warn("Failed to refresh eval tasks rows", e);
         }
       }
     };

--- a/frontend/src/sections/common/EvaluationDrawer/common.js
+++ b/frontend/src/sections/common/EvaluationDrawer/common.js
@@ -134,9 +134,19 @@ export function buildFormSchema(functionEvalsList) {
       }),
     }),
   ];
+  const seenEvalTypeIds = new Set([
+    "",
+    "CustomPromptEvaluator",
+    "DeterministicEvaluator",
+  ]);
   for (let i = 0; i < functionEvalsList.length; i++) {
     const element = functionEvalsList[i];
-    const config = element.config.config;
+    const evalTypeId = element?.config?.evalTypeId;
+    const config = element?.config?.config;
+    if (!evalTypeId || seenEvalTypeIds.has(evalTypeId) || !config) {
+      continue;
+    }
+    seenEvalTypeIds.add(evalTypeId);
     const configKeys = Object.keys(config);
     const configMapping = {};
     for (let j = 0; j < configKeys.length; j++) {
@@ -144,7 +154,7 @@ export function buildFormSchema(functionEvalsList) {
       configMapping[key] = getAppropriateField(config[key]["type"]);
     }
     const validationObject = z.object({
-      evalTypeId: z.literal(element.config.evalTypeId),
+      evalTypeId: z.literal(evalTypeId),
       config: z.object({
         config: z.object({ ...configMapping }),
       }),

--- a/frontend/src/sections/dashboards/WidgetChart.jsx
+++ b/frontend/src/sections/dashboards/WidgetChart.jsx
@@ -843,7 +843,8 @@ export default function WidgetChart({ widget, globalDateRange }) {
 
           if (isStacked && dpi >= 0) {
             const w = chartContext.w;
-            const gridRect = w.globals.gridRect;
+            const gridRect = w?.globals?.gridRect;
+            if (!gridRect) return;
             const chartRect = el.getBoundingClientRect();
             const mouseY = event.clientY - chartRect.top - gridRect.y;
             const plotH = gridRect.height;

--- a/frontend/src/sections/develop-detail/DataTab/AddRowData.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/AddRowData.jsx
@@ -14,6 +14,7 @@ import { useForm } from "react-hook-form";
 import { useQuery } from "@tanstack/react-query";
 import { enqueueSnackbar } from "notistack";
 import axios, { endpoints } from "src/utils/axios";
+import { copyToClipboard as copyTextToClipboard } from "src/utils/utils";
 import PropTypes from "prop-types";
 import Iconify from "src/components/iconify";
 
@@ -57,14 +58,13 @@ const AddRowData = ({ dataset }) => {
   const [currentTab, setCurrentTab] = useState("python");
 
   const copyToClipboard = (text, type) => {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
+    copyTextToClipboard(text).then((ok) => {
+      if (ok) {
         enqueueSnackbar(`${type} copied to clipboard!`, { variant: "success" });
-      })
-      .catch(() => {
+      } else {
         enqueueSnackbar(`Failed to copy ${type}`, { variant: "error" });
-      });
+      }
+    });
   };
 
   const { data, isLoading } = useQuery({

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -874,6 +874,10 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
   }, [tableData]);
 
   const refreshRowsManual = useCallback(async () => {
+    // The 5s polling interval can fire after the grid has been unmounted
+    // (navigation / tab switch), leaving gridApiRef.current null. Bail out
+    // instead of dereferencing .api -> 'Cannot read properties of null'.
+    if (!gridApiRef.current?.api) return;
     const cacheBlockState = gridApiRef?.current?.api?.getCacheBlockState();
 
     // Get only loaded/active blocks

--- a/frontend/src/sections/evals/EvalDetails/EvalsLog/LogsTabGrid.jsx
+++ b/frontend/src/sections/evals/EvalDetails/EvalsLog/LogsTabGrid.jsx
@@ -345,9 +345,12 @@ const LogsTabGrid = ({
         onSelectionChanged(null);
         setSelectedAll(false);
 
-        // Calculate page size dynamically from AG Grid request
-        const pageSize = request.endRow - request.startRow;
-        const pageNumber = Math.floor((request?.startRow ?? 0) / pageSize);
+        // Calculate page size dynamically from AG Grid request.
+        // onGridReady calls getRows without a `request`, so default safely.
+        const startRow = request?.startRow ?? 0;
+        const endRow = request?.endRow ?? startRow + 10;
+        const pageSize = endRow - startRow;
+        const pageNumber = Math.floor(startRow / pageSize);
         const source = isFeedback
           ? "feedback"
           : isEvalPlayGround

--- a/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDataView.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ExperimentDataView.jsx
@@ -500,7 +500,7 @@ function ExperimentDataView() {
         }
         // Process column data
       } catch (error) {
-        logger.error(`Error refreshing page ${p}:`, error);
+        logger.warn(`Error refreshing page ${p}:`, error);
       }
     }
   }, [experimentId, diffMode, refetchExperimentColumns]);

--- a/frontend/src/sections/test-detail/TestRunDetailGrid.jsx
+++ b/frontend/src/sections/test-detail/TestRunDetailGrid.jsx
@@ -54,7 +54,7 @@ const SelectionHeader = (props) => {
   const onCheckboxClick = (e) => {
     e.stopPropagation(); // Stop event from reaching the header
     const api = props.api;
-    const { selectAll } = api.getServerSideSelectionState();
+    const { selectAll } = api.getServerSideSelectionState() || { selectAll: false };
     if (selectAll) {
       api.setServerSideSelectionState({ selectAll: false, toggledNodes: [] });
     } else {
@@ -190,7 +190,7 @@ const TestRunDetailGrid = () => {
           try {
             const { data } = await queryClient.fetchQuery(query);
             const status = data?.status;
-            if (TestRunLoadingStatus.includes(status.toLowerCase())) {
+            if (TestRunLoadingStatus.includes(status?.toLowerCase())) {
               isRefreshingRef.current = true;
             }
             const totalRows = data?.count ?? 0;
@@ -248,7 +248,7 @@ const TestRunDetailGrid = () => {
               queryClient.prefetchQuery(nextQuery);
             }
           } catch (error) {
-            logger.error("Failed to get test run detail", { error });
+            logger.warn("Failed to get test run detail", { error });
             params.fail();
             params.api.showNoRowsOverlay();
           }
@@ -355,7 +355,7 @@ const TestRunDetailGrid = () => {
       }
     }
     setStatus(status);
-    if (TestRunLoadingStatus.includes(status.toLowerCase())) {
+    if (TestRunLoadingStatus.includes(status?.toLowerCase())) {
       isRefreshingRef.current = true;
     } else {
       isRefreshingRef.current = false;
@@ -367,7 +367,7 @@ const TestRunDetailGrid = () => {
 
   const onRowSelectionChanged = useCallback(({ api, context }) => {
     const totalRowCount = context?.totalRowCount;
-    const { selectAll, toggledNodes } = api.getServerSideSelectionState();
+    const { selectAll, toggledNodes } = api.getServerSideSelectionState() || { selectAll: false, toggledNodes: [] };
 
     if (selectAll && totalRowCount - toggledNodes.length === 0) {
       api.deselectAll();

--- a/frontend/src/utils/__tests__/copyToClipboard.test.js
+++ b/frontend/src/utils/__tests__/copyToClipboard.test.js
@@ -4,20 +4,23 @@ import { logger } from "../logger";
 
 describe("copyToClipboard", () => {
   let writeTextMock;
-  let loggerErrorSpy;
+  let loggerWarnSpy;
+  let originalClipboard;
 
   beforeEach(() => {
     writeTextMock = vi.fn().mockResolvedValue(undefined);
+    originalClipboard = navigator.clipboard;
     Object.assign(navigator, {
       clipboard: { writeText: writeTextMock },
     });
-    // Silence expected error logging from the "does not throw" path so it
-    // doesn't pollute test output.
-    loggerErrorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    // Copy failures are now logged at WARNING (breadcrumb), not ERROR; silence
+    // it so the "does not throw" path doesn't pollute test output.
+    loggerWarnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
-    loggerErrorSpy.mockRestore();
+    loggerWarnSpy.mockRestore();
+    Object.assign(navigator, { clipboard: originalClipboard });
   });
 
   it("copies a string as-is", async () => {
@@ -52,8 +55,28 @@ describe("copyToClipboard", () => {
     expect(writeTextMock).toHaveBeenCalledWith(42);
   });
 
-  it("does not throw on clipboard error", async () => {
+  it("returns true on a successful copy", async () => {
+    await expect(copyToClipboard("text")).resolves.toBe(true);
+  });
+
+  it("does not throw and returns false on clipboard error", async () => {
     writeTextMock.mockRejectedValue(new Error("denied"));
-    await expect(copyToClipboard("text")).resolves.toBeUndefined();
+    await expect(copyToClipboard("text")).resolves.toBe(false);
+  });
+
+  // Regression for the FRONTEND null-guard fix: navigator.clipboard is
+  // undefined on insecure (http) origins — must NOT throw
+  // "Cannot read properties of undefined (reading 'writeText')".
+  it("falls back to execCommand when navigator.clipboard is undefined", async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    // jsdom doesn't implement execCommand — define it so we can assert the fallback.
+    const execMock = vi.fn(() => true);
+    const hadExec = "execCommand" in document;
+    document.execCommand = execMock;
+    const result = await copyToClipboard("text"); // must not throw
+    expect(writeTextMock).not.toHaveBeenCalled();
+    expect(execMock).toHaveBeenCalledWith("copy");
+    expect(result).toBe(true);
+    if (!hadExec) delete document.execCommand;
   });
 });

--- a/frontend/src/utils/__tests__/lazyWithRetry.test.js
+++ b/frontend/src/utils/__tests__/lazyWithRetry.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { retryImport, isChunkError } from "../lazyWithRetry.js";
+
+const RELOAD_KEY = "chunk_reload_attempted";
+
+describe("retryImport — resolved-to-undefined / missing-default recovery", () => {
+  let reloadMock;
+  let store;
+
+  beforeEach(() => {
+    store = {};
+    vi.stubGlobal("sessionStorage", {
+      getItem: (k) => (k in store ? store[k] : null),
+      setItem: (k, v) => {
+        store[k] = String(v);
+      },
+      removeItem: (k) => {
+        delete store[k];
+      },
+    });
+    reloadMock = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { reload: reloadMock },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the module and clears the reload flag on a valid import", async () => {
+    store[RELOAD_KEY] = "1";
+    const mod = { default: () => null };
+    await expect(retryImport(() => Promise.resolve(mod), 3)).resolves.toBe(mod);
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(store[RELOAD_KEY]).toBeUndefined(); // flag cleared on success
+  });
+
+  it("does a one-time reload when the import resolves without a default export", async () => {
+    const importFn = vi.fn().mockResolvedValue({ notDefault: 1 });
+    // Recovery returns a never-resolving promise (keeps Suspense up while
+    // reloading), so don't await it — just flush microtasks and assert.
+    retryImport(importFn, 3);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(importFn).toHaveBeenCalledTimes(1);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(store[RELOAD_KEY]).toBe("1");
+  });
+
+  it("does a one-time reload when the import resolves to undefined", async () => {
+    retryImport(() => Promise.resolve(undefined), 3);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a recognized chunk error (no second reload) if reload already attempted", async () => {
+    store[RELOAD_KEY] = "1";
+    await expect(
+      retryImport(() => Promise.resolve({ noDefault: true }), 3),
+    ).rejects.toThrow(/Failed to fetch dynamically imported module/);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it("retries a thrown chunk error, then succeeds", async () => {
+    const mod = { default: () => null };
+    let calls = 0;
+    const importFn = vi.fn(() => {
+      calls += 1;
+      if (calls === 1)
+        return Promise.reject(new Error("Failed to fetch dynamically imported module"));
+      return Promise.resolve(mod);
+    });
+    // retriesLeft high enough; backoff uses setTimeout — use fake timers.
+    vi.useFakeTimers();
+    const p = retryImport(importFn, 3);
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toBe(mod);
+    expect(importFn).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+});
+
+describe("isChunkError", () => {
+  it("matches known chunk / dynamic-import failures", () => {
+    expect(
+      isChunkError(new Error("Failed to fetch dynamically imported module")),
+    ).toBe(true);
+    expect(isChunkError(new Error("Loading chunk 5 failed"))).toBe(true);
+    expect(isChunkError({ name: "ChunkLoadError" })).toBe(true);
+  });
+  it("does not match unrelated errors or nullish input", () => {
+    expect(isChunkError(new Error("Cannot read properties of null"))).toBe(false);
+    expect(isChunkError(null)).toBe(false);
+    expect(isChunkError(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/utils/lazyWithRetry.js
+++ b/frontend/src/utils/lazyWithRetry.js
@@ -19,9 +19,38 @@ export default function lazyWithRetry(importFn, maxRetries = 3) {
   return lazy(() => retryImport(importFn, maxRetries));
 }
 
-async function retryImport(importFn, retriesLeft) {
+// Exported for unit testing the post-deploy recovery logic directly.
+export async function retryImport(importFn, retriesLeft) {
   try {
     const module = await importFn();
+
+    // A dynamic import can RESOLVE (not reject) to a module that is undefined
+    // or missing its `default` export. This happens with stale module graphs
+    // after a deploy: the browser's module map / SPA index.html fallback can
+    // hand back a default-less namespace instead of throwing. React.lazy then
+    // reads `.default` on it and throws "Cannot read properties of undefined
+    // (reading 'default')" deep in the reconciler — outside this try/catch and
+    // outside isChunkError(). Treat it like a chunk error and recover.
+    //
+    // Re-calling importFn() would just return the same cached bad module, so
+    // skip the retry loop and go straight to a one-time silent reload (a fresh
+    // document gets a fresh module map and a fresh index.html).
+    if (!module || typeof module.default === "undefined") {
+      if (!sessionStorage.getItem(RELOAD_KEY)) {
+        sessionStorage.setItem(RELOAD_KEY, "1");
+        window.location.reload();
+        // Never-resolving promise so React keeps the Suspense fallback while
+        // the page reloads, instead of surfacing the bad module to lazy().
+        return new Promise(() => {});
+      }
+      // Reload already attempted this session — surface a recognized chunk
+      // error (matched by isChunkError/ignoreErrors) rather than letting React
+      // throw the opaque "reading 'default'" TypeError, and avoid a reload loop.
+      throw new Error(
+        "Failed to fetch dynamically imported module (resolved without a default export)",
+      );
+    }
+
     // Success — clear any previous reload flag
     sessionStorage.removeItem(RELOAD_KEY);
     return module;

--- a/frontend/src/utils/logger.js
+++ b/frontend/src/utils/logger.js
@@ -109,15 +109,15 @@ class Logger {
 
     console.warn("⚠️ WARN:", message, data || "");
 
-    // Capture warning in Sentry
+    // Warnings are recorded as breadcrumbs (context for a later error), NOT as
+    // standalone Sentry issues. Capturing every warning as an event floods the
+    // issue stream with non-actionable noise.
     if (this.shouldSendToSentry) {
-      Sentry.captureMessage(message, {
+      Sentry.addBreadcrumb({
+        category: "warning",
         level: "warning",
-        tags: { level: "warning" },
-        extra: {
-          data: data || undefined,
-          ...context,
-        },
+        message,
+        data: { data: data || undefined, ...context },
       });
     }
   }

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -246,15 +246,41 @@ export const getScorePercentage = (s, decimalPlaces = 0) => {
 };
 
 export async function copyToClipboard(text) {
+  // Serialize objects/arrays to JSON to avoid "[object Object]" from .toString();
+  // pass primitives through unchanged.
+  const value =
+    typeof text === "object" && text !== null
+      ? JSON.stringify(text, null, 2)
+      : text;
   try {
-    // Serialize objects/arrays to JSON to avoid "[object Object]" from .toString()
-    const value =
-      typeof text === "object" && text !== null
-        ? JSON.stringify(text, null, 2)
-        : text;
-    await navigator.clipboard.writeText(value);
+    // navigator.clipboard is undefined on insecure (http) origins; guard with
+    // optional chaining before touching .writeText so it never throws
+    // "Cannot read properties of undefined (reading 'writeText')".
+    if (navigator?.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+    // Fallback for contexts without the async Clipboard API.
+    const textarea = document.createElement("textarea");
+    textarea.value = value == null ? "" : String(value);
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    let ok = false;
+    try {
+      ok = document.execCommand("copy");
+    } finally {
+      document.body.removeChild(textarea);
+    }
+    return ok;
   } catch (err) {
-    logger.error("Failed to copy text: ", err);
+    // Expected on non-secure contexts / when clipboard is blocked.
+    // Log as a warning (breadcrumb) rather than an error (Sentry issue).
+    logger.warn("Failed to copy text: ", err);
+    return false;
   }
 }
 

--- a/futureagi/accounts/models/user.py
+++ b/futureagi/accounts/models/user.py
@@ -113,13 +113,24 @@ class User(AbstractBaseUser, PermissionsMixin):
     # --- Multi-org helpers ---
 
     def get_membership(self, organization):
-        """Get the active OrganizationMembership for a specific org, or None."""
+        """Get the active OrganizationMembership for a specific org, or None.
+
+        Memoized per User instance (which lives for a single request) so the
+        many redundant (user, org) membership lookups during one auth pass
+        collapse to a single query (CORE-BACKEND-1074 / CORE-BACKEND-106X).
+        """
+        org_id = getattr(organization, "id", organization)
+        cache = self.__dict__.setdefault("_membership_cache", {})
+        if org_id in cache:
+            return cache[org_id]
         try:
-            return OrganizationMembership.no_workspace_objects.get(
+            membership = OrganizationMembership.no_workspace_objects.get(
                 user=self, organization=organization, is_active=True
             )
         except OrganizationMembership.DoesNotExist:
-            return None
+            membership = None
+        cache[org_id] = membership
+        return membership
 
     def get_membership_level(self, organization):
         """Get integer RBAC level for a specific org."""
@@ -145,11 +156,11 @@ class User(AbstractBaseUser, PermissionsMixin):
     def can_access_organization(self, organization):
         """Check if user has access to a specific organization.
 
-        Uses OrganizationMembership as source of truth.
+        Uses OrganizationMembership as source of truth. Routed through the
+        memoized get_membership so repeated access checks in one request
+        reuse a single query (CORE-BACKEND-1074 / CORE-BACKEND-106X).
         """
-        return OrganizationMembership.no_workspace_objects.filter(
-            user=self, organization=organization, is_active=True
-        ).exists()
+        return self.get_membership(organization) is not None
 
     def get_organization_role(self, organization=None):
         """Get user's role in the given organization.

--- a/futureagi/accounts/serializers/workspace.py
+++ b/futureagi/accounts/serializers/workspace.py
@@ -30,15 +30,19 @@ class WorkspaceListSerializer(serializers.ModelSerializer):
 
     def get_admin_names(self, obj):
         """Get admin names for the workspace"""
-        admin_memberships = WorkspaceMembership.no_workspace_objects.filter(
-            workspace=obj,
-            role__in=[
-                OrganizationRoles.WORKSPACE_ADMIN,
-                OrganizationRoles.OWNER,
-                OrganizationRoles.ADMIN,
-            ],
-            is_active=True,
-        ).select_related("user")
+        # Use the prefetched cache when the view supplies it (avoids the
+        # per-workspace N+1); fall back to a direct query otherwise.
+        admin_memberships = getattr(obj, "admin_memberships_cache", None)
+        if admin_memberships is None:
+            admin_memberships = WorkspaceMembership.no_workspace_objects.filter(
+                workspace=obj,
+                role__in=[
+                    OrganizationRoles.WORKSPACE_ADMIN,
+                    OrganizationRoles.OWNER,
+                    OrganizationRoles.ADMIN,
+                ],
+                is_active=True,
+            ).select_related("user")
 
         return [
             {"name": membership.user.name, "id": str(membership.user.id)}

--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -14,6 +14,7 @@ from django.db.models import (
     F,
     IntegerField,
     OuterRef,
+    Prefetch,
     Q,
     Subquery,
     Value,
@@ -219,6 +220,25 @@ class WorkspaceListAPIView(APIView):
             else:
                 # Default sorting
                 workspaces = workspaces.order_by("-created_at")
+
+            # Prefetch admin memberships (+ their users) so the serializer's
+            # get_admin_names does not issue one query per workspace (N+1).
+            # Use no_workspace_objects to match the serializer's manager
+            # semantics (deleted=False only, no workspace-context filter).
+            workspaces = workspaces.prefetch_related(
+                Prefetch(
+                    "memberships",
+                    queryset=WorkspaceMembership.no_workspace_objects.filter(
+                        role__in=[
+                            OrganizationRoles.WORKSPACE_ADMIN,
+                            OrganizationRoles.OWNER,
+                            OrganizationRoles.ADMIN,
+                        ],
+                        is_active=True,
+                    ).select_related("user"),
+                    to_attr="admin_memberships_cache",
+                )
+            )
 
             # Use default pagination
             paginator = self.pagination_class()

--- a/futureagi/agentic_eval/core/utils/model_config.py
+++ b/futureagi/agentic_eval/core/utils/model_config.py
@@ -129,7 +129,10 @@ class ModelConfigs:
 
     VERTEX_GEMINI_3_5_FLASH: Final[ModelConfig] = ModelConfig(
         provider=LiteLlmProvider.VERTEX_AI.value,
-        model_name="vertex_ai/gemini-3.5-flash",
+        # `gemini-3.5-flash` is not a real Vertex publisher model and 404s
+        # ("Publisher Model gemini-3.5-flash was not found"). Use the real
+        # Gemini-3 flash preview model.
+        model_name="vertex_ai/gemini-3-flash-preview",
         temperature=0.2,
         max_tokens=8100,
     )

--- a/futureagi/agentic_eval/core_evals/run_prompt/error_handler.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/error_handler.py
@@ -288,8 +288,16 @@ def log_verbose_error(
         if field in context:
             log_fields[field] = context[field]
 
-    # Log with all structured fields
-    logger.error(f"LiteLLM API error: {parsed_error['message']}", **log_fields)
+    # Log with all structured fields. "No audio input found for STT" is an
+    # expected user misconfiguration (text-only input to an audio eval), not an
+    # API failure; downgrade only that case to warning so genuine API errors
+    # keep creating Sentry issues.
+    if "No audio input found in messages for STT." in str(
+        parsed_error.get("raw_error", "")
+    ):
+        logger.warning(f"LiteLLM API error: {parsed_error['message']}", **log_fields)
+    else:
+        logger.error(f"LiteLLM API error: {parsed_error['message']}", **log_fields)
 
 
 def handle_api_error(

--- a/futureagi/agentic_eval/core_evals/run_prompt/litellm_response.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/litellm_response.py
@@ -707,7 +707,10 @@ class RunPrompt:
                         logger.info("[STT] Found audio URL in 'audio_url' part.")
                         return audio_url_payload["url"]
 
-        logger.error(
+        # Expected user misconfiguration: an STT/audio eval received text-only
+        # input. Raw emitter before the ValueError the caller catches and
+        # persists as a failed result. Warning.
+        logger.warning(
             f"[STT] No audio input found in messages. Sample: {str(self.messages)[:500]}"
         )
         raise ValueError("No audio input found in messages for STT.")
@@ -3183,7 +3186,20 @@ class RunPrompt:
             return handler_response.to_value_info()
 
         except Exception as e:
-            logger.error(f"[NEW] An error occurred: {str(e)}")
+            # Expected, handled validation failures (text-only input to an STT
+            # eval, or empty messages) are user misconfiguration, not bugs;
+            # the caller persists a failed result. Downgrade only those to
+            # warning so real errors keep creating Sentry issues.
+            if any(
+                s in str(e)
+                for s in (
+                    "No audio input found in messages for STT.",
+                    "Messages are required",
+                )
+            ):
+                logger.warning(f"[NEW] An error occurred: {str(e)}")
+            else:
+                logger.error(f"[NEW] An error occurred: {str(e)}")
             raise Exception(str(e))
 
     async def _litellm_response_async_new(
@@ -3268,7 +3284,20 @@ class RunPrompt:
             return handler_response.to_value_info()
 
         except Exception as e:
-            logger.error(f"[NEW] An error occurred: {str(e)}")
+            # Expected, handled validation failures (text-only input to an STT
+            # eval, or empty messages) are user misconfiguration, not bugs;
+            # the caller persists a failed result. Downgrade only those to
+            # warning so real errors keep creating Sentry issues.
+            if any(
+                s in str(e)
+                for s in (
+                    "No audio input found in messages for STT.",
+                    "Messages are required",
+                )
+            ):
+                logger.warning(f"[NEW] An error occurred: {str(e)}")
+            else:
+                logger.error(f"[NEW] An error occurred: {str(e)}")
             raise Exception(str(e))
 
     # =========================================================================

--- a/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/handlers/stt_handler.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/handlers/stt_handler.py
@@ -135,7 +135,13 @@ class StandardSTTHandler(BaseModelHandler):
             )
 
         except Exception as e:
-            self.logger.exception(f"Standard STT execution failed: {str(e)}")
+            # Expected user misconfiguration (text-only input to an STT eval)
+            # is handled gracefully as a failed HandlerResponse; downgrade only
+            # that case to warning so real STT failures stay as errors.
+            if "No audio input found in messages for STT." in str(e):
+                self.logger.warning(f"Standard STT execution failed: {str(e)}")
+            else:
+                self.logger.exception(f"Standard STT execution failed: {str(e)}")
             return self._build_handler_response(
                 response=None,
                 start_time=start_time,
@@ -177,7 +183,13 @@ class StandardSTTHandler(BaseModelHandler):
             )
 
         except Exception as e:
-            self.logger.exception(f"Standard STT async execution failed: {str(e)}")
+            # Expected user misconfiguration (text-only input to an STT eval)
+            # is handled gracefully as a failed HandlerResponse; downgrade only
+            # that case to warning so real STT failures stay as errors.
+            if "No audio input found in messages for STT." in str(e):
+                self.logger.warning(f"Standard STT async execution failed: {str(e)}")
+            else:
+                self.logger.exception(f"Standard STT async execution failed: {str(e)}")
             return self._build_handler_response(
                 response=None,
                 start_time=start_time,
@@ -265,7 +277,13 @@ class CustomSTTHandler(BaseModelHandler):
             )
 
         except Exception as e:
-            self.logger.exception(f"Custom STT execution failed: {str(e)}")
+            # Expected user misconfiguration (text-only input to an STT eval)
+            # is handled gracefully as a failed HandlerResponse; downgrade only
+            # that case to warning so real STT failures stay as errors.
+            if "No audio input found in messages for STT." in str(e):
+                self.logger.warning(f"Custom STT execution failed: {str(e)}")
+            else:
+                self.logger.exception(f"Custom STT execution failed: {str(e)}")
             return self._build_handler_response(
                 response=None,
                 start_time=start_time,
@@ -318,7 +336,13 @@ class CustomSTTHandler(BaseModelHandler):
             )
 
         except Exception as e:
-            self.logger.exception(f"Custom STT async execution failed: {str(e)}")
+            # Expected user misconfiguration (text-only input to an STT eval)
+            # is handled gracefully as a failed HandlerResponse; downgrade only
+            # that case to warning so real STT failures stay as errors.
+            if "No audio input found in messages for STT." in str(e):
+                self.logger.warning(f"Custom STT async execution failed: {str(e)}")
+            else:
+                self.logger.exception(f"Custom STT async execution failed: {str(e)}")
             return self._build_handler_response(
                 response=None,
                 start_time=start_time,

--- a/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/handlers/tts_handler.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/handlers/tts_handler.py
@@ -158,7 +158,14 @@ class TTSHandler(BaseModelHandler):
             return sub_handler.execute_sync(streaming=streaming)
 
         except Exception as e:
-            self.logger.exception(f"TTS sync execution failed: {str(e)}")
+            # Expected, handled validation failure (empty messages) is user
+            # misconfiguration, not a bug; it is returned as a failed
+            # HandlerResponse. Downgrade only that case to warning so real TTS
+            # failures keep creating Sentry issues.
+            if "Messages are required" in str(e):
+                self.logger.warning(f"TTS sync execution failed: {str(e)}")
+            else:
+                self.logger.exception(f"TTS sync execution failed: {str(e)}")
             return self._build_handler_response(
                 response=None,
                 start_time=start_time,
@@ -187,7 +194,14 @@ class TTSHandler(BaseModelHandler):
             return await sub_handler.execute_async(streaming=streaming)
 
         except Exception as e:
-            self.logger.exception(f"TTS async execution failed: {str(e)}")
+            # Expected, handled validation failure (empty messages) is user
+            # misconfiguration, not a bug; it is returned as a failed
+            # HandlerResponse. Downgrade only that case to warning so real TTS
+            # failures keep creating Sentry issues.
+            if "Messages are required" in str(e):
+                self.logger.warning(f"TTS async execution failed: {str(e)}")
+            else:
+                self.logger.exception(f"TTS async execution failed: {str(e)}")
             return self._build_handler_response(
                 response=None,
                 start_time=start_time,

--- a/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/utils/audio_processor.py
+++ b/futureagi/agentic_eval/core_evals/run_prompt/runprompt_handlers/utils/audio_processor.py
@@ -163,7 +163,10 @@ class AudioProcessor:
                         logger.info("[STT] Found audio URL in 'audio_url' part.")
                         return audio_url_payload["url"]
 
-        logger.error(
+        # Expected user misconfiguration: an STT/audio eval received text-only
+        # input. Raw emitter before the ValueError the STT handler catches and
+        # persists as a failed result. Warning.
+        logger.warning(
             f"[STT] No audio input found in messages. Sample: {str(messages)[:500]}"
         )
         raise ValueError("No audio input found in messages for STT.")

--- a/futureagi/analytics/utils.py
+++ b/futureagi/analytics/utils.py
@@ -11,6 +11,9 @@ logger = structlog.get_logger(__name__)
 
 
 def mixpanel_slack_notfy(msg):
+    if not settings.ERROR_LOGS_WEBHOOK:
+        logger.debug("Skipping Slack notification: ERROR_LOGS_WEBHOOK is not set")
+        return
     try:
         data = msg + "\n" + f"ENV_TYPE: {os.getenv('ENV_TYPE')}"
         webhook = WebhookClient(settings.ERROR_LOGS_WEBHOOK)

--- a/futureagi/mcp_server/usage_helpers.py
+++ b/futureagi/mcp_server/usage_helpers.py
@@ -106,7 +106,18 @@ class _UUIDEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, uuid.UUID):
             return str(obj)
-        return super().default(obj)
+        # Tool params may arrive as Pydantic model instances (FastMCP validates
+        # nested fields like render_widget's WidgetConfig into model objects),
+        # which json can't serialize natively.
+        from pydantic import BaseModel as _PydanticBaseModel
+
+        if isinstance(obj, _PydanticBaseModel):
+            return obj.model_dump(mode="json")
+        # Last-resort fallback so usage recording never crashes a tool call.
+        try:
+            return super().default(obj)
+        except TypeError:
+            return str(obj)
 
 
 def _sanitize_params(params):

--- a/futureagi/model_hub/apps.py
+++ b/futureagi/model_hub/apps.py
@@ -49,9 +49,14 @@ class ModelHubConfig(AppConfig):
         )
 
         ch = get_clickhouse_client()
+        # Server profiles may set data_type_default_nullable=1, which would
+        # auto-wrap bare LowCardinality(String)/Array(String)/key columns into
+        # Nullable and break these CREATE statements (ClickHouse Code 43/44).
+        # Force it off for schema DDL so the canonical types are honored.
+        ddl_settings = {"data_type_default_nullable": 0}
         for name, ddl in get_all_schema_ddl():
             try:
-                ch.execute(ddl)
+                ch.execute(ddl, settings=ddl_settings)
             except Exception as e:
                 if "already exists" not in str(e).lower():
                     logger.warning(f"CH schema {name}: {e}")
@@ -59,7 +64,7 @@ class ModelHubConfig(AppConfig):
         # Ensure materialized columns on CDC tables that PeerDB may recreate
         for alter in POST_DDL_ALTERS:
             try:
-                ch.execute(alter)
+                ch.execute(alter, settings=ddl_settings)
             except Exception as e:
                 if "already exists" not in str(e).lower():
                     logger.warning(f"CH post-DDL alter: {e}")

--- a/futureagi/model_hub/serializers/annotation_queues.py
+++ b/futureagi/model_hub/serializers/annotation_queues.py
@@ -484,7 +484,9 @@ class QueueItemSerializer(serializers.ModelSerializer):
         read_only_fields = ["queue"]
 
     def get_assigned_users(self, obj):
-        assignments = obj.assignments.filter(deleted=False).select_related("user")
+        assignments = getattr(obj, "active_assignments", None)
+        if assignments is None:
+            assignments = obj.assignments.filter(deleted=False).select_related("user")
         return [
             {
                 "id": str(a.user_id),

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -689,7 +689,9 @@ def _validate_error_localizer_fields(rule_prompt, input_data, eval_result):
 
     if missing_fields:
         error_msg = f"Missing required fields: {', '.join(missing_fields)}"
-        logger.error(f"ErrorLocalizerTask validation failed - {error_msg}")
+        # Expected, handled: localizer is skipped (FAILED status persisted) when
+        # required fields are absent (e.g. no eval_result). Warning, not error.
+        logger.warning(f"ErrorLocalizerTask validation failed - {error_msg}")
         return ErrorLocalizerStatus.FAILED, error_msg
 
     return ErrorLocalizerStatus.PENDING, ""
@@ -1039,26 +1041,32 @@ def trigger_error_localization_for_simulate(
             rule_prompt, input_data_dict, value
         )
 
-        task = ErrorLocalizerTask(
-            eval_template=eval_template,
-            source=ErrorLocalizerSource.SIMULATE,
+        # Idempotent on Temporal retry: source_id has a partial unique index
+        # (unique_source_id WHERE deleted=False), so a re-run must update the
+        # existing row instead of re-inserting. Use no_workspace_objects so the
+        # lookup matches the global (workspace-agnostic) unique index.
+        task, _created = ErrorLocalizerTask.no_workspace_objects.update_or_create(
             source_id=call_execution.id,
-            input_data=input_data_dict,
-            input_keys=input_keys,
-            input_types=input_type_dict,
-            eval_result=value,
-            eval_explanation=eval_explanation,
-            rule_prompt=rule_prompt,
-            organization=call_execution.test_execution.run_test.organization,
-            metadata={
-                "log_id": log_id,
-                # "call_execution_id": str(call_execution.id),
-                "eval_config_id": str(eval_config.id),
+            deleted=False,
+            defaults={
+                "eval_template": eval_template,
+                "source": ErrorLocalizerSource.SIMULATE,
+                "input_data": input_data_dict,
+                "input_keys": input_keys,
+                "input_types": input_type_dict,
+                "eval_result": value,
+                "eval_explanation": eval_explanation,
+                "rule_prompt": rule_prompt,
+                "organization": call_execution.test_execution.run_test.organization,
+                "metadata": {
+                    "log_id": log_id,
+                    # "call_execution_id": str(call_execution.id),
+                    "eval_config_id": str(eval_config.id),
+                },
+                "status": initial_status,
+                "error_message": error_message,
             },
-            status=initial_status,
-            error_message=error_message,
         )
-        task.save()
 
         logger.info(
             f"Created ErrorLocalizerTask for Simulate Eval - Call: {call_execution.id}, Config: {eval_config.id}"

--- a/futureagi/model_hub/utils/eval_list.py
+++ b/futureagi/model_hub/utils/eval_list.py
@@ -212,12 +212,19 @@ def get_created_by_name(template: "EvalTemplate") -> str:
     try:
         from model_hub.models.evals_metric import EvalTemplateVersion
 
-        version = (
-            EvalTemplateVersion.objects.filter(eval_template=template)
-            .select_related("created_by")
-            .order_by("version_number")
-            .first()
-        )
+        # Prefer a prefetched, version_number-ordered list when the caller
+        # supplied one (e.g. via Prefetch(..., to_attr="_prefetched_versions"))
+        # so we don't issue a per-row query inside a list loop (N+1).
+        prefetched_versions = getattr(template, "_prefetched_versions", None)
+        if prefetched_versions is not None:
+            version = prefetched_versions[0] if prefetched_versions else None
+        else:
+            version = (
+                EvalTemplateVersion.objects.filter(eval_template=template)
+                .select_related("created_by")
+                .order_by("version_number")
+                .first()
+            )
         if version and version.created_by:
             name = getattr(version.created_by, "name", "") or ""
             if name.strip():

--- a/futureagi/model_hub/utils/json_path_resolver.py
+++ b/futureagi/model_hub/utils/json_path_resolver.py
@@ -292,7 +292,7 @@ def parse_json_safely(value: Any) -> Tuple[Optional[Any], bool]:
         data = json_repair.loads(stripped)
         if isinstance(data, (dict, list)):
             return data, True
-    except (json.JSONDecodeError, ValueError, TypeError):
+    except (json.JSONDecodeError, ValueError, TypeError, IndexError, RecursionError):
         pass
 
     # 3. Python literal eval (handles True/False/None, single-quoted keys)

--- a/futureagi/model_hub/utils/utils.py
+++ b/futureagi/model_hub/utils/utils.py
@@ -410,7 +410,13 @@ def validate_model_working(model_name, api_key, provider):
             return response.choices[0].message.content
 
     except Exception as e:
-        logger.exception(f"An error occurred: {str(e)}")
+        # Expected user-input/connectivity validation failure (e.g. a bad
+        # Vertex/Bedrock credential or an invalid private key). This function
+        # only validates user-supplied model credentials and always returns the
+        # error to the caller as an Exception (-> clean 400), so log at WARNING
+        # to keep it out of Sentry (event_level=ERROR) while preserving a
+        # breadcrumb. See CORE-BACKEND-119X.
+        logger.warning(f"An error occurred: {str(e)}")
         status = False
         try:
             error_message = str(e).split("litellm.")[1].split("Traceback")[0]

--- a/futureagi/model_hub/views/annotation_queues.py
+++ b/futureagi/model_hub/views/annotation_queues.py
@@ -2867,7 +2867,9 @@ class AnnotationQueueViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelVie
         else:
             queryset = super().get_queryset()
 
-        queryset = queryset.select_related("created_by").prefetch_related(
+        queryset = queryset.select_related(
+            "created_by", "organization", "workspace"
+        ).prefetch_related(
             Prefetch(
                 "queue_labels",
                 queryset=AnnotationQueueLabel.objects.filter(
@@ -4461,6 +4463,13 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
                 "prototype_run",
                 "call_execution",
                 "trace_session",
+                Prefetch(
+                    "assignments",
+                    queryset=QueueItemAssignment.objects.filter(
+                        deleted=False
+                    ).select_related("user"),
+                    to_attr="active_assignments",
+                ),
             )
         )
         queue_id = self.kwargs.get("queue_id")
@@ -5643,7 +5652,9 @@ class QueueItemViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelViewSet):
         # Review mode compares every annotator's scores. Outside review mode,
         # even reviewer/manager users get their own annotation draft so a
         # multi-role user can still annotate an assigned item.
-        annotations_qs = _scores_for_queue_item(item).select_related("label")
+        annotations_qs = _scores_for_queue_item(item).select_related(
+            "label", "annotator"
+        )
         raw_annotator_id = query_params.get("annotator_id") or None
         viewing_annotator_id = None
         if raw_annotator_id and is_reviewer:

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -9039,7 +9039,7 @@ class ClassifyColumnView(APIView):
         try:
             close_old_connections()
             if not cell.value:
-                return None
+                return None, None
 
             prompt = (
                 f"Classify the following text into exactly one of these labels: {', '.join(labels)}.\n\n"

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -6972,12 +6972,38 @@ class GetEvalsListView(APIView):
             get_created_by_name,
         )
 
-        eval_templates = EvalTemplate.objects.filter(
-            organization=organization,
-            owner=OwnerChoices.USER.value,
-            deleted=False,
-            visible_ui=True,
-        ).prefetch_related("evaluators__user", "versions__created_by")
+        from model_hub.models.evals_metric import EvalTemplateVersion, Evaluator
+
+        eval_templates = (
+            EvalTemplate.objects.filter(
+                organization=organization,
+                owner=OwnerChoices.USER.value,
+                deleted=False,
+                visible_ui=True,
+            )
+            # Prefetch the relations get_created_by_name() walks so it reads
+            # from memory instead of issuing a query per template (N+1 on
+            # model_hub_evaluator, model_hub_eval_template_version and
+            # accounts_organization — CORE-BACKEND-10TP / CORE-BACKEND-1161).
+            # to_attr names match what get_created_by_name() looks for.
+            .prefetch_related(
+                Prefetch(
+                    "evaluators",
+                    queryset=Evaluator.objects.select_related("user").filter(
+                        user__isnull=False
+                    )[:1],
+                    to_attr="_prefetched_evaluators",
+                ),
+                Prefetch(
+                    "versions",
+                    queryset=EvalTemplateVersion.objects.select_related(
+                        "created_by"
+                    ).order_by("version_number"),
+                    to_attr="_prefetched_versions",
+                ),
+            )
+            .select_related("organization")
+        )
 
         if search_text:
             eval_templates = eval_templates.filter(Q(name__icontains=search_text))
@@ -15121,7 +15147,7 @@ class GetKnowledgeBaseDetailsView(APIView):
                 ]
                 kbs = KnowledgeBaseFile.objects.filter(
                     organization_id=org.id, deleted=False
-                ).all()
+                ).prefetch_related("files")
                 if not kbs:
                     if KnowledgeBaseFile.all_objects.filter(
                         organization=org, deleted=True

--- a/futureagi/model_hub/views/dynamic_columns.py
+++ b/futureagi/model_hub/views/dynamic_columns.py
@@ -705,7 +705,7 @@ class ClassifyColumnView(APIView):
         try:
             close_old_connections()
             if not cell.value:
-                return None
+                return None, None
 
             prompt = (
                 f"Classify the following text into exactly one of these labels: {', '.join(labels)}.\n\n"

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1272,8 +1272,18 @@ class EvaluationRunner:
                     )
 
         except Exception as e:
-            logger.exception(f"Error in evaluation of row: {str(e)}")
-            traceback.print_exc()
+            # Expected, handled validation failures (a required input was not
+            # mapped/provided, or the eval targets a cell that already errored)
+            # are user-driven, not bugs; the row is persisted as a failed result
+            # below. Downgrade only those to warning so genuine errors keep
+            # creating Sentry issues.
+            if str(e).startswith("No input received") or str(e) == get_error_message(
+                "EVALUATION_NOT_FOR_ERROR_CELL"
+            ):
+                logger.warning(f"Error in evaluation of row: {str(e)}")
+            else:
+                logger.exception(f"Error in evaluation of row: {str(e)}")
+                traceback.print_exc()
 
             # Use the centralized error handling function
             error_message = get_specific_error_message(e)

--- a/futureagi/model_hub/views/experiment_runner.py
+++ b/futureagi/model_hub/views/experiment_runner.py
@@ -1327,7 +1327,13 @@ class ExperimentRunner:
             value_info["reason"] = value_info.get("data", {}).get("response")
 
         except Exception as e:
-            logger.exception(f"Error in processing the row: {str(e)}")
+            # Expected, handled validation failure (empty messages) is user
+            # misconfiguration; the row is persisted as a failed cell below.
+            # Downgrade only that case to warning so real failures stay errors.
+            if "Messages are required" in str(e):
+                logger.warning(f"Error in processing the row: {str(e)}")
+            else:
+                logger.exception(f"Error in processing the row: {str(e)}")
             # if unsupported_exception:
             response = str(e)
             value_info = {"reason": str(e)}
@@ -1599,7 +1605,13 @@ def _process_row_impl(
         value_info["reason"] = value_info.get("data", {}).get("response")
 
     except Exception as e:
-        logger.exception(f"Error in processing the row: {str(e)}")
+        # Expected, handled validation failure (empty messages) is user
+        # misconfiguration; the row is persisted as a failed cell below.
+        # Downgrade only that case to warning so real failures stay errors.
+        if "Messages are required" in str(e):
+            logger.warning(f"Error in processing the row: {str(e)}")
+        else:
+            logger.exception(f"Error in processing the row: {str(e)}")
         # if unsupported_exception:
         response = str(e)
         value_info = {"reason": str(e)}

--- a/futureagi/requirements-test.txt
+++ b/futureagi/requirements-test.txt
@@ -122,7 +122,6 @@ colorama==0.4.6
     # via griffe
 coloredlogs==15.0.1
     # via
-    #   guardrails-ai
     #   onnxruntime
 cron-descriptor==1.4.5
     # via django-celery-beat
@@ -143,7 +142,6 @@ defusedxml==0.7.1
 deprecation==2.1.0
     # via weaviate-client
 diff-match-patch==20230430
-    # via guardrails-ai
 dill==0.3.8
     # via
     #   datasets
@@ -207,7 +205,6 @@ ecdsa==0.19.1
 elementpath==4.8.0
     # via xmlschema
 faker==25.9.2
-    # via guardrails-ai
 ffmpeg-python==0.2.0
     # via core-backend (pyproject.toml)
 filelock==3.18.0
@@ -288,7 +285,6 @@ googleapis-common-protos==1.70.0
 greenlet==3.2.3
     # via gevent
 griffe==0.36.9
-    # via guardrails-ai
 grpc-google-iam-v1==0.14.2
     # via google-cloud-resource-manager
 grpcio==1.73.1
@@ -315,12 +311,7 @@ grpcio-tools==1.71.2
     #   core-backend (pyproject.toml)
     #   django-socio-grpc
     #   weaviate-client
-guardrails-ai==0.5.12
     # via core-backend (pyproject.toml)
-guardrails-api-client==0.3.9
-    # via guardrails-ai
-guardrails-hub-types==0.0.4
-    # via guardrails-ai
 gunicorn==23.0.0
     # via core-backend (pyproject.toml)
 h11==0.16.0
@@ -403,11 +394,9 @@ jsonpointer==3.0.0
     #   jsonpatch
     #   jsonschema
 jsonref==1.1.0
-    # via guardrails-ai
 jsonschema==4.24.0
     # via
     #   chromadb
-    #   guardrails-ai
     #   litellm
 jsonschema-specifications==2025.4.1
     # via jsonschema
@@ -423,7 +412,6 @@ langchain-community==0.2.19
     # via core-backend (pyproject.toml)
 langchain-core==0.2.43
     # via
-    #   guardrails-ai
     #   langchain
     #   langchain-community
     #   langchain-text-splitters
@@ -447,14 +435,12 @@ librosa==0.11.0
 litellm==1.68.1
     # via
     #   core-backend (pyproject.toml)
-    #   guardrails-ai
 llvmlite==0.44.0
     # via
     #   core-backend (pyproject.toml)
     #   numba
 lxml==4.9.4
     # via
-    #   guardrails-ai
     #   python-docx
     #   xmlsec
 markdown-it-py==3.0.0
@@ -490,7 +476,6 @@ newrelic==10.14.0
 nltk==3.8.1
     # via
     #   core-backend (pyproject.toml)
-    #   guardrails-ai
     #   rouge-score
 nodeenv==1.9.1
     # via pre-commit
@@ -526,7 +511,6 @@ onnxruntime==1.22.0
 openai==1.75.0
     # via
     #   core-backend (pyproject.toml)
-    #   guardrails-ai
     #   litellm
 opentelemetry-api==1.34.1
     # via
@@ -548,11 +532,9 @@ opentelemetry-exporter-otlp-proto-grpc==1.34.1
     # via
     #   core-backend (pyproject.toml)
     #   chromadb
-    #   guardrails-ai
 opentelemetry-exporter-otlp-proto-http==1.34.1
     # via
     #   core-backend (pyproject.toml)
-    #   guardrails-ai
 opentelemetry-instrumentation==0.55b1
     # via
     #   core-backend (pyproject.toml)
@@ -574,7 +556,6 @@ opentelemetry-sdk==1.34.1
     # via
     #   core-backend (pyproject.toml)
     #   chromadb
-    #   guardrails-ai
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.55b1
@@ -636,7 +617,6 @@ pinecone-plugin-interface==0.0.7
     #   pinecone
     #   pinecone-plugin-inference
 pip==25.1.1
-    # via guardrails-ai
 platformdirs==4.3.8
     # via
     #   pooch
@@ -711,7 +691,6 @@ pydantic==2.11.7
     #   chromadb
     #   google-cloud-aiplatform
     #   google-genai
-    #   guardrails-ai
     #   langchain
     #   langchain-core
     #   langsmith
@@ -722,7 +701,6 @@ pydantic==2.11.7
 pydantic-core==2.33.2
     # via pydantic
 pydash==7.0.7
-    # via guardrails-ai
 pydub==0.25.1
     # via core-backend (pyproject.toml)
 pygments==2.19.2
@@ -731,7 +709,6 @@ pyjwt==2.9.0
     # via
     #   core-backend (pyproject.toml)
     #   djangorestframework-simplejwt
-    #   guardrails-ai
 pymeta3==0.5.1
     # via pybars3
 pymongo==4.13.2
@@ -755,7 +732,6 @@ python-dateutil==2.9.0.post0
     #   celery
     #   faker
     #   google-cloud-bigquery
-    #   guardrails-ai
     #   kubernetes
     #   pandas
     #   pinecone
@@ -802,7 +778,6 @@ referencing==0.36.2
     #   jsonschema-specifications
 regex==2023.12.25
     # via
-    #   guardrails-ai
     #   nltk
     #   tiktoken
     #   transformers
@@ -815,7 +790,6 @@ requests==2.32.4
     #   google-cloud-bigquery
     #   google-cloud-storage
     #   google-genai
-    #   guardrails-ai
     #   huggingface-hub
     #   kubernetes
     #   langchain
@@ -844,7 +818,6 @@ rfc3987==1.3.8
 rich==13.9.4
     # via
     #   chromadb
-    #   guardrails-ai
     #   typer
 rouge-score==0.1.2
     # via core-backend (pyproject.toml)
@@ -857,7 +830,6 @@ rsa==4.9.1
     #   google-auth
     #   python-jose
 rstr==3.2.2
-    # via guardrails-ai
 s3transfer==0.13.0
     # via boto3
 safetensors==0.5.3
@@ -870,7 +842,6 @@ scipy==1.16.0
     #   librosa
     #   scikit-learn
 semver==3.0.4
-    # via guardrails-ai
 sentry-sdk==2.32.0
     # via core-backend (pyproject.toml)
 setuptools==80.9.0
@@ -923,7 +894,6 @@ tenacity==8.5.0
     #   core-backend (pyproject.toml)
     #   chromadb
     #   google-genai
-    #   guardrails-ai
     #   langchain
     #   langchain-community
     #   langchain-core
@@ -931,7 +901,6 @@ threadpoolctl==3.6.0
     # via scikit-learn
 tiktoken==0.9.0
     # via
-    #   guardrails-ai
     #   litellm
 tokenizers==0.21.2
     # via
@@ -954,7 +923,6 @@ transformers==4.53.0
 typer==0.12.5
     # via
     #   chromadb
-    #   guardrails-ai
 types-python-dateutil==2.9.0.20250516
     # via arrow
 typing-extensions==4.14.0
@@ -964,7 +932,6 @@ typing-extensions==4.14.0
     #   chromadb
     #   google-cloud-aiplatform
     #   google-genai
-    #   guardrails-ai
     #   huggingface-hub
     #   langchain-core
     #   librosa

--- a/futureagi/sdk/utils/helpers.py
+++ b/futureagi/sdk/utils/helpers.py
@@ -20,7 +20,14 @@ def _get_api_call_type(model: str):
 
         model_key: ModelChoices | str = model
         if isinstance(model, str):
-            model_key = ModelChoices(model)
+            try:
+                model_key = ModelChoices(model)
+            except ValueError:
+                # Non-Turing/Protect models (e.g. "gpt-5", "gemini-...") are
+                # legitimate user input but not part of ModelChoices. This is
+                # expected, not an error: fall back to the default api call type.
+                logger.warning("unknown_model_for_api_call_type", model=model)
+                return APICallTypeChoices.TURING_LARGE_EVALUATOR.value
 
         return model_to_api_call_type.get(
             model_key, APICallTypeChoices.TURING_LARGE_EVALUATOR.value

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -2003,6 +2003,8 @@ class TestExecutionDetailView(APIView):
                     "test_execution",
                     "test_execution__simulator_agent",
                     "test_execution__agent_definition",
+                    "test_execution__run_test",
+                    "test_execution__run_test__agent_definition",
                 )
                 .prefetch_related("transcripts", "snapshots", "chat_messages")
             ).order_by("created_at")

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -313,10 +313,24 @@ class RunTestListView(APIView):
                 queryset=AgentVersion.objects.order_by("-version_number"),
                 to_attr="_prefetched_versions",
             )
+            # Prefetch scenarios with their FK relations so the nested
+            # ScenarioResponseSerializer's get_dataset_* / get_agent / get_agent_type
+            # do not issue per-scenario FK lookups (model_hub_dataset, simulator_agents,
+            # simulate_agent_definition). Fixes CORE-BACKEND-Z49.
+            scenarios_prefetch = Prefetch(
+                "scenarios",
+                queryset=Scenarios.objects.select_related(
+                    "dataset",
+                    "simulator_agent",
+                    "agent_definition",
+                    "prompt_template",
+                    "prompt_version",
+                ),
+            )
             run_tests = (
                 RunTest.objects.filter(organization=user_organization, deleted=False)
                 .prefetch_related(
-                    "scenarios", "simulate_eval_configs", latest_version_prefetch
+                    scenarios_prefetch, "simulate_eval_configs", latest_version_prefetch
                 )
                 .select_related(
                     "agent_definition",
@@ -1987,8 +2001,11 @@ class TestExecutionDetailView(APIView):
             group_keys = query_data.get("group_keys", [])
 
             # Get the test execution
+            # select_related("run_test") loads the already-JOINed run_test row in the
+            # same query so later test_execution.run_test access does not fire a
+            # separate simulate_run_test SELECT. Fixes CORE-BACKEND-10G3.
             test_execution = get_object_or_404(
-                TestExecution,
+                TestExecution.objects.select_related("run_test"),
                 run_test_workspace_filter(request, "run_test"),
                 id=test_execution_id,
                 run_test__organization=user_organization,
@@ -4966,6 +4983,7 @@ class RunTestExecutionsView(APIView):
                     "agent_definition",
                     "agent_version",
                 )
+                .prefetch_related("calls")
                 .annotate(
                     _total_calls=Count("calls"),
                     _completed_calls=Count(

--- a/futureagi/tfc/logging/config.py
+++ b/futureagi/tfc/logging/config.py
@@ -3,9 +3,7 @@ Structlog configuration for Django/Celery logging.
 Uses a centralized django-structlog configuration.
 """
 
-import logging
 import os
-import sys
 
 import structlog
 
@@ -82,7 +80,6 @@ def get_logging_config(base_dir: str) -> dict:
     Returns:
         Django LOGGING dict
     """
-    env_type = get_env()
     log_level = os.getenv("LOG_LEVEL", "INFO")
     logs_dir = os.path.join(base_dir, "logs")
 
@@ -191,14 +188,17 @@ def get_logging_config(base_dir: str) -> dict:
         },
     }
 
-    # Add error tracking handler for staging/prod
-    if env_type in ("staging", "prod"):
-        sentry_level = os.getenv("SENTRY_LOG_LEVEL", "ERROR")
-        config["handlers"]["sentry"] = {
-            "class": "sentry_sdk.integrations.logging.EventHandler",
-            "level": sentry_level,
-            "formatter": "plain",
-        }
-        config["loggers"][""]["handlers"].append("sentry")
+    # NOTE: We deliberately do NOT attach a sentry EventHandler here.
+    #
+    # Sentry's LoggingIntegration (configured in tfc.logging.sentry.init_sentry)
+    # already captures every ERROR-level log record as an event by patching
+    # logging.Logger.callHandlers. Adding an explicit EventHandler on the root
+    # logger double-captured each error and, because the integration runs in
+    # Temporal/Celery too (which never load this Django LOGGING dict), split
+    # capture across two code paths. Routing all log->event capture through the
+    # single LoggingIntegration keeps behaviour consistent everywhere and lets
+    # noise control (ignore_logger + before_send) live in one place.
+    #
+    # SENTRY_LOG_LEVEL is still honoured by the LoggingIntegration's event_level.
 
     return config

--- a/futureagi/tfc/logging/sentry.py
+++ b/futureagi/tfc/logging/sentry.py
@@ -78,6 +78,10 @@ IGNORED_MESSAGE_SUBSTRINGS = (
     "trace_payload_not_found_in_redis",  # expected ingestion race (payload TTL)
     "Failed to export traces",  # OTel exporter (backstop for logger check)
     "Exception while exporting metrics",  # OTel exporter (backstop)
+    # litellm's internal 'LiteLLM' logger emits this at ERROR when a user
+    # supplies an invalid/partial Vertex AI service-account key during model
+    # validation. Expected user-input error, not actionable. CORE-BACKEND-119Y.
+    "Failed to load vertex credentials",
 )
 
 # Keys whose values must be redacted before leaving the process. Matched

--- a/futureagi/tfc/logging/sentry.py
+++ b/futureagi/tfc/logging/sentry.py
@@ -18,14 +18,85 @@ Usage:
 """
 
 import os
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 # Environment detection
 ENV_TYPE = os.getenv("ENV_TYPE", "local")
 IS_PRODUCTION = ENV_TYPE in ("prod", "production")
 IS_STAGING = ENV_TYPE == "staging"
-SENTRY_ENABLED = ENV_TYPE in ("staging", "prod", "production")
+
+# Sentry is enabled in staging/prod by default. An explicit SENTRY_ENABLED env
+# var (also read by settings.py) always wins so the two never diverge.
+_sentry_enabled_override = os.getenv("SENTRY_ENABLED")
+if _sentry_enabled_override not in (None, ""):
+    SENTRY_ENABLED = _sentry_enabled_override.lower() == "true"
+else:
+    SENTRY_ENABLED = ENV_TYPE in ("staging", "prod", "production")
 SENTRY_DSN = os.getenv("SENTRY_DSN")
+
+# Noise control
+# Loggers whose records must NEVER become Sentry issues. These are pure
+# infrastructure/SDK loggers that emit ERROR records for transient, expected
+# conditions (e.g. the OTel exporter failing to reach its collector). Left
+# unchecked, a single unreachable collector produced tens of millions of
+# identical events. Real application exceptions never originate here.
+#
+# NOTE: Sentry's LoggingIntegration patches logging.Logger.callHandlers, so a
+# logger's `propagate=False`/`level` in Django's LOGGING dict does NOT stop it
+# from becoming an event. ignore_logger() (below) and the before_send prefix
+# check are the only reliable levers.
+NOISY_LOGGER_PREFIXES = (
+    "opentelemetry",  # OTLP exporter/instrumentation export failures
+)
+
+# Exact logger names handed to sentry_sdk.integrations.logging.ignore_logger.
+# Children are covered by the before_send prefix check as a backstop.
+IGNORED_LOGGERS = (
+    "opentelemetry",
+    "opentelemetry.sdk.metrics._internal.export",
+    "opentelemetry.sdk.trace.export",
+    "opentelemetry.exporter.otlp.proto.grpc.exporter",
+    "opentelemetry.exporter.otlp.proto.http.metric_exporter",
+    "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    "opentelemetry.exporter.otlp.proto.http._log_exporter",
+)
+
+# Exception class names that are expected/handled and not actionable as issues.
+IGNORED_EXCEPTIONS = frozenset(
+    {
+        "DisallowedHost",  # Django - invalid host header (scanner/bot traffic)
+        "SuspiciousOperation",  # Django - security-related, handled
+        "ConnectionResetError",  # Client/peer disconnected mid-request
+        "BrokenPipeError",  # Client disconnected mid-response
+    }
+)
+
+# Substrings of structlog/event messages that represent expected, non-actionable
+# conditions. Kept deliberately specific so real bugs are never hidden.
+IGNORED_MESSAGE_SUBSTRINGS = (
+    "trace_payload_not_found_in_redis",  # expected ingestion race (payload TTL)
+    "Failed to export traces",  # OTel exporter (backstop for logger check)
+    "Exception while exporting metrics",  # OTel exporter (backstop)
+)
+
+# Keys whose values must be redacted before leaving the process. Matched
+# case-insensitively as substrings against header/cookie/body/extra keys.
+SENSITIVE_KEY_SUBSTRINGS = (
+    "authorization",
+    "cookie",
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "x-api-key",
+    "access_key",
+    "private_key",
+    "csrf",
+)
+_REDACTED = "[Filtered]"
 
 # Sample rates - configurable via env, lower in production to reduce costs
 # Production: 10% sampling, Staging: 100% sampling
@@ -39,38 +110,114 @@ PROFILES_SAMPLE_RATE = float(
 _initialized_components: set = set()
 
 
+def _is_sensitive_key(key: Any) -> bool:
+    """True if a dict/header key looks like it carries a secret or PII token."""
+    if not isinstance(key, str):
+        return False
+    lowered = key.lower()
+    return any(s in lowered for s in SENSITIVE_KEY_SUBSTRINGS)
+
+
+def _scrub(value: Any, depth: int = 0) -> Any:
+    """Recursively redact values under sensitive keys (defensive, bounded)."""
+    if depth > 6:
+        return value
+    if isinstance(value, dict):
+        return {
+            k: (_REDACTED if _is_sensitive_key(k) else _scrub(v, depth + 1))
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_scrub(v, depth + 1) for v in value]
+    return value
+
+
+def _scrub_event(event: dict) -> None:
+    """
+    Redact obvious secrets/PII in-place before the event leaves the process.
+
+    Complements Sentry's server-side scrubbing and the EventScrubber denylist
+    so secrets never transit the wire even when send_default_pii is on.
+    """
+    request = event.get("request")
+    if isinstance(request, dict):
+        # Cookies are session/CSRF tokens almost by definition - redact wholesale.
+        if request.get("cookies"):
+            request["cookies"] = _REDACTED
+        for section in ("headers", "data", "env"):
+            if isinstance(request.get(section), dict):
+                request[section] = _scrub(request[section])
+        # Strip query-string credentials wholesale rather than parse them.
+        if isinstance(request.get("query_string"), str) and any(
+            s in request["query_string"].lower() for s in SENSITIVE_KEY_SUBSTRINGS
+        ):
+            request["query_string"] = _REDACTED
+
+    if isinstance(event.get("extra"), dict):
+        event["extra"] = _scrub(event["extra"])
+    contexts = event.get("contexts")
+    if isinstance(contexts, dict):
+        event["contexts"] = _scrub(contexts)
+
+
+def _event_message(event: dict) -> str:
+    """Best-effort extraction of an event's human-readable message."""
+    msg = event.get("message")
+    if isinstance(msg, dict):
+        msg = msg.get("formatted") or msg.get("message") or ""
+    logentry = event.get("logentry")
+    logentry_msg = logentry.get("message", "") if isinstance(logentry, dict) else ""
+    parts = [str(msg or ""), str(logentry_msg or "")]
+    return " ".join(p for p in parts if p)
+
+
 def _get_before_send() -> Callable:
     """
-    Create before_send hook to filter/modify events before sending to Sentry.
+    Create the before_send hook that runs on every error event.
 
-    This can be used to:
-    - Filter out noisy/expected errors
-    - Scrub sensitive data
-    - Add additional context
+    Responsibilities, in order:
+    1. Drop pure-infrastructure logger noise (OTel exporter, etc.).
+    2. Drop expected/handled exceptions and expected 4xx responses.
+    3. Drop known expected log conditions matched by message substring.
+    4. Scrub secrets/PII from whatever remains.
     """
 
-    def before_send(event: dict, hint: dict) -> Optional[dict]:
-        # Filter out expected/noisy exceptions
-        if "exc_info" in hint:
-            exc_type, exc_value, tb = hint["exc_info"]
-            exc_name = exc_type.__name__ if exc_type else ""
+    def before_send(event: dict, hint: dict) -> dict | None:
+        # 1. Infrastructure logger noise - never actionable as an issue.
+        logger_name = event.get("logger") or ""
+        if isinstance(logger_name, str) and any(
+            logger_name.startswith(p) for p in NOISY_LOGGER_PREFIXES
+        ):
+            return None
 
-            # Skip common expected errors that don't need tracking
-            ignored_exceptions = [
-                "DisallowedHost",  # Django - invalid host header attacks
-                "SuspiciousOperation",  # Django - security-related
-                "ConnectionResetError",  # Client disconnected
-                "BrokenPipeError",  # Client disconnected
-            ]
-            if exc_name in ignored_exceptions:
+        # 2. Expected/handled exceptions and expected client (4xx) errors.
+        if "exc_info" in hint:
+            exc_type, exc_value, _tb = hint["exc_info"]
+            exc_name = exc_type.__name__ if exc_type else ""
+            if exc_name in IGNORED_EXCEPTIONS:
                 return None
 
-            # Skip 4xx client errors that are expected behavior
-            if hasattr(exc_value, "status_code"):
-                status_code = getattr(exc_value, "status_code", 500)
-                if 400 <= status_code < 500 and status_code not in (401, 403):
-                    # Skip 400, 404, 405, etc. but keep 401/403 for security monitoring
-                    return None
+            status_code = getattr(exc_value, "status_code", None)
+            if (
+                isinstance(status_code, int)
+                and 400 <= status_code < 500
+                and status_code not in (401, 403)
+            ):
+                # Drop 400/404/405/429/etc. (client behaviour); keep 401/403
+                # for security monitoring.
+                return None
+
+        # 3. Known expected conditions identified by message text.
+        message = _event_message(event)
+        if message and any(s in message for s in IGNORED_MESSAGE_SUBSTRINGS):
+            return None
+
+        # 4. Scrub secrets/PII from the surviving event.
+        try:
+            _scrub_event(event)
+        except Exception:
+            # Never let scrubbing failures drop a real error.
+            pass
 
         return event
 
@@ -117,7 +264,7 @@ def _get_traces_sampler() -> Callable:
 
 def init_sentry(
     component: str = "django",
-    tags: Optional[dict] = None,
+    tags: dict | None = None,
 ) -> bool:
     """
     Initialize Sentry for a specific component.
@@ -141,21 +288,42 @@ def init_sentry(
     try:
         import sentry_sdk
         from sentry_sdk.integrations.httpx import HttpxIntegration
-        from sentry_sdk.integrations.logging import LoggingIntegration
+        from sentry_sdk.integrations.logging import (
+            LoggingIntegration,
+            ignore_logger,
+        )
 
-        # from sentry_sdk.integrations.redis import RedisIntegration
-        # Increase max string length for better error context
+        # Keep a generous-but-bounded string length so stack frames and request
+        # bodies stay readable without bloating every event (the old 10MB cap
+        # multiplied payload size across millions of events).
         try:
-            sentry_sdk.utils.MAX_STRING_LENGTH = 10_000_000
+            sentry_sdk.utils.MAX_STRING_LENGTH = 8192
         except AttributeError:
             pass  # Newer SDK versions may not have this
 
+        # Suppress pure-infrastructure loggers at the source. This is the
+        # single most important noise lever: it stops the OTel exporter's
+        # transient "failed to reach collector" ERRORs from becoming issues.
+        for logger_name in IGNORED_LOGGERS:
+            ignore_logger(logger_name)
+
+        import logging as _logging
+
+        # Level at/above which a log record becomes a Sentry event. ERROR by
+        # default; overridable via SENTRY_LOG_LEVEL (e.g. WARNING, CRITICAL).
+        _event_level = getattr(
+            _logging, os.getenv("SENTRY_LOG_LEVEL", "ERROR").upper(), _logging.ERROR
+        )
+
         integrations = [
+            # The ONLY path that turns ERROR logs into Sentry events. The
+            # redundant Django EventHandler was removed from logging/config.py
+            # so events are captured exactly once and Temporal/Celery (which do
+            # not use the Django LOGGING dict) are covered too.
             LoggingIntegration(
-                level=20,  # INFO - capture as breadcrumbs
-                event_level=40,  # ERROR - send as events
+                level=_logging.INFO,  # capture INFO+ as breadcrumbs
+                event_level=_event_level,  # send ERROR+ as events
             ),
-            # RedisIntegration(),
             HttpxIntegration(),  # Track outgoing HTTP requests via httpx
         ]
 
@@ -193,6 +361,14 @@ def init_sentry(
         if tags:
             default_tags.update(tags)
 
+        # Defence-in-depth scrubbing: even with send_default_pii on, redact a
+        # broad denylist of secret-bearing keys recursively before send.
+        from sentry_sdk.scrubber import DEFAULT_DENYLIST, EventScrubber
+
+        scrubber_denylist = list(DEFAULT_DENYLIST) + [
+            k for k in SENSITIVE_KEY_SUBSTRINGS if k not in DEFAULT_DENYLIST
+        ]
+
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             integrations=integrations,
@@ -204,9 +380,13 @@ def init_sentry(
             traces_sampler=_get_traces_sampler(),
             # Profiling configuration
             profiles_sample_rate=PROFILES_SAMPLE_RATE,
-            # Error capture configuration
+            # Error capture configuration. PII is captured for debugging but
+            # passed through the scrubber + before_send redaction below.
             send_default_pii=True,
-            max_request_body_size="always",  # Capture full request bodies
+            event_scrubber=EventScrubber(denylist=scrubber_denylist, recursive=True),
+            # "medium" caps bodies at ~10KB: enough to debug, small enough that
+            # large uploads/payloads don't dominate the event volume or leak.
+            max_request_body_size="medium",
             max_breadcrumbs=100,
             attach_stacktrace=True,  # Attach stack traces to all messages
             include_source_context=True,  # Include source code context
@@ -269,9 +449,9 @@ def set_user_context(user_id: str, email: str = "", username: str = "") -> None:
 
 def capture_exception_with_context(
     exception: Exception,
-    context: Optional[dict] = None,
-    tags: Optional[dict] = None,
-) -> Optional[str]:
+    context: dict | None = None,
+    tags: dict | None = None,
+) -> str | None:
     """
     Capture an exception with additional context.
 
@@ -304,9 +484,9 @@ def capture_exception_with_context(
 def capture_message(
     message: str,
     level: str = "info",
-    context: Optional[dict] = None,
-    tags: Optional[dict] = None,
-) -> Optional[str]:
+    context: dict | None = None,
+    tags: dict | None = None,
+) -> str | None:
     """
     Capture a message to Sentry.
 
@@ -341,7 +521,7 @@ def add_breadcrumb(
     message: str,
     category: str = "custom",
     level: str = "info",
-    data: Optional[dict] = None,
+    data: dict | None = None,
 ) -> None:
     """
     Add a breadcrumb for debugging.

--- a/futureagi/tfc/tests/test_sentry_filtering.py
+++ b/futureagi/tfc/tests/test_sentry_filtering.py
@@ -1,0 +1,128 @@
+"""Tests for Sentry noise filtering and PII scrubbing in `tfc.logging.sentry`.
+
+These exercise the pure `before_send` pipeline and the scrubbing helpers, which
+import without the Sentry SDK or Django settings. They lock in the two things
+that keep the issue stream clean and safe:
+
+- Infrastructure / expected events are dropped (logger prefix, ignored
+  exception types, expected 4xx, expected log messages).
+- Real errors survive, with their secrets/PII redacted before send.
+"""
+
+from __future__ import annotations
+
+from tfc.logging.sentry import (
+    _REDACTED,
+    _get_before_send,
+    _is_sensitive_key,
+    _scrub,
+    _scrub_event,
+)
+
+before_send = _get_before_send()
+
+
+class _Exc(Exception):
+    """Exception carrying a status_code attribute, like DRF/HTTP exceptions."""
+
+    def __init__(self, status_code):
+        super().__init__("boom")
+        self.status_code = status_code
+
+
+def _hint(exc):
+    return {"exc_info": (type(exc), exc, None)}
+
+
+# Noise: dropped
+
+
+def test_drops_opentelemetry_logger_events():
+    event = {"logger": "opentelemetry.sdk.metrics._internal.export", "message": "x"}
+    assert before_send(event, {}) is None
+
+
+def test_drops_opentelemetry_child_loggers_by_prefix():
+    event = {"logger": "opentelemetry.exporter.otlp.proto.grpc.exporter"}
+    assert before_send(event, {}) is None
+
+
+def test_drops_ignored_exception_types():
+    assert before_send({}, _hint(ConnectionResetError(104, "reset"))) is None
+    assert before_send({}, _hint(BrokenPipeError())) is None
+
+
+def test_drops_expected_4xx_but_keeps_auth_failures():
+    assert before_send({}, _hint(_Exc(404))) is None
+    assert before_send({}, _hint(_Exc(429))) is None
+    # 401/403 are kept for security monitoring.
+    assert before_send({}, _hint(_Exc(401))) is not None
+    assert before_send({}, _hint(_Exc(403))) is not None
+    # 5xx is always kept.
+    assert before_send({}, _hint(_Exc(500))) is not None
+
+
+def test_drops_known_expected_messages():
+    event = {"message": "trace_payload_not_found_in_redis"}
+    assert before_send(event, {}) is None
+
+
+# Real errors: kept
+
+
+def test_keeps_real_application_errors():
+    event = {"logger": "tracer.utils.eval", "message": "unexpected boom"}
+    assert before_send(event, {}) is not None
+
+
+def test_keeps_real_exception():
+    assert before_send({}, _hint(ValueError("genuine bug"))) is not None
+
+
+# Scrubbing
+
+
+def test_sensitive_key_detection():
+    assert _is_sensitive_key("Authorization")
+    assert _is_sensitive_key("X-Api-Key")
+    assert _is_sensitive_key("password")
+    assert not _is_sensitive_key("user_id")
+
+
+def test_scrub_redacts_nested_secrets():
+    scrubbed = _scrub({"ok": 1, "token": "abc", "nested": {"password": "p"}})
+    assert scrubbed["ok"] == 1
+    assert scrubbed["token"] == _REDACTED
+    assert scrubbed["nested"]["password"] == _REDACTED
+
+
+def test_before_send_scrubs_request_and_extra():
+    event = {
+        "logger": "tracer.views.foo",
+        "message": "real error",
+        "request": {
+            "headers": {"Authorization": "Bearer secret", "Accept": "json"},
+            "cookies": {"sessionid": "xyz"},
+            "query_string": "api_key=leak&page=1",
+        },
+        "extra": {"api_key": "leak", "count": 5},
+    }
+    out = before_send(event, {})
+    assert out is not None
+    assert out["request"]["headers"]["Authorization"] == _REDACTED
+    assert out["request"]["headers"]["Accept"] == "json"
+    assert out["request"]["query_string"] == _REDACTED
+    assert out["request"]["cookies"] == _REDACTED  # cookies redacted wholesale
+    assert out["extra"]["api_key"] == _REDACTED
+    assert out["extra"]["count"] == 5
+
+
+def test_scrub_event_is_resilient_to_unexpected_shapes():
+    # Non-dict request/extra must not raise.
+    event = {"request": "not-a-dict", "extra": None, "message": "x"}
+    _scrub_event(event)  # should be a no-op, not an error
+
+
+def test_before_send_handles_unexpected_logentry_shape():
+    event = {"logger": "tracer.views.foo", "message": "real error", "logentry": "x"}
+    assert before_send(event, {}) is not None

--- a/futureagi/tfc/utils/functions.py
+++ b/futureagi/tfc/utils/functions.py
@@ -546,8 +546,7 @@ def calculate_column_average(column_id, row_ids=None):
                                                 sum(cell_scores) / len(cell_scores)
                                             )
                             except Exception as e:
-                                logger.error(f"Error processing cell: {str(e)}")
-                                traceback.print_exc()
+                                logger.warning(f"Error processing cell: {str(e)}")
                                 continue
                         if valid_scores:
                             stats["average"] = round(
@@ -605,7 +604,7 @@ def calculate_column_average(column_id, row_ids=None):
                             stats["success_rate"] = stats["average"]
 
                 except UserEvalMetric.DoesNotExist:
-                    logger.error(
+                    logger.warning(
                         f"UserEvalMetric does not exist for column {column_id}"
                     )
                     stats["average"] = None

--- a/futureagi/tfc/utils/storage.py
+++ b/futureagi/tfc/utils/storage.py
@@ -524,7 +524,11 @@ def upload_image_to_s3(
                     traceback.print_exc()
                     raise ValueError(get_error_message("INVALID_BASE64_STRING")) from e
 
-        img = Image.open(BytesIO(img_bytes))
+        try:
+            img = Image.open(BytesIO(img_bytes))
+        except Image.UnidentifiedImageError as e:
+            logger.warning(f"Skipping image upload: payload is not a valid image file: {str(e)}")
+            raise ValueError(get_error_message("INVALID_IMAGE")) from e
         format_detected = img.format
         if format_detected:
             format_detected = format_detected.lower()

--- a/futureagi/tracer/queries/eval_clustering.py
+++ b/futureagi/tracer/queries/eval_clustering.py
@@ -15,6 +15,7 @@ from typing import List, Optional, Tuple
 
 import structlog
 from django.conf import settings
+from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.utils import timezone
 
@@ -354,26 +355,42 @@ def create_cluster(
     # returns "medium" when severity is None (the fallback default).
     from tracer.queries.feed import severity_to_priority
 
-    cluster = TraceErrorGroup.objects.create(
-        project_id=project_id,
-        cluster_id=cluster_id,
-        source=ClusterSource.EVAL,
-        issue_group=result.eval_name,
-        issue_category=None,
-        fix_layer=meta.fix_layer,
-        title=meta.title,
-        combined_description=result.explanation,
-        combined_impact=_score_to_impact(result.score),
-        status=FeedIssueStatus.ESCALATING,
-        priority=severity_to_priority(meta.severity),
-        error_type=result.eval_name,
-        eval_config_id=result.eval_config_id,
-        total_events=1,
-        unique_traces=1,
-        error_count=1,
-        first_seen=timezone.now(),
-        last_seen=timezone.now(),
-    )
+    try:
+        # Savepoint so a unique-constraint violation here doesn't poison the
+        # surrounding transaction/connection.
+        with transaction.atomic():
+            cluster = TraceErrorGroup.objects.create(
+                project_id=project_id,
+                cluster_id=cluster_id,
+                source=ClusterSource.EVAL,
+                issue_group=result.eval_name,
+                issue_category=None,
+                fix_layer=meta.fix_layer,
+                title=meta.title,
+                combined_description=result.explanation,
+                combined_impact=_score_to_impact(result.score),
+                status=FeedIssueStatus.ESCALATING,
+                priority=severity_to_priority(meta.severity),
+                error_type=result.eval_name,
+                eval_config_id=result.eval_config_id,
+                total_events=1,
+                unique_traces=1,
+                error_count=1,
+                first_seen=timezone.now(),
+                last_seen=timezone.now(),
+            )
+    except IntegrityError:
+        # Another concurrent run created this cluster between our .exists()
+        # check and the insert (unique_project_cluster_if_not_deleted). Treat
+        # this as an assignment so the trace is still linked and the centroid
+        # still updated.
+        logger.info(
+            "eval_cluster_create_race_assigning",
+            cluster_id=cluster_id,
+            eval_logger_id=result.eval_logger_id,
+        )
+        assign_to_cluster(cluster_id, project_id, result, embedding)
+        return cluster_id
 
     # Create junction entry
     ErrorClusterTraces.objects.create(
@@ -437,12 +454,18 @@ def assign_to_cluster(
         update_fields=["error_count", "total_events", "last_seen", "updated_at"]
     )
 
-    # Create junction entry (ignore if trace already linked for this cluster)
-    ErrorClusterTraces.objects.get_or_create(
-        cluster=cluster,
-        trace_id=result.trace_id,
-        defaults={"eval_logger_id": result.eval_logger_id},
-    )
+    # Create junction entry (ignore if trace already linked for this cluster).
+    # Cannot use get_or_create: the unique key is (cluster, trace, span) and
+    # span is left NULL here, so duplicate (cluster, trace) rows accumulate
+    # and get_or_create's internal .get() raises MultipleObjectsReturned.
+    if not ErrorClusterTraces.objects.filter(
+        cluster=cluster, trace_id=result.trace_id
+    ).exists():
+        ErrorClusterTraces.objects.create(
+            cluster=cluster,
+            trace_id=result.trace_id,
+            eval_logger_id=result.eval_logger_id,
+        )
 
     # Refresh unique traces count + recompute impact from avg score
     unique = cluster.clusters.values("trace").distinct().count()

--- a/futureagi/tracer/queries/feed.py
+++ b/futureagi/tracer/queries/feed.py
@@ -1558,7 +1558,10 @@ def _fetch_trace_rows(
     )
 
     total = base.values("trace_id").distinct().count()
-    rows: list[TracesListRow] = []
+
+    # First pass: dedupe by trace id so the batch helpers below only fetch
+    # what we'll actually emit (mirrors _fetch_representative_traces).
+    deduped: list = []
     seen: set = set()
     for ect in base[offset : offset + limit * 3]:  # over-fetch for dedupe
         if not ect.trace:
@@ -1567,20 +1570,35 @@ def _fetch_trace_rows(
         if tid in seen:
             continue
         seen.add(tid)
+        deduped.append(ect.trace)
+        if len(deduped) >= limit:
+            break
 
-        latency, prompt, completion = _get_trace_totals(tid)
+    if not deduped:
+        return [], total
+
+    trace_ids = [str(t.id) for t in deduped]
+    roots = _get_root_spans_batch(trace_ids)
+    totals = _get_trace_totals_batch(trace_ids)
+    scores = _get_trace_scores_batch(trace_ids)
+    scans = _get_scan_results_batch(trace_ids)
+
+    rows: list[TracesListRow] = []
+    for trace in deduped:
+        tid = str(trace.id)
+        latency, prompt, completion = totals.get(tid, (None, None, None))
         tokens = (prompt or 0) + (completion or 0)
-        score = _get_trace_score(tid)
-        root = _get_root_span(tid)
+        score = scores.get(tid)
+        root = roots.get(tid)
         input_text = None
         if root:
             attrs = root.span_attributes or {}
             input_text = attrs.get("input.value")
         if not input_text:
-            input_text = _trace_input_str(ect.trace)
+            input_text = _trace_input_str(trace)
 
         turns = None
-        scan_result = TraceScanResult.objects.filter(trace_id=tid).only("meta").first()
+        scan_result = scans.get(tid)
         if scan_result and scan_result.meta:
             turns = scan_result.meta.get("turn_count")
 
@@ -1588,7 +1606,7 @@ def _fetch_trace_rows(
             TracesListRow(
                 id=tid,
                 input=input_text,
-                timestamp=ect.trace.created_at,
+                timestamp=trace.created_at,
                 latency_ms=latency,
                 tokens=tokens if tokens else None,
                 cost=round(tokens * _COST_PER_TOKEN, 6) if tokens else None,
@@ -1596,8 +1614,6 @@ def _fetch_trace_rows(
                 turns=turns,
             )
         )
-        if len(rows) >= limit:
-            break
 
     return rows, total
 

--- a/futureagi/tracer/services/clickhouse/client.py
+++ b/futureagi/tracer/services/clickhouse/client.py
@@ -213,6 +213,7 @@ class ClickHouseClient:
         query: str,
         params: Optional[Dict[str, Any]] = None,
         timeout_ms: Optional[int] = None,
+        settings: Optional[Dict[str, Any]] = None,
     ) -> Tuple[List[Tuple], List[Tuple], float]:
         """
         Execute a read-only query with ClickHouse readonly=2 setting.
@@ -233,7 +234,7 @@ class ClickHouseClient:
         client = self._get_client()
         t_start = time.monotonic()
 
-        query_settings = {"readonly": 2}
+        query_settings = {**(settings or {}), "readonly": 2}
         if timeout_ms is not None:
             # max_execution_time is in seconds
             query_settings["max_execution_time"] = max(timeout_ms / 1000.0, 0.001)

--- a/futureagi/tracer/services/clickhouse/client.py
+++ b/futureagi/tracer/services/clickhouse/client.py
@@ -151,6 +151,7 @@ class ClickHouseClient:
         query: str,
         params: Optional[Dict[str, Any]] = None,
         with_column_types: bool = False,
+        settings: Optional[Dict[str, Any]] = None,
     ) -> List[Tuple]:
         """
         Execute a query and return results.
@@ -159,6 +160,9 @@ class ClickHouseClient:
             query: SQL query string
             params: Query parameters for parameterized queries
             with_column_types: If True, returns (results, column_types)
+            settings: Optional per-query ClickHouse settings (e.g.
+                {"data_type_default_nullable": 0} for DDL that must not be
+                auto-wrapped in Nullable when the server profile sets it to 1)
 
         Returns:
             List of result tuples, or (results, column_types) if with_column_types=True
@@ -172,6 +176,7 @@ class ClickHouseClient:
                 query,
                 params or {},
                 with_column_types=with_column_types,
+                settings=settings,
             )
 
             query_time_ms = (time.monotonic() - t_start) * 1000

--- a/futureagi/tracer/services/clickhouse/query_builders/session_analytics.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_analytics.py
@@ -92,7 +92,7 @@ class SessionAnalyticsQueryBuilder(BaseQueryBuilder):
             sum(cost) AS total_cost
         FROM {self.TABLE}
         {self.project_where()}
-          AND trace_session_id != ''
+          AND trace_session_id IS NOT NULL
           AND trace_session_id != toUUID('{NIL_UUID}')
         GROUP BY trace_session_id
         ORDER BY started_at DESC

--- a/futureagi/tracer/services/clickhouse/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_list.py
@@ -139,6 +139,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
           AND trace_session_id IS NOT NULL
           AND trace_session_id != toUUID('{NIL_UUID}')
           AND (parent_span_id IS NULL OR parent_span_id = '')
+          AND created_at >= %(start_date)s - INTERVAL 1 DAY
           AND start_time >= %(start_date)s
           AND start_time < %(end_date)s
           {user_clause}
@@ -219,6 +220,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
           AND trace_session_id IS NOT NULL
           AND trace_session_id != toUUID('{NIL_UUID}')
           AND (parent_span_id IS NULL OR parent_span_id = '')
+          AND created_at >= %(start_date)s - INTERVAL 1 DAY
           AND start_time >= %(start_date)s
           AND start_time < %(end_date)s
           {user_clause}
@@ -265,6 +267,7 @@ class SessionListQueryBuilder(BaseQueryBuilder):
               AND trace_session_id IS NOT NULL
               AND trace_session_id != toUUID('{NIL_UUID}')
               AND (parent_span_id IS NULL OR parent_span_id = '')
+              AND created_at >= %(start_date)s - INTERVAL 1 DAY
               AND start_time >= %(start_date)s
               AND start_time < %(end_date)s
               {user_clause}

--- a/futureagi/tracer/services/clickhouse/query_builders/span_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/span_list.py
@@ -265,6 +265,7 @@ class SpanListQueryBuilder(BaseQueryBuilder):
           AND observation_span_id IN %(span_ids)s
           AND custom_eval_config_id IN %(eval_config_ids)s
         GROUP BY observation_span_id, custom_eval_config_id
+        SETTINGS max_bytes_before_external_group_by = 1073741824, max_bytes_before_external_sort = 1073741824
         """
         return query, params
 

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -401,6 +401,23 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             "eval_config_ids": tuple(self.eval_config_ids),
         }
 
+        # Partition-prune `tracer_eval_logger` (PARTITION BY toYYYYMM(created_at))
+        # so the FINAL merge can skip months that cannot match this page.
+        # The page of trace_ids was selected by build() within the user's
+        # [start_date, end_date] window on `start_time`, so the matching eval
+        # rows' `created_at` falls inside that window plus ingestion skew. A
+        # lower-bound-only filter with a 1-day skew buffer (identical to the
+        # mitigation in build()/build_count_query()) prunes old partitions
+        # without dropping any legitimately-matching eval row. Guarded on
+        # self.start_date so callers that invoke build_eval_query() without a
+        # prior build() (e.g. unit tests) keep their current behavior.
+        created_at_fragment = ""
+        if self.start_date is not None:
+            params["start_date"] = self.start_date
+            created_at_fragment = (
+                "AND created_at >= %(start_date)s - INTERVAL 1 DAY"
+            )
+
         # Include errored rows but compute aggregates only over successful
         # rows (error = 0). ``success_count`` / ``error_count`` let the
         # pivot surface an explicit error state on the UI when every eval
@@ -446,6 +463,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
           AND (deleted = 0 OR deleted IS NULL)
           AND trace_id IN %(trace_ids)s
           AND custom_eval_config_id IN %(eval_config_ids)s
+          {created_at_fragment}
         GROUP BY trace_id, custom_eval_config_id
         """
         return query, params

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -121,12 +121,12 @@ class AnalyticsQueryService:
         return is_clickhouse_enabled()
 
     def execute_ch_query(
-        self, query: str, params: dict = None, timeout_ms: int = 10000
+        self, query: str, params: dict = None, timeout_ms: int = 10000, settings: dict = None
     ) -> QueryResult:
         """Execute a query on ClickHouse and return QueryResult."""
         start = time.monotonic()
         rows, columns, qt = self.ch_client.execute_read(
-            query, params or {}, timeout_ms=timeout_ms
+            query, params or {}, timeout_ms=timeout_ms, settings=settings
         )
         elapsed = (time.monotonic() - start) * 1000
 
@@ -256,6 +256,7 @@ class AnalyticsQueryService:
             cdc_query,
             {"sample_ids": sample_ids, "project_id": project_id},
             timeout_ms=10000,
+            settings={"max_memory_usage": 2000000000},
         )
         return [{"key": row["key"], "type": row["type"]} for row in cdc_result.data]
 

--- a/futureagi/tracer/services/clickhouse/span_attribute_lookups.py
+++ b/futureagi/tracer/services/clickhouse/span_attribute_lookups.py
@@ -173,8 +173,11 @@ def span_id_by_provider_log_id(
         return None
 
     # The previous PG query also matched ``metadata.provider_log_id`` (note:
-    # ``metadata`` lives in ``metadata_map`` in CH). We OR all three sources,
-    # consistent with the old behaviour.
+    # ``metadata`` lives in ``metadata_map`` in CH) and ``eval_attributes``.
+    # The denormalized ``spans`` table has no ``eval_attributes`` column
+    # (only the CDC landing table ``tracer_observation_span`` does), so that
+    # branch is dropped here: ``metadata_map['provider_log_id']`` reliably
+    # carries the provider_log_id written at span creation.
     query = """
         SELECT toString(id)
         FROM spans
@@ -183,7 +186,6 @@ def span_id_by_provider_log_id(
           AND (
                 metadata_map['provider_log_id']                                = %(pid)s
              OR JSONExtractString(span_attributes_raw, 'raw_log', 'id')       = %(pid)s
-             OR JSONExtractString(eval_attributes,     'raw_log', 'id')       = %(pid)s
           )
         ORDER BY updated_at DESC
         LIMIT 1

--- a/futureagi/tracer/tests/test_clickhouse.py
+++ b/futureagi/tracer/tests/test_clickhouse.py
@@ -7414,7 +7414,7 @@ class TestSessionAnalyticsQueryBuilder:
         assert "trace_session_id" in query
         assert "GROUP BY trace_session_id" in query
         assert "ORDER BY started_at DESC" in query
-        assert "trace_session_id != ''" in query
+        assert "trace_session_id IS NOT NULL" in query
 
     def test_session_navigation_has_aggregate_columns(self):
         """Navigation query should include count, tokens, cost."""

--- a/futureagi/tracer/tests/test_trace_ingestion_serialize.py
+++ b/futureagi/tracer/tests/test_trace_ingestion_serialize.py
@@ -1,0 +1,70 @@
+"""Unit tests for JSON-field serialization in trace ingestion.
+
+Covers CORE-BACKEND-YQK: non-finite floats (Infinity/NaN) in span jsonb
+fields broke the Postgres COPY ("invalid input syntax for type json /
+Token 'Infinity' is invalid"). _serialize_json_field_value must scrub them
+to null and never emit bare Infinity/NaN tokens, while leaving clean JSON
+byte-identical.
+"""
+
+import json
+
+import pytest
+
+from tracer.utils.trace_ingestion import (
+    _sanitize_nonfinite_floats,
+    _serialize_json_field_value,
+)
+
+
+class TestSanitizeNonFiniteFloats:
+    def test_inf_and_nan_become_none(self):
+        assert _sanitize_nonfinite_floats(float("inf")) is None
+        assert _sanitize_nonfinite_floats(float("-inf")) is None
+        assert _sanitize_nonfinite_floats(float("nan")) is None
+
+    def test_finite_floats_unchanged(self):
+        assert _sanitize_nonfinite_floats(3.5) == 3.5
+        assert _sanitize_nonfinite_floats(0.0) == 0.0
+
+    def test_recurses_dict_list_tuple(self):
+        assert _sanitize_nonfinite_floats({"a": [{"b": float("inf")}]}) == {
+            "a": [{"b": None}]
+        }
+        assert _sanitize_nonfinite_floats([1, float("nan"), 3]) == [1, None, 3]
+
+    def test_non_floats_passthrough(self):
+        assert _sanitize_nonfinite_floats("x") == "x"
+        assert _sanitize_nonfinite_floats(7) == 7
+        assert _sanitize_nonfinite_floats(None) is None
+
+
+class TestSerializeJsonFieldValue:
+    def test_none_passthrough(self):
+        assert _serialize_json_field_value(None) is None
+
+    def test_clean_json_string_unchanged(self):
+        s = '{"a": 1, "b": [2, 3.5]}'
+        assert _serialize_json_field_value(s) == s
+
+    def test_dict_with_infinity_scrubbed_and_valid_json(self):
+        out = _serialize_json_field_value({"request_id": float("inf"), "ok": 1})
+        assert "Infinity" not in out
+        assert json.loads(out) == {"request_id": None, "ok": 1}
+
+    def test_dict_with_nan_scrubbed(self):
+        out = _serialize_json_field_value({"x": float("nan")})
+        assert json.loads(out)["x"] is None
+
+    def test_json_string_containing_infinity_token_is_scrubbed(self):
+        # The exact YQK shape: a JSON string whose value is the bare Infinity token.
+        s = '{"request_id": Infinity, "name": "cartesia.tts.TTS"}'
+        out = _serialize_json_field_value(s)
+        assert "Infinity" not in out
+        assert json.loads(out) == {"request_id": None, "name": "cartesia.tts.TTS"}
+
+    def test_output_is_valid_postgres_json(self):
+        # Whatever comes out must be parseable JSON (no bare NaN/Infinity tokens).
+        for val in [{"a": float("inf")}, [float("nan")], {"n": {"m": float("-inf")}}]:
+            out = _serialize_json_field_value(val)
+            json.loads(out)  # must not raise

--- a/futureagi/tracer/tests/test_vapi_recording_urls.py
+++ b/futureagi/tracer/tests/test_vapi_recording_urls.py
@@ -1,0 +1,38 @@
+"""Unit test for CORE-BACKEND-1190.
+
+`_extract_recording_urls` crashed with "AttributeError: 'str' object has no
+attribute 'get'" when a Vapi log's `artifact` key was present but its value was
+a string (malformed provider payload). The fix type-guards `artifact` before
+calling `.get`. These are pure-dict transforms — no DB needed.
+"""
+
+from tracer.utils.vapi import _extract_recording_urls
+
+
+def test_string_artifact_does_not_crash():
+    attrs = {}
+    # Previously raised AttributeError: 'str' object has no attribute 'get'
+    _extract_recording_urls({"artifact": "unexpected-string"}, attrs)
+    assert attrs == {}
+
+
+def test_missing_artifact_does_not_crash():
+    attrs = {}
+    _extract_recording_urls({}, attrs)
+    assert attrs == {}
+
+
+def test_none_artifact_does_not_crash():
+    attrs = {}
+    _extract_recording_urls({"artifact": None}, attrs)
+    assert attrs == {}
+
+
+def test_well_formed_recording_still_extracted():
+    attrs = {}
+    _extract_recording_urls(
+        {"artifact": {"recording": {"mono": {"combinedUrl": "https://x/r.wav"}}}},
+        attrs,
+    )
+    # The mono combined URL should have been written into eval_attributes.
+    assert any("https://x/r.wav" == v for v in attrs.values())

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -457,7 +457,10 @@ def _process_mapping(
             # what dataset/playground do when a column cell is empty.
             parsed_mapping[key] = ""
         else:
-            logger.error(
+            # Expected: the user's eval references an attribute absent on this
+            # span. Raw emitter before the ValueError that the outer
+            # evaluate_*_observe handler catches and persists as failed. Warning.
+            logger.warning(
                 f"Required attribute '{attribute}' for key '{key}' not found for span {span.id}"
             )
             raise ValueError(
@@ -1799,7 +1802,9 @@ def evaluate_observation_span_observe(
                     eval_task.failed_spans = failed_spans
                     eval_task.save(update_fields=["failed_spans", "updated_at"])
             except EvalTask.DoesNotExist:
-                logger.error(f"EvalTask with id {eval_task_id} does not exist.")
+                # Expected race: the EvalTask was deleted before this async task
+                # ran. Nothing to update; downgrade to warning.
+                logger.warning(f"EvalTask with id {eval_task_id} does not exist.")
             except Exception as e:
                 logger.error(
                     f"Error during updating failed spans in exception handling evaluate_observation_span_observe: {e}"
@@ -2394,7 +2399,10 @@ def _process_trace_mapping(
                 # (partial). Mirrors the span / dataset behaviour.
                 parsed[key] = ""
                 continue
-            logger.error(
+            # Expected: the user's eval references an attribute absent on this
+            # trace. Raw emitter before the ValueError that the outer
+            # evaluate_trace_observe handler catches and persists as failed. Warning.
+            logger.warning(
                 f"Required attribute '{attribute}' for key '{key}' not found "
                 f"on trace {trace.id}"
             )
@@ -2445,7 +2453,10 @@ def _process_session_mapping(
                 # (partial), matching dataset/span behaviour.
                 parsed[key] = ""
                 continue
-            logger.error(
+            # Expected: the user's eval references an attribute absent on this
+            # session. Raw emitter before the ValueError that the outer
+            # evaluate_trace_session_observe handler catches and persists as failed. Warning.
+            logger.warning(
                 f"Required attribute '{attribute}' for key '{key}' not found "
                 f"on session {trace_session.id}"
             )
@@ -3085,7 +3096,9 @@ def evaluate_trace_observe(
                     eval_task.failed_spans = failed
                     eval_task.save(update_fields=["failed_spans", "updated_at"])
             except EvalTask.DoesNotExist:
-                logger.error(f"EvalTask with id {eval_task_id} does not exist.")
+                # Expected race: the EvalTask was deleted before this async task
+                # ran. Nothing to update; downgrade to warning.
+                logger.warning(f"EvalTask with id {eval_task_id} does not exist.")
             except Exception as save_err:
                 logger.error(
                     f"Error updating failed_spans during trace eval error: {save_err}"
@@ -3183,7 +3196,9 @@ def evaluate_trace_session_observe(
                     eval_task.failed_spans = failed
                     eval_task.save(update_fields=["failed_spans", "updated_at"])
             except EvalTask.DoesNotExist:
-                logger.error(f"EvalTask with id {eval_task_id} does not exist.")
+                # Expected race: the EvalTask was deleted before this async task
+                # ran. Nothing to update; downgrade to warning.
+                logger.warning(f"EvalTask with id {eval_task_id} does not exist.")
             except Exception as save_err:
                 logger.error(
                     f"Error updating failed_spans during session eval error: {save_err}"

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -1635,7 +1635,10 @@ def evaluate_observation_span(
         )
         return True
     except ValueError as e:
-        logger.error(f"Error during evaluation in evaluate_observation_span: {e}")
+        # Expected validation failure (e.g. missing required input for the eval).
+        # Recorded as a failed-eval result below; logged at WARNING so it does
+        # not page Sentry as a code bug.
+        logger.warning(f"Error during evaluation in evaluate_observation_span: {e}")
         _create_error_eval_logger(observation_span, custom_eval_config, None, str(e))
         return False
 
@@ -1770,7 +1773,9 @@ def evaluate_observation_span_observe(
 
         return True
     except ValueError as e:
-        logger.error(
+        # Expected validation failure (missing/invalid eval input). Persisted as
+        # a failed span below; WARNING keeps it out of the Sentry issue stream.
+        logger.warning(
             f"Error during evaluation in evaluate_observation_span_observe: {e}"
         )
         if eval_task_id:
@@ -3061,7 +3066,8 @@ def evaluate_trace_observe(
         )
         return True
     except ValueError as e:
-        logger.error(f"Error during evaluation in evaluate_trace_observe: {e}")
+        # Expected validation failure; persisted as a failed eval below.
+        logger.warning(f"Error during evaluation in evaluate_trace_observe: {e}")
         if eval_task_id:
             try:
                 with transaction.atomic():
@@ -3156,7 +3162,10 @@ def evaluate_trace_session_observe(
         )
         return True
     except ValueError as e:
-        logger.error(f"Error during evaluation in evaluate_trace_session_observe: {e}")
+        # Expected validation failure; persisted as a failed eval below.
+        logger.warning(
+            f"Error during evaluation in evaluate_trace_session_observe: {e}"
+        )
         if eval_task_id:
             try:
                 with transaction.atomic():

--- a/futureagi/tracer/utils/otel.py
+++ b/futureagi/tracer/utils/otel.py
@@ -1456,7 +1456,9 @@ def _convert_single_span(otel_span, projects, project_versions, organization_id)
         version_key = (project.id, project_version_name, project_version_id)
         project_version = project_versions.get(version_key)
     else:
-        raise Exception(f"Project not found for version data: {version_key}")
+        raise Exception(
+            f"Project not found for version data: project_name={project_name}, project_type={project_type}"
+        )
 
     # Process Input/Output
     input_val = attributes.get("fi.llm.input") or attributes.get(

--- a/futureagi/tracer/utils/session.py
+++ b/futureagi/tracer/utils/session.py
@@ -63,8 +63,8 @@ def _try_session_navigation_ch(request, project_id, current_session_id, query_da
             # Add user filter to the navigation query
             nav_params["user_id"] = user_id
             nav_query = nav_query.replace(
-                "AND trace_session_id != ''",
-                "AND trace_session_id != '' AND end_user_id = %(user_id)s",
+                "AND trace_session_id IS NOT NULL",
+                "AND trace_session_id IS NOT NULL AND end_user_id = %(user_id)s",
             )
 
         nav_result = service.execute_ch_query(nav_query, nav_params)

--- a/futureagi/tracer/utils/trace_ingestion.py
+++ b/futureagi/tracer/utils/trace_ingestion.py
@@ -91,6 +91,47 @@ def _sanitize_nonfinite_floats(value: Any) -> Any:
     return value
 
 
+def _strip_null_chars(value: Any) -> Any:
+    """Recursively strip NUL (``\\x00``) bytes from string keys and values.
+
+    PostgreSQL's text and json/jsonb types cannot store the NUL code point: a
+    real ``\\x00`` inside a string is emitted by ``json.dumps`` as the escape
+    ``\\u0000``, which jsonb rejects during COPY (``unsupported Unicode escape
+    sequence ... \\u0000 cannot be converted to text``). User-supplied span
+    attributes can carry NUL (e.g. extracted PDF/document text), so scrub them
+    before serialization. Distinct from ``_sanitize_nonfinite_floats``: NUL is
+    silently escaped by ``json.dumps`` rather than raising, so the strip must
+    run unconditionally on the JSON path. Only ``\\x00`` is removed; other
+    control characters (e.g. ``\\u0013``) are valid in jsonb and preserved.
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, dict):
+        return {
+            (k.replace("\x00", "") if isinstance(k, str) else k): _strip_null_chars(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_strip_null_chars(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_strip_null_chars(v) for v in value)
+    return value
+
+
+def _contains_null_char(value: Any) -> bool:
+    """Return True if any string key/value in ``value`` contains a NUL byte."""
+    if isinstance(value, str):
+        return "\x00" in value
+    if isinstance(value, dict):
+        return any(
+            (isinstance(k, str) and "\x00" in k) or _contains_null_char(v)
+            for k, v in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_null_char(v) for v in value)
+    return False
+
+
 def _serialize_json_field_value(val: Any) -> str | None:
     """
     Serialize a value for PostgreSQL JSONField in COPY operations.
@@ -108,20 +149,36 @@ def _serialize_json_field_value(val: Any) -> str | None:
         try:
             parsed = json.loads(val)
         except (json.JSONDecodeError, TypeError):
-            return json.dumps(val, allow_nan=False)
+            # Not JSON: COPY writes the raw string into the text-backed column,
+            # so strip NUL directly off the byte stream.
+            return json.dumps(val.replace("\x00", ""), allow_nan=False)
         try:
-            # Fast path: already-valid JSON with no non-finite floats.
+            # Fast path: already-valid JSON with no non-finite floats or NUL
+            # bytes. A NUL survives json.loads as a real \x00 inside ``parsed``
+            # (the source text held the backslash-u-0000 escape), so check ``parsed``.
             json.dumps(parsed, allow_nan=False)
-            return val
+            if not _contains_null_char(parsed):
+                return val
+            return json.dumps(_strip_null_chars(parsed), allow_nan=False)
         except ValueError:
-            return json.dumps(_sanitize_nonfinite_floats(parsed), allow_nan=False)
+            return json.dumps(
+                _strip_null_chars(_sanitize_nonfinite_floats(parsed)), allow_nan=False
+            )
 
     # Fast path: dump directly; only pay the recursive scrub when a non-finite
-    # float is actually present (keeps the common clean-data path allocation-free).
+    # float or NUL byte is actually present (keeps the common clean-data path
+    # allocation-free).
     try:
-        return json.dumps(val, allow_nan=False)
+        dumped = json.dumps(val, allow_nan=False)
     except ValueError:
-        return json.dumps(_sanitize_nonfinite_floats(val), allow_nan=False)
+        return json.dumps(
+            _strip_null_chars(_sanitize_nonfinite_floats(val)), allow_nan=False
+        )
+    # json.dumps does not raise on NUL; it silently emits the \u0000 escape,
+    # so guard the dumped output explicitly.
+    if "\\u0000" not in dumped:
+        return dumped
+    return json.dumps(_strip_null_chars(val), allow_nan=False)
 
 
 def _bulk_create_with_copy(model: models.Model, objects: list[models.Model]):
@@ -142,6 +199,10 @@ def _bulk_create_with_copy(model: models.Model, objects: list[models.Model]):
                 # Handle JSONField values
                 if isinstance(field, models.JSONField):
                     val = _serialize_json_field_value(val)
+                elif isinstance(val, str):
+                    # text/varchar columns cannot store NUL either; COPY writes
+                    # the raw byte stream, so strip \x00 off plain strings too.
+                    val = val.replace("\x00", "")
 
                 row.append(val)
             values_list.append(tuple(row))

--- a/futureagi/tracer/utils/trace_ingestion.py
+++ b/futureagi/tracer/utils/trace_ingestion.py
@@ -71,6 +71,26 @@ def _format_if_needed(raw: str) -> str | None:
 # --- Helper Functions for Database Interaction ---
 
 
+def _sanitize_nonfinite_floats(value: Any) -> Any:
+    """Recursively replace NaN/+-Infinity floats with ``None``.
+
+    Python's ``json.dumps`` emits the bare tokens ``NaN``/``Infinity``/
+    ``-Infinity`` for non-finite floats, which PostgreSQL's json/jsonb type
+    rejects during COPY (``invalid input syntax for type json``). User-supplied
+    span attributes can carry these values, so scrub them before serialization.
+    Mirrors ``tracer.views.trace._sanitize_nonfinite_floats`` on the read path.
+    """
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {k: _sanitize_nonfinite_floats(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_nonfinite_floats(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_sanitize_nonfinite_floats(v) for v in value)
+    return value
+
+
 def _serialize_json_field_value(val: Any) -> str | None:
     """
     Serialize a value for PostgreSQL JSONField in COPY operations.
@@ -86,12 +106,22 @@ def _serialize_json_field_value(val: Any) -> str | None:
 
     if isinstance(val, str):
         try:
-            json.loads(val)
-            return val
+            parsed = json.loads(val)
         except (json.JSONDecodeError, TypeError):
-            return json.dumps(val)
+            return json.dumps(val, allow_nan=False)
+        try:
+            # Fast path: already-valid JSON with no non-finite floats.
+            json.dumps(parsed, allow_nan=False)
+            return val
+        except ValueError:
+            return json.dumps(_sanitize_nonfinite_floats(parsed), allow_nan=False)
 
-    return json.dumps(val)
+    # Fast path: dump directly; only pay the recursive scrub when a non-finite
+    # float is actually present (keeps the common clean-data path allocation-free).
+    try:
+        return json.dumps(val, allow_nan=False)
+    except ValueError:
+        return json.dumps(_sanitize_nonfinite_floats(val), allow_nan=False)
 
 
 def _bulk_create_with_copy(model: models.Model, objects: list[models.Model]):
@@ -593,7 +623,27 @@ def _bulk_insert_observation_spans(spans_to_create: list[ObservationSpan]):
         if not span.updated_at:
             span.updated_at = now
 
-    _bulk_create_with_copy(ObservationSpan, spans_to_create)
+    # Idempotent on Temporal retry: COPY FROM STDIN has no ON CONFLICT support,
+    # so a re-ingest of the same span IDs would violate tracer_observation_span_pkey.
+    # Use a savepoint (we run inside an outer transaction.atomic) so a conflict does
+    # not poison the outer transaction, then fall back to an ON CONFLICT DO NOTHING
+    # insert. NOTE: _bulk_create_with_copy uses psycopg3's COPY API, which bypasses
+    # Django's error wrapping — the duplicate-key error surfaces as a raw psycopg
+    # UniqueViolation (often chained via __cause__), NOT django.db.IntegrityError.
+    # Mirror the sibling Trace handler above and match on that.
+    try:
+        with transaction.atomic():
+            _bulk_create_with_copy(ObservationSpan, spans_to_create)
+    except Exception as e:
+        from django.db import DatabaseError
+        from psycopg.errors import UniqueViolation
+
+        if isinstance(getattr(e, "__cause__", None), UniqueViolation) or isinstance(
+            e, DatabaseError
+        ):
+            ObservationSpan.objects.bulk_create(spans_to_create, ignore_conflicts=True)
+        else:
+            raise
 
 
 def _bulk_update_traces(

--- a/futureagi/tracer/utils/trace_ingestion.py
+++ b/futureagi/tracer/utils/trace_ingestion.py
@@ -669,7 +669,11 @@ def bulk_create_observation_span_task(
         payload_bytes = payload_storage.retrieve(payload_key)
 
         if payload_bytes is None:
-            logger.error(
+            # Expected race: the payload TTL'd out (or its writer hasn't landed)
+            # before this task ran. The raised ValueError below is what Temporal
+            # retries on, so this log is purely informational - WARNING avoids
+            # double-reporting the same condition as a Sentry error.
+            logger.warning(
                 "trace_payload_not_found_in_redis",
                 payload_key=payload_key,
             )

--- a/futureagi/tracer/utils/vapi.py
+++ b/futureagi/tracer/utils/vapi.py
@@ -250,7 +250,8 @@ def _extract_metadata(log: dict, eval_attributes: dict):
 
 def _extract_recording_urls(log: dict, eval_attributes: dict):
     """Extracts recording URLs and adds them to eval_attributes."""
-    recording = log.get("artifact", {}).get("recording")
+    artifact = log.get("artifact")
+    recording = artifact.get("recording") if isinstance(artifact, dict) else None
     if not (recording and isinstance(recording, dict)):
         return
 

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1049,6 +1049,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                             "FROM tracer_eval_logger "
                             "WHERE _peerdb_is_deleted = 0 AND deleted = 0 "
                             "AND custom_eval_config_id != toUUID('00000000-0000-0000-0000-000000000000') "
+                            "AND created_at >= now() - INTERVAL 90 DAY "
                             "AND dictGet('trace_dict', 'project_id', trace_id) IN %(project_ids)s",
                             {"project_ids": project_ids},
                             timeout_ms=5000,

--- a/futureagi/tracer/views/project.py
+++ b/futureagi/tracer/views/project.py
@@ -498,6 +498,7 @@ class ProjectView(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
                             "AND _peerdb_is_deleted = 0 "
                             "AND (parent_span_id IS NULL OR parent_span_id = %(e)s) "
                             "AND start_time >= %(since)s "
+                            "AND created_at >= %(since)s "
                             "GROUP BY project_id",
                             {"pids": project_ids, "e": "", "since": thirty_days_ago},
                             timeout_ms=5000,
@@ -517,6 +518,7 @@ class ProjectView(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
                             "AND _peerdb_is_deleted = 0 "
                             "AND (parent_span_id IS NULL OR parent_span_id = %(e)s) "
                             "AND start_time >= %(since)s "
+                            "AND created_at >= %(since)s "
                             "GROUP BY project_id, day "
                             "ORDER BY project_id, day",
                             {"pids": project_ids, "e": "", "since": thirty_days_ago},

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -1366,7 +1366,10 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
               AND (deleted = 0 OR deleted IS NULL)
             """
             eval_result = analytics.execute_ch_query(
-                eval_query, {"trace_id": str(trace_id)}, timeout_ms=30000
+                eval_query,
+                {"trace_id": str(trace_id)},
+                timeout_ms=30000,
+                settings={"do_not_merge_across_partitions_select_final": 1},
             )
             # Collect unique config IDs for name lookup
             config_ids_set = set()
@@ -5840,8 +5843,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 "SELECT id, span_attributes, provider "
                 "FROM tracer_observation_span FINAL "
                 "PREWHERE id IN %(span_ids)s "
-                "WHERE _peerdb_is_deleted = 0",
-                {"span_ids": tuple(span_ids)},
+                "WHERE project_id = %(project_id)s "
+                "AND _peerdb_is_deleted = 0",
+                {"span_ids": tuple(span_ids), "project_id": str(project_id)},
                 timeout_ms=10000,
             )
             for arow in attrs_result.data:
@@ -6406,11 +6410,14 @@ class UsersView(APIView):
                     PREWHERE end_user_id IN %(eu_ids)s
                     WHERE _peerdb_is_deleted = 0
                       {project_clause}
+                      AND created_at >= now() - INTERVAL 30 DAY
                       AND (
                         (span_attributes_raw != '{{}}' AND span_attributes_raw != '')
                         OR length(mapKeys(span_attr_str)) > 0
                         OR length(mapKeys(span_attr_num)) > 0
                       )
+                    ORDER BY created_at DESC
+                    LIMIT 50000
                     """
                     attr_result = analytics.execute_ch_query(
                         attr_query, attr_params, timeout_ms=30000


### PR DESCRIPTION
## Sentry overhaul: noise/PII reduction, alerting, and a last-2-months issue sweep

Single PR for all the Sentry work, based directly on **`dev`** and containing **only the
Sentry changes (72 files)** — fully independent of the `fix/TH-4812` feature branch (none of
its ~150 commits / 290 files are here). The 3 commits below were cherry-picked onto `dev`
(clean, no conflicts) and re-validated: frontend 16/16 vitest + backend 80/80 pytest green.

3 commits:
1. `chore: reduce sentry noise` — the infra/PII/capture-path overhaul.
2. `fix: resolve recent Sentry bugs` — the top ~75-by-impact bugs.
3. `fix: second-wave Sentry fixes + tests` — the remaining long tail (perf, more bugs, frontend clusters) **with tests**.

### 1. Noise, PII, capture path (commit 1)
- **One log→event path**: removed the redundant Django `EventHandler`; `LoggingIntegration` is the only path (also covers Celery/Temporal). `ignore_logger("opentelemetry")` + a `before_send` prefix filter kill the **~23M-event** OTel-exporter spam (`propagate=False` can't gate it — it patches `callHandlers`).
- **`before_send`**: drops infra-logger noise, expected exceptions, expected 4xx (keeps 401/403), known-expected messages; then **scrubs PII** (`EventScrubber` + recursive header/cookie/body/query/extra redaction). `max_request_body_size` `always→medium`, `MAX_STRING_LENGTH` 10MB→8KB.
- **Frontend**: replay text masked + media blocked, `sendDefaultPii:false`, prod traces 1.0→0.1, `ignoreErrors`/`denyUrls`/`beforeSend` for browser/vite-deps/third-party noise, `warn()`→breadcrumb.

### 2–3. Bug fixes (both waves)
**Backend** — ClickHouse `Nullable` schema bug (~750k events: `data_type_default_nullable=1` guard), `otel.py` `version_key` UnboundLocalError, `Infinity`/`NaN` in jsonb breaking Postgres COPY (YQK, 152k), duplicate-key idempotency (span COPY + ErrorLocalizer + clustering), ClickHouse memory/slow-query mitigations (date bounds, per-query SETTINGS), N+1s (annotation-queues, simulate, feed + workspace-membership memoization), `vapi` str-guard, uuid-parse `IS NOT NULL`, json-path `IndexError` guard, `_UUIDEncoder`, S3 image guard, invalid Gemini model id, `'gpt-5'` enum, empty Slack webhook, and source-level WARNING downgrades for expected eval/STT/validation conditions.

**Frontend** — `lazyWithRetry` recovers the post-deploy stale-module-graph `"reading 'default'"` cluster (~15 routes), `copyToClipboard` guard, `use-url-state` render-loop fix, null guards, eval discriminator dedup.

> Heavy DB migrations (a `spans` `MATERIALIZE PROJECTION`, a GIN index) were **deliberately not auto-applied** — flagged for a separate reviewed change.

### Tests (run, not just written)
- **Frontend**: `vitest` — 16/16 green; running them caught + fixed a real `copyToClipboard` regression. New specs for `lazyWithRetry` + `copyToClipboard`.
- **Backend**: run against the ws2 test stack (Postgres + ClickHouse). New unit tests (Infinity/NaN serialization, `vapi`, sentry filtering) + a **regression sweep** on every changed area — RBAC (24), clustering (3), annotation-queues (56), workspace serializers (8), feed (7), ClickHouse query-builders (463). **No regressions.** (5 CH pagination failures are **pre-existing** — verified by stashing this branch — and are not touched here.)

### Sentry status reconciliation
Issues are being reconciled in Sentry: code-fixed → `resolvedInNextRelease` (with commit refs), infra/third-party → `ignored (untilEscalating)`, expected-validation → resolved-via-downgrade. Resolutions are **provisional on merge + deploy** (and on setting `APP_VERSION`/`GIT_SHA` so release tracking works).

### Docs & follow-ups (not in this PR)
- `internal-docs/SENTRY_GUIDE.md` — architecture, noise levers, PII policy, sampling, and an **8-rule alerting playbook** (API error-rate, DB-exception spike, p95 API/DB latency, crash-free sessions, cron monitors).
- `internal-docs/SENTRY_EE_PATCHES.md` — ready-to-apply patches for the gitignored `ee/` enterprise code: the two **billing-cron bugs** (auto-reload crash + January `month-1`), the **Stripe Meter-Events migration** (⚠ verify delta-vs-total billing), and the gateway model id.
- **Infra action items**: fix `OTEL_EXPORTER_OTLP_ENDPOINT` in prod (the 23M-event root cause), create the alert rules, set `APP_VERSION`.

> Note: backend test deps include a Linux/CUDA-only stack; `requirements-test.txt` also had its already-unused `guardrails-ai` pin removed (it was absent from `pyproject.toml`). Nothing here was run in production — **CI on this PR is the runtime gate** for the backend integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
