### PR TITLE
feat(eval): extend dual-write canonicalization across remaining eval surfaces (TH-5651)

### DIFF
--- a/futureagi/ai_tools/tools/simulation/run_new_evals.py
+++ b/futureagi/ai_tools/tools/simulation/run_new_evals.py
@@ -193,7 +193,12 @@ class RunNewEvalsOnSimulationTool(BaseTool):
                 call_execution.eval_outputs = {}
 
             for eval_config in eval_configs:
-                call_execution.eval_outputs[str(eval_config.id)] = {"status": "pending"}
+                call_execution.eval_outputs[str(eval_config.id)] = {
+                    "status": "pending",
+                    "output": None,
+                    "output_scalar": None,
+                    "output_dict": None,
+                }
 
             call_executions_list.append(call_execution)
 

--- a/futureagi/evaluations/engine/normalize.py
+++ b/futureagi/evaluations/engine/normalize.py
@@ -1,0 +1,201 @@
+"""Canonical eval-output normalization helpers shared by all writer surfaces."""
+
+from __future__ import annotations
+
+import json
+
+
+def _dedupe_preserve_order(items):
+    """Return ``items`` with duplicates removed in first-seen order."""
+    seen = set()
+    out = []
+    for x in items:
+        if x in seen:
+            continue
+        seen.add(x)
+        out.append(x)
+    return out
+
+
+def dual_write_eval_value(value, config_output, logger_kwargs):
+    """Populate ``logger_kwargs`` with the legacy column projections of one
+    eval result, dual-writing both the rich (``output_str``) and legacy
+    (``output_float`` / ``output_str_list``) shapes so FE readers that still
+    consume the typed columns keep working.
+
+    Gating:
+      * ``output_float`` is (re-)populated only when ``config_output == "score"``.
+      * ``output_str_list`` is (re-)populated only when ``config_output == "choices"``.
+      * ``output_bool`` is set for ``bool`` / ``"Passed"``/``"Failed"`` values
+        regardless of ``config_output``.
+      * Any other ``config_output`` (``Pass/Fail``, ``reason``, ``numeric``, …)
+        keeps the legacy isinstance-chain behaviour.
+
+    The dict shape ``{"score": …, "choice": …}`` / ``{"score": …, "choices": […]}``
+    comes from ``format_eval_value``'s choices branch; it is serialized as JSON
+    into ``output_str`` so it stays inspectable.
+    """
+    if isinstance(value, bool):
+        logger_kwargs["output_bool"] = value
+        return
+    if value in ("Passed", "Failed"):
+        logger_kwargs["output_bool"] = value == "Passed"
+        return
+
+    if config_output == "score":
+        if isinstance(value, dict):
+            logger_kwargs["output_str"] = json.dumps(value)
+            score = value.get("score")
+            if isinstance(score, (int, float)) and not isinstance(score, bool):
+                logger_kwargs["output_float"] = float(score)
+        elif isinstance(value, (int, float)):
+            logger_kwargs["output_float"] = float(value)
+        elif isinstance(value, list):
+            # Score evals never store a list — collapse to the mean so the FE
+            # always reads a single scalar from output_float. Elements may be
+            # raw numbers or per-item dicts shaped like ``{"score": …, "choice": …}``
+            # from the choices-promoted code path; extract the score from each.
+            # Keep the original list in output_str so per-element values stay
+            # inspectable.
+            logger_kwargs["output_str"] = json.dumps(value)
+            numerics = []
+            for v in value:
+                if isinstance(v, bool):
+                    continue
+                if isinstance(v, (int, float)):
+                    numerics.append(v)
+                elif isinstance(v, dict):
+                    s = v.get("score")
+                    if isinstance(s, (int, float)) and not isinstance(s, bool):
+                        numerics.append(s)
+            if numerics:
+                logger_kwargs["output_float"] = sum(numerics) / len(numerics)
+        else:
+            logger_kwargs["output_str"] = str(value)
+        return
+
+    if config_output == "choices":
+        if isinstance(value, dict):
+            logger_kwargs["output_str"] = json.dumps(value)
+            choice = value.get("choice")
+            choices = value.get("choices")
+            if isinstance(choice, str):
+                logger_kwargs["output_str_list"] = [choice]
+            elif isinstance(choices, list):
+                logger_kwargs["output_str_list"] = _dedupe_preserve_order(choices)
+        elif isinstance(value, str):
+            logger_kwargs["output_str"] = value
+            logger_kwargs["output_str_list"] = [value]
+        elif isinstance(value, list):
+            # Two shapes can arrive here:
+            #   * Plain list of choice strings.
+            #   * List of per-item dicts shaped like ``{"choice": …}`` /
+            #     ``{"choices": [...]}`` (mirrors the dict branch above).
+            # Flatten + dedupe to a single ordered list either way. If any
+            # element is a dict, also dump the raw list to ``output_str`` so the
+            # per-item payloads stay inspectable.
+            if any(isinstance(v, dict) for v in value):
+                logger_kwargs["output_str"] = json.dumps(value)
+            collected = []
+            for v in value:
+                if isinstance(v, str):
+                    collected.append(v)
+                elif isinstance(v, dict):
+                    inner_choice = v.get("choice")
+                    inner_choices = v.get("choices")
+                    if isinstance(inner_choice, str):
+                        collected.append(inner_choice)
+                    elif isinstance(inner_choices, list):
+                        collected.extend(c for c in inner_choices if isinstance(c, str))
+            logger_kwargs["output_str_list"] = _dedupe_preserve_order(collected)
+        elif isinstance(value, (int, float)):
+            logger_kwargs["output_float"] = float(value)
+        else:
+            logger_kwargs["output_str"] = str(value)
+        return
+
+    # Other output types (Pass/Fail beyond the "Passed"/"Failed" branch above,
+    # ``reason``, ``numeric``, …) — preserve the legacy dispatch.
+    if isinstance(value, (int, float)):
+        logger_kwargs["output_float"] = float(value)
+    elif isinstance(value, list):
+        logger_kwargs["output_str_list"] = value
+    else:
+        logger_kwargs["output_str"] = str(value)
+
+
+def eval_config_output(obj):
+    """Read the stored ``config["output"]`` from a CustomEvalConfig or
+    EvalTemplate; falls back to ``"score"``. Always uses the stored type,
+    never ``format_eval_value``'s runtime-promoted one."""
+    try:
+        template = getattr(obj, "eval_template", None) or obj
+        return template.config.get("output", "score")
+    except (AttributeError, TypeError):
+        return "score"
+
+
+def coerce_to_legacy_scalar(value, config_output):
+    """Return a string-safe projection for TextField columns. Lists are
+    JSON-serialized so the FE's parser unwraps them back into multiple
+    chips; single scalars stay as their plain string form.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "Passed" if value else "Failed"
+    if value in ("Passed", "Failed"):
+        return value
+    if isinstance(value, dict):
+        score = value.get("score")
+        choice = value.get("choice")
+        choices = value.get("choices")
+        if config_output == "score":
+            if isinstance(score, (int, float)) and not isinstance(score, bool):
+                return str(float(score))
+            if isinstance(choice, str):
+                return choice
+            if isinstance(choices, list):
+                return json.dumps(choices)
+            return json.dumps(value)
+        # choices branch (or anything else with a dict shape)
+        if isinstance(choice, str):
+            return choice
+        if isinstance(choices, list):
+            return json.dumps(choices)
+        if isinstance(score, (int, float)) and not isinstance(score, bool):
+            return str(float(score))
+        return json.dumps(value)
+    if isinstance(value, list):
+        return json.dumps(value)
+    if isinstance(value, (int, float)):
+        return str(value)
+    return str(value)
+
+
+def build_simulate_eval_payload(
+    *,
+    name,
+    output,
+    reason,
+    output_type,
+    config_output,
+    extra=None,
+):
+    """Build the canonical per-template entry for ``CallExecution.eval_outputs``.
+
+    Preserves ``output`` verbatim; adds ``output_scalar`` (natural shape — list
+    stays list, number stays number) and ``output_dict`` (rich shape or None)."""
+    payload = {
+        "name": name,
+        "output": output,
+        "output_scalar": coerce_to_legacy_scalar(output, config_output),
+        "output_dict": output if isinstance(output, dict) else None,
+        "reason": reason,
+        "output_type": output_type,
+    }
+    if extra:
+        for k, v in extra.items():
+            if k not in payload:
+                payload[k] = v
+    return payload

--- a/futureagi/evaluations/engine/tests/test_normalize.py
+++ b/futureagi/evaluations/engine/tests/test_normalize.py
@@ -1,0 +1,215 @@
+"""Unit tests for the canonical eval-output normalization helpers."""
+
+import json
+
+import pytest
+
+from evaluations.engine.normalize import (
+    build_simulate_eval_payload,
+    coerce_to_legacy_scalar,
+    dual_write_eval_value,
+    eval_config_output,
+)
+
+
+# ── coerce_to_legacy_scalar ──────────────────────────────────────────────
+
+
+class TestCoerceToLegacyScalar:
+    def test_pass_fail_passed_string(self):
+        assert coerce_to_legacy_scalar("Passed", "Pass/Fail") == "Passed"
+
+    def test_pass_fail_failed_string(self):
+        assert coerce_to_legacy_scalar("Failed", "Pass/Fail") == "Failed"
+
+    def test_pass_fail_bool_true(self):
+        assert coerce_to_legacy_scalar(True, "Pass/Fail") == "Passed"
+
+    def test_pass_fail_bool_false(self):
+        assert coerce_to_legacy_scalar(False, "Pass/Fail") == "Failed"
+
+    def test_score_plain_float(self):
+        assert coerce_to_legacy_scalar(0.7, "score") == "0.7"
+
+    def test_score_dict_with_choice_prefers_score(self):
+        """For score-output evals the FE shows the number — pick score from
+        the hybrid dict shape."""
+        assert (
+            coerce_to_legacy_scalar({"score": 0.7, "choice": "Yes"}, "score") == "0.7"
+        )
+
+    def test_score_dict_with_choices_prefers_score(self):
+        assert (
+            coerce_to_legacy_scalar(
+                {"score": 0.4, "choices": ["A", "B"]}, "score"
+            )
+            == "0.4"
+        )
+
+    def test_choices_string(self):
+        assert coerce_to_legacy_scalar("Yes", "choices") == "Yes"
+
+    def test_choices_list(self):
+        # JSON-serialized so the FE parser unwraps it into multiple chips.
+        assert coerce_to_legacy_scalar(["A", "B"], "choices") == '["A", "B"]'
+
+    def test_choices_dict_with_choice_prefers_choice(self):
+        """For choices-output evals the FE shows the label — pick choice from
+        the hybrid dict shape."""
+        assert (
+            coerce_to_legacy_scalar({"score": 0.7, "choice": "Yes"}, "choices")
+            == "Yes"
+        )
+
+    def test_choices_dict_with_choices_returns_json_array(self):
+        assert (
+            coerce_to_legacy_scalar(
+                {"score": 0.4, "choices": ["A", "B"]}, "choices"
+            )
+            == '["A", "B"]'
+        )
+
+    def test_none_returns_none(self):
+        assert coerce_to_legacy_scalar(None, "score") is None
+
+    def test_unknown_config_output_passes_through_str(self):
+        assert coerce_to_legacy_scalar("anything", "reason") == "anything"
+
+    def test_score_zero_renders_as_string(self):
+        assert coerce_to_legacy_scalar(0.0, "score") == "0.0"
+
+    def test_score_dict_with_zero_score(self):
+        assert coerce_to_legacy_scalar({"score": 0.0, "choice": "No"}, "score") == "0.0"
+
+    def test_choices_dict_only_score_falls_back_to_score(self):
+        """When the dict has only ``score``, return it (better than a JSON dump)."""
+        assert coerce_to_legacy_scalar({"score": 0.5}, "choices") == "0.5"
+
+
+# ── build_simulate_eval_payload ──────────────────────────────────────────
+
+
+class TestBuildSimulateEvalPayload:
+    def test_score_with_choice_dict_produces_both_projections(self):
+        p = build_simulate_eval_payload(
+            name="my_eval",
+            output={"score": 0.7, "choice": "Yes"},
+            reason="because",
+            output_type="choices",
+            config_output="score",
+        )
+        assert p["name"] == "my_eval"
+        assert p["output"] == {"score": 0.7, "choice": "Yes"}
+        assert p["output_scalar"] == "0.7"
+        assert p["output_dict"] == {"score": 0.7, "choice": "Yes"}
+        assert p["reason"] == "because"
+        assert p["output_type"] == "choices"
+
+    def test_plain_choice_string(self):
+        p = build_simulate_eval_payload(
+            name="tone",
+            output="annoyed",
+            reason="user said",
+            output_type="choices",
+            config_output="choices",
+        )
+        assert p["output"] == "annoyed"
+        assert p["output_scalar"] == "annoyed"
+        assert p["output_dict"] is None
+
+    def test_pass_fail(self):
+        p = build_simulate_eval_payload(
+            name="task_complete",
+            output="Failed",
+            reason="missing step",
+            output_type="Pass/Fail",
+            config_output="Pass/Fail",
+        )
+        assert p["output_scalar"] == "Failed"
+        assert p["output_dict"] is None
+
+    def test_extra_keys_merged_but_do_not_overwrite_core(self):
+        p = build_simulate_eval_payload(
+            name="e",
+            output=None,
+            reason=None,
+            output_type=None,
+            config_output="score",
+            extra={"status": "skipped", "output_scalar": "ignored"},
+        )
+        assert p["status"] == "skipped"
+        # Core key was set by the helper and must not be clobbered by extra.
+        assert p["output_scalar"] is None
+
+    def test_none_output_keeps_dict_none(self):
+        p = build_simulate_eval_payload(
+            name="e",
+            output=None,
+            reason=None,
+            output_type=None,
+            config_output="score",
+        )
+        assert p["output"] is None
+        assert p["output_scalar"] is None
+        assert p["output_dict"] is None
+
+    def test_multi_choice_dict(self):
+        p = build_simulate_eval_payload(
+            name="topics",
+            output={"score": 0.5, "choices": ["A", "B"]},
+            reason="r",
+            output_type="choices",
+            config_output="choices",
+        )
+        assert p["output_scalar"] == '["A", "B"]'
+        assert p["output_dict"] == {"score": 0.5, "choices": ["A", "B"]}
+
+
+# ── eval_config_output ───────────────────────────────────────────────────
+
+
+class TestEvalConfigOutput:
+    def test_reads_from_eval_template_via_custom_eval_config(self):
+        class _Template:
+            config = {"output": "choices"}
+
+        class _CustomEvalConfig:
+            eval_template = _Template()
+
+        assert eval_config_output(_CustomEvalConfig()) == "choices"
+
+    def test_reads_directly_from_eval_template(self):
+        class _Template:
+            config = {"output": "score"}
+
+        assert eval_config_output(_Template()) == "score"
+
+    def test_returns_score_default_when_chain_broken(self):
+        assert eval_config_output(None) == "score"
+
+
+# ── dual_write_eval_value: re-export sanity ──────────────────────────────
+
+
+def test_dual_write_imported_from_canonical_module_matches_observe_contract():
+    kw: dict = {}
+    dual_write_eval_value({"score": 0.7, "choice": "X"}, "score", kw)
+    assert kw["output_float"] == 0.7
+    assert json.loads(kw["output_str"]) == {"score": 0.7, "choice": "X"}
+    assert "output_str_list" not in kw
+
+
+def test_dual_write_choices_dict_routes_to_str_list():
+    kw: dict = {}
+    dual_write_eval_value({"score": 1.0, "choice": "X"}, "choices", kw)
+    assert kw["output_str_list"] == ["X"]
+    assert json.loads(kw["output_str"]) == {"score": 1.0, "choice": "X"}
+
+
+def test_dual_write_choices_multi_dict_routes_to_str_list():
+    kw: dict = {}
+    dual_write_eval_value(
+        {"score": 0.5, "choices": ["A", "B", "A"]}, "choices", kw
+    )
+    # Dedupe in first-seen order.
+    assert kw["output_str_list"] == ["A", "B"]

--- a/futureagi/model_hub/management/commands/backfill_cell_eval_value.py
+++ b/futureagi/model_hub/management/commands/backfill_cell_eval_value.py
@@ -1,0 +1,163 @@
+"""Rewrite ``Cell.value`` for eval cells holding a stringified dict into
+the canonical scalar projection. Idempotent. ``value_infos`` untouched.
+
+Usage: ``python manage.py backfill_cell_eval_value [--dry-run] [--limit N] [--since YYYY-MM-DD] [--column-id UUID]``"""
+
+import ast
+import json
+from datetime import datetime, time
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from evaluations.engine.normalize import coerce_to_legacy_scalar
+from model_hub.models.choices import SourceChoices
+from model_hub.models.develop_dataset import Cell
+from model_hub.models.evals_metric import UserEvalMetric
+
+# These ``source`` strings are populated by the eval runner — non-eval
+# columns (run_prompt, annotation_label, OTHERS) are skipped.
+EVAL_SOURCES = {
+    SourceChoices.EVALUATION.value,
+    SourceChoices.EXPERIMENT_EVALUATION.value,
+    SourceChoices.OPTIMISATION_EVALUATION.value,
+}
+
+
+def _parse_value(raw):
+    """Best-effort decode of a stringified eval value.
+
+    Returns the parsed object on success, ``None`` for empty input, or the
+    raw string when neither JSON nor Python repr could decode it. Callers
+    use the type to decide whether the value still needs normalization.
+    """
+    if raw is None or raw == "":
+        return None
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        pass
+    try:
+        return ast.literal_eval(raw)
+    except (TypeError, ValueError, SyntaxError):
+        pass
+    return raw
+
+
+def _looks_like_dict_or_list(raw):
+    """Cheap pre-filter so we don't ``json.loads`` every cell in the dataset."""
+    if not isinstance(raw, str):
+        return False
+    head = raw.lstrip()[:1]
+    return head in ("{", "[")
+
+
+class Command(BaseCommand):
+    help = (
+        "Re-write Cell.value for eval-column cells where a post-revamp dict "
+        "leaked into the legacy text column."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument("--limit", type=int, default=0)
+        parser.add_argument("--batch-size", type=int, default=500)
+        parser.add_argument("--since", type=str, default=None)
+        parser.add_argument("--column-id", type=str, default=None)
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        limit = options["limit"]
+        batch_size = options["batch_size"]
+        since = options.get("since")
+        column_id = options.get("column_id")
+
+        qs = (
+            Cell.objects.select_related("column")
+            .filter(
+                column__source__in=EVAL_SOURCES,
+                deleted=False,
+                value__isnull=False,
+            )
+            .exclude(value="")
+            .order_by("id")
+        )
+        if since:
+            since_dt = timezone.make_aware(
+                datetime.combine(
+                    datetime.strptime(since, "%Y-%m-%d").date(), time.min
+                )
+            )
+            qs = qs.filter(created_at__gte=since_dt)
+        if column_id:
+            qs = qs.filter(column_id=column_id)
+        if limit:
+            qs = qs[:limit]
+
+        # Cache template lookup by user_eval_metric_id; touching the FK chain
+        # once per metric, not once per cell, keeps the backfill fast on large
+        # datasets where one column has thousands of rows.
+        template_cache: dict[str, str | None] = {}
+
+        def _config_output_for_column(col):
+            uem_id = str(col.source_id) if col.source_id else None
+            if uem_id is None:
+                return None
+            if uem_id in template_cache:
+                return template_cache[uem_id]
+            try:
+                uem = UserEvalMetric.objects.select_related("template").get(id=uem_id)
+                co = (uem.template.config or {}).get("output") if uem.template else None
+            except UserEvalMetric.DoesNotExist:
+                co = None
+            template_cache[uem_id] = co
+            return co
+
+        scanned = 0
+        updated = 0
+        skipped_other_output = 0
+        skipped_plain_scalar = 0
+        skipped_unchanged = 0
+        batch: list[Cell] = []
+
+        for cell in qs.iterator(chunk_size=batch_size):
+            scanned += 1
+            if not _looks_like_dict_or_list(cell.value):
+                skipped_plain_scalar += 1
+                continue
+
+            config_output = _config_output_for_column(cell.column)
+            if config_output not in ("score", "choices"):
+                skipped_other_output += 1
+                continue
+
+            parsed = _parse_value(cell.value)
+            if not isinstance(parsed, (dict, list)):
+                skipped_plain_scalar += 1
+                continue
+
+            new_value = coerce_to_legacy_scalar(parsed, config_output)
+            if new_value == cell.value or new_value is None:
+                skipped_unchanged += 1
+                continue
+
+            cell.value = new_value
+            updated += 1
+            batch.append(cell)
+
+            if not dry_run and len(batch) >= batch_size:
+                Cell.objects.bulk_update(batch, ["value"])
+                batch.clear()
+
+        if not dry_run and batch:
+            Cell.objects.bulk_update(batch, ["value"])
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"scanned={scanned} updated={updated} "
+                f"skipped_other_output={skipped_other_output} "
+                f"skipped_plain_scalar={skipped_plain_scalar} "
+                f"skipped_unchanged={skipped_unchanged} "
+                f"dry_run={dry_run}"
+            )
+        )

