### PR TITLE
feat(evals): restore custom tag support on create/edit + filtering

### DIFF
--- a/frontend/src/sections/evals/components/CustomTagInput.jsx
+++ b/frontend/src/sections/evals/components/CustomTagInput.jsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { Box, IconButton, TextField } from "@mui/material";
+
+import Iconify from "src/components/iconify";
+
+import { canonicalizeTag } from "../constant";
+
+/**
+ * Free-text input for adding a custom tag to an eval.
+ *
+ * On commit it resolves the typed text against the predefined tags first
+ * (so "image" selects the existing "Image" chip instead of creating a
+ * near-duplicate), otherwise adds a canonical UPPERCASE_UNDERSCORE value.
+ * Duplicates (case/spacing-insensitive) are ignored.
+ */
+export default function CustomTagInput({
+  predefinedTags = [],
+  selected = [],
+  onAdd,
+  disabled = false,
+}) {
+  const [text, setText] = useState("");
+
+  const commit = () => {
+    const canon = canonicalizeTag(text);
+    if (!canon) return;
+
+    const match = predefinedTags.find(
+      (t) =>
+        canonicalizeTag(t.value) === canon ||
+        canonicalizeTag(t.label) === canon,
+    );
+    const value = match ? match.value : canon;
+
+    const already = selected.some(
+      (t) => canonicalizeTag(t) === canonicalizeTag(value),
+    );
+    if (!already) onAdd(value);
+    setText("");
+  };
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.75 }}>
+      <TextField
+        size="small"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+          }
+        }}
+        placeholder="Add custom tag"
+        disabled={disabled}
+        sx={{
+          width: 180,
+          "& .MuiInputBase-input": { fontSize: 12, py: 0.5 },
+        }}
+      />
+      <IconButton
+        size="small"
+        onClick={commit}
+        disabled={disabled || !text.trim()}
+        aria-label="Add custom tag"
+      >
+        <Iconify icon="mdi:plus" width={16} />
+      </IconButton>
+    </Box>
+  );
+}
+
+CustomTagInput.propTypes = {
+  predefinedTags: PropTypes.array,
+  selected: PropTypes.array,
+  onAdd: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -22,6 +22,8 @@ import { useSnackbar } from "notistack";
 import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 import { FAGI_MODEL_VALUES } from "./ModelSelector";
 
+import CustomTagInput from "./CustomTagInput";
+import { canonicalizeTag, humanizeTag } from "../constant";
 import { useCreateEval } from "../hooks/useCreateEval";
 import { useUpdateEval } from "../hooks/useEvalDetail";
 import { useCreateCompositeEval } from "../hooks/useCompositeEval";
@@ -1147,6 +1149,37 @@ const EvalCreatePage = () => {
                               gap: 0.75,
                             }}
                           >
+                            {/* Custom tags (not in the predefined list) */}
+                            {tags
+                              .filter(
+                                (t) =>
+                                  !EVAL_TAGS.some(
+                                    (p) =>
+                                      canonicalizeTag(p.value) ===
+                                      canonicalizeTag(t),
+                                  ),
+                              )
+                              .map((t) => (
+                                <Chip
+                                  key={`custom-${t}`}
+                                  icon={
+                                    <Iconify icon="mdi:tag-outline" width={14} />
+                                  }
+                                  label={humanizeTag(t)}
+                                  size="small"
+                                  variant="filled"
+                                  color="primary"
+                                  onDelete={() =>
+                                    setTags((prev) =>
+                                      prev.filter((x) => x !== t),
+                                    )
+                                  }
+                                  sx={{
+                                    fontSize: "12px",
+                                    "& .MuiChip-icon": { fontSize: "14px" },
+                                  }}
+                                />
+                              ))}
                             {EVAL_TAGS.map((tag) => {
                               const selected = tags.includes(tag.value);
                               return (
@@ -1173,6 +1206,13 @@ const EvalCreatePage = () => {
                               );
                             })}
                           </Box>
+                          <CustomTagInput
+                            predefinedTags={EVAL_TAGS}
+                            selected={tags}
+                            onAdd={(value) =>
+                              setTags((prev) => [...prev, value])
+                            }
+                          />
                         </Box>
                       </Box>
                     )}

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -47,6 +47,7 @@ import LLMPromptEditor from "./LLMPromptEditor";
 import OutputTypeConfig from "./OutputTypeConfig";
 import FewShotExamples from "./FewShotExamples";
 import CodeEvalEditor from "./CodeEvalEditor";
