### PR TITLE
fix(frontend): wire tracing graph toolbar controls

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
@@ -414,6 +414,8 @@ const AgentPathInner = ({
   const [containerWidth, setContainerWidth] = useState(900);
   const [containerHeight, setContainerHeight] = useState(200);
   const [isHovering, setIsHovering] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [zoom, setZoom] = useState(1);
   const layout = useMemo(() => computeSankeyLayout(data), [data]);
 
   useEffect(() => {
@@ -460,6 +462,18 @@ const AgentPathInner = ({
     );
   }
 
+  const chartHeight = isFullscreen ? Math.max(containerHeight, 320) : 200;
+  const chartWidth = Math.max(320, Math.round(containerWidth * zoom));
+  const scaledChartHeight = Math.max(120, Math.round(chartHeight * zoom));
+  const btnSx = {
+    p: 0.5,
+    borderRadius: 0,
+    borderRight: "1px solid",
+    borderRightColor: "divider",
+    "&:last-child": { borderRight: "none" },
+    color: "text.secondary",
+  };
+
   return (
     <Box
       ref={containerRef}
@@ -473,14 +487,14 @@ const AgentPathInner = ({
           : { mx: 2, my: 1 }),
       }}
     >
-      {/* Reveal on hover */}
+      {/* Zoom controls, top right (matches AgentGraph) */}
       {(isHovering || isFullscreen) && (
         <Box
           sx={{
             position: "absolute",
-            top: 8,
-            right: 8,
-            zIndex: 10,
+            top: isFullscreen ? 24 : 8,
+            right: isFullscreen ? 24 : 8,
+            zIndex: isFullscreen ? (t) => t.zIndex.modal + 1 : 10,
             display: "flex",
             bgcolor: "background.paper",
             border: "1px solid",
@@ -492,25 +506,64 @@ const AgentPathInner = ({
         >
           <IconButton
             size="small"
+            title="Zoom in"
+            onClick={() => setZoom((value) => Math.min(2, value + 0.2))}
+            sx={btnSx}
+          >
+            <Iconify icon="mdi:plus" width={14} />
+          </IconButton>
+          <IconButton
+            size="small"
+            title="Zoom out"
+            onClick={() => setZoom((value) => Math.max(0.6, value - 0.2))}
+            sx={btnSx}
+          >
+            <Iconify icon="mdi:minus" width={14} />
+          </IconButton>
+          <IconButton
+            size="small"
+            title="Fit"
+            onClick={() => setZoom(1)}
+            sx={btnSx}
+          >
+            <Iconify icon="mdi:crosshairs-gps" width={14} />
+          </IconButton>
+          <IconButton
+            size="small"
             title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
             onClick={onToggleFullscreen}
-            sx={{ p: 0.5, borderRadius: 0, color: "text.secondary" }}
+            sx={btnSx}
           >
             <Iconify
               icon={isFullscreen ? "mdi:fullscreen-exit" : "mdi:fullscreen"}
               width={14}
             />
           </IconButton>
+          <IconButton
+            size="small"
+            title={isCollapsed ? "Expand" : "Collapse"}
+            onClick={() => setIsCollapsed((value) => !value)}
+            sx={btnSx}
+          >
+            <Iconify
+              icon={isCollapsed ? "mdi:chevron-up" : "mdi:chevron-down"}
+              width={14}
+            />
+          </IconButton>
         </Box>
       )}
 
-      <SankeyChart
-        layout={layout}
-        width={containerWidth}
-        height={isFullscreen ? Math.max(containerHeight, 200) : 200}
-        onNodeClick={onNodeClick}
-        theme={theme}
-      />
+      {!isCollapsed && (
+        <Box sx={{ overflow: "auto" }}>
+          <SankeyChart
+            layout={layout}
+            width={chartWidth}
+            height={scaledChartHeight}
+            onNodeClick={onNodeClick}
+            theme={theme}
+          />
+        </Box>
+      )}
     </Box>
   );
 };

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
@@ -480,8 +480,11 @@ const AgentPathInner = ({
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       sx={{
+        display: "flex",
+        flexDirection: "column",
         position: "relative",
         bgcolor: "background.paper",
+        overflow: "hidden",
         ...(isFullscreen
           ? { height: "100%", width: "100%" }
           : { mx: 2, my: 1 }),
@@ -500,7 +503,8 @@ const AgentPathInner = ({
             border: "1px solid",
             borderColor: "divider",
             borderRadius: "6px",
-            boxShadow: (t) => `0 1px 3px ${alpha(t.palette.common.black, 0.06)}`,
+            boxShadow: (t) =>
+              `0 1px 3px ${alpha(t.palette.common.black, 0.06)}`,
             overflow: "hidden",
           }}
         >
@@ -554,7 +558,13 @@ const AgentPathInner = ({
       )}
 
       {!isCollapsed && (
-        <Box sx={{ overflow: "auto" }}>
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            overflow: "auto",
+          }}
+        >
           <SankeyChart
             layout={layout}
             width={chartWidth}

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
@@ -466,6 +466,9 @@ const AgentPathInner = ({
   const chartHeight = isFullscreen ? Math.max(containerHeight, 320) : 200;
   const chartWidth = Math.max(320, Math.round(containerWidth * zoom));
   const scaledChartHeight = Math.max(120, Math.round(chartHeight * zoom));
+  const controlInset = isFullscreen ? 24 : 8;
+  const collapsedToolbarHeight = controlInset * 2 + 28;
+  const showToolbar = isHovering || isFullscreen || isCollapsed;
   const btnSx = {
     p: 0.5,
     borderRadius: 0,
@@ -485,19 +488,19 @@ const AgentPathInner = ({
         flexDirection: "column",
         position: "relative",
         bgcolor: "background.paper",
-        overflow: "hidden",
+        overflow: isCollapsed ? "visible" : "hidden",
         ...(isFullscreen
-          ? { height: "100%", width: "100%" }
-          : { mx: 2, my: 1 }),
+          ? { height: isCollapsed ? collapsedToolbarHeight : "100%", width: "100%" }
+          : { mx: 2, my: 1, minHeight: isCollapsed ? collapsedToolbarHeight : undefined }),
       }}
     >
       {/* Zoom controls, top right (matches AgentGraph) */}
-      {(isHovering || isFullscreen) && (
+      {showToolbar && (
         <Box
           sx={{
             position: "absolute",
-            top: isFullscreen ? 24 : 8,
-            right: isFullscreen ? 24 : 8,
+            top: controlInset,
+            right: controlInset,
             zIndex: isFullscreen ? (t) => t.zIndex.modal + 1 : 10,
             display: "flex",
             bgcolor: "background.paper",

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
@@ -8,6 +8,7 @@ import React, { useMemo, useRef, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import {
   Box,
+  Collapse,
   CircularProgress,
   IconButton,
   Typography,
@@ -557,11 +558,10 @@ const AgentPathInner = ({
         </Box>
       )}
 
-      {!isCollapsed && (
+      <Collapse in={!isCollapsed} timeout="auto" sx={{ flex: 1, minHeight: 0 }}>
         <Box
           sx={{
-            flex: 1,
-            minHeight: 0,
+            height: "100%",
             overflow: "auto",
           }}
         >
@@ -573,7 +573,7 @@ const AgentPathInner = ({
             theme={theme}
           />
         </Box>
-      )}
+      </Collapse>
     </Box>
   );
 };

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx
@@ -561,7 +561,11 @@ const AgentPathInner = ({
         </Box>
       )}
 
-      <Collapse in={!isCollapsed} timeout="auto" sx={{ flex: 1, minHeight: 0 }}>
+      <Collapse
+        in={!isCollapsed}
+        timeout="auto"
+        sx={isFullscreen ? { flex: 1, minHeight: 0 } : { minHeight: 0 }}
+      >
         <Box
           sx={{
             height: "100%",


### PR DESCRIPTION
Closes #517.

## Summary
- Wire the tracing graph fullscreen button to an actual fullscreen toggle instead of duplicating `fitView`.
- Keep the graph controls visible while fullscreen is active and allow Escape to exit fullscreen.
- Wire the Sankey path toolbar buttons for zoom in, zoom out, fit, fullscreen, and collapse/expand.

## Validation
- `npx --yes prettier@3.3.0 --write frontend/src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx`
- `yarn install --frozen-lockfile --ignore-scripts --non-interactive`
- `./node_modules/.bin/eslint src/sections/projects/LLMTracing/GraphSection/AgentPath.jsx src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx`

Note: `npm ci --ignore-scripts --no-audit --no-fund` currently fails on the existing dependency tree because `react-data-grid@7.0.0-beta.59` declares a React 19 peer while the app uses React 18, so I used the repository's Yarn workflow for local lint validation.