### PR TITLE
fix(ch-direct): v2 query-layer column + eval-logger fixes for the CH25 spans cutover

### DIFF
--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -795,6 +795,15 @@ CLICKHOUSE_V2 = {
     "QUERY_TYPES_DISABLED":   os.getenv("CH25_QUERY_TYPES_DISABLED", ""),
 }
 
+# Eval-logger table read by the trace/voice/user eval-config discovery queries.
+# The CH25 spans cutover intentionally kept the legacy peerdb CDC table
+# `tracer_eval_logger` (`_peerdb_is_deleted`/`deleted` columns); the v2 table
+# `tracer_eval_logger_v2` (`is_deleted`) is its prepared replacement. Flip this
+# per-deployment (default = legacy so the peerdb-backed stacks are unaffected;
+# CH-direct stacks set it to `tracer_eval_logger_v2`). See
+# tracer/services/clickhouse/v2/schema/011_eval_logger_v2.sql + docs/CH25_MIGRATION.md.
+CH25_EVAL_LOGGER_TABLE = os.getenv("CH25_EVAL_LOGGER_TABLE", "tracer_eval_logger")
+
 # Where the eval runner reads span data from.
 #   "postgres"   — current behavior; reads from tracer_observation_span (Django ORM)
 #   "clickhouse" — reads span data from CH 25.3 via the hybrid loader

--- a/futureagi/tracer/services/clickhouse/eval_logger_table.py
+++ b/futureagi/tracer/services/clickhouse/eval_logger_table.py
@@ -1,0 +1,33 @@
+"""Resolve the eval-logger CH table + its not-deleted predicate.
+
+The CH25 spans cutover intentionally left the legacy peerdb CDC table
+``tracer_eval_logger`` in place (read directly by the trace/voice/user
+eval-config discovery queries). A v2 table ``tracer_eval_logger_v2`` is
+prepared — it drops the peerdb columns (``_peerdb_is_deleted`` / ``deleted``)
+in favour of the unified ``is_deleted`` ReplacingMergeTree marker.
+
+``settings.CH25_EVAL_LOGGER_TABLE`` selects which one the read paths use, so a
+peerdb-backed deployment keeps the legacy table (default) while a CH-direct
+stack flips to v2 without code edits. See
+``v2/schema/011_eval_logger_v2.sql`` + ``docs/CH25_MIGRATION.md``.
+"""
+from __future__ import annotations
+
+from django.conf import settings
+
+
+def eval_logger_source(alias: str = "") -> tuple[str, str]:
+    """Return ``(table_name, not_deleted_predicate)`` for the configured table.
+
+    ``alias`` prefixes the column references (e.g. ``"e"`` →
+    ``e.is_deleted = 0``) for queries that alias the table in a JOIN.
+    """
+    table = getattr(settings, "CH25_EVAL_LOGGER_TABLE", "tracer_eval_logger")
+    p = f"{alias}." if alias else ""
+    if table.endswith("_v2"):
+        # v2: single is_deleted marker, no peerdb CDC columns.
+        predicate = f"{p}is_deleted = 0"
+    else:
+        # legacy peerdb CDC table.
+        predicate = f"{p}_peerdb_is_deleted = 0 AND ({p}deleted = 0 OR {p}deleted IS NULL)"
+    return table, predicate

--- a/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/annotation_graph.py
@@ -21,7 +21,11 @@ from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
 from tracer.services.clickhouse.query_builders.expressions import (
     annotation_numeric_value_expr,
 )
-from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
+# CH-direct: use the v2 filter builder (rewrites span_attr_* -> attrs_*) since
+# this graph reads the v2 `spans` table. Aliased to keep the call sites unchanged.
+from tracer.services.clickhouse.v2.query_builders.filters import (
+    ClickHouseFilterBuilderV2 as ClickHouseFilterBuilder,
+)
 
 
 class AnnotationGraphQueryBuilder(BaseQueryBuilder):

