### PR TITLE
fix(eval-task): scope annotation filters by row_type

### DIFF
--- a/futureagi/tracer/tests/integration/_seed.py
+++ b/futureagi/tracer/tests/integration/_seed.py
@@ -59,6 +59,10 @@ class SeededRow:
     annotation_value: float | None
     has_choice_eval: bool
     choice_value: str | None
+    # Score scope the annotation was created at: "span" (base corpus) or
+    # "trace" (voice corpus — mirrors prod, where voice-call annotations are
+    # created trace-scoped via the trace-backed voice grid).
+    annotation_scope: str = "span"
 
 
 @dataclass
@@ -464,7 +468,7 @@ class DualWriter:
         )
 
     def _insert_annotation_pg_ch(
-        self, row: SeededRow, trace, project, annotation_label
+        self, row: SeededRow, trace, project, annotation_label, scope: str = "span"
     ) -> None:
         """Create the per-row Score and mirror to CH.
 
@@ -472,6 +476,9 @@ class DualWriter:
         (process_eval_task's per-label annotate subquery reads model_hub.Score).
         The CH-side mirror is a best-effort: the list endpoints' annotation
         filter path is exercised against the CH copy.
+
+        ``scope`` picks the Score source: "span" attaches to the row's span,
+        "trace" attaches to its trace (the shape the voice grid creates).
         """
         from model_hub.models.choices import QueueItemSourceType, ScoreSource
         from model_hub.models.score import Score
@@ -480,15 +487,25 @@ class DualWriter:
         # (observation_span, label, annotator) when the same label is reused.
         # NULL annotator is also fine here since we only have one row per
         # (span, label) but make it explicit.
+        if scope == "trace":
+            source_kwargs = {
+                "source_type": QueueItemSourceType.TRACE.value,
+                "trace_id": row.trace_id,
+            }
+        else:
+            source_kwargs = {
+                "source_type": QueueItemSourceType.OBSERVATION_SPAN.value,
+                "observation_span_id": row.span_id,
+            }
         Score.objects.create(
-            source_type=QueueItemSourceType.OBSERVATION_SPAN.value,
-            observation_span_id=row.span_id,
+            **source_kwargs,
             label=annotation_label,
             value={"value": row.annotation_value},
             organization=project.organization,
             workspace=project.workspace,
             score_source=ScoreSource.HUMAN.value,
         )
+        row.annotation_scope = scope
         # CH mirror is informational only — the list endpoints' annotation
         # path in CH doesn't currently consume this in the SpanListQueryBuilder
         # the way PG does. Skipped to avoid coupling tests to a CH schema we
@@ -544,7 +561,11 @@ class DualWriter:
             if row.has_choice_eval:
                 self._insert_choice_eval_pg_ch(row, trace, choice_eval_config)
             if row.has_annotation:
-                self._insert_annotation_pg_ch(row, trace, project, annotation_label)
+                # Voice annotations land trace-scoped in prod (the voice grid
+                # is trace-backed) — seed the same shape here.
+                self._insert_annotation_pg_ch(
+                    row, trace, project, annotation_label, scope="trace"
+                )
             rows.append(row)
 
         self.seeded = rows

