### PR TITLE
TH-4812: Cover eval SDK copy smoke

### DIFF
--- a/frontend/scripts/api-journeys/browser/eval-sdk-copy-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/eval-sdk-copy-smoke.mjs
@@ -1,0 +1,575 @@
+/* eslint-disable no-console */
+import { createRequire } from "node:module";
+import process from "node:process";
+import {
+  apiPath,
+  assert,
+  createAuthenticatedContext,
+  isUuid,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const SCREENSHOT_PATH = "/tmp/eval-sdk-copy-smoke.png";
+const FAILURE_SCREENSHOT_PATH = "/tmp/eval-sdk-copy-smoke-failure.png";
+const EVAL_PREFIX = "ui_eval_sdk_copy_";
+const SDK_LANGUAGES = ["python", "javascript", "curl"];
+const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+
+async function main() {
+  const auth = await createAuthenticatedContext();
+  const evalName = `${EVAL_PREFIX}${shortRunId(auth.runId)}`;
+  const browserMutations = [];
+  const apiFailures = [];
+  const pageErrors = [];
+  const consoleMessages = [];
+  const failedRequests = [];
+  let evalId = null;
+  let browser = null;
+  let caughtError = null;
+
+  try {
+    const created = await createCodeEval(auth.client, evalName);
+    evalId = created.id;
+
+    const sdkQuery = {
+      template_id: evalId,
+      model: "turing_large",
+      mapping: JSON.stringify({}),
+      error_localizer: false,
+    };
+    const directSdkPayload = await auth.client.get(
+      apiPath("/model-hub/eval-sdk-code/"),
+      { query: sdkQuery },
+    );
+    assertEvalSdkPayload({
+      payload: directSdkPayload,
+      evalId,
+      evalName,
+      label: "direct API",
+    });
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+    await browser
+      .defaultBrowserContext()
+      .overridePermissions(APP_BASE, ["clipboard-read", "clipboard-write"])
+      .catch(() => null);
+
+    const page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (!isEvalApiUrl(url)) return;
+      if (MUTATION_METHODS.has(request.method())) {
+        browserMutations.push(`${request.method()} ${url}`);
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isEvalApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${url}`);
+      }
+    });
+    page.on("console", (message) => {
+      if (["error", "warning"].includes(message.type())) {
+        consoleMessages.push(`${message.type()}: ${message.text()}`);
+      }
+    });
+    page.on("requestfailed", (request) => {
+      failedRequests.push(`${request.method()} ${request.url()}`);
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    const browserSdkResponse = await waitForEvalSdkTab(page, evalId);
+    const browserSdkEnvelope = await responseJson(browserSdkResponse);
+    const browserSdkPayload = browserSdkEnvelope?.result || browserSdkEnvelope;
+    assertEvalSdkPayload({
+      payload: browserSdkPayload,
+      evalId,
+      evalName,
+      label: "browser API",
+    });
+
+    for (const language of SDK_LANGUAGES) {
+      assert(
+        browserSdkPayload[language] === directSdkPayload[language],
+        `${language} browser SDK snippet differs from direct API snippet.`,
+      );
+    }
+
+    await waitForVisibleText(page, "SDK Code", { exact: true });
+    await waitForVisibleText(page, "placeholder credentials");
+
+    const copiedSnippets = {};
+    for (const language of SDK_LANGUAGES) {
+      const label = languageLabel(language);
+      await clickAriaButton(page, `Show ${label} Eval SDK Code`);
+      copiedSnippets[language] = await clickAndReadClipboard(
+        page,
+        `Copy ${label} Eval SDK Code`,
+      );
+      assert(
+        copiedSnippets[language] === directSdkPayload[language],
+        `${label} clipboard did not match direct API snippet.`,
+      );
+      assertSnippetSafe({
+        language,
+        snippet: copiedSnippets[language],
+        evalId,
+        evalName,
+      });
+    }
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+
+    assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+    assert(
+      browserMutations.length === 0,
+      `Read-only SDK tab fired mutations: ${browserMutations
+        .map(maskRequest)
+        .join("; ")}`,
+    );
+
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          eval_id: evalId,
+          eval_name: evalName,
+          direct_sdk_keys: Object.keys(directSdkPayload).sort(),
+          browser_sdk_keys: Object.keys(browserSdkPayload).sort(),
+          copied: Object.fromEntries(
+            Object.entries(copiedSnippets).map(([language, snippet]) => [
+              language,
+              summarizeSnippetCopy(snippet, { evalId, evalName }),
+            ]),
+          ),
+          browser_mutations: browserMutations.map(maskRequest),
+          screenshot: SCREENSHOT_PATH,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    caughtError = error;
+    console.error(
+      JSON.stringify(
+        {
+          status: "failed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          eval_id: evalId,
+          eval_name: evalName,
+          api_failures: apiFailures,
+          page_errors: pageErrors,
+          console_messages: consoleMessages.slice(-20),
+          failed_requests: failedRequests,
+          browser_mutations: browserMutations.map(maskRequest),
+        },
+        null,
+        2,
+      ),
+    );
+    if (browser) {
+      const pages = await browser.pages();
+      const page = pages[pages.length - 1];
+      await page
+        ?.screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .catch(() => null);
+      console.error(`failure_screenshot=${FAILURE_SCREENSHOT_PATH}`);
+    }
+  } finally {
+    if (browser) await browser.close();
+    await cleanupEvalTemplate(auth.client, evalId).catch((error) => {
+      caughtError = appendCleanupError(caughtError, error);
+    });
+  }
+
+  if (caughtError) throw caughtError;
+}
+
+async function createCodeEval(client, name) {
+  const created = await client.post(
+    apiPath("/model-hub/eval-templates/create-v2/"),
+    {
+      name,
+      eval_type: "code",
+      code: [
+        "def evaluate(output=None, expected=None, **kwargs):",
+        "    return True",
+      ].join("\n"),
+      code_language: "python",
+      output_type: "pass_fail",
+      pass_threshold: 0.5,
+      description: "Eval SDK copy browser smoke.",
+      tags: ["api-journey", "eval-sdk-copy-ui"],
+    },
+  );
+  assert(isUuid(created?.id), "Code eval create did not return a UUID id.");
+  return created;
+}
+
+async function cleanupEvalTemplate(client, templateId) {
+  if (!templateId) return;
+  await client.post(
+    apiPath("/model-hub/eval-templates/bulk-delete/"),
+    { template_ids: [templateId] },
+    { okStatuses: [200, 404] },
+  );
+  console.error(`cleanup eval sdk copy template: ${templateId}`);
+}
+
+async function waitForEvalSdkTab(page, evalId) {
+  const detailResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/model-hub/eval-templates/${evalId}/detail/`) &&
+      response.status() < 400,
+    { timeout: 60000 },
+  );
+  const sdkResponsePromise = page.waitForResponse(
+    (response) => {
+      if (
+        !response.url().includes("/model-hub/eval-sdk-code/") ||
+        response.request().method() !== "GET" ||
+        response.status() >= 400
+      ) {
+        return false;
+      }
+      const url = new URL(response.url());
+      return url.searchParams.get("template_id") === evalId;
+    },
+    { timeout: 60000 },
+  );
+  await page.goto(`${APP_BASE}/dashboard/evaluations/${evalId}?tab=sdk_code`, {
+    waitUntil: "domcontentloaded",
+  });
+  await detailResponsePromise;
+  return sdkResponsePromise;
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+
+      const nativeClipboard = navigator.clipboard;
+      window.__evalSdkClipboardText = "";
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: async (text) => {
+            window.__evalSdkClipboardText = String(text ?? "");
+            if (nativeClipboard?.writeText) {
+              try {
+                await nativeClipboard.writeText(text);
+              } catch {
+                // The recorder remains authoritative when local dev
+                // permissions block the native clipboard.
+              }
+            }
+          },
+          readText: async () => {
+            if (window.__evalSdkClipboardText) {
+              return window.__evalSdkClipboardText;
+            }
+            if (nativeClipboard?.readText) {
+              try {
+                return await nativeClipboard.readText();
+              } catch {
+                return "";
+              }
+            }
+            return "";
+          },
+        },
+      });
+
+      window.normalizeText = (value) =>
+        String(value || "")
+          .replace(/\s+/g, " ")
+          .trim();
+      window.dispatchClick = (element) => {
+        element.dispatchEvent(
+          new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+        );
+        element.dispatchEvent(
+          new MouseEvent("mouseup", { bubbles: true, cancelable: true }),
+        );
+        element.dispatchEvent(
+          new MouseEvent("click", { bubbles: true, cancelable: true }),
+        );
+      };
+      window.visibleElements = (selector = "body *") => {
+        const isVisible = (element) => {
+          const style = window.getComputedStyle(element);
+          const rect = element.getBoundingClientRect();
+          return (
+            style.visibility !== "hidden" &&
+            style.display !== "none" &&
+            rect.width > 0 &&
+            rect.height > 0
+          );
+        };
+        return Array.from(document.querySelectorAll(selector)).filter(
+          isVisible,
+        );
+      };
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) => {
+      return window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      });
+    },
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function clickAriaButton(page, ariaLabel, timeout = 30000) {
+  await page.waitForFunction(
+    (label) =>
+      window
+        .visibleElements("button")
+        .some(
+          (button) =>
+            button.getAttribute("aria-label") === label && !button.disabled,
+        ),
+    { timeout },
+    ariaLabel,
+  );
+  const clicked = await page.evaluate((label) => {
+    const button = window
+      .visibleElements("button")
+      .find(
+        (candidate) =>
+          candidate.getAttribute("aria-label") === label && !candidate.disabled,
+      );
+    if (!button) return false;
+    window.dispatchClick(button);
+    return true;
+  }, ariaLabel);
+  assert(clicked, `Could not click aria button: ${ariaLabel}`);
+}
+
+async function clickAndReadClipboard(page, ariaLabel) {
+  const previousText = await page
+    .evaluate(() => navigator.clipboard.readText())
+    .catch(() => "");
+  await clickAriaButton(page, ariaLabel);
+  await page.waitForFunction(
+    async (previous) => {
+      try {
+        const text = await navigator.clipboard.readText();
+        return Boolean(text) && text !== previous;
+      } catch {
+        return false;
+      }
+    },
+    {},
+    previousText,
+  );
+  return page.evaluate(() => navigator.clipboard.readText());
+}
+
+async function responseJson(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function assertEvalSdkPayload({ payload, evalId, evalName, label }) {
+  for (const language of SDK_LANGUAGES) {
+    assert(
+      typeof payload?.[language] === "string" && payload[language].length > 0,
+      `${label} SDK payload missing non-empty ${language}.`,
+    );
+    assertSnippetSafe({
+      language,
+      snippet: payload[language],
+      evalId,
+      evalName,
+    });
+  }
+}
+
+function assertSnippetSafe({ language, snippet, evalId, evalName }) {
+  assert(snippet.length > 0, `${language} copied an empty SDK snippet.`);
+  assert(
+    snippet.includes("YOUR_API_KEY") && snippet.includes("YOUR_SECRET_KEY"),
+    `${language} SDK snippet did not include placeholder credentials: ${snippetSummary(
+      snippet,
+      { evalId, evalName },
+    )}`,
+  );
+  if (language === "python") {
+    assert(
+      snippet.includes(evalName),
+      `${language} SDK snippet did not include the evaluation name.`,
+    );
+  } else {
+    assert(
+      snippet.includes(evalId),
+      `${language} SDK snippet did not include the evaluation id.`,
+    );
+  }
+  const rawCredentialPatterns = [
+    /FI_API_KEY["'\]]*\s*[:=]\s*["'][0-9a-f]{32}["']/iu,
+    /FI_SECRET_KEY["'\]]*\s*[:=]\s*["'][0-9a-f]{32}["']/iu,
+    /fi_api_key\s*=\s*["'][0-9a-f]{32}["']/iu,
+    /fi_secret_key\s*=\s*["'][0-9a-f]{32}["']/iu,
+    /X-Api-Key:\s*[0-9a-f]{32}/iu,
+    /X-Secret-Key:\s*[0-9a-f]{32}/iu,
+  ];
+  assert(
+    !rawCredentialPatterns.some((pattern) => pattern.test(snippet)),
+    `${language} SDK snippet included a raw credential-looking value.`,
+  );
+}
+
+function summarizeSnippetCopy(snippet, { evalId, evalName }) {
+  const value = String(snippet || "");
+  return {
+    length: value.length,
+    has_api_placeholder: value.includes("YOUR_API_KEY"),
+    has_secret_placeholder: value.includes("YOUR_SECRET_KEY"),
+    has_eval_id: value.includes(evalId),
+    has_eval_name: value.includes(evalName),
+  };
+}
+
+function snippetSummary(snippet, { evalId, evalName }) {
+  const value = String(snippet || "");
+  return JSON.stringify({
+    length: value.length,
+    has_api_placeholder: value.includes("YOUR_API_KEY"),
+    has_secret_placeholder: value.includes("YOUR_SECRET_KEY"),
+    has_eval_id: value.includes(evalId),
+    has_eval_name: value.includes(evalName),
+    preview: value
+      .replace(/[0-9a-f]{32}/giu, "<redacted-hex>")
+      .replace(new RegExp(evalId, "gu"), "<eval-id>")
+      .replace(new RegExp(evalName, "gu"), "<eval-name>")
+      .slice(0, 160),
+  });
+}
+
+function languageLabel(language) {
+  if (language === "javascript") return "JavaScript";
+  if (language === "curl") return "cURL";
+  return "Python";
+}
+
+function isEvalApiUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  return (
+    url.origin ===
+      new URL(process.env.API_BASE || "http://localhost:8003").origin &&
+    (url.pathname.startsWith("/model-hub/eval-templates/") ||
+      url.pathname === "/model-hub/eval-sdk-code/")
+  );
+}
+
+function maskRequest(rawRequest) {
+  const [method, rawUrl] = rawRequest.split(" ");
+  const url = new URL(rawUrl);
+  return `${method} ${url.pathname}`;
+}
+
+function appendCleanupError(caughtError, cleanupError) {
+  if (!caughtError) return cleanupError;
+  caughtError.message = `${caughtError.message}; cleanup failed: ${cleanupError.message}`;
+  return caughtError;
+}
+
+function shortRunId(runId) {
+  return String(runId || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "")
+    .slice(-8);
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") {
+    return "/usr/bin/google-chrome";
+  }
+  return undefined;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/frontend/src/sections/evals/EvalPlayground/BottomEvaluationSection/BottomEvaluationSection.jsx
+++ b/frontend/src/sections/evals/EvalPlayground/BottomEvaluationSection/BottomEvaluationSection.jsx
@@ -1,12 +1,13 @@
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box, IconButton, Tooltip, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 import LogsTabGrid from "../../EvalDetails/EvalsLog/LogsTabGrid";
 import { useQuery } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
-import SvgColor from "src/components/svg-color";
 import Iconify from "src/components/iconify";
 import { Editor } from "@monaco-editor/react";
+import { useSnackbar } from "notistack";
+import { copyToClipboard } from "src/utils/utils";
 
 const editorOptions = {
   selectOnLineNumbers: true,
@@ -48,6 +49,7 @@ const BottomEvaluationSection = ({
 }) => {
   const [activeTab, setActiveTab] = React.useState("");
   const editorRef = React.useRef(null);
+  const { enqueueSnackbar } = useSnackbar();
 
   const { data, isPending, isLoading, isRefetching } = useQuery({
     queryFn: ({ signal }) => {
@@ -55,7 +57,14 @@ const BottomEvaluationSection = ({
         template_id: evaluation?.id,
         ...selectedData,
       };
-      delete params["mapping"]["model"];
+      if (params.mapping && typeof params.mapping === "object") {
+        const mapping = { ...params.mapping };
+        delete mapping.model;
+        params.mapping = JSON.stringify(mapping);
+      } else if (!params.mapping) {
+        params.mapping = JSON.stringify({});
+      }
+      if (!params.model) delete params.model;
       return axios.get(endpoints.develop.eval.evalsSDKCode, {
         params,
         signal,
@@ -94,6 +103,15 @@ const BottomEvaluationSection = ({
       readOnly: true,
       domReadOnly: true,
     });
+  };
+
+  const activeSnippet = data?.[activeTab] || "";
+  const handleCopy = async () => {
+    const copied = await copyToClipboard(activeSnippet);
+    enqueueSnackbar(
+      copied ? `${activeTab} SDK code copied` : "Failed to copy SDK code",
+      { variant: copied ? "success" : "error" },
+    );
   };
 
   return (
@@ -159,27 +177,35 @@ const BottomEvaluationSection = ({
               position: "relative",
             }}
           >
-            <SvgColor
-              // @ts-ignore
-              src="/assets/icons/ic_copy.svg"
-              alt="Copy"
-              sx={{
-                width: "16px",
-                height: "16px",
-                position: "absolute",
-                top: "10px",
-                right: "10px",
-                cursor: "pointer",
-                zIndex: 1,
-              }}
-            />
+            <Tooltip title={`Copy ${activeTab} SDK Code`} arrow>
+              <span>
+                <IconButton
+                  aria-label={`Copy ${activeTab} Eval SDK Code`}
+                  size="small"
+                  onClick={handleCopy}
+                  disabled={!activeSnippet}
+                  sx={{
+                    position: "absolute",
+                    top: "6px",
+                    right: "6px",
+                    zIndex: 1,
+                    bgcolor: "background.paper",
+                    border: "1px solid",
+                    borderColor: "divider",
+                    "&:hover": { bgcolor: "action.hover" },
+                  }}
+                >
+                  <Iconify icon="basil:copy-outline" width={16} />
+                </IconButton>
+              </span>
+            </Tooltip>
             <Box>
               <Editor
                 ref={editorRef}
                 defaultLanguage={activeTab.toLowerCase()}
                 height="300px"
                 options={editorOptions}
-                value={data[activeTab]}
+                value={activeSnippet}
                 onMount={handleEditorMount}
               />
             </Box>

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -53,6 +53,7 @@ import { buildCompositeChildConfigs } from "../Helpers/compositeRuntimeConfig";
 import EvalFeedbackTab from "./EvalFeedbackTab";
 import EvalGroundTruthTab from "./EvalGroundTruthTab";
 import EvalUsageTab from "./EvalUsageTab";
+import EvalSdkCodeTab from "./EvalSdkCodeTab";
 import VersionBadge from "./VersionBadge";
 import BulkDeleteDialog from "./BulkDeleteDialog";
 import { EVAL_TAGS } from "../constant";
@@ -384,9 +385,7 @@ const EvalDetailPage = () => {
           const next = new URLSearchParams(prev);
           next.set(
             "v",
-            String(
-              versionToLoad.version_number ?? versionToLoad.versionNumber,
-            ),
+            String(versionToLoad.version_number ?? versionToLoad.versionNumber),
           );
           return next;
         },
@@ -515,7 +514,6 @@ const EvalDetailPage = () => {
   const initialLoadDone = useRef(false);
   useEffect(() => {
     if (evalData && !viewingVersion) {
-
       const isCustom = evalData.owner !== "system";
       const urlVersion = searchParams.get("v");
       if (urlVersion && !initialLoadDone.current) {
@@ -647,6 +645,13 @@ const EvalDetailPage = () => {
 
   const evalType = evalData?.eval_type || "llm";
   const isSystemEval = evalData?.owner === "system";
+  const detailTabs = useMemo(
+    () =>
+      evalType === "code" || isComposite
+        ? ["details", "sdk_code", "usage"]
+        : ["details", "sdk_code", "usage", "feedback", "ground_truth"],
+    [evalType, isComposite],
+  );
 
   // Fetch composite detail (children, weights) when viewing a composite
   const { data: compositeDetail } = useCompositeDetail(evalId, isComposite);
@@ -1286,12 +1291,10 @@ const EvalDetailPage = () => {
               : "#f4f4f5",
         }}
       >
-        {(evalType === "code" || isComposite
-          ? ["details", "usage"]
-          : ["details", "usage", "feedback", "ground_truth"]
-        ).map((tab) => {
+        {detailTabs.map((tab) => {
           const labels = {
             details: "Eval Details",
+            sdk_code: "SDK Code",
             usage: "Usage",
             feedback: "Feedback",
             ground_truth: "Ground Truth",
@@ -2008,6 +2011,19 @@ const EvalDetailPage = () => {
                 </Box>
               </Box>
             }
+          />
+        </Box>
+      )}
+
+      {/* ═══ SDK Code Tab ═══ */}
+      {activeTab === "sdk_code" && (
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <EvalSdkCodeTab
+            templateId={evalId}
+            templateName={evalData?.name}
+            model={model}
+            mapping={playgroundMapping}
+            errorLocalizerEnabled={errorLocalizerEnabled}
           />
         </Box>
       )}

--- a/frontend/src/sections/evals/components/EvalSdkCodeTab.jsx
+++ b/frontend/src/sections/evals/components/EvalSdkCodeTab.jsx
@@ -1,0 +1,219 @@
+import { Editor } from "@monaco-editor/react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { useQuery } from "@tanstack/react-query";
+import PropTypes from "prop-types";
+import { useMemo, useState } from "react";
+import { useSnackbar } from "notistack";
+import Iconify from "src/components/iconify";
+import axios, { endpoints } from "src/utils/axios";
+import { copyToClipboard } from "src/utils/utils";
+
+const SDK_LANGUAGES = [
+  { key: "python", label: "Python", icon: "hugeicons:python" },
+  { key: "javascript", label: "JavaScript", icon: "proicons:javascript" },
+  { key: "curl", label: "cURL", icon: "icon-park-outline:code" },
+];
+
+const editorOptions = {
+  automaticLayout: true,
+  domReadOnly: true,
+  lineNumbers: "off",
+  minimap: { enabled: false },
+  readOnly: true,
+  scrollBeyondLastLine: false,
+  wordWrap: "on",
+};
+
+function removeEmptyMappingValues(mapping) {
+  return Object.fromEntries(
+    Object.entries(mapping || {}).filter(
+      ([, value]) => value !== null && value !== undefined && String(value),
+    ),
+  );
+}
+
+function editorLanguage(languageKey) {
+  if (languageKey === "curl") return "shell";
+  return languageKey;
+}
+
+const EvalSdkCodeTab = ({
+  templateId,
+  templateName,
+  model,
+  mapping,
+  errorLocalizerEnabled,
+}) => {
+  const { enqueueSnackbar } = useSnackbar();
+  const [activeLanguage, setActiveLanguage] = useState("python");
+
+  const requestMapping = useMemo(
+    () => removeEmptyMappingValues(mapping),
+    [mapping],
+  );
+  const mappingParam = useMemo(
+    () => JSON.stringify(requestMapping),
+    [requestMapping],
+  );
+
+  const { data, isFetching, error } = useQuery({
+    queryKey: [
+      "evalsSDKCode",
+      templateId,
+      model,
+      mappingParam,
+      errorLocalizerEnabled,
+    ],
+    queryFn: async ({ signal }) => {
+      const response = await axios.get(endpoints.develop.eval.evalsSDKCode, {
+        params: {
+          template_id: templateId,
+          model: model || undefined,
+          mapping: mappingParam,
+          error_localizer: Boolean(errorLocalizerEnabled),
+        },
+        signal,
+      });
+      return response?.data?.result || {};
+    },
+    enabled: Boolean(templateId),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const activeSnippet = data?.[activeLanguage] || "";
+  const activeLabel =
+    SDK_LANGUAGES.find((language) => language.key === activeLanguage)?.label ||
+    "SDK";
+
+  const handleCopy = async () => {
+    const copied = await copyToClipboard(activeSnippet);
+    enqueueSnackbar(
+      copied ? `${activeLabel} SDK code copied` : "Failed to copy SDK code",
+      { variant: copied ? "success" : "error" },
+    );
+  };
+
+  return (
+    <Box
+      sx={{
+        height: "100%",
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+      }}
+    >
+      <Box>
+        <Typography variant="m2" fontWeight="fontWeightSemiBold">
+          SDK Code
+        </Typography>
+        <Typography variant="s1" color="text.secondary">
+          {templateName || "Evaluation"} snippets use placeholder credentials.
+        </Typography>
+      </Box>
+
+      <Stack direction="row" spacing={1}>
+        {SDK_LANGUAGES.map((language) => {
+          const active = activeLanguage === language.key;
+          return (
+            <Button
+              key={language.key}
+              variant={active ? "contained" : "outlined"}
+              size="small"
+              aria-label={`Show ${language.label} Eval SDK Code`}
+              startIcon={<Iconify icon={language.icon} width={16} />}
+              onClick={() => setActiveLanguage(language.key)}
+              sx={{ textTransform: "none" }}
+            >
+              {language.label}
+            </Button>
+          );
+        })}
+      </Stack>
+
+      <Box
+        sx={{
+          position: "relative",
+          flex: 1,
+          minHeight: 360,
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: 1,
+          bgcolor: "background.neutral",
+          overflow: "hidden",
+        }}
+      >
+        <Tooltip title={`Copy ${activeLabel} SDK Code`} arrow>
+          <span>
+            <IconButton
+              aria-label={`Copy ${activeLabel} Eval SDK Code`}
+              size="small"
+              onClick={handleCopy}
+              disabled={!activeSnippet || isFetching}
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                zIndex: 1,
+                bgcolor: "background.paper",
+                border: "1px solid",
+                borderColor: "divider",
+                "&:hover": { bgcolor: "action.hover" },
+              }}
+            >
+              <Iconify icon="basil:copy-outline" width={16} />
+            </IconButton>
+          </span>
+        </Tooltip>
+
+        {isFetching ? (
+          <Box
+            sx={{
+              height: "100%",
+              minHeight: 360,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <CircularProgress size={24} />
+          </Box>
+        ) : error ? (
+          <Box sx={{ p: 2 }}>
+            <Typography color="error" variant="s1">
+              Failed to load SDK code
+            </Typography>
+          </Box>
+        ) : (
+          <Editor
+            height="100%"
+            language={editorLanguage(activeLanguage)}
+            options={editorOptions}
+            value={activeSnippet}
+            onMount={(editor) => {
+              editor.updateOptions({ readOnly: true, domReadOnly: true });
+            }}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+EvalSdkCodeTab.propTypes = {
+  templateId: PropTypes.string,
+  templateName: PropTypes.string,
+  model: PropTypes.string,
+  mapping: PropTypes.object,
+  errorLocalizerEnabled: PropTypes.bool,
+};
+
+export default EvalSdkCodeTab;


### PR DESCRIPTION
## Summary
- Add an active Eval Detail > SDK Code tab backed by /model-hub/eval-sdk-code/.
- Add eval-sdk-copy-smoke.mjs to verify direct/browser SDK code parity and Python/JavaScript/cURL copy behavior against a real local API.
- Fix the legacy eval playground drawer SDK copy icon and make its mapping request handling resilient.

## Validation
- node --check frontend/scripts/api-journeys/browser/eval-sdk-copy-smoke.mjs
- prettier --check scripts/api-journeys/browser/eval-sdk-copy-smoke.mjs src/sections/evals/components/EvalSdkCodeTab.jsx src/sections/evals/components/EvalDetailPage.jsx src/sections/evals/EvalPlayground/BottomEvaluationSection/BottomEvaluationSection.jsx
- eslint --resolve-plugins-relative-to <shared frontend install> scripts/api-journeys/browser/eval-sdk-copy-smoke.mjs src/sections/evals/components/EvalSdkCodeTab.jsx src/sections/evals/components/EvalDetailPage.jsx src/sections/evals/EvalPlayground/BottomEvaluationSection/BottomEvaluationSection.jsx (0 errors; existing EvalDetailPage hook warnings)
- npm run type-check (skipped: no tsconfig.json)
- git diff --check
- Live smoke passed with API_BASE=http://localhost:8003 APP_BASE=http://127.0.0.1:3034 FUTURE_AGI_TOKEN_FILE=/tmp/futureagi-ws2-api-journey-token.error-feed-stats.clean.json API_JOURNEY_MUTATIONS=1 node frontend/scripts/api-journeys/browser/eval-sdk-copy-smoke.mjs
- Evidence: /tmp/eval-sdk-copy-smoke-ws2-20260610.json, /tmp/eval-sdk-copy-smoke.png
- Residue check for ui_eval_sdk_copy_ returned total=0
