### PR TITLE
fix(trace-graph): map camelCase graph node properties to snake_case for tooltip

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
@@ -466,7 +466,7 @@ const layoutGraph = (nodes, edges, direction = "LR") => {
 // ---------------------------------------------------------------------------
 // Build React Flow nodes + edges from API data
 // ---------------------------------------------------------------------------
-const buildFlowData = (graphData, direction = "LR", theme = null) => {
+export const buildFlowData = (graphData, direction = "LR", theme = null) => {
   if (!graphData?.nodes?.length) return { nodes: [], edges: [] };
 
   const nodeIdSet = new Set(graphData.nodes.map((n) => n.id));

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx
@@ -474,7 +474,15 @@ const buildFlowData = (graphData, direction = "LR", theme = null) => {
   const flowNodes = graphData.nodes.map((node) => ({
     id: node.id,
     type: "agentNode",
-    data: { ...node, _direction: direction },
+    data: {
+      ...node,
+      span_count: node.spanCount ?? 0,
+      avg_latency_ms: node.avgLatencyMs ?? 0,
+      total_tokens: node.totalTokens ?? 0,
+      total_cost: node.totalCost ?? 0,
+      error_count: node.errorCount ?? 0,
+      _direction: direction,
+    },
     position: { x: 0, y: 0 },
     connectable: false,
   }));

--- a/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/AgentGraph.test.jsx
+++ b/frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/AgentGraph.test.jsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { buildFlowData } from "../AgentGraph";
+
+const dataById = (result, id) => result.nodes.find((n) => n.id === id)?.data;
+
+// buildFlowData feeds two different producers into the same AgentNode tooltip,
+// which reads snake_case keys (span_count, avg_latency_ms, ...):
+//   - the agent_graph API (snake_case; the axios interceptor also adds camelCase aliases)
+//   - buildTraceGraph (client-side, camelCase only — never hits axios)
+// The mapping has to land real snake_case values for both.
+describe("buildFlowData metric mapping", () => {
+  it("preserves API metrics that arrive with both snake_case and camelCase (no regression on project/compare graph)", () => {
+    const apiNode = {
+      id: "LLM:openai_chat",
+      name: "openai_chat",
+      type: "llm",
+      span_count: 5,
+      spanCount: 5,
+      avg_latency_ms: 800,
+      avgLatencyMs: 800,
+      total_tokens: 2250,
+      totalTokens: 2250,
+      total_cost: 0.06,
+      totalCost: 0.06,
+      error_count: 0,
+      errorCount: 0,
+    };
+
+    const data = dataById(
+      buildFlowData({ nodes: [apiNode], edges: [] }),
+      "LLM:openai_chat",
+    );
+
+    expect(data.span_count).toBe(5);
+    expect(data.avg_latency_ms).toBe(800);
+    expect(data.total_tokens).toBe(2250);
+    expect(data.total_cost).toBe(0.06);
+    expect(data.error_count).toBe(0);
+  });
+
+  it("populates snake_case metrics from a camelCase-only node (fixes the blank trace-detail tooltip)", () => {
+    const traceNode = {
+      id: "LLM:openai_chat",
+      name: "openai_chat",
+      type: "llm",
+      spanCount: 2,
+      avgLatencyMs: 700,
+      totalTokens: 750,
+      totalCost: 0.02,
+      errorCount: 1,
+    };
+
+    const data = dataById(
+      buildFlowData({ nodes: [traceNode], edges: [] }),
+      "LLM:openai_chat",
+    );
+
+    expect(data.span_count).toBe(2);
+    expect(data.avg_latency_ms).toBe(700);
+    expect(data.total_tokens).toBe(750);
+    expect(data.total_cost).toBe(0.02);
+    expect(data.error_count).toBe(1);
+  });
+
+  it("defaults missing metrics to 0", () => {
+    const bareNode = { id: "TOOL:noop", name: "noop", type: "tool" };
+
+    const data = dataById(
+      buildFlowData({ nodes: [bareNode], edges: [] }),
+      "TOOL:noop",
+    );
+
+    expect(data.span_count).toBe(0);
+    expect(data.avg_latency_ms).toBe(0);
+    expect(data.total_tokens).toBe(0);
+    expect(data.total_cost).toBe(0);
+    expect(data.error_count).toBe(0);
+  });
+
+  it("returns empty nodes/edges for empty or missing graph data", () => {
+    expect(buildFlowData({ nodes: [], edges: [] })).toEqual({
+      nodes: [],
+      edges: [],
+    });
+    expect(buildFlowData(null)).toEqual({ nodes: [], edges: [] });
+  });
+});


### PR DESCRIPTION
## Summary

`buildTraceGraph` outputs graph node properties in camelCase (`spanCount`, `avgLatencyMs`, `totalTokens`, `totalCost`, `errorCount`) but the `AgentNode` hover tooltip reads them in snake_case (`span_count`, `avg_latency_ms`, `total_tokens`, `total_cost`, `error_count`). All five metric values were `undefined` on hover — Duration, Tokens, Cost, Runs, and Errors showed blank. The trace tree was unaffected because it reads directly from raw span objects.

## Changes

- `frontend/src/sections/projects/LLMTracing/GraphSection/AgentGraph.jsx` — map camelCase properties from `buildTraceGraph` to snake_case in `buildFlowData` before passing to React Flow nodes

## Test plan

- [x] Open any trace detail with multiple span types
- [x] Hover a graph node — Duration, Total Tokens, Cost, Runs, Errors should all display values
- [x] Verify evals and annotations still render correctly in tooltip

BEFORE
<img width="286" height="845" alt="Screenshot 2026-06-08 at 7 06 10 PM" src="https://github.com/user-attachments/assets/9f9169e3-5e9f-489a-8bd9-f03ebd16c49f" />
<img width="292" height="846" alt="Screenshot 2026-06-08 at 7 06 16 PM" src="https://github.com/user-attachments/assets/4b83f524-38a4-435b-811f-9ad4ca023a99" />

AFTER
<img width="294" height="844" alt="Screenshot 2026-06-08 at 7 04 36 PM" src="https://github.com/user-attachments/assets/283e365b-93e6-4c49-b060-173dd494390c" />
<img width="294" height="867" alt="Screenshot 2026-06-08 at 7 04 29 PM" src="https://github.com/user-attachments/assets/90e4e853-ceb6-4947-aea4-77603514f3c6" />


## Automated tests

Added `frontend/src/sections/projects/LLMTracing/GraphSection/__tests__/AgentGraph.test.jsx` covering the exact mapping this PR adds in `buildFlowData` (`buildFlowData` is now exported for the test):

- backend nodes that arrive with both snake_case and camelCase keep their real values — guards the project / compare graph against the zeroing regression raised in review
- camelCase-only nodes from `buildTraceGraph` get snake_case populated — the trace-detail fix
- missing metrics default to `0`; empty/missing graph data returns empty

```
 ✓ GraphSection/__tests__/AgentGraph.test.jsx (4 tests)
   ✓ buildFlowData metric mapping › preserves API metrics that arrive with both snake_case and camelCase (no regression on project/compare graph)
   ✓ buildFlowData metric mapping › populates snake_case metrics from a camelCase-only node (fixes the blank trace-detail tooltip)
   ✓ buildFlowData metric mapping › defaults missing metrics to 0
   ✓ buildFlowData metric mapping › returns empty nodes/edges for empty or missing graph data

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Full `vitest run`: 1299/1299 tests pass. (7 unrelated suites fail to load on a pre-existing `localStorage`/AG-Grid test-env issue in Voice/annotations/Sessions/test-detail/develop-detail — not touched by this PR, which changes only the agent graph.)