--- a/futureagi/tracer/tests/integration/test_eval_task_annotation_scope.py
+++ b/futureagi/tracer/tests/integration/test_eval_task_annotation_scope.py
@@ -1,0 +1,393 @@
+"""Row_type-aware annotation scoping for the eval-task runner.
+
+Each test creates Score rows at a specific source scope (span / trace /
+session), runs ``process_eval_task`` with an ANNOTATION-flavoured filter, and
+asserts which entities were selected. Guards the prod incident where a
+voiceCalls task with an annotator filter selected 0 spans because the
+annotator's scores were trace-scoped (task f8481965-cd74-44b1-9b6d-f4bb66ec2218)
+while the runner matched span-scoped scores only.
+
+Pure-Postgres: the runner never reads ClickHouse, so spans/traces/sessions are
+created via the ORM directly and roll back with the ``db`` fixture.
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from django.db import transaction
+
+from model_hub.models.choices import (
+    AnnotationTypeChoices,
+    QueueItemSourceType,
+    ScoreSource,
+)
+from model_hub.models.develop_annotations import AnnotationsLabels
+from model_hub.models.score import Score
+from tracer.models.eval_task import EvalTask, EvalTaskStatus, RowType, RunType
+from tracer.models.observation_span import EvalLogger, EvalTargetType, ObservationSpan
+from tracer.models.trace import Trace
+from tracer.models.trace_session import TraceSession
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+_NOW = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def scope_project(integration_setup, db):
+    """Fresh project so corpus spans never enter the candidate set."""
+    from model_hub.models.ai_model import AIModel
+    from tracer.models.project import Project
+
+    return Project.objects.create(
+        name=f"annotation_scope_{uuid.uuid4().hex[:8]}",
+        organization=integration_setup.organization,
+        workspace=integration_setup.workspace,
+        model_type=AIModel.ModelTypes.GENERATIVE_LLM,
+        trace_type="observe",
+        metadata={},
+    )
+
+
+@pytest.fixture
+def annotation_label(scope_project):
+    return AnnotationsLabels.objects.create(
+        name=f"scope_label_{uuid.uuid4().hex[:6]}",
+        type=AnnotationTypeChoices.NUMERIC.value,
+        organization=scope_project.organization,
+        workspace=scope_project.workspace,
+        project=scope_project,
+        settings={"min": 0, "max": 1, "step_size": 0.1, "display_type": "slider"},
+    )
+
+
+def _make_call(project, session=None):
+    """One voice-call shaped unit: a trace with a root conversation span."""
+    trace = Trace.objects.create(
+        id=uuid.uuid4(),
+        project=project,
+        session=session,
+        name=f"call_{uuid.uuid4().hex[:8]}",
+    )
+    span = ObservationSpan.objects.create(
+        id=f"span_{uuid.uuid4().hex[:16]}",
+        project=project,
+        trace=trace,
+        name=trace.name,
+        observation_type="conversation",
+        status="OK",
+        parent_span_id=None,
+        start_time=_NOW,
+        end_time=_NOW + timedelta(seconds=30),
+    )
+    return trace, span
+
+
+def _make_score(label, project, *, annotator=None, value=0.7, **source_kwargs):
+    source_type = next(
+        st
+        for st, fk in (
+            (QueueItemSourceType.OBSERVATION_SPAN.value, "observation_span_id"),
+            (QueueItemSourceType.TRACE.value, "trace_id"),
+            (QueueItemSourceType.TRACE_SESSION.value, "trace_session_id"),
+        )
+        if fk in source_kwargs
+    )
+    return Score.objects.create(
+        source_type=source_type,
+        label=label,
+        value={"value": value},
+        annotator=annotator,
+        organization=project.organization,
+        workspace=project.workspace,
+        score_source=ScoreSource.HUMAN.value,
+        **source_kwargs,
+    )
+
+
+def _annotator_filter(user):
+    # camelCase prod shape (task f8481965's filter) — exercises key
+    # normalization alongside the scope fix.
+    return {
+        "columnId": "annotator",
+        "filterConfig": {
+            "colType": "ANNOTATION",
+            "filterOp": "equals",
+            "filterType": "text",
+            "filterValue": str(user.id),
+        },
+    }
+
+
+def _has_annotation_filter(value=True):
+    return {
+        "column_id": "has_annotation",
+        "col_type": "has_annotation",
+        "filter_config": {
+            "filter_type": "boolean",
+            "filter_op": "equals",
+            "filter_value": value,
+        },
+    }
+
+
+def _label_value_filter(label, threshold=0.4):
+    return {
+        "column_id": str(label.id),
+        "col_type": "ANNOTATION",
+        "filter_config": {
+            "filter_type": "number",
+            "filter_op": "greater_than",
+            "filter_value": threshold,
+        },
+    }
+
+
+def _run_task(project, row_type, filter_items, eval_config):
+    from tracer.utils.eval_tasks import process_eval_task
+
+    task = EvalTask.objects.create(
+        project=project,
+        filters={"project_id": str(project.id), "filters": filter_items},
+        row_type=row_type,
+        run_type=RunType.HISTORICAL,
+        sampling_rate=100.0,
+        spans_limit=10_000,
+        status=EvalTaskStatus.PENDING,
+    )
+    task.evals.add(eval_config)
+    with transaction.atomic():
+        process_eval_task._original_func(str(task.id))
+    return task
+
+
+def _logger_qs(task):
+    return EvalLogger.objects.filter(eval_task_id=str(task.id))
+
+
+class TestVoiceCallsScope:
+    def test_trace_scoped_annotation_matches(
+        self,
+        scope_project,
+        annotation_label,
+        user,
+        custom_eval_config_factory,
+        stub_run_eval,
+        inline_temporal,
+        stub_cost_log,
+    ):
+        # The f8481965 incident shape: annotation lives on the TRACE,
+        # the task filters voiceCalls by annotator.
+        _, span_a = _make_call(scope_project)
+        trace_a = span_a.trace
+        _make_call(scope_project)  # unannotated control
+        _make_score(
+            annotation_label, scope_project, annotator=user, trace_id=trace_a.id
+        )
+
+        task = _run_task(
+            scope_project,
+            RowType.VOICE_CALLS,
+            [_annotator_filter(user)],
+            custom_eval_config_factory(project=scope_project),
+        )
+
+        loggers = _logger_qs(task)
+        assert loggers.count() == 1
+        assert loggers.first().observation_span_id == span_a.id
+
+    def test_span_scoped_annotation_still_matches(
+        self,
+        scope_project,
+        annotation_label,
+        user,
+        custom_eval_config_factory,
+        stub_run_eval,
+        inline_temporal,
+        stub_cost_log,
+    ):
+        # The other arm of the OR bridge: span-scoped scores keep matching.
+        _, span_a = _make_call(scope_project)
+        _make_call(scope_project)
+        _make_score(
+            annotation_label,
+            scope_project,
+            annotator=user,
+            observation_span_id=span_a.id,
+        )
+
+        task = _run_task(
+            scope_project,
+            RowType.VOICE_CALLS,
+            [_annotator_filter(user)],
+            custom_eval_config_factory(project=scope_project),
+        )
+
+        loggers = _logger_qs(task)
+        assert loggers.count() == 1
+        assert loggers.first().observation_span_id == span_a.id
+
+    def test_per_label_value_filter_sees_trace_scoped_score(
+        self,
+        scope_project,
+        annotation_label,
+        user,
+        custom_eval_config_factory,
+        stub_run_eval,
+        inline_temporal,
+        stub_cost_log,
+    ):
+        # Per-label value filters resolve through build_annotation_subqueries,
+        # which must use the same trace bridge as the Exists-based filters.
+        _, span_a = _make_call(scope_project)
+        _make_call(scope_project)
+        _make_score(
+            annotation_label,
+            scope_project,
+            annotator=user,
+            value=0.8,
+            trace_id=span_a.trace.id,
+        )
+
+        task = _run_task(
+            scope_project,
+            RowType.VOICE_CALLS,
+            [_label_value_filter(annotation_label, threshold=0.4)],
+            custom_eval_config_factory(project=scope_project),
+        )
+
+        loggers = _logger_qs(task)
+        assert loggers.count() == 1
+        assert loggers.first().observation_span_id == span_a.id
+
+    def test_has_annotation_sees_trace_scoped_score(
+        self,
+        scope_project,
+        annotation_label,
+        user,
+        custom_eval_config_factory,
+        stub_run_eval,
+        inline_temporal,
+        stub_cost_log,
+    ):
+        _, span_a = _make_call(scope_project)
+        _make_call(scope_project)
+        _make_score(
+            annotation_label, scope_project, annotator=user, trace_id=span_a.trace.id
+        )
+
+        task = _run_task(
+            scope_project,
+            RowType.VOICE_CALLS,
+            [_has_annotation_filter(True)],
+            custom_eval_config_factory(project=scope_project),
+        )
+
+        loggers = _logger_qs(task)
+        assert loggers.count() == 1
+        assert loggers.first().observation_span_id == span_a.id
+
+
+class TestSpansScope:
+    def test_trace_scoped_annotation_does_not_match(
+        self,
+        scope_project,
+        annotation_label,
+        user,
+        custom_eval_config_factory,
+        stub_run_eval,
+        inline_temporal,
+        stub_cost_log,
+    ):
+        # Span tasks mirror the spans grid: trace-scoped scores are invisible.
+        _, span_a = _make_call(scope_project)
+        _make_score(
+            annotation_label, scope_project, annotator=user, trace_id=span_a.trace.id
+        )
+
+        task = _run_task(
+            scope_project,
+            RowType.SPANS,
+            [_annotator_filter(user)],
+            custom_eval_config_factory(project=scope_project),
+        )
+
+        assert _logger_qs(task).count() == 0
+
+
+class TestTracesScope:
+    def test_trace_scoped_annotation_matches(
+        self,
+        scope_project,
+        annotation_label,
+        user,
+        custom_eval_config_factory,
+        stub_run_eval,
+        inline_temporal,
+        stub_cost_log,
+    ):
+        _, span_a = _make_call(scope_project)
+        trace_a = span_a.trace
+        _make_call(scope_project)
+        _make_score(
+            annotation_label, scope_project, annotator=user, trace_id=trace_a.id
+        )
+
+        task = _run_task(
+            scope_project,
+            RowType.TRACES,
+            [_annotator_filter(user)],
+            custom_eval_config_factory(project=scope_project),
+        )
+
+        loggers = _logger_qs(task)
+        assert loggers.count() == 1
+        sample = loggers.first()
+        assert sample.target_type == EvalTargetType.TRACE
+        assert sample.trace_id == trace_a.id
+
+
+class TestSessionsScope:
+    def test_session_scoped_matches_and_span_scoped_does_not(
+        self,
+        scope_project,
+        annotation_label,
+        user,
+        custom_eval_config_factory,
+        stub_run_eval,
+        inline_temporal,
+        stub_cost_log,
+    ):
+        # Session 1 carries a session-scoped score; session 2 only has a
+        # span-scoped score. Sessions tasks mirror the sessions grid:
+        # only session-scoped scores count.
+        sess_1 = TraceSession.objects.create(
+            id=uuid.uuid4(), project=scope_project, name="sess_1"
+        )
+        sess_2 = TraceSession.objects.create(
+            id=uuid.uuid4(), project=scope_project, name="sess_2"
+        )
+        _make_call(scope_project, session=sess_1)
+        _, span_2 = _make_call(scope_project, session=sess_2)
+        _make_score(
+            annotation_label, scope_project, annotator=user, trace_session_id=sess_1.id
+        )
+        _make_score(
+            annotation_label,
+            scope_project,
+            annotator=user,
+            observation_span_id=span_2.id,
+        )
+
+        task = _run_task(
+            scope_project,
+            RowType.SESSIONS,
+            [_annotator_filter(user)],
+            custom_eval_config_factory(project=scope_project),
+        )
+
+        loggers = _logger_qs(task)
+        assert loggers.count() == 1
+        sample = loggers.first()
+        assert sample.target_type == EvalTargetType.SESSION
+        assert sample.trace_session_id == sess_1.id

--- a/futureagi/tracer/tests/integration/test_eval_task_filter_e2e.py
+++ b/futureagi/tracer/tests/integration/test_eval_task_filter_e2e.py
@@ -63,7 +63,51 @@ def _rebind_case(
     )
 
 
+def _is_truthy(value) -> bool:
+    return value.lower() == "true" if isinstance(value, str) else bool(value)
+
+
+def _expected_annotation_units(case: FilterCase, seeded: list[SeededRow]) -> int:
+    """Annotation predicates are scoped per row_type (grid parity):
+    spans -> span-scoped scores only; traces/voiceCalls -> any score on the
+    trace (trace- or span-scoped, via the OR bridge); sessions -> session-
+    scoped scores only (the corpora seed none).
+    """
+    pred = case.expected_predicate
+
+    if case.target_type == "sessions":
+        if case.col_type == "has_annotation" and not _is_truthy(case.filter_value):
+            return len({r.session_id for r in seeded})
+        return 0
+
+    if case.target_type == "spans":
+        if case.col_type == "has_annotation" and not _is_truthy(case.filter_value):
+            return sum(
+                1
+                for r in seeded
+                if not (r.has_annotation and r.annotation_scope == "span")
+            )
+        return sum(
+            1 for r in seeded if r.annotation_scope == "span" and pred(r)
+        )
+
+    # traces / voiceCalls: a span sees every score on its trace.
+    if case.col_type == "has_annotation":
+        annotated_traces = {r.trace_id for r in seeded if r.has_annotation}
+        if _is_truthy(case.filter_value):
+            matching_traces = annotated_traces
+        else:
+            matching_traces = {r.trace_id for r in seeded} - annotated_traces
+    else:
+        matching_traces = {r.trace_id for r in seeded if pred(r)}
+    if case.target_type == "traces":
+        return len(matching_traces)
+    return sum(1 for r in seeded if r.trace_id in matching_traces)
+
+
 def _expected_unit_count(case: FilterCase, seeded: list[SeededRow]) -> int:
+    if case.col_type in ("ANNOTATION", "has_annotation"):
+        return _expected_annotation_units(case, seeded)
     if case.target_type in ("spans", "voiceCalls"):
         return sum(1 for r in seeded if case.expected_predicate(r))
     if case.target_type == "traces":

--- a/futureagi/tracer/tests/test_eval_task_filter_dispatch.py
+++ b/futureagi/tracer/tests/test_eval_task_filter_dispatch.py
@@ -17,11 +17,17 @@ The bug this guards against: until 2026-06-04 the dispatcher only handled
 """
 
 import uuid