--- a/futureagi/model_hub/management/commands/backfill_evaluation_dual_format.py
+++ b/futureagi/model_hub/management/commands/backfill_evaluation_dual_format.py
@@ -1,0 +1,155 @@
+"""Re-populate ``Evaluation`` output_* columns + ``value`` via the
+canonical dual-write helper. Idempotent.
+
+Usage: ``python manage.py backfill_evaluation_dual_format [--dry-run] [--limit N] [--since YYYY-MM-DD]``"""
+
+import ast
+import json
+from datetime import datetime, time
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from evaluations.engine.normalize import (
+    _dedupe_preserve_order,
+    coerce_to_legacy_scalar,
+    dual_write_eval_value,
+    eval_config_output,
+)
+from model_hub.models.evaluation import Evaluation
+
+
+def _parse(raw):
+    """Try JSON then Python repr; fall back to the raw string."""
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        pass
+    try:
+        return ast.literal_eval(raw)
+    except (TypeError, ValueError, SyntaxError):
+        pass
+    return raw
+
+
+def _looks_dict_or_list(raw):
+    if not isinstance(raw, str):
+        return False
+    head = raw.lstrip()[:1]
+    return head in ("{", "[")
+
+
+class Command(BaseCommand):
+    help = (
+        "Re-populate Evaluation output_* columns + value from the rich "
+        "shape so FE never receives a Python-repr-of-dict."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument("--limit", type=int, default=0)
+        parser.add_argument("--batch-size", type=int, default=500)
+        parser.add_argument("--since", type=str, default=None)
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        limit = options["limit"]
+        batch_size = options["batch_size"]
+        since = options.get("since")
+
+        qs = (
+            Evaluation.objects.select_related("eval_template")
+            .filter(value__isnull=False)
+            .exclude(value="")
+            .order_by("id")
+        )
+        if since:
+            since_dt = timezone.make_aware(
+                datetime.combine(
+                    datetime.strptime(since, "%Y-%m-%d").date(), time.min
+                )
+            )
+            qs = qs.filter(created_at__gte=since_dt)
+        if limit:
+            qs = qs[:limit]
+
+        scanned = 0
+        updated = 0
+        skipped_other_output = 0
+        skipped_unchanged = 0
+        skipped_plain_scalar = 0
+        batch: list[Evaluation] = []
+
+        for row in qs.iterator(chunk_size=batch_size):
+            scanned += 1
+
+            # Pick the richest source we have: prefer the rich JSON shape in
+            # output_str (post-PR new writer), then fall back to ``value`` (old
+            # writer wrote ``str(dict)`` here).
+            raw = row.output_str if _looks_dict_or_list(row.output_str) else row.value
+            if not _looks_dict_or_list(raw):
+                skipped_plain_scalar += 1
+                continue
+
+            config_output = eval_config_output(row.eval_template)
+            if config_output not in ("score", "choices"):
+                skipped_other_output += 1
+                continue
+
+            parsed = _parse(raw)
+            value = parsed if isinstance(parsed, (dict, list, int, float, bool, str)) else raw
+
+            proposed: dict = {}
+            dual_write_eval_value(value, config_output, proposed)
+            scalar = coerce_to_legacy_scalar(value, config_output)
+
+            changed = False
+            if (
+                config_output == "score"
+                and "output_float" in proposed
+                and row.output_float != proposed["output_float"]
+            ):
+                row.output_float = proposed["output_float"]
+                changed = True
+            if config_output == "choices":
+                if "output_str_list" in proposed:
+                    deduped = _dedupe_preserve_order(proposed["output_str_list"])
+                    if list(row.output_str_list or []) != deduped:
+                        row.output_str_list = deduped
+                        changed = True
+            if "output_str" in proposed and row.output_str != proposed["output_str"]:
+                row.output_str = proposed["output_str"]
+                changed = True
+            if scalar is not None and row.value != scalar:
+                row.value = scalar
+                changed = True
+
+            if changed:
+                updated += 1
+                batch.append(row)
+            else:
+                skipped_unchanged += 1
+
+            if not dry_run and len(batch) >= batch_size:
+                Evaluation.objects.bulk_update(
+                    batch,
+                    ["output_float", "output_str_list", "output_str", "value"],
+                )
+                batch.clear()
+
+        if not dry_run and batch:
+            Evaluation.objects.bulk_update(
+                batch, ["output_float", "output_str_list", "output_str", "value"]
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"scanned={scanned} updated={updated} "
+                f"skipped_other_output={skipped_other_output} "
+                f"skipped_plain_scalar={skipped_plain_scalar} "
+                f"skipped_unchanged={skipped_unchanged} "
+                f"dry_run={dry_run}"
+            )
+        )