--- a/futureagi/tracer/services/clickhouse/query_builders/filters.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/filters.py
@@ -346,7 +346,10 @@ class ClickHouseFilterBuilder:
             id_filter = (
                 f" AND id IN ("
                 f"SELECT observation_span_id FROM model_hub_score AS s FINAL "
-                f"WHERE s._peerdb_is_deleted = 0 AND s.deleted = false "
+                # model_hub_score keeps the legacy `_peerdb_is_deleted` column;
+                # the v2 SQL rewriter renames it to `is_deleted` (which this table
+                # lacks). `s.deleted = false` is the real soft-delete filter.
+                f"WHERE s.deleted = false "
                 f"AND notEmpty(s.observation_span_id)"
                 f"{score_date}"
                 f" {score_side_where})"
@@ -432,8 +435,7 @@ class ClickHouseFilterBuilder:
             f"FROM model_hub_score AS s FINAL "
             f"LEFT JOIN {spans_subq} AS sp "
             f"ON sp.id = s.observation_span_id "
-            f"WHERE s._peerdb_is_deleted = 0 "
-            f"AND s.deleted = false "
+            f"WHERE s.deleted = false "
             f"AND isNotNull({score_trace_expr}) "
             f"AND {score_trace_expr} != ''"
             f"{date_clause}"
@@ -506,8 +508,7 @@ class ClickHouseFilterBuilder:
             f"FROM model_hub_score AS s FINAL "
             f"LEFT JOIN {spans_subq} AS root_sp "
             f"ON root_sp.trace_id = toString(s.trace_id) "
-            f"WHERE s._peerdb_is_deleted = 0 "
-            f"AND s.deleted = false "
+            f"WHERE s.deleted = false "
             f"AND isNotNull({score_span_expr}) "
             f"AND {score_span_expr} != ''"
             f"{date_clause}"

--- a/futureagi/tracer/services/clickhouse/query_builders/time_series.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/time_series.py
@@ -22,7 +22,13 @@ from datetime import datetime
 from typing import Any
 
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
-from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
+# CH-direct: the embedded filter builder must emit v2 attribute columns
+# (attrs_string/number/bool) since this builder reads the v2 `spans` table.
+# The V2 subclass rewrites span_attr_* -> attrs_* in translate(); aliased to the
+# v1 name so the call sites below are unchanged.
+from tracer.services.clickhouse.v2.query_builders.filters import (
+    ClickHouseFilterBuilderV2 as ClickHouseFilterBuilder,
+)
 
 
 class TimeSeriesQueryBuilder(BaseQueryBuilder):

--- a/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/trace_list.py
@@ -245,7 +245,7 @@ class TraceListQueryBuilder(BaseQueryBuilder):
             attrs_string,
             attrs_number,
             toJSONString(metadata) AS metadata,
-            trace_tags
+            dictGetOrDefault('trace_dict', 'tags', toUUID(trace_id), '[]') AS trace_tags
         FROM {self.TABLE}
         PREWHERE trace_id IN %(content_trace_ids)s
         WHERE {self.project_filter_sql()}

--- a/futureagi/tracer/services/clickhouse/query_builders/user_list.py
+++ b/futureagi/tracer/services/clickhouse/query_builders/user_list.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_builders.base import BaseQueryBuilder
 from tracer.services.clickhouse.query_builders.filters import ClickHouseFilterBuilder
 from tracer.services.clickhouse.v2.id_remap_sql import (
@@ -174,6 +175,7 @@ class UserListQueryBuilder(BaseQueryBuilder):
         )
         resolved_eu = resolved_id_expr("rs.end_user_id", "eu_remap")
         resolved_ts = resolved_id_expr("rs.trace_session_id", "ts_remap")
+        eval_table, eval_nd_e = eval_logger_source("e")
 
         query = f"""
         WITH
@@ -297,10 +299,9 @@ class UserListQueryBuilder(BaseQueryBuilder):
                     2
                 ) AS bool_eval_pass_rate,
                 round(avg(e.output_float), 2) AS avg_output_float
-            FROM tracer_eval_logger AS e FINAL
+            FROM {eval_table} AS e FINAL
             INNER JOIN user_traces AS ut ON toString(e.trace_id) = ut.trace_id
-            WHERE e._peerdb_is_deleted = 0
-              AND e.deleted = 0
+            WHERE {eval_nd_e}
             GROUP BY ut.end_user_id
         ),
         final_rows AS (

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -1226,17 +1226,17 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                         """
                         SELECT key, argMax(type, cnt) AS type FROM (
                             SELECT key, 'text' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_str) AS key
+                            FROM spans ARRAY JOIN mapKeys(attrs_string) AS key
                             WHERE project_id IN %(project_ids)s AND is_deleted = 0
                             GROUP BY key
                             UNION ALL
                             SELECT key, 'number' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_num) AS key
