### PR TITLE
fix: add API key credential test

### DIFF
--- a/frontend/scripts/api-journeys/browser/settings-api-keys-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-api-keys-smoke.mjs
@@ -19,6 +19,7 @@ const SCREENSHOT_PATH = "/tmp/settings-api-keys-smoke.png";
 const ACTION_MENU_SCREENSHOT_PATH =
   "/tmp/settings-api-keys-smoke-action-menu.png";
 const DISABLED_SCREENSHOT_PATH = "/tmp/settings-api-keys-smoke-disabled.png";
+const TEST_KEY_SCREENSHOT_PATH = "/tmp/settings-api-keys-smoke-test-key.png";
 const FAILURE_SCREENSHOT_PATH = "/tmp/settings-api-keys-smoke-failure.png";
 
 async function main() {
@@ -28,6 +29,7 @@ async function main() {
   const apiFailures = [];
   const pageErrors = [];
   let createdKey = null;
+  let testKeyStatus = null;
   let uiDeleted = false;
   let hardCleanup = null;
   let caughtError = null;
@@ -90,8 +92,38 @@ async function main() {
     assertMaskedKey(createdKey.masked_secret_key, "created masked_secret_key");
 
     await waitForVisibleText(page, "Generated");
+    await waitForVisibleText(page, "Organization scoped", { exact: true });
     await waitForInputValue(page, createdKey.masked_api_key);
     await waitForInputValue(page, createdKey.masked_secret_key);
+    await assertRawKeysNotRendered(page, createdKey);
+    const testKeyResponse = await waitForResponseDuring(
+      page,
+      "API key credential test",
+      (response) => {
+        const request = response.request();
+        const headers = request.headers();
+        return (
+          response.url().includes("/accounts/user-info/") &&
+          request.method() === "GET" &&
+          headers["x-api-key"] === createdKey.api_key &&
+          headers["x-secret-key"] === createdKey.secret_key &&
+          !headers.authorization &&
+          response.status() < 400
+        );
+      },
+      () => clickVisibleText(page, "Test key", { exact: true }),
+    );
+    testKeyStatus = testKeyResponse.status();
+    const testKeyBody = await testKeyResponse.json().catch(() => ({}));
+    assert(
+      testKeyBody?.email || testKeyBody?.user?.email || testKeyBody?.id,
+      "API key credential test did not return user identity.",
+    );
+    await waitForVisibleText(page, "Test passed");
+    await page.screenshot({
+      path: TEST_KEY_SCREENSHOT_PATH,
+      fullPage: true,
+    });
     await assertRawKeysNotRendered(page, createdKey);
 
     await clickVisibleText(page, "Done", { exact: true });
@@ -235,6 +267,10 @@ async function main() {
           key_id: createdKey.key_id,
           list_api_key_masked: true,
           list_secret_key_masked: true,
+          scope_label_visible: true,
+          test_key_user_info_status: testKeyStatus,
+          test_key_success_visible: true,
+          test_key_screenshot: TEST_KEY_SCREENSHOT_PATH,
           ui_disable_chip_visible: true,
           ui_reenable_removed_disabled_chip: true,
           ui_delete_removed_row: true,

--- a/frontend/src/pages/dashboard/settings/api-keys/CreateApiKey.jsx
+++ b/frontend/src/pages/dashboard/settings/api-keys/CreateApiKey.jsx
@@ -1,6 +1,8 @@
 import {
   Box,
   Button,
+  Alert,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -20,14 +22,17 @@ import { ShowComponent } from "src/components/show";
 import { enqueueSnackbar } from "notistack";
 import { copyToClipboard } from "src/utils/utils";
 import SvgColor from "src/components/svg-color";
+import { HOST_API } from "src/config-global";
 
 const CreateApiKey = ({ open, onClose, refreshGrid }) => {
   const [keyName, setKeyName] = useState("");
   const [showKeys, setShowKeys] = useState(false);
+  const [testResult, setTestResult] = useState(null);
 
   const handleClose = () => {
     setKeyName("");
     setShowKeys(false);
+    setTestResult(null);
     reset();
     onClose();
   };
@@ -44,6 +49,7 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
       }),
     onSuccess: () => {
       setShowKeys(true);
+      setTestResult(null);
       refreshGrid();
     },
   });
@@ -60,6 +66,45 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
     maskedSecretKey:
       keyResult.masked_secret_key || keyResult.maskedSecretKey || "",
   };
+
+  const { mutate: handleTestKey, isPending: testingKey } = useMutation({
+    mutationFn: async () => {
+      const headers = {
+        "X-Api-Key": keys.apiKey,
+        "X-Secret-Key": keys.secretKey,
+      };
+      const organizationId = sessionStorage.getItem("organizationId");
+      const workspaceId = sessionStorage.getItem("workspaceId");
+      if (organizationId) headers["X-Organization-Id"] = organizationId;
+      if (workspaceId) headers["X-Workspace-Id"] = workspaceId;
+
+      const response = await fetch(new URL(endpoints.auth.me, HOST_API), {
+        method: "GET",
+        headers,
+        credentials: "omit",
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok || body?.status === false) {
+        throw new Error("The key test failed. Please try again.");
+      }
+      return body;
+    },
+    onSuccess: (data) => {
+      const email = data?.email || data?.user?.email;
+      setTestResult({
+        status: "success",
+        message: email
+          ? `Test passed for ${email}`
+          : "Test passed for this organization",
+      });
+    },
+    onError: (error) => {
+      setTestResult({
+        status: "error",
+        message: error?.message || "The key test failed. Please try again.",
+      });
+    },
+  });
 
   return (
     <Dialog
@@ -134,6 +179,28 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
                 visible again in your Future AGI account. If you lose it, you’ll
                 need to generate a new one.
               </Typography>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  flexWrap: "wrap",
+                }}
+              >
+                <Typography
+                  typography="s1"
+                  fontWeight="fontWeightMedium"
+                  color="text.primary"
+                >
+                  Scope
+                </Typography>
+                <Chip
+                  label="Organization scoped"
+                  size="small"
+                  variant="outlined"
+                  sx={{ borderRadius: "4px" }}
+                />
+              </Box>
               <Box display="flex" gap={1}>
                 <TextField
                   label={"API key"}
@@ -208,6 +275,33 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
                   />
                 </Box>
               </Box>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  flexWrap: "wrap",
+                }}
+              >
+                <LoadingButton
+                  size="small"
+                  variant="outlined"
+                  onClick={() => handleTestKey()}
+                  loading={testingKey}
+                  disabled={!keys.apiKey || !keys.secretKey}
+                >
+                  Test key
+                </LoadingButton>
+              </Box>
+              {testResult && (
+                <Alert
+                  severity={testResult.status}
+                  data-api-key-test-status={testResult.status}
+                  sx={{ py: 0.5 }}
+                >
+                  {testResult.message}
+                </Alert>
+              )}
               <Divider orientation="horizontal" />
             </Box>
           </ShowComponent>


### PR DESCRIPTION
Adds the generated API-key scope label and a safe Test key action that probes /accounts/user-info/ with the generated X-Api-Key/X-Secret-Key headers and no bearer authorization. Extends settings-api-keys-smoke to verify the test call, masked values, disable/re-enable/delete flow, and DB cleanup.\n\nValidation: node --check settings-api-keys-smoke.mjs; Prettier check; targeted ESLint; npm run type-check skipped because no tsconfig exists; live browser/API smoke passed against API_BASE=http://localhost:8003 and APP_BASE=http://127.0.0.1:3033; direct ws2-postgres residue query returned zero rows for the disposable key.