### PR TITLE
fix(tracer): trim has-more sentinel row in ClickHouse trace list views (TH-5574)

### DIFF
--- a/futureagi/tracer/tests/test_traces_of_session_pagination.py
+++ b/futureagi/tracer/tests/test_traces_of_session_pagination.py
@@ -1,0 +1,94 @@
+"""Regression test for TH-5574 — Trace View selection counts off by one.
+
+``TraceListQueryBuilder.build()`` fetches ``page_size + 1`` rows per page as a
+has-more sentinel (asserted in ``test_trace_list_ch.py``). The consuming views
+must trim that sentinel back to ``page_size`` before building the response,
+otherwise a page returns one extra trace — the off-by-one the user saw when
+"select all on this page" reported 26 selections for a 25-row page.
+
+This pins the trim in ``TraceView._list_traces_of_session_clickhouse`` (the
+``list_traces_of_session`` endpoint named in the ticket).
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+@pytest.mark.unit
+class TestTracesOfSessionPagination:
+    def _make_view(self):
+        from tracer.views.trace import TraceView
+
+        view = TraceView.__new__(TraceView)
+        view._gm = SimpleNamespace(
+            success_response=lambda payload: ("ok", payload),
+            bad_request=lambda msg: ("bad_request", msg),
+        )
+        return view
+
+    def _make_request(self, *, page_size):
+        org = SimpleNamespace(id=uuid.uuid4())
+        return SimpleNamespace(
+            query_params={"page_number": "0", "page_size": str(page_size)},
+            organization=org,
+            user=SimpleNamespace(organization=org),
+        )
+
+    def _routing_analytics(self, *, trace_rows, total):
+        """Stub ``execute_ch_query`` routing by SQL so build() runs but no CH hit.
+
+        Phase-1 trace query returns ``trace_rows`` (page_size + 1 of them); the
+        count query returns ``total``; every other auxiliary query returns [].
+        """
+
+        def _side_effect(query, params=None, **kwargs):
+            q = query
+            if "uniq(trace_id) AS total" in q:
+                return SimpleNamespace(data=[{"total": total}])
+            # Phase-1 paginated trace list (default light-column SELECT).
+            if "trace_session_id" in q and "uniq(" not in q and "AS cid" not in q:
+                return SimpleNamespace(data=list(trace_rows))
+            return SimpleNamespace(data=[])
+
+        analytics = mock.MagicMock()
+        analytics.execute_ch_query.side_effect = _side_effect
+        return analytics
+
+    def test_page_trimmed_to_page_size(self):
+        """A page that fetched page_size + 1 rows returns exactly page_size."""
+        page_size = 25
+        view = self._make_view()
+        request = self._make_request(page_size=page_size)
+
+        # build() asks for page_size + 1 rows for has-more detection.
+        trace_rows = [{"trace_id": str(uuid.uuid4())} for _ in range(page_size + 1)]
+        total = 40
+        analytics = self._routing_analytics(trace_rows=trace_rows, total=total)
+
+        with (
+            mock.patch(
+                "tracer.views.trace.get_annotation_labels_for_project",
+                return_value=[],
+            ),
+            mock.patch(
+                "tracer.views.trace._build_annotation_map_from_scores",
+                return_value={},
+            ),
+        ):
+            status, payload = view._list_traces_of_session_clickhouse(
+                request,
+                project_id=str(uuid.uuid4()),
+                validated_data={"filters": []},
+                analytics=analytics,
+                org_project_ids=None,
+                org=request.organization,
+            )
+
+        assert status == "ok"
+        # The sentinel row must be trimmed — exactly page_size, not page_size + 1.
+        assert len(payload["table"]) == page_size
+        # total_rows comes from the (correct) uniq() count, unchanged by the trim.
+        assert payload["metadata"]["total_rows"] == total

--- a/futureagi/tracer/views/trace.py
+++ b/futureagi/tracer/views/trace.py
@@ -4949,6 +4949,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         # Phase 1: Paginated traces (light columns only — no input/output)
         query, params = builder.build()
         result = analytics.execute_ch_query(query, params, timeout_ms=10000)
+        result.data = result.data[:page_size]
 
         # Count
         count_query, count_params = builder.build_count_query()
@@ -5226,6 +5227,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         # Phase 1: Paginated root conversation spans (light columns only)
         query, params = builder.build()
         result = analytics.execute_ch_query(query, params, timeout_ms=10000)
+        result.data = result.data[:page_size]
 
         # Phase 1b: Fetch span_attributes from the CH CDC table for the
         # paginated spans.  The denormalized `spans` table has empty
@@ -5520,6 +5522,7 @@ class TraceView(BaseModelViewSetMixin, ModelViewSet):
         # Phase 1: Get paginated traces
         query, params = builder.build()
         result = analytics.execute_ch_query(query, params, timeout_ms=10000)
+        result.data = result.data[:page_size]
 
         # Get count
         count_query, count_params = builder.build_count_query()


### PR DESCRIPTION
## Summary

Fixes **TH-5574 — Trace View selection counts are off by one**.

The ClickHouse trace-list query builder intentionally fetches `page_size + 1` rows per page as a has-more sentinel (`trace_list.py:137`, asserted in `test_trace_list_ch.py`). The consuming views are responsible for trimming that sentinel back to `page_size` before building the response. Three CH list views iterated the **full** result set without trimming, so each page returned one extra trace — the off-by-one users saw:

- Page size 25, but "select all on this page" reported **26** selections.
- "Select all XX traces" total disagreed with a manual row count.

The `uniq(trace_id)` count query was already correct, so trimming the rendered rows brings everything back in sync.

## Changes

`futureagi/tracer/views/trace.py` — add `result.data = result.data[:page_size]` after the paginated Phase-1 query in:

| View | Endpoint |
|------|----------|
| `_list_traces_of_session_clickhouse` | `list_traces_of_session` (the endpoint in the ticket) |
| `_list_traces_clickhouse` | trace list (main Trace View) |
| `_list_voice_calls_clickhouse` | `list_voice_calls` |

Verified unaffected: PG fallbacks (already slice; voice calls' PG path uses DRF pagination), `agent_graph` (not paginated), and the spans-of-session / session views which already trim correctly.

## Tests

- Added `tracer/tests/test_traces_of_session_pagination.py` — pins the trim on `list_traces_of_session` (returns 26 stubbed rows, asserts the response table has exactly 25).
- `test_trace_list_ch.py`, `test_trace_session_ch_query.py`, `test_list_sessions_org_scope.py` and the new test all pass.