+                            FROM spans ARRAY JOIN mapKeys(attrs_number) AS key
                             WHERE project_id IN %(project_ids)s AND is_deleted = 0
                             GROUP BY key
                             UNION ALL
                             SELECT key, 'boolean' AS type, count() AS cnt
-                            FROM spans ARRAY JOIN mapKeys(span_attr_bool) AS key
+                            FROM spans ARRAY JOIN mapKeys(attrs_bool) AS key
                             WHERE project_id IN %(project_ids)s AND is_deleted = 0
                             GROUP BY key
                         )
@@ -2325,7 +2325,7 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                     values = []
 
             elif metric_type == "custom_attribute":
-                # Use mapContains() so the `idx_span_attr_str_keys` bloom
+                # Use mapContains() so the `idx_attrs_string_keys` bloom
                 # filter index prunes granules that don't have the key.
                 # Without this, wide-attribute projects can blow past
                 # ClickHouse's `max_bytes_to_read` limit (code 307) and
@@ -2333,12 +2333,12 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                 # conversation.recording.mono.assistant / ended_reason for
                 # heavy voice projects.
                 sql = (
-                    "SELECT DISTINCT span_attr_str[%(attr_key)s] AS val "
+                    "SELECT DISTINCT attrs_string[%(attr_key)s] AS val "
                     "FROM spans "
                     "WHERE project_id IN %(project_ids)s "
                     "AND is_deleted = 0 "
-                    "AND mapContains(span_attr_str, %(attr_key)s) "
-                    "AND span_attr_str[%(attr_key)s] != '' "
+                    "AND mapContains(attrs_string, %(attr_key)s) "
+                    "AND attrs_string[%(attr_key)s] != '' "
                     "ORDER BY val "
                     "LIMIT 500"
                 )

--- a/futureagi/tracer/views/span_attributes.py
+++ b/futureagi/tracer/views/span_attributes.py
@@ -61,7 +61,7 @@ class SpanAttributeKeysView(APIView):
         query = """
             SELECT key, 'string' AS type, count() AS cnt
             FROM (
-                SELECT arrayJoin(mapKeys(span_attr_str)) AS key
+                SELECT arrayJoin(mapKeys(attrs_string)) AS key
                 FROM spans
                 WHERE project_id = %(project_id)s
             )
@@ -71,7 +71,7 @@ class SpanAttributeKeysView(APIView):
 
             SELECT key, 'number' AS type, count() AS cnt
             FROM (
-                SELECT arrayJoin(mapKeys(span_attr_num)) AS key
+                SELECT arrayJoin(mapKeys(attrs_number)) AS key
                 FROM spans
                 WHERE project_id = %(project_id)s
             )
@@ -81,7 +81,7 @@ class SpanAttributeKeysView(APIView):
 
             SELECT key, 'boolean' AS type, count() AS cnt
             FROM (
-                SELECT arrayJoin(mapKeys(span_attr_bool)) AS key
+                SELECT arrayJoin(mapKeys(attrs_bool)) AS key
                 FROM spans
                 WHERE project_id = %(project_id)s
             )
@@ -152,12 +152,12 @@ class SpanAttributeValuesView(APIView):
 
         if q:
             query = """
