### PR TITLE
refactor(error-localizer): centralize trigger gate + add tracing manual trigger endpoint

### DIFF
--- a/futureagi/model_hub/tasks/user_evaluation.py
+++ b/futureagi/model_hub/tasks/user_evaluation.py
@@ -651,28 +651,6 @@ def _get_input_type(input):
     return input_type
 
 
-def _eval_passed(value) -> bool:
-    """
-    Determine if an eval result represents a passing evaluation.
-    Returns True if the eval passed (error localizer should be skipped).
-    """
-    if value is None:
-        return False
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return value >= 0.8
-    if isinstance(value, str):
-        return value.lower() in ("passed", "pass", "true", "1")
-    if isinstance(value, list):
-        return all(_eval_passed(v) for v in value) if value else False
-    if isinstance(value, dict):
-        inner = value.get("result") or value.get("output")
-        if inner is not None:
-            return _eval_passed(inner)
-    return False
-
-
 def _validate_error_localizer_fields(rule_prompt, input_data, eval_result):
     """
     Validate required fields for error localization.
@@ -693,6 +671,139 @@ def _validate_error_localizer_fields(rule_prompt, input_data, eval_result):
         return ErrorLocalizerStatus.FAILED, error_msg
 
     return ErrorLocalizerStatus.PENDING, ""
+
+
+def _is_code_only_eval(eval_template):
+    if not eval_template:
+        return False
+    if getattr(eval_template, "template_type", "single") != "composite":
+        return getattr(eval_template, "eval_type", "") == "code"
+    cached = getattr(eval_template, "_el_code_only_cache", None)
+    if cached is not None:
+        return cached
+    try:
+        from model_hub.models.evals_metric import CompositeEvalChild
+
+        child_eval_types = list(
+            CompositeEvalChild.objects
+                .filter(parent=eval_template, deleted=False)
+                .values_list("child__eval_type", flat=True)
+        )
+    except Exception:
+        return False
+    result = bool(child_eval_types) and all((etype or "") == "code" for etype in child_eval_types)
+    try:
+        eval_template._el_code_only_cache = result
+    except Exception:
+        pass
+    return result
+
+
+_PASS_LABELS = ("passed", "pass", "true", "1")
+_FAIL_LABELS = ("failed", "fail", "false", "0")
+
+
+def _resolve_pass_threshold(eval_template) -> float:
+    if eval_template is None:
+        return 0.5
+    pt = getattr(eval_template, "pass_threshold", None)
+    try:
+        return float(pt) if pt is not None else 0.5
+    except (ValueError, TypeError):
+        return 0.5
+
+
+def _is_pass_fail_output(eval_template) -> bool:
+    if eval_template is None:
+        return False
+    if getattr(eval_template, "output_type_normalized", None) == "pass_fail":
+        return True
+    cfg = getattr(eval_template, "config", None) or {}
+    return cfg.get("output") == "Pass/Fail"
+
+
+def _is_passed_label(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in _PASS_LABELS
+    if isinstance(value, dict):
+        if isinstance(value.get("failure"), bool):
+            return not value["failure"]
+        for key in ("result", "output", "choice"):
+            inner = value.get(key)
+            if inner is not None:
+                return _is_passed_label(inner)
+    return False
+
+
+def _lookup_choice_score(choice_value, eval_template):
+    if eval_template is None:
+        return 0.5
+    cs = getattr(eval_template, "choice_scores", None)
+    if not isinstance(cs, dict) or not cs:
+        return 0.5
+    target = str(choice_value).strip().lower()
+    for key, val in cs.items():
+        if str(key).strip().lower() == target:
+            try:
+                return max(0.0, min(1.0, float(val)))
+            except (ValueError, TypeError):
+                return 0.5
+    return 0.5
+
+
+def _normalize_to_score(value, eval_template):
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        return max(0.0, min(1.0, float(value)))
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _PASS_LABELS:
+            return 1.0
+        if normalized in _FAIL_LABELS:
+            return 0.0
+        return _lookup_choice_score(value, eval_template)
+    if isinstance(value, list):
+        if not value:
+            return None
+        sub_scores = []
+        for v in value:
+            s = _normalize_to_score(v, eval_template)
+            sub_scores.append(s if s is not None else 0.5)
+        return sum(sub_scores) / len(sub_scores)
+    if isinstance(value, dict):
+        if isinstance(value.get("failure"), bool):
+            return 0.0 if value["failure"] else 1.0
+        for key in ("score", "result", "output", "choice"):
+            inner = value.get(key)
+            if inner is not None:
+                inner_score = _normalize_to_score(inner, eval_template)
+                if inner_score is not None:
+                    return inner_score
+        return None
+    return None
+
+
+def should_run_error_localizer(value, eval_template, *, manual=False):
+    if eval_template is None:
+        return False, "no template context"
+    if _is_code_only_eval(eval_template):
+        return False, "code-only template"
+    if _is_pass_fail_output(eval_template):
+        if _is_passed_label(value):
+            return False, "eval passed (Pass/Fail)"
+        return True, "eval failed (Pass/Fail)"
+    score = _normalize_to_score(value, eval_template)
+    if score is None:
+        return False, "unrecognized result shape"
+    threshold = _resolve_pass_threshold(eval_template)
+    if score >= threshold:
+        return False, f"score={score:.2f} >= threshold={threshold:.2f}"
+    return True, f"score={score:.2f} < threshold={threshold:.2f}"
 
 
 def trigger_error_localization_for_column(
@@ -731,7 +842,9 @@ def trigger_error_localization_for_column(
     input_type_dict = _get_input_type(input_data_dict)
     input_keys = list(input_data_dict.keys())
     rule_prompt = (
-        config.get("rule_prompt") or eval_template.criteria or eval_template.description
+        config.get("rule_prompt")
+        or eval_template.criteria
+        or eval_template.description
     )
 
     cell = Cell.objects.select_related(
@@ -871,12 +984,6 @@ def _get_input_keys(input_data):
 
 def trigger_error_localization_for_standalone(evaluation: Evaluation):
     try:
-        if _eval_passed(evaluation.data):
-            logger.info(
-                f"Skipping error localization for passing eval {evaluation.id}"
-            )
-            return None
-
         input_keys = _get_input_keys(evaluation.input_data)
         input_types = _get_input_type(evaluation.input_data)
 
@@ -1071,10 +1178,38 @@ def trigger_error_localization_for_simulate(
 def process_single_error_localization(task_id):
     """
     Process a single error localization task.
