### PR TITLE
fix(evals): lock output type and rename Pass Rate to Task Completion Rate

### DIFF
--- a/frontend/src/sections/evals/components/EvalUsageTab.jsx
+++ b/frontend/src/sections/evals/components/EvalUsageTab.jsx
@@ -580,7 +580,7 @@ const EvalUsageTab = ({
               }}
             >
               <Typography variant="caption" color="text.disabled">
-                No data for this period
+              No data to show for selected period, update filters to view graph/data when no data is available.
               </Typography>
             </Box>
           )}

--- a/frontend/src/sections/evals/components/EvalUsageTab.jsx
+++ b/frontend/src/sections/evals/components/EvalUsageTab.jsx
@@ -542,7 +542,7 @@ const EvalUsageTab = ({
                 sx={{ width: "1px", height: 14, backgroundColor: "divider" }}
               />
               <StatPill
-                label="Pass Rate"
+                label="Task Completion Rate"
                 value={`${stats.pass_rate ?? 0}%`}
                 color="info.main"
               />

--- a/frontend/src/sections/evals/components/OutputTypeConfig.jsx
+++ b/frontend/src/sections/evals/components/OutputTypeConfig.jsx
@@ -16,6 +16,7 @@ import {
 import PropTypes from "prop-types";
 import React, { useCallback } from "react";
 import Iconify from "src/components/iconify";
+import CustomTooltip from "src/components/tooltip/CustomTooltip";
 
 const OutputTypeConfig = ({
   outputType,
@@ -115,38 +116,58 @@ const OutputTypeConfig = ({
             </Typography>
           </Box>
         )}
-        <RadioGroup
-          row
-          value={outputType}
-          onChange={(e) => {
-            const val = e.target.value;
-            onOutputTypeChange(val);
-            // Auto-add a default row if switching to scoring/deterministic with no choices
-            if (
-              (val === "percentage" || val === "deterministic") &&
-              Object.keys(choiceScores || {}).length === 0
-            ) {
-              onChoiceScoresChange({ "Choice 1": 0.5 });
-            }
-          }}
-          sx={{px:0.25}}
+        <CustomTooltip
+        size="small"
+        type="black"
+          show={radioDisabled}
+          title="Output type is fixed for this evaluation and can't be changed."
+          arrow
+          placement="top"
         >
-          <FormControlLabel
-            value="pass_fail"
-            control={<Radio size="small" disabled={radioDisabled} />}
-            label="Pass/fail"
-          />
-          <FormControlLabel
-            value="percentage"
-            control={<Radio size="small" disabled={radioDisabled} />}
-            label="Scoring"
-          />
-          <FormControlLabel
-            value="deterministic"
-            control={<Radio size="small" disabled={radioDisabled} />}
-            label="Choices"
-          />
-        </RadioGroup>
+          <Box
+            component="span"
+            sx={{
+              display: "inline-block",
+              cursor: radioDisabled ? "not-allowed" : "default",
+            }}
+          >
+            <RadioGroup
+              row
+              value={outputType}
+              onChange={(e) => {
+                const val = e.target.value;
+                onOutputTypeChange(val);
+                // Auto-add a default row if switching to scoring/deterministic with no choices
+                if (
+                  (val === "percentage" || val === "deterministic") &&
+                  Object.keys(choiceScores || {}).length === 0
+                ) {
+                  onChoiceScoresChange({ "Choice 1": 0.5 });
+                }
+              }}
+              sx={{
+                px: 0.25,
+                ...(radioDisabled && { pointerEvents: "none" }),
+              }}
+            >
+              <FormControlLabel
+                value="pass_fail"
+                control={<Radio size="small" disabled={radioDisabled} />}
+                label="Pass/fail"
+              />
+              <FormControlLabel
+                value="percentage"
+                control={<Radio size="small" disabled={radioDisabled} />}
+                label="Scoring"
+              />
+              <FormControlLabel
+                value="deterministic"
+                control={<Radio size="small" disabled={radioDisabled} />}
+                label="Choices"
+              />
+            </RadioGroup>
+          </Box>
+        </CustomTooltip>
       </Box>
 
       {/* ══════ Scoring mode ══════ */}

--- a/frontend/src/sections/evals/components/UsageChart.jsx
+++ b/frontend/src/sections/evals/components/UsageChart.jsx
@@ -44,7 +44,7 @@ const UsageChart = ({ data, outputType = "pass_fail" }) => {
       }
     }
 
-    const label = outputType === "pass_fail" ? "Pass Rate" : "Avg Score";
+    const label = "Task Completion Rate";
     return { volumeData: vol, valueData: val, valueLabel: label };
   }, [data, outputType]);
 


### PR DESCRIPTION
## Summary

Two UX improvements in the evals section:

- **Output Type is now read-only when fixed.** The Pass/fail / Scoring / Choices radio group is locked when the evaluation's output shape can't be changed, while the inner choice labels, scores, and thresholds stay editable. Added an inline info notice plus a CustomTooltip on hover explaining the field can't be changed, and a not-allowed cursor on the locked control.
- **Renamed Pass Rate to Task Completion Rate.** Updated the usage stat pill and the usage chart line label. The chart label now always reads Task Completion Rate regardless of output type.

## Test plan

- [ ] Open an eval where the output type is fixed and confirm the radio group is disabled, shows the info notice, and displays the tooltip on hover
- [ ] Confirm choice labels, scores, and pass threshold remain editable while the output type is locked
- [ ] Open an editable eval and confirm the output type radios still work and switching to Scoring/Choices auto-adds a default choice
- [ ] Check the Usage tab shows Task Completion Rate on the stat pill
- [ ] Verify the usage chart line label reads Task Completion Rate for both pass_fail and percentage output types


Closes TH-4976,TH-4478,Th-4003