### PR TITLE
fix: encrypt provider keys with Fernet instead of base64

### DIFF
--- a/futureagi/model_hub/migrations/0102_encrypt_api_keys_fernet.py
+++ b/futureagi/model_hub/migrations/0102_encrypt_api_keys_fernet.py
@@ -1,7 +1,10 @@
 import base64
+import logging
 import os
 
 from django.db import migrations
+
+logger = logging.getLogger(__name__)
 
 
 def _to_fernet(stored, credential_manager):
@@ -49,7 +52,7 @@ def reencrypt(apps, schema_editor):
     # under it would make these rows undecryptable after the next restart.
     # The dual-format read path keeps legacy base64 rows working until then.
     if not os.environ.get("INTEGRATION_ENCRYPTION_KEY"):
-        print("INTEGRATION_ENCRYPTION_KEY not set in env; skipping re-encryption.")
+        logger.warning("INTEGRATION_ENCRYPTION_KEY not set in env; skipping re-encryption.")
         return
 
     from integrations.services.credentials import CredentialManager

--- a/futureagi/model_hub/migrations/0102_encrypt_api_keys_fernet.py
+++ b/futureagi/model_hub/migrations/0102_encrypt_api_keys_fernet.py
@@ -1,0 +1,93 @@
+import base64
+import os
+
+from django.db import migrations
+
+
+def _to_fernet(stored, credential_manager):
+    """Convert a single legacy base64(salt+value) string to a Fernet token.
+
+    Returns None when there is nothing to do (empty, already Fernet, or
+    undecodable) so callers can treat None as "leave the value untouched".
+    """
+    if not stored or str(stored).startswith("gAAAAA"):
+        return None
+    try:
+        plaintext = base64.b64decode(stored)[16:].decode()
+    except Exception:
+        return None
+    return credential_manager.encrypt({"v": plaintext}).decode()
+
+
+def _migrate_json(value, credential_manager):
+    """Recursively re-encrypt string leaves of a JSON value. Returns
+    (new_value, changed)."""
+    if isinstance(value, dict):
+        out, changed = {}, False
+        for k, v in value.items():
+            nv, c = _migrate_json(v, credential_manager)
+            out[k] = nv
+            changed = changed or c
+        return out, changed
+    if isinstance(value, list):
+        out, changed = [], False
+        for item in value:
+            nv, c = _migrate_json(item, credential_manager)
+            out.append(nv)
+            changed = changed or c
+        return out, changed
+    if isinstance(value, str):
+        nv = _to_fernet(value, credential_manager)
+        if nv is not None:
+            return nv, True
+    return value, False
+
+
+def reencrypt(apps, schema_editor):
+    # Only migrate when a persisted key is configured. In local dev
+    # INTEGRATION_ENCRYPTION_KEY is regenerated every restart, so re-encrypting
+    # under it would make these rows undecryptable after the next restart.
+    # The dual-format read path keeps legacy base64 rows working until then.
+    if not os.environ.get("INTEGRATION_ENCRYPTION_KEY"):
+        print("INTEGRATION_ENCRYPTION_KEY not set in env; skipping re-encryption.")
+        return
+
+    from integrations.services.credentials import CredentialManager
+
+    ApiKey = apps.get_model("model_hub", "ApiKey")
+    SecretModel = apps.get_model("model_hub", "SecretModel")
+    CustomAIModel = apps.get_model("model_hub", "CustomAIModel")
+
+    for row in ApiKey.objects.all().iterator():
+        fields = {}
+        new_key = _to_fernet(row.key, CredentialManager)
+        if new_key is not None:
+            fields["key"] = new_key
+        if row.config_json:
+            new_json, changed = _migrate_json(row.config_json, CredentialManager)
+            if changed:
+                fields["config_json"] = new_json
+        if fields:
+            ApiKey.objects.filter(pk=row.pk).update(**fields)
+
+    for row in SecretModel.objects.all().iterator():
+        new_key = _to_fernet(row.key, CredentialManager)
+        if new_key is not None:
+            SecretModel.objects.filter(pk=row.pk).update(key=new_key)
+
+    for row in CustomAIModel.objects.all().iterator():
+        if not row.key_config:
+            continue
+        new_json, changed = _migrate_json(row.key_config, CredentialManager)
+        if changed:
+            CustomAIModel.objects.filter(pk=row.pk).update(key_config=new_json)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("model_hub", "0101_backfill_composite_v1_config_snapshots"),
+    ]
+
+    operations = [
+        migrations.RunPython(reencrypt, migrations.RunPython.noop),
+    ]

--- a/futureagi/model_hub/models/api_key.py
+++ b/futureagi/model_hub/models/api_key.py
@@ -6,9 +6,29 @@ from django.db import models
 
 from accounts.models import Organization, User
 from accounts.models.workspace import Workspace
+from integrations.services.credentials import CredentialManager
 from model_hub.models.choices import LiteLlmModelProvider
 from tfc.settings import settings
 from tfc.utils.base_model import BaseModel
+
+
+def _encrypt_secret(value):
+    if not value:
+        return None
+    return CredentialManager.encrypt({"v": value}).decode()
+
+
+def _decrypt_secret(stored):
+    """Decrypt a stored secret, transparently handling both the legacy
+    base64(salt+value) format and the current Fernet format."""
+    if not stored:
+        return None
+    try:
+        if str(stored).startswith("gAAAAA"):
+            return CredentialManager.decrypt(stored.encode())["v"]
+        return base64.b64decode(stored)[16:].decode()
+    except Exception:
+        return None
 
 
 def validate_model_provider_choice(value):