+import CustomTagInput from "./CustomTagInput";
 import ResizablePanels from "src/components/resizablePanels/ResizablePanels";
 import TestPlayground from "./TestPlayground";
 import CompositeDetailPanel from "./CompositeDetailPanel";
@@ -1847,6 +1848,16 @@ const EvalDetailPage = () => {
                         );
                       })()}
                     </Box>
+                    {!isSystemEval && (
+                      <CustomTagInput
+                        predefinedTags={EVAL_TAGS}
+                        selected={tags}
+                        onAdd={(value) => {
+                          setTags((prev) => [...prev, value]);
+                          markDirty();
+                        }}
+                      />
+                    )}
                   </Box>
                 )}
               </Box>

--- a/frontend/src/sections/evals/components/EvalsListView.jsx
+++ b/frontend/src/sections/evals/components/EvalsListView.jsx
@@ -460,20 +460,44 @@ const EvalsListView = () => {
     if (changed) setCreatorsVersion((v) => v + 1);
   }, [items]);
 
+  // Accumulate tags seen across loaded evals (same pattern as creators) so
+  // custom tags — not just the predefined EVAL_TAGS — become filter choices.
+  const tagsRef = useRef(new Set());
+  const [tagsVersion, setTagsVersion] = useState(0);
+  useEffect(() => {
+    let changed = false;
+    for (const item of items) {
+      const itemTags = Array.isArray(item?.tags) ? item.tags : [];
+      for (const t of itemTags) {
+        if (t && !tagsRef.current.has(t)) {
+          tagsRef.current.add(t);
+          changed = true;
+        }
+      }
+    }
+    if (changed) setTagsVersion((v) => v + 1);
+  }, [items]);
+
   const filterFields = useMemo(() => {
     const evalNames = (allEvalNames || [])
       .map((e) => e.name)
       .filter(Boolean)
       .sort();
     const creators = [...creatorsRef.current].sort();
+    // Predefined tags + any custom tags harvested from loaded evals.
+    const tagChoices = [
+      ...new Set([...EVAL_TAGS.map((t) => t.value), ...tagsRef.current]),
+    ].sort();
     return [
       { value: "name", label: "Name", type: "enum", choices: evalNames },
       { value: "owner", label: "Created By", type: "enum", choices: creators },
-      ...STATIC_FILTER_FIELDS,
+      ...STATIC_FILTER_FIELDS.map((f) =>
+        f.value === "tags" ? { ...f, choices: tagChoices } : f,
+      ),
     ];
-    // creatorsVersion is the reactivity bump — the real data is in the ref.
+    // creatorsVersion / tagsVersion are reactivity bumps — real data is in refs.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allEvalNames, creatorsVersion]);
+  }, [allEvalNames, creatorsVersion, tagsVersion]);
 
   // Fetch 30-day charts separately (ClickHouse, async)
   const templateIds = useMemo(() => items.map((item) => item.id), [items]);

--- a/frontend/src/sections/evals/constant.js
+++ b/frontend/src/sections/evals/constant.js
@@ -253,3 +253,19 @@ export const TAG_LOOKUP = (() => {
   });
   return map;
 })();
+
+// Normalize free-text tag input into a canonical value (UPPERCASE_UNDERSCORE),
+// matching the convention used by EVAL_TAGS values and backend semantic tags.
+export const canonicalizeTag = (s) =>
+  String(s || "")
+    .trim()
+    .replace(/\s+/g, "_")
+    .replace(/_+/g, "_")
+    .toUpperCase();
+
+// Turn a stored tag value (e.g. "CUSTOMER_SUPPORT") into a readable label.
+export const humanizeTag = (s) =>
+  String(s || "")
+    .toLowerCase()
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase());


