### PR TITLE
fix(evals): dedupe CustomTooltip import in TracingTestMode

### DIFF
--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -44,7 +44,7 @@ import {
   isRecordingObjectKey,
 } from "src/components/inline-audio/audio-detection";
 import { useForm, useWatch } from "react-hook-form";
-import CustomTooltip from "src/components/tooltip/CustomTooltip";
+import CustomTooltip from "src/components/tooltip";
 import TaskFilterBar from "src/sections/tasks/components/TaskFilterBar";
 import { buildApiFilterArray } from "src/sections/tasks/components/TaskLivePreview";
 import { JsonValueTree } from "./DatasetTestMode";
@@ -53,7 +53,6 @@ import EvalResultDisplay from "./EvalResultDisplay";
 import SpanRowList from "./SpanRowList";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
-import CustomTooltip from "src/components/tooltip";
 
 const ROW_TYPE_OPTIONS = [
   { value: "Span", label: "Spans", icon: "solar:layers-outline" },


### PR DESCRIPTION
## Summary
- `TracingTestMode.jsx` had two `CustomTooltip` imports pointing to the same component (one via the explicit file path, one via the `tooltip/index` barrel). Kept the barrel import only.

## Files Changed
- `frontend/src/sections/evals/components/TracingTestMode.jsx`

## Test plan
- [ ] Open the eval Tracing test mode drawer — tooltips on the columns/value table and span list still render