### PR TITLE
fix(evals): route composite evals through composite endpoint from TaskLivePreview

### DIFF
--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -51,11 +51,13 @@ import CustomTooltip from "src/components/tooltip/CustomTooltip";
 import TaskFilterBar from "src/sections/tasks/components/TaskFilterBar";
 import { buildApiFilterArray } from "src/sections/tasks/components/TaskLivePreview";
 import { JsonValueTree } from "./DatasetTestMode";
-import { buildCompositeRuntimeConfig } from "../Helpers/compositeRuntimeConfig";
 import EvalResultDisplay from "./EvalResultDisplay";
 import SpanRowList from "./SpanRowList";
 import useErrorLocalizerPoll from "../hooks/useErrorLocalizerPoll";
-import { useExecuteCompositeEvalAdhoc } from "../hooks/useCompositeEval";
+import {
+  buildFlatValueMap,
+  executeEvalForRow,
+} from "../utils/evalExecution";
 
 const ROW_TYPE_OPTIONS = [
   { value: "Span", label: "Spans", icon: "solar:layers-outline" },
@@ -388,7 +390,6 @@ const TracingTestMode = React.forwardRef(
     // Async error localization poll — see DatasetTestMode for rationale.
     const { state: errorLocalizerState, start: startErrorLocalizerPoll } =
       useErrorLocalizerPoll();
-    const executeCompositeAdhoc = useExecuteCompositeEvalAdhoc();
 
     // ── Fetch project list (skip when project is pre-selected/locked) ──
     useEffect(() => {
@@ -852,7 +853,9 @@ const TracingTestMode = React.forwardRef(
         (rowType === "Session" || rowType === "Trace");
       if (usePrecomputed) {
         return pickerSourceColumns
-          .map((c) => (typeof c === "string" ? c : c?.field || c?.name || c?.headerName))
+          .map((c) =>
+            typeof c === "string" ? c : c?.field || c?.name || c?.headerName,
+          )
           .filter(Boolean);
       }
       return walkedFromDetail || rowFields.map((f) => f?.colId || f?.key);
@@ -951,190 +954,45 @@ const TracingTestMode = React.forwardRef(
         return;
       }
 
-      try {
-        // Build a flat fieldName→value lookup by walking spanDetail with
-        // the same logic used to populate the fieldNames dropdown. This
-        // ensures that a field name selected from the dropdown (e.g.
-        // "input.value" — which may have been soft-flattened from
-        // "span_attributes.input.value") always resolves to the correct
-        // value, even when the top-level key shadows a deeper path.
-        // Limits match the dropdown walker so every path offered in the UI
-        // also resolves — otherwise deep paths (e.g. gen_ai.* under a big
-        // span_attributes dict) would be selectable but unresolvable.
-        const ARRAY_PEEK = 500;
-        const DICT_LIMIT = 5000;
-        const valueMap = {};
-        const walkValues = (node, prefix) => {
-          if (Array.isArray(node)) {
-            node.slice(0, ARRAY_PEEK).forEach((item, idx) => {
-              const path = prefix ? `${prefix}.${idx}` : String(idx);
-              valueMap[path] = item;
-              if (item && typeof item === "object") {
-                walkValues(item, path);
-              }
-            });
-            return;
-          }
-          // canonicalEntries drops the camelCase aliases the axios
-          // interceptor layers on — otherwise valueMap gets both
-          // `span_attributes.*` and `spanAttributes.*` branches of the
-          // same data, and only the snake side is stripped by the
-          // soft-flatten below.
-          for (const [k, v] of canonicalEntries(node)) {
-            if (k.startsWith("_")) continue;
-            const path = prefix ? `${prefix}.${k}` : k;
-            valueMap[path] = v;
-            if (v && typeof v === "object") {
-              if (
-                Array.isArray(v) ||
-                Object.keys(v).length < DICT_LIMIT
-              ) {
-                walkValues(v, path);
-              }
+      const flatValueMap = buildFlatValueMap(spanDetail);
+      const evalItem = {
+        template_id: tid,
+        template_type: isComposite ? "composite" : undefined,
+        model,
+      };
+      const result = await executeEvalForRow({
+        evalItem,
+        rowType,
+        currentRow,
+        spanDetail,
+        mapping,
+        flatValueMap,
+        rowFields,
+        codeParams,
+        errorLocalizerEnabled,
+        compositeAdhocConfig,
+      });
+
+      if (result.ok) {
+        // EvalResultDisplay reads `compositeResult` for composite, or the
+        // legacy `output`/`reason`/`score` keys for single.
+        const nextResult = result.isComposite
+          ? {
+              output: result.output,
+              reason: result.reason,
+              compositeResult: result.compositeResult,
             }
-          }
-        };
-        walkValues(spanDetail, "");
-
-        // Build the soft-flattened lookup via `stripAttributePathPrefix`
-        // — the same util the `fieldNames` walker uses, so the dropdown
-        // and resolution keys stay in lockstep. The util strips any
-        // `span_attributes.` segment (anchored or nested under
-        // `spans.<n>.` / `traces.<i>.spans.<j>.`), which the previous
-        // anchored-only strip got wrong for trace/session row types
-        // (their detail nests `span_attributes.` mid-path).
-        const flatValueMap = {};
-        for (const [path, val] of Object.entries(valueMap)) {
-          const short = stripAttributePathPrefix(path);
-          // Top-level (unstripped) paths win — only fall back to a
-          // stripped path when no top-level entry exists for that short
-          // form.
-          if (!(short in flatValueMap) || short === path) {
-            flatValueMap[short] = val;
-          }
+          : result.raw;
+        setResult(nextResult);
+        onTestResult?.(true, nextResult);
+        if (!result.isComposite && errorLocalizerEnabled && result.logId) {
+          startErrorLocalizerPoll(result.logId);
         }
-
-        const evalMapping = {};
-        for (const variable of variables) {
-          const mappedField = mapping[variable];
-          if (!mappedField) continue;
-
-          // 1. Try the flat value map (same resolution as the dropdown)
-          let val = flatValueMap[mappedField];
-
-          // 2. Fallback: rowFields by key or colId
-          if (val === undefined) {
-            const rf = rowFields.find(
-              (f) => f.key === mappedField || f.colId === mappedField,
-            );
-            if (rf?.raw !== undefined && rf.raw !== null) {
-              val = rf.raw;
-            }
-          }
-
-          if (val !== undefined) {
-            evalMapping[variable] =
-              typeof val === "object"
-                ? JSON.stringify(val)
-                : String(val ?? "");
-          }
-        }
-
-        // Single-eval playground resolves {{span}} / {{trace}} /
-        // {{session}} server-side from IDs. Composite execution expects
-        // the concrete context objects directly.
-        const autoCtx = {};
-        const _spanId = currentRow?.span_id || currentRow?.spanId;
-        const _traceId = currentRow?.trace_id || currentRow?.traceId;
-        const _sessionId = currentRow?.session_id || currentRow?.sessionId;
-        if (rowType === "Span" && _spanId) autoCtx.span_id = _spanId;
-        if ((rowType === "Span" || rowType === "Trace") && _traceId)
-          autoCtx.trace_id = _traceId;
-        if (rowType === "Session" && _sessionId)
-          autoCtx.session_id = _sessionId;
-        if (rowType === "VoiceCall" && _traceId) autoCtx.trace_id = _traceId;
-
-        const compositeCtx = {};
-        if (rowType === "Span" && spanDetail) compositeCtx.span_context = spanDetail;
-        if (rowType === "Trace" && currentRow)
-          compositeCtx.trace_context = currentRow;
-        if (rowType === "Session" && currentRow)
-          compositeCtx.session_context = currentRow;
-        if (rowType === "VoiceCall" && currentRow)
-          compositeCtx.trace_context = currentRow;
-
-        const compositeConfig = buildCompositeRuntimeConfig({
-          codeParams,
-        });
-
-        const { data } = isComposite
-          ? compositeAdhocConfig
-            ? {
-                data: {
-                  status: true,
-                  result: await executeCompositeAdhoc.mutateAsync({
-                    ...compositeAdhocConfig,
-                    mapping: evalMapping,
-                    model,
-                    error_localizer: errorLocalizerEnabled,
-                    config: compositeConfig,
-                    ...compositeCtx,
-                  }),
-                },
-              }
-            : await axios.post(endpoints.develop.eval.executeCompositeEval(tid), {
-                mapping: evalMapping,
-                model,
-                error_localizer: errorLocalizerEnabled,
-                config: compositeConfig,
-                ...compositeCtx,
-              })
-          : await axios.post(endpoints.develop.eval.evalPlayground, {
-              template_id: tid,
-              model,
-              error_localizer: errorLocalizerEnabled,
-              config: {
-                mapping: evalMapping,
-                ...(Object.keys(codeParams || {}).length > 0
-                  ? { params: codeParams }
-                  : {}),
-              },
-              ...autoCtx,
-            });
-
-        if (data?.status) {
-          const nextResult = isComposite
-            ? {
-                output:
-                  data.result?.aggregation_enabled &&
-                  data.result?.aggregate_score != null
-                    ? data.result.aggregate_score
-                    : null,
-                reason: data.result?.summary || "",
-                compositeResult: data.result,
-              }
-            : data.result;
-          setResult(nextResult);
-          onTestResult?.(true, nextResult);
-          if (!isComposite && errorLocalizerEnabled && data.result?.log_id) {
-            startErrorLocalizerPoll(data.result.log_id);
-          }
-        } else {
-          const errMsg = data?.result || "Evaluation failed";
-          setError(errMsg);
-          onTestResult?.(false, errMsg);
-        }
-      } catch (err) {
-        const errMsg =
-          err?.result ||
-          err?.detail ||
-          err?.message ||
-          "Failed to run evaluation";
-        setError(errMsg);
-        onTestResult?.(false, errMsg);
-      } finally {
-        setIsRunning(false);
+      } else {
+        setError(result.errorMessage);
+        onTestResult?.(false, result.errorMessage);
       }
+      setIsRunning(false);
     }, [
       templateId,
       variables,
@@ -1150,7 +1008,6 @@ const TracingTestMode = React.forwardRef(
       startErrorLocalizerPoll,
       codeParams,
       model,
-      executeCompositeAdhoc,
     ]);
 
     useImperativeHandle(
@@ -1181,14 +1038,10 @@ const TracingTestMode = React.forwardRef(
               getOptionLabel={(opt) => opt?.name || opt?.id || ""}
               value={projects.find((p) => p.id === selectedProjectId) || null}
               onChange={(_, val) => {
-
-                setSelectedProjectId(val?.id || "")
+                setSelectedProjectId(val?.id || "");
                 setMapping({});
                 setColumns([]);
-
-              }
-
-              }
+              }}
               loading={loadingProjects}
               openOnFocus
               renderInput={(params) => (
@@ -1373,66 +1226,66 @@ const TracingTestMode = React.forwardRef(
           (rows?.length ?? 0) > 0 &&
           !loading &&
           !isPendingNewFetch && (
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 1,
-            }}
-          >
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ fontSize: "11px" }}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 1,
+              }}
             >
-              Row {Math.min(currentRowIndex + 1, rows?.length ?? 0)} of{" "}
-              {rows?.length ?? 0}
-              {(totalRows ?? 0) > (rows?.length ?? 0) && (
-                <Typography
-                  component="span"
-                  sx={{
-                    fontSize: "11px",
-                    color: "text.disabled",
-                    ml: 0.5,
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ fontSize: "11px" }}
+              >
+                Row {Math.min(currentRowIndex + 1, rows?.length ?? 0)} of{" "}
+                {rows?.length ?? 0}
+                {(totalRows ?? 0) > (rows?.length ?? 0) && (
+                  <Typography
+                    component="span"
+                    sx={{
+                      fontSize: "11px",
+                      color: "text.disabled",
+                      ml: 0.5,
+                    }}
+                  >
+                    ({totalRows} matching total)
+                  </Typography>
+                )}
+              </Typography>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <IconButton
+                  size="small"
+                  disabled={currentRowIndex === 0}
+                  onClick={() => {
+                    setCurrentRowIndex((i) => Math.max(0, i - 1));
+                    setResult(null);
+                    setError(null);
+                    onClearResult?.();
                   }}
+                  sx={{ width: 24, height: 24 }}
                 >
-                  ({totalRows} matching total)
-                </Typography>
-              )}
-            </Typography>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-              <IconButton
-                size="small"
-                disabled={currentRowIndex === 0}
-                onClick={() => {
-                  setCurrentRowIndex((i) => Math.max(0, i - 1));
-                  setResult(null);
-                  setError(null);
-                  onClearResult?.();
-                }}
-                sx={{ width: 24, height: 24 }}
-              >
-                <Iconify icon="mdi:chevron-left" width={16} />
-              </IconButton>
-              <IconButton
-                size="small"
-                disabled={currentRowIndex >= (rows?.length ?? 0) - 1}
-                onClick={() => {
-                  setCurrentRowIndex((i) =>
-                    Math.min((rows?.length ?? 0) - 1, i + 1),
-                  );
-                  setResult(null);
-                  setError(null);
-                  onClearResult?.();
-                }}
-                sx={{ width: 24, height: 24 }}
-              >
-                <Iconify icon="mdi:chevron-right" width={16} />
-              </IconButton>
+                  <Iconify icon="mdi:chevron-left" width={16} />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  disabled={currentRowIndex >= (rows?.length ?? 0) - 1}
+                  onClick={() => {
+                    setCurrentRowIndex((i) =>
+                      Math.min((rows?.length ?? 0) - 1, i + 1),
+                    );
+                    setResult(null);
+                    setError(null);
+                    onClearResult?.();
+                  }}
+                  sx={{ width: 24, height: 24 }}
+                >
+                  <Iconify icon="mdi:chevron-right" width={16} />
+                </IconButton>
+              </Box>
             </Box>
-          </Box>
-        )}
+          )}
 
         {/* Span/Trace detail — table format like DatasetTestMode */}
         {loadingDetail && (
@@ -1699,203 +1552,211 @@ const TracingTestMode = React.forwardRef(
           !loading &&
           !isPendingNewFetch &&
           totalRows === 0 && (
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: 0.75,
-              py: 3,
-              border: "1px dashed",
-              borderColor: "divider",
-              borderRadius: "8px",
-            }}
-          >
-            <Iconify
-              icon="mdi:table-off"
-              width={28}
-              sx={{ color: "text.disabled" }}
-            />
-            <Typography variant="body2" fontWeight={600} color="text.secondary">
-              No {rowType.toLowerCase()} data found
-            </Typography>
-            <Typography variant="caption" color="text.disabled">
-              Add {rowType.toLowerCase()} to this project before running a test
-            </Typography>
-          </Box>
-        )}
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 0.75,
+                py: 3,
+                border: "1px dashed",
+                borderColor: "divider",
+                borderRadius: "8px",
+              }}
+            >
+              <Iconify
+                icon="mdi:table-off"
+                width={28}
+                sx={{ color: "text.disabled" }}
+              />
+              <Typography
+                variant="body2"
+                fontWeight={600}
+                color="text.secondary"
+              >
+                No {rowType.toLowerCase()} data found
+              </Typography>
+              <Typography variant="caption" color="text.disabled">
+                Add {rowType.toLowerCase()} to this project before running a
+                test
+              </Typography>
+            </Box>
+          )}
 
         {/* Variable mapping */}