-                SELECT span_attr_str[%(key)s] AS value, count() AS cnt
+                SELECT attrs_string[%(key)s] AS value, count() AS cnt
                 FROM spans
                 WHERE project_id = %(project_id)s
-                  AND mapContains(span_attr_str, %(key)s)
-                  AND span_attr_str[%(key)s] != ''
-                  AND span_attr_str[%(key)s] LIKE %(q_pattern)s
+                  AND mapContains(attrs_string, %(key)s)
+                  AND attrs_string[%(key)s] != ''
+                  AND attrs_string[%(key)s] LIKE %(q_pattern)s
                 GROUP BY value
                 ORDER BY cnt DESC
                 LIMIT %(limit)s
@@ -165,11 +165,11 @@ class SpanAttributeValuesView(APIView):
             params["q_pattern"] = f"%{q}%"
         else:
             query = """
-                SELECT span_attr_str[%(key)s] AS value, count() AS cnt
+                SELECT attrs_string[%(key)s] AS value, count() AS cnt
                 FROM spans
                 WHERE project_id = %(project_id)s
-                  AND mapContains(span_attr_str, %(key)s)
-                  AND span_attr_str[%(key)s] != ''
+                  AND mapContains(attrs_string, %(key)s)
+                  AND attrs_string[%(key)s] != ''
                 GROUP BY value
                 ORDER BY cnt DESC
                 LIMIT %(limit)s
@@ -261,9 +261,9 @@ class SpanAttributeDetailView(APIView):
         """Determine which attribute map contains the given key."""
         type_query = """
             SELECT
-                countIf(mapContains(span_attr_str, %(key)s))  AS str_cnt,
-                countIf(mapContains(span_attr_num, %(key)s))  AS num_cnt,
-                countIf(mapContains(span_attr_bool, %(key)s)) AS bool_cnt
+                countIf(mapContains(attrs_string, %(key)s))  AS str_cnt,
+                countIf(mapContains(attrs_number, %(key)s))  AS num_cnt,
+                countIf(mapContains(attrs_bool, %(key)s)) AS bool_cnt
             FROM spans
             WHERE project_id = %(project_id)s
         """
@@ -287,12 +287,12 @@ class SpanAttributeDetailView(APIView):
         """Return top values with percentages for a string attribute."""
         query = """
             SELECT
-                span_attr_str[%(key)s] AS value,
+                attrs_string[%(key)s] AS value,
                 count() AS cnt
             FROM spans
             WHERE project_id = %(project_id)s
-              AND mapContains(span_attr_str, %(key)s)
-              AND span_attr_str[%(key)s] != ''
+              AND mapContains(attrs_string, %(key)s)
+              AND attrs_string[%(key)s] != ''
             GROUP BY value
             ORDER BY cnt DESC
             LIMIT 100
@@ -336,14 +336,14 @@ class SpanAttributeDetailView(APIView):
         query = """
             SELECT
                 count()                                          AS cnt,
-                min(span_attr_num[%(key)s])                      AS min_val,
-                max(span_attr_num[%(key)s])                      AS max_val,
-                avg(span_attr_num[%(key)s])                      AS avg_val,
-                quantile(0.50)(span_attr_num[%(key)s])           AS p50,
-                quantile(0.95)(span_attr_num[%(key)s])           AS p95
+                min(attrs_number[%(key)s])                      AS min_val,
+                max(attrs_number[%(key)s])                      AS max_val,
+                avg(attrs_number[%(key)s])                      AS avg_val,
+                quantile(0.50)(attrs_number[%(key)s])           AS p50,
+                quantile(0.95)(attrs_number[%(key)s])           AS p95
             FROM spans
             WHERE project_id = %(project_id)s
-              AND mapContains(span_attr_num, %(key)s)
+              AND mapContains(attrs_number, %(key)s)
         """
         rows, _, query_time_ms = client.execute_read(query, params)
 
