### PR TITLE
fix(eval-task): dispatch all filter col_types in parsing_evaltask_filters [TH-5645]

### DIFF
--- a/futureagi/tracer/migrations/0081_rename_eval_task_filters_key.py
+++ b/futureagi/tracer/migrations/0081_rename_eval_task_filters_key.py
@@ -1,0 +1,103 @@
+"""Rename ``tracer_eval_task.filters['span_attributes_filters']`` → ``filters``.
+
+The inner key historically held the per-item filter list (one entry per filter
+chip). It was named ``span_attributes_filters`` back when only SPAN_ATTRIBUTE
+chips were stored there. The list now carries items of every col_type
+(SPAN_ATTRIBUTE, SYSTEM_METRIC, EVAL_METRIC, ANNOTATION, has_eval, ...) and
+the eval-task dispatcher (``tracer/utils/eval_tasks.py::parsing_evaltask_filters``)
+now mirrors the per-col_type dispatch pattern used by ``list_spans_observe``
+(``tracer/views/observation_span.py:1755-1826``). The new canonical key is just
+``filters`` — aligned with the rest of the API surface.
+
+The BE dispatcher reads both keys during a transition window
+(``parsing_evaltask_filters`` accepts ``filters`` or ``span_attributes_filters``
+with a one-line ``logger.info`` on the legacy path), so this migration is
+cleanup, not a hard cut. After this runs every row uses the canonical key
+and the legacy-key branch goes quiet.
+
+Scope: ``tracer_eval_task`` only. ``tracer_useralertmonitor`` and
+``tracer_savedview`` carry the same shape but are intentionally out of scope
+for this PR — they get the same treatment in a follow-up.
+"""
+
+import logging
+
+from django.db import migrations
+
+logger = logging.getLogger(__name__)
+
+
+def _rename_in_eval_task_filters(apps, stats):
+    EvalTask = apps.get_model("tracer", "EvalTask")
+    for et in EvalTask.objects.iterator(chunk_size=500):
+        try:
+            f = et.filters
+            if not isinstance(f, dict):
+                continue
+            if "span_attributes_filters" not in f:
+                continue
+            # Don't clobber a pre-existing canonical key — if both exist
+            # (shouldn't happen in practice) keep ``filters`` as truth and
+            # drop the legacy key.
+            if "filters" not in f:
+                f["filters"] = f.pop("span_attributes_filters")
+            else:
+                f.pop("span_attributes_filters")
+            et.filters = f
+            et.save(update_fields=["filters"])
+            stats["renamed"] += 1
+        except Exception as e:
+            stats["failed"] += 1
+            logger.exception(
+                f"[rename_eval_task_filters_key] EvalTask id={et.pk} failed: {e}"
+            )
+
+
+def _restore_in_eval_task_filters(apps, stats):
+    """Reverse: rename ``filters`` back to ``span_attributes_filters``."""
+    EvalTask = apps.get_model("tracer", "EvalTask")
+    for et in EvalTask.objects.iterator(chunk_size=500):
+        try:
+            f = et.filters
+            if not isinstance(f, dict):
+                continue
+            if "filters" not in f or "span_attributes_filters" in f:
+                continue
+            f["span_attributes_filters"] = f.pop("filters")
+            et.filters = f
+            et.save(update_fields=["filters"])
+            stats["renamed"] += 1
+        except Exception as e:
+            stats["failed"] += 1
+            logger.exception(
+                f"[rename_eval_task_filters_key] reverse EvalTask id={et.pk} "
+                f"failed: {e}"
+            )
+
+
+def forwards(apps, schema_editor):
+    stats = {"renamed": 0, "failed": 0}
+    _rename_in_eval_task_filters(apps, stats)
+    print(
+        f"[rename_eval_task_filters_key] {stats['renamed']} eval tasks "
+        f"renamed, {stats['failed']} rows skipped due to errors"
+    )
+
+
+def backwards(apps, schema_editor):
+    stats = {"renamed": 0, "failed": 0}
+    _restore_in_eval_task_filters(apps, stats)
+    print(
+        f"[rename_eval_task_filters_key] reverse: {stats['renamed']} "
+        f"eval tasks restored, {stats['failed']} rows skipped"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tracer", "0080_alter_tracescanconfig_sampling_rate"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/futureagi/tracer/tests/test_eval_task_filter_dispatch.py
+++ b/futureagi/tracer/tests/test_eval_task_filter_dispatch.py
@@ -1,0 +1,311 @@
+"""
+Tests for parsing_evaltask_filters dispatcher.
+
+Verifies the eval-task path now routes each ``col_type`` through the right
+FilterEngine handler — mirroring ``list_spans_observe``
+(``tracer/views/observation_span.py:1755-1826``) — and silently ignores
+unrecognised col_types. Structural assertions: we check the shape and
+``repr`` of the returned ``Q`` (and the annotation dict) rather than
+running queries against a DB, because the underlying handlers each have
+their own integration tests.
+
+The bug this guards against: until 2026-06-04 the dispatcher only handled
+``SPAN_ATTRIBUTE`` and silently dropped every other col_type, including the
+``ANNOTATION`` annotator filter behind the prod task
+``f8481965-cd74-44b1-9b6d-f4bb66ec2218``. See plan
+``~/.claude/plans/shift-to-fix-nightly-dev-27-05-and-zazzy-eagle.md``.
+"""
+
+import uuid
+
+import pytest
+from django.db.models import Q
+
+from tracer.utils.eval_tasks import parsing_evaltask_filters
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wrap(items, key="filters"):
+    """Wrap a list of filter items in the eval-task top-level filters dict."""
+    return {key: items}
+
+
+def _span_attr_item(column_id="ended_reason", value="completed"):
+    return {
+        "column_id": column_id,
+        "filter_config": {
+            "col_type": "SPAN_ATTRIBUTE",
+            "filter_type": "text",
+            "filter_op": "equals",
+            "filter_value": value,
+        },
+    }
+
+
+def _annotator_item(user_uuid="c65a0f3c-8a72-432a-987f-ddbd8391df29"):
+    """Mirrors the prod bug task's annotator filter shape (camelCase, top-level
+    col_type-by-config). The dispatcher tolerates either case."""
+    return {
+        "columnId": "annotator",
+        "filterConfig": {
+            "colType": "ANNOTATION",
+            "filterOp": "equals",
+            "filterType": "text",
+            "filterValue": user_uuid,
+        },
+    }
+
+
+def _label_value_item(label_uuid, value):
+    return {
+        "column_id": label_uuid,
+        "filter_config": {
+            "col_type": "ANNOTATION",
+            "filter_type": "number",
+            "filter_op": "greater_than",
+            "filter_value": value,
+        },
+    }
+
+
+def _system_metric_item(column_id="cost", op="greater_than", value=0.5):
+    return {
+        "column_id": column_id,
+        "filter_config": {
+            "col_type": "SYSTEM_METRIC",
+            "filter_type": "number",
+            "filter_op": op,
+            "filter_value": value,
+        },
+    }
+
+
+def _eval_metric_item(eval_template_id, op="greater_than", value=0.8):
+    return {
+        "column_id": eval_template_id,
+        "filter_config": {
+            "col_type": "EVAL_METRIC",
+            "filter_type": "number",
+            "filter_op": op,
+            "filter_value": value,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Empty / None handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEmpty:
+    def test_none_returns_empty_tuple(self):
+        q, anns = parsing_evaltask_filters(None)
+        assert q == Q()
+        assert anns == {}
+
+    def test_empty_dict_returns_empty_tuple(self):
+        q, anns = parsing_evaltask_filters({})
+        assert q == Q()
+        assert anns == {}
+
+    def test_empty_filters_list_returns_empty_tuple(self):
+        q, anns = parsing_evaltask_filters({"filters": []})
+        assert q == Q()
+        assert anns == {}
+
+
+# ---------------------------------------------------------------------------
+# Legacy `span_attributes_filters` key still parsed (transition)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLegacyKey:
+    def test_legacy_key_with_span_attribute_filter(self):
+        items = [_span_attr_item()]
+        q, anns = parsing_evaltask_filters(
+            _wrap(items, key="span_attributes_filters")
+        )
+        # Legacy key produces the same Q as the canonical key.
+        q_canonical, _ = parsing_evaltask_filters(_wrap(items, key="filters"))
+        assert repr(q) == repr(q_canonical)
+        assert anns == {}
+
+    def test_legacy_key_with_annotator_filter(self):
+        # The specific shape that motivated the fix: prod task f8481965.
+        items = [_annotator_item()]
+        q, anns = parsing_evaltask_filters(
+            _wrap(items, key="span_attributes_filters")
+        )
+        assert q != Q()
+        assert "Exists" in repr(q)  # routed through the voice annotation handler
+
+
+# ---------------------------------------------------------------------------
+# SPAN_ATTRIBUTE — regression guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSpanAttribute:
+    def test_span_attribute_only(self):
+        q, anns = parsing_evaltask_filters(_wrap([_span_attr_item()]))
+        assert q != Q()
+        # SPAN_ATTRIBUTE filters resolve via the span_attributes JSONB
+        # (`has_key` + `contains`) — verify by string match on the Q repr.
+        assert "span_attributes" in repr(q)
+        assert anns == {}
+
+
+# ---------------------------------------------------------------------------
+# ANNOTATION — the original bug
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAnnotation:
+    def test_annotator_filter_produces_exists_clause(self):
+        items = [_annotator_item()]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert q != Q()
+        # The annotator branch builds an Exists(Score.objects...) subquery.
+        assert "Exists" in repr(q)
+        # The annotator path is pure-Q — no annotate() kwargs.
+        assert anns == {}
+
+    def test_per_label_score_filter_builds_annotation_field_q(self):
+        # A per-label ANNOTATION filter (e.g. "quality > 3") builds a Q
+        # referencing the `annotation_<uuid>__score` field. The actual
+        # `.annotate(annotation_<uuid>=...)` step is contributed by
+        # `build_annotation_subqueries` (observation_span.py:1167-1169),
+        # which `process_eval_task` does not yet call — see the dispatcher
+        # docstring. So `extra_anns` remains empty here; this test guards
+        # the Q shape only. When `build_annotation_subqueries` is wired in
+        # for eval tasks, replace this with an integration test that asserts
+        # the queryset actually returns the right rows.
+        label_uuid = str(uuid.uuid4())
+        items = [_label_value_item(label_uuid, 3.0)]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert q != Q()
+        assert f"annotation_{label_uuid}__score" in repr(q)
+        assert anns == {}
+
+    def test_annotation_does_not_leak_into_non_system_handler(self):
+        # Per list_spans_observe (observation_span.py:1769-1777), ANNOTATION
+        # items and the annotation-special column_ids must be excluded from
+        # the eval-metrics handler. Mixing both should still produce a single
+        # well-formed Q without raising.
+        items = [
+            _annotator_item(),
+            _eval_metric_item(str(uuid.uuid4())),
+        ]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert q != Q()
+
+
+# ---------------------------------------------------------------------------
+# SYSTEM_METRIC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSystemMetric:
+    def test_system_metric_filter(self):
+        items = [_system_metric_item("cost", "greater_than", 0.1)]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        # The system-metrics handler maps `cost` to `row_avg_cost`
+        # (FilterEngine.DEFAULT_FIELD_MAP) and emits a Q referencing it.
+        assert q != Q()
+        assert anns == {}
+
+
+# ---------------------------------------------------------------------------
+# EVAL_METRIC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEvalMetric:
+    def test_eval_metric_filter(self):
+        items = [_eval_metric_item(str(uuid.uuid4()), "greater_than", 0.8)]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert q != Q()
+
+
+# ---------------------------------------------------------------------------
+# Mixed — all four colTypes at once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMixed:
+    def test_all_four_col_types_combine(self):
+        items = [
+            _span_attr_item(),
+            _system_metric_item("cost", "greater_than", 0.1),
+            _eval_metric_item(str(uuid.uuid4())),
+            _annotator_item(),
+        ]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert q != Q()
+        # Each handler contributes its own clause; combined Q should reference
+        # all the underlying mechanisms.
+        rep = repr(q)
+        assert "span_attributes" in rep   # SPAN_ATTRIBUTE
+        assert "Exists" in rep             # ANNOTATION (annotator) Exists subquery
+
+
+# ---------------------------------------------------------------------------
+# Sibling keys at the top level
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSiblingKeys:
+    def test_date_range_still_applied(self):
+        q, _ = parsing_evaltask_filters(
+            {"date_range": ["2026-01-01T00:00:00Z", "2026-06-01T00:00:00Z"]}
+        )
+        assert q != Q()
+        assert "created_at" in repr(q)
+
+    def test_project_id_still_applied(self):
+        q, _ = parsing_evaltask_filters({"project_id": str(uuid.uuid4())})
+        assert q != Q()
+        assert "project_id" in repr(q)
+
+    def test_observation_type_still_applied(self):
+        q, _ = parsing_evaltask_filters({"observation_type": ["llm", "tool"]})
+        assert q != Q()
+        assert "observation_type" in repr(q)
+
+
+# ---------------------------------------------------------------------------
+# Unrecognised col_type — silent skip (no raise)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestUnrecognisedColType:
+    def test_unknown_col_type_does_not_raise(self):
+        items = [
+            {
+                "column_id": "some_id",
+                "filter_config": {
+                    "col_type": "TOTALLY_MADE_UP",
+                    "filter_type": "text",
+                    "filter_op": "equals",
+                    "filter_value": "x",
+                },
+            }
+        ]
+        # Must not raise. The handlers' own col_type gates skip items they
+        # don't recognise; the dispatcher itself doesn't enumerate types.
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert isinstance(q, Q)
+        assert anns == {}

--- a/futureagi/tracer/utils/eval_tasks.py
+++ b/futureagi/tracer/utils/eval_tasks.py
@@ -4,7 +4,7 @@ from random import sample
 import structlog
 from django.core.cache import cache
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import OuterRef, Q
 from django.utils import timezone
 
 logger = structlog.get_logger(__name__)
@@ -32,7 +32,9 @@ from tracer.utils.eval import (
     evaluate_trace_observe,
     evaluate_trace_session_observe,
 )
-from tracer.utils.filters import FilterEngine
+from tracer.utils.annotations import build_annotation_subqueries
+from tracer.utils.filters import ColType, FilterEngine
+from tracer.utils.helper import get_annotation_labels_for_project
 
 # Cron-side drain window — once the dispatcher has fired every
 # per-span activity, the task stays in RUNNING until either the
@@ -133,10 +135,122 @@ def compute_drain_state(eval_task, eval_task_logger=None):
     }
 
 
-def parsing_evaltask_filters(filters: dict) -> Q:
+def parsing_evaltask_filters(filters: dict) -> tuple[Q, dict]:
+    """Combine eval-task filter JSON into ``(Q, annotation_kwargs)``.
+
+    Per-handler dispatch mirrors ``list_spans_observe``
+    (``tracer/views/observation_span.py:1755-1826``): one flat ``filters``
+    list, each item carrying ``col_type``, passed to every handler.
+
+    Callers must apply ``.annotate(**extra_annotations).filter(combined_q)``.
+    Per-label ANNOTATION filters (e.g. ``columnId == "<label_uuid>"``)
+    additionally require ``build_annotation_subqueries`` to have been
+    applied to the queryset first — ``process_eval_task`` does that;
+    other callers must mirror it if they accept per-label filters.
+
+    Accepts both ``filters`` and legacy ``span_attributes_filters`` keys.
     """
-    Parses the input filters dictionary and returns a single combined Q object
-    for Django ORM filtering.
+    combined_q = Q()
+    extra_anns: dict = {}
+
+    if filters is None:
+        return combined_q, extra_anns
+
+    for key, value in filters.items():
+        if key in ("filters", "span_attributes_filters") and isinstance(value, list):
+            if key == "span_attributes_filters":
+                logger.info("eval_task_filter_legacy_key")
+
+            items = value
+            if not items:
+                continue
+
+            q_sys = FilterEngine.get_filter_conditions_for_system_metrics(items)
+            if q_sys:
+                combined_q &= q_sys
+
+            # ANNOTATION + my_annotations/annotator are routed through the
+            # voice annotation handler below; exclude them here so they
+            # don't double-match.
+            non_anno = [
+                f
+                for f in items
+                if _filter_col_type(f) != ColType.ANNOTATION.value
+                and _filter_column_id(f) not in ("my_annotations", "annotator")
+            ]
+            if non_anno:
+                q_eval = FilterEngine.get_filter_conditions_for_non_system_metrics(
+                    non_anno
+                )
+                if q_eval:
+                    combined_q &= q_eval
+
+            # span_filter_kwargs re-targets the Score join to span scope
+            # (filters.py:1683-1692); user_id=None because we're in a
+            # background activity, which makes my_annotations a no-op.
+            q_anno, anno_anns = (
+                FilterEngine.get_filter_conditions_for_voice_call_annotations(
+                    items,
+                    user_id=None,
+                    span_filter_kwargs={"observation_span_id": OuterRef("id")},
+                )
+            )
+            if q_anno:
+                combined_q &= q_anno
+            if anno_anns:
+                extra_anns.update(anno_anns)
+
+            q_span = FilterEngine.get_filter_conditions_for_span_attributes(items)
+            if q_span:
+                combined_q &= q_span
+
+            q_has_eval = FilterEngine.get_filter_conditions_for_has_eval(
+                items, observe_type="span"
+            )
+            if q_has_eval:
+                combined_q &= q_has_eval
+            q_has_anno = FilterEngine.get_filter_conditions_for_has_annotation(
+                items, observe_type="span"
+            )
+            if q_has_anno:
+                combined_q &= q_has_anno
+
+        elif key == "observation_type":
+            if isinstance(value, list):
+                combined_q &= Q(observation_type__in=list(value))
+            elif isinstance(value, str):
+                combined_q &= Q(observation_type=value)
+            else:
+                raise Exception(
+                    "Invalid value for observation_type filter; expected list or string"
+                )
+        elif key == "session_id":
+            traces = Trace.objects.filter(session_id=value).values_list("id", flat=True)
+            combined_q &= Q(trace_id__in=list(traces))
+        elif key == "date_range":
+            if isinstance(value, list) and len(value) == 2:
+                start_date, end_date = value
+                combined_q &= Q(created_at__range=[start_date, end_date])
+        elif key == "created_at":
+            combined_q &= Q(created_at__gte=value)
+        elif key == "project_id":
+            combined_q &= Q(project_id=value)
+
+    return combined_q, extra_anns
+
+
+def parsing_monitor_filters(filters: dict) -> Q:
+    """Legacy filter parser kept for monitor.py and monitor_graphs.py.
+
+    Monitors use a simpler filter UI than eval tasks — only SPAN_ATTRIBUTE
+    chips, no annotation/eval-metric/system-metric col_types. Keeping the
+    old single-handler dispatch here avoids monitor pages paying for the
+    annotate-subqueries cost or surfacing FieldErrors for filters they
+    never carry.
+
+    Eval task create/edit and the eval-task rerun count use the richer
+    ``parsing_evaltask_filters`` (above), which returns ``(Q, dict)`` and
+    routes by col_type.
     """
     combined_q = Q()
 
@@ -174,6 +288,24 @@ def parsing_evaltask_filters(filters: dict) -> Q:
             combined_q &= Q(project_id=value)
 
     return combined_q
+
+
+def _filter_col_type(item: dict) -> str:
+    """Read col_type from a filter item, tolerating both camel- and snake-case
+    keys at either the top level or nested in filter_config (mirrors the
+    normalisation in `_normalize_filter_params`)."""
+    cfg = item.get("filter_config") or item.get("filterConfig") or {}
+    return (
+        item.get("col_type")
+        or item.get("colType")
+        or cfg.get("col_type")
+        or cfg.get("colType")
+        or ""
+    )
+
+
+def _filter_column_id(item: dict) -> str:
+    return item.get("column_id") or item.get("columnId") or ""
 
 
 @temporal_activity(
@@ -237,8 +369,22 @@ def process_eval_task(eval_task_id: str):
             )
 
         filters = Q()
+        extra_anns: dict = {}
         if eval_task.filters is not None:
-            filters = parsing_evaltask_filters(eval_task.filters)
+            filters, extra_anns = parsing_evaltask_filters(eval_task.filters)
+
+        # Pre-annotate ``annotation_<label_id>`` JSON columns on the span
+        # queryset (mirrors list_spans_observe at observation_span.py:1164-1172)
+        # so per-label ANNOTATION filters resolve. ``extra_anns`` is reserved
+        # for any future per-handler annotate kwargs.
+        annotation_labels = get_annotation_labels_for_project(eval_task.project_id)
+        span_qs = build_annotation_subqueries(
+            ObservationSpan.objects.all(),
+            annotation_labels,
+            eval_task.project.organization,
+            span_filter_kwargs={"observation_span_id": OuterRef("id")},
+        )
+        span_qs = span_qs.annotate(**extra_anns).filter(filters)
 
         # Branch the candidate queryset and dispatch activity on
         # row_type. The rest of the function operates on ``entity_qs``
@@ -253,9 +399,7 @@ def process_eval_task(eval_task_id: str):
             # A trace is in scope iff at least one of its spans matches
             # the existing span-level filters.
             entity_qs = Trace.objects.filter(
-                id__in=ObservationSpan.objects.filter(filters)
-                .values("trace_id")
-                .distinct()
+                id__in=span_qs.values("trace_id").distinct()
             )
             dispatch = evaluate_trace_observe
         elif eval_task.row_type == RowType.SESSIONS:
@@ -267,9 +411,7 @@ def process_eval_task(eval_task_id: str):
             # in the sampling step below misbehaves under PostgreSQL.
             matching_session_ids = (
                 Trace.objects.filter(
-                    id__in=ObservationSpan.objects.filter(filters)
-                    .values("trace_id")
-                    .distinct()
+                    id__in=span_qs.values("trace_id").distinct()
                 )
                 .exclude(session__isnull=True)
                 .values("session_id")
@@ -282,7 +424,7 @@ def process_eval_task(eval_task_id: str):
             # already aliases voiceCalls→spans (observation_span.py:2890),
             # and any conversation-type narrowing the user wants comes
             # through ``filters`` like every other span query.
-            entity_qs = ObservationSpan.objects.filter(filters)
+            entity_qs = span_qs
             dispatch = evaluate_observation_span_observe
         else:
             # Fail fast on unknown / future row types instead of silently

--- a/futureagi/tracer/utils/monitor.py
+++ b/futureagi/tracer/utils/monitor.py
@@ -44,7 +44,7 @@ from tracer.services.clickhouse.query_builders.monitor_metrics import (
     MonitorMetricsQueryBuilder,
 )
 from tracer.services.clickhouse.query_service import AnalyticsQueryService, QueryType
-from tracer.utils.eval_tasks import parsing_evaltask_filters
+from tracer.utils.eval_tasks import parsing_monitor_filters
 
 
 def _build_monitor_ch_builder(monitor):
@@ -268,7 +268,7 @@ def _get_metric_value(monitor, start_time, end_time):
             )
 
     # --- PostgreSQL fallback ---
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
     base_queryset = ObservationSpan.objects.filter(
         project=monitor.project, created_at__range=(start_time, end_time)
     )
@@ -395,7 +395,7 @@ def _get_evaluation_metric_stats(monitor, start_time, end_time):
         _mute_monitor(monitor)
         return None, None
 
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
 
     eval_results = EvalLogger.objects.filter(
         custom_eval_config=custom_eval_config,
@@ -465,7 +465,7 @@ def _get_time_series_data_for_time_aggregated_metrics(
     Groups spans in certain intervals and returns a dictionary of {timestamp: value}.
     `interval_kind` must be one of 'minute', 'hour', 'day', 'week', 'month', 'year'.
     """
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
     base_queryset = ObservationSpan.objects.filter(project=monitor.project).filter(
         filters
     )
@@ -556,7 +556,7 @@ def _get_historical_stats(monitor, start_time, end_time):
             )
 
     # --- PostgreSQL fallback ---
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
     base_queryset = ObservationSpan.objects.filter(
         project=monitor.project, created_at__range=(start_time, end_time)
     ).filter(filters)
@@ -724,7 +724,7 @@ def _get_time_series_df_for_other_metrics(monitor, now):
     For non-aggregated metrics, fetches individual data points and returns a
     Prophet-ready DataFrame, averaging values for duplicate timestamps.
     """
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
     base_queryset = ObservationSpan.objects.filter(
         project=monitor.project, created_at__lte=now
     ).filter(filters)

--- a/futureagi/tracer/utils/monitor_graphs.py
+++ b/futureagi/tracer/utils/monitor_graphs.py
@@ -34,7 +34,7 @@ from tracer.services.clickhouse.query_builders.monitor_metrics import (
     MonitorMetricsQueryBuilder,
 )
 from tracer.services.clickhouse.query_service import AnalyticsQueryService, QueryType
-from tracer.utils.eval_tasks import parsing_evaltask_filters
+from tracer.utils.eval_tasks import parsing_monitor_filters
 
 
 def _build_monitor_graph_ch_builder(monitor):
@@ -188,7 +188,7 @@ def get_static_metric_graph_data(monitor, time_window_start=None, time_window_en
                 monitor, time_window_start, time_window_end, frequency_seconds
             )
 
-        filters = parsing_evaltask_filters(monitor.filters)
+        filters = parsing_monitor_filters(monitor.filters)
 
         base_queryset = ObservationSpan.objects.filter(project=monitor.project)
 
@@ -288,7 +288,7 @@ def _get_eval_metric_graph_data(
         )
         return []
 
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
 
     base_queryset = EvalLogger.objects.filter(
         custom_eval_config=custom_eval_config,
@@ -355,7 +355,7 @@ def _get_group_error_free_rate_data(
 ):
     """Handles graph data generation for group-based error-free rate metrics."""
     metric_type = monitor.metric_type
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
 
     # Build the base queryset with optional time filtering
     base_queryset = ObservationSpan.objects.filter(project=monitor.project)
@@ -764,7 +764,7 @@ def get_percentage_change_metric_graph_data(
         auto_threshold_time_window = timedelta(
             minutes=monitor.auto_threshold_time_window
         )
-        filters = parsing_evaltask_filters(monitor.filters)
+        filters = parsing_monitor_filters(monitor.filters)
 
         # Extend time window backwards for historical data
         extended_start = None

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -1470,8 +1470,12 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             filters = update_fields.get("filters") or eval_task.filters
 
             # Validate filters and get total spans count
-            parsed_filters = parsing_evaltask_filters(filters)
-            total_spans = ObservationSpan.objects.filter(parsed_filters).count()
+            parsed_filters, parsed_filter_anns = parsing_evaltask_filters(filters)
+            total_spans = (
+                ObservationSpan.objects.annotate(**parsed_filter_anns)
+                .filter(parsed_filters)
+                .count()
+            )
 
             if total_spans == 0:
                 logger.warning(


### PR DESCRIPTION
## Context

Production eval task [`f8481965-cd74-44b1-9b6d-f4bb66ec2218`](https://app.futureagi.com/dashboard/tasks/f8481965-cd74-44b1-9b6d-f4bb66ec2218) (`row_type=voiceCalls`) carries this annotator predicate inside `tracer_eval_task.filters.span_attributes_filters`:

```json
{"columnId": "annotator",
 "filterConfig": {"colType": "ANNOTATION", "filterOp": "equals",
                  "filterType": "text", "filterValue": "<user uuid>"}}
```

It evaluated **138 distinct spans**. The annotation-honoring scope is **≤17**. The annotator predicate is silently dropped today; so is every other non-`SPAN_ATTRIBUTE` `col_type`.

Linear: [TH-5645](https://linear.app/futureagi/issue/TH-5645)

## What this PR does

### BE dispatcher mirrors `list_spans_observe`

`parsing_evaltask_filters` (`tracer/utils/eval_tasks.py:138`) now passes the flat `filters` list to every `FilterEngine` handler in turn and lets each one self-filter by `col_type` — the same pattern used at `tracer/views/observation_span.py:1755-1826`.

Supported `col_type`s end-to-end: `SPAN_ATTRIBUTE`, `SYSTEM_METRIC`, `EVAL_METRIC`, `ANNOTATION` — plus the special `has_eval` / `has_annotation` column_ids. `PROMPT_METRIC` and `ANNOTATION_RUNS` ride along via the existing `get_filter_conditions_for_non_system_metrics`.

### Per-label annotation support via `build_annotation_subqueries`

`process_eval_task` now calls `build_annotation_subqueries(...)` on the span queryset before applying the filter Q, so per-label `ANNOTATION` filters (`columnId=<label_uuid>`, `filter_type=number/boolean/categorical`) resolve against `annotation_<label_id>__score` fields. Mirrors `observation_span.py:1164-1172` exactly.

### Persisted-JSON key rename — `filters` instead of `span_attributes_filters`

The inner list lives under `filters` now. The dispatcher accepts both keys during the transition and emits a one-line `logger.info("eval_task_filter_legacy_key")` when it sees the legacy key. Migration `0081_rename_eval_task_filters_key` renames existing rows.

### Monitors keep their legacy behaviour

Monitors only use `SPAN_ATTRIBUTE` filter chips. To avoid widening their dispatch surface, `parsing_monitor_filters` keeps the pre-PR single-`Q` behaviour. 5 sites in `monitor.py` + 4 in `monitor_graphs.py` use it; they're functionally unchanged from production.

### Return shape

`parsing_evaltask_filters` returns `tuple[Q, dict]`. Callers (`process_eval_task`, the rerun-count view) unpack and apply `.annotate(**extra_anns).filter(q)`. The dict is reserved for future per-handler annotate kwargs.

## Files changed

- `tracer/utils/eval_tasks.py` — rewrite `parsing_evaltask_filters`; add `parsing_monitor_filters`; wire `build_annotation_subqueries` into `process_eval_task`
- `tracer/utils/monitor.py` + `tracer/utils/monitor_graphs.py` — switch to `parsing_monitor_filters` (no behaviour change)
- `tracer/views/eval_task.py` — unpack tuple in the rerun-count view
- `tracer/migrations/0081_rename_eval_task_filters_key.py` — NEW: rename JSON key for existing eval-task rows
- `tracer/tests/test_eval_task_filter_dispatch.py` — NEW: 16 unit cases

## Verification

- **New dispatcher tests:** 16/16 pass
- **Regression:** 148/148 in `test_eval_task_runtime` + `test_eval_task_aggregations` + `test_voice_call_annotation_filters` still pass
- **Monitor regression:** monitor call sites use the legacy function — behaviour preserved

```sql
-- For task f8481965 the annotation-honoring scope is:
WITH base AS (
  SELECT os.id::text AS sid FROM tracer_observation_span os
  WHERE os.project_id='e5862a0e-118b-4fb4-968f-7d94a51aa4be'
    AND os.start_time BETWEEN '2026-05-02T17:42:32+00' AND '2026-06-01T18:30:00+00'
    AND NOT (os.span_attributes->>'ended_reason' IN ('twilio-failed-to-connect-call','voicemail','silence-timed-out'))
    AND (os.span_attributes->>'call.total_turns')::numeric > 2
)
SELECT (SELECT COUNT(*) FROM base) AS pass_span_attr,        -- 156
       (SELECT COUNT(DISTINCT s.observation_span_id) FROM model_hub_score s
        JOIN base b ON b.sid=s.observation_span_id::text
        WHERE s.annotator_id='<user uuid>' AND s.deleted=false) AS score_anno;
```

Post-deploy: rerun the task and confirm `tracer_eval_logger` distinct `observation_span_id` count ≈ `score_anno`.

## Follow-up

FE PR (separate, stacked on this branch):
- Rename outgoing payload key to `filters`
- Preserve `colType` through the `TaskFilterBar` round-trip (`convertNewToOld` / `convertOldToNew`)
- Replace the hardcoded `colType: "SPAN_ATTRIBUTE"` in `extractAttributeFilters`
- Preserve `colType` in `formatTaskFilters` when hydrating from DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)