### PR TITLE
TH-5626: simulate billing + secret-masking fixes (chat double-bill, snapshot secret leak)

### DIFF
--- a/futureagi/simulate/serializers/response/agent_version.py
+++ b/futureagi/simulate/serializers/response/agent_version.py
@@ -3,6 +3,34 @@ from rest_framework import serializers
 from agentcc.services.credential_manager import mask_key
 from simulate.models import AgentVersion
 
+# Provider-secret fields that may live in an AgentVersion.configuration_snapshot
+# and must never be returned to API clients in cleartext (they mirror the
+# credentials encrypted in ProviderCredentials). "Keys" get a partial mask
+# (first/last 4) so the UI can show *which* credential is set; the raw secret is
+# fully hidden. Keep in sync with the snapshot schema.
+_SNAPSHOT_MASKED_KEYS = ("api_key", "livekit_api_key")
+_SNAPSHOT_HIDDEN_SECRETS = ("livekit_api_secret",)
+
+
+def mask_snapshot_secrets(snapshot):
+    """Return a shallow copy of an agent configuration_snapshot with every
+    provider secret masked.
+
+    Safe on any input: a non-dict is returned unchanged. Use this everywhere a
+    configuration_snapshot is embedded in an API response so plaintext provider
+    secrets never reach clients, logs, or browser history.
+    """
+    if not isinstance(snapshot, dict):
+        return snapshot
+    masked = dict(snapshot)
+    for field in _SNAPSHOT_MASKED_KEYS:
+        if masked.get(field):
+            masked[field] = mask_key(masked[field])
+    for field in _SNAPSHOT_HIDDEN_SECRETS:
+        if masked.get(field):
+            masked[field] = "********"
+    return masked
+
 
 class AgentVersionResponseSerializer(serializers.ModelSerializer):
     """
@@ -49,11 +77,10 @@ class AgentVersionResponseSerializer(serializers.ModelSerializer):
             for key in ["organization", "knowledge_base", "workspace", "id"]:
                 if key in snapshot and snapshot[key] is not None:
                     snapshot[key] = str(snapshot[key])
-            # Mask sensitive secret so frontend knows it's set but can't read it
-            if "api_key" in snapshot and snapshot["api_key"]:
-                snapshot["api_key"] = mask_key(snapshot["api_key"])
-            if "livekit_api_secret" in snapshot and snapshot["livekit_api_secret"]:
-                snapshot["livekit_api_secret"] = "********"
+            # Mask every provider secret so the frontend knows a credential is
+            # set but can't read it. livekit_api_key was previously left in
+            # cleartext — mask_snapshot_secrets closes that gap.
+            snapshot = mask_snapshot_secrets(snapshot)
         data["configuration_snapshot"] = snapshot
         return data
 

--- a/futureagi/simulate/serializers/run_test.py
+++ b/futureagi/simulate/serializers/run_test.py
@@ -171,6 +171,10 @@ class RunTestSerializer(serializers.ModelSerializer):
         # re-serializing the same queryset a third time.
         data["evals"] = data.get("evals_detail", [])
         try:
+            from simulate.serializers.response.agent_version import (
+                mask_snapshot_secrets,
+            )
+
             # Only set agent_version for agent_definition source type.
             # Check for soft-deleted agent definition first: FK traversal bypasses
             # BaseModelManager's deleted=False filter, so we check explicitly.
@@ -190,7 +194,7 @@ class RunTestSerializer(serializers.ModelSerializer):
                     data["agent_version"] = {
                         "id": instance.agent_version.id,
                         "name": instance.agent_version.version_name,
-                        "configuration_snapshot": snapshot,
+                        "configuration_snapshot": mask_snapshot_secrets(snapshot),
                     }
                 else:
                     # Try to use prefetched versions first to avoid N+1.
@@ -218,7 +222,7 @@ class RunTestSerializer(serializers.ModelSerializer):
                         data["agent_version"] = {
                             "id": latest_version.id,
                             "name": latest_version.version_name,
-                            "configuration_snapshot": snapshot,
+                            "configuration_snapshot": mask_snapshot_secrets(snapshot),
                         }
         except Exception as e:
             logger.exception(

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -3644,36 +3644,47 @@ class TestExecutor:
                     f"Successfully deducted cost for chat call {call_execution.id}"
                 )
 
-                # Dual-write: emit usage event for text sim
+                # Dual-write: emit usage event for text sim. This is the SINGLE
+                # canonical TEXT_CALL emit — it is reached on every chat terminal
+                # path (interactive endCall, prompt-chat endCall via
+                # store_chat_messages, and prompt-chat max-turns via
+                # finalize_chat_execution). Do NOT emit TEXT_CALL anywhere else
+                # for the same source_id, or the call is double-billed.
                 try:
-                    try:
-                        from ee.usage.schemas.event_types import BillingEventType
-                    except ImportError:
-                        BillingEventType = None
-                    try:
-                        from ee.usage.schemas.events import UsageEvent
-                    except ImportError:
-                        UsageEvent = None
-                    try:
-                        from ee.usage.services.emitter import emit
-                    except ImportError:
-                        emit = None
+                    from ee.usage.schemas.event_types import BillingEventType
+                    from ee.usage.schemas.events import UsageEvent
+                    from ee.usage.services.emitter import emit
+                except ImportError:
+                    BillingEventType = UsageEvent = emit = None
 
-                    emit(
-                        UsageEvent(
-                            org_id=str(organization.id),
-                            event_type=BillingEventType.TEXT_CALL,
-                            amount=total_tokens,
-                            properties={
-                                "source": "simulate",
-                                "source_id": str(call_execution.id),
-                                "turns": no_of_fagi_agent_turns,
-                                "total_tokens": total_tokens,
-                            },
+                if emit and UsageEvent and BillingEventType:
+                    try:
+                        emit(
+                            UsageEvent(
+                                org_id=str(organization.id),
+                                event_type=BillingEventType.TEXT_CALL,
+                                # Floor at 1 so a token-tracking miss still bills a
+                                # non-zero TEXT_CALL (mirrors the voice
+                                # max(1, duration_minutes) floor) — never silent $0.
+                                amount=max(1, total_tokens),
+                                properties={
+                                    "source": "simulate",
+                                    "source_id": str(call_execution.id),
+                                    "turns": no_of_fagi_agent_turns,
+                                    "total_tokens": total_tokens,
+                                },
+                            )
                         )
+                    except Exception:
+                        logger.exception(
+                            "chat_usage_emit_failed",
+                            call_execution_id=str(call_execution.id),
+                        )
+                else:
+                    logger.error(
+                        "chat_usage_emit_unavailable",
+                        call_execution_id=str(call_execution.id),
                     )
-                except Exception:
-                    pass
 
                 return
 

--- a/futureagi/simulate/tasks/chat_sim.py
+++ b/futureagi/simulate/tasks/chat_sim.py
@@ -600,41 +600,12 @@ def run_single_prompt_chat(call_execution_id: str):
             max_turns=10,
         )
 
-        try:
-            call_execution.refresh_from_db()
-            from django.db.models import Sum
-
-            from simulate.models import ChatMessageModel
-            try:
-                from ee.usage.schemas.events import UsageEvent
-            except ImportError:
-                UsageEvent = None
-            try:
-                from ee.usage.services.emitter import emit
-            except ImportError:
-                emit = None
-
-            total_tokens = (
-                ChatMessageModel.objects.filter(
-                    call_execution=call_execution
-                ).aggregate(total=Sum("tokens"))["total"]
-                or 0
-            )
-
-            emit(
-                UsageEvent(
-                    org_id=str(organization.id),
-                    event_type=BillingEventType.TEXT_CALL,
-                    amount=total_tokens,
-                    properties={
-                        "source": "simulate_prompt_chat",
-                        "source_id": str(call_execution.id),
-                        "total_tokens": total_tokens,
-                    },
-                )
-            )
-        except Exception:
-            pass  # Metering failure must not break the action
+        # Billing is emitted exactly once by the canonical path
+        # (TestExecutor._deduct_call_cost), which runs on BOTH terminal exits of
+        # run_prompt_based_conversation: the endCall exit (via
+        # store_chat_messages(chat_ended=True)) and the max-turns/empty exit (via
+        # finalize_chat_execution()). Emitting a second TEXT_CALL UsageEvent here
+        # for the same source_id double-billed every prompt-based chat — removed.
 
         logger.info(
             "prompt_chat_simulation_completed",

--- a/futureagi/simulate/tests/test_e2e_prompt_simulation.py
+++ b/futureagi/simulate/tests/test_e2e_prompt_simulation.py
@@ -1375,6 +1375,107 @@ class E2EPromptSimulationTestCase(TestCase):
         self.assertGreaterEqual(result_data.get("count", 0), 2)
         print(f"✓ Scenario pagination: 1 item per page, total >= 2")
 
+    # =========================================================================
+    # FLOW 16: Billing — exactly one TEXT_CALL emit (A9 double-bill regression)
+    # =========================================================================
+
+    def _make_text_call_execution(self, token_counts):
+        """Create a TEXT CallExecution with one ChatMessageModel per token count.
+
+        Roles alternate user/assistant starting with user, so the number of
+        user-role rows (the billed "turns") is deterministic.
+        """
+        from simulate.models.chat_message import ChatMessageModel
+
+        simulation = RunTest.objects.create(
+            name=f"A9 Billing Sim {uuid.uuid4()}",
+            source_type="prompt",
+            prompt_template=self.prompt_template,
+            prompt_version=self.prompt_version,
+            organization=self.org,
+            workspace=self.workspace,
+        )
+        test_execution = TestExecution.objects.create(
+            run_test=simulation, status="pending"
+        )
+        call_execution = CallExecution.objects.create(
+            test_execution=test_execution,
+            scenario=self.scenario,
+            status=CallExecution.CallStatus.ANALYZING,
+            simulation_call_type=CallExecution.SimulationCallType.TEXT,
+        )
+        for i, tok in enumerate(token_counts):
+            ChatMessageModel.objects.create(
+                call_execution=call_execution,
+                organization=self.org,
+                workspace=self.workspace,
+                role=(
+                    ChatMessageModel.RoleChoices.USER
+                    if i % 2 == 0
+                    else ChatMessageModel.RoleChoices.ASSISTANT
+                ),
+                content=[{"role": "user", "content": "hi"}],
+                tokens=tok,
+            )
+        return call_execution
+
+    def test_flow16a_deduct_call_cost_emits_single_floored_text_call(self):
+        """A9: the canonical _deduct_call_cost emits exactly ONE TEXT_CALL event."""
+        from ee.usage.schemas.event_types import BillingEventType
+        from simulate.services.test_executor import TestExecutor
+
+        call_execution = self._make_text_call_execution([100, 50])  # total 150
+
+        with patch("ee.usage.services.emitter.emit") as mock_emit, patch(
+            "simulate.services.test_executor.deduct_cost_for_request"
+        ):
+            TestExecutor._deduct_call_cost(call_execution)
+
+        self.assertEqual(mock_emit.call_count, 1)
+        event = mock_emit.call_args.args[0]
+        self.assertEqual(event.event_type, BillingEventType.TEXT_CALL)
+        self.assertEqual(event.amount, 150)
+        print("✓ A9: canonical emit fires exactly once, amount=150")
+
+    def test_flow16b_zero_token_text_call_floored_to_one(self):
+        """A9: a token-tracking miss (0 tokens) still bills a non-zero TEXT_CALL."""
+        from simulate.services.test_executor import TestExecutor
+
+        call_execution = self._make_text_call_execution([0, 0])  # total 0
+
+        with patch("ee.usage.services.emitter.emit") as mock_emit, patch(
+            "simulate.services.test_executor.deduct_cost_for_request"
+        ):
+            TestExecutor._deduct_call_cost(call_execution)
+
+        self.assertEqual(mock_emit.call_count, 1)
+        self.assertEqual(mock_emit.call_args.args[0].amount, 1)  # floored, never $0
+        print("✓ A9: 0-token chat floored to amount=1 (never silent $0)")
+
+    def test_flow16c_finalize_max_turns_emits_single_text_call(self):
+        """A9: the max-turns exit (finalize_chat_execution) bills exactly once.
+
+        Guards against the inverse bug: deleting the redundant task-level emit
+        must NOT zero-bill max-turns chats — finalize_chat_execution covers them
+        via the same canonical _deduct_call_cost.
+        """
+        from simulate.services.chat_sim import finalize_chat_execution
+
+        call_execution = self._make_text_call_execution([10, 20])  # total 30
+
+        with patch("ee.usage.services.emitter.emit") as mock_emit, patch(
+            "simulate.services.test_executor.deduct_cost_for_request"
+        ), patch("simulate.services.chat_sim.notify_simulation_update"), patch(
+            "simulate.services.test_executor._run_simulate_evaluations_task"
+        ), patch(
+            "simulate.utils.chat_simulation._aggregate_chat_metrics"
+        ):
+            finalize_chat_execution(call_execution)
+
+        self.assertEqual(mock_emit.call_count, 1)
+        self.assertEqual(mock_emit.call_args.args[0].amount, 30)
+        print("✓ A9: max-turns finalize emits exactly one TEXT_CALL (no zero-bill)")
+
 
 def run_comprehensive_e2e_test():
     """