@@ -378,11 +378,11 @@ class SpanAttributeDetailView(APIView):
         """Return true/false distribution for a boolean attribute."""
         query = """
             SELECT
-                span_attr_bool[%(key)s] AS value,
+                attrs_bool[%(key)s] AS value,
                 count() AS cnt
             FROM spans
             WHERE project_id = %(project_id)s
-              AND mapContains(span_attr_bool, %(key)s)
+              AND mapContains(attrs_bool, %(key)s)
             GROUP BY value
             ORDER BY cnt DESC
         """

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -77,6 +77,7 @@ from tracer.services.clickhouse.query_builders import (
     AgentGraphQueryBuilder,
     UserListQueryBuilder,
 )
+from tracer.services.clickhouse.eval_logger_table import eval_logger_source
 from tracer.services.clickhouse.query_builders.base import NIL_UUID
 from tracer.services.clickhouse.query_service import AnalyticsQueryService
 from tracer.services.observability_providers import ObservabilityService
@@ -1359,7 +1360,8 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         # ----- Phase 8: Batch fetch eval scores from CH -----
         eval_map = {}
         try:
-            eval_query = """
+            eval_table, eval_nd = eval_logger_source()
+            eval_query = f"""
             SELECT
                 toString(observation_span_id) AS span_id,
                 toString(custom_eval_config_id) AS eval_config_id,
@@ -1367,10 +1369,9 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 output_bool,
                 output_str,
                 eval_explanation
-            FROM tracer_eval_logger FINAL
+            FROM {eval_table} FINAL
             WHERE trace_id = %(trace_id)s
