### PR TITLE
fix(eval-task): annotation filter dispatch + per-label score aggregation [TH-5703]

### DIFF
--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
@@ -249,13 +249,9 @@ const DetailsEdit = ({
   });
 
   const onUpdateSubmit = (data, editType) => {
-    // extractAttributeFilters now returns every chip (SPAN_ATTRIBUTE,
-    // SYSTEM_METRIC, EVAL_METRIC, ANNOTATION, has_*) as a flat list with
-    // `col_type` — matches list_spans_observe / the new BE dispatcher.
-    // observation_type still rides as a sibling key.
+    // Flat chip list with col_type for the BE dispatcher; observation_type
+    // (incl. node_type alias) still rides as a sibling key.
     const attributeFilters = extractAttributeFilters(data?.filters);
-    // node_type is the FE alias for observation_type — both end up in
-    // the outer `observation_type` sibling key (see TaskDetailPage.jsx).
     const observationTypes = (data.filters || [])
       .filter(
         (f) => f.property === "observation_type" || f.property === "node_type",

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
@@ -249,24 +249,22 @@ const DetailsEdit = ({
   });
 
   const onUpdateSubmit = (data, editType) => {
+    // extractAttributeFilters now returns every chip (SPAN_ATTRIBUTE,
+    // SYSTEM_METRIC, EVAL_METRIC, ANNOTATION, has_*) as a flat list with
+    // `col_type` — matches list_spans_observe / the new BE dispatcher.
+    // observation_type still rides as a sibling key.
     const attributeFilters = extractAttributeFilters(data?.filters);
-
-    // Generic system filter aggregation — every non-attribute filter
-    // row contributes its value to a BE key named after `f.property`.
-    // Mirrors the create-side getNewTaskFilters (validation.js) so
-    // span_kind, latency_ms, total_tokens, etc. all round-trip without
-    // each one being hard-coded.
-    const systemFilters = {};
-    (data.filters || []).forEach((f) => {
-      if (!f?.property || f.property === "attributes") return;
-      const v = f?.filterConfig?.filterValue;
-      if (v === undefined || v === null || v === "") return;
-      if (systemFilters[f.property]) {
-        systemFilters[f.property].push(v);
-      } else {
-        systemFilters[f.property] = [v];
-      }
-    });
+    // node_type is the FE alias for observation_type — both end up in
+    // the outer `observation_type` sibling key (see TaskDetailPage.jsx).
+    const observationTypes = (data.filters || [])
+      .filter(
+        (f) => f.property === "observation_type" || f.property === "node_type",
+      )
+      .flatMap((f) => {
+        const v = f?.filterConfig?.filterValue;
+        if (Array.isArray(v)) return v;
+        return v !== undefined && v !== null && v !== "" ? [v] : [];
+      });
 
     const transformedData = {
       evals: data.evalsDetails?.map((item) => item.id) || [],
@@ -276,9 +274,11 @@ const DetailsEdit = ({
           new Date(startDateField.value).toISOString(),
           new Date(endDateField.value).toISOString(),
         ],
-        ...systemFilters,
+        ...(observationTypes?.length > 0
+          ? { observation_type: observationTypes }
+          : {}),
         ...(attributeFilters && attributeFilters?.length > 0
-          ? { span_attributes_filters: attributeFilters }
+          ? { filters: attributeFilters }
           : {}),
       },
       project_id: data.project,

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/__tests__/validation.test.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/__tests__/validation.test.js
@@ -1,0 +1,295 @@
+import { describe, it, expect } from "vitest";
+import { extractAttributeFilters, getNewTaskFilters } from "../validation";
+
+const makeRow = (overrides = {}) => ({
+  property: "attributes",
+  propertyId: "ended_reason",
+  apiColType: "SPAN_ATTRIBUTE",
+  filterConfig: {
+    filterType: "text",
+    filterOp: "equals",
+    filterValue: "completed",
+  },
+  ...overrides,
+});
+
+describe("extractAttributeFilters — colType round-trip", () => {
+  it("emits the row's apiColType (SPAN_ATTRIBUTE) by default", () => {
+    const out = extractAttributeFilters([makeRow()]);
+    expect(out).toHaveLength(1);
+    expect(out[0].filterConfig.colType).toBe("SPAN_ATTRIBUTE");
+  });
+
+  it("preserves apiColType=ANNOTATION (the bug behind TH-5645)", () => {
+    const row = makeRow({
+      propertyId: "annotator",
+      apiColType: "ANNOTATION",
+      filterConfig: {
+        filterType: "text",
+        filterOp: "equals",
+        filterValue: "c65a0f3c-8a72-432a-987f-ddbd8391df29",
+      },
+    });
+    const out = extractAttributeFilters([row]);
+    expect(out[0].filterConfig.colType).toBe("ANNOTATION");
+    expect(out[0].columnId).toBe("annotator");
+  });
+
+  it("preserves apiColType=SYSTEM_METRIC", () => {
+    const row = makeRow({
+      propertyId: "cost",
+      apiColType: "SYSTEM_METRIC",
+      filterConfig: {
+        filterType: "number",
+        filterOp: "greater_than",
+        filterValue: 0.5,
+      },
+    });
+    const out = extractAttributeFilters([row]);
+    expect(out[0].filterConfig.colType).toBe("SYSTEM_METRIC");
+  });
+
+  it("preserves apiColType=EVAL_METRIC", () => {
+    const row = makeRow({
+      propertyId: "4d808ee6-38bd-4cb2-9ed0-77d1c1488737",
+      apiColType: "EVAL_METRIC",
+      filterConfig: {
+        filterType: "number",
+        filterOp: "greater_than",
+        filterValue: 0.8,
+      },
+    });
+    const out = extractAttributeFilters([row]);
+    expect(out[0].filterConfig.colType).toBe("EVAL_METRIC");
+  });
+
+  it("falls back to SPAN_ATTRIBUTE when apiColType is missing", () => {
+    const { apiColType, ...row } = makeRow();
+    const out = extractAttributeFilters([row]);
+    expect(out[0].filterConfig.colType).toBe("SPAN_ATTRIBUTE");
+  });
+
+  it("keeps each col_type when multiple rows are mixed", () => {
+    const out = extractAttributeFilters([
+      makeRow({ propertyId: "ended_reason" }),
+      makeRow({
+        propertyId: "annotator",
+        apiColType: "ANNOTATION",
+        filterConfig: {
+          filterType: "text",
+          filterOp: "equals",
+          filterValue: "uid-1",
+        },
+      }),
+      makeRow({
+        propertyId: "cost",
+        apiColType: "SYSTEM_METRIC",
+        filterConfig: {
+          filterType: "number",
+          filterOp: "greater_than",
+          filterValue: 0.1,
+        },
+      }),
+    ]);
+    const byCol = Object.fromEntries(out.map((o) => [o.columnId, o.filterConfig.colType]));
+    expect(byCol.ended_reason).toBe("SPAN_ATTRIBUTE");
+    expect(byCol.annotator).toBe("ANNOTATION");
+    expect(byCol.cost).toBe("SYSTEM_METRIC");
+  });
+});
+
+describe("extractAttributeFilters — non-attribute rows go through the same list", () => {
+  // The bug the FE PR fixes: an EVAL_METRIC chip used to land as a
+  // top-level dict key (`b6a017ba-...: ["Pass"]`) which the BE dispatcher
+  // silently dropped. Now it rides inside the canonical filters[] list
+  // with col_type=EVAL_METRIC, matching list_spans_observe.
+  it("emits an EVAL_METRIC chip as a filters[] item, not a top-level key", () => {
+    const evalChip = {
+      property: "b6a017ba-7683-4458-8a5d-d6aeaa37a2e8",
+      propertyId: "b6a017ba-7683-4458-8a5d-d6aeaa37a2e8",
+      fieldCategory: "eval",
+      apiColType: "EVAL_METRIC",
+      filterConfig: {
+        filterType: "categorical",
+        filterOp: "in",
+        filterValue: ["Pass"],
+      },
+    };
+    const out = extractAttributeFilters([evalChip]);
+    expect(out).toHaveLength(1);
+    expect(out[0].columnId).toBe(evalChip.propertyId);
+    expect(out[0].filterConfig.colType).toBe("EVAL_METRIC");
+    expect(out[0].filterConfig.filterValue).toEqual(["Pass"]);
+  });
+
+  it("emits a SYSTEM_METRIC chip (e.g. cost) as a filters[] item", () => {
+    const sysChip = {
+      property: "cost",
+      propertyId: "cost",
+      fieldCategory: "system",
+      apiColType: "SYSTEM_METRIC",
+      filterConfig: {
+        filterType: "number",
+        filterOp: "greater_than",
+        filterValue: 0.5,
+      },
+    };
+    const out = extractAttributeFilters([sysChip]);
+    expect(out).toHaveLength(1);
+    expect(out[0].columnId).toBe("cost");
+    expect(out[0].filterConfig.colType).toBe("SYSTEM_METRIC");
+  });
+
+  it("emits an ANNOTATION annotator chip as a filters[] item", () => {
+    const annChip = {
+      property: "annotator",
+      propertyId: "annotator",
+      fieldCategory: "annotation",
+      apiColType: "ANNOTATION",
+      filterConfig: {
+        filterType: "text",
+        filterOp: "equals",
+        filterValue: "c65a0f3c-8a72-432a-987f-ddbd8391df29",
+      },
+    };
+    const out = extractAttributeFilters([annChip]);
+    expect(out).toHaveLength(1);
+    expect(out[0].columnId).toBe("annotator");
+    expect(out[0].filterConfig.colType).toBe("ANNOTATION");
+  });
+
+  it("skips observation_type rows — they ride as a sibling top-level key", () => {
+    const obsChip = {
+      property: "observation_type",
+      propertyId: "observation_type",
+      filterConfig: { filterType: "text", filterOp: "in", filterValue: ["llm"] },
+    };
+    const out = extractAttributeFilters([obsChip]);
+    expect(out).toHaveLength(0);
+  });
+
+  // node_type is the panel's FE alias for observation_type. It must NOT
+  // ride through the canonical filters list (the BE SYSTEM_METRIC handler
+  // can't resolve `node_type` against ObservationSpan without an
+  // observation_type alias annotation that process_eval_task doesn't apply).
+  it("skips node_type rows — they ride via the observation_type sibling key", () => {
+    const nodeTypeChip = {
+      property: "node_type",
+      propertyId: "node_type",
+      fieldCategory: "system",
+      apiColType: "SYSTEM_METRIC",
+      filterConfig: { filterType: "text", filterOp: "in", filterValue: ["llm"] },
+    };
+    const out = extractAttributeFilters([nodeTypeChip]);
+    expect(out).toHaveLength(0);
+  });
+
+  // The TraceFilterPanel labels the global annotator chip with
+  // apiColType="SYSTEM_METRIC" (a deliberate UI choice — see
+  // TraceFilterPanel.jsx:372). If we let that through verbatim, the
+  // eval-task BE dispatcher would feed the row to the SYSTEM_METRIC /
+  // SPAN_ATTRIBUTE handlers too, where the column_id="annotator"
+  // matches no rows → 0-span result poisons the combined AND.
+  it("pins col_type=ANNOTATION for the annotator chip regardless of apiColType", () => {
+    const row = {
+      property: "annotator",
+      propertyId: "annotator",
+      fieldCategory: "annotation",
+      apiColType: "SYSTEM_METRIC", // what TraceFilterPanel emits
+      filterConfig: {
+        filterType: "text",
+        filterOp: "equals",
+        filterValue: "d60a1556-8562-4a76-99e3-ab422a18e39e",
+      },
+    };
+    const out = extractAttributeFilters([row]);
+    expect(out).toHaveLength(1);
+    expect(out[0].columnId).toBe("annotator");
+    expect(out[0].filterConfig.colType).toBe("ANNOTATION");
+  });
+
+  it("pins col_type=ANNOTATION for my_annotations regardless of apiColType", () => {
+    const row = {
+      property: "my_annotations",
+      propertyId: "my_annotations",
+      apiColType: "SYSTEM_METRIC",
+      filterConfig: { filterType: "boolean", filterOp: "equals", filterValue: true },
+    };
+    const out = extractAttributeFilters([row]);
+    expect(out).toHaveLength(1);
+    expect(out[0].filterConfig.colType).toBe("ANNOTATION");
+  });
+
+  // The static panel fields (status, model, service_name, …) at
+  // TraceFilterPanel.jsx:1650-1666 don't always set apiColType, so the
+  // form row arrives with apiColType=undefined. The fieldCategory
+  // fallback ensures the wire still gets the right col_type.
+  // (node_type is excluded — it's rerouted to the observation_type
+  // sibling key; see the separate test below.)
+  it("falls back to fieldCategory when apiColType is missing (status → SYSTEM_METRIC)", () => {
+    const row = {
+      property: "status",
+      propertyId: "status",
+      fieldCategory: "system",
+      // apiColType deliberately omitted
+      filterConfig: { filterType: "text", filterOp: "equals", filterValue: "OK" },
+    };
+    const out = extractAttributeFilters([row]);
+    expect(out).toHaveLength(1);
+    expect(out[0].columnId).toBe("status");
+    expect(out[0].filterConfig.colType).toBe("SYSTEM_METRIC");
+  });
+
+  it("falls back to fieldCategory=annotation → ANNOTATION", () => {
+    const row = {
+      property: "some-label-uuid",
+      propertyId: "some-label-uuid",
+      fieldCategory: "annotation",
+      filterConfig: {
+        filterType: "categorical",
+        filterOp: "equals",
+        filterValue: "Pass",
+      },
+    };
+    const out = extractAttributeFilters([row]);
+    expect(out[0].filterConfig.colType).toBe("ANNOTATION");
+  });
+
+  it("getNewTaskFilters: a node_type chip lands under outer key 'observation_type'", () => {
+    const data = {
+      filters: [
+        {
+          property: "node_type",
+          propertyId: "node_type",
+          fieldCategory: "system",
+          apiColType: "SYSTEM_METRIC",
+          filterConfig: {
+            filterType: "text",
+            filterOp: "in",
+            filterValue: ["llm"],
+          },
+        },
+      ],
+    };
+    const { filters, attributeFilters } = getNewTaskFilters(
+      data,
+      "542cb448-ced4-420e-b728-bc55315e2e68",
+      /* ignoreDate */ true,
+    );
+    expect(filters.observation_type).toEqual(["llm"]);
+    expect(filters.node_type).toBeUndefined();
+    expect(attributeFilters).toEqual([]);
+  });
+
+  it("skips legacy hydrated rows that carry no apiColType and no propertyId", () => {
+    // Existing tasks may have top-level system keys hydrated as bare
+    // form rows with property=<key> only. They were BE no-ops before;
+    // we drop them here so re-save doesn't perpetuate the wrong shape.
+    const legacyChip = {
+      property: "some_legacy_key",
+      filterConfig: { filterType: "text", filterOp: "equals", filterValue: "x" },
+    };
+    const out = extractAttributeFilters([legacyChip]);
+    expect(out).toHaveLength(0);
+  });
+});

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
@@ -1,63 +1,34 @@
 import { getNumberValidation } from "src/utils/validation";
 import { z } from "zod";
+import {
+  ANNOTATION_COLUMN_IDS,
+  FIELD_CATEGORY_TO_COL_TYPE,
+} from "src/sections/common/EvalsTasks/common";
 
 const RANGE_OPS = new Set(["between", "not_between"]);
 const LIST_OPS = new Set(["in", "not_in"]);
 
-// Maps a form-row `property` to the outer-filters-dict sibling key the
-// BE honors (see `parsing_evaltask_filters` in tracer/utils/eval_tasks.py).
-//
-// `node_type` is the FE-side alias for `observation_type`; the SYSTEM_METRIC
-// handler doesn't translate it (its DEFAULT_FIELD_MAP entry points at the
-// non-existent `node_type` Django field, relying on the caller having
-// annotated `node_type=F("observation_type")` the way list_spans_observe
-// does at observation_span.py:1617). process_eval_task doesn't replicate
-// that annotate, so we route the chip via the BE's direct
-// observation_type sibling branch instead.
+// Form-row `property` → outer-filters sibling key the BE honors. `node_type`
+// is a FE alias for `observation_type` (the eval-task handler can't resolve
+// it directly), so route it via the dedicated sibling branch.
 const TOP_LEVEL_SIBLING_KEY_BY_PROPERTY = {
   observation_type: "observation_type",
   node_type: "observation_type",
   session_id: "session_id",
 };
 
-// Column ids the BE always routes via its annotation handler regardless
-// of col_type (filters.py:1711-1755 in get_filter_conditions_for_voice_call_annotations).
-// Forcing col_type=ANNOTATION on the wire keeps the eval-task dispatcher
-// from also feeding the same row to the SPAN_ATTRIBUTE / SYSTEM_METRIC
-// handlers — where it'd otherwise match no rows and poison the AND.
-const ANNOTATION_COLUMN_IDS = new Set(["annotator", "my_annotations"]);
-
-// fieldCategory → col_type fallback. Used when the form row didn't
-// carry an apiColType (e.g. the panel's static system fields at
-// TraceFilterPanel.jsx:1650-1666 don't set one). Mirrors the
-// PANEL_CAT_TO_COL_TYPE in TaskFilterBar.jsx — duplicated here so the
-// wire encoding is correct even if the form-row producer skipped it.
-const FIELD_CATEGORY_TO_COL_TYPE = {
-  attribute: "SPAN_ATTRIBUTE",
-  system: "SYSTEM_METRIC",
-  eval: "EVAL_METRIC",
-  annotation: "ANNOTATION",
-};
-
-// Group multiple form rows for the same (columnId, op) into a single wire
-// entry. Scalar rows for list ops collapse to array `filterValue`; multiple
-// scalar rows for a single-value op (legacy multi-value `equals` from saved
-// tasks) are promoted to `in` so the BE filter validator accepts them.
-//
-// Mirrors `list_spans_observe`'s shape (observation_span.py:1755-1826):
-// every chip — SPAN_ATTRIBUTE, SYSTEM_METRIC, EVAL_METRIC, ANNOTATION,
-// has_eval, has_annotation, annotator — goes into the same flat list with
-// its own `col_type`. The dispatcher fans out per col_type on the BE.
+// Merge form rows for the same (columnId, op) into one wire entry. Scalar
+// rows for list ops fold into array `filterValue`; multiple scalars under a
+// single-value op are promoted to `in`. Matches list_spans_observe's flat
+// shape — every chip carries its own `col_type` and the BE dispatches.
 export const extractAttributeFilters = (filters) => {
   const merged = new Map();
   (filters || [])
     .filter((f) => {
       if (!f) return false;
-      // Sibling top-level keys (observation_type, node_type → observation_type,
-      // session_id) are emitted separately by `getNewTaskFilters`.
+      // Sibling keys are emitted separately by getNewTaskFilters.
       if (f.property in TOP_LEVEL_SIBLING_KEY_BY_PROPERTY) return false;
-      // Hydrated legacy rows with no apiColType and no propertyId are
-      // BE no-ops anyway — drop them.
+      // Legacy rows with neither apiColType nor propertyId are BE no-ops.
       if (!f.propertyId && f.property !== "attributes") return false;
       return true;
     })
@@ -68,15 +39,8 @@ export const extractAttributeFilters = (filters) => {
       const filterType = f?.filterConfig?.filterType || "text";
       const key = `${columnId}|${op}|${filterType}`;
       if (!merged.has(key)) {
-        // Resolution order:
-        //   1. ANNOTATION_COLUMN_IDS — annotator / my_annotations are
-        //      always ANNOTATION regardless of what the panel said.
-        //   2. row's explicit apiColType (set by TaskFilterBar via
-        //      resolveApiColType — the canonical source).
-        //   3. fieldCategory mapping (covers form rows whose
-        //      apiColType was lost upstream, e.g. when the panel's
-        //      static system fields skipped setting it).
-        //   4. SPAN_ATTRIBUTE default (last resort).
+        // Resolution: pinned ANNOTATION ids → row.apiColType (canonical) →
+        // fieldCategory fallback → SPAN_ATTRIBUTE default.
         let apiColType;
         if (ANNOTATION_COLUMN_IDS.has(columnId)) {
           apiColType = "ANNOTATION";
@@ -139,10 +103,8 @@ export const extractAttributeFilters = (filters) => {
   });
 };
 
-// Extract rows whose property maps to a BE-honored sibling top-level key
-// (observation_type / node_type → observation_type, session_id). Each
-// contributes its values to a flat per-field array on the outer filters
-// dict, with the property renamed to the BE-side key when they differ.
+// Sibling-key extraction: rows whose property maps to a top-level BE key
+// (observation_type / node_type / session_id) → flat per-field array.
 const extractSiblingFilters = (filters) => {
   const out = {};
   (filters || []).forEach((f) => {
@@ -207,10 +169,7 @@ export const NewTaskValidationSchema = () =>
       runType: z.enum(["historical", "continuous"], {
         message: "Run Type is required",
       }),
-      // Without listing rowType here, zod's .object() strips it before
-      // the transform runs and the form-state value (set by the
-      // Spans/Traces/Sessions tabs in TaskConfigPanel) is silently
-      // dropped — every payload then defaults to "spans".
+      // Declared so zod's strip doesn't drop the tab-selected value pre-transform.
       rowType: z.enum(["spans", "traces", "sessions", "voiceCalls"]).optional(),
       filters: z
         .array(

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
@@ -4,25 +4,95 @@ import { z } from "zod";
 const RANGE_OPS = new Set(["between", "not_between"]);
 const LIST_OPS = new Set(["in", "not_in"]);
 
+// Maps a form-row `property` to the outer-filters-dict sibling key the
+// BE honors (see `parsing_evaltask_filters` in tracer/utils/eval_tasks.py).
+//
+// `node_type` is the FE-side alias for `observation_type`; the SYSTEM_METRIC
+// handler doesn't translate it (its DEFAULT_FIELD_MAP entry points at the
+// non-existent `node_type` Django field, relying on the caller having
+// annotated `node_type=F("observation_type")` the way list_spans_observe
+// does at observation_span.py:1617). process_eval_task doesn't replicate
+// that annotate, so we route the chip via the BE's direct
+// observation_type sibling branch instead.
+const TOP_LEVEL_SIBLING_KEY_BY_PROPERTY = {
+  observation_type: "observation_type",
+  node_type: "observation_type",
+  session_id: "session_id",
+};
+
+// Column ids the BE always routes via its annotation handler regardless
+// of col_type (filters.py:1711-1755 in get_filter_conditions_for_voice_call_annotations).
+// Forcing col_type=ANNOTATION on the wire keeps the eval-task dispatcher
+// from also feeding the same row to the SPAN_ATTRIBUTE / SYSTEM_METRIC
+// handlers — where it'd otherwise match no rows and poison the AND.
+const ANNOTATION_COLUMN_IDS = new Set(["annotator", "my_annotations"]);
+
+// fieldCategory → col_type fallback. Used when the form row didn't
+// carry an apiColType (e.g. the panel's static system fields at
+// TraceFilterPanel.jsx:1650-1666 don't set one). Mirrors the
+// PANEL_CAT_TO_COL_TYPE in TaskFilterBar.jsx — duplicated here so the
+// wire encoding is correct even if the form-row producer skipped it.
+const FIELD_CATEGORY_TO_COL_TYPE = {
+  attribute: "SPAN_ATTRIBUTE",
+  system: "SYSTEM_METRIC",
+  eval: "EVAL_METRIC",
+  annotation: "ANNOTATION",
+};
+
 // Group multiple form rows for the same (columnId, op) into a single wire
 // entry. Scalar rows for list ops collapse to array `filterValue`; multiple
 // scalar rows for a single-value op (legacy multi-value `equals` from saved
 // tasks) are promoted to `in` so the BE filter validator accepts them.
+//
+// Mirrors `list_spans_observe`'s shape (observation_span.py:1755-1826):
+// every chip — SPAN_ATTRIBUTE, SYSTEM_METRIC, EVAL_METRIC, ANNOTATION,
+// has_eval, has_annotation, annotator — goes into the same flat list with
+// its own `col_type`. The dispatcher fans out per col_type on the BE.
 export const extractAttributeFilters = (filters) => {
   const merged = new Map();
   (filters || [])
-    .filter((f) => f?.property === "attributes")
+    .filter((f) => {
+      if (!f) return false;
+      // Sibling top-level keys (observation_type, node_type → observation_type,
+      // session_id) are emitted separately by `getNewTaskFilters`.
+      if (f.property in TOP_LEVEL_SIBLING_KEY_BY_PROPERTY) return false;
+      // Hydrated legacy rows with no apiColType and no propertyId are
+      // BE no-ops anyway — drop them.
+      if (!f.propertyId && f.property !== "attributes") return false;
+      return true;
+    })
     .forEach((f) => {
-      const columnId = f.propertyId;
+      const columnId = f.propertyId || f.property;
       if (!columnId) return;
       const op = f?.filterConfig?.filterOp || "equals";
       const filterType = f?.filterConfig?.filterType || "text";
       const key = `${columnId}|${op}|${filterType}`;
       if (!merged.has(key)) {
+        // Resolution order:
+        //   1. ANNOTATION_COLUMN_IDS — annotator / my_annotations are
+        //      always ANNOTATION regardless of what the panel said.
+        //   2. row's explicit apiColType (set by TaskFilterBar via
+        //      resolveApiColType — the canonical source).
+        //   3. fieldCategory mapping (covers form rows whose
+        //      apiColType was lost upstream, e.g. when the panel's
+        //      static system fields skipped setting it).
+        //   4. SPAN_ATTRIBUTE default (last resort).
+        let apiColType;
+        if (ANNOTATION_COLUMN_IDS.has(columnId)) {
+          apiColType = "ANNOTATION";
+        } else if (f?.apiColType) {
+          apiColType = f.apiColType;
+        } else if (FIELD_CATEGORY_TO_COL_TYPE[f?.fieldCategory]) {
+          apiColType = FIELD_CATEGORY_TO_COL_TYPE[f.fieldCategory];
+        } else {
+          apiColType = "SPAN_ATTRIBUTE";
+        }
+
         merged.set(key, {
           columnId,
           op,
           filterType,
+          apiColType,
           rangeValue: undefined,
           values: [],
         });
@@ -62,36 +132,43 @@ export const extractAttributeFilters = (filters) => {
       filterConfig: {
         filterType: entry.filterType,
         filterOp,
-        colType: "SPAN_ATTRIBUTE",
+        colType: entry.apiColType,
         ...(filterValue !== undefined && { filterValue }),
       },
     };
   });
 };
 
-export const getNewTaskFilters = (data, projectId, ignoreDate = false) => {
-  const filters = { project_id: projectId?.length ? projectId : null };
-
-  const attributeFilters = extractAttributeFilters(data?.filters);
-
-  // System filters: spread array `filterValue` (from canonical `in`/`not_in`
-  // or `between` rows) into the per-field array so the BE wire stays in the
-  // historical `{ field: [v1, v2, ...] }` shape it expects.
-  data?.filters?.forEach((filter) => {
-    if (filter?.property === "attributes") return;
-    const val = filter?.filterConfig?.filterValue;
+// Extract rows whose property maps to a BE-honored sibling top-level key
+// (observation_type / node_type → observation_type, session_id). Each
+// contributes its values to a flat per-field array on the outer filters
+// dict, with the property renamed to the BE-side key when they differ.
+const extractSiblingFilters = (filters) => {
+  const out = {};
+  (filters || []).forEach((f) => {
+    const beKey = TOP_LEVEL_SIBLING_KEY_BY_PROPERTY[f?.property];
+    if (!beKey) return;
+    const val = f?.filterConfig?.filterValue;
     const vals = Array.isArray(val)
       ? val
       : val !== undefined && val !== null && val !== ""
         ? [val]
         : [];
     if (vals.length === 0) return;
-    if (filter?.property in filters) {
-      filters[filter?.property].push(...vals);
+    if (out[beKey]) {
+      out[beKey].push(...vals);
     } else {
-      filters[filter?.property] = [...vals];
+      out[beKey] = [...vals];
     }
   });
+  return out;
+};
+
+export const getNewTaskFilters = (data, projectId, ignoreDate = false) => {
+  const filters = { project_id: projectId?.length ? projectId : null };
+
+  const attributeFilters = extractAttributeFilters(data?.filters);
+  Object.assign(filters, extractSiblingFilters(data?.filters));
 
   if (data?.runType === "historical" && !ignoreDate) {
     filters["date_range"] = [
@@ -183,7 +260,7 @@ export const NewTaskValidationSchema = () =>
         filters: {
           ...filters,
           ...(attributeFilters && attributeFilters?.length > 0
-            ? { span_attributes_filters: attributeFilters }
+            ? { filters: attributeFilters }
             : {}),
         },
       };

--- a/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
+++ b/frontend/src/sections/common/EvalsTasks/NewTaskDrawer/validation.js
@@ -195,9 +195,7 @@ export const NewTaskValidationSchema = () =>
         .min(1, { message: "At least one evaluation is required" })
         .refine(
           (evals) =>
-            evals.every(
-              (e) => typeof e?.id === "string" && e.id.length > 0,
-            ),
+            evals.every((e) => typeof e?.id === "string" && e.id.length > 0),
           {
             message:
               "Remove the highlighted evaluation(s) and re-add them before continuing.",
@@ -213,20 +211,22 @@ export const NewTaskValidationSchema = () =>
       // the transform runs and the form-state value (set by the
       // Spans/Traces/Sessions tabs in TaskConfigPanel) is silently
       // dropped — every payload then defaults to "spans".
-      rowType: z
-        .enum(["spans", "traces", "sessions", "voiceCalls"])
-        .optional(),
+      rowType: z.enum(["spans", "traces", "sessions", "voiceCalls"]).optional(),
       filters: z
         .array(
           z.object({
             id: z.string().optional(),
             propertyId: z.string().optional(),
             property: z.string().optional(),
+            fieldCategory: z.string().optional(),
+            fieldLabel: z.string().optional(),
+            apiColType: z.string().optional(),
             filterConfig: z
               .object({
                 filterType: z.string().optional(),
                 filterOp: z.any().optional(),
                 filterValue: z.any().optional(),
+                colType: z.string().optional(),
               })
               .optional(),
           }),

--- a/frontend/src/sections/common/EvalsTasks/common.js
+++ b/frontend/src/sections/common/EvalsTasks/common.js
@@ -181,22 +181,23 @@ export const EvalTaskFilterDefinition = (observeId) => {
   return filters;
 };
 
-// span_attributes_filters
-// [
-//     {
-//         "columnId": "llm.output_messages.0.message.content",
-//         "filterConfig": {
-//             "colType": "SPAN_ATTRIBUTE",
-//             "filterOp": "equals",
-//             "filterType": "text",
-//             "filterValue": "asdasdasd"
-//         }
-//     }
-// ]
+// TraceFilterPanel `fieldCategory` → BE col_type enum. Fallback only —
+// the row's `apiColType` (set by TraceFilterPanel via metricToTraceFilterProperty)
+// is the source of truth when present.
+export const FIELD_CATEGORY_TO_COL_TYPE = {
+  attribute: "SPAN_ATTRIBUTE",
+  system: "SYSTEM_METRIC",
+  eval: "EVAL_METRIC",
+  annotation: "ANNOTATION",
+};
 
-// Reserved keys on the saved BE filters dict that are metadata, not
-// user-visible filter rows. Everything else is treated as a generic
-// system filter (one row per value).
+// Column ids the BE always routes through its annotation handler regardless
+// of col_type. Pin them to ANNOTATION on the wire so the dispatcher doesn't
+// also feed them to SPAN_ATTRIBUTE / SYSTEM_METRIC handlers.
+export const ANNOTATION_COLUMN_IDS = new Set(["annotator", "my_annotations"]);
+
+// Reserved metadata keys on the saved BE filters dict — every other key
+// becomes a generic system filter row.
 const RESERVED_FILTER_KEYS = new Set([
   "project_id",
   "date_range",
@@ -206,12 +207,7 @@ const RESERVED_FILTER_KEYS = new Set([
   "span_attributes_filters",
 ]);
 
-// Legacy → current vocabulary aliases. The TraceFilterPanel column
-// for span observation type was renamed from `observation_type` to
-// `span_kind`; old tasks in the DB still use the legacy key, so map
-// it back to the new field on hydration so the filter row appears
-// under the correct column in the UI. Add a new entry here if any
-// other system column is ever renamed.
+// Legacy → current vocabulary aliases for the system-filter hydration path.
 const FILTER_KEY_ALIAS = {
   observation_type: "span_kind",
 };
@@ -219,12 +215,9 @@ const FILTER_KEY_ALIAS = {
 export const formatTaskFilters = (filters_applied) => {
   if (!filters_applied) return [];
 
-  // Attribute filters carry a nested {columnId, filterConfig} shape on
-  // the BE — keep their dedicated converter. Prefer the canonical
-  // `filters` key; fall back to the legacy `span_attributes_filters` so
-  // un-migrated rows still hydrate. `colType` is carried back into
-  // `apiColType` so TaskFilterBar.convertOldToNew can re-route the row
-  // to the right panel chip (annotator picker, eval-score input, ...).
+  // Attribute filters carry a {columnId, filterConfig} shape. Prefer the
+  // canonical `filters` key; fall back to legacy `span_attributes_filters`.
+  // `colType` round-trips as `apiColType` so the panel picks the right chip.
   const span_attributes_filters = (
     filters_applied.filters || filters_applied.span_attributes_filters || []
   ).map((i) => ({
@@ -239,16 +232,9 @@ export const formatTaskFilters = (filters_applied) => {
     },
   }));
 
-  // Every other top-level key is treated as a generic system filter:
-  // one filter row per value. Round-trips arbitrary keys (span_kind,
-  // latency_ms, total_tokens, status_code, …) without each one needing
-  // to be hard-coded here.
-  //
-  // canonicalEntries (not Object.entries) drops the camelCase aliases
-  // the axios interceptor auto-attaches alongside every snake_case
-  // key — without it we'd render duplicate chips like `span_kind` AND
-  // `spanKind`, and the reserved-key skip would miss `projectId` /
-  // `dateRange` because the set only lists the snake_case forms.
+  // Every other top-level key → one generic system-filter row per value.
+  // canonicalEntries skips the camelCase aliases the axios interceptor adds
+  // (avoids duplicate chips + correctly filters reserved keys).
   const systemFilters = [];
   canonicalEntries(filters_applied).forEach(([key, vals]) => {
     if (RESERVED_FILTER_KEYS.has(key)) return;

--- a/frontend/src/sections/common/EvalsTasks/common.js
+++ b/frontend/src/sections/common/EvalsTasks/common.js
@@ -40,8 +40,12 @@ export const getEvalsTaskColumnConfig = (observeId) => {
           );
         }
 
+        // Canonical key is `filters`; `span_attributes_filters` is the
+        // legacy form still present on un-migrated rows.
         const spanAttributes =
-          params?.data?.filters_applied?.span_attributes_filters ?? [];
+          params?.data?.filters_applied?.filters ??
+          params?.data?.filters_applied?.span_attributes_filters ??
+          [];
 
         if (spanAttributes.length > 0) {
           const customAttributeString = `Custom attribute is ${spanAttributes
@@ -198,6 +202,7 @@ const RESERVED_FILTER_KEYS = new Set([
   "date_range",
   "start_date",
   "end_date",
+  "filters",
   "span_attributes_filters",
 ]);
 
@@ -215,17 +220,24 @@ export const formatTaskFilters = (filters_applied) => {
   if (!filters_applied) return [];
 
   // Attribute filters carry a nested {columnId, filterConfig} shape on
-  // the BE — keep their dedicated converter.
-  const span_attributes_filters = (filters_applied.span_attributes_filters || [])
-    .map((i) => ({
-      property: "attributes",
-      propertyId: i?.columnId,
-      filterConfig: {
-        filterType: i?.filterConfig?.filterType,
-        filterOp: i?.filterConfig?.filterOp,
-        filterValue: i?.filterConfig?.filterValue,
-      },
-    }));
+  // the BE — keep their dedicated converter. Prefer the canonical
+  // `filters` key; fall back to the legacy `span_attributes_filters` so
+  // un-migrated rows still hydrate. `colType` is carried back into
+  // `apiColType` so TaskFilterBar.convertOldToNew can re-route the row
+  // to the right panel chip (annotator picker, eval-score input, ...).
+  const span_attributes_filters = (
+    filters_applied.filters || filters_applied.span_attributes_filters || []
+  ).map((i) => ({
+    property: "attributes",
+    propertyId: i?.columnId,
+    apiColType: i?.filterConfig?.colType,
+    filterConfig: {
+      filterType: i?.filterConfig?.filterType,
+      filterOp: i?.filterConfig?.filterOp,
+      filterValue: i?.filterConfig?.filterValue,
+      colType: i?.filterConfig?.colType,
+    },
+  }));
 
   // Every other top-level key is treated as a generic system filter:
   // one filter row per value. Round-trips arbitrary keys (span_kind,

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -398,6 +398,13 @@ function metricToTraceFilterProperty(m) {
   // thumbs labels have two fixed choices — surface them so the value picker
   // renders a multi-select without needing a dashboard lookup.
   const choices = type === "thumbs" ? ["Thumbs Up", "Thumbs Down"] : m.choices;
+  const apiColType = isEval
+    ? "EVAL_METRIC"
+    : isAnnotation
+      ? "ANNOTATION"
+      : m.category === "system_metric" || m.category === "systemMetric"
+        ? "SYSTEM_METRIC"
+        : "SPAN_ATTRIBUTE";
   return {
     id: m.name,
     name: m.displayName || m.display_name || m.name,
@@ -406,6 +413,7 @@ function metricToTraceFilterProperty(m) {
     type,
     outputType,
     choices,
+    apiColType,
   };
 }
 

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -1654,12 +1654,18 @@ const TraceFilterPanel = ({
           name: "Span Name",
           category: "system",
           type: "string",
+          apiColType: "SYSTEM_METRIC",
         };
       }
       return {
         id: f.value,
         name: f.label,
         category: "system",
+        // Pinned so the eval-task wire encoding doesn't have to guess
+        // from `category` alone — without this every static field would
+        // round-trip through the chain with apiColType=undefined and
+        // get coerced to SPAN_ATTRIBUTE downstream.
+        apiColType: "SYSTEM_METRIC",
         type: f.type === "enum" ? "string" : f.type,
         ...(f.choices ? { choices: f.choices } : {}),
       };

--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -469,7 +469,7 @@ export function buildTraceFilterProperties(
   return properties;
 }
 
-function useTraceFilterProperties(
+export function useTraceFilterProperties(
   projectId,
   { enabled = true, isSimulator = false } = {},
 ) {

--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -131,15 +131,9 @@ const TaskDetailPage = () => {
   const handleConfirm = useCallback(
     (editType) => {
       const data = formValues;
-      // extractAttributeFilters now returns every chip (SPAN_ATTRIBUTE,
-      // SYSTEM_METRIC, EVAL_METRIC, ANNOTATION, has_*) as a flat list
-      // with `col_type` (matches list_spans_observe / the new BE
-      // dispatcher). observation_type still rides as a sibling key.
+      // Flat chip list with col_type for the BE dispatcher; observation_type
+      // (incl. node_type alias) still rides as a sibling key.
       const attributeFilters = extractAttributeFilters(data?.filters);
-      // node_type is the FE alias for observation_type — both end up in
-      // the outer `observation_type` sibling key (the BE's SYSTEM_METRIC
-      // handler can't resolve `node_type` against ObservationSpan
-      // directly, but its dedicated observation_type branch can).
       const observationTypes = (data.filters || [])
         .filter(
           (f) => f.property === "observation_type" || f.property === "node_type",

--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -131,12 +131,19 @@ const TaskDetailPage = () => {
   const handleConfirm = useCallback(
     (editType) => {
       const data = formValues;
+      // extractAttributeFilters now returns every chip (SPAN_ATTRIBUTE,
+      // SYSTEM_METRIC, EVAL_METRIC, ANNOTATION, has_*) as a flat list
+      // with `col_type` (matches list_spans_observe / the new BE
+      // dispatcher). observation_type still rides as a sibling key.
       const attributeFilters = extractAttributeFilters(data?.filters);
-      // observation_type rows may now carry an array `filterValue` (canonical
-      // `in`/`not_in`) or a scalar (legacy `equals`). Flatten + drop empties
-      // so the BE always sees a flat list of selected values.
+      // node_type is the FE alias for observation_type — both end up in
+      // the outer `observation_type` sibling key (the BE's SYSTEM_METRIC
+      // handler can't resolve `node_type` against ObservationSpan
+      // directly, but its dedicated observation_type branch can).
       const observationTypes = (data.filters || [])
-        .filter((f) => f.property === "observation_type")
+        .filter(
+          (f) => f.property === "observation_type" || f.property === "node_type",
+        )
         .flatMap((f) => {
           const v = f?.filterConfig?.filterValue;
           if (Array.isArray(v)) return v;
@@ -155,7 +162,7 @@ const TaskDetailPage = () => {
             ? { observation_type: observationTypes }
             : {}),
           ...(attributeFilters?.length > 0
-            ? { span_attributes_filters: attributeFilters }
+            ? { filters: attributeFilters }
             : {}),
         },
         project_id: data.project,

--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -13,36 +13,27 @@ import { getRandomId } from "src/utils/utils";
 import TraceFilterPanel, {
   useTraceFilterProperties,
 } from "src/sections/projects/LLMTracing/TraceFilterPanel";
+import { FIELD_CATEGORY_TO_COL_TYPE } from "src/sections/common/EvalsTasks/common";
+import { useDashboardFilterValues } from "src/hooks/useDashboards";
+import {
+  getPickerOptionLabel,
+  getPickerOptionSecondaryLabel,
+  getPickerOptionValue,
+} from "src/sections/projects/LLMTracing/filterValuePickerUtils";
 
-// ── Operator handling — canonical backend ops ──
-//
-// `TraceFilterPanel` (PR #432 / TH-4924) emits canonical backend op names
-// directly: `equals`, `not_equals`, `in`, `not_in`, `contains`,
-// `not_contains`, `starts_with`, `ends_with`, `is_null`, `is_not_null`,
-// `greater_than`, `greater_than_or_equal`, `less_than`,
-// `less_than_or_equal`, `between`, `not_between`. The thumbs / categorical
-// / id-only dropdowns inside the panel still emit legacy `is`/`is_not` —
-// alias those to canonical so the wire is consistent.
+// Legacy `is`/`is_not` (from thumbs / categorical / id-only dropdowns) →
+// canonical BE ops emitted by TraceFilterPanel everywhere else.
 const LEGACY_OP_ALIAS = { is: "equals", is_not: "not_equals" };
 
 const RANGE_OPS = new Set(["between", "not_between"]);
 const LIST_OPS = new Set(["in", "not_in"]);
 const NO_VALUE_OPS = new Set(["is_null", "is_not_null"]);
 
-// TraceFilterPanel emits `apiColType` directly on each row. When it's
-// missing (legacy rows / hand-built filters), derive from `fieldCategory`.
-const PANEL_CAT_TO_COL_TYPE = {
-  attribute: "SPAN_ATTRIBUTE",
-  system: "SYSTEM_METRIC",
-  eval: "EVAL_METRIC",
-  annotation: "ANNOTATION",
-};
 const resolveApiColType = (apiColType, fieldCategory) =>
-  apiColType || PANEL_CAT_TO_COL_TYPE[fieldCategory] || "SPAN_ATTRIBUTE";
+  apiColType || FIELD_CATEGORY_TO_COL_TYPE[fieldCategory] || "SPAN_ATTRIBUTE";
 
-// Legacy string ops persisted before TH-4924 land in form state as
-// `equals`/`not_equals`. Rewrite to `in`/`not_in` on read so the new
-// panel renders the row under the multi-value picker.
+// Legacy `equals`/`not_equals` on string rows → multi-value `in`/`not_in`
+// on hydration so the new panel renders the multi-select picker.
 const HYDRATE_STRING_OP = { equals: "in", not_equals: "not_in" };
 
 const isStringLike = (fieldType) =>
@@ -88,14 +79,8 @@ const OP_DISPLAY = {
   not_equal_to: "≠",
 };
 
-// ── new panel filter → form filter(s) ──
-//
-// List ops (`in`/`not_in`) carry the full array on a single form row so
-// the wire keeps the BE's canonical shape; range ops carry a 2-element
-// array; no-value ops omit `filterValue`; other ops explode into one
-// scalar row per value so system-filter accumulation keeps working.
-// `fieldCategory` / `fieldLabel` are stashed for the live preview and
-// chip rendering — zod strips them on submit.
+// Panel filter → form row(s). List/range ops keep array `filterValue`;
+// no-value ops drop it; other ops explode into one scalar row per value.
 function convertNewToOld(newFilters) {
   const out = [];
   (newFilters || []).forEach((f) => {
@@ -118,7 +103,6 @@ function convertNewToOld(newFilters) {
       property: isAttribute ? "attributes" : f.field,
       propertyId: f.field,
       fieldCategory: f.fieldCategory || "system",
-      // Panel rows expose the display name as `fieldName`; fall back for legacy callers.
       fieldLabel: f.fieldName || f.fieldLabel || f.field,
       apiColType: resolveApiColType(f.apiColType, f.fieldCategory),
     };
@@ -211,8 +195,7 @@ function convertOldToNew(oldFilters) {
         fieldLabel: f.fieldLabel || field,
         fieldType,
         fieldCategory: category,
-        // Preserved across the round-trip so the panel re-renders the right
-        // chip (annotator picker, eval-score input, ...) on edit-open.
+        // Preserved so the panel re-renders the right chip on edit-open.
         apiColType: resolveApiColType(
           f.apiColType || f?.filterConfig?.colType,
           category,
@@ -311,10 +294,8 @@ FilterChip.propTypes = {
   onRemove: PropTypes.func.isRequired,
 };
 
-// Map task rowType → TraceFilterPanel `tab` so the property picker
-// surfaces Trace ID / Span ID the same way LLM Tracing does. Callers
-// use inconsistent casing ("spans"/"Span", "traces"/"Trace") so we
-// normalize. Sessions / voiceCalls return null (no id fields).
+// Task rowType → TraceFilterPanel `tab`. Sessions / voiceCalls have no
+// id-field tab. Casing is normalized to handle inconsistent callers.
 const rowTypeToFilterTab = (rowType) => {
   const key = String(rowType || "").toLowerCase();
   if (key === "spans" || key === "span") return "spans";
@@ -346,14 +327,46 @@ const TaskFilterBar = ({
     for (const p of properties) map[p.id] = p;
     return map;
   }, [properties]);
+
+  // Resolve annotator user UUIDs → "Name (email)" for chip values.
+  const hasAnnotatorFilter = panelFilters.some((f) => f.field === "annotator");
+  const { data: annotatorOptions = [] } = useDashboardFilterValues({
+    metricName: "annotator",
+    metricType: "annotation_metric",
+    projectIds: projectId ? [projectId] : [],
+    source: "traces",
+    enabled: hasAnnotatorFilter,
+  });
+  const annotatorLabelById = useMemo(() => {
+    const map = {};
+    for (const opt of annotatorOptions) {
+      const value = String(getPickerOptionValue(opt));
+      if (!value) continue;
+      const label = getPickerOptionLabel(opt);
+      const email = getPickerOptionSecondaryLabel(opt);
+      map[value] = email ? `${label} (${email})` : label;
+    }
+    return map;
+  }, [annotatorOptions]);
+
   const enrichedFilters = useMemo(
     () =>
       panelFilters.map((f) => {
-        if (f.fieldName || f.fieldLabel !== f.field) return f;
         const prop = propertyById[f.field];
-        return prop ? { ...f, fieldLabel: prop.name } : f;
+        let next = f;
+        if (!f.fieldName && f.fieldLabel === f.field && prop) {
+          next = { ...next, fieldLabel: prop.name };
+        }
+        if (f.field === "annotator" && Object.keys(annotatorLabelById).length) {
+          const remap = (v) => annotatorLabelById[String(v)] || v;
+          next = {
+            ...next,
+            value: Array.isArray(f.value) ? f.value.map(remap) : remap(f.value),
+          };
+        }
+        return next;
       }),
-    [panelFilters, propertyById],
+    [panelFilters, propertyById, annotatorLabelById],
   );
 
   // Keep local panel state in sync with form filters when they change externally

--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -1,10 +1,18 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import PropTypes from "prop-types";
 import { Box, Button, Typography } from "@mui/material";
 import { useWatch } from "react-hook-form";
 import Iconify from "src/components/iconify";
 import { getRandomId } from "src/utils/utils";
-import TraceFilterPanel from "src/sections/projects/LLMTracing/TraceFilterPanel";
+import TraceFilterPanel, {
+  useTraceFilterProperties,
+} from "src/sections/projects/LLMTracing/TraceFilterPanel";
 
 // ── Operator handling — canonical backend ops ──
 //
@@ -329,6 +337,25 @@ const TaskFilterBar = ({
   );
   const suppressNextSync = useRef(false);
 
+  // Resolve UUID column ids → display names. Shares cache with TraceFilterPanel.
+  const { data: properties = [] } = useTraceFilterProperties(projectId, {
+    isSimulator,
+  });
+  const propertyById = useMemo(() => {
+    const map = {};
+    for (const p of properties) map[p.id] = p;
+    return map;
+  }, [properties]);
+  const enrichedFilters = useMemo(
+    () =>
+      panelFilters.map((f) => {
+        if (f.fieldName || f.fieldLabel !== f.field) return f;
+        const prop = propertyById[f.field];
+        return prop ? { ...f, fieldLabel: prop.name } : f;
+      }),
+    [panelFilters, propertyById],
+  );
+
   // Keep local panel state in sync with form filters when they change externally
   // (e.g. edit mode hydration). Skip the sync right after our own apply.
   useEffect(() => {
@@ -392,7 +419,7 @@ const TaskFilterBar = ({
             flexWrap: "wrap",
           }}
         >
-          {panelFilters.map((f, idx) => (
+          {enrichedFilters.map((f, idx) => (
             <FilterChip
               key={`${f.field}-${idx}`}
               filter={f}

--- a/frontend/src/sections/tasks/components/TaskFilterBar.jsx
+++ b/frontend/src/sections/tasks/components/TaskFilterBar.jsx
@@ -21,6 +21,17 @@ const RANGE_OPS = new Set(["between", "not_between"]);
 const LIST_OPS = new Set(["in", "not_in"]);
 const NO_VALUE_OPS = new Set(["is_null", "is_not_null"]);
 
+// TraceFilterPanel emits `apiColType` directly on each row. When it's
+// missing (legacy rows / hand-built filters), derive from `fieldCategory`.
+const PANEL_CAT_TO_COL_TYPE = {
+  attribute: "SPAN_ATTRIBUTE",
+  system: "SYSTEM_METRIC",
+  eval: "EVAL_METRIC",
+  annotation: "ANNOTATION",
+};
+const resolveApiColType = (apiColType, fieldCategory) =>
+  apiColType || PANEL_CAT_TO_COL_TYPE[fieldCategory] || "SPAN_ATTRIBUTE";
+
 // Legacy string ops persisted before TH-4924 land in form state as
 // `equals`/`not_equals`. Rewrite to `in`/`not_in` on read so the new
 // panel renders the row under the multi-value picker.
@@ -101,6 +112,7 @@ function convertNewToOld(newFilters) {
       fieldCategory: f.fieldCategory || "system",
       // Panel rows expose the display name as `fieldName`; fall back for legacy callers.
       fieldLabel: f.fieldName || f.fieldLabel || f.field,
+      apiColType: resolveApiColType(f.apiColType, f.fieldCategory),
     };
 
     if (NO_VALUE_OPS.has(op)) {
@@ -191,6 +203,12 @@ function convertOldToNew(oldFilters) {
         fieldLabel: f.fieldLabel || field,
         fieldType,
         fieldCategory: category,
+        // Preserved across the round-trip so the panel re-renders the right
+        // chip (annotator picker, eval-score input, ...) on edit-open.
+        apiColType: resolveApiColType(
+          f.apiColType || f?.filterConfig?.colType,
+          category,
+        ),
         operator: op,
         value: [],
       });

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -45,36 +45,20 @@ import {
 } from "src/components/inline-audio/audio-detection";
 import { ID_ONLY_FIELDS } from "src/sections/projects/LLMTracing/idFields";
 import { NULL_OPERATORS } from "src/components/ComplexFilter/common";
+import {
+  ANNOTATION_COLUMN_IDS,
+  FIELD_CATEGORY_TO_COL_TYPE,
+} from "src/sections/common/EvalsTasks/common";
 
 // ───────────────────────────────────────────────────────────────
 // Helpers (ported from TracingTestMode)
 // ───────────────────────────────────────────────────────────────
-// Maps a TraceFilterPanel `fieldCategory` to its BE col_type enum value.
-// Used only as a fallback — the row's `apiColType` is the source of truth
-// when present (set by TaskFilterBar.convertNewToOld from the panel's
-// property metadata).
-const COL_TYPE_MAP = {
-  attribute: "SPAN_ATTRIBUTE",
-  system: "SYSTEM_METRIC",
-  eval: "EVAL_METRIC",
-  annotation: "ANNOTATION",
-};
-
-// Column ids the BE always routes through its annotation handler
-// regardless of col_type. Forcing ANNOTATION on the wire keeps the
-// row from also being picked up by non-annotation handlers (see the
-// matching set in NewTaskDrawer/validation.js).
-const ANNOTATION_COLUMN_IDS = new Set(["annotator", "my_annotations"]);
-
 const RANGE_OPS = new Set(["between", "not_between"]);
 const LIST_OPS = new Set(["in", "not_in"]);
 const NO_VALUE_OPS = new Set(NULL_OPERATORS);
 
-// Form rows from `TaskFilterBar.convertNewToOld` carry scalar `filterValue`
-// for single-value ops and arrays for `in`/`not_in`/`between`/`not_between`.
-// Multiple scalar rows for the same (field, op) need to be merged into one
-// wire entry so the BE `in` validator gets a single array clause instead of
-// N independently-evaluated scalar clauses.
+// Merge multiple scalar rows for the same (field, op) into one wire entry
+// so the BE `in` validator receives a single array clause.
 function mergeRowsByFieldAndOp(rows) {
   const merged = new Map();
   rows.forEach((f) => {
@@ -88,9 +72,6 @@ function mergeRowsByFieldAndOp(rows) {
       merged.set(key, {
         columnId,
         fieldCategory: f.fieldCategory,
-        // Preserved straight from TaskFilterBar.convertNewToOld so the
-        // downstream colType derivation matches the panel's property
-        // metadata (annotator → ANNOTATION, b6a017ba… → EVAL_METRIC, …).
         apiColType: f.apiColType,
         op,
         filterType,
@@ -119,15 +100,11 @@ export function buildApiFilterArray(oldFormatFilters, startDate, endDate) {
   const userFilters = mergeRowsByFieldAndOp(oldFormatFilters || []).map(
     (entry) => {
       const isIdColumn = ID_ONLY_FIELDS.has(entry.columnId);
-      // `apiColType` from the panel is the source of truth; `fieldCategory`
-      // is a UI-side label, and the `isAttribute` boolean only distinguishes
-      // SPAN_ATTRIBUTE from "anything else" — neither can tell EVAL_METRIC
-      // apart from ANNOTATION or SYSTEM_METRIC on its own. Annotation-
-      // special column_ids are pinned to ANNOTATION (see ANNOTATION_COLUMN_IDS).
+      // apiColType is source of truth; fieldCategory/isAttribute are UI hints.
       const colType = ANNOTATION_COLUMN_IDS.has(entry.columnId)
         ? "ANNOTATION"
         : entry.apiColType ||
-          COL_TYPE_MAP[entry.fieldCategory] ||
+          FIELD_CATEGORY_TO_COL_TYPE[entry.fieldCategory] ||
           (entry.isAttribute ? "SPAN_ATTRIBUTE" : "SYSTEM_METRIC");
       let filterValue;
       if (NO_VALUE_OPS.has(entry.op)) {

--- a/frontend/src/sections/tasks/components/TaskLivePreview.jsx
+++ b/frontend/src/sections/tasks/components/TaskLivePreview.jsx
@@ -49,12 +49,22 @@ import { NULL_OPERATORS } from "src/components/ComplexFilter/common";
 // ───────────────────────────────────────────────────────────────
 // Helpers (ported from TracingTestMode)
 // ───────────────────────────────────────────────────────────────
+// Maps a TraceFilterPanel `fieldCategory` to its BE col_type enum value.
+// Used only as a fallback — the row's `apiColType` is the source of truth
+// when present (set by TaskFilterBar.convertNewToOld from the panel's
+// property metadata).
 const COL_TYPE_MAP = {
   attribute: "SPAN_ATTRIBUTE",
   system: "SYSTEM_METRIC",
-  eval: "EVALUATION_METRIC",
+  eval: "EVAL_METRIC",
   annotation: "ANNOTATION",
 };
+
+// Column ids the BE always routes through its annotation handler
+// regardless of col_type. Forcing ANNOTATION on the wire keeps the
+// row from also being picked up by non-annotation handlers (see the
+// matching set in NewTaskDrawer/validation.js).
+const ANNOTATION_COLUMN_IDS = new Set(["annotator", "my_annotations"]);
 
 const RANGE_OPS = new Set(["between", "not_between"]);
 const LIST_OPS = new Set(["in", "not_in"]);
@@ -78,6 +88,10 @@ function mergeRowsByFieldAndOp(rows) {
       merged.set(key, {
         columnId,
         fieldCategory: f.fieldCategory,
+        // Preserved straight from TaskFilterBar.convertNewToOld so the
+        // downstream colType derivation matches the panel's property
+        // metadata (annotator → ANNOTATION, b6a017ba… → EVAL_METRIC, …).
+        apiColType: f.apiColType,
         op,
         filterType,
         isAttribute,
@@ -105,9 +119,16 @@ export function buildApiFilterArray(oldFormatFilters, startDate, endDate) {
   const userFilters = mergeRowsByFieldAndOp(oldFormatFilters || []).map(
     (entry) => {
       const isIdColumn = ID_ONLY_FIELDS.has(entry.columnId);
-      const colType =
-        COL_TYPE_MAP[entry.fieldCategory] ||
-        (entry.isAttribute ? "SPAN_ATTRIBUTE" : "SYSTEM_METRIC");
+      // `apiColType` from the panel is the source of truth; `fieldCategory`
+      // is a UI-side label, and the `isAttribute` boolean only distinguishes
+      // SPAN_ATTRIBUTE from "anything else" — neither can tell EVAL_METRIC
+      // apart from ANNOTATION or SYSTEM_METRIC on its own. Annotation-
+      // special column_ids are pinned to ANNOTATION (see ANNOTATION_COLUMN_IDS).
+      const colType = ANNOTATION_COLUMN_IDS.has(entry.columnId)
+        ? "ANNOTATION"
+        : entry.apiColType ||
+          COL_TYPE_MAP[entry.fieldCategory] ||
+          (entry.isAttribute ? "SPAN_ATTRIBUTE" : "SYSTEM_METRIC");
       let filterValue;
       if (NO_VALUE_OPS.has(entry.op)) {
         filterValue = "";

--- a/futureagi/tracer/migrations/0081_rename_eval_task_filters_key.py
+++ b/futureagi/tracer/migrations/0081_rename_eval_task_filters_key.py
@@ -1,0 +1,103 @@
+"""Rename ``tracer_eval_task.filters['span_attributes_filters']`` → ``filters``.
+
+The inner key historically held the per-item filter list (one entry per filter
+chip). It was named ``span_attributes_filters`` back when only SPAN_ATTRIBUTE
+chips were stored there. The list now carries items of every col_type
+(SPAN_ATTRIBUTE, SYSTEM_METRIC, EVAL_METRIC, ANNOTATION, has_eval, ...) and
+the eval-task dispatcher (``tracer/utils/eval_tasks.py::parsing_evaltask_filters``)
+now mirrors the per-col_type dispatch pattern used by ``list_spans_observe``
+(``tracer/views/observation_span.py:1755-1826``). The new canonical key is just
+``filters`` — aligned with the rest of the API surface.
+
+The BE dispatcher reads both keys during a transition window
+(``parsing_evaltask_filters`` accepts ``filters`` or ``span_attributes_filters``
+with a one-line ``logger.info`` on the legacy path), so this migration is
+cleanup, not a hard cut. After this runs every row uses the canonical key
+and the legacy-key branch goes quiet.
+
+Scope: ``tracer_eval_task`` only. ``tracer_useralertmonitor`` and
+``tracer_savedview`` carry the same shape but are intentionally out of scope
+for this PR — they get the same treatment in a follow-up.
+"""
+
+import logging
+
+from django.db import migrations
+
+logger = logging.getLogger(__name__)
+
+
+def _rename_in_eval_task_filters(apps, stats):
+    EvalTask = apps.get_model("tracer", "EvalTask")
+    for et in EvalTask.objects.iterator(chunk_size=500):
+        try:
+            f = et.filters
+            if not isinstance(f, dict):
+                continue
+            if "span_attributes_filters" not in f:
+                continue
+            # Don't clobber a pre-existing canonical key — if both exist
+            # (shouldn't happen in practice) keep ``filters`` as truth and
+            # drop the legacy key.
+            if "filters" not in f:
+                f["filters"] = f.pop("span_attributes_filters")
+            else:
+                f.pop("span_attributes_filters")
+            et.filters = f
+            et.save(update_fields=["filters"])
+            stats["renamed"] += 1
+        except Exception as e:
+            stats["failed"] += 1
+            logger.exception(
+                f"[rename_eval_task_filters_key] EvalTask id={et.pk} failed: {e}"
+            )
+
+
+def _restore_in_eval_task_filters(apps, stats):
+    """Reverse: rename ``filters`` back to ``span_attributes_filters``."""
+    EvalTask = apps.get_model("tracer", "EvalTask")
+    for et in EvalTask.objects.iterator(chunk_size=500):
+        try:
+            f = et.filters
+            if not isinstance(f, dict):
+                continue
+            if "filters" not in f or "span_attributes_filters" in f:
+                continue
+            f["span_attributes_filters"] = f.pop("filters")
+            et.filters = f
+            et.save(update_fields=["filters"])
+            stats["renamed"] += 1
+        except Exception as e:
+            stats["failed"] += 1
+            logger.exception(
+                f"[rename_eval_task_filters_key] reverse EvalTask id={et.pk} "
+                f"failed: {e}"
+            )
+
+
+def forwards(apps, schema_editor):
+    stats = {"renamed": 0, "failed": 0}
+    _rename_in_eval_task_filters(apps, stats)
+    print(
+        f"[rename_eval_task_filters_key] {stats['renamed']} eval tasks "
+        f"renamed, {stats['failed']} rows skipped due to errors"
+    )
+
+
+def backwards(apps, schema_editor):
+    stats = {"renamed": 0, "failed": 0}
+    _restore_in_eval_task_filters(apps, stats)
+    print(
+        f"[rename_eval_task_filters_key] reverse: {stats['renamed']} "
+        f"eval tasks restored, {stats['failed']} rows skipped"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tracer", "0080_alter_tracescanconfig_sampling_rate"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/futureagi/tracer/tests/integration/__init__.py
+++ b/futureagi/tracer/tests/integration/__init__.py
@@ -1,0 +1,6 @@
+"""Integration tests for eval-task filter parity across list endpoints and the runner.
+
+Each test is parametrized over the FilterCase matrix in _filter_matrix.py.
+List-endpoint tests exercise ClickHouse (CH_ROUTE_* overridden to 'clickhouse').
+Runner tests exercise Postgres ORM via process_eval_task with the eval engine stubbed.
+"""

--- a/futureagi/tracer/tests/integration/_filter_matrix.py
+++ b/futureagi/tracer/tests/integration/_filter_matrix.py
@@ -1,0 +1,419 @@
+"""Cartesian filter matrix for eval-task filter parity tests.
+
+Each FilterCase is uniquely identified by case_id and pairs a filter dict shape
+(matching what FE produces and BE parses in parsing_evaltask_filters) with an
+expected_predicate that, given a SeededRow, returns True iff that row should
+match the filter under BE semantics.
+
+When a new (col_type, filter_type, filter_op) leaf is added to the FE/BE, add
+it here as well — completeness is enforced by test_filter_matrix_completeness.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterator
+
+from tracer.tests.integration._seed import _NOW, SeededRow
+
+TARGET_TYPES = ("spans", "traces", "sessions", "voiceCalls")
+COL_TYPES = (
+    "SYSTEM_METRIC",
+    "SPAN_ATTRIBUTE",
+    "EVAL_METRIC",
+    "ANNOTATION",
+    "has_eval",
+    "has_annotation",
+)
+
+
+@dataclass(frozen=True)
+class FilterCase:
+    case_id: str
+    target_type: str
+    col_type: str
+    filter_type: str
+    filter_op: str
+    column_id: str
+    filter_value: Any
+    expected_predicate: Callable[[SeededRow], bool]
+
+    def to_filter_dict(self) -> dict:
+        """Return the JSON shape parsing_evaltask_filters() expects."""
+        return {
+            "filters": [
+                {
+                    "column_id": self.column_id,
+                    "col_type": self.col_type,
+                    "filter_config": {
+                        "filter_type": self.filter_type,
+                        "filter_op": self.filter_op,
+                        "filter_value": self.filter_value,
+                    },
+                }
+            ],
+        }
+
+
+# ---------- SYSTEM_METRIC leaves (per filter_type × filter_op) ---------------
+
+
+def _sm_number_leaves():
+    """SYSTEM_METRIC × number — column_id 'cost'."""
+    leaves = [
+        ("equals", 0.003, lambda r: r.cost == 0.003),
+        ("not_equals", 0.003, lambda r: r.cost != 0.003),
+        ("greater_than", 0.01, lambda r: r.cost > 0.01),
+        ("less_than", 0.01, lambda r: r.cost < 0.01),
+        ("greater_than_or_equal", 0.003, lambda r: r.cost >= 0.003),
+        ("less_than_or_equal", 0.003, lambda r: r.cost <= 0.003),
+        ("between", [0.002, 0.02], lambda r: 0.002 <= r.cost <= 0.02),
+        ("not_between", [0.002, 0.02], lambda r: not (0.002 <= r.cost <= 0.02)),
+        ("is_null", None, lambda r: r.cost is None),
+        ("is_not_null", None, lambda r: r.cost is not None),
+    ]
+    return [("SYSTEM_METRIC", "number", op, "cost", val, pred) for op, val, pred in leaves]
+
+
+def _sm_text_leaves():
+    leaves = [
+        ("equals", "gpt-4", lambda r: r.model == "gpt-4"),
+        ("not_equals", "gpt-4", lambda r: r.model != "gpt-4"),
+        ("contains", "gpt", lambda r: "gpt" in (r.model or "")),
+        ("in", ["gpt-4", "claude-3-opus"], lambda r: r.model in ("gpt-4", "claude-3-opus")),
+        ("not_in", ["gpt-4"], lambda r: r.model != "gpt-4"),
+    ]
+    return [("SYSTEM_METRIC", "text", op, "model", val, pred) for op, val, pred in leaves]
+
+
+def _sm_datetime_leaves():
+    from datetime import timedelta
+
+    # _NOW = the corpus' base anchor; end = +1 day so the range covers session 0
+    # spans (s_idx=0 → created_at in day 0).
+    end = _NOW + timedelta(days=1)
+    leaves = [
+        (
+            "between",
+            [_NOW.isoformat(), end.isoformat()],
+            lambda r: _NOW <= r.created_at <= end,
+        ),
+        ("greater_than", _NOW.isoformat(), lambda r: r.created_at > _NOW),
+        ("less_than", end.isoformat(), lambda r: r.created_at < end),
+        ("equals", _NOW.isoformat(), lambda r: r.created_at == _NOW),
+    ]
+    return [("SYSTEM_METRIC", "datetime", op, "created_at", val, pred) for op, val, pred in leaves]
+
+
+# ---------- SPAN_ATTRIBUTE leaves --------------------------------------------
+
+
+def _sa_leaves():
+    return [
+        (
+            "SPAN_ATTRIBUTE",
+            "text",
+            "equals",
+            "user_intent",
+            "checkout",
+            lambda r: r.span_attr_str.get("user_intent") == "checkout",
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "text",
+            "contains",
+            "user_intent",
+            "check",
+            lambda r: "check" in r.span_attr_str.get("user_intent", ""),
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "text",
+            "in",
+            "channel",
+            ["web", "voice"],
+            lambda r: r.span_attr_str.get("channel") in ("web", "voice"),
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "number",
+            "greater_than",
+            "retries",
+            1.0,
+            lambda r: r.span_attr_num.get("retries", 0) > 1.0,
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "number",
+            "between",
+            "score",
+            [0.2, 0.35],
+            lambda r: 0.2 <= r.span_attr_num.get("score", 0) <= 0.35,
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "number",
+            "equals",
+            "retries",
+            2.0,
+            lambda r: r.span_attr_num.get("retries") == 2.0,
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "number",
+            "is_null",
+            "missing_attr",
+            None,
+            lambda r: "missing_attr" not in r.span_attr_num,
+        ),
+        (
+            "SPAN_ATTRIBUTE",
+            "boolean",
+            "equals",
+            "premium",
+            True,
+            lambda r: r.span_attr_bool.get("premium") is True,
+        ),
+    ]
+
+
+# ---------- EVAL_METRIC leaves -----------------------------------------------
+
+
+def _em_leaves(eval_config_id: str):
+    # Corpus eval_value ∈ {0.3, 0.6, 0.9}. BE annotates score = output_float * 100
+    # (views/observation_span.py:1659), so filter values are on the 0-100 scale.
+    return [
+        (
+            "EVAL_METRIC",
+            "number",
+            "greater_than",
+            eval_config_id,
+            50,
+            lambda r: r.has_eval and (r.eval_value or 0) * 100 > 50,
+        ),
+        (
+            "EVAL_METRIC",
+            "number",
+            "less_than",
+            eval_config_id,
+            50,
+            lambda r: r.has_eval and (r.eval_value or 0) * 100 < 50,
+        ),
+        (
+            "EVAL_METRIC",
+            "number",
+            "equals",
+            eval_config_id,
+            30,
+            lambda r: r.has_eval and (r.eval_value or 0) * 100 == 30,
+        ),
+        (
+            "EVAL_METRIC",
+            "number",
+            "between",
+            eval_config_id,
+            [40, 70],
+            lambda r: r.has_eval and 40 <= (r.eval_value or 0) * 100 <= 70,
+        ),
+        (
+            "EVAL_METRIC",
+            "boolean",
+            "equals",
+            eval_config_id,
+            True,
+            lambda r: r.has_eval and (r.eval_value or 0) >= 0.5,
+        ),
+    ]
+
+
+# ---------- ANNOTATION leaves ------------------------------------------------
+
+
+def _ann_leaves(label_id: str):
+    # Corpus annotation_value ∈ {0.2, 0.5, 0.8} (one per session).
+    return [
+        (
+            "ANNOTATION",
+            "number",
+            "greater_than",
+            label_id,
+            0.4,
+            lambda r: r.has_annotation and (r.annotation_value or 0) > 0.4,
+        ),
+        (
+            "ANNOTATION",
+            "number",
+            "less_than",
+            label_id,
+            0.4,
+            lambda r: r.has_annotation and (r.annotation_value or 0) < 0.4,
+        ),
+        (
+            "ANNOTATION",
+            "number",
+            "equals",
+            label_id,
+            0.5,
+            lambda r: r.has_annotation and r.annotation_value == 0.5,
+        ),
+        (
+            "ANNOTATION",
+            "number",
+            "between",
+            label_id,
+            [0.3, 0.6],
+            lambda r: r.has_annotation and 0.3 <= (r.annotation_value or 0) <= 0.6,
+        ),
+    ]
+
+
+# ---------- has_eval / has_annotation ----------------------------------------
+
+
+def _meta_leaves():
+    return [
+        ("has_eval", "boolean", "equals", "has_eval", True, lambda r: r.has_eval),
+        ("has_eval", "boolean", "equals", "has_eval", False, lambda r: not r.has_eval),
+        (
+            "has_annotation",
+            "boolean",
+            "equals",
+            "has_annotation",
+            True,
+            lambda r: r.has_annotation,
+        ),
+        (
+            "has_annotation",
+            "boolean",
+            "equals",
+            "has_annotation",
+            False,
+            lambda r: not r.has_annotation,
+        ),
+    ]
+
+
+def _em_choice_leaves(choice_eval_config_id: str):
+    # CHOICE / CHOICES evals: spans seeded with output_str_list=[choice_value]
+    # where choice_value ∈ {"good", "bad", "neutral"} cycled by sp_idx.
+    # Production filter handler routes EVAL_METRIC+array through
+    # _eval_choice_condition (filters.py:1482-1505), which builds
+    # Q(metric_<id>__<value>__score__gt=0). My _build_metric_annotation
+    # exposes str_list_score = {choice: {"score": pct_present}} so the
+    # JSON navigation lines up.
+    return [
+        (
+            "EVAL_METRIC",
+            "array",
+            "contains",
+            choice_eval_config_id,
+            "good",
+            lambda r: r.has_choice_eval and r.choice_value == "good",
+        ),
+        (
+            "EVAL_METRIC",
+            "array",
+            "contains",
+            choice_eval_config_id,
+            "bad",
+            lambda r: r.has_choice_eval and r.choice_value == "bad",
+        ),
+        (
+            "EVAL_METRIC",
+            "array",
+            "contains",
+            choice_eval_config_id,
+            "neutral",
+            lambda r: r.has_choice_eval and r.choice_value == "neutral",
+        ),
+    ]
+
+
+def _all_leaves(eval_config_id: str, label_id: str, choice_eval_config_id: str):
+    return (
+        _sm_number_leaves()
+        + _sm_text_leaves()
+        + _sm_datetime_leaves()
+        + _sa_leaves()
+        + _em_leaves(eval_config_id)
+        + _em_choice_leaves(choice_eval_config_id)
+        + _ann_leaves(label_id)
+        + _meta_leaves()
+    )
+
+
+def _short(s: str) -> str:
+    """Stable suffix for case_id from a column_id (full UUIDs are noisy)."""
+    if "-" in s and len(s) > 16:
+        return s.replace("-", "")[-8:]
+    return s
+
+
+def _wrap_predicate_for_target(span_pred, target_type):
+    """Given a per-span predicate, return a per-span predicate adjusted for the
+    target type. For traces / sessions the aggregation to trace_id / session_id
+    happens in the test harness; here we only need to narrow voiceCalls to root
+    conversation spans."""
+    if target_type == "voiceCalls":
+        return lambda r: (
+            r.observation_type == "conversation"
+            and r.parent_span_id is None
+            and span_pred(r)
+        )
+    return span_pred
+
+
+def all_cases(
+    eval_config_id: str = "00000000-0000-0000-0000-000000000001",
+    label_id: str = "00000000-0000-0000-0000-000000000002",
+    choice_eval_config_id: str = "00000000-0000-0000-0000-000000000003",
+) -> Iterator[FilterCase]:
+    """Yield FilterCases for every (target_type, leaf) combination."""
+    for target_type in TARGET_TYPES:
+        for (
+            col_type,
+            filter_type,
+            filter_op,
+            column_id,
+            filter_value,
+            pred,
+        ) in _all_leaves(eval_config_id, label_id, choice_eval_config_id):
+            adjusted_pred = _wrap_predicate_for_target(pred, target_type)
+            val_suffix = ""
+            if col_type in ("has_eval", "has_annotation"):
+                # Disambiguate the True/False variants in the case_id.
+                val_suffix = f"-{str(filter_value).lower()}"
+            elif filter_type == "array" and isinstance(filter_value, str):
+                # CHOICE leaves share column_id (eval_config_id) and differ
+                # only on filter_value (e.g. "good"/"bad"/"neutral").
+                val_suffix = f"-{filter_value}"
+            case_id = (
+                f"{target_type}-{col_type.lower()}-{filter_type}-"
+                f"{filter_op}-{_short(column_id)}{val_suffix}"
+            )
+            yield FilterCase(
+                case_id=case_id,
+                target_type=target_type,
+                col_type=col_type,
+                filter_type=filter_type,
+                filter_op=filter_op,
+                column_id=column_id,
+                filter_value=filter_value,
+                expected_predicate=adjusted_pred,
+            )
+
+
+def all_cases_for(
+    eval_config_id: str,
+    label_id: str,
+    choice_eval_config_id: str = "00000000-0000-0000-0000-000000000003",
+) -> list[FilterCase]:
+    """Materialized list for parametrize; callers that need the real
+    eval_config_id / label_id pass them through here."""
+    return list(
+        all_cases(
+            eval_config_id=eval_config_id,
+            label_id=label_id,
+            choice_eval_config_id=choice_eval_config_id,
+        )
+    )

--- a/futureagi/tracer/tests/integration/_seed.py
+++ b/futureagi/tracer/tests/integration/_seed.py
@@ -1,0 +1,561 @@
+"""Dual-write seeding helpers for the eval-task filter integration suite.
+
+Every seeded row lands in BOTH Postgres (Django ORM) and ClickHouse (direct INSERT
+into the CDC landing tables; spans_mv repopulates the denormalized `spans` table).
+The base corpus is a fixed 24-row span set across 6 traces and 3 sessions, with
+distinct values for every column the FilterCase matrix can filter on.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from tracer.models.observation_span import (
+    EvalLogger,
+    EvalTargetType,
+    ObservationSpan,
+)
+from tracer.models.trace import Trace
+from tracer.models.trace_session import TraceSession
+
+# ---------- Base corpus shape ------------------------------------------------
+
+# 3 sessions × 2 traces/session × 4 spans/trace = 24 spans.
+# Each session's first trace's first span is a root conversation span (voice call).
+# Each session has one "high cost" trace and one "low cost" trace.
+
+_NOW = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+_MODELS = ["gpt-4", "gpt-3.5-turbo", "claude-3-opus"]
+_PROVIDERS = ["openai", "openai", "anthropic"]
+CHOICE_OPTIONS = ["good", "bad", "neutral"]
+
+
+@dataclass
+class SeededRow:
+    span_id: str
+    trace_id: str
+    session_id: str
+    project_id: str
+    observation_type: str
+    parent_span_id: str | None
+    model: str
+    provider: str
+    status: str
+    cost: float
+    latency_ms: int
+    total_tokens: int
+    prompt_tokens: int
+    completion_tokens: int
+    created_at: datetime
+    span_attr_str: dict[str, str]
+    span_attr_num: dict[str, float]
+    span_attr_bool: dict[str, bool]
+    has_eval: bool
+    eval_value: float | None
+    has_annotation: bool
+    annotation_value: float | None
+    has_choice_eval: bool
+    choice_value: str | None
+
+
+@dataclass
+class DualWriter:
+    ch: Any  # clickhouse_connect Client
+    ch_database: str
+    seeded: list[SeededRow] = field(default_factory=list)
+
+    # Lazily-allocated when first eval / annotation row is seeded; the matrix
+    # uses these to target EVAL_METRIC / ANNOTATION cases.
+    _eval_config_id: uuid.UUID | None = None
+    _annotation_label_id: uuid.UUID | None = None
+    _choice_eval_config_id: uuid.UUID | None = None
+
+    @property
+    def eval_config_id(self) -> str:
+        return str(self._eval_config_id) if self._eval_config_id else ""
+
+    @property
+    def annotation_label_id(self) -> str:
+        return str(self._annotation_label_id) if self._annotation_label_id else ""
+
+    @property
+    def choice_eval_config_id(self) -> str:
+        return str(self._choice_eval_config_id) if self._choice_eval_config_id else ""
+
+    # ------- public ---------------------------------------------------------
+
+    def seed_base_corpus(self, project) -> dict:
+        """Dual-write the 24-span corpus. Returns counts dict."""
+        # Materialize the eval template + label up front so PG row inserts
+        # have valid FKs.
+        eval_template = self._get_or_create_eval_template(project)
+        eval_config = self._get_or_create_eval_config(project, eval_template)
+        choice_template = self._get_or_create_choice_eval_template(project)
+        choice_eval_config = self._get_or_create_choice_eval_config(
+            project, choice_template
+        )
+        annotation_label = self._get_or_create_annotation_label(project)
+        self._eval_config_id = eval_config.id
+        self._choice_eval_config_id = choice_eval_config.id
+        self._annotation_label_id = annotation_label.id
+
+        rows: list[SeededRow] = []
+        sessions = []
+        for s_idx in range(3):
+            sess = TraceSession.objects.create(
+                id=uuid.uuid4(), project=project, name=f"session_{s_idx}"
+            )
+            sessions.append(sess)
+            self._insert_session_ch(sess)
+            for t_idx in range(2):
+                trace = Trace.objects.create(
+                    id=uuid.uuid4(),
+                    project=project,
+                    session=sess,
+                    name=f"trace_s{s_idx}_t{t_idx}",
+                )
+                self._insert_trace_ch(trace)
+                for sp_idx in range(4):
+                    row = self._build_row(project, trace, sess, s_idx, t_idx, sp_idx)
+                    self._insert_span_pg(row, trace, project)
+                    self._insert_span_ch(row)
+                    if row.has_eval:
+                        self._insert_eval_pg_ch(row, trace, eval_config)
+                    if row.has_choice_eval:
+                        self._insert_choice_eval_pg_ch(row, trace, choice_eval_config)
+                    if row.has_annotation:
+                        self._insert_annotation_pg_ch(
+                            row, trace, project, annotation_label
+                        )
+                    rows.append(row)
+        self.seeded = rows
+        # spans_mv is non-refreshable; INSERT INTO tracer_observation_span fires
+        # the MV write to ``spans`` synchronously. OPTIMIZE FINAL eliminates
+        # any ReplicatedReplacingMergeTree merge lag before the test reads.
+        try:
+            self.ch.command(f"OPTIMIZE TABLE {self.ch_database}.spans FINAL")
+        except Exception:
+            pass
+        return {
+            "span_count": len(rows),
+            "session_count": len(sessions),
+            "trace_count": len(sessions) * 2,
+        }
+
+    # ------- row construction ----------------------------------------------
+
+    def _build_row(self, project, trace, sess, s_idx, t_idx, sp_idx) -> SeededRow:
+        is_voice_root = (sp_idx == 0 and t_idx == 0)
+        is_root = (sp_idx == 0)
+        parent = None if is_root else f"span_root_{trace.id.hex[:12]}"
+        observation_type = (
+            "conversation" if is_voice_root else ("llm" if sp_idx > 0 else "chain")
+        )
+        model = _MODELS[s_idx]
+        provider = _PROVIDERS[s_idx]
+        status = "ERROR" if (s_idx == 2 and sp_idx == 3) else "OK"
+        cost = 0.001 * (s_idx + 1) * (t_idx + 1) * (sp_idx + 1)
+        latency_ms = 100 * (sp_idx + 1) + 50 * t_idx
+        total_tokens = 10 * (sp_idx + 1)
+        created_at = _NOW + timedelta(days=s_idx, hours=t_idx, minutes=sp_idx)
+        span_attr_str = {
+            "user_intent": "checkout" if sp_idx % 2 == 0 else "browse",
+            "channel": ["web", "mobile", "voice"][s_idx],
+        }
+        span_attr_num = {"retries": float(sp_idx), "score": 0.1 * (sp_idx + 1)}
+        span_attr_bool = {"premium": (s_idx == 0)}
+        # Eval: spans at sp_idx ∈ {1,2,3} all get an eval, with three distinct
+        # values so range filters (lt / gt / between) have real boundaries.
+        _EVAL_VALUE_BY_SP_IDX = {1: 0.3, 2: 0.6, 3: 0.9}
+        has_eval = sp_idx in _EVAL_VALUE_BY_SP_IDX
+        eval_value = _EVAL_VALUE_BY_SP_IDX.get(sp_idx)
+        # Annotation: 6 spans (sp_idx=2 across both traces of all sessions),
+        # values 0.2/0.5/0.8 cycled by s_idx for non-trivial range coverage.
+        _ANNOTATION_VALUE_BY_S_IDX = {0: 0.2, 1: 0.5, 2: 0.8}
+        has_annotation = (sp_idx == 2)
+        annotation_value = (
+            _ANNOTATION_VALUE_BY_S_IDX.get(s_idx) if has_annotation else None
+        )
+        # CHOICE eval: same 18 spans as float eval (sp_idx ∈ {1,2,3}),
+        # choice_value cycled by sp_idx so each option discriminates 6 spans.
+        _CHOICE_BY_SP_IDX = {1: "good", 2: "bad", 3: "neutral"}
+        has_choice_eval = sp_idx in _CHOICE_BY_SP_IDX
+        choice_value = _CHOICE_BY_SP_IDX.get(sp_idx)
+
+        span_id = (
+            f"span_root_{trace.id.hex[:12]}"
+            if is_root
+            else f"span_{uuid.uuid4().hex[:16]}"
+        )
+        return SeededRow(
+            span_id=span_id,
+            trace_id=str(trace.id),
+            session_id=str(sess.id),
+            project_id=str(project.id),
+            observation_type=observation_type,
+            parent_span_id=parent,
+            model=model,
+            provider=provider,
+            status=status,
+            cost=cost,
+            latency_ms=latency_ms,
+            total_tokens=total_tokens,
+            prompt_tokens=total_tokens // 2,
+            completion_tokens=total_tokens // 2,
+            created_at=created_at,
+            span_attr_str=span_attr_str,
+            span_attr_num=span_attr_num,
+            span_attr_bool=span_attr_bool,
+            has_eval=has_eval,
+            eval_value=eval_value,
+            has_annotation=has_annotation,
+            annotation_value=annotation_value,
+            has_choice_eval=has_choice_eval,
+            choice_value=choice_value,
+        )
+
+    # ------- PG insert helpers ---------------------------------------------
+
+    def _get_or_create_eval_template(self, project):
+        from model_hub.models.evals_metric import EvalTemplate
+
+        template, _ = EvalTemplate.objects.get_or_create(
+            name=f"int_test_template_{project.id}",
+            organization=project.organization,
+            workspace=project.workspace,
+            defaults={
+                "description": "integration test template",
+                "config": {"type": "pass_fail", "criteria": "x"},
+            },
+        )
+        return template
+
+    def _get_or_create_choice_eval_template(self, project):
+        from model_hub.models.evals_metric import EvalTemplate
+
+        template, _ = EvalTemplate.objects.get_or_create(
+            name=f"int_test_choice_template_{project.id}",
+            organization=project.organization,
+            workspace=project.workspace,
+            defaults={
+                "description": "integration test CHOICE template",
+                "config": {"type": "choice", "criteria": "x", "output": "CHOICE"},
+                "choices": CHOICE_OPTIONS,
+            },
+        )
+        return template
+
+    def _get_or_create_choice_eval_config(self, project, eval_template):
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        cfg, _ = CustomEvalConfig.objects.get_or_create(
+            project=project,
+            name=f"int_test_choice_cfg_{project.id}",
+            defaults={
+                "eval_template": eval_template,
+                "config": {"output": "CHOICE", "choices": CHOICE_OPTIONS},
+                "mapping": {"input": "input", "output": "output"},
+                "filters": {},
+            },
+        )
+        return cfg
+
+    def _get_or_create_eval_config(self, project, eval_template):
+        from tracer.models.custom_eval_config import CustomEvalConfig
+
+        cfg, _ = CustomEvalConfig.objects.get_or_create(
+            project=project,
+            name=f"int_test_eval_cfg_{project.id}",
+            defaults={
+                "eval_template": eval_template,
+                "config": {"threshold": 0.5},
+                "mapping": {"input": "input", "output": "output"},
+                "filters": {},
+            },
+        )
+        return cfg
+
+    def _get_or_create_annotation_label(self, project):
+        from model_hub.models.choices import AnnotationTypeChoices
+        from model_hub.models.develop_annotations import AnnotationsLabels
+
+        label, _ = AnnotationsLabels.objects.get_or_create(
+            name=f"int_test_label_{project.id}",
+            type=AnnotationTypeChoices.NUMERIC.value,
+            organization=project.organization,
+            workspace=project.workspace,
+            project=project,
+            defaults={
+                "settings": {
+                    "min": 0,
+                    "max": 1,
+                    "step_size": 0.1,
+                    "display_type": "slider",
+                },
+            },
+        )
+        return label
+
+    def _insert_span_pg(self, row: SeededRow, trace, project) -> None:
+        attrs = {
+            **{k: v for k, v in row.span_attr_str.items()},
+            **{k: v for k, v in row.span_attr_num.items()},
+            **{k: v for k, v in row.span_attr_bool.items()},
+        }
+        ObservationSpan.objects.create(
+            id=row.span_id,
+            project=project,
+            trace=trace,
+            name=row.span_id,
+            observation_type=row.observation_type,
+            status=row.status,
+            parent_span_id=row.parent_span_id,
+            start_time=row.created_at,
+            end_time=row.created_at + timedelta(milliseconds=row.latency_ms),
+            latency_ms=row.latency_ms,
+            model=row.model,
+            provider=row.provider,
+            prompt_tokens=row.prompt_tokens,
+            completion_tokens=row.completion_tokens,
+            total_tokens=row.total_tokens,
+            cost=row.cost,
+            span_attributes=attrs,
+        )
+        # BaseModel.created_at is auto_now_add — override post-create.
+        ObservationSpan.objects.filter(id=row.span_id).update(
+            created_at=row.created_at
+        )
+
+    def _insert_span_ch(self, row: SeededRow) -> None:
+        attrs_json = json.dumps(
+            {
+                **row.span_attr_str,
+                **row.span_attr_num,
+                **{k: bool(v) for k, v in row.span_attr_bool.items()},
+            }
+        ).replace("'", "''")
+        parent_sql = f"'{row.parent_span_id}'" if row.parent_span_id else "NULL"
+        start = row.created_at.strftime("%Y-%m-%d %H:%M:%S")
+        end = (row.created_at + timedelta(milliseconds=row.latency_ms)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        self.ch.command(
+            f"""
+            INSERT INTO {self.ch_database}.tracer_observation_span
+              (id, trace_id, project_id, name, observation_type, status,
+               parent_span_id, start_time, end_time, latency_ms, model, provider,
+               prompt_tokens, completion_tokens, total_tokens, cost,
+               input, output, span_attributes, resource_attributes,
+               metadata, tags, span_events, created_at, updated_at,
+               _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            VALUES
+              ('{row.span_id}', '{row.trace_id}', '{row.project_id}',
+               '{row.span_id}', '{row.observation_type}', '{row.status}',
+               {parent_sql},
+               '{start}', '{end}',
+               {row.latency_ms}, '{row.model}', '{row.provider}',
+               {row.prompt_tokens}, {row.completion_tokens}, {row.total_tokens}, {row.cost},
+               '', '', '{attrs_json}', '{{}}',
+               '{{}}', '[]', '[]',
+               '{start}', '{start}',
+               now64(), 0, 1)
+            """
+        )
+
+    def _insert_trace_ch(self, trace) -> None:
+        sess_sql = f"'{trace.session_id}'" if trace.session_id else "NULL"
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        self.ch.command(
+            f"""
+            INSERT INTO {self.ch_database}.tracer_trace
+              (id, project_id, name, session_id, external_id, tags,
+               metadata, input, output, error,
+               created_at, updated_at,
+               _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            VALUES
+              ('{trace.id}', '{trace.project_id}', '{trace.name}',
+               {sess_sql}, '', '[]',
+               '{{}}', '{{}}', '{{}}', '{{}}',
+               '{now}', '{now}',
+               now64(), 0, 1)
+            """
+        )
+
+    def _insert_session_ch(self, sess) -> None:
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        self.ch.command(
+            f"""
+            INSERT INTO {self.ch_database}.trace_session
+              (id, project_id, name,
+               created_at, updated_at,
+               _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            VALUES
+              ('{sess.id}', '{sess.project_id}', '{sess.name}',
+               '{now}', '{now}',
+               now64(), 0, 1)
+            """
+        )
+
+    def _insert_eval_pg_ch(self, row: SeededRow, trace, eval_config) -> None:
+        # Span-level eval row mirrors what process_eval_task would create
+        # (target_type=SPAN, FK to span + trace).
+        EvalLogger.objects.create(
+            id=uuid.uuid4(),
+            observation_span_id=row.span_id,
+            trace=trace,
+            custom_eval_config=eval_config,
+            target_type=EvalTargetType.SPAN,
+            output_float=row.eval_value,
+            output_bool=(row.eval_value or 0) >= 0.5,
+        )
+        ch_id = uuid.uuid4()
+        created = row.created_at.strftime("%Y-%m-%d %H:%M:%S")
+        self.ch.command(
+            f"""
+            INSERT INTO {self.ch_database}.tracer_eval_logger
+              (id, observation_span_id, trace_id,
+               custom_eval_config_id, target_type,
+               output_float, output_bool, eval_task_id,
+               created_at, updated_at,
+               _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            VALUES
+              ('{ch_id}', '{row.span_id}', '{row.trace_id}',
+               '{eval_config.id}', 'span',
+               {row.eval_value}, {int((row.eval_value or 0) >= 0.5)}, NULL,
+               '{created}', '{created}',
+               now64(), 0, 1)
+            """
+        )
+
+    def _insert_choice_eval_pg_ch(self, row: SeededRow, trace, eval_config) -> None:
+        # CHOICE-type EvalLogger: output_str_list set, output_float/_bool null.
+        # The `When(output_str_list__isnull=False, ...)` branch of the metric
+        # annotation requires the null shape to dispatch correctly.
+        EvalLogger.objects.create(
+            id=uuid.uuid4(),
+            observation_span_id=row.span_id,
+            trace=trace,
+            custom_eval_config=eval_config,
+            target_type=EvalTargetType.SPAN,
+            output_str_list=[row.choice_value],
+        )
+        ch_id = uuid.uuid4()
+        created = row.created_at.strftime("%Y-%m-%d %H:%M:%S")
+        # CH expects output_str_list as a JSON string ("[\"good\"]").
+        choice_json = json.dumps([row.choice_value])
+        self.ch.command(
+            f"""
+            INSERT INTO {self.ch_database}.tracer_eval_logger
+              (id, observation_span_id, trace_id,
+               custom_eval_config_id, target_type,
+               output_str_list, eval_task_id,
+               created_at, updated_at,
+               _peerdb_synced_at, _peerdb_is_deleted, _peerdb_version)
+            VALUES
+              ('{ch_id}', '{row.span_id}', '{row.trace_id}',
+               '{eval_config.id}', 'span',
+               '{choice_json}', NULL,
+               '{created}', '{created}',
+               now64(), 0, 1)
+            """
+        )
+
+    def _insert_annotation_pg_ch(
+        self, row: SeededRow, trace, project, annotation_label
+    ) -> None:
+        """Create the per-row Score and mirror to CH.
+
+        Only the PG-side Score is required for the eval-task runner
+        (process_eval_task's per-label annotate subquery reads model_hub.Score).
+        The CH-side mirror is a best-effort: the list endpoints' annotation
+        filter path is exercised against the CH copy.
+        """
+        from model_hub.models.choices import QueueItemSourceType, ScoreSource
+        from model_hub.models.score import Score
+
+        # Per-row distinct annotator user to dodge the unique constraint on
+        # (observation_span, label, annotator) when the same label is reused.
+        # NULL annotator is also fine here since we only have one row per
+        # (span, label) but make it explicit.
+        Score.objects.create(
+            source_type=QueueItemSourceType.OBSERVATION_SPAN.value,
+            observation_span_id=row.span_id,
+            label=annotation_label,
+            value={"value": row.annotation_value},
+            organization=project.organization,
+            workspace=project.workspace,
+            score_source=ScoreSource.HUMAN.value,
+        )
+        # CH mirror is informational only — the list endpoints' annotation
+        # path in CH doesn't currently consume this in the SpanListQueryBuilder
+        # the way PG does. Skipped to avoid coupling tests to a CH schema we
+        # don't drive.
+
+    # ------- voice corpus ---------------------------------------------------
+
+    def seed_voice_corpus(self, project) -> dict:
+        """Seed 24 voice-call root spans (observation_type='conversation',
+        parent_span_id=NULL) into ``project``. Each call is its own trace;
+        per-span attribute variation matches the base corpus so the same
+        FilterCase predicates discriminate identically."""
+        eval_template = self._get_or_create_eval_template(project)
+        eval_config = self._get_or_create_eval_config(project, eval_template)
+        choice_template = self._get_or_create_choice_eval_template(project)
+        choice_eval_config = self._get_or_create_choice_eval_config(
+            project, choice_template
+        )
+        annotation_label = self._get_or_create_annotation_label(project)
+        self._eval_config_id = eval_config.id
+        self._choice_eval_config_id = choice_eval_config.id
+        self._annotation_label_id = annotation_label.id
+
+        rows: list[SeededRow] = []
+        sess = TraceSession.objects.create(
+            id=uuid.uuid4(), project=project, name="voice_session"
+        )
+        self._insert_session_ch(sess)
+
+        for i in range(24):
+            # Mirror base corpus variation axes (3 × 2 × 4 = 24 cells).
+            s_idx = i // 8
+            t_idx = (i // 4) % 2
+            sp_idx = i % 4
+
+            trace = Trace.objects.create(
+                id=uuid.uuid4(),
+                project=project,
+                session=sess,
+                name=f"voice_call_{i}",
+            )
+            self._insert_trace_ch(trace)
+
+            row = self._build_row(project, trace, sess, s_idx, t_idx, sp_idx)
+            # Force voice-call shape.
+            row.observation_type = "conversation"
+            row.parent_span_id = None
+
+            self._insert_span_pg(row, trace, project)
+            self._insert_span_ch(row)
+            if row.has_eval:
+                self._insert_eval_pg_ch(row, trace, eval_config)
+            if row.has_choice_eval:
+                self._insert_choice_eval_pg_ch(row, trace, choice_eval_config)
+            if row.has_annotation:
+                self._insert_annotation_pg_ch(row, trace, project, annotation_label)
+            rows.append(row)
+
+        self.seeded = rows
+        try:
+            self.ch.command(f"OPTIMIZE TABLE {self.ch_database}.spans FINAL")
+        except Exception:
+            pass
+        return {"span_count": len(rows), "session_count": 1, "trace_count": 24}
+
+    # ------- accessors ------------------------------------------------------
+
+    def expected_predicate_count(self, predicate) -> int:
+        """Convenience for tests: count rows matching a per-row predicate."""
+        return sum(1 for r in self.seeded if predicate(r))

--- a/futureagi/tracer/tests/integration/conftest.py
+++ b/futureagi/tracer/tests/integration/conftest.py
@@ -1,0 +1,386 @@
+"""Integration suite fixtures (sub-package scoped).
+
+These do not leak into the parent ``tracer/tests/`` namespace — only tests
+collected from ``futureagi/tracer/tests/integration/`` resolve these fixtures.
+"""
+import os
+import uuid
+
+import pytest
+from django.conf import settings
+from django.test import override_settings
+
+_CH_TABLES_TO_TRUNCATE = [
+    "tracer_observation_span",
+    "tracer_trace",
+    "trace_session",
+    "tracer_eval_logger",
+    "spans",  # MV target; truncate to keep cross-test isolation
+]
+
+
+class _CHDriverAdapter:
+    """Adapter around clickhouse_driver.Client exposing a ``command(sql, ...)``
+    surface matching clickhouse_connect.
+
+    The repo ships ``clickhouse-driver`` (native protocol, port 19000); the
+    plan was written against ``clickhouse-connect`` (HTTP, port 18123) which
+    isn't a runtime dep. Adapting here keeps the seeder generic without
+    requiring a new dependency.
+    """
+
+    def __init__(self, native_client):
+        self._client = native_client
+
+    def command(self, sql, *args, **kwargs):
+        rows = self._client.execute(sql)
+        # Mirror clickhouse_connect.command: scalar -> scalar, otherwise rows.
+        if isinstance(rows, list) and len(rows) == 1 and len(rows[0]) == 1:
+            return rows[0][0]
+        return rows
+
+    def query(self, sql, *args, **kwargs):
+        # Best-effort match for clickhouse_connect.query — returns rows list.
+        # Used by smoke tests; production callers don't rely on the object
+        # shape returned here.
+        rows = self._client.execute(sql)
+
+        class _R:
+            def __init__(self, data):
+                self.result_rows = data
+                self.data = data
+
+        return _R(rows)
+
+
+@pytest.fixture(scope="session")
+def ch_client():
+    """Client to the test ClickHouse container (native protocol, port 19000).
+
+    The wrapper exposes a ``.command()`` method so the rest of the suite can
+    pretend it's talking to the clickhouse_connect HTTP client.
+    """
+    try:
+        from clickhouse_driver import Client
+    except ImportError:
+        pytest.skip("clickhouse-driver not installed")
+    ch = settings.CLICKHOUSE
+    try:
+        native = Client(
+            host=ch.get("CH_HOST", "localhost"),
+            port=int(os.environ.get("CH_PORT", ch.get("CH_PORT", "19000"))),
+            user=ch.get("CH_USERNAME", "default"),
+            password=ch.get("CH_PASSWORD", ""),
+        )
+        native.execute("SELECT 1")
+        return _CHDriverAdapter(native)
+    except Exception as exc:
+        pytest.skip(f"ClickHouse not reachable for integration tests: {exc}")
+
+
+@pytest.fixture(scope="session")
+def ch_schema(ch_client):
+    """Apply schema DDL once per session. Targets the database in settings.CLICKHOUSE['CH_DATABASE']."""
+    from tracer.services.clickhouse.schema import get_all_schema_ddl
+
+    db = settings.CLICKHOUSE["CH_DATABASE"]
+    ch_client.command(f"CREATE DATABASE IF NOT EXISTS {db}")
+    # Switch session default DB so unqualified table refs in the DDL resolve.
+    try:
+        ch_client.command(f"USE {db}")
+    except Exception:
+        pass
+    for name, ddl in get_all_schema_ddl():
+        rewritten = ddl.replace("futureagi.", f"{db}.")
+        try:
+            ch_client.command(rewritten)
+        except Exception:
+            # idempotent — table/view already exists from a previous session,
+            # or DDL refers to dependencies that don't materialize here.
+            pass
+    return ch_client
+
+
+@pytest.fixture
+def clean_ch(ch_schema):
+    """Truncate CH tables before AND after the test so cross-test state never leaks."""
+    db = settings.CLICKHOUSE["CH_DATABASE"]
+    for tbl in _CH_TABLES_TO_TRUNCATE:
+        try:
+            ch_schema.command(f"TRUNCATE TABLE {db}.{tbl}")
+        except Exception:
+            pass
+    yield ch_schema
+    for tbl in _CH_TABLES_TO_TRUNCATE:
+        try:
+            ch_schema.command(f"TRUNCATE TABLE {db}.{tbl}")
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def ch_routes_on():
+    """Override CH route settings so list endpoints hit ClickHouse, not Postgres.
+
+    ``CH_ENABLED=True`` is required because ``is_clickhouse_enabled()`` short-
+    circuits to False otherwise. We also force-reset the lazily-cached
+    ``_clickhouse_client`` so the new connection settings (CH_HOST=localhost,
+    CH_PORT=19000) take effect — production tooling caches a module-level
+    client that may be misconfigured if Django apps initialized before this
+    test process picked up the right env vars.
+    """
+    routes = {
+        **settings.CLICKHOUSE,
+        "CH_HOST": os.environ.get("CH_HOST", "localhost"),
+        "CH_PORT": os.environ.get("CH_PORT", "19000"),
+        "CH_USERNAME": os.environ.get("CH_USERNAME", "default"),
+        "CH_PASSWORD": os.environ.get("CH_PASSWORD", ""),
+        "CH_DATABASE": os.environ.get("CH_DATABASE", "test_tfc"),
+        "CH_ENABLED": True,
+        "CH_ROUTE_SPAN_LIST": "clickhouse",
+        "CH_ROUTE_TRACE_LIST": "clickhouse",
+        "CH_ROUTE_TRACE_OF_SESSION_LIST": "clickhouse",
+        "CH_ROUTE_SESSION_LIST": "clickhouse",
+        "CH_ROUTE_VOICE_CALL_LIST": "clickhouse",
+        "CH_SHADOW_MODE": False,
+    }
+    from tracer.services.clickhouse import client as ch_client_module
+
+    prior_client = ch_client_module._clickhouse_client
+    ch_client_module._clickhouse_client = None
+    try:
+        with override_settings(CLICKHOUSE=routes):
+            yield
+    finally:
+        # Drop any test-scoped client so the next test reads fresh settings.
+        ch_client_module._clickhouse_client = prior_client
+
+
+@pytest.fixture
+def dual_writer(clean_ch, db):
+    """Per-test seeder — retained for the smoke test only; real suites use
+    ``seeded_corpus`` (session-scoped)."""
+    from tracer.tests.integration._seed import DualWriter
+
+    return DualWriter(ch=clean_ch, ch_database=settings.CLICKHOUSE["CH_DATABASE"])
+
+
+@pytest.fixture(scope="session")
+def integration_setup(django_db_setup, django_db_blocker, ch_schema):
+    """Session-scoped: commit org/user/workspace/project + seed corpus once,
+    outside the per-test transaction. Returns SimpleNamespace."""
+    from types import SimpleNamespace
+
+    from accounts.models.organization import Organization
+    from accounts.models.organization_membership import OrganizationMembership
+    from accounts.models.user import User
+    from accounts.models.workspace import Workspace, WorkspaceMembership
+    from model_hub.models.ai_model import AIModel
+    from tfc.constants.levels import Level
+    from tfc.constants.roles import OrganizationRoles
+    from tfc.middleware.workspace_context import (
+        clear_workspace_context,
+        set_workspace_context,
+    )
+    from tracer.models.project import Project
+    from tracer.tests.integration._seed import DualWriter
+
+    db_name = settings.CLICKHOUSE["CH_DATABASE"]
+
+    # Fresh CH state at session start.
+    for tbl in _CH_TABLES_TO_TRUNCATE:
+        try:
+            ch_schema.command(f"TRUNCATE TABLE {db_name}.{tbl}")
+        except Exception:
+            pass
+
+    with django_db_blocker.unblock():
+        clear_workspace_context()
+        org = Organization.objects.create(
+            name=f"int_test_org_{uuid.uuid4().hex[:8]}"
+        )
+        set_workspace_context(organization=org)
+        user = User.objects.create_user(
+            email=f"integration-{uuid.uuid4().hex[:8]}@futureagi.com",
+            password="testpassword123",
+            name="Integration Test User",
+            organization=org,
+            organization_role=OrganizationRoles.OWNER,
+        )
+        OrganizationMembership.no_workspace_objects.get_or_create(
+            user=user,
+            organization=org,
+            defaults={
+                "role": OrganizationRoles.OWNER,
+                "level": Level.OWNER,
+                "is_active": True,
+            },
+        )
+        ws = Workspace.objects.create(
+            name="Integration Test Workspace",
+            organization=org,
+            is_default=True,
+            is_active=True,
+            created_by=user,
+        )
+        org_membership = OrganizationMembership.no_workspace_objects.get(
+            user=user, organization=org
+        )
+        WorkspaceMembership.no_workspace_objects.get_or_create(
+            user=user,
+            workspace=ws,
+            defaults={
+                "role": "Workspace Owner",
+                "level": Level.OWNER,
+                "is_active": True,
+                "organization_membership": org_membership,
+            },
+        )
+        set_workspace_context(workspace=ws, organization=org, user=user)
+
+        project = Project.objects.create(
+            name="Integration Test Observe",
+            organization=org,
+            workspace=ws,
+            model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+            trace_type="observe",
+            metadata={},
+            session_config=[
+                {"id": "session_input", "name": "Session Input", "is_visible": True},
+            ],
+        )
+
+        writer = DualWriter(ch=ch_schema, ch_database=db_name)
+        counts = writer.seed_base_corpus(project=project)
+
+    snapshot = SimpleNamespace(
+        organization=org,
+        workspace=ws,
+        user=user,
+        project=project,
+        rows=writer.seeded,
+        eval_config_id=writer.eval_config_id,
+        annotation_label_id=writer.annotation_label_id,
+        choice_eval_config_id=writer.choice_eval_config_id,
+        counts=counts,
+    )
+    yield snapshot
+
+    with django_db_blocker.unblock():
+        try:
+            org.delete()
+        except Exception:
+            pass
+
+
+# Per-test wrappers — each requests ``db`` so per-test writes roll back.
+
+@pytest.fixture
+def organization(integration_setup, db):
+    return integration_setup.organization
+
+
+@pytest.fixture
+def workspace(integration_setup, db, organization):
+    from tfc.middleware.workspace_context import (
+        clear_workspace_context,
+        set_workspace_context,
+    )
+
+    clear_workspace_context()
+    set_workspace_context(
+        workspace=integration_setup.workspace,
+        organization=organization,
+        user=integration_setup.user,
+    )
+    yield integration_setup.workspace
+    clear_workspace_context()
+
+
+@pytest.fixture
+def user(integration_setup, db):
+    return integration_setup.user
+
+
+@pytest.fixture
+def observe_project(integration_setup, db):
+    return integration_setup.project
+
+
+@pytest.fixture
+def seeded_corpus(integration_setup, db):
+    return integration_setup
+
+
+@pytest.fixture(scope="session")
+def voice_integration_setup(django_db_setup, django_db_blocker, ch_schema, integration_setup):
+    """Session-scoped voice-only project + corpus for voiceCalls cases."""
+    from types import SimpleNamespace
+
+    from model_hub.models.ai_model import AIModel
+    from tracer.models.project import Project
+    from tracer.tests.integration._seed import DualWriter
+
+    db_name = settings.CLICKHOUSE["CH_DATABASE"]
+
+    with django_db_blocker.unblock():
+        voice_project = Project.objects.create(
+            name="Integration Test Voice",
+            organization=integration_setup.organization,
+            workspace=integration_setup.workspace,
+            model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+            trace_type="observe",
+            metadata={},
+            session_config=[
+                {"id": "session_input", "name": "Session Input", "is_visible": True},
+            ],
+        )
+        writer = DualWriter(ch=ch_schema, ch_database=db_name)
+        counts = writer.seed_voice_corpus(project=voice_project)
+
+    snapshot = SimpleNamespace(
+        organization=integration_setup.organization,
+        workspace=integration_setup.workspace,
+        user=integration_setup.user,
+        project=voice_project,
+        rows=writer.seeded,
+        eval_config_id=writer.eval_config_id,
+        annotation_label_id=writer.annotation_label_id,
+        choice_eval_config_id=writer.choice_eval_config_id,
+        counts=counts,
+    )
+    yield snapshot
+
+    with django_db_blocker.unblock():
+        try:
+            voice_project.delete()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def voice_corpus(voice_integration_setup, db):
+    return voice_integration_setup
+
+
+@pytest.fixture
+def custom_eval_config_factory(db, eval_template):
+    """Factory that creates an extra CustomEvalConfig per call."""
+    from tracer.models.custom_eval_config import CustomEvalConfig
+
+    def _make(project):
+        return CustomEvalConfig.objects.create(
+            project=project,
+            eval_template=eval_template,
+            name=f"extra_eval_{uuid.uuid4().hex[:6]}",
+            config={"threshold": 0.8},
+            mapping={"input": "input", "output": "output"},
+            filters={},
+        )
+
+    return _make
+
+
+def test_ch_routes_on_flips_setting(ch_routes_on):
+    """Sanity: the override actually flips the route to clickhouse for the test scope."""
+    assert settings.CLICKHOUSE["CH_ROUTE_SPAN_LIST"] == "clickhouse"

--- a/futureagi/tracer/tests/integration/test_eval_task_filter_e2e.py
+++ b/futureagi/tracer/tests/integration/test_eval_task_filter_e2e.py
@@ -1,0 +1,132 @@
+"""For every FilterCase: seed the corpus, create an EvalTask with the matching
+filter and target type, run process_eval_task inline (engine stubbed), and assert
+EvalLogger count == matched_rows × num_evals, with the right target_type set."""
+import pytest
+from django.db import transaction
+
+from tracer.models.eval_task import EvalTask, EvalTaskStatus, RowType, RunType
+from tracer.models.observation_span import EvalLogger, EvalTargetType
+from tracer.tests.integration._filter_matrix import all_cases_for, FilterCase
+from tracer.tests.integration._seed import SeededRow
+from tracer.utils.eval_tasks import process_eval_task
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.django_db]
+
+_TARGET_TYPE_TO_ROW_TYPE = {
+    "spans": RowType.SPANS,
+    "traces": RowType.TRACES,
+    "sessions": RowType.SESSIONS,
+    "voiceCalls": RowType.VOICE_CALLS,
+}
+
+_ROW_TYPE_TO_EVAL_TARGET = {
+    RowType.SPANS: EvalTargetType.SPAN,
+    RowType.TRACES: EvalTargetType.TRACE,
+    RowType.SESSIONS: EvalTargetType.SESSION,
+    RowType.VOICE_CALLS: EvalTargetType.SPAN,
+}
+
+
+_PLACEHOLDER_EVAL_CFG = "00000000-0000-0000-0000-000000000001"
+_PLACEHOLDER_LABEL = "00000000-0000-0000-0000-000000000002"
+_PLACEHOLDER_CHOICE_CFG = "00000000-0000-0000-0000-000000000003"
+_ALL_CASES = all_cases_for(
+    _PLACEHOLDER_EVAL_CFG, _PLACEHOLDER_LABEL, _PLACEHOLDER_CHOICE_CFG
+)
+
+
+def _rebind_case(
+    case: FilterCase,
+    eval_config_id: str,
+    label_id: str,
+    choice_eval_config_id: str,
+) -> FilterCase:
+    new_col_id = case.column_id
+    if case.col_type == "EVAL_METRIC":
+        if case.column_id == _PLACEHOLDER_EVAL_CFG:
+            new_col_id = eval_config_id
+        elif case.column_id == _PLACEHOLDER_CHOICE_CFG:
+            new_col_id = choice_eval_config_id
+    if case.col_type == "ANNOTATION" and case.column_id == _PLACEHOLDER_LABEL:
+        new_col_id = label_id
+    if new_col_id == case.column_id:
+        return case
+    return FilterCase(
+        case_id=case.case_id,
+        target_type=case.target_type,
+        col_type=case.col_type,
+        filter_type=case.filter_type,
+        filter_op=case.filter_op,
+        column_id=new_col_id,
+        filter_value=case.filter_value,
+        expected_predicate=case.expected_predicate,
+    )
+
+
+def _expected_unit_count(case: FilterCase, seeded: list[SeededRow]) -> int:
+    if case.target_type in ("spans", "voiceCalls"):
+        return sum(1 for r in seeded if case.expected_predicate(r))
+    if case.target_type == "traces":
+        return len({r.trace_id for r in seeded if case.expected_predicate(r)})
+    if case.target_type == "sessions":
+        return len({r.session_id for r in seeded if case.expected_predicate(r)})
+    raise AssertionError(case.target_type)
+
+
+@pytest.mark.parametrize("case", _ALL_CASES, ids=lambda c: c.case_id)
+def test_eval_task_creates_correct_logger_count(
+    case,
+    seeded_corpus,
+    voice_corpus,
+    custom_eval_config_factory,
+    stub_run_eval,
+    inline_temporal,
+    stub_cost_log,
+):
+    # voiceCalls → voice-only project; everything else → mixed corpus.
+    corpus = voice_corpus if case.target_type == "voiceCalls" else seeded_corpus
+    project = corpus.project
+    seeded = corpus.rows
+    case = _rebind_case(
+        case,
+        corpus.eval_config_id,
+        corpus.annotation_label_id,
+        corpus.choice_eval_config_id,
+    )
+    expected_units = _expected_unit_count(case, seeded)
+
+    eval_a = custom_eval_config_factory(project=project)
+    eval_b = custom_eval_config_factory(project=project)
+    # Include project_id so the runner scopes the queryset.
+    filters_dict = {"project_id": str(project.id), **case.to_filter_dict()}
+    task = EvalTask.objects.create(
+        project=project,
+        filters=filters_dict,
+        row_type=_TARGET_TYPE_TO_ROW_TYPE[case.target_type],
+        run_type=RunType.HISTORICAL,
+        sampling_rate=100.0,  # percentage in [0, 100], not a fraction
+        spans_limit=10_000,
+        status=EvalTaskStatus.PENDING,
+    )
+    task.evals.add(eval_a, eval_b)
+
+    # ``._original_func`` bypasses the Temporal activity wrapper; savepoint
+    # isolates parser exceptions from poisoning the outer test transaction.
+    try:
+        with transaction.atomic():
+            process_eval_task._original_func(str(task.id))
+    except Exception as exc:
+        raise AssertionError(
+            f"{case.case_id}: runner raised {type(exc).__name__}: {exc}"
+        ) from exc
+
+    actual = EvalLogger.objects.filter(eval_task_id=str(task.id)).count()
+    expected_loggers = expected_units * 2  # two evals attached
+    assert actual == expected_loggers, (
+        f"{case.case_id}: row_type={task.row_type} expected {expected_loggers} "
+        f"({expected_units} units × 2 evals), got {actual}"
+    )
+
+    if expected_loggers > 0:
+        sample = EvalLogger.objects.filter(eval_task_id=str(task.id)).first()
+        assert sample.target_type == _ROW_TYPE_TO_EVAL_TARGET[task.row_type]

--- a/futureagi/tracer/tests/integration/test_filter_matrix_completeness.py
+++ b/futureagi/tracer/tests/integration/test_filter_matrix_completeness.py
@@ -1,0 +1,80 @@
+"""Matrix completeness + non-degeneracy guards.
+
+Cheap, runs without ClickHouse if you skip the dual_writer fixture (we don't —
+the non-degeneracy guard needs the seeded corpus).
+"""
+import pytest
+
+from tracer.tests.integration._filter_matrix import (
+    COL_TYPES,
+    TARGET_TYPES,
+    all_cases,
+)
+
+
+def test_matrix_covers_every_col_type_per_target():
+    by_target_coltype: dict[str, set[str]] = {}
+    for case in all_cases():
+        by_target_coltype.setdefault(case.target_type, set()).add(case.col_type)
+    expected_cols = set(COL_TYPES)
+    for tt in TARGET_TYPES:
+        assert by_target_coltype[tt] == expected_cols, (
+            f"target {tt} missing col_types {expected_cols - by_target_coltype[tt]}"
+        )
+
+
+def test_no_duplicate_case_ids():
+    ids = [c.case_id for c in all_cases()]
+    dupes = [i for i in set(ids) if ids.count(i) > 1]
+    assert not dupes, f"duplicate case_id in matrix: {dupes}"
+
+
+def test_every_case_has_a_predicate():
+    for c in all_cases():
+        assert callable(c.expected_predicate), c.case_id
+
+
+# Set of (col_type, filter_op) pairs where a 0-match or all-match result is the
+# meaningful assertion (e.g. is_null on a column that's always set proves
+# "no false positives" — and the matrix's job is to cover these explicitly).
+_ALLOWED_DEGENERATE = {
+    ("SYSTEM_METRIC", "is_null"),  # cost is always set in corpus
+    ("SYSTEM_METRIC", "is_not_null"),  # ditto, inverse
+    ("SPAN_ATTRIBUTE", "is_null"),  # ``missing_attr`` is intentionally absent
+}
+
+
+@pytest.mark.django_db
+def test_every_case_matches_a_non_trivial_subset(seeded_corpus):
+    """Catch degenerate FilterCases — every filter should match >0 and <ALL rows
+    in the corpus (otherwise the case is undiscriminating and a bug in the
+    matrix could slip through). Explicit allowlist for is_null-style filters."""
+    seeded = seeded_corpus.rows
+    total = len(seeded)
+    degenerate = []
+    for case in all_cases(
+        eval_config_id=seeded_corpus.eval_config_id,
+        label_id=seeded_corpus.annotation_label_id,
+        choice_eval_config_id=seeded_corpus.choice_eval_config_id,
+    ):
+        if (case.col_type, case.filter_op) in _ALLOWED_DEGENERATE:
+            continue
+        # has_eval/has_annotation with value=False legitimately matches the
+        # complement; both subsets are non-empty in the corpus, so don't skip.
+        matched = sum(1 for r in seeded if case.expected_predicate(r))
+        # voiceCalls only has 3 root rows AND voice roots have sp_idx=0, which
+        # carry no eval / annotation in the corpus. Most filters touching
+        # those features therefore match 0 voice rows — that's not a matrix
+        # bug, it's the corpus shape. Skip the non-degeneracy guard here; the
+        # parametrized tests still assert against the predicate-derived count
+        # (0 or otherwise) and lock the contract.
+        if case.target_type == "voiceCalls":
+            continue
+        if matched == 0 or matched == total:
+            degenerate.append((case.case_id, matched, total))
+    assert not degenerate, (
+        "These FilterCases are non-discriminating against the seeded corpus "
+        "(matched 0 or ALL rows). Either tune the threshold, vary the corpus, "
+        "or add to _ALLOWED_DEGENERATE with justification:\n  "
+        + "\n  ".join(f"{cid}: matched {m}/{t}" for cid, m, t in degenerate)
+    )

--- a/futureagi/tracer/tests/integration/test_list_endpoints_filter_count.py
+++ b/futureagi/tracer/tests/integration/test_list_endpoints_filter_count.py
@@ -1,0 +1,116 @@
+"""For every FilterCase: seed the corpus, hit the list endpoint with the filter,
+assert response total_rows equals the predicate-derived count.
+
+The matrix carries placeholder UUIDs for eval_config_id / annotation_label_id;
+we rebind to the real seeded values at parametrize-time inside the test body.
+"""
+import json
+
+import pytest
+
+from tracer.tests.integration._filter_matrix import all_cases_for
+from tracer.tests.integration._seed import SeededRow
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.django_db]
+
+
+ENDPOINTS = {
+    "spans": "/tracer/observation-span/list_spans_observe/",
+    "traces": "/tracer/trace/list_traces_of_session/",
+    "sessions": "/tracer/trace-session/list_sessions/",
+    "voiceCalls": "/tracer/trace/list_voice_calls/",
+}
+
+
+def _expected_count(case, seeded: list[SeededRow]) -> int:
+    """Aggregate per-span predicate to the case's target unit."""
+    if case.target_type == "spans":
+        return sum(1 for r in seeded if case.expected_predicate(r))
+    if case.target_type == "voiceCalls":
+        return sum(1 for r in seeded if case.expected_predicate(r))
+    if case.target_type == "traces":
+        return len({r.trace_id for r in seeded if case.expected_predicate(r)})
+    if case.target_type == "sessions":
+        return len({r.session_id for r in seeded if case.expected_predicate(r)})
+    raise AssertionError(case.target_type)
+
+
+# We need eval_config_id / annotation_label_id to be filled in for EVAL_METRIC
+# and ANNOTATION cases. Parametrize uses placeholder UUIDs; the fixture
+# rebinds them before each test.
+_PLACEHOLDER_EVAL_CFG = "00000000-0000-0000-0000-000000000001"
+_PLACEHOLDER_LABEL = "00000000-0000-0000-0000-000000000002"
+_PLACEHOLDER_CHOICE_CFG = "00000000-0000-0000-0000-000000000003"
+_ALL_CASES = all_cases_for(
+    _PLACEHOLDER_EVAL_CFG, _PLACEHOLDER_LABEL, _PLACEHOLDER_CHOICE_CFG
+)
+
+
+def _rebind_case(case, eval_config_id: str, label_id: str, choice_eval_config_id: str):
+    """If a case targets a placeholder eval_config / label, rewrite the
+    column_id to the real seeded id before sending to the endpoint. The
+    predicate doesn't read column_id, only row fields, so it stays valid."""
+    from tracer.tests.integration._filter_matrix import FilterCase
+
+    new_col_id = case.column_id
+    if case.col_type == "EVAL_METRIC":
+        if case.column_id == _PLACEHOLDER_EVAL_CFG:
+            new_col_id = eval_config_id
+        elif case.column_id == _PLACEHOLDER_CHOICE_CFG:
+            new_col_id = choice_eval_config_id
+    if case.col_type == "ANNOTATION" and case.column_id == _PLACEHOLDER_LABEL:
+        new_col_id = label_id
+    if new_col_id == case.column_id:
+        return case
+    return FilterCase(
+        case_id=case.case_id,
+        target_type=case.target_type,
+        col_type=case.col_type,
+        filter_type=case.filter_type,
+        filter_op=case.filter_op,
+        column_id=new_col_id,
+        filter_value=case.filter_value,
+        expected_predicate=case.expected_predicate,
+    )
+
+
+@pytest.mark.parametrize("case", _ALL_CASES, ids=lambda c: c.case_id)
+def test_list_endpoint_total_rows(
+    case, auth_client, seeded_corpus, voice_corpus, ch_routes_on
+):
+    # voiceCalls → voice-only project; everything else → mixed corpus.
+    corpus = voice_corpus if case.target_type == "voiceCalls" else seeded_corpus
+    project = corpus.project
+    seeded = corpus.rows
+    case = _rebind_case(
+        case,
+        corpus.eval_config_id,
+        corpus.annotation_label_id,
+        corpus.choice_eval_config_id,
+    )
+    expected = _expected_count(case, seeded)
+
+    filter_json = json.dumps(case.to_filter_dict()["filters"])
+    url = ENDPOINTS[case.target_type]
+    resp = auth_client.get(
+        url,
+        {
+            "project_id": str(project.id),
+            "page_number": 0,
+            "page_size": 100,
+            "filters": filter_json,
+        },
+    )
+    assert resp.status_code == 200, getattr(resp, "content", resp)
+    body = resp.data
+    # success_response wraps payload in {"status":..., "result": <payload>}
+    payload = body.get("result", body)
+    total = payload.get("metadata", {}).get("total_rows")
+    if total is None:
+        # Some endpoints (sessions list) return total_rows at a different
+        # path — fall back to len(table)/data length as a best-effort.
+        table = payload.get("table") or payload.get("data") or []
+        total = len(table)
+    assert total == expected, (
+        f"{case.case_id}: endpoint returned {total}, predicate expected {expected}"
+    )

--- a/futureagi/tracer/tests/integration/test_seed_smoke.py
+++ b/futureagi/tracer/tests/integration/test_seed_smoke.py
@@ -1,0 +1,24 @@
+"""Smoke test for the dual-write seeder.
+
+Asserts the 24-span corpus lands in both Postgres (ORM) and ClickHouse (SQL).
+"""
+import pytest
+from django.conf import settings
+
+from tracer.models.observation_span import ObservationSpan
+
+
+@pytest.mark.django_db
+def test_seeded_corpus_lands_in_pg_and_ch(seeded_corpus, ch_schema):
+    """Sanity: the session-scoped seed wrote the same row set to PG and CH."""
+    project = seeded_corpus.project
+    expected = seeded_corpus.counts["span_count"]
+    # PG side
+    assert ObservationSpan.objects.filter(project=project).count() == expected
+    # CH side
+    db = settings.CLICKHOUSE["CH_DATABASE"]
+    ch_count = ch_schema.command(
+        f"SELECT count() FROM {db}.tracer_observation_span "
+        f"WHERE project_id = '{project.id}' AND _peerdb_is_deleted = 0"
+    )
+    assert int(ch_count) == expected

--- a/futureagi/tracer/tests/test_eval_task_filter_dispatch.py
+++ b/futureagi/tracer/tests/test_eval_task_filter_dispatch.py
@@ -1,0 +1,311 @@
+"""
+Tests for parsing_evaltask_filters dispatcher.
+
+Verifies the eval-task path now routes each ``col_type`` through the right
+FilterEngine handler — mirroring ``list_spans_observe``
+(``tracer/views/observation_span.py:1755-1826``) — and silently ignores
+unrecognised col_types. Structural assertions: we check the shape and
+``repr`` of the returned ``Q`` (and the annotation dict) rather than
+running queries against a DB, because the underlying handlers each have
+their own integration tests.
+
+The bug this guards against: until 2026-06-04 the dispatcher only handled
+``SPAN_ATTRIBUTE`` and silently dropped every other col_type, including the
+``ANNOTATION`` annotator filter behind the prod task
+``f8481965-cd74-44b1-9b6d-f4bb66ec2218``. See plan
+``~/.claude/plans/shift-to-fix-nightly-dev-27-05-and-zazzy-eagle.md``.
+"""
+
+import uuid
+
+import pytest
+from django.db.models import Q
+
+from tracer.utils.eval_tasks import parsing_evaltask_filters
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wrap(items, key="filters"):
+    """Wrap a list of filter items in the eval-task top-level filters dict."""
+    return {key: items}
+
+
+def _span_attr_item(column_id="ended_reason", value="completed"):
+    return {
+        "column_id": column_id,
+        "filter_config": {
+            "col_type": "SPAN_ATTRIBUTE",
+            "filter_type": "text",
+            "filter_op": "equals",
+            "filter_value": value,
+        },
+    }
+
+
+def _annotator_item(user_uuid="c65a0f3c-8a72-432a-987f-ddbd8391df29"):
+    """Mirrors the prod bug task's annotator filter shape (camelCase, top-level
+    col_type-by-config). The dispatcher tolerates either case."""
+    return {
+        "columnId": "annotator",
+        "filterConfig": {
+            "colType": "ANNOTATION",
+            "filterOp": "equals",
+            "filterType": "text",
+            "filterValue": user_uuid,
+        },
+    }
+
+
+def _label_value_item(label_uuid, value):
+    return {
+        "column_id": label_uuid,
+        "filter_config": {
+            "col_type": "ANNOTATION",
+            "filter_type": "number",
+            "filter_op": "greater_than",
+            "filter_value": value,
+        },
+    }
+
+
+def _system_metric_item(column_id="cost", op="greater_than", value=0.5):
+    return {
+        "column_id": column_id,
+        "filter_config": {
+            "col_type": "SYSTEM_METRIC",
+            "filter_type": "number",
+            "filter_op": op,
+            "filter_value": value,
+        },
+    }
+
+
+def _eval_metric_item(eval_template_id, op="greater_than", value=0.8):
+    return {
+        "column_id": eval_template_id,
+        "filter_config": {
+            "col_type": "EVAL_METRIC",
+            "filter_type": "number",
+            "filter_op": op,
+            "filter_value": value,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Empty / None handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEmpty:
+    def test_none_returns_empty_tuple(self):
+        q, anns = parsing_evaltask_filters(None)
+        assert q == Q()
+        assert anns == {}
+
+    def test_empty_dict_returns_empty_tuple(self):
+        q, anns = parsing_evaltask_filters({})
+        assert q == Q()
+        assert anns == {}
+
+    def test_empty_filters_list_returns_empty_tuple(self):
+        q, anns = parsing_evaltask_filters({"filters": []})
+        assert q == Q()
+        assert anns == {}
+
+
+# ---------------------------------------------------------------------------
+# Legacy `span_attributes_filters` key still parsed (transition)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLegacyKey:
+    def test_legacy_key_with_span_attribute_filter(self):
+        items = [_span_attr_item()]
+        q, anns = parsing_evaltask_filters(
+            _wrap(items, key="span_attributes_filters")
+        )
+        # Legacy key produces the same Q as the canonical key.
+        q_canonical, _ = parsing_evaltask_filters(_wrap(items, key="filters"))
+        assert repr(q) == repr(q_canonical)
+        assert anns == {}
+
+    def test_legacy_key_with_annotator_filter(self):
+        # The specific shape that motivated the fix: prod task f8481965.
+        items = [_annotator_item()]
+        q, anns = parsing_evaltask_filters(
+            _wrap(items, key="span_attributes_filters")
+        )
+        assert q != Q()
+        assert "Exists" in repr(q)  # routed through the voice annotation handler
+
+
+# ---------------------------------------------------------------------------
+# SPAN_ATTRIBUTE — regression guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSpanAttribute:
+    def test_span_attribute_only(self):
+        q, anns = parsing_evaltask_filters(_wrap([_span_attr_item()]))
+        assert q != Q()
+        # SPAN_ATTRIBUTE filters resolve via the span_attributes JSONB
+        # (`has_key` + `contains`) — verify by string match on the Q repr.
+        assert "span_attributes" in repr(q)
+        assert anns == {}
+
+
+# ---------------------------------------------------------------------------
+# ANNOTATION — the original bug
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAnnotation:
+    def test_annotator_filter_produces_exists_clause(self):
+        items = [_annotator_item()]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert q != Q()
+        # The annotator branch builds an Exists(Score.objects...) subquery.
+        assert "Exists" in repr(q)
+        # The annotator path is pure-Q — no annotate() kwargs.
+        assert anns == {}
+
+    def test_per_label_score_filter_builds_annotation_field_q(self):
+        # A per-label ANNOTATION filter (e.g. "quality > 3") builds a Q
+        # referencing the `annotation_<uuid>__score` field. The actual
+        # `.annotate(annotation_<uuid>=...)` step is contributed by
+        # `build_annotation_subqueries` (observation_span.py:1167-1169),
+        # which `process_eval_task` does not yet call — see the dispatcher
+        # docstring. So `extra_anns` remains empty here; this test guards
+        # the Q shape only. When `build_annotation_subqueries` is wired in
+        # for eval tasks, replace this with an integration test that asserts
+        # the queryset actually returns the right rows.
+        label_uuid = str(uuid.uuid4())
+        items = [_label_value_item(label_uuid, 3.0)]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert q != Q()
+        assert f"annotation_{label_uuid}__score" in repr(q)
+        assert anns == {}
+
+    def test_annotation_does_not_leak_into_non_system_handler(self):
+        # Per list_spans_observe (observation_span.py:1769-1777), ANNOTATION
+        # items and the annotation-special column_ids must be excluded from
+        # the eval-metrics handler. Mixing both should still produce a single
+        # well-formed Q without raising.
+        items = [
+            _annotator_item(),
+            _eval_metric_item(str(uuid.uuid4())),
+        ]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert q != Q()
+
+
+# ---------------------------------------------------------------------------
+# SYSTEM_METRIC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSystemMetric:
+    def test_system_metric_filter(self):
+        items = [_system_metric_item("cost", "greater_than", 0.1)]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        # The system-metrics handler maps `cost` to `row_avg_cost`
+        # (FilterEngine.DEFAULT_FIELD_MAP) and emits a Q referencing it.
+        assert q != Q()
+        assert anns == {}
+
+
+# ---------------------------------------------------------------------------
+# EVAL_METRIC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEvalMetric:
+    def test_eval_metric_filter(self):
+        items = [_eval_metric_item(str(uuid.uuid4()), "greater_than", 0.8)]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert q != Q()
+
+
+# ---------------------------------------------------------------------------
+# Mixed — all four colTypes at once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMixed:
+    def test_all_four_col_types_combine(self):
+        items = [
+            _span_attr_item(),
+            _system_metric_item("cost", "greater_than", 0.1),
+            _eval_metric_item(str(uuid.uuid4())),
+            _annotator_item(),
+        ]
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert q != Q()
+        # Each handler contributes its own clause; combined Q should reference
+        # all the underlying mechanisms.
+        rep = repr(q)
+        assert "span_attributes" in rep   # SPAN_ATTRIBUTE
+        assert "Exists" in rep             # ANNOTATION (annotator) Exists subquery
+
+
+# ---------------------------------------------------------------------------
+# Sibling keys at the top level
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSiblingKeys:
+    def test_date_range_still_applied(self):
+        q, _ = parsing_evaltask_filters(
+            {"date_range": ["2026-01-01T00:00:00Z", "2026-06-01T00:00:00Z"]}
+        )
+        assert q != Q()
+        assert "created_at" in repr(q)
+
+    def test_project_id_still_applied(self):
+        q, _ = parsing_evaltask_filters({"project_id": str(uuid.uuid4())})
+        assert q != Q()
+        assert "project_id" in repr(q)
+
+    def test_observation_type_still_applied(self):
+        q, _ = parsing_evaltask_filters({"observation_type": ["llm", "tool"]})
+        assert q != Q()
+        assert "observation_type" in repr(q)
+
+
+# ---------------------------------------------------------------------------
+# Unrecognised col_type — silent skip (no raise)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestUnrecognisedColType:
+    def test_unknown_col_type_does_not_raise(self):
+        items = [
+            {
+                "column_id": "some_id",
+                "filter_config": {
+                    "col_type": "TOTALLY_MADE_UP",
+                    "filter_type": "text",
+                    "filter_op": "equals",
+                    "filter_value": "x",
+                },
+            }
+        ]
+        # Must not raise. The handlers' own col_type gates skip items they
+        # don't recognise; the dispatcher itself doesn't enumerate types.
+        q, anns = parsing_evaltask_filters(_wrap(items))
+        assert isinstance(q, Q)
+        assert anns == {}

--- a/futureagi/tracer/utils/annotations.py
+++ b/futureagi/tracer/utils/annotations.py
@@ -93,10 +93,7 @@ def build_annotation_subqueries(
             )
             score_field = Cast(KeyTextTransform(value_key, "value"), FloatField())
 
-            # STAR is integer (1-5); Floor matches that. NUMERIC can be a
-            # continuous float (e.g. 0.0-1.0 with step 0.1) where Floor would
-            # destroy precision (0.5 → 0). Use Round to preserve sub-integer
-            # values.
+            # STAR is integer (Floor); NUMERIC can be sub-integer (Round to keep precision).
             avg_score = (
                 Floor(Avg(score_field))
                 if label.type == AnnotationTypeChoices.STAR.value

--- a/futureagi/tracer/utils/annotations.py
+++ b/futureagi/tracer/utils/annotations.py
@@ -23,7 +23,7 @@ from django.db.models import (
     When,
 )
 from django.db.models.fields.json import KeyTextTransform
-from django.db.models.functions import Cast, Coalesce, Floor, JSONObject, NullIf
+from django.db.models.functions import Cast, Coalesce, Floor, JSONObject, NullIf, Round
 
 from model_hub.models.choices import AnnotationTypeChoices
 from model_hub.models.score import Score
@@ -93,13 +93,22 @@ def build_annotation_subqueries(
             )
             score_field = Cast(KeyTextTransform(value_key, "value"), FloatField())
 
+            # STAR is integer (1-5); Floor matches that. NUMERIC can be a
+            # continuous float (e.g. 0.0-1.0 with step 0.1) where Floor would
+            # destroy precision (0.5 → 0). Use Round to preserve sub-integer
+            # values.
+            avg_score = (
+                Floor(Avg(score_field))
+                if label.type == AnnotationTypeChoices.STAR.value
+                else Round(Avg(score_field), 2)
+            )
             subq = (
                 Score.objects.filter(base_ann_q)
                 .exclude(**{f"value__{value_key}__isnull": True})
                 .values("label_id")
                 .annotate(
                     result=JSONObject(
-                        score=Floor(Avg(score_field)),
+                        score=avg_score,
                         annotators=JSONBObjectAgg(
                             Cast(F("annotator_id"), TextField()),
                             JSONObject(
@@ -107,6 +116,8 @@ def build_annotation_subqueries(
                                 user_name=annotator_name,
                                 score=score_field,
                             ),
+                            # jsonb_object_agg() requires NOT NULL keys.
+                            filter=Q(annotator_id__isnull=False),
                         ),
                     )
                 )
@@ -149,6 +160,7 @@ def build_annotation_subqueries(
                                     output_field=FloatField(),
                                 ),
                             ),
+                            filter=Q(annotator_id__isnull=False),
                         ),
                     )
                 )
@@ -222,6 +234,7 @@ def build_annotation_subqueries(
                                 user_name=annotator_name,
                                 value=F("value__text"),
                             ),
+                            filter=Q(annotator_id__isnull=False),
                         ),
                     )
                 )

--- a/futureagi/tracer/utils/eval_tasks.py
+++ b/futureagi/tracer/utils/eval_tasks.py
@@ -33,7 +33,7 @@ from tracer.utils.eval import (
     evaluate_trace_session_observe,
 )
 from tracer.utils.annotations import build_annotation_subqueries
-from tracer.utils.filters import ColType, FilterEngine
+from tracer.utils.filters import FilterEngine
 from tracer.utils.helper import get_annotation_labels_for_project
 
 # Cron-side drain window — once the dispatcher has fired every
@@ -169,21 +169,12 @@ def parsing_evaltask_filters(filters: dict) -> tuple[Q, dict]:
             if q_sys:
                 combined_q &= q_sys
 
-            # ANNOTATION + my_annotations/annotator are routed through the
-            # voice annotation handler below; exclude them here so they
-            # don't double-match.
-            non_anno = [
-                f
-                for f in items
-                if _filter_col_type(f) != ColType.ANNOTATION.value
-                and _filter_column_id(f) not in ("my_annotations", "annotator")
-            ]
-            if non_anno:
-                q_eval = FilterEngine.get_filter_conditions_for_non_system_metrics(
-                    non_anno
-                )
-                if q_eval:
-                    combined_q &= q_eval
+            # ANNOTATION rows (incl. my_annotations/annotator pinned to
+            # col_type=ANNOTATION) are skipped inside the handler at
+            # filters.py:1386-1391 — no call-site pre-filter needed.
+            q_eval = FilterEngine.get_filter_conditions_for_non_system_metrics(items)
+            if q_eval:
+                combined_q &= q_eval
 
             # span_filter_kwargs re-targets the Score join to span scope
             # (filters.py:1683-1692); user_id=None because we're in a
@@ -288,24 +279,6 @@ def parsing_monitor_filters(filters: dict) -> Q:
             combined_q &= Q(project_id=value)
 
     return combined_q
-
-
-def _filter_col_type(item: dict) -> str:
-    """Read col_type from a filter item, tolerating both camel- and snake-case
-    keys at either the top level or nested in filter_config (mirrors the
-    normalisation in `_normalize_filter_params`)."""
-    cfg = item.get("filter_config") or item.get("filterConfig") or {}
-    return (
-        item.get("col_type")
-        or item.get("colType")
-        or cfg.get("col_type")
-        or cfg.get("colType")
-        or ""
-    )
-
-
-def _filter_column_id(item: dict) -> str:
-    return item.get("column_id") or item.get("columnId") or ""
 
 
 @temporal_activity(

--- a/futureagi/tracer/utils/eval_tasks.py
+++ b/futureagi/tracer/utils/eval_tasks.py
@@ -159,7 +159,11 @@ def parsing_evaltask_filters(filters: dict) -> tuple[Q, dict]:
     for key, value in filters.items():
         if key in ("filters", "span_attributes_filters") and isinstance(value, list):
             if key == "span_attributes_filters":
-                logger.info("eval_task_filter_legacy_key")
+                logger.error(
+                    "Eval task still uses the legacy "
+                    "`span_attributes_filters` key; re-save the task to "
+                    "migrate it to the canonical `filters` key."
+                )
 
             items = value
             if not items:

--- a/futureagi/tracer/utils/eval_tasks.py
+++ b/futureagi/tracer/utils/eval_tasks.py
@@ -4,7 +4,7 @@ from random import sample
 import structlog
 from django.core.cache import cache
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import OuterRef, Q
 from django.utils import timezone
 
 logger = structlog.get_logger(__name__)
@@ -32,7 +32,9 @@ from tracer.utils.eval import (
     evaluate_trace_observe,
     evaluate_trace_session_observe,
 )
-from tracer.utils.filters import FilterEngine
+from tracer.utils.annotations import build_annotation_subqueries
+from tracer.utils.filters import ColType, FilterEngine
+from tracer.utils.helper import get_annotation_labels_for_project
 
 # Cron-side drain window — once the dispatcher has fired every
 # per-span activity, the task stays in RUNNING until either the
@@ -133,10 +135,122 @@ def compute_drain_state(eval_task, eval_task_logger=None):
     }
 
 
-def parsing_evaltask_filters(filters: dict) -> Q:
+def parsing_evaltask_filters(filters: dict) -> tuple[Q, dict]:
+    """Combine eval-task filter JSON into ``(Q, annotation_kwargs)``.
+
+    Per-handler dispatch mirrors ``list_spans_observe``
+    (``tracer/views/observation_span.py:1755-1826``): one flat ``filters``
+    list, each item carrying ``col_type``, passed to every handler.
+
+    Callers must apply ``.annotate(**extra_annotations).filter(combined_q)``.
+    Per-label ANNOTATION filters (e.g. ``columnId == "<label_uuid>"``)
+    additionally require ``build_annotation_subqueries`` to have been
+    applied to the queryset first — ``process_eval_task`` does that;
+    other callers must mirror it if they accept per-label filters.
+
+    Accepts both ``filters`` and legacy ``span_attributes_filters`` keys.
     """
-    Parses the input filters dictionary and returns a single combined Q object
-    for Django ORM filtering.
+    combined_q = Q()
+    extra_anns: dict = {}
+
+    if filters is None:
+        return combined_q, extra_anns
+
+    for key, value in filters.items():
+        if key in ("filters", "span_attributes_filters") and isinstance(value, list):
+            if key == "span_attributes_filters":
+                logger.info("eval_task_filter_legacy_key")
+
+            items = value
+            if not items:
+                continue
+
+            q_sys = FilterEngine.get_filter_conditions_for_system_metrics(items)
+            if q_sys:
+                combined_q &= q_sys
+
+            # ANNOTATION + my_annotations/annotator are routed through the
+            # voice annotation handler below; exclude them here so they
+            # don't double-match.
+            non_anno = [
+                f
+                for f in items
+                if _filter_col_type(f) != ColType.ANNOTATION.value
+                and _filter_column_id(f) not in ("my_annotations", "annotator")
+            ]
+            if non_anno:
+                q_eval = FilterEngine.get_filter_conditions_for_non_system_metrics(
+                    non_anno
+                )
+                if q_eval:
+                    combined_q &= q_eval
+
+            # span_filter_kwargs re-targets the Score join to span scope
+            # (filters.py:1683-1692); user_id=None because we're in a
+            # background activity, which makes my_annotations a no-op.
+            q_anno, anno_anns = (
+                FilterEngine.get_filter_conditions_for_voice_call_annotations(
+                    items,
+                    user_id=None,
+                    span_filter_kwargs={"observation_span_id": OuterRef("id")},
+                )
+            )
+            if q_anno:
+                combined_q &= q_anno
+            if anno_anns:
+                extra_anns.update(anno_anns)
+
+            q_span = FilterEngine.get_filter_conditions_for_span_attributes(items)
+            if q_span:
+                combined_q &= q_span
+
+            q_has_eval = FilterEngine.get_filter_conditions_for_has_eval(
+                items, observe_type="span"
+            )
+            if q_has_eval:
+                combined_q &= q_has_eval
+            q_has_anno = FilterEngine.get_filter_conditions_for_has_annotation(
+                items, observe_type="span"
+            )
+            if q_has_anno:
+                combined_q &= q_has_anno
+
+        elif key == "observation_type":
+            if isinstance(value, list):
+                combined_q &= Q(observation_type__in=list(value))
+            elif isinstance(value, str):
+                combined_q &= Q(observation_type=value)
+            else:
+                raise Exception(
+                    "Invalid value for observation_type filter; expected list or string"
+                )
+        elif key == "session_id":
+            traces = Trace.objects.filter(session_id=value).values_list("id", flat=True)
+            combined_q &= Q(trace_id__in=list(traces))
+        elif key == "date_range":
+            if isinstance(value, list) and len(value) == 2:
+                start_date, end_date = value
+                combined_q &= Q(created_at__range=[start_date, end_date])
+        elif key == "created_at":
+            combined_q &= Q(created_at__gte=value)
+        elif key == "project_id":
+            combined_q &= Q(project_id=value)
+
+    return combined_q, extra_anns
+
+
+def parsing_monitor_filters(filters: dict) -> Q:
+    """Legacy filter parser kept for monitor.py and monitor_graphs.py.
+
+    Monitors use a simpler filter UI than eval tasks — only SPAN_ATTRIBUTE
+    chips, no annotation/eval-metric/system-metric col_types. Keeping the
+    old single-handler dispatch here avoids monitor pages paying for the
+    annotate-subqueries cost or surfacing FieldErrors for filters they
+    never carry.
+
+    Eval task create/edit and the eval-task rerun count use the richer
+    ``parsing_evaltask_filters`` (above), which returns ``(Q, dict)`` and
+    routes by col_type.
     """
     combined_q = Q()
 
@@ -174,6 +288,24 @@ def parsing_evaltask_filters(filters: dict) -> Q:
             combined_q &= Q(project_id=value)
 
     return combined_q
+
+
+def _filter_col_type(item: dict) -> str:
+    """Read col_type from a filter item, tolerating both camel- and snake-case
+    keys at either the top level or nested in filter_config (mirrors the
+    normalisation in `_normalize_filter_params`)."""
+    cfg = item.get("filter_config") or item.get("filterConfig") or {}
+    return (
+        item.get("col_type")
+        or item.get("colType")
+        or cfg.get("col_type")
+        or cfg.get("colType")
+        or ""
+    )
+
+
+def _filter_column_id(item: dict) -> str:
+    return item.get("column_id") or item.get("columnId") or ""
 
 
 @temporal_activity(
@@ -237,8 +369,22 @@ def process_eval_task(eval_task_id: str):
             )
 
         filters = Q()
+        extra_anns: dict = {}
         if eval_task.filters is not None:
-            filters = parsing_evaltask_filters(eval_task.filters)
+            filters, extra_anns = parsing_evaltask_filters(eval_task.filters)
+
+        # Pre-annotate ``annotation_<label_id>`` JSON columns on the span
+        # queryset (mirrors list_spans_observe at observation_span.py:1164-1172)
+        # so per-label ANNOTATION filters resolve. ``extra_anns`` is reserved
+        # for any future per-handler annotate kwargs.
+        annotation_labels = get_annotation_labels_for_project(eval_task.project_id)
+        span_qs = build_annotation_subqueries(
+            ObservationSpan.objects.all(),
+            annotation_labels,
+            eval_task.project.organization,
+            span_filter_kwargs={"observation_span_id": OuterRef("id")},
+        )
+        span_qs = span_qs.annotate(**extra_anns).filter(filters)
 
         # Branch the candidate queryset and dispatch activity on
         # row_type. The rest of the function operates on ``entity_qs``
@@ -253,9 +399,7 @@ def process_eval_task(eval_task_id: str):
             # A trace is in scope iff at least one of its spans matches
             # the existing span-level filters.
             entity_qs = Trace.objects.filter(
-                id__in=ObservationSpan.objects.filter(filters)
-                .values("trace_id")
-                .distinct()
+                id__in=span_qs.values("trace_id").distinct()
             )
             dispatch = evaluate_trace_observe
         elif eval_task.row_type == RowType.SESSIONS:
@@ -267,9 +411,7 @@ def process_eval_task(eval_task_id: str):
             # in the sampling step below misbehaves under PostgreSQL.
             matching_session_ids = (
                 Trace.objects.filter(
-                    id__in=ObservationSpan.objects.filter(filters)
-                    .values("trace_id")
-                    .distinct()
+                    id__in=span_qs.values("trace_id").distinct()
                 )
                 .exclude(session__isnull=True)
                 .values("session_id")
@@ -282,7 +424,7 @@ def process_eval_task(eval_task_id: str):
             # already aliases voiceCalls→spans (observation_span.py:2890),
             # and any conversation-type narrowing the user wants comes
             # through ``filters`` like every other span query.
-            entity_qs = ObservationSpan.objects.filter(filters)
+            entity_qs = span_qs
             dispatch = evaluate_observation_span_observe
         else:
             # Fail fast on unknown / future row types instead of silently

--- a/futureagi/tracer/utils/monitor.py
+++ b/futureagi/tracer/utils/monitor.py
@@ -44,7 +44,7 @@ from tracer.services.clickhouse.query_builders.monitor_metrics import (
     MonitorMetricsQueryBuilder,
 )
 from tracer.services.clickhouse.query_service import AnalyticsQueryService, QueryType
-from tracer.utils.eval_tasks import parsing_evaltask_filters
+from tracer.utils.eval_tasks import parsing_monitor_filters
 
 
 def _build_monitor_ch_builder(monitor):
@@ -268,7 +268,7 @@ def _get_metric_value(monitor, start_time, end_time):
             )
 
     # --- PostgreSQL fallback ---
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
     base_queryset = ObservationSpan.objects.filter(
         project=monitor.project, created_at__range=(start_time, end_time)
     )
@@ -395,7 +395,7 @@ def _get_evaluation_metric_stats(monitor, start_time, end_time):
         _mute_monitor(monitor)
         return None, None
 
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
 
     eval_results = EvalLogger.objects.filter(
         custom_eval_config=custom_eval_config,
@@ -465,7 +465,7 @@ def _get_time_series_data_for_time_aggregated_metrics(
     Groups spans in certain intervals and returns a dictionary of {timestamp: value}.
     `interval_kind` must be one of 'minute', 'hour', 'day', 'week', 'month', 'year'.
     """
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
     base_queryset = ObservationSpan.objects.filter(project=monitor.project).filter(
         filters
     )
@@ -556,7 +556,7 @@ def _get_historical_stats(monitor, start_time, end_time):
             )
 
     # --- PostgreSQL fallback ---
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
     base_queryset = ObservationSpan.objects.filter(
         project=monitor.project, created_at__range=(start_time, end_time)
     ).filter(filters)
@@ -724,7 +724,7 @@ def _get_time_series_df_for_other_metrics(monitor, now):
     For non-aggregated metrics, fetches individual data points and returns a
     Prophet-ready DataFrame, averaging values for duplicate timestamps.
     """
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
     base_queryset = ObservationSpan.objects.filter(
         project=monitor.project, created_at__lte=now
     ).filter(filters)

--- a/futureagi/tracer/utils/monitor_graphs.py
+++ b/futureagi/tracer/utils/monitor_graphs.py
@@ -34,7 +34,7 @@ from tracer.services.clickhouse.query_builders.monitor_metrics import (
     MonitorMetricsQueryBuilder,
 )
 from tracer.services.clickhouse.query_service import AnalyticsQueryService, QueryType
-from tracer.utils.eval_tasks import parsing_evaltask_filters
+from tracer.utils.eval_tasks import parsing_monitor_filters
 
 
 def _build_monitor_graph_ch_builder(monitor):
@@ -188,7 +188,7 @@ def get_static_metric_graph_data(monitor, time_window_start=None, time_window_en
                 monitor, time_window_start, time_window_end, frequency_seconds
             )
 
-        filters = parsing_evaltask_filters(monitor.filters)
+        filters = parsing_monitor_filters(monitor.filters)
 
         base_queryset = ObservationSpan.objects.filter(project=monitor.project)
 
@@ -288,7 +288,7 @@ def _get_eval_metric_graph_data(
         )
         return []
 
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
 
     base_queryset = EvalLogger.objects.filter(
         custom_eval_config=custom_eval_config,
@@ -355,7 +355,7 @@ def _get_group_error_free_rate_data(
 ):
     """Handles graph data generation for group-based error-free rate metrics."""
     metric_type = monitor.metric_type
-    filters = parsing_evaltask_filters(monitor.filters)
+    filters = parsing_monitor_filters(monitor.filters)
 
     # Build the base queryset with optional time filtering
     base_queryset = ObservationSpan.objects.filter(project=monitor.project)
@@ -764,7 +764,7 @@ def get_percentage_change_metric_graph_data(
         auto_threshold_time_window = timedelta(
             minutes=monitor.auto_threshold_time_window
         )
-        filters = parsing_evaltask_filters(monitor.filters)
+        filters = parsing_monitor_filters(monitor.filters)
 
         # Extend time window backwards for historical data
         extended_start = None

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -1470,8 +1470,12 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             filters = update_fields.get("filters") or eval_task.filters
 
             # Validate filters and get total spans count
-            parsed_filters = parsing_evaltask_filters(filters)
-            total_spans = ObservationSpan.objects.filter(parsed_filters).count()
+            parsed_filters, parsed_filter_anns = parsing_evaltask_filters(filters)
+            total_spans = (
+                ObservationSpan.objects.annotate(**parsed_filter_anns)
+                .filter(parsed_filters)
+                .count()
+            )
 
             if total_spans == 0:
                 logger.warning(


### PR DESCRIPTION
## What

Two coordinated fixes that make annotation filters on eval-task targeting (and every annotation-aware list endpoint) actually work end-to-end.

### BE — `futureagi/tracer/utils/annotations.py`

`build_annotation_subqueries` had two bugs in the per-label score aggregation:

1. **`Floor(Avg(score))` collapsed NUMERIC labels to 0.** STAR labels are integer 1–5, so `Floor` is correct there — but NUMERIC labels can be continuous floats (e.g. 0.0–1.0 with step 0.1), and `Floor(0.5) → 0`. Split the path: keep `Floor` for STAR, use `Round(Avg(_), 2)` for NUMERIC.
2. **`JSONBObjectAgg` over `annotator_id` errored on system-emitted Score rows.** Postgres `jsonb_object_agg` rejects NULL keys, so a single score row with `annotator_id IS NULL` would fail the entire annotation query with *"field name must not be null"*. Add `filter=Q(annotator_id__isnull=False)` to every `JSONBObjectAgg` call site (NUMERIC/STAR, THUMBS_UP_DOWN, TEXT — CATEGORICAL already filters on `value__selected__isnull=False` so its key can't be NULL).

### FE — colType round-trip across the eval-task / filter-panel surface

Annotation filters (`annotator`, `my_annotations`, per-label score) and `eval_metric` filters share the BE wire shape with `span_attribute` filters: `{columnId, filterConfig: {colType, filterType, filterOp, filterValue}}`. The dispatcher in `parsing_evaltask_filters` routes on `colType` — but the FE was dropping `colType` through the formatter → extractor cycle, so re-saved tasks lost their routing and collapsed into the SPAN_ATTRIBUTE branch on the BE.

Carry `colType` end-to-end:
- `validation.js` `extractAttributeFilters` emits `colType` inside `filterConfig` for every attribute-shaped filter; annotation rows force `colType=ANNOTATION` via `ANNOTATION_COLUMN_IDS`.
- `common.js` `formatTaskFilters` reads both the canonical `filters` key and the legacy `span_attributes_filters` (for un-migrated rows), preserves `colType` into `filterConfig`, and surfaces `apiColType` so `TaskFilterBar.convertOldToNew` can re-route rehydrated rows back to the right picker chip.
- `TaskFilterBar` / `TaskLivePreview` / `TaskDetailPage` / `EditTaskDrawer/DetailsEdit` / `TraceFilterPanel` pass `colType` through the display + edit-and-rerun paths.

## Why

Without the BE fix, any project with a system-emitted Score row (auto-eval scoring, programmatic annotations) silently broke every list endpoint that surfaces annotation values, and any NUMERIC label aggregation reported zeros instead of the real score.

Without the FE fix, a user who builds an eval-task with an annotation filter, saves, re-opens it, and saves again has their filter rewritten as a span_attribute filter — running against the wrong code path on the BE.

## Stacking

Stacked on #800 (`test/TH-5699-eval-task-integration-suite`) and #782 (`fix/th-5645-eval-task-filter-dispatch`). The integration suite in #800 covers all 16 annotation cases (4 ops × 4 target_types) and exercises both the FE-shaped filter dict and the BE annotation handler — every case green with these two fixes applied.

## Test plan

Integration suite green: `uv run pytest tracer/tests/integration/test_eval_task_filter_e2e.py -k annotation` — 16/16 passing on the runner path. Manual verification: create an eval-task with an annotator filter via the New Task Drawer → save → edit → confirm the annotator chip rehydrates as an annotator (not a span_attribute) row → save again → confirm the BE log shows `colType=ANNOTATION` in the dispatched filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