--- a/futureagi/simulate/tests/test_snapshot_secret_masking.py
+++ b/futureagi/simulate/tests/test_snapshot_secret_masking.py
@@ -1,0 +1,63 @@
+"""A5b: provider secrets must never leave an API response in cleartext.
+
+`mask_snapshot_secrets` is the single masking choke point used by both the
+agent-version response serializer and the run_test serializer (which previously
+embedded the raw configuration_snapshot verbatim, leaking customer api_key /
+livekit_api_key / livekit_api_secret).
+"""
+
+import pytest
+
+from simulate.serializers.response.agent_version import mask_snapshot_secrets
+
+PLAINTEXT_SECRET = "supersecretvalue1234567890"
+
+
+class TestMaskSnapshotSecrets:
+    @pytest.mark.unit
+    def test_masks_all_three_secret_fields(self):
+        raw = {
+            "api_key": "sk-vapi-1234567890abcdef",
+            "livekit_api_key": "APIabcdef123456",
+            "livekit_api_secret": PLAINTEXT_SECRET,
+            "provider": "livekit",
+            "livekit_url": "wss://example.livekit.cloud",
+        }
+        masked = mask_snapshot_secrets(raw)
+
+        # Input dict is not mutated (callers reuse the snapshot).
+        assert raw["api_key"] == "sk-vapi-1234567890abcdef"
+        assert raw["livekit_api_secret"] == PLAINTEXT_SECRET
+
+        # No secret field is returned in cleartext.
+        assert masked["api_key"] != raw["api_key"]
+        assert masked["livekit_api_key"] != raw["livekit_api_key"]
+        assert masked["livekit_api_secret"] == "********"
+
+        # Non-secret fields are preserved unchanged.
+        assert masked["provider"] == "livekit"
+        assert masked["livekit_url"] == "wss://example.livekit.cloud"
+
+        # The raw secret value appears nowhere in the masked output.
+        assert PLAINTEXT_SECRET not in masked.values()
+
+    @pytest.mark.unit
+    def test_livekit_api_key_is_masked(self):
+        # Regression for the specific gap: livekit_api_key used to pass through.
+        masked = mask_snapshot_secrets({"livekit_api_key": "APIverylongkey123"})
+        assert masked["livekit_api_key"] != "APIverylongkey123"
+        assert "verylongkey" not in masked["livekit_api_key"]
+
+    @pytest.mark.unit
+    def test_non_dict_returned_unchanged(self):
+        assert mask_snapshot_secrets(None) is None
+        assert mask_snapshot_secrets("not-a-dict") == "not-a-dict"
+
+    @pytest.mark.unit
+    def test_empty_or_missing_secrets_are_not_masked_to_noise(self):
+        masked = mask_snapshot_secrets(
+            {"api_key": "", "livekit_api_key": None, "provider": "vapi"}
+        )
+        assert masked["api_key"] == ""
+        assert masked["livekit_api_key"] is None
+        assert masked["provider"] == "vapi"


### PR DESCRIPTION
Stacked on `feat/livekit-simulation-migration` (PR #755). Part of the LiveKit simulation E2E hardening — see Linear **TH-5626**.

### Fixes (backend / `simulate`)
- **A9 — prompt-chat double-bill:** deleted the redundant `TEXT_CALL` emit; the canonical `_deduct_call_cost` is now the single source of truth on both terminal paths (endCall + max-turns), with a `max(1, tokens)` floor and loud-fail logging. Regression tests assert exactly one emit per chat.
- **A5b — provider secrets leaked unmasked:** the run_test serializer embedded the raw `configuration_snapshot` (decrypted `api_key`/`livekit_api_key`/`livekit_api_secret`) in API responses. Added a single `mask_snapshot_secrets()` choke point used by both the agent-version response and run_test serializer; repo-wide grep confirms no other endpoint leaks. Unit tests included.

### Validation
~200 unit/integration tests green; both fixes exercised by tests. The voice path was also validated end-to-end via a local SIP harness (real STT/LLM/TTS over SIP) documented on TH-5626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)