### PR TITLE
test(tracer): integration suite for eval-task filter dispatch [TH-5699]

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/__tests__/validation.test.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/__tests__/validation.test.js
@@ -1,0 +1,295 @@
+import { describe, it, expect } from "vitest";
+import { extractAttributeFilters, getNewTaskFilters } from "../validation";
+
+const makeRow = (overrides = {}) => ({
+  property: "attributes",
+  propertyId: "ended_reason",
+  apiColType: "SPAN_ATTRIBUTE",
+  filterConfig: {
+    filterType: "text",
+    filterOp: "equals",
+    filterValue: "completed",
+  },
+  ...overrides,
+});
+
+describe("extractAttributeFilters — colType round-trip", () => {
+  it("emits the row's apiColType (SPAN_ATTRIBUTE) by default", () => {
+    const out = extractAttributeFilters([makeRow()]);
+    expect(out).toHaveLength(1);
+    expect(out[0].filterConfig.colType).toBe("SPAN_ATTRIBUTE");
+  });
+
+  it("preserves apiColType=ANNOTATION (the bug behind TH-5645)", () => {
+    const row = makeRow({
+      propertyId: "annotator",
+      apiColType: "ANNOTATION",
+      filterConfig: {
+        filterType: "text",
+        filterOp: "equals",
+        filterValue: "c65a0f3c-8a72-432a-987f-ddbd8391df29",
+      },
+    });
+    const out = extractAttributeFilters([row]);
+    expect(out[0].filterConfig.colType).toBe("ANNOTATION");
+    expect(out[0].columnId).toBe("annotator");
+  });
+
+  it("preserves apiColType=SYSTEM_METRIC", () => {
+    const row = makeRow({
+      propertyId: "cost",
+      apiColType: "SYSTEM_METRIC",
+      filterConfig: {
+        filterType: "number",
+        filterOp: "greater_than",
+        filterValue: 0.5,
+      },
+    });
+    const out = extractAttributeFilters([row]);
+    expect(out[0].filterConfig.colType).toBe("SYSTEM_METRIC");
+  });
+
+  it("preserves apiColType=EVAL_METRIC", () => {
+    const row = makeRow({
+      propertyId: "4d808ee6-38bd-4cb2-9ed0-77d1c1488737",
+      apiColType: "EVAL_METRIC",
+      filterConfig: {
+        filterType: "number",
+        filterOp: "greater_than",
+        filterValue: 0.8,
+      },
+    });
+    const out = extractAttributeFilters([row]);
+    expect(out[0].filterConfig.colType).toBe("EVAL_METRIC");
+  });
+
+  it("falls back to SPAN_ATTRIBUTE when apiColType is missing", () => {
+    const { apiColType, ...row } = makeRow();
+    const out = extractAttributeFilters([row]);
+    expect(out[0].filterConfig.colType).toBe("SPAN_ATTRIBUTE");
+  });
+
+  it("keeps each col_type when multiple rows are mixed", () => {
+    const out = extractAttributeFilters([
+      makeRow({ propertyId: "ended_reason" }),
+      makeRow({
+        propertyId: "annotator",
+        apiColType: "ANNOTATION",
+        filterConfig: {
+          filterType: "text",
+          filterOp: "equals",
+          filterValue: "uid-1",
+        },
+      }),
+      makeRow({
+        propertyId: "cost",
+        apiColType: "SYSTEM_METRIC",
+        filterConfig: {
+          filterType: "number",
+          filterOp: "greater_than",
+          filterValue: 0.1,
+        },
+      }),
+    ]);
+    const byCol = Object.fromEntries(out.map((o) => [o.columnId, o.filterConfig.colType]));
+    expect(byCol.ended_reason).toBe("SPAN_ATTRIBUTE");
+    expect(byCol.annotator).toBe("ANNOTATION");
+    expect(byCol.cost).toBe("SYSTEM_METRIC");
+  });
+});
+
+describe("extractAttributeFilters — non-attribute rows go through the same list", () => {
+  // The bug the FE PR fixes: an EVAL_METRIC chip used to land as a
+  // top-level dict key (`b6a017ba-...: ["Pass"]`) which the BE dispatcher
+  // silently dropped. Now it rides inside the canonical filters[] list
+  // with col_type=EVAL_METRIC, matching list_spans_observe.
+  it("emits an EVAL_METRIC chip as a filters[] item, not a top-level key", () => {
+    const evalChip = {
+      property: "b6a017ba-7683-4458-8a5d-d6aeaa37a2e8",
+      propertyId: "b6a017ba-7683-4458-8a5d-d6aeaa37a2e8",
+      fieldCategory: "eval",
+      apiColType: "EVAL_METRIC",
+      filterConfig: {
+        filterType: "categorical",
+        filterOp: "in",
+        filterValue: ["Pass"],
+      },
+    };
+    const out = extractAttributeFilters([evalChip]);
+    expect(out).toHaveLength(1);
+    expect(out[0].columnId).toBe(evalChip.propertyId);
+    expect(out[0].filterConfig.colType).toBe("EVAL_METRIC");
+    expect(out[0].filterConfig.filterValue).toEqual(["Pass"]);
+  });
+
+  it("emits a SYSTEM_METRIC chip (e.g. cost) as a filters[] item", () => {
+    const sysChip = {
+      property: "cost",
+      propertyId: "cost",
+      fieldCategory: "system",
+      apiColType: "SYSTEM_METRIC",
+      filterConfig: {
+        filterType: "number",
+        filterOp: "greater_than",
+        filterValue: 0.5,
+      },
+    };
+    const out = extractAttributeFilters([sysChip]);
+    expect(out).toHaveLength(1);
+    expect(out[0].columnId).toBe("cost");
+    expect(out[0].filterConfig.colType).toBe("SYSTEM_METRIC");
+  });
+
+  it("emits an ANNOTATION annotator chip as a filters[] item", () => {
+    const annChip = {
+      property: "annotator",
+      propertyId: "annotator",
+      fieldCategory: "annotation",
+      apiColType: "ANNOTATION",
+      filterConfig: {
+        filterType: "text",
+        filterOp: "equals",
+        filterValue: "c65a0f3c-8a72-432a-987f-ddbd8391df29",
+      },
+    };
+    const out = extractAttributeFilters([annChip]);
+    expect(out).toHaveLength(1);
+    expect(out[0].columnId).toBe("annotator");
+    expect(out[0].filterConfig.colType).toBe("ANNOTATION");
+  });
+
+  it("skips observation_type rows — they ride as a sibling top-level key", () => {
+    const obsChip = {
+      property: "observation_type",
+      propertyId: "observation_type",
+      filterConfig: { filterType: "text", filterOp: "in", filterValue: ["llm"] },
+    };
+    const out = extractAttributeFilters([obsChip]);
+    expect(out).toHaveLength(0);
+  });
+
+  // node_type is the panel's FE alias for observation_type. It must NOT
+  // ride through the canonical filters list (the BE SYSTEM_METRIC handler
+  // can't resolve `node_type` against ObservationSpan without an
+  // observation_type alias annotation that process_eval_task doesn't apply).
+  it("skips node_type rows — they ride via the observation_type sibling key", () => {
+    const nodeTypeChip = {
+      property: "node_type",
+      propertyId: "node_type",
+      fieldCategory: "system",
+      apiColType: "SYSTEM_METRIC",
+      filterConfig: { filterType: "text", filterOp: "in", filterValue: ["llm"] },
+    };
+    const out = extractAttributeFilters([nodeTypeChip]);
+    expect(out).toHaveLength(0);
+  });
+
+  // The TraceFilterPanel labels the global annotator chip with
+  // apiColType="SYSTEM_METRIC" (a deliberate UI choice — see
+  // TraceFilterPanel.jsx:372). If we let that through verbatim, the
+  // eval-task BE dispatcher would feed the row to the SYSTEM_METRIC /
+  // SPAN_ATTRIBUTE handlers too, where the column_id="annotator"
+  // matches no rows → 0-span result poisons the combined AND.
+  it("pins col_type=ANNOTATION for the annotator chip regardless of apiColType", () => {
+    const row = {
+      property: "annotator",
+      propertyId: "annotator",
+      fieldCategory: "annotation",
+      apiColType: "SYSTEM_METRIC", // what TraceFilterPanel emits
+      filterConfig: {
+        filterType: "text",
+        filterOp: "equals",
+        filterValue: "d60a1556-8562-4a76-99e3-ab422a18e39e",
+      },
+    };
+    const out = extractAttributeFilters([row]);
+    expect(out).toHaveLength(1);
+    expect(out[0].columnId).toBe("annotator");
+    expect(out[0].filterConfig.colType).toBe("ANNOTATION");
+  });
+
+  it("pins col_type=ANNOTATION for my_annotations regardless of apiColType", () => {
+    const row = {
+      property: "my_annotations",
+      propertyId: "my_annotations",
+      apiColType: "SYSTEM_METRIC",
+      filterConfig: { filterType: "boolean", filterOp: "equals", filterValue: true },
+    };
+    const out = extractAttributeFilters([row]);
+    expect(out).toHaveLength(1);
+    expect(out[0].filterConfig.colType).toBe("ANNOTATION");
+  });
+
+  // The static panel fields (status, model, service_name, …) at
+  // TraceFilterPanel.jsx:1650-1666 don't always set apiColType, so the
+  // form row arrives with apiColType=undefined. The fieldCategory
+  // fallback ensures the wire still gets the right col_type.
+  // (node_type is excluded — it's rerouted to the observation_type
+  // sibling key; see the separate test below.)
+  it("falls back to fieldCategory when apiColType is missing (status → SYSTEM_METRIC)", () => {
+    const row = {
+      property: "status",
+      propertyId: "status",
+      fieldCategory: "system",
+      // apiColType deliberately omitted
+      filterConfig: { filterType: "text", filterOp: "equals", filterValue: "OK" },
+    };
+    const out = extractAttributeFilters([row]);
+    expect(out).toHaveLength(1);
+    expect(out[0].columnId).toBe("status");
+    expect(out[0].filterConfig.colType).toBe("SYSTEM_METRIC");
+  });
+
+  it("falls back to fieldCategory=annotation → ANNOTATION", () => {
+    const row = {
+      property: "some-label-uuid",
+      propertyId: "some-label-uuid",
+      fieldCategory: "annotation",
+      filterConfig: {
+        filterType: "categorical",
+        filterOp: "equals",
+        filterValue: "Pass",
+      },
+    };
+    const out = extractAttributeFilters([row]);
+    expect(out[0].filterConfig.colType).toBe("ANNOTATION");
+  });
+
+  it("getNewTaskFilters: a node_type chip lands under outer key 'observation_type'", () => {
+    const data = {
+      filters: [
+        {
+          property: "node_type",
+          propertyId: "node_type",
+          fieldCategory: "system",
+          apiColType: "SYSTEM_METRIC",
+          filterConfig: {
+            filterType: "text",
+            filterOp: "in",
+            filterValue: ["llm"],
+          },
+        },
+      ],
+    };
+    const { filters, attributeFilters } = getNewTaskFilters(
+      data,
+      "542cb448-ced4-420e-b728-bc55315e2e68",
+      /* ignoreDate */ true,
+    );
+    expect(filters.observation_type).toEqual(["llm"]);
+    expect(filters.node_type).toBeUndefined();
+    expect(attributeFilters).toEqual([]);
+  });
+
+  it("skips legacy hydrated rows that carry no apiColType and no propertyId", () => {
+    // Existing tasks may have top-level system keys hydrated as bare
+    // form rows with property=<key> only. They were BE no-ops before;
+    // we drop them here so re-save doesn't perpetuate the wrong shape.
+    const legacyChip = {
+      property: "some_legacy_key",
+      filterConfig: { filterType: "text", filterOp: "equals", filterValue: "x" },
+    };
+    const out = extractAttributeFilters([legacyChip]);
+    expect(out).toHaveLength(0);
+  });
+});

