### PR TITLE
fix(observe): disable agent graph + agent path tabs for voice projects [TH-4413]

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/DisplayPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/DisplayPanel.jsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from "@mui/material";
 import Iconify from "src/components/iconify";
+import CustomTooltip from "src/components/tooltip";
 
 const GROUP_OPTIONS = [
   { key: "trace", label: "Trace" },
@@ -120,50 +121,88 @@ const VIEW_MODES = [
   },
 ];
 
-const ViewTabButton = ({ icon, label, isActive, onClick }) => (
-  <ButtonBase
-    onClick={onClick}
-    sx={{
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "center",
-      gap: 0.25,
-      flex: 1,
-      py: 0.75,
-      px: 0.5,
-      borderRadius: 0.5,
-      bgcolor: isActive ? "background.paper" : "transparent",
-      boxShadow: isActive ? "2px 2px 6px 0px rgba(0,0,0,0.08)" : "none",
-      "&:hover": {
-        bgcolor: isActive ? "background.paper" : "action.hover",
-      },
-    }}
-  >
-    <Iconify
-      icon={icon}
-      width={14}
-      sx={{ color: isActive ? "text.primary" : "text.secondary" }}
-    />
-    <Typography
-      variant="caption"
+const ViewTabButton = ({
+  icon,
+  label,
+  isActive,
+  onClick,
+  disabled = false,
+  disabledTooltip,
+}) => {
+  const button = (
+    <ButtonBase
+      onClick={onClick}
+      disabled={disabled}
       sx={{
-        fontSize: 12,
-        fontWeight: 400,
-        color: isActive ? "text.primary" : "text.secondary",
-        lineHeight: "18px",
-        textAlign: "center",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 0.25,
+        flex: 1,
+        py: 0.75,
+        px: 0.5,
+        borderRadius: 0.5,
+        bgcolor: isActive ? "background.paper" : "transparent",
+        boxShadow: isActive ? "2px 2px 6px 0px rgba(0,0,0,0.08)" : "none",
+        opacity: disabled ? 0.5 : 1,
+        "&:hover": {
+          bgcolor: isActive ? "background.paper" : "action.hover",
+        },
       }}
     >
-      {label}
-    </Typography>
-  </ButtonBase>
-);
+      <Iconify
+        icon={icon}
+        width={14}
+        sx={{
+          color: disabled
+            ? "text.disabled"
+            : isActive
+              ? "text.primary"
+              : "text.secondary",
+        }}
+      />
+      <Typography
+        variant="caption"
+        sx={{
+          fontSize: 12,
+          fontWeight: 400,
+          color: disabled
+            ? "text.disabled"
+            : isActive
+              ? "text.primary"
+              : "text.secondary",
+          lineHeight: "18px",
+          textAlign: "center",
+        }}
+      >
+        {label}
+      </Typography>
+    </ButtonBase>
+  );
+
+  if (!disabled || !disabledTooltip) return button;
+  return (
+    <CustomTooltip
+      show
+      arrow
+      size="small"
+      type="black"
+      title={disabledTooltip}
+    >
+      <Box sx={{ flex: 1, display: "flex", cursor: "not-allowed" }}>
+        {button}
+      </Box>
+    </CustomTooltip>
+  );
+};
 
 ViewTabButton.propTypes = {
   icon: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   isActive: PropTypes.bool,
   onClick: PropTypes.func,
+  disabled: PropTypes.bool,
+  disabledTooltip: PropTypes.string,
 };
 
 // ---------------------------------------------------------------------------
@@ -259,15 +298,24 @@ const DisplayPanel = ({
                   theme.palette.mode === "dark" ? "action.hover" : "grey.200",
               }}
             >
-              {VIEW_MODES.map((vm) => (
-                <ViewTabButton
-                  key={vm.key}
-                  icon={vm.icon}
-                  label={vm.label}
-                  isActive={viewMode === vm.key}
-                  onClick={() => onViewModeChange?.(vm.key)}
-                />
-              ))}
+              {VIEW_MODES.map((vm) => {
+                const isDisabled = isSimulator && vm.key !== "graph";
+                return (
+                  <ViewTabButton
+                    key={vm.key}
+                    icon={vm.icon}
+                    label={vm.label}
+                    isActive={viewMode === vm.key}
+                    onClick={() => onViewModeChange?.(vm.key)}
+                    disabled={isDisabled}
+                    disabledTooltip={
+                      isDisabled
+                        ? "Not available for voice projects"
+                        : undefined
+                    }
+                  />
+                );
+              })}
             </Box>
           </Box>
           <Divider sx={{ my: 0.5 }} />