-        {variables.length > 0 && (() => {
-          const isFetchingColumns =
-            !!selectedProjectId &&
-            (loading || isPendingNewFetch || loadingDetail);
-          const mappingDisabledTooltip = isFetchingColumns
-            ? "Columns are being fetched"
-            : "";
-          return (
-            <Box>
-              <Typography
-                variant="caption"
-                fontWeight={600}
-                sx={{ mb: 0.5, display: "block" }}
-              >
-                Variable Mapping
-              </Typography>
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
-                {variables.map((variable) => {
-                  const autocomplete = (
-                    <Autocomplete
-                      size="small"
-                      freeSolo={allowCustomFieldPath}
-                      disabled={isFetchingColumns}
-                      options={
-                        mapping[variable] &&
+        {variables.length > 0 &&
+          (() => {
+            const isFetchingColumns =
+              !!selectedProjectId &&
+              (loading || isPendingNewFetch || loadingDetail);
+            const mappingDisabledTooltip = isFetchingColumns
+              ? "Columns are being fetched"
+              : "";
+            return (
+              <Box>
+                <Typography
+                  variant="caption"
+                  fontWeight={600}
+                  sx={{ mb: 0.5, display: "block" }}
+                >
+                  Variable Mapping
+                </Typography>
+                <Box
+                  sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}
+                >
+                  {variables.map((variable) => {
+                    const autocomplete = (
+                      <Autocomplete
+                        size="small"
+                        freeSolo={allowCustomFieldPath}
+                        disabled={isFetchingColumns}
+                        options={
+                          mapping[variable] &&
                           !fieldNames.includes(mapping[variable])
-                          ? [mapping[variable], ...fieldNames]
-                          : fieldNames
-                      }
-                      value={mapping[variable] || null}
-                      onChange={(_, val) =>
-                        setMapping((prev) => ({
-                          ...prev,
-                          [variable]: val || "",
-                        }))
-                      }
-                      {...(allowCustomFieldPath
-                        ? {
-                          inputValue: mapping[variable] || "",
-                          onInputChange: (_, val, reason) => {
-                            if (reason === "reset") return;
-                            setMapping((prev) => ({
-                              ...prev,
-                              [variable]: val || "",
-                            }));
-                          },
+                            ? [mapping[variable], ...fieldNames]
+                            : fieldNames
                         }
-                        : {})}
-                      openOnFocus
-                      autoHighlight
-                      selectOnFocus
-                      handleHomeEndKeys
-                      isOptionEqualToValue={(opt, val) => opt === val}
-                      sx={{ flex: 1 }}
-                      ListboxProps={{ style: { maxHeight: 260 } }}
-                      renderInput={(params) => (
-                        <TextField
-                          {...params}
-                          placeholder={
-                            isFetchingColumns
-                              ? "Loading columns..."
-                              : allowCustomFieldPath
-                                ? "Search or type a path (e.g. attributes.input.value)"
-                                : "Search column..."
-                          }
-                          InputProps={{
-                            ...params.InputProps,
-                            sx: {
-                              ...params.InputProps.sx,
-                              fontSize: "12px",
-                              fontFamily: "monospace",
-                              height: 28,
-                              py: 0,
-                            },
-                            endAdornment: isFetchingColumns ? (
-                              <InputAdornment position="end">
-                                <CircularProgress size={14} />
-                              </InputAdornment>
-                            ) : (
-                              params.InputProps.endAdornment
-                            ),
-                          }}
-                        />
-                      )}
-                      renderOption={(props, col) => {
-                        const { key, ...rest } = props;
-                        return (
-                          <Box
-                            component="li"
-                            key={key}
-                            {...rest}
-                            title={col}
-                            sx={{
-                              ...rest.sx,
-                              fontSize: "12px",
-                              fontFamily: "monospace",
-                              pl: col.includes(".")
-                                ? `${12 + (col.split(".").length - 1) * 12}px`
-                                : undefined,
-                              color: col.includes(".")
-                                ? "primary.main"
-                                : "text.primary",
-                              whiteSpace: "nowrap",
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
+                        value={mapping[variable] || null}
+                        onChange={(_, val) =>
+                          setMapping((prev) => ({
+                            ...prev,
+                            [variable]: val || "",
+                          }))
+                        }
+                        {...(allowCustomFieldPath
+                          ? {
+                              inputValue: mapping[variable] || "",
+                              onInputChange: (_, val, reason) => {
+                                if (reason === "reset") return;
+                                setMapping((prev) => ({
+                                  ...prev,
+                                  [variable]: val || "",
+                                }));
+                              },
+                            }
+                          : {})}
+                        openOnFocus
+                        autoHighlight
+                        selectOnFocus
+                        handleHomeEndKeys
+                        isOptionEqualToValue={(opt, val) => opt === val}
+                        sx={{ flex: 1 }}
+                        ListboxProps={{ style: { maxHeight: 260 } }}
+                        renderInput={(params) => (
+                          <TextField
+                            {...params}
+                            placeholder={
+                              isFetchingColumns
+                                ? "Loading columns..."
+                                : allowCustomFieldPath
+                                  ? "Search or type a path (e.g. attributes.input.value)"
+                                  : "Search column..."
+                            }
+                            InputProps={{
+                              ...params.InputProps,
+                              sx: {
+                                ...params.InputProps.sx,
+                                fontSize: "12px",
+                                fontFamily: "monospace",
+                                height: 28,
+                                py: 0,
+                              },
+                              endAdornment: isFetchingColumns ? (
+                                <InputAdornment position="end">
+                                  <CircularProgress size={14} />
+                                </InputAdornment>
+                              ) : (
+                                params.InputProps.endAdornment
+                              ),
                             }}
-                          >
-                            {col}
-                          </Box>
-                        );
-                      }}
-                    />
-                  );
-                  return (
-                    <Box
-                      key={variable}
-                      sx={{ display: "flex", alignItems: "center", gap: 1 }}
-                    >
-                      <Box
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 0.5,
-                          px: 1,
-                          py: 0.25,
-                          borderRadius: "4px",
-                          border: "1px solid",
-                          borderColor: "divider",
-                          minWidth: 120,
+                          />
+                        )}
+                        renderOption={(props, col) => {
+                          const { key, ...rest } = props;
+                          return (
+                            <Box
+                              component="li"
+                              key={key}
+                              {...rest}
+                              title={col}
+                              sx={{
+                                ...rest.sx,
+                                fontSize: "12px",
+                                fontFamily: "monospace",
+                                pl: col.includes(".")
+                                  ? `${12 + (col.split(".").length - 1) * 12}px`
+                                  : undefined,
+                                color: col.includes(".")
+                                  ? "primary.main"
+                                  : "text.primary",
+                                whiteSpace: "nowrap",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                              }}
+                            >
+                              {col}
+                            </Box>
+                          );
                         }}
-                      >
-                        <Iconify
-                          icon="mdi:code-braces"
-                          width={14}
-                          sx={{ color: "text.secondary" }}
-                        />
-                        <Typography
-                          variant="caption"
-                          fontWeight={600}
-                          sx={{ fontSize: "12px" }}
-                        >
-                          {variable}
-                        </Typography>
-                      </Box>
-                      <Iconify
-                        icon="mdi:arrow-right"
-                        width={14}
-                        sx={{ color: "text.disabled" }}
                       />
-                      {isFetchingColumns ? (
-                        <CustomTooltip
-                          show
-                          type="black"
-                          size="small"
-                          title={mappingDisabledTooltip}
-                          placement="top"
-                          arrow
+                    );
+                    return (
+                      <Box
+                        key={variable}
+                        sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                      >
+                        <Box
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 0.5,
+                            px: 1,
+                            py: 0.25,
+                            borderRadius: "4px",
+                            border: "1px solid",
+                            borderColor: "divider",
+                            minWidth: 120,
+                          }}
                         >
-                          <Box sx={{ flex: 1 }}>{autocomplete}</Box>
-                        </CustomTooltip>
-                      ) : (
-                        autocomplete
-                      )}
-                    </Box>
-                  );
-                })}
+                          <Iconify
+                            icon="mdi:code-braces"
+                            width={14}
+                            sx={{ color: "text.secondary" }}
+                          />
+                          <Typography
+                            variant="caption"
+                            fontWeight={600}
+                            sx={{ fontSize: "12px" }}
+                          >
+                            {variable}
+                          </Typography>
+                        </Box>
+                        <Iconify
+                          icon="mdi:arrow-right"
+                          width={14}
+                          sx={{ color: "text.disabled" }}
+                        />
+                        {isFetchingColumns ? (
+                          <CustomTooltip
+                            show
+                            type="black"
+                            size="small"
+                            title={mappingDisabledTooltip}
+                            placement="top"
+                            arrow
+                          >
+                            <Box sx={{ flex: 1 }}>{autocomplete}</Box>
+                          </CustomTooltip>
+                        ) : (
+                          autocomplete
+                        )}
+                      </Box>
+                    );
+                  })}
+                </Box>
               </Box>
-            </Box>
-          );
-        })()}
+            );
+          })()}
 
         {/* Result */}
         {result && (

--- a/frontend/src/sections/evals/utils/__tests__/evalExecution.test.js
+++ b/frontend/src/sections/evals/utils/__tests__/evalExecution.test.js
@@ -1,0 +1,361 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildAutoCtx,
+  buildCompositeCtx,
+  buildFlatValueMap,
+  executeEvalForRow,
+  normalizeRowType,
+  resolveMappingFromRow,
+} from "../evalExecution";
+
+// We mock the axios *module* used by the helper. The helper imports the
+// default export and pushes `endpoints` through the same module, so both
+// `axios.post` and `endpoints.develop.eval.*` resolve to the mock.
+vi.mock("src/utils/axios", () => {
+  const post = vi.fn();
+  return {
+    default: { post },
+    endpoints: {
+      develop: {
+        eval: {
+          evalPlayground: "/model-hub/eval-playground/",
+          executeCompositeEval: (id) =>
+            `/model-hub/eval-templates/${id}/composite/execute/`,
+          executeCompositeEvalAdhoc:
+            "/model-hub/eval-templates/composite/execute-adhoc/",
+        },
+      },
+    },
+  };
+});
+
+import axios from "src/utils/axios";
+
+const POST = axios.post;
+
+beforeEach(() => {
+  POST.mockReset();
+});
+
+describe("normalizeRowType", () => {
+  it.each([
+    ["Span", "Span"],
+    ["spans", "Span"],
+    ["TRACE", "Trace"],
+    ["traces", "Trace"],
+    ["session", "Session"],
+    ["sessions", "Session"],
+    ["voicecall", "VoiceCall"],
+    ["voice_calls", "VoiceCall"],
+    ["voiceCalls", "VoiceCall"],
+    [undefined, "Span"],
+    [null, "Span"],
+    ["nonsense", "Span"],
+  ])("normalizes %p -> %p", (input, expected) => {
+    expect(normalizeRowType(input)).toBe(expected);
+  });
+});
+
+describe("buildAutoCtx", () => {
+  const spanRow = { span_id: "s1", trace_id: "t1", session_id: null };
+  it("sends span_id + trace_id for Span", () => {
+    expect(buildAutoCtx({ rowType: "Span", currentRow: spanRow })).toEqual({
+      span_id: "s1",
+      trace_id: "t1",
+    });
+  });
+  it("sends only trace_id for Trace", () => {
+    expect(buildAutoCtx({ rowType: "Trace", currentRow: spanRow })).toEqual({
+      trace_id: "t1",
+    });
+  });
+  it("sends only session_id for Session", () => {
+    expect(
+      buildAutoCtx({
+        rowType: "Session",
+        currentRow: { session_id: "sess1" },
+      }),
+    ).toEqual({ session_id: "sess1" });
+  });
+  it("sends trace_id for VoiceCall", () => {
+    expect(
+      buildAutoCtx({ rowType: "VoiceCall", currentRow: { trace_id: "t1" } }),
+    ).toEqual({ trace_id: "t1" });
+  });
+  it("returns empty when currentRow is null", () => {
+    expect(buildAutoCtx({ rowType: "Span", currentRow: null })).toEqual({});
+  });
+});
+
+describe("buildCompositeCtx", () => {
+  it("sends span_context = spanDetail for Span", () => {
+    const spanDetail = { foo: "bar" };
+    const currentRow = { span_id: "s1" };
+    expect(
+      buildCompositeCtx({ rowType: "Span", currentRow, spanDetail }),
+    ).toEqual({ span_context: spanDetail });
+  });
+  it("sends trace_context = currentRow for Trace", () => {
+    const row = { trace_id: "t1" };
+    expect(
+      buildCompositeCtx({ rowType: "Trace", currentRow: row, spanDetail: {} }),
+    ).toEqual({ trace_context: row });
+  });
+  it("sends session_context = currentRow for Session", () => {
+    const row = { session_id: "sess1" };
+    expect(
+      buildCompositeCtx({
+        rowType: "Session",
+        currentRow: row,
+        spanDetail: null,
+      }),
+    ).toEqual({ session_context: row });
+  });
+  it("sends trace_context = currentRow for VoiceCall", () => {
+    const row = { trace_id: "t1" };
+    expect(
+      buildCompositeCtx({
+        rowType: "VoiceCall",
+        currentRow: row,
+        spanDetail: null,
+      }),
+    ).toEqual({ trace_context: row });
+  });
+});
+
+describe("buildFlatValueMap", () => {
+  it("returns empty for null/undefined", () => {
+    expect(buildFlatValueMap(null)).toEqual({});
+    expect(buildFlatValueMap(undefined)).toEqual({});
+  });
+
+  it("soft-flattens span_attributes prefixes — top-level wins", () => {
+    const detail = {
+      input: { value: "top" },
+      span_attributes: { input: { value: "nested" } },
+    };
+    const flat = buildFlatValueMap(detail);
+    // Top-level `input.value` wins because the stripped form already
+    // exists from the unstripped walk; nested wouldn't overwrite.
+    expect(flat["input.value"]).toBe("top");
+  });
+
+  it("exposes nested span_attributes paths under their stripped names", () => {
+    const detail = {
+      span_attributes: { gen_ai: { response: { id: "abc" } } },
+    };
+    const flat = buildFlatValueMap(detail);
+    expect(flat["gen_ai.response.id"]).toBe("abc");
+  });
+});
+
+describe("resolveMappingFromRow", () => {
+  it("returns variable->string for present fields, stringifies objects", () => {
+    const flat = { "input.value": "hello", payload: { x: 1 } };
+    expect(
+      resolveMappingFromRow(
+        { question: "input.value", body: "payload" },
+        flat,
+      ),
+    ).toEqual({ question: "hello", body: '{"x":1}' });
+  });
+
+  it("falls back to rowFields when the flat lookup misses", () => {
+    const rowFields = [{ key: "annotation_label", raw: "good" }];
+    expect(
+      resolveMappingFromRow({ q: "annotation_label" }, {}, rowFields),
+    ).toEqual({ q: "good" });
+  });
+
+  it("skips variables whose field is empty or whose value is undefined", () => {
+    expect(
+      resolveMappingFromRow({ a: "", b: "missing" }, { other: "x" }),
+    ).toEqual({});
+  });
+});
+
+describe("executeEvalForRow — single eval", () => {
+  it("posts to /eval-playground/ with autoCtx + resolved mapping for Span", async () => {
+    POST.mockResolvedValueOnce({
+      data: { status: true, result: { score: 1, log_id: "log-1" } },
+    });
+    const flatValueMap = { "input.value": "hi" };
+    const result = await executeEvalForRow({
+      evalItem: { template_id: "tpl-1", model: "turing_large" },
+      rowType: "Span",
+      currentRow: { span_id: "s1", trace_id: "t1" },
+      spanDetail: {},
+      mapping: { question: "input.value" },
+      flatValueMap,
+    });
+    expect(POST).toHaveBeenCalledWith("/model-hub/eval-playground/", {
+      template_id: "tpl-1",
+      model: "turing_large",
+      error_localizer: false,
+      config: { mapping: { question: "hi" } },
+      span_id: "s1",
+      trace_id: "t1",
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      isComposite: false,
+      logId: "log-1",
+    });
+  });
+
+  it("uses mapping_paths and omits config.mapping for Session", async () => {
+    POST.mockResolvedValueOnce({
+      data: { status: true, result: { score: 0.5 } },
+    });
+    await executeEvalForRow({
+      evalItem: { template_id: "tpl-1" },
+      rowType: "Session",
+      currentRow: { session_id: "sess1" },
+      spanDetail: null,
+      mapping: { input: "user_message_text" },
+      singleEvalConfigExtras: {
+        run_config: { data_injection: { messages: true } },
+      },
+    });
+    expect(POST).toHaveBeenCalledWith("/model-hub/eval-playground/", {
+      template_id: "tpl-1",
+      model: "turing_large",
+      error_localizer: false,
+      config: { run_config: { data_injection: { messages: true } } },
+      mapping_paths: { input: "user_message_text" },
+      session_id: "sess1",
+    });
+  });
+
+  it("returns ok:false with errorMessage on non-status response", async () => {
+    POST.mockResolvedValueOnce({
+      data: { status: false, result: "boom" },
+    });
+    const result = await executeEvalForRow({
+      evalItem: { template_id: "tpl-1" },
+      rowType: "Span",
+      currentRow: { span_id: "s1" },
+      spanDetail: {},
+      mapping: {},
+    });
+    expect(result).toMatchObject({ ok: false, errorMessage: "boom" });
+  });
+
+  it("catches axios throw and returns ok:false", async () => {
+    POST.mockRejectedValueOnce({ message: "network down" });
+    const result = await executeEvalForRow({
+      evalItem: { template_id: "tpl-1" },
+      rowType: "Span",
+      currentRow: { span_id: "s1" },
+      spanDetail: {},
+      mapping: {},
+    });
+    expect(result).toMatchObject({ ok: false, errorMessage: "network down" });
+  });
+});
+
+describe("executeEvalForRow — composite", () => {
+  it("posts to /composite/execute/{id}/ with span_context for saved composite", async () => {
+    POST.mockResolvedValueOnce({
+      data: {
+        status: true,
+        result: {
+          aggregation_enabled: true,
+          aggregate_score: 0.8,
+          summary: "looks good",
+        },
+      },
+    });
+    const spanDetail = { foo: "bar" };
+    const result = await executeEvalForRow({
+      evalItem: {
+        template_id: "tpl-c",
+        template_type: "composite",
+        model: "turing_large",
+      },
+      rowType: "Span",
+      currentRow: { span_id: "s1" },
+      spanDetail,
+      mapping: {},
+      flatValueMap: {},
+    });
+    expect(POST).toHaveBeenCalledWith(
+      "/model-hub/eval-templates/tpl-c/composite/execute/",
+      {
+        mapping: {},
+        model: "turing_large",
+        error_localizer: false,
+        config: {},
+        span_context: spanDetail,
+      },
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      isComposite: true,
+      output: 0.8,
+      reason: "looks good",
+    });
+    expect(result.compositeResult).toEqual({
+      aggregation_enabled: true,
+      aggregate_score: 0.8,
+      summary: "looks good",
+    });
+  });
+
+  it("posts to /composite/execute-adhoc/ when compositeAdhocConfig is provided", async () => {
+    POST.mockResolvedValueOnce({
+      data: {
+        status: true,
+        result: { aggregation_enabled: false, summary: "n/a" },
+      },
+    });
+    const compositeAdhocConfig = {
+      child_template_ids: ["a", "b"],
+      child_configs: {},
+      aggregation_enabled: false,
+      pass_threshold: 0.5,
+    };
+    await executeEvalForRow({
+      evalItem: { model: "turing_large" }, // no template_type — adhoc forces composite
+      rowType: "Trace",
+      currentRow: { trace_id: "t1" },
+      spanDetail: {},
+      mapping: {},
+      flatValueMap: {},
+      compositeAdhocConfig,
+    });
+    expect(POST).toHaveBeenCalledWith(
+      "/model-hub/eval-templates/composite/execute-adhoc/",
+      expect.objectContaining({
+        ...compositeAdhocConfig,
+        model: "turing_large",
+        error_localizer: false,
+        config: {},
+        trace_context: { trace_id: "t1" },
+      }),
+    );
+  });
+
+  it("aggregate_score is null when aggregation is disabled", async () => {
+    POST.mockResolvedValueOnce({
+      data: {
+        status: true,
+        result: {
+          aggregation_enabled: false,
+          aggregate_score: 0.4,
+          summary: "",
+        },
+      },
+    });
+    const result = await executeEvalForRow({
+      evalItem: { template_id: "tpl-c", template_type: "composite" },
+      rowType: "Span",
+      currentRow: { span_id: "s1" },
+      spanDetail: {},
+      mapping: {},
+      flatValueMap: {},
+    });
+    expect(result.output).toBeNull();
+  });
+});

