### PR TITLE
Add user_id to CH and update end_user_id selection logic

### DIFF
--- a/futureagi/tracer/services/clickhouse/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_list.py
@@ -133,7 +133,11 @@ class SessionListQueryBuilder(BaseQueryBuilder):
             dateDiff('second', min(start_time), max(end_time)) AS duration,
             sum(cost) AS total_cost,
             sum(total_tokens) AS total_tokens,
-            uniq(trace_id) AS traces_count
+            uniq(trace_id) AS traces_count,
+            anyIf(
+                end_user_id,
+                end_user_id IS NOT NULL AND end_user_id != toUUID('{NIL_UUID}')
+            ) AS end_user_id
         FROM {self.TABLE}
         {self.project_where()}
           AND trace_session_id IS NOT NULL
@@ -370,6 +374,13 @@ class SessionListQueryBuilder(BaseQueryBuilder):
                     "total_traces_count": int(_get(row, "traces_count", 6, 0) or 0),
                     "first_message": _get(row, "first_message", 7, "") or "",
                     "last_message": _get(row, "last_message", 8, "") or "",
+                    # Carried for view-side EndUser resolution; the actual
+                    # user_id/type/hash are stitched on in the view (and
+                    # end_user_id is popped before the response is returned).
+                    "end_user_id": _get(row, "end_user_id", 9),
+                    "user_id": None,
+                    "user_id_type": None,
+                    "user_id_hash": None,
                 }
             )
         return results

--- a/futureagi/tracer/services/clickhouse/query_builders/session_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/session_list.py
@@ -134,8 +134,9 @@ class SessionListQueryBuilder(BaseQueryBuilder):
             sum(cost) AS total_cost,
             sum(total_tokens) AS total_tokens,
             uniq(trace_id) AS traces_count,
-            anyIf(
+            argMinIf(
                 end_user_id,
+                start_time,
                 end_user_id IS NOT NULL AND end_user_id != toUUID('{NIL_UUID}')
             ) AS end_user_id
         FROM {self.TABLE}

--- a/futureagi/tracer/tests/test_session_list_performance.py
+++ b/futureagi/tracer/tests/test_session_list_performance.py
@@ -370,3 +370,84 @@ class TestQueryTimeoutBudget:
         assert "LIMIT 500" in query
         assert "parent_span_id IS NULL OR parent_span_id = ''" in query
         assert "PREWHERE" in query
+
+
+@pytest.mark.unit
+class TestSessionListUserId:
+    """Unit tests for end-user (`user_id`) resolution in the session list.
+
+    Regression: the ClickHouse session-list path never selected the
+    end-user, so the response had no ``user_id`` key and the frontend
+    "User ID" column rendered blank (the Postgres fallback populated it).
+    See ``_list_sessions_clickhouse`` in ``tracer.views.trace_session``.
+    """
+
+    def _builder(self):
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        return SessionListQueryBuilder(
+            project_id=str(uuid.uuid4()),
+            filters=[],
+            page_number=0,
+            page_size=30,
+        )
+
+    def test_build_selects_end_user_id(self):
+        """build() must surface one end_user_id per session via anyIf()."""
+        query, _ = self._builder().build()
+        assert "anyIf(" in query
+        assert "AS end_user_id" in query
+        # Aggregate column — must not change the grouping granularity.
+        assert "GROUP BY trace_session_id" in query
+        assert "GROUP BY trace_session_id, end_user_id" not in query
+        # No extra session-list query was introduced for resolution.
+        assert not hasattr(self._builder(), "build_end_user_query")
+
+    def test_format_sessions_emits_user_id_keys(self):
+        """format_sessions() always emits the user_id keys (never undefined)."""
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        sid = str(uuid.uuid4())
+        euid = str(uuid.uuid4())
+        columns = [
+            "session_id",
+            "session_start",
+            "session_end",
+            "duration",
+            "total_cost",
+            "total_tokens",
+            "traces_count",
+            "end_user_id",
+        ]
+        rows = [
+            (sid, datetime.utcnow(), datetime.utcnow(), 5, 1.0, 10, 2, euid),
+        ]
+        out = SessionListQueryBuilder.format_sessions(rows, columns)
+        assert len(out) == 1
+        assert out[0]["end_user_id"] == euid
+        # Placeholders present so the view can stitch resolved values on.
+        assert out[0]["user_id"] is None
+        assert out[0]["user_id_type"] is None
+        assert out[0]["user_id_hash"] is None
+
+    def test_format_sessions_user_id_keys_present_without_end_user(self):
+        """Rows with no end_user_id still carry the user_id keys (as None)."""
+        from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
+
+        sid = str(uuid.uuid4())
+        columns = [
+            "session_id",
+            "session_start",
+            "session_end",
+            "duration",
+            "total_cost",
+            "total_tokens",
+            "traces_count",
+            "end_user_id",
+        ]
+        rows = [(sid, datetime.utcnow(), datetime.utcnow(), 5, 1.0, 10, 2, None)]
+        out = SessionListQueryBuilder.format_sessions(rows, columns)
+        assert out[0]["user_id"] is None
+        assert "user_id" in out[0]
+        assert "user_id_type" in out[0]
+        assert "user_id_hash" in out[0]

--- a/futureagi/tracer/tests/test_session_list_performance.py
+++ b/futureagi/tracer/tests/test_session_list_performance.py
@@ -392,10 +392,15 @@ class TestSessionListUserId:
             page_size=30,
         )
 
