### PR TITLE
Fix/multi choice output type in eval playground

### DIFF
--- a/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerConfigFull.jsx
@@ -154,6 +154,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
   const [outputType, setOutputType] = useState("pass_fail");
   const [passThreshold, setPassThreshold] = useState(0.5);
   const [choiceScores, setChoiceScores] = useState({});
+  const [multiChoice, setMultiChoice] = useState(false);
   const [messages, setMessages] = useState([{ role: "system", content: "" }]);
   const [fewShotExamples, setFewShotExamples] = useState([]);
   const [templateFormat, setTemplateFormat] = useState("mustache");
@@ -427,6 +428,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
           rawRunConfig.choiceScores ??
           evalData?.choice_scores ??
           evalData?.choiceScores,
+        multi_choice:
+          rawRunConfig.multi_choice ??
+          rawRunConfig.multiChoice ??
+          evalData?.multi_choice ??
+          evalData?.multiChoice,
         params: rawRunConfig.params ?? evalData?.params,
         messages: rawRunConfig.messages ?? evalData?.messages,
       };
@@ -467,6 +473,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       // Prefer user's saved run_config overrides (edit flow) over template defaults
       setPassThreshold(config.pass_threshold ?? fullEval.pass_threshold ?? 0.5);
       setChoiceScores(config.choice_scores || fullEval.choice_scores || {});
+      setMultiChoice(config.multi_choice ?? fullEval.multi_choice ?? false);
       // Messages: use config.messages if present, otherwise build from
       // instructions — but only for llm/agent evals, since code evals
       // don't have a prompt to seed into a system message.
@@ -925,6 +932,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
       messages,
       pass_threshold: passThreshold,
       choice_scores: choiceScores,
+      multi_choice: multiChoice,
       // Code-eval static params (function_params_schema inputs, e.g.
       // min_words / max_words). Persisted so the backend writes them onto
       // UserEvalMetric.config.params and future runs can read them via
@@ -961,6 +969,7 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
     fewShotExamples,
     passThreshold,
     choiceScores,
+    multiChoice,
     codeParams,
     agentMode,
     useInternet,
@@ -1521,6 +1530,11 @@ const EvalPickerConfigFull = ({ evalData, onBack, onSave, isSaving }) => {
                   choiceScores={choiceScores}
                   onChoiceScoresChange={(v) => {
                     setChoiceScores(v);
+                    setIsDirty(true);
+                  }}
+                  multiChoice={multiChoice}
+                  onMultiChoiceChange={(v) => {
+                    setMultiChoice(v);
                     setIsDirty(true);
                   }}
                   passThreshold={passThreshold}

--- a/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
+++ b/frontend/src/sections/common/EvaluationDrawer/EvaluationDrawer.jsx
@@ -612,6 +612,8 @@ const EvaluationDrawerChild = ({
               Object.keys(evalConfig.choice_scores).length
             )
               runConfig.choice_scores = evalConfig.choice_scores;
+            if (evalConfig.multi_choice !== undefined)
+              runConfig.multi_choice = !!evalConfig.multi_choice;
           }
           // Data injection applies to both single and composite — the
           // backend resolves it at row-evaluation time.

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -1828,6 +1828,7 @@ const EvalDetailPage = () => {
                     codeLanguage={codeLanguage}
                     isSystemEval={isSystemEval}
                     requiredKeys={variables}
+                    multiChoice={multiChoice}
                     showVersions={!(isSystemEval && evalType === "code")}
                     errorLocalizerEnabled={errorLocalizerEnabled}
                     onTestResult={handleTestResult}

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -635,6 +635,7 @@ const TestPlayground = React.forwardRef(
       codeLanguage = "python",
       isSystemEval = false,
       onReadyChange,
+      multiChoice = false,
     },
     ref,
   ) => {
@@ -954,6 +955,7 @@ const TestPlayground = React.forwardRef(
             template_id: tid,
             model,
             error_localizer: errorLocalizerEnabled,
+            multi_choice: multiChoice,
             config: {
               mapping,
               ...(evalType === "code" ? { params } : {}),
@@ -1009,6 +1011,7 @@ const TestPlayground = React.forwardRef(
       compositeAdhocConfig,
       executeCompositeAdhoc,
       handleCreditError,
+      multiChoice,
     ]);
 
     // Expose runTest and switchToVersion to parent via ref
@@ -1889,6 +1892,7 @@ TestPlayground.propTypes = {
   codeLanguage: PropTypes.string,
   onReadyChange: PropTypes.func,
   isSystemEval: PropTypes.bool,
+  multiChoice: PropTypes.bool,
 };
 
 export default TestPlayground;


### PR DESCRIPTION
## Summary

Multi-choice (allow the LLM to select more than one category) was not being
propagated to eval runs from either the playground or the add-eval picker.
This wires the flag through both paths so multi-choice evals score correctly.

- **Eval playground** — `EvalDetailPage` now passes the template's
  `multiChoice` flag into `TestPlayground`, which sends it as `multi_choice`
  in the `eval-playground` request payload.
- **Add eval to a module** — wired the multi-choice toggle into
  `OutputTypeConfig` in `EvalPickerConfigFull`, seeded from the template /
  saved `run_config` (including edit mode), and included `multi_choice` in the
  `handleAdd` save payload. `EvaluationDrawer` maps it into
  `config.run_config.multi_choice`, which the backend already accepts as a
  per-binding runtime override and applies at run time.

## Changes

- `EvalDetailPage.jsx` — pass `multiChoice` to `TestPlayground`.
- `TestPlayground.jsx` — accept `multiChoice` prop, send `multi_choice` in the
  playground request, add to run deps + propTypes.
- `EvalPickerConfigFull.jsx` — `multiChoice` state, `OutputTypeConfig` toggle
  wiring, load-time init from `run_config` / template, `multi_choice` in the
  save payload.
- `EvaluationDrawer.jsx` — map `evalConfig.multi_choice` into
  `config.run_config.multi_choice` for single (non-composite) evals.

## Test plan

- [x] In the eval playground, create/open a deterministic eval with categories and enable "Allow multiple choices"; run a test and confirm the request sends `multi_choice: true` and the result reflects multiple selected categories.
- [x] Toggle multi-choice off and re-run; confirm `multi_choice: false` is sent and only a single category is selectable in the output.
- [x] Run the playground across all source tabs (Dataset / Tracing / Simulation / Custom) — confirm no regression where multi-choice forwarding was removed from the sibling test modes.
- [x] In the eval picker, add a deterministic eval to a **dataset** with multi-choice enabled; verify the add request body contains `config.run_config.multi_choice: true` and the saved `UserEvalMetric` runs as multi-choice.
- [x] Repeat the add flow for **experiment** and **tracing/task** modules; confirm `run_config.multi_choice` is persisted in each.
- [x] Edit an existing multi-choice eval binding; confirm the toggle reloads in the enabled state from saved `run_config` and re-saving preserves `multi_choice`.
- [x] Add an eval with multi-choice **disabled**; confirm `run_config.multi_choice: false` is sent and applied.

Closes TH-4712