--- a/futureagi/tracer/tests/integration/__init__.py
+++ b/futureagi/tracer/tests/integration/__init__.py
@@ -1,0 +1,6 @@
+"""Integration tests for eval-task filter parity across list endpoints and the runner.
+
+Each test is parametrized over the FilterCase matrix in _filter_matrix.py.
+List-endpoint tests exercise ClickHouse (CH_ROUTE_* overridden to 'clickhouse').
+Runner tests exercise Postgres ORM via process_eval_task with the eval engine stubbed.
+"""

--- a/futureagi/tracer/tests/integration/_filter_matrix.py
+++ b/futureagi/tracer/tests/integration/_filter_matrix.py
@@ -1,0 +1,419 @@
+"""Cartesian filter matrix for eval-task filter parity tests.
+
+Each FilterCase is uniquely identified by case_id and pairs a filter dict shape
+(matching what FE produces and BE parses in parsing_evaltask_filters) with an
+expected_predicate that, given a SeededRow, returns True iff that row should
+match the filter under BE semantics.
+
+When a new (col_type, filter_type, filter_op) leaf is added to the FE/BE, add
+it here as well — completeness is enforced by test_filter_matrix_completeness.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterator
+
+from tracer.tests.integration._seed import _NOW, SeededRow
+
+TARGET_TYPES = ("spans", "traces", "sessions", "voiceCalls")
+COL_TYPES = (
+    "SYSTEM_METRIC",
+    "SPAN_ATTRIBUTE",
+    "EVAL_METRIC",
+    "ANNOTATION",
+    "has_eval",
+    "has_annotation",
+)
+
+
+@dataclass(frozen=True)
+class FilterCase:
+    case_id: str
+    target_type: str
+    col_type: str
+    filter_type: str
+    filter_op: str
+    column_id: str
+    filter_value: Any
+    expected_predicate: Callable[[SeededRow], bool]
+
+    def to_filter_dict(self) -> dict:
+        """Return the JSON shape parsing_evaltask_filters() expects."""
+        return {
+            "filters": [
+                {
+                    "column_id": self.column_id,
+                    "col_type": self.col_type,
+                    "filter_config": {
+                        "filter_type": self.filter_type,
+                        "filter_op": self.filter_op,
+                        "filter_value": self.filter_value,
+                    },
+                }
+            ],
+        }
+
+
+# ---------- SYSTEM_METRIC leaves (per filter_type × filter_op) ---------------
+
+
+def _sm_number_leaves():
+    """SYSTEM_METRIC × number — column_id 'cost'."""
+    leaves = [
+        ("equals", 0.003, lambda r: r.cost == 0.003),
+        ("not_equals", 0.003, lambda r: r.cost != 0.003),
+        ("greater_than", 0.01, lambda r: r.cost > 0.01),
+        ("less_than", 0.01, lambda r: r.cost < 0.01),
+        ("greater_than_or_equal", 0.003, lambda r: r.cost >= 0.003),
+        ("less_than_or_equal", 0.003, lambda r: r.cost <= 0.003),
+        ("between", [0.002, 0.02], lambda r: 0.002 <= r.cost <= 0.02),
+        ("not_between", [0.002, 0.02], lambda r: not (0.002 <= r.cost <= 0.02)),
+        ("is_null", None, lambda r: r.cost is None),
+        ("is_not_null", None, lambda r: r.cost is not None),
+    ]
+    return [("SYSTEM_METRIC", "number", op, "cost", val, pred) for op, val, pred in leaves]
+
+
+def _sm_text_leaves():
+    leaves = [
+        ("equals", "gpt-4", lambda r: r.model == "gpt-4"),
+        ("not_equals", "gpt-4", lambda r: r.model != "gpt-4"),
+        ("contains", "gpt", lambda r: "gpt" in (r.model or "")),
+        ("in", ["gpt-4", "claude-3-opus"], lambda r: r.model in ("gpt-4", "claude-3-opus")),
+        ("not_in", ["gpt-4"], lambda r: r.model != "gpt-4"),
+    ]
+    return [("SYSTEM_METRIC", "text", op, "model", val, pred) for op, val, pred in leaves]
+
+
+def _sm_datetime_leaves():
+    from datetime import timedelta
+
+    # _NOW = the corpus' base anchor; end = +1 day so the range covers session 0
+    # spans (s_idx=0 → created_at in day 0).
+    end = _NOW + timedelta(days=1)
+    leaves = [
+        (
+            "between",
+            [_NOW.isoformat(), end.isoformat()],
+            lambda r: _NOW <= r.created_at <= end,
+        ),
+        ("greater_than", _NOW.isoformat(), lambda r: r.created_at > _NOW),
+        ("less_than", end.isoformat(), lambda r: r.created_at < end),
+        ("equals", _NOW.isoformat(), lambda r: r.created_at == _NOW),
+    ]
+    return [("SYSTEM_METRIC", "datetime", op, "created_at", val, pred) for op, val, pred in leaves]
+
+
+# ---------- SPAN_ATTRIBUTE leaves --------------------------------------------
+
+
+def _sa_leaves():
+    return [
+        (
+            "SPAN_ATTRIBUTE",
+            "text",
+            "equals",
+            "user_intent",
+            "checkout",
+            lambda r: r.span_attr_str.get("user_intent") == "checkout",
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "text",
+            "contains",
+            "user_intent",
+            "check",
+            lambda r: "check" in r.span_attr_str.get("user_intent", ""),
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "text",
+            "in",
+            "channel",
+            ["web", "voice"],
+            lambda r: r.span_attr_str.get("channel") in ("web", "voice"),
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "number",
+            "greater_than",
+            "retries",
+            1.0,
+            lambda r: r.span_attr_num.get("retries", 0) > 1.0,
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "number",
+            "between",
+            "score",
+            [0.2, 0.35],
+            lambda r: 0.2 <= r.span_attr_num.get("score", 0) <= 0.35,
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "number",
+            "equals",
+            "retries",
+            2.0,
+            lambda r: r.span_attr_num.get("retries") == 2.0,
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "number",
+            "is_null",
+            "missing_attr",
+            None,
+            lambda r: "missing_attr" not in r.span_attr_num,
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "boolean",
+            "equals",
+            "premium",
+            True,
+            lambda r: r.span_attr_bool.get("premium") is True,
+        ),
+    ]
+
+
+# ---------- EVAL_METRIC leaves -----------------------------------------------
+
+
+def _em_leaves(eval_config_id: str):
+    # Corpus eval_value ∈ {0.3, 0.6, 0.9}. BE annotates score = output_float * 100
+    # (views/observation_span.py:1659), so filter values are on the 0-100 scale.
+    return [
+        (
+            "EVAL_METRIC",
+            "number",
+            "greater_than",
+            eval_config_id,
+            50,
+            lambda r: r.has_eval and (r.eval_value or 0) * 100 > 50,
+        ),
+        (
+            "EVAL_METRIC",
+            "number",
+            "less_than",
+            eval_config_id,
+            50,
+            lambda r: r.has_eval and (r.eval_value or 0) * 100 < 50,
+        ),
+        (
+            "EVAL_METRIC",
+            "number",
+            "equals",
+            eval_config_id,
+            30,
+            lambda r: r.has_eval and (r.eval_value or 0) * 100 == 30,
+        ),
+        (
+            "EVAL_METRIC",
+            "number",
+            "between",
+            eval_config_id,
+            [40, 70],
+            lambda r: r.has_eval and 40 <= (r.eval_value or 0) * 100 <= 70,
+        ),
+        (
+            "EVAL_METRIC",
+            "boolean",
+            "equals",
+            eval_config_id,
+            True,
+            lambda r: r.has_eval and (r.eval_value or 0) >= 0.5,
+        ),
+    ]
+
+
+# ---------- ANNOTATION leaves ------------------------------------------------
+
+
+def _ann_leaves(label_id: str):
+    # Corpus annotation_value ∈ {0.2, 0.5, 0.8} (one per session).
+    return [
+        (
+            "ANNOTATION",
+            "number",
+            "greater_than",
+            label_id,
+            0.4,
+            lambda r: r.has_annotation and (r.annotation_value or 0) > 0.4,
+        ),
+        (
+            "ANNOTATION",
+            "number",
+            "less_than",
+            label_id,
+            0.4,
+            lambda r: r.has_annotation and (r.annotation_value or 0) < 0.4,
+        ),
+        (
+            "ANNOTATION",
+            "number",
+            "equals",
+            label_id,
+            0.5,
+            lambda r: r.has_annotation and r.annotation_value == 0.5,
+        ),
+        (
+            "ANNOTATION",
+            "number",
+            "between",
+            label_id,
+            [0.3, 0.6],
+            lambda r: r.has_annotation and 0.3 <= (r.annotation_value or 0) <= 0.6,
+        ),
+    ]
+
+
+# ---------- has_eval / has_annotation ----------------------------------------
+
+
+def _meta_leaves():
+    return [
+        ("has_eval", "boolean", "equals", "has_eval", True, lambda r: r.has_eval),
+        ("has_eval", "boolean", "equals", "has_eval", False, lambda r: not r.has_eval),
+        (
+            "has_annotation",
+            "boolean",
+            "equals",
+            "has_annotation",
+            True,
+            lambda r: r.has_annotation,
+        ),
+        (
+            "has_annotation",
+            "boolean",
+            "equals",
+            "has_annotation",
+            False,
+            lambda r: not r.has_annotation,
+        ),
+    ]
+
+
+def _em_choice_leaves(choice_eval_config_id: str):
+    # CHOICE / CHOICES evals: spans seeded with output_str_list=[choice_value]
+    # where choice_value ∈ {"good", "bad", "neutral"} cycled by sp_idx.
+    # Production filter handler routes EVAL_METRIC+array through
+    # _eval_choice_condition (filters.py:1482-1505), which builds
+    # Q(metric_<id>__<value>__score__gt=0). My _build_metric_annotation
+    # exposes str_list_score = {choice: {"score": pct_present}} so the
+    # JSON navigation lines up.
+    return [
+        (
+            "EVAL_METRIC",
+            "array",
+            "contains",
+            choice_eval_config_id,
+            "good",
+            lambda r: r.has_choice_eval and r.choice_value == "good",
+        ),
+        (
+            "EVAL_METRIC",
+            "array",
+            "contains",
+            choice_eval_config_id,
+            "bad",
+            lambda r: r.has_choice_eval and r.choice_value == "bad",
+        ),
+        (
+            "EVAL_METRIC",
+            "array",
+            "contains",
+            choice_eval_config_id,
+            "neutral",
+            lambda r: r.has_choice_eval and r.choice_value == "neutral",
+        ),
+    ]
+
+
+def _all_leaves(eval_config_id: str, label_id: str, choice_eval_config_id: str):
+    return (
+        _sm_number_leaves()
+        + _sm_text_leaves()
+        + _sm_datetime_leaves()
+        + _sa_leaves()
+        + _em_leaves(eval_config_id)
+        + _em_choice_leaves(choice_eval_config_id)
+        + _ann_leaves(label_id)
+        + _meta_leaves()
+    )
+
+
+def _short(s: str) -> str:
+    """Stable suffix for case_id from a column_id (full UUIDs are noisy)."""
+    if "-" in s and len(s) > 16:
+        return s.replace("-", "")[-8:]
+    return s
+
+
+def _wrap_predicate_for_target(span_pred, target_type):
+    """Given a per-span predicate, return a per-span predicate adjusted for the
+    target type. For traces / sessions the aggregation to trace_id / session_id
+    happens in the test harness; here we only need to narrow voiceCalls to root
+    conversation spans."""
+    if target_type == "voiceCalls":
+        return lambda r: (
+            r.observation_type == "conversation"
+            and r.parent_span_id is None
+            and span_pred(r)
+        )
+    return span_pred
+
+
+def all_cases(
+    eval_config_id: str = "00000000-0000-0000-0000-000000000001",
+    label_id: str = "00000000-0000-0000-0000-000000000002",
+    choice_eval_config_id: str = "00000000-0000-0000-0000-000000000003",
+) -> Iterator[FilterCase]:
+    """Yield FilterCases for every (target_type, leaf) combination."""
+    for target_type in TARGET_TYPES:
+        for (
+            col_type,
+            filter_type,
+            filter_op,
+            column_id,
+            filter_value,
+            pred,
+        ) in _all_leaves(eval_config_id, label_id, choice_eval_config_id):
+            adjusted_pred = _wrap_predicate_for_target(pred, target_type)
+            val_suffix = ""
+            if col_type in ("has_eval", "has_annotation"):
+                # Disambiguate the True/False variants in the case_id.
+                val_suffix = f"-{str(filter_value).lower()}"
+            elif filter_type == "array" and isinstance(filter_value, str):
+                # CHOICE leaves share column_id (eval_config_id) and differ
+                # only on filter_value (e.g. "good"/"bad"/"neutral").
+                val_suffix = f"-{filter_value}"
+            case_id = (
+                f"{target_type}-{col_type.lower()}-{filter_type}-"
+                f"{filter_op}-{_short(column_id)}{val_suffix}"
+            )
+            yield FilterCase(
+                case_id=case_id,
+                target_type=target_type,
+                col_type=col_type,
+                filter_type=filter_type,
+                filter_op=filter_op,
+                column_id=column_id,
+                filter_value=filter_value,
+                expected_predicate=adjusted_pred,
+            )
+
+
+def all_cases_for(
+    eval_config_id: str,
+    label_id: str,
+    choice_eval_config_id: str = "00000000-0000-0000-0000-000000000003",
+) -> list[FilterCase]:
+    """Materialized list for parametrize; callers that need the real
+    eval_config_id / label_id pass them through here."""
+    return list(
+        all_cases(
+            eval_config_id=eval_config_id,
+            label_id=label_id,
+            choice_eval_config_id=choice_eval_config_id,
+        )
+    )

--- a/futureagi/tracer/tests/integration/_seed.py
+++ b/futureagi/tracer/tests/integration/_seed.py
@@ -1,0 +1,561 @@
+"""Dual-write seeding helpers for the eval-task filter integration suite.
+
+Every seeded row lands in BOTH Postgres (Django ORM) and ClickHouse (direct INSERT
+into the CDC landing tables; spans_mv repopulates the denormalized `spans` table).
+The base corpus is a fixed 24-row span set across 6 traces and 3 sessions, with
+distinct values for every column the FilterCase matrix can filter on.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from tracer.models.observation_span import (
+    EvalLogger,
+    EvalTargetType,
+    ObservationSpan,
+)
+from tracer.models.trace import Trace
+from tracer.models.trace_session import TraceSession
+
+# ---------- Base corpus shape ------------------------------------------------
+
+# 3 sessions × 2 traces/session × 4 spans/trace = 24 spans.
+# Each session's first trace's first span is a root conversation span (voice call).
+# Each session has one "high cost" trace and one "low cost" trace.
+
+_NOW = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+_MODELS = ["gpt-4", "gpt-3.5-turbo", "claude-3-opus"]
+_PROVIDERS = ["openai", "openai", "anthropic"]
+CHOICE_OPTIONS = ["good", "bad", "neutral"]
+
+
+@dataclass
+class SeededRow:
+    span_id: str
+    trace_id: str
+    session_id: str
+    project_id: str
+    observation_type: str
+    parent_span_id: str | None
+    model: str
+    provider: str
+    status: str
+    cost: float
+    latency_ms: int
+    total_tokens: int
+    prompt_tokens: int
+    completion_tokens: int
+    created_at: datetime
+    span_attr_str: dict[str, str]
+    span_attr_num: dict[str, float]
+    span_attr_bool: dict[str, bool]
+    has_eval: bool
+    eval_value: float | None
+    has_annotation: bool
+    annotation_value: float | None
+    has_choice_eval: bool
+    choice_value: str | None
+
+
+@dataclass
+class DualWriter:
+    ch: Any  # clickhouse_connect Client
+    ch_database: str
+    seeded: list[SeededRow] = field(default_factory=list)
+
+    # Lazily-allocated when first eval / annotation row is seeded; the matrix
+    # uses these to target EVAL_METRIC / ANNOTATION cases.
+    _eval_config_id: uuid.UUID | None = None
+    _annotation_label_id: uuid.UUID | None = None
+    _choice_eval_config_id: uuid.UUID | None = None
+
+    @property
+    def eval_config_id(self) -> str:
+        return str(self._eval_config_id) if self._eval_config_id else ""
+
+    @property
+    def annotation_label_id(self) -> str:
+        return str(self._annotation_label_id) if self._annotation_label_id else ""
+
+    @property
+    def choice_eval_config_id(self) -> str:
+        return str(self._choice_eval_config_id) if self._choice_eval_config_id else ""
+
+    # ------- public ---------------------------------------------------------
+
+    def seed_base_corpus(self, project) -> dict:
+        """Dual-write the 24-span corpus. Returns counts dict."""
+        # Materialize the eval template + label up front so PG row inserts
+        # have valid FKs.
+        eval_template = self._get_or_create_eval_template(project)
+        eval_config = self._get_or_create_eval_config(project, eval_template)
+        choice_template = self._get_or_create_choice_eval_template(project)
+        choice_eval_config = self._get_or_create_choice_eval_config(
+            project, choice_template
+        )
+        annotation_label = self._get_or_create_annotation_label(project)
+        self._eval_config_id = eval_config.id
+        self._choice_eval_config_id = choice_eval_config.id
+        self._annotation_label_id = annotation_label.id
+
+        rows: list[SeededRow] = []
+        sessions = []
+        for s_idx in range(3):
+            sess = TraceSession.objects.create(
+                id=uuid.uuid4(), project=project, name=f"session_{s_idx}"
+            )
+            sessions.append(sess)
+            self._insert_session_ch(sess)
+            for t_idx in range(2):
+                trace = Trace.objects.create(
+                    id=uuid.uuid4(),
+                    project=project,
+                    session=sess,
+                    name=f"trace_s{s_idx}_t{t_idx}",
+                )
+                self._insert_trace_ch(trace)
+                for sp_idx in range(4):
+                    row = self._build_row(project, trace, sess, s_idx, t_idx, sp_idx)
+                    self._insert_span_pg(row, trace, project)
+                    self._insert_span_ch(row)
+                    if row.has_eval:
+                        self._insert_eval_pg_ch(row, trace, eval_config)
+                    if row.has_choice_eval:
+                        self._insert_choice_eval_pg_ch(row, trace, choice_eval_config)
+                    if row.has_annotation:
+                        self._insert_annotation_pg_ch(
+                            row, trace, project, annotation_label
+                        )
+                    rows.append(row)
+        self.seeded = rows
+        # spans_mv is non-refreshable; INSERT INTO tracer_observation_span fires
+        # the MV write to ``spans`` synchronously. OPTIMIZE FINAL eliminates
+        # any ReplicatedReplacingMergeTree merge lag before the test reads.
+        try:
+            self.ch.command(f"OPTIMIZE TABLE {self.ch_database}.spans FINAL")
+        except Exception:
+            pass
+        return {
+            "span_count": len(rows),
+            "session_count": len(sessions),
+            "trace_count": len(sessions) * 2,
+        }
+
+    # ------- row construction ----------------------------------------------
+
+    def _build_row(self, project, trace, sess, s_idx, t_idx, sp_idx) -> SeededRow:
+        is_voice_root = (sp_idx == 0 and t_idx == 0)
+        is_root = (sp_idx == 0)
+        parent = None if is_root else f"span_root_{trace.id.hex[:12]}"
+        observation_type = (
+            "conversation" if is_voice_root else ("llm" if sp_idx > 0 else "chain")
+        )
+        model = _MODELS[s_idx]
+        provider = _PROVIDERS[s_idx]
+        status = "ERROR" if (s_idx == 2 and sp_idx == 3) else "OK"
+        cost = 0.001 * (s_idx + 1) * (t_idx + 1) * (sp_idx + 1)
+        latency_ms = 100 * (sp_idx + 1) + 50 * t_idx
+        total_tokens = 10 * (sp_idx + 1)
+        created_at = _NOW + timedelta(days=s_idx, hours=t_idx, minutes=sp_idx)
+        span_attr_str = {
+            "user_intent": "checkout" if sp_idx % 2 == 0 else "browse",
+            "channel": ["web", "mobile", "voice"][s_idx],
+        }
+        span_attr_num = {"retries": float(sp_idx), "score": 0.1 * (sp_idx + 1)}
+        span_attr_bool = {"premium": (s_idx == 0)}
+        # Eval: spans at sp_idx ∈ {1,2,3} all get an eval, with three distinct
+        # values so range filters (lt / gt / between) have real boundaries.
+        _EVAL_VALUE_BY_SP_IDX = {1: 0.3, 2: 0.6, 3: 0.9}
+        has_eval = sp_idx in _EVAL_VALUE_BY_SP_IDX
+        eval_value = _EVAL_VALUE_BY_SP_IDX.get(sp_idx)
+        # Annotation: 6 spans (sp_idx=2 across both traces of all sessions),
+        # values 0.2/0.5/0.8 cycled by s_idx for non-trivial range coverage.
+        _ANNOTATION_VALUE_BY_S_IDX = {0: 0.2, 1: 0.5, 2: 0.8}
+        has_annotation = (sp_idx == 2)
+        annotation_value = (
+            _ANNOTATION_VALUE_BY_S_IDX.get(s_idx) if has_annotation else None
+        )
+        # CHOICE eval: same 18 spans as float eval (sp_idx ∈ {1,2,3}),
+        # choice_value cycled by sp_idx so each option discriminates 6 spans.
+        _CHOICE_BY_SP_IDX = {1: "good", 2: "bad", 3: "neutral"}
+        has_choice_eval = sp_idx in _CHOICE_BY_SP_IDX
+        choice_value = _CHOICE_BY_SP_IDX.get(sp_idx)
+
+        span_id = (
+            f"span_root_{trace.id.hex[:12]}"
+            if is_root
+            else f"span_{uuid.uuid4().hex[:16]}"
+        )
+        return SeededRow(
+            span_id=span_id,
+            trace_id=str(trace.id),
+            session_id=str(sess.id),
+            project_id=str(project.id),
+            observation_type=observation_type,
+            parent_span_id=parent,
+            model=model,
+            provider=provider,
+            status=status,
+            cost=cost,
+            latency_ms=latency_ms,
+            total_tokens=total_tokens,
+            prompt_tokens=total_tokens // 2,
+            completion_tokens=total_tokens // 2,
+            created_at=created_at,
+            span_attr_str=span_attr_str,
+            span_attr_num=span_attr_num,
+            span_attr_bool=span_attr_bool,
+            has_eval=has_eval,
+            eval_value=eval_value,
+            has_annotation=has_annotation,
+            annotation_value=annotation_value,
+            has_choice_eval=has_choice_eval,
+            choice_value=choice_value,
+        )
+
+    # ------- PG insert helpers ---------------------------------------------
+
+    def _get_or_create_eval_template(self, project):
+        from model_hub.models.evals_metric import EvalTemplate
+
+        template, _ = EvalTemplate.objects.get_or_create(
+            name=f"int_test_template_{project.id}",
+            organization=project.organization,
+            workspace=project.workspace,
+            defaults={
+                "description": "integration test template",
+                "config": {"type": "pass_fail", "criteria": "x"},
+            },
+        )
+        return template
+
+    def _get_or_create_choice_eval_template(self, project):
+        from model_hub.models.evals_metric import EvalTemplate
+
+        template, _ = EvalTemplate.objects.get_or_create(
+            name=f"int_test_choice_template_{project.id}",
+            organization=project.organization,
+            workspace=project.workspace,
+            defaults={
+                "description": "integration test CHOICE template",
+                "config": {"type": "choice", "criteria": "x", "output": "CHOICE"},
+                "choices": CHOICE_OPTIONS,
+            },
+        )
+        return template
+
+    def _get_or_create_choice_eval_config(self, project, eval_template):
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        cfg, _ = CustomEvalConfig.objects.get_or_create(
+            project=project,
+            name=f"int_test_choice_cfg_{project.id}",
+            defaults={
+                "eval_template": eval_template,
+                "config": {"output": "CHOICE", "choices": CHOICE_OPTIONS},
+                "mapping": {"input": "input", "output": "output"},
+                "filters": {},
+            },
+        )
+        return cfg
+
+    def _get_or_create_eval_config(self, project, eval_template):
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        cfg, _ = CustomEvalConfig.objects.get_or_create(
+            project=project,
+            name=f"int_test_eval_cfg_{project.id}",
+            defaults={
+                "eval_template": eval_template,
+                "config": {"threshold": 0.5},
+                "mapping": {"input": "input", "output": "output"},
+                "filters": {},
+            },
+        )
+        return cfg
+
+    def _get_or_create_annotation_label(self, project):
+        from model_hub.models.choices import AnnotationTypeChoices
+        from model_hub.models.develop_annotations import AnnotationsLabels
+
+        label, _ = AnnotationsLabels.objects.get_or_create(
+            name=f"int_test_label_{project.id}",
+            type=AnnotationTypeChoices.NUMERIC.value,
+            organization=project.organization,
+            workspace=project.workspace,
+            project=project,
+            defaults={
+                "settings": {
+                    "min": 0,
+                    "max": 1,
+                    "step_size": 0.1,
+                    "display_type": "slider",
+                },
+            },
+        )
+        return label
+
+    def _insert_span_pg(self, row: SeededRow, trace, project) -> None:
+        attrs = {
+            **{k: v for k, v in row.span_attr_str.items()},
+            **{k: v for k, v in row.span_attr_num.items()},
+            **{k: v for k, v in row.span_attr_bool.items()},
+        }
+        ObservationSpan.objects.create(
+            id=row.span_id,
+            project=project,
+            trace=trace,
+            name=row.span_id,
+            observation_type=row.observation_type,
+            status=row.status,
+            parent_span_id=row.parent_span_id,
+            start_time=row.created_at,
+            end_time=row.created_at + timedelta(milliseconds=row.latency_ms),
+            latency_ms=row.latency_ms,
+            model=row.model,
+            provider=row.provider,
+            prompt_tokens=row.prompt_tokens,
+            completion_tokens=row.completion_tokens,
+            total_tokens=row.total_tokens,
+            cost=row.cost,
+            span_attributes=attrs,
+        )
+        # BaseModel.created_at is auto_now_add — override post-create.
+        ObservationSpan.objects.filter(id=row.span_id).update(
+            created_at=row.created_at
+        )
+
+    def _insert_span_ch(self, row: SeededRow) -> None:
+        attrs_json = json.dumps(
+            {
+                **row.span_attr_str,
+                **row.span_attr_num,
+                **{k: bool(v) for k, v in row.span_attr_bool.items()},
+            }
+        ).replace("'", "''")
+        parent_sql = f"'{row.parent_span_id}'" if row.parent_span_id else "NULL"
+        start = row.created_at.strftime("%Y-%m-%d %H:%M:%S")
+        end = (row.created_at + timedelta(milliseconds=row.latency_ms)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        self.ch.command(
+            f"""
+            INSERT INTO {self.ch_database}.tracer_observation_span
+              (id, trace_id, project_id, name, observation_type, status,
+               parent_span_id, start_time, end_time, latency_ms, model, provider,
+               prompt_tokens, completion_tokens, total_tokens, cost,
+               input, output, span_attributes, resource_attributes,
+               metadata, tags, span_events, created_at, updated_at,
+               _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            VALUES
+              ('{row.span_id}', '{row.trace_id}', '{row.project_id}',
+               '{row.span_id}', '{row.observation_type}', '{row.status}',
+               {parent_sql},
+               '{start}', '{end}',
+               {row.latency_ms}, '{row.model}', '{row.provider}',
+               {row.prompt_tokens}, {row.completion_tokens}, {row.total_tokens}, {row.cost},
+               '', '', '{attrs_json}', '{{}}',
+               '{{}}', '[]', '[]',
+               '{start}', '{start}',
+               now64(), 0, 1)
+            """
+        )
+
+    def _insert_trace_ch(self, trace) -> None:
+        sess_sql = f"'{trace.session_id}'" if trace.session_id else "NULL"
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        self.ch.command(
+            f"""
+            INSERT INTO {self.ch_database}.tracer_trace
+              (id, project_id, name, session_id, external_id, tags,
+               metadata, input, output, error,
+               created_at, updated_at,
+               _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            VALUES
+              ('{trace.id}', '{trace.project_id}', '{trace.name}',
+               {sess_sql}, '', '[]',
+               '{{}}', '{{}}', '{{}}', '{{}}',
+               '{now}', '{now}',
+               now64(), 0, 1)
+            """
+        )
+
+    def _insert_session_ch(self, sess) -> None:
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        self.ch.command(
+            f"""
+            INSERT INTO {self.ch_database}.trace_session
+              (id, project_id, name,
+               created_at, updated_at,
+               _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            VALUES
+              ('{sess.id}', '{sess.project_id}', '{sess.name}',
+               '{now}', '{now}',
+               now64(), 0, 1)
+            """
+        )
+
+    def _insert_eval_pg_ch(self, row: SeededRow, trace, eval_config) -> None:
+        # Span-level eval row mirrors what process_eval_task would create
+        # (target_type=SPAN, FK to span + trace).
+        EvalLogger.objects.create(
+            id=uuid.uuid4(),
+            observation_span_id=row.span_id,
+            trace=trace,
+            custom_eval_config=eval_config,
+            target_type=EvalTargetType.SPAN,
+            output_float=row.eval_value,
+            output_bool=(row.eval_value or 0) >= 0.5,
+        )
+        ch_id = uuid.uuid4()
+        created = row.created_at.strftime("%Y-%m-%d %H:%M:%S")
+        self.ch.command(
+            f"""
+            INSERT INTO {self.ch_database}.tracer_eval_logger
+              (id, observation_span_id, trace_id,
+               custom_eval_config_id, target_type,
+               output_float, output_bool, eval_task_id,
+               created_at, updated_at,
+               _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            VALUES
+              ('{ch_id}', '{row.span_id}', '{row.trace_id}',
+               '{eval_config.id}', 'span',
+               {row.eval_value}, {int((row.eval_value or 0) >= 0.5)}, NULL,
+               '{created}', '{created}',
+               now64(), 0, 1)
+            """
+        )
+
+    def _insert_choice_eval_pg_ch(self, row: SeededRow, trace, eval_config) -> None:
+        # CHOICE-type EvalLogger: output_str_list set, output_float/_bool null.
+        # The `When(output_str_list__isnull=False, ...)` branch of the metric
+        # annotation requires the null shape to dispatch correctly.
+        EvalLogger.objects.create(
+            id=uuid.uuid4(),
+            observation_span_id=row.span_id,
+            trace=trace,
+            custom_eval_config=eval_config,
+            target_type=EvalTargetType.SPAN,
+            output_str_list=[row.choice_value],
+        )
+        ch_id = uuid.uuid4()
+        created = row.created_at.strftime("%Y-%m-%d %H:%M:%S")
+        # CH expects output_str_list as a JSON string ("[\"good\"]").
+        choice_json = json.dumps([row.choice_value])
+        self.ch.command(
+            f"""
+            INSERT INTO {self.ch_database}.tracer_eval_logger
+              (id, observation_span_id, trace_id,
+               custom_eval_config_id, target_type,
+               output_str_list, eval_task_id,
+               created_at, updated_at,
+               _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            VALUES
+              ('{ch_id}', '{row.span_id}', '{row.trace_id}',
+               '{eval_config.id}', 'span',
+               '{choice_json}', NULL,
+               '{created}', '{created}',
+               now64(), 0, 1)
+            """
+        )
+
+    def _insert_annotation_pg_ch(
+        self, row: SeededRow, trace, project, annotation_label
+    ) -> None:
+        """Create the per-row Score and mirror to CH.
+
+        Only the PG-side Score is required for the eval-task runner
+        (process_eval_task's per-label annotate subquery reads model_hub.Score).
+        The CH-side mirror is a best-effort: the list endpoints' annotation
+        filter path is exercised against the CH copy.
+        """
+        from model_hub.models.choices import QueueItemSourceType, ScoreSource
+        from model_hub.models.score import Score
+
+        # Per-row distinct annotator user to dodge the unique constraint on
+        # (observation_span, label, annotator) when the same label is reused.
+        # NULL annotator is also fine here since we only have one row per
+        # (span, label) but make it explicit.
+        Score.objects.create(
+            source_type=QueueItemSourceType.OBSERVATION_SPAN.value,
+            observation_span_id=row.span_id,
+            label=annotation_label,
+            value={"value": row.annotation_value},
+            organization=project.organization,
+            workspace=project.workspace,
+            score_source=ScoreSource.HUMAN.value,
+        )
+        # CH mirror is informational only — the list endpoints' annotation
+        # path in CH doesn't currently consume this in the SpanListQueryBuilder
+        # the way PG does. Skipped to avoid coupling tests to a CH schema we
+        # don't drive.
+
+    # ------- voice corpus ---------------------------------------------------
+
+    def seed_voice_corpus(self, project) -> dict:
+        """Seed 24 voice-call root spans (observation_type='conversation',
+        parent_span_id=NULL) into ``project``. Each call is its own trace;
+        per-span attribute variation matches the base corpus so the same
+        FilterCase predicates discriminate identically."""
+        eval_template = self._get_or_create_eval_template(project)
+        eval_config = self._get_or_create_eval_config(project, eval_template)
+        choice_template = self._get_or_create_choice_eval_template(project)
+        choice_eval_config = self._get_or_create_choice_eval_config(
+            project, choice_template
+        )
+        annotation_label = self._get_or_create_annotation_label(project)
+        self._eval_config_id = eval_config.id
+        self._choice_eval_config_id = choice_eval_config.id
+        self._annotation_label_id = annotation_label.id
+
+        rows: list[SeededRow] = []
+        sess = TraceSession.objects.create(
+            id=uuid.uuid4(), project=project, name="voice_session"
+        )
+        self._insert_session_ch(sess)
+
+        for i in range(24):
+            # Mirror base corpus variation axes (3 × 2 × 4 = 24 cells).
+            s_idx = i // 8
+            t_idx = (i // 4) % 2
+            sp_idx = i % 4
+
+            trace = Trace.objects.create(
+                id=uuid.uuid4(),
+                project=project,
+                session=sess,
+                name=f"voice_call_{i}",
+            )
+            self._insert_trace_ch(trace)
+
+            row = self._build_row(project, trace, sess, s_idx, t_idx, sp_idx)
+            # Force voice-call shape.
+            row.observation_type = "conversation"
+            row.parent_span_id = None
+
+            self._insert_span_pg(row, trace, project)
+            self._insert_span_ch(row)
+            if row.has_eval:
+                self._insert_eval_pg_ch(row, trace, eval_config)
+            if row.has_choice_eval:
+                self._insert_choice_eval_pg_ch(row, trace, choice_eval_config)
+            if row.has_annotation:
+                self._insert_annotation_pg_ch(row, trace, project, annotation_label)
+            rows.append(row)
+
+        self.seeded = rows
+        try:
+            self.ch.command(f"OPTIMIZE TABLE {self.ch_database}.spans FINAL")
+        except Exception:
+            pass
+        return {"span_count": len(rows), "session_count": 1, "trace_count": 24}
+
+    # ------- accessors ------------------------------------------------------
+
+    def expected_predicate_count(self, predicate) -> int:
+        """Convenience for tests: count rows matching a per-row predicate."""
+        return sum(1 for r in self.seeded if predicate(r))

--- a/futureagi/tracer/tests/integration/conftest.py
+++ b/futureagi/tracer/tests/integration/conftest.py
@@ -1,0 +1,386 @@
+"""Integration suite fixtures (sub-package scoped).
+
+These do not leak into the parent ``tracer/tests/`` namespace — only tests
+collected from ``futureagi/tracer/tests/integration/`` resolve these fixtures.
+"""
+import os
+import uuid
+
+import pytest
+from django.conf import settings
+from django.test import override_settings
+
+_CH_TABLES_TO_TRUNCATE = [
+    "tracer_observation_span",
+    "tracer_trace",
+    "trace_session",
+    "tracer_eval_logger",
+    "spans",  # MV target; truncate to keep cross-test isolation
+]
+
+
+class _CHDriverAdapter:
+    """Adapter around clickhouse_driver.Client exposing a ``command(sql, ...)``
+    surface matching clickhouse_connect.
+
+    The repo ships ``clickhouse-driver`` (native protocol, port 19000); the
+    plan was written against ``clickhouse-connect`` (HTTP, port 18123) which
+    isn't a runtime dep. Adapting here keeps the seeder generic without
+    requiring a new dependency.
+    """
+
+    def __init__(self, native_client):
+        self._client = native_client
+
+    def command(self, sql, *args, **kwargs):
+        rows = self._client.execute(sql)
+        # Mirror clickhouse_connect.command: scalar -> scalar, otherwise rows.
+        if isinstance(rows, list) and len(rows) == 1 and len(rows[0]) == 1:
+            return rows[0][0]
+        return rows
+
+    def query(self, sql, *args, **kwargs):
+        # Best-effort match for clickhouse_connect.query — returns rows list.
+        # Used by smoke tests; production callers don't rely on the object
+        # shape returned here.
+        rows = self._client.execute(sql)
+
+        class _R:
+            def __init__(self, data):
+                self.result_rows = data
+                self.data = data
+
+        return _R(rows)
+
+
+@pytest.fixture(scope="session")
+def ch_client():
+    """Client to the test ClickHouse container (native protocol, port 19000).
+
+    The wrapper exposes a ``.command()`` method so the rest of the suite can
+    pretend it's talking to the clickhouse_connect HTTP client.
+    """
+    try:
+        from clickhouse_driver import Client
+    except ImportError:
+        pytest.skip("clickhouse-driver not installed")
+    ch = settings.CLICKHOUSE
+    try:
+        native = Client(
+            host=ch.get("CH_HOST", "localhost"),
+            port=int(os.environ.get("CH_PORT", ch.get("CH_PORT", "19000"))),
+            user=ch.get("CH_USERNAME", "default"),
+            password=ch.get("CH_PASSWORD", ""),
+        )
+        native.execute("SELECT 1")
+        return _CHDriverAdapter(native)
+    except Exception as exc:
+        pytest.skip(f"ClickHouse not reachable for integration tests: {exc}")
+
+
+@pytest.fixture(scope="session")
+def ch_schema(ch_client):
+    """Apply schema DDL once per session. Targets the database in settings.CLICKHOUSE['CH_DATABASE']."""
+    from tracer.services.clickhouse.schema import get_all_schema_ddl
+
+    db = settings.CLICKHOUSE["CH_DATABASE"]
+    ch_client.command(f"CREATE DATABASE IF NOT EXISTS {db}")
+    # Switch session default DB so unqualified table refs in the DDL resolve.
+    try:
+        ch_client.command(f"USE {db}")
+    except Exception:
+        pass
+    for name, ddl in get_all_schema_ddl():
+        rewritten = ddl.replace("futureagi.", f"{db}.")
+        try:
+            ch_client.command(rewritten)
+        except Exception:
+            # idempotent — table/view already exists from a previous session,
+            # or DDL refers to dependencies that don't materialize here.
+            pass
+    return ch_client
+
+
+@pytest.fixture
+def clean_ch(ch_schema):
+    """Truncate CH tables before AND after the test so cross-test state never leaks."""
+    db = settings.CLICKHOUSE["CH_DATABASE"]
+    for tbl in _CH_TABLES_TO_TRUNCATE:
+        try:
+            ch_schema.command(f"TRUNCATE TABLE {db}.{tbl}")
+        except Exception:
+            pass
+    yield ch_schema
+    for tbl in _CH_TABLES_TO_TRUNCATE:
+        try:
+            ch_schema.command(f"TRUNCATE TABLE {db}.{tbl}")
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def ch_routes_on():
+    """Override CH route settings so list endpoints hit ClickHouse, not Postgres.
+
+    ``CH_ENABLED=True`` is required because ``is_clickhouse_enabled()`` short-
+    circuits to False otherwise. We also force-reset the lazily-cached
+    ``_clickhouse_client`` so the new connection settings (CH_HOST=localhost,
+    CH_PORT=19000) take effect — production tooling caches a module-level
+    client that may be misconfigured if Django apps initialized before this
+    test process picked up the right env vars.
+    """
+    routes = {
+        **settings.CLICKHOUSE,
+        "CH_HOST": os.environ.get("CH_HOST", "localhost"),
+        "CH_PORT": os.environ.get("CH_PORT", "19000"),
+        "CH_USERNAME": os.environ.get("CH_USERNAME", "default"),
+        "CH_PASSWORD": os.environ.get("CH_PASSWORD", ""),
+        "CH_DATABASE": os.environ.get("CH_DATABASE", "test_tfc"),
+        "CH_ENABLED": True,
+        "CH_ROUTE_SPAN_LIST": "clickhouse",
+        "CH_ROUTE_TRACE_LIST": "clickhouse",
+        "CH_ROUTE_TRACE_OF_SESSION_LIST": "clickhouse",
+        "CH_ROUTE_SESSION_LIST": "clickhouse",
+        "CH_ROUTE_VOICE_CALL_LIST": "clickhouse",
+        "CH_SHADOW_MODE": False,
+    }
+    from tracer.services.clickhouse import client as ch_client_module
+
+    prior_client = ch_client_module._clickhouse_client
+    ch_client_module._clickhouse_client = None
+    try:
+        with override_settings(CLICKHOUSE=routes):
+            yield
+    finally:
+        # Drop any test-scoped client so the next test reads fresh settings.
+        ch_client_module._clickhouse_client = prior_client
+
+
+@pytest.fixture
+def dual_writer(clean_ch, db):
+    """Per-test seeder — retained for the smoke test only; real suites use
+    ``seeded_corpus`` (session-scoped)."""
+    from tracer.tests.integration._seed import DualWriter
+
+    return DualWriter(ch=clean_ch, ch_database=settings.CLICKHOUSE["CH_DATABASE"])
+
+
+@pytest.fixture(scope="session")
+def integration_setup(django_db_setup, django_db_blocker, ch_schema):
+    """Session-scoped: commit org/user/workspace/project + seed corpus once,
+    outside the per-test transaction. Returns SimpleNamespace."""
+    from types import SimpleNamespace
+
+    from accounts.models.organization import Organization
+    from accounts.models.organization_membership import OrganizationMembership
+    from accounts.models.user import User
+    from accounts.models.workspace import Workspace, WorkspaceMembership
+    from model_hub.models.ai_model import AIModel
+    from tfc.constants.levels import Level
+    from tfc.constants.roles import OrganizationRoles
+    from tfc.middleware.workspace_context import (
+        clear_workspace_context,
+        set_workspace_context,
+    )
+    from tracer.models.project import Project
+    from tracer.tests.integration._seed import DualWriter
+
+    db_name = settings.CLICKHOUSE["CH_DATABASE"]
+
+    # Fresh CH state at session start.
+    for tbl in _CH_TABLES_TO_TRUNCATE:
+        try:
+            ch_schema.command(f"TRUNCATE TABLE {db_name}.{tbl}")
+        except Exception:
+            pass
+
+    with django_db_blocker.unblock():
+        clear_workspace_context()
+        org = Organization.objects.create(
+            name=f"int_test_org_{uuid.uuid4().hex[:8]}"
+        )
+        set_workspace_context(organization=org)
+        user = User.objects.create_user(
+            email=f"integration-{uuid.uuid4().hex[:8]}@futureagi.com",
+            password="testpassword123",
+            name="Integration Test User",
+            organization=org,
+            organization_role=OrganizationRoles.OWNER,
+        )
+        OrganizationMembership.no_workspace_objects.get_or_create(
+            user=user,
+            organization=org,
+            defaults={
+                "role": OrganizationRoles.OWNER,
+                "level": Level.OWNER,
+                "is_active": True,
+            },
+        )
+        ws = Workspace.objects.create(
+            name="Integration Test Workspace",
+            organization=org,
+            is_default=True,
+            is_active=True,
+            created_by=user,
+        )
+        org_membership = OrganizationMembership.no_workspace_objects.get(
+            user=user, organization=org
+        )
+        WorkspaceMembership.no_workspace_objects.get_or_create(
+            user=user,
+            workspace=ws,
+            defaults={
+                "role": "Workspace Owner",
+                "level": Level.OWNER,
+                "is_active": True,
+                "organization_membership": org_membership,
+            },
+        )
+        set_workspace_context(workspace=ws, organization=org, user=user)
+
+        project = Project.objects.create(
+            name="Integration Test Observe",
+            organization=org,
+            workspace=ws,
+            model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+            trace_type="observe",
+            metadata={},
+            session_config=[
+                {"id": "session_input", "name": "Session Input", "is_visible": True},
+            ],
+        )
+
+        writer = DualWriter(ch=ch_schema, ch_database=db_name)
+        counts = writer.seed_base_corpus(project=project)
+
+    snapshot = SimpleNamespace(
+        organization=org,
+        workspace=ws,
+        user=user,
+        project=project,
+        rows=writer.seeded,
+        eval_config_id=writer.eval_config_id,
+        annotation_label_id=writer.annotation_label_id,
+        choice_eval_config_id=writer.choice_eval_config_id,
+        counts=counts,
+    )
+    yield snapshot
+
+    with django_db_blocker.unblock():
+        try:
+            org.delete()
+        except Exception:
+            pass
+
+
+# Per-test wrappers — each requests ``db`` so per-test writes roll back.
+
+@pytest.fixture
+def organization(integration_setup, db):
+    return integration_setup.organization
+
+
+@pytest.fixture
+def workspace(integration_setup, db, organization):
+    from tfc.middleware.workspace_context import (
+        clear_workspace_context,
+        set_workspace_context,
+    )
+
+    clear_workspace_context()
+    set_workspace_context(
+        workspace=integration_setup.workspace,
+        organization=organization,
+        user=integration_setup.user,
+    )
+    yield integration_setup.workspace
+    clear_workspace_context()
+
+
+@pytest.fixture
+def user(integration_setup, db):
+    return integration_setup.user
+
+
+@pytest.fixture
+def observe_project(integration_setup, db):
+    return integration_setup.project
+
+
+@pytest.fixture
+def seeded_corpus(integration_setup, db):
+    return integration_setup
+
+
+@pytest.fixture(scope="session")
+def voice_integration_setup(django_db_setup, django_db_blocker, ch_schema, integration_setup):
+    """Session-scoped voice-only project + corpus for voiceCalls cases."""
+    from types import SimpleNamespace
+
+    from model_hub.models.ai_model import AIModel
+    from tracer.models.project import Project
+    from tracer.tests.integration._seed import DualWriter
+
+    db_name = settings.CLICKHOUSE["CH_DATABASE"]
+
+    with django_db_blocker.unblock():
+        voice_project = Project.objects.create(
+            name="Integration Test Voice",
+            organization=integration_setup.organization,
+            workspace=integration_setup.workspace,
+            model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+            trace_type="observe",
+            metadata={},
+            session_config=[
+                {"id": "session_input", "name": "Session Input", "is_visible": True},
+            ],
+        )
+        writer = DualWriter(ch=ch_schema, ch_database=db_name)
+        counts = writer.seed_voice_corpus(project=voice_project)
+
+    snapshot = SimpleNamespace(
+        organization=integration_setup.organization,
+        workspace=integration_setup.workspace,
+        user=integration_setup.user,
+        project=voice_project,
+        rows=writer.seeded,
+        eval_config_id=writer.eval_config_id,
+        annotation_label_id=writer.annotation_label_id,
+        choice_eval_config_id=writer.choice_eval_config_id,
+        counts=counts,
+    )
+    yield snapshot
+
+    with django_db_blocker.unblock():
+        try:
+            voice_project.delete()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def voice_corpus(voice_integration_setup, db):
+    return voice_integration_setup
+
+
+@pytest.fixture
+def custom_eval_config_factory(db, eval_template):
+    """Factory that creates an extra CustomEvalConfig per call."""
+    from tracer.models.custom_eval_config import CustomEvalConfig
+
+    def _make(project):
+        return CustomEvalConfig.objects.create(
+            project=project,
+            eval_template=eval_template,
+            name=f"extra_eval_{uuid.uuid4().hex[:6]}",
+            config={"threshold": 0.8},
+            mapping={"input": "input", "output": "output"},
+            filters={},
+        )
+
+    return _make
+
+
+def test_ch_routes_on_flips_setting(ch_routes_on):
+    """Sanity: the override actually flips the route to clickhouse for the test scope."""
+    assert settings.CLICKHOUSE["CH_ROUTE_SPAN_LIST"] == "clickhouse"

--- a/futureagi/tracer/tests/integration/test_eval_task_filter_e2e.py
+++ b/futureagi/tracer/tests/integration/test_eval_task_filter_e2e.py
@@ -1,0 +1,132 @@
+"""For every FilterCase: seed the corpus, create an EvalTask with the matching
+filter and target type, run process_eval_task inline (engine stubbed), and assert
+EvalLogger count == matched_rows × num_evals, with the right target_type set."""
+import pytest
+from django.db import transaction
+
+from tracer.models.eval_task import EvalTask, EvalTaskStatus, RowType, RunType
+from tracer.models.observation_span import EvalLogger, EvalTargetType
+from tracer.tests.integration._filter_matrix import all_cases_for, FilterCase
+from tracer.tests.integration._seed import SeededRow
+from tracer.utils.eval_tasks import process_eval_task
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.django_db]
+
+_TARGET_TYPE_TO_ROW_TYPE = {
+    "spans": RowType.SPANS,
+    "traces": RowType.TRACES,
+    "sessions": RowType.SESSIONS,
+    "voiceCalls": RowType.VOICE_CALLS,
+}
+
+_ROW_TYPE_TO_EVAL_TARGET = {
+    RowType.SPANS: EvalTargetType.SPAN,
+    RowType.TRACES: EvalTargetType.TRACE,
+    RowType.SESSIONS: EvalTargetType.SESSION,
+    RowType.VOICE_CALLS: EvalTargetType.SPAN,
+}
+
+
+_PLACEHOLDER_EVAL_CFG = "00000000-0000-0000-0000-000000000001"
+_PLACEHOLDER_LABEL = "00000000-0000-0000-0000-000000000002"
+_PLACEHOLDER_CHOICE_CFG = "00000000-0000-0000-0000-000000000003"
+_ALL_CASES = all_cases_for(
+    _PLACEHOLDER_EVAL_CFG, _PLACEHOLDER_LABEL, _PLACEHOLDER_CHOICE_CFG
+)
+
+
+def _rebind_case(
+    case: FilterCase,
+    eval_config_id: str,
+    label_id: str,
+    choice_eval_config_id: str,
+) -> FilterCase:
+    new_col_id = case.column_id
+    if case.col_type == "EVAL_METRIC":
+        if case.column_id == _PLACEHOLDER_EVAL_CFG:
+            new_col_id = eval_config_id
+        elif case.column_id == _PLACEHOLDER_CHOICE_CFG:
+            new_col_id = choice_eval_config_id
+    if case.col_type == "ANNOTATION" and case.column_id == _PLACEHOLDER_LABEL:
+        new_col_id = label_id
+    if new_col_id == case.column_id:
+        return case
+    return FilterCase(
+        case_id=case.case_id,
+        target_type=case.target_type,
+        col_type=case.col_type,
+        filter_type=case.filter_type,
+        filter_op=case.filter_op,
+        column_id=new_col_id,
+        filter_value=case.filter_value,
+        expected_predicate=case.expected_predicate,
+    )
+
+
+def _expected_unit_count(case: FilterCase, seeded: list[SeededRow]) -> int:
+    if case.target_type in ("spans", "voiceCalls"):
+        return sum(1 for r in seeded if case.expected_predicate(r))
+    if case.target_type == "traces":
+        return len({r.trace_id for r in seeded if case.expected_predicate(r)})
+    if case.target_type == "sessions":
+        return len({r.session_id for r in seeded if case.expected_predicate(r)})
+    raise AssertionError(case.target_type)
+
+
+@pytest.mark.parametrize("case", _ALL_CASES, ids=lambda c: c.case_id)
+def test_eval_task_creates_correct_logger_count(
+    case,
+    seeded_corpus,
+    voice_corpus,
+    custom_eval_config_factory,
+    stub_run_eval,
+    inline_temporal,
+    stub_cost_log,
+):
+    # voiceCalls → voice-only project; everything else → mixed corpus.
+    corpus = voice_corpus if case.target_type == "voiceCalls" else seeded_corpus
+    project = corpus.project
+    seeded = corpus.rows
+    case = _rebind_case(
+        case,
+        corpus.eval_config_id,
+        corpus.annotation_label_id,
+        corpus.choice_eval_config_id,
+    )
+    expected_units = _expected_unit_count(case, seeded)
+
+    eval_a = custom_eval_config_factory(project=project)
+    eval_b = custom_eval_config_factory(project=project)
+    # Include project_id so the runner scopes the queryset.
+    filters_dict = {"project_id": str(project.id), **case.to_filter_dict()}
+    task = EvalTask.objects.create(
+        project=project,
+        filters=filters_dict,
+        row_type=_TARGET_TYPE_TO_ROW_TYPE[case.target_type],
+        run_type=RunType.HISTORICAL,
+        sampling_rate=100.0,  # percentage in [0, 100], not a fraction
+        spans_limit=10_000,
+        status=EvalTaskStatus.PENDING,
+    )
+    task.evals.add(eval_a, eval_b)
+
+    # ``._original_func`` bypasses the Temporal activity wrapper; savepoint
+    # isolates parser exceptions from poisoning the outer test transaction.
+    try:
+        with transaction.atomic():
+            process_eval_task._original_func(str(task.id))
+    except Exception as exc:
+        raise AssertionError(
+            f"{case.case_id}: runner raised {type(exc).__name__}: {exc}"
+        ) from exc
+
+    actual = EvalLogger.objects.filter(eval_task_id=str(task.id)).count()
+    expected_loggers = expected_units * 2  # two evals attached
+    assert actual == expected_loggers, (
+        f"{case.case_id}: row_type={task.row_type} expected {expected_loggers} "
+        f"({expected_units} units × 2 evals), got {actual}"
+    )
+
+    if expected_loggers > 0:
+        sample = EvalLogger.objects.filter(eval_task_id=str(task.id)).first()
+        assert sample.target_type == _ROW_TYPE_TO_EVAL_TARGET[task.row_type]

--- a/futureagi/tracer/tests/integration/test_filter_matrix_completeness.py
+++ b/futureagi/tracer/tests/integration/test_filter_matrix_completeness.py
@@ -1,0 +1,80 @@
+"""Matrix completeness + non-degeneracy guards.
+
+Cheap, runs without ClickHouse if you skip the dual_writer fixture (we don't —
+the non-degeneracy guard needs the seeded corpus).
+"""
+import pytest
+
+from tracer.tests.integration._filter_matrix import (
+    COL_TYPES,
+    TARGET_TYPES,
+    all_cases,
+)
+
+
+def test_matrix_covers_every_col_type_per_target():
+    by_target_coltype: dict[str, set[str]] = {}
+    for case in all_cases():
+        by_target_coltype.setdefault(case.target_type, set()).add(case.col_type)
+    expected_cols = set(COL_TYPES)
+    for tt in TARGET_TYPES:
+        assert by_target_coltype[tt] == expected_cols, (
+            f"target {tt} missing col_types {expected_cols - by_target_coltype[tt]}"
+        )
+
+
+def test_no_duplicate_case_ids():
+    ids = [c.case_id for c in all_cases()]
+    dupes = [i for i in set(ids) if ids.count(i) > 1]
+    assert not dupes, f"duplicate case_id in matrix: {dupes}"
+
+
+def test_every_case_has_a_predicate():
+    for c in all_cases():
+        assert callable(c.expected_predicate), c.case_id
+
+
+# Set of (col_type, filter_op) pairs where a 0-match or all-match result is the
+# meaningful assertion (e.g. is_null on a column that's always set proves
+# "no false positives" — and the matrix's job is to cover these explicitly).
+_ALLOWED_DEGENERATE = {
+    ("SYSTEM_METRIC", "is_null"),  # cost is always set in corpus
+    ("SYSTEM_METRIC", "is_not_null"),  # ditto, inverse
+    ("SPAN_ATTRIBUTE", "is_null"),  # ``missing_attr`` is intentionally absent
+}
+
+
+@pytest.mark.django_db
+def test_every_case_matches_a_non_trivial_subset(seeded_corpus):
+    """Catch degenerate FilterCases — every filter should match >0 and <ALL rows
+    in the corpus (otherwise the case is undiscriminating and a bug in the
+    matrix could slip through). Explicit allowlist for is_null-style filters."""
+    seeded = seeded_corpus.rows
+    total = len(seeded)
+    degenerate = []
+    for case in all_cases(
+        eval_config_id=seeded_corpus.eval_config_id,
+        label_id=seeded_corpus.annotation_label_id,
+        choice_eval_config_id=seeded_corpus.choice_eval_config_id,
+    ):
+        if (case.col_type, case.filter_op) in _ALLOWED_DEGENERATE:
+            continue
+        # has_eval/has_annotation with value=False legitimately matches the
+        # complement; both subsets are non-empty in the corpus, so don't skip.
+        matched = sum(1 for r in seeded if case.expected_predicate(r))
+        # voiceCalls only has 3 root rows AND voice roots have sp_idx=0, which
+        # carry no eval / annotation in the corpus. Most filters touching
+        # those features therefore match 0 voice rows — that's not a matrix
+        # bug, it's the corpus shape. Skip the non-degeneracy guard here; the
+        # parametrized tests still assert against the predicate-derived count
+        # (0 or otherwise) and lock the contract.
+        if case.target_type == "voiceCalls":
+            continue
+        if matched == 0 or matched == total:
+            degenerate.append((case.case_id, matched, total))
+    assert not degenerate, (
+        "These FilterCases are non-discriminating against the seeded corpus "
+        "(matched 0 or ALL rows). Either tune the threshold, vary the corpus, "
+        "or add to _ALLOWED_DEGENERATE with justification:\n  "
+        + "\n  ".join(f"{cid}: matched {m}/{t}" for cid, m, t in degenerate)
+    )

--- a/futureagi/tracer/tests/integration/test_list_endpoints_filter_count.py
+++ b/futureagi/tracer/tests/integration/test_list_endpoints_filter_count.py
@@ -1,0 +1,116 @@
+"""For every FilterCase: seed the corpus, hit the list endpoint with the filter,
+assert response total_rows equals the predicate-derived count.
+
+The matrix carries placeholder UUIDs for eval_config_id / annotation_label_id;
+we rebind to the real seeded values at parametrize-time inside the test body.
+"""
+import json
+
+import pytest
+
+from tracer.tests.integration._filter_matrix import all_cases_for
+from tracer.tests.integration._seed import SeededRow
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.django_db]
+
+
+ENDPOINTS = {
+    "spans": "/tracer/observation-span/list_spans_observe/",
+    "traces": "/tracer/trace/list_traces_of_session/",
+    "sessions": "/tracer/trace-session/list_sessions/",
+    "voiceCalls": "/tracer/trace/list_voice_calls/",
+}
+
+
+def _expected_count(case, seeded: list[SeededRow]) -> int:
+    """Aggregate per-span predicate to the case's target unit."""
+    if case.target_type == "spans":
+        return sum(1 for r in seeded if case.expected_predicate(r))
+    if case.target_type == "voiceCalls":
+        return sum(1 for r in seeded if case.expected_predicate(r))
+    if case.target_type == "traces":
+        return len({r.trace_id for r in seeded if case.expected_predicate(r)})
+    if case.target_type == "sessions":
+        return len({r.session_id for r in seeded if case.expected_predicate(r)})
+    raise AssertionError(case.target_type)
+
+
+# We need eval_config_id / annotation_label_id to be filled in for EVAL_METRIC
+# and ANNOTATION cases. Parametrize uses placeholder UUIDs; the fixture
+# rebinds them before each test.
+_PLACEHOLDER_EVAL_CFG = "00000000-0000-0000-0000-000000000001"
+_PLACEHOLDER_LABEL = "00000000-0000-0000-0000-000000000002"
+_PLACEHOLDER_CHOICE_CFG = "00000000-0000-0000-0000-000000000003"
+_ALL_CASES = all_cases_for(
+    _PLACEHOLDER_EVAL_CFG, _PLACEHOLDER_LABEL, _PLACEHOLDER_CHOICE_CFG
+)
+
+
+def _rebind_case(case, eval_config_id: str, label_id: str, choice_eval_config_id: str):
+    """If a case targets a placeholder eval_config / label, rewrite the
+    column_id to the real seeded id before sending to the endpoint. The
+    predicate doesn't read column_id, only row fields, so it stays valid."""
+    from tracer.tests.integration._filter_matrix import FilterCase
+
+    new_col_id = case.column_id
+    if case.col_type == "EVAL_METRIC":
+        if case.column_id == _PLACEHOLDER_EVAL_CFG:
+            new_col_id = eval_config_id
+        elif case.column_id == _PLACEHOLDER_CHOICE_CFG:
+            new_col_id = choice_eval_config_id
+    if case.col_type == "ANNOTATION" and case.column_id == _PLACEHOLDER_LABEL:
+        new_col_id = label_id
+    if new_col_id == case.column_id:
+        return case
+    return FilterCase(
+        case_id=case.case_id,
+        target_type=case.target_type,
+        col_type=case.col_type,
+        filter_type=case.filter_type,
+        filter_op=case.filter_op,
+        column_id=new_col_id,
+        filter_value=case.filter_value,
+        expected_predicate=case.expected_predicate,
+    )
+
+
+@pytest.mark.parametrize("case", _ALL_CASES, ids=lambda c: c.case_id)
+def test_list_endpoint_total_rows(
+    case, auth_client, seeded_corpus, voice_corpus, ch_routes_on
+):
+    # voiceCalls → voice-only project; everything else → mixed corpus.
+    corpus = voice_corpus if case.target_type == "voiceCalls" else seeded_corpus
+    project = corpus.project
+    seeded = corpus.rows
+    case = _rebind_case(
+        case,
+        corpus.eval_config_id,
+        corpus.annotation_label_id,
+        corpus.choice_eval_config_id,
+    )
+    expected = _expected_count(case, seeded)
+
+    filter_json = json.dumps(case.to_filter_dict()["filters"])
+    url = ENDPOINTS[case.target_type]
+    resp = auth_client.get(
+        url,
+        {
+            "project_id": str(project.id),
+            "page_number": 0,
+            "page_size": 100,
+            "filters": filter_json,
+        },
+    )
+    assert resp.status_code == 200, getattr(resp, "content", resp)
+    body = resp.data
+    # success_response wraps payload in {"status":..., "result": <payload>}
+    payload = body.get("result", body)
+    total = payload.get("metadata", {}).get("total_rows")
+    if total is None:
+        # Some endpoints (sessions list) return total_rows at a different
+        # path — fall back to len(table)/data length as a best-effort.
+        table = payload.get("table") or payload.get("data") or []
+        total = len(table)
+    assert total == expected, (
+        f"{case.case_id}: endpoint returned {total}, predicate expected {expected}"
+    )

