### PR TITLE
fix: repair rate limit upgrade dialog

### DIFF
--- a/frontend/src/components/rate-limit-modal/RateLimitModal.jsx
+++ b/frontend/src/components/rate-limit-modal/RateLimitModal.jsx
@@ -9,6 +9,7 @@ import {
   Slide,
 } from "@mui/material";
 import PropTypes from "prop-types";
+import { closeSnackbar } from "notistack";
 import PricingDialog from "./UpgradeNowModal";
 import Iconify from "../iconify";
 import { useSocket } from "src/hooks/use-socket";
@@ -81,6 +82,7 @@ const UploadLimitNotification = () => {
   const handleOpenDialog = useCallback(() => {
     setDialogOpen(true);
     setShowRateLimiter(false);
+    closeSnackbar();
   }, []);
 
   const handleCloseDialog = useCallback(() => {

--- a/frontend/src/components/rate-limit-modal/RateLimitModal.jsx
+++ b/frontend/src/components/rate-limit-modal/RateLimitModal.jsx
@@ -9,18 +9,17 @@ import {
   Slide,
 } from "@mui/material";
 import PropTypes from "prop-types";
-import PricingDialog from "./UpgradeNowModal";
 import Iconify from "../iconify";
 import { useNavigate } from "react-router";
 import { useSocket } from "src/hooks/use-socket";
 import { ShowComponent } from "../show";
 import logger from "src/utils/logger";
+import { paths } from "src/routes/paths";
 
 const UploadLimitNotification = () => {
   const { socket } = useSocket();
   const [showRateLimiter, setShowRateLimiter] = useState(false);
   const [alertData, setAlertData] = useState(null);
-  const [dialogOpen, setDialogOpen] = useState(false);
   const theme = useTheme();
   const navigate = useNavigate();
 
@@ -80,20 +79,10 @@ const UploadLimitNotification = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [window.location.pathname]);
 
-  const handleOpenDialog = useCallback(() => {
-    setDialogOpen(true);
-    setShowRateLimiter(false);
-  }, []);
-
-  const handleCloseDialog = useCallback(() => {
-    setDialogOpen(false);
-    setShowRateLimiter(false);
-  }, []);
-
   const handleUpgrade = useCallback(() => {
-    navigate("/dashboard/settings/pricing");
-    handleCloseDialog();
-  }, [navigate, handleCloseDialog]);
+    setShowRateLimiter(false);
+    navigate(paths.dashboard.settings.pricing);
+  }, [navigate]);
 
   return (
     <>
@@ -177,7 +166,7 @@ const UploadLimitNotification = () => {
               </Typography>
               <Box sx={{ display: "flex", justifyContent: "flex-start" }}>
                 <Typography
-                  onClick={handleOpenDialog}
+                  onClick={handleUpgrade}
                   sx={{
                     textDecoration: "underline",
                     fontSize: "14px",
@@ -193,13 +182,6 @@ const UploadLimitNotification = () => {
           </Alert>
         </Slide>
       </ShowComponent>
-      <PricingDialog
-        open={dialogOpen}
-        onClose={handleCloseDialog}
-        onUpgradeToBusiness={handleUpgrade}
-        title={alertData?.subscription_title}
-        description={alertData?.subscription_description}
-      />
     </>
   );
 };

--- a/frontend/src/components/rate-limit-modal/RateLimitModal.jsx
+++ b/frontend/src/components/rate-limit-modal/RateLimitModal.jsx
@@ -9,19 +9,18 @@ import {
   Slide,
 } from "@mui/material";
 import PropTypes from "prop-types";
+import PricingDialog from "./UpgradeNowModal";
 import Iconify from "../iconify";
-import { useNavigate } from "react-router";
 import { useSocket } from "src/hooks/use-socket";
 import { ShowComponent } from "../show";
 import logger from "src/utils/logger";
-import { paths } from "src/routes/paths";
 
 const UploadLimitNotification = () => {
   const { socket } = useSocket();
   const [showRateLimiter, setShowRateLimiter] = useState(false);
   const [alertData, setAlertData] = useState(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
   const theme = useTheme();
-  const navigate = useNavigate();
 
   // Store message handler in a ref for proper cleanup
   const messageHandler = useRef((event) => {
@@ -79,10 +78,15 @@ const UploadLimitNotification = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [window.location.pathname]);
 
-  const handleUpgrade = useCallback(() => {
+  const handleOpenDialog = useCallback(() => {
+    setDialogOpen(true);
     setShowRateLimiter(false);
-    navigate(paths.dashboard.settings.pricing);
-  }, [navigate]);
+  }, []);
+
+  const handleCloseDialog = useCallback(() => {
+    setDialogOpen(false);
+    setShowRateLimiter(false);
+  }, []);
 
   return (
     <>
@@ -118,34 +122,44 @@ const UploadLimitNotification = () => {
               maxWidth: 510,
               boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
               padding: "16px",
-              borderRadius: "14px",
+              borderRadius: "8px",
               position: "fixed",
-              bottom: "64px",
+              bottom: "24px",
               right: "24px",
               zIndex: 9999,
+              transition: "all 0.3s ease-in-out",
             }}
           >
-            <AlertTitle>
+            <AlertTitle sx={{ m: 0 }}>
               <Box
                 sx={{
                   display: "flex",
+                  alignItems: "center",
                   justifyContent: "space-between",
+                  mb: 0.5,
                 }}
               >
                 <Typography
+                  variant="subtitle1"
                   sx={{
+                    fontSize: "16px",
                     fontWeight: "600",
-                    fontSize: "15px",
                     color: "text.primary",
                   }}
                 >
                   {alertData?.alert_title}
                 </Typography>
                 <IconButton
-                  onClick={() => setShowRateLimiter(false)}
+                  size="small"
+                  onClick={() => {
+                    setShowRateLimiter(false);
+                  }}
                   sx={{
-                    padding: "0px",
                     color: "text.primary",
+                    padding: "4px",
+                    "&:hover": {
+                      backgroundColor: "rgba(0, 0, 0, 0.04)",
+                    },
                   }}
                 >
                   <Iconify icon="oui:cross" />
@@ -166,7 +180,7 @@ const UploadLimitNotification = () => {
               </Typography>
               <Box sx={{ display: "flex", justifyContent: "flex-start" }}>
                 <Typography
-                  onClick={handleUpgrade}
+                  onClick={handleOpenDialog}
                   sx={{
                     textDecoration: "underline",
                     fontSize: "14px",
@@ -182,6 +196,12 @@ const UploadLimitNotification = () => {
           </Alert>
         </Slide>
       </ShowComponent>
+      <PricingDialog
+        open={dialogOpen}
+        onClose={handleCloseDialog}
+        title={alertData?.subscription_title}
+        description={alertData?.subscription_description}
+      />
     </>
   );
 };

--- a/frontend/src/components/rate-limit-modal/UpgradeNowModal.jsx
+++ b/frontend/src/components/rate-limit-modal/UpgradeNowModal.jsx
@@ -81,6 +81,7 @@ function PlanCard({
   redirectToPlan,
 }) {
   const [isLoadingButton, setIsLoadingButton] = useState(false);
+  const isPaygPlan = plan === PLAN_TYPES.PRO;
 
   const handleContactSales = () => {
     trackEvent(Events.contactSalesClicked);
@@ -177,7 +178,7 @@ function PlanCard({
         </Box>
       </Box>
       <Box sx={{ borderBottom: "1px solid", borderColor: "divider", pb: 1 }}>
-        {plan != PLAN_TYPES.CUSTOM && (
+        {plan != PLAN_TYPES.CUSTOM && !isPaygPlan && (
           <Typography
             variant="h5"
             sx={{ fontSize: "16px" }}
@@ -195,6 +196,27 @@ function PlanCard({
               /monthly
             </Typography>
           </Typography>
+        )}
+
+        {isPaygPlan && (
+          <Box>
+            <Typography
+              variant="h5"
+              sx={{ fontSize: "16px" }}
+              color={"text.primary"}
+              fontWeight={600}
+            >
+              Usage-based
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ fontSize: "12px" }}
+              fontWeight={400}
+              color="text.primary"
+            >
+              No monthly platform fee
+            </Typography>
+          </Box>
         )}
 
         {plan == PLAN_TYPES.CUSTOM && (

--- a/frontend/src/components/rate-limit-modal/UpgradeNowModal.jsx
+++ b/frontend/src/components/rate-limit-modal/UpgradeNowModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -25,6 +25,8 @@ import { enqueueSnackbar } from "notistack";
 import { LoadingButton } from "@mui/lab";
 import { useNavigate } from "react-router";
 import logger from "src/utils/logger";
+import { formatFeatures } from "src/utils/planFormatters";
+import { usePlansAndAddons } from "src/hooks/use-plans-and-addons";
 
 const PLAN_TYPES = {
   FREE: "free",
@@ -86,7 +88,7 @@ function PlanCard({
   const handleContactSales = () => {
     trackEvent(Events.contactSalesClicked);
     window.open(
-      "https://calendly.com/nikhil-pareek/futureagi-demo?month=2024-12",
+      "https://meetings.hubspot.com/salil-kolhe/help-futureagi-app?uuid=3b9c0e31-9f37-4d63-ad15-88190748204a",
     );
   };
 
@@ -342,92 +344,32 @@ PlanCard.propTypes = {
 };
 
 const PricingDialog = ({ open, onClose, title, description }) => {
-  const [plansLoading, setPlanLoading] = useState(true);
-  const [currentPlan, setCurrentPlan] = useState(PLAN_TYPES.FREE);
-  const [businessMonthlyPrice, setBusinessMonthlyPrice] = useState(null);
-  const [data, setData] = useState(null);
   const theme = useTheme();
   const navigate = useNavigate();
+
+  const { data: result, isLoading: plansLoading } = usePlansAndAddons(open);
+
+  const plansByKey = [
+    ...(result?.tiers || []),
+    ...(result?.addons || []),
+  ].reduce((acc, plan) => {
+    acc[plan.key] = plan;
+    return acc;
+  }, {});
+
+  const currentPlan = result?.current_plan || PLAN_TYPES.FREE;
+  const data = {
+    ...plansByKey,
+    [PLAN_TYPES.CUSTOM]:
+      result?.customDetails || plansByKey.enterprise || plansByKey.scale,
+  };
+  const businessMonthlyPrice =
+    plansByKey[PLAN_TYPES.PRO]?.platform_fee_monthly || 0;
 
   const redirectToPlan = () => {
     onClose();
     navigate("/dashboard/settings/pricing");
   };
-
-  const formatCompact = (value) => {
-    if (value === -1) return "Unlimited";
-    if (value >= 1000000) return `${Number(value / 1000000).toPrecision(3)}M`;
-    if (value >= 10000) return `${Number(value / 1000).toPrecision(3)}K`;
-    return value?.toLocaleString?.() ?? value;
-  };
-
-  const formatFeatureLabel = (key) =>
-    key
-      .replace(/^has_/, "")
-      .replace(/_/g, " ")
-      .replace(/\b\w/g, (char) => char.toUpperCase());
-
-  const formatFeatures = (features) => {
-    if (Array.isArray(features)) return features;
-    if (!features) return [];
-
-    return Object.entries(features)
-      .filter(([, value]) => value === true || value === -1 || value > 0)
-      .map(([key, value]) => {
-        const label = formatFeatureLabel(key);
-        if (typeof value === "number")
-          return `${label}: ${formatCompact(value)}`;
-        return label;
-      })
-      .slice(0, 8);
-  };
-
-  useEffect(() => {
-    let isMounted = true;
-
-    const fetchAllData = async () => {
-      setPlanLoading(true);
-      try {
-        const planRes = await axios.get(endpoints.settings.v2.plansAndAddons);
-
-        if (!isMounted) return;
-
-        const result = planRes.data?.result || {};
-        const plansByKey = [
-          ...(result.tiers || []),
-          ...(result.addons || []),
-        ].reduce((acc, plan) => {
-          acc[plan.key] = plan;
-          return acc;
-        }, {});
-
-        setCurrentPlan(result.current_plan || PLAN_TYPES.FREE);
-        setData({
-          ...plansByKey,
-          [PLAN_TYPES.CUSTOM]:
-            result.customDetails || plansByKey.enterprise || plansByKey.scale,
-        });
-        setBusinessMonthlyPrice(
-          plansByKey[PLAN_TYPES.PRO]?.platform_fee_monthly || 0,
-        );
-      } catch (err) {
-        logger.error("Error fetching subscription or pricing details:", err);
-        if (isMounted) {
-          setData({});
-        }
-      } finally {
-        if (isMounted) setPlanLoading(false);
-      }
-    };
-
-    if (open) {
-      fetchAllData();
-    }
-
-    return () => {
-      isMounted = false;
-    };
-  }, [open]);
 
   return (
     <Dialog

--- a/frontend/src/components/rate-limit-modal/UpgradeNowModal.jsx
+++ b/frontend/src/components/rate-limit-modal/UpgradeNowModal.jsx
@@ -19,18 +19,16 @@ import {
 } from "@mui/material";
 import PropTypes from "prop-types";
 import Iconify from "../iconify";
-// purple import removed - using theme tokens for dark mode support
 import { Events, trackEvent } from "src/utils/Mixpanel";
 import axios, { endpoints } from "src/utils/axios";
 import { enqueueSnackbar } from "notistack";
-import { stripePromise } from "src/pages/dashboard/settings/stripeVariables";
 import { LoadingButton } from "@mui/lab";
 import { useNavigate } from "react-router";
 import logger from "src/utils/logger";
 
 const PLAN_TYPES = {
   FREE: "free",
-  PRO: "basic",
+  PRO: "payg",
   CUSTOM: "custom",
 };
 
@@ -45,11 +43,10 @@ const planData = {
     footerText: "Advanced features with higher limits and SLAs",
   },
   [PLAN_TYPES.PRO]: {
-    name: "Pro/Business plan",
+    name: "Pay-as-you-go",
     icon: "circle",
     iconColor: "divider", // Gray color based on the image
-    tagline: "For fast growing organization",
-    // price: 50,
+    tagline: "For fast growing organizations",
     isCurrentPlan: false,
     includes: PLAN_TYPES.FREE,
     includesLowerTier: true,
@@ -92,38 +89,14 @@ function PlanCard({
     );
   };
 
-  const handleUpgradeClick = async (subscription_type) => {
+  const handleUpgradeClick = async () => {
     setIsLoadingButton(true);
     try {
-      const stripe = await stripePromise;
-      if (!stripe) {
-        enqueueSnackbar("Failed to create checkout session", {
-          variant: "error",
-        });
-        setIsLoadingButton(false);
-        return;
-      }
-      const response = await axios.post(
-        endpoints.stripe.createCheckoutSession,
-        {
-          subscription_type: subscription_type,
-        },
-      );
+      const response = await axios.post(endpoints.settings.v2.upgradeToPayg);
+      const checkoutUrl = response?.data?.result?.checkout_url;
 
-      if (response?.data?.session_id) {
-        const { error } = await stripe.redirectToCheckout({
-          sessionId: response.data.session_id,
-        });
-        if (error) {
-          logger.error("Error during checkout:", error);
-        }
-      } else if (response?.data?.result?.message) {
-        enqueueSnackbar(response?.data?.result?.message, {
-          variant: "success",
-        });
-        enqueueSnackbar("Please refresh the page to view the changes.", {
-          variant: "info",
-        });
+      if (checkoutUrl) {
+        window.location.href = checkoutUrl;
       } else {
         enqueueSnackbar("Failed to create checkout session", {
           variant: "error",
@@ -131,6 +104,9 @@ function PlanCard({
       }
     } catch (err) {
       logger.error("Failed to create checkout session:", err);
+      enqueueSnackbar("Failed to create checkout session", {
+        variant: "error",
+      });
     } finally {
       setIsLoadingButton(false);
     }
@@ -292,27 +268,29 @@ function PlanCard({
           variant="contained"
           fullWidth
           color="primary"
-          onClick={() => handleUpgradeClick(plan)}
+          onClick={handleUpgradeClick}
           loading={isLoadingButton}
           sx={{
             mt: 3,
             borderRadius: "8px",
           }}
         >
-          Upgrade to Pro
+          Upgrade to PAYG
         </LoadingButton>
       )}
 
       {((currentPlan == PLAN_TYPES.FREE && plan == PLAN_TYPES.PRO) ||
         currentPlan == PLAN_TYPES.PRO) && (
         <Typography
+          component="div"
           fontSize={"10px"}
           sx={{
             mt: 0.5,
           }}
         >
-          Annual pro plan has upgraded limits and discounts
+          Pay-as-you-go unlocks higher limits and usage-based billing
           <Typography
+            component="span"
             fontSize={"10px"}
             fontWeight={500}
             onClick={() => redirectToPlan()}
@@ -330,7 +308,7 @@ PlanCard.propTypes = {
   name: PropTypes.string,
   icon: PropTypes.string,
   tagline: PropTypes.string,
-  price: PropTypes.number,
+  price: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   plan: PropTypes.string,
   includes: PropTypes.string,
   includesLowerTier: PropTypes.bool,
@@ -354,24 +332,67 @@ const PricingDialog = ({ open, onClose, title, description }) => {
     navigate("/dashboard/settings/pricing");
   };
 
+  const formatCompact = (value) => {
+    if (value === -1) return "Unlimited";
+    if (value >= 1000000) return `${Number(value / 1000000).toPrecision(3)}M`;
+    if (value >= 10000) return `${Number(value / 1000).toPrecision(3)}K`;
+    return value?.toLocaleString?.() ?? value;
+  };
+
+  const formatFeatureLabel = (key) =>
+    key
+      .replace(/^has_/, "")
+      .replace(/_/g, " ")
+      .replace(/\b\w/g, (char) => char.toUpperCase());
+
+  const formatFeatures = (features) => {
+    if (Array.isArray(features)) return features;
+    if (!features) return [];
+
+    return Object.entries(features)
+      .filter(([, value]) => value === true || value === -1 || value > 0)
+      .map(([key, value]) => {
+        const label = formatFeatureLabel(key);
+        if (typeof value === "number")
+          return `${label}: ${formatCompact(value)}`;
+        return label;
+      })
+      .slice(0, 8);
+  };
+
   useEffect(() => {
     let isMounted = true;
 
     const fetchAllData = async () => {
       setPlanLoading(true);
       try {
-        const [planRes, pricingRes] = await Promise.all([
-          axios.get(endpoints.stripe.subscriptionPlanStatus),
-          axios.post(endpoints.stripe.pricingCardDetails),
-        ]);
+        const planRes = await axios.get(endpoints.settings.v2.plansAndAddons);
 
         if (!isMounted) return;
 
-        setCurrentPlan(planRes.data?.result?.currentSubscription);
-        setData(planRes.data?.result?.data);
-        setBusinessMonthlyPrice(pricingRes.data?.result?.businessMonthlyPrice);
+        const result = planRes.data?.result || {};
+        const plansByKey = [
+          ...(result.tiers || []),
+          ...(result.addons || []),
+        ].reduce((acc, plan) => {
+          acc[plan.key] = plan;
+          return acc;
+        }, {});
+
+        setCurrentPlan(result.current_plan || PLAN_TYPES.FREE);
+        setData({
+          ...plansByKey,
+          [PLAN_TYPES.CUSTOM]:
+            result.customDetails || plansByKey.enterprise || plansByKey.scale,
+        });
+        setBusinessMonthlyPrice(
+          plansByKey[PLAN_TYPES.PRO]?.platform_fee_monthly || 0,
+        );
       } catch (err) {
         logger.error("Error fetching subscription or pricing details:", err);
+        if (isMounted) {
+          setData({});
+        }
       } finally {
         if (isMounted) setPlanLoading(false);
       }
@@ -460,7 +481,7 @@ const PricingDialog = ({ open, onClose, title, description }) => {
             <Grid item xs={12} md={4}>
               <PlanCard
                 {...planData[PLAN_TYPES?.FREE]}
-                features={data[PLAN_TYPES?.FREE]?.features}
+                features={formatFeatures(data?.[PLAN_TYPES?.FREE]?.features)}
                 currentPlan={currentPlan}
                 plan={PLAN_TYPES?.FREE}
                 redirectToPlan={redirectToPlan}
@@ -473,7 +494,7 @@ const PricingDialog = ({ open, onClose, title, description }) => {
               <PlanCard
                 {...planData[PLAN_TYPES?.PRO]}
                 price={businessMonthlyPrice}
-                features={data[PLAN_TYPES?.PRO]?.features}
+                features={formatFeatures(data?.[PLAN_TYPES?.PRO]?.features)}
                 currentPlan={currentPlan}
                 plan={PLAN_TYPES?.PRO}
                 redirectToPlan={redirectToPlan}
@@ -485,7 +506,7 @@ const PricingDialog = ({ open, onClose, title, description }) => {
             <Grid item xs={12} md={4}>
               <PlanCard
                 {...planData[PLAN_TYPES?.CUSTOM]}
-                features={data[PLAN_TYPES?.CUSTOM]?.features}
+                features={formatFeatures(data?.[PLAN_TYPES?.CUSTOM]?.features)}
                 currentPlan={currentPlan}
                 plan={PLAN_TYPES?.CUSTOM}
                 redirectToPlan={redirectToPlan}

--- a/frontend/src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx
+++ b/frontend/src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx
@@ -134,6 +134,8 @@ describe("UploadLimitNotification", () => {
       await screen.findByText("Want to process more data per minute?"),
     ).toBeInTheDocument();
     expect(screen.getByText("Upgrade to PAYG")).toBeInTheDocument();
+    expect(screen.getByText("Usage-based")).toBeInTheDocument();
+    expect(screen.getByText("No monthly platform fee")).toBeInTheDocument();
     expect(mocks.get).toHaveBeenCalledWith("/usage/v2/plans-and-addons/");
     await waitFor(() => expect(mocks.navigate).not.toHaveBeenCalled());
   });

--- a/frontend/src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx
+++ b/frontend/src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "src/utils/test-utils";
 import { createTheme } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import UploadLimitNotification from "../RateLimitModal";
 
 const mocks = vi.hoisted(() => ({
@@ -40,6 +41,7 @@ vi.mock("src/utils/axios", () => ({
 
 vi.mock("notistack", () => ({
   enqueueSnackbar: vi.fn(),
+  closeSnackbar: vi.fn(),
 }));
 
 const theme = createTheme({
@@ -109,7 +111,15 @@ describe("UploadLimitNotification", () => {
   });
 
   it("opens pricing dialog from upgrade CTA without routing away", async () => {
-    render(<UploadLimitNotification />, { theme });
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={qc}>
+        <UploadLimitNotification />
+      </QueryClientProvider>,
+      { theme },
+    );
 
     act(() => {
       mocks.socket.dispatchEvent(

--- a/frontend/src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx
+++ b/frontend/src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen } from "src/utils/test-utils";
+import { createTheme } from "@mui/material/styles";
+import UploadLimitNotification from "../RateLimitModal";
+
+const mocks = vi.hoisted(() => ({
+  socket: new EventTarget(),
+  navigate: vi.fn(),
+}));
+
+vi.mock("src/hooks/use-socket", () => ({
+  useSocket: () => ({ socket: mocks.socket }),
+}));
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+const theme = createTheme({
+  palette: {
+    red: {
+      500: "#f04438",
+    },
+  },
+});
+
+describe("UploadLimitNotification", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.socket = new EventTarget();
+    mocks.navigate.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("routes upgrade CTA to the current pricing page", async () => {
+    render(<UploadLimitNotification />, { theme });
+
+    act(() => {
+      mocks.socket.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "rate_limit_notification",
+            alert_title: "Minutely Turing large evaluator limit reached.",
+            alert_description:
+              "You have reached the minutely turing large evaluator limit.",
+          }),
+        }),
+      );
+      vi.advanceTimersByTime(500);
+    });
+
+    const upgradeLink = await screen.findByText("Upgrade now");
+
+    fireEvent.click(upgradeLink);
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/dashboard/settings/pricing");
+  });
+});

--- a/frontend/src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx
+++ b/frontend/src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { act, fireEvent, render, screen } from "src/utils/test-utils";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "src/utils/test-utils";
 import { createTheme } from "@mui/material/styles";
 import UploadLimitNotification from "../RateLimitModal";
 
 const mocks = vi.hoisted(() => ({
   socket: new EventTarget(),
   navigate: vi.fn(),
+  get: vi.fn(),
+  post: vi.fn(),
 }));
 
 vi.mock("src/hooks/use-socket", () => ({
@@ -21,26 +23,92 @@ vi.mock("react-router", async (importOriginal) => {
   };
 });
 
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: (...args) => mocks.get(...args),
+    post: (...args) => mocks.post(...args),
+  },
+  endpoints: {
+    settings: {
+      v2: {
+        plansAndAddons: "/usage/v2/plans-and-addons/",
+        upgradeToPayg: "/usage/v2/upgrade-to-payg/",
+      },
+    },
+  },
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
 const theme = createTheme({
   palette: {
+    primary: {
+      main: "#6f4ef2",
+      lighter: "#ede8ff",
+    },
     red: {
       500: "#f04438",
+    },
+    pink: {
+      500: "#ec4899",
     },
   },
 });
 
 describe("UploadLimitNotification", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     mocks.socket = new EventTarget();
     mocks.navigate.mockReset();
+    mocks.get.mockResolvedValue({
+      data: {
+        result: {
+          current_plan: "free",
+          tiers: [
+            {
+              key: "free",
+              display_name: "Free",
+              platform_fee_monthly: 0,
+              features: {
+                monitors: 3,
+                retention_traces_days: 30,
+              },
+            },
+            {
+              key: "payg",
+              display_name: "Pay-as-you-go",
+              platform_fee_monthly: 0,
+              features: {
+                monitors: -1,
+                has_agentic_eval: true,
+              },
+            },
+          ],
+          addons: [
+            {
+              key: "enterprise",
+              display_name: "Enterprise",
+              platform_fee_monthly: 2000,
+              features: {
+                monitors: -1,
+                has_scim: true,
+              },
+            },
+          ],
+        },
+      },
+    });
+    mocks.post.mockResolvedValue({
+      data: {
+        result: {
+          checkout_url: "https://checkout.stripe.test/session",
+        },
+      },
+    });
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("routes upgrade CTA to the current pricing page", async () => {
+  it("opens pricing dialog from upgrade CTA without routing away", async () => {
     render(<UploadLimitNotification />, { theme });
 
     act(() => {
@@ -51,16 +119,22 @@ describe("UploadLimitNotification", () => {
             alert_title: "Minutely Turing large evaluator limit reached.",
             alert_description:
               "You have reached the minutely turing large evaluator limit.",
+            subscription_title: "Want to process more data per minute?",
+            subscription_description: "Upgrade to continue immediately.",
           }),
         }),
       );
-      vi.advanceTimersByTime(500);
     });
 
     const upgradeLink = await screen.findByText("Upgrade now");
 
     fireEvent.click(upgradeLink);
 
-    expect(mocks.navigate).toHaveBeenCalledWith("/dashboard/settings/pricing");
+    expect(
+      await screen.findByText("Want to process more data per minute?"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Upgrade to PAYG")).toBeInTheDocument();
+    expect(mocks.get).toHaveBeenCalledWith("/usage/v2/plans-and-addons/");
+    await waitFor(() => expect(mocks.navigate).not.toHaveBeenCalled());
   });
 });

--- a/frontend/src/hooks/use-plans-and-addons.js
+++ b/frontend/src/hooks/use-plans-and-addons.js
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import axios, { endpoints } from "src/utils/axios";
+
+export const PLANS_QUERY_KEY = ["v2-plans-and-addons"];
+
+export function usePlansAndAddons(enabled = true) {
+  return useQuery({
+    queryKey: PLANS_QUERY_KEY,
+    queryFn: () => axios.get(endpoints.settings.v2.plansAndAddons),
+    select: (res) => res.data?.result,
+    enabled,
+  });
+}

--- a/frontend/src/sections/settings/PricingV3/PricingPage.jsx
+++ b/frontend/src/sections/settings/PricingV3/PricingPage.jsx
@@ -11,7 +11,11 @@
 
 import React, { useState, useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  usePlansAndAddons,
+  PLANS_QUERY_KEY,
+} from "src/hooks/use-plans-and-addons";
 import {
   Box,
   Typography,
@@ -553,7 +557,7 @@ export default function PricingPage() {
         .put(endpoints.settings.v2.upgradeToPayg, { session_id: sessionId })
         .then(() => {
           enqueueSnackbar("Upgraded to Pay-as-you-go!", { variant: "success" });
-          queryClient.invalidateQueries({ queryKey: ["v2-plans-and-addons"] });
+          queryClient.invalidateQueries({ queryKey: PLANS_QUERY_KEY });
         })
         .catch((err) => {
           enqueueSnackbar(
@@ -571,11 +575,7 @@ export default function PricingPage() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const { data, isLoading } = useQuery({
-    queryKey: ["v2-plans-and-addons"],
-    queryFn: () => axios.get(endpoints.settings.v2.plansAndAddons),
-    select: (res) => res.data?.result,
-  });
+  const { data, isLoading } = usePlansAndAddons();
 
   const closeDialog = () =>
     setAddonDialog({ open: false, plan: null, action: null });
@@ -598,7 +598,7 @@ export default function PricingPage() {
       enqueueSnackbar(`${res.data?.result?.plan} add-on activated!`, {
         variant: "success",
       });
-      queryClient.invalidateQueries({ queryKey: ["v2-plans-and-addons"] });
+      queryClient.invalidateQueries({ queryKey: PLANS_QUERY_KEY });
       closeDialog();
     },
     onError: () => {
@@ -614,7 +614,7 @@ export default function PricingPage() {
       enqueueSnackbar("Add-on will be removed at end of billing period", {
         variant: "info",
       });
-      queryClient.invalidateQueries({ queryKey: ["v2-plans-and-addons"] });
+      queryClient.invalidateQueries({ queryKey: PLANS_QUERY_KEY });
       queryClient.invalidateQueries({ queryKey: ["v2-billing-overview"] });
       queryClient.invalidateQueries({ queryKey: ["v2-usage-overview"] });
       closeDialog();
@@ -631,7 +631,7 @@ export default function PricingPage() {
       enqueueSnackbar("Add-on reinstated. Your plan stays active.", {
         variant: "success",
       });
-      queryClient.invalidateQueries({ queryKey: ["v2-plans-and-addons"] });
+      queryClient.invalidateQueries({ queryKey: PLANS_QUERY_KEY });
       queryClient.invalidateQueries({ queryKey: ["v2-billing-overview"] });
       queryClient.invalidateQueries({ queryKey: ["v2-usage-overview"] });
     },
@@ -646,7 +646,7 @@ export default function PricingPage() {
     mutationFn: () => axios.post(endpoints.settings.v2.downgradeToFree),
     onSuccess: () => {
       enqueueSnackbar("Downgraded to Free plan", { variant: "success" });
-      queryClient.invalidateQueries({ queryKey: ["v2-plans-and-addons"] });
+      queryClient.invalidateQueries({ queryKey: PLANS_QUERY_KEY });
     },
     onError: (err) =>
       enqueueSnackbar(err?.response?.data?.result || "Downgrade failed", {

--- a/frontend/src/utils/planFormatters.js
+++ b/frontend/src/utils/planFormatters.js
@@ -1,0 +1,26 @@
+export const formatCompact = (value) => {
+  if (value === -1) return "Unlimited";
+  if (value >= 1000000) return `${Number(value / 1000000).toPrecision(3)}M`;
+  if (value >= 10000) return `${Number(value / 1000).toPrecision(3)}K`;
+  return value?.toLocaleString?.() ?? value;
+};
+
+export const formatFeatureLabel = (key) =>
+  key
+    .replace(/^has_/, "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+export const formatFeatures = (features) => {
+  if (Array.isArray(features)) return features;
+  if (!features) return [];
+
+  return Object.entries(features)
+    .filter(([, value]) => value === true || value === -1 || value > 0)
+    .map(([key, value]) => {
+      const label = formatFeatureLabel(key);
+      if (typeof value === "number") return `${label}: ${formatCompact(value)}`;
+      return label;
+    })
+    .slice(0, 8);
+};

--- a/futureagi/.env.example
+++ b/futureagi/.env.example
@@ -125,7 +125,7 @@ VITE_GOOGLE_SITE_KEY=
 # -----------------------------------------------------------------------------
 RABBITMQ_USER=user
 RABBITMQ_PASSWORD=password
-CELERY_BROKER_URL=amqp://user:password@rabbitmq:5672//
+CELERY_BROKER_URL=amqp://user:password@rabbitmq:5672/%2F
 
 # -----------------------------------------------------------------------------
 # Redis (Distributed Locking & State)


### PR DESCRIPTION
## Summary

Fixes the rate-limit toast upgrade CTA by opening a repaired pricing dialog instead of sending users through the stale legacy checkout path that can land on the app error page. The dialog now reads pricing data from the current V2 `plans-and-addons` API and starts PAYG checkout with the same `upgrade-to-payg` endpoint used by the pricing page. PAYG is labeled as usage-based in the dialog instead of `$0/month`, and the backend example RabbitMQ URL stays escaped as `%2F` so local Channels websocket setup can connect through carehare.

## Linked issues

Closes TH-5603

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only
- [ ] Chore / refactor (no user-visible change)
- [ ] Performance improvement
- [ ] Test-only change

## How was this tested?

- `git diff --check`
- `npx prettier --check src/components/rate-limit-modal/RateLimitModal.jsx src/components/rate-limit-modal/UpgradeNowModal.jsx src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx`
- `npx eslint src/components/rate-limit-modal/RateLimitModal.jsx src/components/rate-limit-modal/UpgradeNowModal.jsx src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx`
- `npx vitest run src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx --config vitest.no-checker.config.mjs --reporter=verbose` passed with a temporary local config that disables Vite checker.
- `npm run test:run -- src/components/rate-limit-modal/__tests__/RateLimitModal.test.jsx --reporter=verbose` was attempted, but Vite checker exits nonzero on existing repo-wide ESLint warnings (`0 errors and 439 warnings`).

## Screenshots / recordings (if UI)

https://github.com/user-attachments/assets/def05dd1-f3c0-4958-af18-5d7872af123a

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [x] I updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
