### PR TITLE
fix(TraceFilterPanel): de-dupe ID_ONLY_FIELDS, add session to shared set

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx
@@ -188,7 +188,6 @@ const ANNOTATOR_OPS = [
 
 // Direct UUID identifiers support exact multi-select through the canonical
 // list operators. Avoid substring/null operators for these fields.
-const ID_ONLY_FIELDS = new Set(["trace_id", "span_id", "session"]);
 const ID_ONLY_OPS = [
   { value: "in", label: "equals" },
   { value: "not_in", label: "not equals" },

--- a/frontend/src/sections/projects/LLMTracing/idFields.js
+++ b/frontend/src/sections/projects/LLMTracing/idFields.js
@@ -1,3 +1,3 @@
 // Backend treats these columns as direct equality filters; sending
 // `col_type` for them routes through the metric pipeline and matches nothing.
-export const ID_ONLY_FIELDS = new Set(["trace_id", "span_id"]);
+export const ID_ONLY_FIELDS = new Set(["trace_id", "span_id", "session"]);


### PR DESCRIPTION
## Problem

\`TraceFilterPanel.jsx\` has two declarations of \`ID_ONLY_FIELDS\`:

| Line | Origin | Set |
|---|---|---|
| 45 | \`import { ID_ONLY_FIELDS } from \"./idFields\"\` (added 2026-05-15) | \`{trace_id, span_id}\` |
| 191 | \`const ID_ONLY_FIELDS = new Set(...)\` (added 2026-05-24) | \`{trace_id, span_id, session}\` |

Browser throws \`SyntaxError: Identifier 'ID_ONLY_FIELDS' has already been declared\` and the entire trace filter view fails to load. The two sets also disagree on membership, so even if the JS engine silently kept one declaration, the other's intent (\`session\` membership) would be lost.

## Fix

- \`idFields.js\` — add \`session\` to the exported set, preserving the more recent intent.
- \`TraceFilterPanel.jsx\` — delete the inline redeclaration on line 191; the import on line 45 is now the only declaration.

\`idFields.js\` becomes the single source of truth for these UUID-only fields.

## Diff
\`\`\`
frontend/src/sections/projects/LLMTracing/TraceFilterPanel.jsx | 1 -
frontend/src/sections/projects/LLMTracing/idFields.js          | 2 +-
2 files changed, 1 insertion(+), 2 deletions(-)
\`\`\`

## Verification

Reload the Observe / Traces page locally — the SyntaxError is gone and the filter panel renders. Filters for \`trace_id\`, \`span_id\`, and \`session\` continue to use the canonical \`in\` / \`not_in\` (\"equals\" / \"not equals\") operators via \`ID_ONLY_OPS\`.