### PR TITLE
fix(frontend): stop app crashing under Google Translate (insertBefore NotFoundError)

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -50,6 +50,9 @@ import { initPostHog } from "./utils/PostHog";
 import { initGoogleAds } from "./utils/googleAds";
 import { initReddit } from "./utils/redditAds";
 import { initTwitter } from "./utils/twitterAds";
+import { applyTranslationDomGuard } from "./utils/translationDomGuard";
+
+applyTranslationDomGuard();
 
 Sentry.init({
   dsn: SENTRY_DSN,

--- a/frontend/src/utils/translationDomGuard.js
+++ b/frontend/src/utils/translationDomGuard.js
@@ -1,0 +1,31 @@
+import logger from "./logger";
+
+let applied = false;
+
+export function applyTranslationDomGuard() {
+  if (applied) return;
+  if (typeof Node !== "function" || !Node.prototype) return;
+  applied = true;
+
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function (child) {
+    if (child && child.parentNode !== this) {
+      logger.debug(
+        "translationDomGuard: skipped removeChild on detached node",
+      );
+      return child;
+    }
+    return originalRemoveChild.apply(this, arguments);
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function (newNode, referenceNode) {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      logger.debug(
+        "translationDomGuard: skipped insertBefore on detached reference",
+      );
+      return newNode;
+    }
+    return originalInsertBefore.apply(this, arguments);
+  };
+}


### PR DESCRIPTION
## Problem

When users run the app through browser translation (Google Translate and
similar), the app crashes with:

> NotFoundError: Failed to execute 'insertBefore' on 'Node': The node
> before which the new node is to be inserted is not a child of this node.

The translator swaps React-managed text nodes for translated `<font>`
nodes. React still holds a reference to the original text node, so its
next `insertBefore`/`removeChild` targets a node that is no longer in the
tree → the browser throws → white screen. Tables (MUI `TableCell`) are hit
hardest because they contain many small text nodes.

## Fix

Add `frontend/src/utils/translationDomGuard.js`, which monkey-patches
`Node.prototype.insertBefore` and `Node.prototype.removeChild` to check
that the target node is actually a child of the expected parent. If it
isn't (because the translator moved it), the call is skipped instead of
throwing; otherwise it delegates to the native method unchanged. The
guard is idempotent and installed once in `main.jsx` before React mounts.

## Impact

- Normal rendering and Google Translate behaviour are unchanged — the
  guard only intercepts the specific collision that used to crash.
- Translation still applies to updated data (re-translated by the
  translator's MutationObserver as usual).

## Test plan

- [x] Open a falcon page or any pag
- [x] Chrome → right-click → Translate to Hindi (or another language)

- [x] Translate back to English and repeat — page stays stable


Closes  TH-5640