-              AND _peerdb_is_deleted = 0
-              AND (deleted = 0 OR deleted IS NULL)
+              AND {eval_nd}
             """
             eval_result = analytics.execute_ch_query(
                 eval_query, {"trace_id": str(trace_id)}, timeout_ms=30000
@@ -3253,7 +3254,8 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         eval_outputs = {}
         trace_evals: dict[str, Any] = {}
         if eval_config_ids:
-            eval_query = """
+            eval_table, eval_nd = eval_logger_source()
+            eval_query = f"""
             SELECT
                 trace_id,
                 toString(custom_eval_config_id) AS eval_config_id,
@@ -3261,9 +3263,8 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
                 avg(CASE WHEN output_bool = 1 THEN 100.0 ELSE 0.0 END) AS pass_rate,
                 count() AS eval_count,
                 any(output_str_list) AS output_str_list
-            FROM tracer_eval_logger FINAL
-            WHERE _peerdb_is_deleted = 0
-              AND (deleted = 0 OR deleted IS NULL)
+            FROM {eval_table} FINAL
+            WHERE {eval_nd}
               AND trace_id = %(trace_id)s
               AND custom_eval_config_id IN %(eval_config_ids)s
             GROUP BY trace_id, custom_eval_config_id
@@ -3855,11 +3856,11 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
             ).select_related("eval_template")
             eval_config_ids = [str(c.id) for c in eval_configs]
         else:
+            eval_table, eval_nd = eval_logger_source()
             ch_result = analytics.execute_ch_query(
                 "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
-                "FROM tracer_eval_logger FINAL "
-                "WHERE _peerdb_is_deleted = 0 "
-                "AND (deleted = 0 OR deleted IS NULL) "
+                f"FROM {eval_table} FINAL "
+                f"WHERE {eval_nd} "
                 "AND dictGet('trace_dict', 'project_id', "
                 "trace_id) = toUUID(%(pid)s)",
                 {"pid": str(project_id)},
@@ -4156,11 +4157,11 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
 
         # Get eval config IDs from CH (fast) instead of PG EvalLogger scan
         eval_config_ids = []
+        eval_table, eval_nd = eval_logger_source()
         ch_result = analytics.execute_ch_query(
             "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
-            "FROM tracer_eval_logger FINAL "
-            "WHERE _peerdb_is_deleted = 0 "
-            "AND (deleted = 0 OR deleted IS NULL) "
+            f"FROM {eval_table} FINAL "
+            f"WHERE {eval_nd} "
             "AND dictGet('trace_dict', 'project_id', "
             "trace_id) = toUUID(%(pid)s)",
             {"pid": str(project_id)},
@@ -4470,11 +4471,11 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
 
         # Get eval config IDs from CH (fast) instead of PG EvalLogger scan
         eval_config_ids = []
+        eval_table, eval_nd = eval_logger_source()
         ch_result = analytics.execute_ch_query(
             "SELECT DISTINCT toString(custom_eval_config_id) AS cid "
-            "FROM tracer_eval_logger FINAL "
-            "WHERE _peerdb_is_deleted = 0 "
-            "AND (deleted = 0 OR deleted IS NULL) "
+            f"FROM {eval_table} FINAL "
+            f"WHERE {eval_nd} "
             "AND dictGet('trace_dict', 'project_id', "
             "trace_id) = toUUID(%(pid)s)",
             {"pid": project_id},

--- a/futureagi/tracer/views/trace_session.py
+++ b/futureagi/tracer/views/trace_session.py
@@ -2272,8 +2272,8 @@ class TraceSessionView(BaseModelViewSetMixin, ModelViewSet):
                             attrs = {}
                         # Fallback: merge from typed Map columns when raw is empty
                         if not attrs:
-                            str_map = attr_row.get("span_attr_str") or {}
-                            num_map = attr_row.get("span_attr_num") or {}
+                            str_map = attr_row.get("attrs_string") or {}
+                            num_map = attr_row.get("attrs_number") or {}
                             if isinstance(str_map, dict):
                                 attrs.update(str_map)
                             if isinstance(num_map, dict):


### PR DESCRIPTION
## What

Read-path fixes **required for the new ClickHouse (CH-direct / v2) schema**. The new
`spans` table uses typed Map columns `attrs_string` / `attrs_number` / `attrs_bool`
and a unified `is_deleted` marker; the legacy peerdb/v1 columns (`span_attr_*`,
`_peerdb_is_deleted`) are **gone**. Several read paths still emitted the old names
and **error on the new CH** — so these queries fail until the column references are
moved to v2.

## Validated against the new CH (local CH-direct stack)

Proven by direct probe on CH 25.3:
- `attrs_string` → ✅ 104,249 rows; `is_deleted = 0` → ✅ 142,134 rows
- the **old** `span_attr_str` → ❌ `UNKNOWN_IDENTIFIER` (column no longer exists)

End-to-end in the app on the new CH: trend graph (`dashboard/metrics`), trace list
(8,053), voice-call list, `has_annotation` filter, and span-attribute discovery all
return 200 with data; the 12-month project view renders graph + traces.

> The standalone data box still running the **old** v1 CH (24.10, peerdb) is behind
> and is **not** the reference for this change — on the new CH the original code is
> what breaks.

## Changes

- **span_attributes / dashboard / trace_session** — `span_attr_* → attrs_*` on the `spans` reads.
- **time_series / annotation_graph** — use `ClickHouseFilterBuilderV2` for the embedded filter builder (its `translate()` rewrites `span_attr_* → attrs_*`).
- **trace_list** — `trace_tags` → `dictGetOrDefault('trace_dict', 'tags', toUUID(trace_id), '[]')`.
- **filters (`has_annotation` / `model_hub_score`)** — drop the `_peerdb_is_deleted` predicate the v2 SQL rewriter renames to `is_deleted` (which `model_hub_score` lacks); keep `deleted = false`. _Cleaner fix = exclude `model_hub_score` from that rewrite; flagged for the rewriter owners._
- **eval_logger_table (new) + settings** — centralize the eval-logger table + not-deleted predicate behind `settings.CH25_EVAL_LOGGER_TABLE` (default = legacy `tracer_eval_logger`; CH-direct sets `tracer_eval_logger_v2`).

## Dependency

Lands with the new CH (v2/CH-direct) `spans` schema. The `eval_logger` piece is
additionally env-gated (legacy default) so it is safe regardless of schema.

## Excluded

Local-only ClickHouse stack config (`config/clickhouse/ws1-*.xml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
