### PR TITLE
feat(simulate): add reproducibility passports

### DIFF
--- a/frontend/src/api/tests/testDetails.js
+++ b/frontend/src/api/tests/testDetails.js
@@ -9,6 +9,16 @@ export const useRerunTest = (executionId, options) => {
   });
 };
 
+export const useExecutionReproducibility = (executionId, options = {}) => {
+  return useQuery({
+    queryKey: ["test-execution-reproducibility", executionId],
+    queryFn: () => axios.get(endpoints.testExecutions.reproducibility(executionId)),
+    enabled: !!executionId,
+    select: (data) => data.data,
+    ...options,
+  });
+};
+
 export const useGetTestDetail = (testId, options = {}) => {
   return useQuery({
     queryKey: ["test-runs-detail", testId],

--- a/frontend/src/sections/test-detail/RerunModal.jsx
+++ b/frontend/src/sections/test-detail/RerunModal.jsx
@@ -8,6 +8,7 @@ import {
   FormControl,
   FormControlLabel,
   IconButton,
+  LinearProgress,
   Radio,
   RadioGroup,
   Typography,
@@ -16,8 +17,17 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import Iconify from "src/components/iconify";
 import { RerunTestOptions } from "./common";
-import { useRerunTest } from "src/api/tests/testDetails";
+import {
+  useExecutionReproducibility,
+  useRerunTest,
+} from "src/api/tests/testDetails";
 import { AGENT_TYPES } from "../agents/constants";
+
+const riskColor = {
+  high: "error.main",
+  medium: "warning.main",
+  low: "success.main",
+};
 
 const RerunModal = ({
   open,
@@ -42,6 +52,14 @@ const RerunModal = ({
       },
     },
   );
+  const { data: reproReport, isFetching: isReproFetching } =
+    useExecutionReproducibility(executionId, {
+      enabled: open && !!executionId,
+      retry: false,
+    });
+
+  const stabilizationPlan = reproReport?.stabilization_plan;
+  const stabilizationActions = stabilizationPlan?.actions ?? [];
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
@@ -106,6 +124,71 @@ const RerunModal = ({
               </RadioGroup>
             )}
           </FormControl>
+        </Box>
+        <Box
+          sx={{
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: 1,
+            p: 1.5,
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 1,
+            }}
+          >
+            <Typography typography="m3" fontWeight="fontWeightMedium">
+              Replay preflight
+            </Typography>
+            {stabilizationPlan?.risk_level && (
+              <Typography
+                typography="caption"
+                sx={{
+                  color:
+                    riskColor[stabilizationPlan.risk_level] ?? "text.secondary",
+                  textTransform: "capitalize",
+                }}
+              >
+                {stabilizationPlan.risk_level} risk
+              </Typography>
+            )}
+          </Box>
+          {isReproFetching && <LinearProgress />}
+          {stabilizationPlan ? (
+            <>
+              <Typography typography="caption" color="text.secondary">
+                {stabilizationPlan.summary}
+              </Typography>
+              {stabilizationActions.slice(0, 3).map((action) => (
+                <Box key={`${action.source}-${action.section}`}>
+                  <Typography
+                    typography="caption"
+                    fontWeight="fontWeightMedium"
+                  >
+                    {action.title}
+                  </Typography>
+                  <Typography
+                    typography="caption"
+                    color="text.secondary"
+                    display="block"
+                  >
+                    {action.action}
+                  </Typography>
+                </Box>
+              ))}
+            </>
+          ) : (
+            <Typography typography="caption" color="text.secondary">
+              Preflight report is not available yet.
+            </Typography>
+          )}
         </Box>
         <Box
           sx={{

--- a/frontend/src/sections/test-detail/TestRunDetailHeader.jsx
+++ b/frontend/src/sections/test-detail/TestRunDetailHeader.jsx
@@ -11,7 +11,10 @@ import { useCancelExecution } from "../test/common";
 import { useTestExecutionStore } from "./states";
 import { RerunTestOptions, TestRunLoadingStatus } from "./common";
 import { ShowComponent } from "src/components/show";
-import { useRerunTest } from "src/api/tests/testDetails";
+import {
+  useExecutionReproducibility,
+  useRerunTest,
+} from "src/api/tests/testDetails";
 import { LoadingButton } from "@mui/lab";
 import { ConfirmDialog } from "src/components/custom-dialog";
 import CustomTooltip from "src/components/tooltip";
@@ -54,7 +57,23 @@ const TestRunDetailHeader = () => {
   );
   const { data: testData } = useTestRunDetails(testId);
   const { data: kpis } = useKpis(executionId);
+  const { data: reproducibility } = useExecutionReproducibility(executionId, {
+    enabled: confirmRerun && !!executionId,
+  });
   const agentType = kpis?.agent_type;
+  const preflight = reproducibility?.preflight;
+  const inputDrift = preflight?.input_drift ?? preflight?.inputDrift;
+  const diagnosis =
+    reproducibility?.score_change_diagnosis ??
+    reproducibility?.scoreChangeDiagnosis;
+  const preflightIssues = preflight?.issues ?? [];
+  const preflightStatus = preflight?.status;
+  const inputFingerprint =
+    reproducibility?.current?.replay_plan?.input_fingerprint ??
+    reproducibility?.current?.replayPlan?.inputFingerprint;
+  const isReplayBlocked = ["blocked", "input_drift_blocked"].includes(
+    preflightStatus,
+  );
   const handleRerun = () => {
     if (agentType === AGENT_TYPES.VOICE) {
       setConfirmRerun(true);
@@ -247,12 +266,65 @@ const TestRunDetailHeader = () => {
           onClose={() => setConfirmRerun(false)}
           onConfirm={() => setConfirmRerun(false)}
           title="Confirm Rerun Test"
-          content="This will rerun all the calls and evaluations present in the test."
+          content={
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+              <Typography typography="m3" color="text.secondary">
+                This will rerun all calls and evaluations in this execution.
+              </Typography>
+              <Box
+                sx={{
+                  border: "1px solid",
+                  borderColor:
+                    preflightStatus === "ready"
+                      ? "success.light"
+                      : "warning.light",
+                  borderRadius: "4px",
+                  padding: 1.25,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 0.75,
+                }}
+              >
+                <Typography
+                  typography="s2"
+                  fontWeight="fontWeightSemiBold"
+                  color={
+                    preflightStatus === "ready"
+                      ? "success.main"
+                      : "warning.main"
+                  }
+                >
+                  Replay preflight: {preflightStatus || "checking"}
+                </Typography>
+                <ShowComponent condition={!!inputFingerprint}>
+                  <Typography typography="s2" color="text.secondary">
+                    Input fingerprint: {String(inputFingerprint).slice(0, 12)}
+                  </Typography>
+                </ShowComponent>
+                <ShowComponent condition={!!inputDrift?.has_drift}>
+                  <Typography typography="s2" color="warning.main">
+                    Drift: {(inputDrift?.changed_sections || []).join(", ")}
+                  </Typography>
+                </ShowComponent>
+                <ShowComponent condition={preflightIssues.length > 0}>
+                  <Typography typography="s2" color="text.secondary">
+                    {preflightIssues[0]?.message}
+                  </Typography>
+                </ShowComponent>
+                <ShowComponent condition={!!diagnosis?.summary}>
+                  <Typography typography="s2" color="text.secondary">
+                    {diagnosis?.summary}
+                  </Typography>
+                </ShowComponent>
+              </Box>
+            </Box>
+          }
           action={
             <LoadingButton
               variant="contained"
               color="primary"
               loading={isRerunPending}
+              disabled={isReplayBlocked}
               size="small"
               onClick={() => {
                 rerunTest({

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1244,6 +1244,8 @@ export const endpoints = {
       `/simulate/call-executions/${executionId}/branch-analysis/`,
     cancelExecution: (id) => `/simulate/test-executions/${id}/cancel/`,
     rerunExecution: (id) => `/simulate/test-executions/${id}/rerun-calls/`,
+    reproducibility: (id) =>
+      `/simulate/test-executions/${id}/reproducibility/`,
     getDetailLogs: (id) => `/simulate/call-executions/${id}/logs/`,
     getErrorLocalizerTasks: (id) =>
       `/simulate/call-executions/${id}/error-localizer-tasks/`,

--- a/futureagi/docs/reproducibility_passports.md
+++ b/futureagi/docs/reproducibility_passports.md
@@ -10,8 +10,10 @@ The backend helper lives in:
 
 ```python
 from simulate.services.reproducibility_passport import (
+    build_replay_plan,
     build_test_execution_passport,
     diff_passports,
+    explain_passport_drift,
 )
 ```
 
@@ -35,7 +37,24 @@ hashes instead of copied into the passport.
 
 ## How to use it for replay
 
-Capture a passport before starting a rerun or regression investigation:
+First build a replay plan:
+
+```python
+plan = build_replay_plan(test_execution)
+
+if not plan["can_replay"]:
+    logger.warning("simulation_replay_not_ready", extra={"issues": plan["issues"]})
+```
+
+The plan includes:
+
+- `replay_key`: stable key for this replay baseline
+- `can_replay`: false when required pinned state is missing
+- `issues`: blocker/warning/info readiness checks with remediation text
+- `replay_inputs`: run, prompt, agent, scenario, eval, and dataset-row ids
+- `baseline`: passport and section hashes to compare against later
+
+Then capture a passport before starting a rerun or regression investigation:
 
 ```python
 original = build_test_execution_passport(test_execution)
@@ -49,6 +68,15 @@ drift = diff_passports(original, rerun)
 
 if drift.has_drift:
     logger.info("simulation_replay_drift", extra=drift.as_dict())
+```
+
+For user-facing or self-healing workflows, use the explanation helper:
+
+```python
+explanation = explain_passport_drift(original, rerun)
+
+if explanation["highest_severity"] == "blocker":
+    logger.warning("simulation_replay_inputs_changed", extra=explanation)
 ```
 
 Section-level drift lets the caller decide whether a result changed because of

--- a/futureagi/docs/reproducibility_passports.md
+++ b/futureagi/docs/reproducibility_passports.md
@@ -1,0 +1,64 @@
+# Reproducibility passports for simulation runs
+
+Simulation and eval runs can fail for reasons that are hard to separate after
+the fact: a prompt version changed, an eval mapping drifted, a scenario row was
+filtered differently, or a simulator agent moved to a different model. A
+reproducibility passport is a deterministic JSON artifact that records the
+configuration surface needed to explain and replay a `TestExecution`.
+
+The backend helper lives in:
+
+```python
+from simulate.services.reproducibility_passport import (
+    build_test_execution_passport,
+    diff_passports,
+)
+```
+
+## What the passport captures
+
+`build_test_execution_passport(test_execution)` returns:
+
+- `execution`: run status, scenario ids, call counts, timestamps, and error reason
+- `run_test`: source type, dataset row selection, workspace, and tool-eval flag
+- `agent`: agent definition fields, agent version snapshot hash, and simulator hash
+- `prompt`: prompt template/version ids and prompt config snapshot hash
+- `scenarios`: scenario ids, dataset ids, metadata, and source hashes
+- `eval_configs`: eval template/config/mapping/filter fields and criteria hash
+- `execution_options`: execution metadata and selected dataset/scenario ids
+- `section_hashes`: stable SHA-256 hashes for every section
+- `passport_hash`: a top-level hash of the passport schema and section hashes
+
+Secrets are recursively redacted from nested config objects before hashing or
+returning the artifact. Free-text prompt and scenario bodies are represented by
+hashes instead of copied into the passport.
+
+## How to use it for replay
+
+Capture a passport before starting a rerun or regression investigation:
+
+```python
+original = build_test_execution_passport(test_execution)
+```
+
+After recreating or rerunning the execution, compare the new passport:
+
+```python
+rerun = build_test_execution_passport(rerun_execution)
+drift = diff_passports(original, rerun)
+
+if drift.has_drift:
+    logger.info("simulation_replay_drift", extra=drift.as_dict())
+```
+
+Section-level drift lets the caller decide whether a result changed because of
+model behavior or because the replay inputs were no longer identical.
+
+## Why this matters
+
+The same artifact can support several product surfaces:
+
+- rerun preflight checks before comparing eval scores
+- self-healing workflows that explain which input section changed
+- audit logs for prompt and eval version changes
+- bug reports that are useful without exposing raw transcripts or credentials

--- a/futureagi/docs/reproducibility_passports.md
+++ b/futureagi/docs/reproducibility_passports.md
@@ -14,6 +14,7 @@ from simulate.services.reproducibility_passport import (
     build_test_execution_passport,
     diff_passports,
     explain_passport_drift,
+    explain_replay_input_drift,
 )
 ```
 
@@ -29,6 +30,8 @@ from simulate.services.reproducibility_passport import (
 - `eval_configs`: eval template/config/mapping/filter fields and criteria hash
 - `execution_options`: execution metadata and selected dataset/scenario ids
 - `section_hashes`: stable SHA-256 hashes for every section
+- `input_fingerprint`: hash of replay-relevant inputs only
+- `runtime_fingerprint`: hash of execution status, counters, and timestamps
 - `passport_hash`: a top-level hash of the passport schema and section hashes
 
 Secrets are recursively redacted from nested config objects before hashing or
@@ -52,7 +55,7 @@ The plan includes:
 - `can_replay`: false when required pinned state is missing
 - `issues`: blocker/warning/info readiness checks with remediation text
 - `replay_inputs`: run, prompt, agent, scenario, eval, and dataset-row ids
-- `baseline`: passport and section hashes to compare against later
+- `baseline`: passport hash, input fingerprint, and section hashes
 
 Then capture a passport before starting a rerun or regression investigation:
 
@@ -73,14 +76,18 @@ if drift.has_drift:
 For user-facing or self-healing workflows, use the explanation helper:
 
 ```python
-explanation = explain_passport_drift(original, rerun)
+explanation = explain_replay_input_drift(original, rerun)
 
 if explanation["highest_severity"] == "blocker":
     logger.warning("simulation_replay_inputs_changed", extra=explanation)
 ```
 
-Section-level drift lets the caller decide whether a result changed because of
-model behavior or because the replay inputs were no longer identical.
+`explain_replay_input_drift` ignores runtime-only changes such as status and
+call counters. Use `explain_passport_drift` when the caller also wants to audit
+runtime/output drift.
+
+This split lets the caller decide whether a result changed because of model
+behavior or because the replay inputs were no longer identical.
 
 ## Why this matters
 

--- a/futureagi/docs/reproducibility_passports.md
+++ b/futureagi/docs/reproducibility_passports.md
@@ -11,7 +11,9 @@ The backend helper lives in:
 ```python
 from simulate.services.reproducibility_passport import (
     build_replay_plan,
+    build_reproducibility_report,
     build_test_execution_passport,
+    capture_reproducibility_snapshot,
     diff_passports,
     explain_passport_drift,
     explain_replay_input_drift,
@@ -57,6 +59,19 @@ The plan includes:
 - `replay_inputs`: run, prompt, agent, scenario, eval, and dataset-row ids
 - `baseline`: passport hash, input fingerprint, and section hashes
 
+The API-ready report combines the current passport, replay plan, stored
+snapshots, input drift, full drift, and score-change diagnosis:
+
+```python
+report = build_reproducibility_report(test_execution)
+```
+
+The same report is available over HTTP:
+
+```text
+GET /simulate/test-executions/{test_execution_id}/reproducibility/
+```
+
 Then capture a passport before starting a rerun or regression investigation:
 
 ```python
@@ -97,3 +112,16 @@ The same artifact can support several product surfaces:
 - self-healing workflows that explain which input section changed
 - audit logs for prompt and eval version changes
 - bug reports that are useful without exposing raw transcripts or credentials
+
+## Stored snapshots
+
+Execution lifecycle code stores best-effort `start` and terminal `completion`
+snapshots in `TestExecution.execution_metadata["reproducibility_passports"]`.
+The passport intentionally excludes that internal metadata key while hashing
+execution options, so saving a snapshot does not make the next passport drift
+against itself.
+
+```python
+capture_reproducibility_snapshot(test_execution, "start")
+capture_reproducibility_snapshot(test_execution, "completion")
+```

--- a/futureagi/simulate/README.md
+++ b/futureagi/simulate/README.md
@@ -28,6 +28,24 @@ GET/POST /simulate/api/scenarios/
 GET/PUT/DELETE /simulate/api/scenarios/<uuid>/
 ```
 
+### Test Execution Reproducibility
+```
+GET /simulate/test-executions/<uuid>/reproducibility/
+```
+
+Returns a replay passport and rerun preflight report for a test execution.
+
+The response includes:
+- `current.passport`: deterministic hashes for the replay inputs and runtime state
+- `current.replay_plan`: replay inputs, replay key, and readiness issues
+- `preflight`: replay status plus input drift from the stored start snapshot
+- `score_change_diagnosis`: likely cause of score movement from replay-input drift
+- `stabilization_plan`: ranked actions to make the rerun comparable before launch
+
+The rerun modal uses the stabilization plan to show whether the rerun is low,
+medium, or high risk. This helps teams avoid attributing an eval score change to
+model behavior when prompt, agent, scenario, eval, or execution options changed.
+
 ## Example Usage
 
 ### Create a new scenario

--- a/futureagi/simulate/services/reproducibility_passport.py
+++ b/futureagi/simulate/services/reproducibility_passport.py
@@ -62,6 +62,38 @@ DRIFT_REASON_BY_SECTION = {
     "execution_options": "Execution metadata or selected ids changed.",
     "execution": "Execution status or counters changed.",
 }
+STABILIZATION_ACTION_BY_SECTION = {
+    "agent": {
+        "title": "Pin the agent version",
+        "action": "Replay against the same agent version snapshot used by the baseline.",
+        "why": "Agent configuration drift can change behavior before the model output is compared.",
+    },
+    "prompt": {
+        "title": "Pin the prompt version",
+        "action": "Replay against the baseline prompt version and prompt config snapshot.",
+        "why": "Prompt text, variables, or provider config changes can dominate score movement.",
+    },
+    "scenarios": {
+        "title": "Replay the same scenarios",
+        "action": "Restore the baseline scenario ids and dataset row selection before rerunning.",
+        "why": "Scenario drift changes the task distribution, so scores are no longer comparable.",
+    },
+    "eval_configs": {
+        "title": "Freeze eval configuration",
+        "action": "Compare eval template, mapping, filters, threshold, and model before rerun.",
+        "why": "Eval drift can change the judge, scoring rubric, or rows being scored.",
+    },
+    "run_test": {
+        "title": "Confirm run-level settings",
+        "action": "Check run source, dataset rows, and tool-evaluation settings.",
+        "why": "Run-level drift can change which execution path is measured.",
+    },
+    "execution_options": {
+        "title": "Match execution options",
+        "action": "Replay with the same selected scenarios, dataset rows, and external metadata.",
+        "why": "Execution option drift can make a rerun look like a model regression when it is not.",
+    },
+}
 REPLAY_INPUT_SECTIONS = (
     "run_test",
     "agent",
@@ -135,6 +167,11 @@ def build_reproducibility_report(test_execution: TestExecution) -> dict[str, obj
         baseline_passport,
         current_passport,
     )
+    stabilization_plan = build_stabilization_plan(
+        replay_plan,
+        input_drift,
+        score_change_diagnosis,
+    )
 
     return {
         "test_execution_id": str(test_execution.id),
@@ -155,6 +192,7 @@ def build_reproducibility_report(test_execution: TestExecution) -> dict[str, obj
             "input_from_start": input_drift,
         },
         "score_change_diagnosis": score_change_diagnosis,
+        "stabilization_plan": stabilization_plan,
         "has_start_snapshot": isinstance(start_snapshot, Mapping),
         "has_completion_snapshot": isinstance(completion_snapshot, Mapping),
     }
@@ -444,6 +482,86 @@ def diagnose_eval_score_change(
     }
 
 
+def build_stabilization_plan(
+    replay_plan: Mapping[str, object],
+    input_drift: Mapping[str, object],
+    diagnosis: Mapping[str, object],
+) -> dict[str, object]:
+    """Return concrete rerun-stabilization actions for the UI and API."""
+
+    issues = _sequence_or_empty(replay_plan.get("issues"))
+    drift_changes = _sequence_or_empty(input_drift.get("changes"))
+    actions: list[dict[str, object]] = []
+    seen_keys: set[tuple[str, str]] = set()
+
+    for issue in issues:
+        action = {
+            "priority": _action_priority(str(issue.get("severity"))),
+            "source": "readiness_issue",
+            "section": str(issue.get("section") or "unknown"),
+            "title": str(issue.get("message") or "Replay readiness issue"),
+            "action": str(issue.get("remediation") or "Resolve this issue before rerun."),
+            "why": "The replay plan is not fully pinned.",
+            "severity": str(issue.get("severity") or "warning"),
+        }
+        _append_unique_action(actions, seen_keys, action)
+
+    for change in drift_changes:
+        section = str(change.get("section") or "unknown")
+        template = STABILIZATION_ACTION_BY_SECTION.get(
+            section,
+            {
+                "title": f"Review {section} drift",
+                "action": "Compare the baseline and current section hashes before rerun.",
+                "why": "This replay input changed from the baseline.",
+            },
+        )
+        action = {
+            "priority": _action_priority(str(change.get("severity"))),
+            "source": "input_drift",
+            "section": section,
+            "title": template["title"],
+            "action": template["action"],
+            "why": template["why"],
+            "severity": str(change.get("severity") or "warning"),
+            "before_hash": change.get("before_hash"),
+            "after_hash": change.get("after_hash"),
+        }
+        _append_unique_action(actions, seen_keys, action)
+
+    actions.sort(
+        key=lambda item: (
+            int(item.get("priority", 99)),
+            str(item.get("section") or ""),
+            str(item.get("source") or ""),
+        )
+    )
+
+    can_run_without_stabilization = (
+        replay_plan.get("can_replay") is True
+        and input_drift.get("highest_severity") not in {"blocker", "warning"}
+    )
+    if not actions and diagnosis.get("classification") == "runtime_or_model_behavior":
+        actions.append(
+            {
+                "priority": 2,
+                "source": "runtime_comparison",
+                "section": "execution",
+                "title": "Compare runtime outputs",
+                "action": "Inspect transcripts, provider responses, eval outputs, and latency traces.",
+                "why": "Replay inputs match, so the score movement is likely runtime or model behavior.",
+                "severity": "info",
+            }
+        )
+
+    return {
+        "can_run_without_stabilization": can_run_without_stabilization,
+        "risk_level": _stabilization_risk_level(actions),
+        "summary": _stabilization_summary(actions, diagnosis),
+        "actions": actions,
+    }
+
+
 def stable_hash(value: object) -> str:
     """Hash a JSON-compatible value after stable normalization."""
 
@@ -711,6 +829,42 @@ def _diagnosis_recommendation(changed_sections: Sequence[object]) -> str:
     if "scenarios" in sections:
         return "Verify the same scenario and dataset rows were replayed."
     return "Resolve replay-input drift before attributing score deltas."
+
+
+def _append_unique_action(
+    actions: list[dict[str, object]],
+    seen_keys: set[tuple[str, str]],
+    action: dict[str, object],
+) -> None:
+    key = (str(action.get("source")), str(action.get("section")))
+    if key in seen_keys:
+        return
+    seen_keys.add(key)
+    actions.append(action)
+
+
+def _action_priority(severity: str) -> int:
+    return {"blocker": 0, "warning": 1, "info": 2}.get(severity, 3)
+
+
+def _stabilization_risk_level(actions: Sequence[Mapping[str, object]]) -> str:
+    severities = {str(action.get("severity")) for action in actions}
+    if "blocker" in severities:
+        return "high"
+    if "warning" in severities:
+        return "medium"
+    return "low"
+
+
+def _stabilization_summary(
+    actions: Sequence[Mapping[str, object]],
+    diagnosis: Mapping[str, object],
+) -> str:
+    if not actions:
+        return "Replay inputs look stable. Compare runtime outputs if scores moved."
+    if diagnosis.get("classification") == "replay_inputs_changed":
+        return "Stabilize changed replay inputs before treating score movement as model behavior."
+    return "Resolve replay readiness issues before starting a high-confidence rerun."
 
 
 def _agent_definition_payload(

--- a/futureagi/simulate/services/reproducibility_passport.py
+++ b/futureagi/simulate/services/reproducibility_passport.py
@@ -1,0 +1,407 @@
+"""Build reproducibility passports for simulation test executions.
+
+A passport is a deterministic, JSON-serializable summary of the inputs that
+made a simulate/eval run happen: agent or prompt version, scenarios, eval
+configs, and execution options. It is meant to make reruns and regression
+debugging explicit without storing raw transcripts or provider responses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from django.db.models import Model, QuerySet
+
+from simulate.models.eval_config import SimulateEvalConfig
+from simulate.models.run_test import RunTest
+from simulate.models.scenarios import Scenarios
+from simulate.models.test_execution import TestExecution
+
+PASSPORT_SCHEMA_VERSION = "2026-06-09"
+REDACTED = "[redacted]"
+SECRET_KEY_FRAGMENTS = (
+    "api_key",
+    "apikey",
+    "apiSecret",
+    "api_secret",
+    "auth",
+    "authorization",
+    "bearer",
+    "credential",
+    "password",
+    "secret",
+    "token",
+)
+
+
+@dataclass(frozen=True)
+class PassportDiff:
+    """Section-level drift between two reproducibility passports."""
+
+    changed_sections: list[str]
+    before_hashes: dict[str, str | None]
+    after_hashes: dict[str, str | None]
+
+    @property
+    def has_drift(self) -> bool:
+        return bool(self.changed_sections)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "has_drift": self.has_drift,
+            "changed_sections": self.changed_sections,
+            "before_hashes": self.before_hashes,
+            "after_hashes": self.after_hashes,
+        }
+
+
+def build_test_execution_passport(
+    test_execution: TestExecution,
+) -> dict[str, object]:
+    """Return a deterministic passport for a completed or in-flight run.
+
+    The passport intentionally captures configuration snapshots and identifiers
+    instead of live transcript payloads. That keeps the artifact useful for
+    replay planning while avoiding accidental leakage of call content or secrets.
+    """
+
+    run_test = test_execution.run_test
+    sections: dict[str, object] = {
+        "execution": _execution_section(test_execution),
+        "run_test": _run_test_section(run_test),
+        "agent": _agent_section(test_execution, run_test),
+        "prompt": _prompt_section(run_test),
+        "scenarios": _scenario_section(run_test, test_execution),
+        "eval_configs": _eval_config_section(run_test),
+        "execution_options": _execution_options_section(test_execution, run_test),
+    }
+
+    section_hashes = {
+        name: stable_hash(payload) for name, payload in sections.items()
+    }
+
+    return {
+        "schema_version": PASSPORT_SCHEMA_VERSION,
+        "passport_hash": stable_hash(
+            {
+                "schema_version": PASSPORT_SCHEMA_VERSION,
+                "section_hashes": section_hashes,
+            }
+        ),
+        "section_hashes": section_hashes,
+        **sections,
+    }
+
+
+def diff_passports(
+    before: Mapping[str, object],
+    after: Mapping[str, object],
+) -> PassportDiff:
+    """Compare two passports using their section hashes."""
+
+    before_hashes = _extract_section_hashes(before)
+    after_hashes = _extract_section_hashes(after)
+    section_names = sorted(set(before_hashes) | set(after_hashes))
+    changed = [
+        section
+        for section in section_names
+        if before_hashes.get(section) != after_hashes.get(section)
+    ]
+    return PassportDiff(
+        changed_sections=changed,
+        before_hashes={
+            section: before_hashes.get(section) for section in section_names
+        },
+        after_hashes={section: after_hashes.get(section) for section in section_names},
+    )
+
+
+def stable_hash(value: object) -> str:
+    """Hash a JSON-compatible value after stable normalization."""
+
+    payload = json.dumps(
+        _normalize(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _execution_section(test_execution: TestExecution) -> dict[str, object]:
+    return {
+        "id": str(test_execution.id),
+        "status": test_execution.status,
+        "started_at": _normalize(test_execution.started_at),
+        "completed_at": _normalize(test_execution.completed_at),
+        "total_scenarios": test_execution.total_scenarios,
+        "scenario_ids": _normalize(test_execution.scenario_ids),
+        "total_calls": test_execution.total_calls,
+        "completed_calls": test_execution.completed_calls,
+        "failed_calls": test_execution.failed_calls,
+        "error_reason": test_execution.error_reason,
+    }
+
+
+def _run_test_section(run_test: RunTest) -> dict[str, object]:
+    return {
+        "id": str(run_test.id),
+        "name": run_test.name,
+        "description": run_test.description,
+        "source_type": run_test.source_type,
+        "organization_id": _model_id(run_test, "organization_id"),
+        "workspace_id": _model_id(run_test, "workspace_id"),
+        "dataset_row_ids": _normalize(run_test.dataset_row_ids),
+        "enable_tool_evaluation": run_test.enable_tool_evaluation,
+    }
+
+
+def _agent_section(
+    test_execution: TestExecution,
+    run_test: RunTest,
+) -> dict[str, object]:
+    agent_definition = test_execution.agent_definition or run_test.agent_definition
+    agent_version = test_execution.agent_version or run_test.agent_version
+    simulator_agent = test_execution.simulator_agent or run_test.simulator_agent
+
+    return {
+        "agent_definition": _agent_definition_payload(agent_definition),
+        "agent_version": _agent_version_payload(agent_version),
+        "simulator_agent": _simulator_agent_payload(simulator_agent),
+    }
+
+
+def _prompt_section(run_test: RunTest) -> dict[str, object] | None:
+    prompt_version = run_test.prompt_version
+    prompt_template = run_test.prompt_template
+    if not prompt_version and not prompt_template:
+        return None
+
+    snapshot = getattr(prompt_version, "prompt_config_snapshot", None)
+    return {
+        "prompt_template_id": _model_id(prompt_template),
+        "prompt_template_name": getattr(prompt_template, "name", None),
+        "prompt_version_id": _model_id(prompt_version),
+        "template_version": getattr(prompt_version, "template_version", None),
+        "commit_message": getattr(prompt_version, "commit_message", None),
+        "config_snapshot": _normalize(snapshot),
+        "config_snapshot_hash": stable_hash(snapshot or {}),
+        "variable_names": _normalize(getattr(prompt_version, "variable_names", None)),
+        "placeholders": _normalize(getattr(prompt_version, "placeholders", None)),
+    }
+
+
+def _scenario_section(
+    run_test: RunTest,
+    test_execution: TestExecution,
+) -> list[dict[str, object]]:
+    scenarios = _selected_scenarios(run_test, test_execution)
+    return [
+        {
+            "id": str(scenario.id),
+            "name": scenario.name,
+            "scenario_type": scenario.scenario_type,
+            "source_type": scenario.source_type,
+            "status": scenario.status,
+            "dataset_id": _model_id(scenario, "dataset_id"),
+            "agent_definition_id": _model_id(scenario, "agent_definition_id"),
+            "prompt_template_id": _model_id(scenario, "prompt_template_id"),
+            "prompt_version_id": _model_id(scenario, "prompt_version_id"),
+            "simulator_agent_id": _model_id(scenario, "simulator_agent_id"),
+            "metadata": _normalize(scenario.metadata),
+            "source_hash": stable_hash(scenario.source or ""),
+        }
+        for scenario in scenarios
+    ]
+
+
+def _eval_config_section(run_test: RunTest) -> list[dict[str, object]]:
+    eval_configs = (
+        SimulateEvalConfig.objects.filter(run_test=run_test, deleted=False)
+        .select_related("eval_template", "eval_group", "kb_id")
+        .order_by("id")
+    )
+    return [_eval_config_payload(eval_config) for eval_config in eval_configs]
+
+
+def _execution_options_section(
+    test_execution: TestExecution,
+    run_test: RunTest,
+) -> dict[str, object]:
+    metadata = _normalize(test_execution.execution_metadata or {})
+    return {
+        "execution_metadata": metadata,
+        "execution_metadata_hash": stable_hash(metadata),
+        "dataset_row_ids": _normalize(run_test.dataset_row_ids),
+        "scenario_ids": _normalize(test_execution.scenario_ids),
+        "enable_tool_evaluation": run_test.enable_tool_evaluation,
+    }
+
+
+def _agent_definition_payload(
+    agent_definition: Model | None,
+) -> dict[str, object] | None:
+    if not agent_definition:
+        return None
+
+    return {
+        "id": str(agent_definition.id),
+        "name": getattr(agent_definition, "agent_name", None),
+        "agent_type": getattr(agent_definition, "agent_type", None),
+        "provider": getattr(agent_definition, "provider", None),
+        "assistant_id": getattr(agent_definition, "assistant_id", None),
+        "language": getattr(agent_definition, "language", None),
+        "languages": _normalize(getattr(agent_definition, "languages", None)),
+        "model": getattr(agent_definition, "model", None),
+        "model_details": _normalize(getattr(agent_definition, "model_details", None)),
+        "knowledge_base_id": _model_id(agent_definition, "knowledge_base_id"),
+        "observability_provider_id": _model_id(
+            agent_definition, "observability_provider_id"
+        ),
+    }
+
+
+def _agent_version_payload(agent_version: Model | None) -> dict[str, object] | None:
+    if not agent_version:
+        return None
+
+    snapshot = getattr(agent_version, "configuration_snapshot", None)
+    return {
+        "id": str(agent_version.id),
+        "version_number": getattr(agent_version, "version_number", None),
+        "version_name": getattr(agent_version, "version_name", None),
+        "status": getattr(agent_version, "status", None),
+        "commit_message": getattr(agent_version, "commit_message", None),
+        "configuration_snapshot": _normalize(snapshot),
+        "configuration_snapshot_hash": stable_hash(snapshot or {}),
+    }
+
+
+def _simulator_agent_payload(simulator_agent: Model | None) -> dict[str, object] | None:
+    if not simulator_agent:
+        return None
+
+    return {
+        "id": str(simulator_agent.id),
+        "name": getattr(simulator_agent, "name", None),
+        "model": getattr(simulator_agent, "model", None),
+        "voice_provider": getattr(simulator_agent, "voice_provider", None),
+        "voice_name": getattr(simulator_agent, "voice_name", None),
+        "prompt_hash": stable_hash(getattr(simulator_agent, "prompt", "") or ""),
+    }
+
+
+def _eval_config_payload(eval_config: SimulateEvalConfig) -> dict[str, object]:
+    eval_template = eval_config.eval_template
+    eval_group = eval_config.eval_group
+    return {
+        "id": str(eval_config.id),
+        "name": eval_config.name,
+        "status": eval_config.status,
+        "model": eval_config.model,
+        "error_localizer": eval_config.error_localizer,
+        "knowledge_base_id": _model_id(eval_config, "kb_id_id"),
+        "eval_group": (
+            {
+                "id": str(eval_group.id),
+                "name": eval_group.name,
+            }
+            if eval_group
+            else None
+        ),
+        "eval_template": {
+            "id": str(eval_template.id),
+            "name": eval_template.name,
+            "eval_id": eval_template.eval_id,
+            "eval_type": eval_template.eval_type,
+            "template_type": eval_template.template_type,
+            "model": eval_template.model,
+            "config": _normalize(eval_template.config),
+            "criteria_hash": stable_hash(eval_template.criteria or ""),
+            "choices": _normalize(eval_template.choices),
+        },
+        "config": _normalize(eval_config.config),
+        "mapping": _normalize(eval_config.mapping),
+        "filters": _normalize(eval_config.filters),
+    }
+
+
+def _selected_scenarios(
+    run_test: RunTest,
+    test_execution: TestExecution,
+) -> list[Scenarios]:
+    scenario_ids = [str(item) for item in test_execution.scenario_ids or []]
+    queryset = run_test.scenarios.filter(deleted=False)
+    if scenario_ids:
+        queryset = queryset.filter(id__in=scenario_ids)
+    return list(
+        queryset.select_related(
+            "dataset",
+            "agent_definition",
+            "prompt_template",
+            "prompt_version",
+            "simulator_agent",
+        ).order_by("id")
+    )
+
+
+def _extract_section_hashes(passport: Mapping[str, object]) -> dict[str, str]:
+    raw_hashes = passport.get("section_hashes")
+    if not isinstance(raw_hashes, Mapping):
+        return {}
+    return {
+        str(section): str(section_hash)
+        for section, section_hash in raw_hashes.items()
+        if section_hash is not None
+    }
+
+
+def _model_id(instance: object | None, attr: str = "id") -> str | None:
+    if instance is None:
+        return None
+    value = getattr(instance, attr, None)
+    if value is None:
+        return None
+    return str(value)
+
+
+def _normalize(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {
+            str(key): REDACTED if _is_secret_key(str(key)) else _normalize(item)
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+
+    if isinstance(value, QuerySet):
+        return [_normalize(item) for item in value]
+
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_normalize(item) for item in value]
+
+    if isinstance(value, UUID):
+        return str(value)
+
+    if isinstance(value, datetime):
+        return value.isoformat()
+
+    if isinstance(value, date):
+        return value.isoformat()
+
+    if isinstance(value, Decimal):
+        return str(value)
+
+    if isinstance(value, Model):
+        return str(value.pk)
+
+    return value
+
+
+def _is_secret_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(fragment.lower() in lowered for fragment in SECRET_KEY_FRAGMENTS)

--- a/futureagi/simulate/services/reproducibility_passport.py
+++ b/futureagi/simulate/services/reproducibility_passport.py
@@ -38,6 +38,24 @@ SECRET_KEY_FRAGMENTS = (
     "secret",
     "token",
 )
+DRIFT_SEVERITY_BY_SECTION = {
+    "agent": "blocker",
+    "prompt": "blocker",
+    "scenarios": "blocker",
+    "eval_configs": "blocker",
+    "run_test": "warning",
+    "execution_options": "warning",
+    "execution": "info",
+}
+DRIFT_REASON_BY_SECTION = {
+    "agent": "The agent definition, version snapshot, or simulator changed.",
+    "prompt": "The prompt template, prompt version, or prompt snapshot changed.",
+    "scenarios": "The scenario set, dataset links, metadata, or source hashes changed.",
+    "eval_configs": "The eval templates, configs, mappings, or filters changed.",
+    "run_test": "Run-level settings changed.",
+    "execution_options": "Execution metadata or selected ids changed.",
+    "execution": "Execution status or counters changed.",
+}
 
 
 @dataclass(frozen=True)
@@ -58,6 +76,26 @@ class PassportDiff:
             "changed_sections": self.changed_sections,
             "before_hashes": self.before_hashes,
             "after_hashes": self.after_hashes,
+        }
+
+
+@dataclass(frozen=True)
+class ReplayReadinessIssue:
+    """A concrete reason a run may not be replayable as-is."""
+
+    severity: str
+    code: str
+    section: str
+    message: str
+    remediation: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "severity": self.severity,
+            "code": self.code,
+            "section": self.section,
+            "message": self.message,
+            "remediation": self.remediation,
         }
 
 
@@ -99,6 +137,38 @@ def build_test_execution_passport(
     }
 
 
+def build_replay_plan(test_execution: TestExecution) -> dict[str, object]:
+    """Build a replay-oriented plan from a test execution passport.
+
+    The plan is intentionally declarative. It does not rerun anything; it tells
+    a caller which stable inputs should be used and whether the current run has
+    enough pinned state to make a future replay trustworthy.
+    """
+
+    passport = build_test_execution_passport(test_execution)
+    issues = _replay_readiness_issues(passport)
+    replay_inputs = _replay_inputs(passport)
+    replay_key = stable_hash(
+        {
+            "schema_version": passport["schema_version"],
+            "passport_hash": passport["passport_hash"],
+            "replay_inputs": replay_inputs,
+        }
+    )
+
+    return {
+        "replay_key": replay_key,
+        "passport_hash": passport["passport_hash"],
+        "can_replay": not any(issue.severity == "blocker" for issue in issues),
+        "issues": [issue.as_dict() for issue in issues],
+        "replay_inputs": replay_inputs,
+        "baseline": {
+            "section_hashes": passport["section_hashes"],
+            "passport_hash": passport["passport_hash"],
+        },
+    }
+
+
 def diff_passports(
     before: Mapping[str, object],
     after: Mapping[str, object],
@@ -120,6 +190,37 @@ def diff_passports(
         },
         after_hashes={section: after_hashes.get(section) for section in section_names},
     )
+
+
+def explain_passport_drift(
+    before: Mapping[str, object],
+    after: Mapping[str, object],
+) -> dict[str, object]:
+    """Return a severity-ranked explanation of section-level drift."""
+
+    diff = diff_passports(before, after)
+    changes = [
+        {
+            "section": section,
+            "severity": DRIFT_SEVERITY_BY_SECTION.get(section, "info"),
+            "reason": DRIFT_REASON_BY_SECTION.get(
+                section,
+                "The section hash changed.",
+            ),
+            "before_hash": diff.before_hashes.get(section),
+            "after_hash": diff.after_hashes.get(section),
+        }
+        for section in diff.changed_sections
+    ]
+    severity_rank = {"blocker": 0, "warning": 1, "info": 2}
+    changes.sort(key=lambda item: severity_rank.get(str(item["severity"]), 3))
+
+    return {
+        "has_drift": diff.has_drift,
+        "highest_severity": _highest_drift_severity(changes),
+        "changed_sections": diff.changed_sections,
+        "changes": changes,
+    }
 
 
 def stable_hash(value: object) -> str:
@@ -244,6 +345,115 @@ def _execution_options_section(
     }
 
 
+def _replay_inputs(passport: Mapping[str, object]) -> dict[str, object]:
+    agent = _mapping_or_empty(passport.get("agent"))
+    agent_definition = _mapping_or_empty(agent.get("agent_definition"))
+    agent_version = _mapping_or_empty(agent.get("agent_version"))
+    simulator_agent = _mapping_or_empty(agent.get("simulator_agent"))
+    prompt = _mapping_or_empty(passport.get("prompt"))
+    scenarios = _sequence_or_empty(passport.get("scenarios"))
+    eval_configs = _sequence_or_empty(passport.get("eval_configs"))
+    run_test = _mapping_or_empty(passport.get("run_test"))
+
+    return {
+        "run_test_id": run_test.get("id"),
+        "source_type": run_test.get("source_type"),
+        "agent_definition_id": agent_definition.get("id"),
+        "agent_version_id": agent_version.get("id"),
+        "simulator_agent_id": simulator_agent.get("id"),
+        "prompt_template_id": prompt.get("prompt_template_id"),
+        "prompt_version_id": prompt.get("prompt_version_id"),
+        "scenario_ids": [scenario.get("id") for scenario in scenarios],
+        "eval_config_ids": [config.get("id") for config in eval_configs],
+        "dataset_row_ids": run_test.get("dataset_row_ids", []),
+        "enable_tool_evaluation": run_test.get("enable_tool_evaluation"),
+    }
+
+
+def _replay_readiness_issues(
+    passport: Mapping[str, object],
+) -> list[ReplayReadinessIssue]:
+    issues: list[ReplayReadinessIssue] = []
+    run_test = _mapping_or_empty(passport.get("run_test"))
+    execution = _mapping_or_empty(passport.get("execution"))
+    agent = _mapping_or_empty(passport.get("agent"))
+    prompt = _mapping_or_empty(passport.get("prompt"))
+    scenarios = _sequence_or_empty(passport.get("scenarios"))
+    eval_configs = _sequence_or_empty(passport.get("eval_configs"))
+
+    source_type = run_test.get("source_type")
+    if source_type == RunTest.SourceTypes.PROMPT and not prompt.get(
+        "prompt_version_id"
+    ):
+        issues.append(
+            ReplayReadinessIssue(
+                severity="blocker",
+                code="missing_prompt_version",
+                section="prompt",
+                message="Prompt simulation does not have a pinned prompt version.",
+                remediation="Attach a prompt version before treating reruns as exact.",
+            )
+        )
+
+    agent_definition = _mapping_or_empty(agent.get("agent_definition"))
+    agent_version = _mapping_or_empty(agent.get("agent_version"))
+    if source_type == RunTest.SourceTypes.AGENT_DEFINITION and not agent_definition:
+        issues.append(
+            ReplayReadinessIssue(
+                severity="blocker",
+                code="missing_agent_definition",
+                section="agent",
+                message="Agent-definition simulation has no agent definition.",
+                remediation="Attach the agent definition used by the original run.",
+            )
+        )
+    elif source_type == RunTest.SourceTypes.AGENT_DEFINITION and not agent_version:
+        issues.append(
+            ReplayReadinessIssue(
+                severity="warning",
+                code="missing_agent_version_snapshot",
+                section="agent",
+                message="Agent-definition simulation has no pinned agent version.",
+                remediation="Create or attach an agent version snapshot for reruns.",
+            )
+        )
+
+    requested_scenarios = execution.get("scenario_ids") or []
+    if not scenarios:
+        issues.append(
+            ReplayReadinessIssue(
+                severity="blocker",
+                code="missing_scenarios",
+                section="scenarios",
+                message="No scenarios are available in the passport.",
+                remediation="Attach at least one scenario before replaying this run.",
+            )
+        )
+    elif requested_scenarios and len(scenarios) != len(requested_scenarios):
+        issues.append(
+            ReplayReadinessIssue(
+                severity="blocker",
+                code="scenario_selection_mismatch",
+                section="scenarios",
+                message="Some scenario ids from the execution were not resolved.",
+                remediation="Restore the missing scenarios or replay a new baseline.",
+            )
+        )
+
+    if not eval_configs:
+        issues.append(
+            ReplayReadinessIssue(
+                severity="warning",
+                code="missing_eval_configs",
+                section="eval_configs",
+                message="No eval configs are attached to the run.",
+                remediation="Attach eval configs before comparing eval outcomes.",
+            )
+        )
+
+    return issues
+
+
 def _agent_definition_payload(
     agent_definition: Model | None,
 ) -> dict[str, object] | None:
@@ -360,6 +570,29 @@ def _extract_section_hashes(passport: Mapping[str, object]) -> dict[str, str]:
         for section, section_hash in raw_hashes.items()
         if section_hash is not None
     }
+
+
+def _highest_drift_severity(changes: Sequence[Mapping[str, object]]) -> str | None:
+    if not changes:
+        return None
+
+    severity_rank = {"blocker": 0, "warning": 1, "info": 2}
+    return str(
+        min(
+            (change.get("severity", "info") for change in changes),
+            key=lambda severity: severity_rank.get(str(severity), 3),
+        )
+    )
+
+
+def _mapping_or_empty(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _sequence_or_empty(value: object) -> Sequence[Mapping[str, object]]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes | bytearray):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
 
 
 def _model_id(instance: object | None, attr: str = "id") -> str | None:

--- a/futureagi/simulate/services/reproducibility_passport.py
+++ b/futureagi/simulate/services/reproducibility_passport.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -17,14 +18,19 @@ from decimal import Decimal
 from uuid import UUID
 
 from django.db.models import Model, QuerySet
+from django.utils import timezone
 
 from simulate.models.eval_config import SimulateEvalConfig
 from simulate.models.run_test import RunTest
 from simulate.models.scenarios import Scenarios
 from simulate.models.test_execution import TestExecution
 
+logger = logging.getLogger(__name__)
+
 PASSPORT_SCHEMA_VERSION = "2026-06-09"
+REPRO_METADATA_KEY = "reproducibility_passports"
 REDACTED = "[redacted]"
+INTERNAL_EXECUTION_METADATA_KEYS = (REPRO_METADATA_KEY,)
 SECRET_KEY_FRAGMENTS = (
     "api_key",
     "apikey",
@@ -106,6 +112,109 @@ class ReplayReadinessIssue:
             "message": self.message,
             "remediation": self.remediation,
         }
+
+
+def build_reproducibility_report(test_execution: TestExecution) -> dict[str, object]:
+    """Return the API-ready reproducibility state for a test execution."""
+
+    current_passport = build_test_execution_passport(test_execution)
+    replay_plan = build_replay_plan(test_execution)
+    snapshots = get_reproducibility_snapshots(test_execution)
+    start_snapshot = snapshots.get("start")
+    completion_snapshot = snapshots.get("completion")
+
+    baseline_passport = None
+    if isinstance(start_snapshot, Mapping):
+        baseline_passport = _mapping_or_empty(start_snapshot.get("passport"))
+    if not baseline_passport:
+        baseline_passport = current_passport
+
+    input_drift = explain_replay_input_drift(baseline_passport, current_passport)
+    full_drift = explain_passport_drift(baseline_passport, current_passport)
+    score_change_diagnosis = diagnose_eval_score_change(
+        baseline_passport,
+        current_passport,
+    )
+
+    return {
+        "test_execution_id": str(test_execution.id),
+        "run_test_id": str(test_execution.run_test_id),
+        "current": {
+            "passport": current_passport,
+            "replay_plan": replay_plan,
+        },
+        "snapshots": snapshots,
+        "preflight": {
+            "can_replay": replay_plan["can_replay"],
+            "issues": replay_plan["issues"],
+            "input_drift": input_drift,
+            "status": _preflight_status(replay_plan, input_drift),
+        },
+        "drift": {
+            "from_start": full_drift,
+            "input_from_start": input_drift,
+        },
+        "score_change_diagnosis": score_change_diagnosis,
+        "has_start_snapshot": isinstance(start_snapshot, Mapping),
+        "has_completion_snapshot": isinstance(completion_snapshot, Mapping),
+    }
+
+
+def capture_reproducibility_snapshot(
+    test_execution: TestExecution,
+    stage: str,
+) -> dict[str, object]:
+    """Store a passport snapshot in execution metadata without a migration."""
+
+    if stage not in {"start", "completion"}:
+        raise ValueError("stage must be 'start' or 'completion'")
+
+    passport = build_test_execution_passport(test_execution)
+    replay_plan = build_replay_plan(test_execution)
+    snapshot = {
+        "stage": stage,
+        "captured_at": timezone.now().isoformat(),
+        "passport_hash": passport["passport_hash"],
+        "input_fingerprint": passport["input_fingerprint"],
+        "runtime_fingerprint": passport["runtime_fingerprint"],
+        "section_hashes": passport["section_hashes"],
+        "input_section_hashes": passport["input_section_hashes"],
+        "runtime_section_hashes": passport["runtime_section_hashes"],
+        "passport": passport,
+        "replay_plan": replay_plan,
+    }
+
+    metadata = dict(test_execution.execution_metadata or {})
+    snapshots = dict(metadata.get(REPRO_METADATA_KEY) or {})
+    snapshots[stage] = snapshot
+    metadata[REPRO_METADATA_KEY] = snapshots
+    test_execution.execution_metadata = metadata
+    test_execution.save(update_fields=["execution_metadata"])
+    return snapshot
+
+
+def safe_capture_reproducibility_snapshot(
+    test_execution: TestExecution,
+    stage: str,
+) -> dict[str, object] | None:
+    """Best-effort snapshot capture for execution lifecycle hooks."""
+
+    try:
+        return capture_reproducibility_snapshot(test_execution, stage)
+    except Exception:
+        logger.exception(
+            "Failed to capture reproducibility snapshot",
+            extra={"test_execution_id": str(test_execution.id), "stage": stage},
+        )
+        return None
+
+
+def get_reproducibility_snapshots(
+    test_execution: TestExecution,
+) -> dict[str, object]:
+    metadata = test_execution.execution_metadata or {}
+    snapshots = metadata.get(REPRO_METADATA_KEY)
+    return dict(snapshots) if isinstance(snapshots, Mapping) else {}
 
 
 def build_test_execution_passport(
@@ -301,6 +410,40 @@ def explain_replay_input_drift(
     }
 
 
+def diagnose_eval_score_change(
+    before: Mapping[str, object],
+    after: Mapping[str, object],
+) -> dict[str, object]:
+    """Explain likely score-change causes from replay-input drift."""
+
+    input_drift = explain_replay_input_drift(before, after)
+    if not input_drift["has_drift"]:
+        return {
+            "classification": "runtime_or_model_behavior",
+            "confidence": "medium",
+            "summary": (
+                "Replay inputs match. Any score change is more likely from model "
+                "nondeterminism, provider behavior, or runtime output differences."
+            ),
+            "evidence": [],
+            "recommended_action": (
+                "Compare call transcripts, provider responses, and eval outputs."
+            ),
+        }
+
+    changed_sections = input_drift["changed_sections"]
+    return {
+        "classification": "replay_inputs_changed",
+        "confidence": "high",
+        "summary": (
+            "Replay inputs changed before scores were compared, so the score delta "
+            "cannot be attributed to model behavior alone."
+        ),
+        "evidence": input_drift["changes"],
+        "recommended_action": _diagnosis_recommendation(changed_sections),
+    }
+
+
 def stable_hash(value: object) -> str:
     """Hash a JSON-compatible value after stable normalization."""
 
@@ -413,7 +556,9 @@ def _execution_options_section(
     test_execution: TestExecution,
     run_test: RunTest,
 ) -> dict[str, object]:
-    metadata = _normalize(test_execution.execution_metadata or {})
+    metadata = _normalize(
+        _external_execution_metadata(test_execution.execution_metadata or {})
+    )
     return {
         "execution_metadata": metadata,
         "execution_metadata_hash": stable_hash(metadata),
@@ -530,6 +675,42 @@ def _replay_readiness_issues(
         )
 
     return issues
+
+
+def _external_execution_metadata(
+    execution_metadata: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        str(key): value
+        for key, value in execution_metadata.items()
+        if str(key) not in INTERNAL_EXECUTION_METADATA_KEYS
+    }
+
+
+def _preflight_status(
+    replay_plan: Mapping[str, object],
+    input_drift: Mapping[str, object],
+) -> str:
+    if not replay_plan.get("can_replay"):
+        return "blocked"
+    if input_drift.get("highest_severity") == "blocker":
+        return "input_drift_blocked"
+    if input_drift.get("has_drift") or replay_plan.get("issues"):
+        return "warning"
+    return "ready"
+
+
+def _diagnosis_recommendation(changed_sections: Sequence[object]) -> str:
+    sections = {str(section) for section in changed_sections}
+    if "eval_configs" in sections:
+        return "Review eval template, mapping, filter, and threshold changes first."
+    if "prompt" in sections:
+        return "Compare prompt version snapshots before interpreting score deltas."
+    if "agent" in sections:
+        return "Compare agent version snapshots and simulator settings."
+    if "scenarios" in sections:
+        return "Verify the same scenario and dataset rows were replayed."
+    return "Resolve replay-input drift before attributing score deltas."
 
 
 def _agent_definition_payload(

--- a/futureagi/simulate/services/reproducibility_passport.py
+++ b/futureagi/simulate/services/reproducibility_passport.py
@@ -56,6 +56,15 @@ DRIFT_REASON_BY_SECTION = {
     "execution_options": "Execution metadata or selected ids changed.",
     "execution": "Execution status or counters changed.",
 }
+REPLAY_INPUT_SECTIONS = (
+    "run_test",
+    "agent",
+    "prompt",
+    "scenarios",
+    "eval_configs",
+    "execution_options",
+)
+RUNTIME_SECTIONS = ("execution",)
 
 
 @dataclass(frozen=True)
@@ -123,6 +132,28 @@ def build_test_execution_passport(
     section_hashes = {
         name: stable_hash(payload) for name, payload in sections.items()
     }
+    input_section_hashes = {
+        name: section_hashes[name]
+        for name in REPLAY_INPUT_SECTIONS
+        if name in section_hashes
+    }
+    runtime_section_hashes = {
+        name: section_hashes[name]
+        for name in RUNTIME_SECTIONS
+        if name in section_hashes
+    }
+    input_fingerprint = stable_hash(
+        {
+            "schema_version": PASSPORT_SCHEMA_VERSION,
+            "section_hashes": input_section_hashes,
+        }
+    )
+    runtime_fingerprint = stable_hash(
+        {
+            "schema_version": PASSPORT_SCHEMA_VERSION,
+            "section_hashes": runtime_section_hashes,
+        }
+    )
 
     return {
         "schema_version": PASSPORT_SCHEMA_VERSION,
@@ -132,7 +163,11 @@ def build_test_execution_passport(
                 "section_hashes": section_hashes,
             }
         ),
+        "input_fingerprint": input_fingerprint,
+        "runtime_fingerprint": runtime_fingerprint,
         "section_hashes": section_hashes,
+        "input_section_hashes": input_section_hashes,
+        "runtime_section_hashes": runtime_section_hashes,
         **sections,
     }
 
@@ -151,7 +186,7 @@ def build_replay_plan(test_execution: TestExecution) -> dict[str, object]:
     replay_key = stable_hash(
         {
             "schema_version": passport["schema_version"],
-            "passport_hash": passport["passport_hash"],
+            "input_fingerprint": passport["input_fingerprint"],
             "replay_inputs": replay_inputs,
         }
     )
@@ -159,12 +194,15 @@ def build_replay_plan(test_execution: TestExecution) -> dict[str, object]:
     return {
         "replay_key": replay_key,
         "passport_hash": passport["passport_hash"],
+        "input_fingerprint": passport["input_fingerprint"],
         "can_replay": not any(issue.severity == "blocker" for issue in issues),
         "issues": [issue.as_dict() for issue in issues],
         "replay_inputs": replay_inputs,
         "baseline": {
             "section_hashes": passport["section_hashes"],
+            "input_section_hashes": passport["input_section_hashes"],
             "passport_hash": passport["passport_hash"],
+            "input_fingerprint": passport["input_fingerprint"],
         },
     }
 
@@ -220,6 +258,46 @@ def explain_passport_drift(
         "highest_severity": _highest_drift_severity(changes),
         "changed_sections": diff.changed_sections,
         "changes": changes,
+    }
+
+
+def explain_replay_input_drift(
+    before: Mapping[str, object],
+    after: Mapping[str, object],
+) -> dict[str, object]:
+    """Explain only replay-input drift, ignoring runtime execution changes."""
+
+    before_hashes = _extract_input_section_hashes(before)
+    after_hashes = _extract_input_section_hashes(after)
+    section_names = sorted(set(before_hashes) | set(after_hashes))
+    changed_sections = [
+        section
+        for section in section_names
+        if before_hashes.get(section) != after_hashes.get(section)
+    ]
+    changes = [
+        {
+            "section": section,
+            "severity": DRIFT_SEVERITY_BY_SECTION.get(section, "info"),
+            "reason": DRIFT_REASON_BY_SECTION.get(
+                section,
+                "The replay input section hash changed.",
+            ),
+            "before_hash": before_hashes.get(section),
+            "after_hash": after_hashes.get(section),
+        }
+        for section in changed_sections
+    ]
+    severity_rank = {"blocker": 0, "warning": 1, "info": 2}
+    changes.sort(key=lambda item: severity_rank.get(str(item["severity"]), 3))
+
+    return {
+        "has_drift": bool(changed_sections),
+        "highest_severity": _highest_drift_severity(changes),
+        "changed_sections": changed_sections,
+        "changes": changes,
+        "before_input_fingerprint": before.get("input_fingerprint"),
+        "after_input_fingerprint": after.get("input_fingerprint"),
     }
 
 
@@ -569,6 +647,23 @@ def _extract_section_hashes(passport: Mapping[str, object]) -> dict[str, str]:
         str(section): str(section_hash)
         for section, section_hash in raw_hashes.items()
         if section_hash is not None
+    }
+
+
+def _extract_input_section_hashes(passport: Mapping[str, object]) -> dict[str, str]:
+    raw_hashes = passport.get("input_section_hashes")
+    if isinstance(raw_hashes, Mapping):
+        return {
+            str(section): str(section_hash)
+            for section, section_hash in raw_hashes.items()
+            if section_hash is not None
+        }
+
+    section_hashes = _extract_section_hashes(passport)
+    return {
+        section: section_hashes[section]
+        for section in REPLAY_INPUT_SECTIONS
+        if section in section_hashes
     }
 
 

--- a/futureagi/simulate/services/test_executor.py
+++ b/futureagi/simulate/services/test_executor.py
@@ -92,6 +92,9 @@ from simulate.models.simulator_agent import SimulatorAgent
 from simulate.models.test_execution import EvalExplanationSummaryStatus
 from simulate.pydantic_schemas.chat import SimulationCallType
 from simulate.services.branch_deviation_analyzer import BranchDeviationAnalyzer
+from simulate.services.reproducibility_passport import (
+    safe_capture_reproducibility_snapshot,
+)
 try:
     from ee.voice.services.conversation_metrics import ConversationMetricsCalculator
     from ee.voice.services.phone_number_service import PhoneNumberService
@@ -208,6 +211,10 @@ class TestExecutor:
                 if test.status != TestExecution.ExecutionStatus.CANCELLED:
                     test_execution.status = TestExecution.ExecutionStatus.COMPLETED
                     test_execution.save()
+                    safe_capture_reproducibility_snapshot(
+                        test_execution,
+                        "completion",
+                    )
                     logger.info(
                         f"Test execution {test_execution.id} marked as completed"
                     )
@@ -431,6 +438,10 @@ class TestExecutor:
                             EvalExplanationSummaryStatus.PENDING
                         )
                         test_execution.save()
+                        safe_capture_reproducibility_snapshot(
+                            test_execution,
+                            "completion",
+                        )
                         # Lazy import to avoid circular dependency
                         from simulate.tasks.eval_summary_tasks import (
                             run_eval_summary_task,
@@ -518,6 +529,10 @@ class TestExecutor:
                     simulator_agent=simulator_agent,
                     agent_definition=agent_definition,
                     agent_version=agent_version,
+                )
+                safe_capture_reproducibility_snapshot(
+                    test_execution_record,
+                    "start",
                 )
             except Exception as e:
                 logger.error(f"Error creating TestExecution record: {str(e)}")
@@ -2198,6 +2213,10 @@ class TestExecutor:
                 test_execution_record.status = TestExecution.ExecutionStatus.FAILED
                 test_execution_record.error_reason = validation_error
                 test_execution_record.save()
+                safe_capture_reproducibility_snapshot(
+                    test_execution_record,
+                    "completion",
+                )
                 return {
                     "phone_number": "",
                     "metadata": call_data.get("metadata", {}),
@@ -2804,6 +2823,10 @@ class TestExecutor:
             test_execution_record.completed_at = timezone.now()
             test_execution_record.picked_up_by_executor = False
             test_execution_record.save()
+            safe_capture_reproducibility_snapshot(
+                test_execution_record,
+                "completion",
+            )
 
             logger.info(
                 f"Successfully cancelled test execution {test_execution_record.id}"

--- a/futureagi/simulate/tasks/chat_sim.py
+++ b/futureagi/simulate/tasks/chat_sim.py
@@ -26,6 +26,9 @@ from simulate.services.test_executor import (
     TestExecutor,
     _run_simulate_evaluations_task,
 )
+from simulate.services.reproducibility_passport import (
+    safe_capture_reproducibility_snapshot,
+)
 from simulate.utils.chat_simulation import (
     _aggregate_chat_metrics,
     _calculate_tokens_from_messages,
@@ -316,6 +319,7 @@ def monitor_test_execution_for_chat(test_execution_id: str):
         ):
             test_execution.status = TestExecution.ExecutionStatus.COMPLETED
             test_execution.save()
+            safe_capture_reproducibility_snapshot(test_execution, "completion")
 
             logger.info(f"Test execution {test_execution.id} marked as completed")
 
@@ -373,6 +377,7 @@ def monitor_test_execution_for_chat(test_execution_id: str):
         elif all_terminal and not has_any_completed and has_any_failed:
             test_execution.status = TestExecution.ExecutionStatus.FAILED
             test_execution.save(update_fields=["status"])
+            safe_capture_reproducibility_snapshot(test_execution, "completion")
             status_changed = True
             logger.info(
                 f"Test execution {test_execution.id} marked as FAILED (all calls failed)"
@@ -386,6 +391,7 @@ def monitor_test_execution_for_chat(test_execution_id: str):
             test_execution.save(
                 update_fields=["status", "eval_explanation_summary_status"]
             )
+            safe_capture_reproducibility_snapshot(test_execution, "completion")
             status_changed = True
 
             # Lazy import to avoid circular dependency

--- a/futureagi/simulate/temporal/activities/rerun.py
+++ b/futureagi/simulate/temporal/activities/rerun.py
@@ -186,6 +186,20 @@ async def finalize_rerun_execution(input: FinalizeRerunInput) -> None:
             # Still in progress - just update counts and status
             await test_execution.asave(update_fields=update_fields)
 
+        if final_status in [
+            TestExecution.ExecutionStatus.COMPLETED,
+            TestExecution.ExecutionStatus.FAILED,
+        ]:
+            from asgiref.sync import sync_to_async
+            from simulate.services.reproducibility_passport import (
+                safe_capture_reproducibility_snapshot,
+            )
+
+            await sync_to_async(
+                safe_capture_reproducibility_snapshot,
+                thread_sensitive=True,
+            )(test_execution, "completion")
+
         logger.info(
             "finalized_rerun_execution",
             test_execution_id=input.test_execution_id,

--- a/futureagi/simulate/temporal/activities/test_execution.py
+++ b/futureagi/simulate/temporal/activities/test_execution.py
@@ -675,6 +675,16 @@ async def finalize_test_execution(input: FinalizeInput) -> None:
                 ]
             )
 
+        from asgiref.sync import sync_to_async
+        from simulate.services.reproducibility_passport import (
+            safe_capture_reproducibility_snapshot,
+        )
+
+        await sync_to_async(
+            safe_capture_reproducibility_snapshot,
+            thread_sensitive=True,
+        )(test_execution, "completion")
+
         activity.logger.info(f"Finalized test execution: {input.test_execution_id}")
 
     except TestExecution.DoesNotExist:

--- a/futureagi/simulate/tests/test_reproducibility_passport.py
+++ b/futureagi/simulate/tests/test_reproducibility_passport.py
@@ -16,6 +16,7 @@ from simulate.services.reproducibility_passport import (
     build_test_execution_passport,
     diff_passports,
     explain_passport_drift,
+    explain_replay_input_drift,
     stable_hash,
 )
 
@@ -244,6 +245,15 @@ class TestReproducibilityPassport:
             "eval_configs",
             "execution_options",
         }
+        assert set(passport["input_section_hashes"]) == {
+            "run_test",
+            "agent",
+            "prompt",
+            "scenarios",
+            "eval_configs",
+            "execution_options",
+        }
+        assert set(passport["runtime_section_hashes"]) == {"execution"}
         assert passport["agent"]["agent_definition"]["model"] == "gpt-4o-mini"
         assert (
             passport["agent"]["agent_definition"]["model_details"]["api_key"]
@@ -267,6 +277,34 @@ class TestReproducibilityPassport:
         assert replay_plan["replay_inputs"]["scenario_ids"] == [str(scenario.id)]
         assert replay_plan["replay_inputs"]["eval_config_ids"] == [str(eval_config.id)]
         assert replay_plan["baseline"]["passport_hash"] == passport["passport_hash"]
+        assert (
+            replay_plan["baseline"]["input_fingerprint"]
+            == passport["input_fingerprint"]
+        )
+
+        test_execution.status = TestExecutionModel.ExecutionStatus.COMPLETED
+        test_execution.completed_calls = 3
+        test_execution.save()
+        completed_passport = build_test_execution_passport(test_execution)
+        completed_plan = build_replay_plan(test_execution)
+
+        assert completed_passport["passport_hash"] != passport["passport_hash"]
+        assert (
+            completed_passport["runtime_fingerprint"]
+            != passport["runtime_fingerprint"]
+        )
+        assert (
+            completed_passport["input_fingerprint"] == passport["input_fingerprint"]
+        )
+        assert completed_plan["replay_key"] == replay_plan["replay_key"]
+        assert explain_replay_input_drift(passport, completed_passport) == {
+            "has_drift": False,
+            "highest_severity": None,
+            "changed_sections": [],
+            "changes": [],
+            "before_input_fingerprint": passport["input_fingerprint"],
+            "after_input_fingerprint": completed_passport["input_fingerprint"],
+        }
 
     def test_prompt_passport_captures_prompt_snapshot_hash(
         self,

--- a/futureagi/simulate/tests/test_reproducibility_passport.py
+++ b/futureagi/simulate/tests/test_reproducibility_passport.py
@@ -13,10 +13,13 @@ from simulate.models.test_execution import TestExecution as TestExecutionModel
 from simulate.services.reproducibility_passport import (
     REDACTED,
     build_replay_plan,
+    build_reproducibility_report,
     build_test_execution_passport,
+    capture_reproducibility_snapshot,
     diff_passports,
     explain_passport_drift,
     explain_replay_input_drift,
+    get_reproducibility_snapshots,
     stable_hash,
 )
 
@@ -419,3 +422,70 @@ class TestReproducibilityPassport:
             "message": "Prompt simulation does not have a pinned prompt version.",
             "remediation": "Attach a prompt version before treating reruns as exact.",
         }
+
+    def test_snapshots_do_not_poison_input_fingerprint(
+        self,
+        test_execution,
+        scenario,
+        agent_version,
+    ):
+        test_execution.agent_version = agent_version
+        test_execution.scenario_ids = [str(scenario.id)]
+        test_execution.execution_metadata = {
+            "column_order": ["overall_score"],
+            "active_rerun_workflow_id": "wf-before",
+        }
+        test_execution.save()
+
+        before = build_test_execution_passport(test_execution)
+        start_snapshot = capture_reproducibility_snapshot(test_execution, "start")
+        test_execution.refresh_from_db()
+        after_start = build_test_execution_passport(test_execution)
+        completion_snapshot = capture_reproducibility_snapshot(
+            test_execution,
+            "completion",
+        )
+        test_execution.refresh_from_db()
+        after_completion = build_test_execution_passport(test_execution)
+
+        assert start_snapshot["input_fingerprint"] == before["input_fingerprint"]
+        assert (
+            completion_snapshot["input_fingerprint"]
+            == before["input_fingerprint"]
+        )
+        assert after_start["input_fingerprint"] == before["input_fingerprint"]
+        assert after_completion["input_fingerprint"] == before["input_fingerprint"]
+        assert set(get_reproducibility_snapshots(test_execution)) == {
+            "start",
+            "completion",
+        }
+
+    def test_report_includes_preflight_drift_and_score_change_diagnosis(
+        self,
+        test_execution,
+        scenario,
+        agent_version,
+    ):
+        test_execution.agent_version = agent_version
+        test_execution.scenario_ids = [str(scenario.id)]
+        test_execution.save()
+        capture_reproducibility_snapshot(test_execution, "start")
+
+        test_execution.execution_metadata = {
+            **test_execution.execution_metadata,
+            "column_order": ["overall_score", "latency_ms"],
+        }
+        test_execution.save()
+
+        report = build_reproducibility_report(test_execution)
+
+        assert report["has_start_snapshot"] is True
+        assert report["has_completion_snapshot"] is False
+        assert report["preflight"]["status"] == "warning"
+        assert report["drift"]["input_from_start"]["changed_sections"] == [
+            "execution_options"
+        ]
+        assert (
+            report["score_change_diagnosis"]["classification"]
+            == "replay_inputs_changed"
+        )

--- a/futureagi/simulate/tests/test_reproducibility_passport.py
+++ b/futureagi/simulate/tests/test_reproducibility_passport.py
@@ -12,6 +12,7 @@ from simulate.models.simulator_agent import SimulatorAgent
 from simulate.models.test_execution import TestExecution as TestExecutionModel
 from simulate.services.reproducibility_passport import (
     REDACTED,
+    build_stabilization_plan,
     build_replay_plan,
     build_reproducibility_report,
     build_test_execution_passport,
@@ -489,3 +490,49 @@ class TestReproducibilityPassport:
             report["score_change_diagnosis"]["classification"]
             == "replay_inputs_changed"
         )
+        assert report["stabilization_plan"]["risk_level"] == "medium"
+        assert report["stabilization_plan"]["actions"][0]["section"] == (
+            "execution_options"
+        )
+        assert report["stabilization_plan"]["actions"][0]["title"] == (
+            "Match execution options"
+        )
+
+    def test_stabilization_plan_prefers_blocking_replay_issues(
+        self,
+        db,
+        organization,
+        workspace,
+        prompt_scenario,
+    ):
+        run_test = RunTest.objects.create(
+            name="Unpinned prompt run",
+            source_type=RunTest.SourceTypes.PROMPT,
+            organization=organization,
+            workspace=workspace,
+        )
+        run_test.scenarios.add(prompt_scenario)
+        execution = TestExecutionModel.objects.create(
+            run_test=run_test,
+            status=TestExecutionModel.ExecutionStatus.PENDING,
+            total_scenarios=1,
+            total_calls=1,
+            scenario_ids=[str(prompt_scenario.id)],
+        )
+        replay_plan = build_replay_plan(execution)
+
+        plan = build_stabilization_plan(
+            replay_plan,
+            {
+                "has_drift": False,
+                "highest_severity": None,
+                "changes": [],
+            },
+            {"classification": "runtime_or_model_behavior"},
+        )
+
+        assert plan["can_run_without_stabilization"] is False
+        assert plan["risk_level"] == "high"
+        assert plan["actions"][0]["source"] == "readiness_issue"
+        assert plan["actions"][0]["section"] == "prompt"
+        assert plan["actions"][0]["severity"] == "blocker"

--- a/futureagi/simulate/tests/test_reproducibility_passport.py
+++ b/futureagi/simulate/tests/test_reproducibility_passport.py
@@ -12,8 +12,10 @@ from simulate.models.simulator_agent import SimulatorAgent
 from simulate.models.test_execution import TestExecution as TestExecutionModel
 from simulate.services.reproducibility_passport import (
     REDACTED,
+    build_replay_plan,
     build_test_execution_passport,
     diff_passports,
+    explain_passport_drift,
     stable_hash,
 )
 
@@ -258,6 +260,14 @@ class TestReproducibilityPassport:
             == REDACTED
         )
 
+        replay_plan = build_replay_plan(test_execution)
+
+        assert replay_plan["can_replay"] is True
+        assert replay_plan["replay_inputs"]["agent_version_id"] == str(agent_version.id)
+        assert replay_plan["replay_inputs"]["scenario_ids"] == [str(scenario.id)]
+        assert replay_plan["replay_inputs"]["eval_config_ids"] == [str(eval_config.id)]
+        assert replay_plan["baseline"]["passport_hash"] == passport["passport_hash"]
+
     def test_prompt_passport_captures_prompt_snapshot_hash(
         self,
         prompt_run_test,
@@ -301,3 +311,73 @@ class TestReproducibilityPassport:
         assert diff.has_drift is True
         assert diff.changed_sections == ["eval_configs"]
         assert diff.as_dict()["has_drift"] is True
+
+        drift = explain_passport_drift(before, after)
+
+        assert drift["highest_severity"] == "blocker"
+        assert drift["changes"] == [
+            {
+                "section": "eval_configs",
+                "severity": "blocker",
+                "reason": "The eval templates, configs, mappings, or filters changed.",
+                "before_hash": before["section_hashes"]["eval_configs"],
+                "after_hash": after["section_hashes"]["eval_configs"],
+            }
+        ]
+
+    def test_replay_plan_flags_unpinned_agent_versions(self, test_execution, scenario):
+        test_execution.scenario_ids = [str(scenario.id)]
+        test_execution.save()
+
+        replay_plan = build_replay_plan(test_execution)
+
+        assert replay_plan["can_replay"] is True
+        assert replay_plan["issues"] == [
+            {
+                "severity": "warning",
+                "code": "missing_agent_version_snapshot",
+                "section": "agent",
+                "message": "Agent-definition simulation has no pinned agent version.",
+                "remediation": "Create or attach an agent version snapshot for reruns.",
+            },
+            {
+                "severity": "warning",
+                "code": "missing_eval_configs",
+                "section": "eval_configs",
+                "message": "No eval configs are attached to the run.",
+                "remediation": "Attach eval configs before comparing eval outcomes.",
+            },
+        ]
+
+    def test_replay_plan_blocks_prompt_runs_without_prompt_version(
+        self,
+        db,
+        organization,
+        workspace,
+        prompt_scenario,
+    ):
+        run_test = RunTest.objects.create(
+            name="Unpinned prompt run",
+            source_type=RunTest.SourceTypes.PROMPT,
+            organization=organization,
+            workspace=workspace,
+        )
+        run_test.scenarios.add(prompt_scenario)
+        execution = TestExecutionModel.objects.create(
+            run_test=run_test,
+            status=TestExecutionModel.ExecutionStatus.PENDING,
+            total_scenarios=1,
+            total_calls=1,
+            scenario_ids=[str(prompt_scenario.id)],
+        )
+
+        replay_plan = build_replay_plan(execution)
+
+        assert replay_plan["can_replay"] is False
+        assert replay_plan["issues"][0] == {
+            "severity": "blocker",
+            "code": "missing_prompt_version",
+            "section": "prompt",
+            "message": "Prompt simulation does not have a pinned prompt version.",
+            "remediation": "Attach a prompt version before treating reruns as exact.",
+        }

--- a/futureagi/simulate/tests/test_reproducibility_passport.py
+++ b/futureagi/simulate/tests/test_reproducibility_passport.py
@@ -1,0 +1,303 @@
+import copy
+
+import pytest
+
+from model_hub.models.choices import DatasetSourceChoices, SourceChoices, StatusType
+from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
+from model_hub.models.evals_metric import EvalTemplate
+from model_hub.models.run_prompt import PromptTemplate, PromptVersion
+from simulate.models import AgentDefinition, AgentVersion, RunTest, Scenarios
+from simulate.models.eval_config import SimulateEvalConfig
+from simulate.models.simulator_agent import SimulatorAgent
+from simulate.models.test_execution import TestExecution as TestExecutionModel
+from simulate.services.reproducibility_passport import (
+    REDACTED,
+    build_test_execution_passport,
+    diff_passports,
+    stable_hash,
+)
+
+
+@pytest.fixture
+def agent_definition(db, organization, workspace):
+    return AgentDefinition.objects.create(
+        agent_name="Checkout support agent",
+        agent_type=AgentDefinition.AgentTypeChoices.VOICE,
+        contact_number="+1234567890",
+        inbound=True,
+        description="Handles checkout and billing support calls",
+        organization=organization,
+        workspace=workspace,
+        languages=["en"],
+    )
+
+
+@pytest.fixture
+def agent_version(agent_definition):
+    return agent_definition.create_version(
+        description="Regression baseline",
+        commit_message="Capture stable agent config",
+        status=AgentVersion.StatusChoices.ACTIVE,
+    )
+
+
+@pytest.fixture
+def simulator_agent(db, organization, workspace):
+    return SimulatorAgent.objects.create(
+        name="Impatient enterprise buyer",
+        prompt="Push for a clear refund path and ask for escalation.",
+        voice_provider="elevenlabs",
+        voice_name="marissa",
+        model="gpt-4",
+        organization=organization,
+        workspace=workspace,
+    )
+
+
+@pytest.fixture
+def dataset_for_scenario(db, organization, user, workspace):
+    dataset = Dataset.no_workspace_objects.create(
+        name="Billing regression scenarios",
+        organization=organization,
+        workspace=workspace,
+        user=user,
+        source=DatasetSourceChoices.SCENARIO.value,
+    )
+    column = Column.objects.create(
+        dataset=dataset,
+        name="situation",
+        data_type="text",
+        source=SourceChoices.OTHERS.value,
+    )
+    dataset.column_order = [str(column.id)]
+    dataset.save()
+
+    row = Row.objects.create(dataset=dataset, order=0)
+    Cell.objects.create(
+        dataset=dataset,
+        column=column,
+        row=row,
+        value="Customer was billed twice.",
+    )
+    return dataset
+
+
+@pytest.fixture
+def scenario(db, organization, workspace, dataset_for_scenario, agent_definition):
+    return Scenarios.objects.create(
+        name="Duplicate billing call",
+        description="Customer requests urgent refund",
+        source="Customer: I was charged twice and need a refund today.",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        organization=organization,
+        workspace=workspace,
+        dataset=dataset_for_scenario,
+        agent_definition=agent_definition,
+        status=StatusType.COMPLETED.value,
+    )
+
+
+@pytest.fixture
+def run_test(db, organization, workspace, agent_definition, scenario, simulator_agent):
+    run_test = RunTest.objects.create(
+        name="Billing voice regression",
+        description="Checks refund escalation behavior",
+        agent_definition=agent_definition,
+        simulator_agent=simulator_agent,
+        organization=organization,
+        workspace=workspace,
+    )
+    run_test.scenarios.add(scenario)
+    return run_test
+
+
+@pytest.fixture
+def test_execution(db, run_test, simulator_agent, agent_definition):
+    return TestExecutionModel.objects.create(
+        run_test=run_test,
+        status=TestExecutionModel.ExecutionStatus.PENDING,
+        total_scenarios=1,
+        total_calls=3,
+        simulator_agent=simulator_agent,
+        agent_definition=agent_definition,
+    )
+
+
+@pytest.fixture
+def prompt_run_test(db, organization, workspace, prompt_scenario, prompt_version):
+    run_test = RunTest.objects.create(
+        name="Prompt regression run",
+        description="Replay customer onboarding failures",
+        source_type=RunTest.SourceTypes.PROMPT,
+        prompt_template=prompt_version.original_template,
+        prompt_version=prompt_version,
+        organization=organization,
+        workspace=workspace,
+        dataset_row_ids=["row-1", "row-2"],
+        enable_tool_evaluation=True,
+    )
+    run_test.scenarios.add(prompt_scenario)
+    return run_test
+
+
+@pytest.fixture
+def prompt_template(db, organization, workspace):
+    return PromptTemplate.no_workspace_objects.create(
+        name="Support copilot",
+        organization=organization,
+        workspace=workspace,
+    )
+
+
+@pytest.fixture
+def prompt_version(db, prompt_template):
+    return PromptVersion.no_workspace_objects.create(
+        original_template=prompt_template,
+        template_version="v3",
+        commit_message="Tighten escalation behavior",
+        prompt_config_snapshot={
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Escalate billing disputes after two failed attempts.",
+                }
+            ],
+            "provider": "openai",
+            "api_key": "sk-test",
+        },
+        variable_names={"customer_tier": "enterprise"},
+        placeholders={"region": "us"},
+    )
+
+
+@pytest.fixture
+def prompt_scenario(db, organization, workspace, dataset_for_scenario, prompt_version):
+    return Scenarios.objects.create(
+        name="Billing escalation",
+        description="Customer asks for refund twice",
+        source="Customer: I was charged twice and need this fixed today.",
+        scenario_type=Scenarios.ScenarioTypes.DATASET,
+        source_type=Scenarios.SourceTypes.PROMPT,
+        organization=organization,
+        workspace=workspace,
+        dataset=dataset_for_scenario,
+        prompt_template=prompt_version.original_template,
+        prompt_version=prompt_version,
+        metadata={"segment": "enterprise", "auth_token": "should-not-leak"},
+    )
+
+
+@pytest.mark.unit
+class TestReproducibilityPassport:
+    def test_builds_stable_passport_for_agent_simulation(
+        self,
+        test_execution,
+        run_test,
+        scenario,
+        agent_definition,
+        agent_version,
+        organization,
+    ):
+        agent_definition.provider = "vapi"
+        agent_definition.model = "gpt-4o-mini"
+        agent_definition.model_details = {"temperature": 0.2, "api_key": "secret"}
+        agent_definition.save()
+        test_execution.agent_version = agent_version
+        test_execution.scenario_ids = [str(scenario.id)]
+        test_execution.execution_metadata = {
+            "workflow_id": "wf-123",
+            "column_order": ["overall_score", "latency_ms"],
+            "provider_token": "secret",
+        }
+        test_execution.save()
+
+        eval_template = EvalTemplate.objects.create(
+            name="Task completion",
+            criteria="Check if the agent resolved the billing dispute.",
+            config={"rubric": "binary", "api_secret": "hidden"},
+            organization=organization,
+        )
+        eval_config = SimulateEvalConfig.objects.create(
+            name="Resolution eval",
+            eval_template=eval_template,
+            run_test=run_test,
+            config={"threshold": 0.8},
+            mapping={"transcript": "call_transcript"},
+            filters={"channel": "voice"},
+            error_localizer=True,
+            model="turing_flash",
+        )
+
+        passport = build_test_execution_passport(test_execution)
+        rebuilt = build_test_execution_passport(test_execution)
+
+        assert passport == rebuilt
+        assert passport["passport_hash"] == rebuilt["passport_hash"]
+        assert set(passport["section_hashes"]) == {
+            "execution",
+            "run_test",
+            "agent",
+            "prompt",
+            "scenarios",
+            "eval_configs",
+            "execution_options",
+        }
+        assert passport["agent"]["agent_definition"]["model"] == "gpt-4o-mini"
+        assert (
+            passport["agent"]["agent_definition"]["model_details"]["api_key"]
+            == REDACTED
+        )
+        assert (
+            passport["execution_options"]["execution_metadata"]["provider_token"]
+            == REDACTED
+        )
+        assert passport["scenarios"][0]["source_hash"] == stable_hash(scenario.source)
+        assert passport["eval_configs"][0]["id"] == str(eval_config.id)
+        assert (
+            passport["eval_configs"][0]["eval_template"]["config"]["api_secret"]
+            == REDACTED
+        )
+
+    def test_prompt_passport_captures_prompt_snapshot_hash(
+        self,
+        prompt_run_test,
+        prompt_scenario,
+        prompt_version,
+        simulator_agent,
+    ):
+        execution = TestExecutionModel.objects.create(
+            run_test=prompt_run_test,
+            status=TestExecutionModel.ExecutionStatus.COMPLETED,
+            total_scenarios=1,
+            total_calls=1,
+            completed_calls=1,
+            scenario_ids=[str(prompt_scenario.id)],
+            simulator_agent=simulator_agent,
+        )
+
+        passport = build_test_execution_passport(execution)
+
+        assert passport["run_test"]["source_type"] == RunTest.SourceTypes.PROMPT
+        assert passport["prompt"]["prompt_version_id"] == str(prompt_version.id)
+        assert passport["prompt"]["config_snapshot_hash"] == stable_hash(
+            prompt_version.prompt_config_snapshot
+        )
+        assert passport["prompt"]["config_snapshot"]["api_key"] == REDACTED
+        assert passport["agent"]["simulator_agent"]["prompt_hash"] == stable_hash(
+            simulator_agent.prompt
+        )
+        assert passport["scenarios"][0]["metadata"]["auth_token"] == REDACTED
+
+    def test_diff_passports_reports_changed_sections(self, test_execution):
+        before = build_test_execution_passport(test_execution)
+        after = copy.deepcopy(before)
+        after["section_hashes"]["eval_configs"] = stable_hash(
+            {"new_eval": "hallucination_regression"}
+        )
+        after["passport_hash"] = stable_hash(after["section_hashes"])
+
+        diff = diff_passports(before, after)
+
+        assert diff.has_drift is True
+        assert diff.changed_sections == ["eval_configs"]
+        assert diff.as_dict()["has_drift"] is True

--- a/futureagi/simulate/urls.py
+++ b/futureagi/simulate/urls.py
@@ -56,6 +56,7 @@ from simulate.views.run_test import (
     TestExecutionDetailView,
     TestExecutionOptimiserAnalysisRefreshView,
     TestExecutionOptimiserAnalysisView,
+    TestExecutionReproducibilityView,
     TestExecutionRerunView,
     TestExecutionStatusView,
     UpdateEvalConfigView,
@@ -428,6 +429,11 @@ urlpatterns = [
         "test-executions/<uuid:test_execution_id>/column-order/",
         TestExecutionColumnOrderView.as_view(),
         name="test-execution-column-order",
+    ),
+    path(
+        "test-executions/<uuid:test_execution_id>/reproducibility/",
+        TestExecutionReproducibilityView.as_view(),
+        name="test-execution-reproducibility",
     ),
     path(
         "call-executions/<uuid:call_execution_id>/",

--- a/futureagi/simulate/views/chat_simulation.py
+++ b/futureagi/simulate/views/chat_simulation.py
@@ -18,6 +18,9 @@ from simulate.models import (
 )
 from simulate.pydantic_schemas.chat import ChatSendMessageViewResponse, SendChatRequest
 from simulate.services.chat_sim import initiate_chat, send_message_to_chat
+from simulate.services.reproducibility_passport import (
+    safe_capture_reproducibility_snapshot,
+)
 from simulate.services.test_executor import TestExecutor
 from simulate.utils.scenario_completeness import check_scenarios_incomplete
 from simulate.utils.test_execution_utils import generate_simulator_agent_prompt
@@ -131,6 +134,7 @@ class RunTestChatExecutionView(APIView):
                 agent_definition=run_test.agent_definition,
                 agent_version=run_test.agent_version,
             )
+            safe_capture_reproducibility_snapshot(test_execution_record, "start")
 
             return self.gm.success_response(
                 {

--- a/futureagi/simulate/views/run_test.py
+++ b/futureagi/simulate/views/run_test.py
@@ -11,7 +11,7 @@ from urllib.parse import urlencode
 import structlog
 from django.db import connection, models, transaction
 from django.db.models import Avg, Count, Max, Prefetch, Q
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from drf_yasg import openapi
@@ -147,6 +147,10 @@ from simulate.services.test_executor import (
     TestExecutor,
     _run_simulate_evaluations_task,
     run_new_evals_on_call_executions_task,
+)
+from simulate.services.reproducibility_passport import (
+    build_reproducibility_report,
+    safe_capture_reproducibility_snapshot,
 )
 from simulate.tasks.eval_summary_tasks import run_eval_summary_task
 from simulate.utils.baseline import resolve_baseline_id
@@ -815,6 +819,7 @@ class RunTestExecutionView(APIView):
                 agent_definition=run_test.agent_definition,
                 agent_version=run_test.agent_version,
             )
+            safe_capture_reproducibility_snapshot(test_execution, "start")
 
             # Start Temporal workflow
             workflow_id = start_test_execution_workflow(
@@ -1917,6 +1922,51 @@ class RunTestCallExecutionsView(APIView):
         }
 
         return snapshot_as_call_exec
+
+
+class TestExecutionReproducibilityView(APIView):
+    """Return replay passport, preflight, drift, and diagnosis for an execution."""
+
+    permission_classes = [IsAuthenticated]
+
+    @swagger_auto_schema(
+        responses={
+            200: openapi.Schema(type=openapi.TYPE_OBJECT),
+            404: ErrorResponseSerializer,
+            500: ErrorResponseSerializer,
+        },
+    )
+    def get(self, request, test_execution_id, *args, **kwargs):
+        try:
+            user_organization = (
+                getattr(request, "organization", None) or request.user.organization
+            )
+            if not user_organization:
+                return Response(
+                    {"error": "Organization not found for the user."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+            test_execution = get_object_or_404(
+                TestExecution,
+                id=test_execution_id,
+                run_test__organization=user_organization,
+                run_test__deleted=False,
+            )
+            return Response(
+                build_reproducibility_report(test_execution),
+                status=status.HTTP_200_OK,
+            )
+        except Http404:
+            return Response(
+                {"error": "Test execution not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except Exception as e:
+            return Response(
+                {"error": f"Failed to build reproducibility report: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
 
 class TestExecutionDetailView(APIView):


### PR DESCRIPTION
## Summary

Adds reproducibility passports for simulate/eval TestExecution runs and turns them into a rerun preflight and stabilization workflow.

The passport captures replay-relevant inputs, redacts secrets, hashes prompt/scenario free text, and separates replay input fingerprints from runtime execution fingerprints so status/counter changes do not invalidate a replay baseline.

This now includes an API-ready report for rerun/self-healing workflows: current passport, replay plan, stored start/completion snapshots, input drift, full drift, score-change diagnosis, and a stabilization plan with ranked actions for making the rerun comparable before launch. The rerun modal fetches that report and shows risk plus concrete stabilization actions before the user starts a rerun.

## What changed

- Added deterministic passports with input_fingerprint, runtime_fingerprint, section hashes, and input-only drift explanations.
- Added replay plans with readiness issues and stable replay keys.
- Added score-change diagnosis from replay-input drift.
- Added stabilization plans with risk level, action priority, and section-specific remediation.
- Stored best-effort start and terminal completion snapshots in execution_metadata across legacy, Temporal, rerun, and chat/prompt execution paths.
- Added GET /simulate/test-executions/{test_execution_id}/reproducibility/.
- Added a rerun preflight panel in the execution detail rerun dialog.
- Documented the API and lifecycle behavior.

## Linked issues

Closes #454

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only
- [ ] Chore / refactor (no user-visible change)
- [ ] Performance improvement
- [ ] Test-only change

## How was this tested?

- python3.11 -m py_compile futureagi/simulate/services/reproducibility_passport.py futureagi/simulate/tests/test_reproducibility_passport.py
- git diff --check
- Changed Python and JSX line-length scan.
- node --check frontend/src/api/tests/testDetails.js frontend/src/utils/axios.js from the earlier PR iteration.
- Attempted focused pytest with uv/Python 3.11. Local pytest reached Django DB setup but failed because PostgreSQL was not running on 127.0.0.1:15432.

Frontend lint was not run locally because frontend/node_modules is not installed in this checkout, and node --check cannot parse .jsx files directly.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my feature works
- [ ] make check-all / yarn check-all passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA if required by the bot