--- a/futureagi/tracer/tests/integration/test_seed_smoke.py
+++ b/futureagi/tracer/tests/integration/test_seed_smoke.py
@@ -1,0 +1,24 @@
+"""Smoke test for the dual-write seeder.
+
+Asserts the 24-span corpus lands in both Postgres (ORM) and ClickHouse (SQL).
+"""
+import pytest
+from django.conf import settings
+
+from tracer.models.observation_span import ObservationSpan
+
+
+@pytest.mark.django_db
+def test_seeded_corpus_lands_in_pg_and_ch(seeded_corpus, ch_schema):
+    """Sanity: the session-scoped seed wrote the same row set to PG and CH."""
+    project = seeded_corpus.project
+    expected = seeded_corpus.counts["span_count"]
+    # PG side
+    assert ObservationSpan.objects.filter(project=project).count() == expected
+    # CH side
+    db = settings.CLICKHOUSE["CH_DATABASE"]
+    ch_count = ch_schema.command(
+        f"SELECT count() FROM {db}.tracer_observation_span "
+        f"WHERE project_id = '{project.id}' AND _peerdb_is_deleted = 0"
+    )
+    assert int(ch_count) == expected


### PR DESCRIPTION
## Summary

Cartesian-coverage integration tests for `process_eval_task` and the four list endpoints, parametrized over every `(target_type × col_type × filter_type × filter_op)` combination — ~165 cases per test file.