+
+    The single decision point for "should we actually run EL?" — every
+    auto-trigger and every manual-trigger surface eventually lands here,
+    so gating once at the worker keeps the policy consistent (no per-
+    callsite drift) and avoids paying for usage / cost-log / LLM calls
+    on tasks that should never have been billed.
     """
     try:
         close_old_connections()
         task = ErrorLocalizerTask.objects.get(id=task_id)
+
+        # Centralized gate. Both auto-created and manually-created tasks
+        # pass through here; the worker decides whether to run the chain
+        # based on the eval's result + template, not on a per-caller
+        # check. Short-circuits before any usage / cost / LLM work.
+        should_run, reason = should_run_error_localizer(
+            task.eval_result,
+            task.eval_template,
+        )
+        if not should_run:
+            logger.info(
+                "error_localizer_skipped",
+                task_id=str(task.id),
+                source=str(task.source),
+                source_id=str(task.source_id),
+                eval_template_id=(
+                    str(task.eval_template_id) if task.eval_template_id else None
+                ),
+                reason=reason,
+            )
+            task.mark_as_skipped(reason)
+            return
 
         # Make sure the task is marked as running
         if task.status != ErrorLocalizerStatus.RUNNING:

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1177,33 +1177,29 @@ class EvaluationRunner:
             except Exception:
                 pass
 
-            # Trigger error localization when enabled either on the dataset binding
-            # (UserEvalMetric) or directly on the eval template.
-            should_run_error_localizer = bool(
+            el_enabled = bool(
                 self.user_eval_metric.error_localizer
                 or getattr(self.user_eval_metric.template, "error_localizer_enabled", False)
             )
-            if should_run_error_localizer:
+            if el_enabled:
                 from model_hub.tasks.user_evaluation import (
-                    _eval_passed,
                     trigger_error_localization_for_column,
                 )
 
-                if not _eval_passed(value):
-                    cell = Cell.objects.filter(
-                        column__id=self.replace_column_id, row=row, deleted=False
-                    ).first()
+                cell = Cell.objects.filter(
+                    column__id=self.replace_column_id, row=row, deleted=False
+                ).first()
 
-                    trigger_error_localization_for_column(
-                        eval_template=self.user_eval_metric.template,
-                        config=config_error,
-                        required_field=required_field_error,
-                        mapping=mapping_error,
-                        eval_result=value,
-                        response=response,
-                        cell=cell,
-                        log_id=str(api_call_log_row.log_id) if api_call_log_row else None,
-                    )
+                trigger_error_localization_for_column(
+                    eval_template=self.user_eval_metric.template,
+                    config=config_error,
+                    required_field=required_field_error,
+                    mapping=mapping_error,
+                    eval_result=value,
+                    response=response,
+                    cell=cell,
+                    log_id=str(api_call_log_row.log_id) if api_call_log_row else None,
+                )
 
         except Exception as e:
             logger.exception(f"Error in evaluation of row: {str(e)}")

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -521,21 +521,19 @@ def run_eval_func(
 
         if error_localizer:
             from model_hub.tasks.user_evaluation import (
-                _eval_passed,
                 trigger_error_localization_for_playground,
             )
 
-            if not _eval_passed(value):
-                logger.info(
-                    f"sending to error localizer: {api_call_log_row.log_id}, {value}, {param_values}, {response.get('reason')}"
-                )
-                trigger_error_localization_for_playground(
-                    eval_template=template,
-                    log=api_call_log_row,
-                    value=value,
-                    mapping=mappings,
-                    eval_explanation=response.get("reason"),
-                )
+            logger.info(
+                f"sending to error localizer: {api_call_log_row.log_id}, {value}, {param_values}, {response.get('reason')}"
+            )
+            trigger_error_localization_for_playground(
+                eval_template=template,
+                log=api_call_log_row,
+                value=value,
+                mapping=mappings,
+                eval_explanation=response.get("reason"),
+            )
 
         return output
 

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -1624,19 +1624,17 @@ def _execute_evaluation(
 
         if custom_eval_config.error_localizer:
             from model_hub.tasks.user_evaluation import (
-                _eval_passed,
                 trigger_error_localization_for_span,
             )
 
-            if not _eval_passed(value):
-                trigger_error_localization_for_span(
-                    eval_template=eval_model,
-                    eval_logger=eval_log,
-                    mapping=raw_mapping,
-                    eval_explanation=logger_kwargs.get("eval_explanation", ""),
-                    value=value,
-                    log_id=str(log_id),
-                )
+            trigger_error_localization_for_span(
+                eval_template=eval_model,
+                eval_logger=eval_log,
+                mapping=raw_mapping,
+                eval_explanation=logger_kwargs.get("eval_explanation", ""),
+                value=value,
+                log_id=str(log_id),
+            )
 
         if type == EXPERIMENT:
             # updating project version config

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -1663,3 +1663,152 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
         except Exception as e:
             traceback.print_exc()
             return self._gm.bad_request(f"Error fetching eval task details {str(e)}")
+
+    @action(detail=False, methods=["post"], url_path="run-error-localizer")
+    def run_error_localizer(self, request, *args, **kwargs):
+        try:
+            from accounts.models.workspace import Workspace
+            from model_hub.models.error_localizer_model import (
+                ErrorLocalizerSource,
+                ErrorLocalizerTask,
+            )
+            from model_hub.tasks.user_evaluation import (
+                _get_input_type,
+                _validate_error_localizer_fields,
+            )
+            from tracer.utils.eval import _process_mapping
+
+            eval_logger_id = request.data.get("eval_logger_id")
+            if not eval_logger_id:
+                return self._gm.bad_request("eval_logger_id is required.")
+
+            org = getattr(request, "organization", None) or request.user.organization
+
+            try:
+                eval_logger = (
+                    EvalLogger.objects
+                    .select_related(
+                        "observation_span",
+                        "observation_span__project",
+                        "observation_span__project__organization",
+                        "observation_span__project__workspace",
+                        "custom_eval_config",
+                        "custom_eval_config__eval_template",
+                    )
+                    .get(id=eval_logger_id, deleted=False)
+                )
+            except EvalLogger.DoesNotExist:
+                return self._gm.not_found("EvalLogger not found.")
+
+            project = (
+                eval_logger.observation_span.project
+                if eval_logger.observation_span
+                else None
+            )
+            if not project or project.organization_id != org.id:
+                return self._gm.not_found("EvalLogger not found.")
+
+            custom_eval_config = eval_logger.custom_eval_config
+            if not custom_eval_config:
+                return self._gm.bad_request(
+                    "EvalLogger has no associated eval config."
+                )
+
+            template = custom_eval_config.eval_template
+            if not template:
+                return self._gm.bad_request(
+                    "The underlying eval template no longer exists."
+                )
+
+            run_params = _process_mapping(
+                custom_eval_config.mapping or {},
+                eval_logger.observation_span,
+                template.id,
+            )
+            input_data = run_params or {}
+            if not input_data:
+                return self._gm.bad_request(
+                    "Cannot run error localization — this eval has no input "
+                    "variable mapping. Add at least one mapping in the eval "
+                    "config and re-run the eval first."
+                )
+
+            eval_result = (
+                eval_logger.output_str
+                if eval_logger.output_str is not None
+                else (
+                    str(eval_logger.output_bool)
+                    if eval_logger.output_bool is not None
+                    else (
+                        str(eval_logger.output_float)
+                        if eval_logger.output_float is not None
+                        else ""
+                    )
+                )
+            )
+            eval_explanation = eval_logger.eval_explanation or ""
+
+            rule_prompt = (
+                (custom_eval_config.config or {}).get("rule_prompt")
+                or template.criteria
+                or template.description
+            )
+
+            input_keys = list(input_data.keys())
+            input_types = _get_input_type(input_data)
+
+            initial_status, error_message = _validate_error_localizer_fields(
+                rule_prompt, input_data, eval_result
+            )
+
+            workspace = project.workspace
+            if not workspace:
+                workspace = Workspace.objects.filter(
+                    organization=org, is_default=True, is_active=True
+                ).first()
+
+            task = ErrorLocalizerTask.objects.filter(
+                source_id=eval_logger.id
+            ).first()
+            if task:
+                task.eval_template = template
+                task.eval_result = eval_result
+                task.eval_explanation = eval_explanation
+                task.input_data = input_data
+                task.input_keys = input_keys
+                task.input_types = input_types
+                task.rule_prompt = rule_prompt
+                task.status = initial_status
+                task.error_message = error_message
+                task.error_analysis = {}
+                task.selected_input_key = None
+                task.save()
+            else:
+                task = ErrorLocalizerTask.objects.create(
+                    eval_template=template,
+                    source=ErrorLocalizerSource.OBSERVE,
+                    source_id=eval_logger.id,
+                    input_data=input_data,
+                    input_keys=input_keys,
+                    input_types=input_types,
+                    eval_result=eval_result,
+                    eval_explanation=eval_explanation,
+                    rule_prompt=rule_prompt,
+                    organization=org,
+                    workspace=workspace,
+                    status=initial_status,
+                    error_message=error_message,
+                )
+
+            return self._gm.success_response(
+                {
+                    "task_id": str(task.id),
+                    "eval_logger_id": str(eval_logger.id),
+                    "status": task.status,
+                    "error_message": task.error_message,
+                }
+            )
+
+        except Exception as e:
+            traceback.print_exc()
+            return self._gm.bad_request(f"Error running error localization: {str(e)}")


### PR DESCRIPTION
## Summary

Collapses the per-callsite error-localizer guard logic into a single decision function and adds a manual EL trigger endpoint for tracing-side eval logger rows. Resolves [TH-5152](https://linear.app/future-agi/issue/TH-5152).

## Why

The trigger logic had drifted across five auto-trigger sites and two manual entry-points. Each callsite duplicated its own pass/fail extraction and choices-shape probing. The legacy `_eval_passed` helper used a hardcoded `>= 0.8` threshold that ignored each template's per-template `pass_threshold`, and its dict probe looked for `"result"` / `"output"` keys but missed the canonical `"score"` key used by choices output (so choices evals always read as failed). Tracing surface had no manual EL trigger at all.

## What changed

### Single decision function

`should_run_error_localizer(value, eval_template, *, manual=False) -> (bool, reason)` in `model_hub/tasks/user_evaluation.py`. Normalizes any value shape into a float in `[0, 1]` and compares against `template.pass_threshold` (default 0.5). Pass/Fail templates use a direct binary check. Choices use `template.choice_scores`; unmapped choices default to `0.5` (neutral). Code-only templates (single, or composite where every bound child is code) short-circuit at the gate. A per-template-instance cache (`_el_code_only_cache`) keeps batched dataset evals at one ORM query.

### Worker as single convergence point

`process_single_error_localization` calls `should_run_error_localizer` at the top, before the usage check / cost log / LLM chain. Tasks that don't pass land in `status=skipped` with the reason on `error_message`. Both auto-trigger and manual-trigger paths flow through the same gate.

### Tracing manual trigger

New `@action(detail=False, methods=["post"], url_path="run-error-localizer")` on `EvalTaskView`. Body: `{eval_logger_id}`. Mirrors `CellErrorLocalizerView` for tracing-side `EvalLogger` rows.

### Removed

- `_eval_passed` (hardcoded threshold + dict-probe bug).
- `_should_skip_el_for_eval_type` folded into `_is_code_only_eval`.
- Per-trigger-function skip guards removed from all five trigger functions and the manual `CellErrorLocalizerView`.

Per-binding opt-in flags (`CustomEvalConfig.error_localizer`, `UserEvalMetric.error_localizer`, `EvalTemplate.error_localizer_enabled`) are still respected at the callsites.

## Test plan

- [ ] Dataset eval column with score-typed template + `pass_threshold=0.5`: passing rows do not create EL tasks; failing rows do.
- [ ] Dataset eval column with Pass/Fail template: "Passed" rows do not create EL tasks; "Failed" rows do.
- [ ] Dataset eval column with choices template + `choice_scores`: rows whose mapped choice score >= threshold do not create EL tasks; others do.
- [ ] Dataset eval column with code template: no EL tasks created at all.
- [ ] Composite-of-all-code template: worker short-circuits with `status=skipped`.
- [ ] Composite with at least one llm/agent child: worker proceeds normally.
- [ ] Manual click on a passing eval: task is created, worker marks `status=skipped` with a readable reason, no LLM call.
- [ ] `POST /tracer/eval-task/run-error-localizer/` with a valid `eval_logger_id` creates/updates the EL task and returns task id + status.
