### PR TITLE
fix(error-localizer): repair text Show More UX and hide localizer for composite evals

### DIFF
--- a/frontend/src/sections/common/ErrorLocalizeCard.jsx
+++ b/frontend/src/sections/common/ErrorLocalizeCard.jsx
@@ -295,18 +295,25 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
   const imageData = useMemo(() => getImageUrlFromData(datapoint), [datapoint]);
   const isImage = imageData?.format === "image";
   const isText = imageData?.format === "text";
-  const showMoreCondition =
-    !datapoint?.data?.imageUrl &&
-    imageData?.dataFile?.length > 150 &&
-    !expanded;
+  const renderedText =
+    datapoint?.input_data?.[datapoint?.selected_input_key] ??
+    imageData?.dataFile ??
+    "";
+  const isLongText = renderedText.length > 150;
 
-  const showLessCondition =
-    !datapoint?.data?.imageUrl && imageData?.dataFile?.length > 150 && expanded;
+  const showMoreCondition = isLongText && !expanded && !isImage;
+
+  const showLessCondition = isLongText && expanded;
+
+  const selectedInputKey =
+    datapoint?.selected_input_key ??
+    datapoint?.cell_metadata?.selected_input_key;
 
   useEffect(() => {
     setExpanded(false);
     setHoveredData(null);
-  }, [value, datapoint, column]);
+  }, [column, selectedInputKey, value?.length]);
+
 
   const renderLocalizerDetails = (item) => {
     const reason = item?.reason;
@@ -444,70 +451,6 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
     );
   };
 
-  const renderTextWithAllHighlights = (text, highlights) => {
-    if (!text || !highlights || highlights.length === 0) {
-      return text;
-    }
-
-    const getStartIdx = (highlight) =>
-      highlight?.orgSen?.startIdx ?? highlight?.orgSen?.start_idx ?? 0;
-    const getEndIdx = (highlight) =>
-      highlight?.orgSen?.endIdx ??
-      highlight?.orgSen?.end_idx ??
-      getStartIdx(highlight);
-
-    const sortedHighlights = [...highlights].sort(
-      (a, b) => getStartIdx(a) - getStartIdx(b),
-    );
-
-    const result = [];
-    let lastIndex = 0;
-
-    sortedHighlights.forEach((highlight, index) => {
-      const startIdx = getStartIdx(highlight);
-      const endIdx = getEndIdx(highlight);
-
-      if (startIdx > lastIndex) {
-        result.push(text.slice(lastIndex, startIdx));
-      }
-
-      const highlightedText = text.slice(startIdx, endIdx);
-      result.push(
-        <CustomTooltip
-          key={`highlight-${index}`}
-          show={Boolean(hoveredData)}
-          title={
-            <Box sx={{ maxHeight: "100px", overflow: "auto" }}>
-              {highlight?.reason}
-            </Box>
-          }
-          enterDelay={500}
-        >
-          <span
-            onMouseEnter={() => setHoveredData(highlight.reason)}
-            onMouseLeave={() => setHoveredData(null)}
-            style={{
-              backgroundColor: getMarkColor(highlight.weight),
-              fontWeight: "",
-              display: "inline",
-            }}
-          >
-            {highlightedText}
-          </span>
-        </CustomTooltip>,
-      );
-
-      lastIndex = endIdx;
-    });
-
-    // Add remaining text after the last highlight
-    if (lastIndex < text.length) {
-      result.push(text.slice(lastIndex));
-    }
-
-    return result;
-  };
-
   return (
     <Accordion
       defaultExpanded
@@ -572,43 +515,48 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
                               )}
                             </Box>
                           </Typography>