+from unittest import mock
 
 import pytest
-from django.db.models import Q
+from django.db.models import OuterRef, Q
 
-from tracer.utils.eval_tasks import parsing_evaltask_filters
+from tracer.models.eval_task import RowType
+from tracer.utils.eval_tasks import (
+    annotation_source_q_for_row_type,
+    parsing_evaltask_filters,
+)
+from tracer.utils.filters import FilterEngine
 
 
 # ---------------------------------------------------------------------------
@@ -104,17 +110,17 @@ def _eval_metric_item(eval_template_id, op="greater_than", value=0.8):
 @pytest.mark.unit
 class TestEmpty:
     def test_none_returns_empty_tuple(self):
-        q, anns = parsing_evaltask_filters(None)
+        q, anns = parsing_evaltask_filters(None, row_type=RowType.SPANS)
         assert q == Q()
         assert anns == {}
 
     def test_empty_dict_returns_empty_tuple(self):
-        q, anns = parsing_evaltask_filters({})
+        q, anns = parsing_evaltask_filters({}, row_type=RowType.SPANS)
         assert q == Q()
         assert anns == {}
 
     def test_empty_filters_list_returns_empty_tuple(self):
-        q, anns = parsing_evaltask_filters({"filters": []})
+        q, anns = parsing_evaltask_filters({"filters": []}, row_type=RowType.SPANS)
         assert q == Q()
         assert anns == {}
 
