### PR TITLE
fix(semantic_list_contains): handle numeric expected values (TH-5599)

### DIFF
--- a/futureagi/model_hub/management/commands/seed_system_evals.py
+++ b/futureagi/model_hub/management/commands/seed_system_evals.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 logger = structlog.get_logger(__name__)
 
 # Bump this when system evals change. Seeder skips if DB is already at this version.
-SYSTEM_EVALS_VERSION = 13
+SYSTEM_EVALS_VERSION = 14
 
 # Postgres advisory-lock key. Serialises concurrent seed_evals() calls
 # across pods so the bulk_create path can't race on new eval_ids. Any

--- a/futureagi/model_hub/system_evals/function/semantic_list_contains.yaml
+++ b/futureagi/model_hub/system_evals/function/semantic_list_contains.yaml
@@ -42,8 +42,8 @@ config:
         THRESHOLD = float(kwargs.get("similarity_threshold", 0.5))
         MATCH_ALL = bool(kwargs.get("match_all", False))
 
-        generated = str(output or "")
-        expected_val = expected or ""
+        generated = str(output) if output is not None else ""
+        expected_val = expected if expected is not None else ""
 
         # Parse expected as a list
         if isinstance(expected_val, str):
@@ -52,6 +52,9 @@ config:
             except (json.JSONDecodeError, ValueError):
                 expected_val = [s.strip() for s in expected_val.split(",") if s.strip()]
         if isinstance(expected_val, str):
+            expected_val = [expected_val]
+        # Coerce non-list scalars (int, float, bool) to a single-item list
+        if not isinstance(expected_val, (list, tuple)):
             expected_val = [expected_val]
         if not expected_val:
             return {"score": 0.0, "reason": "No expected phrases provided"}


### PR DESCRIPTION
## Summary
The ``semantic_list_contains`` system eval crashed with ``'int' object is not iterable`` whenever a row's ``expected`` (or ``output``) column held a numeric scalar. Numeric ``expected`` values are a valid use case for this eval (semantic match against ``"1"``, ``"42"`` etc.), so the template now coerces them instead of 500-ing.

## Failure trace
The argument-normalization block guarded ``str`` and falsy values but had no branch for truthy non-string scalars:

| Step | With ``expected = 42`` |
|---|---|
| ``expected_val = expected or ""`` | ``42`` is truthy → stays ``42`` |
| ``isinstance(expected_val, str)`` checks | int isn't str → skipped |
| ``if not expected_val:`` | ``not 42`` is False → skipped |
| ``phrases = [str(p) for p in expected_val]`` | iterating an int → **crash** |

Sentry: [CORE-BACKEND-11A4](https://future-agi.sentry.io/issues/CORE-BACKEND-11A4) — 18 occurrences in ~3h.

## Changes
- ``str(output) if output is not None else ""`` — preserves the integer ``0`` instead of collapsing it to ``""`` via ``output or ""``.
- ``expected if expected is not None else ""`` — same on the expected side.
- After the existing string-handling branches, coerce any remaining non-list scalar (int, float, bool) to a single-item list so the downstream iteration is always safe.

## Test plan
- [x] Manually re-ran the failing path locally — verified ``int 42``, ``int 0``, ``float 3.14``, ``bool True``, ``output=0``, and all previously-supported str/list/None paths produce the expected result.
- [x] Trigger ``semantic_list_contains`` on a dataset with integer ``expected`` values in playground.
- [x] Confirm Sentry stops receiving new ``CORE-BACKEND-11A4`` events after rollout.

TH-5599.

## Screen Shots:
<img width="1618" height="1069" alt="image" src="https://github.com/user-attachments/assets/ecee4fe0-dfd1-49b0-bb79-5f2191eff1b6" />