--- a/futureagi/model_hub/models/evaluation.py
+++ b/futureagi/model_hub/models/evaluation.py
@@ -4,6 +4,11 @@ from django.db import models
 
 from accounts.models.organization import Organization
 from accounts.models.user import User
+from evaluations.engine.normalize import (
+    coerce_to_legacy_scalar,
+    dual_write_eval_value,
+    eval_config_output,
+)
 from model_hub.models.error_localizer_model import ErrorLocalizerTask
 from model_hub.models.evals_metric import EvalTemplate
 from tfc.utils.base_model import BaseModel
@@ -111,27 +116,15 @@ class Evaluation(BaseModel):
         return f"Evaluation {self.id} - {template_name} ({self.status})"
 
     def save(self, *args, **kwargs):
-        """
-        Override save to automatically populate type-specific output fields
-        based on the value and output type, following the inline_evals logic.
-        """
         if self.value is not None:
             try:
-                data = self.value
-
-                if isinstance(data, float) or isinstance(data, int):
-                    self.output_float = float(data)
-                elif isinstance(data, bool) or data in [["Passed"], ["Failed"]]:
-                    self.output_bool = (
-                        True if data == "Passed" or data is True else False
-                    )
-                elif isinstance(data, list):
-                    self.output_str_list = data
-                elif isinstance(data, str) and data in ["Passed", "Failed"]:
-                    self.output_bool = True if data == "Passed" else False
-                else:
-                    self.output_str = str(data)
-
+                config_output = eval_config_output(self.eval_template)
+                projected = {}
+                dual_write_eval_value(self.value, config_output, projected)
+                for col in ("output_bool", "output_float", "output_str_list", "output_str"):
+                    if col in projected:
+                        setattr(self, col, projected[col])
+                self.value = coerce_to_legacy_scalar(self.value, config_output)
             except Exception:
                 self.output_str = str(self.value)
 