### PR DESCRIPTION
## 1. Why

The ability to add, remove, and filter evals by **custom tags** had been lost from the UI. The backend already stores eval `tags` as an arbitrary string array — only the front-end affordance was missing — so this restores it (frontend-only).

## 2. What changed

- **`CustomTagInput.jsx`** (new): reusable free-text tag input. Resolves typed text to a predefined tag when it matches (avoids near-duplicates), otherwise adds a canonical `UPPERCASE_UNDERSCORE` value; ignores duplicates.
- **`constant.js`**: `canonicalizeTag` / `humanizeTag` helpers.
- **`EvalCreatePage.jsx` / `EvalDetailPage.jsx`**: render removable custom-tag chips + the add-tag input. Hidden for read-only system evals; edit page marks the form dirty on change.
- **`EvalsListView.jsx`**: harvest tags actually in use from loaded evals (same pattern as the existing "Created By" filter) so custom tags appear as selectable Tags-filter choices — not just the predefined set.

## 3. Tests written (new & old)

- **New automated tests:** none added. (`canonicalizeTag` / `humanizeTag` in `constant.js` are pure functions and are the natural unit-test target if we add coverage later.)
- **Existing / regression:** repo vitest suite passes unchanged; ESLint clean on all changed/new files.

## 4. Test scenarios covered (manual)

- Type a free-text tag on **Create** → adds a canonical `UPPERCASE_UNDERSCORE` chip; typing an existing predefined tag resolves to it instead of duplicating; duplicates ignored.
- Remove a tag chip → chip disappears; on **edit**, the form is marked dirty.
- System (read-only) evals → tag input hidden.
- **List filter:** a custom tag in use on loaded evals appears as a selectable choice in the Tags filter and filters correctly.

## 5. Commands to run tests

```bash
cd frontend
yarn lint "src/sections/evals/components/CustomTagInput.jsx" "src/sections/evals/components/EvalCreatePage.jsx" "src/sections/evals/components/EvalDetailPage.jsx" "src/sections/evals/components/EvalsListView.jsx" "src/sections/evals/constant.js"
yarn test:run
yarn dev
```

## 6. Steps to test on local/dev

1. `cd frontend && yarn dev`, open **Evals → Create**.
2. Add a custom tag (free text) and a predefined tag → confirm canonicalization + de-dup.
3. Save, reopen in **edit** → remove a tag, confirm dirty state + save.
4. Back on the **Evals list**, open the **Tags** filter → confirm the custom tag is a selectable choice and filters the list.

## 7. Screenshots & videos

**Custom-tag chips + add-tag input on the eval create/edit page:**

<img width="1480" height="933" alt="Custom-tag chips and add-tag input on the eval page" src="https://github.com/user-attachments/assets/8374e042-d535-4188-ab3b-dee52d7e75b5" />

**Evals list — custom tag appears as a selectable choice in the Tags filter:**

<img width="1480" height="933" alt="Custom tag as a selectable Tags-filter choice on the Evals list" src="https://github.com/user-attachments/assets/f2321efc-4082-4008-9889-d23ab198c097" />

## 8. Key decisions & rationale

- **Canonicalize to `UPPERCASE_UNDERSCORE` + resolve to predefined on match** — keeps tags consistent and prevents near-duplicate sprawl (`Customer Support` vs `CUSTOMER_SUPPORT`).
- **Harvest filter choices from loaded evals** (mirroring the existing "Created By" filter) rather than inventing a new endpoint — consistent with current patterns.

## Known limitation

Filter choices are built from tags on **loaded** evals (same as the creators filter); a custom tag on a not-yet-loaded page won't appear until loaded. A backend "distinct tags in use" endpoint would make this exhaustive — none exists today.