@@ -129,10 +135,12 @@ class TestLegacyKey:
     def test_legacy_key_with_span_attribute_filter(self):
         items = [_span_attr_item()]
         q, anns = parsing_evaltask_filters(
-            _wrap(items, key="span_attributes_filters")
+            _wrap(items, key="span_attributes_filters"), row_type=RowType.SPANS
         )
         # Legacy key produces the same Q as the canonical key.
-        q_canonical, _ = parsing_evaltask_filters(_wrap(items, key="filters"))
+        q_canonical, _ = parsing_evaltask_filters(
+            _wrap(items, key="filters"), row_type=RowType.SPANS
+        )
         assert repr(q) == repr(q_canonical)
         assert anns == {}
 
@@ -140,7 +148,7 @@ class TestLegacyKey:
         # The specific shape that motivated the fix: prod task f8481965.
         items = [_annotator_item()]
         q, anns = parsing_evaltask_filters(
-            _wrap(items, key="span_attributes_filters")
+            _wrap(items, key="span_attributes_filters"), row_type=RowType.SPANS
         )
         assert q != Q()
         assert "Exists" in repr(q)  # routed through the voice annotation handler
@@ -154,7 +162,9 @@ class TestLegacyKey:
 @pytest.mark.unit
 class TestSpanAttribute:
     def test_span_attribute_only(self):
-        q, anns = parsing_evaltask_filters(_wrap([_span_attr_item()]))
+        q, anns = parsing_evaltask_filters(
+            _wrap([_span_attr_item()]), row_type=RowType.SPANS
+        )
         assert q != Q()
         # SPAN_ATTRIBUTE filters resolve via the span_attributes JSONB
         # (`has_key` + `contains`) — verify by string match on the Q repr.
@@ -171,7 +181,7 @@ class TestSpanAttribute:
 class TestAnnotation:
     def test_annotator_filter_produces_exists_clause(self):
         items = [_annotator_item()]
-        q, anns = parsing_evaltask_filters(_wrap(items))
+        q, anns = parsing_evaltask_filters(_wrap(items), row_type=RowType.SPANS)
         assert q != Q()
         # The annotator branch builds an Exists(Score.objects...) subquery.
         assert "Exists" in repr(q)
@@ -182,15 +192,13 @@ class TestAnnotation:
         # A per-label ANNOTATION filter (e.g. "quality > 3") builds a Q
         # referencing the `annotation_<uuid>__score` field. The actual
         # `.annotate(annotation_<uuid>=...)` step is contributed by
-        # `build_annotation_subqueries` (observation_span.py:1167-1169),
-        # which `process_eval_task` does not yet call — see the dispatcher
-        # docstring. So `extra_anns` remains empty here; this test guards
-        # the Q shape only. When `build_annotation_subqueries` is wired in
-        # for eval tasks, replace this with an integration test that asserts
-        # the queryset actually returns the right rows.
+        # `build_annotation_subqueries`, which `process_eval_task` applies
+        # with the row_type's source Q. So `extra_anns` remains empty here;
+        # this test guards the Q shape only — row-level behaviour lives in
+        # the integration suite (test_eval_task_annotation_scope.py).
         label_uuid = str(uuid.uuid4())
         items = [_label_value_item(label_uuid, 3.0)]
-        q, anns = parsing_evaltask_filters(_wrap(items))
+        q, anns = parsing_evaltask_filters(_wrap(items), row_type=RowType.SPANS)
         assert q != Q()
         assert f"annotation_{label_uuid}__score" in repr(q)
         assert anns == {}
