### PR TITLE
fix: encrypt provider keys with Fernet + harden code-executor (tough)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,7 +253,9 @@ services:
   code-executor:
     image: futureagi/code-executor:${CODE_EXECUTOR_VERSION:-latest}
     ports:
-      - "${CODE_EXECUTOR_PORT:-8060}:8060"
+      - "127.0.0.1:${CODE_EXECUTOR_PORT:-8060}:8060"
+    environment:
+      AGENTCC_INTERNAL_API_KEY: ${AGENTCC_INTERNAL_API_KEY:-local-dev-only-shared-secret-replace-me}
     privileged: true
     deploy:
       resources:

--- a/futureagi/agentic_eval/core_evals/fi_utils/sandbox.py
+++ b/futureagi/agentic_eval/core_evals/fi_utils/sandbox.py
@@ -468,7 +468,10 @@ def _call_executor_service(code: str, input_data: dict, language: str, timeout: 
         req = urllib.request.Request(
             f"{CODE_EXECUTOR_URL}/execute",
             data=payload,
-            headers={"Content-Type": "application/json"},
+            headers={
+                "Content-Type": "application/json",
+                "X-Internal-Api-Key": os.environ.get("AGENTCC_INTERNAL_API_KEY", ""),
+            },
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=timeout + 10) as resp:

--- a/futureagi/code-executor/server.py
+++ b/futureagi/code-executor/server.py
@@ -66,7 +66,6 @@ def _execute_python_nsjail(code: str, input_data: dict, timeout: int) -> dict:
             "64",  # Max open files (needs more for network)
             "--time_limit",
             str(timeout),  # Wall clock limit
-            "-N",  # Allow network access — code can fetch URLs
             "-R",
             "/",  # Bind-mount root read-only (includes /sandbox/scripts)
             "-T",
@@ -184,7 +183,6 @@ def _execute_javascript(code: str, input_data: dict, timeout: int) -> dict:
                 "64",
                 "--time_limit",
                 str(timeout),
-                "-N",  # Allow network
                 "-R",
                 "/",
                 "-T",
@@ -379,6 +377,19 @@ class HealthResource:
         }
 
 
-app = falcon.App()
+class AuthMiddleware:
+    """Reject /execute calls that don't present the shared internal API key."""
+
+    def __init__(self):
+        self._key = os.environ.get("AGENTCC_INTERNAL_API_KEY")
+
+    def process_request(self, req, resp):
+        if req.path == "/health":
+            return
+        if not self._key or req.get_header("X-Internal-Api-Key") != self._key:
+            raise falcon.HTTPUnauthorized(title="Unauthorized")
+
+
+app = falcon.App(middleware=[AuthMiddleware()])
 app.add_route("/execute", ExecuteResource())
 app.add_route("/health", HealthResource())

--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -128,7 +128,9 @@ services:
       context: ./code-executor
       dockerfile: Dockerfile
     ports:
-      - "8060:8060"
+      - "127.0.0.1:8060:8060"
+    environment:
+      AGENTCC_INTERNAL_API_KEY: ${AGENTCC_INTERNAL_API_KEY:-local-dev-only-shared-secret-replace-me}
     # Privileged needed for nsjail namespace creation
     privileged: true
     restart: unless-stopped

--- a/futureagi/model_hub/migrations/0102_encrypt_api_keys_fernet.py
+++ b/futureagi/model_hub/migrations/0102_encrypt_api_keys_fernet.py
@@ -1,7 +1,10 @@
 import base64
+import logging
 import os
 
 from django.db import migrations
+
+logger = logging.getLogger(__name__)
 
 
 def _to_fernet(stored, credential_manager):
@@ -49,7 +52,7 @@ def reencrypt(apps, schema_editor):
     # under it would make these rows undecryptable after the next restart.
     # The dual-format read path keeps legacy base64 rows working until then.
     if not os.environ.get("INTEGRATION_ENCRYPTION_KEY"):
-        print("INTEGRATION_ENCRYPTION_KEY not set in env; skipping re-encryption.")
+        logger.warning("INTEGRATION_ENCRYPTION_KEY not set in env; skipping re-encryption.")
         return
 
     from integrations.services.credentials import CredentialManager

