### PR TITLE
fix(frontend): wait-for-ready reCAPTCHA at submit + preconnect to speed up load

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,6 +55,9 @@
       name="keywords"
       content="react,material,kit,application,dashboard,admin,template"
     />
+
+    <link rel="preconnect" href="https://www.google.com" crossorigin />
+    <link rel="dns-prefetch" href="https://www.google.com" />
   </head>
 
   <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -58,6 +58,8 @@
 
     <link rel="preconnect" href="https://www.google.com" crossorigin />
     <link rel="dns-prefetch" href="https://www.google.com" />
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin />
+    <link rel="dns-prefetch" href="https://www.gstatic.com" />
   </head>
 
   <body>

--- a/frontend/src/sections/auth/jwt/jwt-login-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-login-view.jsx
@@ -20,7 +20,6 @@ import { useRouter } from "src/routes/hooks";
 import { useBoolean } from "src/hooks/use-boolean";
 import { useAuthContext } from "src/auth/hooks";
 import { setSession, setRefreshToken } from "src/auth/context/jwt/utils";
-import { GOOGLE_SITE_KEY } from "src/config-global";
 
 import Iconify from "src/components/iconify";
 import FormProvider, { RHFTextField } from "src/components/hook-form";
@@ -32,7 +31,7 @@ import { LOGIN_ERROR_CODES } from "src/utils/constants";
 import { useSnackbar } from "src/components/snackbar";
 import { useMutation } from "@tanstack/react-query";
 import { useParams } from "src/routes/hooks";
-import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
+import { getRecaptchaToken } from "src/utils/recaptchaService";
 import logger from "src/utils/logger";
 import { FormCheckboxField } from "src/components/FormCheckboxField";
 import SvgColor from "src/components/svg-color";