@@ -204,7 +212,7 @@ class TestAnnotation:
             _annotator_item(),
             _eval_metric_item(str(uuid.uuid4())),
         ]
-        q, anns = parsing_evaltask_filters(_wrap(items))
+        q, anns = parsing_evaltask_filters(_wrap(items), row_type=RowType.SPANS)
         assert q != Q()
 
 
@@ -217,7 +225,7 @@ class TestAnnotation:
 class TestSystemMetric:
     def test_system_metric_filter(self):
         items = [_system_metric_item("cost", "greater_than", 0.1)]
-        q, anns = parsing_evaltask_filters(_wrap(items))
+        q, anns = parsing_evaltask_filters(_wrap(items), row_type=RowType.SPANS)
         # The system-metrics handler maps `cost` to `row_avg_cost`
         # (FilterEngine.DEFAULT_FIELD_MAP) and emits a Q referencing it.
         assert q != Q()
@@ -233,7 +241,7 @@ class TestSystemMetric:
 class TestEvalMetric:
     def test_eval_metric_filter(self):
         items = [_eval_metric_item(str(uuid.uuid4()), "greater_than", 0.8)]
-        q, anns = parsing_evaltask_filters(_wrap(items))
+        q, anns = parsing_evaltask_filters(_wrap(items), row_type=RowType.SPANS)
         assert q != Q()
 
 
@@ -251,7 +259,7 @@ class TestMixed:
             _eval_metric_item(str(uuid.uuid4())),
             _annotator_item(),
         ]
-        q, anns = parsing_evaltask_filters(_wrap(items))
+        q, anns = parsing_evaltask_filters(_wrap(items), row_type=RowType.SPANS)
         assert q != Q()
         # Each handler contributes its own clause; combined Q should reference
         # all the underlying mechanisms.
@@ -269,20 +277,127 @@ class TestMixed:
 class TestSiblingKeys:
     def test_date_range_still_applied(self):
         q, _ = parsing_evaltask_filters(
-            {"date_range": ["2026-01-01T00:00:00Z", "2026-06-01T00:00:00Z"]}
+            {"date_range": ["2026-01-01T00:00:00Z", "2026-06-01T00:00:00Z"]},
+            row_type=RowType.SPANS,
         )
         assert q != Q()
         assert "created_at" in repr(q)
 
     def test_project_id_still_applied(self):
-        q, _ = parsing_evaltask_filters({"project_id": str(uuid.uuid4())})
+        q, _ = parsing_evaltask_filters(
+            {"project_id": str(uuid.uuid4())}, row_type=RowType.SPANS
+        )
         assert q != Q()
         assert "project_id" in repr(q)
 
     def test_observation_type_still_applied(self):
-        q, _ = parsing_evaltask_filters({"observation_type": ["llm", "tool"]})
+        q, _ = parsing_evaltask_filters(
+            {"observation_type": ["llm", "tool"]}, row_type=RowType.SPANS
+        )
         assert q != Q()
         assert "observation_type" in repr(q)
+
+
+# ---------------------------------------------------------------------------
+# RowType → annotation source Q mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRowTypeSourceMapping:
+    def test_spans_is_span_scoped(self):
+        assert annotation_source_q_for_row_type(RowType.SPANS) == Q(
+            observation_span_id=OuterRef("id")
+        )
+
+    def test_voice_calls_bridges_trace_and_span_scopes(self):
+        expected = Q(trace_id=OuterRef("trace_id")) | Q(
+            observation_span__trace_id=OuterRef("trace_id")
+        )
+        assert annotation_source_q_for_row_type(RowType.VOICE_CALLS) == expected
+
+    def test_traces_matches_voice_calls_mapping(self):
+        assert annotation_source_q_for_row_type(
+            RowType.TRACES
+        ) == annotation_source_q_for_row_type(RowType.VOICE_CALLS)
+
+    def test_sessions_is_session_scoped(self):
+        assert annotation_source_q_for_row_type(RowType.SESSIONS) == Q(
+            trace_session_id=OuterRef("trace__session_id")
+        )
+
+    def test_accepts_stored_string_values(self):
+        assert annotation_source_q_for_row_type(
+            "voiceCalls"
+        ) == annotation_source_q_for_row_type(RowType.VOICE_CALLS)
+
+    def test_unknown_row_type_raises(self):
+        with pytest.raises(ValueError):
+            annotation_source_q_for_row_type("bogus")
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher threads the row_type source Q into the annotation handlers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRowTypeDispatch:
+    @pytest.mark.parametrize(
+        "row_type",
+        [RowType.SPANS, RowType.TRACES, RowType.SESSIONS, RowType.VOICE_CALLS],
+    )
+    def test_annotation_handlers_receive_row_type_source_q(self, row_type):
+        items = [
+            _annotator_item(),
+            {
+                "column_id": "has_annotation",
+                "filter_config": {
+                    "filter_type": "boolean",
+                    "filter_op": "equals",
+                    "filter_value": True,
+                },
+            },
+        ]
+        with mock.patch.object(
+            FilterEngine,
+            "get_filter_conditions_for_voice_call_annotations",
+            return_value=(Q(), {}),
+        ) as anno_mock, mock.patch.object(
+            FilterEngine,
+            "get_filter_conditions_for_has_annotation",
+            return_value=Q(),
+        ) as has_anno_mock:
+            parsing_evaltask_filters(_wrap(items), row_type=row_type)
+
+        expected_source_q = annotation_source_q_for_row_type(row_type)
+        assert anno_mock.call_args.kwargs["source_q"] == expected_source_q
+        assert anno_mock.call_args.kwargs["user_id"] is None
+        assert has_anno_mock.call_args.kwargs["source_q"] == expected_source_q
+
+    @pytest.mark.parametrize(
+        "row_type",
+        [RowType.SPANS, RowType.TRACES, RowType.SESSIONS, RowType.VOICE_CALLS],
+    )
+    def test_has_eval_stays_span_scoped(self, row_type):
+        items = [
+            {
+                "column_id": "has_eval",
+                "filter_config": {
+                    "filter_type": "boolean",
+                    "filter_op": "equals",
+                    "filter_value": True,
+                },
+            }
+        ]
+        with mock.patch.object(
+            FilterEngine,
+            "get_filter_conditions_for_has_eval",
+            return_value=Q(),
+        ) as has_eval_mock:
+            parsing_evaltask_filters(_wrap(items), row_type=row_type)
+
+        assert has_eval_mock.call_args.kwargs["observe_type"] == "span"
 
 
 # ---------------------------------------------------------------------------