--- a/futureagi/model_hub/migrations/0102_encrypt_api_keys_fernet.py
+++ b/futureagi/model_hub/migrations/0102_encrypt_api_keys_fernet.py
@@ -1,0 +1,93 @@
+import base64
+import os
+
+from django.db import migrations
+
+
+def _to_fernet(stored, credential_manager):
+    """Convert a single legacy base64(salt+value) string to a Fernet token.
+
+    Returns None when there is nothing to do (empty, already Fernet, or
+    undecodable) so callers can treat None as "leave the value untouched".
+    """
+    if not stored or str(stored).startswith("gAAAAA"):
+        return None
+    try:
+        plaintext = base64.b64decode(stored)[16:].decode()
+    except Exception:
+        return None
+    return credential_manager.encrypt({"v": plaintext}).decode()
+
+
+def _migrate_json(value, credential_manager):
+    """Recursively re-encrypt string leaves of a JSON value. Returns
+    (new_value, changed)."""
+    if isinstance(value, dict):
+        out, changed = {}, False
+        for k, v in value.items():
+            nv, c = _migrate_json(v, credential_manager)
+            out[k] = nv
+            changed = changed or c
+        return out, changed
+    if isinstance(value, list):
+        out, changed = [], False
+        for item in value:
+            nv, c = _migrate_json(item, credential_manager)
+            out.append(nv)
+            changed = changed or c
+        return out, changed
+    if isinstance(value, str):
+        nv = _to_fernet(value, credential_manager)
+        if nv is not None:
+            return nv, True
+    return value, False
+
+
+def reencrypt(apps, schema_editor):
+    # Only migrate when a persisted key is configured. In local dev
+    # INTEGRATION_ENCRYPTION_KEY is regenerated every restart, so re-encrypting
+    # under it would make these rows undecryptable after the next restart.
+    # The dual-format read path keeps legacy base64 rows working until then.
+    if not os.environ.get("INTEGRATION_ENCRYPTION_KEY"):
+        print("INTEGRATION_ENCRYPTION_KEY not set in env; skipping re-encryption.")
+        return
+
+    from integrations.services.credentials import CredentialManager
+
+    ApiKey = apps.get_model("model_hub", "ApiKey")
+    SecretModel = apps.get_model("model_hub", "SecretModel")
+    CustomAIModel = apps.get_model("model_hub", "CustomAIModel")
+
+    for row in ApiKey.objects.all().iterator():
+        fields = {}
+        new_key = _to_fernet(row.key, CredentialManager)
+        if new_key is not None:
+            fields["key"] = new_key
+        if row.config_json:
+            new_json, changed = _migrate_json(row.config_json, CredentialManager)
+            if changed:
+                fields["config_json"] = new_json
+        if fields:
+            ApiKey.objects.filter(pk=row.pk).update(**fields)
+
+    for row in SecretModel.objects.all().iterator():
+        new_key = _to_fernet(row.key, CredentialManager)
+        if new_key is not None:
+            SecretModel.objects.filter(pk=row.pk).update(key=new_key)
+
+    for row in CustomAIModel.objects.all().iterator():
+        if not row.key_config:
+            continue
+        new_json, changed = _migrate_json(row.key_config, CredentialManager)
+        if changed:
+            CustomAIModel.objects.filter(pk=row.pk).update(key_config=new_json)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("model_hub", "0101_backfill_composite_v1_config_snapshots"),
+    ]
+
+    operations = [
+        migrations.RunPython(reencrypt, migrations.RunPython.noop),
+    ]

--- a/futureagi/model_hub/models/api_key.py
+++ b/futureagi/model_hub/models/api_key.py
@@ -6,9 +6,29 @@ from django.db import models
 
 from accounts.models import Organization, User
 from accounts.models.workspace import Workspace
+from integrations.services.credentials import CredentialManager
 from model_hub.models.choices import LiteLlmModelProvider
 from tfc.settings import settings
 from tfc.utils.base_model import BaseModel
+
+
+def _encrypt_secret(value):
+    if not value:
+        return None
+    return CredentialManager.encrypt({"v": value}).decode()
+
+
+def _decrypt_secret(stored):
+    """Decrypt a stored secret, transparently handling both the legacy
+    base64(salt+value) format and the current Fernet format."""
+    if not stored:
+        return None
+    try:
+        if str(stored).startswith("gAAAAA"):
+            return CredentialManager.decrypt(stored.encode())["v"]
+        return base64.b64decode(stored)[16:].decode()
+    except Exception:
+        return None
 
 
 def validate_model_provider_choice(value):
@@ -86,26 +106,10 @@ class ApiKey(BaseModel):
             self._actual_json = self.decrypt_json(self.config_json)
 
     def encrypt_key(self, key):
-        if not key:
-            return None
-        # Use a secret salt from settings
-        salt = settings.SECRET_KEY[:16].encode()
-        # Combine salt and key, then encode
-        salted = salt + key.encode()
-        encoded = base64.b64encode(salted).decode()
-        return encoded
+        return _encrypt_secret(key)
 
     def decrypt_key(self):
-        if not self.key:
-            return None
-        try:
-            # Decode the stored value
-            decoded = base64.b64decode(self.key)
-            # Remove the salt (first 16 bytes)
-            actual_key = decoded[16:].decode()
-            return actual_key
-        except Exception:
-            return None
+        return _decrypt_secret(self.key)
 
     @property
     def actual_key(self):
