### PR TITLE
updates in regex pii to support none detect types

### DIFF
--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 11
+SYSTEM_EVALS_VERSION = 13
 
 # Postgres advisory-lock key. Serialises concurrent seed_evals() calls
 # across pods so the bulk_create path can't race on new eval_ids. Any

--- a/futureagi/model_hub/system_evals/function/regex_pii_detection.yaml
+++ b/futureagi/model_hub/system_evals/function/regex_pii_detection.yaml
@@ -22,7 +22,7 @@ config:
     detect_types:
       type: string
       default: null
-      required: true
+      required: false
   config_params_desc:
     text: Text to scan for PII
     detect_types: 'Comma-separated types to detect (default: all). Options: ssn, credit_card, phone, email, ip_address'
@@ -40,8 +40,8 @@ config:
             "ip_address": (r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b", "IP"),
         }
         dt = kwargs.get("detect_types")
-        if dt is None:
-            return {"score": 0.0, "reason": "detect_types is required"}
+        if dt is None or (isinstance(dt, str) and not dt.strip()):
+            dt = list(patterns.keys())
         if isinstance(dt, str):
             try:
                 dt = json.loads(dt)


### PR DESCRIPTION
<!--
Thanks for contributing to Future AGI!

For a good review, please make sure:
  • The PR title follows Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:, perf:)
  • You've linked the relevant issue(s) below
  • The PR description answers **what** and **why** (the diff shows **how**)
  • `make check-all` (backend) or `yarn check-all` (frontend) passes locally
-->

## Summary

The `regex_pii_detection` system eval (eval_id 177) advertised `detect_types` as defaulting to "all" types, but the code actually returned a hard failure ("detect_types is required") whenever no value was provided — and the schema's `required: true` meant param normalization rejected the empty case before the eval code ever ran. This PR makes an unset/empty `detect_types` fall back to scanning all five PII types (ssn, credit_card, phone, email, ip_address), matching the documented behavior and the safer default for a PII-detection eval. The schema's `required` flag is flipped to `false` so the empty case is actually reachable, and `SYSTEM_EVALS_VERSION` is bumped (11 → 13) so the seeder re-reads the updated YAML on startup.

## Linked issues

<!-- "Closes #123" links and auto-closes on merge. -->
Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Restarted the local `backend` container so `ModelHubConfig.ready()` re-ran `seed_evals()`, then verified the change landed in the DB (ground truth) rather than just the YAML on disk by querying `model_hub_evaltemplate` for eval_id 177: the stored `config.code` now matches `list(patterns.keys())` (has_new_default = t) and `function_params_schema.detect_types.required` = false. Behavior verified by tracing the runtime path: `default: null` becomes Python `None` in kwargs (normalize_function_params line 112), and the code falls back to all pattern keys.

## Screenshots / recordings (if UI)

N/A — no UI changes.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