@@ -306,6 +421,6 @@ class TestUnrecognisedColType:
         ]
         # Must not raise. The handlers' own col_type gates skip items they
         # don't recognise; the dispatcher itself doesn't enumerate types.
-        q, anns = parsing_evaltask_filters(_wrap(items))
+        q, anns = parsing_evaltask_filters(_wrap(items), row_type=RowType.SPANS)
         assert isinstance(q, Q)
         assert anns == {}

--- a/futureagi/tracer/utils/annotations.py
+++ b/futureagi/tracer/utils/annotations.py
@@ -31,7 +31,7 @@ from tracer.utils.aggregates import JSONBObjectAgg
 
 
 def build_annotation_subqueries(
-    base_query, annotation_labels, organization, span_filter_kwargs=None
+    base_query, annotation_labels, organization, span_filter_kwargs=None, source_q=None
 ):
     """
     Annotate *base_query* with aggregated annotation subqueries for every
@@ -51,6 +51,8 @@ def build_annotation_subqueries(
             created directly on traces OR on observation spans belonging to
             the trace.  For span-level queries pass
             ``{"observation_span_id": OuterRef("id")}``.
+        source_q: Optional prebuilt Q matching scores to the outer row.
+            Takes precedence over ``span_filter_kwargs`` (allows OR scopes).
 
     Returns:
         The annotated *base_query*.
@@ -62,7 +64,16 @@ def build_annotation_subqueries(
     )
 
     for label in annotation_labels:
-        if span_filter_kwargs is not None:
+        if source_q is not None:
+            base_ann_q = (
+                Q(
+                    label_id=label.id,
+                    organization=organization,
+                    deleted=False,
+                )
+                & source_q
+            )
+        elif span_filter_kwargs is not None:
             base_ann_q = Q(
                 **span_filter_kwargs,
                 label_id=label.id,

--- a/futureagi/tracer/utils/eval_tasks.py
+++ b/futureagi/tracer/utils/eval_tasks.py
@@ -135,21 +135,45 @@ def compute_drain_state(eval_task, eval_task_logger=None):
     }
 
 
-def parsing_evaltask_filters(filters: dict) -> tuple[Q, dict]:
+def annotation_source_q_for_row_type(row_type: RowType | str) -> Q:
+    """Q matching Score rows against a span-outer queryset, scoped per row_type.
+
+    Mirrors each row_type's grid so the runner selects the same rows the
+    user previewed. Voice/trace annotations are stored trace-scoped, so
+    those bridge trace OR span; spans and sessions match their own scope.
+    """
+    row_type = RowType(row_type)
+    if row_type in (RowType.TRACES, RowType.VOICE_CALLS):
+        return Q(trace_id=OuterRef("trace_id")) | Q(
+            observation_span__trace_id=OuterRef("trace_id")
+        )
+    if row_type == RowType.SESSIONS:
+        return Q(trace_session_id=OuterRef("trace__session_id"))
+    return Q(observation_span_id=OuterRef("id"))
+
+
+def parsing_evaltask_filters(
+    filters: dict, *, row_type: RowType | str
+) -> tuple[Q, dict]:
     """Combine eval-task filter JSON into ``(Q, annotation_kwargs)``.
 
     Per-handler dispatch mirrors ``list_spans_observe``
     (``tracer/views/observation_span.py:1755-1826``): one flat ``filters``
     list, each item carrying ``col_type``, passed to every handler.
 
+    ANNOTATION predicates are scoped per ``row_type`` (see
+    ``annotation_source_q_for_row_type``); everything else stays span-outer.
+
     Callers must apply ``.annotate(**extra_annotations).filter(combined_q)``.
     Per-label ANNOTATION filters (e.g. ``columnId == "<label_uuid>"``)
