### PR TITLE
fix(observe): resolve duplicate ID_ONLY_FIELDS declaration crashing Create Eval

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -42,7 +42,6 @@ import {
   getPickerOptionSecondaryLabel,
   getPickerOptionValue,
 } from "./filterValuePickerUtils";
-import { ID_ONLY_FIELDS } from "./idFields";
 
 // ---------------------------------------------------------------------------
 // Trace filter fields (for Query tab via shared FilterPanel)


### PR DESCRIPTION
## What

`TraceFilterPanel.jsx` both **imported** `ID_ONLY_FIELDS` from `./idFields` and **redeclared** a local `const` of the same name, causing a hard parse error:

> Identifier 'ID_ONLY_FIELDS' has already been declared

Because the module fails to parse, it fails to load — crashing every screen that transitively imports it into the global error boundary ("Houston, we have a problem!").

## Impact

Most visibly, the **Create Eval** page crashes. Import chain:

`EvalCreate → EvalCreatePage → TestPlayground → TracingTestMode → TaskFilterBar → TraceFilterPanel`

LLM Tracing / Observe trace-filter surfaces are affected too.

## Root cause

A May 15 refactor consolidated `ID_ONLY_FIELDS` into the shared `idFields` module (adding the `import`), while a later branch still carried the local `const` (which adds `"session"`). The merge into `dev` kept **both**.

## Fix

Remove the redundant `import` and keep the local `const` — it's the newer superset (includes `"session"`) and is what all in-file usages reference. **No behavior change**; the shared `idFields` module and its other consumers are untouched.

## Verification

- `eslint` on the file: parse error gone (repo error count 67 → 66; remainder are pre-existing, unrelated).
- Vite now transforms and serves the module that previously failed dep-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)