This is the **verification contract** for the bug fixes filed under [TH-5645](https://linear.app/future-agi/issue/TH-5645) (TH-5700..TH-5704). Stacks on top of #782; each downstream fix PR will turn failing cases green.

## Linear

[TH-5699](https://linear.app/future-agi/issue/TH-5699) — Integration test suite for eval-task filter dispatch

## What's in this PR

| File | Purpose |
|---|---|
| `tracer/tests/integration/_seed.py` | `DualWriter` — seeds 24-span base + 24-span voice-only corpus; dual-writes to Postgres ORM AND ClickHouse (`tracer_observation_span` CDC landing table, simulating PeerDB) |
| `tracer/tests/integration/_filter_matrix.py` | `FilterCase` Cartesian generator + per-row predicates; covers SCORE / PASS_FAIL / CHOICE EVAL_METRIC variants |
| `tracer/tests/integration/conftest.py` | Session-scoped `integration_setup` + `voice_integration_setup` (seed once, EvalTask writes roll back per-test); `ch_routes_on` flips `CH_ROUTE_*` for CH-path tests |
| `tracer/tests/integration/test_eval_task_filter_e2e.py` | Drives `process_eval_task._original_func` with `stub_run_eval` + `inline_temporal`; asserts `EvalLogger.count() == matched × num_evals` |
| `tracer/tests/integration/test_list_endpoints_filter_count.py` | Hits the four list endpoints via `ch_routes_on`; asserts `total_rows` parity with predicate |
| `tracer/tests/integration/test_filter_matrix_completeness.py` | Non-degeneracy guard — every FilterCase must match a non-trivial subset of seeded rows |
| `tracer/tests/integration/test_seed_smoke.py` | PG ↔ CH row-count parity sanity |
| `frontend/.../NewTaskDrawer/__tests__/validation.test.js` | Regression test for `extractAttributeFilters` colType round-trip (the bug behind TH-5645) |

## Baseline numbers when run against current dev

- **77/165 cases pass** in `test_eval_task_filter_e2e.py` (runner)
- **23/160 cases pass** in `test_list_endpoints_filter_count.py` (CH-path list endpoints)

Failures are categorized in the sub-tickets:
- TH-5700 (Bug #4) — `has_eval/has_annotation=False` inversion
- TH-5701 (Bug #1 + #1c) — SYSTEM_METRIC number/datetime/is_null + PG fallback
- TH-5702 (Bug #2) — EVAL_METRIC `metric_<id>` annotation + 3-type dispatch
- TH-5703 (Bug #3) — ANNOTATION filter on per-label scores
- TH-5704 (Bug #6b) — `ClickHouseFilterBuilder` `project_id` propagation

## Why standalone

Landing the test suite first means each subsequent fix PR can run this matrix as the gate. No fix ships without proving against the same contract.

## How to run

```bash
cd futureagi
docker compose -f docker-compose.test.yml -p futureagi-test ps  # ensure test CH not paused
uv run pytest tracer/tests/integration/ -v --tb=line --no-header
```

## Notes

- Stacked on top of #782 (filter key dispatch). When #782 merges, this PR rebases onto dev cleanly.
- No production code changes — pure test infrastructure.
- ClickHouse seeding bypasses PeerDB by writing directly to CDC landing tables with synthetic `_peerdb_*` meta-columns; `spans_mv` then auto-populates `spans` denormalized table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)