-    additionally require ``build_annotation_subqueries`` to have been
-    applied to the queryset first — ``process_eval_task`` does that;
-    other callers must mirror it if they accept per-label filters.
+    additionally require ``build_annotation_subqueries`` (with the same
+    row_type source Q) to have been applied to the queryset first —
+    ``process_eval_task`` does that; other callers must mirror it if they
+    accept per-label filters.
 
     Accepts both ``filters`` and legacy ``span_attributes_filters`` keys.
     """
+    annotation_source_q = annotation_source_q_for_row_type(row_type)
     combined_q = Q()
     extra_anns: dict = {}
 
@@ -180,14 +204,12 @@ def parsing_evaltask_filters(filters: dict) -> tuple[Q, dict]:
             if q_eval:
                 combined_q &= q_eval
 
-            # span_filter_kwargs re-targets the Score join to span scope
-            # (filters.py:1683-1692); user_id=None because we're in a
-            # background activity, which makes my_annotations a no-op.
+            # user_id=None: background activity, so my_annotations is a no-op.
             q_anno, anno_anns = (
                 FilterEngine.get_filter_conditions_for_voice_call_annotations(
                     items,
                     user_id=None,
-                    span_filter_kwargs={"observation_span_id": OuterRef("id")},
+                    source_q=annotation_source_q,
                 )
             )
             if q_anno:
@@ -205,7 +227,7 @@ def parsing_evaltask_filters(filters: dict) -> tuple[Q, dict]:
             if q_has_eval:
                 combined_q &= q_has_eval
             q_has_anno = FilterEngine.get_filter_conditions_for_has_annotation(
-                items, observe_type="span"
+                items, source_q=annotation_source_q
             )
             if q_has_anno:
                 combined_q &= q_has_anno
@@ -348,18 +370,18 @@ def process_eval_task(eval_task_id: str):
         filters = Q()
         extra_anns: dict = {}
         if eval_task.filters is not None:
-            filters, extra_anns = parsing_evaltask_filters(eval_task.filters)
+            filters, extra_anns = parsing_evaltask_filters(
+                eval_task.filters, row_type=eval_task.row_type
+            )
 
-        # Pre-annotate ``annotation_<label_id>`` JSON columns on the span
-        # queryset (mirrors list_spans_observe at observation_span.py:1164-1172)
-        # so per-label ANNOTATION filters resolve. ``extra_anns`` is reserved
-        # for any future per-handler annotate kwargs.
+        # Pre-annotate the ``annotation_<label_id>`` columns that per-label
+        # ANNOTATION filters reference, scoped to the row_type's Score sources.
         annotation_labels = get_annotation_labels_for_project(eval_task.project_id)
         span_qs = build_annotation_subqueries(
             ObservationSpan.objects.all(),
             annotation_labels,
             eval_task.project.organization,
-            span_filter_kwargs={"observation_span_id": OuterRef("id")},
+            source_q=annotation_source_q_for_row_type(eval_task.row_type),
         )
         span_qs = span_qs.annotate(**extra_anns).filter(filters)
 

--- a/futureagi/tracer/utils/filters.py
+++ b/futureagi/tracer/utils/filters.py
@@ -1576,7 +1576,7 @@ class FilterEngine:
 
     @staticmethod
     def get_filter_conditions_for_voice_call_annotations(
-        filters, user_id=None, span_filter_kwargs=None
+        filters, user_id=None, span_filter_kwargs=None, source_q=None
     ):
         """
         Create Django Q objects for filtering voice call traces based on annotations.
@@ -1670,6 +1670,11 @@ class FilterEngine:
         Args:
             filters: List of filter conditions
             user_id: Current user's ID (needed for my_annotations filter)
+            span_filter_kwargs: Equality kwargs matching scores to the outer
+                row, e.g. ``{"observation_span_id": OuterRef("id")}`` for
+                span-level queries.
+            source_q: Prebuilt Q matching scores to the outer row. Takes
+                precedence over ``span_filter_kwargs`` (allows OR scopes).
 
         Returns:
             tuple[Q, dict]: A Django Q object for filtering, and a dict of extra
@@ -1680,16 +1685,15 @@ class FilterEngine:
         if not filters:
             return Q(), {}
 
-        # Build a Q object for matching scores to the outer row.
-        # For span-level queries, callers pass span_filter_kwargs directly.
-        # For the default trace-level context, match scores on the trace
-        # directly OR on any observation span belonging to the trace.
-        if span_filter_kwargs is not None:
-            source_q = Q(**span_filter_kwargs)
-        else:
-            source_q = Q(trace_id=OuterRef("trace_id")) | Q(
-                observation_span__trace_id=OuterRef("trace_id")
-            )
+        # Default (no source_q / span_filter_kwargs): trace-level — scores
+        # on the trace OR on any span of the trace.
+        if source_q is None:
+            if span_filter_kwargs is not None:
+                source_q = Q(**span_filter_kwargs)
+            else:
+                source_q = Q(trace_id=OuterRef("trace_id")) | Q(
+                    observation_span__trace_id=OuterRef("trace_id")
+                )
 
         q_conditions = Q()
         extra_annotations = {}
@@ -2113,7 +2117,7 @@ class FilterEngine:
 
     @staticmethod
     def get_filter_conditions_for_has_annotation(
-        filters, observe_type="trace", annotation_label_ids=None
+        filters, observe_type="trace", annotation_label_ids=None, source_q=None
     ):
         """
         Create a Django Q object to filter traces/spans by annotation completeness.
@@ -2123,6 +2127,8 @@ class FilterEngine:
 
         When ``annotation_label_ids`` is provided, checks that ALL labels are
         present (fully annotated).  Without it, falls back to simple existence.
+
+        ``source_q`` (a prebuilt Q) overrides the ``observe_type`` dispatch.
         """
         if not filters:
             return Q()
@@ -2142,16 +2148,19 @@ class FilterEngine:
 
             label_ids = annotation_label_ids or []
 
+            # Score.trace_id is often NULL (annotations live on spans), so
+            # the trace branch checks both trace_id and the span's trace_id.
+            if source_q is not None:
+                score_filter = source_q
+            elif observe_type == "span":
+                score_filter = Q(observation_span_id=OuterRef("id"))
+            else:
+                score_filter = Q(trace_id=OuterRef("id")) | Q(
+                    observation_span__trace_id=OuterRef("id")
+                )
+
             if label_ids:
                 # Completeness check: fully annotated = has score for ALL labels.
