### PR TITLE
fix(tracer): default TraceScanConfig.sampling_rate to 0 [TH-5628]

### DIFF
--- a/futureagi/tracer/migrations/0078_alter_tracescanconfig_sampling_rate.py
+++ b/futureagi/tracer/migrations/0078_alter_tracescanconfig_sampling_rate.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tracer", "0077_merge_20260514_1559"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="tracescanconfig",
+            name="sampling_rate",
+            field=models.FloatField(
+                default=0, help_text="0.0-1.0, fraction of traces to scan"
+            ),
+        ),
+    ]

--- a/futureagi/tracer/models/trace_scan.py
+++ b/futureagi/tracer/models/trace_scan.py
@@ -30,7 +30,7 @@ class TraceScanConfig(BaseModel):
         related_name="scan_config",
     )
     sampling_rate = models.FloatField(
-        default=0.1, help_text="0.0-1.0, fraction of traces to scan"
+        default=0, help_text="0.0-1.0, fraction of traces to scan"
     )
     enabled = models.BooleanField(default=True)
     scan_version = models.CharField(max_length=20, default="v7.2")

--- a/futureagi/tracer/queries/trace_scanner.py
+++ b/futureagi/tracer/queries/trace_scanner.py
@@ -32,7 +32,7 @@ def get_scan_config(project_id: str) -> Optional[ScanConfig]:
     """
     config, _ = TraceScanConfig.objects.get_or_create(
         project_id=project_id,
-        defaults={"sampling_rate": 0.1, "enabled": True},
+        defaults={"sampling_rate": 0, "enabled": True},
     )
     if not config.enabled:
         return None

--- a/futureagi/tracer/views/project.py
+++ b/futureagi/tracer/views/project.py
@@ -179,7 +179,7 @@ class ProjectView(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
                 scan_config = TraceScanConfig.objects.get(project=instance)
                 data["sampling_rate"] = scan_config.sampling_rate
             except TraceScanConfig.DoesNotExist:
-                data["sampling_rate"] = 0.1
+                data["sampling_rate"] = 0
 
             return self._gm.success_response(data)
 


### PR DESCRIPTION
## Why

`TraceScanConfig.sampling_rate` currently defaults to `0.1`, so any new project silently gets 10% trace scanning the first time the scanner pipeline (or `update_project_name`) lazily creates its config row. Customers haven't opted into scanning by creating a project — scanning should be off until they explicitly turn it on.

## What

Flips the literal `0.1` → `0` in the three places it lives:

- `futureagi/tracer/models/trace_scan.py` — model field default
- `futureagi/tracer/queries/trace_scanner.py` — \`get_or_create\` defaults inside \`get_scan_config\`
- `futureagi/tracer/views/project.py` — \`DoesNotExist\` fallback in \`GET /projects/{pk}/\`

Plus a single \`AlterField\` migration (\`0078_alter_tracescanconfig_sampling_rate.py\`) carrying the new field default.

## Scope

- **No backfill** of existing rows. Projects currently sitting at any non-default value (including 0.1) keep what they have. Only new projects from this point forward default to 0.
- \`enabled\` stays \`True\` by default. With \`sampling_rate=0\` + \`enabled=True\`, \`apply_sampling([...], 0)\` already returns \`[]\`, so the scanner runs the config lookup but samples zero traces. No special-casing needed.

## Verification

- \`rg "0\.1"\` over the three touched src files → 0 hits.
- \`makemigrations --dry-run\` after writing the migration → no further \`tracescanconfig\` changes pending.
- \`test_project.py\` errors on an unrelated \`accounts_user.last_timezone\` fixture bug that reproduces on clean \`origin/main\`; not caused by this change.

Linear: [TH-5628](https://linear.app/future-agi/issue/TH-5628/default-tracescanconfigsampling-rate-to-0-scanning-off-by-default)