### PR TITLE
fix(evals): skip instructions from dynamic-ID resolution on dataset path (TH-5279)

### DIFF
--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1627,6 +1627,9 @@ class EvaluationRunner:
         self.eval_class = get_eval_class(eval_type_id)
 
     def update_config_list_values(self, config, row=None):
+        # Prompt-template fields hold {{var}} placeholders resolved later by
+        # the evaluator via the user's mapping — not column UUIDs/names.
+        PROMPT_KEYS = {"rule_prompt", "criteria", "instructions"}
         if config:
             config = config.copy()
             for key, value in config.items():
@@ -1634,7 +1637,7 @@ class EvaluationRunner:
                 if (
                     isinstance(value, str)
                     and "," in value
-                    and key not in ["rule_prompt", "criteria"]
+                    and key not in PROMPT_KEYS
                 ):
                     # Split the string by commas and update the value as a list
                     config[key] = value.split(",")
@@ -1646,7 +1649,7 @@ class EvaluationRunner:
                     config[key] = comparator_class()  # Instantiate comparator
                 # Handle both string and list values for dynamic ID replacement
                 if isinstance(value, str):
-                    if key != "rule_prompt":
+                    if key not in PROMPT_KEYS:
                         config[key] = self._replace_dynamic_ids(value, row)
                 elif isinstance(value, list):
                     # Process each item in the list


### PR DESCRIPTION
## Summary

Dataset evals errored with `'content' is not a valid UUID` when the eval template's `instructions` field contained `{{var}}` placeholders. `update_config_list_values` was passing `instructions` through `_replace_dynamic_ids`, which only resolves column UUIDs/names — it has no concept of input-variable aliases (those get resolved later by the evaluator via the user's mapping).

`rule_prompt` was already skipped. `instructions` (a legacy duplicate field; migration 0099 treats them equivalently) and `criteria` (UI copy of the prompt) need the same treatment. Consolidated into a single `PROMPT_KEYS` set used by both the comma-split and dynamic-ID-resolve branches.

## Test plan

- Repro: dataset eval with a custom template whose `instructions` had `{{content}}` → fails with `'content' is not a valid UUID`.
- After fix: same eval runs cleanly end-to-end; MCP connector reaches the agent and tool calls succeed.