### PR TITLE
feat(tracer): multi-target dispatch for observe eval feedback [TH-5462]

### DIFF
--- a/futureagi/tracer/serializers/observation_span.py
+++ b/futureagi/tracer/serializers/observation_span.py
@@ -257,14 +257,23 @@ def _validate_target_anchor_ids(attrs):
             raise serializers.ValidationError(
                 "target_type='session' requires trace_session_id."
             )
+    elif target_type == EvalTargetType.TRACE:
+        if session_id:
+            raise serializers.ValidationError(
+                "target_type='trace' must not set trace_session_id."
+            )
+        if not trace_id:
+            raise serializers.ValidationError(
+                "target_type='trace' requires trace_id."
+            )
     else:
         if session_id:
             raise serializers.ValidationError(
-                f"target_type='{target_type}' must not set trace_session_id."
+                "target_type='span' must not set trace_session_id."
             )
         if not span_id:
             raise serializers.ValidationError(
-                f"target_type='{target_type}' requires observation_span_id."
+                "target_type='span' requires observation_span_id."
             )
     return attrs
 

--- a/futureagi/tracer/serializers/trace_session.py
+++ b/futureagi/tracer/serializers/trace_session.py
@@ -54,6 +54,23 @@ class TraceSessionSerializer(serializers.ModelSerializer):
         )
 
 
+class TraceSessionFeedbackSerializer(serializers.ModelSerializer):
+    """Embedding payload for session-level feedback writes."""
+
+    traces = serializers.SerializerMethodField()
+
+    class Meta:
+        model = TraceSession
+        fields = ["id", "name", "traces"]
+
+    def get_traces(self, instance):
+        # Local import sidesteps the TraceSerializer → Trace.session → TraceSession cycle.
+        from tracer.serializers.trace import TraceSerializer
+
+        qs = instance.traces.order_by("created_at")
+        return TraceSerializer(qs, many=True, context=self.context).data
+
+
 class TraceSessionFilterValuesQuerySerializer(serializers.Serializer):
     project_id = serializers.UUIDField(required=True)
     column = serializers.ChoiceField(

--- a/futureagi/tracer/tests/test_observation_span.py
+++ b/futureagi/tracer/tests/test_observation_span.py
@@ -802,30 +802,117 @@ class TestObservationSpanSubmitFeedbackAPI:
             custom_eval_config_id=custom_eval_config.id
         ).exists()
 
