### PR TITLE
fix: keep strong references to PromptStreamConsumer background tasks

### DIFF
--- a/futureagi/sockets/prompt_stream_consumer.py
+++ b/futureagi/sockets/prompt_stream_consumer.py
@@ -44,6 +44,16 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
         self.session_uuid = None
         self.organization_id = None
         self.workspace_id = None
+        # asyncio keeps only a weak reference to a bare create_task() result, so a
+        # fire-and-forget task can be garbage-collected mid-run. Hold a strong
+        # reference until it finishes (and cancel any leftovers on disconnect).
+        self._background_tasks: set[asyncio.Task] = set()
+
+    def _spawn(self, coro):
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
 
     async def connect(self):
         self.user = self.scope.get("user")
@@ -75,6 +85,8 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
         logger.info(
             f"PromptStream connection closed: session={self.session_uuid}, code={close_code}"
         )
+        for task in list(self._background_tasks):
+            task.cancel()
 
     async def receive_json(self, content):
         message_type = content.get("type")
@@ -117,7 +129,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
             }
         )
 
-        asyncio.create_task(self.execute_template_async(content, template_id))
+        self._spawn(self.execute_template_async(content, template_id))
 
     async def execute_template_async(self, content, template_id):
         try:
@@ -221,7 +233,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
             }
         )
 
-        asyncio.create_task(
+        self._spawn(
             self.execute_improve_prompt_async(payload, payload.get("improve_id"))
         )
 
@@ -312,7 +324,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
             }
         )
 
-        asyncio.create_task(self.execute_generate_prompt_async(payload, generation_id))
+        self._spawn(self.execute_generate_prompt_async(payload, generation_id))
 
     async def execute_generate_prompt_async(self, content, generation_id):
         try:

--- a/futureagi/sockets/prompt_stream_consumer.py
+++ b/futureagi/sockets/prompt_stream_consumer.py
@@ -46,6 +46,16 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
         super().__init__(*args, **kwargs)
         self.session_uuid = None
         self.workspace_id = None
+        # asyncio keeps only a weak reference to a bare create_task() result, so a
+        # fire-and-forget task can be garbage-collected mid-run. Hold a strong
+        # reference until it finishes (and cancel any leftovers on disconnect).
+        self._background_tasks: set[asyncio.Task] = set()
+
+    def _spawn(self, coro):
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
 
     async def connect(self):
         self.user = self.scope.get("user")
@@ -76,6 +86,8 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
         logger.info(
             f"PromptStream connection closed: session={self.session_uuid}, code={close_code}"
         )
+        for task in list(self._background_tasks):
+            task.cancel()
 
     async def receive_json(self, content):
         message_type = content.get("type")
@@ -264,7 +276,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
                 "session_uuid": self.session_uuid,
             }
         )
-        asyncio.create_task(self.execute_template_async(content, template_id))
+        self._spawn(self.execute_template_async(content, template_id))
 
     async def execute_template_async(self, content, template_id):
         correlation = {"template_id": template_id}
@@ -344,9 +356,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
                 "session_uuid": self.session_uuid,
             }
         )
-        asyncio.create_task(
-            self.execute_improve_prompt_async(payload, payload["improve_id"])
-        )
+        self._spawn(self.execute_improve_prompt_async(payload, payload["improve_id"]))
 
     async def execute_improve_prompt_async(self, content, improve_id):
         correlation = {"improve_id": improve_id}
@@ -407,7 +417,7 @@ class PromptStreamConsumer(AsyncJsonWebsocketConsumer):
                 "session_uuid": self.session_uuid,
             }
         )
-        asyncio.create_task(self.execute_generate_prompt_async(payload, generation_id))
+        self._spawn(self.execute_generate_prompt_async(payload, generation_id))
 
     async def execute_generate_prompt_async(self, content, generation_id):
         correlation = {"generation_id": generation_id}

