### PR TITLE
fix: require password on login, enable gateway auth

### DIFF
--- a/agentcc-gateway/config.example.yaml
+++ b/agentcc-gateway/config.example.yaml
@@ -240,7 +240,9 @@ providers:
 
 # Virtual API key authentication.
 # When enabled, all requests must include Authorization: Bearer sk-agentcc-xxx
-# When disabled (default), the gateway runs in open mode.
+# Setting AGENTCC_INTERNAL_API_KEY in the environment turns this on automatically
+# and registers that key. Running with no key and no auth block leaves the
+# gateway open — only do that on a trusted, non-public network.
 # auth:
 #   enabled: true
 #   keys:

--- a/agentcc-gateway/internal/config/config.go
+++ b/agentcc-gateway/internal/config/config.go
@@ -979,6 +979,20 @@ func loadFromEnv(cfg *Config) {
 		cfg.ControlPlane.WebhookSecret = v
 	}
 
+	// Auth env overrides. A present internal API key both seeds the key store
+	// and turns auth on, so a default deploy is closed rather than an open proxy.
+	if v := os.Getenv("AGENTCC_INTERNAL_API_KEY"); v != "" {
+		cfg.Auth.Enabled = true
+		cfg.Auth.Keys = append(cfg.Auth.Keys, AuthKeyConfig{
+			Name:  "internal-backend",
+			Key:   v,
+			Owner: "futureagi-backend",
+		})
+	}
+	if v := os.Getenv("AGENTCC_AUTH_ENABLED"); v != "" {
+		cfg.Auth.Enabled = v == "true" || v == "1"
+	}
+
 	// Redis state env overrides.
 	if v := os.Getenv("AGENTCC_REDIS_ADDRESS"); v != "" {
 		cfg.Redis.Address = v

--- a/futureagi/accounts/views/user.py
+++ b/futureagi/accounts/views/user.py
@@ -206,7 +206,11 @@ class CustomTokenObtainPairView(TokenObtainPairView):
 
             # --- Password check (must come before any token issuance) ---
             password_entered = request.data.get("password")
-            if password_entered and not check_password(password_entered, user.password):
+            if (
+                not password_entered
+                or not str(password_entered).strip()
+                or not check_password(password_entered, user.password)
+            ):
                 failed_attempts += 1
                 cache.set(
                     attempts_key, failed_attempts, settings.FAILED_ATTEMPTS_TIMEOUT

--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - FAST_STARTUP=${FAST_STARTUP:-true}
       - AGENTCC_INTERNAL_URL=http://agentcc-gateway:8090
-      - AGENTCC_INTERNAL_API_KEY=${AGENTCC_INTERNAL_API_KEY:-}
+      - AGENTCC_INTERNAL_API_KEY=${AGENTCC_INTERNAL_API_KEY:-local-dev-only-shared-secret-replace-me}
       # Read replica: uncomment to test read/write split locally (points to same DB)
       # - PGBOUNCER_READ_HOST=pgbouncer
       # - PGBOUNCER_READ_PORT=6432
@@ -109,7 +109,7 @@ services:
     env_file:
       - .env
     environment:
-      - AGENTCC_INTERNAL_API_KEY=${AGENTCC_INTERNAL_API_KEY:-}
+      - AGENTCC_INTERNAL_API_KEY=${AGENTCC_INTERNAL_API_KEY:-local-dev-only-shared-secret-replace-me}
       # Gateway WORKDIR is /, so credentials_file resolution needs an absolute
       # path. Override the relative value from .env.
       - GOOGLE_APPLICATION_CREDENTIALS=/app/Vertex_AI_Creds.json


### PR DESCRIPTION
## Problem
Two security issues reported via private disclosure:

1. **Login bypass** (`futureagi/accounts/views/user.py:208`): password check is conditional — omitting the password field skips the check entirely, issuing tokens with just an email.

2. **Gateway open by default** (`agentcc-gateway/internal/middleware/auth.go`): `AGENTCC_INTERNAL_API_KEY` is passed to every compose deploy but never read. Auth plugin absent from pipeline.

## Fix / Changes
- **Login:** Make password check unconditional — reject missing/empty/whitespace password. Also closes the 2FA first-factor bypass.
- **Gateway:** Auto-enable auth and seed the keystore from `AGENTCC_INTERNAL_API_KEY` when present. Mirrors the existing Redis `address→Enabled` pattern.

## Verification
Both proven live on the running stack:
- Login: `POST /accounts/token/` with email only → 200+tokens → 400 `LOGIN_INVALID_CREDENTIALS`
- Gateway: `GET /v1/models` no auth → 200 models served → 401

## Out of scope
- Code-executor `privileged` flag (nsjail namespace needs)
- Base64→Fernet key encryption (separate PR)

Closes (security disclosure — Slack thread: https://futureagi.slack.com/archives/C077SFLMS82/p1780646117717549)