--- a/frontend/src/sections/projects/LLMTracing/DisplayPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/DisplayPanel.jsx
@@ -127,7 +127,6 @@ const ViewTabButton = ({
   isActive,
   onClick,
   disabled = false,
-  disabledTooltip,
 }) => {
   const button = (
     <ButtonBase
@@ -180,14 +179,14 @@ const ViewTabButton = ({
     </ButtonBase>
   );
 
-  if (!disabled || !disabledTooltip) return button;
+  if (!disabled) return button;
   return (
     <CustomTooltip
       show
       arrow
       size="small"
       type="black"
-      title={disabledTooltip}
+      title="Not available for voice projects"
     >
       <Box sx={{ flex: 1, display: "flex", cursor: "not-allowed" }}>
         {button}
@@ -202,7 +201,6 @@ ViewTabButton.propTypes = {
   isActive: PropTypes.bool,
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
-  disabledTooltip: PropTypes.string,
 };
 
 // ---------------------------------------------------------------------------
@@ -308,11 +306,6 @@ const DisplayPanel = ({
                     isActive={viewMode === vm.key}
                     onClick={() => onViewModeChange?.(vm.key)}
                     disabled={isDisabled}
-                    disabledTooltip={
-                      isDisabled
-                        ? "Not available for voice projects"
-                        : undefined
-                    }
                   />
                 );
               })}

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -957,12 +957,10 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     ? PROJECT_SOURCE.OBSERVE
     : projectDetail?.source;
 
-  // Simulator (voice) projects only support the "graph" view.
-  useEffect(() => {
-    if (projectSource === PROJECT_SOURCE.SIMULATOR && viewMode !== "graph") {
-      setViewMode("graph");
-    }
-  }, [projectSource, viewMode, setViewMode]);
+  const effectiveViewMode =
+    projectSource === PROJECT_SOURCE.SIMULATOR && viewMode !== "graph"
+      ? "graph"
+      : viewMode;
 
   const defaultDateFilter = useMemo(() => getDefaultDateRange(), []);
 
@@ -1181,7 +1179,9 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       : primarySpanValidatedFilters,
     {
       enabled:
-        !isUserMode && (viewMode === "agentGraph" || viewMode === "agentPath"),
+        !isUserMode &&
+        (effectiveViewMode === "agentGraph" ||
+          effectiveViewMode === "agentPath"),
     },
   );
 
@@ -1199,7 +1199,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       enabled:
         !isUserMode &&
         showCompare &&
-        (viewMode === "agentGraph" || viewMode === "agentPath"),
+        (effectiveViewMode === "agentGraph" ||
+          effectiveViewMode === "agentPath"),
     },
   );
 
@@ -3151,7 +3152,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
         >
           {/* Primary Graph — dual-axis bars + line. Hidden in user mode
               (PrimaryGraph requires observeId for its query). */}
-          {viewMode === "graph" && !isUserMode && (
+          {effectiveViewMode === "graph" && !isUserMode && (
             <>
               <PrimaryGraph
                 filters={
@@ -3224,7 +3225,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
           )}
 
           {/* Agent Graph — DAG visualization */}
-          {viewMode === "agentGraph" && (
+          {effectiveViewMode === "agentGraph" && (
             <>
               <Box sx={{ mx: 2, my: 1 }}>
                 {showCompare && (
@@ -3304,7 +3305,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
           )}
 
           {/* Agent Path — sequential flow */}
-          {viewMode === "agentPath" && (
+          {effectiveViewMode === "agentPath" && (
             <>
               <Box>
                 {showCompare && (
@@ -3503,7 +3504,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
               onAddCustomColumn={() => setOpenCustomColumn(true)}
               cellHeight={cellHeight}
               setCellHeight={setCellHeight}
-              viewMode={viewMode}
+              viewMode={effectiveViewMode}
               onViewModeChange={setViewMode}
               hasEvalFilter={hasEvalFilter}
               onToggleEvalFilter={() => setHasEvalFilter(!hasEvalFilter)}

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -956,6 +956,14 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   const projectSource = isUserMode
     ? PROJECT_SOURCE.OBSERVE
     : projectDetail?.source;
+
+  // Simulator (voice) projects only support the "graph" view.
+  useEffect(() => {
+    if (projectSource === PROJECT_SOURCE.SIMULATOR && viewMode !== "graph") {
+      setViewMode("graph");
+    }
+  }, [projectSource, viewMode, setViewMode]);
+
   const defaultDateFilter = useMemo(() => getDefaultDateRange(), []);
 
   const [isPrimaryFilterOpen, setIsPrimaryFilterOpen] = useUrlState(


### PR DESCRIPTION
## Summary
- Agent Graph and Agent Path view-mode tabs rendered a black screen for voice (SIMULATOR-source / VAPI / Retell) projects because no DAG data exists for them.
- Keep both tabs visible but disabled with a CustomTooltip ("Not available for voice projects"). Graph View stays the only selectable option for voice projects.
- Reuses the existing `isSimulator` prop already flowing `LLMTracingView → ObserveToolbar → DisplayPanel` — no new prop drilling needed.

Closes TH-4413

## Linear ticket
[TH-4413 — Observe: Agent graph shows black screen for voice bot](https://linear.app/future-agi/issue/TH-4413/uiux-observe-agent-graph-shows-black-screen-for-voice-bot-needs)

## Files changed
- `frontend/src/sections/projects/LLMTracing/DisplayPanel.jsx`

## Test plan
- [ ] Open a voice (SIMULATOR) project → Display popover → Agent Graph and Agent Path are dimmed; hovering each shows "Not available for voice projects"; clicking does nothing.
- [ ] Open a non-voice (OBSERVE) project → all three tabs render and toggle as before.
- [ ] Verify cursor changes to `not-allowed` over the disabled tabs.