@@ -50,7 +49,6 @@ import { usePostLoginPath } from "src/hooks/useDeploymentMode";
 export default function JwtLoginView() {
   const { login } = useAuthContext();
   const postLoginPath = usePostLoginPath();
-  const { executeRecaptcha } = useGoogleReCaptcha();
   const router = useRouter();
   const [errorMsg, setErrorMsg] = useState("");
   const [searchParams] = useSearchParams();
@@ -194,14 +192,16 @@ export default function JwtLoginView() {
 
   const onSubmit = handleSubmit(async (data) => {
     persistReturnTo();
-    if (GOOGLE_SITE_KEY && !executeRecaptcha) {
+    let token;
+    try {
+      token = await getRecaptchaToken("login");
+    } catch (err) {
       enqueueSnackbar({
         message: "reCAPTCHA not ready. Please try again",
         variant: "error",
       });
       return;
     }
-    const token = GOOGLE_SITE_KEY ? await executeRecaptcha("login") : "";
 
     trackEvent(Events.loginClicked, {
       [PropertyName.status]: true,

--- a/frontend/src/sections/auth/jwt/jwt-register-view.jsx
+++ b/frontend/src/sections/auth/jwt/jwt-register-view.jsx
@@ -22,20 +22,18 @@ import { trackTwitterSignup } from "src/utils/twitterAds";
 import Iconify from "src/components/iconify";
 import FormProvider, { RHFTextField } from "src/components/hook-form";
 import "./register.css";
-import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
+import { getRecaptchaToken } from "src/utils/recaptchaService";
 import PasswordSentView from "./password-sent-view";
 import { useBoolean } from "src/hooks/use-boolean";
 import logger from "src/utils/logger";
 import SvgColor from "src/components/svg-color";
 import { RouterLink } from "src/routes/components";
 import RegionSelect from "src/components/RegionSelect";
-import { GOOGLE_SITE_KEY } from "src/config-global";
 import RightSectionAuth from "./RightSectionAuth";
 import { isValidUtm } from "src/utils/utmUtils";
 
 export default function JwtRegisterView() {
   const { register, login, awsRegister } = useAuthContext();
-  const { executeRecaptcha } = useGoogleReCaptcha();
   const [errorMsg, setErrorMsg] = useState("");
   const [registerSuccess, setRegisterSuccess] = useState(false);
   const password = useBoolean();
@@ -121,7 +119,16 @@ export default function JwtRegisterView() {
 
   const handleSignup = async (data) => {
     persistReturnTo();
-    const token = GOOGLE_SITE_KEY ? await executeRecaptcha("signup") : "";
+    let token;
+    try {
+      token = await getRecaptchaToken("signup");
+    } catch (err) {
+      enqueueSnackbar({
+        message: "reCAPTCHA not ready. Please try again",
+        variant: "error",
+      });
+      return;
+    }
     setErrorMsg("");
     try {
       setLoading(true);
@@ -193,7 +200,16 @@ export default function JwtRegisterView() {
 
   const handleLogin = async (data) => {
     persistReturnTo();
-    const token = GOOGLE_SITE_KEY ? await executeRecaptcha("login") : "";
+    let token;
+    try {
+      token = await getRecaptchaToken("login");
+    } catch (err) {
+      enqueueSnackbar({
+        message: "reCAPTCHA not ready. Please try again",
+        variant: "error",
+      });
+      return;
+    }
 
     trackEvent(Events.loginClicked, {
       [PropertyName.status]: true,
@@ -238,13 +254,7 @@ export default function JwtRegisterView() {
   };
 
   const onSubmit = handleSubmit(async (data) => {
-    if (GOOGLE_SITE_KEY && !executeRecaptcha) {
-      enqueueSnackbar({
-        message: "reCAPTCHA not ready. Please try again",
-        variant: "error",
-      });
-      return;
-    }
+   
     (await registerSuccess) ? handleLogin(data) : handleSignup(data);
   });
 

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -44,7 +44,7 @@ import {
   isRecordingObjectKey,
 } from "src/components/inline-audio/audio-detection";
 import { useForm, useWatch } from "react-hook-form";
-import CustomTooltip from "src/components/tooltip/CustomTooltip";
+import CustomTooltip from "src/components/tooltip";
 import TaskFilterBar from "src/sections/tasks/components/TaskFilterBar";
 import { buildApiFilterArray } from "src/sections/tasks/components/TaskLivePreview";
 import { JsonValueTree } from "./DatasetTestMode";
@@ -53,7 +53,7 @@ import EvalResultDisplay from "./EvalResultDisplay";
 import SpanRowList from "./SpanRowList";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
 import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
-import CustomTooltip from "src/components/tooltip";
+
 
 const ROW_TYPE_OPTIONS = [
   { value: "Span", label: "Spans", icon: "solar:layers-outline" },

--- a/frontend/src/utils/recaptchaService.js
+++ b/frontend/src/utils/recaptchaService.js
@@ -1,30 +1,56 @@
+import { GOOGLE_SITE_KEY } from "src/config-global";
+
 let recaptchaExecutor = null;
-let executorReadyPromise = null;
+// Callbacks waiting for the executor to become available.
+let waiters = [];
+
+
+export const RECAPTCHA_WAIT_MS = 8000;
+
+export class RecaptchaNotReadyError extends Error {
+  constructor() {
+    super("recaptcha-not-ready");
+    this.name = "RecaptchaNotReadyError";
+  }
+}
 
 export const setRecaptchaExecutor = (executorFn) => {
   recaptchaExecutor = executorFn;
-  // Resolve any pending waits
-  if (executorReadyPromise) {
-    executorReadyPromise.resolve();
-    executorReadyPromise = null;
-  }
+
+  const pending = waiters;
+  waiters = [];
+  pending.forEach((notify) => notify());
 };
 
-// Create a helper that waits for the executor
-const waitForExecutor = () => {
-  if (recaptchaExecutor) return Promise.resolve();
+// Resolves once the executor is available, or rejects after `timeoutMs`.
+const waitForExecutor = (timeoutMs) =>
+  new Promise((resolve, reject) => {
+    if (recaptchaExecutor) {
+      resolve();
+      return;
+    }
 
-  if (!executorReadyPromise) {
-    executorReadyPromise = {};
-    executorReadyPromise.promise = new Promise((resolve) => {
-      executorReadyPromise.resolve = resolve;
-    });
-  }
+    let settled = false;
 
-  return executorReadyPromise.promise;
-};
+    const onReady = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
 
-export const getRecaptchaToken = async (action) => {
-  await waitForExecutor();
-  return await recaptchaExecutor(action);
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      waiters = waiters.filter((w) => w !== onReady);
+      reject(new RecaptchaNotReadyError());
+    }, timeoutMs);
+
+    waiters.push(onReady);
+  });
+
+export const getRecaptchaToken = async (action, timeoutMs = RECAPTCHA_WAIT_MS) => {
+  if (!GOOGLE_SITE_KEY) return "";
+  await waitForExecutor(timeoutMs);
+  return recaptchaExecutor(action);
 };


### PR DESCRIPTION
 Summary

  ## What
  Fixes the intermittent **"reCAPTCHA not ready. Please try again"** error on
  login/register, and speeds up how fast the reCAPTCHA v3 script loads.

  ## Why
  reCAPTCHA v3's `executeRecaptcha` is `undefined` until Google's `api.js`
  (and the heavier bundle from `www.gstatic.com`) finishes loading. A network
  trace showed the script didn't finish until **~15s** after page load. The old
  submit path **failed instantly** if a user submitted before then:

  ```js
  if (GOOGLE_SITE_KEY && !executeRecaptcha) { /* error + return */ }

  So any user who submitted quickly hit the error.

  Changes
  
  1. Wait instead of fail-fast — recaptchaService.js
  - getRecaptchaToken(action) now waits up to 8s (RECAPTCHA_WAIT_MS) for
  the executor to load via a waiters queue, then returns a token — instead of
  failing immediately. 
  - Rejects with a typed RecaptchaNotReadyError only on a genuine timeout.
  - Returns "" when GOOGLE_SITE_KEY is unset (reCAPTCHA disabled), so the
  empty-key path is preserved.
  - Supports multiple concurrent waiters and uses a settled flag + clearTimeout
  so each wait resolves/rejects exactly once.
  
  2. Route auth submits through the resilient helper
  - jwt-login-view.jsx and jwt-register-view.jsx now await getRecaptchaToken()
  inside a try/catch (all submit paths: login, signup, register-then-login).
  - On timeout → the same "reCAPTCHA not ready" snackbar, but only after the wait.
  - Removed the now-unused useGoogleReCaptcha hook and GOOGLE_SITE_KEY import
  from both views.

  3. Faster loading — index.html
  - Added preconnect + dns-prefetch for www.google.com and
  www.gstatic.com (the heavy bundle host), so the connections are warm before
  the library requests the scripts. 

  Behavior

  - A user who submits before reCAPTCHA is ready now waits the remaining moment
  and the request goes through, instead of being rejected outright.
  - The "not ready" error now appears only if the script genuinely never loads
  within 8s.
  - OAuth ("Continue with Google/GitHub") is unchanged — it never used reCAPTCHA.
  - Empty GOOGLE_SITE_KEY deployments still send recaptcha-response: "".
  Files

  - frontend/src/utils/recaptchaService.js
  - frontend/src/sections/auth/jwt/jwt-login-view.jsx
  - frontend/src/sections/auth/jwt/jwt-register-view.jsx
  - frontend/index.html
  Closes TH-5580