### PR TITLE
fix(evals): expand static few-shot dataset examples

### DIFF
--- a/futureagi/evaluations/engine/instance.py
+++ b/futureagi/evaluations/engine/instance.py
@@ -299,7 +299,14 @@ def prepare_eval_config(
         if eval_template.config.get("messages"):
             config["messages"] = eval_template.config.get("messages")
         if eval_template.config.get("few_shot_examples"):
-            config["few_shot_examples"] = eval_template.config.get("few_shot_examples")
+            from model_hub.utils.few_shot_examples import (
+                expand_static_few_shot_examples,
+            )
+
+            config["few_shot_examples"] = expand_static_few_shot_examples(
+                eval_template.config.get("few_shot_examples"),
+                organization=eval_template.organization,
+            )
 
         # Resolve model
         raw_model = model or eval_template.config.get("model")

--- a/futureagi/model_hub/tests/test_few_shot_examples.py
+++ b/futureagi/model_hub/tests/test_few_shot_examples.py
@@ -1,0 +1,126 @@
+import pytest
+
+from evaluations.engine.instance import prepare_eval_config
+from model_hub.models.choices import DataTypeChoices, OwnerChoices, SourceChoices
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from model_hub.models.evals_metric import EvalTemplate
+from model_hub.utils.few_shot_examples import expand_static_few_shot_examples
+
+
+def _create_dataset_with_rows(organization):
+    dataset = Dataset.objects.create(
+        name="few-shot-source",
+        organization=organization,
+    )
+    input_column = Column.objects.create(
+        name="input",
+        data_type=DataTypeChoices.TEXT.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+    output_column = Column.objects.create(
+        name="output",
+        data_type=DataTypeChoices.TEXT.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+    score_column = Column.objects.create(
+        name="score",
+        data_type=DataTypeChoices.TEXT.value,
+        dataset=dataset,
+        source=SourceChoices.OTHERS.value,
+    )
+
+    rows = [Row.objects.create(dataset=dataset, order=i) for i in range(2)]
+    values = [
+        ("input 1", "output 1", "Passed"),
+        ("input 2", "output 2", "Failed"),
+    ]
+    for row, (input_value, output_value, score_value) in zip(rows, values, strict=True):
+        Cell.objects.create(
+            dataset=dataset,
+            row=row,
+            column=input_column,
+            value=input_value,
+        )
+        Cell.objects.create(
+            dataset=dataset,
+            row=row,
+            column=output_column,
+            value=output_value,
+        )
+        Cell.objects.create(
+            dataset=dataset,
+            row=row,
+            column=score_column,
+            value=score_value,
+        )
+
+    return dataset
+
+
+@pytest.mark.django_db
+def test_expand_static_few_shot_examples_resolves_dataset_refs(
+    organization,
+):
+    dataset = _create_dataset_with_rows(organization)
+
+    examples = expand_static_few_shot_examples(
+        [{"id": str(dataset.id), "name": dataset.name}],
+        organization=organization,
+    )
+
+    assert examples == [
+        {"input": "input 1", "output": "output 1", "score": "Passed"},
+        {"input": "input 2", "output": "output 2", "score": "Failed"},
+    ]
+
+
+@pytest.mark.django_db
+def test_expand_static_few_shot_examples_preserves_literal_examples(
+    organization,
+):
+    dataset = _create_dataset_with_rows(organization)
+    literal = {"input": "literal input", "output": "literal output"}
+
+    examples = expand_static_few_shot_examples(
+        [literal, {"id": str(dataset.id), "name": dataset.name}],
+        organization=organization,
+    )
+
+    assert examples[0] == literal
+    assert examples[1:] == [
+        {"input": "input 1", "output": "output 1", "score": "Passed"},
+        {"input": "input 2", "output": "output 2", "score": "Failed"},
+    ]
+
+
+@pytest.mark.django_db
+def test_prepare_eval_config_expands_few_shot_dataset_refs(organization):
+    dataset = _create_dataset_with_rows(organization)
+    template = EvalTemplate.no_workspace_objects.create(
+        name="few-shot-eval",
+        organization=organization,
+        owner=OwnerChoices.USER.value,
+        eval_type="llm",
+        criteria="Check {{output}}",
+        model="turing_small",
+        config={
+            "eval_type_id": "CustomPromptEvaluator",
+            "output": "Pass/Fail",
+            "rule_prompt": "Check {{output}}",
+            "few_shot_examples": [{"id": str(dataset.id), "name": dataset.name}],
+        },
+    )
+
+    config, _ = prepare_eval_config(
+        eval_template=template,
+        config={},
+        model="turing_small",
+        organization_id=str(organization.id),
+    )
+
+    assert config["few_shot_examples"] == [
+        {"input": "input 1", "output": "output 1", "score": "Passed"},
+        {"input": "input 2", "output": "output 2", "score": "Failed"},
+    ]

--- a/futureagi/model_hub/tests/test_few_shot_examples.py
+++ b/futureagi/model_hub/tests/test_few_shot_examples.py
@@ -7,9 +7,9 @@ from model_hub.models.evals_metric import EvalTemplate
 from model_hub.utils.few_shot_examples import expand_static_few_shot_examples
 
 
-def _create_dataset_with_rows(organization):
+def _create_dataset_with_rows(organization, name="few-shot-source", row_count=2):
     dataset = Dataset.objects.create(
-        name="few-shot-source",
+        name=name,
         organization=organization,
     )
     input_column = Column.objects.create(
@@ -31,10 +31,10 @@ def _create_dataset_with_rows(organization):
         source=SourceChoices.OTHERS.value,
     )
 
-    rows = [Row.objects.create(dataset=dataset, order=i) for i in range(2)]
+    rows = [Row.objects.create(dataset=dataset, order=i) for i in range(row_count)]
     values = [
-        ("input 1", "output 1", "Passed"),
-        ("input 2", "output 2", "Failed"),
+        (f"input {i + 1}", f"output {i + 1}", "Passed" if i % 2 == 0 else "Failed")
+        for i in range(row_count)
     ]
     for row, (input_value, output_value, score_value) in zip(rows, values, strict=True):
         Cell.objects.create(
@@ -90,6 +90,51 @@ def test_expand_static_few_shot_examples_preserves_literal_examples(
 
     assert examples[0] == literal
     assert examples[1:] == [
+        {"input": "input 1", "output": "output 1", "score": "Passed"},
+        {"input": "input 2", "output": "output 2", "score": "Failed"},
+    ]
+
+
+@pytest.mark.django_db
+def test_expand_static_few_shot_examples_caps_dataset_rows(organization):
+    dataset = _create_dataset_with_rows(
+        organization,
+        row_count=25,
+    )
+
+    examples = expand_static_few_shot_examples(
+        [{"id": str(dataset.id), "name": dataset.name}],
+        organization=organization,
+    )
+
+    assert len(examples) == 20
+    assert examples[-1] == {
+        "input": "input 20",
+        "output": "output 20",
+        "score": "Failed",
+    }
+
+
+@pytest.mark.django_db
+def test_expand_static_few_shot_examples_batches_dataset_queries(
+    organization,
+    django_assert_num_queries,
+):
+    first_dataset = _create_dataset_with_rows(organization, name="first")
+    second_dataset = _create_dataset_with_rows(organization, name="second")
+
+    with django_assert_num_queries(4):
+        examples = expand_static_few_shot_examples(
+            [
+                {"id": str(first_dataset.id), "name": first_dataset.name},
+                {"id": str(second_dataset.id), "name": second_dataset.name},
+            ],
+            organization=organization,
+        )
+
+    assert examples == [
+        {"input": "input 1", "output": "output 1", "score": "Passed"},
+        {"input": "input 2", "output": "output 2", "score": "Failed"},
         {"input": "input 1", "output": "output 1", "score": "Passed"},
         {"input": "input 2", "output": "output 2", "score": "Failed"},
     ]

--- a/futureagi/model_hub/utils/few_shot_examples.py
+++ b/futureagi/model_hub/utils/few_shot_examples.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from uuid import UUID
+
+
+def expand_static_few_shot_examples(
+    few_shot_examples: list[dict] | None,
+    organization=None,
+) -> list[dict]:
+    """
+    Resolve eval config few-shot entries into the literal examples expected by
+    CustomPromptEvaluator.
+    """
+    if not few_shot_examples:
+        return []
+
+    literal_examples: list[dict] = []
+    dataset_ids: list[str] = []
+
+    for example in few_shot_examples:
+        if not isinstance(example, dict):
+            continue
+
+        if "input" in example or "output" in example:
+            literal_examples.append(example)
+            continue
+
+        dataset_id = example.get("id")
+        if _is_uuid(dataset_id):
+            dataset_ids.append(str(dataset_id))
+
+    if not dataset_ids:
+        return literal_examples
+
+    return literal_examples + _examples_from_datasets(dataset_ids, organization)
+
+
+def _examples_from_datasets(
+    dataset_ids: Iterable[str], organization=None
+) -> list[dict]:
+    from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+
+    ordered_ids = list(dict.fromkeys(str(dataset_id) for dataset_id in dataset_ids))
+    dataset_filter = {"id__in": ordered_ids, "deleted": False}
+    if organization is not None:
+        dataset_filter["organization"] = organization
+
+    datasets = Dataset.objects.filter(**dataset_filter)
+    datasets_by_id = {str(dataset.id): dataset for dataset in datasets}
+
+    examples: list[dict] = []
+    for dataset_id in ordered_ids:
+        dataset = datasets_by_id.get(dataset_id)
+        if dataset is None:
+            continue
+
+        columns = Column.objects.filter(dataset=dataset, deleted=False)
+        columns_by_name = {}
+        for column in columns:
+            normalized_name = column.name.strip().lower()
+            columns_by_name.setdefault(normalized_name, column)
+
+        input_column = columns_by_name.get("input")
+        output_column = columns_by_name.get("output")
+        if input_column is None or output_column is None:
+            continue
+
+        score_column = columns_by_name.get("score")
+        selected_columns = [input_column, output_column]
+        if score_column is not None:
+            selected_columns.append(score_column)
+
+        rows = list(
+            Row.objects.filter(dataset=dataset, deleted=False).order_by(
+                "order", "created_at"
+            )
+        )
+        if not rows:
+            continue
+
+        cells = Cell.objects.filter(
+            dataset=dataset,
+            row__in=rows,
+            column__in=selected_columns,
+            deleted=False,
+        ).select_related("row", "column")
+
+        values_by_row_id: dict[str, dict[str, str]] = {}
+        for cell in cells:
+            row_values = values_by_row_id.setdefault(str(cell.row_id), {})
+            row_values[cell.column.name.strip().lower()] = (
+                "" if cell.value is None else str(cell.value)
+            )
+
+        for row in rows:
+            row_values = values_by_row_id.get(str(row.id), {})
+            input_value = row_values.get("input", "")
+            output_value = row_values.get("output", "")
+            if not input_value or not output_value:
+                continue
+
+            example = {"input": input_value, "output": output_value}
+            if "score" in row_values:
+                example["score"] = row_values["score"]
+            examples.append(example)
+
+    return examples
+
+
+def _is_uuid(value) -> bool:
+    if value is None:
+        return False
+    try:
+        UUID(str(value))
+    except (TypeError, ValueError):
+        return False
+    return True

--- a/futureagi/model_hub/utils/few_shot_examples.py
+++ b/futureagi/model_hub/utils/few_shot_examples.py
@@ -1,18 +1,25 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from uuid import UUID
+
+from django.db.models import Case, IntegerField, Value, When
+
+from agentic_eval.core.utils.functions import is_uuid
+
+STATIC_FEW_SHOT_EXAMPLE_LIMIT = 20
+STATIC_FEW_SHOT_COLUMNS = ("input", "output", "score")
 
 
 def expand_static_few_shot_examples(
     few_shot_examples: list[dict] | None,
     organization=None,
+    max_examples: int = STATIC_FEW_SHOT_EXAMPLE_LIMIT,
 ) -> list[dict]:
     """
     Resolve eval config few-shot entries into the literal examples expected by
     CustomPromptEvaluator.
     """
-    if not few_shot_examples:
+    if not few_shot_examples or max_examples <= 0:
         return []
 
     literal_examples: list[dict] = []
@@ -23,96 +30,130 @@ def expand_static_few_shot_examples(
             continue
 
         if "input" in example or "output" in example:
+            if len(literal_examples) >= max_examples:
+                continue
             literal_examples.append(example)
             continue
 
         dataset_id = example.get("id")
-        if _is_uuid(dataset_id):
+        if is_uuid(str(dataset_id)):
             dataset_ids.append(str(dataset_id))
 
-    if not dataset_ids:
+    remaining = max_examples - len(literal_examples)
+    if not dataset_ids or remaining <= 0:
         return literal_examples
 
-    return literal_examples + _examples_from_datasets(dataset_ids, organization)
+    return literal_examples + _examples_from_datasets(
+        dataset_ids,
+        organization=organization,
+        max_examples=remaining,
+    )
 
 
 def _examples_from_datasets(
-    dataset_ids: Iterable[str], organization=None
+    dataset_ids: Iterable[str],
+    organization=None,
+    max_examples: int = STATIC_FEW_SHOT_EXAMPLE_LIMIT,
 ) -> list[dict]:
     from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 
     ordered_ids = list(dict.fromkeys(str(dataset_id) for dataset_id in dataset_ids))
+    if not ordered_ids or max_examples <= 0:
+        return []
+
     dataset_filter = {"id__in": ordered_ids, "deleted": False}
     if organization is not None:
         dataset_filter["organization"] = organization
 
-    datasets = Dataset.objects.filter(**dataset_filter)
+    datasets = Dataset.objects.filter(**dataset_filter).only("id")
     datasets_by_id = {str(dataset.id): dataset for dataset in datasets}
+    valid_dataset_ids = [
+        dataset_id for dataset_id in ordered_ids if dataset_id in datasets_by_id
+    ]
+    if not valid_dataset_ids:
+        return []
 
-    examples: list[dict] = []
-    for dataset_id in ordered_ids:
-        dataset = datasets_by_id.get(dataset_id)
-        if dataset is None:
-            continue
+    columns = Column.objects.filter(
+        dataset_id__in=valid_dataset_ids,
+        deleted=False,
+    ).only("id", "dataset_id", "name")
+    columns_by_dataset_id: dict[str, dict[str, Column]] = {}
+    for column in columns:
+        dataset_columns = columns_by_dataset_id.setdefault(str(column.dataset_id), {})
+        dataset_columns.setdefault(column.name.strip().lower(), column)
 
-        columns = Column.objects.filter(dataset=dataset, deleted=False)
-        columns_by_name = {}
-        for column in columns:
-            normalized_name = column.name.strip().lower()
-            columns_by_name.setdefault(normalized_name, column)
-
-        input_column = columns_by_name.get("input")
-        output_column = columns_by_name.get("output")
+    selected_column_ids: set[str] = set()
+    required_columns_by_dataset_id: dict[str, dict[str, Column]] = {}
+    for dataset_id in valid_dataset_ids:
+        dataset_columns = columns_by_dataset_id.get(dataset_id, {})
+        input_column = dataset_columns.get("input")
+        output_column = dataset_columns.get("output")
         if input_column is None or output_column is None:
             continue
 
-        score_column = columns_by_name.get("score")
-        selected_columns = [input_column, output_column]
+        selected_columns = {
+            "input": input_column,
+            "output": output_column,
+        }
+        score_column = dataset_columns.get("score")
         if score_column is not None:
-            selected_columns.append(score_column)
-
-        rows = list(
-            Row.objects.filter(dataset=dataset, deleted=False).order_by(
-                "order", "created_at"
-            )
+            selected_columns["score"] = score_column
+        required_columns_by_dataset_id[dataset_id] = selected_columns
+        selected_column_ids.update(
+            str(column.id) for column in selected_columns.values()
         )
-        if not rows:
+
+    if not required_columns_by_dataset_id:
+        return []
+
+    dataset_order = Case(
+        *[
+            When(dataset_id=dataset_id, then=Value(index))
+            for index, dataset_id in enumerate(valid_dataset_ids)
+        ],
+        output_field=IntegerField(),
+    )
+    rows = list(
+        Row.objects.filter(
+            dataset_id__in=required_columns_by_dataset_id.keys(),
+            deleted=False,
+        )
+        .annotate(dataset_order=dataset_order)
+        .order_by("dataset_order", "order", "created_at")
+        .only("id", "dataset_id", "order", "created_at")[:max_examples]
+    )
+    if not rows:
+        return []
+
+    cells = Cell.objects.filter(
+        row_id__in=[str(row.id) for row in rows],
+        column_id__in=selected_column_ids,
+        deleted=False,
+    ).only("row_id", "column_id", "value")
+    values_by_row_and_column_id: dict[str, dict[str, str]] = {}
+    for cell in cells:
+        row_values = values_by_row_and_column_id.setdefault(str(cell.row_id), {})
+        row_values[str(cell.column_id)] = (
+            "" if cell.value is None else str(cell.value)
+        )
+
+    examples: list[dict] = []
+    for row in rows:
+        selected_columns = required_columns_by_dataset_id.get(str(row.dataset_id))
+        if not selected_columns:
+            continue
+        row_values = values_by_row_and_column_id.get(str(row.id), {})
+        input_value = row_values.get(str(selected_columns["input"].id), "")
+        output_value = row_values.get(str(selected_columns["output"].id), "")
+        if not input_value or not output_value:
             continue
 
-        cells = Cell.objects.filter(
-            dataset=dataset,
-            row__in=rows,
-            column__in=selected_columns,
-            deleted=False,
-        ).select_related("row", "column")
-
-        values_by_row_id: dict[str, dict[str, str]] = {}
-        for cell in cells:
-            row_values = values_by_row_id.setdefault(str(cell.row_id), {})
-            row_values[cell.column.name.strip().lower()] = (
-                "" if cell.value is None else str(cell.value)
-            )
-
-        for row in rows:
-            row_values = values_by_row_id.get(str(row.id), {})
-            input_value = row_values.get("input", "")
-            output_value = row_values.get("output", "")
-            if not input_value or not output_value:
-                continue
-
-            example = {"input": input_value, "output": output_value}
-            if "score" in row_values:
-                example["score"] = row_values["score"]
-            examples.append(example)
+        example = {"input": input_value, "output": output_value}
+        score_column = selected_columns.get("score")
+        if score_column is not None:
+            score_value = row_values.get(str(score_column.id))
+            if score_value is not None:
+                example["score"] = score_value
+        examples.append(example)
 
     return examples
-
-
-def _is_uuid(value) -> bool:
-    if value is None:
-        return False
-    try:
-        UUID(str(value))
-    except (TypeError, ValueError):
-        return False
-    return True


### PR DESCRIPTION
## Summary

Expands static few-shot dataset references before custom LLM eval execution so `CustomPromptEvaluator` receives literal `input` / `output` / optional `score` examples instead of unresolved dataset metadata. This fixes TH-5100 cases where playground/runtime configs included a few-shot dataset but the model did not get the dataset rows as examples.

## Linked issues

TH-5100

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- `set -a && source .env.test && set +a && .venv/bin/pytest model_hub/tests/test_few_shot_examples.py -v`
- Manual playground replay for template `1790d85a-16b2-4938-a086-89cbaa14a3b0` returned `Failed` for toxic hiring content after the few-shot dataset rows were normalized.
- Backend logs showed `custom_prompt_eval_llm_call_start message_count=10`, matching system + 4 few-shot pairs + final user input.

## Screenshots / recordings (if UI)

N/A

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)