-                # Score.trace_id is often NULL — annotations are stored on spans.
-                # Must check BOTH Score.trace_id AND Score.observation_span.trace_id.
-                if observe_type == "span":
-                    score_filter = Q(observation_span_id=OuterRef("id"))
-                else:
-                    score_filter = Q(trace_id=OuterRef("id")) | Q(
-                        observation_span__trace_id=OuterRef("id")
-                    )
                 fully_annotated_q = Q()
                 for lid in label_ids:
                     fully_annotated_q &= Q(
@@ -2160,23 +2169,7 @@ class FilterEngine:
                 return fully_annotated_q if filter_value else ~fully_annotated_q
             else:
                 # Fallback: simple existence check
-                if observe_type == "span":
-                    exists_q = Q(
-                        Exists(
-                            Score.objects.filter(
-                                observation_span_id=OuterRef("id"),
-                            )
-                        )
-                    )
-                else:
-                    exists_q = Q(
-                        Exists(
-                            Score.objects.filter(
-                                Q(trace_id=OuterRef("id"))
-                                | Q(observation_span__trace_id=OuterRef("id")),
-                            )
-                        )
-                    )
+                exists_q = Q(Exists(Score.objects.filter(score_filter)))
                 return exists_q if filter_value else ~exists_q
 
         return Q()

--- a/futureagi/tracer/views/eval_task.py
+++ b/futureagi/tracer/views/eval_task.py
@@ -251,9 +251,17 @@ from tracer.serializers.eval_task import (
     EvalTaskSerializer,
     PaginationQuerySerializer,
 )
-from tracer.utils.eval_tasks import parsing_evaltask_filters, run_for_processed_spans
+from tracer.utils.annotations import build_annotation_subqueries
+from tracer.utils.eval_tasks import (
+    annotation_source_q_for_row_type,
+    parsing_evaltask_filters,
+    run_for_processed_spans,
+)
 from tracer.utils.filters import FilterEngine
-from tracer.utils.helper import get_default_eval_task_config
+from tracer.utils.helper import (
+    get_annotation_labels_for_project,
+    get_default_eval_task_config,
+)
 
 
 class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
@@ -1469,12 +1477,22 @@ class EvalTaskView(BaseModelViewSetMixin, ModelViewSet):
             )
             filters = update_fields.get("filters") or eval_task.filters
 
-            # Validate filters and get total spans count
-            parsed_filters, parsed_filter_anns = parsing_evaltask_filters(filters)
+            # build_annotation_subqueries is needed here too: per-label
+            # ANNOTATION filters reference columns it adds (else FieldError).
+            parsed_filters, parsed_filter_anns = parsing_evaltask_filters(
+                filters, row_type=eval_task.row_type
+            )
+            annotation_labels = get_annotation_labels_for_project(
+                eval_task.project_id
+            )
+            span_qs = build_annotation_subqueries(
+                ObservationSpan.objects.all(),
+                annotation_labels,
+                eval_task.project.organization,
+                source_q=annotation_source_q_for_row_type(eval_task.row_type),
+            )
             total_spans = (
-                ObservationSpan.objects.annotate(**parsed_filter_anns)
-                .filter(parsed_filters)
-                .count()
+                span_qs.annotate(**parsed_filter_anns).filter(parsed_filters).count()
             )
 
             if total_spans == 0:


### PR DESCRIPTION
## Problem

Eval-task annotation filters (`annotator`, `my_annotations`, per-label annotation values, `has_annotation`) were hard-coded to **span-scoped** `Score` matching (`observation_span_id=OuterRef("id")`). Annotations on voice calls are created **trace-scoped** (the voice-calls grid is trace-backed), so a `voiceCalls` eval task with an annotator filter selected **zero spans** and produced no evals.

Real incident: prod task `f8481965-cd74-44b1-9b6d-f4bb66ec2218` — annotator had 826 trace-scoped scores, zero span-scoped; the run completed with 0 evals.

## Fix

The runner's annotation predicate now mirrors whatever the row type's grid surface matches. New helper `annotation_source_q_for_row_type()` maps each `RowType` to a Score-source `Q` evaluated against the span-outer queryset:

| RowType | Score source | Grid parity |
|---|---|---|
| `spans` | `observation_span_id` | spans grid |
| `traces` / `voiceCalls` | `trace_id` **OR** any span of the trace | trace-backed grids |
| `sessions` | `trace_session_id` | sessions grid |

- `parsing_evaltask_filters` gains a required keyword-only `row_type` and threads the source `Q` into `get_filter_conditions_for_voice_call_annotations`, `get_filter_conditions_for_has_annotation`, and `build_annotation_subqueries`. Each gains a backward-compatible `source_q` kwarg; **all listing call sites are unchanged**.
- `process_eval_task` and the edit-rerun count path (`_handle_edit_rerun`) pass `eval_task.row_type`. The rerun-count path now also applies `build_annotation_subqueries`, so per-label ANNOTATION filters no longer raise `FieldError` there.
- `has_eval` stays span-scoped (evals are always span-targeted).

## Intentional semantic changes (grid parity)

- For `traces`/`voiceCalls`, `has_annotation=false` is now trace-level ("trace has no annotation anywhere"), and per-label value filters aggregate across all scores of the trace.
- `sessions` tasks match session-scoped scores only.

## Tests

- **Unit** (`test_eval_task_filter_dispatch.py`): `RowType -> Q` mapping equality, string-value coercion, fail-fast on unknown; dispatch tests asserting each handler receives the right `source_q` and that `has_eval` stays span-scoped.
- **Integration** (`test_eval_task_annotation_scope.py`, new): reproduces the incident — trace-scoped annotation + `voiceCalls` → matches; + `spans` → 0; span-scoped + `voiceCalls` → matches via the OR arm; `traces` matches; `sessions` matches session-scoped only.
- Voice seed corpus now creates **trace-scoped** scores (prod reality); e2e matrix expectations are scope-aware.

Verification: the 5 new scope tests fail on the pre-fix code and pass after; diffing the full integration suite before/after shows **zero newly-broken tests** (the pre-existing failures in this environment are unrelated, e.g. `row_avg_cost` resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)