### PR TITLE
refactor(error-localizer): centralize trigger guard + composite fallback + tracing manual trigger

### DIFF
--- a/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
+++ b/frontend/src/components/traceDetail/EvalErrorLocalization.jsx
@@ -88,6 +88,17 @@ const EvalErrorLocalization = ({
     },
     enabled: traceFetchEnabled,
     refetchOnWindowFocus: false,
+    // After the user kicks off a trace-mode localization, the analysis
+    // lands on EvalLogger.output_metadata.error_analysis a few seconds
+    // later. Poll so the drawer renders the result without a manual
+    // refresh — matches the cell-mode polling behaviour.
+    refetchInterval: (q) => {
+      if (!requested) return false;
+      const r = q?.state?.data;
+      const hasAnalysis = r?.errorAnalysis || r?.error_analysis;
+      if (hasAnalysis) return false;
+      return 3000;
+    },
     // Suppress global onError toast (app.jsx); inline empty state already rendered.
     meta: { errorHandled: true },
   });
@@ -113,6 +124,13 @@ const EvalErrorLocalization = ({
     traceData?.error_analysis ||
     null;
 
+  // Eval logger id surfaced by `get_evaluation_details` so the new
+  // tracer-side EL endpoint can target a specific EvalLogger row. The
+  // backend now returns both camelCase and snake_case in some places —
+  // pick whichever is present.
+  const evalLoggerId =
+    traceData?.evalLoggerId || traceData?.eval_logger_id || null;
+
   // ── Cell-mode trigger ───────────────────────────────────────────────────
   const cellTriggerMutation = useMutation({
     mutationFn: async () => {
@@ -130,10 +148,26 @@ const EvalErrorLocalization = ({
     },
   });
 
-  // ── Trace-mode trigger (re-runs the eval config, which recomputes
-  // error analysis on the next tick). ────────────────────────────────────
+  // ── Trace-mode trigger.
+  //
+  // Prefer the dedicated EL endpoint when we have an eval_logger_id from
+  // get_evaluation_details — that keys directly on the EvalLogger row,
+  // upserts an ErrorLocalizerTask, and lets the existing schedule pick it
+  // up. The eval itself is not re-run.
+  //
+  // Fall back to re-running the entire eval config when eval_logger_id
+  // isn't available (older response payloads or surfaces that haven't
+  // been updated yet). That path is heavier and recomputes the analysis
+  // as a side effect.
   const traceTriggerMutation = useMutation({
     mutationFn: async () => {
+      if (evalLoggerId) {
+        const { data } = await axios.post(
+          endpoints.project.runTracerEvalErrorLocalizer,
+          { eval_logger_id: evalLoggerId },
+        );
+        return data?.result;
+      }
       if (!projectVersionId) {
         throw new Error("project_version_id not available for this eval");
       }
@@ -148,9 +182,12 @@ const EvalErrorLocalization = ({
     },
     onSuccess: () => {
       enqueueSnackbar(
-        "Re-running evaluation — localization will appear when it finishes.",
+        evalLoggerId
+          ? "Error localization started — analysis will appear when it finishes."
+          : "Re-running evaluation — localization will appear when it finishes.",
         { variant: "info" },
       );
+      setRequested(true);
       // Invalidate so that when the user reopens the row the fresh results
       // get picked up.
       queryClient.invalidateQueries({

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1120,6 +1120,7 @@ export const endpoints = {
     addExistingDataset: `/tracer/dataset/add_to_existing_dataset/`,
     addNewDataset: `/tracer/dataset/add_to_new_dataset/`,
     reRunTracerEvalutation: `/tracer/custom-eval-config/run_evaluation/`,
+    runTracerEvalErrorLocalizer: `/tracer/eval-task/run-error-localizer/`,
     getCodeBlockTracer: `/tracer/project/project_sdk_code/`,
     getEvalGraph: `/tracer/charts/fetch_graph/`,
     getSystemMetricList: "/tracer/project/fetch_system_metrics/",

--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -651,28 +651,6 @@ def _get_input_type(input):
     return input_type
 
 
-def _eval_passed(value) -> bool:
-    """
-    Determine if an eval result represents a passing evaluation.
-    Returns True if the eval passed (error localizer should be skipped).
-    """
-    if value is None:
-        return False
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return value >= 0.8
-    if isinstance(value, str):
-        return value.lower() in ("passed", "pass", "true", "1")
-    if isinstance(value, list):
-        return all(_eval_passed(v) for v in value) if value else False
-    if isinstance(value, dict):
-        inner = value.get("result") or value.get("output")
-        if inner is not None:
-            return _eval_passed(inner)
-    return False
-
-
 def _validate_error_localizer_fields(rule_prompt, input_data, eval_result):
     """
     Validate required fields for error localization.
@@ -693,6 +671,263 @@ def _validate_error_localizer_fields(rule_prompt, input_data, eval_result):
         return ErrorLocalizerStatus.FAILED, error_msg
 
     return ErrorLocalizerStatus.PENDING, ""
+
+
+def _composite_children_fallback(eval_template):
+    """Last-resort rule_prompt for composite parents whose config / criteria /
+    description are all empty.
+
+    Composite parents normally describe the eval at the parent level; when an
+    operator forgets to set ``description`` the trigger functions fall through
+    the standard chain and hand the localizer an empty string. Returning a
+    synthesised summary of the bound children keeps validation alive and the
+    pipeline produces a (lower-fidelity) analysis rather than a hard failure.
+
+    Returns ``None`` for single templates so the caller can keep the normal
+    fallthrough; non-empty string for composites that have at least one child.
+    """
+    if not eval_template or getattr(eval_template, "template_type", "single") != "composite":
+        return None
+    try:
+        from model_hub.models.evals_metric import CompositeEvalChild
+
+        child_names = list(
+            CompositeEvalChild.objects
+                .filter(parent=eval_template, deleted=False)
+                .order_by("order")
+                .values_list("child__name", flat=True)
+        )
+    except Exception:
+        return None
+    child_names = [name for name in child_names if name]
+    if not child_names:
+        return None
+    return f"Composite evaluation combining: {', '.join(child_names)}"
+
+
+def _is_code_only_eval(eval_template):
+    """True when the localizer's prompt chain has no LLM rubric to reason about.
+
+    Code evaluators produce deterministic numeric / bool outputs from a
+    function — no rubric to reason against — so the chain just burns LLM
+    calls without surfacing real signal.
+
+    Returns True for:
+      - Single ``code`` templates.
+      - Composites where *every* bound child is a ``code`` template.
+
+    Cached on the template instance so a 1000-row dataset batch costs one
+    ORM query instead of N.
+    """
+    if not eval_template:
+        return False
+
+    # Single template — eval_type tells the whole story, no ORM needed.
+    if getattr(eval_template, "template_type", "single") != "composite":
+        return getattr(eval_template, "eval_type", "") == "code"
+
+    # Composite — per-instance cache so batch evals don't re-query per row.
+    cached = getattr(eval_template, "_el_code_only_cache", None)
+    if cached is not None:
+        return cached
+
+    try:
+        from model_hub.models.evals_metric import CompositeEvalChild
+
+        child_eval_types = list(
+            CompositeEvalChild.objects
+                .filter(parent=eval_template, deleted=False)
+                .values_list("child__eval_type", flat=True)
+        )
+    except Exception:
+        return False
+
+    result = bool(child_eval_types) and all((etype or "") == "code" for etype in child_eval_types)
+    try:
+        eval_template._el_code_only_cache = result
+    except Exception:
+        pass
+    return result
+
+
+# ── _eval_passed / threshold helpers ────────────────────────────────────────
+#
+# These power ``should_run_error_localizer`` — the single central decision
+# point for whether the localizer should fire. Every value shape is
+# normalised into a float in [0, 1], then compared against the template's
+# ``pass_threshold`` (default 0.5). See ``_reviews/el.md`` for the design
+# rationale and behaviour table.
+
+
+_PASS_LABELS = ("passed", "pass", "true", "1")
+_FAIL_LABELS = ("failed", "fail", "false", "0")
+
+
+def _resolve_pass_threshold(eval_template) -> float:
+    """Pull the per-template ``pass_threshold``; 0.5 if unset or missing."""
+    if eval_template is None:
+        return 0.5
+    pt = getattr(eval_template, "pass_threshold", None)
+    try:
+        return float(pt) if pt is not None else 0.5
+    except (ValueError, TypeError):
+        return 0.5
+
+
+def _is_pass_fail_output(eval_template) -> bool:
+    """True when the template's output_type is Pass/Fail."""
+    if eval_template is None:
+        return False
+    if getattr(eval_template, "output_type_normalized", None) == "pass_fail":
+        return True
+    cfg = getattr(eval_template, "config", None) or {}
+    return cfg.get("output") == "Pass/Fail"
+
+
+def _is_passed_label(value) -> bool:
+    """Decide whether a Pass/Fail-shaped value represents a pass."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in _PASS_LABELS
+    if isinstance(value, dict):
+        if isinstance(value.get("failure"), bool):
+            return not value["failure"]
+        for key in ("result", "output", "choice"):
+            inner = value.get(key)
+            if inner is not None:
+                return _is_passed_label(inner)
+    return False
+
+
+def _lookup_choice_score(choice_value, eval_template):
+    """Map a choice string to its [0, 1] score via ``template.choice_scores``.
+
+    Returns 0.5 (neutral) when the choice isn't in the map or no map is
+    configured — the safe default that doesn't trigger EL on unmapped
+    custom-choice templates (e.g. the ``tone`` template, which uses
+    custom labels but has no choice_scores configured).
+    """
+    if eval_template is None:
+        return 0.5
+    cs = getattr(eval_template, "choice_scores", None)
+    if not isinstance(cs, dict) or not cs:
+        return 0.5
+    target = str(choice_value).strip().lower()
+    for key, val in cs.items():
+        if str(key).strip().lower() == target:
+            try:
+                return max(0.0, min(1.0, float(val)))
+            except (ValueError, TypeError):
+                return 0.5
+    return 0.5
+
+
+def _normalize_to_score(value, eval_template):
+    """Map an eval result value into a float in [0, 1], or ``None`` when the
+    shape can't be normalised.
+
+    Recognised shapes:
+      - bool                                  → True = 1.0, False = 0.0
+      - int / float                           → clamped to [0, 1]
+      - "passed" / "pass" / "true" / "1"      → 1.0
+      - "failed" / "fail" / "false" / "0"     → 0.0
+      - custom choice string                  → looked up via
+                                                 ``template.choice_scores``,
+                                                 unmapped → 0.5 (neutral)
+      - list                                  → mean of per-element scores,
+                                                 unmapped elements count as 0.5
+                                                 (preserves "tone" template's
+                                                 neutral default; non-strict)
+      - dict {"failure": bool}                → trust the failure bit directly
+      - dict {"score": ...}                   → recurse on "score"
+      - dict {"result"|"output"|"choice": ...} → recurse on the first present
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+
+    if isinstance(value, (int, float)):
+        return max(0.0, min(1.0, float(value)))
+
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _PASS_LABELS:
+            return 1.0
+        if normalized in _FAIL_LABELS:
+            return 0.0
+        # Custom choice string — defaults to 0.5 (neutral) when no
+        # mapping is configured.
+        return _lookup_choice_score(value, eval_template)
+
+    if isinstance(value, list):
+        if not value:
+            return None
+        sub_scores = []
+        for v in value:
+            s = _normalize_to_score(v, eval_template)
+            sub_scores.append(s if s is not None else 0.5)
+        return sum(sub_scores) / len(sub_scores)
+
+    if isinstance(value, dict):
+        if isinstance(value.get("failure"), bool):
+            return 0.0 if value["failure"] else 1.0
+        for key in ("score", "result", "output", "choice"):
+            inner = value.get(key)
+            if inner is not None:
+                inner_score = _normalize_to_score(inner, eval_template)
+                if inner_score is not None:
+                    return inner_score
+        return None
+
+    return None
+
+
+def should_run_error_localizer(value, eval_template, *, manual=False):
+    """Single decision point for whether the error localizer should fire.
+
+    Returns ``(should_run: bool, reason: str)`` so the caller can log /
+    surface the reason to the FE without re-deriving it.
+
+    Called once at the worker (``process_single_error_localization``) —
+    no per-callsite checks. Both auto-trigger and manual-trigger paths
+    create the task row first and let the worker decide. This keeps the
+    policy in one place and prevents drift between trigger sites.
+
+    Decision tree:
+
+      no template?                  → (False, "no template context")
+      code-only template?           → (False, "code-only template — EL has no rubric")
+      Pass/Fail output_type:
+        passed                      → (False, "eval passed (Pass/Fail)")
+        failed                      → (True,  "eval failed (Pass/Fail)")
+      score-based path (score / choices / percentage):
+        normalize value → [0, 1]
+        unknown shape               → (False, "unrecognized result shape")
+        score >= pass_threshold     → (False, "eval passed: score≥threshold")
+        score <  pass_threshold     → (True,  "eval failed: score<threshold")
+    """
+    if eval_template is None:
+        return False, "no template context"
+
+    if _is_code_only_eval(eval_template):
+        return False, "code-only template — EL has no rubric"
+
+    if _is_pass_fail_output(eval_template):
+        if _is_passed_label(value):
+            return False, "eval passed (Pass/Fail)"
+        return True, "eval failed (Pass/Fail)"
+
+    score = _normalize_to_score(value, eval_template)
+    if score is None:
+        return False, "unrecognized result shape"
+
+    threshold = _resolve_pass_threshold(eval_template)
+    if score >= threshold:
+        return False, f"eval passed: score={score:.2f} ≥ threshold={threshold:.2f}"
+    return True, f"eval failed: score={score:.2f} < threshold={threshold:.2f}"
 
 
 def trigger_error_localization_for_column(
@@ -731,7 +966,10 @@ def trigger_error_localization_for_column(
     input_type_dict = _get_input_type(input_data_dict)
     input_keys = list(input_data_dict.keys())
     rule_prompt = (
-        config.get("rule_prompt") or eval_template.criteria or eval_template.description
+        config.get("rule_prompt")
+        or eval_template.criteria
+        or eval_template.description
+        or _composite_children_fallback(eval_template)
     )
 
     cell = Cell.objects.select_related(
@@ -813,6 +1051,7 @@ def trigger_error_localization_for_span(
             eval_template.config.get("rule_prompt")
             or eval_template.criteria
             or eval_template.description
+            or _composite_children_fallback(eval_template)
         )
 
         # Validate required fields before creating/updating task
@@ -871,12 +1110,6 @@ def _get_input_keys(input_data):
 
 def trigger_error_localization_for_standalone(evaluation: Evaluation):
     try:
-        if _eval_passed(evaluation.data):
-            logger.info(
-                f"Skipping error localization for passing eval {evaluation.id}"
-            )
-            return None
-
         input_keys = _get_input_keys(evaluation.input_data)
         input_types = _get_input_type(evaluation.input_data)
 
@@ -890,6 +1123,7 @@ def trigger_error_localization_for_standalone(evaluation: Evaluation):
             evaluation.eval_template.config.get("rule_prompt")
             or evaluation.eval_template.criteria
             or evaluation.eval_template.description
+            or _composite_children_fallback(evaluation.eval_template)
         )
 
         # Validate required fields before creating task
@@ -944,6 +1178,7 @@ def trigger_error_localization_for_playground(
             eval_template.config.get("rule_prompt")
             or eval_template.criteria
             or eval_template.description
+            or _composite_children_fallback(eval_template)
         )
 
         # Validate required fields before creating/updating task
@@ -1032,6 +1267,7 @@ def trigger_error_localization_for_simulate(
             config.get("rule_prompt")
             or eval_template.criteria
             or eval_template.description
+            or _composite_children_fallback(eval_template)
         )
 
         # Validate required fields before creating task
@@ -1071,10 +1307,38 @@ def trigger_error_localization_for_simulate(
 def process_single_error_localization(task_id):
     """
     Process a single error localization task.
+
+    The single decision point for "should we actually run EL?" — every
+    auto-trigger and every manual-trigger surface eventually lands here,
+    so gating once at the worker keeps the policy consistent (no per-
+    callsite drift) and avoids paying for usage / cost-log / LLM calls
+    on tasks that should never have been billed.
     """
     try:
         close_old_connections()
         task = ErrorLocalizerTask.objects.get(id=task_id)
+
+        # Centralized gate. Both auto-created and manually-created tasks
+        # pass through here; the worker decides whether to run the chain
+        # based on the eval's result + template, not on a per-caller
+        # check. Short-circuits before any usage / cost / LLM work.
+        should_run, reason = should_run_error_localizer(
+            task.eval_result,
+            task.eval_template,
+        )
+        if not should_run:
+            logger.info(
+                "error_localizer_skipped",
+                task_id=str(task.id),
+                source=str(task.source),
+                source_id=str(task.source_id),
+                eval_template_id=(
+                    str(task.eval_template_id) if task.eval_template_id else None
+                ),
+                reason=reason,
+            )
+            task.mark_as_skipped(reason)
+            return
 
         # Make sure the task is marked as running
         if task.status != ErrorLocalizerStatus.RUNNING:

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1179,31 +1179,34 @@ class EvaluationRunner:
 
             # Trigger error localization when enabled either on the dataset binding
             # (UserEvalMetric) or directly on the eval template.
-            should_run_error_localizer = bool(
+            # Per-binding EL opt-in. The "is this eval result bad enough to
+            # localize?" policy lives at the worker (see
+            # ``should_run_error_localizer`` in ``user_evaluation.py``) — we
+            # always create the task here when EL is enabled and let the
+            # worker decide whether to actually run the prompt chain.
+            el_enabled = bool(
                 self.user_eval_metric.error_localizer
                 or getattr(self.user_eval_metric.template, "error_localizer_enabled", False)
             )
-            if should_run_error_localizer:
+            if el_enabled:
                 from model_hub.tasks.user_evaluation import (
-                    _eval_passed,
                     trigger_error_localization_for_column,
                 )
 
-                if not _eval_passed(value):
-                    cell = Cell.objects.filter(
-                        column__id=self.replace_column_id, row=row, deleted=False
-                    ).first()
+                cell = Cell.objects.filter(
+                    column__id=self.replace_column_id, row=row, deleted=False
+                ).first()
 
-                    trigger_error_localization_for_column(
-                        eval_template=self.user_eval_metric.template,
-                        config=config_error,
-                        required_field=required_field_error,
-                        mapping=mapping_error,
-                        eval_result=value,
-                        response=response,
-                        cell=cell,
-                        log_id=str(api_call_log_row.log_id) if api_call_log_row else None,
-                    )
+                trigger_error_localization_for_column(
+                    eval_template=self.user_eval_metric.template,
+                    config=config_error,
+                    required_field=required_field_error,
+                    mapping=mapping_error,
+                    eval_result=value,
+                    response=response,
+                    cell=cell,
+                    log_id=str(api_call_log_row.log_id) if api_call_log_row else None,
+                )
 
         except Exception as e:
             logger.exception(f"Error in evaluation of row: {str(e)}")

--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -649,6 +649,7 @@ class CellErrorLocalizerView(APIView):
             )
             from model_hub.models.evals_metric import UserEvalMetric
             from model_hub.tasks.user_evaluation import (
+                _composite_children_fallback,
                 _get_input_type,
                 _validate_error_localizer_fields,
             )
@@ -741,6 +742,7 @@ class CellErrorLocalizerView(APIView):
                 (template.config or {}).get("rule_prompt")
                 or template.criteria
                 or template.description
+                or _composite_children_fallback(template)
             )
 
             initial_status, error_message = _validate_error_localizer_fields(

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -519,23 +519,25 @@ def run_eval_func(
         if response.get("warnings"):
             output["warnings"] = response["warnings"]
 
+        # Per-binding EL opt-in. Whether the eval result is bad enough to
+        # localize is decided centrally at the worker
+        # (``should_run_error_localizer``); the trigger just records the
+        # task and the worker short-circuits passes / unsupported shapes.
         if error_localizer:
             from model_hub.tasks.user_evaluation import (
-                _eval_passed,
                 trigger_error_localization_for_playground,
             )
 
-            if not _eval_passed(value):
-                logger.info(
-                    f"sending to error localizer: {api_call_log_row.log_id}, {value}, {param_values}, {response.get('reason')}"
-                )
-                trigger_error_localization_for_playground(
-                    eval_template=template,
-                    log=api_call_log_row,
-                    value=value,
-                    mapping=mappings,
-                    eval_explanation=response.get("reason"),
-                )
+            logger.info(
+                f"sending to error localizer: {api_call_log_row.log_id}, {value}, {param_values}, {response.get('reason')}"
+            )
+            trigger_error_localization_for_playground(
+                eval_template=template,
+                log=api_call_log_row,
+                value=value,
+                mapping=mappings,
+                eval_explanation=response.get("reason"),
+            )
 
         return output
 

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -1622,21 +1622,24 @@ def _execute_evaluation(
                 "observation_span__project__workspace",
             ).get(pk=eval_log.pk)
 
+        # Per-binding EL opt-in. Whether the eval result is actually bad
+        # enough to localize is a policy decision made centrally at the
+        # worker (``should_run_error_localizer`` in user_evaluation.py) —
+        # the trigger just creates the task row and lets the worker decide
+        # whether to run the chain.
         if custom_eval_config.error_localizer:
             from model_hub.tasks.user_evaluation import (
-                _eval_passed,
                 trigger_error_localization_for_span,
             )
 
-            if not _eval_passed(value):
-                trigger_error_localization_for_span(
-                    eval_template=eval_model,
-                    eval_logger=eval_log,
-                    mapping=raw_mapping,
-                    eval_explanation=logger_kwargs.get("eval_explanation", ""),
-                    value=value,
-                    log_id=str(log_id),
-                )
+            trigger_error_localization_for_span(
+                eval_template=eval_model,
+                eval_logger=eval_log,
+                mapping=raw_mapping,
+                eval_explanation=logger_kwargs.get("eval_explanation", ""),
+                value=value,
+                log_id=str(log_id),
+            )
 
         if type == EXPERIMENT:
             # updating project version config

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -1663,3 +1663,177 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
         except Exception as e:
             traceback.print_exc()
             return self._gm.bad_request(f"Error fetching eval task details {str(e)}")
+
+    @action(detail=False, methods=["post"], url_path="run-error-localizer")
+    def run_error_localizer(self, request, *args, **kwargs):
+        """On-demand error localization for a single tracing-side eval result.
+
+        Mirrors the dataset surface's manual trigger (``CellErrorLocalizerView``)
+        but operates on an ``EvalLogger`` row instead of a ``Cell``. Use case:
+        an eval ran on a span/trace/session with ``error_localizer=False`` on
+        the bound ``CustomEvalConfig`` so the auto-trigger never fired. The
+        user clicks "Run error localization" in the eval drawer and we upsert
+        an ``ErrorLocalizerTask(source=OBSERVE, source_id=eval_logger.id,
+        status=PENDING)`` so the existing schedule picks it up and processes
+        it via ``process_single_error_localization``.
+
+        POST /tracer/eval-task/run-error-localizer/
+        Body: {"eval_logger_id": "<uuid>"}
+        Returns: {task_id, eval_logger_id, status, error_message}
+        """
+        try:
+            from accounts.models.workspace import Workspace
+            from model_hub.models.error_localizer_model import (
+                ErrorLocalizerSource,
+                ErrorLocalizerTask,
+            )
+            from model_hub.tasks.user_evaluation import (
+                _composite_children_fallback,
+                _get_input_type,
+                _validate_error_localizer_fields,
+            )
+            from tracer.utils.eval import _process_mapping
+
+            eval_logger_id = request.data.get("eval_logger_id")
+            if not eval_logger_id:
+                return self._gm.bad_request("eval_logger_id is required.")
+
+            org = getattr(request, "organization", None) or request.user.organization
+
+            try:
+                eval_logger = (
+                    EvalLogger.objects
+                    .select_related(
+                        "observation_span",
+                        "observation_span__project",
+                        "observation_span__project__organization",
+                        "observation_span__project__workspace",
+                        "custom_eval_config",
+                        "custom_eval_config__eval_template",
+                    )
+                    .get(id=eval_logger_id, deleted=False)
+                )
+            except EvalLogger.DoesNotExist:
+                return self._gm.not_found("EvalLogger not found.")
+
+            project = (
+                eval_logger.observation_span.project
+                if eval_logger.observation_span
+                else None
+            )
+            if not project or project.organization_id != org.id:
+                return self._gm.not_found("EvalLogger not found.")
+
+            custom_eval_config = eval_logger.custom_eval_config
+            if not custom_eval_config:
+                return self._gm.bad_request(
+                    "EvalLogger has no associated eval config."
+                )
+
+            template = custom_eval_config.eval_template
+            if not template:
+                return self._gm.bad_request(
+                    "The underlying eval template no longer exists."
+                )
+
+            # Resolve input_data the same way auto-trigger does — via the
+            # shared mapping helper. This keeps span / trace / session
+            # targets working with one code path.
+            run_params = _process_mapping(
+                custom_eval_config.mapping or {},
+                eval_logger.observation_span,
+                template.id,
+            )
+            input_data = run_params or {}
+            if not input_data:
+                return self._gm.bad_request(
+                    "Cannot run error localization — this eval has no input "
+                    "variable mapping. Add at least one mapping in the eval "
+                    "config and re-run the eval first."
+                )
+
+            # Eval verdict — EvalLogger stores typed values across three
+            # columns. Coalesce to the populated one.
+            eval_result = (
+                eval_logger.output_str
+                if eval_logger.output_str is not None
+                else (
+                    str(eval_logger.output_bool)
+                    if eval_logger.output_bool is not None
+                    else (
+                        str(eval_logger.output_float)
+                        if eval_logger.output_float is not None
+                        else ""
+                    )
+                )
+            )
+            eval_explanation = eval_logger.eval_explanation or ""
+
+            rule_prompt = (
+                (custom_eval_config.config or {}).get("rule_prompt")
+                or template.criteria
+                or template.description
+                or _composite_children_fallback(template)
+            )
+
+            input_keys = list(input_data.keys())
+            input_types = _get_input_type(input_data)
+
+            initial_status, error_message = _validate_error_localizer_fields(
+                rule_prompt, input_data, eval_result
+            )
+
+            workspace = project.workspace
+            if not workspace:
+                workspace = Workspace.objects.filter(
+                    organization=org, is_default=True, is_active=True
+                ).first()
+
+            # Upsert keyed on EvalLogger.id (same pattern as the dataset
+            # manual trigger keys on Cell.id). A previous failed task is
+            # reset to PENDING and the existing schedule re-processes it.
+            task = ErrorLocalizerTask.objects.filter(
+                source_id=eval_logger.id
+            ).first()
+            if task:
+                task.eval_template = template
+                task.eval_result = eval_result
+                task.eval_explanation = eval_explanation
+                task.input_data = input_data
+                task.input_keys = input_keys
+                task.input_types = input_types
+                task.rule_prompt = rule_prompt
+                task.status = initial_status
+                task.error_message = error_message
+                task.error_analysis = {}
+                task.selected_input_key = None
+                task.save()
+            else:
+                task = ErrorLocalizerTask.objects.create(
+                    eval_template=template,
+                    source=ErrorLocalizerSource.OBSERVE,
+                    source_id=eval_logger.id,
+                    input_data=input_data,
+                    input_keys=input_keys,
+                    input_types=input_types,
+                    eval_result=eval_result,
+                    eval_explanation=eval_explanation,
+                    rule_prompt=rule_prompt,
+                    organization=org,
+                    workspace=workspace,
+                    status=initial_status,
+                    error_message=error_message,
+                )
+
+            return self._gm.success_response(
+                {
+                    "task_id": str(task.id),
+                    "eval_logger_id": str(eval_logger.id),
+                    "status": task.status,
+                    "error_message": task.error_message,
+                }
+            )
+
+        except Exception as e:
+            traceback.print_exc()
+            return self._gm.bad_request(f"Error running error localization: {str(e)}")

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -3066,6 +3066,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         # session rows don't and are served by /trace-session/:id/eval_logs/.
         query = """
             SELECT
+                toString(id) AS eval_logger_id,
                 output_float,
                 output_bool,
                 output_str_list,
@@ -3106,6 +3107,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
         if row.get("error") or row.get("output_str") == "ERROR":
             return self._gm.success_response(
                 {
+                    "eval_logger_id": row.get("eval_logger_id"),
                     "error_analysis": output_metadata.get("error_analysis"),
                     "selected_input_key": output_metadata.get("selected_input_key"),
                     "input_data": output_metadata.get("input_data"),
@@ -3133,6 +3135,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
 
         return self._gm.success_response(
             {
+                "eval_logger_id": row.get("eval_logger_id"),
                 "error_analysis": output_metadata.get("error_analysis"),
                 "selected_input_key": output_metadata.get("selected_input_key"),
                 "input_data": output_metadata.get("input_data"),
@@ -3194,6 +3197,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             if eval_logger.error or eval_logger.output_str == "ERROR":
                 return self._gm.success_response(
                     {
+                        "eval_logger_id": str(eval_logger.id),
                         "error_analysis": output_metadata.get("error_analysis"),
                         "selected_input_key": output_metadata.get("selected_input_key"),
                         "input_data": output_metadata.get("input_data"),
@@ -3220,6 +3224,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             )
 
             result = {
+                "eval_logger_id": str(eval_logger.id),
                 "error_analysis": output_metadata.get("error_analysis", None),
                 "selected_input_key": output_metadata.get("selected_input_key", None),
                 "input_data": output_metadata.get("input_data", None),


### PR DESCRIPTION
## Summary

Collapses the per-callsite error-localizer guard logic into a single decision function, adds a children-name fallback for composite parents with empty descriptions, and adds a manual EL trigger endpoint for tracing-side eval logger rows. Resolves [TH-5227](https://linear.app/future-agi/issue/TH-5227) and [TH-5152](https://linear.app/future-agi/issue/TH-5152) under the [TH-5500](https://linear.app/future-agi/issue/TH-5500) umbrella.

## Why

The trigger logic had drifted across five auto-trigger sites and two manual entry-points. Each callsite re-implemented its own pass/fail extraction, choices-shape probing, and code-template skip. Different surfaces could disagree on whether the same eval result should localize. Concrete symptoms:

- Composite-parent templates with no `description` failed validation with \"Missing required fields: rule_prompt\" — every customer composite without a description was blocked from EL.
- Tracing surface had no manual EL trigger at all — the existing \"Run\" button re-ran the entire eval as a side effect.
- The legacy `_eval_passed` helper used a hardcoded `>= 0.8` threshold that ignored each template's per-template `pass_threshold`. The dict probe at the bottom looked for `\"result\"` / `\"output\"` keys and missed the canonical `\"score\"` key used by choices output, so choices evals always read as failed.
- Manual-trigger paths (`CellErrorLocalizerView` + dataset Run button) had no skip guard at all — clicking on a passing eval burned five LLM calls and ~80 seconds before the agent returned an empty result.

## What changed

### Single decision function

`should_run_error_localizer(value, eval_template, *, manual=False) -> (bool, reason)` in `model_hub/tasks/user_evaluation.py`. Returns `(should_run, reason)`. Internally:

1. No template → skip.
2. Code-only template (single, or composite where every bound child is `eval_type=\"code\"`) → skip. Per-template-instance cache (`_el_code_only_cache`) so batched dataset evals reuse the composite lookup at one ORM query.
3. Pass/Fail output_type → direct binary check on the value.
4. Otherwise normalize the value into `[0, 1]` (bool, numeric, custom-choice string via `template.choice_scores`, multi-choice list as the mean, dict with `\"failure\"` / `\"score\"` / `\"result\"` / `\"output\"` / `\"choice\"`) and compare against `template.pass_threshold` (default 0.5). Unmapped custom choices default to `0.5` (neutral) so unconfigured custom-choice templates skip rather than over-fire EL.

### Worker as the single convergence point

`process_single_error_localization` now calls `should_run_error_localizer` at the top, before the usage check / cost log / LLM chain. Tasks that don't pass the gate land in `status=skipped` with the reason on `error_message`. No cost log, no LLM, no mirror write. Auto-created and manually-created tasks both flow through the same gate — no per-trigger drift.

### Composite description fallback (TH-5227)

`_composite_children_fallback(eval_template)` synthesises a `Composite evaluation combining: <child names>` rule_prompt when the composite parent has no `config.rule_prompt` / `criteria` / `description`. Wired into all five auto-trigger paths and the manual `CellErrorLocalizerView`.

### Tracing manual trigger (TH-5152)

New `@action(detail=False, methods=[\"post\"], url_path=\"run-error-localizer\")` on `EvalTaskView`. Body: `{eval_logger_id}`. Mirrors `CellErrorLocalizerView` for tracing-side `EvalLogger` rows, using the same composite fallback and going through the same worker gate.

`_get_evaluation_details_clickhouse` (and its PG fallback) now include `eval_logger_id` in the response so the frontend can target the new endpoint without an additional fetch.

### Frontend

- `axios.js`: new `runTracerEvalErrorLocalizer` endpoint.
- `EvalErrorLocalization.jsx` (trace mode): prefers the new endpoint when `eval_logger_id` is present in the eval-details payload, falls back to the existing re-run-eval path for older payloads. Trace-mode polling added so the panel updates when the analysis lands.

### Removed

- `_eval_passed` (hardcoded threshold + dict-probe bug) is gone. All five call paths now delegate to the worker.
- `_should_skip_el_for_eval_type` is folded into `_is_code_only_eval` (private to `should_run_error_localizer`).
- Per-trigger-function `_should_skip_el_for_eval_type` guards removed from all five trigger functions and from the manual `CellErrorLocalizerView` + `EvalTaskView.run_error_localizer` views.

Per-binding opt-in flags (`CustomEvalConfig.error_localizer`, `UserEvalMetric.error_localizer`, `EvalTemplate.error_localizer_enabled`) are still respected at the callsites — those are user feature flags, not a result-based policy decision.

## Test plan

- [ ] Dataset eval column with score-typed template + `pass_threshold=0.5`: passing rows (score >= 0.5) do not create EL tasks; failing rows do.
- [ ] Dataset eval column with Pass/Fail template: \"Passed\" rows do not create EL tasks; \"Failed\" rows do.
- [ ] Dataset eval column with choices template + `choice_scores`: rows whose mapped choice score >= threshold do not create EL tasks; others do.
- [ ] Dataset eval column with code template: no EL tasks are created at all (skipped at the worker).
- [ ] Composite parent eval with empty description: `CellErrorLocalizerView` creates a task with rule_prompt set to the children-names fallback (no \"Missing required fields\").
- [ ] Composite-of-all-code template: worker short-circuits with `status=skipped`, reason mentions \"code-only template\".
- [ ] Composite with at least one llm/agent child: worker proceeds normally.
- [ ] Manual click on a passing eval (any output type): task is created, worker marks `status=skipped` with a readable reason, no LLM call.
- [ ] Tracing eval drawer on a failed eval: clicking Run hits `POST /tracer/eval-task/run-error-localizer/` with the eval_logger_id, returns a task id, drawer polls `get_evaluation_details` and renders highlights once the analysis lands.
- [ ] Tracing eval drawer rendering on payloads without `eval_logger_id`: falls back to the existing re-run-eval path.

## Notes for reviewers

This PR is in draft for review. No backfills required — every change is forward-looking. Old `ErrorLocalizerTask` rows (including those marked FAILED with the old \"Missing required fields: rule_prompt\" message) are not touched. Existing per-binding `error_localizer` flags retain their meaning.