--- a/futureagi/sockets/tests/test_prompt_stream_consumer.py
+++ b/futureagi/sockets/tests/test_prompt_stream_consumer.py
@@ -239,3 +239,89 @@ def test_execute_template_allows_null_workspace_template_in_same_org(monkeypatch
     # permission reasons).
     for call in consumer.close.await_args_list:
         assert call.kwargs.get("code") != WS_CLOSE_CODE_PERMISSION_DENIED
+
+
+# ---------------------------------------------------------------------------
+# Background-task handling (PR #821)
+#
+# asyncio keeps only a weak reference to the result of a bare create_task(), so
+# a fire-and-forget task can be garbage-collected mid-run and silently dropped.
+# `_spawn` holds a strong reference until the task finishes; `disconnect`
+# cancels anything still in flight.
+#
+# Written in the same sync + asyncio.run(...) style as the tests above so they
+# do not depend on pytest-asyncio being registered.
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_retains_strong_reference_while_task_runs():
+    """_spawn() must keep the task in _background_tasks until it completes."""
+    consumer = _make_consumer()
+
+    async def scenario():
+        started = asyncio.Event()
+
+        async def _work():
+            started.set()
+            await asyncio.sleep(3600)
+
+        task = consumer._spawn(_work())
+        await started.wait()
+
+        # Still running -> reference must be held, otherwise GC could collect it.
+        assert task in consumer._background_tasks
+
+        task.cancel()
+        return task
+
+    task = asyncio.run(scenario())
+    assert task.cancelled()
+
+
+def test_spawn_drops_reference_once_task_finishes():
+    """The done callback must discard the task so the set does not leak."""
+    consumer = _make_consumer()
+
+    async def scenario():
+        async def _work():
+            return "done"
+
+        task = consumer._spawn(_work())
+        assert task in consumer._background_tasks
+
+        await task
+        # add_done_callback is scheduled via call_soon; yield so it can run.
+        await asyncio.sleep(0)
+
+        assert task not in consumer._background_tasks
+        assert consumer._background_tasks == set()
+
+    asyncio.run(scenario())
+
+
+def test_disconnect_cancels_inflight_background_tasks():
+    """disconnect() must cancel tasks that are still running."""
+    consumer = _make_consumer()
+
+    async def scenario():
+        started = asyncio.Event()
+
+        async def _work():
+            started.set()
+            await asyncio.sleep(3600)
+
+        task = consumer._spawn(_work())
+        await started.wait()
+
+        await consumer.disconnect(close_code=1000)
+
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert task.cancelled()
+        # The done callback should also have cleaned up the reference.
+        assert task not in consumer._background_tasks
+
+    asyncio.run(scenario())


### PR DESCRIPTION
### What

`PromptStreamConsumer` launched its streaming work with bare `asyncio.create_task(...)` and threw away the returned task in three places (`execute_template_async`, `execute_improve_prompt_async`, `execute_generate_prompt_async`).

The event loop only keeps a **weak** reference to a task, so a fire-and-forget task can be garbage-collected before it finishes — silently dropping a user's prompt execution with no result and no error. Per the [CPython docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task): *"Save a reference to the result of this function, to avoid a task disappearing mid-execution."*

Closes #819.

### How

- Added a `self._background_tasks` set and a small `_spawn()` helper that holds a strong reference to each task and removes it via `add_done_callback` once it completes (no leak).
- Routed the three `create_task` call sites through `_spawn()`.
- Cancel any still-pending tasks in `disconnect()` so they don't outlive the connection.

### Notes

- No behavior change for the happy path — same coroutines, same scheduling; this just prevents the GC race.
- Found while reviewing the async paths with a static analyzer ([codehound](https://github.com/kratos0718/codehound)). It flagged one more spot — `model_hub/utils/kb_helpers.py` uses a deprecated `asyncio.get_event_loop()` plus a fire-and-forget `ensure_future` — happy to send a separate small PR for that to keep this one focused.

### Testing

- `python -m py_compile` clean; static analyzer reports the file clean after the change.