-    def test_build_selects_end_user_id(self):
-        """build() must surface one end_user_id per session via anyIf()."""
+    def test_build_selects_first_linked_end_user_id(self):
+        """build() must surface the FIRST linked end_user_id per session.
+
+        A session can have multiple linked users; we return the end-user on the
+        earliest span via argMinIf(end_user_id, start_time, <non-null>).
+        """
         query, _ = self._builder().build()
-        assert "anyIf(" in query
+        assert "argMinIf(" in query
+        assert "start_time" in query
         assert "AS end_user_id" in query
         # Aggregate column — must not change the grouping granularity.
         assert "GROUP BY trace_session_id" in query

--- a/futureagi/tracer/tests/test_session_list_user_id_ch.py
+++ b/futureagi/tracer/tests/test_session_list_user_id_ch.py
@@ -1,0 +1,159 @@
+"""Integration tests for `user_id` resolution in the ClickHouse session list.
+
+Regression: ``_list_sessions_clickhouse`` never selected the end-user, so
+the response had no ``user_id`` key and the frontend "User ID" column was
+blank (only the Postgres fallback populated it). These tests pin that the
+CH path now resolves ``end_user_id`` -> EndUser fields and returns
+``user_id``/``user_id_type``/``user_id_hash`` — without leaking the
+internal ``end_user_id`` UUID.
+
+Run with: bin/test -k "session_list_user_id_ch" integration
+"""
+
+import json
+import uuid
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+from rest_framework import status
+
+from tracer.models.observation_span import EndUser
+from tracer.models.trace_session import TraceSession
+from tracer.services.clickhouse.query_builders.base import NIL_UUID
+from tracer.services.clickhouse.query_service import AnalyticsQueryService
+
+pytestmark = [pytest.mark.integration, pytest.mark.api]
+
+LIST_SESSIONS_URL = "/tracer/trace-session/list_sessions/"
+
+
+class _FakeCHResult:
+    """Minimal stand-in for the ClickHouse result object (only `.data`)."""
+
+    def __init__(self, data):
+        self.data = data
+
+
+def _result(response):
+    data = response.json()
+    return data.get("result", data)
+
+
+def _date_filters():
+    start = timezone.now() - timedelta(days=1)
+    end = timezone.now() + timedelta(days=1)
+    return [
+        {
+            "column_id": "created_at",
+            "filter_config": {
+                "filter_type": "datetime",
+                "filter_op": "between",
+                "filter_value": [start.isoformat(), end.isoformat()],
+            },
+        }
+    ]
+
+
+def _phase1_row(session_id, end_user_id):
+    """A Phase-1 build() result row, in the builder's SELECT order."""
+    now = timezone.now()
+    return {
+        "session_id": str(session_id),
+        "session_start": now - timedelta(seconds=10),
+        "session_end": now,
+        "duration": 10,
+        "total_cost": 1.5,
+        "total_tokens": 42,
+        "traces_count": 2,
+        "end_user_id": end_user_id,
+    }
+
+
+def _ch_side_effect(phase1_rows):
+    """Route mocked CH calls by query content; only Phase 1 returns rows."""
+
+    def _side_effect(query, params=None, timeout_ms=None):
+        if "AS end_user_id" in query and "session_start" in query:
+            return _FakeCHResult(list(phase1_rows))
+        # content query / span-attributes query / count query -> empty
+        return _FakeCHResult([])
+
+    return _side_effect
+
+
+def _get_sessions(auth_client, project, phase1_rows):
+    with (
+        patch.object(AnalyticsQueryService, "should_use_clickhouse", return_value=True),
+        patch.object(
+            AnalyticsQueryService,
+            "execute_ch_query",
+            side_effect=_ch_side_effect(phase1_rows),
+        ),
+    ):
+        return auth_client.get(
+            LIST_SESSIONS_URL,
+            {
+                "project_id": str(project.id),
+                "page_number": 0,
+                "page_size": 30,
+                "sort_params": json.dumps([]),
+                "filters": json.dumps(_date_filters()),
+            },
+        )
+
+
+class TestSessionListUserIdClickHouse:
+    def test_user_id_resolved_from_end_user(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        end_user = EndUser.objects.create(
+            organization=organization,
+            workspace=workspace,
+            project=observe_project,
+            user_id="alice@example.com",
+            user_id_type="email",
+            user_id_hash="alice-hash",
+        )
+        session = TraceSession.objects.create(
+            project=observe_project, name="session-alice"
+        )
+        rows = [_phase1_row(session.id, str(end_user.id))]
+
+        response = _get_sessions(auth_client, observe_project, rows)
+
+        assert response.status_code == status.HTTP_200_OK
+        table = _result(response)["table"]
+        row = next(r for r in table if r["session_id"] == str(session.id))
+        assert row["user_id"] == "alice@example.com"
+        assert row["user_id_type"] == "email"
+        assert row["user_id_hash"] == "alice-hash"
+        # Internal UUID must not leak into the response.
+        assert "end_user_id" not in row
+
+    def test_nil_or_missing_end_user_id_yields_none(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        s_nil = TraceSession.objects.create(project=observe_project, name="s-nil")
+        s_none = TraceSession.objects.create(project=observe_project, name="s-none")
+        s_unknown = TraceSession.objects.create(
+            project=observe_project, name="s-unknown"
+        )
+        rows = [
+            _phase1_row(s_nil.id, NIL_UUID),
+            _phase1_row(s_none.id, None),
+            # A well-formed UUID that resolves to no EndUser row.
+            _phase1_row(s_unknown.id, str(uuid.uuid4())),
+        ]
+
+        response = _get_sessions(auth_client, observe_project, rows)
+
+        assert response.status_code == status.HTTP_200_OK
+        table = _result(response)["table"]
+        for r in table:
+            assert r["user_id"] is None
+            assert "user_id" in r
+            assert "user_id_type" in r
+            assert "user_id_hash" in r
+            assert "end_user_id" not in r

--- a/futureagi/tracer/tests/test_session_list_user_id_ch.py
+++ b/futureagi/tracer/tests/test_session_list_user_id_ch.py
@@ -19,7 +19,8 @@ import pytest
 from django.utils import timezone
 from rest_framework import status
 
-from tracer.models.observation_span import EndUser
+from tracer.models.observation_span import EndUser, ObservationSpan
+from tracer.models.trace import Trace
 from tracer.models.trace_session import TraceSession
 from tracer.services.clickhouse.query_builders.base import NIL_UUID
 from tracer.services.clickhouse.query_service import AnalyticsQueryService
@@ -157,3 +158,101 @@ class TestSessionListUserIdClickHouse:
             assert "user_id_type" in r
             assert "user_id_hash" in r
             assert "end_user_id" not in r
+
+
+class TestSessionListFirstLinkedUser:
+    """When a session has spans linked to multiple end-users, the list must
+    return the FIRST linked one (earliest span by start_time). Exercised via
+    the Postgres path (CH disabled) against real spans."""
+
+    def test_first_linked_user_returned_via_pg(
+        self, auth_client, organization, workspace, observe_project
+    ):
+        first_user = EndUser.objects.create(
+            organization=organization,
+            workspace=workspace,
+            project=observe_project,
+            user_id="first@example.com",
+            user_id_type="email",
+            user_id_hash="first-hash",
+        )
+        second_user = EndUser.objects.create(
+            organization=organization,
+            workspace=workspace,
+            project=observe_project,
+            user_id="second@example.com",
+            user_id_type="email",
+            user_id_hash="second-hash",
+        )
+        session = TraceSession.objects.create(
+            project=observe_project, name="multi-user-session"
+        )
+        trace = Trace.objects.create(
+            project=observe_project, session=session, name="multi-user-trace"
+        )
+        base = timezone.now() - timedelta(hours=1)
+
+        # Earlier span -> first_user; later span -> second_user.
+        ObservationSpan.objects.create(
+            id=f"first_span_{uuid.uuid4().hex[:16]}",
+            project=observe_project,
+            trace=trace,
+            end_user=first_user,
+            name="early span",
+            observation_type="llm",
+            start_time=base,
+            end_time=base + timedelta(seconds=2),
+            total_tokens=5,
+            cost=0.01,
+            status="OK",
+        )
+        ObservationSpan.objects.create(
+            id=f"second_span_{uuid.uuid4().hex[:16]}",
+            project=observe_project,
+            trace=trace,
+            end_user=second_user,
+            name="late span",
+            observation_type="llm",
+            start_time=base + timedelta(minutes=5),
+            end_time=base + timedelta(minutes=5, seconds=2),
+            total_tokens=7,
+            cost=0.02,
+            status="OK",
+        )
+
+        filters = [
+            {
+                "column_id": "created_at",
+                "filter_config": {
+                    "filter_type": "datetime",
+                    "filter_op": "between",
+                    "filter_value": [
+                        (base - timedelta(hours=1)).isoformat(),
+                        (base + timedelta(hours=1)).isoformat(),
+                    ],
+                },
+            }
+        ]
+
+        # Force the Postgres path so we exercise _fetch_end_user_info ordering.
+        with patch.object(
+            AnalyticsQueryService, "should_use_clickhouse", return_value=False
+        ):
+            response = auth_client.get(
+                LIST_SESSIONS_URL,
+                {
+                    "project_id": str(observe_project.id),
+                    "page_number": 0,
+                    "page_size": 30,
+                    "sort_params": json.dumps([]),
+                    "filters": json.dumps(filters),
+                },
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        table = _result(response)["table"]
+        row = next(r for r in table if r["session_id"] == str(session.id))
+        # First linked (earliest span) wins, not the later one.
+        assert row["user_id"] == "first@example.com"
+        assert row["user_id_type"] == "email"
+        assert row["user_id_hash"] == "first-hash"

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -206,9 +206,13 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
     def get_queryset(self):
         trace_session_id = self.kwargs.get("pk")
         # Get base queryset with automatic filtering from mixin
-        queryset = super().get_queryset().filter(
-            _project_workspace_scope_q(self.request),
-            project__deleted=False,
+        queryset = (
+            super()
+            .get_queryset()
+            .filter(
+                _project_workspace_scope_q(self.request),
+                project__deleted=False,
+            )
         )
 
         if trace_session_id:
@@ -777,7 +781,11 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
 
             query_params = query_serializer.validated_data
             project_id = str(query_params["project_id"])
-            if not _project_queryset_for_request(request).filter(id=project_id).exists():
+            if (
+                not _project_queryset_for_request(request)
+                .filter(id=project_id)
+                .exists()
+            ):
                 return self._gm.bad_request("Project not found")
             column = query_params["column"]
             search = query_params.get("search", "")
@@ -960,9 +968,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                             "CH session time-series failed",
                             error=str(e),
                         )
-                        session_logger.warning(
-                            "Falling back to Postgres session graph"
-                        )
+                        session_logger.warning("Falling back to Postgres session graph")
 
             # --- EVAL / ANNOTATION: delegate to shared helpers ---
             # Filter traces to only those belonging to sessions
@@ -997,9 +1003,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                             "ClickHouse session eval graph failed",
                             error=str(e),
                         )
-                        session_logger.warning(
-                            "Falling back to Postgres session graph"
-                        )
+                        session_logger.warning("Falling back to Postgres session graph")
 
                 if metric_type == "ANNOTATION" and analytics.should_use_clickhouse(
                     QueryType.ANNOTATION_GRAPH
@@ -1020,9 +1024,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                             "ClickHouse session annotation graph failed",
                             error=str(e),
                         )
-                        session_logger.warning(
-                            "Falling back to Postgres session graph"
-                        )
+                        session_logger.warning("Falling back to Postgres session graph")
 
                 from tracer.utils.graphs_optimized import (
                     get_annotation_graph_data,
@@ -1116,9 +1118,8 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
 
             analytics = AnalyticsQueryService()
             bookmarked = validated_data.get("bookmarked")
-            if (
-                bookmarked is None
-                and analytics.should_use_clickhouse(QueryType.SESSION_LIST)
+            if bookmarked is None and analytics.should_use_clickhouse(
+                QueryType.SESSION_LIST
             ):
                 try:
                     return self._list_sessions_clickhouse(
@@ -1554,6 +1555,13 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
         """
         from tracer.services.clickhouse.query_builders import SessionListQueryBuilder
 
+        # Resolve `org` once at the top — referenced both when injecting the
+        # synthetic end_user_id filter (for the user_id query param) and when
+        # decorating the formatted output with EndUser info (later). Without
+        # this the earlier reference NameError'd whenever ``user_id_raw`` was
+        # truthy and silently fell through to the Postgres path.
+        org = getattr(request, "organization", None) or request.user.organization
+
         org_scope = bool(org_project_ids)
         filters = list(validated_data.get("filters", []) or [])
         sort_params = validated_data.get("sort_params", [])
@@ -1678,6 +1686,38 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     entry["session_name"] = _name_map.get(_UUID(sid))
                 except (ValueError, TypeError):
                     entry["session_name"] = None
+
+        # Resolve end_user_id -> EndUser system fields (user_id, type, hash).
+        # build() carries one end_user_id per session via
+        # anyIf(end_user_id, ...) — verified to be present on the root spans
+        # the query aggregates whenever a session has a linked user, and never
+        # ambiguous (at most one distinct end_user per session). Resolution is
+        # one batched query (no extra CH round-trip, no N+1). Mirrors the
+        # Postgres _fetch_end_user_info path so both backends return the same
+        # shape.
+        eu_ids = {
+            str(e["end_user_id"])
+            for e in formatted
+            if e.get("end_user_id") and str(e["end_user_id"]) not in ("", NIL_UUID)
+        }
+        if eu_ids:
+            eu_map = {
+                str(r["id"]): r
+                for r in EndUser.objects.filter(
+                    id__in=eu_ids, organization=org, deleted=False
+                ).values("id", "user_id", "user_id_type", "user_id_hash")
+            }
+            for entry in formatted:
+                info = eu_map.get(str(entry.get("end_user_id") or ""))
+                if info:
+                    entry["user_id"] = info["user_id"]
+                    entry["user_id_type"] = info["user_id_type"]
+                    entry["user_id_hash"] = info["user_id_hash"]
+
+        # Drop the internal UUID before returning — keeps response/CSV parity
+        # with the Postgres _build_row shape, which exposes only user_id.
+        for entry in formatted:
+            entry.pop("end_user_id", None)
 
         # Phase 2: Aggregated span attributes for custom columns
         _SKIP_ATTR_PREFIXES = (

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -1509,7 +1509,14 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
 
     @staticmethod
     def _fetch_end_user_info(session_ids, end_user_filter, organization):
-        """Fetch end user info for a small set of session IDs using DISTINCT ON."""
+        """Fetch end user info for a small set of session IDs using DISTINCT ON.
+
+        A session may have spans linked to more than one end-user (session.id
+        and user.id are independent span attributes). We return the *first*
+        linked end-user — the one on the earliest span by ``start_time`` —
+        matching the ClickHouse ``argMinIf(end_user_id, start_time, ...)`` path
+        so both backends agree.
+        """
         if not session_ids:
             return {}
 
@@ -1519,7 +1526,7 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                 end_user__isnull=False,
                 **end_user_filter,
             )
-            .order_by("trace__session_id", "-start_time")
+            .order_by("trace__session_id", "start_time")
             .distinct("trace__session_id")
             .values(
                 "trace__session_id",
@@ -1688,13 +1695,12 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                     entry["session_name"] = None
 
         # Resolve end_user_id -> EndUser system fields (user_id, type, hash).
-        # build() carries one end_user_id per session via
-        # anyIf(end_user_id, ...) — verified to be present on the root spans
-        # the query aggregates whenever a session has a linked user, and never
-        # ambiguous (at most one distinct end_user per session). Resolution is
-        # one batched query (no extra CH round-trip, no N+1). Mirrors the
-        # Postgres _fetch_end_user_info path so both backends return the same
-        # shape.
+        # A session can have spans linked to multiple end-users (session.id and
+        # user.id are independent span attributes); build() picks the FIRST
+        # linked one via argMinIf(end_user_id, start_time, ...) — the end-user
+        # on the earliest span. Resolution is one batched query (no extra CH
+        # round-trip, no N+1) and mirrors the Postgres _fetch_end_user_info
+        # ordering so both backends return the same first-linked user.
         eu_ids = {
             str(e["end_user_id"])
             for e in formatted


### PR DESCRIPTION
## Summary

Populate `user_id` in the **ClickHouse** trace-sessions list (`GET /tracer/trace-session/list_sessions/`) and make the end-user selection deterministic and consistent across the ClickHouse and Postgres code paths. When a session has more than one linked end-user, the **first linked** user (the end-user on the earliest span by `start_time`) is returned.

Linear: **TH-5109**

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 1) What changed

**ClickHouse session list — `tracer/services/clickhouse/query_builders/session_list.py`**
- `build()` now selects the session's end-user from the root-span aggregation that already runs (no extra query / round-trip):
  ```sql
  argMinIf(
      end_user_id,
      start_time,
      end_user_id IS NOT NULL AND end_user_id != toUUID('<NIL>')
  ) AS end_user_id
  ```
  `argMinIf` returns the `end_user_id` of the **earliest span that has a user** → the *first linked* user (`NULL` when the session has none).
- `format_sessions()` carries `end_user_id` through and always emits `user_id` / `user_id_type` / `user_id_hash` keys (placeholders), so the response shape is stable and the frontend binding is never `undefined`.

**View — `tracer/views/trace_session.py::_list_sessions_clickhouse()`**
- After formatting, resolves `end_user_id` → `EndUser` fields with **one batched, org-scoped query** (no N+1) and stitches `user_id`/`user_id_type`/`user_id_hash` onto each session, then **pops the internal `end_user_id`** before returning (response/CSV parity with the Postgres `_build_row` shape).
- Defines `org` once at the top of the method — this also fixes a **latent `NameError`** in the `user_id`-filter path (`org` was referenced before assignment and silently dropped the request to the Postgres fallback).

**Postgres fallback — `tracer/views/trace_session.py::_fetch_end_user_info()`**
- Changed ordering from `-start_time` (latest) to `start_time` (earliest), so the fallback returns the **same first-linked user** as the ClickHouse path. Both backends now agree.

## 2) Why

- On ClickHouse-enabled setups (i.e. production), the session-list response **never contained `user_id`**, so the frontend "User ID" column was blank. The Postgres fallback *did* populate it — so the bug was invisible off-ClickHouse and only surfaced in prod.
- A session can legitimately be linked to **multiple users**: `session.id` and `user.id` are independent span attributes (confirmed in ingestion `create_otel_span.py` and the traceAI / `fi_instrumentation` SDK — `using_session` and `using_user` set unrelated OTel context keys, applied per span). The data model (`TraceSession`) has no user field and the ingestion groups purely by `session.id`. The previous behavior picked an **arbitrary** user (CH `anyIf`) while Postgres picked the **latest** — i.e. the two paths could disagree. We make the choice deterministic and identical everywhere: **first linked wins**.
- The end-user is present on the **root spans** the session query already aggregates (verified against live data: 0 sessions where a linked user was missing from root spans), so resolving it inline via `argMinIf` needs **no additional ClickHouse query**.

## 3) Tests added & scenarios covered

**Unit — `tracer/tests/test_session_list_performance.py::TestSessionListUserId`**
- `test_build_selects_first_linked_end_user_id` — `build()` SQL uses `argMinIf(end_user_id, start_time, …) AS end_user_id`, keeps `GROUP BY trace_session_id` granularity, and introduces no extra query method.
- `test_format_sessions_emits_user_id_keys` — `format_sessions()` carries `end_user_id` and emits `user_id`/`user_id_type`/`user_id_hash` (placeholders).
- `test_format_sessions_user_id_keys_present_without_end_user` — those keys are present (as `None`) even when a row has no end-user.

**Integration — `tracer/tests/test_session_list_user_id_ch.py`**
- `TestSessionListUserIdClickHouse.test_user_id_resolved_from_end_user` — ClickHouse path resolves `end_user_id` → correct `user_id`/`user_id_type`/`user_id_hash`; internal `end_user_id` is **not** leaked in the response.
- `TestSessionListUserIdClickHouse.test_nil_or_missing_end_user_id_yields_none` — `NIL_UUID`, `None`, and an unknown/unresolvable UUID all yield `user_id = None`, keys still present, request returns 200 (no crash, no leak).
- `TestSessionListFirstLinkedUser.test_first_linked_user_returned_via_pg` — a session with **two** users on spans at different times returns the **earliest** user (validates the first-linked ordering against a real Postgres DB via the fallback path).

**Scenarios covered:** user present & resolved (CH); user absent / NIL / None / unresolved; first-of-multiple-users wins; response-shape parity (no `end_user_id` leak, user keys always present); SQL correctness and no added round-trip.

## 4) How to run the tests (this PR + relevant regression)

```bash
cd futureagi

# --- This PR ---
bin/test --no-services unit -k "TestSessionListUserId"      # new unit tests (fast)
bin/test integration -k "session_list_user_id_ch"           # new integration tests

# --- Related existing suites (regression — ensure nothing else breaks) ---
bin/test -k "session_list_performance"                      # session-list query builder
bin/test -k "user_id_filter"                                # user_id -> end_user_id filter resolution
bin/test -k "trace_session_ch_query"                        # ClickHouse session/trace query regression
bin/test app tracer                                         # full tracer app

# --- Lint / format / types ---
make check-all
```

## Screenshots
# bin/test --no-services unit tracer/tests/test_session_list_performance.py -k "TestSessionListUserId"

<img width="1512" height="982" alt="Screenshot 2026-06-01 at 9 04 11 PM" src="https://github.com/user-attachments/assets/6621be1d-d04b-44e2-ad58-ca4fe550e849" />

# bin/test integration tracer/tests/test_session_list_user_id_ch.py
<img width="1512" height="982" alt="Screenshot 2026-06-01 at 9 05 53 PM" src="https://github.com/user-attachments/assets/773f0a8f-bb3f-4391-9a2c-09c298863fa5" />

# bin/test --no-services unit tracer/tests/test_session_list_performance.py 
<img width="1512" height="982" alt="Screenshot 2026-06-01 at 9 06 39 PM" src="https://github.com/user-attachments/assets/362cd0b1-1962-4411-9875-0a8c88116c82" />

# bin/test --no-services tracer/tests/test_user_id_filter.py 
<img width="1201" height="454" alt="Screenshot 2026-06-01 at 9 07 08 PM" src="https://github.com/user-attachments/assets/a3fa68d0-2746-4ae8-a954-d0918165f28a" />

#bin/test integration tracer/tests/test_trace_session_ch_query.py 
<img width="1512" height="982" alt="Screenshot 2026-06-01 at 9 16 22 PM" src="https://github.com/user-attachments/assets/e3884e04-7ff1-42aa-b8e6-3331ad8c2f2b" />


## How was this tested?

- Ran the suites above locally — **44 passed** (3 new unit + 3 new integration + existing session-list / user_id-filter regression). `black` / `isort` / `ruff` clean on the changed files.
- Verified the generated SQL parses and behaves on a live ClickHouse instance: `argMinIf(...)` returns the first-linked `end_user_id` for a session with a user and `NULL` when none.
- Verified end-to-end on the running dev stack (ClickHouse-enabled): the resolved `end_user_id` maps to the expected `EndUser.user_id`, and the `list_sessions` endpoint responds correctly.

## Checklist

- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII
