### PR TITLE
[TH-4558] Wire real fullscreen for trace agent graph + agent path

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
@@ -12,7 +12,6 @@ import PropTypes from "prop-types";
 import {
   Box,
   CircularProgress,
-  Dialog,
   IconButton,
   Typography,
   useTheme,
@@ -32,6 +31,7 @@ import "@xyflow/react/dist/style.css";
 import Dagre from "@dagrejs/dagre";
 import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip";
+import FullscreenGraphDialog from "./FullscreenGraphDialog";
 
 // ---------------------------------------------------------------------------
 // Node type → color + icon
@@ -578,7 +578,12 @@ const ZoomControls = ({ isFullscreen, onToggleFullscreen }) => {
       >
         <Iconify icon="mdi:crosshairs-gps" width={14} />
       </IconButton>
-      <IconButton size="small" onClick={onToggleFullscreen} sx={btnSx}>
+      <IconButton
+        size="small"
+        title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+        onClick={onToggleFullscreen}
+        sx={btnSx}
+      >
         <Iconify
           icon={isFullscreen ? "mdi:fullscreen-exit" : "mdi:fullscreen"}
           width={14}
@@ -728,37 +733,21 @@ AgentGraphInner.propTypes = {
   onToggleFullscreen: PropTypes.func,
 };
 
-const AgentGraph = (props) => {
-  const { onNodeClick } = props;
-  const [fsOpen, setFsOpen] = useState(false);
-  return (
-    <>
+const AgentGraph = (props) => (
+  <FullscreenGraphDialog
+    onNodeClick={props.onNodeClick}
+    renderGraph={({ isFullscreen, onToggleFullscreen, onNodeClick }) => (
       <ReactFlowProvider>
-        <AgentGraphInner {...props} onToggleFullscreen={() => setFsOpen(true)} />
+        <AgentGraphInner
+          {...props}
+          isFullscreen={isFullscreen}
+          onToggleFullscreen={onToggleFullscreen}
+          onNodeClick={onNodeClick}
+        />
       </ReactFlowProvider>
-      <Dialog
-        fullScreen
-        open={fsOpen}
-        onClose={() => setFsOpen(false)}
-        PaperProps={{ sx: { borderRadius: 0, bgcolor: "background.paper" } }}
-      >
-        <Box sx={{ height: "100vh", width: "100%" }}>
-          <ReactFlowProvider>
-            <AgentGraphInner
-              {...props}
-              isFullscreen
-              onToggleFullscreen={() => setFsOpen(false)}
-              onNodeClick={(node) => {
-                onNodeClick?.(node);
-                setFsOpen(false);
-              }}
-            />
-          </ReactFlowProvider>
-        </Box>
-      </Dialog>
-    </>
-  );
-};
+    )}
+  />
+);
 
 AgentGraph.propTypes = {
   data: PropTypes.object,

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
@@ -12,6 +12,7 @@ import PropTypes from "prop-types";
 import {
   Box,
   CircularProgress,
+  Dialog,
   IconButton,
   Typography,
   useTheme,
@@ -529,7 +530,7 @@ const buildFlowData = (graphData, direction = "LR", theme = null) => {
 // ---------------------------------------------------------------------------
 // Zoom controls — top-right, appear on hover
 // ---------------------------------------------------------------------------
-const ZoomControls = () => {
+const ZoomControls = ({ isFullscreen, onToggleFullscreen }) => {
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const btnSx = {
     p: 0.5,
@@ -577,15 +578,19 @@ const ZoomControls = () => {
       >
         <Iconify icon="mdi:crosshairs-gps" width={14} />
       </IconButton>
-      <IconButton
-        size="small"
-        onClick={() => fitView({ duration: 300, padding: 0.2 })}
-        sx={btnSx}
-      >
-        <Iconify icon="mdi:fullscreen" width={14} />
+      <IconButton size="small" onClick={onToggleFullscreen} sx={btnSx}>
+        <Iconify
+          icon={isFullscreen ? "mdi:fullscreen-exit" : "mdi:fullscreen"}
+          width={14}
+        />
       </IconButton>
     </Box>
   );
+};
+
+ZoomControls.propTypes = {
+  isFullscreen: PropTypes.bool,
+  onToggleFullscreen: PropTypes.func,
 };
 
 // ---------------------------------------------------------------------------
@@ -597,6 +602,8 @@ const AgentGraphInner = ({
   isError,
   direction = "LR",
   onNodeClick,
+  isFullscreen = false,
+  onToggleFullscreen,
 }) => {
   const theme = useTheme();
   const [isHovering, setIsHovering] = useState(false);
@@ -671,6 +678,7 @@ const AgentGraphInner = ({
         minHeight: 120,
         width: "100%",
         position: "relative",
+        bgcolor: "background.paper",
       }}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
@@ -699,7 +707,12 @@ const AgentGraphInner = ({
         maxZoom={2}
         proOptions={{ hideAttribution: true }}
       >
-        {isHovering && <ZoomControls />}
+        {(isHovering || isFullscreen) && (
+          <ZoomControls
+            isFullscreen={isFullscreen}
+            onToggleFullscreen={onToggleFullscreen}
+          />
+        )}
       </ReactFlow>
     </Box>
   );
@@ -711,13 +724,41 @@ AgentGraphInner.propTypes = {
   isError: PropTypes.bool,
   direction: PropTypes.oneOf(["LR", "TB"]),
   onNodeClick: PropTypes.func,
+  isFullscreen: PropTypes.bool,
+  onToggleFullscreen: PropTypes.func,
 };
 
-const AgentGraph = (props) => (
-  <ReactFlowProvider>
-    <AgentGraphInner {...props} />
-  </ReactFlowProvider>
-);
+const AgentGraph = (props) => {
+  const { onNodeClick } = props;
+  const [fsOpen, setFsOpen] = useState(false);
+  return (
+    <>
+      <ReactFlowProvider>
+        <AgentGraphInner {...props} onToggleFullscreen={() => setFsOpen(true)} />
+      </ReactFlowProvider>
+      <Dialog
+        fullScreen
+        open={fsOpen}
+        onClose={() => setFsOpen(false)}
+        PaperProps={{ sx: { borderRadius: 0, bgcolor: "background.paper" } }}
+      >
+        <Box sx={{ height: "100vh", width: "100%" }}>
+          <ReactFlowProvider>
+            <AgentGraphInner
+              {...props}
+              isFullscreen
+              onToggleFullscreen={() => setFsOpen(false)}
+              onNodeClick={(node) => {
+                onNodeClick?.(node);
+                setFsOpen(false);
+              }}
+            />
+          </ReactFlowProvider>
+        </Box>
+      </Dialog>
+    </>
+  );
+};
 
 AgentGraph.propTypes = {
   data: PropTypes.object,

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
@@ -9,13 +9,13 @@ import PropTypes from "prop-types";
 import {
   Box,
   CircularProgress,
-  Dialog,
   IconButton,
   Typography,
   useTheme,
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import Iconify from "src/components/iconify";
+import FullscreenGraphDialog from "./FullscreenGraphDialog";
 
 // Node type → color mapping (matches AgentGraph)
 const TYPE_COLORS = {
@@ -413,6 +413,7 @@ const AgentPathInner = ({
   const containerRef = useRef(null);
   const [containerWidth, setContainerWidth] = useState(900);
   const [containerHeight, setContainerHeight] = useState(200);
+  const [isHovering, setIsHovering] = useState(false);
   const layout = useMemo(() => computeSankeyLayout(data), [data]);
 
   useEffect(() => {
@@ -462,6 +463,8 @@ const AgentPathInner = ({
   return (
     <Box
       ref={containerRef}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
       sx={{
         position: "relative",
         bgcolor: "background.paper",
@@ -470,34 +473,36 @@ const AgentPathInner = ({
           : { mx: 2, my: 1 }),
       }}
     >
-      {/* Fullscreen control, top right (matches AgentGraph) */}
-      <Box
-        sx={{
-          position: "absolute",
-          top: 8,
-          right: 8,
-          zIndex: 10,
-          display: "flex",
-          bgcolor: "background.paper",
-          border: "1px solid",
-          borderColor: "divider",
-          borderRadius: "6px",
-          boxShadow: (t) => `0 1px 3px ${alpha(t.palette.common.black, 0.06)}`,
-          overflow: "hidden",
-        }}
-      >
-        <IconButton
-          size="small"
-          title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-          onClick={onToggleFullscreen}
-          sx={{ p: 0.5, borderRadius: 0, color: "text.secondary" }}
+      {/* Reveal on hover */}
+      {(isHovering || isFullscreen) && (
+        <Box
+          sx={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            zIndex: 10,
+            display: "flex",
+            bgcolor: "background.paper",
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: "6px",
+            boxShadow: (t) => `0 1px 3px ${alpha(t.palette.common.black, 0.06)}`,
+            overflow: "hidden",
+          }}
         >
-          <Iconify
-            icon={isFullscreen ? "mdi:fullscreen-exit" : "mdi:fullscreen"}
-            width={14}
-          />
-        </IconButton>
-      </Box>
+          <IconButton
+            size="small"
+            title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+            onClick={onToggleFullscreen}
+            sx={{ p: 0.5, borderRadius: 0, color: "text.secondary" }}
+          >
+            <Iconify
+              icon={isFullscreen ? "mdi:fullscreen-exit" : "mdi:fullscreen"}
+              width={14}
+            />
+          </IconButton>
+        </Box>
+      )}
 
       <SankeyChart
         layout={layout}
@@ -518,33 +523,19 @@ AgentPathInner.propTypes = {
   onToggleFullscreen: PropTypes.func,
 };
 
-const AgentPath = (props) => {
-  const { onNodeClick } = props;
-  const [fsOpen, setFsOpen] = useState(false);
-  return (
-    <>
-      <AgentPathInner {...props} onToggleFullscreen={() => setFsOpen(true)} />
-      <Dialog
-        fullScreen
-        open={fsOpen}
-        onClose={() => setFsOpen(false)}
-        PaperProps={{ sx: { borderRadius: 0, bgcolor: "background.paper" } }}
-      >
-        <Box sx={{ height: "100vh", width: "100%" }}>
-          <AgentPathInner
-            {...props}
-            isFullscreen
-            onToggleFullscreen={() => setFsOpen(false)}
-            onNodeClick={(node) => {
-              onNodeClick?.(node);
-              setFsOpen(false);
-            }}
-          />
-        </Box>
-      </Dialog>
-    </>
-  );
-};
+const AgentPath = (props) => (
+  <FullscreenGraphDialog
+    onNodeClick={props.onNodeClick}
+    renderGraph={({ isFullscreen, onToggleFullscreen, onNodeClick }) => (
+      <AgentPathInner
+        {...props}
+        isFullscreen={isFullscreen}
+        onToggleFullscreen={onToggleFullscreen}
+        onNodeClick={onNodeClick}
+      />
+    )}
+  />
+);
 
 AgentPath.propTypes = {
   data: PropTypes.object,

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
@@ -9,6 +9,7 @@ import PropTypes from "prop-types";
 import {
   Box,
   CircularProgress,
+  Dialog,
   IconButton,
   Typography,
   useTheme,
@@ -401,10 +402,17 @@ SankeyChart.propTypes = {
 // ---------------------------------------------------------------------------
 // AgentPath component
 // ---------------------------------------------------------------------------
-const AgentPath = ({ data, isLoading, onNodeClick }) => {
+const AgentPathInner = ({
+  data,
+  isLoading,
+  onNodeClick,
+  isFullscreen = false,
+  onToggleFullscreen,
+}) => {
   const theme = useTheme();
   const containerRef = useRef(null);
   const [containerWidth, setContainerWidth] = useState(900);
+  const [containerHeight, setContainerHeight] = useState(200);
   const layout = useMemo(() => computeSankeyLayout(data), [data]);
 
   useEffect(() => {
@@ -412,6 +420,7 @@ const AgentPath = ({ data, isLoading, onNodeClick }) => {
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         setContainerWidth(entry.contentRect.width || 900);
+        setContainerHeight(entry.contentRect.height || 200);
       }
     });
     observer.observe(containerRef.current);
@@ -451,8 +460,17 @@ const AgentPath = ({ data, isLoading, onNodeClick }) => {
   }
 
   return (
-    <Box ref={containerRef} sx={{ position: "relative", mx: 2, my: 1 }}>
-      {/* Zoom controls, top right (matches AgentGraph) */}
+    <Box
+      ref={containerRef}
+      sx={{
+        position: "relative",
+        bgcolor: "background.paper",
+        ...(isFullscreen
+          ? { height: "100%", width: "100%" }
+          : { mx: 2, my: 1 }),
+      }}
+    >
+      {/* Fullscreen control, top right (matches AgentGraph) */}
       <Box
         sx={{
           position: "absolute",
@@ -468,39 +486,63 @@ const AgentPath = ({ data, isLoading, onNodeClick }) => {
           overflow: "hidden",
         }}
       >
-        {[
-          { icon: "mdi:plus", label: "Zoom in" },
-          { icon: "mdi:minus", label: "Zoom out" },
-          { icon: "mdi:crosshairs-gps", label: "Fit" },
-          { icon: "mdi:fullscreen", label: "Fullscreen" },
-          { icon: "mdi:chevron-down", label: "Collapse" },
-        ].map((btn) => (
-          <IconButton
-            key={btn.icon}
-            size="small"
-            title={btn.label}
-            sx={{
-              p: 0.5,
-              borderRadius: 0,
-              borderRight: "1px solid",
-              borderRightColor: "divider",
-              "&:last-child": { borderRight: "none" },
-              color: "text.secondary",
-            }}
-          >
-            <Iconify icon={btn.icon} width={14} />
-          </IconButton>
-        ))}
+        <IconButton
+          size="small"
+          title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+          onClick={onToggleFullscreen}
+          sx={{ p: 0.5, borderRadius: 0, color: "text.secondary" }}
+        >
+          <Iconify
+            icon={isFullscreen ? "mdi:fullscreen-exit" : "mdi:fullscreen"}
+            width={14}
+          />
+        </IconButton>
       </Box>
 
       <SankeyChart
         layout={layout}
         width={containerWidth}
-        height={200}
+        height={isFullscreen ? Math.max(containerHeight, 200) : 200}
         onNodeClick={onNodeClick}
         theme={theme}
       />
     </Box>
+  );
+};
+
+AgentPathInner.propTypes = {
+  data: PropTypes.object,
+  isLoading: PropTypes.bool,
+  onNodeClick: PropTypes.func,
+  isFullscreen: PropTypes.bool,
+  onToggleFullscreen: PropTypes.func,
+};
+
+const AgentPath = (props) => {
+  const { onNodeClick } = props;
+  const [fsOpen, setFsOpen] = useState(false);
+  return (
+    <>
+      <AgentPathInner {...props} onToggleFullscreen={() => setFsOpen(true)} />
+      <Dialog
+        fullScreen
+        open={fsOpen}
+        onClose={() => setFsOpen(false)}
+        PaperProps={{ sx: { borderRadius: 0, bgcolor: "background.paper" } }}
+      >
+        <Box sx={{ height: "100vh", width: "100%" }}>
+          <AgentPathInner
+            {...props}
+            isFullscreen
+            onToggleFullscreen={() => setFsOpen(false)}
+            onNodeClick={(node) => {
+              onNodeClick?.(node);
+              setFsOpen(false);
+            }}
+          />
+        </Box>
+      </Dialog>
+    </>
   );
 };
 

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/FullscreenGraphDialog.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/FullscreenGraphDialog.jsx
@@ -1,0 +1,44 @@
+// Shared fullscreen wrapper for the trace graphs. `renderGraph` runs for both
+// the inline and dialog renders, so each caller can wrap its own provider
+// (AgentGraph needs ReactFlowProvider, AgentPath doesn't).
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { Box, Dialog } from "@mui/material";
+
+const FullscreenGraphDialog = ({ onNodeClick, renderGraph }) => {
+  const [fsOpen, setFsOpen] = useState(false);
+
+  return (
+    <>
+      {renderGraph?.({
+        isFullscreen: false,
+        onToggleFullscreen: () => setFsOpen(true),
+        onNodeClick,
+      })}
+      <Dialog
+        fullScreen
+        open={fsOpen}
+        onClose={() => setFsOpen(false)}
+        PaperProps={{ sx: { borderRadius: 0, bgcolor: "background.paper" } }}
+      >
+        <Box sx={{ height: "100vh", width: "100%" }}>
+          {renderGraph?.({
+            isFullscreen: true,
+            onToggleFullscreen: () => setFsOpen(false),
+            onNodeClick: (node) => {
+              onNodeClick?.(node);
+              setFsOpen(false);
+            },
+          })}
+        </Box>
+      </Dialog>
+    </>
+  );
+};
+
+FullscreenGraphDialog.propTypes = {
+  onNodeClick: PropTypes.func,
+  renderGraph: PropTypes.func.isRequired,
+};
+
+export default FullscreenGraphDialog;


### PR DESCRIPTION
## Summary
Wires up real fullscreen for both trace-graph tabs (Agent Graph + Agent Path), which previously had non-functional fullscreen buttons.

- **Agent Graph (React Flow):** the fullscreen button was wired to `fitView()` (just re-fit the canvas). It now opens a `<Dialog fullScreen>` rendering the graph at full viewport, with its own `ReactFlowProvider` so zoom/fit/pan work independently. Icon toggles `fullscreen ⇄ fullscreen-exit`.
- **Agent Path (SVG Sankey):** the fullscreen button had no handler at all. Split into `AgentPathInner` + wrapper; same `<Dialog fullScreen>` pattern. The `ResizeObserver` now tracks height too so the Sankey fills the viewport.
- **Trimmed dead controls on Agent Path:** the zoom-in / zoom-out / fit / collapse buttons were never wired (pure visual stubs copied from Agent Graph) and don't make sense for the hand-rolled Sankey — removed, leaving a single fullscreen button.
- **Node-click in fullscreen** now closes the dialog after applying the filter, so the resulting filter chips + re-filtered grid (which render in normal page flow) are immediately visible instead of being hidden behind the dialog.

Closes TH-4558

## Linear Ticket
[TH-4558](https://linear.app/future-agi/issue/TH-4558/tracing-graph-full-screen-not-working)

## Files Changed
- `frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx`
- `frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx`

## Test plan
- [ ] Agent Graph: click fullscreen → opens full-viewport dialog; zoom/fit/pan work; exit via button or Esc
- [ ] Agent Path: click fullscreen → Sankey fills viewport; exit via button or Esc
- [ ] Click a node in either fullscreen graph → dialog closes and the trace grid filters by that node's type
- [ ] Inline (non-fullscreen) graphs behave exactly as before
