### PR TITLE
feat(tracer): batch recalculate workflow for retune_recalculate feedback [TH-5462]

### DIFF
--- a/futureagi/tfc/temporal/common/registry.py
+++ b/futureagi/tfc/temporal/common/registry.py
@@ -197,6 +197,23 @@ def _ensure_workflows_registered() -> None:
             "could_not_load_evaluation_workflows", error=str(e)
         )
 
+    # Register eval-logger batch recalculate workflow for tasks_s queue
+    try:
+        from tfc.temporal.eval_logger_recalculate.workflows import (
+            RecalculateEvalTaskWorkflow,
+        )
+
+        register_for_queues(
+            queues=["tasks_s", "default"],
+            workflows=[RecalculateEvalTaskWorkflow],
+        )
+    except ImportError as e:
+        from tfc.logging.temporal import get_logger
+
+        get_logger(__name__).warning(
+            "could_not_load_recalculate_eval_task_workflow", error=str(e)
+        )
+
     # Register ground truth embedding workflows for tasks_xl queue
     try:
         from tfc.temporal.ground_truth.workflows import (
@@ -415,6 +432,27 @@ def _ensure_activities_registered() -> None:
         log.info("registered_evaluation_activities", queues=["tasks_s", "default"])
     except ImportError as e:
         log.warning("could_not_load_evaluation_activities", error=str(e))
+
+    # Register eval-logger batch recalculate activities for tasks_s queue
+    try:
+        from tfc.temporal.eval_logger_recalculate.activities import (
+            dispatch_rerun_activity,
+            soft_delete_sibling_eval_loggers_activity,
+        )
+
+        register_for_queues(
+            queues=["tasks_s", "default"],
+            activities=[
+                soft_delete_sibling_eval_loggers_activity,
+                dispatch_rerun_activity,
+            ],
+        )
+        log.info(
+            "registered_recalculate_eval_task_activities",
+            queues=["tasks_s", "default"],
+        )
+    except ImportError as e:
+        log.warning("could_not_load_recalculate_eval_task_activities", error=str(e))
 
     # Register ground truth embedding activities for tasks_xl queue
     try:

--- a/futureagi/tfc/temporal/eval_logger_recalculate/__init__.py
+++ b/futureagi/tfc/temporal/eval_logger_recalculate/__init__.py
@@ -1,0 +1,6 @@
+"""Temporal workflow for batch-recalculating every EvalLogger under an EvalTask.
+
+Triggered by submit_feedback_action_type when the user picks the
+retune_recalculate radio. The view picks the sibling target rows and hands
+them off; this package does the bulk soft-delete + the fan-out reruns.
+"""

--- a/futureagi/tfc/temporal/eval_logger_recalculate/activities.py
+++ b/futureagi/tfc/temporal/eval_logger_recalculate/activities.py
@@ -1,0 +1,137 @@
+"""Activities that touch the DB. Django imports stay here, not in workflows.py."""
+
+from django.db import close_old_connections
+from django.utils import timezone
+from temporalio import activity
+
+from tfc.telemetry import otel_sync_to_async
+from tfc.temporal.eval_logger_recalculate.types import (
+    DispatchRerunInput,
+    DispatchRerunOutput,
+    SoftDeleteSiblingsInput,
+    SoftDeleteSiblingsOutput,
+)
+
+
+def _soft_delete_siblings_sync(
+    eval_task_id: str, custom_eval_config_id: str
+) -> int:
+    from tracer.models.observation_span import EvalLogger
+
+    return EvalLogger.objects.filter(
+        eval_task_id=eval_task_id,
+        custom_eval_config_id=custom_eval_config_id,
+        deleted=False,
+    ).update(deleted=True, deleted_at=timezone.now())
+
+
+def _dispatch_rerun_sync(input: DispatchRerunInput) -> DispatchRerunOutput:
+    from tracer.models.observation_span import EvalTargetType
+    from tracer.utils.eval import (
+        evaluate_observation_span_observe,
+        evaluate_trace_observe,
+        evaluate_trace_session_observe,
+    )
+
+    if input.target_type == EvalTargetType.SPAN:
+        ok = evaluate_observation_span_observe(
+            input.observation_span_id,
+            input.custom_eval_config_id,
+            input.eval_task_id,
+            input.feedback_id,
+        )
+    elif input.target_type == EvalTargetType.TRACE:
+        ok = evaluate_trace_observe(
+            input.trace_id,
+            input.custom_eval_config_id,
+            input.eval_task_id,
+            input.feedback_id,
+        )
+    elif input.target_type == EvalTargetType.SESSION:
+        ok = evaluate_trace_session_observe(
+            input.trace_session_id,
+            input.custom_eval_config_id,
+            input.eval_task_id,
+            input.feedback_id,
+        )
+    else:
+        return DispatchRerunOutput(
+            target_type=input.target_type,
+            status="failed",
+            error=f"Unhandled target_type={input.target_type!r}",
+        )
+    return DispatchRerunOutput(
+        target_type=input.target_type,
+        status="completed" if ok else "failed",
+    )
+
+
+def _soft_delete_siblings_with_connection_lifecycle(
+    eval_task_id: str, custom_eval_config_id: str
+) -> int:
+    close_old_connections()
+    try:
+        return _soft_delete_siblings_sync(eval_task_id, custom_eval_config_id)
+    finally:
+        close_old_connections()
+
+
+@activity.defn
+async def soft_delete_sibling_eval_loggers_activity(
+    input: SoftDeleteSiblingsInput,
+) -> SoftDeleteSiblingsOutput:
+    """One UPDATE soft-deleting every live sibling EvalLogger under the eval task."""
+    activity.logger.info(
+        f"Soft-deleting siblings for eval_task={input.eval_task_id} "
+        f"eval_config={input.custom_eval_config_id}"
+    )
+    deleted = await otel_sync_to_async(
+        _soft_delete_siblings_with_connection_lifecycle, thread_sensitive=False
+    )(input.eval_task_id, input.custom_eval_config_id)
+    activity.logger.info(f"Soft-deleted {deleted} rows")
+    return SoftDeleteSiblingsOutput(deleted_count=deleted)
+
+
+def _dispatch_rerun_with_connection_lifecycle(
+    input: DispatchRerunInput,
+) -> DispatchRerunOutput:
+    close_old_connections()
+    try:
+        return _dispatch_rerun_sync(input)
+    finally:
+        close_old_connections()
+
+
+@activity.defn
+async def dispatch_rerun_activity(input: DispatchRerunInput) -> DispatchRerunOutput:
+    """Dispatch the right per-target evaluate_*_observe for one row.
+
+    The prior bulk soft-delete already cleared the live row; the rerun is
+    idempotent because each evaluate_*_observe dedups on
+    (eval_task_id, target, eval_config).
+    """
+    from tfc.temporal.common.heartbeat import Heartbeater
+
+    activity.logger.info(
+        f"Dispatching rerun target_type={input.target_type} "
+        f"eval_task={input.eval_task_id}"
+    )
+    try:
+        async with Heartbeater():
+            result = await otel_sync_to_async(
+                _dispatch_rerun_with_connection_lifecycle, thread_sensitive=False
+            )(input)
+        return result
+    except Exception as e:
+        activity.logger.exception(
+            f"Error in dispatch_rerun_activity target_type={input.target_type}: {e}"
+        )
+        return DispatchRerunOutput(
+            target_type=input.target_type, status="failed", error=str(e)
+        )
+
+
+__all__ = [
+    "soft_delete_sibling_eval_loggers_activity",
+    "dispatch_rerun_activity",
+]

--- a/futureagi/tfc/temporal/eval_logger_recalculate/client.py
+++ b/futureagi/tfc/temporal/eval_logger_recalculate/client.py
@@ -1,0 +1,82 @@
+"""Workflow starters for Django callers."""
+
+import uuid
+from typing import List, Optional
+
+from tfc.temporal.common.client import (
+    start_workflow_async,
+    start_workflow_sync,
+)
+from tfc.temporal.eval_logger_recalculate.types import (
+    RecalculateEvalTaskWorkflowInput,
+    RecalculateTarget,
+)
+
+
+def _workflow_id(eval_task_id: str) -> str:
+    # Per-eval-task prefix + short uuid so retries on the same task get distinct ids.
+    return f"recalculate-eval-task-{eval_task_id}-{uuid.uuid4().hex[:8]}"
+
+
+async def start_recalculate_eval_task_workflow_async(
+    eval_task_id: str,
+    custom_eval_config_id: str,
+    targets: List[RecalculateTarget],
+    feedback_id: Optional[str] = None,
+    max_concurrent: int = 10,
+    task_queue: str = "tasks_s",
+) -> str:
+    from tfc.temporal.eval_logger_recalculate.workflows import (
+        RecalculateEvalTaskWorkflow,
+    )
+
+    handle = await start_workflow_async(
+        workflow_class=RecalculateEvalTaskWorkflow,
+        workflow_input=RecalculateEvalTaskWorkflowInput(
+            eval_task_id=eval_task_id,
+            custom_eval_config_id=custom_eval_config_id,
+            feedback_id=feedback_id,
+            targets=targets,
+            max_concurrent=max_concurrent,
+            task_queue=task_queue,
+        ),
+        workflow_id=_workflow_id(eval_task_id),
+        task_queue=task_queue,
+        cancel_existing=False,
+    )
+    return handle.id
+
+
+def start_recalculate_eval_task_workflow(
+    eval_task_id: str,
+    custom_eval_config_id: str,
+    targets: List[RecalculateTarget],
+    feedback_id: Optional[str] = None,
+    max_concurrent: int = 10,
+    task_queue: str = "tasks_s",
+) -> str:
+    from tfc.temporal.eval_logger_recalculate.workflows import (
+        RecalculateEvalTaskWorkflow,
+    )
+
+    handle = start_workflow_sync(
+        workflow_class=RecalculateEvalTaskWorkflow,
+        workflow_input=RecalculateEvalTaskWorkflowInput(
+            eval_task_id=eval_task_id,
+            custom_eval_config_id=custom_eval_config_id,
+            feedback_id=feedback_id,
+            targets=targets,
+            max_concurrent=max_concurrent,
+            task_queue=task_queue,
+        ),
+        workflow_id=_workflow_id(eval_task_id),
+        task_queue=task_queue,
+        cancel_existing=False,
+    )
+    return handle.id
+
+
+__all__ = [
+    "start_recalculate_eval_task_workflow",
+    "start_recalculate_eval_task_workflow_async",
+]

--- a/futureagi/tfc/temporal/eval_logger_recalculate/tests/test_activities.py
+++ b/futureagi/tfc/temporal/eval_logger_recalculate/tests/test_activities.py
@@ -1,0 +1,65 @@
+"""Tests for the eval_logger_recalculate dispatch helper (pure-mock).
+
+The DB-touching ``_soft_delete_siblings_sync`` tests live under
+``tracer/tests/test_eval_logger_recalculate_soft_delete.py`` since they
+depend on tracer-side fixtures.
+"""
+
+import pytest
+
+from tfc.temporal.eval_logger_recalculate.activities import _dispatch_rerun_sync
+from tfc.temporal.eval_logger_recalculate.types import DispatchRerunInput
+
+
+@pytest.mark.integration
+class TestDispatchRerunSync:
+    def _input(self, target_type, **ids):
+        return DispatchRerunInput(
+            target_type=target_type,
+            custom_eval_config_id="cfg",
+            eval_task_id="task",
+            feedback_id=None,
+            **ids,
+        )
+
+    def test_dispatches_span_runner(self, db, mocker):
+        span_mock = mocker.patch(
+            "tracer.utils.eval.evaluate_observation_span_observe", return_value=True
+        )
+        result = _dispatch_rerun_sync(
+            self._input("span", observation_span_id="span-1")
+        )
+        assert result.status == "completed"
+        span_mock.assert_called_once_with("span-1", "cfg", "task", None)
+
+    def test_dispatches_trace_runner(self, db, mocker):
+        trace_mock = mocker.patch(
+            "tracer.utils.eval.evaluate_trace_observe", return_value=True
+        )
+        result = _dispatch_rerun_sync(self._input("trace", trace_id="trace-1"))
+        assert result.status == "completed"
+        trace_mock.assert_called_once_with("trace-1", "cfg", "task", None)
+
+    def test_dispatches_session_runner(self, db, mocker):
+        session_mock = mocker.patch(
+            "tracer.utils.eval.evaluate_trace_session_observe", return_value=True
+        )
+        result = _dispatch_rerun_sync(
+            self._input("session", trace_session_id="session-1")
+        )
+        assert result.status == "completed"
+        session_mock.assert_called_once_with("session-1", "cfg", "task", None)
+
+    def test_marks_failed_when_runner_returns_falsy(self, db, mocker):
+        mocker.patch(
+            "tracer.utils.eval.evaluate_observation_span_observe", return_value=None
+        )
+        result = _dispatch_rerun_sync(
+            self._input("span", observation_span_id="span-1")
+        )
+        assert result.status == "failed"
+
+    def test_unknown_target_type_returns_failed(self, db):
+        result = _dispatch_rerun_sync(self._input("bogus"))
+        assert result.status == "failed"
+        assert "Unhandled target_type" in (result.error or "")

--- a/futureagi/tfc/temporal/eval_logger_recalculate/types.py
+++ b/futureagi/tfc/temporal/eval_logger_recalculate/types.py
@@ -1,0 +1,75 @@
+"""Dataclasses shared by the workflow + activities + client.
+
+Kept Django-free so the workflow sandbox can import them.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class RecalculateTarget:
+    """One sibling EvalLogger to rerun. Exactly one of the three id fields is set."""
+
+    target_type: str  # EvalTargetType value: "span" / "trace" / "session"
+    observation_span_id: Optional[str] = None
+    trace_id: Optional[str] = None
+    trace_session_id: Optional[str] = None
+
+
+@dataclass
+class SoftDeleteSiblingsInput:
+    eval_task_id: str
+    custom_eval_config_id: str
+
+
+@dataclass
+class SoftDeleteSiblingsOutput:
+    deleted_count: int
+
+
+@dataclass
+class DispatchRerunInput:
+    target_type: str
+    custom_eval_config_id: str
+    eval_task_id: Optional[str] = None
+    feedback_id: Optional[str] = None
+    observation_span_id: Optional[str] = None
+    trace_id: Optional[str] = None
+    trace_session_id: Optional[str] = None
+
+
+@dataclass
+class DispatchRerunOutput:
+    target_type: str
+    status: str  # "completed" / "failed"
+    error: Optional[str] = None
+
+
+@dataclass
+class RecalculateEvalTaskWorkflowInput:
+    eval_task_id: str
+    custom_eval_config_id: str
+    feedback_id: Optional[str] = None
+    targets: List[RecalculateTarget] = field(default_factory=list)
+    max_concurrent: int = 10
+    task_queue: str = "tasks_s"
+
+
+@dataclass
+class RecalculateEvalTaskWorkflowOutput:
+    total: int
+    completed: int
+    failed: int
+    status: str  # "COMPLETED" / "PARTIAL" / "FAILED"
+
+
+__all__ = [
+    "RecalculateTarget",
+    "SoftDeleteSiblingsInput",
+    "SoftDeleteSiblingsOutput",
+    "DispatchRerunInput",
+    "DispatchRerunOutput",
+    "RecalculateEvalTaskWorkflowInput",
+    "RecalculateEvalTaskWorkflowOutput",
+]

--- a/futureagi/tfc/temporal/eval_logger_recalculate/workflows.py
+++ b/futureagi/tfc/temporal/eval_logger_recalculate/workflows.py
@@ -1,0 +1,88 @@
+"""Workflow for batch-recalculating sibling EvalLoggers.
+
+IMPORTANT: Do NOT use workflow.logger - stdlib logging locks cause sandbox
+deadlocks. Logging goes in activities.
+"""
+
+import asyncio
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from tfc.temporal.eval_logger_recalculate.types import (
+    DispatchRerunInput,
+    RecalculateEvalTaskWorkflowInput,
+    RecalculateEvalTaskWorkflowOutput,
+    SoftDeleteSiblingsInput,
+)
+
+RECALCULATE_RETRY_POLICY = RetryPolicy(
+    initial_interval=timedelta(seconds=5),
+    maximum_interval=timedelta(minutes=2),
+    maximum_attempts=3,
+    backoff_coefficient=2.0,
+)
+
+
+@workflow.defn
+class RecalculateEvalTaskWorkflow:
+    """Bulk soft-delete + per-target rerun fan-out."""
+
+    @workflow.run
+    async def run(
+        self, input: RecalculateEvalTaskWorkflowInput
+    ) -> RecalculateEvalTaskWorkflowOutput:
+        await workflow.execute_activity(
+            "soft_delete_sibling_eval_loggers_activity",
+            SoftDeleteSiblingsInput(
+                eval_task_id=input.eval_task_id,
+                custom_eval_config_id=input.custom_eval_config_id,
+            ),
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RECALCULATE_RETRY_POLICY,
+        )
+
+        total = len(input.targets)
+        semaphore = asyncio.Semaphore(input.max_concurrent)
+
+        async def process_one(target) -> bool:
+            async with semaphore:
+                try:
+                    result = await workflow.execute_activity(
+                        "dispatch_rerun_activity",
+                        DispatchRerunInput(
+                            target_type=target.target_type,
+                            observation_span_id=target.observation_span_id,
+                            trace_id=target.trace_id,
+                            trace_session_id=target.trace_session_id,
+                            custom_eval_config_id=input.custom_eval_config_id,
+                            eval_task_id=input.eval_task_id,
+                            feedback_id=input.feedback_id,
+                        ),
+                        start_to_close_timeout=timedelta(hours=2),
+                        heartbeat_timeout=timedelta(minutes=5),
+                        retry_policy=RECALCULATE_RETRY_POLICY,
+                    )
+                    return result["status"] == "completed"
+                except Exception:
+                    return False
+
+        tasks = [process_one(t) for t in input.targets]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        completed = sum(1 for r in results if isinstance(r, bool) and r)
+        failed = total - completed
+        status = (
+            "COMPLETED" if failed == 0 else "PARTIAL" if completed > 0 else "FAILED"
+        )
+
+        return RecalculateEvalTaskWorkflowOutput(
+            total=total,
+            completed=completed,
+            failed=failed,
+            status=status,
+        )
+
+
+__all__ = ["RecalculateEvalTaskWorkflow"]

--- a/futureagi/tracer/tests/test_eval_logger_recalculate_soft_delete.py
+++ b/futureagi/tracer/tests/test_eval_logger_recalculate_soft_delete.py
@@ -1,0 +1,75 @@
+"""DB-touching tests for the soft-delete activity helper.
+
+Lives under tracer/tests so it picks up the tracer conftest's
+observation_span + custom_eval_config fixtures. Logically owned by the
+``tfc/temporal/eval_logger_recalculate`` package.
+"""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.integration
+class TestSoftDeleteSiblingsSync:
+    def test_soft_deletes_only_matching_task_and_config(
+        self, db, observation_span, custom_eval_config
+    ):
+        from tfc.temporal.eval_logger_recalculate.activities import (
+            _soft_delete_siblings_sync,
+        )
+        from tracer.models.observation_span import EvalLogger, EvalTargetType
+
+        task_id = str(uuid.uuid4())
+        other_task_id = str(uuid.uuid4())
+
+        match_span = EvalLogger.objects.create(
+            trace=observation_span.trace,
+            observation_span=observation_span,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.SPAN,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+            eval_task_id=task_id,
+        )
+        match_trace = EvalLogger.objects.create(
+            trace=observation_span.trace,
+            observation_span=observation_span,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.TRACE,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+            eval_task_id=task_id,
+        )
+        decoy = EvalLogger.objects.create(
+            trace=observation_span.trace,
+            observation_span=observation_span,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.SPAN,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+            eval_task_id=other_task_id,
+        )
+
+        deleted = _soft_delete_siblings_sync(task_id, str(custom_eval_config.id))
+
+        assert deleted == 2
+        match_span.refresh_from_db()
+        match_trace.refresh_from_db()
+        decoy.refresh_from_db()
+        assert match_span.deleted is True
+        assert match_trace.deleted is True
+        assert decoy.deleted is False
+
+    def test_returns_zero_when_no_matches(self, db, custom_eval_config):
+        from tfc.temporal.eval_logger_recalculate.activities import (
+            _soft_delete_siblings_sync,
+        )
+
+        deleted = _soft_delete_siblings_sync(
+            "no-such-task", str(custom_eval_config.id)
+        )
+        assert deleted == 0

--- a/futureagi/tracer/tests/test_observation_span.py
+++ b/futureagi/tracer/tests/test_observation_span.py
@@ -1281,6 +1281,124 @@ class TestObservationSpanSubmitFeedbackActionTypeAPI:
         eval_logger.refresh_from_db()
         assert eval_logger.deleted is False
 
+    def test_action_type_retune_recalculate_starts_workflow(
+        self,
+        auth_client,
+        user,
+        organization,
+        workspace,
+        observation_span,
+        custom_eval_config,
+        mocker,
+    ):
+        from tracer.models.observation_span import EvalLogger, EvalTargetType
+        from tracer.models.trace_session import TraceSession
+
+        feedback, anchor_logger = self._seed_feedback_and_logger(
+            user, organization, workspace, observation_span, custom_eval_config
+        )
+        shared_eval_task_id = anchor_logger.eval_task_id
+
+        # Two more siblings under the same eval_task_id: one trace-level, one
+        # session-level. The batch workflow should sweep up all three.
+        EvalLogger.objects.create(
+            trace=observation_span.trace,
+            observation_span=observation_span,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.TRACE,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+            eval_task_id=shared_eval_task_id,
+        )
+        trace_session = TraceSession.objects.create(
+            project=observation_span.project, name="batch session"
+        )
+        EvalLogger.objects.create(
+            trace=None,
+            observation_span=None,
+            trace_session=trace_session,
+            custom_eval_config=custom_eval_config,
+            target_type=EvalTargetType.SESSION,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+            eval_task_id=shared_eval_task_id,
+        )
+
+        workflow_mock = mocker.patch(
+            "tracer.views.observation_span.start_recalculate_eval_task_workflow",
+            return_value="recalculate-eval-task-abcd",
+        )
+
+        response = auth_client.post(
+            self.ACTION_TYPE_URL,
+            self._valid_span_action_payload(
+                observation_span, custom_eval_config, feedback, "retune_recalculate"
+            ),
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        result = get_result(response)
+        assert result["action_type"] == "retune_recalculate"
+        assert result["recalculated_count"] == 3
+
+        workflow_mock.assert_called_once()
+        call_kwargs = workflow_mock.call_args.kwargs
+        assert call_kwargs["eval_task_id"] == shared_eval_task_id
+        assert call_kwargs["custom_eval_config_id"] == str(custom_eval_config.id)
+        target_types = sorted(t.target_type for t in call_kwargs["targets"])
+        assert target_types == ["session", "span", "trace"]
+
+    def test_action_type_retune_recalculate_rejects_when_no_eval_task(
+        self,
+        auth_client,
+        user,
+        organization,
+        workspace,
+        observation_span,
+        custom_eval_config,
+        mocker,
+    ):
+        from tracer.models.observation_span import EvalLogger
+
+        feedback = Feedback.objects.create(
+            source=FeedbackSourceChoices.OBSERVE.value,
+            source_id=str(observation_span.id),
+            value="passed",
+            eval_template=custom_eval_config.eval_template,
+            custom_eval_config_id=custom_eval_config.id,
+            user=user,
+            organization=organization,
+            workspace=workspace,
+        )
+        # EvalLogger without an eval_task_id — created by a one-off rerun.
+        EvalLogger.objects.create(
+            trace=observation_span.trace,
+            observation_span=observation_span,
+            custom_eval_config=custom_eval_config,
+            output_str="passed",
+            eval_explanation="ok",
+            results_explanation={"reason": "ok"},
+            eval_task_id=None,
+        )
+        workflow_mock = mocker.patch(
+            "tracer.views.observation_span.start_recalculate_eval_task_workflow"
+        )
+
+        response = auth_client.post(
+            self.ACTION_TYPE_URL,
+            self._valid_span_action_payload(
+                observation_span, custom_eval_config, feedback, "retune_recalculate"
+            ),
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json().get("code") == "no_eval_task"
+        workflow_mock.assert_not_called()
+
 
 @pytest.mark.integration
 class TestRerunSingleHelper:

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -3614,13 +3614,7 @@ def rerun_single(
     eval_task_id=None,
     feedback_id=None,
 ):
-    """Soft-delete the prior EvalLogger for this row and re-dispatch.
-
-    Shared by submit_feedback_action_type (single-row recalc) and the
-    batch RecalculateEvalTaskWorkflow that ships in a follow-up PR.
-
-    TODO(BE-3): drop the "follow-up PR" wording once the workflow is wired.
-    """
+    """Soft-delete the prior EvalLogger for this row and re-dispatch."""
     if target_type == EvalTargetType.SPAN:
         EvalLogger.objects.filter(
             observation_span_id=observation_span_id,

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -100,6 +100,10 @@ from tracer.services.clickhouse.graph_dispatch import (
 from tracer.services.clickhouse.query_service import AnalyticsQueryService
 from tracer.utils.annotations import build_annotation_subqueries
 from tracer.utils.create_otel_span import create_single_otel_span
+from tfc.temporal.eval_logger_recalculate.client import (
+    start_recalculate_eval_task_workflow,
+)
+from tfc.temporal.eval_logger_recalculate.types import RecalculateTarget
 from tracer.utils.eval import rerun_single
 from tracer.utils.filters import FilterEngine
 from tracer.utils.helper import (
@@ -1292,12 +1296,6 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             custom_eval_config_id = validated_data.get("custom_eval_config_id")
             feedback_id = validated_data.get("feedback_id")
 
-            # TODO(BE-3): batch path replaces this block.
-            # When action_type == FeedbackActionType.RETUNE_RECALCULATE,
-            # gather sibling EvalLoggers sharing eval_task_id, soft-delete
-            # them, start RecalculateEvalTaskWorkflow, return
-            # recalculated_count = len(siblings).
-
             if target_type == EvalTargetType.SPAN:
                 anchor_id = observation_span_id
             elif target_type == EvalTargetType.TRACE:
@@ -1397,6 +1395,56 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 )
                 track_mixpanel_event(
                     MixpanelEvents.EVAL_RUN_COMPLETED.value, properties
+                )
+
+            elif action_type == FeedbackActionType.RETUNE_RECALCULATE:
+                if not eval_logger.eval_task_id:
+                    return self._gm.custom_error_response(
+                        HTTP_400_BAD_REQUEST,
+                        "Eval result is not part of an eval task — cannot batch recalculate.",
+                        code="no_eval_task",
+                    )
+
+                # Siblings = every live EvalLogger this user's eval config wrote
+                # under the same eval_task_id. EvalTask is the natural batch unit:
+                # one task → many rows (mixed span/trace/session). The workflow
+                # reruns each row in its target-type's runner.
+                sibling_qs = EvalLogger.objects.filter(
+                    eval_task_id=eval_logger.eval_task_id,
+                    custom_eval_config_id=custom_eval_config.id,
+                    deleted=False,
+                ).values(
+                    "target_type",
+                    "observation_span_id",
+                    "trace_id",
+                    "trace_session_id",
+                )
+                targets = [
+                    RecalculateTarget(
+                        target_type=row["target_type"],
+                        observation_span_id=(
+                            str(row["observation_span_id"])
+                            if row["observation_span_id"]
+                            else None
+                        ),
+                        trace_id=(
+                            str(row["trace_id"]) if row["trace_id"] else None
+                        ),
+                        trace_session_id=(
+                            str(row["trace_session_id"])
+                            if row["trace_session_id"]
+                            else None
+                        ),
+                    )
+                    for row in sibling_qs
+                ]
+                recalculated_count = len(targets)
+
+                start_recalculate_eval_task_workflow(
+                    eval_task_id=str(eval_logger.eval_task_id),
+                    custom_eval_config_id=str(custom_eval_config.id),
+                    targets=targets,
+                    feedback_id=str(feedback_id) if feedback_id else None,
                 )
 
             return self._gm.success_response(


### PR DESCRIPTION
## Context

**PR 3 of 5** in the stacked work for `TH-5462`. Stacks on top of #731 (BE-2). Wires up the third Feedback action — `retune_recalculate` — by introducing a Temporal workflow that reruns every sibling `EvalLogger` under the same `EvalTask`.

## ⚠️ Amendment notes (2026-06-01)

Force-pushed (`640db817` → `12e48dca`). Pure `git rebase --onto` of the original commit onto the rebased #731 HEAD (`a429e8ad`), which itself sits on the amended #723 HEAD (`f24299a8`). **This PR's diff is unchanged** — the rebase only follows the underlying stack.

The model-field `choices=` constraint #723 originally added is no longer enforced; this PR's `RETUNE_RECALCULATE` workflow keeps writing canonical `action_type` values via `SubmitFeedbackActionTypeSerializer.action_type = ChoiceField(...)` (serializer layer), which is the layer this PR's tests already exercise. Rationale in #723's Amendment notes + [TH-5604](https://linear.app/future-agi/issue/TH-5604).

Re-verified after the rebase:
- 21/21 Feedback-related tests in `test_observation_span.py` (including the 2 new RETUNE_RECALCULATE tests this PR adds)
- 7/7 standalone tests in `tracer/tests/test_eval_logger_recalculate_soft_delete.py` + `tfc/temporal/eval_logger_recalculate/tests/test_activities.py`

## What this PR does

### New package — `tfc/temporal/eval_logger_recalculate/`

```
eval_logger_recalculate/
├── types.py        # RecalculateTarget, *Input/*Output dataclasses (Django-free, workflow sandbox safe)
├── activities.py   # 2 activities + 2 inner sync helpers
├── workflows.py    # RecalculateEvalTaskWorkflow
├── client.py       # sync + async start_recalculate_eval_task_workflow
└── tests/test_activities.py   # 5 pure-mock unit tests for the dispatcher
```

**Activities**

1. `soft_delete_sibling_eval_loggers_activity` — one `UPDATE` setting `deleted=True` on every live row matching `(eval_task_id, custom_eval_config_id)`. Returns the count.
2. `dispatch_rerun_activity` — branches on `target_type` and calls the matching runner from BE-2: `evaluate_observation_span_observe` / `evaluate_trace_observe` / `evaluate_trace_session_observe`.

Inner sync helpers (`_soft_delete_siblings_sync`, `_dispatch_rerun_sync`) are connection-lifecycle-free for testability; thin `_*_with_connection_lifecycle` wrappers handle `close_old_connections` on the Temporal activity path.

**Workflow** — `RecalculateEvalTaskWorkflow.run`:

```python
1. await soft_delete_sibling_eval_loggers_activity(...)   # bulk UPDATE, once
2. semaphore = asyncio.Semaphore(max_concurrent=10)        # matches RunEvaluationBatchWorkflow
3. tasks = [process_one(t) for t in targets]
4. results = await asyncio.gather(*tasks, return_exceptions=True)
5. return COMPLETED / PARTIAL / FAILED based on per-row outcomes
```

Per-row activity failures bubble up as `failed` counts; the workflow itself completes.

**Client** — `start_recalculate_eval_task_workflow` (sync, for Django views) + `..._async` (for async callers), mirroring `tfc/temporal/evaluations/client.py` conventions.

**Worker registry** — workflow + both activities registered on `tasks_s` and `default` queues next to `RunEvaluationBatchWorkflow`.

### View — `submit_feedback_action_type`

Drops the BE-1 `TODO(BE-3)` comment. The new `FeedbackActionType.RETUNE_RECALCULATE` branch:

```python
elif action_type == FeedbackActionType.RETUNE_RECALCULATE:
    if not eval_logger.eval_task_id:
        return self._gm.custom_error_response(
            HTTP_400_BAD_REQUEST,
            "Eval result is not part of an eval task — cannot batch recalculate.",
            code="no_eval_task",
        )
    # Siblings = every live EvalLogger this user's eval config wrote under
    # the same eval_task_id. EvalTask is the natural batch unit.
    sibling_qs = EvalLogger.objects.filter(
        eval_task_id=eval_logger.eval_task_id,
        custom_eval_config_id=custom_eval_config.id,
        deleted=False,
    ).values("target_type", "observation_span_id", "trace_id", "trace_session_id")
    targets = [RecalculateTarget(...) for row in sibling_qs]
    recalculated_count = len(targets)
    start_recalculate_eval_task_workflow(
        eval_task_id=str(eval_logger.eval_task_id),
        custom_eval_config_id=str(custom_eval_config.id),
        targets=targets,
        feedback_id=str(feedback_id) if feedback_id else None,
    )
```

Response carries `recalculated_count = len(targets)` so the FE can toast "Recalculated N evals."

### Misc

- `rerun_single` docstring shortened — the BE-2 "follow-up PR" framing is moot now that the workflow exists.

## Tests

32 / 32 green in 7s. Carries the 23 BE-2 tests forward + adds 9 new ones.

- **View** (in `TestObservationSpanSubmitFeedbackActionTypeAPI`):
  - `test_action_type_retune_recalculate_starts_workflow`: 3 siblings under one eval_task_id (span / trace / session); asserts the workflow is started with all 3 targets and `recalculated_count == 3`.
  - `test_action_type_retune_recalculate_rejects_when_no_eval_task`: 400 + `code="no_eval_task"` when `eval_logger.eval_task_id is None`; workflow not started.

- **Dispatcher** (pure-mock, `tfc/temporal/eval_logger_recalculate/tests/test_activities.py`):
  - 5 tests covering the 3 target_type branches, the falsy-return-marks-failed path, and the unknown-target_type guard.

- **Soft-delete** (DB-touching, `tracer/tests/test_eval_logger_recalculate_soft_delete.py`):
  - 2 tests: only `(eval_task_id, custom_eval_config_id)`-matching rows flip to `deleted=True`; zero-match returns 0. Lives under `tracer/tests/` so it picks up the tracer conftest's `observation_span` + `custom_eval_config` fixtures (pytest conftest discovery doesn't cross trees).

```
============================== 32 passed in 7.06s ==============================
```

## Concurrency notes

The semaphore default is **10**, matching `RunEvaluationBatchWorkflow` (`tfc/temporal/evaluations/workflows.py:101`). The fan-out activity is **not** a delete — the bulk soft-delete runs once before the gather. Each dispatch activity is a full eval rerun (LLM call, ClickHouse write, embedding lookup). The 10-cap exists to avoid 429-ing the LLM provider, exhausting the activity worker pool, and starving normal eval tasks sharing the queue.

If a future caller needs a different rate for an isolated workload, `start_recalculate_eval_task_workflow(..., max_concurrent=N)` is per-call tunable without changing the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
