### PR TITLE
fix(eval-tasks): preserve annotator/system filters on task update + edit [TH-5639]

### DIFF
--- a/frontend/src/components/filter-panel/FilterPanel.jsx
+++ b/frontend/src/components/filter-panel/FilterPanel.jsx
@@ -543,6 +543,21 @@ FilterRow.propTypes = {
  * @param {string} [activeField] — notifies parent which field is selected (for value fetching)
  * @param {Function} [onFieldChange] — called when field changes (so parent can fetch values)
  */
+// Token values are comma-joined strings; resolve ids (e.g. annotator UUIDs)
+// to labels via valueLabelMap, mirroring FilterChips. Falls back to raw.
+const formatTokenValue = (token, valueLabelMap) => {
+  const map = valueLabelMap?.[token.field];
+  if (!map) return token.value;
+  const resolveOne = (v) => map[String(v ?? "")] ?? String(v ?? "");
+  const value = String(token.value ?? "");
+  return value.includes(",")
+    ? value
+        .split(",")
+        .map((v) => resolveOne(v.trim()))
+        .join(", ")
+    : resolveOne(value);
+};
+
 function QueryInput({
   filterFields,
   fieldMap,
@@ -551,6 +566,7 @@ function QueryInput({
   valueOptions = [],
   valueLoading = false,
   onFieldChange,
+  valueLabelMap = {},
 }) {
   const [tokens, setTokens] = useState(initialTokens);
   const [partialField, setPartialField] = useState(null);
@@ -588,7 +604,12 @@ function QueryInput({
       }));
     if (phase === "operator") {
       const fd = fieldMap[partialField];
-      return getOperators(fd?.type || "string").map((o) => ({
+      // A field may pin its own operators (e.g. annotator → "is" only).
+      const ops =
+        Array.isArray(fd?.operators) && fd.operators.length
+          ? fd.operators
+          : getOperators(fd?.type || "string");
+      return ops.map((o) => ({
         id: o.value,
         label: o.label,
         type: "operator",
@@ -869,7 +890,7 @@ function QueryInput({
                 {tokens.map((token, idx) => (
                   <Chip
                     key={idx}
-                    label={`${fieldMap[token.field]?.label || token.field} ${token.operator} ${token.value}`}
+                    label={`${fieldMap[token.field]?.label || token.field} ${token.operator} ${formatTokenValue(token, valueLabelMap)}`}
                     size="small"
                     onClick={() => editToken(idx)}
                     onDelete={() => handleDeleteToken(idx)}
@@ -948,6 +969,7 @@ QueryInput.propTypes = {
   valueOptions: PropTypes.array,
   valueLoading: PropTypes.bool,
   onFieldChange: PropTypes.func,
+  valueLabelMap: PropTypes.object,
 };
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -3448,6 +3448,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
             {/* Toolbar */}
             <ObserveToolbar
               dateLabel={dateLabel}
+              fieldLabelMap={filterChipLabelMap}
               dateFilter={
                 selectedTab === "trace"
                   ? primaryTraceDateFilter

--- a/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
+++ b/frontend/src/sections/projects/LLMTracing/ObserveToolbar.jsx
@@ -66,6 +66,8 @@ const ObserveToolbar = ({
   onClearCompareExtraFilters,
   // Filter fields override (for sessions/users)
   filterFields,
+  // { field: { rawValue: label } } — resolves Query-tab chip values to labels.
+  fieldLabelMap,
   // LLM Tracing tab ("trace" | "spans") — when set, TraceFilterPanel
   // prepends the matching id filter(s) to its property picker.
   tab,
@@ -417,6 +419,7 @@ const ObserveToolbar = ({
             currentFilters={panelFilters}
             filterFields={filterFields}
             tab={tab}
+            fieldLabelMap={fieldLabelMap}
             isSimulator={isSimulator}
             isSpansView={isSpansView}
             source={
@@ -694,6 +697,7 @@ ObserveToolbar.propTypes = {
   onClearExtraFilters: PropTypes.func,
   onClearCompareExtraFilters: PropTypes.func,
   filterFields: PropTypes.array,
+  fieldLabelMap: PropTypes.object,
   tab: PropTypes.oneOf(["trace", "spans"]),
   graphFilters: PropTypes.array,
   onResetView: PropTypes.func,

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -339,6 +339,11 @@ const SINGLE_VALUE_OPS = new Set([
 // List ops — multi-select picker.
 const LIST_VALUE_OPS = new Set(["in", "not_in", "is", "is_not"]);
 
+// Generic placeholders a lossy serializer (e.g. saved eval-task filters) emits
+// when it can't express a field's real type; the registry wins over these on
+// hydration so typed fields aren't downgraded to a plain string row.
+const GENERIC_FIELD_TYPES = new Set(["string", "text"]);
+
 // ---------------------------------------------------------------------------
 // Hook: fetch properties from dashboard metrics
 // ---------------------------------------------------------------------------
@@ -1632,6 +1637,7 @@ const TraceFilterPanel = ({
   isSimulator = false,
   freeSoloValues = false,
   isSpansView = false,
+  fieldLabelMap,
 }) => {
   const { observeId: routeObserveId } = useParams();
   const observeId = projectIdProp || routeObserveId;
@@ -1722,6 +1728,9 @@ const TraceFilterPanel = ({
         panelType: p.type || "string",
         category: p.category, // system, eval, annotation, attribute
         apiColType: p.apiColType,
+        // Query tab flattens type to enum/string, losing "annotator"; pin its
+        // operators to the same ANNOTATOR_OPS the Basic tab uses.
+        ...(p.type === "annotator" ? { operators: ANNOTATOR_OPS } : {}),
       })),
     [properties],
   );
@@ -1752,10 +1761,18 @@ const TraceFilterPanel = ({
   useEffect(() => {
     if (open) {
       if (currentFilters?.length) {
-        // Enrich rows with fieldCategory and fieldType from properties lookup
+        // Registry type/category wins over generic placeholders so a lossy
+        // saved shape (eval-task filters) doesn't downgrade typed fields.
         const enriched = currentFilters.map((f) => {
           const prop = propertyById[f.field];
-          const fieldType = f.fieldType || prop?.type || "string";
+          const fieldType =
+            prop?.type && (!f.fieldType || GENERIC_FIELD_TYPES.has(f.fieldType))
+              ? prop.type
+              : f.fieldType || prop?.type || "string";
+          const fieldCategory =
+            prop?.category && (!f.fieldCategory || f.fieldCategory === "system")
+              ? prop.category
+              : f.fieldCategory || "system";
           // Translate wire ops to the picker's MenuItem values, per fieldType.
           const hydratedOp = ID_ONLY_FIELDS.has(f.field)
             ? "is"
@@ -1780,7 +1797,7 @@ const TraceFilterPanel = ({
           }
           return normalizeFilterRowOperator({
             ...f,
-            fieldCategory: f.fieldCategory || prop?.category || "system",
+            fieldCategory,
             fieldName: f.fieldName || prop?.name,
             fieldType,
             apiColType: f.apiColType || prop?.apiColType,
@@ -2090,6 +2107,7 @@ const TraceFilterPanel = ({
               valueOptions={queryValueOptions}
               valueLoading={queryValuesLoading}
               onFieldChange={setQueryField}
+              valueLabelMap={fieldLabelMap}
             />
             <Stack
               direction="row"
@@ -2146,6 +2164,8 @@ TraceFilterPanel.propTypes = {
   isSimulator: PropTypes.bool,
   freeSoloValues: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   isSpansView: PropTypes.bool,
+  // { field: { rawValue: label } } — Query-tab chip label resolution.
+  fieldLabelMap: PropTypes.object,
 };
 
 export default React.memo(TraceFilterPanel);

--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -132,16 +132,22 @@ const TaskDetailPage = () => {
     (editType) => {
       const data = formValues;
       const attributeFilters = extractAttributeFilters(data?.filters);
-      // observation_type rows may now carry an array `filterValue` (canonical
-      // `in`/`not_in`) or a scalar (legacy `equals`). Flatten + drop empties
-      // so the BE always sees a flat list of selected values.
-      const observationTypes = (data.filters || [])
-        .filter((f) => f.property === "observation_type")
-        .flatMap((f) => {
-          const v = f?.filterConfig?.filterValue;
-          if (Array.isArray(v)) return v;
-          return v !== undefined && v !== null && v !== "" ? [v] : [];
-        });
+      // Aggregate every non-attribute filter row into its BE key (flattening
+      // arrays). Mirrors create-side getNewTaskFilters so all system filters
+      // (annotator, span_kind, …) round-trip on update.
+      const systemFilters = {};
+      (data.filters || []).forEach((f) => {
+        if (!f?.property || f.property === "attributes") return;
+        const val = f?.filterConfig?.filterValue;
+        const vals = Array.isArray(val)
+          ? val
+          : val !== undefined && val !== null && val !== ""
+            ? [val]
+            : [];
+        if (vals.length === 0) return;
+        if (systemFilters[f.property]) systemFilters[f.property].push(...vals);
+        else systemFilters[f.property] = [...vals];
+      });
 
       const transformedData = {
         evals: data.evalsDetails?.map((item) => item.id || item) || [],
@@ -151,9 +157,7 @@ const TaskDetailPage = () => {
             new Date(data.startDate).toISOString(),
             new Date(data.endDate).toISOString(),
           ],
-          ...(observationTypes?.length > 0
-            ? { observation_type: observationTypes }
-            : {}),
+          ...systemFilters,
           ...(attributeFilters?.length > 0
             ? { span_attributes_filters: attributeFilters }
             : {}),

--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -1,10 +1,22 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import PropTypes from "prop-types";
 import { Box, Button, Typography } from "@mui/material";
 import { useWatch } from "react-hook-form";
 import Iconify from "src/components/iconify";
 import { getRandomId } from "src/utils/utils";
+import { useDashboardFilterValues } from "src/hooks/useDashboards";
 import TraceFilterPanel from "src/sections/projects/LLMTracing/TraceFilterPanel";
+import {
+  getPickerOptionLabel,
+  getPickerOptionSecondaryLabel,
+  getPickerOptionValue,
+} from "src/sections/projects/LLMTracing/filterValuePickerUtils";
 
 // ── Operator handling — canonical backend ops ──
 //
@@ -215,11 +227,14 @@ function convertOldToNew(oldFilters) {
 }
 
 // ── Chip display for an active filter ──
-const FilterChip = ({ filter, onRemove }) => {
+const FilterChip = ({ filter, labelMap, onRemove }) => {
   const opLabel = OP_DISPLAY[filter.operator] || filter.operator || "equals";
+  // Resolve opaque ids (e.g. annotator UUIDs) to labels; fall back to raw.
+  const fieldMap = labelMap?.[filter.field];
+  const resolve = (v) => fieldMap?.[String(v)] ?? String(v ?? "");
   const valueStr = Array.isArray(filter.value)
-    ? filter.value.join(", ")
-    : String(filter.value ?? "");
+    ? filter.value.map(resolve).join(", ")
+    : resolve(filter.value);
 
   return (
     <Box
@@ -282,6 +297,7 @@ const FilterChip = ({ filter, onRemove }) => {
 
 FilterChip.propTypes = {
   filter: PropTypes.object.isRequired,
+  labelMap: PropTypes.object,
   onRemove: PropTypes.func.isRequired,
 };
 
@@ -363,6 +379,32 @@ const TaskFilterBar = ({
 
   const hasFilters = panelFilters.length > 0;
 
+  // Build a UUID→name map so annotator chips show the name, not the raw id.
+  const hasAnnotatorFilter = useMemo(
+    () => panelFilters.some((f) => f.field === "annotator"),
+    [panelFilters],
+  );
+  const { data: annotatorFilterOptions = [] } = useDashboardFilterValues({
+    metricName: "annotator",
+    metricType: "annotation_metric",
+    projectIds: projectId ? [projectId] : [],
+    source: "traces",
+    enabled: hasAnnotatorFilter,
+  });
+  const filterChipLabelMap = useMemo(() => {
+    if (!annotatorFilterOptions.length) return undefined;
+    const entries = annotatorFilterOptions
+      .map((option) => {
+        const value = String(getPickerOptionValue(option));
+        if (!value) return null;
+        const label = getPickerOptionLabel(option);
+        const email = getPickerOptionSecondaryLabel(option);
+        return [value, email ? `${label} (${email})` : label];
+      })
+      .filter(Boolean);
+    return entries.length ? { annotator: Object.fromEntries(entries) } : undefined;
+  }, [annotatorFilterOptions]);
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
       {hasFilters ? (
@@ -378,6 +420,7 @@ const TaskFilterBar = ({
             <FilterChip
               key={`${f.field}-${idx}`}
               filter={f}
+              labelMap={filterChipLabelMap}
               onRemove={() => handleRemove(idx)}
             />
           ))}
@@ -467,6 +510,7 @@ const TaskFilterBar = ({
         projectId={projectId}
         isSimulator={isSimulator}
         tab={rowTypeToFilterTab(rowType)}
+        fieldLabelMap={filterChipLabelMap}
         onApply={(next) => applyPanelFilters(next || [])}
       />
     </Box>


### PR DESCRIPTION
## TH-5639 — Annotation filters not passed when eval tasks run

### Problem
Annotator filters on eval tasks were lost in several places, even though the backend filtering itself works (verified: `list_spans_observe` with the annotator filter returns the expected span). The visible symptoms:
- **Update dropped the filter:** the full-page task edit (`PATCH /update_eval_task/`) only serialized `observation_type` + attribute filters, so `annotator` (and every other system filter) silently disappeared from the payload. Create worked; update didn't.
- **Edit re-hydrated annotator as a generic field:** reopening a task showed the annotator as a plain text box with the raw UUID, string operators, and a "system" category instead of the annotator picker / `is` operator / "annotation" category.
- **Chips showed the UUID** instead of the annotator name — both the collapsed chip and the Query-tab token.
- **Query tab offered wrong operators** (`contains`, `starts_with`, …) for annotator instead of just `is`.

### Root cause
The saved filter shape (`{ annotator: ["uuid"] }`) carries no type/category info, so the generic hydration path downgraded it to a string/`equals` row. That generic type then overrode the property registry's real `annotator` type, and the update serializer never re-collected non-hardcoded system filters.

### Changes
- **`TaskDetailPage.jsx`** — update payload now aggregates *every* non-attribute filter row into its BE key (flattening arrays), mirroring create-side `getNewTaskFilters`. `annotator`, `span_kind`, etc. all round-trip on `PATCH`. (The old `observation_type`-only block was both redundant and key-mismatched — hydrated rows use `span_kind`.)
- **`TraceFilterPanel.jsx`** — hydration now lets the property registry's `type`/`category` win over generic `string`/`text`/`system` placeholders, so typed fields aren't downgraded on edit. Also pins annotator operators to `is` in the Query tab.
- **`FilterPanel.jsx`** (`QueryInput`) — resolves token values to labels via a `valueLabelMap`, and lets a field pin its own operator list.
- **`TaskFilterBar.jsx` / `ObserveToolbar.jsx` / `LLMTracingView.jsx`** — build and thread the annotator UUID→name map so chips and Query-tab tokens show the name.

### Scope / safety
- Registry override only kicks in when the incoming type is the generic `string`/`text` placeholder and the field is in the registry — typed fields and attributes (not in registry) are untouched. Also restores categorical/thumbs/number system filters on edit, not just annotator.
- Operator round-trip verified across Basic/Query tabs and create/update (`is` ↔ `equals`/`in`).
- Reviewed via code-review agent: no critical/should-fix issues.