-                          {renderLocalizerDetails(i)}
                           {value.length > 1 && index < value.length - 1 && (
                             <Divider />
                           )}
                         </React.Fragment>
                       ))
                     ) : (
-                      <>
-                        <Typography
-                          sx={{
-                            marginY: theme.spacing(1.5),
-                            overflowY: "auto",
-                            ...sx,
-                          }}
-                          variant="s2"
-                        >
-                          {renderTextWithAllHighlights(
-                            datapoint?.input_data[datapoint.selected_input_key],
-                            value,
-                          )}
-                        </Typography>
-                        <Box
-                          sx={{
-                            display: "flex",
-                            flexDirection: "column",
-                            gap: 1,
-                          }}
-                        >
-                          {value.map((item, index) => (
-                            <React.Fragment
-                              key={item.unitKey || item.unit_key || index}
+                      value.map((item, index) => {
+                        const fullText =
+                          datapoint?.input_data[datapoint.selected_input_key];
+                        const startIdx =
+                          item?.orgSen?.startIdx ?? item?.orgSen?.start_idx;
+                        const endIdx =
+                          item?.orgSen?.endIdx ?? item?.orgSen?.end_idx;
+                        const segment =
+                          fullText?.slice(startIdx, endIdx) ||
+                          item?.orgSen?.text ||
+                          "";
+
+                        return (
+                          <React.Fragment
+                            key={item.unitKey || item.unit_key || index}
+                          >
+                            <Typography
+                              sx={{ marginY: theme.spacing(1.5), ...sx }}
+                              variant="s2"
                             >
-                              {renderLocalizerDetails(item)}
-                            </React.Fragment>
-                          ))}
-                        </Box>
-                      </>
+                              <span
+                                style={{
+                                  backgroundColor: getMarkColor(item.weight),
+                                  display: "inline",
+                                }}
+                              >
+                                {segment}
+                              </span>
+                            </Typography>
+                            {renderLocalizerDetails(item)}
+                            {value.length > 1 && index < value.length - 1 && (
+                              <Divider sx={{ my: 1.5 }} />
+                            )}
+                          </React.Fragment>
+                        );
+                      })
                     )}
                     <ShowComponent condition={showMoreCondition}>
                       <Box
@@ -707,7 +655,7 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
                             textDecoration: "underline",
                             cursor: "pointer",
                           }}
-                          onClick={handleShowMore}
+                          onClick={() => handleShowMore(true)}
                         >
                           Show More
                         </Typography>

--- a/frontend/src/sections/common/ErrorLocalizeCard.jsx
+++ b/frontend/src/sections/common/ErrorLocalizeCard.jsx
@@ -295,8 +295,12 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
   const imageData = useMemo(() => getImageUrlFromData(datapoint), [datapoint]);
   const isImage = imageData?.format === "image";
   const isText = imageData?.format === "text";
+  const selectedInputKey =
+    datapoint?.selected_input_key ??
+    datapoint?.cell_metadata?.selected_input_key;
   const renderedText =
-    datapoint?.input_data?.[datapoint?.selected_input_key] ??
+    datapoint?.input_data?.[selectedInputKey] ??
+    datapoint?.cell_metadata?.input_data?.[selectedInputKey] ??
     imageData?.dataFile ??
     "";
   const isLongText = renderedText.length > 150;