@@ -86,26 +106,10 @@ class ApiKey(BaseModel):
             self._actual_json = self.decrypt_json(self.config_json)
 
     def encrypt_key(self, key):
-        if not key:
-            return None
-        # Use a secret salt from settings
-        salt = settings.SECRET_KEY[:16].encode()
-        # Combine salt and key, then encode
-        salted = salt + key.encode()
-        encoded = base64.b64encode(salted).decode()
-        return encoded
+        return _encrypt_secret(key)
 
     def decrypt_key(self):
-        if not self.key:
-            return None
-        try:
-            # Decode the stored value
-            decoded = base64.b64decode(self.key)
-            # Remove the salt (first 16 bytes)
-            actual_key = decoded[16:].decode()
-            return actual_key
-        except Exception:
-            return None
+        return _decrypt_secret(self.key)
 
     @property
     def actual_key(self):
@@ -133,7 +137,8 @@ class ApiKey(BaseModel):
             self._actual_key = self.key
             self.key = self.encrypt_key(self.key)
         if self.config_json and not all(
-            v.startswith(b"gAAAAA".decode()) for v in self.config_json.values()
+            isinstance(v, str) and v.startswith("gAAAAA")
+            for v in self.config_json.values()
         ):
             self._actual_json = self.config_json
             self.config_json = self.encrypt_json(self.config_json)
@@ -165,16 +170,7 @@ class ApiKey(BaseModel):
             return value
 
     def get_decrypted_json_key(self, json_key):
-        if not json_key:
-            return None
-        try:
-            # Decode the stored value
-            decoded = base64.b64decode(json_key)
-            # Remove the salt (first 16 bytes)
-            actual_key = decoded[16:].decode()
-            return actual_key
-        except Exception:
-            return None
+        return _decrypt_secret(json_key)
 
     def decrypt_json(self, json_key=None):
         actual_key = {}
@@ -256,26 +252,10 @@ class SecretModel(BaseModel):
             self._actual_key = self.decrypt_key()
 
     def encrypt_key(self, key):
-        if not key:
-            return None
-        # Use a secret salt from settings
-        salt = settings.SECRET_KEY[:16].encode()
-        # Combine salt and key, then encode
-        salted = salt + key.encode()
-        encoded = base64.b64encode(salted).decode()
-        return encoded
+        return _encrypt_secret(key)
 
     def decrypt_key(self):
-        if not self.key:
-            return None
-        try:
-            # Decode the stored value
-            decoded = base64.b64decode(self.key)
-            # Remove the salt (first 16 bytes)
-            actual_key = decoded[16:].decode()
-            return actual_key
-        except Exception:
-            return None
+        return _decrypt_secret(self.key)
 
     @property
     def actual_key(self):

--- a/futureagi/model_hub/models/custom_models.py
+++ b/futureagi/model_hub/models/custom_models.py
@@ -39,11 +39,12 @@ class CustomAIModel(BaseModel):
             self._actual_json = ApiKey().decrypt_json(self.key_config)
 
     def save(self, *args, **kwargs):
-        # if self.key_config and not all(
-        #     [v.startswith(b"gAAAAA".decode()) for v in self.key_config.values()]
-        # ):
-        self._actual_json = self.key_config
-        self.key_config = ApiKey().encrypt_json(self.key_config)
+        if self.key_config and not all(
+            isinstance(v, str) and v.startswith("gAAAAA")
+            for v in self.key_config.values()
+        ):
+            self._actual_json = self.key_config
+            self.key_config = ApiKey().encrypt_json(self.key_config)
         self.full_clean()
         super().save(*args, **kwargs)
 


### PR DESCRIPTION
## Problem

Provider keys (API keys for OpenAI, Anthropic, etc.) were stored as `base64(SECRET_KEY[:16] + plaintext)` — encoding, not encryption. Three models affected: `ApiKey`, `SecretModel`, `CustomAIModel`.

Anyone with DB read access could recover the plaintext in 2 lines.

## Fix

- **`api_key.py`:** Replaced homegrown base64 "encryption" with `CredentialManager.encrypt`/`decrypt` (Fernet via existing `INTEGRATION_ENCRYPTION_KEY`). Extracted shared `_encrypt_secret` / `_decrypt_secret` helpers used by both `ApiKey` and `SecretModel` — net −20 lines.
- **`custom_models.py`:** Uncommented the idempotency guard on `save()` (was double-encrypting on every write). Fixed guard to check `isinstance(v, str) and v.startswith("gAAAAA")`.
- **Migration `0102`:** Re-encrypts existing base64 rows to Fernet. Idempotent — skips already-Fernet values. Guards against local dev (no persisted `INTEGRATION_ENCRYPTION_KEY` — dual-format read path keeps legacy rows working until a real key is configured).

## Verification

Before: `base64 -d` on a stored key → `AIzaSyB0...` (plaintext).
After: same row → Fernet ciphertext (`gAAAAA...`), `base64 -d` yields garbage.

CLI proven on the running stack.

## Out of scope

Part of a security disclosure. Code-executor hardening (auth, network isolation) in separate PR.

Closes (security disclosure)