### PR TITLE
 Fix org-removed login redirect bouncing back to login

### DIFF
--- a/frontend/src/auth/guard/auth-guard.jsx
+++ b/frontend/src/auth/guard/auth-guard.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 import { paths } from "src/routes/paths";
 import { useRouter } from "src/routes/hooks";
@@ -38,10 +38,11 @@ AuthGuard.propTypes = {
 function Container({ children }) {
   const router = useRouter();
 
-  const { authenticated, method, user } = useAuthContext();
+  const { authenticated, method, user, initialize } = useAuthContext();
   const postLoginPath = usePostLoginPath();
 
   const [checked, setChecked] = useState(false);
+  const hydrateAttempted = useRef(false);
 
   const {
     currentOrganizationName,
@@ -85,6 +86,15 @@ function Container({ children }) {
         // }
         return;
       }
+
+
+      const existingToken = localStorage.getItem("accessToken");
+      if (existingToken && !hydrateAttempted.current) {
+        hydrateAttempted.current = true;
+        initialize();
+        return;
+      }
+
       const parameters = window.location.search;
       const searchParams = new URLSearchParams({
         returnTo: window.location.pathname + parameters,
@@ -98,7 +108,7 @@ function Container({ children }) {
     } else {
       setChecked(true);
     }
-  }, [authenticated, method, router]);
+  }, [authenticated, method, router, initialize]);
 
   useEffect(() => {
     check();


### PR DESCRIPTION
## Summary

A user who has been removed from their organization could not reach the
`/auth/jwt/org-removed` page after logging in — they were bounced straight
back to the login screen.

The `org-removed` route is wrapped in `AuthGuard`, which treats a user as
authenticated only when the context `user` is populated. The login view's
`requires_org_setup` branch writes the access token via `setSession(...)` and
navigates to `org-removed`, but never populates the context `user`, so
`authenticated` stays `false` and `AuthGuard` redirects to login before the
page can render.

`AuthGuard` now hydrates the session from the stored token before falling back
to the login redirect: when a valid `accessToken` exists but the context isn't
hydrated, it calls `initialize()` once (guarded by a ref) to load `/me`. This
populates the org-less user, flips `authenticated` to `true`, and lets the
`org-removed` page render. A genuinely invalid token clears itself during
`initialize()` and falls through to the login redirect on the next pass, so
there is no redirect loop.

This is a general fix — any "valid token present but context stale" case now
self-heals instead of dumping the user at login. The login view is unchanged.

## Test plan

- [x] Log in as a user removed from their org → lands on `/auth/jwt/org-removed` (no bounce to login).
- [x] Hard-reload `/auth/jwt/org-removed` with the token present → still renders.
- [x] Log in as a normal user → routes to dashboard / get-started as before (no regression).
- [x] Log in with an invalid/expired token state → redirects to login, no infinite `/me` loop.
- [x] Confirm no new lint errors in `auth-guard.jsx`.


Closes TH-5596