### PR TITLE
feat: enable span list view without project_id (fix #775)

### DIFF
--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -1555,15 +1555,14 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             user_id = request.query_params.get("user_id") or request.query_params.get(
                 "userId"
             )
-            
-            organization = getattr(self.request, "organization", None) or self.request.user.organization
-            
-            project = None
-            if project_id:
-                project = Project.objects.get(
-                    id=project_id,
-                    organization=organization,
-                )
+            if not project_id:
+                raise Exception("Project id is required")
+
+            project = Project.objects.get(
+                id=project_id,
+                organization=getattr(self.request, "organization", None)
+                or self.request.user.organization,
+            )
 
             # ClickHouse dispatch
             from tracer.services.clickhouse.query_service import (
@@ -1591,7 +1590,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             )
 
             end_user_id = None
-            if user_id:
+            if user_id and project is not None:
                 try:
                     end_user_id = str(
                         EndUser.objects.get(
@@ -1606,10 +1605,10 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
 
             # Base query with annotations
             base_query = ObservationSpan.objects.filter(
-                project__organization=organization,
+                project_id=project_id,
+                project__organization=getattr(request, "organization", None)
+                or request.user.organization,
             ).select_related("trace")
-            if project_id:
-                base_query = base_query.filter(project_id=project_id)
 
             if end_user_id:
                 base_query = base_query.filter(end_user_id=end_user_id)
@@ -3715,7 +3714,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             )
 
             end_user_id = None
-            if user_id:
+            if user_id and project is not None:
                 try:
                     end_user_id = str(
                         EndUser.objects.get(

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -1555,14 +1555,15 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
             user_id = request.query_params.get("user_id") or request.query_params.get(
                 "userId"
             )
-            if not project_id:
-                raise Exception("Project id is required")
-
-            project = Project.objects.get(
-                id=project_id,
-                organization=getattr(self.request, "organization", None)
-                or self.request.user.organization,
-            )
+            
+            organization = getattr(self.request, "organization", None) or self.request.user.organization
+            
+            project = None
+            if project_id:
+                project = Project.objects.get(
+                    id=project_id,
+                    organization=organization,
+                )
 
             # ClickHouse dispatch
             from tracer.services.clickhouse.query_service import (
@@ -1605,10 +1606,10 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
 
             # Base query with annotations
             base_query = ObservationSpan.objects.filter(
-                project_id=project_id,
-                project__organization=getattr(request, "organization", None)
-                or request.user.organization,
+                project__organization=organization,
             ).select_related("trace")
+            if project_id:
+                base_query = base_query.filter(project_id=project_id)
 
             if end_user_id:
                 base_query = base_query.filter(end_user_id=end_user_id)


### PR DESCRIPTION
## What

Make `project_id` optional in `list_spans_observe`. When not provided, return all spans for the user's organization.

## Why

From [#775](https://github.com/future-agi/future-agi/issues/775): Users want to view spans across all projects without specifying a project_id.

## How

```python
# Before: project_id is mandatory
if not project_id:
    raise Exception("Project id is required")

# After: project_id is optional
organization = getattr(self.request, "organization", None) or self.request.user.organization
project = None
if project_id:
    project = Project.objects.get(id=project_id, organization=organization)
```

The base query now filters by organization first, then by project_id if provided:

```python
base_query = ObservationSpan.objects.filter(
    project__organization=organization,
).select_related("trace")
if project_id:
    base_query = base_query.filter(project_id=project_id)
```

## Testing

```bash
# Test with project_id (existing behavior)
curl "/api/spans/observe?project_id=xxx"

# Test without project_id (new behavior)
curl "/api/spans/observe"
```

## Ref

Closes #775