@@ -304,10 +308,6 @@ const ErrorLocalizeCard = ({ value, datapoint, column, sx = {} }) => {
   const showMoreCondition = isLongText && !expanded && !isImage;
 
   const showLessCondition = isLongText && expanded;
-
-  const selectedInputKey =
-    datapoint?.selected_input_key ??
-    datapoint?.cell_metadata?.selected_input_key;
 
   useEffect(() => {
     setExpanded(false);

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -291,8 +291,7 @@ const DatapointDrawerChild = () => {
     return evalMetaBySourceId[sourceId]?.evalType === "code";
   };
   const evalOpenIsCode = isCodeEvalColumn(column?.col);
-  // TODO(TH-5635): temporary — hide the error localizer for composite evals
-  // until composite EL is redesigned. Remove when TH-5635 ships.
+
   const isCompositeEval =
     evalMetaBySourceId[column?.col?.sourceId || column?.col?.source_id]
       ?.templateType === "composite";
@@ -905,10 +904,7 @@ const DatapointDrawerChild = () => {
                     )}
                   </Box>
                 </Box>
-                {/* Code evals don't produce model traces for the localizer
-                    to introspect — hide the section entirely.
-                    TODO(TH-5635): composite evals are hidden too until
-                    composite EL is redesigned. */}
+               
                 {!evalOpenIsCode && !isCompositeEval && (
                   <ErrorLocalizationCellSection
                     evalOpen={evalOpen}

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -274,19 +274,29 @@ const DatapointDrawerChild = () => {
     { eval_type: "user" },
     "dataset",
   );
-  const evalTypeBySourceId = useMemo(() => {
+  const evalMetaBySourceId = useMemo(() => {
     const map = {};
     (savedEvalsData?.evals || []).forEach((e) => {
       const key = e.id || e.user_eval_id;
-      if (key) map[key] = e.eval_type || e.evalType;
+      if (key)
+        map[key] = {
+          evalType: e.eval_type || e.evalType,
+          templateType: e.template_type || e.templateType,
+        };
     });
     return map;
   }, [savedEvalsData]);
   const isCodeEvalColumn = (col) => {
     const sourceId = col?.sourceId || col?.source_id;
-    return evalTypeBySourceId[sourceId] === "code";
+    return evalMetaBySourceId[sourceId]?.evalType === "code";
   };
   const evalOpenIsCode = isCodeEvalColumn(column?.col);
+  // TODO(TH-5635): temporary — hide the error localizer for composite evals
+  // until composite EL is redesigned. Remove when TH-5635 ships.
+  const isCompositeEval =
+    evalMetaBySourceId[column?.col?.sourceId || column?.col?.source_id]
+      ?.templateType === "composite";
+
 
   const runEvalData = useMemo(() => {
     const evalColumns = allColumns.filter((i) => i.originType === "evaluation");
@@ -896,8 +906,10 @@ const DatapointDrawerChild = () => {
                   </Box>
                 </Box>
                 {/* Code evals don't produce model traces for the localizer
-                    to introspect — hide the section entirely. */}
-                {!evalOpenIsCode && (
+                    to introspect — hide the section entirely.
+                    TODO(TH-5635): composite evals are hidden too until
+                    composite EL is redesigned. */}
+                {!evalOpenIsCode && !isCompositeEval && (
                   <ErrorLocalizationCellSection
                     evalOpen={evalOpen}
                     onAnalysisLoaded={(details) => {

--- a/frontend/src/sections/evals/components/EvalResultDisplay.jsx
+++ b/frontend/src/sections/evals/components/EvalResultDisplay.jsx
@@ -473,6 +473,44 @@ const ErrorLocalizationSection = ({ result }) => {
       </Box>
     );
   }
+    if (errorLocalizerStatus === "skipped") {
+    return (
+      <Box
+        sx={{
+          mx: 1.5,
+          my: 1,
+          px: 1.5,
+          py: 1,
+          borderRadius: "6px",
+          border: "1px solid",
+          borderColor: "divider",
+          backgroundColor: (theme) =>
+            theme.palette.mode === "dark"
+              ? "rgba(145, 158, 171, 0.08)"
+              : "rgba(145, 158, 171, 0.04)",
+        }}
+      >
+        <Typography
+          variant="caption"
+          fontWeight={600}
+          color="text.secondary"
+          sx={{ display: "block" }}
+        >
+          Error localization skipped
+        </Typography>
+        {errorLocalizerMessage && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: "block", fontSize: "11px", mt: 0.25 }}
+          >
+            {errorLocalizerMessage}
+          </Typography>
+        )}
+      </Box>
+    );
+  }
+
 
   // Surface a clear failed state so users don't assume the feature is
   // just silently broken.
@@ -513,6 +551,7 @@ const ErrorLocalizationSection = ({ result }) => {
       </Box>
     );
   }
+
 
   if (!errorDetails) return null;
 

--- a/frontend/src/sections/evals/components/EvalResultDisplay.jsx
+++ b/frontend/src/sections/evals/components/EvalResultDisplay.jsx
@@ -491,8 +491,8 @@ const ErrorLocalizationSection = ({ result }) => {
         }}
       >
         <Typography
-          variant="caption"
-          fontWeight={600}
+      
+          typography="s3"
           color="text.secondary"
           sx={{ display: "block" }}
         >
@@ -532,8 +532,8 @@ const ErrorLocalizationSection = ({ result }) => {
         }}
       >
         <Typography
-          variant="caption"
-          fontWeight={600}
+          typography="s3"
+     
           color="error.main"
           sx={{ display: "block" }}
         >

--- a/frontend/src/sections/experiment-detail/ExperimentData/ViewDetailsModal.jsx
+++ b/frontend/src/sections/experiment-detail/ExperimentData/ViewDetailsModal.jsx
@@ -41,7 +41,6 @@ const ViewDetailsModal = ({
         metadata: data.metadata,
       }
     : null;
-
   // Detect composite eval results from value_infos
   const compositeResult = useMemo(() => {
     const vi = data?.value_infos ?? data?.valueInfos;
@@ -271,6 +270,7 @@ const ViewDetailsModal = ({
               </Box>
             </Box>
           )}
+          {!compositeResult && (
           <Box>
             <Typography
               fontWeight={500}
@@ -384,6 +384,7 @@ const ViewDetailsModal = ({
               </Typography>
             )}
           </Box>
+          )}
         </Box>
         <Box
           sx={{


### PR DESCRIPTION
## Summary

Two related error-localizer fixes on the frontend.

### 1. Text error-localizer rendering fixes (`ErrorLocalizeCard.jsx`)
- Fixed the **Show More** button that passed the click event into `setExpanded` instead of a boolean, so the empty-value/text branch never toggled correctly.
- Gated **Show More / Show Less** on the actually-rendered text length (and dropped a dead camelCase `data.imageUrl` guard).
- Fixed collapsed-state truncation: added `WebkitBoxOrient: "vertical"` so the `-webkit-line-clamp` actually clamps (matching the rest of the codebase).
- Stopped the expanded state from collapsing on scroll — the reset effect now depends on stable primitives (`column`, `selectedInputKey`, `value.length`) instead of object references that change on every parent re-render.
- Reworked the expanded view so each highlight is followed by its own **Reason / Suggested fix / Severity**, instead of one combined text block with all details grouped at the bottom. Collapsed view shows highlighted text only.
- Removed the now-unused `renderTextWithAllHighlights` helper.

### 2. Hide error localizer for composite evals — TH-5636 (`DatapointDrawerV2.jsx`, `ViewDetailsModal.jsx`)
Composite EL currently produces low-quality output, so the UI is hidden until the proper composite EL redesign lands (TH-5635). Each gate is marked with `// TODO(TH-5635)`.
- **Dataset drawer:** detect composite via `templateType === "composite"` from the eval-column metadata (`savedEvalsData`), reusing the same `sourceId` lookup as the code-eval check. Gated the cell EL section on `!evalOpenIsCode && !isCompositeEval`.
- **Experiment ViewDetails modal:** gated the "Possible Error" / `ErrorLocalizeCard` section on `!compositeResult`, reusing existing composite detection. Composite evals show only the Composite Breakdown.

The image error-localizer path is unchanged. The trace view (`EvalsTabView`) gate is **not** included — it is blocked on the backend adding `template_type` to the `eval_scores` payload.

## Test plan
- [x] Long localized text: **Show More** expands and **Show Less** collapses; collapsed text is clamped to ~5 lines with no overflow
- [x] Row with no highlights but long text: **Show More** now expands (previously broken)
- [x] Expanded view shows each highlighted sentence followed by its own Reason / Suggested fix / Severity, separated by dividers
- [x] Expand a card, scroll the list — it stays expanded; switching to a different row/column resets it
- [x] Image-input localization still renders the image with region highlights and hover tooltips
- [x] Dataset drawer: composite eval cell hides the error-localizer section; single eval cell still shows it; code eval still hidden as before
- [x] Experiment ViewDetails: composite eval shows only the Composite Breakdown (no Possible Error section); single eval shows the localizer as before

Closes TH-5267