### PR TITLE
hotfix(observe): prevent trace view crash on masked oversized images

### DIFF
--- a/frontend/src/components/traceDetailDrawer/DrawerRightRenderer/getSpanData.js
+++ b/frontend/src/components/traceDetailDrawer/DrawerRightRenderer/getSpanData.js
@@ -160,13 +160,26 @@ function extractMessages(evalAttributes = {}, type = "input") {
       }
 
       if (isMultipleContent) {
-        if (!tempMessages[index].content[parsedIndex]) {
-          tempMessages[index].content[parsedIndex] = {};
+        // Some SDKs emit BOTH a flat `message.content` summary string and the
+        // structured `message.contents.N.*` parts for the same message — e.g.
+        // when an oversized image is masked to a "[image: …]" placeholder. If a
+        // flat string already occupies this slot, keep it: attaching structured
+        // sub-properties onto a string throws ("Cannot create property 'image.url'
+        // on string") and crashes the whole trace view.
+        const slot = tempMessages[index].content[parsedIndex];
+        if (typeof slot !== "string") {
+          if (!slot) {
+            tempMessages[index].content[parsedIndex] = {};
+          }
+          if (contentProperty.length) {
+            tempMessages[index].content[parsedIndex][contentProperty] = content;
+          }
         }
-        if (contentProperty.length) {
-          tempMessages[index].content[parsedIndex][contentProperty] = content;
-        }
-      } else {
+      } else if (
+        typeof tempMessages[index].content[0] !== "object" ||
+        tempMessages[index].content[0] === null
+      ) {
+        // Don't clobber already-built structured content with a flat summary.
         tempMessages[index].content[0] = content;
       }
     }


### PR DESCRIPTION
Hotfix to `main` — cherry-pick of #826 (which targets `dev`). Same single-file change.

## Problem

Opening a trace and clicking a span whose input contains an **oversized image** crashed the entire trace-detail view to the "Houston, we have a problem!" error boundary.

Root cause: when an image's base64 exceeds the tracing SDK's `FI_BASE64_IMAGE_MAX_LENGTH` cap, the SDK masks it to a `[image: <type>, N base64 bytes]` placeholder. For that message it emits **both** a flat `message.content` summary string **and** the structured `message.contents.N.*` parts. `extractMessages` wrote the flat string into `content[0]`, then tried to attach the structured `image.url` sub-property onto it — `TypeError: Cannot create property 'image.url' on string` — which the error boundary turned into a full-page crash.

Surfaced on the `vision-service` / Auto Heal project, where `claude.vision.compareImages` spans send ~190 KB screenshots.

## Fix

`getSpanData.js` `extractMessages`:
- Never assign a structured sub-property onto a content slot that is already a string.
- Never let a flat `message.content` summary clobber already-built structured content.
- Single-representation (normal) messages are unchanged.

The trace-detail drawer is served the full span content (the masked placeholder included), so this parser guard is the complete fix for the crash.

## Verification

Reproduced locally against a seeded copy of the exact customer trace (`303ec21b…`):
- Toggle the guard off → clicking the `claude.vision.compareImages` span crashes with `TypeError: Cannot create property 'image.url' on string`.
- Guard on → the span renders (system prompt + the `[image: …]` placeholder as text). No crash.
- `eslint` clean on the changed file.

## Screenshots

https://github.com/user-attachments/assets/412b8846-57c8-4129-b348-968cce05ff5f
<img width="5207" height="1722" alt="before_after_v2" src="https://github.com/user-attachments/assets/85f58a23-aa6d-4a32-bea3-ffeda20a1081" />

## Out of scope

- Raising/removing the SDK's `FI_BASE64_IMAGE_MAX_LENGTH` masking — intentional payload-size control, working as designed.
- When an SDK emits the structured image parts *before* the flat summary, the slot renders the raw base64 as text rather than the compact placeholder. Crash-free either way; preferring the placeholder is a follow-up.
- Hydrating child-span content on the Postgres `fetch_children` path (only `compare_traces` uses it post-D-027; the drawer is ClickHouse-served). Parked separately.