-    def test_submit_feedback_gates_trace_path(
-        self, auth_client, observation_span, custom_eval_config
+    def test_submit_feedback_trace_creates_feedback_row(
+        self, auth_client, mocker, observation_span, custom_eval_config
     ):
+        from tracer.models.observation_span import EvalLogger, EvalTargetType
+
+        # Trace-level EvalLogger is anchored on the root span by the
+        # eval_logger_target_type_fks CHECK constraint.
+        EvalLogger.objects.create(
+            trace=observation_span.trace,
+            observation_span=observation_span,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.TRACE,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+        )
+        mocker.patch("tracer.views.observation_span.EmbeddingManager")
+
         payload = self._valid_span_payload(observation_span, custom_eval_config)
+        payload.pop("observation_span_id")
         payload["target_type"] = "trace"
         payload["trace_id"] = str(observation_span.trace.id)
 
         response = auth_client.post(self.SUBMIT_FEEDBACK_URL, payload, format="json")
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json().get("code") == "not_supported"
+        assert response.status_code == status.HTTP_200_OK
+        result = get_result(response)
+        feedback = Feedback.objects.get(id=result["feedback_id"])
+        assert feedback.source_id == str(observation_span.trace.id)
+        assert feedback.eval_template_id == custom_eval_config.eval_template_id
 
-    def test_submit_feedback_gates_session_path(
-        self, auth_client, observation_span, custom_eval_config
+    def test_submit_feedback_session_creates_feedback_row(
+        self, auth_client, mocker, project, custom_eval_config
     ):
-        payload = self._valid_span_payload(observation_span, custom_eval_config)
-        payload.pop("observation_span_id")
-        payload["target_type"] = "session"
-        payload["trace_session_id"] = str(uuid.uuid4())
+        from tracer.models.observation_span import EvalLogger, EvalTargetType
+        from tracer.models.trace_session import TraceSession
 
-        response = auth_client.post(self.SUBMIT_FEEDBACK_URL, payload, format="json")
+        trace_session = TraceSession.objects.create(
+            project=project, name="Test session for feedback"
+        )
+        EvalLogger.objects.create(
+            trace=None,
+            observation_span=None,
+            trace_session=trace_session,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.SESSION,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+        )
+        mocker.patch("tracer.views.observation_span.EmbeddingManager")
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json().get("code") == "not_supported"
+        response = auth_client.post(
+            self.SUBMIT_FEEDBACK_URL,
+            {
+                "target_type": "session",
+                "trace_session_id": str(trace_session.id),
+                "custom_eval_config_id": str(custom_eval_config.id),
+                "feedback_value": "passed",
+                "feedback_explanation": "session correction",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        result = get_result(response)
+        feedback = Feedback.objects.get(id=result["feedback_id"])
+        assert feedback.source_id == str(trace_session.id)
+        assert feedback.source == FeedbackSourceChoices.OBSERVE.value
+
+    def test_submit_feedback_session_embeds_session_payload(
+        self, auth_client, mocker, project, custom_eval_config
+    ):
+        from tracer.models.observation_span import EvalLogger, EvalTargetType
+        from tracer.models.trace_session import TraceSession
+
+        trace_session = TraceSession.objects.create(
+            project=project, name="Embed test session"
+        )
+        EvalLogger.objects.create(
+            trace=None,
+            observation_span=None,
+            trace_session=trace_session,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.SESSION,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+        )
+        embedding_cls = mocker.patch(
+            "tracer.views.observation_span.EmbeddingManager"
+        )
+
+        response = auth_client.post(
+            self.SUBMIT_FEEDBACK_URL,
+            {
+                "target_type": "session",
+                "trace_session_id": str(trace_session.id),
+                "custom_eval_config_id": str(custom_eval_config.id),
+                "feedback_value": "passed",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        embedding_cls.return_value.data_formatter.assert_called_once()
+        call_kwargs = embedding_cls.return_value.data_formatter.call_args.kwargs
+        # Session embedding payload uses TraceSessionFeedbackSerializer shape.
+        assert call_kwargs["row_dict"]["id"] == str(trace_session.id)
+        assert "traces" in call_kwargs["row_dict"]
+        assert call_kwargs["inputs_formater"] == [trace_session.id]
 
     def test_submit_feedback_validator_rejects_inconsistent_ids(
         self, auth_client, observation_span, custom_eval_config
@@ -991,9 +1078,7 @@ class TestObservationSpanSubmitFeedbackActionTypeAPI:
         feedback, _ = self._seed_feedback_and_logger(
             user, organization, workspace, observation_span, custom_eval_config
         )
-        observe_mock = mocker.patch(
-            "tracer.views.observation_span.evaluate_observation_span_observe"
-        )
+        rerun_mock = mocker.patch("tracer.views.observation_span.rerun_single")
 
         response = auth_client.post(
             self.ACTION_TYPE_URL,
@@ -1010,9 +1095,9 @@ class TestObservationSpanSubmitFeedbackActionTypeAPI:
         assert result["recalculated_count"] == 0
         feedback.refresh_from_db()
         assert feedback.action_type == "retune"
-        observe_mock.assert_not_called()
+        rerun_mock.assert_not_called()
 
-    def test_action_type_recalculate_dispatches_observe_rerun(
+    def test_action_type_recalculate_span_dispatches_rerun(
         self,
         auth_client,
         user,
@@ -1026,9 +1111,8 @@ class TestObservationSpanSubmitFeedbackActionTypeAPI:
             user, organization, workspace, observation_span, custom_eval_config
         )
         # observation_span fixture has no project_version, so view picks the observe rerun.
-        observe_mock = mocker.patch(
-            "tracer.views.observation_span.evaluate_observation_span_observe",
-            return_value=True,
+        rerun_mock = mocker.patch(
+            "tracer.views.observation_span.rerun_single", return_value=True
         )
 
         response = auth_client.post(
@@ -1043,14 +1127,127 @@ class TestObservationSpanSubmitFeedbackActionTypeAPI:
         result = get_result(response)
         assert result["recalculated_count"] == 1
 
-        observe_mock.assert_called_once()
-        args = observe_mock.call_args.args
-        assert args[0] == str(observation_span.id)
-        assert args[1] == str(custom_eval_config.id)
-        assert args[2] == eval_logger.eval_task_id
+        rerun_mock.assert_called_once()
+        call_kwargs = rerun_mock.call_args.kwargs
+        assert call_kwargs["target_type"] == "span"
+        assert call_kwargs["observation_span_id"] == str(observation_span.id)
+        assert call_kwargs["custom_eval_config_id"] == str(custom_eval_config.id)
+        assert call_kwargs["eval_task_id"] == eval_logger.eval_task_id
 
-        eval_logger.refresh_from_db()
-        assert eval_logger.deleted is True
+    def test_action_type_recalculate_trace_dispatches_rerun(
+        self,
+        auth_client,
+        user,
+        organization,
+        workspace,
+        observation_span,
+        custom_eval_config,
+        mocker,
+    ):
+        from tracer.models.observation_span import EvalLogger, EvalTargetType
+
+        trace = observation_span.trace
+        EvalLogger.objects.create(
+            trace=trace,
+            observation_span=observation_span,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.TRACE,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+            eval_task_id=str(uuid.uuid4()),
+        )
+        feedback = Feedback.objects.create(
+            source=FeedbackSourceChoices.OBSERVE.value,
+            source_id=str(trace.id),
+            value="passed",
+            eval_template=custom_eval_config.eval_template,
+            custom_eval_config_id=custom_eval_config.id,
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+        rerun_mock = mocker.patch(
+            "tracer.views.observation_span.rerun_single", return_value=True
+        )
+
+        response = auth_client.post(
+            self.ACTION_TYPE_URL,
+            {
+                "target_type": "trace",
+                "trace_id": str(trace.id),
+                "custom_eval_config_id": str(custom_eval_config.id),
+                "feedback_id": str(feedback.id),
+                "action_type": "recalculate",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        rerun_mock.assert_called_once()
+        call_kwargs = rerun_mock.call_args.kwargs
+        assert call_kwargs["target_type"] == "trace"
+        assert call_kwargs["trace_id"] == trace.id
+        assert call_kwargs["observation_span_id"] is None
+
+    def test_action_type_recalculate_session_dispatches_rerun(
+        self,
+        auth_client,
+        user,
+        organization,
+        workspace,
+        project,
+        custom_eval_config,
+        mocker,
+    ):
+        from tracer.models.observation_span import EvalLogger, EvalTargetType
+        from tracer.models.trace_session import TraceSession
+
+        trace_session = TraceSession.objects.create(
+            project=project, name="Action-type session"
+        )
+        EvalLogger.objects.create(
+            trace=None,
+            observation_span=None,
+            trace_session=trace_session,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.SESSION,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+            eval_task_id=str(uuid.uuid4()),
+        )
+        feedback = Feedback.objects.create(
+            source=FeedbackSourceChoices.OBSERVE.value,
+            source_id=str(trace_session.id),
+            value="passed",
+            eval_template=custom_eval_config.eval_template,
+            custom_eval_config_id=custom_eval_config.id,
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+        rerun_mock = mocker.patch(
+            "tracer.views.observation_span.rerun_single", return_value=True
+        )
+
+        response = auth_client.post(
+            self.ACTION_TYPE_URL,
+            {
+                "target_type": "session",
+                "trace_session_id": str(trace_session.id),
+                "custom_eval_config_id": str(custom_eval_config.id),
+                "feedback_id": str(feedback.id),
+                "action_type": "recalculate",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        rerun_mock.assert_called_once()
+        call_kwargs = rerun_mock.call_args.kwargs
+        assert call_kwargs["target_type"] == "session"
+        assert call_kwargs["trace_session_id"] == trace_session.id
 
     def test_action_type_recalculate_rejects_errored_eval(
         self,
@@ -1068,9 +1265,7 @@ class TestObservationSpanSubmitFeedbackActionTypeAPI:
         eval_logger.error = True
         eval_logger.error_message = "judge crashed"
         eval_logger.save(update_fields=["error", "error_message"])
-        observe_mock = mocker.patch(
-            "tracer.views.observation_span.evaluate_observation_span_observe"
-        )
+        rerun_mock = mocker.patch("tracer.views.observation_span.rerun_single")
 
         response = auth_client.post(
             self.ACTION_TYPE_URL,
@@ -1082,37 +1277,129 @@ class TestObservationSpanSubmitFeedbackActionTypeAPI:
 
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.json().get("code") == "errored_eval"
-        observe_mock.assert_not_called()
+        rerun_mock.assert_not_called()
         eval_logger.refresh_from_db()
         assert eval_logger.deleted is False
 
-    def test_action_type_gates_trace_target(
-        self,
-        auth_client,
-        user,
-        organization,
-        workspace,
-        observation_span,
-        custom_eval_config,
+
+@pytest.mark.integration
+class TestRerunSingleHelper:
+    """Unit tests for tracer.utils.eval.rerun_single."""
+
+    def test_rerun_single_span_soft_deletes_and_dispatches(
+        self, db, mocker, observation_span, custom_eval_config
     ):
-        feedback, _ = self._seed_feedback_and_logger(
-            user, organization, workspace, observation_span, custom_eval_config
+        from tracer.models.observation_span import EvalLogger, EvalTargetType
+        from tracer.utils.eval import rerun_single
+
+        EvalLogger.objects.create(
+            trace=observation_span.trace,
+            observation_span=observation_span,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.SPAN,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+        )
+        observe_mock = mocker.patch(
+            "tracer.utils.eval.evaluate_observation_span_observe", return_value=True
         )
 
-        response = auth_client.post(
-            self.ACTION_TYPE_URL,
-            {
-                "target_type": "trace",
-                "observation_span_id": str(observation_span.id),
-                "trace_id": str(observation_span.trace.id),
-                "custom_eval_config_id": str(custom_eval_config.id),
-                "feedback_id": str(feedback.id),
-                "action_type": "recalculate",
-            },
-            format="json",
+        result = rerun_single(
+            target_type=EvalTargetType.SPAN,
+            observation_span_id=str(observation_span.id),
+            custom_eval_config_id=str(custom_eval_config.id),
+            eval_task_id="task-1",
+            feedback_id=None,
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json().get("code") == "not_supported"
+
+        assert result is True
+        observe_mock.assert_called_once_with(
+            str(observation_span.id), str(custom_eval_config.id), "task-1", None
+        )
+        # Prior live row soft-deleted; dispatcher's own write is not under test
+        # here (mocked).
+        assert not EvalLogger.objects.filter(
+            observation_span=observation_span,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.SPAN,
+            deleted=False,
+        ).exists()
+
+    def test_rerun_single_trace_dispatches_evaluate_trace_observe(
+        self, db, mocker, observation_span, custom_eval_config
+    ):
+        from tracer.models.observation_span import EvalLogger, EvalTargetType
+        from tracer.utils.eval import rerun_single
+
+        EvalLogger.objects.create(
+            trace=observation_span.trace,
+            observation_span=observation_span,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.TRACE,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+        )
+        trace_mock = mocker.patch(
+            "tracer.utils.eval.evaluate_trace_observe", return_value=True
+        )
+
+        result = rerun_single(
+            target_type=EvalTargetType.TRACE,
+            trace_id=observation_span.trace.id,
+            custom_eval_config_id=str(custom_eval_config.id),
+            eval_task_id="task-2",
+            feedback_id=None,
+        )
+
+        assert result is True
+        trace_mock.assert_called_once_with(
+            observation_span.trace.id, str(custom_eval_config.id), "task-2", None
+        )
+
+    def test_rerun_single_session_dispatches_evaluate_trace_session_observe(
+        self, db, mocker, project, custom_eval_config
+    ):
+        from tracer.models.observation_span import EvalLogger, EvalTargetType
+        from tracer.models.trace_session import TraceSession
+        from tracer.utils.eval import rerun_single
+
+        trace_session = TraceSession.objects.create(
+            project=project, name="rerun_single session"
+        )
+        EvalLogger.objects.create(
+            trace=None,
+            observation_span=None,
+            trace_session=trace_session,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.SESSION,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+        )
+        session_mock = mocker.patch(
+            "tracer.utils.eval.evaluate_trace_session_observe", return_value=True
+        )
+
+        result = rerun_single(
+            target_type=EvalTargetType.SESSION,
+            trace_session_id=trace_session.id,
+            custom_eval_config_id=str(custom_eval_config.id),
+            eval_task_id="task-3",
+            feedback_id=None,
+        )
+
+        assert result is True
+        session_mock.assert_called_once_with(
+            trace_session.id, str(custom_eval_config.id), "task-3", None
+        )
+
+    def test_rerun_single_unknown_target_type_raises(self, db):
+        from tracer.utils.eval import rerun_single
+
+        with pytest.raises(ValueError):
+            rerun_single(target_type="bogus", custom_eval_config_id="x")
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -3603,3 +3603,52 @@ def evaluate_trace_session_observe(
             f"Exception during evaluation in evaluate_trace_session_observe: {e}"
         )
         return False
+
+
+def rerun_single(
+    target_type,
+    observation_span_id=None,
+    trace_id=None,
+    trace_session_id=None,
+    custom_eval_config_id=None,
+    eval_task_id=None,
+    feedback_id=None,
+):
+    """Soft-delete the prior EvalLogger for this row and re-dispatch.
+
+    Shared by submit_feedback_action_type (single-row recalc) and the
+    batch RecalculateEvalTaskWorkflow that ships in a follow-up PR.
+
+    TODO(BE-3): drop the "follow-up PR" wording once the workflow is wired.
+    """
+    if target_type == EvalTargetType.SPAN:
+        EvalLogger.objects.filter(
+            observation_span_id=observation_span_id,
+            custom_eval_config_id=custom_eval_config_id,
+            target_type=EvalTargetType.SPAN,
+            deleted=False,
+        ).update(deleted=True, deleted_at=timezone.now())
+        return evaluate_observation_span_observe(
+            observation_span_id, custom_eval_config_id, eval_task_id, feedback_id
+        )
+    if target_type == EvalTargetType.TRACE:
+        EvalLogger.objects.filter(
+            trace_id=trace_id,
+            custom_eval_config_id=custom_eval_config_id,
+            target_type=EvalTargetType.TRACE,
+            deleted=False,
+        ).update(deleted=True, deleted_at=timezone.now())
+        return evaluate_trace_observe(
+            trace_id, custom_eval_config_id, eval_task_id, feedback_id
+        )
+    if target_type == EvalTargetType.SESSION:
+        EvalLogger.objects.filter(
+            trace_session_id=trace_session_id,
+            custom_eval_config_id=custom_eval_config_id,
+            target_type=EvalTargetType.SESSION,
+            deleted=False,
+        ).update(deleted=True, deleted_at=timezone.now())
+        return evaluate_trace_session_observe(
+            trace_session_id, custom_eval_config_id, eval_task_id, feedback_id
+        )
+    raise ValueError(f"unknown target_type: {target_type}")

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -91,6 +91,7 @@ from tracer.serializers.observation_span import (
     SubmitFeedbackSerializer,
 )
 from tracer.serializers.trace import TraceSerializer
+from tracer.serializers.trace_session import TraceSessionFeedbackSerializer
 from tracer.services.clickhouse.graph_dispatch import (
     fetch_annotation_graph_ch,
     fetch_eval_graph_ch,
@@ -99,10 +100,7 @@ from tracer.services.clickhouse.graph_dispatch import (
 from tracer.services.clickhouse.query_service import AnalyticsQueryService
 from tracer.utils.annotations import build_annotation_subqueries
 from tracer.utils.create_otel_span import create_single_otel_span
-from tracer.utils.eval import (
-    evaluate_observation_span,
-    evaluate_observation_span_observe,
-)
+from tracer.utils.eval import rerun_single
 from tracer.utils.filters import FilterEngine
 from tracer.utils.helper import (
     FieldConfig,
@@ -1116,27 +1114,12 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             validated_data = request.validated_data
             target_type = validated_data["target_type"]
             observation_span_id = validated_data.get("observation_span_id") or None
+            trace_id = validated_data.get("trace_id")
+            trace_session_id = validated_data.get("trace_session_id")
             custom_eval_config_id = validated_data.get("custom_eval_config_id")
             feedback_value = validated_data.get("feedback_value")
             feedback_explanation = validated_data.get("feedback_explanation")
             feedback_improvement = validated_data.get("feedback_improvement")
-
-            # Trace + session anchors land in a follow-up; reject for now.
-            if target_type != EvalTargetType.SPAN:
-                return self._gm.custom_error_response(
-                    HTTP_400_BAD_REQUEST,
-                    f"target_type='{target_type}' feedback not yet supported",
-                    code="not_supported",
-                )
-
-            try:
-                observation_span = ObservationSpan.objects.get(
-                    _project_workspace_scope_q(request),
-                    id=observation_span_id,
-                    project__organization=_get_request_organization(request),
-                )
-            except ObservationSpan.DoesNotExist:
-                return self._gm.not_found("Observation span not found")
 
             try:
                 custom_eval_config = CustomEvalConfig.objects.get(
@@ -1147,14 +1130,82 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             except CustomEvalConfig.DoesNotExist:
                 return self._gm.not_found("Custom eval config not found")
 
-            try:
-                eval_logger = EvalLogger.objects.get(
-                    observation_span=observation_span,
-                    custom_eval_config_id=custom_eval_config_id,
-                    deleted=False,
+            if target_type == EvalTargetType.SPAN:
+                try:
+                    observation_span = ObservationSpan.objects.get(
+                        _project_workspace_scope_q(request),
+                        id=observation_span_id,
+                        project__organization=_get_request_organization(request),
+                    )
+                except ObservationSpan.DoesNotExist:
+                    return self._gm.not_found("Observation span not found")
+                try:
+                    eval_logger = EvalLogger.objects.get(
+                        observation_span=observation_span,
+                        custom_eval_config=custom_eval_config,
+                        target_type=EvalTargetType.SPAN,
+                        deleted=False,
+                    )
+                except EvalLogger.DoesNotExist:
+                    return self._gm.not_found("No eval associated with this span")
+                source_id = str(observation_span.id)
+                project = observation_span.project
+                trace = Trace.objects.get(id=observation_span.trace.id)
+                embedding_row_dict = TraceSerializer(trace).data
+                embedding_inputs = [observation_span.id]
+
+            elif target_type == EvalTargetType.TRACE:
+                try:
+                    trace = Trace.objects.get(
+                        _project_workspace_scope_q(request),
+                        id=trace_id,
+                        project__organization=_get_request_organization(request),
+                    )
+                except Trace.DoesNotExist:
+                    return self._gm.not_found("Trace not found")
+                try:
+                    eval_logger = EvalLogger.objects.get(
+                        trace=trace,
+                        custom_eval_config=custom_eval_config,
+                        target_type=EvalTargetType.TRACE,
+                        deleted=False,
+                    )
+                except EvalLogger.DoesNotExist:
+                    return self._gm.not_found("No eval associated with this trace")
+                source_id = str(trace.id)
+                project = trace.project
+                embedding_row_dict = TraceSerializer(trace).data
+                embedding_inputs = [trace.id]
+
+            elif target_type == EvalTargetType.SESSION:
+                try:
+                    trace_session = TraceSession.objects.get(
+                        _project_workspace_scope_q(request),
+                        id=trace_session_id,
+                        project__organization=_get_request_organization(request),
+                    )
+                except TraceSession.DoesNotExist:
+                    return self._gm.not_found("Trace session not found")
+                try:
+                    eval_logger = EvalLogger.objects.get(
+                        trace_session=trace_session,
+                        custom_eval_config=custom_eval_config,
+                        target_type=EvalTargetType.SESSION,
+                        deleted=False,
+                    )
+                except EvalLogger.DoesNotExist:
+                    return self._gm.not_found("No eval associated with this session")
+                source_id = str(trace_session.id)
+                project = trace_session.project
+                embedding_row_dict = TraceSessionFeedbackSerializer(
+                    trace_session, context={"request": request}
+                ).data
+                embedding_inputs = [trace_session.id]
+
+            else:
+                return self._gm.internal_server_error_response(
+                    f"Unhandled target_type={target_type!r}"
                 )
-            except EvalLogger.DoesNotExist:
-                return self._gm.not_found("No eval associated with this span")
 
             if eval_logger.error:
                 return self._gm.custom_error_response(
@@ -1166,38 +1217,25 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             eval_template = custom_eval_config.eval_template
 
             feedback = Feedback.objects.create(
-                source=(
-                    FeedbackSourceChoices.EXPERIMENT.value
-                    if observation_span.project_version
-                    else FeedbackSourceChoices.OBSERVE.value
-                ),
-                source_id=observation_span_id,
+                source=FeedbackSourceChoices.OBSERVE.value,
+                source_id=source_id,
                 value=feedback_value,
                 explanation=feedback_explanation,
                 eval_template=eval_template,
                 feedback_improvement=feedback_improvement,
                 user=request.user,
                 custom_eval_config_id=custom_eval_config_id,
-                organization=observation_span.project.organization,
-                workspace=observation_span.project.workspace,
+                organization=project.organization,
+                workspace=project.workspace,
             )
 
-            trace = Trace.objects.get(id=observation_span.trace.id)
-            trace_data = TraceSerializer(trace).data
-
-            # get_fewshots = RAG()
             embedding_manager = EmbeddingManager()
-
             embedding_manager.data_formatter(
                 eval_id=eval_template.id,
-                row_dict=trace_data,
-                inputs_formater=[observation_span.id],
-                organization_id=observation_span.project.organization.id,
-                workspace_id=(
-                    observation_span.project.workspace.id
-                    if observation_span.project.workspace
-                    else None
-                ),
+                row_dict=embedding_row_dict,
+                inputs_formater=embedding_inputs,
+                organization_id=project.organization.id,
+                workspace_id=project.workspace.id if project.workspace else None,
             )
             embedding_manager.close()
 
@@ -1248,17 +1286,11 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             validated_data = request.validated_data
             target_type = validated_data["target_type"]
             observation_span_id = validated_data.get("observation_span_id") or None
+            trace_id = validated_data.get("trace_id")
+            trace_session_id = validated_data.get("trace_session_id")
             action_type = validated_data.get("action_type")
             custom_eval_config_id = validated_data.get("custom_eval_config_id")
             feedback_id = validated_data.get("feedback_id")
-
-            # Trace + session anchors land in a follow-up; reject for now.
-            if target_type != EvalTargetType.SPAN:
-                return self._gm.custom_error_response(
-                    HTTP_400_BAD_REQUEST,
-                    f"target_type='{target_type}' feedback not yet supported",
-                    code="not_supported",
-                )
 
             # TODO(BE-3): batch path replaces this block.
             # When action_type == FeedbackActionType.RETUNE_RECALCULATE,
@@ -1266,23 +1298,24 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             # them, start RecalculateEvalTaskWorkflow, return
             # recalculated_count = len(siblings).
 
+            if target_type == EvalTargetType.SPAN:
+                anchor_id = observation_span_id
+            elif target_type == EvalTargetType.TRACE:
+                anchor_id = str(trace_id) if trace_id else None
+            elif target_type == EvalTargetType.SESSION:
+                anchor_id = str(trace_session_id) if trace_session_id else None
+            else:
+                return self._gm.internal_server_error_response(
+                    f"Unhandled target_type={target_type!r}"
+                )
             try:
                 feedback = Feedback.objects.get(
-                    id=feedback_id, user=request.user, source_id=observation_span_id
+                    id=feedback_id, user=request.user, source_id=anchor_id
                 )
                 feedback.action_type = action_type
                 feedback.save(update_fields=["action_type"])
             except Feedback.DoesNotExist:
                 return self._gm.not_found("Feedback not found")
-
-            try:
-                observation_span = ObservationSpan.objects.get(
-                    _project_workspace_scope_q(request),
-                    id=observation_span_id,
-                    project__organization=_get_request_organization(request),
-                )
-            except ObservationSpan.DoesNotExist:
-                return self._gm.not_found("Observation span not found")
 
             try:
                 custom_eval_config = CustomEvalConfig.objects.get(
@@ -1293,67 +1326,70 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             except CustomEvalConfig.DoesNotExist:
                 return self._gm.not_found("Custom eval config not found")
 
+            eval_logger_filter = {
+                "custom_eval_config": custom_eval_config,
+                "target_type": target_type,
+                "deleted": False,
+            }
+            if target_type == EvalTargetType.SPAN:
+                eval_logger_filter["observation_span_id"] = observation_span_id
+            elif target_type == EvalTargetType.TRACE:
+                eval_logger_filter["trace_id"] = trace_id
+            elif target_type == EvalTargetType.SESSION:
+                eval_logger_filter["trace_session_id"] = trace_session_id
+            else:
+                return self._gm.internal_server_error_response(
+                    f"Unhandled target_type={target_type!r}"
+                )
+
+            try:
+                eval_logger = EvalLogger.objects.get(**eval_logger_filter)
+            except EvalLogger.DoesNotExist:
+                return self._gm.not_found(f"No {target_type}-level eval found")
+
+            if eval_logger.error:
+                return self._gm.custom_error_response(
+                    HTTP_409_CONFLICT,
+                    "Cannot submit feedback on an errored eval",
+                    code="errored_eval",
+                )
+
             recalculated_count = 0
             if action_type == FeedbackActionType.RETUNE:
                 pass  ### This is coz we are using mapping_fields fxn in utils
 
             elif action_type == FeedbackActionType.RECALCULATE:
-                try:
-                    eval_logger = EvalLogger.objects.get(
-                        observation_span=observation_span,
-                        custom_eval_config=custom_eval_config,
-                        deleted=False,
-                    )
-                except EvalLogger.DoesNotExist:
-                    return self._gm.not_found("No eval associated with this span")
+                eval_task_id = eval_logger.eval_task_id
 
-                if eval_logger.error:
-                    return self._gm.custom_error_response(
-                        HTTP_409_CONFLICT,
-                        "Cannot submit feedback on an errored eval",
-                        code="errored_eval",
-                    )
-
-                task_id = eval_logger.eval_task_id
-
-                eval_logger.deleted = True
-                eval_logger.deleted_at = timezone.now()
-                eval_logger.save(update_fields=["deleted", "deleted_at"])
-
+                mixpanel_span = (
+                    eval_logger.observation_span if eval_logger.observation_span_id
+                    else None
+                )
                 properties = get_mixpanel_properties(
                     user=request.user,
-                    span=observation_span,
+                    span=mixpanel_span,
                     eval=custom_eval_config.eval_template,
                     count=1,
                     type=MixpanelTypes.FEEDBACK.value,
                 )
                 track_mixpanel_event(MixpanelEvents.EVAL_RUN_STARTED.value, properties)
 
-                if observation_span.project_version:
-                    status = evaluate_observation_span(
-                        str(observation_span.id),
-                        str(custom_eval_config.id),
-                        task_id,
-                        feedback_id,
-                    )
-                else:
-                    status = evaluate_observation_span_observe(
-                        str(observation_span.id),
-                        str(custom_eval_config.id),
-                        task_id,
-                        feedback_id,
-                    )
+                status = rerun_single(
+                    target_type=target_type,
+                    observation_span_id=observation_span_id,
+                    trace_id=trace_id,
+                    trace_session_id=trace_session_id,
+                    custom_eval_config_id=str(custom_eval_config.id),
+                    eval_task_id=eval_task_id,
+                    feedback_id=feedback_id,
+                )
 
-                if status:
-                    count = 1
-                    failed = 0
-                else:
-                    failed = 1
-                    count = 0
+                count = 1 if status else 0
+                failed = 0 if status else 1
                 recalculated_count = count
                 properties = get_mixpanel_properties(
                     user=request.user,
-                    span=observation_span,
+                    span=mixpanel_span,
                     eval=custom_eval_config.eval_template,
                     count=count,
                     failed=failed,


### PR DESCRIPTION
## Context

**PR 2 of 5** in the stacked work for `TH-5462`. Stacks on top of #723 (BE-1). Unlocks trace-level and session-level feedback end-to-end for single-row recalc, leaving the batch path for PR 3.

## ⚠️ Amendment notes (2026-06-01)

Force-pushed (`2d185e01` → `a429e8ad`). Pure `git rebase --onto` of the original commit onto the amended #723 HEAD (`f24299a8`). **This PR's diff is unchanged** — the rebase only replaces the underlying contract-foundations parent. The model-field `choices=` constraint #723 originally added is no longer enforced; the canonical vocabulary stays enforced at the serializer layer (`SubmitFeedbackActionTypeSerializer.action_type = ChoiceField(...)`), which is the layer this PR's tests already exercise.

Rationale + the legacy-row migration plan are in #723's Amendment notes + [TH-5604](https://linear.app/future-agi/issue/TH-5604).

Re-verified after the rebase: 19/19 Feedback-related tests in `test_observation_span.py` pass; this PR's specific new tests (trace + session multi-target + the 3 `rerun_single` dispatch tests) all green.

## What this PR does

### `submit_feedback` — per-target dispatch

Three branches, one shared tail:

| `target_type` | Anchor lookup | EvalLogger lookup | Embedding payload |
|---|---|---|---|
| `span` | `ObservationSpan.objects.get(id=...)` | `observation_span` + `target_type=span` | `TraceSerializer(trace).data` |
| `trace` | `Trace.objects.get(id=...)` | `trace` + `target_type=trace` | `TraceSerializer(trace).data` |
| `session` | `TraceSession.objects.get(id=...)` | `trace_session` + `target_type=session` | `TraceSessionFeedbackSerializer(session).data` |

`Feedback.source_id` is the canonical id per `target_type` (span_id / trace_id / session_id). `Feedback.source` is always `OBSERVE` — the legacy ternary that wrote `EXPERIMENT` for spans with `project_version` was both semantically wrong (the enum field is "where the feedback came from," not "what kind of span") and unreachable from this endpoint (experiments use their own feedback APIs).

### `submit_feedback_action_type` — RECALCULATE via `rerun_single`

```python
status = rerun_single(
    target_type=target_type,
    observation_span_id=observation_span_id,
    trace_id=trace_id,
    trace_session_id=trace_session_id,
    custom_eval_config_id=str(custom_eval_config.id),
    eval_task_id=eval_task_id,
    feedback_id=feedback_id,
)
```

One call site, three dispatches. The old experiment-runner branch is gone (same reasoning as `submit_feedback`).

### New helper — `tracer.utils.eval.rerun_single`

Soft-deletes the prior live `EvalLogger` by `(anchor, target_type, eval_config)` and re-dispatches to the matching `evaluate_*_observe`:

| `target_type` | Dispatch |
|---|---|
| `span` | `evaluate_observation_span_observe(span_id, eval_config_id, eval_task_id, feedback_id)` |
| `trace` | `evaluate_trace_observe(trace_id, ...)` |
| `session` | `evaluate_trace_session_observe(session_id, ...)` |

The view calls it for single-row recalc; the upcoming batch workflow activity will call the same helper from PR 3.

### New serializer — `TraceSessionFeedbackSerializer`

`{id, name, traces: [...]}`. Local `TraceSerializer` import inside `get_traces()` to sidestep the `TraceSerializer → Trace.session → TraceSession` import cycle.

### Validator tweak

`target_type='trace'` no longer requires `observation_span_id`. The trace_id alone is sufficient — the root-span anchor lives on the `EvalLogger` row (via the existing `CHECK` constraint), not on the request payload.

### Defensive

Both views: explicit `elif EvalTargetType.SESSION` + `else` returning 500 with `Unhandled target_type=...`. Unreachable if the serializer's `ChoiceField` is enforcing — but a server-side invariant violation, not a client error, if it ever happens.

## Tests

23 / 23 green in 23.6s (re-verified 19/19 of those after the rebase, full count unchanged).

- 17 BE-1 tests preserved.
- **6 new in `TestObservationSpanSubmitFeedbackAPI`**: trace happy path (Feedback row + source_id == trace_id), session happy path (source == OBSERVE, source_id == session_id), session embedding payload uses `TraceSessionFeedbackSerializer` shape (asserts `row_dict.id == session_id` and `traces` key).
- **3 new in `TestObservationSpanSubmitFeedbackActionTypeAPI`**: span / trace / session dispatch via `rerun_single` (mocked, asserts call kwargs match the right target).
- **`TestRerunSingleHelper`**: 4 unit tests with real DB writes — soft-delete + dispatch per target, plus the `ValueError` raise on unknown target_type.

## What's still deferred (PR 3)

`action_type='retune_recalculate'` still falls through silently (`recalculated_count=0`). The TODO comment from BE-1 stays at the dispatch site. PR 3 adds the `RecalculateEvalTaskWorkflow` package and lifts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