--- a/frontend/src/sections/evals/utils/evalExecution.js
+++ b/frontend/src/sections/evals/utils/evalExecution.js
@@ -1,0 +1,254 @@
+// Shared router for the "Test eval against a tracing row" surfaces
+// (TracingTestMode, TaskLivePreview). Routes between `/eval-playground/`,
+// `/composite/execute/`, and `/composite/execute-adhoc/` so the
+// composite-vs-single decision lives in one place.
+
+import axios, { endpoints } from "src/utils/axios";
+import { canonicalEntries, stripAttributePathPrefix } from "src/utils/utils";
+
+import { buildCompositeRuntimeConfig } from "../Helpers/compositeRuntimeConfig";
+
+// Walk limits match the mapping-dropdown walker so every path the user can
+// pick during mapping also resolves at test time.
+const ARRAY_PEEK = 500;
+const DICT_LIMIT = 5000;
+
+export const normalizeRowType = (value) => {
+  if (!value) return "Span";
+  const v = String(value).toLowerCase();
+  if (v === "span" || v === "spans") return "Span";
+  if (v === "trace" || v === "traces") return "Trace";
+  if (v === "session" || v === "sessions") return "Session";
+  if (
+    v === "voicecall" ||
+    v === "voicecalls" ||
+    v === "voice_calls" ||
+    v === "voice"
+  ) {
+    return "VoiceCall";
+  }
+  return "Span";
+};
+
+// Single-eval ctx: just IDs — the BE resolves {{span}}/{{trace}}/{{session}}.
+export const buildAutoCtx = ({ rowType, currentRow }) => {
+  const ctx = {};
+  if (!currentRow) return ctx;
+  const t = normalizeRowType(rowType);
+  const spanId = currentRow.span_id || currentRow.spanId;
+  const traceId = currentRow.trace_id || currentRow.traceId;
+  const sessionId = currentRow.session_id || currentRow.sessionId;
+  if (t === "Span" && spanId) ctx.span_id = spanId;
+  if ((t === "Span" || t === "Trace") && traceId) ctx.trace_id = traceId;
+  if (t === "Session" && sessionId) ctx.session_id = sessionId;
+  if (t === "VoiceCall" && traceId) ctx.trace_id = traceId;
+  return ctx;
+};
+
+// Composite ctx: full objects — the composite endpoint doesn't resolve IDs.
+export const buildCompositeCtx = ({ rowType, currentRow, spanDetail }) => {
+  const ctx = {};
+  const t = normalizeRowType(rowType);
+  if (t === "Span" && spanDetail) ctx.span_context = spanDetail;
+  if (t === "Trace" && currentRow) ctx.trace_context = currentRow;
+  if (t === "Session" && currentRow) ctx.session_context = currentRow;
+  if (t === "VoiceCall" && currentRow) ctx.trace_context = currentRow;
+  return ctx;
+};
+
+// Walks spanDetail into a flat `{ "soft-flattened.path": value }` lookup.
+// "span_attributes.x.y" collapses to "x.y" so saved mappings (which store
+// the stripped form) resolve. Top-level paths win over stripped ones.
+export const buildFlatValueMap = (spanDetail) => {
+  if (!spanDetail) return {};
+  const valueMap = {};
+  const walk = (node, prefix) => {
+    if (Array.isArray(node)) {
+      node.slice(0, ARRAY_PEEK).forEach((item, idx) => {
+        const path = prefix ? `${prefix}.${idx}` : String(idx);
+        valueMap[path] = item;
+        if (item && typeof item === "object") {
+          walk(item, path);
+        }
+      });
+      return;
+    }
+    // canonicalEntries skips the camelCase aliases the axios interceptor
+    // layers on, so we only walk the snake side.
+    for (const [k, v] of canonicalEntries(node)) {
+      if (k.startsWith("_")) continue;
+      const path = prefix ? `${prefix}.${k}` : k;
+      valueMap[path] = v;
+      if (v && typeof v === "object") {
+        if (Array.isArray(v) || Object.keys(v).length < DICT_LIMIT) {
+          walk(v, path);
+        }
+      }
+    }
+  };
+  walk(spanDetail, "");
+
+  const flat = {};
+  for (const [path, val] of Object.entries(valueMap)) {
+    const short = stripAttributePathPrefix(path);
+    if (!(short in flat) || short === path) {
+      flat[short] = val;
+    }
+  }
+  return flat;
+};
+
+// `rowFields` is an optional fallback for fields not present in spanDetail
+// (e.g. annotation columns in the TracingTestMode mapping panel).
+export const resolveMappingFromRow = (mapping, flatValueMap, rowFields) => {
+  const resolved = {};
+  for (const [variable, field] of Object.entries(mapping || {})) {
+    if (!field) continue;
+    let val = flatValueMap?.[field];
+    if (val === undefined && Array.isArray(rowFields)) {
+      const rf = rowFields.find(
+        (f) => f.key === field || f.colId === field,
+      );
+      if (rf?.raw !== undefined && rf.raw !== null) {
+        val = rf.raw;
+      }
+    }
+    if (val !== undefined && val !== null) {
+      resolved[variable] =
+        typeof val === "object" ? JSON.stringify(val) : String(val);
+    }
+  }
+  return resolved;
+};
+
+// Returns: { ok, isComposite, output, reason, compositeResult, logId, raw, errorMessage }
+//
+// `singleEvalConfigExtras` / `compositeConfigExtras` are merged into the
+// outgoing `config` — callers use them to forward saved `run_config` flags
+// (TaskLivePreview) or UI-form params (TracingTestMode).
+export const executeEvalForRow = async ({
+  evalItem,
+  rowType,
+  currentRow,
+  spanDetail,
+  mapping,
+  flatValueMap,
+  rowFields,
+  codeParams,
+  errorLocalizerEnabled = false,
+  compositeAdhocConfig = null,
+  singleEvalConfigExtras = {},
+  compositeConfigExtras = {},
+}) => {
+  const templateId = evalItem?.template_id ?? evalItem?.templateId;
+  const model = evalItem?.model || "turing_large";
+  const templateType = evalItem?.template_type ?? evalItem?.templateType;
+  const isComposite =
+    templateType === "composite" || !!compositeAdhocConfig;
+  const t = normalizeRowType(rowType);
+  const isSession = t === "Session";
+
+  // Sessions skip the walk — single delegates via `mapping_paths`, composite
+  // uses `session_context = currentRow`.
+  const flat =
+    flatValueMap ??
+    (isSession ? {} : buildFlatValueMap(spanDetail));
+
+  const resolvedMapping = resolveMappingFromRow(mapping, flat, rowFields);
+
+  try {
+    if (isComposite) {
+      const compositeCtx = buildCompositeCtx({
+        rowType: t,
+        currentRow,
+        spanDetail,
+      });
+      const compositeConfig = buildCompositeRuntimeConfig({
+        config: compositeConfigExtras,
+        codeParams,
+      });
+      const basePayload = {
+        mapping: resolvedMapping,
+        model,
+        error_localizer: errorLocalizerEnabled,
+        config: compositeConfig,
+        ...compositeCtx,
+      };
+      const url = compositeAdhocConfig
+        ? endpoints.develop.eval.executeCompositeEvalAdhoc
+        : endpoints.develop.eval.executeCompositeEval(templateId);
+      const payload = compositeAdhocConfig
+        ? { ...compositeAdhocConfig, ...basePayload }
+        : basePayload;
+      const { data } = await axios.post(url, payload);
+      if (!data?.status) {
+        return {
+          ok: false,
+          isComposite: true,
+          errorMessage: data?.result || "Evaluation failed",
+          raw: data,
+        };
+      }
+      const result = data.result;
+      return {
+        ok: true,
+        isComposite: true,
+        output:
+          result?.aggregation_enabled && result?.aggregate_score != null
+            ? result.aggregate_score
+            : null,
+        reason: result?.summary || "",
+        compositeResult: result,
+        raw: result,
+      };
+    }
+
+    // Single-eval: sessions send `mapping_paths` (BE resolves against the
+    // real DB); other row types send the locally-resolved `mapping`.
+    const autoCtx = buildAutoCtx({ rowType: t, currentRow });
+    const singleConfig = { ...singleEvalConfigExtras };
+    if (!isSession) singleConfig.mapping = resolvedMapping;
+    if (codeParams && Object.keys(codeParams).length > 0) {
+      singleConfig.params = { ...(singleConfig.params || {}), ...codeParams };
+    }
+    const payload = {
+      template_id: templateId,
+      model,
+      error_localizer: errorLocalizerEnabled,
+      config: singleConfig,
+      ...(isSession ? { mapping_paths: mapping || {} } : {}),
+      ...autoCtx,
+    };
+    const { data } = await axios.post(
+      endpoints.develop.eval.evalPlayground,
+      payload,
+    );
+    if (!data?.status) {
+      return {
+        ok: false,
+        isComposite: false,
+        errorMessage: data?.result || "Evaluation failed",
+        raw: data,
+      };
+    }
+    return {
+      ok: true,
+      isComposite: false,
+      output: data.result,
+      raw: data.result,
+      logId: data.result?.log_id ?? null,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      isComposite,
+      errorMessage:
+        err?.response?.data?.result ||
+        err?.result ||
+        err?.detail ||
+        err?.message ||
+        "Failed to run evaluation",
+      raw: err,
+    };
+  }
+};

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -23,6 +23,10 @@ import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import { canonicalEntries, stripAttributePathPrefix } from "src/utils/utils";
 import { ROW_TYPE_LABELS } from "src/utils/constants";