@@ -133,7 +137,8 @@ class ApiKey(BaseModel):
             self._actual_key = self.key
             self.key = self.encrypt_key(self.key)
         if self.config_json and not all(
-            v.startswith(b"gAAAAA".decode()) for v in self.config_json.values()
+            isinstance(v, str) and v.startswith("gAAAAA")
+            for v in self.config_json.values()
         ):
             self._actual_json = self.config_json
             self.config_json = self.encrypt_json(self.config_json)
@@ -165,16 +170,7 @@ class ApiKey(BaseModel):
             return value
 
     def get_decrypted_json_key(self, json_key):
-        if not json_key:
-            return None
-        try:
-            # Decode the stored value
-            decoded = base64.b64decode(json_key)
-            # Remove the salt (first 16 bytes)
-            actual_key = decoded[16:].decode()
-            return actual_key
-        except Exception:
-            return None
+        return _decrypt_secret(json_key)
 
     def decrypt_json(self, json_key=None):
         actual_key = {}
@@ -256,26 +252,10 @@ class SecretModel(BaseModel):
             self._actual_key = self.decrypt_key()
 
     def encrypt_key(self, key):
-        if not key:
-            return None
-        # Use a secret salt from settings
-        salt = settings.SECRET_KEY[:16].encode()
-        # Combine salt and key, then encode
-        salted = salt + key.encode()
-        encoded = base64.b64encode(salted).decode()
-        return encoded
+        return _encrypt_secret(key)
 
     def decrypt_key(self):
-        if not self.key:
-            return None
-        try:
-            # Decode the stored value
-            decoded = base64.b64decode(self.key)
-            # Remove the salt (first 16 bytes)
-            actual_key = decoded[16:].decode()
-            return actual_key
-        except Exception:
-            return None
+        return _decrypt_secret(self.key)
 
     @property
     def actual_key(self):

--- a/futureagi/model_hub/models/custom_models.py
+++ b/futureagi/model_hub/models/custom_models.py
@@ -39,11 +39,12 @@ class CustomAIModel(BaseModel):
             self._actual_json = ApiKey().decrypt_json(self.key_config)
 
     def save(self, *args, **kwargs):
-        # if self.key_config and not all(
-        #     [v.startswith(b"gAAAAA".decode()) for v in self.key_config.values()]
-        # ):
-        self._actual_json = self.key_config
-        self.key_config = ApiKey().encrypt_json(self.key_config)
+        if self.key_config and not all(
+            isinstance(v, str) and v.startswith("gAAAAA")
+            for v in self.key_config.values()
+        ):
+            self._actual_json = self.key_config
+            self.key_config = ApiKey().encrypt_json(self.key_config)
         self.full_clean()
         super().save(*args, **kwargs)
 


### PR DESCRIPTION
## Problem
Two security issues reported via private disclosure:

1. **Provider keys stored as base64, not encrypted** (`futureagi/model_hub/models/api_key.py:88`): `encrypt_key` = `b64encode(salt + key)` — fully reversible, no cipher. The `gAAAAA` prefix guards in `save()` already expect Fernet tokens but never receive them. Three classes affected (`ApiKey`, `SecretModel`, `CustomAIModel`).

2. **Code-executor: unauth RCE, host network, published on 0.0.0.0** (`futureagi/code-executor/server.py:382`): Falcon app has no auth middleware — `/execute` runs caller-supplied code as root. `nsjail` launched with `-N` (host network). Compose publishes :8060 on 0.0.0.0 with `privileged: true`.

## Fix / Changes
- **Fernet encryption:** All 3 model classes now encrypt via `CredentialManager` (existing `INTEGRATION_ENCRYPTION_KEY`). Dual-format read supports legacy base64 rows during transition. Data migration re-encrypts existing keys. Fixed `CustomAIModel` double-encrypt bug (idempotency guard was commented out).
- **Code-executor:** Auth middleware requires `AGENTCC_INTERNAL_API_KEY` header. Dropped `-N` from nsjail. Bound to 127.0.0.1. `privileged: true` left in (nsjail needs it — documented in the compose itself; dropping requires live cap-testing against a rebuilt image).

## Verification
Both proven live on the running stack:
- **Keys:** DB key `base64 -d` → `AIzaSyB0…` plaintext (BROKEN) → new key stored as `gAAAAAB…`, `base64 -d` yields garbage (FIXED). Legacy rows still decrypt via dual-format read.
- **RCE:** unauth `/execute` ran `id` → `uid=0(root)` (BROKEN) → `401 Unauthorized` (FIXED). Correct key still executes.

## Out of scope
- Code-executor `privileged` removal (nsjail namespace cap-testing — needs a rebuilt image)
- Login bypass + gateway fixes — separate PR

Closes (security disclosure — Slack thread: https://futureagi.slack.com/archives/C077SFLMS82/p1780646117717549)