### PR TITLE
fix(observe): run AI filter from the trace filter Apply button

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -1965,6 +1965,14 @@ const TraceFilterPanel = ({
     }
   }, [aiQuery, aiParseQuery, observeId, source, properties, onApply, onClose]);
 
+  const handlePrimaryApply = useCallback(() => {
+    if (showAi && aiQuery.trim()) {
+      handleAiFilter();
+      return;
+    }
+    handleApply();
+  }, [showAi, aiQuery, handleAiFilter, handleApply]);
+
   return (
     <Popover
       open={open}
@@ -2134,7 +2142,8 @@ const TraceFilterPanel = ({
                   size="small"
                   variant="contained"
                   data-filter-panel-action="apply"
-                  onClick={handleApply}
+                  onClick={handlePrimaryApply}
+                  disabled={aiLoading}
                   sx={{
                     textTransform: "none",
                     fontSize: 12,

--- a/frontend/src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
-import {
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "src/utils/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import TraceFilterPanel, {
   buildTraceFilterProperties,
   filterPropertiesForPicker,
   getTraceFilterFields,
@@ -9,6 +11,90 @@ import {
   getPickerOptionSearchText,
   getPickerOptionSecondaryLabel,
 } from "../filterValuePickerUtils";
+
+const parseQueryMock = vi.fn();
+
+vi.mock("src/hooks/use-ai-filter", () => ({
+  useAIFilter: () => ({
+    parseQuery: parseQueryMock,
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("src/hooks/useDashboards", () => ({
+  useDashboardFilterValues: () => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+describe("TraceFilterPanel AI apply (#577)", () => {
+  beforeEach(() => {
+    parseQueryMock.mockReset();
+  });
+
+  it("runs the AI filter when Apply is clicked with an AI query present", async () => {
+    parseQueryMock.mockResolvedValue([
+      { field: "status", operator: "equals", value: "ERROR" },
+    ]);
+    const onApply = vi.fn();
+    const onClose = vi.fn();
+    const anchorEl = document.createElement("button");
+    document.body.appendChild(anchorEl);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TraceFilterPanel
+          anchorEl={anchorEl}
+          open
+          onClose={onClose}
+          onApply={onApply}
+          currentFilters={[]}
+          properties={[
+            {
+              id: "status",
+              name: "Status",
+              category: "system",
+              type: "string",
+            },
+          ]}
+          showQueryTab={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/Ask AI/i), {
+      target: { value: "show errors" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(parseQueryMock).toHaveBeenCalledWith("show errors", {
+        smart: true,
+        projectId: undefined,
+        source: "traces",
+      });
+    });
+    expect(onApply).toHaveBeenCalledWith([
+      {
+        field: "status",
+        fieldCategory: "system",
+        fieldType: "string",
+        apiColType: undefined,
+        operator: "equals",
+        value: ["ERROR"],
+      },
+    ]);
+    expect(onClose).toHaveBeenCalled();
+
+    document.body.removeChild(anchorEl);
+  });
+});
 
 describe("getTraceFilterFields (TH-4571)", () => {
   it("prepends Trace ID when tab is 'trace'", () => {


### PR DESCRIPTION
## Summary

The "Apply" button in the Observe trace filter panel only applied the structured filter rows. Typing a query into the AI filter input and clicking Apply did nothing: the AI filter ran only when you clicked the small arrow icon inside the input (or pressed Enter).

This wires the panel's Apply button to run the AI filter when an AI query is present, and to fall back to the existing structured-row apply otherwise. The arrow icon and Enter already worked and are unchanged.

The change is scoped to the Basic tab's Apply, the button shown alongside the AI input on the default Observe view. The Query tab keeps its own structured-token apply.

## Linked issues

Closes #577

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

Added a regression test in `TraceFilterPanel.test.jsx` that renders the panel, types an AI query, clicks Apply, and asserts the AI parse runs and the converted filter is applied:

```
yarn vitest run src/sections/projects/LLMTracing/__tests__/TraceFilterPanel.test.jsx
# 11 passed
```

The test fails without the fix (Apply calls the structured apply, so the AI parse and the AI-derived `onApply` never fire) and passes with it. `eslint` and `prettier --check` are clean on the changed files.

## Screenshots / recordings (if UI)

No visual change; the button looks the same, only its click behavior changes.

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [ ] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