+import {
+  buildFlatValueMap,
+  executeEvalForRow,
+} from "src/sections/evals/utils/evalExecution";
 import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 
@@ -516,91 +520,13 @@ const TaskLivePreview = forwardRef(function TaskLivePreview(
   const handleRunTest = useCallback(async () => {
     if (!currentRow || !evalsDetails?.length || !spanDetail) return;
 
-    const _spanId = currentRow?.span_id;
-    const _traceId = currentRow?.trace_id;
-    const _sessionId = currentRow?.session_id;
-
-    const autoCtx = {};
-    if (rowType === "spans" && _spanId) autoCtx.span_id = _spanId;
-    if ((rowType === "spans" || rowType === "traces") && _traceId)
-      autoCtx.trace_id = _traceId;
-    if (rowType === "sessions" && _sessionId) autoCtx.session_id = _sessionId;
-    if (rowType === "voiceCalls" && _traceId) autoCtx.trace_id = _traceId;
-
-    // Sessions: the lazy fetch only populates `traces[0].spans` (other
-    // traces have empty `spans` arrays), so a walk over spanDetail can't
-    // resolve mappings into unloaded traces. The BE's
-    // `_process_session_mapping` walks the real DB and handles every path
-    // correctly — delegate by sending the saved mapping as `mapping_paths`
-    // alongside `session_id` (already in autoCtx). Same code path as
-    // eval-task runtime, so preview matches prod.
+    // Sessions delegate mapping resolution to the BE via `mapping_paths`,
+    // so the local walk is skipped. Other row types walk once and reuse
+    // the same lookup across every eval on this row.
     const isSession = rowType === "sessions";
-
-    // Build a flat fieldName→value lookup by walking spanDetail,
-    // soft-flattening span_attributes keys (same logic as the
-    // fieldNames dropdown in TracingTestMode). This ensures mapped
-    // fields like "input.value" (stripped from "span_attributes.input.value")
-    // resolve correctly even when a top-level "input" shadows the path.
-    // Limits match the dropdown walker in TracingTestMode so every path
-    // offered to the user during mapping also resolves at test time.
-    const ARRAY_PEEK = 500;
-    const DICT_LIMIT = 5000;
-    const valueMap = {};
-    const walkValues = (node, prefix) => {
-      if (Array.isArray(node)) {
-        node.slice(0, ARRAY_PEEK).forEach((item, idx) => {
-          const path = prefix ? `${prefix}.${idx}` : String(idx);
-          valueMap[path] = item;
-          if (item && typeof item === "object") {
-            walkValues(item, path);
-          }
-        });
-        return;
-      }
-      // canonicalEntries drops the camelCase aliases the axios interceptor
-      // layers on — otherwise `span_attributes.*` and `spanAttributes.*`
-      // both end up in valueMap and only the snake side gets stripped.
-      for (const [k, v] of canonicalEntries(node)) {
-        if (k.startsWith("_")) continue;
-        const path = prefix ? `${prefix}.${k}` : k;
-        valueMap[path] = v;
-        if (v && typeof v === "object") {
-          if (Array.isArray(v) || Object.keys(v).length < DICT_LIMIT) {
-            walkValues(v, path);
-          }
-        }
-      }
-    };
-    if (!isSession) walkValues(spanDetail, "");
-
-    // Soft-flatten: route through `stripAttributePathPrefix` so any
-    // `span_attributes.` segment — anchored *or* nested inside `spans.<n>.`
-    // or `traces.<i>.spans.<j>.` — collapses to the same form the BE
-    // dropdown emits and that saved mappings store. Top-level keys (i.e.
-    // paths that did NOT need stripping) win the dedupe.
-    const flatValueMap = {};
-    for (const [path, val] of Object.entries(valueMap)) {
-      const short = stripAttributePathPrefix(path);
-      if (!(short in flatValueMap) || short === path) {
-        flatValueMap[short] = val;
-      }
-    }
-
-    const resolveMapping = (mapping) => {
-      const resolved = {};
-      for (const [variable, field] of Object.entries(mapping || {})) {
-        if (!field) continue;
-        const val = flatValueMap[field];
-        if (val !== undefined && val !== null) {
-          resolved[variable] =
-            typeof val === "object" ? JSON.stringify(val) : String(val);
-        }
-      }
-      return resolved;
-    };
+    const flatValueMap = isSession ? {} : buildFlatValueMap(spanDetail);
 
     setIsTesting(true);
-    // Initialize all to running
     setTestResults(
       evalsDetails.reduce((acc, _ev, idx) => {
         acc[idx] = { status: "running" };
@@ -608,75 +534,62 @@ const TaskLivePreview = forwardRef(function TaskLivePreview(
       }, {}),
     );
 
-    // Run evals in parallel — each one independently
     await Promise.all(
       evalsDetails.map(async (evalItem, idx) => {
-        try {
-          const templateId = evalItem?.template_id;
-          if (!templateId) {
-            setTestResults((prev) => ({
-              ...prev,
-              [idx]: {
-                status: "error",
-                error: "Missing template id — re-add this eval",
-              },
-            }));
-            return;
-          }
-          // Build data_injection flags from the eval's saved config
-          // so the BE enables the correct context toggles (same as
-          // EvalPickerConfigFull does for tracing tab).
-          const diFlags =
-            evalItem?.data_injection ||
-            evalItem?.config?.run_config?.data_injection ||
-            evalItem?.config?.data_injection ||
-            {};
-          // Sessions delegate path resolution to the BE
-          // (`_process_session_mapping`) — see `isSession` branch above.
-          // Other row types resolve locally because their lazy fetch
-          // returns the full data they need.
-          const savedMapping = evalItem?.mapping || {};
-          const playgroundConfig = {
-            ...(Object.keys(diFlags).length > 0
-              ? { run_config: { data_injection: diFlags } }
-              : {}),
-          };
-          if (!isSession) {
-            playgroundConfig.mapping = resolveMapping(savedMapping);
-          }
-          const { data } = await axios.post(
-            endpoints.develop.eval.evalPlayground,
-            {
-              template_id: templateId,
-              model: evalItem?.model || "turing_large",
-              config: playgroundConfig,
-              ...(isSession ? { mapping_paths: savedMapping } : {}),
-              ...autoCtx,
-            },
-          );
-          if (data?.status) {
-            setTestResults((prev) => ({
-              ...prev,
-              [idx]: { status: "success", result: data.result },
-            }));
-          } else {
-            setTestResults((prev) => ({
-              ...prev,
-              [idx]: {
-                status: "error",
-                error: data?.result || "Evaluation failed",
-              },
-            }));
-          }
-        } catch (err) {
+        const templateId = evalItem?.template_id;
+        if (!templateId) {
           setTestResults((prev) => ({
             ...prev,
             [idx]: {
               status: "error",
-              error:
-                err?.response?.data?.result ||
-                err?.message ||
-                "Failed to run eval",
+              error: "Missing template id — re-add this eval",
+            },
+          }));
+          return;
+        }
+        // Forward the saved data_injection flags so the BE enables the
+        // matching auto-context (matches EvalPickerConfigFull's tracing tab).
+        const diFlags =
+          evalItem?.data_injection ||
+          evalItem?.config?.run_config?.data_injection ||
+          evalItem?.config?.data_injection ||
+          {};
+        const configExtras =
+          Object.keys(diFlags).length > 0
+            ? { run_config: { data_injection: diFlags } }
+            : {};
+        const result = await executeEvalForRow({
+          evalItem,
+          rowType,
+          currentRow,
+          spanDetail,
+          mapping: evalItem?.mapping || {},
+          flatValueMap,
+          singleEvalConfigExtras: configExtras,
+          compositeConfigExtras: configExtras,
+        });
+        if (result.ok) {
+          setTestResults((prev) => ({
+            ...prev,
+            [idx]: {
+              status: "success",
+              // EvalResultDisplay reads `compositeResult` for composite or
+              // the legacy `output`/`reason`/`score` keys for single.
+              result: result.isComposite
+                ? {
+                    output: result.output,
+                    reason: result.reason,
+                    compositeResult: result.compositeResult,
+                  }
+                : result.raw,
+            },
+          }));
+        } else {
+          setTestResults((prev) => ({
+            ...prev,
+            [idx]: {
+              status: "error",
+              error: result.errorMessage || "Failed to run eval",
             },
           }));
         }


### PR DESCRIPTION
## Problem

`TaskLivePreview.handleRunTest` (the Test button on the Task create/detail page) was unconditionally POSTing every attached eval to `/model-hub/eval-playground/` — the single-eval endpoint. Composite templates silently went through the wrong path and rendered as a flat "Passed" chip instead of the per-child `CompositeResultView` you see in the Evals tab.

Same composite test from `EvalDetail → Tracing tab` was unaffected because `TracingTestMode` already branches on `template_type === "composite"`.

## Fix

Extract the composite-vs-single routing + payload assembly into one helper (`sections/evals/utils/evalExecution.js`) and rewire both `TracingTestMode` and `TaskLivePreview` through it. After the change, exactly one place decides which of the three endpoints to hit (`/eval-playground/`, `/composite/execute/`, `/composite/execute-adhoc/`) for any tracing-rooted Test surface, so the decision can't drift again.

`TaskLivePreview` now:
- Hits `/composite/execute/{template_id}/` for composite evals with the right `span_context` / `trace_context` / `session_context` field.
- Forwards the `{ output, reason, compositeResult }` envelope so `EvalResultDisplay` short-circuits to `CompositeResultView`.
- Preserves today's behavior for single evals: `mapping_paths` shortcut on sessions, `run_config.data_injection` flags from the saved eval, `autoCtx` IDs.

## Files

- **New** `frontend/src/sections/evals/utils/evalExecution.js` — builders (`buildAutoCtx`, `buildCompositeCtx`, `buildFlatValueMap`, `resolveMappingFromRow`, `normalizeRowType`) + orchestrator (`executeEvalForRow`).
- **New** `frontend/src/sections/evals/utils/__tests__/evalExecution.test.js` — 34 tests covering every builder and each routing branch (composite-saved, composite-adhoc, single span, single session with `mapping_paths`, failed status, axios throw).
- **Edit** `frontend/src/sections/evals/components/TracingTestMode.jsx` — `handleRunTest` shrunk from ~200 lines of inline branching to ~50 lines that delegate to the helper. Error-localizer poll trigger preserved. Drops the now-redundant `useExecuteCompositeEvalAdhoc` hook and `buildCompositeRuntimeConfig` import.
- **Edit** `frontend/src/sections/tasks/components/TaskLivePreview.jsx` — inner `Promise.all` loop now calls `executeEvalForRow` instead of POSTing to `/eval-playground/` directly.

## Verification

- `pnpm vitest run` — 34/34 helper tests pass; existing `EvalPickerCreateNew.test.jsx` (the only test mocking `TracingTestMode`) still passes.
- Lint clean on all touched files (only pre-existing unrelated warnings remain).
- Manual on local: composite eval attached to a task → Test on span/trace/session row → DevTools confirms `/composite/execute/{id}/` is hit with the right `*_context`, and `CompositeResultView` renders with per-child cards + aggregate score.

## Manual verification still recommended before merge

1. Task with a composite eval → Test on a span/trace/session row → `/composite/execute/{id}/` (the bug being fixed).
2. Task with a single eval → `/eval-playground/` still hit with `mapping_paths` on sessions and `run_config.data_injection` preserved.
3. EvalDetail composite eval → Tracing tab Test → `/composite/execute/{id}/`.
4. EvalPickerCreateNew composite create → Tracing source Test → `/composite/execute-adhoc/`.
5. EvalDetail single eval → Tracing tab Test → `/eval-playground/` + error-localizer polling fires when enabled and `log_id` is on the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)