### PR TITLE
fix(evals): handle negative NumericSimilarity scores

### DIFF
--- a/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/functions.py
@@ -1036,8 +1036,8 @@ def calculate_numeric_similarity(output: str, expected: str):
             "reason": f"Cannot calculate numeric similarity: {'; '.join(errors)}"
         }
     diff = abs(pred_num - ref_num)
-    normalized_diff = diff / max(pred_num, ref_num, 1)
-    similarity = 1.0 - normalized_diff
+    normalized_diff = diff / max(abs(pred_num), abs(ref_num), 1)
+    similarity = max(0.0, 1.0 - normalized_diff)
     reason = f"Numeric Diff: |{pred_num} - {ref_num}| = {diff}, Normalized Diff: {normalized_diff:.3f}, Similarity: {similarity:.3f}"
     return {
         "result": similarity,

--- a/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_numeric_similarity.py
+++ b/futureagi/agentic_eval/core_evals/fi_evals/function/tests/test_numeric_similarity.py
@@ -1,0 +1,40 @@
+import pytest
+
+from agentic_eval.core_evals.fi_evals.function.functions import (
+    calculate_numeric_similarity,
+)
+
+
+def _score(output, expected):
+    return calculate_numeric_similarity(output, expected)["result"]
+
+
+class TestNumericSimilarityNegatives:
+    def test_close_negatives_score_high(self):
+        assert _score(-100, -110) == pytest.approx(1 - 10 / 110)
+        assert _score(-40, -38) == pytest.approx(0.95)
+        assert _score(-1, -2) == pytest.approx(0.5)
+
+    def test_mixed_sign_clamps_to_zero(self):
+        assert _score(5, -5) == 0.0
+        assert _score(1, -1) == 0.0
+
+    @pytest.mark.parametrize(
+        "a,b", [(-100, -110), (5, -5), (-7, 3), (-0.5, -2.5), (-50, 50)]
+    )
+    def test_score_stays_in_unit_interval(self, a, b):
+        assert 0.0 <= _score(a, b) <= 1.0
+
+
+class TestNumericSimilarityUnchangedBehaviour:
+    def test_identical_values_are_fully_similar(self):
+        assert _score(7, 7) == pytest.approx(1.0)
+        assert _score(-7, -7) == pytest.approx(1.0)
+        assert _score(0, 0) == pytest.approx(1.0)
+
+    def test_positive_inputs_unchanged(self):
+        assert _score(100, 110) == pytest.approx(1 - 10 / 110)
+        assert _score(0.5, 0.6) == pytest.approx(0.9)
+
+    def test_string_inputs_are_parsed(self):
+        assert _score("-40", "-38") == pytest.approx(0.95)


### PR DESCRIPTION
## Summary
`calculate_numeric_similarity` divides by `max(pred_num, ref_num, 1)`. For negative inputs the denominator collapses to `1`, so close values such as `-100` and `-110` return `-9.0` instead of ~`0.909`. The agentic_eval FunctionEvaluator surfaces this raw value unclamped, so it both misleads the `is_failure = not result` flag and, at `pass_threshold=0.5`, scores should-pass negative pairs as failures. The fix uses magnitudes and clamps: `1 - |a - b| / max(|a|, |b|, 1)`. This matches `model_hub/system_evals/function/numeric_similarity.yaml` and keeps positive-input results unchanged (including sub-1 values).

The fix normalises by `max(abs(pred_num), abs(ref_num), 1)` and clamps to `[0, 1]`, matching the shipped `numeric_similarity` system eval (`model_hub/system_evals/function/numeric_similarity.yaml`). Positive-input results are unchanged (the `1` denominator floor is kept), so only the broken negative / mixed-sign cases change.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?
Added regression tests (negative/mixed-sign clamping, positive behaviour preserved, score in [0, 1]). In the OSS backend image they fail on the current code and pass after the fix:

```bash
    cd futureagi && DJANGO_SETTINGS_MODULE=tfc.settings.test python -m pytest \
      agentic_eval/core_evals/fi_evals/function/tests/test_numeric_similarity.py \
      -c agentic_eval/pytest.ini --import-mode=importlib -o consider_namespace_packages=true
```

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)

<!--
On first-time contributions the CLA bot will comment with a one-click signing link.
-->
