### PR TITLE
added task completion eval as a system eval

### DIFF
--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 11
+SYSTEM_EVALS_VERSION = 12
 
 # Postgres advisory-lock key. Serialises concurrent seed_evals() calls
 # across pods so the bulk_create path can't race on new eval_ids. Any

--- a/futureagi/model_hub/system_evals/agent/customer_agent_task_completion.yaml
+++ b/futureagi/model_hub/system_evals/agent/customer_agent_task_completion.yaml
@@ -1,4 +1,4 @@
-eval_id: 125
+eval_id: 133
 name: customer_agent_task_completion
 description: Evaluates whether the agent successfully completes the task assigned to it based on the customer-agent interaction,
   including execution finality, outcome delivery, and correct handling of blockers or policy boundaries.

--- a/futureagi/model_hub/system_evals/agent/customer_agent_task_completion.yaml
+++ b/futureagi/model_hub/system_evals/agent/customer_agent_task_completion.yaml
@@ -1,0 +1,79 @@
+eval_id: 125
+name: customer_agent_task_completion
+description: Evaluates whether the agent successfully completes the task assigned to it based on the customer-agent interaction,
+  including execution finality, outcome delivery, and correct handling of blockers or policy boundaries.
+criteria: "You are evaluating whether the agent successfully completes the task assigned to it based on the customer-agent\
+  \ interaction.\n\n## Criteria\n1. Task execution and finality: The agent carries out the necessary actions to fully resolve\
+  \ the primary objective or core request of the customer.\n2. Explicit confirmation or outcome delivery: The agent clearly\
+  \ communicates the final result, confirmation, or status of the task so that the customer is aware it has been handled.\n\
+  3. Handling blockers or policy boundaries: The agent correctly navigates system constraints, accurately applying company\
+  \ policies or executing valid workarounds to reach the closest possible resolution.\n\n## Anti-bias Rules\n- If the customer\
+  \ abruptly terminates the conversation or refuses to provide mandatory information (e.g., account verification), do not penalize\
+  \ the agent for non-completion.\n- An accurate, policy-compliant refusal (e.g., correctly denying a refund because it violates\
+  \ terms of service) counts as a successful task completion, as the inquiry was definitively resolved according to business\
+  \ logic.\n- If the task requires back-end processing that takes hours or days to complete, the agent fulfills the criteria\
+  \ by successfully initiating the workflow and setting clear timeline expectations.\n\n## Scoring\n- Return PASS if the agent\
+  \ completely resolves the customer's request, delivers a clear and definitive outcome (including valid policy-based refusals),\
+  \ and ensures all necessary execution steps within the scope of the chat are completed.\n- Return FAIL if the agent leaves\
+  \ the request pending, promises an action but fails to execute it, abandons the interaction mid-process, or incorrectly states\
+  \ a task cannot be done due to agent error.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n<conversation>{{conversation}}</conversation>"
+eval_tags:
+- Agents
+- Conversation
+visible_ui: true
+permissions:
+  allow_edit: false
+  allow_copy: true
+choices:
+- Passed
+- Failed
+output_type_normalized: pass_fail
+pass_threshold: 0.5
+config:
+  required_keys:
+  - agent_prompt
+  - conversation
+  output: Pass/Fail
+  eval_type_id: AgentEvaluator
+  config: {}
+  config_params_desc:
+    agent_prompt: The agent's system prompt defining its task and behavior
+    conversation: The conversation to be evaluated
+  param_modalities:
+    agent_prompt:
+    - TEXT
+    - JSON
+    - LIST
+    - NUMBER
+    - BOOLEAN
+    - INTEGER
+    - FLOAT
+    - ARRAY
+    - DATETIME
+    conversation:
+    - TEXT
+    - AUDIO
+    - JSON
+    - LIST
+    - NUMBER
+    - BOOLEAN
+    - INTEGER
+    - FLOAT
+    - ARRAY
+    - DATETIME
+  rule_prompt: "You are evaluating whether the agent successfully completes the task assigned to it based on the customer-agent\
+    \ interaction.\n\n## Criteria\n1. Task execution and finality: The agent carries out the necessary actions to fully resolve\
+    \ the primary objective or core request of the customer.\n2. Explicit confirmation or outcome delivery: The agent clearly\
+    \ communicates the final result, confirmation, or status of the task so that the customer is aware it has been handled.\n\
+    3. Handling blockers or policy boundaries: The agent correctly navigates system constraints, accurately applying company\
+    \ policies or executing valid workarounds to reach the closest possible resolution.\n\n## Anti-bias Rules\n- If the customer\
+    \ abruptly terminates the conversation or refuses to provide mandatory information (e.g., account verification), do not\
+    \ penalize the agent for non-completion.\n- An accurate, policy-compliant refusal (e.g., correctly denying a refund because\
+    \ it violates terms of service) counts as a successful task completion, as the inquiry was definitively resolved according\
+    \ to business logic.\n- If the task requires back-end processing that takes hours or days to complete, the agent fulfills\
+    \ the criteria by successfully initiating the workflow and setting clear timeline expectations.\n\n## Scoring\n- Return\
+    \ PASS if the agent completely resolves the customer's request, delivers a clear and definitive outcome (including valid\
+    \ policy-based refusals), and ensures all necessary execution steps within the scope of the chat are completed.\n- Return\
+    \ FAIL if the agent leaves the request pending, promises an action but fails to execute it, abandons the interaction mid-process,\
+    \ or incorrectly states a task cannot be done due to agent error.\n\n## Input\n<agent_prompt>{{agent_prompt}}</agent_prompt>\n\
+    <conversation>{{conversation}}</conversation>"


### PR DESCRIPTION
## Summary

Adds a new agent system eval, `customer_agent_task_completion` (`eval_id: 125`), which evaluates whether the agent fully completes the task assigned to it in a customer–agent interaction — covering execution finality, explicit outcome delivery, and correct handling of blockers/policy boundaries (including valid policy-based refusals). It returns PASS/FAIL and takes `agent_prompt` + `conversation` as inputs, following the existing `customer_agent_*` YAML format. The `SYSTEM_EVALS_VERSION` constant is bumped `10 → 11` so the startup seeder re-runs and inserts the new eval across all environments on deploy (the seeder short-circuits on a cached version otherwise).

## Linked issues

Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Validated the new YAML parses with `yaml.safe_load`, that `criteria` is byte-identical to `config.rule_prompt` (matching sibling evals), that `eval_id: 125` is unique, and that the `{{agent_prompt}}` / `{{conversation}}` placeholders are present.
- Bumped `SYSTEM_EVALS_VERSION` to 11, restarted the backend container, and verified via Django shell inside the container:
  - `SYSTEM_EVALS_VERSION = 11` (code loaded)
  - Redis `system_evals_version = 11` (seeder ran, not skipped by the version gate)
  - `EvalTemplate` row exists: `{'eval_id': 125, 'name': 'customer_agent_task_completion'}`

## Screenshots / recordings (if UI)

N/A — no frontend changes.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