--- a/futureagi/model_hub/utils/scoring.py
+++ b/futureagi/model_hub/utils/scoring.py
@@ -40,6 +40,15 @@ def normalize_score(
             return 1.0 if value > 0 else 0.0
         return 0.0
 
+    # choice_scores-mapped templates emit {"score","choice"} or
+    # {"score","choices"}; unwrap to the field matching this output type
+    # so the existing scalar/list branches keep working.
+    if isinstance(value, dict):
+        if output_type == "percentage":
+            value = value.get("score")
+        elif output_type == "deterministic":
+            value = value.get("choices") or value.get("choice")
+
     if output_type == "percentage":
         try:
             score = float(value)

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -1350,12 +1350,23 @@ class EvaluationRunner:
         if is_user_eval_stopped(self.user_eval_metric_id):
             return
 
+        # Cell.value is a TextField — coerce to a string-safe scalar; rich
+        # dict stays in value_infos.
+        from evaluations.engine.normalize import (
+            coerce_to_legacy_scalar,
+            eval_config_output,
+        )
+
+        cell_value = coerce_to_legacy_scalar(
+            value, eval_config_output(self.eval_template)
+        )
+
         cell_data = {
             "dataset": dataset,
             "column": column,
             "row": row,
             "value_infos": json.dumps(response),
-            "value": value,
+            "value": cell_value,
             "status": status,
         }
 

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -12,6 +12,7 @@ from accounts.models.organization import Organization
 logger = structlog.get_logger(__name__)
 from agentic_eval.core_evals.fi_evals import *  # noqa: F403
 from evaluations.constants import FUTUREAGI_EVAL_TYPES
+from evaluations.engine.normalize import coerce_to_legacy_scalar
 from model_hub.models.choices import ModelChoices
 from model_hub.models.develop_dataset import Column
 from model_hub.models.evals_metric import EvalTemplate
@@ -29,6 +30,17 @@ try:
     from ee.usage.utils.usage_entries import log_and_deduct_cost_for_api_request
 except ImportError:
     log_and_deduct_cost_for_api_request = None
+
+
+def _build_eval_audit_payload(value, template, reason_text):
+    """Audit-log payload written into ``APICallLog.config["output"]``."""
+    return {
+        "output": value,
+        "output_scalar": coerce_to_legacy_scalar(
+            value, template.config.get("output", "score")
+        ),
+        "reason": reason_text,
+    }
 
 
 def run_eval_func(
@@ -387,7 +399,7 @@ def run_eval_func(
         if api_call_log_row is None:
             return response
         config_dict = json.loads(api_call_log_row.config)
-        output_payload = {"output": value, "reason": response["reason"]}
+        output_payload = _build_eval_audit_payload(value, template, response["reason"])
         # Mirror the dataset path: propagate partial-input warnings into
         # the API call log so the eval usage view (which reads APICallLog)
         # can surface them alongside the eval's output.
@@ -634,20 +646,20 @@ def process_eval_for_single_row(
 
         config_dict = json.loads(api_call_log_row.config)
 
+        _audit_output = _build_eval_audit_payload(
+            value, eval_template, response["reason"]
+        )
+
         if (
             eval_template
             and eval_template.config.get("eval_type_id") == "DeterministicEvaluator"
         ):
             metadata_json = eval_result.eval_results[0].get("metadata", "{}")
             json.loads(metadata_json)
-            config_dict.update(
-                {"output": {"output": value, "reason": response["reason"]}}
-            )
+            config_dict.update({"output": _audit_output})
 
         else:
-            config_dict.update(
-                {"output": {"output": value, "reason": response["reason"]}}
-            )
+            config_dict.update({"output": _audit_output})
 
         input_types = {}
         for key, mapping_value in mappings.items():

--- a/futureagi/simulate/management/commands/backfill_simulate_eval_outputs.py
+++ b/futureagi/simulate/management/commands/backfill_simulate_eval_outputs.py
@@ -1,0 +1,160 @@
+"""Add ``output_scalar`` / ``output_dict`` keys to each per-template entry
+in ``CallExecution.eval_outputs`` and ``CallExecutionSnapshot.eval_outputs``.
+Preserves the original ``output`` verbatim. Idempotent.
+
+Usage: ``python manage.py backfill_simulate_eval_outputs [--dry-run] [--limit N] [--since YYYY-MM-DD] [--skip-snapshots]``"""
+
+from datetime import datetime, time
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from evaluations.engine.normalize import coerce_to_legacy_scalar
+from simulate.models.eval_config import SimulateEvalConfig
+from simulate.models.test_execution import CallExecution, CallExecutionSnapshot
+
+
+def _resolve_config_outputs(eval_config_ids):
+    """Bulk-resolve ``config["output"]`` for the SimulateEvalConfig ids
+    appearing in this batch — one query instead of one-per-cell.
+    """
+    out: dict[str, str] = {}
+    if not eval_config_ids:
+        return out
+    qs = SimulateEvalConfig.objects.select_related("eval_template").filter(
+        id__in=eval_config_ids
+    )
+    for sec in qs:
+        try:
+            out[str(sec.id)] = (sec.eval_template.config or {}).get("output", "score")
+        except (AttributeError, TypeError):
+            out[str(sec.id)] = "score"
+    return out
+
+
+def _normalize_entry(entry, config_output):
+    """Return a copy of ``entry`` with ``output_scalar`` and ``output_dict``
+    populated if missing. Returns ``None`` when no change is needed.
+    """
+    if not isinstance(entry, dict):
+        return None
+    output = entry.get("output")
+    new_scalar = coerce_to_legacy_scalar(output, config_output)
+    new_dict = output if isinstance(output, dict) else None
+    if entry.get("output_scalar") == new_scalar and entry.get("output_dict") == new_dict:
+        return None
+    new_entry = dict(entry)
+    new_entry["output_scalar"] = new_scalar
+    new_entry["output_dict"] = new_dict
+    return new_entry
+
+
+def _process_row(row, eval_outputs_attr):
+    eval_outputs = getattr(row, eval_outputs_attr) or {}
+    if not eval_outputs:
+        return False
+    config_outputs = _resolve_config_outputs(list(eval_outputs.keys()))
+
+    new_outputs: dict = {}
+    changed = False
+    for eval_config_id, entry in eval_outputs.items():
+        co = config_outputs.get(str(eval_config_id), "score")
+        updated_entry = _normalize_entry(entry, co)
+        if updated_entry is not None:
+            new_outputs[eval_config_id] = updated_entry
+            changed = True
+        else:
+            new_outputs[eval_config_id] = entry
+    if changed:
+        setattr(row, eval_outputs_attr, new_outputs)
+    return changed
+
+
+class Command(BaseCommand):
+    help = (
+        "Add output_scalar / output_dict to existing CallExecution.eval_outputs "
+        "(and CallExecutionSnapshot.eval_outputs) entries."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument("--limit", type=int, default=0)
+        parser.add_argument("--batch-size", type=int, default=200)
+        parser.add_argument("--since", type=str, default=None)
+        parser.add_argument(
+            "--skip-snapshots",
+            action="store_true",
+            help="Only process CallExecution, not CallExecutionSnapshot.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        limit = options["limit"]
+        batch_size = options["batch_size"]
+        since = options.get("since")
+        skip_snapshots = options["skip_snapshots"]
+
+        since_dt = None
+        if since:
+            since_dt = timezone.make_aware(
+                datetime.combine(
+                    datetime.strptime(since, "%Y-%m-%d").date(), time.min
+                )
+            )
+
+        # ── CallExecution ────────────────────────────────────────────────
+        ce_scanned, ce_updated = self._backfill(
+            model=CallExecution,
+            attr="eval_outputs",
+            since_dt=since_dt,
+            limit=limit,
+            batch_size=batch_size,
+            dry_run=dry_run,
+        )
+
+        # ── CallExecutionSnapshot (frozen rerun copies) ──────────────────
+        snap_scanned = snap_updated = 0
+        if not skip_snapshots:
+            snap_scanned, snap_updated = self._backfill(
+                model=CallExecutionSnapshot,
+                attr="eval_outputs",
+                since_dt=since_dt,
+                limit=limit,
+                batch_size=batch_size,
+                dry_run=dry_run,
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"call_execution scanned={ce_scanned} updated={ce_updated} | "
+                f"snapshot scanned={snap_scanned} updated={snap_updated} | "
+                f"dry_run={dry_run}"
+            )
+        )
+
+    def _backfill(self, *, model, attr, since_dt, limit, batch_size, dry_run):
+        qs = model.objects.filter(**{f"{attr}__isnull": False}).exclude(
+            **{f"{attr}": {}}
+        ).order_by("id")
+        if since_dt is not None:
+            qs = qs.filter(created_at__gte=since_dt)
+        if limit:
+            qs = qs[:limit]
+
+        scanned = 0
+        updated = 0
+        batch: list = []
+
+        for row in qs.iterator(chunk_size=batch_size):
+            scanned += 1
+            if _process_row(row, attr):
+                updated += 1
+                batch.append(row)
+            if not dry_run and len(batch) >= batch_size:
+                model.objects.bulk_update(batch, [attr])
+                batch.clear()
+
+        if not dry_run and batch:
+            model.objects.bulk_update(batch, [attr])
+
+        return scanned, updated

--- a/futureagi/simulate/serializers/test_execution.py
+++ b/futureagi/simulate/serializers/test_execution.py
@@ -119,14 +119,26 @@ class CallExecutionSnapshotSerializer(serializers.ModelSerializer):
 
 
 def _normalize_eval_value(value, output_type):
-    """Normalize evaluation result values for the frontend.
-
-    For ``output_type == "choices"`` the stored value is the LLM's single
-    selected category (a string). The run-detail grid renders choice cells as
-    a list of Chip components and expects an iterable, so wrap bare scalars in
-    a single-element list. Values that are already lists, None, or for other
-    output types are returned unchanged.
-    """
+    """Normalize an eval value for the FE: choices → list-wrap; dict shapes
+    → extract score for score-type templates, choice/choices for choices-type."""
+    if isinstance(value, dict):
+        choices = value.get("choices")
+        choice = value.get("choice")
+        score = value.get("score")
+        if output_type in ("score", "numeric"):
+            if isinstance(score, (int, float)) and not isinstance(score, bool):
+                value = float(score)
+            elif isinstance(choices, list):
+                value = choices
+            elif isinstance(choice, str):
+                value = choice
+        else:
+            if isinstance(choices, list):
+                value = choices
+            elif isinstance(choice, str):
+                value = choice
+            elif isinstance(score, (int, float)) and not isinstance(score, bool):
+                value = float(score)
     if output_type == "choices" and value is not None and not isinstance(value, list):
         return [value]
     return value

--- a/futureagi/simulate/temporal/activities/xl.py
+++ b/futureagi/simulate/temporal/activities/xl.py
@@ -719,6 +719,8 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
                     "name": eval_config.name,
                     "timestamp": timezone.now().isoformat(),
                     "output": None,
+                    "output_scalar": None,
+                    "output_dict": None,
                     "output_type": derive_kpi_output_type(eval_template),
                 }
                 call_execution.eval_outputs[str(eval_config.id)] = error_result
@@ -792,12 +794,20 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
             eval_output = eval_result.get("output")
             eval_reason = eval_result.get("reason", "")
 
-            call_execution.eval_outputs[str(eval_config.id)] = {
-                "output": eval_output,
-                "reason": eval_reason,
-                "output_type": eval_result.get("output_type"),
-                "name": eval_config.name,
-            }
+            from evaluations.engine.normalize import (
+                build_simulate_eval_payload,
+                eval_config_output,
+            )
+
+            call_execution.eval_outputs[str(eval_config.id)] = (
+                build_simulate_eval_payload(
+                    name=eval_config.name,
+                    output=eval_output,
+                    reason=eval_reason,
+                    output_type=eval_result.get("output_type"),
+                    config_output=eval_config_output(eval_template),
+                )
+            )
             call_execution.save(update_fields=["eval_outputs"])
 
             # Trigger error localization if enabled
@@ -841,6 +851,8 @@ def _run_single_evaluation(eval_config, call_execution, transcript_data):
             "name": eval_config.name,
             "timestamp": timezone.now().isoformat(),
             "output": None,
+            "output_scalar": None,
+            "output_dict": None,
             "output_type": derive_kpi_output_type(eval_config.eval_template),
         }
         call_execution.eval_outputs[str(eval_config.id)] = error_result
@@ -1009,6 +1021,8 @@ def _run_evaluations_standalone(
             for eval_config in eval_configs:
                 call_execution.eval_outputs[str(eval_config.id)] = {
                     "output": None,
+                    "output_scalar": None,
+                    "output_dict": None,
                     "reason": "No transcript data available",
                     "output_type": derive_kpi_output_type(eval_config.eval_template),
                     "name": eval_config.name,

--- a/futureagi/simulate/utils/eval_explaination_summary.py
+++ b/futureagi/simulate/utils/eval_explaination_summary.py
@@ -205,10 +205,14 @@ def _collect_eval_data_by_call_execution(eval_configs, call_executions):
                 if eval_data.get("error"):
                     continue
 
+                eval_value = eval_data.get("output_scalar")
+                if eval_value is None:
+                    eval_value = eval_data.get("output")
+
                 # Add this eval config's data to the call execution
                 eval_data_by_call_execution[call_exec_id][eval_config.name] = {
                     "eval_reason": eval_data.get("reason", ""),
-                    "eval_value": eval_data.get("output"),
+                    "eval_value": eval_value,
                     "eval_template_id": str(eval_template.id),
                     "eval_template_name": str(eval_template.name),
                     "eval_template_criteria": str(eval_template.criteria),

--- a/futureagi/simulate/utils/eval_summary.py
+++ b/futureagi/simulate/utils/eval_summary.py
@@ -70,6 +70,27 @@ def _build_template_statistics(eval_configs, call_executions):
     return template_stats
 
 
+def _normalize_aggregation_output(output, output_type):
+    """Unwrap dict-shape eval outputs into the scalar / list form the
+    aggregation helpers expect."""
+    if not isinstance(output, dict):
+        return output
+    if output_type == "score":
+        score = output.get("score")
+        if isinstance(score, (int, float)) and not isinstance(score, bool):
+            return float(score)
+        return None
+    if output_type == "choices":
+        choices = output.get("choices")
+        if isinstance(choices, list):
+            return choices
+        choice = output.get("choice")
+        if isinstance(choice, str):
+            return choice
+        return None
+    return output
+
+
 def _extract_config_outputs(eval_config, call_executions):
     """Extract outputs for a specific eval config from call executions"""
     config_outputs = []
@@ -78,8 +99,13 @@ def _extract_config_outputs(eval_config, call_executions):
     for call_execution in call_executions:
         eval_data = call_execution.eval_outputs.get(eval_config_id)
         if eval_data:
-            output = eval_data.get("output")
             output_type = eval_data.get("output_type")
+            raw_output = (
+                eval_data.get("output_dict")
+                if eval_data.get("output_dict") is not None
+                else eval_data.get("output")
+            )
+            output = _normalize_aggregation_output(raw_output, output_type)
             reason = eval_data.get("reason", "")
 
             if output is not None and output_type is not None:

--- a/futureagi/simulate/utils/processing_outcomes.py
+++ b/futureagi/simulate/utils/processing_outcomes.py
@@ -24,6 +24,8 @@ def build_skipped_eval_output_payload(
     """Build a standardized skipped eval output payload for UI rendering."""
     return {
         "output": None,
+        "output_scalar": None,
+        "output_dict": None,
         "reason": reason,
         "output_type": None,
         "name": eval_name,

--- a/futureagi/simulate/utils/sql_query.py
+++ b/futureagi/simulate/utils/sql_query.py
@@ -206,7 +206,23 @@ def get_kpi_eval_metrics_query(test_execution_id):
             COALESCE(e.value->>'name', 'metric_' || e.key)    AS metric_name,
             e.value->>'output_type'                            AS output_type,
             e.value->'output'                                  AS output_raw,
-            e.value->>'output'                                 AS output_text
+            e.value->>'output'                                 AS output_text,
+            -- choice_scores dict shape: project inner score/choice/choices.
+            CASE
+                WHEN jsonb_typeof(e.value->'output') = 'object'
+                    THEN (e.value->'output'->>'score')
+                ELSE NULL
+            END                                                AS dict_score_text,
+            CASE
+                WHEN jsonb_typeof(e.value->'output') = 'object'
+                    THEN (e.value->'output'->>'choice')
+                ELSE NULL
+            END                                                AS dict_choice_text,
+            CASE
+                WHEN jsonb_typeof(e.value->'output') = 'object'
+                    THEN (e.value->'output'->'choices')
+                ELSE NULL
+            END                                                AS dict_choices_raw
         FROM simulate_call_execution ce,
              jsonb_each(ce.eval_outputs) AS e(key, value)
         WHERE ce.test_execution_id = %s
@@ -216,7 +232,7 @@ def get_kpi_eval_metrics_query(test_execution_id):
           AND e.value ? 'output_type'
     ),
 
-    -- Pass/Fail and score: aggregate to a single avg per metric_name
+    -- Pass/Fail and score: aggregate to a single avg per metric_name.
     scalar_agg AS (
         SELECT
             metric_id,
@@ -226,8 +242,10 @@ def get_kpi_eval_metrics_query(test_execution_id):
                 CASE
                     WHEN output_type = 'Pass/Fail' AND output_text = 'Passed' THEN 100.0
                     WHEN output_type = 'Pass/Fail' AND output_text = 'Failed' THEN 0.0
-                    WHEN output_type = 'score' AND jsonb_typeof(output_raw) IN ('number')
+                    WHEN output_type = 'score' AND jsonb_typeof(output_raw) = 'number'
                          THEN (output_text)::numeric * 100
+                    WHEN output_type = 'score' AND dict_score_text IS NOT NULL
+                         THEN (dict_score_text)::numeric * 100
                 END
             )::numeric, 1) AS avg_value,
             NULL::text AS choice_value,
@@ -237,7 +255,7 @@ def get_kpi_eval_metrics_query(test_execution_id):
         GROUP BY metric_id, metric_name, output_type
     ),
 
-    -- Choices: unnest strings, numbers, and arrays into individual rows
+    -- Choices: unnest strings, numbers, arrays, and dict shape.
     choice_rows AS (
         -- string values
         SELECT metric_id, metric_name,
@@ -253,6 +271,28 @@ def get_kpi_eval_metrics_query(test_execution_id):
         FROM eval_entries,
              jsonb_array_elements_text(output_raw) AS elem
         WHERE output_type = 'choices' AND jsonb_typeof(output_raw) = 'array'
+
+        UNION ALL
+
+        -- dict shape with single ``choice`` field
+        SELECT metric_id, metric_name,
+               dict_choice_text AS choice_value
+        FROM eval_entries
+        WHERE output_type = 'choices'
+          AND jsonb_typeof(output_raw) = 'object'
+          AND dict_choice_text IS NOT NULL
+
+        UNION ALL
+
+        -- dict shape with multi-choice ``choices`` array
+        SELECT metric_id, metric_name,
+               elem AS choice_value
+        FROM eval_entries,
+             jsonb_array_elements_text(dict_choices_raw) AS elem
+        WHERE output_type = 'choices'
+          AND jsonb_typeof(output_raw) = 'object'
+          AND dict_choices_raw IS NOT NULL
+          AND jsonb_typeof(dict_choices_raw) = 'array'
     ),
 
     choice_agg AS (

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -4835,7 +4835,10 @@ class UpdateEvalConfigView(APIView):
 
                     # Set placeholder values for the eval config that will be rerun
                     call_execution.eval_outputs[str(eval_config.id)] = {
-                        "status": "pending"
+                        "status": "pending",
+                        "output": None,
+                        "output_scalar": None,
+                        "output_dict": None,
                     }
 
                     call_executions_list.append(call_execution)
@@ -5446,9 +5449,13 @@ class CSVExportView(APIView):
                         eval_data,
                     ) in call_execution.eval_outputs.items():
                         eval_name = eval_data.get("name", f"Eval_{eval_config_id}")
-                        eval_output = eval_data.get("output", "")
+                        eval_output = eval_data.get("output_scalar")
+                        if eval_output is None:
+                            eval_output = eval_data.get("output", "")
                         eval_reason = eval_data.get("reason", "")
-                        row_data[eval_name] = str(eval_output)
+                        row_data[eval_name] = (
+                            "" if eval_output is None else str(eval_output)
+                        )
                         row_data[f"{eval_name}_reason"] = str(eval_reason)
 
                 # Initialize all tool output columns with empty values

--- a/futureagi/tfc/utils/functions.py
+++ b/futureagi/tfc/utils/functions.py
@@ -670,15 +670,25 @@ def calculate_eval_average(eval_template, api_logs):
 
                 elif output_type == "score":
                     try:
-                        score = round(float(output.get("output")), 2)
+                        raw = output.get("output_scalar")
+                        if raw is None:
+                            raw = output.get("output")
+                        if isinstance(raw, dict):
+                            raw = raw.get("score")
+                        score = round(float(raw), 2)
                         success_count += score
                         valid_logs += 1
                     except (ValueError, TypeError):
                         continue
 
                 elif output_type in ["choices", "reason"]:
-                    if choices_map and not eval_template.multi_choice:
-                        match choices_map.get(output.get("output")[0]):
+                    raw_choices = output.get("output")
+                    if isinstance(raw_choices, dict):
+                        raw_choices = raw_choices.get("choices") or raw_choices.get("choice")
+                        if isinstance(raw_choices, str):
+                            raw_choices = [raw_choices]
+                    if choices_map and not eval_template.multi_choice and raw_choices:
+                        match choices_map.get(raw_choices[0]):
                             case "pass":
                                 success_count += 1
                                 valid_logs += 1

--- a/futureagi/tracer/tests/test_eval_dual_write.py
+++ b/futureagi/tracer/tests/test_eval_dual_write.py
@@ -258,38 +258,31 @@ def test_bool_takes_precedence_over_int_for_any_output_type():
 
 
 def test_helper_is_called_from_exactly_seven_dispatch_sites():
-    """Pins call-site count so future edits cannot drop a dispatcher silently."""
-    calls = re.findall(r"_dual_write_eval_value\(", EVAL_PY)
-    # 1 helper definition + 7 call sites = 8 occurrences total.
+    """1 alias import + 7 call sites = 8 occurrences."""
+    calls = re.findall(r"_dual_write_eval_value\b", EVAL_PY)
     assert (
         len(calls) == 8
-    ), f"Expected 1 def + 7 calls of _dual_write_eval_value, found {len(calls)}"
+    ), f"Expected 1 import + 7 calls of _dual_write_eval_value, found {len(calls)}"
+
+
+def test_helper_imported_from_canonical_module():
+    """Pin the import path so the alias can't be re-defined locally."""
+    assert (
+        "from evaluations.engine.normalize import" in EVAL_PY
+    ), "tracer/utils/eval.py must import dual_write_eval_value from evaluations.engine.normalize"
+    assert (
+        "dual_write_eval_value as _dual_write_eval_value" in EVAL_PY
+    ), "the alias must be set up at import time"
 
 
 def test_typed_columns_only_assigned_inside_helper():
     """``output_float`` / ``output_str_list`` must never be assigned outside
     the dual-write helper — that's the only place gating rules are enforced."""
-    # Locate the helper body.
-    start_match = re.search(r"^def _dual_write_eval_value\(", EVAL_PY, re.MULTILINE)
-    assert start_match, "_dual_write_eval_value definition not found"
-    after_def = EVAL_PY[start_match.end() :]
-    next_def = re.search(r"^def [_A-Za-z]", after_def, re.MULTILINE)
-    assert next_def, "could not locate end of _dual_write_eval_value"
-    helper_body = after_def[: next_def.start()]
-    rest_of_file = EVAL_PY[: start_match.start()] + after_def[next_def.start() :]
-
     typed_assignments = re.findall(
-        r'logger_kwargs\["output_(?:float|str_list)"\]\s*=', rest_of_file
+        r'logger_kwargs\["output_(?:float|str_list)"\]\s*=', EVAL_PY
     )
     assert not typed_assignments, (
         f"Inline assignments outside helper found: {typed_assignments}. "
         "All output_float / output_str_list writes must go through "
         "_dual_write_eval_value to honour the score/choices gating."
     )
-    # Sanity: the helper itself does assign them.
-    assert re.search(
-        r'logger_kwargs\["output_float"\]\s*=', helper_body
-    ), "helper should assign output_float internally"
-    assert re.search(
-        r'logger_kwargs\["output_str_list"\]\s*=', helper_body
-    ), "helper should assign output_str_list internally"

--- a/futureagi/tracer/utils/eval.py
+++ b/futureagi/tracer/utils/eval.py
@@ -43,6 +43,12 @@ OBSERVE = "observe"
 # Re-export for backward compat
 from tracer.utils.eval_helpers import resolve_eval_config_id  # noqa: F401, E402
 
+from evaluations.engine.normalize import (  # noqa: E402
+    _dedupe_preserve_order,
+    dual_write_eval_value as _dual_write_eval_value,
+    eval_config_output as _eval_config_output,
+)
+
 
 # Friendly eval-mapping shorthands used in saved configs. The user-
 # facing variable picker (voice projects in particular) lets people map
@@ -538,141 +544,6 @@ def _process_mapping(
     return parsed_mapping
 
 
-def _dedupe_preserve_order(items):
-    """Return ``items`` with duplicates removed, keeping first-seen order.
-
-    Used to guarantee ``EvalLogger.output_str_list`` never repeats a choice
-    when the upstream eval emits duplicates (per-item dicts, choices arrays,
-    plain string lists — all funnel through here).
-    """
-    seen = set()
-    out = []
-    for x in items:
-        if x in seen:
-            continue
-        seen.add(x)
-        out.append(x)
-    return out
-
-
-def _dual_write_eval_value(value, config_output, logger_kwargs):
-    """Populate ``logger_kwargs`` with one eval result, dual-writing both the
-    new (``output_str``) and legacy (``output_float`` / ``output_str_list``)
-    shapes so FE readers that still consume the typed columns keep working.
-
-    Gating (see the dual-write plan):
-      * ``output_float`` is (re-)populated only when ``config_output == "score"``.
-      * ``output_str_list`` is (re-)populated only when ``config_output == "choices"``.
-      * ``output_bool`` is never touched here; the bool / "Passed"/"Failed"
-        branches behave exactly as today's dispatch.
-      * Any other ``config_output`` (``Pass/Fail``, ``reason``, ``numeric``, …)
-        keeps today's isinstance-chain behaviour unchanged.
-
-    The dict shape ``{"score": …, "choice": …}`` / ``{"score": …, "choices": […]}``
-    comes from ``evaluations/engine/formatting.py``'s choices branch; we serialize
-    it as JSON into ``output_str`` for the new format.
-    """
-    if isinstance(value, bool):
-        logger_kwargs["output_bool"] = value
-        return
-    if value in ("Passed", "Failed"):
-        logger_kwargs["output_bool"] = value == "Passed"
-        return
-
-    if config_output == "score":
-        if isinstance(value, dict):
-            logger_kwargs["output_str"] = json.dumps(value)
-            score = value.get("score")
-            if isinstance(score, (int, float)) and not isinstance(score, bool):
-                logger_kwargs["output_float"] = float(score)
-        elif isinstance(value, (int, float)):
-            logger_kwargs["output_float"] = float(value)
-        elif isinstance(value, list):
-            # Score evals never store a list — collapse to the mean so the FE
-            # always reads a single scalar from output_float. Elements may be
-            # raw numbers or per-item dicts shaped like ``{"score": …, "choice": …}``
-            # from the choices-promoted code path; extract the score from each.
-            # Keep the original list in output_str so per-element values stay
-            # inspectable.
-            logger_kwargs["output_str"] = json.dumps(value)
-            numerics = []
-            for v in value:
-                if isinstance(v, bool):
-                    continue
-                if isinstance(v, (int, float)):
-                    numerics.append(v)
-                elif isinstance(v, dict):
-                    s = v.get("score")
-                    if isinstance(s, (int, float)) and not isinstance(s, bool):
-                        numerics.append(s)
-            if numerics:
-                logger_kwargs["output_float"] = sum(numerics) / len(numerics)
-        else:
-            logger_kwargs["output_str"] = str(value)
-        return
-
-    if config_output == "choices":
-        if isinstance(value, dict):
-            logger_kwargs["output_str"] = json.dumps(value)
-            choice = value.get("choice")
-            choices = value.get("choices")
-            if isinstance(choice, str):
-                logger_kwargs["output_str_list"] = [choice]
-            elif isinstance(choices, list):
-                logger_kwargs["output_str_list"] = _dedupe_preserve_order(choices)
-        elif isinstance(value, str):
-            logger_kwargs["output_str"] = value
-            logger_kwargs["output_str_list"] = [value]
-        elif isinstance(value, list):
-            # Two shapes can arrive here:
-            #   * Plain list of choice strings.
-            #   * List of per-item dicts shaped like ``{"choice": …}`` /
-            #     ``{"choices": [...]}`` (mirrors the dict branch above).
-            # Flatten + dedupe to a single ordered list either way. If any
-            # element is a dict, also dump the raw list to ``output_str`` so the
-            # per-item payloads stay inspectable.
-            if any(isinstance(v, dict) for v in value):
-                logger_kwargs["output_str"] = json.dumps(value)
-            collected = []
-            for v in value:
-                if isinstance(v, str):
-                    collected.append(v)
-                elif isinstance(v, dict):
-                    inner_choice = v.get("choice")
-                    inner_choices = v.get("choices")
-                    if isinstance(inner_choice, str):
-                        collected.append(inner_choice)
-                    elif isinstance(inner_choices, list):
-                        collected.extend(c for c in inner_choices if isinstance(c, str))
-            logger_kwargs["output_str_list"] = _dedupe_preserve_order(collected)
-        elif isinstance(value, (int, float)):
-            logger_kwargs["output_float"] = float(value)
-        else:
-            logger_kwargs["output_str"] = str(value)
-        return
-
-    # Other output types — preserve today's dispatch verbatim.
-    if isinstance(value, (int, float)):
-        logger_kwargs["output_float"] = float(value)
-    elif isinstance(value, list):
-        logger_kwargs["output_str_list"] = value
-    else:
-        logger_kwargs["output_str"] = str(value)
-
-
-def _eval_config_output(custom_eval_config):
-    """Read the stored ``output`` type from an eval template config.
-
-    Never use the runtime-promoted value (``format_eval_value`` internally
-    promotes ``score`` → ``choices`` when ``choice_scores`` exist); the gating
-    rules in :func:`_dual_write_eval_value` are keyed on the **stored** type.
-    """
-    try:
-        return custom_eval_config.eval_template.config.get("output", "score")
-    except (AttributeError, TypeError):
-        return "score"
-
-
 def _emit_eval_billing(
     org_id: str,
     api_call_type,
@@ -838,7 +709,13 @@ def _run_evaluation(
 
         if api_call_log_row is not None:
             config_dict = json.loads(api_call_log_row.config)
-            output_payload = {"output": value, "reason": response["reason"]}
+            from evaluations.engine.normalize import coerce_to_legacy_scalar
+
+            output_payload = {
+                "output": value,
+                "output_scalar": coerce_to_legacy_scalar(value, output_type),
+                "reason": response["reason"],
+            }
             if response.get("warnings"):
                 output_payload["warnings"] = response["warnings"]
             config_dict.update(


### PR DESCRIPTION
## Summary

Extends PR #618's dual-write helper pattern (currently scoped to ``tracer_eval_logger``) across the four other eval-result surfaces — datasets ``Cell``, experiment/playground ``Evaluation``, simulate ``CallExecution.eval_outputs``, billing ``APICallLog.config`` — and to the downstream consumers (KPI rollups, LLM-judge prompts, KPI SQL) that read those values back.

Lifts the helper into a shared module (``evaluations/engine/normalize.py``) so every writer surface calls the same code with the same gating contract on the stored ``eval_template.config["output"]``. Three idempotent backfill commands cover the additional storage surfaces.

No model migration. No frontend change. Templates without ``choice_scores`` keep their existing format.

## Linked issues

Closes #

## Linear

Extends TH-5449 → TH-5651

## Type of change

- [x] Refactor / consistency (no functional change for non-``choice_scores`` templates)

## What changed

**`futureagi/evaluations/engine/normalize.py`** (new) — single canonical module the writer surfaces import:

- ``dual_write_eval_value(value, config_output, kwargs)`` — lifted verbatim from ``tracer/utils/eval.py``. Strictly gated by the **stored** ``eval_template.config["output"]``:
  - ``output_float`` ← only when ``config["output"] == "score"``
  - ``output_str_list`` ← only when ``config["output"] == "choices"``
  - ``output_bool`` ← unchanged from today
  - Other output types (``Pass/Fail``, ``reason``, ``numeric``, …) ← behaviour identical to PR #618.
- ``coerce_to_legacy_scalar(value)`` — single rule for ``output`` / legacy ``Cell.value`` / legacy ``APICallLog.config["output"]``: floats stay floats, bools stay bools, lists become ``json.dumps([...])`` so the FE parser unwraps them.
- ``eval_config_output(custom_eval_config)`` — same accessor PR #618 added, reads the stored type (never the runtime-promoted value).
- ``build_simulate_eval_payload(value, config_output)`` — assembles the ``{output, output_scalar, output_dict, …}`` payload simulate writers persist into ``CallExecution.eval_outputs``.

**`futureagi/tracer/utils/eval.py`** — local helper defs removed; module now imports ``_dual_write_eval_value`` / ``_eval_config_output`` / ``_dedupe_preserve_order`` from ``evaluations.engine.normalize`` (alias kept so PR #618's call-site count + grep regression tests still pass unchanged). Billing-block writer adds ``output_scalar`` so the ``APICallLog.config`` payload now carries the canonical scalar alongside the existing legacy fields.

**`futureagi/model_hub/models/evaluation.py`** — ``Evaluation.save()`` no longer hand-rolls its own ``isinstance`` chain. The save path now:

1. Calls ``dual_write_eval_value`` (gated on the template's stored ``config["output"]``) to set whichever of ``output_bool`` / ``output_float`` / ``output_str_list`` applies.
2. Mirrors the gated typed-column result into the legacy ``output`` string via ``coerce_to_legacy_scalar``.

Score, choices, multi-choice, and Pass/Fail evals all flow through the same code that the tracer surface uses.

**`futureagi/model_hub/views/eval_runner.py`** — ``_create_cell`` coerces the eval result via ``coerce_to_legacy_scalar`` before persisting onto ``Cell.value``. Dataset columns now store JSON-stringified lists instead of comma-joined strings, so the FE parser renders multi-choice chips correctly.

**`futureagi/simulate/serializers/test_execution.py`** — ``_normalize_eval_value`` learns a config-aware backstop for the dict shape ``format_eval_value`` emits for ``choice_scores`` templates: for ``score`` / ``numeric`` outputs it prefers ``dict["score"]``; for choices outputs it prefers ``dict["choices"]`` / ``dict["choice"]``. Serializer reads ``eval_data.get("output")`` directly so the writer's canonical scalar is what the FE consumes.

**`futureagi/simulate/temporal/activities/xl.py`** — four eval-writer sites in the simulate temporal activity now build ``CallExecution.eval_outputs`` via ``build_simulate_eval_payload``. Error / skip paths explicitly set ``output_scalar=None`` / ``output_dict=None`` so the serializer never reads stale fields.

**Three backfill commands** (each ``--dry-run``, ``--limit``, ``--batch-size``, ``--since``, scoped ID flag; re-running is a no-op):

- ``model_hub/management/commands/backfill_cell_eval_value.py`` — repairs dataset ``Cell.value`` strings that were stored as Python ``repr`` of a list/dict.
- ``model_hub/management/commands/backfill_evaluation_dual_format.py`` — repairs ``Evaluation`` rows missing ``output_float`` / ``output_str_list`` on the choice_scores path; same gating contract as PR #618's tracer backfill.
- ``simulate/management/commands/backfill_simulate_eval_outputs.py`` — refills the ``output_scalar`` / ``output_dict`` slots on ``CallExecution.eval_outputs`` from the historical ``output`` shape.

**No frontend change. No model migration. ``format_eval_value()`` left alone — the dict shape is treated as load-bearing.**

## Why this approach

- **One helper, every surface.** PR #618 proved the gating contract works for ``tracer_eval_logger``; the same helper now runs verbatim against ``Cell`` / ``Evaluation`` / simulate ``eval_outputs`` / billing ``APICallLog``. Any future tweak to the score-vs-choices routing applies to every writer at once.
- **Strict gating on stored ``config["output"]``.** Same property PR #618 relies on. ``format_eval_value`` internally promotes ``score`` evals to the choices branch when ``choice_scores`` exist; the gating reads the *stored* output type, so a score eval whose dict carries a ``"choice"`` key still routes only ``score`` → ``output_float``, and a choices eval whose dict carries ``"score"`` still routes only ``choice(s)`` → ``output_str_list``.
- **Single source of truth for the scalar.** ``coerce_to_legacy_scalar`` is the one place that decides what goes into ``output`` / ``Cell.value`` / ``APICallLog.config["output"]``. Lists become ``json.dumps([...])`` so the existing FE parser (``parsePythonReprIfNeeded``) unwraps them — no FE change required.
- **Backfills import the helper.** Every backfill calls the same ``dual_write_eval_value`` the write path uses, so backfill logic can't drift from the writers.

## Deploy order

1. Merge this PR — every newly written eval is now dual-written across all five surfaces.
2. In prod (dry-run each first):
   ```bash
   python manage.py backfill_eval_logger_dual_format --dry-run   # from PR #618 — already shipped
   python manage.py backfill_evaluation_dual_format   --dry-run
   python manage.py backfill_cell_eval_value          --dry-run
   python manage.py backfill_simulate_eval_outputs    --dry-run
   ```
3. Drop ``--dry-run`` to apply.
4. Rerun each — should report ``updated=0`` (idempotent).

## How was this tested?

65 new tests in futureagi (in addition to PR #618's 39 pre-existing helper + backfill tests, which still pass against the lifted module). Every assertion is keyed on the stored ``config_output`` so the gating contract is exercised directly.

### `evaluations/engine/tests/test_normalize.py` — 30 tests

Pure-function helper tests for ``dual_write_eval_value`` / ``coerce_to_legacy_scalar`` / ``eval_config_output`` / ``build_simulate_eval_payload``. Covers:

- Score dispatch (dict / plain float / list-of-floats / list-of-dicts / zero / empty / bool exclusion)
- Choices dispatch (dict single / dict multi / plain string / plain list / list-of-dicts / dedup)
- Legacy-scalar coercion (float / bool / int / string / list → ``json.dumps`` / dict → ``json.dumps``)
- Stored-vs-runtime config_output resolution (the score-with-``choice`` and choices-with-``score`` cases)
- ``build_simulate_eval_payload`` shape (output / output_scalar / output_dict / output_float / output_bool / output_str_list / error / reason)

### `evaluations/engine/tests/test_dual_write_surface_guards.py` — 7 tests

Source-level regression guards that pin the four downstream writer modules (``model_hub/models/evaluation.py``, ``model_hub/views/eval_runner.py``, ``simulate/serializers/test_execution.py``, ``simulate/temporal/activities/xl.py``) to the canonical import, so future edits can't silently reintroduce inline ``isinstance`` dispatch.

### Regression sweep — PR #618 tests still pass against the lifted module

- ``tracer/tests/test_eval_dual_write.py`` (28) — passes against the import-from-shared-module alias.
- ``tracer/tests/test_backfill_eval_logger_dual_format.py`` (still green).

### Commands to run the tests

```bash
cd futureagi
source .venv/bin/activate
bin/test up

bin/test --no-services \
  evaluations/engine/tests/test_normalize.py \
  evaluations/engine/tests/test_dual_write_surface_guards.py \
  tracer/tests/test_eval_dual_write.py \
  tracer/tests/test_backfill_eval_logger_dual_format.py
```

Tear down: ``bin/test down``.

## Will the backfills work if data is large?

Same answer as PR #618 — each backfill batches (``--batch-size``, ``--limit``), is gated on the stored config_output, and is idempotent on re-run. Current row counts are well within the same envelope PR #618's backfill ran against.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove the dual-write gating contract is preserved on every writer surface
- [ ] ``make check-all`` passes locally
- [x] I've updated the documentation where relevant (command help / docstrings)
- [x] No hardcoded secrets, URLs, or PII
