### PR TITLE
TH-4812: Harden API/UI e2e coverage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -323,6 +323,7 @@ services:
       # from the docker bridge network and gets AUTHENTICATION_FAILED.
       # SKIP_USER_SETUP keeps the upstream default-user config (no IP
       # allowlist) — what every other service expects from local-dev CH.
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
       CLICKHOUSE_SKIP_USER_SETUP: "1"
       CLICKHOUSE_DB: ${CH_DATABASE:-default}
     ports:

--- a/frontend/scripts/api-journeys/browser/agents-playground-run-workflow-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/agents-playground-run-workflow-smoke.mjs
@@ -1,0 +1,765 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import process from "node:process";
+import { promisify } from "node:util";
+import {
+  apiPath,
+  assert,
+  createAuthenticatedContext,
+  isUuid,
+  requireMutations,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const SCREENSHOT_PATH = "/tmp/agents-playground-run-workflow-smoke.png";
+const DEBUG = process.env.DEBUG_AGENT_RUN_SMOKE === "1";
+
+async function main() {
+  requireMutations();
+
+  const auth = await createAuthenticatedContext();
+  const marker = auth.runId.replace(/[^a-z0-9]/gi, "").slice(0, 18);
+  const graphName = `browser run agent ${marker}`;
+  const nodeName = `browser_run_node_${marker}`.slice(0, 80);
+  const promptText = "Answer with one short fact about {{topic}}.";
+  const inputValue = `browser run input ${auth.runId}`;
+
+  let graphId = null;
+  let cleanupAudit = null;
+  const evidence = {
+    graph_name: graphName,
+    node_name: nodeName,
+    input_value: inputValue,
+  };
+
+  try {
+    const setup = await createDisposableAgentGraph({
+      auth,
+      graphName,
+      nodeName,
+      promptText,
+    });
+    graphId = setup.graphId;
+    evidence.graph_id = graphId;
+    evidence.version_id = setup.versionId;
+    evidence.node_id = setup.node.id;
+
+    const variable = await seedGraphVariable({
+      auth,
+      graphId,
+      versionId: setup.versionId,
+      columnName: "topic",
+      value: inputValue,
+    });
+    evidence.variable = variable;
+
+    const activeVersion = await auth.client.patch(
+      apiPath("/agent-playground/graphs/{id}/versions/{version_id}/", {
+        id: graphId,
+        version_id: setup.versionId,
+      }),
+      {
+        status: "active",
+        commit_message: `browser run workflow ${marker}`,
+      },
+    );
+    assert(
+      activeVersion?.id === setup.versionId &&
+        activeVersion.status === "active",
+      "Run smoke setup did not activate the graph version.",
+    );
+
+    const browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+
+    const page = await browser.newPage();
+    await installRuntimeConfig(page, auth);
+    await page.evaluateOnNewDocument(
+      ({ tokens, organizationId, workspaceId, user }) => {
+        localStorage.setItem("accessToken", tokens.access);
+        localStorage.setItem("refreshToken", tokens.refresh || "");
+        localStorage.setItem("rememberMe", "true");
+        localStorage.setItem("initial-render", "done");
+        if (organizationId)
+          sessionStorage.setItem("organizationId", organizationId);
+        if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+        if (user?.id)
+          sessionStorage.setItem("futureagi-current-user-id", user.id);
+      },
+      {
+        tokens: auth.tokens,
+        organizationId: auth.organizationId,
+        workspaceId: auth.workspaceId,
+        user: auth.user,
+      },
+    );
+
+    const apiFailures = [];
+    const pageErrors = [];
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isAgentPlaygroundApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${new URL(url).pathname}`);
+      }
+    });
+    page.on("pageerror", (error) =>
+      pageErrors.push(error.stack || error.message),
+    );
+
+    try {
+      logStep("open active builder");
+      const graphDetailResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes(`/agent-playground/graphs/${graphId}/`) &&
+          !response.url().includes("/versions/") &&
+          response.status() < 400,
+        { timeout: 60000 },
+      );
+      const versionDetailResponse = page.waitForResponse(
+        (response) =>
+          response
+            .url()
+            .includes(
+              `/agent-playground/graphs/${graphId}/versions/${setup.versionId}/`,
+            ) && response.status() < 400,
+        { timeout: 60000 },
+      );
+      await page.goto(
+        `${APP_BASE}/dashboard/agents/playground/${graphId}/build?version=${setup.versionId}`,
+        { waitUntil: "domcontentloaded" },
+      );
+      await Promise.all([graphDetailResponse, versionDetailResponse]);
+      await page.waitForFunction(
+        ({ graphId: expectedGraphId, versionId }) =>
+          window.location.pathname.endsWith(
+            `/dashboard/agents/playground/${expectedGraphId}/build`,
+          ) && window.location.search.includes(`version=${versionId}`),
+        { timeout: 30000 },
+        { graphId, versionId: setup.versionId },
+      );
+
+      await waitForVisibleText(page, graphName, { exact: true });
+      await waitForVisibleText(page, "Agent Builder", { exact: true });
+      await waitForVisibleText(page, "Version 1", { exact: true });
+      await waitForVisibleText(page, nodeName, { exact: true });
+      await waitForNoVisibleText(page, "Draft", { exact: true });
+      await waitForEnabledButton(page, "Run Agent Workflow");
+
+      logStep("click run workflow");
+      const executeResponsePromise = page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          new URL(response.url()).pathname.endsWith(
+            `/agent-playground/graphs/${graphId}/dataset/execute/`,
+          ),
+        { timeout: 60000 },
+      );
+      await clickVisibleText(page, "Run Agent Workflow", { exact: true });
+      const executeResponse = await executeResponsePromise;
+      const executeStatus = executeResponse.status();
+      const executeBody = await parseJsonResponse(executeResponse);
+      const executionIds = executionIdsFromBrowserResponse(executeBody);
+
+      evidence.execute = {
+        status: executeStatus,
+        body: executeBody,
+        execution_ids: executionIds,
+      };
+
+      if (executeStatus >= 200 && executeStatus < 300) {
+        assert(
+          isUuid(executionIds[0]),
+          "Browser run execute response did not expose a UUID execution id.",
+        );
+      } else {
+        assert(
+          executeStatus === 500,
+          `Browser run execute failed with unexpected status ${executeStatus}.`,
+        );
+      }
+
+      await sleep(1000);
+      await waitForNoVisibleText(page, "No execution IDs returned", {
+        exact: true,
+        timeout: 5000,
+      });
+
+      const dispatchAudit = await loadAgentActiveExecutionAudit({ graphId });
+      evidence.dispatch_audit = dispatchAudit;
+      assert(
+        dispatchAudit.execution_count === 1,
+        "Browser run did not create exactly one graph execution row.",
+      );
+      assert(
+        isUuid(dispatchAudit.latest_execution_id),
+        "Browser run DB audit did not find the created execution id.",
+      );
+      assert(
+        dispatchAudit.latest_input_topic === inputValue,
+        "Browser run GraphExecution input payload did not persist the dataset value.",
+      );
+      if (executeStatus === 500) {
+        assert(
+          dispatchAudit.latest_status === "failed",
+          "Browser run dispatch failure left GraphExecution non-failed.",
+        );
+        assert(
+          String(dispatchAudit.latest_error_message || "").includes(
+            "Failed to start graph execution workflow",
+          ),
+          "Browser run dispatch failure did not persist an actionable error message.",
+        );
+      }
+
+      await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+      evidence.screenshot = SCREENSHOT_PATH;
+
+      const unexpectedApiFailures = apiFailures.filter(
+        (failure) =>
+          !failure.endsWith(
+            `/agent-playground/graphs/${graphId}/dataset/execute/`,
+          ),
+      );
+      assert(
+        unexpectedApiFailures.length === 0,
+        `Unexpected Agent Playground API failures: ${unexpectedApiFailures.join(
+          "; ",
+        )}`,
+      );
+      assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+    } finally {
+      await browser.close();
+    }
+
+    await auth.client.post(apiPath("/agent-playground/graphs/delete/"), {
+      ids: [graphId],
+    });
+    const postDeleteAudit = await loadAgentActiveExecutionAudit({ graphId });
+    evidence.post_delete_audit = postDeleteAudit;
+    assert(
+      postDeleteAudit.execution_count === 0,
+      "Public graph delete left browser run executions visible.",
+    );
+  } finally {
+    if (graphId) {
+      cleanupAudit = await hardDeleteAgentGraphResidue({
+        graphId,
+        graphNames: [graphName],
+        promptNames: [nodeName],
+        organizationId: auth.organizationId,
+        workspaceId: auth.workspaceId,
+      });
+      evidence.cleanup_audit = cleanupAudit;
+      assert(
+        cleanupAudit.remaining_graphs === 0 &&
+          cleanupAudit.remaining_prompt_templates === 0,
+        "Hard cleanup left browser run smoke residue.",
+      );
+    }
+  }
+
+  writeJsonLine(process.stdout, evidence);
+}
+
+async function createDisposableAgentGraph({
+  auth,
+  graphName,
+  nodeName,
+  promptText,
+}) {
+  const templatePayload = await auth.client.get(
+    apiPath("/agent-playground/node-templates/"),
+  );
+  const nodeTemplates = Array.isArray(templatePayload?.node_templates)
+    ? templatePayload.node_templates
+    : [];
+  const llmTemplate = nodeTemplates.find((item) => item.name === "llm_prompt");
+  assert(llmTemplate?.id, "Agent node templates did not include llm_prompt.");
+
+  const createdGraph = await auth.client.post(
+    apiPath("/agent-playground/graphs/"),
+    {
+      name: graphName,
+      description: `Disposable browser run workflow graph ${auth.runId}`,
+    },
+  );
+  const graphId = createdGraph.id;
+  const versionId = createdGraph.active_version?.id;
+  assert(isUuid(graphId), "Agent graph create did not return a graph id.");
+  assert(
+    isUuid(versionId),
+    "Agent graph create did not return an active version id.",
+  );
+
+  const node = await auth.client.post(
+    apiPath("/agent-playground/graphs/{id}/versions/{version_id}/nodes/", {
+      id: graphId,
+      version_id: versionId,
+    }),
+    {
+      id: randomUUID(),
+      type: "atomic",
+      name: nodeName,
+      node_template_id: llmTemplate.id,
+      position: { x: 160, y: 120 },
+      prompt_template: {
+        messages: [
+          {
+            id: "browser-run-source",
+            role: "user",
+            content: [{ type: "text", text: promptText }],
+          },
+        ],
+        response_format: "text",
+        model: "gpt-4o-mini",
+        temperature: 0,
+        metadata: { api_journey: "agents-playground-run-workflow-smoke" },
+      },
+    },
+  );
+  assert(isUuid(node.id), "Agent node create did not return an id.");
+
+  return { graphId, versionId, node };
+}
+
+async function seedGraphVariable({
+  auth,
+  graphId,
+  versionId,
+  columnName,
+  value,
+}) {
+  const variable = await loadGraphVariable({
+    auth,
+    graphId,
+    versionId,
+    columnName,
+  });
+  await auth.client.put(
+    apiPath("/agent-playground/graphs/{graph_id}/dataset/cells/{cell_id}/", {
+      graph_id: graphId,
+      cell_id: variable.cell_id,
+    }),
+    { value },
+  );
+  const readback = await loadGraphVariable({
+    auth,
+    graphId,
+    versionId,
+    columnName,
+  });
+  assert(readback.value === value, "Graph variable seed did not persist.");
+  return readback;
+}
+
+async function loadGraphVariable({ auth, graphId, versionId, columnName }) {
+  const dataset = await auth.client.get(
+    apiPath("/agent-playground/graphs/{graph_id}/dataset/", {
+      graph_id: graphId,
+    }),
+    { query: { version_id: versionId, page: 1, page_size: 10 } },
+  );
+  const column = (dataset.columns || []).find(
+    (item) => item.name === columnName,
+  );
+  assert(column?.id, `Graph dataset did not expose ${columnName} column.`);
+  const row = (dataset.rows || [])[0];
+  assert(row?.id, "Graph dataset did not expose a minimum variable row.");
+  const cell = (row.cells || []).find(
+    (item) => getCellColumnId(item) === column.id,
+  );
+  assert(cell?.id, `Graph dataset did not expose a ${columnName} cell.`);
+  return {
+    dataset_id: dataset.dataset_id,
+    column_id: column.id,
+    row_id: row.id,
+    cell_id: cell.id,
+    value: cell.value,
+  };
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const normalized = (value) => String(value || "").trim();
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll("body *")).some((element) => {
+        if (!isVisible(element)) return false;
+        const textContent = normalized(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      });
+    },
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function waitForNoVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const normalized = (value) => String(value || "").trim();
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return !Array.from(document.querySelectorAll("body *")).some(
+        (element) => {
+          if (!isVisible(element)) return false;
+          const textContent = normalized(element.textContent);
+          return exactMatch
+            ? textContent === expectedText
+            : textContent.includes(expectedText);
+        },
+      );
+    },
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function waitForEnabledButton(page, text, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedText) =>
+      Array.from(document.querySelectorAll("button")).some((button) => {
+        if (button.disabled) return false;
+        return String(button.textContent || "").trim() === expectedText;
+      }),
+    { timeout },
+    text,
+  );
+}
+
+async function clickVisibleText(page, text, { exact = false } = {}) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const normalized = (value) => String(value || "").trim();
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(
+        document.querySelectorAll("button,[role='tab'],a"),
+      ).some((element) => {
+        if (!isVisible(element)) return false;
+        const textContent = normalized(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      });
+    },
+    { timeout: 30000 },
+    { text, exact },
+  );
+  await page.evaluate(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const normalized = (value) => String(value || "").trim();
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      const element = Array.from(
+        document.querySelectorAll("button,[role='tab'],a"),
+      ).find((candidate) => {
+        if (!isVisible(candidate)) return false;
+        const textContent = normalized(candidate.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      });
+      element.click();
+    },
+    { text, exact },
+  );
+}
+
+function executionIdsFromBrowserResponse(body) {
+  const result = body?.result || body?.data?.result || body;
+  return result?.execution_ids || result?.executionIds || [];
+}
+
+async function parseJsonResponse(response) {
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}
+
+function getCellColumnId(cell) {
+  return cell?.columnId || cell?.column_id;
+}
+
+async function loadAgentActiveExecutionAudit({ graphId }) {
+  const sql = `
+WITH target_versions AS (
+  SELECT id FROM agent_playground_graph_version
+  WHERE graph_id = ${sqlUuid(graphId)}
+),
+target_executions AS (
+  SELECT id, status, input_payload, error_message, created_at
+  FROM agent_playground_graph_execution
+  WHERE graph_version_id IN (SELECT id FROM target_versions)
+    AND deleted = false
+),
+latest_execution AS (
+  SELECT * FROM target_executions
+  ORDER BY created_at DESC
+  LIMIT 1
+)
+SELECT json_build_object(
+  'execution_count', (SELECT count(*) FROM target_executions),
+  'latest_execution_id', (SELECT id::text FROM latest_execution),
+  'latest_status', (SELECT status FROM latest_execution),
+  'latest_input_topic', (SELECT input_payload->>'topic' FROM latest_execution),
+  'latest_error_message', (SELECT error_message FROM latest_execution)
+);
+`;
+  return runPostgresJson(sql);
+}
+
+async function hardDeleteAgentGraphResidue({
+  graphId,
+  graphNames,
+  promptNames,
+  organizationId,
+  workspaceId,
+}) {
+  const sql = `
+BEGIN;
+CREATE TEMP TABLE _agt_graph_ids(id uuid) ON COMMIT DROP;
+INSERT INTO _agt_graph_ids
+SELECT id FROM agent_playground_graph
+WHERE id = ${sqlUuid(graphId)}
+   OR name = ANY(${sqlTextArray(graphNames)});
+
+CREATE TEMP TABLE _agt_version_ids(id uuid) ON COMMIT DROP;
+INSERT INTO _agt_version_ids
+SELECT id FROM agent_playground_graph_version
+WHERE graph_id IN (SELECT id FROM _agt_graph_ids);
+
+CREATE TEMP TABLE _agt_node_ids(id uuid) ON COMMIT DROP;
+INSERT INTO _agt_node_ids
+SELECT id FROM agent_playground_node
+WHERE graph_version_id IN (SELECT id FROM _agt_version_ids);
+
+CREATE TEMP TABLE _agt_dataset_ids(id uuid) ON COMMIT DROP;
+INSERT INTO _agt_dataset_ids
+SELECT dataset_id FROM agent_playground_graph_dataset
+WHERE graph_id IN (SELECT id FROM _agt_graph_ids);
+
+CREATE TEMP TABLE _agt_prompt_template_ids(id uuid) ON COMMIT DROP;
+INSERT INTO _agt_prompt_template_ids
+SELECT DISTINCT prompt_template_id FROM agent_playground_prompt_template_node
+WHERE node_id IN (SELECT id FROM _agt_node_ids);
+INSERT INTO _agt_prompt_template_ids
+SELECT id FROM model_hub_prompttemplate
+WHERE organization_id = ${sqlUuid(organizationId)}
+  AND workspace_id = ${sqlUuid(workspaceId)}
+  AND name = ANY(${sqlTextArray(promptNames)});
+
+CREATE TEMP TABLE _agt_prompt_version_ids(id uuid) ON COMMIT DROP;
+INSERT INTO _agt_prompt_version_ids
+SELECT id FROM model_hub_promptversion
+WHERE original_template_id IN (SELECT id FROM _agt_prompt_template_ids);
+
+DELETE FROM model_hub_cell
+WHERE dataset_id IN (SELECT id FROM _agt_dataset_ids);
+DELETE FROM model_hub_row
+WHERE dataset_id IN (SELECT id FROM _agt_dataset_ids);
+DELETE FROM model_hub_column
+WHERE dataset_id IN (SELECT id FROM _agt_dataset_ids);
+DELETE FROM agent_playground_graph_dataset
+WHERE graph_id IN (SELECT id FROM _agt_graph_ids);
+DELETE FROM model_hub_dataset
+WHERE id IN (SELECT id FROM _agt_dataset_ids);
+
+DELETE FROM agent_playground_execution_data
+WHERE node_execution_id IN (
+  SELECT id FROM agent_playground_node_execution
+  WHERE graph_execution_id IN (
+    SELECT id FROM agent_playground_graph_execution
+    WHERE graph_version_id IN (SELECT id FROM _agt_version_ids)
+  )
+);
+DELETE FROM agent_playground_node_execution
+WHERE graph_execution_id IN (
+  SELECT id FROM agent_playground_graph_execution
+  WHERE graph_version_id IN (SELECT id FROM _agt_version_ids)
+);
+DELETE FROM agent_playground_graph_execution
+WHERE graph_version_id IN (SELECT id FROM _agt_version_ids);
+DELETE FROM agent_playground_edge
+WHERE graph_version_id IN (SELECT id FROM _agt_version_ids);
+DELETE FROM agent_playground_node_connection
+WHERE graph_version_id IN (SELECT id FROM _agt_version_ids);
+DELETE FROM agent_playground_port
+WHERE node_id IN (SELECT id FROM _agt_node_ids);
+DELETE FROM agent_playground_prompt_template_node
+WHERE node_id IN (SELECT id FROM _agt_node_ids);
+DELETE FROM agent_playground_node
+WHERE id IN (SELECT id FROM _agt_node_ids);
+DELETE FROM agent_playground_graph_version
+WHERE id IN (SELECT id FROM _agt_version_ids);
+DELETE FROM agent_playground_graph_collaborators
+WHERE graph_id IN (SELECT id FROM _agt_graph_ids);
+DELETE FROM agent_playground_graph
+WHERE id IN (SELECT id FROM _agt_graph_ids);
+
+DELETE FROM model_hub_promptversion_labels
+WHERE promptversion_id IN (SELECT id FROM _agt_prompt_version_ids);
+DELETE FROM model_hub_prompttemplate_collaborators
+WHERE prompttemplate_id IN (SELECT id FROM _agt_prompt_template_ids);
+DELETE FROM model_hub_promptversion
+WHERE id IN (SELECT id FROM _agt_prompt_version_ids);
+DELETE FROM model_hub_prompttemplate
+WHERE id IN (SELECT id FROM _agt_prompt_template_ids);
+
+SELECT json_build_object(
+  'remaining_graphs', (
+    SELECT count(*) FROM agent_playground_graph
+    WHERE id = ${sqlUuid(graphId)} OR name = ANY(${sqlTextArray(graphNames)})
+  ),
+  'remaining_prompt_templates', (
+    SELECT count(*) FROM model_hub_prompttemplate
+    WHERE organization_id = ${sqlUuid(organizationId)}
+      AND workspace_id = ${sqlUuid(workspaceId)}
+      AND name = ANY(${sqlTextArray(promptNames)})
+  )
+);
+COMMIT;
+`;
+  return runPostgresJson(sql);
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-qAt", "-U", user, "-d", database, "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const jsonLine = stdout
+    .trim()
+    .split(/\r?\n/)
+    .reverse()
+    .find((line) => line.trim().startsWith("{"));
+  assert(jsonLine, "Postgres DB query returned no JSON object.");
+  return JSON.parse(jsonLine);
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), "SQL UUID value must be a UUID.");
+  return `'${value}'::uuid`;
+}
+
+function sqlTextLiteral(value) {
+  return `'${String(value ?? "").replaceAll("'", "''")}'`;
+}
+
+function sqlTextArray(values) {
+  const rows = values || [];
+  assert(rows.length > 0, "SQL text array cannot be empty.");
+  return `ARRAY[${rows.map((value) => sqlTextLiteral(value)).join(", ")}]::text[]`;
+}
+
+function isAgentPlaygroundApiUrl(url) {
+  return url.includes("/agent-playground/");
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH)
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") return "/usr/bin/google-chrome";
+  return undefined;
+}
+
+function writeJsonLine(stream, value) {
+  stream.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function logStep(message) {
+  if (!DEBUG) return;
+  process.stderr.write(`[agents-run-smoke] ${message}\n`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error?.stack || error}\n`);
+  process.exitCode = 1;
+});

--- a/frontend/scripts/api-journeys/browser/agents-playground-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/agents-playground-smoke.mjs
@@ -26,6 +26,7 @@ async function main() {
   const editedSourceNodeName = `${sourceNodeName}_edited`.slice(0, 80);
   const targetNodeName = `browser_target_${marker}`.slice(0, 80);
   const connectedNodeName = "llm_prompt_node_1";
+  const draggedNodeName = "llm_prompt_node_2";
   const sourcePromptText = "Write one test fact about {{topic}}.";
   const variableInitialValue = `browser variable initial ${auth.runId}`;
   const variableUpdatedValue = `browser variable updated ${auth.runId}`;
@@ -41,6 +42,7 @@ async function main() {
     editedSourceNodeName,
     targetNodeName,
     connectedNodeName,
+    draggedNodeName,
   ];
   let graphId = null;
   let publicDeleteStatus = null;
@@ -150,6 +152,15 @@ async function main() {
           request.method() === "POST" &&
           url.includes(
             `/agent-playground/graphs/${graphId}/versions/${setup.draftVersionId}/nodes/`,
+          )
+        ) {
+          expectedMutations.push(`${request.method()} ${url}`);
+          return;
+        }
+        if (
+          request.method() === "POST" &&
+          url.includes(
+            `/agent-playground/graphs/${graphId}/versions/${setup.draftVersionId}/node-connections/`,
           )
         ) {
           expectedMutations.push(`${request.method()} ${url}`);
@@ -412,6 +423,81 @@ async function main() {
         post_mutation_audit: postBuilderMutationAudit,
       };
 
+      logStep("manual drag/drop node and handle connect");
+      const draggedNodeCreateResponse = page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          response
+            .url()
+            .includes(
+              `/agent-playground/graphs/${graphId}/versions/${setup.draftVersionId}/nodes/`,
+            ) &&
+          response.status() < 400,
+        { timeout: 60000 },
+      );
+      await dragTemplateToCanvas(page, "LLM Prompt", {
+        xRatio: 0.72,
+        yRatio: 0.28,
+      });
+      const draggedNodePayload = await draggedNodeCreateResponse.then(
+        (response) => response.json(),
+      );
+      const draggedNode = draggedNodePayload?.result;
+      assert(
+        draggedNode?.name === draggedNodeName,
+        "Manual palette drag/drop did not create the expected prompt node.",
+      );
+      await waitForVisibleText(page, draggedNodeName, { exact: true });
+
+      const manualConnectionResponse = page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          response
+            .url()
+            .includes(
+              `/agent-playground/graphs/${graphId}/versions/${setup.draftVersionId}/node-connections/`,
+            ) &&
+          response.status() < 400,
+        { timeout: 60000 },
+      );
+      await connectNodesByHandle(page, connectedNodeName, draggedNodeName);
+      const manualConnectionPayload = await manualConnectionResponse.then(
+        (response) => response.json(),
+      );
+      const manualConnection =
+        manualConnectionPayload?.result || manualConnectionPayload;
+      assert(
+        manualConnection?.source_node_id === connectedNode.id,
+        "Manual handle connect did not persist the expected source node.",
+      );
+      assert(
+        manualConnection?.target_node_id === draggedNode.id,
+        "Manual handle connect did not persist the expected target node.",
+      );
+      evidence.rendered_edge_count_after_manual_connect =
+        await waitForRenderedEdgeCount(page, 3);
+      const postManualConnectAudit = await loadAgentGraphDbAudit({ graphId });
+      assert(
+        postManualConnectAudit.node_visible === 4,
+        "Manual drag/connect did not leave four visible nodes.",
+      );
+      assert(
+        postManualConnectAudit.node_connection_visible === 3,
+        "Manual handle connect did not leave three visible node connections.",
+      );
+      assert(
+        postManualConnectAudit.prompt_template_node_visible === 4,
+        "Manual drag/drop did not create a visible prompt-template node link.",
+      );
+      evidence.browser_manual_drag_connect = {
+        dragged_node_id: draggedNode.id,
+        dragged_node_name: draggedNode.name,
+        node_connection_id: manualConnection.id,
+        source_node_id: manualConnection.source_node_id,
+        target_node_id: manualConnection.target_node_id,
+        post_mutation_audit: postManualConnectAudit,
+      };
+
       logStep("edit global variable drawer");
       const graphDatasetResponse = page.waitForResponse(
         (response) =>
@@ -606,8 +692,8 @@ async function main() {
         `Agent playground smoke fired unexpected mutations: ${unexpectedMutations.join("; ")}`,
       );
       assert(
-        expectedMutations.length === 3,
-        `Expected one prompt save, one browser node add mutation, and one variable update mutation, saw ${expectedMutations.length}.`,
+        expectedMutations.length === 5,
+        `Expected one prompt save, two browser node add mutations, one manual connection mutation, and one variable update mutation, saw ${expectedMutations.length}.`,
       );
       evidence.expected_mutation_count = expectedMutations.length;
     } finally {
@@ -1137,6 +1223,133 @@ async function addConnectedBlankPromptFromNode(page, sourceNodeLabel) {
   await clickNodeTemplateFromOpenPopper(page, "LLM Prompt");
   await waitForVisibleText(page, "Add Blank Prompt", { exact: true });
   await clickVisibleText(page, "Add Blank Prompt", { exact: true });
+}
+
+async function dragTemplateToCanvas(
+  page,
+  templateTitle,
+  { xRatio = 0.65, yRatio = 0.35 } = {},
+) {
+  const dropped = await page.evaluate(
+    ({ templateTitle: title, xRatio: targetXRatio, yRatio: targetYRatio }) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      const normalized = (value) => String(value || "").trim();
+      const label = Array.from(document.querySelectorAll("body *")).find(
+        (candidate) =>
+          isVisible(candidate) && normalized(candidate.textContent) === title,
+      );
+      const source = label?.closest("[draggable='true']");
+      const pane =
+        document.querySelector(".react-flow__pane") ||
+        document.querySelector(".react-flow");
+      if (!source || !pane) return false;
+
+      const paneRect = pane.getBoundingClientRect();
+      const clientX = paneRect.left + paneRect.width * targetXRatio;
+      const clientY = paneRect.top + paneRect.height * targetYRatio;
+      const dataTransfer = new DataTransfer();
+      source.dispatchEvent(
+        new DragEvent("dragstart", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      );
+      pane.dispatchEvent(
+        new DragEvent("dragover", {
+          bubbles: true,
+          cancelable: true,
+          clientX,
+          clientY,
+          dataTransfer,
+        }),
+      );
+      pane.dispatchEvent(
+        new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          clientX,
+          clientY,
+          dataTransfer,
+        }),
+      );
+      source.dispatchEvent(
+        new DragEvent("dragend", {
+          bubbles: true,
+          cancelable: true,
+          clientX,
+          clientY,
+          dataTransfer,
+        }),
+      );
+      return true;
+    },
+    { templateTitle, xRatio, yRatio },
+  );
+  assert(dropped, `Could not drag ${templateTitle} template to canvas.`);
+}
+
+async function connectNodesByHandle(page, sourceNodeLabel, targetNodeLabel) {
+  const points = await page.evaluate(
+    ({ sourceLabel, targetLabel }) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      const findNode = (label) =>
+        Array.from(document.querySelectorAll(".react-flow__node")).find(
+          (candidate) =>
+            isVisible(candidate) &&
+            String(candidate.textContent || "").includes(label),
+        );
+      const sourceNode = findNode(sourceLabel);
+      const targetNode = findNode(targetLabel);
+      if (!sourceNode || !targetNode) return null;
+      const sourceHandle =
+        sourceNode.querySelector(".react-flow__handle-right") ||
+        sourceNode.querySelector(".react-flow__handle-source");
+      const targetHandle =
+        targetNode.querySelector(".react-flow__handle-left") ||
+        targetNode.querySelector(".react-flow__handle-target");
+      if (!sourceHandle || !targetHandle) return null;
+      const sourceRect = sourceHandle.getBoundingClientRect();
+      const targetRect = targetHandle.getBoundingClientRect();
+      return {
+        source: {
+          x: sourceRect.left + sourceRect.width / 2,
+          y: sourceRect.top + sourceRect.height / 2,
+        },
+        target: {
+          x: targetRect.left + targetRect.width / 2,
+          y: targetRect.top + targetRect.height / 2,
+        },
+      };
+    },
+    { sourceLabel: sourceNodeLabel, targetLabel: targetNodeLabel },
+  );
+  assert(
+    points,
+    `Could not find connect handles for ${sourceNodeLabel} -> ${targetNodeLabel}.`,
+  );
+  await page.mouse.move(points.source.x, points.source.y);
+  await page.mouse.down();
+  await page.mouse.move(points.target.x, points.target.y, { steps: 24 });
+  await page.mouse.up();
 }
 
 async function clickCanvasNodeAddButton(page, nodeLabel) {

--- a/frontend/scripts/api-journeys/browser/annotation-label-archive-restore-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/annotation-label-archive-restore-smoke.mjs
@@ -1,293 +1,773 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+/* eslint-disable no-console */
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
-import path from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+  currentUserId,
+  isUuid,
+  requireMutations,
+} from "../lib/api-client.mjs";
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const LABEL_PREFIX = "ui_aq_label_archive_";
 const SCREENSHOT_PATH =
   process.env.ANNOTATION_LABEL_ARCHIVE_RESTORE_SCREENSHOT ||
   "/tmp/annotation-label-archive-restore-smoke.png";
-
-const IDS = {
-  archivedLabel: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-};
+const ARCHIVED_SCREENSHOT_PATH =
+  process.env.ANNOTATION_LABEL_ARCHIVE_RESTORE_ARCHIVED_SCREENSHOT ||
+  SCREENSHOT_PATH.replace(/\.png$/, "-archived.png");
+const FAILURE_SCREENSHOT_PATH = SCREENSHOT_PATH.replace(
+  /\.png$/,
+  "-failure.png",
+);
+const MUTATION_METHODS = new Set(["DELETE", "PATCH", "POST", "PUT"]);
 
 async function main() {
-  const frontendRoot = path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "../../..",
-  );
-  const harnessDir = path.join(frontendRoot, ".tmp-smoke");
-  const harnessPath = path.join(
-    harnessDir,
-    "annotation-label-archive-restore-smoke.html",
-  );
-  await mkdir(harnessDir, { recursive: true });
-  await writeFile(harnessPath, smokeHarnessHtml(), "utf8");
+  requireMutations();
 
+  const auth = await createAuthenticatedContext();
+  const userId = currentUserId(auth.user);
+  assert(isUuid(userId), "Authenticated user id could not be resolved.");
+
+  const cleanupEvidence = [];
+  const apiFailures = [];
   const pageErrors = [];
-  const apiRequests = [];
-  let restorePosted = false;
-  const browser = await puppeteer.launch({
-    executablePath: browserExecutablePath(),
-    headless: process.env.HEADLESS !== "0",
-    defaultViewport: { width: 1180, height: 720 },
-    args: ["--no-sandbox"],
-  });
-  const page = await browser.newPage();
-  page.on("pageerror", (error) => pageErrors.push(error.message));
-
-  await page.setRequestInterception(true);
-  page.on("request", (request) => {
-    const url = new URL(request.url());
-    if (url.pathname.includes("/model-hub/annotations-labels/")) {
-      apiRequests.push({
-        method: request.method(),
-        pathname: url.pathname,
-        query: url.search,
-      });
-    }
-    if (
-      url.pathname.endsWith("/model-hub/annotations-labels/") &&
-      request.method() === "GET"
-    ) {
-      const archived = url.searchParams.get("archived") === "true";
-      return request.respond(
-        jsonResponse(
-          200,
-          archived ? archivedLabelsResponse() : activeLabelsResponse(),
-        ),
-      );
-    }
-    if (
-      url.pathname.endsWith(
-        `/model-hub/annotations-labels/${IDS.archivedLabel}/restore/`,
-      )
-    ) {
-      restorePosted = true;
-      return request.respond(
-        jsonResponse(200, {
-          status: true,
-          result: {
-            ...archivedLabelsResponse().results[0],
-            archived: false,
-          },
-        }),
-      );
-    }
-    return request.continue();
-  });
+  const browserMutations = [];
+  const labelRequests = [];
+  let browser = null;
+  let page = null;
+  let fixture = null;
+  let caughtError = null;
 
   try {
-    await page.goto(
-      `${APP_BASE}/.tmp-smoke/annotation-label-archive-restore-smoke.html`,
-      { waitUntil: "domcontentloaded" },
+    await hardDeleteLabelFixturesByPrefix({
+      organizationId: auth.organizationId,
+      evidence: cleanupEvidence,
+    });
+
+    fixture = await createLabelFixture(auth);
+    const createdLabel = await findAnnotationLabelByName(
+      auth.client,
+      fixture.labelName,
     );
-    await clickByText(page, "button", "Archived");
-    await waitForCondition(() =>
-      apiRequests.some((entry) => entry.query.includes("archived=true")),
+    assert(createdLabel, "Created label was not returned by the list API.");
+    assert(
+      String(createdLabel.id) === fixture.labelId,
+      `List API returned a different label id: ${JSON.stringify(createdLabel)}`,
     );
-    await page.waitForFunction(() =>
-      document.body.textContent.includes("Archived accuracy"),
+    assert(
+      createdLabel.type === "text",
+      `Created label type was not text: ${JSON.stringify(createdLabel)}`,
     );
-    await clickByLabel(page, "Restore label actions");
-    await page.waitForFunction(() =>
-      Array.from(document.querySelectorAll('[role="menuitem"]')).some(
-        (item) => item.textContent.trim() === "Restore",
-      ),
+
+    const dbAuditAfterCreate = await loadLabelFixtureAudit({
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      labelId: fixture.labelId,
+      labelName: fixture.labelName,
+    });
+    assert(
+      Number(dbAuditAfterCreate.matching_count) === 1 &&
+        Number(dbAuditAfterCreate.active_count) === 1,
+      `Created label DB audit failed: ${JSON.stringify(dbAuditAfterCreate)}`,
     );
-    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: false });
-    await clickByText(page, '[role="menuitem"]', "Restore");
-    await waitForCondition(() => restorePosted);
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+    page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      if (!isAnnotationLabelApiUrl(request.url())) return;
+      labelRequests.push(`${request.method()} ${request.url()}`);
+      if (MUTATION_METHODS.has(request.method())) {
+        browserMutations.push(`${request.method()} ${request.url()}`);
+      }
+    });
+    page.on("response", (response) => {
+      if (isAnnotationLabelApiUrl(response.url()) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${response.url()}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponseDuring(
+      page,
+      "annotation label list load",
+      (response) => isLabelListResponse(response),
+      () =>
+        page.goto(`${APP_BASE}/dashboard/annotations/labels`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForVisibleText(page, "Annotation labels", { exact: true });
+
+    await waitForResponseDuring(
+      page,
+      "annotation label active search",
+      (response) =>
+        isLabelListResponse(response, { search: fixture.labelName }),
+      () => setSearchValue(page, "Search labels...", fixture.labelName),
+    );
+    await waitForVisibleText(page, fixture.labelName, { exact: true });
+    await waitForVisibleText(page, "Text", { exact: true });
+
+    const archiveResult = await archiveLabelThroughList(page, {
+      id: fixture.labelId,
+      name: fixture.labelName,
+    });
+    const dbAuditAfterArchive = await loadLabelFixtureAudit({
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      labelId: fixture.labelId,
+      labelName: fixture.labelName,
+    });
+    assert(
+      Number(dbAuditAfterArchive.matching_count) === 1 &&
+        Number(dbAuditAfterArchive.archived_count) === 1 &&
+        Number(dbAuditAfterArchive.deleted_at_set_count) === 1,
+      `Archived label DB audit failed: ${JSON.stringify(dbAuditAfterArchive)}`,
+    );
+
+    await waitForResponseDuring(
+      page,
+      "annotation label archived tab search",
+      (response) =>
+        isLabelListResponse(response, {
+          search: fixture.labelName,
+          archived: "true",
+        }),
+      () => clickVisibleText(page, "Archived", { exact: true }),
+    );
+    await waitForVisibleText(page, fixture.labelName, { exact: true });
+    await page.screenshot({ path: ARCHIVED_SCREENSHOT_PATH, fullPage: true });
+
+    const restoreResult = await restoreLabelThroughList(page, {
+      id: fixture.labelId,
+      name: fixture.labelName,
+    });
+    const dbAuditAfterRestore = await loadLabelFixtureAudit({
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      labelId: fixture.labelId,
+      labelName: fixture.labelName,
+    });
+    assert(
+      Number(dbAuditAfterRestore.matching_count) === 1 &&
+        Number(dbAuditAfterRestore.active_count) === 1 &&
+        Number(dbAuditAfterRestore.archived_count) === 0 &&
+        Number(dbAuditAfterRestore.restored_deleted_at_null_count) === 1,
+      `Restored label DB audit failed: ${JSON.stringify(dbAuditAfterRestore)}`,
+    );
+
+    await waitForResponseDuring(
+      page,
+      "annotation label active tab search",
+      (response) =>
+        isLabelListResponse(response, { search: fixture.labelName }),
+      () => clickVisibleText(page, "Active", { exact: true }),
+    );
+    await waitForVisibleText(page, fixture.labelName, { exact: true });
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
 
     assert(
-      apiRequests.some((entry) => entry.query.includes("archived=true")),
-      `Archived label list request missing: ${JSON.stringify(apiRequests)}`,
-    );
-    assert(
-      apiRequests.some(
-        (entry) =>
-          entry.method === "POST" &&
-          entry.pathname.endsWith(
-            `/model-hub/annotations-labels/${IDS.archivedLabel}/restore/`,
-          ),
-      ),
-      `Restore request missing: ${JSON.stringify(apiRequests)}`,
+      apiFailures.length === 0,
+      `Unexpected annotation label API failures: ${apiFailures.join(", ")}`,
     );
     assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+
+    const cleanup = await hardDeleteLabelFixturesByPrefix({
+      organizationId: auth.organizationId,
+      evidence: cleanupEvidence,
+    });
+    assert(
+      Number(cleanup.remaining_label_count) === 0,
+      `Annotation label archive/restore cleanup left residue: ${JSON.stringify(
+        cleanup,
+      )}`,
+    );
 
     console.log(
       JSON.stringify(
         {
           status: "passed",
           app_base: APP_BASE,
-          screenshot: SCREENSHOT_PATH,
-          apiRequests,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          label_id: fixture.labelId,
+          label_name: fixture.labelName,
+          create_result: fixture.createResult,
+          archive_result: archiveResult,
+          restore_result: restoreResult,
+          db_audit_after_create: dbAuditAfterCreate,
+          db_audit_after_archive: dbAuditAfterArchive,
+          db_audit_after_restore: dbAuditAfterRestore,
+          browser_mutations: browserMutations.map(maskRequest),
+          label_requests: labelRequests.map(maskRequest),
+          screenshots: {
+            active: SCREENSHOT_PATH,
+            archived: ARCHIVED_SCREENSHOT_PATH,
+          },
+          cleanup: cleanupEvidence,
         },
         null,
         2,
       ),
     );
   } catch (error) {
-    await page
-      .screenshot({
-        path: SCREENSHOT_PATH.replace(/\.png$/, "-failure.png"),
-        fullPage: true,
-      })
-      .catch(() => null);
-    throw error;
-  } finally {
-    await browser.close();
-    await rm(harnessPath, { force: true }).catch(() => null);
-  }
-}
-
-function smokeHarnessHtml() {
-  return `<!doctype html>
-<html>
-  <head>
-    <meta charset="UTF-8" />
-    <title>Annotation Label Archive Restore Smoke</title>
-    <style>
-      body {
-        margin: 0;
-        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        background: #f7f8fa;
-      }
-      #root {
-        height: 720px;
-      }
-    </style>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module">
-      import React from "react";
-      import { createRoot } from "react-dom/client";
-      import { BrowserRouter } from "react-router-dom";
-      import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-      import {
-        CellSelectionModule,
-        ClipboardModule,
-        MasterDetailModule,
-        MenuModule,
-        RichSelectModule,
-        ServerSideRowModelApiModule,
-        ServerSideRowModelModule,
-        StatusBarModule,
-      } from "ag-grid-enterprise";
-      import { AllCommunityModule, ModuleRegistry } from "ag-grid-community";
-      import AnnotationLabelsView from "/src/sections/annotations/labels/view/annotation-labels-view.jsx";
-
-      ModuleRegistry.registerModules([
-        AllCommunityModule,
-        ServerSideRowModelModule,
-        ServerSideRowModelApiModule,
-        StatusBarModule,
-        MasterDetailModule,
-        RichSelectModule,
-        MenuModule,
-        ClipboardModule,
-        CellSelectionModule,
-      ]);
-
-      const queryClient = new QueryClient({
-        defaultOptions: {
-          queries: { retry: false },
+    caughtError = error;
+    const domDebug = page
+      ? await page
+          .evaluate(() => ({
+            url: window.location.href,
+            text: document.body?.innerText?.slice(0, 2500) || "",
+          }))
+          .catch(() => null)
+      : null;
+    if (page) {
+      await page
+        .screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .catch(() => null);
+    }
+    console.error(
+      JSON.stringify(
+        {
+          status: "failed",
+          error: error.message,
+          dom: domDebug,
+          api_failures: apiFailures.map(maskRequest),
+          browser_mutations: browserMutations.map(maskRequest),
+          label_requests: labelRequests.map(maskRequest),
+          screenshot: FAILURE_SCREENSHOT_PATH,
         },
-      });
-
-      createRoot(document.getElementById("root")).render(
-        React.createElement(
-          QueryClientProvider,
-          { client: queryClient },
-          React.createElement(
-            BrowserRouter,
-            null,
-            React.createElement(AnnotationLabelsView),
-          ),
-        ),
-      );
-    </script>
-  </body>
-</html>`;
-}
-
-function activeLabelsResponse() {
-  return {
-    count: 0,
-    results: [],
-  };
-}
-
-function archivedLabelsResponse() {
-  return {
-    count: 1,
-    results: [
-      {
-        id: IDS.archivedLabel,
-        name: "Archived accuracy",
-        type: "categorical",
-        settings: { options: [{ label: "Accurate" }, { label: "Wrong" }] },
-        description: "Archived label that can be restored",
-        allow_notes: true,
-        created_at: "2026-05-14T06:55:33.127Z",
-        annotation_count: 1,
-        trace_annotations_count: 0,
-        archived: true,
-      },
-    ],
-  };
-}
-
-function jsonResponse(status, body) {
-  return {
-    status,
-    headers: {
-      "content-type": "application/json",
-      "access-control-allow-origin": "*",
-    },
-    body: JSON.stringify(body),
-  };
-}
-
-async function clickByText(page, selector, text) {
-  const handles = await page.$$(selector);
-  for (const handle of handles) {
-    const matches = await handle.evaluate(
-      (node, expected) => node.textContent.trim() === expected,
-      text,
+        null,
+        2,
+      ),
     );
-    if (matches) {
-      await handle.evaluate((node) => node.click());
+  } finally {
+    if (browser) await browser.close();
+    try {
+      await hardDeleteLabelFixturesByPrefix({
+        organizationId: auth.organizationId,
+        evidence: cleanupEvidence,
+      });
+    } catch (cleanupError) {
+      if (caughtError) {
+        caughtError.message = `${caughtError.message}; cleanup failed: ${cleanupError.message}`;
+      } else {
+        caughtError = cleanupError;
+      }
+    }
+  }
+
+  if (caughtError) throw caughtError;
+}
+
+async function createLabelFixture(auth) {
+  const suffix = (auth.runId || randomUUID())
+    .replace(/[^a-z0-9]/gi, "")
+    .toLowerCase();
+  const labelName = `${LABEL_PREFIX}${suffix}`;
+  const response = await auth.client.post(
+    apiPath("/model-hub/annotations-labels/"),
+    {
+      name: labelName,
+      type: "text",
+      description: "Disposable label for browser archive/restore coverage.",
+      settings: {
+        placeholder: "Archive restore coverage",
+        min_length: 0,
+        max_length: 280,
+      },
+      allow_notes: true,
+    },
+  );
+  const data = response?.result || response;
+  const labelId = data?.id || data?.label_id || null;
+  assert(
+    isUuid(labelId),
+    `Label create did not return a UUID: ${JSON.stringify(response)}`,
+  );
+  assert(
+    data?.name === labelName,
+    `Label create returned unexpected name: ${JSON.stringify(response)}`,
+  );
+  return {
+    labelId: String(labelId),
+    labelName,
+    createResult: {
+      id: String(labelId),
+      name: data.name,
+      type: data.type,
+      status: data.status || null,
+    },
+  };
+}
+
+async function findAnnotationLabelByName(client, labelName) {
+  const response = await client.get(apiPath("/model-hub/annotations-labels/"), {
+    query: {
+      page: 1,
+      limit: 10,
+      search: labelName,
+      include_usage_count: true,
+    },
+  });
+  return asArray(response).find(
+    (candidate) => String(candidate?.name || "") === labelName,
+  );
+}
+
+async function archiveLabelThroughList(page, { id, name }) {
+  await openLabelActionsForName(page, name, "Label actions");
+  await clickVisibleText(page, "Archive", { exact: true });
+  await waitForVisibleText(page, "Archive Label", { exact: true });
+  const response = await waitForResponseDuring(
+    page,
+    "annotation label archive submit",
+    (candidate) => {
+      const url = new URL(candidate.url());
+      return (
+        url.pathname === `/model-hub/annotations-labels/${id}/` &&
+        candidate.request().method() === "DELETE"
+      );
+    },
+    () => clickButtonWithText(page, "Archive"),
+  );
+  const payload = await responseJson(response);
+  assert(
+    response.status() >= 200 && response.status() < 300,
+    `Archive returned non-2xx: ${response.status()} ${JSON.stringify(payload)}`,
+  );
+  await waitForVisibleText(page, "Label archived", { exact: false });
+  await waitForNoVisibleText(page, name);
+  return {
+    status: response.status(),
+    id,
+    name,
+    response: payload?.result || payload,
+  };
+}
+
+async function restoreLabelThroughList(page, { id, name }) {
+  await openLabelActionsForName(page, name, "Restore label actions");
+  const response = await waitForResponseDuring(
+    page,
+    "annotation label restore action",
+    (candidate) => {
+      const url = new URL(candidate.url());
+      return (
+        url.pathname === `/model-hub/annotations-labels/${id}/restore/` &&
+        candidate.request().method() === "POST"
+      );
+    },
+    () => clickVisibleText(page, "Restore", { exact: true }),
+  );
+  const payload = await responseJson(response);
+  assert(
+    response.status() >= 200 && response.status() < 300,
+    `Restore returned non-2xx: ${response.status()} ${JSON.stringify(payload)}`,
+  );
+  await waitForVisibleText(page, "Label restored", { exact: false });
+  await waitForNoVisibleText(page, name);
+  return {
+    status: response.status(),
+    id,
+    name,
+    response: payload?.result || payload,
+  };
+}
+
+async function loadLabelFixtureAudit({
+  organizationId,
+  workspaceId,
+  labelId,
+  labelName,
+}) {
+  const sql = `
+SELECT json_build_object(
+  'matching_count', COUNT(*),
+  'active_count', COUNT(*) FILTER (WHERE deleted = FALSE),
+  'archived_count', COUNT(*) FILTER (WHERE deleted = TRUE),
+  'deleted_at_set_count', COUNT(*) FILTER (WHERE deleted = TRUE AND deleted_at IS NOT NULL),
+  'restored_deleted_at_null_count', COUNT(*) FILTER (WHERE deleted = FALSE AND deleted_at IS NULL),
+  'organization_match_count', COUNT(*) FILTER (WHERE organization_id = ${sqlUuid(organizationId)}),
+  'workspace_match_count', COUNT(*) FILTER (WHERE workspace_id = ${sqlUuid(workspaceId)}),
+  'text_type_count', COUNT(*) FILTER (WHERE type = 'text')
+)
+FROM model_hub_annotationslabels
+WHERE id = ${sqlUuid(labelId)}
+  AND name = ${sqlTextLiteral(labelName)};
+`;
+  return runPostgresJson(sql);
+}
+
+async function hardDeleteLabelFixturesByPrefix({ organizationId, evidence }) {
+  const sql = `
+WITH target_labels AS (
+  SELECT id
+  FROM model_hub_annotationslabels
+  WHERE name LIKE ${sqlTextLiteral(`${LABEL_PREFIX}%`)}
+    AND organization_id = ${sqlUuid(organizationId)}
+),
+deleted_bindings AS (
+  DELETE FROM model_hub_annotationqueuelabel
+  WHERE label_id IN (SELECT id FROM target_labels)
+  RETURNING id
+),
+deleted_labels AS (
+  DELETE FROM model_hub_annotationslabels
+  WHERE id IN (SELECT id FROM target_labels)
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_label_count', (SELECT COUNT(*) FROM deleted_labels),
+  'deleted_binding_count', (SELECT COUNT(*) FROM deleted_bindings),
+  'remaining_label_count', (
+    SELECT COUNT(*)
+    FROM model_hub_annotationslabels
+    WHERE name LIKE ${sqlTextLiteral(`${LABEL_PREFIX}%`)}
+      AND organization_id = ${sqlUuid(organizationId)}
+      AND id NOT IN (SELECT id FROM deleted_labels)
+  )
+);
+`;
+  const result = await runPostgresJson(sql);
+  if (
+    Number(result.deleted_label_count) > 0 ||
+    Number(result.deleted_binding_count) > 0 ||
+    Number(result.remaining_label_count) > 0
+  ) {
+    evidence.push({
+      cleanup: "hard delete annotation label archive/restore fixtures",
+      status: Number(result.remaining_label_count) === 0 ? "passed" : "failed",
+      audit: result,
+    });
+  }
+  return result;
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres DB audit returned no JSON output.");
+  return JSON.parse(text);
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
       return;
     }
-    await handle.dispose();
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(() => {
+    window.normalizeText = (value) =>
+      String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+    window.visibleElements = (selector = "body *") => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(selector)).filter(isVisible);
+    };
+    window.dispatchClick = (element) => {
+      element.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("mouseup", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id) {
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+        sessionStorage.setItem("currentUserId", user.id);
+      }
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(predicate, { timeout: 60000 }),
+      action(),
+    ]);
+    return response;
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
   }
-  throw new Error(`Could not find ${selector} with text ${text}`);
 }
 
-async function clickByLabel(page, label) {
-  const handle = await page.$(`[aria-label="${label}"]`);
-  if (!handle) throw new Error(`Could not find control with label ${label}`);
-  await handle.evaluate((node) => node.click());
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) =>
+      window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      }),
+    { timeout },
+    { text, exact },
+  );
 }
 
-async function waitForCondition(condition, timeoutMs = 5000) {
-  const started = Date.now();
-  while (Date.now() - started < timeoutMs) {
-    if (condition()) return;
-    await new Promise((resolve) => setTimeout(resolve, 50));
+async function waitForNoVisibleText(page, text, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedText) =>
+      !window
+        .visibleElements()
+        .some((element) =>
+          window.normalizeText(element.textContent).includes(expectedText),
+        ),
+    { timeout },
+    text,
+  );
+}
+
+async function clickVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await waitForVisibleText(page, text, { exact, timeout });
+  const clicked = await page.evaluate(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const elements = window.visibleElements().filter((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      });
+      const element =
+        elements.find((candidate) => {
+          const button = candidate.closest("button");
+          return button && !button.disabled;
+        }) ||
+        elements.find((candidate) =>
+          candidate.closest("a,[role='button'],[role='menuitem']"),
+        ) ||
+        elements[0];
+      const clickable =
+        element?.closest(
+          "button,a,[role='button'],[role='menuitem'],label,tr",
+        ) || element;
+      if (!clickable || clickable.disabled) return false;
+      clickable.click();
+      return true;
+    },
+    { text, exact },
+  );
+  assert(clicked, `Could not click visible text: ${text}`);
+}
+
+async function clickButtonWithText(page, text) {
+  await waitForVisibleText(page, text, { exact: true });
+  const clicked = await page.evaluate((expectedText) => {
+    const button = window
+      .visibleElements("button")
+      .find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent) === expectedText &&
+          !candidate.disabled,
+      );
+    if (!button) return false;
+    button.click();
+    return true;
+  }, text);
+  assert(clicked, `Could not click button: ${text}`);
+}
+
+async function setSearchValue(page, placeholder, value) {
+  await setInputValue(
+    page,
+    `input[placeholder="${cssEscape(placeholder)}"]`,
+    value,
+  );
+}
+
+async function setInputValue(page, selector, value) {
+  await page.waitForSelector(selector, { timeout: 30000 });
+  await page.evaluate(
+    ({ selector: targetSelector, value: nextValue }) => {
+      const input = document.querySelector(targetSelector);
+      if (!input)
+        throw new Error(`Missing field for selector: ${targetSelector}`);
+      const prototype =
+        input instanceof HTMLTextAreaElement
+          ? window.HTMLTextAreaElement.prototype
+          : window.HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(prototype, "value").set;
+      setter.call(input, nextValue);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    },
+    { selector, value },
+  );
+}
+
+async function openLabelActionsForName(page, name, ariaLabel) {
+  await waitForVisibleText(page, name, { exact: true });
+  const target = await page.evaluate(
+    ({ labelName, buttonLabel }) => {
+      const match = window
+        .visibleElements()
+        .find(
+          (element) => window.normalizeText(element.textContent) === labelName,
+        );
+      const row = match?.closest('[role="row"], .ag-row, tr, [data-rowindex]');
+      const button = row?.querySelector(
+        `button[aria-label="${CSS.escape(buttonLabel)}"]`,
+      );
+      const rect = button?.getBoundingClientRect();
+      if (!rect) {
+        return {
+          ok: false,
+          reason: "button missing",
+          rowFound: Boolean(row),
+          buttonLabels: Array.from(row?.querySelectorAll("button") || []).map(
+            (candidate) => candidate.getAttribute("aria-label") || "",
+          ),
+        };
+      }
+      return {
+        ok: true,
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+      };
+    },
+    { labelName: name, buttonLabel: ariaLabel },
+  );
+  assert(
+    target?.ok,
+    `Could not find ${ariaLabel} for ${name}: ${JSON.stringify(target)}`,
+  );
+  await page.mouse.click(target.x, target.y, { delay: 25 });
+  await waitForVisibleText(
+    page,
+    ariaLabel === "Label actions" ? "Archive" : "Restore",
+    {
+      exact: true,
+    },
+  );
+}
+
+async function responseJson(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
   }
-  throw new Error("Timed out waiting for condition.");
 }
 
-function assert(condition, message) {
-  if (!condition) throw new Error(message);
+function isAnnotationLabelApiUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  return (
+    url.origin ===
+      new URL(process.env.API_BASE || "http://localhost:8003").origin &&
+    url.pathname.startsWith("/model-hub/annotations-labels/")
+  );
+}
+
+function isLabelListResponse(response, expectedQuery = {}) {
+  if (response.request().method() !== "GET") return false;
+  const url = new URL(response.url());
+  if (!isAnnotationLabelApiUrl(response.url())) return false;
+  if (url.pathname !== "/model-hub/annotations-labels/") return false;
+  if (response.status() >= 400) return false;
+  return Object.entries(expectedQuery).every(
+    ([key, value]) => url.searchParams.get(key) === value,
+  );
+}
+
+function maskRequest(rawRequest) {
+  const [method, rawUrl] = rawRequest.split(" ");
+  const url = new URL(rawUrl);
+  return `${method} ${url.pathname}`;
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), "SQL UUID value must be a UUID.");
+  return `'${value}'::uuid`;
+}
+
+function sqlTextLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function cssEscape(value) {
+  return String(value).replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
 function browserExecutablePath() {
@@ -306,5 +786,5 @@ function browserExecutablePath() {
 
 main().catch((error) => {
   console.error(error);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/frontend/scripts/api-journeys/browser/annotation-queue-create-duplicate-drawer-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/annotation-queue-create-duplicate-drawer-smoke.mjs
@@ -5,6 +5,7 @@ import { createRequire } from "node:module";
 import process from "node:process";
 import { promisify } from "node:util";
 import {
+  apiPath,
   assert,
   createAuthenticatedContext,
   currentUserId,
@@ -19,6 +20,7 @@ const execFileAsync = promisify(execFile);
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
 const QUEUE_PREFIX = "ui_aq_form_";
 const COPY_PREFIX = `Copy of ${QUEUE_PREFIX}`;
+const LABEL_PREFIX = `${QUEUE_PREFIX}label_`;
 const SCREENSHOT_PATH =
   process.env.ANNOTATION_QUEUE_FORM_SCREENSHOT ||
   "/tmp/annotation-queue-create-duplicate-drawer-smoke.png";
@@ -48,11 +50,20 @@ async function main() {
       organizationId: auth.organizationId,
       evidence: cleanupEvidence,
     });
+    await hardDeleteLabelFixturesByPrefix({
+      organizationId: auth.organizationId,
+      evidence: cleanupEvidence,
+    });
     fixture = await seedDuplicateSourceQueue({
       runId: auth.runId,
       organizationId: auth.organizationId,
       workspaceId: auth.workspaceId,
       userId,
+    });
+    fixture.member = await loadSelectableOrgMember({
+      client: auth.client,
+      organizationId: auth.organizationId,
+      currentUserId: userId,
     });
 
     browser = await puppeteer.launch({
@@ -67,14 +78,14 @@ async function main() {
     await installBrowserState(page, auth);
 
     page.on("request", (request) => {
-      if (!isAnnotationQueueApiUrl(request.url())) return;
+      if (!isJourneyApiUrl(request.url())) return;
       if (request.method() !== "GET" && request.method() !== "OPTIONS") {
         browserMutations.push(`${request.method()} ${request.url()}`);
       }
     });
     page.on("response", (response) => {
       const url = response.url();
-      if (isAnnotationQueueApiUrl(url) && response.status() >= 500) {
+      if (isJourneyApiUrl(url) && response.status() >= 500) {
         apiFailures.push(`${response.status()} ${url}`);
       }
     });
@@ -95,8 +106,38 @@ async function main() {
     );
     await waitForVisibleText(page, "Annotation queues", { exact: true });
 
-    const createResult = await exerciseCreateDrawer(page, fixture.createName);
+    const createResult = await exerciseCreateDrawer(page, fixture);
     assertCreateResult(createResult, fixture.createName);
+
+    await waitForResponseDuring(
+      page,
+      "annotation queue source search",
+      (response) =>
+        isQueueListResponse(response, {
+          search: fixture.sourceName,
+          archived: "false",
+        }),
+      () => setSearchValue(page, fixture.sourceName),
+    );
+    await waitForVisibleText(page, fixture.sourceName, { exact: true });
+
+    const archiveResult = createResult.created
+      ? await archiveQueueThroughList(page, {
+          id: createResult.id,
+          name: fixture.createName,
+        })
+      : null;
+
+    const retryResult = createResult.created
+      ? await exerciseCreateDrawer(page, {
+          ...fixture,
+          createName: fixture.retryName,
+          labelName: fixture.retryLabelName,
+        })
+      : null;
+    if (retryResult) {
+      assertCreateResult(retryResult, fixture.retryName);
+    }
 
     await waitForResponseDuring(
       page,
@@ -118,6 +159,13 @@ async function main() {
       sourceName: fixture.sourceName,
       createName: fixture.createName,
       copyName: fixture.copyName,
+      retryName: fixture.retryName,
+      labelName: fixture.labelName,
+      labelId: createResult.label?.id,
+      retryLabelName: fixture.retryLabelName,
+      retryLabelId: retryResult?.label?.id,
+      selectedMemberId: fixture.member?.id,
+      creatorUserId: userId,
     });
     assert(
       Number(dbAudit.source_queue_count) === 1,
@@ -128,10 +176,78 @@ async function main() {
         Number(dbAudit.create_queue_count) === 1,
         `Created queue not found in DB audit: ${JSON.stringify(dbAudit)}`,
       );
+      assert(
+        Number(dbAudit.created_label_count) === 1,
+        `Created annotation label not found in DB audit: ${JSON.stringify(
+          dbAudit,
+        )}`,
+      );
+      assert(
+        Number(dbAudit.create_label_binding_count) === 1,
+        `Created queue label binding not found in DB audit: ${JSON.stringify(
+          dbAudit,
+        )}`,
+      );
+      if (fixture.member) {
+        assert(
+          Number(dbAudit.selected_member_count) === 1,
+          `Selected member not persisted on queue: ${JSON.stringify(dbAudit)}`,
+        );
+        const selectedRoles = Array.isArray(dbAudit.selected_member_roles)
+          ? dbAudit.selected_member_roles
+          : [];
+        assert(
+          selectedRoles.includes("annotator") &&
+            selectedRoles.includes("reviewer"),
+          `Selected member roles did not persist annotator+reviewer: ${JSON.stringify(
+            dbAudit,
+          )}`,
+        );
+      } else if (createResult.roleToggle) {
+        assert(
+          Number(dbAudit.creator_member_count) === 1,
+          `Creator member not persisted on queue: ${JSON.stringify(dbAudit)}`,
+        );
+        const creatorRoles = Array.isArray(dbAudit.creator_member_roles)
+          ? dbAudit.creator_member_roles
+          : [];
+        assert(
+          creatorRoles.includes("manager") &&
+            creatorRoles.includes("reviewer") &&
+            creatorRoles.includes("annotator"),
+          `Creator roles did not persist manager+reviewer+annotator: ${JSON.stringify(
+            dbAudit,
+          )}`,
+        );
+      }
+      assert(
+        Number(dbAudit.archived_create_queue_count) === 1,
+        `Created queue was not archived through the browser: ${JSON.stringify(
+          dbAudit,
+        )}`,
+      );
     } else {
       assert(
         Number(dbAudit.create_queue_count) === 0,
         `Blocked create left DB residue: ${JSON.stringify(dbAudit)}`,
+      );
+    }
+    if (retryResult?.created) {
+      assert(
+        Number(dbAudit.retry_queue_count) === 1,
+        `Retry queue not found in DB audit: ${JSON.stringify(dbAudit)}`,
+      );
+      assert(
+        Number(dbAudit.retry_label_count) === 1,
+        `Retry annotation label not found in DB audit: ${JSON.stringify(
+          dbAudit,
+        )}`,
+      );
+      assert(
+        Number(dbAudit.retry_label_binding_count) === 1,
+        `Retry queue label binding not found in DB audit: ${JSON.stringify(
+          dbAudit,
+        )}`,
       );
     }
     if (duplicateResult.created) {
@@ -162,6 +278,16 @@ async function main() {
       Number(cleanup.remaining_queue_count) === 0,
       `Annotation queue form cleanup left residue: ${JSON.stringify(cleanup)}`,
     );
+    const labelCleanup = await hardDeleteLabelFixturesByPrefix({
+      organizationId: auth.organizationId,
+      evidence: cleanupEvidence,
+    });
+    assert(
+      Number(labelCleanup.remaining_label_count) === 0,
+      `Annotation label form cleanup left residue: ${JSON.stringify(
+        labelCleanup,
+      )}`,
+    );
 
     console.log(
       JSON.stringify(
@@ -173,7 +299,17 @@ async function main() {
           workspace_id: auth.workspaceId,
           source_queue_id: fixture.sourceId,
           create_result: summarizeCreateResult(createResult),
+          archive_result: archiveResult,
+          retry_result: retryResult ? summarizeCreateResult(retryResult) : null,
           duplicate_result: summarizeCreateResult(duplicateResult),
+          selected_member: fixture.member
+            ? {
+                id: fixture.member.id,
+                email: fixture.member.email,
+                name: fixture.member.name,
+              }
+            : null,
+          role_toggle: createResult.roleToggle || null,
           db_audit: dbAudit,
           browser_mutations: browserMutations.map(maskRequest),
           screenshot: SCREENSHOT_PATH,
@@ -219,6 +355,10 @@ async function main() {
         organizationId: auth.organizationId,
         evidence: cleanupEvidence,
       });
+      await hardDeleteLabelFixturesByPrefix({
+        organizationId: auth.organizationId,
+        evidence: cleanupEvidence,
+      });
     } catch (cleanupError) {
       if (caughtError) {
         caughtError.message = `${caughtError.message}; cleanup failed: ${cleanupError.message}`;
@@ -231,7 +371,7 @@ async function main() {
   if (caughtError) throw caughtError;
 }
 
-async function exerciseCreateDrawer(page, createName) {
+async function exerciseCreateDrawer(page, fixture) {
   await clickButtonWithText(page, "Create Queue");
   await waitForVisibleText(page, "Create annotation queue", { exact: true });
   await submitAnnotationQueueForm(page);
@@ -239,13 +379,26 @@ async function exerciseCreateDrawer(page, createName) {
   await setFieldByPlaceholder(
     page,
     "eg: Hallucination analysis v2",
-    createName,
+    fixture.createName,
   );
   await setFieldByPlaceholder(
     page,
     "Brief description of this queue's purpose",
     "Browser smoke create form",
   );
+  const label = await createAndSelectLabelInQueueDrawer(
+    page,
+    fixture.labelName,
+  );
+  let resultRoleToggle = null;
+  if (fixture.member) {
+    await selectReviewerMemberInQueueDrawer(page, fixture.member);
+  } else {
+    resultRoleToggle = await toggleCreatorReviewerRoleInQueueDrawer(
+      page,
+      fixture.userId,
+    );
+  }
   const response = await waitForResponseDuring(
     page,
     "annotation queue create submit",
@@ -256,6 +409,9 @@ async function exerciseCreateDrawer(page, createName) {
   );
   const payload = await responseJson(response);
   const result = normalizeCreateResponse(response, payload);
+  result.requestBody = parseRequestJson(response.request());
+  result.label = label;
+  result.roleToggle = resultRoleToggle;
   if (result.created) {
     await waitForNoVisibleText(page, "Create annotation queue");
   } else {
@@ -264,6 +420,276 @@ async function exerciseCreateDrawer(page, createName) {
     await waitForNoVisibleText(page, "Create annotation queue");
   }
   return result;
+}
+
+async function toggleCreatorReviewerRoleInQueueDrawer(page, userId) {
+  const initial = await waitForAnnotatorRole(page, userId, "Reviewer");
+  if (initial.disabled) {
+    return {
+      user_id: userId,
+      role: "reviewer",
+      available: false,
+      reason: "reviewer role checkbox disabled",
+      initial,
+    };
+  }
+  if (!initial.checked) {
+    await clickAnnotatorRole(page, userId, "Reviewer");
+    await waitForAnnotatorRole(page, userId, "Reviewer", {
+      checked: true,
+      disabled: false,
+    });
+  }
+  await clickAnnotatorRole(page, userId, "Reviewer");
+  await waitForAnnotatorRole(page, userId, "Reviewer", {
+    checked: false,
+    disabled: false,
+  });
+  await clickAnnotatorRole(page, userId, "Reviewer");
+  await waitForAnnotatorRole(page, userId, "Reviewer", {
+    checked: true,
+    disabled: false,
+  });
+  return {
+    user_id: userId,
+    role: "reviewer",
+    available: true,
+    toggled_off: true,
+    toggled_on: true,
+    initial,
+  };
+}
+
+async function clickAnnotatorRole(page, userId, roleLabel) {
+  const clicked = await page.evaluate(
+    ({ memberId, role }) => {
+      const row = document.querySelector(
+        `[data-testid="annotator-row-${memberId}"]`,
+      );
+      const label = Array.from(row?.querySelectorAll("label") || []).find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent).includes(role),
+      );
+      const checkbox = label?.querySelector('input[type="checkbox"]');
+      if (!row || !label || !checkbox) {
+        return { ok: false, reason: "role checkbox missing" };
+      }
+      if (checkbox.disabled) return { ok: false, reason: "role disabled" };
+      checkbox.click();
+      return { ok: true };
+    },
+    { memberId: userId, role: roleLabel },
+  );
+  assert(
+    clicked.ok,
+    `Could not click ${roleLabel} role for ${userId}: ${JSON.stringify(
+      clicked,
+    )}`,
+  );
+}
+
+async function waitForAnnotatorRole(
+  page,
+  userId,
+  roleLabel,
+  expected = {},
+  timeout = 30000,
+) {
+  const startedAt = Date.now();
+  let state = null;
+  while (Date.now() - startedAt < timeout) {
+    state = await readAnnotatorRoleState(page, userId, roleLabel);
+    if (
+      state.found &&
+      (expected.checked === undefined || state.checked === expected.checked) &&
+      (expected.disabled === undefined || state.disabled === expected.disabled)
+    ) {
+      return state;
+    }
+    await delay(250);
+  }
+  throw new Error(
+    `Timed out waiting for ${roleLabel} role state on ${userId}: ${JSON.stringify(
+      { expected, last: state },
+    )}`,
+  );
+}
+
+async function readAnnotatorRoleState(page, userId, roleLabel) {
+  return page.evaluate(
+    ({ memberId, role }) => {
+      const row = document.querySelector(
+        `[data-testid="annotator-row-${memberId}"]`,
+      );
+      const label = Array.from(row?.querySelectorAll("label") || []).find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent).includes(role),
+      );
+      const checkbox = label?.querySelector('input[type="checkbox"]');
+      if (!row || !label || !checkbox) {
+        return {
+          found: false,
+          row_found: Boolean(row),
+          labels: Array.from(row?.querySelectorAll("label") || []).map(
+            (candidate) => window.normalizeText(candidate.textContent),
+          ),
+        };
+      }
+      return {
+        found: true,
+        checked: checkbox.checked,
+        disabled: checkbox.disabled,
+        label: window.normalizeText(label.textContent),
+      };
+    },
+    { memberId: userId, role: roleLabel },
+  );
+}
+
+async function createAndSelectLabelInQueueDrawer(page, labelName) {
+  await clickButtonWithText(page, "Create new label");
+  await waitForVisibleText(page, "Create Label", { exact: true });
+  await setFieldByPlaceholder(
+    page,
+    "e.g. Relevance, Tone, Accuracy",
+    labelName,
+  );
+  await selectCreateLabelType(page, "Text");
+
+  const response = await waitForResponseDuring(
+    page,
+    "annotation label create submit",
+    (candidate) => {
+      const url = new URL(candidate.url());
+      return (
+        url.pathname === "/model-hub/annotations-labels/" &&
+        candidate.request().method() === "POST"
+      );
+    },
+    () => submitCreateLabelForm(page),
+  );
+  const payload = await responseJson(response);
+  const data = payload?.result || payload;
+  const labelId = data?.id || data?.label_id || null;
+  assert(
+    response.status() >= 200 && response.status() < 300 && isUuid(labelId),
+    `Label create did not return a UUID: ${JSON.stringify(payload)}`,
+  );
+  await waitForVisibleText(page, labelName, { exact: true });
+  return { id: String(labelId), name: data?.name || labelName };
+}
+
+async function selectCreateLabelType(page, typeLabel) {
+  const selected = await page.evaluate((expectedTypeLabel) => {
+    const form = window.visibleElements("form").find((candidate) => {
+      const text = window.normalizeText(candidate.textContent);
+      return text.includes("Create Label") && text.includes("Type");
+    });
+    if (!form) {
+      return { ok: false, reason: "create label form missing" };
+    }
+    const label = Array.from(form.querySelectorAll("label")).find((candidate) =>
+      window.normalizeText(candidate.textContent).startsWith(expectedTypeLabel),
+    );
+    const radio = label?.querySelector('input[type="radio"]');
+    if (!label || !radio) {
+      return { ok: false, reason: "type radio missing" };
+    }
+    if (!radio.checked) {
+      radio.click();
+    }
+    return {
+      ok: true,
+      checked: radio.checked,
+      label: window.normalizeText(label.textContent),
+    };
+  }, typeLabel);
+  assert(
+    selected.ok,
+    `Could not select create-label type ${typeLabel}: ${JSON.stringify(
+      selected,
+    )}`,
+  );
+  await waitForVisibleText(page, "Placeholder Text", { exact: true });
+}
+
+async function submitCreateLabelForm(page) {
+  const submitted = await page.evaluate(() => {
+    const forms = window.visibleElements("form");
+    const form = forms.find((candidate) =>
+      window.normalizeText(candidate.textContent).includes("Create Label"),
+    );
+    const submitter = form
+      ? Array.from(form.querySelectorAll("button")).find(
+          (button) =>
+            window.normalizeText(button.textContent) === "Create" &&
+            !button.disabled,
+        )
+      : null;
+    if (!form || !submitter) return false;
+    const event =
+      typeof SubmitEvent === "function"
+        ? new SubmitEvent("submit", {
+            bubbles: true,
+            cancelable: true,
+            submitter,
+          })
+        : new Event("submit", { bubbles: true, cancelable: true });
+    form.dispatchEvent(event);
+    return true;
+  });
+  assert(submitted, "Could not submit annotation label form.");
+}
+
+async function selectReviewerMemberInQueueDrawer(page, member) {
+  await waitForResponseDuring(
+    page,
+    "annotation queue member search",
+    (candidate) => {
+      const url = new URL(candidate.url());
+      return (
+        url.pathname ===
+          `/model-hub/organizations/${member.organizationId}/users/` &&
+        candidate.request().method() === "GET" &&
+        url.searchParams.get("search") === member.search
+      );
+    },
+    () =>
+      setInputValue(
+        page,
+        'input[placeholder="Search members..."]',
+        member.search,
+      ),
+  );
+  await waitForVisibleText(page, member.visibleText);
+  const toggled = await page.evaluate((memberId) => {
+    const row = document.querySelector(
+      `[data-testid="annotator-row-${memberId}"]`,
+    );
+    if (!row) return { ok: false, reason: "row missing" };
+    const memberCheckbox = Array.from(
+      row.querySelectorAll('input[type="checkbox"]'),
+    ).find((input) => !input.disabled);
+    if (!memberCheckbox)
+      return { ok: false, reason: "member checkbox missing" };
+    memberCheckbox.click();
+
+    const reviewerLabel = Array.from(row.querySelectorAll("label")).find(
+      (label) => window.normalizeText(label.textContent) === "Reviewer",
+    );
+    const reviewerCheckbox = reviewerLabel?.querySelector(
+      'input[type="checkbox"]',
+    );
+    if (!reviewerCheckbox || reviewerCheckbox.disabled) {
+      return { ok: false, reason: "reviewer checkbox missing" };
+    }
+    reviewerCheckbox.click();
+    return { ok: true };
+  }, member.id);
+  assert(
+    toggled.ok,
+    `Could not select reviewer member ${member.id}: ${JSON.stringify(toggled)}`,
+  );
 }
 
 async function exerciseDuplicateDrawer(page, fixture) {
@@ -301,6 +727,60 @@ async function exerciseDuplicateDrawer(page, fixture) {
   return result;
 }
 
+async function archiveQueueThroughList(page, { id, name }) {
+  await waitForResponseDuring(
+    page,
+    "annotation queue created queue search",
+    (response) =>
+      isQueueListResponse(response, {
+        search: name,
+        archived: "false",
+      }),
+    () => setSearchValue(page, name),
+  );
+  await waitForVisibleText(page, name, { exact: true });
+  await openQueueActionsForName(page, name);
+  await clickVisibleText(page, "Archive", { exact: true });
+  await waitForVisibleText(page, "Archive Queue", { exact: true });
+  const response = await waitForResponseDuring(
+    page,
+    "annotation queue archive submit",
+    (candidate) => {
+      const url = new URL(candidate.url());
+      return (
+        url.pathname === `/model-hub/annotation-queues/${id}/` &&
+        candidate.request().method() === "DELETE"
+      );
+    },
+    () => clickButtonWithText(page, "Archive"),
+  );
+  const payload = await responseJson(response);
+  assert(
+    response.status() >= 200 && response.status() < 300,
+    `Archive returned non-2xx: ${response.status()} ${JSON.stringify(payload)}`,
+  );
+  await waitForVisibleText(page, "Queue archived", { exact: false });
+  await waitForResponseDuring(
+    page,
+    "annotation queue archived tab search",
+    (candidate) =>
+      isQueueListResponse(candidate, {
+        search: name,
+        archived: "true",
+      }),
+    () => clickVisibleText(page, "Archived", { exact: true }),
+  );
+  await waitForVisibleText(page, name, { exact: true });
+  await clickVisibleText(page, "Active", { exact: true });
+  await waitForNoVisibleText(page, name);
+  return {
+    status: response.status(),
+    id,
+    name,
+    response: payload?.result || payload,
+  };
+}
+
 function normalizeCreateResponse(response, payload) {
   const created = response.status() >= 200 && response.status() < 300;
   const data = payload?.result || payload;
@@ -309,6 +789,8 @@ function normalizeCreateResponse(response, payload) {
     status: response.status(),
     id: data?.id || null,
     name: data?.name || null,
+    label_ids: data?.label_ids || null,
+    annotator_ids: data?.annotator_ids || null,
     code: payload?.code || payload?.error?.code || null,
     message:
       payload?.message ||
@@ -348,6 +830,9 @@ function summarizeCreateResult(result) {
     created: result.created,
     status: result.status,
     id: result.id,
+    label_ids: result.requestBody?.label_ids || result.label_ids,
+    annotator_ids: result.requestBody?.annotator_ids || result.annotator_ids,
+    annotator_roles: result.requestBody?.annotator_roles || null,
     code: result.code,
     message: result.message ? String(result.message).slice(0, 180) : null,
   };
@@ -364,6 +849,9 @@ async function seedDuplicateSourceQueue({
   const sourceName = `${QUEUE_PREFIX}${suffix}_source`;
   const createName = `${QUEUE_PREFIX}${suffix}_create`;
   const copyName = `Copy of ${sourceName}`;
+  const labelName = `${LABEL_PREFIX}${suffix}`;
+  const retryName = `${QUEUE_PREFIX}${suffix}_retry`;
+  const retryLabelName = `${LABEL_PREFIX}${suffix}_retry`;
   const fullRoles = ["manager", "reviewer", "annotator"];
   const sql = `
 WITH inserted_queue AS (
@@ -454,10 +942,14 @@ SELECT json_build_object(
     "Expected manager membership on source queue fixture.",
   );
   return {
+    userId,
     sourceId,
     sourceName,
     createName,
     copyName,
+    labelName,
+    retryName,
+    retryLabelName,
   };
 }
 
@@ -466,13 +958,106 @@ async function loadFormJourneyAudit({
   sourceName,
   createName,
   copyName,
+  retryName,
+  labelName,
+  labelId,
+  retryLabelName,
+  retryLabelId,
+  selectedMemberId,
+  creatorUserId,
 }) {
   const sql = `
 SELECT json_build_object(
   'source_queue_count', COUNT(*) FILTER (WHERE name = ${sqlTextLiteral(sourceName)}),
   'create_queue_count', COUNT(*) FILTER (WHERE name = ${sqlTextLiteral(createName)}),
+  'archived_create_queue_count', COUNT(*) FILTER (WHERE name = ${sqlTextLiteral(createName)} AND deleted = TRUE),
   'copy_queue_count', COUNT(*) FILTER (WHERE name = ${sqlTextLiteral(copyName)}),
+  'retry_queue_count', COUNT(*) FILTER (WHERE name = ${sqlTextLiteral(retryName || "")}),
   'active_fixture_count', COUNT(*) FILTER (WHERE deleted = FALSE),
+  'created_label_count', (
+    SELECT COUNT(*)
+    FROM model_hub_annotationslabels label
+    WHERE label.name = ${sqlTextLiteral(labelName || "")}
+      AND label.organization_id = ${sqlUuid(organizationId)}
+      AND label.deleted = FALSE
+  ),
+  'retry_label_count', (
+    SELECT COUNT(*)
+    FROM model_hub_annotationslabels label
+    WHERE label.name = ${sqlTextLiteral(retryLabelName || "")}
+      AND label.organization_id = ${sqlUuid(organizationId)}
+      AND label.deleted = FALSE
+  ),
+  'create_label_binding_count', (
+    SELECT COUNT(*)
+    FROM model_hub_annotationqueuelabel ql
+    JOIN model_hub_annotationqueue q ON q.id = ql.queue_id
+    WHERE q.name = ${sqlTextLiteral(createName)}
+      AND q.organization_id = ${sqlUuid(organizationId)}
+      AND ql.deleted = FALSE
+      ${labelId ? `AND ql.label_id = ${sqlUuid(labelId)}` : ""}
+  ),
+  'retry_label_binding_count', (
+    SELECT COUNT(*)
+    FROM model_hub_annotationqueuelabel ql
+    JOIN model_hub_annotationqueue q ON q.id = ql.queue_id
+    WHERE q.name = ${sqlTextLiteral(retryName || "")}
+      AND q.organization_id = ${sqlUuid(organizationId)}
+      AND ql.deleted = FALSE
+      ${retryLabelId ? `AND ql.label_id = ${sqlUuid(retryLabelId)}` : ""}
+  ),
+  'selected_member_count', (
+    SELECT COUNT(*)
+    FROM model_hub_annotationqueueannotator qa
+    JOIN model_hub_annotationqueue q ON q.id = qa.queue_id
+    WHERE q.name = ${sqlTextLiteral(createName)}
+      AND q.organization_id = ${sqlUuid(organizationId)}
+      AND qa.deleted = FALSE
+      ${selectedMemberId ? `AND qa.user_id = ${sqlUuid(selectedMemberId)}` : "AND FALSE"}
+  ),
+  'selected_member_roles', (
+    SELECT COALESCE(jsonb_agg(DISTINCT role_value), '[]'::jsonb)
+    FROM (
+      SELECT jsonb_array_elements_text(
+        CASE
+          WHEN jsonb_typeof(qa.roles) = 'array' THEN qa.roles
+          ELSE to_jsonb(ARRAY[qa.role])
+        END
+      ) AS role_value
+      FROM model_hub_annotationqueueannotator qa
+      JOIN model_hub_annotationqueue q ON q.id = qa.queue_id
+      WHERE q.name = ${sqlTextLiteral(createName)}
+        AND q.organization_id = ${sqlUuid(organizationId)}
+        AND qa.deleted = FALSE
+        ${selectedMemberId ? `AND qa.user_id = ${sqlUuid(selectedMemberId)}` : "AND FALSE"}
+    ) roles
+  ),
+  'creator_member_count', (
+    SELECT COUNT(*)
+    FROM model_hub_annotationqueueannotator qa
+    JOIN model_hub_annotationqueue q ON q.id = qa.queue_id
+    WHERE q.name = ${sqlTextLiteral(createName)}
+      AND q.organization_id = ${sqlUuid(organizationId)}
+      AND qa.deleted = FALSE
+      ${creatorUserId ? `AND qa.user_id = ${sqlUuid(creatorUserId)}` : "AND FALSE"}
+  ),
+  'creator_member_roles', (
+    SELECT COALESCE(jsonb_agg(DISTINCT role_value), '[]'::jsonb)
+    FROM (
+      SELECT jsonb_array_elements_text(
+        CASE
+          WHEN jsonb_typeof(qa.roles) = 'array' THEN qa.roles
+          ELSE to_jsonb(ARRAY[qa.role])
+        END
+      ) AS role_value
+      FROM model_hub_annotationqueueannotator qa
+      JOIN model_hub_annotationqueue q ON q.id = qa.queue_id
+      WHERE q.name = ${sqlTextLiteral(createName)}
+        AND q.organization_id = ${sqlUuid(organizationId)}
+        AND qa.deleted = FALSE
+        ${creatorUserId ? `AND qa.user_id = ${sqlUuid(creatorUserId)}` : "AND FALSE"}
+    ) roles
+  ),
   'manager_membership_count', (
     SELECT COUNT(*)
     FROM model_hub_annotationqueueannotator qa
@@ -488,6 +1073,85 @@ WHERE (${fixtureNamePredicate("name")})
   AND organization_id = ${sqlUuid(organizationId)};
 `;
   return runPostgresJson(sql);
+}
+
+async function hardDeleteLabelFixturesByPrefix({ organizationId, evidence }) {
+  const sql = `
+WITH target_labels AS (
+  SELECT id
+  FROM model_hub_annotationslabels
+  WHERE name LIKE ${sqlTextLiteral(`${LABEL_PREFIX}%`)}
+    AND organization_id = ${sqlUuid(organizationId)}
+),
+deleted_bindings AS (
+  DELETE FROM model_hub_annotationqueuelabel
+  WHERE label_id IN (SELECT id FROM target_labels)
+  RETURNING id
+),
+deleted_labels AS (
+  DELETE FROM model_hub_annotationslabels
+  WHERE id IN (SELECT id FROM target_labels)
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_label_count', (SELECT COUNT(*) FROM deleted_labels),
+  'deleted_binding_count', (SELECT COUNT(*) FROM deleted_bindings),
+  'remaining_label_count', (
+    SELECT COUNT(*)
+    FROM model_hub_annotationslabels
+    WHERE name LIKE ${sqlTextLiteral(`${LABEL_PREFIX}%`)}
+      AND organization_id = ${sqlUuid(organizationId)}
+      AND id NOT IN (SELECT id FROM deleted_labels)
+  )
+);
+`;
+  const result = await runPostgresJson(sql);
+  if (
+    Number(result.deleted_label_count) > 0 ||
+    Number(result.deleted_binding_count) > 0 ||
+    Number(result.remaining_label_count) > 0
+  ) {
+    evidence.push({
+      cleanup: "hard delete annotation label form fixtures",
+      status: Number(result.remaining_label_count) === 0 ? "passed" : "failed",
+      audit: result,
+    });
+  }
+  return result;
+}
+
+async function loadSelectableOrgMember({
+  client,
+  organizationId,
+  currentUserId,
+}) {
+  const response = await client.get(
+    apiPath("/model-hub/organizations/{organization_id}/users/", {
+      organization_id: organizationId,
+    }),
+    { query: { page: 1, limit: 30, is_active: true } },
+  );
+  const members = Array.isArray(response?.results)
+    ? response.results
+    : Array.isArray(response)
+      ? response
+      : [];
+  const member = members.find(
+    (candidate) =>
+      candidate?.id &&
+      String(candidate.id) !== String(currentUserId) &&
+      (candidate.email || candidate.name),
+  );
+  if (!member) return null;
+  const search = member.email || member.name;
+  return {
+    id: String(member.id),
+    email: member.email || "",
+    name: member.name || "",
+    search,
+    visibleText: member.email || member.name,
+    organizationId,
+  };
 }
 
 async function hardDeleteQueueFixturesByPrefix({ organizationId, evidence }) {
@@ -847,6 +1511,12 @@ async function responseJson(response) {
   }
 }
 
+function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 function isAnnotationQueueApiUrl(rawUrl) {
   const url = new URL(rawUrl);
   return (
@@ -854,6 +1524,16 @@ function isAnnotationQueueApiUrl(rawUrl) {
       new URL(process.env.API_BASE || "http://localhost:8003").origin &&
     url.pathname.startsWith("/model-hub/annotation-queues/")
   );
+}
+
+function isJourneyApiUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  const apiOrigin = new URL(process.env.API_BASE || "http://localhost:8003")
+    .origin;
+  if (url.origin !== apiOrigin) return false;
+  if (url.pathname.startsWith("/model-hub/annotation-queues/")) return true;
+  if (url.pathname.startsWith("/model-hub/annotations-labels/")) return true;
+  return /^\/model-hub\/organizations\/[^/]+\/users\/?$/.test(url.pathname);
 }
 
 function isQueueListResponse(response, expectedQuery = {}) {
@@ -875,6 +1555,16 @@ function maskRequest(rawRequest) {
   const [method, rawUrl] = rawRequest.split(" ");
   const url = new URL(rawUrl);
   return `${method} ${url.pathname}`;
+}
+
+function parseRequestJson(request) {
+  const body = request.postData();
+  if (!body) return null;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return null;
+  }
 }
 
 function sqlUuid(value) {

--- a/frontend/scripts/api-journeys/browser/annotation-queue-settings-members-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/annotation-queue-settings-members-smoke.mjs
@@ -1,0 +1,1130 @@
+/* eslint-disable no-console */
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import process from "node:process";
+import { promisify } from "node:util";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+  currentUserId,
+  isUuid,
+  requireMutations,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const QUEUE_PREFIX = "ui_aq_settings_";
+const SCREENSHOT_PATH =
+  process.env.ANNOTATION_QUEUE_SETTINGS_SCREENSHOT ||
+  "/tmp/annotation-queue-settings-members-smoke.png";
+const FAILURE_SCREENSHOT_PATH = SCREENSHOT_PATH.replace(
+  /\.png$/,
+  "-failure.png",
+);
+const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+
+async function main() {
+  requireMutations();
+
+  const auth = await createAuthenticatedContext();
+  const userId = currentUserId(auth.user);
+  assert(isUuid(userId), "Authenticated user id could not be resolved.");
+
+  const cleanupEvidence = [];
+  const apiFailures = [];
+  const pageErrors = [];
+  const browserMutations = [];
+  const queueRequests = [];
+  let browser = null;
+  let page = null;
+  let fixture = null;
+  let caughtError = null;
+
+  try {
+    await hardDeleteSettingsFixturesByPrefix({
+      organizationId: auth.organizationId,
+      evidence: cleanupEvidence,
+    });
+
+    fixture = await seedSettingsFixture({
+      runId: auth.runId,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      userId,
+    });
+
+    const detailBefore = await auth.client.get(
+      apiPath("/model-hub/annotation-queues/{id}/", { id: fixture.queueId }),
+    );
+    assertQueueDetail(detailBefore, fixture, { afterSave: false });
+
+    const membersBefore = await auth.client.get(
+      apiPath("/model-hub/organizations/{organization_id}/users/", {
+        organization_id: auth.organizationId,
+      }),
+      { query: { search: fixture.altEmail, limit: 30 }, unwrap: false },
+    );
+    assert(
+      asArray(membersBefore).some((member) => member.id === fixture.altUserId),
+      `Temporary alternate member is not visible to the member picker API: ${JSON.stringify(
+        membersBefore,
+      )}`,
+    );
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+    page = await browser.newPage();
+    page.setDefaultTimeout(60_000);
+    page.setDefaultNavigationTimeout(60_000);
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      if (!isJourneyApiUrl(request.url())) return;
+      const masked = maskRequest(`${request.method()} ${request.url()}`);
+      queueRequests.push(masked);
+      if (MUTATION_METHODS.has(request.method())) {
+        browserMutations.push(masked);
+      }
+    });
+    page.on("response", (response) => {
+      if (isJourneyApiUrl(response.url()) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${response.url()}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponseDuring(
+      page,
+      "annotation queue detail load",
+      (response) => isQueueDetailResponse(response, fixture.queueId),
+      () =>
+        page.goto(
+          `${APP_BASE}/dashboard/annotations/queues/${fixture.queueId}`,
+          { waitUntil: "domcontentloaded" },
+        ),
+    );
+    await waitForVisibleText(page, fixture.queueName, { exact: true });
+    await clickButtonByText(page, "Settings");
+    await waitForVisibleText(page, "General", { exact: true });
+    await waitForVisibleText(page, "Labels", { exact: true });
+    await waitForVisibleText(page, "Members", { exact: true });
+    await waitForVisibleText(page, "Workflow", { exact: true });
+    await waitForVisibleText(page, "Danger zone", { exact: true });
+    await waitForVisibleText(page, fixture.labelName, { exact: false });
+    await waitForVisibleText(page, fixture.altEmail, { exact: false });
+
+    const beforeVisualState = await collectSettingsVisualState(page, {
+      ...fixture,
+      currentUserId: userId,
+    });
+    assertSettingsVisualState(beforeVisualState, fixture);
+
+    await setFieldValue(
+      page,
+      'textarea[name="instructions"]',
+      fixture.updatedInstructions,
+    );
+    await clickCheckboxByLabel(
+      page,
+      "Auto-assign items to all annotator members",
+    );
+
+    const patchResult = await waitForResponseDuring(
+      page,
+      "annotation queue settings PATCH",
+      (response) => isQueuePatchResponse(response, fixture.queueId),
+      () => clickButtonByText(page, "Save Changes"),
+    );
+    const patchJson = await responseJson(patchResult);
+    assertQueueDetail(patchJson?.result || patchJson, fixture, {
+      afterSave: true,
+    });
+    await waitForVisibleText(page, "Queue updated successfully", {
+      exact: false,
+    });
+
+    const dbAudit = await loadSettingsFixtureAudit({
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      queueId: fixture.queueId,
+      labelId: fixture.labelId,
+      currentUserId: userId,
+      altUserId: fixture.altUserId,
+    });
+    assertSettingsDbAudit(dbAudit, fixture);
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+
+    assert(
+      browserMutations.length === 1 &&
+        browserMutations[0] ===
+          `PATCH /model-hub/annotation-queues/${fixture.queueId}/`,
+      `Unexpected browser mutations: ${browserMutations.join(", ")}`,
+    );
+    assert(
+      apiFailures.length === 0,
+      `Unexpected API failures: ${apiFailures.map(maskRequest).join(", ")}`,
+    );
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+
+    const cleanup = await hardDeleteSettingsFixturesByPrefix({
+      organizationId: auth.organizationId,
+      evidence: cleanupEvidence,
+    });
+    assert(
+      Number(cleanup.remaining_queue_count) === 0 &&
+        Number(cleanup.remaining_label_count) === 0 &&
+        Number(cleanup.remaining_member_count) === 0 &&
+        Number(cleanup.remaining_temp_workspace_membership_count) === 0 &&
+        Number(cleanup.remaining_temp_org_membership_count) === 0,
+      `Annotation queue settings cleanup left residue: ${JSON.stringify(
+        cleanup,
+      )}`,
+    );
+
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          queue_id: fixture.queueId,
+          queue_name: fixture.queueName,
+          label_id: fixture.labelId,
+          label_name: fixture.labelName,
+          alternate_member: {
+            id: fixture.altUserId,
+            email: fixture.altEmail,
+            temp_org_membership_id: fixture.tempOrgMembershipId,
+            temp_workspace_membership_id: fixture.tempWorkspaceMembershipId,
+          },
+          browser_request_count: queueRequests.length,
+          browser_mutations: browserMutations,
+          visual_state: beforeVisualState,
+          patch: summarizePatch(patchJson?.result || patchJson),
+          db_audit: dbAudit,
+          screenshot: SCREENSHOT_PATH,
+          cleanup: cleanupEvidence,
+        },
+        null,
+        2,
+      ),
+    );
+    fixture = null;
+  } catch (error) {
+    caughtError = error;
+    const domDebug = page
+      ? await page
+          .evaluate(() => ({
+            url: window.location.href,
+            text: document.body?.innerText?.slice(0, 3000) || "",
+          }))
+          .catch(() => null)
+      : null;
+    if (page) {
+      await page
+        .screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .catch(() => null);
+    }
+    console.error(
+      JSON.stringify(
+        {
+          status: "failed",
+          error: error.message,
+          dom: domDebug,
+          api_failures: apiFailures.map(maskRequest),
+          browser_mutations: browserMutations,
+          screenshot: FAILURE_SCREENSHOT_PATH,
+        },
+        null,
+        2,
+      ),
+    );
+    throw error;
+  } finally {
+    if (browser) await browser.close().catch(() => null);
+    if (fixture || caughtError) {
+      await hardDeleteSettingsFixturesByPrefix({
+        organizationId: auth.organizationId,
+        evidence: cleanupEvidence,
+      }).catch((cleanupError) => {
+        console.error(
+          JSON.stringify({
+            status: "cleanup_failed",
+            error: cleanupError.message,
+          }),
+        );
+      });
+    }
+  }
+}
+
+async function seedSettingsFixture({
+  runId,
+  organizationId,
+  workspaceId,
+  userId,
+}) {
+  const suffix = runId.replace(/[^a-z0-9]/gi, "").slice(-16);
+  const queueId = randomUUID();
+  const labelId = randomUUID();
+  const queueLabelId = randomUUID();
+  const creatorMemberId = randomUUID();
+  const altQueueMemberId = randomUUID();
+  const tempOrgMembershipId = randomUUID();
+  const tempWorkspaceMembershipId = randomUUID();
+  const queueName = `${QUEUE_PREFIX}${suffix}`;
+  const labelName = `${QUEUE_PREFIX}label_${suffix}`;
+  const initialInstructions =
+    "Initial settings smoke instructions for annotators.";
+  const updatedInstructions =
+    "Updated settings smoke instructions from browser save.";
+
+  const sql = `
+WITH candidate_user AS (
+  SELECT u.id, u.email, u.name
+  FROM accounts_user u
+  WHERE u.is_active = true
+    AND u.id <> ${sqlUuid(userId)}
+    AND NOT EXISTS (
+      SELECT 1
+      FROM accounts_workspacemembership wm
+      WHERE wm.workspace_id = ${sqlUuid(workspaceId)}
+        AND wm.user_id = u.id
+        AND wm.deleted = false
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM accounts_organization_membership om
+      WHERE om.organization_id = ${sqlUuid(organizationId)}
+        AND om.user_id = u.id
+        AND om.deleted = false
+    )
+  ORDER BY u.created_at ASC
+  LIMIT 1
+),
+inserted_org_membership AS (
+  INSERT INTO accounts_organization_membership (
+    created_at, updated_at, deleted, deleted_at, id, role, joined_at,
+    is_active, invited_by_id, organization_id, user_id, level
+  )
+  SELECT
+    now(), now(), false, NULL,
+    ${sqlUuid(tempOrgMembershipId)},
+    'Member',
+    now(),
+    true,
+    ${sqlUuid(userId)},
+    ${sqlUuid(organizationId)},
+    candidate_user.id,
+    3
+  FROM candidate_user
+  RETURNING id, user_id
+),
+inserted_workspace_membership AS (
+  INSERT INTO accounts_workspacemembership (
+    created_at, updated_at, deleted, deleted_at, id, role, is_active,
+    invited_by_id, user_id, workspace_id, granted_at, granted_by_id, level,
+    organization_membership_id
+  )
+  SELECT
+    now(), now(), false, NULL,
+    ${sqlUuid(tempWorkspaceMembershipId)},
+    'workspace_member',
+    true,
+    ${sqlUuid(userId)},
+    candidate_user.id,
+    ${sqlUuid(workspaceId)},
+    now(),
+    ${sqlUuid(userId)},
+    3,
+    inserted_org_membership.id
+  FROM candidate_user
+  JOIN inserted_org_membership ON inserted_org_membership.user_id = candidate_user.id
+  RETURNING id, user_id
+),
+inserted_label AS (
+  INSERT INTO model_hub_annotationslabels (
+    created_at, updated_at, deleted, deleted_at, id, name, type, settings,
+    organization_id, description, project_id, workspace_id, metadata, allow_notes
+  )
+  VALUES (
+    now(), now(), false, NULL,
+    ${sqlUuid(labelId)},
+    ${sqlText(labelName)},
+    'text',
+    ${sqlJson({
+      placeholder: "Write queue settings feedback",
+      min_length: 0,
+      max_length: 500,
+    })},
+    ${sqlUuid(organizationId)},
+    ${sqlText("Disposable label for annotation queue settings smoke.")},
+    NULL,
+    ${sqlUuid(workspaceId)},
+    '{}'::jsonb,
+    true
+  )
+  RETURNING id
+),
+inserted_queue AS (
+  INSERT INTO model_hub_annotationqueue (
+    created_at, updated_at, deleted, deleted_at, id, name, description,
+    instructions, status, assignment_strategy, annotations_required,
+    reservation_timeout_minutes, requires_review, auto_assign,
+    organization_id, workspace_id, project_id, dataset_id,
+    agent_definition_id, is_default, created_by_id
+  )
+  VALUES (
+    now(), now(), false, NULL,
+    ${sqlUuid(queueId)},
+    ${sqlText(queueName)},
+    ${sqlText("Disposable queue for settings and member-role browser coverage.")},
+    ${sqlText(initialInstructions)},
+    'active',
+    'manual',
+    1,
+    60,
+    false,
+    false,
+    ${sqlUuid(organizationId)},
+    ${sqlUuid(workspaceId)},
+    NULL,
+    NULL,
+    NULL,
+    false,
+    ${sqlUuid(userId)}
+  )
+  RETURNING id
+),
+inserted_queue_label AS (
+  INSERT INTO model_hub_annotationqueuelabel (
+    created_at, updated_at, deleted, deleted_at, id, required, "order",
+    label_id, queue_id
+  )
+  SELECT
+    now(), now(), false, NULL,
+    ${sqlUuid(queueLabelId)},
+    true,
+    0,
+    inserted_label.id,
+    inserted_queue.id
+  FROM inserted_label, inserted_queue
+  RETURNING id
+),
+inserted_creator_member AS (
+  INSERT INTO model_hub_annotationqueueannotator (
+    created_at, updated_at, deleted, deleted_at, id, role, roles, queue_id,
+    user_id
+  )
+  SELECT
+    now(), now(), false, NULL,
+    ${sqlUuid(creatorMemberId)},
+    'manager',
+    ${sqlJson(["manager", "reviewer", "annotator"])},
+    inserted_queue.id,
+    ${sqlUuid(userId)}
+  FROM inserted_queue
+  RETURNING id
+),
+inserted_alt_member AS (
+  INSERT INTO model_hub_annotationqueueannotator (
+    created_at, updated_at, deleted, deleted_at, id, role, roles, queue_id,
+    user_id
+  )
+  SELECT
+    now(), now(), false, NULL,
+    ${sqlUuid(altQueueMemberId)},
+    'reviewer',
+    ${sqlJson(["annotator", "reviewer"])},
+    inserted_queue.id,
+    candidate_user.id
+  FROM inserted_queue, candidate_user
+  RETURNING id, user_id
+)
+SELECT json_build_object(
+  'queue_id', ${sqlText(queueId)},
+  'queue_name', ${sqlText(queueName)},
+  'label_id', ${sqlText(labelId)},
+  'label_name', ${sqlText(labelName)},
+  'initial_instructions', ${sqlText(initialInstructions)},
+  'updated_instructions', ${sqlText(updatedInstructions)},
+  'alt_user_id', (SELECT user_id::text FROM inserted_alt_member),
+  'alt_email', (SELECT email FROM candidate_user),
+  'temp_org_membership_id', (SELECT id::text FROM inserted_org_membership),
+  'temp_workspace_membership_id', (SELECT id::text FROM inserted_workspace_membership),
+  'queue_count', (SELECT count(*) FROM inserted_queue),
+  'label_count', (SELECT count(*) FROM inserted_label),
+  'queue_label_count', (SELECT count(*) FROM inserted_queue_label),
+  'queue_member_count',
+    (SELECT count(*) FROM inserted_creator_member) + (SELECT count(*) FROM inserted_alt_member)
+)::text;
+`;
+  const result = await runPostgresJson(sql);
+  assert(result.queue_id === queueId, "Settings queue fixture insert failed.");
+  assert(
+    Number(result.queue_count) === 1 &&
+      Number(result.label_count) === 1 &&
+      Number(result.queue_label_count) === 1 &&
+      Number(result.queue_member_count) === 2,
+    `Settings fixture counts are wrong: ${JSON.stringify(result)}`,
+  );
+  assert(
+    isUuid(result.alt_user_id) &&
+      isUuid(result.temp_org_membership_id) &&
+      isUuid(result.temp_workspace_membership_id),
+    `Could not seed a temporary alternate workspace member: ${JSON.stringify(
+      result,
+    )}`,
+  );
+  return {
+    queueId,
+    queueName,
+    labelId,
+    labelName,
+    initialInstructions,
+    updatedInstructions,
+    altUserId: result.alt_user_id,
+    altEmail: result.alt_email,
+    tempOrgMembershipId: result.temp_org_membership_id,
+    tempWorkspaceMembershipId: result.temp_workspace_membership_id,
+  };
+}
+
+function assertQueueDetail(queue, fixture, { afterSave }) {
+  assert(queue?.id === fixture.queueId, "Queue detail id mismatch.");
+  assert(queue?.name === fixture.queueName, "Queue detail name mismatch.");
+  const labels = asArray(queue?.labels);
+  const annotators = asArray(queue?.annotators);
+  assert(
+    labels.some(
+      (label) => String(label.label_id || label.id) === fixture.labelId,
+    ),
+    `Queue detail is missing seeded label: ${JSON.stringify(queue?.labels)}`,
+  );
+  const alt = annotators.find(
+    (annotator) => String(annotator.user_id) === fixture.altUserId,
+  );
+  assert(
+    alt &&
+      asArray(alt.roles).includes("annotator") &&
+      asArray(alt.roles).includes("reviewer"),
+    `Queue detail is missing alternate annotator/reviewer roles: ${JSON.stringify(
+      queue?.annotators,
+    )}`,
+  );
+  if (afterSave) {
+    assert(
+      queue.instructions === fixture.updatedInstructions,
+      `Queue PATCH did not persist instructions: ${JSON.stringify(queue)}`,
+    );
+    assert(
+      queue.auto_assign === true,
+      `Queue PATCH did not enable auto_assign: ${JSON.stringify(queue)}`,
+    );
+  }
+}
+
+async function collectSettingsVisualState(page, fixture) {
+  return page.evaluate(
+    ({ currentUserId, altUserId, labelName }) => {
+      const hasVisibleText = (text) =>
+        window
+          .visibleElements()
+          .some((element) =>
+            window.normalizeText(element.textContent).includes(text),
+          );
+      const roleState = (userId) => {
+        const row = document.querySelector(
+          `[data-testid="annotator-row-${userId}"]`,
+        );
+        const state = {};
+        for (const label of Array.from(row?.querySelectorAll("label") || [])) {
+          const text = window.normalizeText(label.textContent);
+          const input = label.querySelector('input[type="checkbox"]');
+          if (!["Annotator", "Reviewer", "Manager"].includes(text) || !input) {
+            continue;
+          }
+          state[text.toLowerCase()] = {
+            checked: Boolean(input.checked),
+            disabled: Boolean(input.disabled),
+          };
+        }
+        return {
+          present: Boolean(row),
+          text: row ? window.normalizeText(row.textContent) : "",
+          roles: state,
+        };
+      };
+      return {
+        url: window.location.href,
+        hasGeneral: hasVisibleText("General"),
+        hasLabels: hasVisibleText("Labels"),
+        hasMembers: hasVisibleText("Members"),
+        hasWorkflow: hasVisibleText("Workflow"),
+        hasDangerZone: hasVisibleText("Danger zone"),
+        hasLabelName: hasVisibleText(labelName),
+        creator: roleState(currentUserId),
+        alternate: roleState(altUserId),
+      };
+    },
+    {
+      currentUserId: fixture.currentUserId,
+      altUserId: fixture.altUserId,
+      labelName: fixture.labelName,
+    },
+  );
+}
+
+function assertSettingsVisualState(state, fixture) {
+  assert(
+    state.hasGeneral &&
+      state.hasLabels &&
+      state.hasMembers &&
+      state.hasWorkflow &&
+      state.hasDangerZone &&
+      state.hasLabelName,
+    `Settings tab sections are missing: ${JSON.stringify(state)}`,
+  );
+  assert(
+    state.creator.present &&
+      state.creator.roles.manager?.checked &&
+      state.creator.roles.manager?.disabled &&
+      state.creator.roles.reviewer?.checked &&
+      state.creator.roles.annotator?.checked,
+    `Creator role checkboxes are wrong: ${JSON.stringify(state.creator)}`,
+  );
+  assert(
+    state.alternate.present &&
+      state.alternate.text.includes(fixture.altEmail) &&
+      state.alternate.roles.annotator?.checked &&
+      state.alternate.roles.reviewer?.checked &&
+      !state.alternate.roles.manager?.checked,
+    `Alternate role checkboxes are wrong: ${JSON.stringify(state.alternate)}`,
+  );
+}
+
+async function loadSettingsFixtureAudit({
+  organizationId,
+  workspaceId,
+  queueId,
+  labelId,
+  currentUserId,
+  altUserId,
+}) {
+  const sql = `
+WITH target_queue AS (
+  SELECT id, name, instructions, auto_assign, requires_review,
+         annotations_required, reservation_timeout_minutes, status
+  FROM model_hub_annotationqueue
+  WHERE id = ${sqlUuid(queueId)}
+    AND organization_id = ${sqlUuid(organizationId)}
+    AND workspace_id = ${sqlUuid(workspaceId)}
+    AND deleted = false
+),
+members AS (
+  SELECT user_id, role, roles
+  FROM model_hub_annotationqueueannotator
+  WHERE queue_id IN (SELECT id FROM target_queue)
+    AND deleted = false
+)
+SELECT json_build_object(
+  'queue_id', (SELECT id::text FROM target_queue),
+  'queue_name', (SELECT name FROM target_queue),
+  'instructions', (SELECT instructions FROM target_queue),
+  'auto_assign', (SELECT auto_assign FROM target_queue),
+  'requires_review', (SELECT requires_review FROM target_queue),
+  'annotations_required', (SELECT annotations_required FROM target_queue),
+  'reservation_timeout_minutes', (SELECT reservation_timeout_minutes FROM target_queue),
+  'status', (SELECT status FROM target_queue),
+  'label_binding_count', (
+    SELECT count(*)
+    FROM model_hub_annotationqueuelabel
+    WHERE queue_id IN (SELECT id FROM target_queue)
+      AND label_id = ${sqlUuid(labelId)}
+      AND deleted = false
+  ),
+  'member_count', (SELECT count(*) FROM members),
+  'current_roles', (
+    SELECT roles
+    FROM members
+    WHERE user_id = ${sqlUuid(currentUserId)}
+    LIMIT 1
+  ),
+  'alternate_roles', (
+    SELECT roles
+    FROM members
+    WHERE user_id = ${sqlUuid(altUserId)}
+    LIMIT 1
+  ),
+  'temp_workspace_member_count', (
+    SELECT count(*)
+    FROM accounts_workspacemembership
+    WHERE workspace_id = ${sqlUuid(workspaceId)}
+      AND user_id = ${sqlUuid(altUserId)}
+      AND deleted = false
+      AND is_active = true
+  ),
+  'temp_org_member_count', (
+    SELECT count(*)
+    FROM accounts_organization_membership
+    WHERE organization_id = ${sqlUuid(organizationId)}
+      AND user_id = ${sqlUuid(altUserId)}
+      AND deleted = false
+      AND is_active = true
+  )
+)::text;
+`;
+  return runPostgresJson(sql);
+}
+
+function assertSettingsDbAudit(audit, fixture) {
+  assert(
+    audit.queue_id === fixture.queueId,
+    "Settings DB audit queue missing.",
+  );
+  assert(
+    audit.instructions === fixture.updatedInstructions &&
+      audit.auto_assign === true &&
+      audit.requires_review === false &&
+      Number(audit.annotations_required) === 1 &&
+      Number(audit.reservation_timeout_minutes) === 60 &&
+      audit.status === "active",
+    `Settings DB audit fields mismatch: ${JSON.stringify(audit)}`,
+  );
+  assert(
+    Number(audit.label_binding_count) === 1 &&
+      Number(audit.member_count) === 2 &&
+      Number(audit.temp_workspace_member_count) === 1 &&
+      Number(audit.temp_org_member_count) === 1,
+    `Settings DB audit relation counts mismatch: ${JSON.stringify(audit)}`,
+  );
+  const currentRoles = asArray(audit.current_roles);
+  const alternateRoles = asArray(audit.alternate_roles);
+  assert(
+    currentRoles.includes("manager") &&
+      currentRoles.includes("reviewer") &&
+      currentRoles.includes("annotator") &&
+      alternateRoles.includes("annotator") &&
+      alternateRoles.includes("reviewer") &&
+      !alternateRoles.includes("manager"),
+    `Settings DB role audit mismatch: ${JSON.stringify(audit)}`,
+  );
+}
+
+async function hardDeleteSettingsFixturesByPrefix({
+  organizationId,
+  evidence = [],
+}) {
+  const sql = `
+WITH target_queues AS (
+  SELECT id, workspace_id
+  FROM model_hub_annotationqueue
+  WHERE name LIKE ${sqlText(`${QUEUE_PREFIX}%`)}
+    AND organization_id = ${sqlUuid(organizationId)}
+),
+target_labels AS (
+  SELECT id
+  FROM model_hub_annotationslabels
+  WHERE name LIKE ${sqlText(`${QUEUE_PREFIX}%`)}
+    AND organization_id = ${sqlUuid(organizationId)}
+),
+target_queue_members AS (
+  SELECT user_id
+  FROM model_hub_annotationqueueannotator
+  WHERE queue_id IN (SELECT id FROM target_queues)
+),
+target_workspace_memberships AS (
+  SELECT wm.id, wm.organization_membership_id
+  FROM accounts_workspacemembership wm
+  WHERE wm.workspace_id IN (SELECT workspace_id FROM target_queues)
+    AND wm.user_id IN (SELECT user_id FROM target_queue_members)
+    AND wm.granted_by_id IS NOT NULL
+    AND wm.invited_by_id IS NOT NULL
+    AND wm.organization_membership_id IN (
+      SELECT id
+      FROM accounts_organization_membership
+      WHERE organization_id = ${sqlUuid(organizationId)}
+        AND user_id IN (SELECT user_id FROM target_queue_members)
+        AND invited_by_id IS NOT NULL
+    )
+),
+target_org_memberships AS (
+  SELECT id
+  FROM accounts_organization_membership
+  WHERE id IN (
+    SELECT organization_membership_id
+    FROM target_workspace_memberships
+    WHERE organization_membership_id IS NOT NULL
+  )
+),
+deleted_members AS (
+  DELETE FROM model_hub_annotationqueueannotator
+  WHERE queue_id IN (SELECT id FROM target_queues)
+  RETURNING id, user_id
+),
+deleted_queue_labels AS (
+  DELETE FROM model_hub_annotationqueuelabel
+  WHERE queue_id IN (SELECT id FROM target_queues)
+     OR label_id IN (SELECT id FROM target_labels)
+  RETURNING id
+),
+deleted_queues AS (
+  DELETE FROM model_hub_annotationqueue
+  WHERE id IN (SELECT id FROM target_queues)
+  RETURNING id
+),
+deleted_labels AS (
+  DELETE FROM model_hub_annotationslabels
+  WHERE id IN (SELECT id FROM target_labels)
+  RETURNING id
+),
+deleted_workspace_memberships AS (
+  DELETE FROM accounts_workspacemembership
+  WHERE id IN (SELECT id FROM target_workspace_memberships)
+  RETURNING id, organization_membership_id
+),
+deleted_org_memberships AS (
+  DELETE FROM accounts_organization_membership
+  WHERE id IN (SELECT id FROM target_org_memberships)
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_queue_count', (SELECT count(*) FROM deleted_queues),
+  'deleted_label_count', (SELECT count(*) FROM deleted_labels),
+  'deleted_member_count', (SELECT count(*) FROM deleted_members),
+  'deleted_queue_label_count', (SELECT count(*) FROM deleted_queue_labels),
+  'deleted_temp_workspace_membership_count', (SELECT count(*) FROM deleted_workspace_memberships),
+  'deleted_temp_org_membership_count', (SELECT count(*) FROM deleted_org_memberships),
+  'remaining_queue_count', (
+    SELECT count(*)
+    FROM target_queues
+    WHERE id NOT IN (SELECT id FROM deleted_queues)
+  ),
+  'remaining_label_count', (
+    SELECT count(*)
+    FROM target_labels
+    WHERE id NOT IN (SELECT id FROM deleted_labels)
+  ),
+  'remaining_member_count', (
+    SELECT count(*)
+    FROM model_hub_annotationqueueannotator
+    WHERE queue_id IN (SELECT id FROM target_queues)
+      AND id NOT IN (SELECT id FROM deleted_members)
+  ),
+  'remaining_temp_workspace_membership_count', (
+    SELECT count(*)
+    FROM target_workspace_memberships
+    WHERE id NOT IN (SELECT id FROM deleted_workspace_memberships)
+  ),
+  'remaining_temp_org_membership_count', (
+    SELECT count(*)
+    FROM target_org_memberships
+    WHERE id NOT IN (SELECT id FROM deleted_org_memberships)
+  )
+)::text;
+`;
+  const result = await runPostgresJson(sql);
+  if (
+    Number(result.deleted_queue_count) > 0 ||
+    Number(result.deleted_label_count) > 0 ||
+    Number(result.deleted_temp_workspace_membership_count) > 0 ||
+    Number(result.remaining_queue_count) > 0
+  ) {
+    evidence.push({
+      cleanup: "hard delete annotation queue settings fixtures",
+      status:
+        Number(result.remaining_queue_count) === 0 &&
+        Number(result.remaining_label_count) === 0 &&
+        Number(result.remaining_member_count) === 0 &&
+        Number(result.remaining_temp_workspace_membership_count) === 0 &&
+        Number(result.remaining_temp_org_membership_count) === 0
+          ? "passed"
+          : "failed",
+      audit: result,
+    });
+  }
+  return result;
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(() => {
+    window.normalizeText = (value) =>
+      String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+    window.visibleElements = (selector = "body *") => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(selector)).filter(isVisible);
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id) {
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+        sessionStorage.setItem("currentUserId", user.id);
+      }
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(predicate, { timeout: 60_000 }),
+      action(),
+    ]);
+    return response;
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30_000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) =>
+      window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      }),
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function clickButtonByText(page, text) {
+  await waitForVisibleText(page, text, { exact: true });
+  const clicked = await page.evaluate((expectedText) => {
+    const button = window
+      .visibleElements("button, [role='tab']")
+      .find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent) === expectedText &&
+          !candidate.disabled &&
+          candidate.getAttribute("aria-disabled") !== "true",
+      );
+    if (!button) return false;
+    button.click();
+    return true;
+  }, text);
+  assert(clicked, `Could not click button/tab: ${text}`);
+}
+
+async function setFieldValue(page, selector, value) {
+  await page.waitForSelector(selector, { timeout: 30_000 });
+  await page.evaluate(
+    ({ selector: targetSelector, value: nextValue }) => {
+      const input = document.querySelector(targetSelector);
+      if (!input) throw new Error(`Missing field for ${targetSelector}`);
+      const prototype =
+        input instanceof HTMLTextAreaElement
+          ? window.HTMLTextAreaElement.prototype
+          : window.HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(prototype, "value").set;
+      setter.call(input, nextValue);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    },
+    { selector, value },
+  );
+}
+
+async function clickCheckboxByLabel(page, labelText) {
+  const clicked = await page.evaluate((expectedText) => {
+    const label = window
+      .visibleElements("label")
+      .find((candidate) =>
+        window.normalizeText(candidate.textContent).includes(expectedText),
+      );
+    const input = label?.querySelector('input[type="checkbox"]');
+    if (!input || input.disabled) return false;
+    input.click();
+    return true;
+  }, labelText);
+  assert(clicked, `Could not click checkbox label: ${labelText}`);
+}
+
+function isQueueDetailResponse(response, queueId) {
+  if (response.request().method() !== "GET" || response.status() >= 400) {
+    return false;
+  }
+  const url = new URL(response.url());
+  return (
+    isAnnotationQueueApiUrl(response.url()) &&
+    url.pathname === `/model-hub/annotation-queues/${queueId}/`
+  );
+}
+
+function isQueuePatchResponse(response, queueId) {
+  if (response.request().method() !== "PATCH" || response.status() >= 400) {
+    return false;
+  }
+  const url = new URL(response.url());
+  return (
+    isAnnotationQueueApiUrl(response.url()) &&
+    url.pathname === `/model-hub/annotation-queues/${queueId}/`
+  );
+}
+
+function isAnnotationQueueApiUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  return (
+    url.origin ===
+      new URL(process.env.API_BASE || "http://localhost:8003").origin &&
+    url.pathname.startsWith("/model-hub/annotation-queues/")
+  );
+}
+
+function isJourneyApiUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  const apiOrigin = new URL(process.env.API_BASE || "http://localhost:8003")
+    .origin;
+  if (url.origin !== apiOrigin) return false;
+  if (url.pathname.startsWith("/model-hub/annotation-queues/")) return true;
+  if (url.pathname.startsWith("/model-hub/organizations/")) return true;
+  if (url.pathname.startsWith("/model-hub/annotations-labels/")) return true;
+  return false;
+}
+
+async function responseJson(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function summarizePatch(queue) {
+  return {
+    id: queue?.id,
+    instructions: queue?.instructions,
+    auto_assign: queue?.auto_assign,
+    annotator_count: asArray(queue?.annotators).length,
+    label_count: asArray(queue?.labels).length,
+  };
+}
+
+function maskRequest(rawRequest) {
+  const parts = String(rawRequest || "").split(" ");
+  if (parts.length < 2) return rawRequest;
+  const [method, rawUrl] = parts;
+  try {
+    const url = new URL(rawUrl);
+    return `${method} ${url.pathname}${url.search}`;
+  } catch {
+    return rawRequest;
+  }
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres annotation settings query returned no JSON output.");
+  return JSON.parse(text);
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), "SQL UUID value must be a UUID.");
+  return `'${value}'::uuid`;
+}
+
+function sqlText(value) {
+  return `'${String(value ?? "").replaceAll("'", "''")}'`;
+}
+
+function sqlJson(value) {
+  return `${sqlText(JSON.stringify(value ?? null))}::jsonb`;
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") {
+    return "/usr/bin/google-chrome";
+  }
+  return undefined;
+}
+
+main().catch((error) => {
+  if (error?.name === "SkipJourney") {
+    console.log(JSON.stringify({ status: "skipped", reason: error.reason }));
+    return;
+  }
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/frontend/scripts/api-journeys/browser/annotation-workspace-mode-switch-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/annotation-workspace-mode-switch-smoke.mjs
@@ -1,0 +1,1239 @@
+/* eslint-disable no-console */
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import process from "node:process";
+import { promisify } from "node:util";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+  currentUserId,
+  isUuid,
+  requireMutations,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const QUEUE_PREFIX = "ui_aq_mode_";
+const SCREENSHOT_PATH =
+  process.env.ANNOTATION_WORKSPACE_MODE_SCREENSHOT ||
+  "/tmp/annotation-workspace-mode-switch-smoke.png";
+const FAILURE_SCREENSHOT_PATH = SCREENSHOT_PATH.replace(
+  /\.png$/,
+  "-failure.png",
+);
+const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+
+async function main() {
+  requireMutations();
+
+  const auth = await createAuthenticatedContext();
+  const userId = currentUserId(auth.user);
+  assert(isUuid(userId), "Authenticated user id could not be resolved.");
+
+  const cleanupEvidence = [];
+  const apiFailures = [];
+  const pageErrors = [];
+  const annotationRequests = [];
+  const browserMutations = [];
+  let browser = null;
+  let page = null;
+  let fixture = null;
+  let caughtError = null;
+
+  try {
+    await hardDeleteModeFixturesByPrefix({
+      organizationId: auth.organizationId,
+      evidence: cleanupEvidence,
+    });
+
+    const source = await resolveTraceAndSpanSample(auth.client);
+    fixture = await seedModeSwitchFixture({
+      runId: auth.runId,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      userId,
+      source,
+    });
+
+    const apiAudit = await loadModeFixtureAudit({
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      queueId: fixture.queueId,
+      userId,
+    });
+    assertModeFixtureAudit(apiAudit, fixture);
+    const apiEvidence = await assertModeApis(auth.client, fixture);
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+    page = await browser.newPage();
+    page.setDefaultTimeout(60_000);
+    page.setDefaultNavigationTimeout(60_000);
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (!isAnnotationQueueApiUrl(url)) return;
+      annotationRequests.push(maskRequest(`${request.method()} ${url}`));
+      if (MUTATION_METHODS.has(request.method())) {
+        browserMutations.push(maskRequest(`${request.method()} ${url}`));
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isAnnotationQueueApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${url}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponseDuring(
+      page,
+      "annotate-mode next item",
+      (response) =>
+        isNextItemResponse(response, fixture.queueId, {
+          exclude_review_status: "pending_review",
+        }),
+      () =>
+        page.goto(
+          `${APP_BASE}/dashboard/annotations/queues/${fixture.queueId}/annotate?mode=annotate`,
+          { waitUntil: "domcontentloaded" },
+        ),
+    );
+    await waitForPathIncludes(
+      page,
+      `/dashboard/annotations/queues/${fixture.queueId}/annotate`,
+    );
+    await waitForVisibleText(page, "Workspace action", { exact: true });
+    await waitForVisibleText(page, "Annotate my answers", { exact: true });
+    await waitForVisibleText(page, "Review submissions", { exact: true });
+    await waitForVisibleText(page, "Submit for Review", { exact: true });
+    await waitForVisibleText(page, fixture.labelName, { exact: false });
+    await assertTogglePressed(page, "Annotate my answers");
+
+    const annotateModeState = await collectModeState(page);
+    assert(
+      annotateModeState.submitButtonVisible,
+      `Annotate mode did not show the submit action: ${JSON.stringify(
+        annotateModeState,
+      )}`,
+    );
+
+    await waitForResponseDuring(
+      page,
+      "review-mode next item",
+      (response) =>
+        isNextItemResponse(response, fixture.queueId, {
+          view_mode: "review",
+          review_status: "pending_review",
+        }),
+      () => clickToggleButton(page, "Review submissions"),
+    );
+    await waitForLocationSearchParam(page, "mode", "review");
+    await waitForVisibleText(page, "Review Annotations", { exact: true });
+    await waitForVisibleText(page, fixture.reviewValueText, { exact: false });
+    await assertTogglePressed(page, "Review submissions");
+
+    const reviewModeState = await collectModeState(page);
+    if (fixture.hasAlternateAnnotator) {
+      await waitForVisibleText(page, "Ready for review", { exact: true });
+      await waitForVisibleText(page, "Approve", { exact: true });
+      await waitForVisibleText(page, "Request changes", { exact: true });
+      assert(
+        reviewModeState.reviewActionBarVisible,
+        `Review mode did not expose reviewer actions: ${JSON.stringify(
+          reviewModeState,
+        )}`,
+      );
+    } else {
+      await waitForVisibleText(page, "In review", { exact: true });
+      await waitForVisibleText(
+        page,
+        "You submitted annotations for this item",
+        { exact: false },
+      );
+    }
+
+    await waitForRequestSeen(
+      annotationRequests,
+      (request) =>
+        request.includes("/annotate-detail/") &&
+        request.includes("exclude_review_status=pending_review"),
+    );
+    await waitForRequestSeen(
+      annotationRequests,
+      (request) =>
+        request.includes("/annotate-detail/") &&
+        request.includes("view_mode=review") &&
+        request.includes("review_status=pending_review"),
+    );
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+
+    assert(
+      browserMutations.length === 0,
+      `Unexpected browser mutations: ${browserMutations.join(", ")}`,
+    );
+    assert(
+      apiFailures.length === 0,
+      `Unexpected annotation queue API failures: ${apiFailures.join(", ")}`,
+    );
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+
+    const cleanup = await hardDeleteModeFixturesByPrefix({
+      organizationId: auth.organizationId,
+      evidence: cleanupEvidence,
+    });
+    assert(
+      Number(cleanup.remaining_queue_count) === 0 &&
+        Number(cleanup.remaining_item_count) === 0 &&
+        Number(cleanup.remaining_score_count) === 0,
+      `Annotation mode-switch cleanup left residue: ${JSON.stringify(cleanup)}`,
+    );
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          queue_id: apiAudit.queue_id,
+          queue_name: fixture?.queueName || apiAudit.queue_name,
+          pending_item_id: apiEvidence.annotate_next_item_id,
+          review_item_id: apiEvidence.review_next_item_id,
+          review_annotator: {
+            id: apiAudit.review_annotator_id,
+            email: apiAudit.review_annotator_email,
+            is_alternate: fixture?.hasAlternateAnnotator,
+          },
+          browser_request_count: annotationRequests.length,
+          browser_mutations: browserMutations,
+          annotate_mode_state: annotateModeState,
+          review_mode_state: reviewModeState,
+          screenshot: SCREENSHOT_PATH,
+          source,
+          cleanup: cleanupEvidence,
+        },
+        null,
+        2,
+      ),
+    );
+    fixture = null;
+  } catch (error) {
+    if (error?.name === "SkipJourney") {
+      throw error;
+    }
+    caughtError = error;
+    const domDebug = page
+      ? await page
+          .evaluate(() => ({
+            url: window.location.href,
+            text: document.body?.innerText?.slice(0, 3000) || "",
+          }))
+          .catch(() => null)
+      : null;
+    if (page) {
+      await page
+        .screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .catch(() => null);
+    }
+    console.error(
+      JSON.stringify(
+        {
+          status: "failed",
+          error: error.message,
+          dom: domDebug,
+          api_failures: apiFailures.map(maskRequest),
+          browser_mutations: browserMutations,
+          requests: annotationRequests,
+          screenshot: FAILURE_SCREENSHOT_PATH,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    if (browser) await browser.close();
+    if (fixture) {
+      await hardDeleteModeFixturesByPrefix({
+        organizationId: auth.organizationId,
+        evidence: cleanupEvidence,
+      }).catch(() => null);
+    }
+  }
+
+  if (caughtError) throw caughtError;
+}
+
+async function assertModeApis(client, fixture) {
+  const queue = await client.get(
+    apiPath("/model-hub/annotation-queues/{id}/", { id: fixture.queueId }),
+  );
+  assert(
+    asArray(queue.viewer_roles).includes("manager") &&
+      asArray(queue.viewer_roles).includes("reviewer") &&
+      asArray(queue.viewer_roles).includes("annotator"),
+    `Queue detail did not expose all viewer roles: ${JSON.stringify(
+      queue.viewer_roles,
+    )}`,
+  );
+
+  const annotateNext = await client.get(
+    apiPath("/model-hub/annotation-queues/{queue_id}/items/next-item/", {
+      queue_id: fixture.queueId,
+    }),
+    { query: { exclude_review_status: "pending_review" } },
+  );
+  assert(
+    String(annotateNext.item?.id) === String(fixture.pendingItemId),
+    `Annotate navigation chose the wrong item: ${JSON.stringify(annotateNext)}`,
+  );
+
+  const reviewNext = await client.get(
+    apiPath("/model-hub/annotation-queues/{queue_id}/items/next-item/", {
+      queue_id: fixture.queueId,
+    }),
+    { query: { view_mode: "review", review_status: "pending_review" } },
+  );
+  assert(
+    String(reviewNext.item?.id) === String(fixture.reviewItemId),
+    `Review navigation chose the wrong item: ${JSON.stringify(reviewNext)}`,
+  );
+
+  const reviewDetail = await client.get(
+    apiPath(
+      "/model-hub/annotation-queues/{queue_id}/items/{id}/annotate-detail/",
+      {
+        queue_id: fixture.queueId,
+        id: fixture.reviewItemId,
+      },
+    ),
+    { query: { view_mode: "review", review_status: "pending_review" } },
+  );
+  assert(
+    reviewDetail.item?.review_status === "pending_review" &&
+      asArray(reviewDetail.annotations).some(
+        (annotation) =>
+          String(annotation.annotator) === String(fixture.reviewAnnotatorId) &&
+          annotation.value?.text === fixture.reviewValueText,
+      ),
+    `Review detail did not expose the seeded submitted answer: ${JSON.stringify(
+      reviewDetail,
+    )}`,
+  );
+
+  return {
+    annotate_next_item_id: annotateNext.item?.id,
+    review_next_item_id: reviewNext.item?.id,
+    review_annotation_count: asArray(reviewDetail.annotations).length,
+  };
+}
+
+async function resolveTraceAndSpanSample(client) {
+  const projects = asArray(
+    await client.get(apiPath("/tracer/project/list_projects/"), {
+      query: { page_number: 0, page_size: 25 },
+    }),
+  );
+  const accessibleProjectIds = new Set(
+    projects.map((project) => String(project?.id || "")).filter(Boolean),
+  );
+
+  const preferredTraceId = process.env.OBSERVE_TRACE_ID;
+  const preferredSpanId = process.env.OBSERVE_SPAN_ID;
+  if (preferredTraceId && preferredSpanId) {
+    try {
+      const detail = await client.get(
+        apiPath("/tracer/trace/{id}/", { id: preferredTraceId }),
+      );
+      const projectId = traceProjectId(detail);
+      const spans = flattenTraceEntries(detail);
+      if (
+        projectId &&
+        accessibleProjectIds.has(String(projectId)) &&
+        spans.some((row) => String(row.spanId) === preferredSpanId)
+      ) {
+        return {
+          traceId: preferredTraceId,
+          spanId: preferredSpanId,
+          projectId,
+        };
+      }
+    } catch {
+      // Fall back to discovery below.
+    }
+  }
+
+  for (const project of projects) {
+    if (!project?.id) continue;
+    const list = await client.get(
+      apiPath("/tracer/trace/list_traces_of_session/"),
+      {
+        query: {
+          project_id: project.id,
+          page_number: 0,
+          page_size: 10,
+        },
+      },
+    );
+    for (const trace of asArray(list.table || list)) {
+      const traceId = trace.trace_id || trace.id;
+      if (!traceId) continue;
+      try {
+        const detail = await client.get(
+          apiPath("/tracer/trace/{id}/", { id: traceId }),
+        );
+        const span = flattenTraceEntries(detail).find((row) => row.spanId);
+        if (span?.spanId) {
+          return {
+            traceId,
+            spanId: span.spanId,
+            projectId: traceProjectId(detail) || relatedId(trace.project),
+          };
+        }
+      } catch {
+        // Try the next trace.
+      }
+    }
+  }
+
+  return {
+    traceId: null,
+    spanId: null,
+    projectId: null,
+    source: "nullable-source-fallback",
+    reason: "No trace with a resolvable observation span is available.",
+  };
+}
+
+async function seedModeSwitchFixture({
+  runId,
+  organizationId,
+  workspaceId,
+  userId,
+  source,
+}) {
+  const suffix = runId.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  const queueId = randomUUID();
+  const labelId = randomUUID();
+  const queueLabelId = randomUUID();
+  const memberId = randomUUID();
+  const altMemberId = randomUUID();
+  const pendingItemId = randomUUID();
+  const reviewItemId = randomUUID();
+  const scoreId = randomUUID();
+  const queueName = `${QUEUE_PREFIX}${suffix}`;
+  const labelName = `${QUEUE_PREFIX}${suffix}_text`;
+  const reviewValueText = `Mode switch review answer ${suffix}`;
+  const labelSettings = {
+    placeholder: "Mode switch answer",
+    min_length: 0,
+    max_length: 500,
+  };
+  const metadata = {
+    journey: "annotation-workspace-mode-switch-smoke",
+    run_id: runId,
+  };
+
+  const sql = `
+WITH alternate_user AS (
+  SELECT u.id, u.email
+  FROM accounts_user u
+  LEFT JOIN accounts_workspacemembership wm
+    ON wm.user_id = u.id
+   AND wm.workspace_id = ${sqlUuid(workspaceId)}
+   AND wm.deleted = false
+   AND wm.is_active = true
+  LEFT JOIN accounts_organization_membership om
+    ON om.user_id = u.id
+   AND om.organization_id = ${sqlUuid(organizationId)}
+   AND om.deleted = false
+   AND om.is_active = true
+  WHERE u.id <> ${sqlUuid(userId)}
+    AND u.is_active = true
+  ORDER BY
+    CASE WHEN wm.id IS NOT NULL THEN 0 ELSE 1 END,
+    CASE
+      WHEN u.organization_id = ${sqlUuid(organizationId)} OR om.id IS NOT NULL
+      THEN 0
+      ELSE 1
+    END,
+    u.email ASC
+  LIMIT 1
+),
+fixture_user AS (
+  SELECT
+    COALESCE((SELECT id FROM alternate_user), ${sqlUuid(userId)}) AS review_annotator_id,
+    COALESCE((SELECT email FROM alternate_user), (SELECT email FROM accounts_user WHERE id = ${sqlUuid(userId)})) AS review_annotator_email,
+    EXISTS(SELECT 1 FROM alternate_user) AS has_alternate_annotator
+),
+inserted_label AS (
+  INSERT INTO model_hub_annotationslabels (
+    created_at, updated_at, deleted, deleted_at, id, name, type, settings,
+    description, organization_id, project_id, workspace_id, metadata, allow_notes
+  )
+  VALUES (
+    now(), now(), false, NULL,
+    ${sqlUuid(labelId)},
+    ${sqlText(labelName)},
+    'text',
+    ${sqlJson(labelSettings)},
+    ${sqlText("Disposable text label for annotation workspace mode switch coverage.")},
+    ${sqlUuid(organizationId)},
+    NULL,
+    ${sqlUuid(workspaceId)},
+    ${sqlJson(metadata)},
+    true
+  )
+  RETURNING id
+),
+inserted_queue AS (
+  INSERT INTO model_hub_annotationqueue (
+    created_at, updated_at, deleted, deleted_at, id, name, description,
+    instructions, status, assignment_strategy, annotations_required,
+    reservation_timeout_minutes, requires_review, created_by_id,
+    organization_id, workspace_id, project_id, is_default, dataset_id,
+    agent_definition_id, auto_assign
+  )
+  VALUES (
+    now(), now(), false, NULL,
+    ${sqlUuid(queueId)},
+    ${sqlText(queueName)},
+    ${sqlText("Disposable queue for annotation workspace mode switch coverage.")},
+    ${sqlText("Verify a user with all roles can switch annotate and review workspaces.")},
+    'active',
+    'manual',
+    1,
+    60,
+    true,
+    ${sqlUuid(userId)},
+    ${sqlUuid(organizationId)},
+    ${sqlUuid(workspaceId)},
+    NULL,
+    false,
+    NULL,
+    NULL,
+    true
+  )
+  RETURNING id
+),
+inserted_queue_label AS (
+  INSERT INTO model_hub_annotationqueuelabel (
+    created_at, updated_at, deleted, deleted_at, id, required, "order", label_id, queue_id
+  )
+  SELECT
+    now(), now(), false, NULL,
+    ${sqlUuid(queueLabelId)},
+    true,
+    0,
+    inserted_label.id,
+    inserted_queue.id
+  FROM inserted_label, inserted_queue
+  RETURNING id
+),
+inserted_member AS (
+  INSERT INTO model_hub_annotationqueueannotator (
+    created_at, updated_at, deleted, deleted_at, id, role, roles, queue_id, user_id
+  )
+  SELECT
+    now(), now(), false, NULL,
+    ${sqlUuid(memberId)},
+    'manager',
+    ${sqlJson(["manager", "reviewer", "annotator"])},
+    inserted_queue.id,
+    ${sqlUuid(userId)}
+  FROM inserted_queue
+  RETURNING id
+),
+inserted_alt_member AS (
+  INSERT INTO model_hub_annotationqueueannotator (
+    created_at, updated_at, deleted, deleted_at, id, role, roles, queue_id, user_id
+  )
+  SELECT
+    now(), now(), false, NULL,
+    ${sqlUuid(altMemberId)},
+    'annotator',
+    ${sqlJson(["annotator"])},
+    inserted_queue.id,
+    fixture_user.review_annotator_id
+  FROM inserted_queue, fixture_user
+  WHERE fixture_user.has_alternate_annotator = true
+  RETURNING id
+),
+inserted_items AS (
+  INSERT INTO model_hub_queueitem (
+    created_at, updated_at, deleted, deleted_at, id, source_type, status,
+    priority, "order", metadata, reserved_at, reservation_expires_at,
+    review_status, reviewed_at, review_notes, assigned_to_id, call_execution_id,
+    dataset_row_id, observation_span_id, organization_id, prototype_run_id,
+    queue_id, reserved_by_id, reviewed_by_id, trace_id, workspace_id,
+    trace_session_id
+  )
+  VALUES
+    (
+      now() + interval '2 seconds', now() + interval '2 seconds', false, NULL,
+      ${sqlUuid(pendingItemId)},
+      'trace',
+      'pending',
+      10,
+      0,
+      ${sqlJson({ ...metadata, mode_item: "annotate" })},
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      ${sqlUuid(organizationId)},
+      NULL,
+      ${sqlUuid(queueId)},
+      NULL,
+      NULL,
+      ${sqlNullableUuid(source.traceId)},
+      ${sqlUuid(workspaceId)},
+      NULL
+    ),
+    (
+      now(), now(), false, NULL,
+      ${sqlUuid(reviewItemId)},
+      'observation_span',
+      'in_progress',
+      20,
+      1,
+      ${sqlJson({ ...metadata, mode_item: "review" })},
+      NULL,
+      NULL,
+      'pending_review',
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      ${sqlNullableUuid(source.spanId)},
+      ${sqlUuid(organizationId)},
+      NULL,
+      ${sqlUuid(queueId)},
+      NULL,
+      NULL,
+      NULL,
+      ${sqlUuid(workspaceId)},
+      NULL
+    )
+  RETURNING id
+),
+inserted_score AS (
+  INSERT INTO model_hub_score (
+    created_at, updated_at, deleted, deleted_at, id, source_type, value,
+    score_source, notes, annotator_id, call_execution_id, dataset_row_id,
+    label_id, observation_span_id, organization_id, project_id, prototype_run_id,
+    queue_item_id, trace_id, trace_session_id, workspace_id, value_history
+  )
+  SELECT
+    now(), now(), false, NULL,
+    ${sqlUuid(scoreId)},
+    'observation_span',
+    ${sqlJson({ text: reviewValueText })},
+    'human',
+    ${sqlText("Submitted answer for annotation workspace mode switch coverage.")},
+    fixture_user.review_annotator_id,
+    NULL,
+    NULL,
+    ${sqlUuid(labelId)},
+    ${sqlNullableUuid(source.spanId)},
+    ${sqlUuid(organizationId)},
+    NULL,
+    NULL,
+    ${sqlUuid(reviewItemId)},
+    NULL,
+    NULL,
+    ${sqlUuid(workspaceId)},
+    '[]'::jsonb
+  FROM fixture_user
+  RETURNING id
+)
+SELECT json_build_object(
+  'queue_id', ${sqlText(queueId)},
+  'queue_name', ${sqlText(queueName)},
+  'label_id', ${sqlText(labelId)},
+  'label_name', ${sqlText(labelName)},
+  'pending_item_id', ${sqlText(pendingItemId)},
+  'review_item_id', ${sqlText(reviewItemId)},
+  'score_id', ${sqlText(scoreId)},
+  'review_value_text', ${sqlText(reviewValueText)},
+  'review_annotator_id', (SELECT review_annotator_id::text FROM fixture_user),
+  'review_annotator_email', (SELECT review_annotator_email FROM fixture_user),
+  'has_alternate_annotator', (SELECT has_alternate_annotator FROM fixture_user),
+  'member_count',
+    (SELECT count(*) FROM inserted_member) + (SELECT count(*) FROM inserted_alt_member),
+  'item_count', (SELECT count(*) FROM inserted_items),
+  'score_count', (SELECT count(*) FROM inserted_score)
+)::text;
+`;
+  const result = await runPostgresJson(sql);
+  assert(
+    result.queue_id === queueId,
+    "Mode-switch queue fixture insert failed.",
+  );
+  assert(Number(result.item_count) === 2, "Expected two mode-switch items.");
+  assert(Number(result.score_count) === 1, "Expected one review score.");
+  return {
+    queueId,
+    queueName,
+    labelId,
+    labelName,
+    pendingItemId,
+    reviewItemId,
+    scoreId,
+    reviewValueText,
+    reviewAnnotatorId: result.review_annotator_id,
+    reviewAnnotatorEmail: result.review_annotator_email,
+    hasAlternateAnnotator: Boolean(result.has_alternate_annotator),
+  };
+}
+
+async function loadModeFixtureAudit({
+  organizationId,
+  workspaceId,
+  queueId,
+  userId,
+}) {
+  const sql = `
+WITH target_queue AS (
+  SELECT id, name, requires_review, auto_assign, status
+  FROM model_hub_annotationqueue
+  WHERE id = ${sqlUuid(queueId)}
+    AND deleted = false
+    AND organization_id = ${sqlUuid(organizationId)}
+    AND workspace_id = ${sqlUuid(workspaceId)}
+),
+target_items AS (
+  SELECT id, status, review_status, source_type, "order"
+  FROM model_hub_queueitem
+  WHERE queue_id IN (SELECT id FROM target_queue)
+    AND deleted = false
+),
+target_scores AS (
+  SELECT s.id, s.queue_item_id, s.annotator_id, u.email AS annotator_email, s.value
+  FROM model_hub_score s
+  LEFT JOIN accounts_user u ON u.id = s.annotator_id
+  WHERE s.queue_item_id IN (SELECT id FROM target_items)
+    AND s.deleted = false
+)
+SELECT json_build_object(
+  'queue_id', (SELECT id::text FROM target_queue),
+  'queue_name', (SELECT name FROM target_queue),
+  'requires_review', (SELECT requires_review FROM target_queue),
+  'auto_assign', (SELECT auto_assign FROM target_queue),
+  'status', (SELECT status FROM target_queue),
+  'item_count', (SELECT count(*) FROM target_items),
+  'pending_item_count', (
+    SELECT count(*) FROM target_items
+    WHERE status = 'pending' AND review_status IS NULL
+  ),
+  'pending_review_item_count', (
+    SELECT count(*) FROM target_items
+    WHERE status = 'in_progress' AND review_status = 'pending_review'
+  ),
+  'score_count', (SELECT count(*) FROM target_scores),
+  'review_annotator_id', (SELECT annotator_id::text FROM target_scores LIMIT 1),
+  'review_annotator_email', (SELECT annotator_email FROM target_scores LIMIT 1),
+  'current_member_count', (
+    SELECT count(*)
+    FROM model_hub_annotationqueueannotator
+    WHERE queue_id IN (SELECT id FROM target_queue)
+      AND user_id = ${sqlUuid(userId)}
+      AND deleted = false
+      AND roles @> '["manager", "reviewer", "annotator"]'::jsonb
+  ),
+  'member_count', (
+    SELECT count(*)
+    FROM model_hub_annotationqueueannotator
+    WHERE queue_id IN (SELECT id FROM target_queue)
+      AND deleted = false
+  )
+)::text;
+`;
+  return runPostgresJson(sql);
+}
+
+function assertModeFixtureAudit(audit, fixture) {
+  assert(audit.queue_id === fixture.queueId, "Mode-switch queue is missing.");
+  assert(
+    audit.requires_review === true && audit.auto_assign === true,
+    `Mode-switch queue flags are wrong: ${JSON.stringify(audit)}`,
+  );
+  assert(
+    Number(audit.current_member_count) === 1,
+    `Current user all-role membership missing: ${JSON.stringify(audit)}`,
+  );
+  assert(
+    Number(audit.item_count) === 2 &&
+      Number(audit.pending_item_count) === 1 &&
+      Number(audit.pending_review_item_count) === 1 &&
+      Number(audit.score_count) === 1,
+    `Mode-switch item/score audit mismatch: ${JSON.stringify(audit)}`,
+  );
+  assert(
+    String(audit.review_annotator_id) === String(fixture.reviewAnnotatorId),
+    `Review annotator mismatch: ${JSON.stringify(audit)}`,
+  );
+}
+
+async function hardDeleteModeFixturesByPrefix({
+  organizationId,
+  evidence = [],
+}) {
+  const sql = `
+WITH target_queues AS (
+  SELECT id
+  FROM model_hub_annotationqueue
+  WHERE name LIKE ${sqlText(`${QUEUE_PREFIX}%`)}
+    AND organization_id = ${sqlUuid(organizationId)}
+),
+target_labels AS (
+  SELECT id
+  FROM model_hub_annotationslabels
+  WHERE name LIKE ${sqlText(`${QUEUE_PREFIX}%`)}
+    AND organization_id = ${sqlUuid(organizationId)}
+),
+target_items AS (
+  SELECT id
+  FROM model_hub_queueitem
+  WHERE queue_id IN (SELECT id FROM target_queues)
+),
+deleted_review_mentions AS (
+  DELETE FROM model_hub_queueitemreviewcomment_mentioned_users
+  WHERE queueitemreviewcomment_id IN (
+    SELECT id FROM model_hub_queueitemreviewcomment
+    WHERE queue_item_id IN (SELECT id FROM target_items)
+  )
+  RETURNING queueitemreviewcomment_id
+),
+deleted_review_comments AS (
+  DELETE FROM model_hub_queueitemreviewcomment
+  WHERE queue_item_id IN (SELECT id FROM target_items)
+  RETURNING id
+),
+deleted_review_threads AS (
+  DELETE FROM model_hub_queueitemreviewthread
+  WHERE queue_item_id IN (SELECT id FROM target_items)
+  RETURNING id
+),
+deleted_assignments AS (
+  DELETE FROM model_hub_queueitemassignment
+  WHERE queue_item_id IN (SELECT id FROM target_items)
+  RETURNING id
+),
+deleted_scores AS (
+  DELETE FROM model_hub_score
+  WHERE queue_item_id IN (SELECT id FROM target_items)
+     OR label_id IN (SELECT id FROM target_labels)
+  RETURNING id
+),
+deleted_notes AS (
+  DELETE FROM model_hub_queueitemnote
+  WHERE queue_item_id IN (SELECT id FROM target_items)
+  RETURNING id
+),
+deleted_members AS (
+  DELETE FROM model_hub_annotationqueueannotator
+  WHERE queue_id IN (SELECT id FROM target_queues)
+  RETURNING id
+),
+deleted_queue_labels AS (
+  DELETE FROM model_hub_annotationqueuelabel
+  WHERE queue_id IN (SELECT id FROM target_queues)
+     OR label_id IN (SELECT id FROM target_labels)
+  RETURNING id
+),
+deleted_items AS (
+  DELETE FROM model_hub_queueitem
+  WHERE id IN (SELECT id FROM target_items)
+  RETURNING id
+),
+deleted_queues AS (
+  DELETE FROM model_hub_annotationqueue
+  WHERE id IN (SELECT id FROM target_queues)
+  RETURNING id
+),
+deleted_labels AS (
+  DELETE FROM model_hub_annotationslabels
+  WHERE id IN (SELECT id FROM target_labels)
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_queue_count', (SELECT count(*) FROM deleted_queues),
+  'deleted_label_count', (SELECT count(*) FROM deleted_labels),
+  'deleted_item_count', (SELECT count(*) FROM deleted_items),
+  'deleted_score_count', (SELECT count(*) FROM deleted_scores),
+  'deleted_member_count', (SELECT count(*) FROM deleted_members),
+  'remaining_queue_count', (
+    SELECT count(*)
+    FROM target_queues
+    WHERE id NOT IN (SELECT id FROM deleted_queues)
+  ),
+  'remaining_item_count', (
+    SELECT count(*)
+    FROM target_items
+    WHERE id NOT IN (SELECT id FROM deleted_items)
+  ),
+  'remaining_score_count', (
+    SELECT count(*)
+    FROM model_hub_score
+    WHERE (
+        queue_item_id IN (SELECT id FROM target_items)
+        OR label_id IN (SELECT id FROM target_labels)
+      )
+      AND id NOT IN (SELECT id FROM deleted_scores)
+  )
+)::text;
+`;
+  const result = await runPostgresJson(sql);
+  if (
+    Number(result.deleted_queue_count) > 0 ||
+    Number(result.deleted_label_count) > 0 ||
+    Number(result.remaining_queue_count) > 0 ||
+    Number(result.remaining_score_count) > 0
+  ) {
+    evidence.push({
+      cleanup: "hard delete annotation workspace mode fixtures",
+      status:
+        Number(result.remaining_queue_count) === 0 &&
+        Number(result.remaining_item_count) === 0 &&
+        Number(result.remaining_score_count) === 0
+          ? "passed"
+          : "failed",
+      audit: result,
+    });
+  }
+  return result;
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(() => {
+    window.normalizeText = (value) =>
+      String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+    window.visibleElements = (selector = "body *") => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(selector)).filter(isVisible);
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id) {
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+        sessionStorage.setItem("currentUserId", user.id);
+      }
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function collectModeState(page) {
+  return page.evaluate(() => {
+    const hasVisibleText = (text) =>
+      window
+        .visibleElements()
+        .some((element) =>
+          window.normalizeText(element.textContent).includes(text),
+        );
+    return {
+      url: window.location.href,
+      annotatePressed: Boolean(
+        Array.from(document.querySelectorAll("button")).find(
+          (button) =>
+            window.normalizeText(button.textContent) ===
+              "Annotate my answers" &&
+            button.getAttribute("aria-pressed") === "true",
+        ),
+      ),
+      reviewPressed: Boolean(
+        Array.from(document.querySelectorAll("button")).find(
+          (button) =>
+            window.normalizeText(button.textContent) === "Review submissions" &&
+            button.getAttribute("aria-pressed") === "true",
+        ),
+      ),
+      submitButtonVisible: hasVisibleText("Submit for Review"),
+      reviewAnnotationsVisible: hasVisibleText("Review Annotations"),
+      reviewActionBarVisible: Boolean(
+        document.querySelector('[data-testid="review-action-bar"]'),
+      ),
+    };
+  });
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(predicate, { timeout: 60_000 }),
+      action(),
+    ]);
+    return response;
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForPathIncludes(page, pathName, timeout = 30_000) {
+  await page.waitForFunction(
+    (expectedPath) => window.location.pathname.includes(expectedPath),
+    { timeout },
+    pathName,
+  );
+}
+
+async function waitForLocationSearchParam(
+  page,
+  param,
+  value,
+  timeout = 30_000,
+) {
+  await page.waitForFunction(
+    ({ key, expected }) =>
+      new URLSearchParams(window.location.search).get(key) === expected,
+    { timeout },
+    { key: param, expected: value },
+  );
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30_000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) =>
+      window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      }),
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function clickToggleButton(page, text) {
+  await waitForVisibleText(page, text, { exact: true });
+  const clicked = await page.evaluate((expectedText) => {
+    const button = window
+      .visibleElements("button")
+      .find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent) === expectedText &&
+          !candidate.disabled,
+      );
+    if (!button) return false;
+    button.click();
+    return true;
+  }, text);
+  assert(clicked, `Could not click toggle button: ${text}`);
+}
+
+async function assertTogglePressed(page, text) {
+  const pressed = await page.evaluate((expectedText) => {
+    const button = window
+      .visibleElements("button")
+      .find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent) === expectedText,
+      );
+    return button?.getAttribute("aria-pressed") === "true";
+  }, text);
+  assert(pressed, `${text} toggle is not pressed.`);
+}
+
+async function waitForRequestSeen(requests, predicate, timeout = 30_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeout) {
+    if (requests.some(predicate)) return;
+    await sleep(100);
+  }
+  throw new Error(
+    `Timed out waiting for request. Seen requests: ${requests.join(", ")}`,
+  );
+}
+
+function isNextItemResponse(response, queueId, expectedParams = {}) {
+  if (response.request().method() !== "GET" || response.status() >= 400) {
+    return false;
+  }
+  const url = new URL(response.url());
+  if (
+    !isAnnotationQueueApiUrl(response.url()) ||
+    url.pathname !== `/model-hub/annotation-queues/${queueId}/items/next-item/`
+  ) {
+    return false;
+  }
+  return Object.entries(expectedParams).every(
+    ([key, value]) => url.searchParams.get(key) === String(value),
+  );
+}
+
+function isAnnotationQueueApiUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  return (
+    url.origin ===
+      new URL(process.env.API_BASE || "http://localhost:8003").origin &&
+    url.pathname.startsWith("/model-hub/annotation-queues/")
+  );
+}
+
+function maskRequest(rawRequest) {
+  const parts = rawRequest.split(" ");
+  if (parts.length < 2) return rawRequest;
+  const [method, rawUrl] = parts;
+  try {
+    const url = new URL(rawUrl);
+    return `${method} ${url.pathname}${url.search}`;
+  } catch {
+    return rawRequest;
+  }
+}
+
+function traceProjectId(detail) {
+  return relatedId(detail?.trace?.project || detail?.project);
+}
+
+function relatedId(value) {
+  if (!value) return null;
+  if (typeof value === "string") return value;
+  return value.id || value.project_id || value.uuid || null;
+}
+
+function flattenTraceEntries(detail) {
+  const roots = asArray(detail?.observation_spans).length
+    ? asArray(detail.observation_spans)
+    : [detail?.root || detail?.data || detail?.trace || detail];
+  const rows = [];
+  function walk(entry) {
+    if (!entry || typeof entry !== "object") return;
+    const span = entry.observation_span || entry.span || entry;
+    const spanId = span?.id || span?.span_id;
+    rows.push({ entry, spanId });
+    for (const child of asArray(entry.children)) walk(child);
+  }
+  for (const root of roots) walk(root);
+  return rows;
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres mode-switch audit returned no JSON output.");
+  return JSON.parse(text);
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), "SQL UUID value must be a UUID.");
+  return `'${value}'::uuid`;
+}
+
+function sqlNullableUuid(value) {
+  if (value === null || value === undefined || value === "") return "NULL";
+  return sqlUuid(value);
+}
+
+function sqlText(value) {
+  return `'${String(value ?? "").replaceAll("'", "''")}'`;
+}
+
+function sqlJson(value) {
+  return `${sqlText(JSON.stringify(value ?? null))}::jsonb`;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") {
+    return "/usr/bin/google-chrome";
+  }
+  return undefined;
+}
+
+main().catch((error) => {
+  if (error?.name === "SkipJourney") {
+    console.log(JSON.stringify({ status: "skipped", reason: error.reason }));
+    return;
+  }
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/frontend/scripts/api-journeys/browser/dataset-annotations-preview-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/dataset-annotations-preview-smoke.mjs
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
+import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
 import process from "node:process";
+import { promisify } from "node:util";
 import {
   apiPath,
   asArray,
@@ -12,6 +14,7 @@ import {
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
 const DATASET_PREFIX = "ui_annotation_preview_";
@@ -46,6 +49,7 @@ async function main() {
 
   await cleanupDatasetsByPrefix(auth.client, DATASET_PREFIX, cleanupEvidence);
   await cleanupLabelsByPrefix(auth.client, LABEL_PREFIX, cleanupEvidence);
+  await hardDeleteAnnotationPreviewFixtures(cleanupEvidence);
 
   try {
     const source = await createSourceDataset(auth.client, {
@@ -198,6 +202,16 @@ async function main() {
     labelId = null;
     await deleteDatasets(auth.client, [datasetId], cleanupEvidence);
     datasetId = null;
+    const hardCleanup =
+      await hardDeleteAnnotationPreviewFixtures(cleanupEvidence);
+    assert(
+      Number(hardCleanup.remaining_dataset_count) === 0 &&
+        Number(hardCleanup.remaining_annotation_count) === 0 &&
+        Number(hardCleanup.remaining_label_count) === 0,
+      `Annotation preview hard cleanup left fixture rows: ${JSON.stringify(
+        hardCleanup,
+      )}`,
+    );
 
     console.log(
       JSON.stringify(
@@ -260,6 +274,15 @@ async function main() {
     }
     await cleanupDatasetsByPrefix(auth.client, DATASET_PREFIX, cleanupEvidence);
     await cleanupLabelsByPrefix(auth.client, LABEL_PREFIX, cleanupEvidence);
+    await hardDeleteAnnotationPreviewFixtures(cleanupEvidence).catch(
+      (error) => {
+        cleanupEvidence.push({
+          cleanup: "hard delete annotation preview fixtures after failure",
+          status: "failed",
+          error: error.message,
+        });
+      },
+    );
     if (browser) await browser.close();
   }
 }
@@ -506,6 +529,147 @@ async function deleteDatasets(client, datasetIds, evidence) {
     status: "passed",
     dataset_ids: datasetIds,
   });
+}
+
+async function hardDeleteAnnotationPreviewFixtures(evidence) {
+  const deleteSql = `
+WITH fixture_datasets AS (
+  SELECT id
+  FROM model_hub_dataset
+  WHERE name LIKE ${sqlTextLiteral(`${DATASET_PREFIX}%`)}
+),
+fixture_annotations AS (
+  SELECT id
+  FROM model_hub_annotations
+  WHERE name LIKE ${sqlTextLiteral(`${ANNOTATION_PREFIX}%`)}
+     OR dataset_id IN (SELECT id FROM fixture_datasets)
+),
+fixture_labels AS (
+  SELECT id
+  FROM model_hub_annotationslabels
+  WHERE name LIKE ${sqlTextLiteral(`${LABEL_PREFIX}%`)}
+),
+deleted_annotation_labels AS (
+  DELETE FROM model_hub_annotations_labels
+  WHERE annotations_id IN (SELECT id FROM fixture_annotations)
+     OR annotationslabels_id IN (SELECT id FROM fixture_labels)
+  RETURNING id
+),
+deleted_annotation_users AS (
+  DELETE FROM model_hub_annotations_assigned_users
+  WHERE annotations_id IN (SELECT id FROM fixture_annotations)
+  RETURNING id
+),
+deleted_annotation_columns AS (
+  DELETE FROM model_hub_annotations_columns
+  WHERE annotations_id IN (SELECT id FROM fixture_annotations)
+  RETURNING id
+),
+deleted_annotations AS (
+  DELETE FROM model_hub_annotations
+  WHERE id IN (SELECT id FROM fixture_annotations)
+  RETURNING id
+),
+deleted_cells AS (
+  DELETE FROM model_hub_cell
+  WHERE dataset_id IN (SELECT id FROM fixture_datasets)
+  RETURNING id
+),
+deleted_rows AS (
+  DELETE FROM model_hub_row
+  WHERE dataset_id IN (SELECT id FROM fixture_datasets)
+  RETURNING id
+),
+deleted_columns AS (
+  DELETE FROM model_hub_column
+  WHERE dataset_id IN (SELECT id FROM fixture_datasets)
+  RETURNING id
+),
+deleted_datasets AS (
+  DELETE FROM model_hub_dataset
+  WHERE id IN (SELECT id FROM fixture_datasets)
+  RETURNING id
+),
+deleted_labels AS (
+  DELETE FROM model_hub_annotationslabels
+  WHERE id IN (SELECT id FROM fixture_labels)
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_annotation_label_link_count', (SELECT count(*) FROM deleted_annotation_labels),
+  'deleted_annotation_user_link_count', (SELECT count(*) FROM deleted_annotation_users),
+  'deleted_annotation_column_link_count', (SELECT count(*) FROM deleted_annotation_columns),
+  'deleted_annotation_count', (SELECT count(*) FROM deleted_annotations),
+  'deleted_cell_count', (SELECT count(*) FROM deleted_cells),
+  'deleted_row_count', (SELECT count(*) FROM deleted_rows),
+  'deleted_column_count', (SELECT count(*) FROM deleted_columns),
+  'deleted_dataset_count', (SELECT count(*) FROM deleted_datasets),
+  'deleted_label_count', (SELECT count(*) FROM deleted_labels)
+);
+`;
+  const remainingSql = `
+SELECT json_build_object(
+  'remaining_dataset_count', (
+    SELECT count(*)
+    FROM model_hub_dataset
+    WHERE name LIKE ${sqlTextLiteral(`${DATASET_PREFIX}%`)}
+  ),
+  'remaining_annotation_count', (
+    SELECT count(*)
+    FROM model_hub_annotations
+    WHERE name LIKE ${sqlTextLiteral(`${ANNOTATION_PREFIX}%`)}
+  ),
+  'remaining_label_count', (
+    SELECT count(*)
+    FROM model_hub_annotationslabels
+    WHERE name LIKE ${sqlTextLiteral(`${LABEL_PREFIX}%`)}
+  )
+);
+`;
+  const deleteAudit = await runPostgresJson(deleteSql);
+  const remainingAudit = await runPostgresJson(remainingSql);
+  const audit = {
+    ...deleteAudit,
+    ...remainingAudit,
+  };
+  if (
+    Number(audit.deleted_dataset_count) > 0 ||
+    Number(audit.deleted_annotation_count) > 0 ||
+    Number(audit.deleted_label_count) > 0 ||
+    Number(audit.remaining_dataset_count) > 0 ||
+    Number(audit.remaining_annotation_count) > 0 ||
+    Number(audit.remaining_label_count) > 0
+  ) {
+    evidence.push({
+      cleanup: "hard delete annotation preview fixtures",
+      status:
+        Number(audit.remaining_dataset_count) === 0 &&
+        Number(audit.remaining_annotation_count) === 0 &&
+        Number(audit.remaining_label_count) === 0
+          ? "passed"
+          : "failed",
+      audit,
+    });
+  }
+  return audit;
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres DB audit returned no JSON output.");
+  return JSON.parse(text);
+}
+
+function sqlTextLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
 }
 
 async function installRuntimeConfig(page, auth) {

--- a/frontend/scripts/api-journeys/browser/dataset-local-file-create-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/dataset-local-file-create-smoke.mjs
@@ -1,0 +1,1179 @@
+/* eslint-disable no-console */
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+  isUuid,
+  requireMutations,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
+const backendRoot = fileURLToPath(
+  new URL("../../../../futureagi/", import.meta.url),
+);
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const DATASET_PREFIX = "ui_local_file_create_";
+const SCREENSHOT_PATH = "/tmp/dataset-local-file-create-smoke.png";
+const PLAN_LIMIT_SCREENSHOT_PATH =
+  "/tmp/dataset-local-file-create-plan-limited-smoke.png";
+const FAILURE_SCREENSHOT_PATH =
+  "/tmp/dataset-local-file-create-smoke-failure.png";
+const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+
+async function main() {
+  requireMutations();
+  const auth = await createAuthenticatedContext();
+  const suffix = auth.runId.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+  const datasetName = `${DATASET_PREFIX}${suffix}`;
+  const csvFileName = `${datasetName}.csv`;
+  const tmpDir = await mkdtemp(join(tmpdir(), "dataset-local-file-create-"));
+  const csvPath = join(tmpDir, csvFileName);
+  const inputOne = `ui local file input one ${suffix}`;
+  const inputTwo = `ui local file input two ${suffix}`;
+  const expectedOne = `ui local file expected one ${suffix}`;
+  const expectedTwo = `ui local file expected two ${suffix}`;
+  const cleanupEvidence = [];
+  const apiFailures = [];
+  const pageErrors = [];
+  const modelHubRequests = [];
+  const browserMutations = [];
+  const unexpectedMutations = [];
+  let browser = null;
+  let page = null;
+  let datasetId = null;
+  let caughtError = null;
+
+  await writeFile(
+    csvPath,
+    `input,expected\n${inputOne},${expectedOne}\n${inputTwo},${expectedTwo}\n`,
+    "utf8",
+  );
+
+  try {
+    await hardDeleteDatasetFixturesByPrefix(DATASET_PREFIX, cleanupEvidence);
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+    page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (!isModelHubApiUrl(url)) return;
+      modelHubRequests.push(`${request.method()} ${url}`);
+      if (MUTATION_METHODS.has(request.method())) {
+        const mutation = `${request.method()} ${url}`;
+        browserMutations.push(mutation);
+        if (!isAllowedMutation(request.method(), url)) {
+          unexpectedMutations.push(mutation);
+        }
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isModelHubApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${url}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponsesDuring(
+      page,
+      "initial datasets list load",
+      [
+        (response) =>
+          response.url().includes("/model-hub/develops/get-datasets/") &&
+          response.request().method() === "GET" &&
+          response.status() < 400,
+      ],
+      () =>
+        page.goto(`${APP_BASE}/dashboard/develop`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForPath(page, "/dashboard/develop");
+
+    await waitForVisibleText(page, "Add Dataset", { exact: true });
+    await clickVisibleText(page, "Add Dataset", { exact: true });
+    await waitForVisibleText(page, "Add dataset", { exact: true });
+    await clickVisibleText(page, "Upload a file (JSON, CSV)", {
+      exact: true,
+    });
+    await waitForVisibleText(page, "Upload a File", { exact: true });
+
+    const input = await page.waitForSelector('input[type="file"]', {
+      timeout: 30000,
+    });
+    await input.uploadFile(csvPath);
+    await waitForVisibleText(page, csvFileName, { exact: true });
+
+    const uploadResponse = await waitForResponseDuring(
+      page,
+      "local-file dataset upload",
+      (response) =>
+        response
+          .url()
+          .includes("/model-hub/develops/create-dataset-from-local-file/") &&
+        response.request().method() === "POST",
+      () => clickVisibleButton(page, "Save"),
+    );
+    const uploadPayload = await responseJson(uploadResponse);
+
+    if (uploadResponse.status() === 429) {
+      await page.screenshot({
+        path: PLAN_LIMIT_SCREENSHOT_PATH,
+        fullPage: true,
+      });
+      console.log(
+        JSON.stringify(
+          {
+            status: "skipped",
+            reason: "local-file dataset creation is plan-limited",
+            app_base: APP_BASE,
+            api_base: auth.apiBase,
+            organization_id: auth.organizationId,
+            workspace_id: auth.workspaceId,
+            response_status: uploadResponse.status(),
+            response_message:
+              uploadPayload?.message ||
+              uploadPayload?.detail ||
+              uploadPayload?.error ||
+              null,
+            screenshot: PLAN_LIMIT_SCREENSHOT_PATH,
+            browser_mutations: browserMutations.map(maskRequest),
+            cleanup: cleanupEvidence,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    assert(
+      uploadResponse.status() >= 200 && uploadResponse.status() < 300,
+      `Local-file dataset upload returned HTTP ${uploadResponse.status()}: ${JSON.stringify(
+        uploadPayload,
+      )}`,
+    );
+
+    const created = uploadPayload?.result || uploadPayload || {};
+    datasetId = created.dataset_id || created.datasetId || null;
+    assert(datasetId, "Local-file dataset upload response omitted dataset_id.");
+    assert(
+      created.dataset_name === datasetName,
+      "Local-file dataset upload returned a different dataset name.",
+    );
+    assert(
+      created.processing_status === "queued",
+      "Local-file dataset upload did not return queued status.",
+    );
+    assert(
+      Number(created.estimated_rows) === 2 &&
+        Number(created.estimated_columns) === 2,
+      "Local-file dataset upload returned unexpected row/column estimates.",
+    );
+
+    await waitForPathIncludes(page, `/dashboard/develop/${datasetId}`, 30000);
+
+    const queuedProgress = await getDatasetCreationProgress(
+      auth.client,
+      datasetId,
+    );
+    assert(
+      queuedProgress.processing_status === "queued" ||
+        queuedProgress.processing_status === "completed",
+      "Local-file progress returned an unexpected status after upload.",
+    );
+    assert(
+      queuedProgress.original_filename === csvFileName,
+      "Local-file progress did not expose the uploaded filename.",
+    );
+
+    const queuedAudit = await loadLocalFileDatasetAudit({
+      datasetId,
+      datasetName,
+      fileName: csvFileName,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+    });
+    assertLocalFileQueuedAudit(queuedAudit, {
+      datasetId,
+      datasetName,
+      fileName: csvFileName,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      expectedProcessingStatus: queuedProgress.processing_status,
+    });
+
+    let workerResult = null;
+    if (queuedProgress.processing_status !== "completed") {
+      workerResult = await materializeLocalFileDataset(datasetId);
+      assert(
+        workerResult.processing_status === "completed",
+        "Local-file worker did not complete the browser-created dataset.",
+      );
+    }
+
+    const completedProgress = await waitForCompletedProgress(
+      auth.client,
+      datasetId,
+    );
+    assert(
+      completedProgress.original_filename === csvFileName,
+      "Completed progress did not preserve the uploaded filename.",
+    );
+
+    await waitForTableValues(auth.client, datasetId, [
+      inputOne,
+      inputTwo,
+      expectedOne,
+      expectedTwo,
+    ]);
+    await waitForResponsesDuring(
+      page,
+      "completed local-file dataset detail table load",
+      [
+        (response) =>
+          response
+            .url()
+            .includes(`/model-hub/develops/${datasetId}/get-dataset-table/`) &&
+          response.request().method() === "GET" &&
+          response.status() < 400,
+      ],
+      () =>
+        page.goto(`${APP_BASE}/dashboard/develop/${datasetId}?tab=data`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForVisibleText(page, inputOne, { exact: true, timeout: 60000 });
+    await waitForVisibleText(page, expectedTwo, {
+      exact: true,
+      timeout: 60000,
+    });
+    await waitForNoVisibleText(page, "Invalid Date");
+    await waitForNoVisibleText(page, "undefined");
+
+    const table = await getDatasetTable(auth.client, datasetId);
+    const rows = asArray(table.table).filter((row) => row?.row_id);
+    const columns = asArray(table.column_config);
+    assert(rows.length === 2, "Local-file upload did not produce two rows.");
+    assert(
+      columns.some((column) => column?.name === "input") &&
+        columns.some((column) => column?.name === "expected"),
+      "Local-file upload did not expose input/expected columns.",
+    );
+
+    const completedAudit = await loadLocalFileDatasetAudit({
+      datasetId,
+      datasetName,
+      fileName: csvFileName,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+    });
+    assertLocalFileCompletedAudit(completedAudit, {
+      datasetId,
+      datasetName,
+      fileName: csvFileName,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      inputValues: [inputOne, inputTwo],
+      expectedValues: [expectedOne, expectedTwo],
+    });
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+
+    assert(
+      unexpectedMutations.length === 0,
+      `Unexpected Model Hub mutations: ${unexpectedMutations
+        .map(maskRequest)
+        .join(", ")}`,
+    );
+    assert(
+      apiFailures.length === 0,
+      `Unexpected Model Hub API failures: ${apiFailures
+        .map(maskRequest)
+        .join(", ")}`,
+    );
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+
+    await deleteDataset(auth.client, datasetId, cleanupEvidence);
+    const deleteAudit = await loadDatasetDeleteAudit(datasetId);
+    assert(
+      deleteAudit.active_dataset_count === 0 &&
+        deleteAudit.deleted_dataset_count === 1 &&
+        deleteAudit.deleted_at_count === 1,
+      `Dataset delete audit mismatch: ${JSON.stringify(deleteAudit)}`,
+    );
+    cleanupEvidence.push({
+      cleanup: "verify public local-file dataset delete",
+      status: "passed",
+      audit: deleteAudit,
+    });
+    datasetId = null;
+
+    const hardCleanup = await hardDeleteDatasetFixturesByPrefix(
+      DATASET_PREFIX,
+      cleanupEvidence,
+    );
+    assert(
+      hardCleanup.remaining_dataset_count === 0,
+      `Hard cleanup left local-file dataset fixtures: ${JSON.stringify(
+        hardCleanup,
+      )}`,
+    );
+
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          dataset_id: completedAudit.dataset_id,
+          dataset_name: completedAudit.dataset_name,
+          uploaded_file_name: csvFileName,
+          initial_processing_status: queuedProgress.processing_status,
+          completed_processing_status: completedProgress.processing_status,
+          rows_after_worker: Number(completedAudit.row_count),
+          columns_after_worker: Number(completedAudit.column_count),
+          cells_after_worker: Number(completedAudit.cell_count),
+          worker_result: workerResult,
+          browser_mutations: browserMutations.map(maskRequest),
+          model_hub_request_count: modelHubRequests.length,
+          screenshot: SCREENSHOT_PATH,
+          cleanup: cleanupEvidence,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    caughtError = error;
+    const domDebug = page
+      ? await collectDomDebug(page).catch(() => null)
+      : null;
+    console.error(
+      JSON.stringify(
+        {
+          status: "failed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          dataset_id: datasetId,
+          browser_mutations: browserMutations.map(maskRequest),
+          model_hub_request_count: modelHubRequests.length,
+          api_failures: apiFailures.map(maskRequest),
+          page_errors: pageErrors,
+          dom_debug: domDebug,
+        },
+        null,
+        2,
+      ),
+    );
+    if (page) {
+      await page
+        .screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .then(() => {
+          console.error(`failure_screenshot=${FAILURE_SCREENSHOT_PATH}`);
+        })
+        .catch(() => null);
+    }
+  } finally {
+    if (browser) await browser.close();
+    if (datasetId) {
+      await deleteDataset(auth.client, datasetId, cleanupEvidence).catch(
+        (error) => {
+          caughtError = appendCleanupError(caughtError, error);
+        },
+      );
+    }
+    await hardDeleteDatasetFixturesByPrefix(
+      DATASET_PREFIX,
+      cleanupEvidence,
+    ).catch((error) => {
+      caughtError = appendCleanupError(caughtError, error);
+    });
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => null);
+  }
+
+  if (caughtError) throw caughtError;
+}
+
+async function collectDomDebug(page) {
+  return page.evaluate(() => {
+    const visibleText = (selector) =>
+      window
+        .visibleElements(selector)
+        .map((element) => window.normalizeText(element.textContent))
+        .filter(Boolean);
+    return {
+      path: window.location.pathname,
+      visible_buttons: visibleText("button").slice(0, 20),
+      dialog_text: visibleText('[role="dialog"]').slice(0, 8),
+      file_input_count: document.querySelectorAll('input[type="file"]').length,
+      file_input_files: Array.from(
+        document.querySelectorAll('input[type="file"]'),
+      ).map((input) => input.files?.length || 0),
+      helper_text: visibleText(".MuiFormHelperText-root"),
+    };
+  });
+}
+
+async function getDatasetCreationProgress(client, datasetId) {
+  return client.get(
+    apiPath("/model-hub/develops/dataset-creation-progress/{dataset_id}/", {
+      dataset_id: datasetId,
+    }),
+  );
+}
+
+async function waitForCompletedProgress(client, datasetId) {
+  const deadline = Date.now() + 60000;
+  let lastProgress = null;
+  while (Date.now() < deadline) {
+    lastProgress = await getDatasetCreationProgress(client, datasetId);
+    if (lastProgress.processing_status === "completed") return lastProgress;
+    if (lastProgress.processing_status === "failed") {
+      throw new Error(
+        `Local-file dataset processing failed: ${JSON.stringify(lastProgress)}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error(
+    `Timed out waiting for local-file dataset completion; last progress ${JSON.stringify(
+      lastProgress,
+    )}`,
+  );
+}
+
+async function materializeLocalFileDataset(datasetId) {
+  assert(isUuid(datasetId), "datasetId must be a UUID for worker run.");
+  const script = `
+import json
+from model_hub.models.develop_dataset import Cell, Dataset
+from model_hub.models.choices import CellStatus, DataTypeChoices
+from model_hub.views.datasets.create.file_upload import process_dataset_from_file
+
+dataset = Dataset.objects.get(id=${JSON.stringify(datasetId)})
+dataset_config = dataset.dataset_config or {}
+process_dataset_from_file.run_sync(
+    str(dataset.id),
+    dataset_config["file_url"],
+    dataset_config["original_filename"],
+)
+dataset.refresh_from_db()
+media_cell_count = Cell.objects.filter(
+    dataset=dataset,
+    deleted=False,
+    status=CellStatus.RUNNING.value,
+    column__data_type__in=[
+        DataTypeChoices.IMAGE.value,
+        DataTypeChoices.IMAGES.value,
+        DataTypeChoices.AUDIO.value,
+        DataTypeChoices.DOCUMENT.value,
+    ],
+).count()
+print(json.dumps({
+    "dataset_id": str(dataset.id),
+    "processing_status": (dataset.dataset_config or {}).get("file_processing_status"),
+    "completed_columns": (dataset.dataset_config or {}).get("completed_columns"),
+    "error_columns": (dataset.dataset_config or {}).get("error_columns"),
+    "media_dispatch_skipped": media_cell_count == 0,
+}))
+`;
+  return runBackendShellJson(script);
+}
+
+async function waitForTableValues(client, datasetId, expectedValues) {
+  const deadline = Date.now() + 60000;
+  let lastValues = [];
+  while (Date.now() < deadline) {
+    const table = await getDatasetTable(client, datasetId);
+    const columns = asArray(table.column_config);
+    const rows = asArray(table.table).filter((row) => row?.row_id);
+    lastValues = rows.flatMap((row) =>
+      columns.map((column) => cellValueFor(row, column.id)).filter(Boolean),
+    );
+    if (expectedValues.every((value) => lastValues.includes(value))) return;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error(
+    `Timed out waiting for local-file table values; saw ${JSON.stringify(
+      lastValues,
+    )}`,
+  );
+}
+
+async function getDatasetTable(client, datasetId) {
+  return client.get(
+    apiPath("/model-hub/develops/{dataset_id}/get-dataset-table/", {
+      dataset_id: datasetId,
+    }),
+    { query: { current_page_index: 0, page_size: 50 } },
+  );
+}
+
+function cellValueFor(row, columnId) {
+  if (!row || !columnId) return undefined;
+  const direct = row[columnId];
+  if (direct && typeof direct === "object" && "cell_value" in direct) {
+    return direct.cell_value;
+  }
+  return direct;
+}
+
+async function deleteDataset(client, datasetId, evidence) {
+  await client.delete(apiPath("/model-hub/develops/delete_dataset/"), {
+    body: { dataset_ids: [datasetId] },
+    okStatuses: [200, 404],
+  });
+  evidence.push({
+    cleanup: "public delete local-file dataset fixture",
+    status: "passed",
+    dataset_id: datasetId,
+  });
+}
+
+async function loadLocalFileDatasetAudit({
+  datasetId,
+  datasetName,
+  fileName,
+  organizationId,
+  workspaceId,
+}) {
+  assert(isUuid(datasetId), "datasetId must be a UUID for DB audit.");
+  assert(isUuid(organizationId), "organizationId must be a UUID for DB audit.");
+  if (workspaceId)
+    assert(isUuid(workspaceId), "workspaceId must be a UUID for DB audit.");
+  const sql = `
+WITH dataset_row AS (
+  SELECT id, name, organization_id, workspace_id, dataset_config
+  FROM model_hub_dataset
+  WHERE id = ${sqlUuid(datasetId)}
+    AND name = ${sqlTextLiteral(datasetName)}
+    AND deleted = false
+),
+rows AS (
+  SELECT id, "order"
+  FROM model_hub_row
+  WHERE dataset_id = ${sqlUuid(datasetId)}
+    AND deleted = false
+),
+columns AS (
+  SELECT id, name, status
+  FROM model_hub_column
+  WHERE dataset_id = ${sqlUuid(datasetId)}
+    AND deleted = false
+)
+SELECT COALESCE((
+  SELECT json_build_object(
+    'dataset_id', d.id::text,
+    'dataset_name', d.name,
+    'organization_id', d.organization_id::text,
+    'workspace_id', d.workspace_id::text,
+    'dataset_source_local', COALESCE((d.dataset_config->>'dataset_source_local')::boolean, false),
+    'processing_status', d.dataset_config->>'file_processing_status',
+    'original_filename', d.dataset_config->>'original_filename',
+    'file_url_set', COALESCE(d.dataset_config->>'file_url', '') <> '',
+    'estimated_rows', d.dataset_config->>'estimated_rows',
+    'estimated_columns', d.dataset_config->>'estimated_columns',
+    'total_rows', d.dataset_config->>'total_rows',
+    'total_columns', d.dataset_config->>'total_columns',
+    'completed_columns', d.dataset_config->>'completed_columns',
+    'error_columns', d.dataset_config->>'error_columns',
+    'completed_at_set', d.dataset_config ? 'file_processing_completed_at',
+    'row_count', (SELECT count(*) FROM rows),
+    'column_count', (SELECT count(*) FROM columns),
+    'cell_count', (
+      SELECT count(*)
+      FROM model_hub_cell c
+      WHERE c.dataset_id = d.id
+        AND c.deleted = false
+    ),
+    'column_names', (
+      SELECT COALESCE(json_agg(name ORDER BY name), '[]'::json)
+      FROM columns
+    ),
+    'column_statuses', (
+      SELECT COALESCE(json_object_agg(name, status), '{}'::json)
+      FROM columns
+    ),
+    'input_values', (
+      SELECT COALESCE(json_agg(c.value ORDER BY r."order"), '[]'::json)
+      FROM rows r
+      JOIN columns col ON col.name = 'input'
+      JOIN model_hub_cell c
+        ON c.row_id = r.id
+       AND c.column_id = col.id
+       AND c.deleted = false
+    ),
+    'expected_values', (
+      SELECT COALESCE(json_agg(c.value ORDER BY r."order"), '[]'::json)
+      FROM rows r
+      JOIN columns col ON col.name = 'expected'
+      JOIN model_hub_cell c
+        ON c.row_id = r.id
+       AND c.column_id = col.id
+       AND c.deleted = false
+    )
+  )
+  FROM dataset_row d
+), '{}'::json);
+`;
+  const audit = await runPostgresJson(sql);
+  assert(
+    audit.organization_id === organizationId,
+    "Local-file dataset audit organization mismatch.",
+  );
+  if (workspaceId) {
+    assert(
+      audit.workspace_id === workspaceId,
+      "Local-file dataset audit workspace mismatch.",
+    );
+  }
+  assert(
+    audit.original_filename === fileName,
+    "Local-file dataset audit original filename mismatch.",
+  );
+  return audit;
+}
+
+function assertLocalFileQueuedAudit(
+  audit,
+  {
+    datasetId,
+    datasetName,
+    expectedProcessingStatus,
+    fileName,
+    organizationId,
+    workspaceId,
+  },
+) {
+  assertBaseLocalFileAudit(audit, {
+    datasetId,
+    datasetName,
+    fileName,
+    organizationId,
+    workspaceId,
+  });
+  assert(
+    audit.processing_status === expectedProcessingStatus,
+    "Local-file queued audit processing status mismatch.",
+  );
+  if (expectedProcessingStatus === "queued") {
+    assert(
+      Number(audit.row_count) === 0 &&
+        Number(audit.column_count) === 0 &&
+        Number(audit.cell_count) === 0,
+      "Queued local-file dataset materialized rows before worker completion.",
+    );
+  }
+}
+
+function assertLocalFileCompletedAudit(
+  audit,
+  {
+    datasetId,
+    datasetName,
+    expectedValues,
+    fileName,
+    inputValues,
+    organizationId,
+    workspaceId,
+  },
+) {
+  assertBaseLocalFileAudit(audit, {
+    datasetId,
+    datasetName,
+    fileName,
+    organizationId,
+    workspaceId,
+  });
+  assert(
+    audit.processing_status === "completed",
+    "Local-file completed audit processing status mismatch.",
+  );
+  assert(
+    Number(audit.total_rows) === 2 &&
+      Number(audit.total_columns) === 2 &&
+      Number(audit.row_count) === 2 &&
+      Number(audit.column_count) === 2 &&
+      Number(audit.cell_count) === 4,
+    "Local-file completed audit row/column/cell counts mismatch.",
+  );
+  assert(
+    Number(audit.completed_columns) === 2 &&
+      Number(audit.error_columns) === 0 &&
+      audit.completed_at_set === true,
+    "Local-file completed audit status metadata mismatch.",
+  );
+  assert(
+    JSON.stringify(audit.column_names) ===
+      JSON.stringify(["expected", "input"]),
+    "Local-file completed audit column names mismatch.",
+  );
+  assert(
+    JSON.stringify(audit.input_values) === JSON.stringify(inputValues),
+    "Local-file completed audit input values mismatch.",
+  );
+  assert(
+    JSON.stringify(audit.expected_values) === JSON.stringify(expectedValues),
+    "Local-file completed audit expected values mismatch.",
+  );
+}
+
+function assertBaseLocalFileAudit(
+  audit,
+  { datasetId, datasetName, fileName, organizationId, workspaceId },
+) {
+  assert(
+    audit?.dataset_id === datasetId,
+    "Local-file dataset audit dataset id mismatch.",
+  );
+  assert(
+    audit.dataset_name === datasetName,
+    "Local-file dataset audit dataset name mismatch.",
+  );
+  assert(
+    audit.organization_id === organizationId,
+    "Local-file dataset audit organization mismatch.",
+  );
+  if (workspaceId) {
+    assert(
+      audit.workspace_id === workspaceId,
+      "Local-file dataset audit workspace mismatch.",
+    );
+  }
+  assert(
+    audit.dataset_source_local === true,
+    "Local-file dataset audit did not preserve dataset_source_local.",
+  );
+  assert(
+    audit.original_filename === fileName,
+    "Local-file dataset audit original filename mismatch.",
+  );
+  assert(
+    audit.file_url_set === true,
+    "Local-file dataset audit did not persist file_url.",
+  );
+  assert(
+    Number(audit.estimated_rows) === 2 && Number(audit.estimated_columns) === 2,
+    "Local-file dataset audit estimated row/column counts mismatch.",
+  );
+}
+
+async function loadDatasetDeleteAudit(datasetId) {
+  const sql = `
+SELECT json_build_object(
+  'active_dataset_count', count(*) FILTER (WHERE deleted = false),
+  'deleted_dataset_count', count(*) FILTER (WHERE deleted = true),
+  'deleted_at_count', count(*) FILTER (WHERE deleted_at IS NOT NULL)
+)
+FROM model_hub_dataset
+WHERE id = ${sqlUuid(datasetId)};
+`;
+  return runPostgresJson(sql);
+}
+
+async function hardDeleteDatasetFixturesByPrefix(prefix, evidence) {
+  const sql = `
+WITH fixture_datasets AS (
+  SELECT id
+  FROM model_hub_dataset
+  WHERE name LIKE ${sqlTextLiteral(`${prefix}%`)}
+),
+deleted_cells AS (
+  DELETE FROM model_hub_cell
+  WHERE dataset_id IN (SELECT id FROM fixture_datasets)
+  RETURNING id
+),
+deleted_rows AS (
+  DELETE FROM model_hub_row
+  WHERE dataset_id IN (SELECT id FROM fixture_datasets)
+  RETURNING id
+),
+deleted_columns AS (
+  DELETE FROM model_hub_column
+  WHERE dataset_id IN (SELECT id FROM fixture_datasets)
+  RETURNING id
+),
+deleted_datasets AS (
+  DELETE FROM model_hub_dataset
+  WHERE id IN (SELECT id FROM fixture_datasets)
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_cell_count', (SELECT count(*) FROM deleted_cells),
+  'deleted_row_count', (SELECT count(*) FROM deleted_rows),
+  'deleted_column_count', (SELECT count(*) FROM deleted_columns),
+  'deleted_dataset_count', (SELECT count(*) FROM deleted_datasets),
+  'remaining_dataset_count', (
+    SELECT count(*)
+    FROM model_hub_dataset
+    WHERE name LIKE ${sqlTextLiteral(`${prefix}%`)}
+      AND id NOT IN (SELECT id FROM deleted_datasets)
+  )
+);
+`;
+  const result = await runPostgresJson(sql);
+  if (
+    Number(result.deleted_dataset_count) > 0 ||
+    Number(result.remaining_dataset_count) > 0
+  ) {
+    evidence.push({
+      cleanup: "hard delete local-file dataset fixtures",
+      status:
+        Number(result.remaining_dataset_count) === 0 ? "passed" : "failed",
+      audit: result,
+    });
+  }
+  return result;
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres DB audit returned no JSON output.");
+  return JSON.parse(text);
+}
+
+async function runBackendShellJson(script) {
+  let stdout;
+  if (process.env.API_JOURNEY_BACKEND_CONTAINER) {
+    const container = process.env.API_JOURNEY_BACKEND_CONTAINER;
+    const python = process.env.API_JOURNEY_BACKEND_PYTHON || "python";
+    ({ stdout } = await execFileAsync(
+      "docker",
+      [
+        "exec",
+        "-w",
+        "/app/backend",
+        container,
+        python,
+        "manage.py",
+        "shell",
+        "-c",
+        script,
+      ],
+      { maxBuffer: 20 * 1024 * 1024 },
+    ));
+  } else {
+    ({ stdout } = await execFileAsync(
+      "uv",
+      ["run", "python", "manage.py", "shell", "-c", script],
+      {
+        cwd: process.env.API_JOURNEY_BACKEND_DIR || backendRoot,
+        env: {
+          ...process.env,
+          EE_LICENSE_KEY: process.env.EE_LICENSE_KEY || "test-license-key",
+          PGBOUNCER_HOST: process.env.PGBOUNCER_HOST || "127.0.0.1",
+          PGBOUNCER_PORT: process.env.PGBOUNCER_PORT || "5436",
+          REDIS_URL: process.env.REDIS_URL || "redis://127.0.0.1:6382/0",
+          REDIS_CACHE_URL:
+            process.env.REDIS_CACHE_URL || "redis://127.0.0.1:6382/0",
+        },
+        maxBuffer: 20 * 1024 * 1024,
+      },
+    ));
+  }
+  const lines = stdout
+    .trim()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const jsonLine = [...lines].reverse().find((line) => line.startsWith("{"));
+  assert(jsonLine, "Backend shell returned no JSON output.");
+  return JSON.parse(jsonLine);
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(() => {
+    window.normalizeText = (value) =>
+      String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+    window.dispatchClick = (element) => {
+      element.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("mouseup", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    };
+    window.visibleElements = (selector = "body *") => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(selector)).filter(isVisible);
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(predicate, { timeout: 60000 }),
+      action(),
+    ]);
+    return response;
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForResponsesDuring(page, label, predicates, action) {
+  try {
+    return await Promise.all([
+      ...predicates.map((predicate) =>
+        page.waitForResponse(predicate, { timeout: 60000 }),
+      ),
+      action(),
+    ]);
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForPath(page, pathname, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedPath) => window.location.pathname === expectedPath,
+    { timeout },
+    pathname,
+  );
+}
+
+async function waitForPathIncludes(page, pathname, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedPath) => window.location.pathname.includes(expectedPath),
+    { timeout },
+    pathname,
+  );
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) =>
+      window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      }),
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function waitForNoVisibleText(page, text, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedText) =>
+      !window
+        .visibleElements()
+        .some((element) =>
+          window.normalizeText(element.textContent).includes(expectedText),
+        ),
+    { timeout },
+    text,
+  );
+}
+
+async function clickVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await waitForVisibleText(page, text, { exact, timeout });
+  const clicked = await page.evaluate(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const elements = window.visibleElements().filter((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      });
+      const element =
+        elements.find((candidate) => {
+          const button = candidate.closest("button");
+          return button && !button.disabled;
+        }) ||
+        elements.find((candidate) => candidate.closest("a,[role='button']")) ||
+        elements[0];
+      const clickable =
+        element?.closest(
+          "button,a,[role='button'],[role='menuitem'],label,tr",
+        ) || element;
+      if (!clickable || clickable.disabled) return false;
+      window.dispatchClick(clickable);
+      return true;
+    },
+    { text, exact },
+  );
+  assert(clicked, `Could not click visible text: ${text}`);
+}
+
+async function clickVisibleButton(page, label, timeout = 30000) {
+  await waitForVisibleText(page, label, { exact: true, timeout });
+  const clicked = await page.evaluate((expectedLabel) => {
+    const button = window
+      .visibleElements("button")
+      .find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent) === expectedLabel &&
+          !candidate.disabled,
+      );
+    if (!button) return false;
+    window.dispatchClick(button);
+    return true;
+  }, label);
+  assert(clicked, `Could not click visible button: ${label}`);
+}
+
+async function responseJson(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function isModelHubApiUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  return (
+    url.origin ===
+      new URL(process.env.API_BASE || "http://localhost:8003").origin &&
+    (url.pathname.startsWith("/model-hub/develops/") ||
+      url.pathname.startsWith("/model-hub/datasets/") ||
+      url.pathname.startsWith("/model-hub/dataset/"))
+  );
+}
+
+function isAllowedMutation(method, rawUrl) {
+  const path = new URL(rawUrl).pathname;
+  return (
+    method === "POST" &&
+    /\/model-hub\/develops\/create-dataset-from-local-file\/?$/.test(path)
+  );
+}
+
+function maskRequest(rawRequest) {
+  const [method, rawUrl] = rawRequest.split(" ");
+  const url = new URL(rawUrl);
+  return `${method} ${url.pathname}`;
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), "SQL UUID value must be a UUID.");
+  return `'${value}'::uuid`;
+}
+
+function sqlTextLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function appendCleanupError(currentError, cleanupError) {
+  if (!currentError) return cleanupError;
+  currentError.message = `${currentError.message}; cleanup failed: ${cleanupError.message}`;
+  return currentError;
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") {
+    return "/usr/bin/google-chrome";
+  }
+  return undefined;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/frontend/scripts/api-journeys/browser/dataset-sdk-copy-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/dataset-sdk-copy-smoke.mjs
@@ -1,0 +1,747 @@
+/* eslint-disable no-console */
+import { createRequire } from "node:module";
+import process from "node:process";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+  requireMutations,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const DATASET_PREFIX = "ui_dataset_sdk_copy_";
+const SCREENSHOT_PATH = "/tmp/dataset-sdk-copy-smoke.png";
+const FAILURE_SCREENSHOT_PATH = "/tmp/dataset-sdk-copy-smoke-failure.png";
+const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+const SDK_MODAL_HEADING = "Add Rows via SDK or API";
+
+async function main() {
+  requireMutations();
+  const auth = await createAuthenticatedContext();
+  const suffix = auth.runId.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  const datasetName = `${DATASET_PREFIX}${suffix}`;
+  const cleanupEvidence = [];
+  const apiFailures = [];
+  const pageErrors = [];
+  const modelHubRequests = [];
+  const browserMutations = [];
+  const unexpectedMutations = [];
+  let browser = null;
+  let page = null;
+  let datasetId = null;
+
+  await cleanupDatasetsByPrefix(auth.client, DATASET_PREFIX, cleanupEvidence);
+
+  try {
+    const source = await createSourceDataset(auth.client, datasetName);
+    if (source.skipped) {
+      console.log(JSON.stringify(source.output, null, 2));
+      return;
+    }
+    datasetId = source.datasetId;
+
+    const directSdkPayload = await auth.client.post(
+      apiPath("/model-hub/develops/add_rows_sdk/"),
+      { dataset_id: datasetId },
+    );
+    assertDatasetSdkPayload({
+      payload: directSdkPayload,
+      datasetId,
+      datasetName,
+      label: "direct API",
+    });
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+    await browser
+      .defaultBrowserContext()
+      .overridePermissions(APP_BASE, ["clipboard-read", "clipboard-write"])
+      .catch(() => null);
+
+    page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (!isModelHubApiUrl(url)) return;
+      const requestKey = `${request.method()} ${url}`;
+      modelHubRequests.push(requestKey);
+      if (MUTATION_METHODS.has(request.method())) {
+        browserMutations.push(requestKey);
+        if (!isAllowedBrowserMutation(request.method(), url)) {
+          unexpectedMutations.push(requestKey);
+        }
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isModelHubApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${url}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponsesDuring(
+      page,
+      "dataset detail table load",
+      [
+        (response) =>
+          response
+            .url()
+            .includes(`/model-hub/develops/${datasetId}/get-dataset-table/`) &&
+          response.request().method() === "GET" &&
+          response.status() < 400,
+      ],
+      () =>
+        page.goto(`${APP_BASE}/dashboard/develop/${datasetId}?tab=data`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForPathIncludes(page, `/dashboard/develop/${datasetId}`);
+    await waitForVisibleText(page, "Column 1", { exact: true });
+
+    await clickEnabledButton(page, "Add Row");
+    await waitForVisibleText(page, "Add Rows", { exact: true });
+
+    const browserSdkResponse = await waitForResponseDuring(
+      page,
+      "browser add rows SDK payload",
+      (response) =>
+        response.url().includes("/model-hub/develops/add_rows_sdk/") &&
+        response.request().method() === "POST" &&
+        response.status() < 400,
+      () => clickVisibleText(page, "Add data using SDK", { exact: true }),
+    );
+    const browserSdkEnvelope = await responseJson(browserSdkResponse);
+    const browserSdkPayload =
+      browserSdkEnvelope?.result || browserSdkEnvelope || {};
+    assertDatasetSdkPayload({
+      payload: browserSdkPayload,
+      datasetId,
+      datasetName,
+      label: "browser API",
+    });
+
+    await waitForVisibleText(page, "Add Rows via SDK or API", { exact: true });
+    await waitForVisibleText(page, datasetName, { exact: true });
+    await waitForVisibleText(page, datasetId, { exact: true });
+    await waitForVisibleText(page, "YOUR_API_KEY", { exact: true });
+    await waitForVisibleText(page, "YOUR_SECRET_KEY", { exact: true });
+
+    const clipboard = {};
+    clipboard.dataset_name = await clickAndReadClipboard(page, {
+      ariaLabel: "Copy Dataset Name",
+      scopeText: SDK_MODAL_HEADING,
+    });
+    clipboard.dataset_id = await clickAndReadClipboard(page, {
+      ariaLabel: "Copy Dataset ID",
+      scopeText: SDK_MODAL_HEADING,
+    });
+    clipboard.api_key = await clickAndReadClipboard(page, {
+      ariaLabel: "Copy API Key",
+      scopeText: SDK_MODAL_HEADING,
+    });
+    clipboard.secret_key = await clickAndReadClipboard(page, {
+      ariaLabel: "Copy Secret Key",
+      scopeText: SDK_MODAL_HEADING,
+    });
+    assert(
+      clipboard.dataset_name === datasetName,
+      `Dataset Name copy wrote ${clipboard.dataset_name}`,
+    );
+    assert(
+      clipboard.dataset_id === datasetId,
+      `Dataset ID copy wrote ${clipboard.dataset_id}`,
+    );
+    assert(
+      clipboard.api_key === "YOUR_API_KEY",
+      `API Key copy wrote ${clipboard.api_key}`,
+    );
+    assert(
+      clipboard.secret_key === "YOUR_SECRET_KEY",
+      `Secret Key copy wrote ${clipboard.secret_key}`,
+    );
+
+    const snippetCopies = {};
+    snippetCopies.python = await clickAndReadClipboard(page, {
+      ariaLabel: "Copy code",
+      scopeText: SDK_MODAL_HEADING,
+    });
+    await clickVisibleText(page, "Typescript", { exact: true });
+    snippetCopies.typescript = await clickAndReadClipboard(page, {
+      ariaLabel: "Copy code",
+      scopeText: SDK_MODAL_HEADING,
+    });
+    await clickVisibleText(page, "Curl", { exact: true });
+    snippetCopies.curl = await clickAndReadClipboard(page, {
+      ariaLabel: "Copy code",
+      scopeText: SDK_MODAL_HEADING,
+    });
+    for (const [language, snippet] of Object.entries(snippetCopies)) {
+      assertSnippetSafe({ language, snippet, datasetId, datasetName });
+    }
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+
+    assert(
+      unexpectedMutations.length === 0,
+      `Unexpected Model Hub mutations: ${unexpectedMutations
+        .map(maskRequest)
+        .join(", ")}`,
+    );
+    assert(
+      apiFailures.length === 0,
+      `Unexpected Model Hub API failures: ${apiFailures.join(", ")}`,
+    );
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+
+    const finalDatasetId = datasetId;
+    await deleteDatasets(auth.client, [datasetId], cleanupEvidence);
+    datasetId = null;
+
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          dataset_id: finalDatasetId,
+          dataset_name: datasetName,
+          direct_code_keys: Object.keys(directSdkPayload?.code || {}).sort(),
+          browser_code_keys: Object.keys(browserSdkPayload?.code || {}).sort(),
+          copied: {
+            dataset_name: clipboard.dataset_name === datasetName,
+            dataset_id: clipboard.dataset_id === finalDatasetId,
+            api_key: clipboard.api_key,
+            secret_key: clipboard.secret_key,
+            snippets: Object.fromEntries(
+              Object.entries(snippetCopies).map(([language, snippet]) => [
+                language,
+                {
+                  length: snippet.length,
+                  has_api_placeholder: snippet.includes("YOUR_API_KEY"),
+                  has_secret_placeholder: snippet.includes("YOUR_SECRET_KEY"),
+                  has_dataset_id: snippet.includes(finalDatasetId),
+                  has_dataset_name: snippet.includes(datasetName),
+                },
+              ]),
+            ),
+          },
+          browser_mutations: browserMutations.map(maskRequest),
+          model_hub_request_count: modelHubRequests.length,
+          screenshot: SCREENSHOT_PATH,
+          cleanup: cleanupEvidence,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    if (page) {
+      await page.screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true });
+      console.error(`failure_screenshot=${FAILURE_SCREENSHOT_PATH}`);
+    }
+    throw error;
+  } finally {
+    if (datasetId) {
+      await deleteDatasets(auth.client, [datasetId], cleanupEvidence).catch(
+        (error) => {
+          cleanupEvidence.push({
+            cleanup: "delete dataset SDK copy dataset after failure",
+            status: "failed",
+            error: error.message,
+          });
+        },
+      );
+    }
+    await cleanupDatasetsByPrefix(auth.client, DATASET_PREFIX, cleanupEvidence);
+    if (browser) await browser.close();
+  }
+}
+
+async function createSourceDataset(client, datasetName) {
+  let created;
+  try {
+    created = await client.post(
+      apiPath("/model-hub/develops/create-dataset-manually/"),
+      {
+        dataset_name: datasetName,
+        number_of_rows: 1,
+        number_of_columns: 1,
+      },
+    );
+  } catch (error) {
+    if (error?.status === 429) {
+      return {
+        skipped: true,
+        output: {
+          status: "skipped",
+          reason: "source manual dataset creation is plan-limited",
+          response_status: error.status,
+        },
+      };
+    }
+    throw error;
+  }
+  const datasetId = created?.dataset_id;
+  assert(datasetId, "Manual dataset create did not return dataset_id.");
+
+  const table = await getDatasetTable(client, datasetId);
+  const columns = asArray(table.column_config);
+  const rows = asArray(table.table).filter((row) => row?.row_id);
+  assert(rows.length === 1, "Dataset SDK copy fixture did not have one row.");
+  assert(
+    columns.some((column) => column?.name === "Column 1"),
+    "Dataset SDK copy fixture was missing Column 1.",
+  );
+
+  return { datasetId };
+}
+
+async function getDatasetTable(client, datasetId) {
+  return client.get(
+    apiPath("/model-hub/develops/{dataset_id}/get-dataset-table/", {
+      dataset_id: datasetId,
+    }),
+    { query: { current_page_index: 0, page_size: 50 } },
+  );
+}
+
+async function cleanupDatasetsByPrefix(client, prefix, evidence) {
+  const listPayload = await client.get(
+    apiPath("/model-hub/develops/get-datasets/"),
+    {
+      query: { page: 0, page_size: 100 },
+    },
+  );
+  const ids = asArray(listPayload)
+    .filter((dataset) => String(dataset?.name || "").startsWith(prefix))
+    .map((dataset) => dataset.id)
+    .filter(Boolean);
+  if (ids.length) {
+    await deleteDatasets(client, ids, evidence);
+  }
+}
+
+async function deleteDatasets(client, datasetIds, evidence) {
+  if (!datasetIds.length) return;
+  await client.delete(apiPath("/model-hub/develops/delete_dataset/"), {
+    body: { dataset_ids: datasetIds },
+    okStatuses: [200, 404],
+  });
+  evidence.push({
+    cleanup: "delete dataset SDK copy dataset",
+    status: "passed",
+    dataset_ids: datasetIds,
+  });
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(() => {
+    window.normalizeText = (value) =>
+      String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+    window.dispatchClick = (element) => {
+      element.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("mouseup", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    };
+    window.visibleElements = (selector = "body *") => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(selector)).filter(isVisible);
+    };
+    window.isScopedAriaButton = (button, label, scopeText) => {
+      if (
+        button.getAttribute("aria-label") !== label ||
+        button.disabled ||
+        !window.visibleElements("button").includes(button)
+      ) {
+        return false;
+      }
+      if (!scopeText) return true;
+      const modalRoot = button.closest(".MuiModal-root,[role='presentation']");
+      return Boolean(
+        modalRoot &&
+          window.normalizeText(modalRoot.textContent).includes(scopeText),
+      );
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId) {
+        sessionStorage.setItem("organizationId", organizationId);
+      }
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id) {
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+      }
+
+      window.__datasetSdkClipboardWrites = [];
+      const clipboard = {
+        writeText: async (text) => {
+          window.__datasetSdkClipboardWrites.push(String(text));
+        },
+        readText: async () =>
+          window.__datasetSdkClipboardWrites[
+            window.__datasetSdkClipboardWrites.length - 1
+          ] || "",
+      };
+      Object.defineProperty(Navigator.prototype, "clipboard", {
+        configurable: true,
+        get: () => clipboard,
+      });
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function clickAndReadClipboard(page, { ariaLabel, scopeText }) {
+  const previousWriteCount = await page.evaluate(
+    () => window.__datasetSdkClipboardWrites?.length || 0,
+  );
+  await clickButtonByAriaLabel(page, { ariaLabel, scopeText });
+  await page.waitForFunction(
+    (writeCount) =>
+      (window.__datasetSdkClipboardWrites?.length || 0) > writeCount,
+    { timeout: 10000 },
+    previousWriteCount,
+  );
+  return page.evaluate(() => navigator.clipboard.readText());
+}
+
+async function clickButtonByAriaLabel(
+  page,
+  { ariaLabel, scopeText },
+  timeout = 30000,
+) {
+  await page.waitForFunction(
+    ({ label, scope }) =>
+      Array.from(document.querySelectorAll("button")).some((button) =>
+        window.isScopedAriaButton(button, label, scope),
+      ),
+    { timeout },
+    { label: ariaLabel, scope: scopeText },
+  );
+  const clicked = await page.evaluate(
+    ({ label, scope }) => {
+      const button = Array.from(document.querySelectorAll("button")).find(
+        (candidate) => window.isScopedAriaButton(candidate, label, scope),
+      );
+      if (!button) return false;
+      window.dispatchClick(button);
+      return true;
+    },
+    { label: ariaLabel, scope: scopeText },
+  );
+  assert(clicked, `Could not click button with aria-label ${ariaLabel}.`);
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(predicate, { timeout: 60000 }),
+      action(),
+    ]);
+    return response;
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForResponsesDuring(page, label, predicates, action) {
+  try {
+    return await Promise.all([
+      ...predicates.map((predicate) =>
+        page.waitForResponse(predicate, { timeout: 60000 }),
+      ),
+      action(),
+    ]);
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForPathIncludes(page, pathname, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedPath) => window.location.pathname.includes(expectedPath),
+    { timeout },
+    pathname,
+  );
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) =>
+      window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      }),
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function clickVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await waitForVisibleText(page, text, { exact, timeout });
+  const clicked = await page.evaluate(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const elements = window.visibleElements().filter((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      });
+      const element =
+        elements.find((candidate) => {
+          const button = candidate.closest("button");
+          return button && !button.disabled;
+        }) ||
+        elements.find((candidate) => candidate.closest("a,[role='button']")) ||
+        elements[0];
+      const clickable =
+        element?.closest(
+          "button,a,[role='button'],[role='menuitem'],li.MuiMenuItem-root",
+        ) || element;
+      if (!clickable || clickable.disabled) return false;
+      window.dispatchClick(clickable);
+      return true;
+    },
+    { text, exact },
+  );
+  assert(clicked, `Could not click visible text: ${text}`);
+}
+
+async function clickEnabledButton(page, label, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedLabel) =>
+      window
+        .visibleElements("button")
+        .some(
+          (candidate) =>
+            window.normalizeText(candidate.textContent) === expectedLabel &&
+            !candidate.disabled,
+        ),
+    { timeout },
+    label,
+  );
+  const clicked = await page.evaluate((expectedLabel) => {
+    const button = window
+      .visibleElements("button")
+      .find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent) === expectedLabel &&
+          !candidate.disabled,
+      );
+    if (!button) return false;
+    window.dispatchClick(button);
+    return true;
+  }, label);
+  assert(clicked, `Could not click enabled button: ${label}`);
+}
+
+async function responseJson(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function assertDatasetSdkPayload({ payload, datasetId, datasetName, label }) {
+  assert(
+    payload?.dataset?.id === datasetId,
+    `${label} SDK payload returned dataset ${payload?.dataset?.id}`,
+  );
+  assert(
+    payload?.dataset?.name === datasetName,
+    `${label} SDK payload returned dataset name ${payload?.dataset?.name}`,
+  );
+  const apiKeys = payload?.api_keys || payload?.apiKeys || {};
+  assert(
+    (apiKeys?.api_key || apiKeys?.apiKey) === "YOUR_API_KEY",
+    `${label} SDK payload exposed a non-placeholder API key.`,
+  );
+  assert(
+    (apiKeys?.secret_key || apiKeys?.secretKey) === "YOUR_SECRET_KEY",
+    `${label} SDK payload exposed a non-placeholder secret key.`,
+  );
+
+  const expectedCodeKeys = [
+    "curl_add_col",
+    "curl_add_row",
+    "python_add_col",
+    "python_add_row",
+    "typescript_add_col",
+    "typescript_add_row",
+  ];
+  const code = payload?.code || {};
+  for (const key of expectedCodeKeys) {
+    assert(
+      typeof code[key] === "string" && code[key].length > 0,
+      `${label} SDK payload missing non-empty code.${key}.`,
+    );
+  }
+  for (const [key, snippet] of Object.entries(code)) {
+    assertSnippetSafe({ language: key, snippet, datasetId, datasetName });
+  }
+}
+
+function assertSnippetSafe({ language, snippet, datasetId, datasetName }) {
+  assert(snippet.length > 0, `${language} copied an empty SDK snippet.`);
+  const hasApiPlaceholder = snippet.includes("YOUR_API_KEY");
+  const hasSecretPlaceholder = snippet.includes("YOUR_SECRET_KEY");
+  assert(
+    hasApiPlaceholder && hasSecretPlaceholder,
+    `${language} SDK snippet did not include placeholder credentials: ${snippetSummary(
+      snippet,
+      { datasetId, datasetName },
+    )}`,
+  );
+  if (String(language).toLowerCase().includes("curl")) {
+    assert(
+      snippet.includes(datasetId),
+      `${language} SDK snippet did not include the selected dataset id.`,
+    );
+  }
+  assert(
+    snippet.includes(datasetId) || snippet.includes(datasetName),
+    `${language} SDK snippet did not reference the selected dataset: ${snippetSummary(
+      snippet,
+      { datasetId, datasetName },
+    )}`,
+  );
+  const rawCredentialPatterns = [
+    /FI_API_KEY["'\]]*\s*[:=]\s*["'][0-9a-f]{32}["']/iu,
+    /FI_SECRET_KEY["'\]]*\s*[:=]\s*["'][0-9a-f]{32}["']/iu,
+    /X-Api-Key:\s*[0-9a-f]{32}/iu,
+    /X-Secret-Key:\s*[0-9a-f]{32}/iu,
+  ];
+  assert(
+    !rawCredentialPatterns.some((pattern) => pattern.test(snippet)),
+    `${language} SDK snippet included a raw credential-looking value.`,
+  );
+}
+
+function snippetSummary(snippet, { datasetId, datasetName }) {
+  const value = String(snippet || "");
+  return JSON.stringify({
+    length: value.length,
+    has_api_placeholder: value.includes("YOUR_API_KEY"),
+    has_secret_placeholder: value.includes("YOUR_SECRET_KEY"),
+    has_dataset_id: value.includes(datasetId),
+    has_dataset_name: value.includes(datasetName),
+    preview: value
+      .replace(/[0-9a-f]{32}/giu, "<redacted-hex>")
+      .replace(new RegExp(datasetId, "gu"), "<dataset-id>")
+      .replace(new RegExp(datasetName, "gu"), "<dataset-name>")
+      .slice(0, 160),
+  });
+}
+
+function isModelHubApiUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  return (
+    url.origin ===
+      new URL(process.env.API_BASE || "http://localhost:8003").origin &&
+    (url.pathname.startsWith("/model-hub/develops/") ||
+      url.pathname.startsWith("/model-hub/datasets/"))
+  );
+}
+
+function isAllowedBrowserMutation(method, rawUrl) {
+  const path = new URL(rawUrl).pathname;
+  return method === "POST" && path === "/model-hub/develops/add_rows_sdk/";
+}
+
+function maskRequest(rawRequest) {
+  const [method, rawUrl] = rawRequest.split(" ");
+  const url = new URL(rawUrl);
+  return `${method} ${url.pathname}`;
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") {
+    return "/usr/bin/google-chrome";
+  }
+  return undefined;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/frontend/scripts/api-journeys/browser/error-feed-add-evals-task-draft-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/error-feed-add-evals-task-draft-smoke.mjs
@@ -1,0 +1,867 @@
+/* eslint-disable no-console */
+import { execFile as execFileCallback } from "node:child_process";
+import { createRequire } from "node:module";
+import process from "node:process";
+import { promisify } from "node:util";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+  envFlag,
+  isUuid,
+  requireMutations,
+} from "../lib/api-client.mjs";
+import {
+  browserExecutablePath,
+  installRuntimeConfig,
+  prepareErrorFeedRow,
+} from "./error-feed-smoke.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+const execFile = promisify(execFileCallback);
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const SCREENSHOT_PATH = "/tmp/error-feed-add-evals-task-draft-smoke.png";
+const FAILURE_SCREENSHOT_PATH =
+  "/tmp/error-feed-add-evals-task-draft-smoke-failure.png";
+
+async function main() {
+  requireMutations();
+  assert(
+    envFlag("ERROR_FEED_FORCE_FIXTURE"),
+    "Set ERROR_FEED_FORCE_FIXTURE=1 so this mutation smoke only touches a disposable Error Feed fixture.",
+  );
+
+  const auth = await createAuthenticatedContext();
+  const fixtureEvidence = [];
+  const cleanupEvidence = [];
+  const prepared = await prepareErrorFeedRow({
+    client: auth.client,
+    organizationId: auth.organizationId,
+    workspaceId: auth.workspaceId,
+    runId: auth.runId,
+    evidence: fixtureEvidence,
+  });
+  const row = prepared.row;
+  const clusterId = row.cluster_id;
+  const projectId = row.project_id;
+  const traceId = prepared.seededFixture?.trace_id || row.trace_id;
+  assert(
+    isUuid(projectId),
+    `Error Feed row missing project_id: ${JSON.stringify(row)}`,
+  );
+  assert(
+    isUuid(traceId),
+    `Error Feed row missing trace_id: ${JSON.stringify(row)}`,
+  );
+
+  const seedEval = await createDisposableEvalConfig(auth.client, {
+    projectId,
+    runId: auth.runId,
+  });
+  const taskName = `api journey error feed linked task ${auth.runId}`;
+  const apiFailures = [];
+  const pageErrors = [];
+  const traceListRequests = [];
+  const evidence = {};
+  let browser = null;
+  let caughtError = null;
+  let cleanupError = null;
+  let createdTaskId = null;
+  let requestPhase = "error-feed";
+  let result = null;
+
+  try {
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 980 },
+      args: ["--no-sandbox"],
+    });
+    const page = await browser.newPage();
+    await preparePage(page, auth, { seedEval, taskName });
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (isTraceListUrl(url)) {
+        traceListRequests.push({
+          url,
+          method: request.method(),
+          phase: requestPhase,
+        });
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isRelevantApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(
+          `${response.status()} ${response.request().method()} ${url}`,
+        );
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponseDuring(
+      page,
+      "Error Feed linked-task detail load",
+      (response) =>
+        response.request().method() === "GET" &&
+        isIssueDetailUrl(response.url(), clusterId) &&
+        response.status() < 400,
+      () =>
+        page.goto(`${APP_BASE}/dashboard/error-feed/${clusterId}`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForPath(page, `/dashboard/error-feed/${clusterId}`);
+    await expectVisibleText(page, row.error.name);
+    await expectVisibleText(page, "Add Evals", { exact: true });
+    await expectNoVisibleText(page, "Invalid Date");
+
+    requestPhase = "task-create";
+    await clickButtonWithText(page, "Add Evals");
+    await waitForPath(page, "/dashboard/tasks/create");
+    await expectVisibleText(page, "Create Task", { exact: true });
+    await expectVisibleText(page, taskName);
+    await expectVisibleText(page, seedEval.name);
+    await expectVisibleText(page, "Run evaluations on", { exact: true });
+    await expectVisibleText(page, traceId.slice(0, 8));
+    await expectVisibleText(page, "Live Preview");
+    await expectNoVisibleText(page, "Invalid Date");
+
+    const draftEvidence = await readTaskDraft(page);
+    assert(
+      draftEvidence.project === projectId,
+      `Task draft project mismatch: ${JSON.stringify(draftEvidence)}`,
+    );
+    assert(
+      draftEvidence.rowType === "traces",
+      `Task draft rowType mismatch: ${JSON.stringify(draftEvidence)}`,
+    );
+    assert(
+      draftEvidence.returnTo === `/dashboard/error-feed/${clusterId}`,
+      `Task draft returnTo mismatch: ${JSON.stringify(draftEvidence)}`,
+    );
+    assert(
+      draftEvidence.traceFilter?.filterConfig?.filterValue === traceId,
+      `Task draft did not preserve trace_id filter: ${JSON.stringify(
+        draftEvidence,
+      )}`,
+    );
+    assert(
+      draftEvidence.evalConfigIds.includes(seedEval.id),
+      `Task draft omitted seeded eval config: ${JSON.stringify(draftEvidence)}`,
+    );
+
+    const previewRequest = traceListRequests.find(
+      (request) =>
+        request.phase === "task-create" && hasTraceFilter(request.url, traceId),
+    );
+    assert(
+      previewRequest,
+      "Task create page did not request trace preview with Error Feed trace_id filter.",
+    );
+
+    const createResponse = await waitForResponseDuring(
+      page,
+      "Error Feed linked task create",
+      (response) =>
+        response.request().method() === "POST" &&
+        isEvalTaskCreateUrl(response.url()) &&
+        response.status() < 400,
+      () => clickButtonWithText(page, "Create Task"),
+    );
+    const createBody = await createResponse.json();
+    createdTaskId = createBody?.result?.id || createBody?.id;
+    assert(
+      isUuid(createdTaskId),
+      `Create Task did not return a task id: ${JSON.stringify(createBody)}`,
+    );
+    await waitForPath(page, `/dashboard/tasks/${createdTaskId}`);
+    await expectVisibleText(page, taskName);
+    await expectVisibleText(page, "Open source", { exact: true });
+    await expectNoVisibleText(page, "Invalid Date");
+
+    const createdDetail = await auth.client.get(
+      apiPath("/tracer/eval-task/get_eval_details/"),
+      { query: { eval_id: createdTaskId } },
+    );
+    assert(createdDetail?.id === createdTaskId, "Created task id mismatch.");
+    assert(createdDetail?.name === taskName, "Created task name mismatch.");
+    assert(
+      createdDetail?.project_id === projectId,
+      "Created task project mismatch.",
+    );
+    assert(
+      asArray(createdDetail?.filters_applied?.trace_id).includes(traceId),
+      "Created task detail did not preserve Error Feed trace_id filter.",
+    );
+    assert(
+      asArray(createdDetail?.evals_applied).some(
+        (evalItem) => evalItem?.id === seedEval.id,
+      ),
+      "Created task detail did not include the seeded eval config.",
+    );
+
+    await waitForResponseDuring(
+      page,
+      "Error Feed linked task Open source trace load",
+      (response) =>
+        response.request().method() === "GET" &&
+        isTraceDetailUrl(response.url(), traceId) &&
+        response.status() < 400,
+      () => clickButtonWithText(page, "Open source"),
+    );
+    await waitForPath(page, `/dashboard/observe/${projectId}/trace/${traceId}`);
+    await expectVisibleText(page, "Trace ID");
+    await expectVisibleText(page, traceId);
+    await expectNoVisibleText(page, "Invalid Date");
+
+    assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+    Object.assign(evidence, {
+      cluster_id: clusterId,
+      project_id: projectId,
+      trace_id: traceId,
+      seed_eval_config_id: seedEval.id,
+      seed_eval_template_id: seedEval.templateId,
+      task_name: taskName,
+      created_task_id: createdTaskId,
+      draft_id: draftEvidence.draftId,
+      draft_trace_filter_value:
+        draftEvidence.traceFilter?.filterConfig?.filterValue,
+      task_preview_trace_request: previewRequest.url,
+      detail_source_path: `/dashboard/observe/${projectId}/trace/${traceId}`,
+      screenshot: SCREENSHOT_PATH,
+      fixture: fixtureEvidence,
+      cleanup: cleanupEvidence,
+    });
+
+    result = {
+      status: "passed",
+      app_base: APP_BASE,
+      api_base: auth.apiBase,
+      organization_id: auth.organizationId,
+      workspace_id: auth.workspaceId,
+      evidence,
+    };
+  } catch (error) {
+    caughtError = error;
+    if (browser) {
+      const pages = await browser.pages().catch(() => []);
+      await pages[0]
+        ?.screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .catch(() => null);
+    }
+  } finally {
+    if (browser) await browser.close();
+    if (createdTaskId) {
+      try {
+        await auth.client.post(
+          apiPath("/tracer/eval-task/mark_eval_tasks_deleted/"),
+          { eval_task_ids: [createdTaskId] },
+          { okStatuses: [200, 404] },
+        );
+        const cleanupAudit = await deleteEvalTaskDbArtifacts({
+          taskId: createdTaskId,
+        });
+        assert(
+          Number(cleanupAudit.remaining_task_count) === 0,
+          `Error Feed linked task cleanup left task residue: ${JSON.stringify(
+            cleanupAudit,
+          )}`,
+        );
+        evidence.task_cleanup = cleanupAudit;
+      } catch (error) {
+        cleanupError = cleanupError || error;
+      }
+    }
+    try {
+      const seedCleanupAudit = await deleteCustomEvalConfigDbArtifacts({
+        evalConfigId: seedEval.id,
+      });
+      assert(
+        Number(seedCleanupAudit.remaining_custom_eval_config_count) === 0,
+        `Error Feed linked task seed cleanup left custom eval config residue: ${JSON.stringify(
+          seedCleanupAudit,
+        )}`,
+      );
+      evidence.seed_cleanup = seedCleanupAudit;
+    } catch (error) {
+      cleanupError = cleanupError || error;
+    }
+    if (seedEval.createdEvalTemplateId) {
+      try {
+        await auth.client.post(
+          apiPath("/model-hub/eval-templates/bulk-delete/"),
+          { template_ids: [seedEval.createdEvalTemplateId] },
+          { okStatuses: [200, 404] },
+        );
+        evidence.seed_eval_template_cleanup = {
+          template_id: seedEval.createdEvalTemplateId,
+          status: "deleted",
+        };
+      } catch (error) {
+        cleanupError = cleanupError || error;
+      }
+    }
+    const cleanupFailures = await prepared.cleanup.run(cleanupEvidence);
+    if (cleanupFailures.length > 0) {
+      cleanupError =
+        cleanupError ||
+        new Error(
+          `Error Feed linked task fixture cleanup failed: ${JSON.stringify(
+            cleanupFailures,
+          )}`,
+        );
+    }
+  }
+
+  if (caughtError || cleanupError) {
+    if (caughtError && cleanupError) {
+      caughtError.message = `${caughtError.message}; cleanup failed: ${cleanupError.message}`;
+      throw caughtError;
+    }
+    throw caughtError || cleanupError;
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function createDisposableEvalConfig(client, { projectId, runId }) {
+  const evalTemplate = await resolveTaskEvalTemplateForConfig(client, runId);
+  const name = `api journey error feed eval ${shortRunId(runId)}`;
+  const created = await client.post(apiPath("/tracer/custom-eval-config/"), {
+    eval_template: evalTemplate.id,
+    name,
+    config: { params: evalTemplate.params },
+    mapping: evalTemplate.mapping,
+    project: projectId,
+    filters: {},
+    error_localizer: false,
+  });
+  const evalConfigId = created?.id;
+  assert(
+    isUuid(evalConfigId),
+    `Custom eval config seed did not return a UUID id: ${JSON.stringify(
+      created,
+    )}`,
+  );
+
+  return {
+    id: evalConfigId,
+    name,
+    template_id: evalTemplate.id,
+    templateId: evalTemplate.id,
+    templateName: evalTemplate.name,
+    mapping: evalTemplate.mapping,
+    config: { params: evalTemplate.expectedParams },
+    createdEvalTemplateId:
+      evalTemplate.source === "created" ? evalTemplate.id : null,
+  };
+}
+
+async function resolveTaskEvalTemplateForConfig(client, runId) {
+  const systemTemplate = await findEvalTemplateDetailByName(
+    client,
+    "word_count_in_range",
+  );
+  if (systemTemplate) {
+    const requiredKeys = evalTemplateRequiredKeys(systemTemplate);
+    const paramsConfig = evalTemplateParamsForConfig(systemTemplate, {
+      min_words: "1",
+      max_words: "20",
+      k: "3",
+    });
+    return {
+      id: systemTemplate.id,
+      name: systemTemplate.name,
+      source: "system",
+      requiredKeys,
+      mapping: buildEvalConfigMapping(requiredKeys),
+      params: paramsConfig.submitted,
+      expectedParams: paramsConfig.expected,
+    };
+  }
+
+  const name = `api_journey_error_feed_eval_${shortRunId(runId)}`;
+  const created = await client.post(
+    apiPath("/model-hub/eval-templates/create-v2/"),
+    {
+      name,
+      eval_type: "code",
+      code: [
+        "def evaluate(output=None, expected=None, **kwargs):",
+        "    return True",
+      ].join("\n"),
+      code_language: "python",
+      output_type: "pass_fail",
+      pass_threshold: 0.5,
+      description:
+        "Temporary Error Feed linked-task browser smoke eval template.",
+      tags: ["api-journey", "error-feed"],
+    },
+  );
+  assert(
+    isUuid(created?.id),
+    `Fallback eval template seed did not return a UUID id: ${JSON.stringify(
+      created,
+    )}`,
+  );
+  const detail = await client.get(
+    apiPath("/model-hub/eval-templates/{template_id}/detail/", {
+      template_id: created.id,
+    }),
+  );
+  const requiredKeys = evalTemplateRequiredKeys(detail);
+  return {
+    id: created.id,
+    name: detail?.name || name,
+    source: "created",
+    requiredKeys,
+    mapping: buildEvalConfigMapping(requiredKeys),
+    params: {},
+    expectedParams: {},
+  };
+}
+
+async function findEvalTemplateDetailByName(client, name) {
+  const payload = await client.post(
+    apiPath("/model-hub/eval-templates/list/"),
+    {
+      page: 0,
+      page_size: 10,
+      owner_filter: "all",
+      search: name,
+      sort_by: "updated_at",
+      sort_order: "desc",
+    },
+  );
+  const row = asArray(payload?.items).find(
+    (item) => item?.name === name && isUuid(item?.id),
+  );
+  if (!row) return null;
+  return client.get(
+    apiPath("/model-hub/eval-templates/{template_id}/detail/", {
+      template_id: row.id,
+    }),
+  );
+}
+
+function evalTemplateRequiredKeys(detail) {
+  return asArray(
+    detail?.required_keys ||
+      detail?.eval_required_keys ||
+      detail?.config?.required_keys,
+  ).filter((key) => typeof key === "string" && key.length > 0);
+}
+
+function evalTemplateParamsForConfig(detail, values = {}) {
+  const schema = detail?.config?.function_params_schema || {};
+  const submitted = {};
+  const expected = {};
+  for (const [key, definition] of Object.entries(schema)) {
+    const fallback = definition?.default;
+    const rawValue = Object.prototype.hasOwnProperty.call(values, key)
+      ? values[key]
+      : fallback;
+    if (rawValue === undefined || rawValue === null) continue;
+    submitted[key] = rawValue;
+    expected[key] =
+      definition?.type === "integer" || definition?.type === "number"
+        ? Number(rawValue)
+        : rawValue;
+  }
+  return { submitted, expected };
+}
+
+function buildEvalConfigMapping(requiredKeys) {
+  const fallbackByKey = {
+    actual_json: "input",
+    expected: "expected",
+    expected_json: "expected",
+    expected_output: "expected",
+    ground_truth: "expected",
+    hypothesis: "input",
+    input: "input",
+    output: "output",
+    query: "input",
+    reference: "expected",
+    response: "output",
+    text: "input",
+  };
+  const mapping = {};
+  for (const key of requiredKeys) {
+    mapping[key] = fallbackByKey[key] || "input";
+  }
+  return mapping;
+}
+
+async function preparePage(page, auth, { seedEval, taskName }) {
+  await page.setBypassServiceWorker(true);
+  await installRuntimeConfig(page, auth);
+  await page.evaluateOnNewDocument(() => {
+    window.__apiJourneyNormalizeText = (value) => String(value || "").trim();
+    window.__apiJourneyElementText = (element) => {
+      const values = [element.textContent];
+      if ("value" in element) values.push(element.value);
+      values.push(element.getAttribute?.("aria-label"));
+      return values
+        .map((value) => window.__apiJourneyNormalizeText(value))
+        .filter(Boolean)
+        .join(" ");
+    };
+    window.__apiJourneyVisibleElements = () => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll("body *")).filter(isVisible);
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user, seedEval, taskName }) => {
+      const originalSetItem = Storage.prototype.setItem;
+      Storage.prototype.setItem = function patchedSetItem(key, value) {
+        if (
+          this === localStorage &&
+          typeof key === "string" &&
+          key.startsWith("task-draft-")
+        ) {
+          try {
+            const parsed = JSON.parse(value);
+            const values = parsed?.values || {};
+            value = JSON.stringify({
+              ...parsed,
+              values: {
+                ...values,
+                name: taskName,
+                samplingRate: 100,
+                evalsDetails: [seedEval],
+              },
+            });
+          } catch {
+            // Keep the original value if the app changes the draft shape.
+          }
+        }
+        return originalSetItem.call(this, key, value);
+      };
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+      seedEval,
+      taskName,
+    },
+  );
+}
+
+async function readTaskDraft(page) {
+  const url = new URL(page.url());
+  const draftId = url.searchParams.get("draft");
+  assert(draftId, `Task create URL did not include a draft id: ${page.url()}`);
+  return page.evaluate((id) => {
+    const raw = localStorage.getItem(`task-draft-${id}`);
+    const parsed = raw ? JSON.parse(raw) : null;
+    const values = parsed?.values || {};
+    const traceFilter = (values.filters || []).find(
+      (filter) =>
+        filter?.property === "trace_id" || filter?.propertyId === "trace_id",
+    );
+    return {
+      draftId: id,
+      project: values.project,
+      rowType: values.rowType,
+      name: values.name,
+      evalConfigIds: (values.evalsDetails || []).map((item) => item?.id),
+      returnTo: new URL(window.location.href).searchParams.get("returnTo"),
+      traceFilter,
+    };
+  }, draftId);
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(predicate, { timeout: 60000 }),
+      action(),
+    ]);
+    return response;
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForPath(page, expectedPath) {
+  await page.waitForFunction(
+    (pathName) => window.location.pathname === pathName,
+    { timeout: 30000 },
+    expectedPath,
+  );
+}
+
+async function expectVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ expectedText, exactMatch }) =>
+      window.__apiJourneyVisibleElements().some((element) => {
+        const textContent = window.__apiJourneyElementText(element);
+        if (exactMatch) return textContent === expectedText;
+        return textContent.includes(expectedText);
+      }),
+    { timeout },
+    { expectedText: text, exactMatch: exact },
+  );
+}
+
+async function expectNoVisibleText(page, text, { timeout = 30000 } = {}) {
+  await page.waitForFunction(
+    (expectedText) =>
+      !window
+        .__apiJourneyVisibleElements()
+        .some((element) =>
+          window.__apiJourneyElementText(element).includes(expectedText),
+        ),
+    { timeout },
+    text,
+  );
+}
+
+async function clickButtonWithText(page, text) {
+  await page.waitForFunction(
+    (expectedText) =>
+      window.__apiJourneyVisibleElements().some((element) => {
+        const button = element.closest("button,[role='button'],a");
+        return (
+          button &&
+          window.__apiJourneyNormalizeText(button.textContent) === expectedText
+        );
+      }),
+    { timeout: 30000 },
+    text,
+  );
+  const box = await page.evaluate((expectedText) => {
+    const element = window.__apiJourneyVisibleElements().find((candidate) => {
+      const button = candidate.closest("button,[role='button'],a");
+      return (
+        button &&
+        window.__apiJourneyNormalizeText(button.textContent) === expectedText
+      );
+    });
+    const button = element?.closest("button,[role='button'],a");
+    if (!button) return null;
+    button.scrollIntoView({ block: "center", inline: "center" });
+    const rect = button.getBoundingClientRect();
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+  }, text);
+  assert(box, `Could not click button ${text}.`);
+  await page.mouse.click(box.x, box.y);
+}
+
+function isRelevantApiUrl(url) {
+  return (
+    url.includes("/tracer/feed/") ||
+    url.includes("/tracer/eval-task/") ||
+    url.includes("/model-hub/eval-templates/") ||
+    url.includes("/tracer/project/") ||
+    url.includes("/tracer/trace/") ||
+    url.includes("/tracer/observation-span/")
+  );
+}
+
+function isIssueDetailUrl(url, clusterId) {
+  return stripQuery(url).endsWith(
+    `/tracer/feed/issues/${encodeURIComponent(clusterId)}/`,
+  );
+}
+
+function isTraceListUrl(url) {
+  return url.includes("/tracer/trace/list_traces_of_session/");
+}
+
+function isEvalTaskCreateUrl(url) {
+  const parsed = new URL(url);
+  return parsed.pathname === "/tracer/eval-task/";
+}
+
+function isTraceDetailUrl(url, traceId) {
+  const parsed = new URL(url);
+  return parsed.pathname === `/tracer/trace/${traceId}/`;
+}
+
+function hasTraceFilter(url, traceId) {
+  const parsed = new URL(url);
+  if (!parsed.searchParams.get("project_id")) return false;
+  const filters = parseFilters(parsed.searchParams.get("filters"));
+  return filters.some(
+    (filter) =>
+      filter?.column_id === "trace_id" &&
+      filterValueMatches(filter?.filter_config?.filter_value, traceId),
+  );
+}
+
+function parseFilters(raw) {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function filterValueMatches(value, expected) {
+  if (Array.isArray(value)) return value.map(String).includes(String(expected));
+  return String(value) === String(expected);
+}
+
+function stripQuery(url) {
+  return String(url || "").split("?")[0];
+}
+
+async function deleteEvalTaskDbArtifacts({ taskId }) {
+  const sql = `
+WITH requested AS (
+  SELECT ${sqlUuid(taskId)} AS task_id
+),
+deleted_task_evals AS (
+  DELETE FROM tracer_eval_task_evals
+  WHERE evaltask_id = (SELECT task_id FROM requested)
+  RETURNING evaltask_id
+),
+deleted_task_loggers AS (
+  DELETE FROM tracer_eval_task_logger
+  WHERE eval_task_id = (SELECT task_id FROM requested)
+  RETURNING id
+),
+deleted_eval_logs AS (
+  DELETE FROM tracer_eval_logger
+  WHERE eval_task_id = (SELECT task_id::text FROM requested)
+  RETURNING id
+),
+deleted_tasks AS (
+  DELETE FROM tracer_eval_task
+  WHERE id = (SELECT task_id FROM requested)
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_task_eval_rows', (SELECT count(*) FROM deleted_task_evals),
+  'deleted_task_logger_rows', (SELECT count(*) FROM deleted_task_loggers),
+  'deleted_eval_log_rows', (SELECT count(*) FROM deleted_eval_logs),
+  'deleted_task_rows', (SELECT count(*) FROM deleted_tasks)
+);
+`;
+  const cleanup = await runPostgresJson(sql);
+  const residueSql = `
+WITH requested AS (
+  SELECT ${sqlUuid(taskId)} AS task_id
+)
+SELECT json_build_object(
+  'remaining_task_count', (
+    SELECT count(*) FROM tracer_eval_task
+    WHERE id = (SELECT task_id FROM requested)
+  ),
+  'remaining_task_logger_count', (
+    SELECT count(*) FROM tracer_eval_task_logger
+    WHERE eval_task_id = (SELECT task_id FROM requested)
+  ),
+  'remaining_eval_log_count', (
+    SELECT count(*) FROM tracer_eval_logger
+    WHERE eval_task_id = (SELECT task_id::text FROM requested)
+  )
+);
+`;
+  const residue = await runPostgresJson(residueSql);
+  return { ...cleanup, ...residue };
+}
+
+async function deleteCustomEvalConfigDbArtifacts({ evalConfigId }) {
+  const sql = `
+WITH requested AS (
+  SELECT ${sqlUuid(evalConfigId)} AS eval_config_id
+),
+deleted_custom_eval_configs AS (
+  DELETE FROM tracer_custom_eval_config
+  WHERE id = (SELECT eval_config_id FROM requested)
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_custom_eval_config_rows', (
+    SELECT count(*) FROM deleted_custom_eval_configs
+  )
+);
+`;
+  const cleanup = await runPostgresJson(sql);
+  const residueSql = `
+WITH requested AS (
+  SELECT ${sqlUuid(evalConfigId)} AS eval_config_id
+)
+SELECT json_build_object(
+  'remaining_custom_eval_config_count', (
+    SELECT count(*)
+    FROM tracer_custom_eval_config
+    WHERE id = (SELECT eval_config_id FROM requested)
+  )
+);
+`;
+  const residue = await runPostgresJson(residueSql);
+  return { ...cleanup, ...residue };
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFile(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres DB audit returned no JSON output.");
+  return JSON.parse(text);
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), `Expected UUID, got ${value}`);
+  return `'${String(value).replaceAll("'", "''")}'::uuid`;
+}
+
+function shortRunId(runId) {
+  return String(runId || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "")
+    .slice(-8);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/frontend/scripts/api-journeys/browser/error-feed-metadata-mutation-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/error-feed-metadata-mutation-smoke.mjs
@@ -1,0 +1,528 @@
+/* eslint-disable no-console */
+import { createRequire } from "node:module";
+import process from "node:process";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+  currentUserEmail,
+  envFlag,
+  requireMutations,
+} from "../lib/api-client.mjs";
+import {
+  browserExecutablePath,
+  installRuntimeConfig,
+  prepareErrorFeedRow,
+} from "./error-feed-smoke.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const SCREENSHOT_PATH = "/tmp/error-feed-metadata-mutation-smoke.png";
+const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+
+async function main() {
+  requireMutations();
+  assert(
+    envFlag("ERROR_FEED_FORCE_FIXTURE"),
+    "Set ERROR_FEED_FORCE_FIXTURE=1 so this mutation smoke only touches a disposable Error Feed fixture.",
+  );
+
+  const auth = await createAuthenticatedContext();
+  const fixtureEvidence = [];
+  const cleanupEvidence = [];
+  const prepared = await prepareErrorFeedRow({
+    client: auth.client,
+    organizationId: auth.organizationId,
+    workspaceId: auth.workspaceId,
+    runId: auth.runId,
+    evidence: fixtureEvidence,
+  });
+  const row = prepared.row;
+  const clusterId = row.cluster_id;
+  const traceId = prepared.seededFixture?.trace_id || row.trace_id;
+  const assignableMember = await resolveAssignableMember(auth);
+  const memberLabel =
+    assignableMember.name || assignableMember.email.split("@")[0];
+
+  const apiFailures = [];
+  const pageErrors = [];
+  const browserMutations = [];
+  const unexpectedMutations = [];
+  let browser = null;
+  let caughtError = null;
+  let cleanupError = null;
+  let result = null;
+
+  try {
+    const initialDetail = await loadIssueDetail(auth.client, clusterId);
+    assertIssueState(initialDetail.row, {
+      status: "escalating",
+      severity: "high",
+      assignees: [],
+      label: "initial fixture state",
+    });
+
+    const deepAnalysis = await auth.client.get(rootCausePath(clusterId), {
+      query: { trace_id: traceId },
+    });
+    assert(
+      deepAnalysis?.status === "done",
+      `Expected cached deep-analysis status=done, got ${JSON.stringify(
+        deepAnalysis,
+      )}`,
+    );
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 980 },
+      args: ["--no-sandbox"],
+    });
+    const page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installAuthState(page, auth);
+    await installBrowserHelpers(page);
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (!isErrorFeedApiUrl(url)) return;
+      if (!MUTATION_METHODS.has(request.method())) return;
+
+      const mutation = {
+        method: request.method(),
+        path: new URL(url).pathname,
+        body: parseJson(request.postData()),
+      };
+      browserMutations.push(mutation);
+      if (!isAllowedMutation(request.method(), url, clusterId)) {
+        unexpectedMutations.push(
+          `${request.method()} ${url} ${request.postData() || ""}`.trim(),
+        );
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isErrorFeedApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(
+          `${response.status()} ${response.request().method()} ${url}`,
+        );
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponseDuring(
+      page,
+      "Error Feed metadata detail load",
+      (response) =>
+        response.request().method() === "GET" &&
+        isIssueDetailUrl(response.url(), clusterId) &&
+        response.status() < 400,
+      () =>
+        page.goto(`${APP_BASE}/dashboard/error-feed/${clusterId}`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForPath(page, `/dashboard/error-feed/${clusterId}`);
+    await expectVisibleText(page, row.error.name);
+    await expectVisibleText(page, "Triage", { exact: true });
+    await expectTestIdText(page, "error-feed-status-dropdown", "Escalating");
+    await expectTestIdText(page, "error-feed-severity-dropdown", "High");
+    await expectTestIdText(page, "error-feed-assignee-dropdown", "Assign");
+    await expectVisibleText(page, "Analysis complete", { exact: true });
+
+    await patchFromAction(page, "status mutation", clusterId, async () => {
+      await clickByTestId(page, "error-feed-status-dropdown");
+      await clickByTestId(page, "error-feed-status-option-acknowledged");
+    });
+    await expectTestIdText(page, "error-feed-status-dropdown", "Acknowledged");
+    const afterStatus = await loadIssueDetail(auth.client, clusterId);
+    assertIssueState(afterStatus.row, {
+      status: "acknowledged",
+      severity: "high",
+      assignees: [],
+      label: "after status mutation",
+    });
+
+    await patchFromAction(page, "severity mutation", clusterId, async () => {
+      await clickByTestId(page, "error-feed-severity-dropdown");
+      await clickByTestId(page, "error-feed-severity-option-low");
+    });
+    await expectTestIdText(page, "error-feed-severity-dropdown", "Low");
+    const afterSeverity = await loadIssueDetail(auth.client, clusterId);
+    assertIssueState(afterSeverity.row, {
+      status: "acknowledged",
+      severity: "low",
+      assignees: [],
+      label: "after severity mutation",
+    });
+
+    await patchFromAction(page, "assignee mutation", clusterId, async () => {
+      await clickByTestId(page, "error-feed-assignee-dropdown");
+      await clickAssigneeOption(page, assignableMember.email);
+    });
+    await expectTestIdText(page, "error-feed-assignee-dropdown", memberLabel);
+    const afterAssign = await loadIssueDetail(auth.client, clusterId);
+    assertIssueState(afterAssign.row, {
+      status: "acknowledged",
+      severity: "low",
+      assignees: [assignableMember.email],
+      label: "after assignee mutation",
+    });
+
+    await patchFromAction(
+      page,
+      "assignee clear mutation",
+      clusterId,
+      async () => {
+        await clickByTestId(page, "error-feed-assignee-dropdown");
+        await clickByTestId(page, "error-feed-assignee-unassign-option");
+      },
+    );
+    await expectTestIdText(page, "error-feed-assignee-dropdown", "Assign");
+    const afterUnassign = await loadIssueDetail(auth.client, clusterId);
+    assertIssueState(afterUnassign.row, {
+      status: "acknowledged",
+      severity: "low",
+      assignees: [],
+      label: "after assignee clear mutation",
+    });
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+
+    assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+    assert(
+      unexpectedMutations.length === 0,
+      `Unexpected Error Feed mutations: ${unexpectedMutations.join("; ")}`,
+    );
+    assert(
+      browserMutations.length === 4,
+      `Expected 4 browser PATCH mutations, got ${JSON.stringify(
+        browserMutations,
+      )}`,
+    );
+    assertMutationBodies(browserMutations, assignableMember.email);
+
+    result = {
+      status: "passed",
+      app_base: APP_BASE,
+      api_base: auth.apiBase,
+      organization_id: auth.organizationId,
+      workspace_id: auth.workspaceId,
+      evidence: {
+        cluster_id: clusterId,
+        project_id: row.project_id,
+        trace_id: traceId,
+        assignable_email: assignableMember.email,
+        deep_analysis_status: deepAnalysis.status,
+        final_state: {
+          status: afterUnassign.row.status,
+          severity: afterUnassign.row.severity,
+          assignees: afterUnassign.row.assignees,
+        },
+        browser_mutations: browserMutations,
+        screenshot: SCREENSHOT_PATH,
+        fixture: fixtureEvidence,
+        cleanup: cleanupEvidence,
+      },
+    };
+  } catch (error) {
+    caughtError = error;
+    throw error;
+  } finally {
+    if (browser) await browser.close();
+    const cleanupFailures = await prepared.cleanup.run(cleanupEvidence);
+    if (cleanupFailures.length > 0 && !caughtError) {
+      cleanupError = new Error(
+        `Error Feed metadata mutation cleanup failed: ${JSON.stringify(
+          cleanupFailures,
+        )}`,
+      );
+    }
+  }
+
+  if (cleanupError) throw cleanupError;
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function resolveAssignableMember(auth) {
+  const payload = await auth.client.get(
+    apiPath("/model-hub/organizations/{organization_id}/users/", {
+      organization_id: auth.organizationId,
+    }),
+    { query: { is_active: true } },
+  );
+  const members = asArray(payload).filter((member) => member?.email);
+  const currentEmail = currentUserEmail(auth.user);
+  const member =
+    members.find(
+      (candidate) =>
+        currentEmail &&
+        candidate.email.toLowerCase() === currentEmail.toLowerCase(),
+    ) || members[0];
+  assert(
+    member?.email,
+    `No assignable organization member found: ${JSON.stringify(payload)}`,
+  );
+  return member;
+}
+
+async function loadIssueDetail(client, clusterId) {
+  return client.get(issueDetailPath(clusterId));
+}
+
+function assertIssueState(row, { status, severity, assignees, label }) {
+  assert(
+    row?.status === status,
+    `${label}: expected status=${status}, got ${row?.status}`,
+  );
+  assert(
+    row?.severity === severity,
+    `${label}: expected severity=${severity}, got ${row?.severity}`,
+  );
+  const actualAssignees = asArray(row?.assignees).map((email) =>
+    String(email).toLowerCase(),
+  );
+  const expectedAssignees = assignees.map((email) =>
+    String(email).toLowerCase(),
+  );
+  assert(
+    JSON.stringify(actualAssignees) === JSON.stringify(expectedAssignees),
+    `${label}: expected assignees=${JSON.stringify(
+      expectedAssignees,
+    )}, got ${JSON.stringify(actualAssignees)}`,
+  );
+}
+
+async function installAuthState(page, auth) {
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function installBrowserHelpers(page) {
+  await page.evaluateOnNewDocument(() => {
+    window.__apiJourneyIsVisible = (element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    };
+    window.__apiJourneyVisibleTexts = () =>
+      Array.from(document.querySelectorAll("body *"))
+        .filter(window.__apiJourneyIsVisible)
+        .map((element) => String(element.textContent || "").trim())
+        .filter(Boolean);
+  });
+}
+
+async function patchFromAction(page, label, clusterId, action) {
+  return waitForResponseDuring(
+    page,
+    label,
+    (response) =>
+      response.request().method() === "PATCH" &&
+      isIssueDetailUrl(response.url(), clusterId) &&
+      response.status() < 400,
+    action,
+  );
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(predicate, { timeout: 60000 }),
+      action(),
+    ]);
+    return response;
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForPath(page, expectedPath) {
+  await page.waitForFunction(
+    (pathName) => window.location.pathname === pathName,
+    { timeout: 30000 },
+    expectedPath,
+  );
+}
+
+async function expectVisibleText(page, text, { exact = false } = {}) {
+  await page.waitForFunction(
+    ({ expectedText, exactMatch }) =>
+      window
+        .__apiJourneyVisibleTexts()
+        .some((value) =>
+          exactMatch ? value === expectedText : value.includes(expectedText),
+        ),
+    { timeout: 30000 },
+    { expectedText: text, exactMatch: exact },
+  );
+}
+
+async function expectTestIdText(page, testId, text) {
+  await page.waitForFunction(
+    ({ targetTestId, expectedText }) => {
+      const element = document.querySelector(`[data-testid="${targetTestId}"]`);
+      return (
+        element &&
+        window.__apiJourneyIsVisible(element) &&
+        (element.textContent || "").trim().includes(expectedText)
+      );
+    },
+    { timeout: 30000 },
+    { targetTestId: testId, expectedText: text },
+  );
+}
+
+async function clickByTestId(page, testId) {
+  await page.waitForFunction(
+    (targetTestId) =>
+      Array.from(
+        document.querySelectorAll(`[data-testid="${targetTestId}"]`),
+      ).some((element) => window.__apiJourneyIsVisible(element)),
+    { timeout: 30000 },
+    testId,
+  );
+  const clicked = await page.evaluate((targetTestId) => {
+    const element = Array.from(
+      document.querySelectorAll(`[data-testid="${targetTestId}"]`),
+    ).find((candidate) => window.__apiJourneyIsVisible(candidate));
+    if (!element) return false;
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    return true;
+  }, testId);
+  assert(clicked, `Could not click [data-testid="${testId}"].`);
+}
+
+async function clickAssigneeOption(page, email) {
+  await page.waitForFunction(
+    (targetEmail) =>
+      Array.from(
+        document.querySelectorAll('[data-testid="error-feed-assignee-option"]'),
+      ).some(
+        (element) =>
+          window.__apiJourneyIsVisible(element) &&
+          element.getAttribute("data-email") === targetEmail,
+      ),
+    { timeout: 30000 },
+    email,
+  );
+  const clicked = await page.evaluate((targetEmail) => {
+    const element = Array.from(
+      document.querySelectorAll('[data-testid="error-feed-assignee-option"]'),
+    ).find(
+      (candidate) =>
+        window.__apiJourneyIsVisible(candidate) &&
+        candidate.getAttribute("data-email") === targetEmail,
+    );
+    if (!element) return false;
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    return true;
+  }, email);
+  assert(clicked, `Could not click assignee option ${email}.`);
+}
+
+function assertMutationBodies(mutations, assigneeEmail) {
+  assert(
+    mutations.some(
+      (mutation) =>
+        mutation.method === "PATCH" && mutation.body?.status === "acknowledged",
+    ),
+    `Missing acknowledged status PATCH: ${JSON.stringify(mutations)}`,
+  );
+  assert(
+    mutations.some(
+      (mutation) =>
+        mutation.method === "PATCH" && mutation.body?.severity === "low",
+    ),
+    `Missing low severity PATCH: ${JSON.stringify(mutations)}`,
+  );
+  assert(
+    mutations.some(
+      (mutation) =>
+        mutation.method === "PATCH" &&
+        mutation.body?.assignee === assigneeEmail,
+    ),
+    `Missing assignee PATCH: ${JSON.stringify(mutations)}`,
+  );
+  assert(
+    mutations.some(
+      (mutation) =>
+        mutation.method === "PATCH" &&
+        Object.prototype.hasOwnProperty.call(mutation.body || {}, "assignee") &&
+        mutation.body.assignee === null,
+    ),
+    `Missing assignee clear PATCH: ${JSON.stringify(mutations)}`,
+  );
+}
+
+function issueDetailPath(clusterId) {
+  return `/tracer/feed/issues/${encodeURIComponent(clusterId)}/`;
+}
+
+function rootCausePath(clusterId) {
+  return `/tracer/feed/issues/${encodeURIComponent(clusterId)}/root-cause/`;
+}
+
+function isIssueDetailUrl(url, clusterId) {
+  return stripQuery(url).endsWith(issueDetailPath(clusterId));
+}
+
+function isErrorFeedApiUrl(url) {
+  return (
+    url.includes("/tracer/feed/") ||
+    url.includes("/tracer/trace-error-analysis/")
+  );
+}
+
+function isAllowedMutation(method, url, clusterId) {
+  return method === "PATCH" && isIssueDetailUrl(url, clusterId);
+}
+
+function stripQuery(url) {
+  return String(url || "").split("?")[0];
+}
+
+function parseJson(value) {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/frontend/scripts/api-journeys/browser/error-feed-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/error-feed-smoke.mjs
@@ -1,36 +1,47 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import {
+  CleanupStack,
   apiPath,
   asArray,
   assert,
   createAuthenticatedContext,
+  envFlag,
+  isUuid,
+  requireMutations,
 } from "../lib/api-client.mjs";
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
+const execFile = promisify(execFileCallback);
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
 const SCREENSHOT_PATH = "/tmp/error-feed-smoke.png";
 
 async function main() {
   const auth = await createAuthenticatedContext();
-  const preflight = await auth.client.get(apiPath("/tracer/feed/issues/"), {
-    query: {
-      time_range_days: 90,
-      sort_by: "last_seen",
-      sort_dir: "desc",
-      limit: 5,
-      offset: 0,
-    },
+  const fixtureEvidence = [];
+  const cleanupEvidence = [];
+  const prepared = await prepareErrorFeedRow({
+    client: auth.client,
+    organizationId: auth.organizationId,
+    workspaceId: auth.workspaceId,
+    runId: auth.runId,
+    evidence: fixtureEvidence,
   });
-  const rows = asArray(preflight);
-  assert(rows.length > 0, "Error Feed preflight returned no rows.");
-  const row = rows[0];
+  const row = prepared.row;
   const errorName = row.error?.name || row.cluster_id;
+  let initialStats = null;
   const apiFailures = [];
   const pageErrors = [];
   const unexpectedMutations = [];
+  let caughtError = null;
+  let cleanupError = null;
+  let result = null;
 
   const browser = await puppeteer.launch({
     executablePath: browserExecutablePath(),
@@ -47,9 +58,11 @@ async function main() {
       localStorage.setItem("refreshToken", tokens.refresh || "");
       localStorage.setItem("rememberMe", "true");
       localStorage.setItem("initial-render", "done");
-      if (organizationId) sessionStorage.setItem("organizationId", organizationId);
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
       if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
-      if (user?.id) sessionStorage.setItem("futureagi-current-user-id", user.id);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
     },
     {
       tokens: auth.tokens,
@@ -77,13 +90,26 @@ async function main() {
   page.on("pageerror", (error) => pageErrors.push(error.message));
 
   try {
+    const initialStatsResponsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "GET" &&
+        isErrorFeedStatsUrl(response.url()) &&
+        response.status() < 400,
+      { timeout: 60000 },
+    );
     await waitForResponseDuring(
       page,
       "initial Error Feed load",
       (response) =>
-        response.url().includes("/tracer/feed/issues/") && response.status() < 400,
-      () => page.goto(`${APP_BASE}/dashboard/feed`, { waitUntil: "domcontentloaded" }),
+        response.request().method() === "GET" &&
+        isErrorFeedListUrl(response.url()) &&
+        response.status() < 400,
+      () =>
+        page.goto(`${APP_BASE}/dashboard/feed`, {
+          waitUntil: "domcontentloaded",
+        }),
     );
+    initialStats = await parseStatsResponse(await initialStatsResponsePromise);
     await page.waitForFunction(
       () => window.location.pathname === "/dashboard/error-feed",
       { timeout: 30000 },
@@ -91,12 +117,22 @@ async function main() {
     await expectVisibleText(page, "Error Feed", { exact: true });
     await expectVisibleText(page, "Severity", { exact: true });
     await expectVisibleText(page, "Last seen", { exact: true });
+    assert(
+      Number(initialStats.totalErrors) >= 1,
+      `Expected Error Feed stats totalErrors >= 1, got ${JSON.stringify(
+        initialStats,
+      )}`,
+    );
+    await expectErrorFeedStat(page, "totalErrors", initialStats.totalErrors);
+    await expectErrorFeedStat(page, "escalating", initialStats.escalating);
+    await expectVisibleText(page, "Users affected", { exact: true });
 
     await waitForResponseDuring(
       page,
       "time range filter",
       (response) =>
-        response.url().includes("/tracer/feed/issues/") &&
+        response.request().method() === "GET" &&
+        isErrorFeedListUrl(response.url()) &&
         response.url().includes("time_range_days=90") &&
         response.status() < 400,
       () => selectComboboxOption(page, "Last 7 days", "Last 90 days"),
@@ -108,16 +144,25 @@ async function main() {
       page,
       "severity filter",
       (response) =>
-        response.url().includes("/tracer/feed/issues/") &&
-        response.url().includes(`severity=${encodeURIComponent(row.severity)}`) &&
+        response.request().method() === "GET" &&
+        isErrorFeedListUrl(response.url()) &&
+        response
+          .url()
+          .includes(`severity=${encodeURIComponent(row.severity)}`) &&
         response.status() < 400,
-      () => selectComboboxOption(page, "All Severities", severityLabel(row.severity)),
+      () =>
+        selectComboboxOption(
+          page,
+          "All Severities",
+          severityLabel(row.severity),
+        ),
     );
     await expectVisibleText(page, errorName, { exact: false });
 
     await clickVisibleRowText(page, errorName);
     await page.waitForFunction(
-      (clusterId) => window.location.pathname.endsWith(`/dashboard/error-feed/${clusterId}`),
+      (clusterId) =>
+        window.location.pathname.endsWith(`/dashboard/error-feed/${clusterId}`),
       { timeout: 30000 },
       row.cluster_id,
     );
@@ -135,31 +180,823 @@ async function main() {
       `Read-only Error Feed smoke fired mutations: ${unexpectedMutations.join("; ")}`,
     );
 
-    console.log(
-      JSON.stringify(
-        {
-          status: "passed",
-          app_base: APP_BASE,
-          api_base: auth.apiBase,
-          organization_id: auth.organizationId,
-          workspace_id: auth.workspaceId,
-          evidence: {
-            cluster_id: row.cluster_id,
-            project_id: row.project_id,
-            severity: row.severity,
-            screenshot: SCREENSHOT_PATH,
-          },
-        },
-        null,
-        2,
-      ),
-    );
+    result = {
+      status: "passed",
+      app_base: APP_BASE,
+      api_base: auth.apiBase,
+      organization_id: auth.organizationId,
+      workspace_id: auth.workspaceId,
+      evidence: {
+        cluster_id: row.cluster_id,
+        project_id: row.project_id,
+        severity: row.severity,
+        stats: initialStats,
+        screenshot: SCREENSHOT_PATH,
+        fixture: fixtureEvidence,
+        cleanup: cleanupEvidence,
+      },
+    };
+  } catch (error) {
+    caughtError = error;
+    throw error;
   } finally {
     await browser.close();
+    const cleanupFailures = await prepared.cleanup.run(cleanupEvidence);
+    if (cleanupFailures.length > 0 && !caughtError) {
+      cleanupError = new Error(
+        `Error Feed smoke cleanup failed: ${JSON.stringify(cleanupFailures)}`,
+      );
+    }
+  }
+  if (cleanupError) throw cleanupError;
+  console.log(JSON.stringify(result, null, 2));
+}
+
+export async function prepareErrorFeedRow({
+  client,
+  organizationId,
+  workspaceId,
+  runId,
+  evidence,
+}) {
+  assert(
+    isUuid(organizationId),
+    "Authenticated context did not resolve an organization id.",
+  );
+  assert(
+    isUuid(workspaceId),
+    "Authenticated context did not resolve a workspace id.",
+  );
+
+  const cleanup = new CleanupStack();
+  const forceFixture = envFlag("ERROR_FEED_FORCE_FIXTURE");
+  let seededFixture = null;
+  let list = { data: [], total: 0, limit: 0, offset: 0 };
+  let rows = [];
+
+  try {
+    if (!forceFixture) {
+      list = await loadErrorFeedList(client, { limit: 5 });
+      rows = asArray(list);
+    }
+
+    if (forceFixture || rows.length === 0) {
+      requireMutations();
+      const project = await resolveErrorFeedProject({
+        client,
+        cleanup,
+        organizationId,
+        workspaceId,
+        runId,
+        evidence,
+      });
+      seededFixture = await seedDisposableErrorFeedFixture({
+        organizationId,
+        workspaceId,
+        projectId: project.id,
+        runId,
+      });
+      cleanup.defer("hard delete Error Feed browser fixture", async () => {
+        const cleanupAudit =
+          await hardDeleteDisposableErrorFeedFixture(seededFixture);
+        assertErrorFeedFixtureCleanup(cleanupAudit);
+      });
+      evidence.push({
+        error_feed_fixture_source: "seeded-db-fixture",
+        cluster_id: seededFixture.cluster_id,
+        project_id: seededFixture.project_id,
+        trace_id: seededFixture.trace_id,
+      });
+      list = await loadErrorFeedList(client, { limit: 25 });
+      rows = asArray(list);
+    }
+
+    const row = seededFixture
+      ? rows.find(
+          (candidate) => candidate.cluster_id === seededFixture.cluster_id,
+        )
+      : rows[0];
+    assert(
+      row,
+      seededFixture
+        ? `Seeded Error Feed cluster ${seededFixture.cluster_id} was not returned by the feed list.`
+        : "Error Feed preflight returned no rows.",
+    );
+
+    return { cleanup, list, row, rows, seededFixture };
+  } catch (error) {
+    const cleanupFailures = await cleanup.run([]);
+    if (cleanupFailures.length > 0) {
+      error.message = `${error.message}; fixture cleanup failures: ${JSON.stringify(
+        cleanupFailures,
+      )}`;
+    }
+    throw error;
   }
 }
 
-async function installRuntimeConfig(page, auth) {
+async function loadErrorFeedList(client, { limit }) {
+  return client.get(apiPath("/tracer/feed/issues/"), {
+    query: {
+      time_range_days: 90,
+      sort_by: "last_seen",
+      sort_dir: "desc",
+      limit,
+      offset: 0,
+    },
+  });
+}
+
+async function seedDisposableErrorFeedProject({
+  organizationId,
+  workspaceId,
+  runId,
+}) {
+  assert(
+    isUuid(organizationId),
+    "organizationId must be a UUID for Error Feed project fixture.",
+  );
+  assert(
+    isUuid(workspaceId),
+    "workspaceId must be a UUID for Error Feed project fixture.",
+  );
+
+  const projectId = randomUUID();
+  const suffix = journeySafeId(runId);
+  const projectName = `api journey error feed project ${suffix}`;
+  const sql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(organizationId)} AS organization_id,
+    ${sqlUuid(workspaceId)} AS workspace_id,
+    ${sqlUuid(projectId)} AS project_id,
+    ${sqlString(projectName)} AS project_name
+),
+workspace_row AS (
+  SELECT workspace.id, workspace.organization_id
+  FROM accounts_workspace workspace
+  JOIN requested r ON workspace.id = r.workspace_id
+  WHERE workspace.organization_id = r.organization_id
+    AND workspace.is_active = true
+),
+inserted_project AS (
+  INSERT INTO tracer_project (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    model_type,
+    name,
+    trace_type,
+    metadata,
+    config,
+    session_config,
+    source,
+    organization_id,
+    workspace_id,
+    tags
+  )
+  SELECT
+    r.project_id,
+    NOW(),
+    NOW(),
+    false,
+    'GenerativeLLM',
+    r.project_name,
+    'observe',
+    ${sqlString(JSON.stringify({ source: "api-journey", run_id: runId }))}::jsonb,
+    '[]'::jsonb,
+    '[]'::jsonb,
+    'prototype',
+    r.organization_id,
+    workspace_row.id,
+    ${sqlString(JSON.stringify(["api-journey", "error-feed"]))}::jsonb
+  FROM requested r
+  JOIN workspace_row ON true
+  RETURNING id, name
+)
+SELECT json_build_object(
+  'project_created', EXISTS (SELECT 1 FROM inserted_project),
+  'project_id', (SELECT id::text FROM inserted_project),
+  'project_name', (SELECT name FROM inserted_project)
+);
+`;
+  const project = await runPostgresJson(sql);
+  assert(
+    project?.project_created === true && isUuid(project?.project_id),
+    `Error Feed disposable project seed failed: ${JSON.stringify(project)}`,
+  );
+  return project;
+}
+
+async function hardDeleteDisposableErrorFeedProject(project) {
+  assert(
+    isUuid(project?.project_id),
+    "Error Feed disposable project cleanup requires project_id.",
+  );
+  const sql = `
+WITH requested AS (
+  SELECT ${sqlUuid(project.project_id)} AS project_id
+),
+deleted_project AS (
+  DELETE FROM tracer_project project
+  USING requested r
+  WHERE project.id = r.project_id
+  RETURNING project.id
+)
+SELECT json_build_object(
+  'deleted_project_count', (SELECT count(*) FROM deleted_project),
+  'remaining_project_count', CASE
+    WHEN (SELECT count(*) FROM deleted_project) > 0 THEN 0
+    ELSE (
+      SELECT count(*)
+      FROM tracer_project project
+      JOIN requested r ON project.id = r.project_id
+    )
+  END
+);
+`;
+  return runPostgresJson(sql);
+}
+
+async function seedDisposableErrorFeedFixture({
+  organizationId,
+  workspaceId,
+  projectId,
+  runId,
+}) {
+  assert(
+    isUuid(organizationId),
+    "organizationId must be a UUID for Error Feed fixture.",
+  );
+  assert(
+    isUuid(workspaceId),
+    "workspaceId must be a UUID for Error Feed fixture.",
+  );
+  assert(isUuid(projectId), "projectId must be a UUID for Error Feed fixture.");
+
+  const traceId = randomUUID();
+  const analysisId = randomUUID();
+  const detailId = randomUUID();
+  const groupId = randomUUID();
+  const scanResultId = randomUUID();
+  const scanIssueId = randomUUID();
+  const membershipId = randomUUID();
+  const clusterId = `EF${randomUUID().replaceAll("-", "").slice(0, 16)}`;
+  const suffix = journeySafeId(runId);
+  const title = `api journey error feed ${suffix} ${clusterId}`;
+  const rootCause =
+    "Tool output was not checked before the final response, producing a stale answer.";
+  const sql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(organizationId)} AS organization_id,
+    ${sqlUuid(workspaceId)} AS workspace_id,
+    ${sqlUuid(projectId)} AS project_id
+),
+project_row AS (
+  SELECT project.id, project.organization_id, project.workspace_id
+  FROM tracer_project project
+  JOIN requested r ON project.id = r.project_id
+  WHERE project.deleted = false
+    AND project.organization_id = r.organization_id
+    AND project.workspace_id = r.workspace_id
+),
+inserted_trace AS (
+  INSERT INTO tracer_trace (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    project_id,
+    name,
+    metadata,
+    input,
+    output,
+    error,
+    tags,
+    error_analysis_status
+  )
+  SELECT
+    ${sqlUuid(traceId)},
+    NOW() - INTERVAL '2 minutes',
+    NOW(),
+    false,
+    project_row.id,
+    ${sqlString(`${title} trace`)},
+    ${sqlString(JSON.stringify({ source: "api-journey", run_id: runId }))}::jsonb,
+    ${sqlString(
+      JSON.stringify({ prompt: "Need shipping status for order A-100" }),
+    )}::jsonb,
+    ${sqlString(
+      JSON.stringify({ response: "The order shipped yesterday." }),
+    )}::jsonb,
+    ${sqlString(
+      JSON.stringify({ name: "ToolValidationError", message: title }),
+    )}::jsonb,
+    ${sqlString(JSON.stringify(["api-journey", "error-feed"]))}::jsonb,
+    'completed'
+  FROM project_row
+  RETURNING id, project_id
+),
+inserted_analysis AS (
+  INSERT INTO tracer_trace_error_analysis (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    trace_id,
+    project_id,
+    analysis_date,
+    agent_version,
+    memory_enhanced,
+    overall_score,
+    total_errors,
+    high_impact_errors,
+    medium_impact_errors,
+    low_impact_errors,
+    recommended_priority,
+    insights,
+    memory_context,
+    grouped_errors_count
+  )
+  SELECT
+    ${sqlUuid(analysisId)},
+    NOW() - INTERVAL '90 seconds',
+    NOW(),
+    false,
+    inserted_trace.id,
+    inserted_trace.project_id,
+    NOW() - INTERVAL '90 seconds',
+    'api-journey',
+    false,
+    0.25,
+    1,
+    1,
+    0,
+    0,
+    'HIGH',
+    ${sqlString("Disposable Error Feed fixture for API journey coverage.")},
+    '{}'::jsonb,
+    1
+  FROM inserted_trace
+  RETURNING id, trace_id, project_id
+),
+inserted_group AS (
+  INSERT INTO tracer_trace_error_group (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    project_id,
+    source,
+    issue_group,
+    issue_category,
+    fix_layer,
+    title,
+    status,
+    cluster_id,
+    error_type,
+    total_events,
+    unique_traces,
+    unique_users,
+    first_seen,
+    last_seen,
+    error_ids,
+    combined_impact,
+    combined_description,
+    error_count,
+    trace_impact,
+    priority
+  )
+  SELECT
+    ${sqlUuid(groupId)},
+    NOW() - INTERVAL '80 seconds',
+    NOW(),
+    false,
+    inserted_trace.project_id,
+    'scanner',
+    'Tool Failures',
+    'Language-only',
+    'Tools',
+    ${sqlString(title)},
+    'escalating',
+    ${sqlString(clusterId)},
+    'Tool Failures > Language-only > Missing tool validation',
+    1,
+    1,
+    0,
+    NOW() - INTERVAL '80 seconds',
+    NOW(),
+    ${sqlString(JSON.stringify(["E001"]))}::jsonb,
+    'HIGH',
+    ${sqlString(
+      "The assistant answered from stale state after the tool failed.",
+    )},
+    1,
+    ${sqlString("High user impact because the final answer is incorrect.")},
+    'high'
+  FROM inserted_trace
+  RETURNING id, cluster_id, project_id
+),
+inserted_detail AS (
+  INSERT INTO tracer_trace_error_detail (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    analysis_id,
+    error_id,
+    cluster_id,
+    category,
+    impact,
+    urgency_to_fix,
+    location_spans,
+    evidence_snippets,
+    description,
+    root_causes,
+    recommendation,
+    immediate_fix,
+    trace_impact,
+    trace_assessment,
+    llm_analysis,
+    memory_enhanced
+  )
+  SELECT
+    ${sqlUuid(detailId)},
+    NOW() - INTERVAL '70 seconds',
+    NOW(),
+    false,
+    inserted_analysis.id,
+    'E001',
+    ${sqlString(clusterId)},
+    'Tool Failures > Language-only > Missing tool validation',
+    'HIGH',
+    'IMMEDIATE',
+    '[]'::jsonb,
+    ${sqlString(
+      JSON.stringify([
+        "The final response used stale shipping data after the tool error.",
+      ]),
+    )}::jsonb,
+    ${sqlString("Tool result failure was not handled before responding.")},
+    ${sqlString(JSON.stringify([rootCause]))}::jsonb,
+    ${sqlString("Check the tool status and retry or surface a bounded error.")},
+    ${sqlString("Add a guard that blocks final answers after tool failure.")},
+    ${sqlString("Incorrect customer-facing shipment status.")},
+    ${sqlString("The trace should be treated as failed.")},
+    ${sqlString("Synthetic local fixture for Error Feed root-cause readback.")},
+    false
+  FROM inserted_analysis
+  RETURNING id
+),
+inserted_scan_result AS (
+  INSERT INTO tracer_trace_scan_result (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    trace_id,
+    project_id,
+    status,
+    has_issues,
+    key_moments,
+    meta,
+    scan_version
+  )
+  SELECT
+    ${sqlUuid(scanResultId)},
+    NOW() - INTERVAL '65 seconds',
+    NOW(),
+    false,
+    inserted_trace.id,
+    inserted_trace.project_id,
+    'completed',
+    true,
+    ${sqlString(
+      JSON.stringify([
+        {
+          kevinified: "Tool failed but answer continued.",
+          verbatim: "tool_status=failed; final_answer=shipped",
+        },
+      ]),
+    )}::jsonb,
+    ${sqlString(
+      JSON.stringify({
+        turn_count: 2,
+        tools_available: ["shipping.lookup"],
+        tools_called: [],
+      }),
+    )}::jsonb,
+    'api-journey'
+  FROM inserted_trace
+  RETURNING id, trace_id
+),
+inserted_scan_issue AS (
+  INSERT INTO tracer_trace_scan_issue (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    scan_result_id,
+    category,
+    "group",
+    fix_layer,
+    confidence,
+    brief,
+    cluster_id
+  )
+  SELECT
+    ${sqlUuid(scanIssueId)},
+    NOW() - INTERVAL '60 seconds',
+    NOW(),
+    false,
+    inserted_scan_result.id,
+    'Language-only',
+    'Tool Failures',
+    'Tools',
+    'H',
+    ${sqlString("The trace skipped a required shipping.lookup tool check.")},
+    inserted_group.id
+  FROM inserted_scan_result
+  CROSS JOIN inserted_group
+  RETURNING id
+),
+inserted_membership AS (
+  INSERT INTO tracer_error_cluster_traces (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    trace_id,
+    span_id,
+    cluster_id,
+    scan_issue_id,
+    eval_logger_id
+  )
+  SELECT
+    ${sqlUuid(membershipId)},
+    NOW() - INTERVAL '55 seconds',
+    NOW(),
+    false,
+    inserted_trace.id,
+    NULL,
+    inserted_group.id,
+    inserted_scan_issue.id,
+    NULL
+  FROM inserted_trace
+  CROSS JOIN inserted_group
+  CROSS JOIN inserted_scan_issue
+  RETURNING id
+)
+SELECT json_build_object(
+  'project_visible', EXISTS (SELECT 1 FROM project_row),
+  'project_id', (SELECT project_id::text FROM requested),
+  'trace_id', (SELECT id::text FROM inserted_trace),
+  'analysis_id', (SELECT id::text FROM inserted_analysis),
+  'detail_id', (SELECT id::text FROM inserted_detail),
+  'group_id', (SELECT id::text FROM inserted_group),
+  'cluster_id', (SELECT cluster_id FROM inserted_group),
+  'scan_result_id', (SELECT id::text FROM inserted_scan_result),
+  'scan_issue_id', (SELECT id::text FROM inserted_scan_issue),
+  'membership_id', (SELECT id::text FROM inserted_membership)
+);
+`;
+  const fixture = await runPostgresJson(sql);
+  assert(
+    fixture?.project_visible === true && fixture?.cluster_id === clusterId,
+    `Error Feed fixture seed failed: ${JSON.stringify(fixture)}`,
+  );
+  return fixture;
+}
+
+async function hardDeleteDisposableErrorFeedFixture(fixture) {
+  const ids = {
+    traceId: fixture?.trace_id,
+    analysisId: fixture?.analysis_id,
+    detailId: fixture?.detail_id,
+    groupId: fixture?.group_id,
+    scanResultId: fixture?.scan_result_id,
+    scanIssueId: fixture?.scan_issue_id,
+    membershipId: fixture?.membership_id,
+  };
+  for (const [name, value] of Object.entries(ids)) {
+    assert(isUuid(value), `Error Feed cleanup requires ${name}.`);
+  }
+
+  const deleteSql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(ids.traceId)} AS trace_id,
+    ${sqlUuid(ids.analysisId)} AS analysis_id,
+    ${sqlUuid(ids.detailId)} AS detail_id,
+    ${sqlUuid(ids.groupId)} AS group_id,
+    ${sqlUuid(ids.scanResultId)} AS scan_result_id,
+    ${sqlUuid(ids.scanIssueId)} AS scan_issue_id,
+    ${sqlUuid(ids.membershipId)} AS membership_id
+),
+deleted_membership AS (
+  DELETE FROM tracer_error_cluster_traces membership
+  USING requested r
+  WHERE membership.id = r.membership_id
+  RETURNING membership.id
+),
+deleted_scan_issue AS (
+  DELETE FROM tracer_trace_scan_issue issue
+  USING requested r
+  WHERE issue.id = r.scan_issue_id
+  RETURNING issue.id
+),
+deleted_scan_result AS (
+  DELETE FROM tracer_trace_scan_result scan_result
+  USING requested r
+  WHERE scan_result.id = r.scan_result_id
+  RETURNING scan_result.id
+),
+deleted_detail AS (
+  DELETE FROM tracer_trace_error_detail detail
+  USING requested r
+  WHERE detail.id = r.detail_id
+  RETURNING detail.id
+),
+deleted_analysis AS (
+  DELETE FROM tracer_trace_error_analysis analysis
+  USING requested r
+  WHERE analysis.id = r.analysis_id
+  RETURNING analysis.id
+),
+deleted_group AS (
+  DELETE FROM tracer_trace_error_group groups
+  USING requested r
+  WHERE groups.id = r.group_id
+  RETURNING groups.id
+),
+deleted_trace AS (
+  DELETE FROM tracer_trace trace
+  USING requested r
+  WHERE trace.id = r.trace_id
+  RETURNING trace.id
+)
+SELECT json_build_object(
+  'deleted_membership_count', (SELECT count(*) FROM deleted_membership),
+  'deleted_scan_issue_count', (SELECT count(*) FROM deleted_scan_issue),
+  'deleted_scan_result_count', (SELECT count(*) FROM deleted_scan_result),
+  'deleted_detail_count', (SELECT count(*) FROM deleted_detail),
+  'deleted_analysis_count', (SELECT count(*) FROM deleted_analysis),
+  'deleted_group_count', (SELECT count(*) FROM deleted_group),
+  'deleted_trace_count', (SELECT count(*) FROM deleted_trace)
+);
+`;
+  const deleted = await runPostgresJson(deleteSql);
+  const auditSql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(ids.traceId)} AS trace_id,
+    ${sqlUuid(ids.analysisId)} AS analysis_id,
+    ${sqlUuid(ids.detailId)} AS detail_id,
+    ${sqlUuid(ids.groupId)} AS group_id,
+    ${sqlUuid(ids.scanResultId)} AS scan_result_id,
+    ${sqlUuid(ids.scanIssueId)} AS scan_issue_id,
+    ${sqlUuid(ids.membershipId)} AS membership_id
+)
+SELECT json_build_object(
+  'remaining_trace_count', (
+    SELECT count(*) FROM tracer_trace trace, requested r WHERE trace.id = r.trace_id
+  ),
+  'remaining_analysis_count', (
+    SELECT count(*) FROM tracer_trace_error_analysis analysis, requested r WHERE analysis.id = r.analysis_id
+  ),
+  'remaining_detail_count', (
+    SELECT count(*) FROM tracer_trace_error_detail detail, requested r WHERE detail.id = r.detail_id
+  ),
+  'remaining_group_count', (
+    SELECT count(*) FROM tracer_trace_error_group groups, requested r WHERE groups.id = r.group_id
+  ),
+  'remaining_scan_result_count', (
+    SELECT count(*) FROM tracer_trace_scan_result scan_result, requested r WHERE scan_result.id = r.scan_result_id
+  ),
+  'remaining_scan_issue_count', (
+    SELECT count(*) FROM tracer_trace_scan_issue issue, requested r WHERE issue.id = r.scan_issue_id
+  ),
+  'remaining_membership_count', (
+    SELECT count(*) FROM tracer_error_cluster_traces membership, requested r WHERE membership.id = r.membership_id
+  )
+);
+`;
+  return { ...deleted, ...(await runPostgresJson(auditSql)) };
+}
+
+function assertErrorFeedFixtureCleanup(cleanupAudit) {
+  assert(
+    Number(cleanupAudit.remaining_trace_count) === 0 &&
+      Number(cleanupAudit.remaining_analysis_count) === 0 &&
+      Number(cleanupAudit.remaining_detail_count) === 0 &&
+      Number(cleanupAudit.remaining_group_count) === 0 &&
+      Number(cleanupAudit.remaining_scan_result_count) === 0 &&
+      Number(cleanupAudit.remaining_scan_issue_count) === 0 &&
+      Number(cleanupAudit.remaining_membership_count) === 0,
+    `Error Feed fixture cleanup left rows behind: ${JSON.stringify(
+      cleanupAudit,
+    )}`,
+  );
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFile(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres DB audit returned no JSON output.");
+  return JSON.parse(text);
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), "SQL UUID value must be a UUID.");
+  return `'${value}'::uuid`;
+}
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function journeySafeId(value) {
+  return String(value || Date.now().toString(36)).replace(
+    /[^a-zA-Z0-9_-]/g,
+    "_",
+  );
+}
+
+async function resolveErrorFeedProject({
+  client,
+  cleanup,
+  organizationId,
+  workspaceId,
+  runId,
+  evidence,
+}) {
+  if (process.env.ERROR_FEED_PROJECT_ID) {
+    assert(
+      isUuid(process.env.ERROR_FEED_PROJECT_ID),
+      "ERROR_FEED_PROJECT_ID must be a UUID.",
+    );
+    evidence.push({
+      endpoint: "error feed project env",
+      project_id: process.env.ERROR_FEED_PROJECT_ID,
+    });
+    return { id: process.env.ERROR_FEED_PROJECT_ID };
+  }
+
+  const payload = await client.get(apiPath("/tracer/project/list_projects/"), {
+    query: { page_number: 0, page_size: 100 },
+  });
+  const projects = asArray(payload).filter(
+    (candidate) => isUuid(candidate?.id) || isUuid(candidate?.project_id),
+  );
+  const project =
+    projects.find((candidate) => candidate.trace_type === "observe") ||
+    projects[0];
+  if (project) {
+    const projectId = project.id || project.project_id;
+    evidence.push({
+      endpoint: "error feed project list",
+      project_id: projectId,
+      trace_type: project.trace_type || null,
+    });
+    return { ...project, id: projectId };
+  }
+
+  const disposableProject = await seedDisposableErrorFeedProject({
+    organizationId,
+    workspaceId,
+    runId,
+  });
+  cleanup.defer("hard delete Error Feed disposable project", async () => {
+    const cleanupAudit =
+      await hardDeleteDisposableErrorFeedProject(disposableProject);
+    assert(
+      Number(cleanupAudit.remaining_project_count) === 0,
+      `Error Feed disposable project cleanup left rows behind: ${JSON.stringify(
+        cleanupAudit,
+      )}`,
+    );
+  });
+  evidence.push({
+    error_feed_project_source: "seeded-db-project",
+    project_id: disposableProject.project_id,
+    project_name: disposableProject.project_name,
+  });
+  return {
+    id: disposableProject.project_id,
+    name: disposableProject.project_name,
+  };
+}
+
+export async function installRuntimeConfig(page, auth) {
   await page.setRequestInterception(true);
   page.on("request", (request) => {
     const url = new URL(request.url());
@@ -214,29 +1051,31 @@ async function selectComboboxOption(page, currentText, optionText) {
   await combo.click();
   await page.waitForFunction(
     (targetText) =>
-      Array.from(document.querySelectorAll('[role="option"]')).some((candidate) => {
-        const style = window.getComputedStyle(candidate);
-        return (
-          style.visibility !== "hidden" &&
-          style.display !== "none" &&
-          candidate.getClientRects().length > 0 &&
-          (candidate.textContent || "").trim() === targetText
-        );
-      }),
+      Array.from(document.querySelectorAll('[role="option"]')).some(
+        (candidate) => {
+          const style = window.getComputedStyle(candidate);
+          return (
+            style.visibility !== "hidden" &&
+            style.display !== "none" &&
+            candidate.getClientRects().length > 0 &&
+            (candidate.textContent || "").trim() === targetText
+          );
+        },
+      ),
     { timeout: 30000 },
     optionText,
   );
   const clicked = await page.evaluate((targetText) => {
-    const options = Array.from(document.querySelectorAll('[role="option"]')).filter(
-      (candidate) => {
-        const style = window.getComputedStyle(candidate);
-        return (
-          style.visibility !== "hidden" &&
-          style.display !== "none" &&
-          candidate.getClientRects().length > 0
-        );
-      },
-    );
+    const options = Array.from(
+      document.querySelectorAll('[role="option"]'),
+    ).filter((candidate) => {
+      const style = window.getComputedStyle(candidate);
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        candidate.getClientRects().length > 0
+      );
+    });
     const option = options.find(
       (candidate) => (candidate.textContent || "").trim() === targetText,
     );
@@ -262,44 +1101,10 @@ async function clickVisibleRowText(page, text) {
     const row = Array.from(document.querySelectorAll("tr")).find((candidate) =>
       candidate.textContent.includes(targetText),
     );
-    row?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    row?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
   }, text);
-}
-
-async function clickVisibleText(page, text, { exact = false } = {}) {
-  await page.waitForFunction(
-    ({ targetText, exactMatch }) =>
-      Array.from(document.querySelectorAll("body *")).some((el) => {
-        const style = window.getComputedStyle(el);
-        const visible =
-          style.visibility !== "hidden" &&
-          style.display !== "none" &&
-          el.getClientRects().length > 0;
-        if (!visible) return false;
-        const value = (el.textContent || "").trim();
-        return exactMatch ? value === targetText : value.includes(targetText);
-      }),
-    { timeout: 30000 },
-    { targetText: text, exactMatch: exact },
-  );
-  await page.evaluate(
-    ({ targetText, exactMatch }) => {
-      const match = Array.from(document.querySelectorAll("body *")).find((el) => {
-        const style = window.getComputedStyle(el);
-        const visible =
-          style.visibility !== "hidden" &&
-          style.display !== "none" &&
-          el.getClientRects().length > 0;
-        if (!visible) return false;
-        const value = (el.textContent || "").trim();
-        return exactMatch ? value === targetText : value.includes(targetText);
-      });
-      match?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
-      match?.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
-      match?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    },
-    { targetText: text, exactMatch: exact },
-  );
 }
 
 async function expectVisibleText(page, text, { exact = false } = {}) {
@@ -334,8 +1139,51 @@ async function expectNoVisibleText(page, text) {
   assert(!found, `Unexpected visible text: ${text}`);
 }
 
+async function parseStatsResponse(response) {
+  const payload = await response.json();
+  const stats = payload?.result || payload?.data?.result || payload?.data || {};
+  return {
+    totalErrors: Number(stats.totalErrors ?? stats.total_errors ?? 0),
+    escalating: Number(stats.escalating ?? 0),
+    acknowledged: Number(stats.acknowledged ?? 0),
+    forReview: Number(stats.forReview ?? stats.for_review ?? 0),
+    resolved: Number(stats.resolved ?? 0),
+    affectedUsers: Number(stats.affectedUsers ?? stats.affected_users ?? 0),
+  };
+}
+
+async function expectErrorFeedStat(page, key, expectedValue) {
+  await page.waitForFunction(
+    ({ statKey, value }) => {
+      const el = document.querySelector(
+        `[data-testid="error-feed-stat-${statKey}"]`,
+      );
+      if (!el) return false;
+      const text = (el.textContent || "").replaceAll(",", "");
+      return text.includes(String(value));
+    },
+    { timeout: 30000 },
+    { statKey: key, value: Number(expectedValue) },
+  );
+}
+
+function isErrorFeedListUrl(url) {
+  return stripQuery(url).endsWith("/tracer/feed/issues/");
+}
+
+function isErrorFeedStatsUrl(url) {
+  return stripQuery(url).endsWith("/tracer/feed/issues/stats/");
+}
+
+function stripQuery(url) {
+  return String(url || "").split("?")[0];
+}
+
 function isErrorFeedApiUrl(url) {
-  return url.includes("/tracer/feed/") || url.includes("/tracer/trace-error-analysis/");
+  return (
+    url.includes("/tracer/feed/") ||
+    url.includes("/tracer/trace-error-analysis/")
+  );
 }
 
 function severityLabel(value) {
@@ -348,7 +1196,7 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function browserExecutablePath() {
+export function browserExecutablePath() {
   return (
     process.env.PUPPETEER_EXECUTABLE_PATH ||
     process.env.CHROME_PATH ||
@@ -356,7 +1204,12 @@ function browserExecutablePath() {
   );
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/frontend/scripts/api-journeys/browser/falcon-ai-file-upload-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/falcon-ai-file-upload-smoke.mjs
@@ -445,8 +445,7 @@ async function removeFalconMinioObjects(storageKeys) {
 }
 
 async function runFalconMinioCommand(args) {
-  const container =
-    process.env.API_JOURNEY_MINIO_CONTAINER || "futureagi-ws2-minio-1";
+  const container = await resolveFalconMinioContainer();
   const command = [
     'mc alias set local http://127.0.0.1:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null',
     `mc ${args.map((arg) => shellQuote(arg)).join(" ")}`,
@@ -456,8 +455,34 @@ async function runFalconMinioCommand(args) {
   });
 }
 
+async function resolveFalconMinioContainer() {
+  if (process.env.API_JOURNEY_MINIO_CONTAINER) {
+    return process.env.API_JOURNEY_MINIO_CONTAINER;
+  }
+  const candidates = [
+    "ws2-minio",
+    "futureagi-ws2-minio-1",
+    "minio",
+    "futureagi-minio-1",
+  ];
+  for (const candidate of candidates) {
+    try {
+      await execFileAsync("docker", [
+        "inspect",
+        "--type",
+        "container",
+        candidate,
+      ]);
+      return candidate;
+    } catch {
+      // Try the next local compose naming convention.
+    }
+  }
+  return "futureagi-ws2-minio-1";
+}
+
 function falconMinioTarget(storageKey) {
-  const bucket = process.env.API_JOURNEY_MINIO_BUCKET || "fi-content";
+  const bucket = process.env.API_JOURNEY_MINIO_BUCKET || "fi-content-dev";
   return `local/${bucket}/${storageKey}`;
 }
 

--- a/frontend/scripts/api-journeys/browser/gateway-api-only-surfaces-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/gateway-api-only-surfaces-smoke.mjs
@@ -1,0 +1,405 @@
+/* eslint-disable no-console */
+import { createRequire } from "node:module";
+import process from "node:process";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const SCREENSHOT_PATH = "/tmp/gateway-api-only-surfaces-smoke.png";
+const FAILURE_SCREENSHOT_PATH =
+  "/tmp/gateway-api-only-surfaces-smoke-failure.png";
+const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+const STALE_SURFACES = [
+  {
+    key: "blocklists",
+    label: "Blocklists",
+    path: "/dashboard/gateway/blocklists",
+    apiPath: "/agentcc/blocklists/",
+    forbiddenTexts: ["Create blocklist", "Add words", "Remove words"],
+  },
+  {
+    key: "routing_policies",
+    label: "Routing Policies",
+    path: "/dashboard/gateway/routing-policies",
+    apiPath: "/agentcc/routing-policies/",
+    forbiddenTexts: ["Create policy", "Activate policy", "Sync policies"],
+  },
+];
+
+async function main() {
+  const auth = await createAuthenticatedContext();
+  const evidence = await preflightApiOnlySurfaces(auth.client);
+  const apiFailures = [];
+  const pageErrors = [];
+  const gatewayRequests = [];
+  const browserMutations = [];
+  let browser = null;
+  let caughtError = null;
+
+  try {
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+    const page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (!isGatewayApiUrl(url)) return;
+      gatewayRequests.push(`${request.method()} ${url}`);
+      if (MUTATION_METHODS.has(request.method())) {
+        browserMutations.push(`${request.method()} ${url}`);
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isGatewayApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${url}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponsesDuring(
+      page,
+      "initial Gateway overview load",
+      [
+        (response) =>
+          response.url().includes("/agentcc/gateways/") &&
+          response.request().method() === "GET" &&
+          response.status() < 400,
+      ],
+      () =>
+        page.goto(`${APP_BASE}/dashboard/gateway`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForPath(page, "/dashboard/gateway");
+    await waitForVisibleText(page, "Quick Links", { exact: true });
+
+    const overviewLabels = await visibleTextSnapshot(page);
+    evidence.overview_has_blocklists_label = overviewLabels.some((text) =>
+      text.includes("Blocklists"),
+    );
+    evidence.overview_has_routing_policies_label = overviewLabels.some((text) =>
+      text.includes("Routing Policies"),
+    );
+    assert(
+      !evidence.overview_has_blocklists_label,
+      "Gateway overview rendered a Blocklists nav/quick-link label, but no route is documented.",
+    );
+    assert(
+      !evidence.overview_has_routing_policies_label,
+      "Gateway overview rendered a Routing Policies nav/quick-link label, but no route is documented.",
+    );
+
+    evidence.direct_route_probes = {};
+    for (const surface of STALE_SURFACES) {
+      evidence.direct_route_probes[surface.key] = await probeStaleRoute(
+        page,
+        surface,
+      );
+    }
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+    evidence.screenshot = SCREENSHOT_PATH;
+
+    const staleBrowserApiRequests = gatewayRequests.filter((request) =>
+      STALE_SURFACES.some((surface) => request.includes(surface.apiPath)),
+    );
+    assert(
+      staleBrowserApiRequests.length === 0,
+      `Stale API-only Gateway browser routes unexpectedly called APIs: ${staleBrowserApiRequests.join(
+        "; ",
+      )}`,
+    );
+    assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+    assert(
+      browserMutations.length === 0,
+      `Read-only Gateway API-only surfaces smoke fired mutations: ${browserMutations.join(
+        "; ",
+      )}`,
+    );
+
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          evidence,
+          gateway_request_count: gatewayRequests.length,
+          browser_mutations: browserMutations,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    caughtError = error;
+    console.error(
+      JSON.stringify(
+        {
+          status: "failed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          evidence,
+          api_failures: apiFailures,
+          page_errors: pageErrors,
+          gateway_requests: gatewayRequests,
+          browser_mutations: browserMutations,
+        },
+        null,
+        2,
+      ),
+    );
+    if (browser) {
+      const pages = await browser.pages();
+      const page = pages[pages.length - 1];
+      await page
+        ?.screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .catch(() => null);
+    }
+  } finally {
+    if (browser) await browser.close();
+  }
+
+  if (caughtError) throw caughtError;
+}
+
+async function preflightApiOnlySurfaces(client) {
+  const gateways = asArray(await client.get(apiPath("/agentcc/gateways/")));
+  assert(gateways.length > 0, "Gateway list returned no configured gateway.");
+
+  const blocklistsPayload = await client.get(apiPath("/agentcc/blocklists/"), {
+    unwrap: false,
+  });
+  const routingPoliciesPayload = await client.get(
+    apiPath("/agentcc/routing-policies/"),
+    { unwrap: false },
+  );
+
+  const blocklists = asArray(blocklistsPayload);
+  const routingPolicies = asArray(routingPoliciesPayload);
+  assert(
+    blocklistsPayload && typeof blocklistsPayload === "object",
+    "Blocklists API did not return an object/array payload.",
+  );
+  assert(
+    routingPoliciesPayload && typeof routingPoliciesPayload === "object",
+    "Routing policies API did not return an object/array payload.",
+  );
+
+  return {
+    gateway_id: gateways[0].id || "default",
+    gateway_count: gateways.length,
+    blocklist_count: blocklists.length,
+    routing_policy_count: routingPolicies.length,
+    blocklists_payload_shape: payloadShape(blocklistsPayload),
+    routing_policies_payload_shape: payloadShape(routingPoliciesPayload),
+  };
+}
+
+async function probeStaleRoute(page, surface) {
+  const beforeRequestCount = await page.evaluate(() => performance.now());
+  await page.goto(`${APP_BASE}${surface.path}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForFunction(
+    () =>
+      document.readyState === "interactive" ||
+      document.readyState === "complete",
+    { timeout: 30000 },
+  );
+  await sleep(750);
+
+  const textSnapshot = await visibleTextSnapshot(page);
+  const foundForbiddenTexts = surface.forbiddenTexts.filter((text) =>
+    textSnapshot.some((visibleText) => visibleText.includes(text)),
+  );
+  assert(
+    foundForbiddenTexts.length === 0,
+    `${surface.label} stale route rendered management controls: ${foundForbiddenTexts.join(
+      ", ",
+    )}`,
+  );
+
+  const titleVisible = textSnapshot.some((text) => text === surface.label);
+  assert(
+    !titleVisible,
+    `${surface.label} stale route rendered a dedicated page title.`,
+  );
+
+  return {
+    probed_at_ms: beforeRequestCount,
+    requested_path: surface.path,
+    final_path: await page.evaluate(() => window.location.pathname),
+    title_visible: titleVisible,
+    forbidden_controls_visible: foundForbiddenTexts,
+    visible_text_sample: textSnapshot.slice(0, 25),
+  };
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(() => {
+    window.normalizeText = (value) => String(value || "").trim();
+    window.visibleElements = (selector = "body *") => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(selector)).filter(isVisible);
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function waitForResponsesDuring(page, label, predicates, action) {
+  try {
+    return await Promise.all([
+      ...predicates.map((predicate) =>
+        page.waitForResponse(predicate, { timeout: 60000 }),
+      ),
+      action(),
+    ]);
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForPath(page, pathname, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedPath) => window.location.pathname === expectedPath,
+    { timeout },
+    pathname,
+  );
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) =>
+      window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      }),
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function visibleTextSnapshot(page) {
+  return page.evaluate(() => {
+    const seen = new Set();
+    return window
+      .visibleElements()
+      .map((element) => window.normalizeText(element.textContent))
+      .filter(Boolean)
+      .filter((text) => {
+        if (seen.has(text)) return false;
+        seen.add(text);
+        return true;
+      });
+  });
+}
+
+function payloadShape(payload) {
+  if (Array.isArray(payload)) return "array";
+  if (Array.isArray(payload?.results)) return "paginated_results";
+  if (Array.isArray(payload?.result)) return "result_array";
+  if (payload && typeof payload === "object") return "object";
+  return typeof payload;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isGatewayApiUrl(url) {
+  return url.includes("/agentcc/");
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") {
+    return "/usr/bin/google-chrome";
+  }
+  return undefined;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/frontend/scripts/api-journeys/browser/gateway-fallbacks-mutation-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/gateway-fallbacks-mutation-smoke.mjs
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import process from "node:process";
 import {
@@ -20,6 +21,11 @@ const REMOVE_SCREENSHOT_PATH =
 const FAILURE_SCREENSHOT_PATH =
   "/tmp/gateway-fallbacks-mutation-smoke-failure.png";
 const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+const FALLBACK_PROVIDER_MODELS = [
+  "fallback-smoke-primary-model",
+  "fallback-smoke-backup-model",
+];
+let dbConnection = null;
 
 async function main() {
   requireMutations();
@@ -264,6 +270,17 @@ async function main() {
       .catch(() => null);
   } finally {
     if (browser) await browser.close();
+    if (evidence.disposable_provider) {
+      try {
+        evidence.provider_cleanup = await cleanupDisposableFallbackProvider(
+          auth.client,
+          evidence,
+        );
+      } catch (error) {
+        cleanupError = error;
+        evidence.provider_cleanup = { status: "failed", error: error.message };
+      }
+    }
     if (cleanup) {
       try {
         evidence.cleanup = await cleanup();
@@ -324,10 +341,21 @@ async function preflightFallbacks(client, baseline) {
     gateways[0].id ||
     "default";
 
-  const providerHealth = await client.get(
+  let providerHealth = await client.get(
     apiPath("/agentcc/gateways/{id}/providers/", { id: gatewayId }),
   );
-  const models = providerModels(providerHealth?.providers);
+  let models = providerModels(providerHealth?.providers);
+  let disposableProvider = null;
+  if (models.length < 2) {
+    disposableProvider = await createDisposableFallbackProvider(
+      client,
+      gatewayId,
+    );
+    providerHealth = await client.get(
+      apiPath("/agentcc/gateways/{id}/providers/", { id: gatewayId }),
+    );
+    models = providerModels(providerHealth?.providers);
+  }
   assert(
     models.length >= 2,
     "Gateway fallbacks mutation smoke requires at least two configured provider models.",
@@ -396,7 +424,77 @@ async function preflightFallbacks(client, baseline) {
     fallback_model: fallbackModel,
     max_attempts: 4,
     timeout: "35s",
+    disposable_provider: disposableProvider,
   };
+}
+
+async function createDisposableFallbackProvider(client, gatewayId) {
+  const providerName = `fallback_smoke_${Date.now().toString(36)}`;
+  const updateResult = await client.post(
+    apiPath("/agentcc/gateways/{id}/update-provider/", { id: gatewayId }),
+    {
+      name: providerName,
+      config: {
+        api_key: "fallback-smoke-fake-key",
+        display_name: "Fallback smoke provider",
+        api_format: "openai",
+        models: FALLBACK_PROVIDER_MODELS,
+        base_url: "https://api.example.com/v1",
+        default_timeout: 30,
+        max_concurrent: 2,
+        conn_pool_size: 5,
+      },
+    },
+  );
+  const gatewayConfig = await client.get(
+    apiPath("/agentcc/gateways/{id}/config/", { id: gatewayId }),
+  );
+  const providerConfig = gatewayConfig?.providers?.[providerName];
+  assert(
+    providerConfig?.id &&
+      FALLBACK_PROVIDER_MODELS.every((model) =>
+        asArray(providerConfig.models).includes(model),
+      ),
+    `Disposable fallback provider was not visible in config: ${JSON.stringify(
+      providerConfig,
+    )}`,
+  );
+  return {
+    id: providerConfig.id,
+    name: providerName,
+    models: FALLBACK_PROVIDER_MODELS,
+    update_response: updateResult,
+  };
+}
+
+async function cleanupDisposableFallbackProvider(client, evidence) {
+  const provider = evidence.disposable_provider;
+  const cleanup = {
+    status: "passed",
+    api_removed: false,
+    hard_deleted_provider_id: null,
+  };
+  if (!provider?.name) return cleanup;
+
+  const config = await client.get(
+    apiPath("/agentcc/gateways/{id}/config/", { id: evidence.gateway_id }),
+  );
+  if (config?.providers?.[provider.name]) {
+    await client.post(
+      apiPath("/agentcc/gateways/{id}/remove-provider/", {
+        id: evidence.gateway_id,
+      }),
+      { name: provider.name },
+    );
+    cleanup.api_removed = true;
+  }
+
+  if (provider.id) {
+    cleanup.hard_deleted_provider_id = await hardDeleteProviderCredential(
+      provider.id,
+    );
+  }
+  return cleanup;
 }
 
 async function prepareOrgConfigRestorer(client) {
@@ -916,6 +1014,84 @@ function browserExecutablePath() {
     return "/usr/bin/google-chrome";
   }
   return undefined;
+}
+
+async function hardDeleteProviderCredential(providerId) {
+  const rows = await runDb(`
+    DELETE FROM agentcc_provider_credential
+    WHERE id = ${sqlString(providerId)}
+    RETURNING id::text
+  `);
+  return rows[0] || null;
+}
+
+async function runDb(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const candidates = dbConnection ? [dbConnection] : databaseCandidates();
+  const failures = [];
+
+  for (const candidate of candidates) {
+    const result = spawnSync(
+      "docker",
+      [
+        "exec",
+        container,
+        "psql",
+        "-U",
+        candidate.user,
+        "-d",
+        candidate.database,
+        "-At",
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-c",
+        sql,
+      ],
+      { encoding: "utf8" },
+    );
+    if (result.status === 0) {
+      dbConnection = candidate;
+      return result.stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+    }
+    failures.push(
+      `${candidate.user}/${candidate.database}: ${result.stderr || result.stdout}`,
+    );
+  }
+
+  throw new Error(`Database command failed: ${failures.join(" | ")}`);
+}
+
+function databaseCandidates() {
+  if (process.env.API_JOURNEY_DB_USER || process.env.API_JOURNEY_DB_NAME) {
+    return [
+      {
+        user: process.env.API_JOURNEY_DB_USER || "postgres",
+        database: process.env.API_JOURNEY_DB_NAME || "postgres",
+      },
+    ];
+  }
+
+  const candidates = [
+    { user: process.env.PG_USER, database: process.env.PG_DB },
+    { user: "user", database: "tfc" },
+    { user: "futureagi", database: "futureagi" },
+    { user: "postgres", database: "postgres" },
+  ];
+  const seen = new Set();
+  return candidates.filter((candidate) => {
+    if (!candidate.user || !candidate.database) return false;
+    const key = `${candidate.user}/${candidate.database}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function sqlString(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
 }
 
 main().catch((error) => {

--- a/frontend/scripts/api-journeys/browser/gateway-fallbacks-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/gateway-fallbacks-smoke.mjs
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import process from "node:process";
 import {
@@ -15,6 +16,11 @@ const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
 const SCREENSHOT_PATH = "/tmp/gateway-fallbacks-smoke.png";
 const FAILURE_SCREENSHOT_PATH = "/tmp/gateway-fallbacks-smoke-failure.png";
 const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+const FALLBACK_PROVIDER_MODELS = [
+  "fallback-smoke-primary-model",
+  "fallback-smoke-backup-model",
+];
+let dbConnection = null;
 
 async function main() {
   const auth = await createAuthenticatedContext();
@@ -171,6 +177,17 @@ async function main() {
       .catch(() => null);
   } finally {
     if (browser) await browser.close();
+    if (evidence.disposable_provider) {
+      try {
+        evidence.provider_cleanup = await cleanupDisposableFallbackProvider(
+          auth.client,
+          evidence,
+        );
+      } catch (error) {
+        cleanupError = error;
+        evidence.provider_cleanup = { status: "failed", error: error.message };
+      }
+    }
     if (cleanup) {
       try {
         evidence.cleanup = await cleanup();
@@ -230,10 +247,21 @@ async function preflightFallbacks(client, baseline) {
     gateways[0].id ||
     "default";
 
-  const providerHealth = await client.get(
+  let providerHealth = await client.get(
     apiPath("/agentcc/gateways/{id}/providers/", { id: gatewayId }),
   );
-  const models = providerModels(providerHealth?.providers);
+  let models = providerModels(providerHealth?.providers);
+  let disposableProvider = null;
+  if (models.length < 2) {
+    disposableProvider = await createDisposableFallbackProvider(
+      client,
+      gatewayId,
+    );
+    providerHealth = await client.get(
+      apiPath("/agentcc/gateways/{id}/providers/", { id: gatewayId }),
+    );
+    models = providerModels(providerHealth?.providers);
+  }
   assert(
     models.length >= 2,
     "Gateway fallbacks smoke requires at least two configured provider models.",
@@ -308,7 +336,77 @@ async function preflightFallbacks(client, baseline) {
     model_count: models.length,
     primary_model: primaryModel,
     fallback_model: fallbackModel,
+    disposable_provider: disposableProvider,
   };
+}
+
+async function createDisposableFallbackProvider(client, gatewayId) {
+  const providerName = `fallback_smoke_${Date.now().toString(36)}`;
+  const updateResult = await client.post(
+    apiPath("/agentcc/gateways/{id}/update-provider/", { id: gatewayId }),
+    {
+      name: providerName,
+      config: {
+        api_key: "fallback-smoke-fake-key",
+        display_name: "Fallback smoke provider",
+        api_format: "openai",
+        models: FALLBACK_PROVIDER_MODELS,
+        base_url: "https://api.example.com/v1",
+        default_timeout: 30,
+        max_concurrent: 2,
+        conn_pool_size: 5,
+      },
+    },
+  );
+  const gatewayConfig = await client.get(
+    apiPath("/agentcc/gateways/{id}/config/", { id: gatewayId }),
+  );
+  const providerConfig = gatewayConfig?.providers?.[providerName];
+  assert(
+    providerConfig?.id &&
+      FALLBACK_PROVIDER_MODELS.every((model) =>
+        asArray(providerConfig.models).includes(model),
+      ),
+    `Disposable fallback provider was not visible in config: ${JSON.stringify(
+      providerConfig,
+    )}`,
+  );
+  return {
+    id: providerConfig.id,
+    name: providerName,
+    models: FALLBACK_PROVIDER_MODELS,
+    update_response: updateResult,
+  };
+}
+
+async function cleanupDisposableFallbackProvider(client, evidence) {
+  const provider = evidence.disposable_provider;
+  const cleanup = {
+    status: "passed",
+    api_removed: false,
+    hard_deleted_provider_id: null,
+  };
+  if (!provider?.name) return cleanup;
+
+  const config = await client.get(
+    apiPath("/agentcc/gateways/{id}/config/", { id: evidence.gateway_id }),
+  );
+  if (config?.providers?.[provider.name]) {
+    await client.post(
+      apiPath("/agentcc/gateways/{id}/remove-provider/", {
+        id: evidence.gateway_id,
+      }),
+      { name: provider.name },
+    );
+    cleanup.api_removed = true;
+  }
+
+  if (provider.id) {
+    cleanup.hard_deleted_provider_id = await hardDeleteProviderCredential(
+      provider.id,
+    );
+  }
+  return cleanup;
 }
 
 async function prepareOrgConfigRestorer(client) {
@@ -632,6 +730,84 @@ function browserExecutablePath() {
     return "/usr/bin/google-chrome";
   }
   return undefined;
+}
+
+async function hardDeleteProviderCredential(providerId) {
+  const rows = await runDb(`
+    DELETE FROM agentcc_provider_credential
+    WHERE id = ${sqlString(providerId)}
+    RETURNING id::text
+  `);
+  return rows[0] || null;
+}
+
+async function runDb(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const candidates = dbConnection ? [dbConnection] : databaseCandidates();
+  const failures = [];
+
+  for (const candidate of candidates) {
+    const result = spawnSync(
+      "docker",
+      [
+        "exec",
+        container,
+        "psql",
+        "-U",
+        candidate.user,
+        "-d",
+        candidate.database,
+        "-At",
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-c",
+        sql,
+      ],
+      { encoding: "utf8" },
+    );
+    if (result.status === 0) {
+      dbConnection = candidate;
+      return result.stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+    }
+    failures.push(
+      `${candidate.user}/${candidate.database}: ${result.stderr || result.stdout}`,
+    );
+  }
+
+  throw new Error(`Database command failed: ${failures.join(" | ")}`);
+}
+
+function databaseCandidates() {
+  if (process.env.API_JOURNEY_DB_USER || process.env.API_JOURNEY_DB_NAME) {
+    return [
+      {
+        user: process.env.API_JOURNEY_DB_USER || "postgres",
+        database: process.env.API_JOURNEY_DB_NAME || "postgres",
+      },
+    ];
+  }
+
+  const candidates = [
+    { user: process.env.PG_USER, database: process.env.PG_DB },
+    { user: "user", database: "tfc" },
+    { user: "futureagi", database: "futureagi" },
+    { user: "postgres", database: "postgres" },
+  ];
+  const seen = new Set();
+  return candidates.filter((candidate) => {
+    if (!candidate.user || !candidate.database) return false;
+    const key = `${candidate.user}/${candidate.database}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function sqlString(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
 }
 
 main().catch((error) => {

--- a/frontend/scripts/api-journeys/browser/gateway-keys-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/gateway-keys-smoke.mjs
@@ -100,15 +100,24 @@ async function main() {
       "Active",
       "Revoked",
       "Expired",
-      "Name",
-      "Key",
-      "Status",
-      "Owner",
-      "Models",
-      "Created",
-      "Last Used",
     ]) {
       await waitForVisibleText(page, label, { exact: true });
+    }
+    if (Number(evidence.starting_api_key_count) === 0) {
+      await waitForVisibleText(page, "No API keys yet", { exact: true });
+      await waitForVisibleText(page, "Create Your First Key", { exact: true });
+    } else {
+      for (const label of [
+        "Name",
+        "Key",
+        "Status",
+        "Owner",
+        "Models",
+        "Created",
+        "Last Used",
+      ]) {
+        await waitForVisibleText(page, label, { exact: true });
+      }
     }
 
     await clickVisibleText(page, "Create Key", { exact: true });
@@ -192,7 +201,7 @@ async function main() {
     await waitForVisibleText(page, "View Logs", { exact: true });
     await waitForVisibleText(page, "Revoke Key", { exact: true });
 
-    await page.click('button[title="Edit"]');
+    await clickVisibleButtonByTitle(page, "Edit");
     await waitForVisibleText(page, "Edit API Key", { exact: true });
     await setDialogInputByLabel(page, "Name", updatedKeyName);
     await setDialogInputByLabel(page, "Owner", updatedOwner);
@@ -616,6 +625,41 @@ async function clickDialogButton(page, label, timeout = 30000) {
     return true;
   }, label);
   assert(clicked, `Could not click dialog button: ${label}`);
+}
+
+async function clickVisibleButtonByTitle(page, title, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedTitle) =>
+      window
+        .visibleElements("button")
+        .some(
+          (button) =>
+            button.getAttribute("title") === expectedTitle && !button.disabled,
+        ),
+    { timeout },
+    title,
+  );
+  const clicked = await page.evaluate((expectedTitle) => {
+    const button = window
+      .visibleElements("button")
+      .find(
+        (candidate) =>
+          candidate.getAttribute("title") === expectedTitle &&
+          !candidate.disabled,
+      );
+    if (!button) return false;
+    button.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+    );
+    button.dispatchEvent(
+      new MouseEvent("mouseup", { bubbles: true, cancelable: true }),
+    );
+    button.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    return true;
+  }, title);
+  assert(clicked, `Could not click visible button titled: ${title}`);
 }
 
 async function setDialogInputByLabel(page, label, value, timeout = 30000) {

--- a/frontend/scripts/api-journeys/browser/gateway-mcp-test-tool-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/gateway-mcp-test-tool-smoke.mjs
@@ -1,0 +1,1085 @@
+/* eslint-disable no-console */
+import { Buffer } from "node:buffer";
+import { execFile as execFileCallback } from "node:child_process";
+import fs from "node:fs/promises";
+import http from "node:http";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+  requireMutations,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+const execFile = promisify(execFileCallback);
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const SCREENSHOT_PATH = "/tmp/gateway-mcp-test-tool-smoke.png";
+const FAILURE_SCREENSHOT_PATH = "/tmp/gateway-mcp-test-tool-smoke-failure.png";
+const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+const MCP_SERVER_ID = process.env.GATEWAY_MCP_TEST_SERVER_ID || "th4812";
+const TOOL_ORIGINAL_NAME = "echo";
+const TOOL_NAME = `${MCP_SERVER_ID}_${TOOL_ORIGINAL_NAME}`;
+const TOOL_ARGUMENTS = {
+  input: "hello from the MCP browser smoke",
+  count: 3,
+  flag: true,
+};
+
+async function main() {
+  requireMutations();
+
+  const auth = await createAuthenticatedContext();
+  const apiFailures = [];
+  const pageErrors = [];
+  const gatewayRequests = [];
+  const browserMutations = [];
+  const unexpectedMutations = [];
+  let browser = null;
+  let page = null;
+  let caughtError = null;
+  let cleanupError = null;
+  let gatewayHarness = null;
+  let mockMCP = null;
+  let cleanupOrgConfig = null;
+  let gatewayWasRestored = false;
+  const evidence = {};
+
+  try {
+    const gateways = asArray(
+      await auth.client.get(apiPath("/agentcc/gateways/")),
+    );
+    assert(gateways.length > 0, "Gateway list returned no configured gateway.");
+    evidence.gateway_id =
+      gateways.find((gateway) => gateway.id === "default")?.id ||
+      gateways[0].id ||
+      "default";
+
+    const baseline = await prepareOrgConfigRestorer(auth.client);
+    cleanupOrgConfig = baseline.cleanup;
+    evidence.original_org_config_id = baseline.originalActiveConfig.id;
+    evidence.original_org_config_version =
+      baseline.originalActiveConfig.version;
+
+    mockMCP = await startMockMCPServer();
+    evidence.mock_mcp_server = {
+      host_url: mockMCP.hostUrl,
+      container_url: mockMCP.containerUrl,
+    };
+
+    gatewayHarness = await startDisposableGateway(mockMCP.port);
+    evidence.gateway_harness = gatewayHarness.evidence;
+
+    evidence.org_mcp_server_update = await responseResult(
+      await auth.client.post(
+        apiPath("/agentcc/gateways/{id}/update-mcp-server/", {
+          id: evidence.gateway_id,
+        }),
+        {
+          server_id: MCP_SERVER_ID,
+          config: {
+            url: mockMCP.containerUrl,
+            transport: "http",
+            auth: { type: "none" },
+            tools_cache_ttl: "5m",
+          },
+        },
+      ),
+    );
+
+    evidence.backend_tools = await waitForBackendTool(
+      auth.client,
+      evidence.gateway_id,
+      TOOL_NAME,
+    );
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 980 },
+      args: ["--no-sandbox"],
+    });
+    page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (!isGatewayApiUrl(url)) return;
+      gatewayRequests.push(`${request.method()} ${url}`);
+      if (MUTATION_METHODS.has(request.method())) {
+        const mutation = `${request.method()} ${url}`;
+        browserMutations.push(mutation);
+        if (!isAllowedBrowserMutation(request.method(), url)) {
+          unexpectedMutations.push(mutation);
+        }
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isGatewayApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${url}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponsesDuring(
+      page,
+      "initial Gateway MCP playground load",
+      [
+        gatewayListResponse(),
+        gatewayConfigResponse(evidence.gateway_id),
+        mcpStatusResponse(evidence.gateway_id),
+        mcpToolsResponse(evidence.gateway_id),
+      ],
+      () =>
+        page.goto(`${APP_BASE}/dashboard/gateway/mcp/playground`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForPath(page, "/dashboard/gateway/mcp/playground");
+    await waitForVisibleText(page, "MCP Tools", { exact: true });
+    await waitForVisibleText(page, "Tool Selection", { exact: true });
+    await selectAutocompleteByTestId(
+      page,
+      "mcp-playground-tool-input",
+      TOOL_NAME,
+    );
+    await waitForVisibleText(page, "Arguments (JSON)", { exact: true });
+    await setTextareaByTestId(
+      page,
+      "mcp-playground-arguments-input",
+      JSON.stringify(TOOL_ARGUMENTS, null, 2),
+    );
+
+    const [testToolResponse] = await waitForResponsesDuring(
+      page,
+      "execute MCP Test Tool through browser",
+      [testMCPToolResponse(evidence.gateway_id)],
+      () => clickByTestId(page, "mcp-playground-execute-button"),
+    );
+    evidence.test_tool_response = await responseResult(testToolResponse);
+    assertMCPTestResult(evidence.test_tool_response);
+
+    await waitForVisibleText(page, "Result", { exact: true });
+    await waitForVisibleText(page, `echo:${TOOL_ARGUMENTS.input}`);
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+    evidence.screenshot = SCREENSHOT_PATH;
+
+    const mockCalls = mockMCP.requests.filter(
+      (request) => request.method === "tools/call",
+    );
+    assert(
+      mockCalls.length === 1,
+      `Expected one upstream tools/call, saw ${mockCalls.length}: ${JSON.stringify(
+        mockMCP.requests,
+      )}`,
+    );
+    evidence.mock_mcp_tool_call = mockCalls[0];
+
+    assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+    assert(
+      unexpectedMutations.length === 0,
+      `Unexpected Gateway MCP Test Tool browser mutations: ${unexpectedMutations.join(
+        "; ",
+      )}`,
+    );
+    assert(
+      browserMutations.length === 1,
+      `Expected one Test Tool browser mutation, saw ${browserMutations.length}: ${browserMutations.join(
+        "; ",
+      )}`,
+    );
+    evidence.browser_mutations = browserMutations;
+  } catch (error) {
+    caughtError = error;
+    await page
+      ?.screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+      .catch(() => null);
+  } finally {
+    if (browser) await browser.close();
+    if (cleanupOrgConfig) {
+      try {
+        evidence.org_config_cleanup = await cleanupOrgConfig();
+      } catch (error) {
+        cleanupError = error;
+        evidence.org_config_cleanup = {
+          status: "failed",
+          error: error.message,
+        };
+      }
+    }
+    if (gatewayHarness) {
+      try {
+        evidence.gateway_cleanup = await gatewayHarness.cleanup();
+        gatewayWasRestored = Boolean(evidence.gateway_cleanup.original_started);
+      } catch (error) {
+        cleanupError = cleanupError || error;
+        evidence.gateway_cleanup = { status: "failed", error: error.message };
+      }
+    }
+    if (gatewayWasRestored && cleanupOrgConfig) {
+      try {
+        evidence.original_gateway_reload = await responseResult(
+          await auth.client.post(
+            apiPath("/agentcc/gateways/{id}/reload/", {
+              id: evidence.gateway_id,
+            }),
+            {},
+          ),
+        );
+      } catch (error) {
+        cleanupError = cleanupError || error;
+        evidence.original_gateway_reload = {
+          status: "failed",
+          error: error.message,
+        };
+      }
+    }
+    if (mockMCP) {
+      try {
+        await mockMCP.close();
+      } catch (error) {
+        cleanupError = cleanupError || error;
+        evidence.mock_mcp_cleanup = { status: "failed", error: error.message };
+      }
+    }
+  }
+
+  if (caughtError || cleanupError) {
+    console.error(
+      JSON.stringify(
+        {
+          status: "failed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          evidence,
+          api_failures: apiFailures,
+          page_errors: pageErrors,
+          gateway_requests: gatewayRequests,
+          browser_mutations: browserMutations,
+          unexpected_mutations: unexpectedMutations,
+          failure_screenshot: FAILURE_SCREENSHOT_PATH,
+        },
+        null,
+        2,
+      ),
+    );
+    throw caughtError || cleanupError;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        status: "passed",
+        app_base: APP_BASE,
+        api_base: auth.apiBase,
+        organization_id: auth.organizationId,
+        workspace_id: auth.workspaceId,
+        evidence,
+        gateway_request_count: gatewayRequests.length,
+        browser_mutations: browserMutations,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function startMockMCPServer() {
+  const requests = [];
+  const server = http.createServer(async (request, response) => {
+    if (request.method !== "POST" || request.url !== "/mcp") {
+      response.writeHead(404, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: "not found" }));
+      return;
+    }
+
+    const rawBody = await readRequestBody(request);
+    let message;
+    try {
+      message = JSON.parse(rawBody || "{}");
+    } catch {
+      response.writeHead(400, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: "invalid json" }));
+      return;
+    }
+
+    const params = parseRpcParams(message.params);
+    requests.push({ method: message.method, params });
+
+    if (!message.id) {
+      response.writeHead(202);
+      response.end();
+      return;
+    }
+
+    const headers = {
+      "Content-Type": "application/json",
+      "MCP-Session-Id": "th4812-mcp-session",
+    };
+    response.writeHead(200, headers);
+    response.end(JSON.stringify(createMCPResponse(message)));
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "0.0.0.0", resolve);
+  });
+
+  const { port } = server.address();
+  return {
+    port,
+    requests,
+    hostUrl: `http://127.0.0.1:${port}`,
+    containerUrl: `http://host.docker.internal:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+function createMCPResponse(message) {
+  const base = { jsonrpc: "2.0", id: message.id };
+  if (message.method === "initialize") {
+    return {
+      ...base,
+      result: {
+        protocolVersion: "2025-11-25",
+        capabilities: { tools: {}, resources: {}, prompts: {} },
+        serverInfo: { name: "th4812-mcp-smoke", version: "1.0.0" },
+      },
+    };
+  }
+  if (message.method === "tools/list") {
+    return {
+      ...base,
+      result: {
+        tools: [
+          {
+            name: TOOL_ORIGINAL_NAME,
+            description: "Echo arguments for the Gateway MCP Test Tool smoke.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                input: { type: "string" },
+                count: { type: "integer" },
+                flag: { type: "boolean" },
+              },
+              required: ["input"],
+            },
+          },
+        ],
+      },
+    };
+  }
+  if (message.method === "tools/call") {
+    const params = parseRpcParams(message.params);
+    return {
+      ...base,
+      result: {
+        content: [
+          {
+            type: "text",
+            text: `echo:${params.arguments?.input || ""}:${params.arguments?.count}`,
+          },
+        ],
+      },
+    };
+  }
+  if (message.method === "resources/list") {
+    return {
+      ...base,
+      result: {
+        resources: [
+          {
+            uri: "futureagi://th4812/mcp-smoke",
+            name: "TH-4812 MCP Smoke Resource",
+            description: "Disposable resource exposed by the MCP smoke server.",
+            mimeType: "text/plain",
+          },
+        ],
+      },
+    };
+  }
+  if (message.method === "prompts/list") {
+    return {
+      ...base,
+      result: {
+        prompts: [
+          {
+            name: "th4812_mcp_prompt",
+            description: "Disposable prompt exposed by the MCP smoke server.",
+            arguments: [{ name: "topic", required: false }],
+          },
+        ],
+      },
+    };
+  }
+  return { ...base, result: {} };
+}
+
+function parseRpcParams(params) {
+  if (!params) return {};
+  if (typeof params === "string") return JSON.parse(params);
+  return params;
+}
+
+async function readRequestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function startDisposableGateway(mockPort) {
+  if (process.env.GATEWAY_MCP_ALLOW_GATEWAY_RESTART !== "1") {
+    throw new Error(
+      "Set GATEWAY_MCP_ALLOW_GATEWAY_RESTART=1 to run this smoke; it temporarily stops ws2-agentcc-gateway and restores it in cleanup.",
+    );
+  }
+
+  const originalContainer =
+    process.env.GATEWAY_MCP_ORIGINAL_CONTAINER || "ws2-agentcc-gateway";
+  const tempContainer =
+    process.env.GATEWAY_MCP_TEMP_CONTAINER || "th4812-gateway-mcp-test-tool";
+  const serviceAlias =
+    process.env.GATEWAY_MCP_SERVICE_ALIAS || "agentcc-gateway";
+  const hostPort = process.env.GATEWAY_MCP_HOST_PORT || "8095";
+  const adminToken = process.env.AGENTCC_ADMIN_TOKEN || "agentcc-admin-secret";
+
+  const originalInspect = await dockerInspect(originalContainer);
+  const originalWasRunning = Boolean(originalInspect.State?.Running);
+  const originalImage =
+    process.env.GATEWAY_MCP_IMAGE || originalInspect.Config?.Image;
+  assert(originalImage, `Could not resolve image for ${originalContainer}.`);
+  const network =
+    process.env.GATEWAY_MCP_DOCKER_NETWORK ||
+    Object.entries(originalInspect.NetworkSettings?.Networks || {}).find(
+      ([, value]) => asArray(value?.Aliases).includes(serviceAlias),
+    )?.[0] ||
+    Object.keys(originalInspect.NetworkSettings?.Networks || {})[0];
+  assert(network, `Could not resolve docker network for ${originalContainer}.`);
+
+  const configPath = path.join(
+    process.env.GATEWAY_MCP_CONFIG_DIR ||
+      path.resolve(process.cwd(), "agentcc-gateway"),
+    `futureagi-mcp-test-gateway-${process.pid}.yaml`,
+  );
+  await fs.writeFile(
+    configPath,
+    gatewayConfigYaml({ mockPort, adminToken }),
+    "utf8",
+  );
+
+  await docker(["rm", "-f", tempContainer], { ignoreFailure: true });
+  if (originalWasRunning) {
+    await docker(["stop", originalContainer], { timeout: 30000 });
+  }
+
+  try {
+    await docker(
+      [
+        "run",
+        "-d",
+        "--name",
+        tempContainer,
+        "--network",
+        network,
+        "--network-alias",
+        serviceAlias,
+        "--add-host",
+        "host.docker.internal:host-gateway",
+        "-p",
+        `${hostPort}:8080`,
+        "-e",
+        `AGENTCC_ADMIN_TOKEN=${adminToken}`,
+        "-v",
+        `${configPath}:/app/config.yaml:ro`,
+        originalImage,
+        "--config",
+        "/app/config.yaml",
+      ],
+      { timeout: 30000 },
+    );
+    const ready = await waitForDisposableGatewayReady({ hostPort, adminToken });
+    return {
+      evidence: {
+        mode: "disposable-docker-gateway",
+        original_container: originalContainer,
+        original_was_running: originalWasRunning,
+        temp_container: tempContainer,
+        image: originalImage,
+        network,
+        service_alias: serviceAlias,
+        host_port: hostPort,
+        ready,
+      },
+      cleanup: async () => {
+        await docker(["rm", "-f", tempContainer], { ignoreFailure: true });
+        const cleanup = {
+          status: "passed",
+          temp_container_removed: true,
+          original_started: false,
+        };
+        if (originalWasRunning) {
+          await docker(["start", originalContainer], { timeout: 30000 });
+          cleanup.original_started = true;
+          cleanup.original_health =
+            await waitForOriginalGatewayHealth(hostPort);
+        }
+        await fs.rm(configPath, { force: true });
+        return cleanup;
+      },
+    };
+  } catch (error) {
+    const logs = await dockerLogs(tempContainer);
+    await docker(["rm", "-f", tempContainer], { ignoreFailure: true });
+    if (originalWasRunning) {
+      await docker(["start", originalContainer], {
+        timeout: 30000,
+        ignoreFailure: true,
+      });
+    }
+    await fs.rm(configPath, { force: true });
+    if (logs)
+      error.message = `${error.message}\nDisposable gateway logs:\n${logs}`;
+    throw error;
+  }
+}
+
+function gatewayConfigYaml({ mockPort, adminToken }) {
+  return `server:
+  port: 8080
+  host: "0.0.0.0"
+admin:
+  token: "${adminToken}"
+logging:
+  level: "info"
+  format: "json"
+mcp:
+  enabled: true
+  endpoint: "/mcp"
+  max_agent_depth: 10
+  tool_call_timeout: 10s
+  session_ttl: 30m
+  separator: "_"
+  servers:
+    ${MCP_SERVER_ID}:
+      url: "http://host.docker.internal:${mockPort}"
+      transport: "http"
+      auth:
+        type: "none"
+      tools_cache_ttl: 5m
+`;
+}
+
+async function waitForDisposableGatewayReady({ hostPort, adminToken }) {
+  const baseUrl = `http://127.0.0.1:${hostPort}`;
+  let lastError = "";
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      const health = await fetch(`${baseUrl}/healthz`);
+      if (!health.ok) throw new Error(`health ${health.status}`);
+      const toolsResponse = await fetch(`${baseUrl}/-/mcp/tools`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+      });
+      if (!toolsResponse.ok) {
+        throw new Error(`mcp tools ${toolsResponse.status}`);
+      }
+      const tools = await toolsResponse.json();
+      if (asArray(tools).some((tool) => tool.name === TOOL_NAME)) {
+        return {
+          health: "ok",
+          tool_count: asArray(tools).length,
+          tool_name: TOOL_NAME,
+        };
+      }
+      lastError = `MCP tools did not include ${TOOL_NAME}: ${JSON.stringify(
+        tools,
+      )}`;
+    } catch (error) {
+      lastError = error.message;
+    }
+    await delay(500);
+  }
+  throw new Error(`Disposable gateway did not become ready: ${lastError}`);
+}
+
+async function waitForOriginalGatewayHealth(hostPort) {
+  const baseUrl = `http://127.0.0.1:${hostPort}`;
+  let lastError = "";
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      const health = await fetch(`${baseUrl}/healthz`);
+      if (health.ok) return { status: "healthy" };
+      lastError = `health ${health.status}`;
+    } catch (error) {
+      lastError = error.message;
+    }
+    await delay(500);
+  }
+  return { status: "unknown", error: lastError };
+}
+
+async function dockerInspect(container) {
+  const { stdout } = await docker(["inspect", container], { timeout: 15000 });
+  return JSON.parse(stdout)[0];
+}
+
+async function docker(args, { timeout = 20000, ignoreFailure = false } = {}) {
+  try {
+    return await execFile("docker", args, { timeout });
+  } catch (error) {
+    if (ignoreFailure) return { stdout: "", stderr: error.stderr || "" };
+    throw error;
+  }
+}
+
+async function dockerLogs(container) {
+  try {
+    const { stdout, stderr } = await docker(["logs", container], {
+      timeout: 10000,
+    });
+    return `${stdout || ""}${stderr || ""}`.trim();
+  } catch {
+    return "";
+  }
+}
+
+async function waitForBackendTool(client, gatewayId, toolName) {
+  let lastTools = [];
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    lastTools = asArray(
+      await client.get(
+        apiPath("/agentcc/gateways/{id}/mcp-tools/", { id: gatewayId }),
+      ),
+    );
+    if (lastTools.some((tool) => tool?.name === toolName)) return lastTools;
+    await delay(500);
+  }
+  throw new Error(
+    `Backend MCP tools did not include ${toolName}: ${JSON.stringify(lastTools)}`,
+  );
+}
+
+async function prepareOrgConfigRestorer(client) {
+  const originalActiveConfig = await client.get(
+    apiPath("/agentcc/org-configs/active/"),
+  );
+  assert(
+    originalActiveConfig?.id && originalActiveConfig?.is_active === true,
+    "AgentCC active org config endpoint did not return an active baseline.",
+  );
+  const beforeConfigIds = new Set(
+    collectionRows(await client.get(apiPath("/agentcc/org-configs/")))
+      .map((config) => config?.id)
+      .filter(Boolean),
+  );
+
+  return {
+    originalActiveConfig,
+    beforeConfigIds,
+    cleanup: createOrgConfigRestorer({
+      client,
+      beforeConfigIds,
+      originalActiveConfigId: originalActiveConfig.id,
+    }),
+  };
+}
+
+function collectionRows(value) {
+  if (Array.isArray(value)) return value;
+  if (Array.isArray(value?.results)) return value.results;
+  if (Array.isArray(value?.data)) return value.data;
+  return asArray(value);
+}
+
+function createOrgConfigRestorer({
+  client,
+  beforeConfigIds,
+  originalActiveConfigId,
+}) {
+  let completed = false;
+
+  return async () => {
+    if (completed) return { status: "already-cleaned" };
+    const restoreEvidence = {
+      status: "passed",
+      original_config_id: originalActiveConfigId,
+      activated_original: false,
+      deleted_config_ids: [],
+      deleted_config_versions: [],
+    };
+
+    const activeConfig = await client.get(
+      apiPath("/agentcc/org-configs/active/"),
+    );
+    if (activeConfig?.id !== originalActiveConfigId) {
+      await client.post(
+        apiPath("/agentcc/org-configs/{id}/activate/", {
+          id: originalActiveConfigId,
+        }),
+        {},
+      );
+      restoreEvidence.activated_original = true;
+    }
+
+    const configs = collectionRows(
+      await client.get(apiPath("/agentcc/org-configs/")),
+    );
+    const disposableConfigs = configs.filter(
+      (config) =>
+        config?.id &&
+        config.id !== originalActiveConfigId &&
+        !beforeConfigIds.has(config.id),
+    );
+
+    for (const config of disposableConfigs) {
+      await ignoreNotFound(() =>
+        client.delete(apiPath("/agentcc/org-configs/{id}/", { id: config.id })),
+      );
+      restoreEvidence.deleted_config_ids.push(config.id);
+      restoreEvidence.deleted_config_versions.push(config.version);
+    }
+
+    const restoredActive = await client.get(
+      apiPath("/agentcc/org-configs/active/"),
+    );
+    assert(
+      restoredActive?.id === originalActiveConfigId,
+      "AgentCC org config cleanup did not restore the original active config.",
+    );
+
+    completed = true;
+    return restoreEvidence;
+  };
+}
+
+async function ignoreNotFound(fn) {
+  try {
+    return await fn();
+  } catch (error) {
+    const message = String(error?.message || "").toLowerCase();
+    if (
+      error?.status === 404 ||
+      message.includes("not found") ||
+      message.includes("does not exist")
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(() => {
+    window.normalizeText = (value) => String(value || "").trim();
+    window.dispatchClick = (element) => {
+      element.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("mouseup", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    };
+    window.setNativeValue = (element, value) => {
+      const prototype =
+        element instanceof HTMLTextAreaElement
+          ? HTMLTextAreaElement.prototype
+          : HTMLInputElement.prototype;
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, "value");
+      descriptor.set.call(element, value);
+      element.dispatchEvent(new Event("input", { bubbles: true }));
+      element.dispatchEvent(new Event("change", { bubbles: true }));
+    };
+    window.visibleElements = (selector = "body *") => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(selector)).filter(isVisible);
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function waitForResponsesDuring(page, label, predicates, action) {
+  try {
+    return await Promise.all([
+      ...predicates.map((predicate) =>
+        page.waitForResponse(predicate, { timeout: 60000 }),
+      ),
+      action(),
+    ]);
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForPath(page, pathname, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedPath) => window.location.pathname === expectedPath,
+    { timeout },
+    pathname,
+  );
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) =>
+      window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      }),
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function selectAutocompleteByTestId(page, testId, value) {
+  const selector = `[data-testid="${cssEscape(testId)}"]`;
+  await page.waitForSelector(selector, { visible: true, timeout: 30000 });
+  await page.click(selector);
+  await page.keyboard.type(value);
+  await page.waitForFunction(
+    (expectedValue) =>
+      window
+        .visibleElements("[role='option'],li")
+        .some(
+          (element) =>
+            window.normalizeText(element.textContent) === expectedValue,
+        ),
+    { timeout: 30000 },
+    value,
+  );
+  const selected = await page.evaluate((expectedValue) => {
+    const option = window
+      .visibleElements("[role='option'],li")
+      .find(
+        (element) =>
+          window.normalizeText(element.textContent) === expectedValue,
+      );
+    if (!option) return false;
+    window.dispatchClick(option);
+    return true;
+  }, value);
+  assert(selected, `Could not select MCP tool ${value}`);
+  await waitForInputValue(page, testId, value);
+}
+
+async function setTextareaByTestId(page, testId, value) {
+  const updated = await page.evaluate(
+    ({ expectedTestId, nextValue }) => {
+      const element = document.querySelector(
+        `[data-testid="${CSS.escape(expectedTestId)}"]`,
+      );
+      if (!element || element.disabled) return false;
+      element.focus();
+      window.setNativeValue(element, nextValue);
+      element.blur();
+      return true;
+    },
+    { expectedTestId: testId, nextValue: value },
+  );
+  assert(updated, `Could not set textarea ${testId}`);
+}
+
+async function clickByTestId(page, testId) {
+  const selector = `button[data-testid="${cssEscape(testId)}"]`;
+  await page.waitForSelector(selector, { visible: true, timeout: 30000 });
+  const clicked = await page.evaluate((expectedSelector) => {
+    const element = document.querySelector(expectedSelector);
+    if (!element || element.disabled) return null;
+    element.scrollIntoView({ block: "center", inline: "center" });
+    window.__mcpExecuteClickCount = 0;
+    element.addEventListener(
+      "click",
+      () => {
+        window.__mcpExecuteClickCount += 1;
+      },
+      { once: true },
+    );
+    element.click();
+    return {
+      event_count: window.__mcpExecuteClickCount,
+      active_element: document.activeElement?.tagName || "",
+    };
+  }, selector);
+  assert(clicked, `Could not click ${testId}`);
+  return clicked;
+}
+
+async function waitForInputValue(page, testId, value, timeout = 30000) {
+  await page.waitForFunction(
+    ({ expectedTestId, expectedValue }) => {
+      const element = document.querySelector(
+        `[data-testid="${CSS.escape(expectedTestId)}"]`,
+      );
+      return element?.value === expectedValue;
+    },
+    { timeout },
+    { expectedTestId: testId, expectedValue: value },
+  );
+}
+
+async function responseResult(response) {
+  if (typeof response?.json === "function") {
+    const data = await response.json();
+    return data?.result ?? data;
+  }
+  return response?.result ?? response;
+}
+
+function assertMCPTestResult(result) {
+  const contentText = asArray(result?.content)
+    .map((part) => part?.text || JSON.stringify(part))
+    .join("\n");
+  assert(
+    result?.server === MCP_SERVER_ID,
+    `Unexpected MCP server: ${result?.server}`,
+  );
+  assert(
+    result?.is_error !== true,
+    `MCP result was an error: ${JSON.stringify(result)}`,
+  );
+  assert(
+    contentText.includes(
+      `echo:${TOOL_ARGUMENTS.input}:${TOOL_ARGUMENTS.count}`,
+    ),
+    `Unexpected MCP content: ${contentText}`,
+  );
+}
+
+function gatewayListResponse() {
+  return (response) =>
+    response.url().includes("/agentcc/gateways/") &&
+    !response.url().includes("/config/") &&
+    response.request().method() === "GET" &&
+    response.status() < 400;
+}
+
+function gatewayConfigResponse(gatewayId = "") {
+  return (response) =>
+    response.url().includes("/agentcc/gateways/") &&
+    response.url().includes("/config/") &&
+    (!gatewayId ||
+      response.url().includes(`/agentcc/gateways/${gatewayId}/`)) &&
+    response.request().method() === "GET" &&
+    response.status() < 400;
+}
+
+function mcpStatusResponse(gatewayId) {
+  return (response) =>
+    response.url().includes(`/agentcc/gateways/${gatewayId}/mcp-status/`) &&
+    response.request().method() === "GET" &&
+    response.status() < 400;
+}
+
+function mcpToolsResponse(gatewayId) {
+  return (response) =>
+    response.url().includes(`/agentcc/gateways/${gatewayId}/mcp-tools/`) &&
+    response.request().method() === "GET" &&
+    response.status() < 400;
+}
+
+function testMCPToolResponse(gatewayId) {
+  return (response) =>
+    response.url().includes(`/agentcc/gateways/${gatewayId}/test-mcp-tool/`) &&
+    response.request().method() === "POST" &&
+    response.status() < 400;
+}
+
+function isGatewayApiUrl(url) {
+  return url.includes("/agentcc/");
+}
+
+function isAllowedBrowserMutation(method, url) {
+  return method === "POST" && url.includes("/test-mcp-tool/");
+}
+
+function cssEscape(value) {
+  return String(value).replace(/["\\]/g, "\\$&");
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") {
+    return "/usr/bin/google-chrome";
+  }
+  return undefined;
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/frontend/scripts/api-journeys/browser/gateway-monitoring-mutation-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/gateway-monitoring-mutation-smoke.mjs
@@ -13,9 +13,17 @@ const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
-const RULE_SCREENSHOT_PATH = "/tmp/gateway-monitoring-rule-create-smoke.png";
-const CHANNEL_SCREENSHOT_PATH =
+const RULE_CREATE_SCREENSHOT_PATH =
+  "/tmp/gateway-monitoring-rule-create-smoke.png";
+const RULE_EDIT_SCREENSHOT_PATH = "/tmp/gateway-monitoring-rule-edit-smoke.png";
+const RULE_DELETE_SCREENSHOT_PATH =
+  "/tmp/gateway-monitoring-rule-delete-smoke.png";
+const CHANNEL_CREATE_SCREENSHOT_PATH =
   "/tmp/gateway-monitoring-channel-create-smoke.png";
+const CHANNEL_EDIT_SCREENSHOT_PATH =
+  "/tmp/gateway-monitoring-channel-edit-smoke.png";
+const CHANNEL_DELETE_SCREENSHOT_PATH =
+  "/tmp/gateway-monitoring-channel-delete-smoke.png";
 const FAILURE_SCREENSHOT_PATH =
   "/tmp/gateway-monitoring-mutation-smoke-failure.png";
 const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
@@ -132,8 +140,11 @@ async function main() {
     ]) {
       await waitForVisibleText(page, label, { exact: true });
     }
-    await page.screenshot({ path: RULE_SCREENSHOT_PATH, fullPage: true });
-    evidence.rule_screenshot = RULE_SCREENSHOT_PATH;
+    await page.screenshot({
+      path: RULE_CREATE_SCREENSHOT_PATH,
+      fullPage: true,
+    });
+    evidence.rule_create_screenshot = RULE_CREATE_SCREENSHOT_PATH;
 
     const configWithRule = await auth.client.get(
       apiPath("/agentcc/gateways/{id}/config/", { id: evidence.gateway_id }),
@@ -154,6 +165,103 @@ async function main() {
       threshold: savedRule.threshold,
       enabled: savedRule.enabled,
     };
+
+    await clickByAriaLabel(page, `Edit alert rule ${evidence.rule_name}`);
+    await waitForVisibleText(page, "Edit Alert Rule", { exact: true });
+    await setDialogInputByLabel(page, "Rule Name", evidence.edited_rule_name);
+    await setDialogInputByLabel(
+      page,
+      "Threshold",
+      String(evidence.edited_threshold),
+    );
+    await setDialogInputByLabel(page, "Window", evidence.edited_window);
+
+    const [editRuleResponse] = await waitForResponsesDuring(
+      page,
+      "edit monitoring alert rule through browser",
+      [
+        updateConfigMutationResponse(evidence.gateway_id),
+        gatewayConfigResponse(),
+      ],
+      () => clickDialogButton(page, "Save Rule"),
+    );
+    evidence.edit_rule_response = await responseResult(editRuleResponse);
+    await waitForNoVisibleText(page, "Edit Alert Rule", { exact: true });
+
+    for (const label of [
+      evidence.edited_rule_name,
+      String(evidence.edited_threshold),
+      evidence.edited_window,
+    ]) {
+      await waitForVisibleText(page, label, { exact: true });
+    }
+    await waitForNoVisibleText(page, evidence.rule_name, { exact: true });
+    await page.screenshot({ path: RULE_EDIT_SCREENSHOT_PATH, fullPage: true });
+    evidence.rule_edit_screenshot = RULE_EDIT_SCREENSHOT_PATH;
+
+    const configWithEditedRule = await auth.client.get(
+      apiPath("/agentcc/gateways/{id}/config/", { id: evidence.gateway_id }),
+    );
+    const oldRuleAfterEdit = extractAlertRules(configWithEditedRule).find(
+      (rule) => rule.name === evidence.rule_name,
+    );
+    const editedRule = extractAlertRules(configWithEditedRule).find(
+      (rule) => rule.name === evidence.edited_rule_name,
+    );
+    assert(
+      !oldRuleAfterEdit &&
+        editedRule?.enabled === true &&
+        editedRule?.metric === "error_rate" &&
+        editedRule?.threshold === evidence.edited_threshold &&
+        editedRule?.window === evidence.edited_window,
+      `Edited alert rule did not match browser form: ${JSON.stringify({
+        oldRuleAfterEdit,
+        editedRule,
+      })}`,
+    );
+    evidence.edited_rule = {
+      name: editedRule.name,
+      threshold: editedRule.threshold,
+      window: editedRule.window,
+      enabled: editedRule.enabled,
+    };
+
+    await clickByAriaLabel(
+      page,
+      `Delete alert rule ${evidence.edited_rule_name}`,
+    );
+    await waitForVisibleText(page, "Delete Alert Rule", { exact: true });
+    const [deleteRuleResponse] = await waitForResponsesDuring(
+      page,
+      "delete monitoring alert rule through browser",
+      [
+        updateConfigMutationResponse(evidence.gateway_id),
+        gatewayConfigResponse(),
+      ],
+      () => clickDialogButton(page, "Delete"),
+    );
+    evidence.delete_rule_response = await responseResult(deleteRuleResponse);
+    await waitForNoVisibleText(page, "Delete Alert Rule", { exact: true });
+    await waitForNoVisibleText(page, evidence.edited_rule_name, {
+      exact: true,
+    });
+    await page.screenshot({
+      path: RULE_DELETE_SCREENSHOT_PATH,
+      fullPage: true,
+    });
+    evidence.rule_delete_screenshot = RULE_DELETE_SCREENSHOT_PATH;
+
+    const configAfterRuleDelete = await auth.client.get(
+      apiPath("/agentcc/gateways/{id}/config/", { id: evidence.gateway_id }),
+    );
+    const deletedRule = extractAlertRules(configAfterRuleDelete).find(
+      (rule) => rule.name === evidence.edited_rule_name,
+    );
+    assert(
+      !deletedRule,
+      `Deleted alert rule remained in /config/: ${JSON.stringify(deletedRule)}`,
+    );
+    evidence.deleted_rule_absent = true;
 
     await clickVisibleText(page, "Add Channel", { exact: true });
     await waitForVisibleText(page, "Add Notification Channel", {
@@ -189,8 +297,11 @@ async function main() {
       await waitForVisibleText(page, label, { exact: true });
     }
     await waitForVisibleText(page, "https://example.com/");
-    await page.screenshot({ path: CHANNEL_SCREENSHOT_PATH, fullPage: true });
-    evidence.channel_screenshot = CHANNEL_SCREENSHOT_PATH;
+    await page.screenshot({
+      path: CHANNEL_CREATE_SCREENSHOT_PATH,
+      fullPage: true,
+    });
+    evidence.channel_create_screenshot = CHANNEL_CREATE_SCREENSHOT_PATH;
 
     const configWithChannel = await auth.client.get(
       apiPath("/agentcc/gateways/{id}/config/", { id: evidence.gateway_id }),
@@ -210,6 +321,115 @@ async function main() {
       type: savedChannel.type,
       url: savedChannel.url,
     };
+    evidence.channel_row_action_controls_after_create =
+      await countMonitoringRowActions(page);
+
+    await clickByAriaLabel(
+      page,
+      `Edit notification channel ${evidence.channel_name}`,
+    );
+    await waitForVisibleText(page, "Edit Notification Channel", {
+      exact: true,
+    });
+    await setDialogInputByLabel(
+      page,
+      "Channel Name",
+      evidence.edited_channel_name,
+    );
+    await setDialogInputByLabel(
+      page,
+      "URL / Endpoint",
+      evidence.edited_channel_url,
+    );
+
+    const [editChannelResponse] = await waitForResponsesDuring(
+      page,
+      "edit monitoring notification channel through browser",
+      [
+        updateConfigMutationResponse(evidence.gateway_id),
+        gatewayConfigResponse(),
+      ],
+      () => clickDialogButton(page, "Save Channel"),
+    );
+    evidence.edit_channel_response = await responseResult(editChannelResponse);
+    await waitForNoVisibleText(page, "Edit Notification Channel", {
+      exact: true,
+    });
+
+    await waitForVisibleText(page, evidence.edited_channel_name, {
+      exact: true,
+    });
+    await waitForNoVisibleText(page, evidence.channel_name, { exact: true });
+    await page.screenshot({
+      path: CHANNEL_EDIT_SCREENSHOT_PATH,
+      fullPage: true,
+    });
+    evidence.channel_edit_screenshot = CHANNEL_EDIT_SCREENSHOT_PATH;
+
+    const configWithEditedChannel = await auth.client.get(
+      apiPath("/agentcc/gateways/{id}/config/", { id: evidence.gateway_id }),
+    );
+    const oldChannelAfterEdit = extractChannels(configWithEditedChannel).find(
+      (channel) => channel.name === evidence.channel_name,
+    );
+    const editedChannel = extractChannels(configWithEditedChannel).find(
+      (channel) => channel.name === evidence.edited_channel_name,
+    );
+    assert(
+      !oldChannelAfterEdit &&
+        editedChannel?.type === "webhook" &&
+        editedChannel?.url === evidence.edited_channel_url,
+      `Edited alert channel did not match browser form: ${JSON.stringify({
+        oldChannelAfterEdit,
+        editedChannel,
+      })}`,
+    );
+    evidence.edited_channel = {
+      name: editedChannel.name,
+      type: editedChannel.type,
+      url: editedChannel.url,
+    };
+
+    await clickByAriaLabel(
+      page,
+      `Delete notification channel ${evidence.edited_channel_name}`,
+    );
+    await waitForVisibleText(page, "Delete Channel", { exact: true });
+    const [deleteChannelResponse] = await waitForResponsesDuring(
+      page,
+      "delete monitoring notification channel through browser",
+      [
+        updateConfigMutationResponse(evidence.gateway_id),
+        gatewayConfigResponse(),
+      ],
+      () => clickDialogButton(page, "Delete"),
+    );
+    evidence.delete_channel_response = await responseResult(
+      deleteChannelResponse,
+    );
+    await waitForNoVisibleText(page, "Delete Channel", { exact: true });
+    await waitForNoVisibleText(page, evidence.edited_channel_name, {
+      exact: true,
+    });
+    await page.screenshot({
+      path: CHANNEL_DELETE_SCREENSHOT_PATH,
+      fullPage: true,
+    });
+    evidence.channel_delete_screenshot = CHANNEL_DELETE_SCREENSHOT_PATH;
+
+    const configAfterChannelDelete = await auth.client.get(
+      apiPath("/agentcc/gateways/{id}/config/", { id: evidence.gateway_id }),
+    );
+    const deletedChannel = extractChannels(configAfterChannelDelete).find(
+      (channel) => channel.name === evidence.edited_channel_name,
+    );
+    assert(
+      !deletedChannel,
+      `Deleted alert channel remained in /config/: ${JSON.stringify(
+        deletedChannel,
+      )}`,
+    );
+    evidence.deleted_channel_absent = true;
     evidence.browser_row_action_controls =
       await countMonitoringRowActions(page);
 
@@ -222,8 +442,8 @@ async function main() {
       )}`,
     );
     assert(
-      browserMutations.length === 2,
-      `Expected two monitoring browser mutations, saw ${browserMutations.length}: ${browserMutations.join(
+      browserMutations.length === 6,
+      `Expected six monitoring browser mutations, saw ${browserMutations.length}: ${browserMutations.join(
         "; ",
       )}`,
     );
@@ -318,10 +538,15 @@ async function preflightMonitoring(client, runId) {
       original_org_config_id: originalActiveConfig.id,
       original_org_config_version: originalActiveConfig.version,
       rule_name: `ui_monitoring_rule_${suffix}`,
+      edited_rule_name: `ui_monitoring_rule_${suffix}_edited`,
       channel_name: `ui_monitoring_channel_${suffix}`,
+      edited_channel_name: `ui_monitoring_channel_${suffix}_edited`,
       channel_url: `https://example.com/futureagi-monitoring-${shortSuffix}`,
+      edited_channel_url: `https://example.com/futureagi-monitoring-${shortSuffix}-edited`,
       threshold: 73,
+      edited_threshold: 41,
       window: "7m",
+      edited_window: "13m",
     },
     cleanup: createOrgConfigRestorer({
       client,
@@ -607,6 +832,35 @@ async function clickVisibleText(
     { text, exact },
   );
   assert(clicked, `Could not click visible text: ${text}`);
+}
+
+async function clickByAriaLabel(page, label, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedLabel) =>
+      window
+        .visibleElements("button")
+        .some(
+          (button) =>
+            button.getAttribute("aria-label") === expectedLabel &&
+            !button.disabled,
+        ),
+    { timeout },
+    label,
+  );
+  const clicked = await page.evaluate((expectedLabel) => {
+    const button = window
+      .visibleElements("button")
+      .find(
+        (candidate) =>
+          candidate.getAttribute("aria-label") === expectedLabel &&
+          !candidate.disabled,
+      );
+    if (!button) return false;
+    button.scrollIntoView({ block: "center", inline: "center" });
+    window.dispatchClick(button);
+    return true;
+  }, label);
+  assert(clicked, `Could not click aria-label: ${label}`);
 }
 
 async function setDialogInputByLabel(page, label, value, timeout = 30000) {

--- a/frontend/scripts/api-journeys/browser/gateway-providers-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/gateway-providers-smoke.mjs
@@ -98,70 +98,94 @@ async function main() {
       "Provider Config",
       "Routing",
       "Cache",
-      "Provider",
-      "Status",
-      "Models",
-      "Latency (P50)",
-      "Error Rate",
-      "Circuit Breaker",
     ]) {
       await waitForVisibleText(page, label, { exact: true });
     }
-    await waitForVisibleText(page, sampleProvider.health_display_name, {
-      exact: true,
-    });
-    if (sampleProvider.models.length > 0) {
-      await waitForVisibleText(page, sampleProvider.models[0], {
+
+    if (sampleProvider) {
+      for (const label of [
+        "Provider",
+        "Status",
+        "Models",
+        "Latency (P50)",
+        "Error Rate",
+        "Circuit Breaker",
+      ]) {
+        await waitForVisibleText(page, label, { exact: true });
+      }
+      await waitForVisibleText(page, sampleProvider.health_display_name, {
         exact: true,
       });
+      if (sampleProvider.models.length > 0) {
+        await waitForVisibleText(page, sampleProvider.models[0], {
+          exact: true,
+        });
+      }
+    } else {
+      await waitForVisibleText(page, "No provider data available.", {
+        exact: true,
+      });
+      evidence.empty_provider_health = true;
     }
 
     await clickVisibleText(page, "Provider Config", { exact: true });
     await waitForPath(page, "/dashboard/gateway/providers/config");
-    await waitForVisibleText(page, sampleProvider.name, { exact: true });
-    for (const label of [
-      "Base URL",
-      "API Format",
-      "API Key",
-      "Timeout",
-      "Max Concurrent",
-      "Connection Pool",
-      "Models",
-    ]) {
-      await waitForVisibleText(page, label, { exact: true });
-    }
-    for (const value of [
-      sampleProvider.base_url,
-      sampleProvider.api_format,
-      sampleProvider.default_timeout,
-      sampleProvider.max_concurrent,
-      sampleProvider.conn_pool_size,
-      sampleProvider.models[0],
-    ]) {
-      if (value !== undefined && value !== null && value !== "") {
-        await waitForVisibleText(page, String(value), { exact: true });
+    if (sampleProvider) {
+      await waitForVisibleText(page, sampleProvider.name, { exact: true });
+      for (const label of [
+        "Base URL",
+        "API Format",
+        "API Key",
+        "Timeout",
+        "Max Concurrent",
+        "Connection Pool",
+        "Models",
+      ]) {
+        await waitForVisibleText(page, label, { exact: true });
       }
+      for (const value of [
+        sampleProvider.base_url,
+        sampleProvider.api_format,
+        sampleProvider.default_timeout,
+        sampleProvider.max_concurrent,
+        sampleProvider.conn_pool_size,
+        sampleProvider.models[0],
+      ]) {
+        if (value !== undefined && value !== null && value !== "") {
+          await waitForVisibleText(page, String(value), { exact: true });
+        }
+      }
+      evidence.provider_config_mode = "configured";
+    } else {
+      await waitForVisibleText(page, "No provider configuration available.", {
+        exact: true,
+      });
+      evidence.provider_config_mode = "empty";
     }
     await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
     evidence.screenshot = SCREENSHOT_PATH;
 
-    const fetchResponse = await waitForResponseDuring(
-      page,
-      "fetch provider models in edit dialog",
-      (response) =>
-        response.url().includes("/agentcc/provider-credentials/fetch_models/") &&
-        response.request().method() === "POST",
-      () => clickTitleWithinText(page, sampleProvider.name, "Edit provider"),
-    );
-    providerFetchResponses.push(
-      `${fetchResponse.status()} ${fetchResponse.url()}`,
-    );
-    await waitForVisibleText(page, "Edit Provider", { exact: true });
-    await waitForVisibleText(page, "Provider Name");
-    await waitForVisibleText(page, "API Format", { exact: true });
-    await waitForVisibleText(page, "Models", { exact: true });
-    await clickDialogButton(page, "Cancel");
-    await waitForNoVisibleText(page, "Edit Provider", { exact: true });
+    if (sampleProvider) {
+      const fetchResponse = await waitForResponseDuring(
+        page,
+        "fetch provider models in edit dialog",
+        (response) =>
+          response
+            .url()
+            .includes("/agentcc/provider-credentials/fetch_models/") &&
+          response.request().method() === "POST",
+        () => clickTitleWithinText(page, sampleProvider.name, "Edit provider"),
+      );
+      providerFetchResponses.push(
+        `${fetchResponse.status()} ${fetchResponse.url()}`,
+      );
+      await waitForVisibleText(page, "Edit Provider", { exact: true });
+      await waitForVisibleText(page, "Provider Name");
+      await waitForVisibleText(page, "API Format", { exact: true });
+      await waitForVisibleText(page, "Models", { exact: true });
+      await clickDialogButton(page, "Cancel");
+      await waitForNoVisibleText(page, "Edit Provider", { exact: true });
+    }
 
     await clickVisibleText(page, "Routing", { exact: true });
     await waitForPath(page, "/dashboard/gateway/providers/routing");
@@ -212,10 +236,12 @@ async function main() {
       unexpectedMutations.length === 0,
       `Unexpected Gateway provider mutations: ${unexpectedMutations.join("; ")}`,
     );
-    assert(
-      providerFetchResponses.length > 0,
-      "Provider edit dialog did not exercise fetch-model path.",
-    );
+    if (sampleProvider) {
+      assert(
+        providerFetchResponses.length > 0,
+        "Provider edit dialog did not exercise fetch-model path.",
+      );
+    }
   } catch (error) {
     caughtError = error;
     await page
@@ -289,9 +315,7 @@ async function preflightGateway(client) {
         name.charAt(0).toUpperCase() + name.slice(1),
       base_url: providerConfig.base_url ?? providerConfig.baseUrl ?? "",
       api_format: providerConfig.api_format ?? providerConfig.apiFormat ?? "",
-      models: Array.isArray(providerConfig.models)
-        ? providerConfig.models
-        : [],
+      models: Array.isArray(providerConfig.models) ? providerConfig.models : [],
       default_timeout:
         providerConfig.default_timeout ?? providerConfig.defaultTimeout,
       max_concurrent:
@@ -300,13 +324,10 @@ async function preflightGateway(client) {
         providerConfig.conn_pool_size ?? providerConfig.connPoolSize,
     }),
   );
-  assert(
-    providerEntries.length > 0,
-    "Gateway config returned no providers to browser-verify.",
-  );
   const sampleProvider =
     providerEntries.find((provider) => provider.models.length > 0) ||
-    providerEntries[0];
+    providerEntries[0] ||
+    null;
 
   return {
     gateway_id: gatewayId,
@@ -534,8 +555,9 @@ async function clickTitleWithinText(page, text, title, timeout = 30000) {
     ({ expectedText, expectedTitle }) => {
       const textElements = window
         .visibleElements()
-        .filter((element) =>
-          window.normalizeText(element.textContent) === expectedText,
+        .filter(
+          (element) =>
+            window.normalizeText(element.textContent) === expectedText,
         );
       for (const element of textElements) {
         const container =
@@ -544,7 +566,9 @@ async function clickTitleWithinText(page, text, title, timeout = 30000) {
           element;
         const button = Array.from(
           container.querySelectorAll("button[title]"),
-        ).find((candidate) => candidate.getAttribute("title") === expectedTitle);
+        ).find(
+          (candidate) => candidate.getAttribute("title") === expectedTitle,
+        );
         if (button && !button.disabled) {
           button.dispatchEvent(
             new MouseEvent("mousedown", { bubbles: true, cancelable: true }),

--- a/frontend/scripts/api-journeys/browser/gateway-settings-mutation-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/gateway-settings-mutation-smoke.mjs
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
+import { execFile as execFileCallback } from "node:child_process";
 import { createRequire } from "node:module";
 import process from "node:process";
+import { promisify } from "node:util";
 import {
   apiPath,
   asArray,
@@ -11,8 +13,15 @@ import {
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
+const execFile = promisify(execFileCallback);
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const EMAIL_ALERT_CREATE_SCREENSHOT_PATH =
+  "/tmp/gateway-settings-email-alert-create-smoke.png";
+const EMAIL_ALERT_EDIT_SCREENSHOT_PATH =
+  "/tmp/gateway-settings-email-alert-edit-smoke.png";
+const EMAIL_ALERT_DELETE_SCREENSHOT_PATH =
+  "/tmp/gateway-settings-email-alert-delete-smoke.png";
 const HEALTH_RELOAD_SCREENSHOT_PATH =
   "/tmp/gateway-settings-health-reload-smoke.png";
 const ORG_CONFIG_SCREENSHOT_PATH =
@@ -20,6 +29,7 @@ const ORG_CONFIG_SCREENSHOT_PATH =
 const BATCH_SCREENSHOT_PATH = "/tmp/gateway-settings-batch-submit-smoke.png";
 const FAILURE_SCREENSHOT_PATH =
   "/tmp/gateway-settings-mutation-smoke-failure.png";
+const EMAIL_ALERT_PREFIX = "ui_settings_email_alert_";
 const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
 
 async function main() {
@@ -31,6 +41,7 @@ async function main() {
   const gatewayRequests = [];
   const browserMutations = [];
   const unexpectedMutations = [];
+  const expectedApiFailures = [];
   let browser = null;
   let page = null;
   let caughtError = null;
@@ -42,6 +53,10 @@ async function main() {
     const baseline = await prepareOrgConfigRestorer(auth.client);
     cleanup = baseline.cleanup;
     evidence = await preflightSettings(auth.client, baseline, auth.runId);
+    evidence.email_alert_initial_cleanup =
+      await hardDeleteEmailAlertFixturesByPrefix({
+        organizationId: auth.organizationId,
+      });
 
     browser = await puppeteer.launch({
       executablePath: browserExecutablePath(),
@@ -68,6 +83,12 @@ async function main() {
     });
     page.on("response", (response) => {
       const url = response.url();
+      if (isExpectedSettingsFailure(response)) {
+        expectedApiFailures.push(
+          `${response.status()} ${response.request().method()} ${url}`,
+        );
+        return;
+      }
       if (isGatewayApiUrl(url) && response.status() >= 400) {
         apiFailures.push(`${response.status()} ${url}`);
       }
@@ -100,6 +121,11 @@ async function main() {
     ]) {
       await waitForVisibleText(page, label, { exact: true });
     }
+
+    evidence.email_alert_lifecycle = await exerciseEmailAlertMutationFlow({
+      page,
+      auth,
+    });
 
     const [healthResponse] = await waitForResponsesDuring(
       page,
@@ -277,8 +303,8 @@ async function main() {
       )}`,
     );
     assert(
-      browserMutations.length === 4,
-      `Expected four Gateway Settings browser mutations, saw ${browserMutations.length}: ${browserMutations.join(
+      browserMutations.length === 8,
+      `Expected eight Gateway Settings browser mutations, saw ${browserMutations.length}: ${browserMutations.join(
         "; ",
       )}`,
     );
@@ -290,6 +316,16 @@ async function main() {
       .catch(() => null);
   } finally {
     if (browser) await browser.close();
+    try {
+      evidence.email_alert_cleanup = await hardDeleteEmailAlertFixturesByPrefix(
+        {
+          organizationId: auth.organizationId,
+        },
+      );
+    } catch (error) {
+      cleanupError ||= error;
+      evidence.email_alert_cleanup = { status: "failed", error: error.message };
+    }
     if (cleanup) {
       try {
         evidence.cleanup = await cleanup();
@@ -315,6 +351,7 @@ async function main() {
           gateway_requests: gatewayRequests,
           browser_mutations: browserMutations,
           unexpected_mutations: unexpectedMutations,
+          expected_api_failures: expectedApiFailures,
           failure_screenshot: FAILURE_SCREENSHOT_PATH,
         },
         null,
@@ -335,6 +372,7 @@ async function main() {
         evidence,
         gateway_request_count: gatewayRequests.length,
         browser_mutations: browserMutations,
+        expected_api_failures: expectedApiFailures,
       },
       null,
       2,
@@ -358,6 +396,196 @@ async function preflightSettings(client, baseline, runId) {
     original_org_config_id: baseline.originalActiveConfig.id,
     original_org_config_version: baseline.originalActiveConfig.version,
     change_description: `Browser Settings mutation ${suffix}`,
+  };
+}
+
+async function exerciseEmailAlertMutationFlow({ page, auth }) {
+  const suffix = String(auth.runId || Date.now())
+    .replace(/[^a-z0-9]/gi, "_")
+    .toLowerCase();
+  const alertName = `${EMAIL_ALERT_PREFIX}${suffix}`;
+  const editedAlertName = `${alertName}_edited`;
+  const recipient = `ui-email-alert-${suffix}@example.com`;
+  const fromEmail = `ui-email-alert-from-${suffix}@example.com`;
+  const editedFromEmail = `ui-email-alert-edited-${suffix}@example.com`;
+
+  await clickVisibleText(page, "Add Alert", { exact: true });
+  await waitForVisibleText(page, "New Email Alert", { exact: true });
+  await typeIntoPlaceholder(page, "e.g. Production Error Alerts", alertName);
+  await typeAutocompleteValue(page, "Type email and press Enter", recipient);
+  await clickVisibleText(page, "Budget Exceeded", { exact: true });
+  await clickVisibleText(page, "Error Occurred", { exact: true });
+  await typeIntoPlaceholder(page, "alerts@yourdomain.com", fromEmail);
+  await setInputByLabel(page, "Cooldown (minutes)", "7");
+
+  const [createResponse] = await waitForResponsesDuring(
+    page,
+    "create Gateway Settings email alert",
+    [emailAlertCreateResponse(), emailAlertsResponse()],
+    () => clickDialogButton(page, "Create"),
+  );
+  const created = await responseResult(createResponse);
+  assert(
+    created?.id,
+    `Email alert browser create did not return an id: ${JSON.stringify(
+      created,
+    )}`,
+  );
+  await waitForTextGone(page, "New Email Alert");
+  await waitForVisibleText(page, alertName, { exact: true });
+  await waitForVisibleText(page, recipient, { exact: true });
+  await waitForVisibleText(page, "2 events", { exact: true });
+  await waitForVisibleText(page, "sendgrid", { exact: true });
+
+  const createdReadback = await auth.client.get(
+    apiPath("/agentcc/email-alerts/{id}/", { id: created.id }),
+  );
+  assert(
+    createdReadback?.name === alertName &&
+      createdReadback?.provider === "sendgrid" &&
+      createdReadback?.cooldown_minutes === 7 &&
+      createdReadback?.provider_config?.from_email === fromEmail &&
+      !createdReadback?.provider_config?.api_key,
+    `Email alert API readback after browser create was unexpected: ${JSON.stringify(
+      createdReadback,
+    )}`,
+  );
+  const createdDbAudit = await loadAgentccEmailAlertDbAudit({
+    alertId: created.id,
+    organizationId: auth.organizationId,
+    rawSecrets: [fromEmail],
+  });
+  assert(
+    createdDbAudit?.id === created.id &&
+      createdDbAudit?.organization_id === auth.organizationId &&
+      createdDbAudit?.deleted === false &&
+      createdDbAudit?.provider === "sendgrid" &&
+      createdDbAudit?.is_active === true &&
+      createdDbAudit?.cooldown_minutes === 7 &&
+      Number(createdDbAudit?.encrypted_config_bytes) > 0 &&
+      createdDbAudit?.raw_secret_present_in_ciphertext === false,
+    `Email alert DB audit after create was unexpected: ${JSON.stringify(
+      createdDbAudit,
+    )}`,
+  );
+  await page.screenshot({
+    path: EMAIL_ALERT_CREATE_SCREENSHOT_PATH,
+    fullPage: true,
+  });
+
+  await clickRowAction(page, alertName, 0);
+  await waitForVisibleText(page, "Edit Email Alert", { exact: true });
+  await waitForVisibleValue(page, alertName);
+  await waitForVisibleValue(page, fromEmail);
+
+  const [testResponse] = await waitForResponsesDuring(
+    page,
+    "validation-only Gateway Settings email alert test",
+    [emailAlertTestFailureResponse(created.id)],
+    () => clickDialogButton(page, "Send Test"),
+  );
+  const testResult = await responseResult(testResponse);
+  await waitForVisibleText(page, "SendGrid API key not configured");
+
+  await setInputValueByCurrentValue(page, alertName, editedAlertName);
+  await setInputValueByCurrentValue(page, fromEmail, editedFromEmail);
+  await setInputByLabel(page, "Cooldown (minutes)", "11");
+  await setCheckboxByLabel(page, "Alert is active", false);
+
+  const [updateResponse] = await waitForResponsesDuring(
+    page,
+    "update Gateway Settings email alert",
+    [emailAlertUpdateResponse(created.id), emailAlertsResponse()],
+    () => clickDialogButton(page, "Update"),
+  );
+  const updated = await responseResult(updateResponse);
+  assert(
+    updated?.id === created.id &&
+      updated?.name === editedAlertName &&
+      updated?.cooldown_minutes === 11 &&
+      updated?.is_active === false &&
+      updated?.provider_config?.from_email === editedFromEmail,
+    `Email alert browser update response was unexpected: ${JSON.stringify(
+      updated,
+    )}`,
+  );
+  await waitForTextGone(page, "Edit Email Alert");
+  await waitForVisibleText(page, editedAlertName, { exact: true });
+  await waitForVisibleText(page, recipient, { exact: true });
+
+  const updatedDbAudit = await loadAgentccEmailAlertDbAudit({
+    alertId: created.id,
+    organizationId: auth.organizationId,
+    rawSecrets: [editedFromEmail],
+  });
+  assert(
+    updatedDbAudit?.deleted === false &&
+      updatedDbAudit?.name === editedAlertName &&
+      updatedDbAudit?.is_active === false &&
+      updatedDbAudit?.cooldown_minutes === 11 &&
+      updatedDbAudit?.raw_secret_present_in_ciphertext === false,
+    `Email alert DB audit after update was unexpected: ${JSON.stringify(
+      updatedDbAudit,
+    )}`,
+  );
+  await page.screenshot({
+    path: EMAIL_ALERT_EDIT_SCREENSHOT_PATH,
+    fullPage: true,
+  });
+
+  const [deleteResponse] = await waitForResponsesDuring(
+    page,
+    "delete Gateway Settings email alert",
+    [emailAlertDeleteResponse(created.id), emailAlertsResponse()],
+    () => dispatchLastRowAction(page, editedAlertName),
+  );
+  const deleted = await responseResult(deleteResponse);
+  assert(
+    deleted?.deleted === true,
+    `Email alert browser delete response was unexpected: ${JSON.stringify(
+      deleted,
+    )}`,
+  );
+  await waitForTextGone(page, editedAlertName);
+  const afterDelete = asArray(
+    await auth.client.get(apiPath("/agentcc/email-alerts/")),
+  );
+  assert(
+    !afterDelete.some((alert) => alert.id === created.id),
+    "Deleted email alert is still visible in API list.",
+  );
+  const deletedDbAudit = await loadAgentccEmailAlertDbAudit({
+    alertId: created.id,
+    organizationId: auth.organizationId,
+    rawSecrets: [editedFromEmail],
+  });
+  assert(
+    deletedDbAudit?.deleted === true && deletedDbAudit?.deleted_at_set === true,
+    `Email alert DB audit after delete was unexpected: ${JSON.stringify(
+      deletedDbAudit,
+    )}`,
+  );
+  await page.screenshot({
+    path: EMAIL_ALERT_DELETE_SCREENSHOT_PATH,
+    fullPage: true,
+  });
+
+  return {
+    alert_id: created.id,
+    alert_name: alertName,
+    edited_alert_name: editedAlertName,
+    recipient,
+    provider: "sendgrid",
+    test_status: testResponse.status(),
+    test_result: testResult,
+    created_db_audit: createdDbAudit,
+    updated_db_audit: updatedDbAudit,
+    deleted_db_audit: deletedDbAudit,
+    screenshots: [
+      EMAIL_ALERT_CREATE_SCREENSHOT_PATH,
+      EMAIL_ALERT_EDIT_SCREENSHOT_PATH,
+      EMAIL_ALERT_DELETE_SCREENSHOT_PATH,
+    ],
   };
 }
 
@@ -490,6 +718,69 @@ async function pollBatchTerminal(client, gatewayId, batchId) {
   );
 }
 
+async function loadAgentccEmailAlertDbAudit({
+  alertId,
+  organizationId,
+  rawSecrets,
+}) {
+  const rawSecretChecks = asArray(rawSecrets)
+    .map(
+      (secret) =>
+        `COALESCE(position(${sqlString(secret)} in encode(encrypted_config, 'escape')) > 0, false)`,
+    )
+    .join(" OR ");
+  const sql = `
+SELECT COALESCE((
+  SELECT json_build_object(
+    'id', id::text,
+    'organization_id', organization_id::text,
+    'name', name,
+    'provider', provider,
+    'recipients', recipients,
+    'events', events,
+    'thresholds', thresholds,
+    'is_active', is_active,
+    'cooldown_minutes', cooldown_minutes,
+    'encrypted_config_bytes', octet_length(encrypted_config),
+    'raw_secret_present_in_ciphertext', ${rawSecretChecks || "false"},
+    'deleted', deleted,
+    'deleted_at_set', deleted_at IS NOT NULL
+  )
+  FROM agentcc_email_alert
+  WHERE id = ${sqlUuid(alertId)}
+    AND organization_id = ${sqlUuid(organizationId)}
+), '{}'::json);
+`;
+  return runPostgresJson(sql);
+}
+
+async function hardDeleteEmailAlertFixturesByPrefix({ organizationId }) {
+  const deleteAudit = await runPostgresJson(`
+WITH deleted_alerts AS (
+  DELETE FROM agentcc_email_alert
+  WHERE organization_id = ${sqlUuid(organizationId)}
+    AND name LIKE ${sqlString(`${EMAIL_ALERT_PREFIX}%`)}
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_alert_count', (SELECT count(*) FROM deleted_alerts)
+);
+`);
+  const remainingAudit = await runPostgresJson(`
+SELECT json_build_object(
+  'remaining_alert_count', count(*)
+)
+FROM agentcc_email_alert
+WHERE organization_id = ${sqlUuid(organizationId)}
+  AND name LIKE ${sqlString(`${EMAIL_ALERT_PREFIX}%`)};
+`);
+  return {
+    status: "passed",
+    deleted_alert_count: Number(deleteAudit.deleted_alert_count || 0),
+    remaining_alert_count: Number(remainingAudit.remaining_alert_count || 0),
+  };
+}
+
 function sleep(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -619,6 +910,25 @@ async function waitForTextGone(page, text, { timeout = 30000 } = {}) {
   );
 }
 
+async function waitForVisibleValue(page, value, { timeout = 30000 } = {}) {
+  await page.waitForFunction(
+    (expectedValue) =>
+      window.visibleElements().some((element) => {
+        if (
+          element instanceof HTMLInputElement &&
+          element.value === expectedValue
+        ) {
+          return true;
+        }
+
+        const input = element.querySelector?.("input");
+        return input?.value === expectedValue;
+      }),
+    { timeout },
+    value,
+  );
+}
+
 async function typeIntoPlaceholder(page, placeholder, value) {
   await page.waitForFunction(
     (expectedPlaceholder) =>
@@ -668,6 +978,7 @@ async function clickVisibleText(
         element?.closest("button,a,[role='button'],[role='menuitem'],tr") ||
         element;
       if (!clickable || clickable.disabled) return false;
+      clickable.scrollIntoView({ block: "center", inline: "center" });
       const rect = clickable.getBoundingClientRect();
       return {
         x: rect.left + rect.width / 2,
@@ -716,6 +1027,7 @@ async function clickRowAction(page, rowText, actionIndex) {
       );
       const button = buttons[index];
       if (!button) return false;
+      button.scrollIntoView({ block: "center", inline: "center" });
       const rect = button.getBoundingClientRect();
       return {
         x: rect.left + rect.width / 2,
@@ -726,6 +1038,108 @@ async function clickRowAction(page, rowText, actionIndex) {
   );
   assert(point, `Could not click row action ${actionIndex} for ${rowText}`);
   await page.mouse.click(point.x, point.y);
+}
+
+async function dispatchLastRowAction(page, rowText) {
+  await waitForVisibleText(page, rowText);
+  const clicked = await page.evaluate((expectedText) => {
+    const row = window
+      .visibleElements("tr")
+      .find((candidate) =>
+        window.normalizeText(candidate.textContent).includes(expectedText),
+      );
+    if (!row) return false;
+    const buttons = Array.from(row.querySelectorAll("button")).filter(
+      (button) => !button.disabled,
+    );
+    const button = buttons.at(-1);
+    if (!button) return false;
+    button.scrollIntoView({ block: "center", inline: "center" });
+    window.dispatchClick(button);
+    return true;
+  }, rowText);
+  assert(clicked, `Could not dispatch last row action for ${rowText}`);
+}
+
+async function typeAutocompleteValue(page, placeholder, value) {
+  const point = await page.evaluate((expectedPlaceholder) => {
+    const input = window
+      .visibleElements("input")
+      .find((element) => element.placeholder === expectedPlaceholder);
+    if (!input || input.disabled) return false;
+    const rect = input.getBoundingClientRect();
+    return {
+      x: rect.left + Math.min(rect.width / 2, 80),
+      y: rect.top + rect.height / 2,
+    };
+  }, placeholder);
+  assert(point, `Could not focus autocomplete placeholder: ${placeholder}`);
+  await page.mouse.click(point.x, point.y);
+  await page.keyboard.type(value);
+  await page.keyboard.press("Enter");
+  await waitForVisibleText(page, value, { exact: true });
+}
+
+async function setInputByLabel(page, label, value) {
+  const updated = await page.evaluate(
+    ({ expectedLabel, text }) => {
+      const labels = window.visibleElements("label").filter((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return textContent === expectedLabel;
+      });
+      for (const labelElement of labels) {
+        const input = labelElement.htmlFor
+          ? document.getElementById(labelElement.htmlFor)
+          : labelElement
+              .closest(".MuiFormControl-root")
+              ?.querySelector("input,textarea");
+        if (!input || input.disabled) continue;
+        input.focus();
+        window.setNativeValue(input, text);
+        return true;
+      }
+      return false;
+    },
+    { expectedLabel: label, text: value },
+  );
+  assert(updated, `Could not set input by label: ${label}`);
+}
+
+async function setInputValueByCurrentValue(page, currentValue, nextValue) {
+  const updated = await page.evaluate(
+    ({ expectedValue, text }) => {
+      const input = window
+        .visibleElements("input,textarea")
+        .find((element) => element.value === expectedValue);
+      if (!input || input.disabled) return false;
+      input.focus();
+      window.setNativeValue(input, text);
+      return true;
+    },
+    { expectedValue: currentValue, text: nextValue },
+  );
+  assert(updated, `Could not update input with value: ${currentValue}`);
+}
+
+async function setCheckboxByLabel(page, label, checked) {
+  const updated = await page.evaluate(
+    ({ expectedLabel, expectedChecked }) => {
+      const labelElement = window
+        .visibleElements("label")
+        .find(
+          (element) =>
+            window.normalizeText(element.textContent) === expectedLabel,
+        );
+      const checkbox = labelElement?.querySelector("input[type='checkbox']");
+      if (!checkbox || checkbox.disabled) return false;
+      if (checkbox.checked !== expectedChecked) {
+        checkbox.click();
+      }
+      return true;
+    },
+    { expectedLabel: label, expectedChecked: checked },
+  );
+  assert(updated, `Could not set checkbox by label: ${label}`);
 }
 
 async function responseResult(response) {
@@ -794,18 +1208,79 @@ function submitBatchResponseFor(gatewayId) {
     response.status() < 400;
 }
 
+function emailAlertCreateResponse() {
+  return (response) =>
+    response.url().endsWith("/agentcc/email-alerts/") &&
+    response.request().method() === "POST" &&
+    response.status() < 400;
+}
+
+function emailAlertUpdateResponse(alertId) {
+  return (response) =>
+    response.url().includes(`/agentcc/email-alerts/${alertId}/`) &&
+    response.request().method() === "PATCH" &&
+    response.status() < 400;
+}
+
+function emailAlertDeleteResponse(alertId) {
+  return (response) =>
+    response.url().includes(`/agentcc/email-alerts/${alertId}/`) &&
+    response.request().method() === "DELETE" &&
+    response.status() < 400;
+}
+
+function emailAlertTestFailureResponse(alertId) {
+  return (response) =>
+    response.url().includes(`/agentcc/email-alerts/${alertId}/test/`) &&
+    response.request().method() === "POST" &&
+    response.status() === 400;
+}
+
 function isGatewayApiUrl(url) {
   return url.includes("/agentcc/");
 }
 
+function isExpectedSettingsFailure(response) {
+  return (
+    response.url().includes("/agentcc/email-alerts/") &&
+    response.url().includes("/test/") &&
+    response.request().method() === "POST" &&
+    response.status() === 400
+  );
+}
+
 function isAllowedSettingsMutation(method, url) {
   return (
-    method === "POST" &&
-    (url.includes("/health_check/") ||
-      url.includes("/reload/") ||
-      (url.includes("/agentcc/org-configs/") && !url.includes("/activate/")) ||
-      url.includes("/submit-batch/"))
+    (method === "POST" &&
+      (url.includes("/health_check/") ||
+        url.includes("/reload/") ||
+        (url.includes("/agentcc/org-configs/") &&
+          !url.includes("/activate/")) ||
+        url.includes("/submit-batch/") ||
+        url.includes("/agentcc/email-alerts/"))) ||
+    (url.includes("/agentcc/email-alerts/") &&
+      (method === "PATCH" || method === "DELETE"))
   );
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const { stdout } = await execFile(
+    "docker",
+    ["exec", container, "psql", "-qAt", "-U", "user", "-d", "tfc", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const output = stdout.trim();
+  return output ? JSON.parse(output) : {};
+}
+
+function sqlUuid(value) {
+  assert(value && /^[0-9a-f-]{36}$/i.test(value), `Invalid UUID: ${value}`);
+  return `'${value}'::uuid`;
+}
+
+function sqlString(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
 }
 
 function browserExecutablePath() {

--- a/frontend/scripts/api-journeys/browser/get-started-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/get-started-smoke.mjs
@@ -1,122 +1,182 @@
+import { execFile as execFileCallback } from "node:child_process";
 import { createRequire } from "node:module";
 import process from "node:process";
+import { promisify } from "node:util";
 import {
+  CleanupStack,
   apiPath,
   assert,
   createAuthenticatedContext,
+  envFlag,
+  isUuid,
 } from "../lib/api-client.mjs";
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFileCallback);
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
 const SCREENSHOT_PATH = "/tmp/get-started-smoke.png";
+const RUN_PROVIDER_FIXTURE = envFlag("API_JOURNEY_MUTATIONS");
+const SAFE_PROVIDER_KEY_CANDIDATES = [
+  "palm",
+  "perplexity",
+  "ai21",
+  "rime",
+  "groq",
+  "lmnt",
+  "cartesia",
+  "hume",
+  "neuphonic",
+  "inworld",
+  "deepgram",
+  "elevenlabs",
+  "sagemaker",
+];
 
 async function main() {
   const auth = await createAuthenticatedContext();
-  const checks = await auth.client.get(apiPath("/accounts/first-checks/"));
-  assertGetStartedChecks(checks);
-
-  const providerStatus = await auth.client.get(
-    apiPath("/model-hub/develops/provider-status/"),
-  );
-  const providers = Array.isArray(providerStatus?.providers)
-    ? providerStatus.providers
-    : [];
-  assert(providers.length > 0, "Provider status returned no providers.");
-  const configuredTextProvider = providers.find(
-    (provider) =>
-      provider?.has_key &&
-      provider?.type === "text" &&
-      typeof provider?.masked_key === "string" &&
-      provider.masked_key.includes("*"),
-  );
-  assert(
-    configuredTextProvider,
-    "No configured text provider with a masked key is available for Get Started smoke.",
-  );
-  assertNoRawSecretString(
-    JSON.stringify(providerStatus || {}),
-    "provider status",
-  );
-
-  const customModelsRaw = await auth.client.get(
-    apiPath("/model-hub/custom-models/"),
-    {
-      query: { page_number: 0, page_size: 20 },
-      unwrap: false,
-    },
-  );
-  assertNoRawSecretString(
-    JSON.stringify(customModelsRaw || {}),
-    "custom models",
-  );
-
-  const apiFailures = [];
-  const pageErrors = [];
-  const unexpectedMutations = [];
-  const evidence = {
-    first_checks: checks,
-    provider_count: providers.length,
-    configured_provider_count: providers.filter((provider) => provider?.has_key)
-      .length,
-    checked_provider: configuredTextProvider.provider,
-    checked_provider_display_name: configuredTextProvider.display_name,
-    checked_provider_masked_key: configuredTextProvider.masked_key,
-    custom_model_count:
-      customModelsRaw?.count ??
-      customModelsRaw?.result?.count ??
-      customModelsRaw?.results?.length ??
-      0,
-  };
-
-  const browser = await puppeteer.launch({
-    executablePath: browserExecutablePath(),
-    headless: process.env.HEADLESS !== "0",
-    defaultViewport: { width: 1440, height: 950 },
-    args: ["--no-sandbox"],
-  });
-
-  const page = await browser.newPage();
-  await installRuntimeConfig(page, auth);
-  await page.evaluateOnNewDocument(
-    ({ tokens, organizationId, workspaceId, user }) => {
-      localStorage.setItem("accessToken", tokens.access);
-      localStorage.setItem("refreshToken", tokens.refresh || "");
-      localStorage.setItem("rememberMe", "true");
-      localStorage.setItem("initial-render", "done");
-      if (organizationId)
-        sessionStorage.setItem("organizationId", organizationId);
-      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
-      if (user?.id)
-        sessionStorage.setItem("futureagi-current-user-id", user.id);
-    },
-    {
-      tokens: auth.tokens,
-      organizationId: auth.organizationId,
-      workspaceId: auth.workspaceId,
-      user: auth.user,
-    },
-  );
-
-  page.on("request", (request) => {
-    const url = request.url();
-    if (
-      isGetStartedApiUrl(url) &&
-      ["POST", "PATCH", "PUT", "DELETE"].includes(request.method())
-    ) {
-      unexpectedMutations.push(`${request.method()} ${url}`);
-    }
-  });
-  page.on("response", (response) => {
-    const url = response.url();
-    if (isGetStartedApiUrl(url) && response.status() >= 400) {
-      apiFailures.push(`${response.status()} ${url}`);
-    }
-  });
-  page.on("pageerror", (error) => pageErrors.push(error.message));
+  const cleanup = new CleanupStack();
+  const cleanupEvidence = [];
+  const rawSecrets = [];
+  let cleanupRan = false;
+  let browser = null;
+  let caughtError = null;
+  let deferredCleanupError = null;
+  let fixture = null;
 
   try {
+    const initialChecks = await auth.client.get(
+      apiPath("/accounts/first-checks/"),
+    );
+    let checks = initialChecks;
+    assertGetStartedChecks(checks);
+
+    let providerStatus = await auth.client.get(
+      apiPath("/model-hub/develops/provider-status/"),
+    );
+    let providers = Array.isArray(providerStatus?.providers)
+      ? providerStatus.providers
+      : [];
+    assert(providers.length > 0, "Provider status returned no providers.");
+    let configuredTextProvider = findConfiguredTextProvider(providers);
+    if (!configuredTextProvider) {
+      assert(
+        RUN_PROVIDER_FIXTURE,
+        "No configured text provider with a masked key is available for Get Started smoke. Set API_JOURNEY_MUTATIONS=1 to create a disposable provider key fixture.",
+      );
+      fixture = await createDisposableProviderKeyFixture({
+        auth,
+        providers,
+        cleanup,
+      });
+      rawSecrets.push(fixture.rawSetupKey);
+
+      checks = await auth.client.get(apiPath("/accounts/first-checks/"));
+      assertGetStartedChecks(checks);
+      providerStatus = await auth.client.get(
+        apiPath("/model-hub/develops/provider-status/"),
+      );
+      providers = Array.isArray(providerStatus?.providers)
+        ? providerStatus.providers
+        : [];
+      configuredTextProvider = findConfiguredTextProvider(providers);
+    }
+    assert(
+      configuredTextProvider,
+      "No configured text provider with a masked key is available for Get Started smoke.",
+    );
+    assertNoRawSecretString(
+      JSON.stringify(providerStatus || {}),
+      "provider status",
+      rawSecrets,
+    );
+
+    const customModelsRaw = await auth.client.get(
+      apiPath("/model-hub/custom-models/"),
+      {
+        query: { page_number: 0, page_size: 20 },
+        unwrap: false,
+      },
+    );
+    assertNoRawSecretString(
+      JSON.stringify(customModelsRaw || {}),
+      "custom models",
+      rawSecrets,
+    );
+
+    const apiFailures = [];
+    const pageErrors = [];
+    const unexpectedMutations = [];
+    const evidence = {
+      first_checks: checks,
+      first_checks_before_fixture: fixture ? initialChecks : undefined,
+      provider_count: providers.length,
+      configured_provider_count: providers.filter(
+        (provider) => provider?.has_key,
+      ).length,
+      checked_provider: configuredTextProvider.provider,
+      checked_provider_display_name: configuredTextProvider.display_name,
+      checked_provider_masked_key: configuredTextProvider.masked_key,
+      provider_fixture_enabled: RUN_PROVIDER_FIXTURE,
+      provider_fixture_created: Boolean(fixture),
+      provider_fixture_provider: fixture?.provider,
+      provider_fixture_key_id: fixture?.keyId,
+      provider_fixture_masked_key: fixture?.maskedKey,
+      custom_model_count:
+        customModelsRaw?.count ??
+        customModelsRaw?.result?.count ??
+        customModelsRaw?.results?.length ??
+        0,
+    };
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+
+    const page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await page.evaluateOnNewDocument(
+      ({ tokens, organizationId, workspaceId, user }) => {
+        localStorage.setItem("accessToken", tokens.access);
+        localStorage.setItem("refreshToken", tokens.refresh || "");
+        localStorage.setItem("rememberMe", "true");
+        localStorage.setItem("initial-render", "done");
+        if (organizationId)
+          sessionStorage.setItem("organizationId", organizationId);
+        if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+        if (user?.id)
+          sessionStorage.setItem("futureagi-current-user-id", user.id);
+      },
+      {
+        tokens: auth.tokens,
+        organizationId: auth.organizationId,
+        workspaceId: auth.workspaceId,
+        user: auth.user,
+      },
+    );
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (
+        isGetStartedApiUrl(url) &&
+        ["POST", "PATCH", "PUT", "DELETE"].includes(request.method())
+      ) {
+        unexpectedMutations.push(`${request.method()} ${url}`);
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isGetStartedApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${url}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
     await page.goto(`${APP_BASE}/dashboard/get-started`, {
       waitUntil: "domcontentloaded",
     });
@@ -126,12 +186,15 @@ async function main() {
     );
 
     await waitForGetStartedPage(page);
+    await openAddKeysTab(page);
+    evidence.add_keys_tab = await getGetStartedTab(page);
     await waitForVisibleText(page, configuredTextProvider.display_name, {
       exact: true,
     });
     await waitForInputValue(page, configuredTextProvider.masked_key);
-    await assertNoRawSecretVisible(page);
+    await assertNoRawSecretVisible(page, rawSecrets);
     await waitForNoVisibleText(page, "Invalid Date");
+    evidence.provider_setup_next_tab = await advanceFromProviderSetupStep(page);
 
     evidence.dataset_navigation_path = await navigateFromGetStarted({
       page,
@@ -163,7 +226,7 @@ async function main() {
       waitUntil: "domcontentloaded",
     });
     await waitForGetStartedPage(page);
-    await assertNoRawSecretVisible(page);
+    await assertNoRawSecretVisible(page, rawSecrets);
     await waitForNoVisibleText(page, "Invalid Date");
 
     await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
@@ -175,6 +238,39 @@ async function main() {
       unexpectedMutations.length === 0,
       `Get Started smoke fired mutations: ${unexpectedMutations.join("; ")}`,
     );
+
+    const cleanupFailures = await cleanup.run(cleanupEvidence);
+    cleanupRan = true;
+    evidence.cleanup = cleanupEvidence;
+    evidence.provider_fixture_cleanup = fixture?.cleanupState;
+    if (fixture) {
+      const postCleanupChecks = await auth.client.get(
+        apiPath("/accounts/first-checks/"),
+      );
+      assertGetStartedChecks(postCleanupChecks);
+      const postCleanupStatus = await auth.client.get(
+        apiPath("/model-hub/develops/provider-status/"),
+      );
+      assertNoRawSecretString(
+        JSON.stringify(postCleanupStatus || {}),
+        "provider status after disposable provider key cleanup",
+        rawSecrets,
+      );
+      const postCleanupProviders = Array.isArray(postCleanupStatus?.providers)
+        ? postCleanupStatus.providers
+        : [];
+      const postCleanupProvider = postCleanupProviders.find(
+        (provider) => provider?.provider === fixture.provider,
+      );
+      evidence.first_checks_after_fixture_cleanup = postCleanupChecks;
+      evidence.provider_fixture_has_key_after_cleanup = Boolean(
+        postCleanupProvider?.has_key,
+      );
+      assert(
+        !postCleanupProvider?.has_key,
+        `Disposable provider ${fixture.provider} still reports has_key after cleanup.`,
+      );
+    }
 
     console.log(
       JSON.stringify(
@@ -190,8 +286,232 @@ async function main() {
         2,
       ),
     );
+    assert(
+      cleanupFailures.length === 0,
+      `Cleanup failures: ${cleanupFailures
+        .map((failure) => `${failure.label}: ${failure.error}`)
+        .join("; ")}`,
+    );
+  } catch (error) {
+    caughtError = error;
+    throw error;
   } finally {
-    await browser.close();
+    if (browser) await closeBrowser(browser);
+    if (!cleanupRan) {
+      const cleanupFailures = await cleanup.run(cleanupEvidence);
+      if (cleanupFailures.length && !caughtError) {
+        deferredCleanupError = new Error(
+          `Cleanup failures: ${cleanupFailures
+            .map((failure) => `${failure.label}: ${failure.error}`)
+            .join("; ")}`,
+        );
+      }
+    }
+  }
+  if (deferredCleanupError) throw deferredCleanupError;
+}
+
+function findConfiguredTextProvider(providers) {
+  return providers.find(
+    (provider) =>
+      provider?.has_key &&
+      provider?.type === "text" &&
+      typeof provider?.masked_key === "string" &&
+      provider.masked_key.includes("*"),
+  );
+}
+
+async function createDisposableProviderKeyFixture({
+  auth,
+  providers,
+  cleanup,
+}) {
+  const existingKeys = await listProviderKeys(auth.client);
+  const existingProviders = new Set(
+    existingKeys.map((key) => key.provider).filter(Boolean),
+  );
+  const provider = chooseSafeUnconfiguredProvider(providers, existingProviders);
+  const rawSetupKey = `get-started-fixture-${auth.runId}`;
+  const created = await auth.client.post(apiPath("/model-hub/api-keys/"), {
+    provider: provider.provider,
+    key: rawSetupKey,
+  });
+  assert(created?.id, "Get Started provider fixture create lacked an id.");
+
+  const cleanupState = {};
+  cleanup.defer("hard-delete Get Started provider key fixture", async () => {
+    cleanupState.hard_delete = await hardDeleteProviderApiKeyFixtureDb({
+      organizationId: auth.organizationId,
+      keyId: created.id,
+    });
+  });
+  cleanup.defer("delete Get Started provider key fixture", () =>
+    ignoreNotFound(() =>
+      auth.client.delete(
+        apiPath("/model-hub/api-keys/{id}/", { id: created.id }),
+      ),
+    ),
+  );
+  assertProviderKeyResponseIsMaskedOnly(
+    created,
+    "Get Started provider fixture create",
+    [rawSetupKey],
+  );
+
+  return {
+    provider: provider.provider,
+    displayName: provider.display_name,
+    keyId: created.id,
+    maskedKey: created.masked_actual_key,
+    rawSetupKey,
+    cleanupState,
+  };
+}
+
+async function listProviderKeys(client) {
+  const payload = await client.get(apiPath("/model-hub/api-keys/"), {
+    query: { page: 1, page_size: 100 },
+    unwrap: false,
+  });
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.results)) return payload.results;
+  if (Array.isArray(payload?.result?.results)) return payload.result.results;
+  if (Array.isArray(payload?.result)) return payload.result;
+  return [];
+}
+
+function chooseSafeUnconfiguredProvider(providers, existingProviders) {
+  const provider =
+    SAFE_PROVIDER_KEY_CANDIDATES.map((candidate) =>
+      providers.find(
+        (row) =>
+          row?.provider === candidate &&
+          row?.type === "text" &&
+          row?.has_key === false &&
+          !existingProviders.has(row.provider),
+      ),
+    ).find(Boolean) ||
+    providers.find(
+      (row) =>
+        row?.provider &&
+        row?.type === "text" &&
+        row?.has_key === false &&
+        !existingProviders.has(row.provider),
+    );
+  assert(
+    provider,
+    "No safe unconfigured text provider is available for Get Started provider fixture coverage.",
+  );
+  return provider;
+}
+
+function assertProviderKeyResponseIsMaskedOnly(
+  payload,
+  label,
+  rawSecrets = [],
+) {
+  assertNoRawSecretString(JSON.stringify(payload ?? {}), label, rawSecrets);
+  assert(
+    typeof payload?.masked_actual_key === "string" &&
+      payload.masked_actual_key.includes("*"),
+    `${label} did not return a masked key.`,
+  );
+  assert(
+    !Object.prototype.hasOwnProperty.call(payload ?? {}, "key") ||
+      isEmptySecretBearingField(payload.key),
+    `${label} exposed non-empty secret-bearing key field.`,
+  );
+  assert(
+    !Object.prototype.hasOwnProperty.call(payload ?? {}, "config_json") ||
+      isEmptySecretBearingField(payload.config_json),
+    `${label} exposed non-empty secret-bearing config_json field.`,
+  );
+}
+
+function isEmptySecretBearingField(value) {
+  if (value == null || value === "") return true;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === "object") return Object.keys(value).length === 0;
+  return false;
+}
+
+async function hardDeleteProviderApiKeyFixtureDb({ organizationId, keyId }) {
+  assert(
+    isUuid(organizationId),
+    "Provider fixture cleanup needs organization id.",
+  );
+  assert(isUuid(keyId), "Provider fixture cleanup needs key id.");
+  const sql = `
+WITH target_keys AS (
+  SELECT id
+  FROM model_hub_apikey
+  WHERE id = ${sqlUuid(keyId)}
+    AND organization_id = ${sqlUuid(organizationId)}
+),
+deleted_keys AS (
+  DELETE FROM model_hub_apikey key
+  USING target_keys target
+  WHERE key.id = target.id
+  RETURNING key.id
+)
+SELECT json_build_object(
+  'deleted_key_count', (SELECT count(*) FROM deleted_keys),
+  'remaining_key_count',
+    (SELECT count(*) FROM target_keys) - (SELECT count(*) FROM deleted_keys)
+);
+`;
+  const result = await runPostgresJson(sql);
+  assert(
+    Number(result.remaining_key_count) === 0,
+    `Provider fixture cleanup left ${result.remaining_key_count} key rows.`,
+  );
+  return result;
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    [
+      "exec",
+      "-i",
+      container,
+      "psql",
+      "-U",
+      user,
+      "-d",
+      database,
+      "-AtX",
+      "-c",
+      sql,
+    ],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres provider fixture cleanup returned no JSON output.");
+  return JSON.parse(text.split("\n").at(-1));
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), `Expected UUID, got ${value}`);
+  return `'${String(value).replaceAll("'", "''")}'::uuid`;
+}
+
+async function ignoreNotFound(fn) {
+  try {
+    return await fn();
+  } catch (error) {
+    const message = String(error?.message || "").toLowerCase();
+    if (
+      error?.status === 404 ||
+      message.includes("not found") ||
+      message.includes("does not exist")
+    ) {
+      return null;
+    }
+    throw error;
   }
 }
 
@@ -234,6 +554,28 @@ async function waitForGetStartedPage(page) {
   await waitForVisibleText(page, "Add dataset", { exact: true });
   await waitForVisibleText(page, "Experiment", { exact: true });
   await waitForVisibleText(page, "Evaluate", { exact: true });
+}
+
+async function openAddKeysTab(page) {
+  await clickVisibleText(page, "Add keys");
+  await waitForVisibleText(page, "Add Keys", { exact: true });
+}
+
+async function advanceFromProviderSetupStep(page) {
+  await clickVisibleText(page, "Next");
+  await waitForVisibleText(page, "Create your first dataset", { exact: true });
+  const tab = await getGetStartedTab(page);
+  assert(
+    tab === "createFirstDataset",
+    `Expected provider setup Next to land on createFirstDataset, got ${tab}.`,
+  );
+  return tab;
+}
+
+async function getGetStartedTab(page) {
+  return page.evaluate(() =>
+    new URLSearchParams(window.location.search).get("tab"),
+  );
 }
 
 async function navigateFromGetStarted({
@@ -386,17 +728,18 @@ async function clickVisibleText(page, text) {
   assert(clicked, `Could not click visible text ${text}.`);
 }
 
-async function assertNoRawSecretVisible(page) {
+async function assertNoRawSecretVisible(page, forbiddenRawValues = []) {
   const visibleText = await page.evaluate(() => {
     const inputValues = Array.from(document.querySelectorAll("input, textarea"))
       .map((element) => element.value || "")
       .join("\n");
     return `${document.body.innerText || ""}\n${inputValues}`;
   });
-  assertNoRawSecretString(visibleText, "visible page text");
+  assertNoRawSecretString(visibleText, "visible page text", forbiddenRawValues);
 }
 
-function assertNoRawSecretString(value, label) {
+function assertNoRawSecretString(value, label, forbiddenRawValues = []) {
+  const text = String(value ?? "");
   const rawSecretPatterns = [
     /sk-[A-Za-z0-9_-]{12,}/,
     /AIza[A-Za-z0-9_-]{20,}/,
@@ -405,10 +748,20 @@ function assertNoRawSecretString(value, label) {
   ];
   for (const pattern of rawSecretPatterns) {
     assert(
-      !pattern.test(value),
+      !pattern.test(text),
       `${label} contains a raw provider secret pattern.`,
     );
   }
+  for (const rawValue of forbiddenRawValues.filter(Boolean)) {
+    assert(
+      !text.includes(rawValue),
+      `${label} exposed raw provider key material.`,
+    );
+  }
+  assert(
+    !/"actual_key"|"actual_json"/.test(text),
+    `${label} exposed decrypted key field names.`,
+  );
 }
 
 function assertGetStartedChecks(checks) {
@@ -441,6 +794,32 @@ function browserExecutablePath() {
     process.env.CHROME_PATH ||
     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
   );
+}
+
+async function closeBrowser(browser) {
+  let closed = false;
+  try {
+    await Promise.race([
+      browser.close().then(() => {
+        closed = true;
+      }),
+      delay(5000),
+    ]);
+  } finally {
+    if (!closed) {
+      const child = browser.process?.();
+      if (child && !child.killed) child.kill("SIGKILL");
+      try {
+        browser.disconnect();
+      } catch {
+        // The browser may already be disconnected after killing the process.
+      }
+    }
+  }
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 main().catch((error) => {

--- a/frontend/scripts/api-journeys/browser/knowledge-base-lifecycle-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/knowledge-base-lifecycle-smoke.mjs
@@ -1,0 +1,795 @@
+/* eslint-disable no-console */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import process from "node:process";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+  isUuid,
+  requireMutations,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const KB_PREFIX = "ui_kb_lifecycle_";
+const SCREENSHOT_PREFIX =
+  process.env.KNOWLEDGE_BASE_LIFECYCLE_SCREENSHOT_PREFIX ||
+  "/tmp/knowledge-base-lifecycle";
+const DETAIL_SCREENSHOT_PATH = `${SCREENSHOT_PREFIX}-detail-smoke.png`;
+const LIST_SCREENSHOT_PATH = `${SCREENSHOT_PREFIX}-list-smoke.png`;
+const FAILURE_SCREENSHOT_PATH = `${SCREENSHOT_PREFIX}-failure-smoke.png`;
+const KB_FILES_PATH = "/model-hub/knowledge-base/files/";
+const KB_PATH = "/model-hub/knowledge-base/";
+const KB_GET_PATH = "/model-hub/knowledge-base/get/";
+const KB_LIST_PATH = "/model-hub/knowledge-base/list/";
+
+async function main() {
+  requireMutations();
+  const auth = await createAuthenticatedContext();
+  const suffix = auth.runId.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+  const kbName = `${KB_PREFIX}${suffix}`;
+  const fileName = `${kbName}.txt`;
+  const tmpDir = await mkdtemp(join(tmpdir(), "knowledge-base-lifecycle-"));
+  const filePath = join(tmpDir, fileName);
+  const cleanupEvidence = [];
+  const apiFailures = [];
+  const pageErrors = [];
+  const knowledgeBaseRequests = [];
+  const browserWrites = [];
+  const unexpectedWrites = [];
+  let browser = null;
+  let page = null;
+  let kbId = "";
+  let fileId = "";
+  let deletedViaUi = false;
+
+  await writeFile(
+    filePath,
+    `Knowledge base browser lifecycle fixture ${auth.runId}\n`,
+    "utf8",
+  );
+
+  try {
+    await deleteKnowledgeBaseFixturesByPrefix(
+      auth.client,
+      KB_PREFIX,
+      cleanupEvidence,
+    );
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+    page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      if (!isKnowledgeBaseApiUrl(request.url())) return;
+      const requestKey = `${request.method()} ${request.url()}`;
+      knowledgeBaseRequests.push(requestKey);
+      if (
+        isStateChangingKnowledgeBaseRequest(request.method(), request.url())
+      ) {
+        browserWrites.push(requestKey);
+        if (!isAllowedBrowserWrite(request.method(), request.url())) {
+          unexpectedWrites.push(requestKey);
+        }
+      }
+    });
+    page.on("response", (response) => {
+      if (isKnowledgeBaseApiUrl(response.url()) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${response.url()}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponsesDuring(
+      page,
+      "Knowledge Base list load",
+      [
+        (response) =>
+          response.url().includes(KB_GET_PATH) &&
+          response.request().method() === "GET" &&
+          response.status() < 400,
+      ],
+      () =>
+        page.goto(`${APP_BASE}/dashboard/knowledge`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForPathIncludes(page, "/dashboard/knowledge");
+    await waitForVisibleText(page, "Create Knowledge Base", { exact: true });
+    await clickEnabledButton(page, "Create Knowledge Base");
+    await waitForVisibleText(page, "Create knowledge base", { exact: true });
+    await setInputByPlaceholder(page, "Name", kbName);
+
+    const input = await page.waitForSelector('input[type="file"]', {
+      timeout: 30000,
+    });
+    await input.uploadFile(filePath);
+    await waitForVisibleText(page, fileName, { exact: true });
+    await waitForVisibleText(page, "Files uploaded: 1/1", { exact: true });
+
+    const createResponse = await waitForResponseDuring(
+      page,
+      "Knowledge Base browser create",
+      (response) =>
+        response.url().includes(KB_PATH) &&
+        response.request().method() === "POST",
+      () => clickEnabledButton(page, "Create"),
+    );
+    const createPayload = await responseJson(createResponse);
+    if (isEntitlementOrPlanLimit(createResponse, createPayload)) {
+      console.log(
+        JSON.stringify(
+          {
+            status: "skipped",
+            reason: "knowledge-base browser create is entitlement-blocked",
+            app_base: APP_BASE,
+            api_base: auth.apiBase,
+            organization_id: auth.organizationId,
+            workspace_id: auth.workspaceId,
+            response_status: createResponse.status(),
+            response_message: apiMessage(createPayload),
+            browser_writes: browserWrites.map(maskRequest),
+            cleanup: cleanupEvidence,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+    assert(
+      createResponse.status() >= 200 && createResponse.status() < 300,
+      `Knowledge Base browser create returned HTTP ${createResponse.status()}: ${JSON.stringify(
+        createPayload,
+      )}`,
+    );
+
+    const createResult = createPayload?.result || createPayload || {};
+    kbId = createResult.kb_id || createResult.kbId || "";
+    const fileIds = asArray(createResult.file_ids || createResult.fileIds);
+    fileId = fileIds[0] || "";
+    assert(isUuid(kbId), "Knowledge Base browser create omitted a UUID kb_id.");
+    assert(
+      isUuid(fileId),
+      "Knowledge Base browser create omitted file_ids[0].",
+    );
+
+    await waitForPathIncludes(page, `/dashboard/knowledge/${kbId}`);
+    await waitForVisibleText(page, fileName, { exact: true });
+    await waitForVisibleText(page, "Add docs", { exact: true });
+    await page.screenshot({ path: DETAIL_SCREENSHOT_PATH, fullPage: true });
+
+    const apiReadback = await assertApiReadback({
+      client: auth.client,
+      kbId,
+      kbName,
+      fileId,
+      fileName,
+    });
+
+    await waitForResponsesDuring(
+      page,
+      "Knowledge Base list reload",
+      [
+        (response) =>
+          response.url().includes(KB_GET_PATH) &&
+          response.request().method() === "GET" &&
+          response.status() < 400,
+      ],
+      () =>
+        page.goto(`${APP_BASE}/dashboard/knowledge`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForPathIncludes(page, "/dashboard/knowledge");
+    await waitForResponseDuring(
+      page,
+      "Knowledge Base list search",
+      (response) => {
+        if (
+          !response.url().includes(KB_GET_PATH) ||
+          response.request().method() !== "GET" ||
+          response.status() >= 400
+        ) {
+          return false;
+        }
+        return new URL(response.url()).searchParams.get("search") === kbName;
+      },
+      () => setInputByPlaceholder(page, "Search", kbName),
+    );
+    await waitForVisibleText(page, kbName, { exact: true });
+    await selectKnowledgeBaseRow(page, kbName);
+    await waitForVisibleText(page, "1 Selected", { exact: true });
+    await page.screenshot({ path: LIST_SCREENSHOT_PATH, fullPage: true });
+
+    await clickVisibleText(page, "Delete", { exact: true });
+    await waitForVisibleText(page, "Delete Knowledge Base", { exact: true });
+    const deleteResponse = await waitForResponseDuring(
+      page,
+      "Knowledge Base browser delete",
+      (response) =>
+        response.url().includes(KB_PATH) &&
+        response.request().method() === "DELETE",
+      () =>
+        clickDialogButton(page, {
+          buttonText: "Delete",
+          dialogText: "Delete Knowledge Base",
+        }),
+    );
+    const deletePayload = await responseJson(deleteResponse);
+    assert(
+      deleteResponse.status() >= 200 && deleteResponse.status() < 300,
+      `Knowledge Base browser delete returned HTTP ${deleteResponse.status()}: ${JSON.stringify(
+        deletePayload,
+      )}`,
+    );
+    deletedViaUi = true;
+    await waitForKnowledgeBaseGone(auth.client, { kbId, kbName });
+    await expectApiErrorStatus(
+      () =>
+        auth.client.post(apiPath(KB_FILES_PATH), {
+          kb_id: kbId,
+          page_number: 0,
+          page_size: 10,
+        }),
+      400,
+      "Knowledge Base files endpoint accepted a deleted KB.",
+    );
+
+    assert(
+      unexpectedWrites.length === 0,
+      `Unexpected Knowledge Base browser writes: ${unexpectedWrites
+        .map(maskRequest)
+        .join(", ")}`,
+    );
+    assert(
+      apiFailures.length === 0,
+      `Knowledge Base browser API failures: ${apiFailures.join(", ")}`,
+    );
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          kb_id: kbId,
+          kb_name: kbName,
+          file_id: fileId,
+          file_name: fileName,
+          api_readback: apiReadback,
+          browser_writes: browserWrites.map(maskRequest),
+          knowledge_base_request_count: knowledgeBaseRequests.length,
+          knowledge_base_requests: knowledgeBaseRequests.map(maskRequest),
+          deleted_via_ui: deletedViaUi,
+          deleted_kb_files_guard: "verified",
+          screenshots: {
+            detail: DETAIL_SCREENSHOT_PATH,
+            list: LIST_SCREENSHOT_PATH,
+          },
+          cleanup: cleanupEvidence,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    if (page) {
+      await page
+        .screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .catch(() => null);
+      console.error(`failure_screenshot=${FAILURE_SCREENSHOT_PATH}`);
+    }
+    throw error;
+  } finally {
+    if (kbId && !deletedViaUi) {
+      await auth.client
+        .delete(apiPath(KB_PATH), { body: { kb_ids: [kbId] } })
+        .then(() =>
+          cleanupEvidence.push({
+            cleanup: "delete browser-created knowledge base",
+            status: "passed",
+            kb_id: kbId,
+          }),
+        )
+        .catch((error) =>
+          cleanupEvidence.push({
+            cleanup: "delete browser-created knowledge base",
+            status: "failed",
+            kb_id: kbId,
+            error: error.message,
+          }),
+        );
+    }
+    if (browser) await browser.close();
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function assertApiReadback({ client, kbId, kbName, fileId, fileName }) {
+  const tablePayload = await client.get(apiPath(KB_GET_PATH), {
+    query: {
+      search: kbName,
+      page_number: 0,
+      page_size: 10,
+      sort: JSON.stringify([{ column_id: "name", type: "ascending" }]),
+    },
+  });
+  const tableRows = payloadArray(tablePayload, "table_data");
+  const tableRow = tableRows.find((row) => row?.id === kbId);
+  assert(tableRow?.name === kbName, "KB table readback missed created row.");
+
+  const optionsPayload = await client.get(apiPath(KB_LIST_PATH), {
+    query: { search: kbName },
+  });
+  const optionsRows = payloadArray(optionsPayload, "table_data");
+  assert(
+    optionsRows.some((row) => row?.id === kbId && row?.name === kbName),
+    "KB list readback missed created option.",
+  );
+
+  const filesPayload = await client.post(apiPath(KB_FILES_PATH), {
+    kb_id: kbId,
+    search: fileName,
+    page_number: 0,
+    page_size: 10,
+    sort: [{ column_id: "name", type: "ascending" }],
+  });
+  const fileRows = payloadArray(filesPayload, "table_data");
+  const fileRow = fileRows.find((row) => row?.id === fileId);
+  assert(fileRow?.name === fileName, "KB files readback missed uploaded file.");
+
+  return {
+    table_rows_seen: tableRows.length,
+    options_seen: optionsRows.length,
+    files_seen: fileRows.length,
+    files_uploaded: tableRow.files_uploaded ?? tableRow.filesUploaded ?? null,
+    status: tableRow.status || null,
+  };
+}
+
+async function deleteKnowledgeBaseFixturesByPrefix(client, prefix, evidence) {
+  const payload = await client.get(apiPath(KB_GET_PATH), {
+    query: {
+      search: prefix,
+      page_number: 0,
+      page_size: 100,
+    },
+  });
+  const rows = payloadArray(payload, "table_data").filter((row) =>
+    String(row?.name || "").startsWith(prefix),
+  );
+  const kbIds = rows.map((row) => row.id).filter(Boolean);
+  if (!kbIds.length) {
+    evidence.push({
+      cleanup: "pre-clean stale Knowledge Base lifecycle fixtures",
+      status: "passed",
+      deleted_count: 0,
+    });
+    return;
+  }
+  await client.delete(apiPath(KB_PATH), { body: { kb_ids: kbIds } });
+  evidence.push({
+    cleanup: "pre-clean stale Knowledge Base lifecycle fixtures",
+    status: "passed",
+    deleted_count: kbIds.length,
+  });
+}
+
+async function waitForKnowledgeBaseGone(client, { kbId, kbName }) {
+  await waitForCondition(async () => {
+    const payload = await client.get(apiPath(KB_GET_PATH), {
+      query: {
+        search: kbName,
+        page_number: 0,
+        page_size: 10,
+      },
+    });
+    return !payloadArray(payload, "table_data").some((row) => row?.id === kbId);
+  }, "Knowledge Base row was still visible after UI delete.");
+}
+
+async function expectApiErrorStatus(fn, expectedStatus, label) {
+  try {
+    await fn();
+  } catch (error) {
+    if (error.status === expectedStatus) return;
+    throw new Error(
+      `${label} Expected HTTP ${expectedStatus}, got ${error.status || "unknown"}: ${
+        error.message
+      }`,
+    );
+  }
+  throw new Error(`${label} Expected HTTP ${expectedStatus}, got success.`);
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(() => {
+    window.normalizeText = (value) =>
+      String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+    window.dispatchClick = (element) => {
+      element.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("mouseup", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    };
+    window.visibleElements = (selector = "body *") => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(selector)).filter(isVisible);
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId) {
+        sessionStorage.setItem("organizationId", organizationId);
+      }
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id) {
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+      }
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function setInputByPlaceholder(page, placeholder, value) {
+  await page.waitForSelector(`input[placeholder="${placeholder}"]`, {
+    timeout: 30000,
+  });
+  const updated = await page.evaluate(
+    ({ expectedPlaceholder, nextValue }) => {
+      const input = Array.from(document.querySelectorAll("input")).find(
+        (candidate) =>
+          candidate.getAttribute("placeholder") === expectedPlaceholder,
+      );
+      if (!input) return false;
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(input, nextValue);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      return true;
+    },
+    { expectedPlaceholder: placeholder, nextValue: value },
+  );
+  assert(updated, `Could not set input with placeholder ${placeholder}.`);
+}
+
+async function selectKnowledgeBaseRow(page, kbName) {
+  await waitForVisibleText(page, kbName, { exact: true });
+  const result = await page.evaluate((expectedName) => {
+    const rows = window
+      .visibleElements('[role="row"]')
+      .filter((row) =>
+        window.normalizeText(row.textContent).includes(expectedName),
+      );
+    const row = rows.find((candidate) =>
+      candidate.querySelector('input[type="checkbox"]'),
+    );
+    const checkbox = row?.querySelector('input[type="checkbox"]');
+    if (!checkbox) {
+      return {
+        selected: false,
+        row_count: rows.length,
+        text: rows.map((candidate) =>
+          window.normalizeText(candidate.textContent),
+        ),
+      };
+    }
+    window.dispatchClick(checkbox);
+    return { selected: true, row_count: rows.length };
+  }, kbName);
+  assert(
+    result.selected,
+    `Could not select Knowledge Base row ${kbName}: ${JSON.stringify(result)}`,
+  );
+}
+
+async function clickDialogButton(page, { buttonText, dialogText }) {
+  await waitForVisibleText(page, dialogText, { exact: true });
+  const clicked = await page.evaluate(
+    ({ expectedButtonText, expectedDialogText }) => {
+      const dialog = window
+        .visibleElements(".MuiDialog-root,[role='dialog']")
+        .find((candidate) =>
+          window
+            .normalizeText(candidate.textContent)
+            .includes(expectedDialogText),
+        );
+      const button = Array.from(dialog?.querySelectorAll("button") || []).find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent) === expectedButtonText &&
+          !candidate.disabled,
+      );
+      if (!button) return false;
+      window.dispatchClick(button);
+      return true;
+    },
+    {
+      expectedButtonText: buttonText,
+      expectedDialogText: dialogText,
+    },
+  );
+  assert(clicked, `Could not click ${buttonText} in ${dialogText} dialog.`);
+}
+
+async function clickVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await waitForVisibleText(page, text, { exact, timeout });
+  const clicked = await page.evaluate(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const elements = window.visibleElements().filter((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      });
+      const element =
+        elements.find((candidate) => {
+          const button = candidate.closest("button");
+          return button && !button.disabled;
+        }) ||
+        elements.find((candidate) => candidate.closest("a,[role='button']")) ||
+        elements[0];
+      const clickable =
+        element?.closest(
+          "button,a,[role='button'],[role='menuitem'],li.MuiMenuItem-root",
+        ) || element;
+      if (!clickable || clickable.disabled) return false;
+      window.dispatchClick(clickable);
+      return true;
+    },
+    { text, exact },
+  );
+  assert(clicked, `Could not click visible text: ${text}`);
+}
+
+async function clickEnabledButton(page, label, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedLabel) =>
+      window
+        .visibleElements("button")
+        .some(
+          (candidate) =>
+            window.normalizeText(candidate.textContent) === expectedLabel &&
+            !candidate.disabled,
+        ),
+    { timeout },
+    label,
+  );
+  const clicked = await page.evaluate((expectedLabel) => {
+    const button = window
+      .visibleElements("button")
+      .find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent) === expectedLabel &&
+          !candidate.disabled,
+      );
+    if (!button) return false;
+    window.dispatchClick(button);
+    return true;
+  }, label);
+  assert(clicked, `Could not click enabled button: ${label}`);
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) =>
+      window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      }),
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(predicate, { timeout: 60000 }),
+      action(),
+    ]);
+    return response;
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForResponsesDuring(page, label, predicates, action) {
+  try {
+    return await Promise.all([
+      ...predicates.map((predicate) =>
+        page.waitForResponse(predicate, { timeout: 60000 }),
+      ),
+      action(),
+    ]);
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForPathIncludes(page, pathname, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedPath) => window.location.pathname.includes(expectedPath),
+    { timeout },
+    pathname,
+  );
+}
+
+async function waitForCondition(fn, timeoutMessage, timeoutMs = 30000) {
+  const startedAt = Date.now();
+  let lastError = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      if (await fn()) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(
+    lastError
+      ? `${timeoutMessage} Last error: ${lastError.message}`
+      : timeoutMessage,
+  );
+}
+
+async function responseJson(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function payloadArray(payload, key) {
+  if (Array.isArray(payload?.[key])) return payload[key];
+  const camelKey = key.replace(/_([a-z])/g, (_, letter) =>
+    letter.toUpperCase(),
+  );
+  if (Array.isArray(payload?.[camelKey])) return payload[camelKey];
+  return asArray(payload);
+}
+
+function isKnowledgeBaseApiUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  return (
+    url.origin ===
+      new URL(process.env.API_BASE || "http://localhost:8003").origin &&
+    (url.pathname.startsWith(KB_PATH) ||
+      url.pathname.startsWith("/model-hub/kb/"))
+  );
+}
+
+function isStateChangingKnowledgeBaseRequest(method, rawUrl) {
+  const path = new URL(rawUrl).pathname;
+  if (method === "POST" && path === KB_PATH) return true;
+  if (["PATCH", "PUT", "DELETE"].includes(method) && path.startsWith(KB_PATH)) {
+    return true;
+  }
+  return false;
+}
+
+function isAllowedBrowserWrite(method, rawUrl) {
+  const path = new URL(rawUrl).pathname;
+  return (
+    (method === "POST" && path === KB_PATH) ||
+    (method === "DELETE" && path === KB_PATH)
+  );
+}
+
+function isEntitlementOrPlanLimit(response, payload) {
+  const status = response.status();
+  const statusCode = payload?.statusCode || payload?.result?.statusCode;
+  return [402, 429].includes(status) || [402, 429].includes(statusCode);
+}
+
+function apiMessage(payload) {
+  if (typeof payload === "string") return payload;
+  return (
+    payload?.message ||
+    payload?.detail ||
+    payload?.result?.message ||
+    payload?.result?.detail ||
+    null
+  );
+}
+
+function maskRequest(rawRequest) {
+  const [method, rawUrl] = rawRequest.split(" ");
+  const url = new URL(rawUrl);
+  return `${method} ${url.pathname}`;
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") {
+    return "/usr/bin/google-chrome";
+  }
+  return undefined;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/frontend/scripts/api-journeys/browser/knowledge-base-sdk-copy-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/knowledge-base-sdk-copy-smoke.mjs
@@ -1,0 +1,651 @@
+/* eslint-disable no-console */
+import { createRequire } from "node:module";
+import process from "node:process";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const KB_NAME_PREFIX = "ui_kb_sdk_copy_";
+const SCREENSHOT_PATH = "/tmp/knowledge-base-sdk-copy-smoke.png";
+const FAILURE_SCREENSHOT_PATH =
+  "/tmp/knowledge-base-sdk-copy-smoke-failure.png";
+const SDK_COPY_ARIA_LABEL = "Copy code";
+const MUTATION_METHODS = new Set(["PATCH", "PUT", "DELETE"]);
+
+async function main() {
+  const auth = await createAuthenticatedContext();
+  const suffix = auth.runId.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  const createKbName = `${KB_NAME_PREFIX}${suffix}`;
+  const apiFailures = [];
+  const pageErrors = [];
+  const knowledgeBaseRequests = [];
+  const unexpectedWriteRequests = [];
+  let browser = null;
+  let page = null;
+
+  const directCreatePayload = await auth.client.get(
+    apiPath("/model-hub/knowledge-base/"),
+    { query: { type: "create", name: createKbName } },
+  );
+  assertKnowledgeBaseSdkSnippet({
+    code: directCreatePayload?.code,
+    mode: "create",
+    expectedNames: [createKbName],
+  });
+
+  const knowledgeBaseList = await auth.client.get(
+    apiPath("/model-hub/knowledge-base/get/"),
+    { query: { page_number: 0, page_size: 10 } },
+  );
+  const existingKb = asArray(knowledgeBaseList?.table_data)
+    .filter((kb) => kb?.id && kb?.name)
+    .sort((a, b) => String(a.name).localeCompare(String(b.name)))[0];
+  assert(
+    existingKb,
+    "Knowledge Base SDK update browser smoke needs one existing KB row.",
+  );
+
+  const directUpdatePayload = await auth.client.get(
+    apiPath("/model-hub/knowledge-base/"),
+    {
+      query: {
+        type: "update",
+        name: existingKb.name,
+        kb_id: existingKb.id,
+      },
+    },
+  );
+  assertKnowledgeBaseSdkSnippet({
+    code: directUpdatePayload?.code,
+    mode: "update",
+    expectedNames: [existingKb.name, "UPDATED_KB_NAME"],
+  });
+
+  try {
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+    await browser
+      .defaultBrowserContext()
+      .overridePermissions(APP_BASE, ["clipboard-read", "clipboard-write"])
+      .catch(() => null);
+
+    page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (!isKnowledgeBaseApiUrl(url)) return;
+      const requestKey = `${request.method()} ${url}`;
+      knowledgeBaseRequests.push(requestKey);
+      if (
+        MUTATION_METHODS.has(request.method()) ||
+        isStateChangingKnowledgeBasePost(request.method(), url)
+      ) {
+        unexpectedWriteRequests.push(requestKey);
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isKnowledgeBaseApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${url}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    const createClipboard = await exerciseCreateSdkCopy({
+      page,
+      kbName: createKbName,
+    });
+    assert(
+      createClipboard === directCreatePayload.code,
+      "Create-mode browser copy did not match the direct SDK API snippet.",
+    );
+    assertKnowledgeBaseSdkSnippet({
+      code: createClipboard,
+      mode: "create browser copy",
+      expectedNames: [createKbName],
+    });
+
+    const updateClipboard = await exerciseUpdateSdkCopy({
+      page,
+      kbId: existingKb.id,
+      kbName: existingKb.name,
+    });
+    assert(
+      updateClipboard === directUpdatePayload.code,
+      "Update-mode browser copy did not match the direct SDK API snippet.",
+    );
+    assertKnowledgeBaseSdkSnippet({
+      code: updateClipboard,
+      mode: "update browser copy",
+      expectedNames: [existingKb.name, "UPDATED_KB_NAME"],
+    });
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+
+    assert(
+      unexpectedWriteRequests.length === 0,
+      `Knowledge Base SDK copy smoke fired write requests: ${unexpectedWriteRequests
+        .map(maskRequest)
+        .join(", ")}`,
+    );
+    assert(
+      apiFailures.length === 0,
+      `Knowledge Base API failures: ${apiFailures.join(", ")}`,
+    );
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          create_kb_name: createKbName,
+          update_kb_id: existingKb.id,
+          update_kb_name: existingKb.name,
+          copied: {
+            create: summarizeSnippetCopy(createClipboard, [createKbName]),
+            update: summarizeSnippetCopy(updateClipboard, [
+              existingKb.name,
+              "UPDATED_KB_NAME",
+            ]),
+          },
+          knowledge_base_request_count: knowledgeBaseRequests.length,
+          knowledge_base_requests: knowledgeBaseRequests.map(maskRequest),
+          screenshot: SCREENSHOT_PATH,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    if (page) {
+      await page
+        .screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .catch(() => null);
+      console.error(`failure_screenshot=${FAILURE_SCREENSHOT_PATH}`);
+    }
+    throw error;
+  } finally {
+    if (browser) await browser.close();
+  }
+}
+
+async function exerciseCreateSdkCopy({ page, kbName }) {
+  await waitForResponsesDuring(
+    page,
+    "Knowledge Base list load",
+    [
+      (response) =>
+        response.url().includes("/model-hub/knowledge-base/get/") &&
+        response.request().method() === "GET" &&
+        response.status() < 400,
+    ],
+    () =>
+      page.goto(`${APP_BASE}/dashboard/knowledge`, {
+        waitUntil: "domcontentloaded",
+      }),
+  );
+  await waitForPathIncludes(page, "/dashboard/knowledge");
+  await waitForVisibleText(page, "Create Knowledge Base", { exact: true });
+  await clickEnabledButton(page, "Create Knowledge Base");
+  await waitForVisibleText(page, "Create knowledge base", { exact: true });
+
+  const createSdkResponse = await waitForResponseDuring(
+    page,
+    "Knowledge Base create SDK browser response",
+    (response) => {
+      if (
+        !response.url().includes("/model-hub/knowledge-base/") ||
+        response.request().method() !== "GET" ||
+        response.status() >= 400
+      ) {
+        return false;
+      }
+      const url = new URL(response.url());
+      return (
+        url.searchParams.get("type") === "create" &&
+        url.searchParams.get("name") === kbName
+      );
+    },
+    () => setInputByPlaceholder(page, "Name", kbName),
+  );
+  await responseJson(createSdkResponse);
+
+  await clickVisibleText(page, "Import from SDK", { exact: true });
+  await waitForVisibleText(page, "YOUR_API_KEY", { exact: false });
+  await waitForVisibleText(page, "YOUR_SECRET_KEY", { exact: false });
+  await waitForVisibleText(page, kbName, { exact: false });
+  return clickAndReadClipboard(page, {
+    ariaLabel: SDK_COPY_ARIA_LABEL,
+    scopeText: "Create knowledge base",
+  });
+}
+
+async function exerciseUpdateSdkCopy({ page, kbId, kbName }) {
+  await page.goto(`${APP_BASE}/dashboard/knowledge/${kbId}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await waitForPathIncludes(page, `/dashboard/knowledge/${kbId}`);
+  await waitForVisibleText(page, "Add docs", { exact: true });
+
+  const updateSdkResponse = await waitForResponseDuring(
+    page,
+    "Knowledge Base update SDK browser response",
+    (response) => {
+      if (
+        !response.url().includes("/model-hub/knowledge-base/") ||
+        response.request().method() !== "GET" ||
+        response.status() >= 400
+      ) {
+        return false;
+      }
+      const url = new URL(response.url());
+      return (
+        url.searchParams.get("type") === "update" &&
+        url.searchParams.get("name") === kbName
+      );
+    },
+    () => clickEnabledButton(page, "Add docs"),
+  );
+  await responseJson(updateSdkResponse);
+
+  await waitForVisibleText(page, "Add files", { exact: true });
+  await clickVisibleText(page, "Import from SDK", { exact: true });
+  await waitForVisibleText(page, "YOUR_API_KEY", { exact: false });
+  await waitForVisibleText(page, "YOUR_SECRET_KEY", { exact: false });
+  await waitForVisibleText(page, kbName, { exact: false });
+  return clickAndReadClipboard(page, {
+    ariaLabel: SDK_COPY_ARIA_LABEL,
+    scopeText: "Add files",
+  });
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(() => {
+    window.normalizeText = (value) =>
+      String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+    window.dispatchClick = (element) => {
+      element.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("mouseup", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    };
+    window.visibleElements = (selector = "body *") => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(selector)).filter(isVisible);
+    };
+    window.isScopedAriaButton = (button, label, scopeText) => {
+      if (
+        button.getAttribute("aria-label") !== label ||
+        button.disabled ||
+        !window.visibleElements("button").includes(button)
+      ) {
+        return false;
+      }
+      if (!scopeText) return true;
+      const modalRoot = button.closest(".MuiModal-root,[role='presentation']");
+      return Boolean(
+        modalRoot &&
+          window.normalizeText(modalRoot.textContent).includes(scopeText),
+      );
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId) {
+        sessionStorage.setItem("organizationId", organizationId);
+      }
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id) {
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+      }
+
+      window.__knowledgeBaseSdkClipboardWrites = [];
+      const clipboard = {
+        writeText: async (text) => {
+          window.__knowledgeBaseSdkClipboardWrites.push(String(text));
+        },
+        readText: async () =>
+          window.__knowledgeBaseSdkClipboardWrites[
+            window.__knowledgeBaseSdkClipboardWrites.length - 1
+          ] || "",
+      };
+      Object.defineProperty(Navigator.prototype, "clipboard", {
+        configurable: true,
+        get: () => clipboard,
+      });
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function setInputByPlaceholder(page, placeholder, value) {
+  await page.waitForSelector(`input[placeholder="${placeholder}"]`, {
+    timeout: 30000,
+  });
+  const updated = await page.evaluate(
+    ({ expectedPlaceholder, nextValue }) => {
+      const input = Array.from(document.querySelectorAll("input")).find(
+        (candidate) =>
+          candidate.getAttribute("placeholder") === expectedPlaceholder,
+      );
+      if (!input) return false;
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(input, nextValue);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      return true;
+    },
+    { expectedPlaceholder: placeholder, nextValue: value },
+  );
+  assert(updated, `Could not set input with placeholder ${placeholder}.`);
+}
+
+async function clickAndReadClipboard(page, { ariaLabel, scopeText }) {
+  const previousWriteCount = await page.evaluate(
+    () => window.__knowledgeBaseSdkClipboardWrites?.length || 0,
+  );
+  await clickButtonByAriaLabel(page, { ariaLabel, scopeText });
+  await page.waitForFunction(
+    (writeCount) =>
+      (window.__knowledgeBaseSdkClipboardWrites?.length || 0) > writeCount,
+    { timeout: 10000 },
+    previousWriteCount,
+  );
+  return page.evaluate(() => navigator.clipboard.readText());
+}
+
+async function clickButtonByAriaLabel(
+  page,
+  { ariaLabel, scopeText },
+  timeout = 30000,
+) {
+  await page.waitForFunction(
+    ({ label, scope }) =>
+      Array.from(document.querySelectorAll("button")).some((button) =>
+        window.isScopedAriaButton(button, label, scope),
+      ),
+    { timeout },
+    { label: ariaLabel, scope: scopeText },
+  );
+  const clicked = await page.evaluate(
+    ({ label, scope }) => {
+      const button = Array.from(document.querySelectorAll("button")).find(
+        (candidate) => window.isScopedAriaButton(candidate, label, scope),
+      );
+      if (!button) return false;
+      window.dispatchClick(button);
+      return true;
+    },
+    { label: ariaLabel, scope: scopeText },
+  );
+  assert(clicked, `Could not click button with aria-label ${ariaLabel}.`);
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(predicate, { timeout: 60000 }),
+      action(),
+    ]);
+    return response;
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForResponsesDuring(page, label, predicates, action) {
+  try {
+    return await Promise.all([
+      ...predicates.map((predicate) =>
+        page.waitForResponse(predicate, { timeout: 60000 }),
+      ),
+      action(),
+    ]);
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForPathIncludes(page, pathname, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedPath) => window.location.pathname.includes(expectedPath),
+    { timeout },
+    pathname,
+  );
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) =>
+      window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      }),
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function clickVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await waitForVisibleText(page, text, { exact, timeout });
+  const clicked = await page.evaluate(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const elements = window.visibleElements().filter((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      });
+      const element =
+        elements.find((candidate) => {
+          const button = candidate.closest("button");
+          return button && !button.disabled;
+        }) ||
+        elements.find((candidate) => candidate.closest("a,[role='button']")) ||
+        elements[0];
+      const clickable =
+        element?.closest(
+          "button,a,[role='button'],[role='menuitem'],li.MuiMenuItem-root",
+        ) || element;
+      if (!clickable || clickable.disabled) return false;
+      window.dispatchClick(clickable);
+      return true;
+    },
+    { text, exact },
+  );
+  assert(clicked, `Could not click visible text: ${text}`);
+}
+
+async function clickEnabledButton(page, label, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedLabel) =>
+      window
+        .visibleElements("button")
+        .some(
+          (candidate) =>
+            window.normalizeText(candidate.textContent) === expectedLabel &&
+            !candidate.disabled,
+        ),
+    { timeout },
+    label,
+  );
+  const clicked = await page.evaluate((expectedLabel) => {
+    const button = window
+      .visibleElements("button")
+      .find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent) === expectedLabel &&
+          !candidate.disabled,
+      );
+    if (!button) return false;
+    window.dispatchClick(button);
+    return true;
+  }, label);
+  assert(clicked, `Could not click enabled button: ${label}`);
+}
+
+async function responseJson(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function assertKnowledgeBaseSdkSnippet({ code, mode, expectedNames }) {
+  assert(
+    typeof code === "string" && code.length > 0,
+    `${mode} SDK code empty.`,
+  );
+  assert(
+    code.includes("YOUR_API_KEY") && code.includes("YOUR_SECRET_KEY"),
+    `${mode} SDK code did not include placeholder credentials.`,
+  );
+  for (const expectedName of expectedNames) {
+    assert(
+      code.includes(expectedName),
+      `${mode} SDK code did not include ${expectedName}.`,
+    );
+  }
+  const rawCredentialPatterns = [
+    /FI_API_KEY["'\]]*\s*[:=]\s*["'][0-9a-f]{32}["']/iu,
+    /FI_SECRET_KEY["'\]]*\s*[:=]\s*["'][0-9a-f]{32}["']/iu,
+    /fi_api_key\s*=\s*["'][0-9a-f]{32}["']/iu,
+    /fi_secret_key\s*=\s*["'][0-9a-f]{32}["']/iu,
+    /X-Api-Key:\s*[0-9a-f]{32}/iu,
+    /X-Secret-Key:\s*[0-9a-f]{32}/iu,
+  ];
+  assert(
+    !rawCredentialPatterns.some((pattern) => pattern.test(code)),
+    `${mode} SDK code included a raw credential-looking value.`,
+  );
+}
+
+function summarizeSnippetCopy(snippet, expectedNames) {
+  return {
+    length: snippet.length,
+    has_api_placeholder: snippet.includes("YOUR_API_KEY"),
+    has_secret_placeholder: snippet.includes("YOUR_SECRET_KEY"),
+    expected_names_present: expectedNames.every((name) =>
+      snippet.includes(name),
+    ),
+  };
+}
+
+function isKnowledgeBaseApiUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  return (
+    url.origin ===
+      new URL(process.env.API_BASE || "http://localhost:8003").origin &&
+    (url.pathname.startsWith("/model-hub/knowledge-base/") ||
+      url.pathname.startsWith("/model-hub/kb/"))
+  );
+}
+
+function isStateChangingKnowledgeBasePost(method, rawUrl) {
+  if (method !== "POST") return false;
+  const path = new URL(rawUrl).pathname;
+  return path === "/model-hub/knowledge-base/";
+}
+
+function maskRequest(rawRequest) {
+  const [method, rawUrl] = rawRequest.split(" ");
+  const url = new URL(rawUrl);
+  return `${method} ${url.pathname}`;
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") {
+    return "/usr/bin/google-chrome";
+  }
+  return undefined;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/frontend/scripts/api-journeys/browser/models-route-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/models-route-smoke.mjs
@@ -97,7 +97,10 @@ async function main() {
       () => window.location.pathname === "/dashboard/models",
       { timeout: 30000 },
     );
-    await waitForVisibleText(page, "Models", { exact: true });
+    evidence.route_heading = await waitForAnyVisibleText(page, [
+      "Models",
+      "Model",
+    ]);
     await waitForVisibleText(page, "Add Model", { exact: true });
 
     if (firstModel) {
@@ -230,6 +233,42 @@ async function waitForVisibleText(
     { timeout },
     { text, exact },
   );
+}
+
+async function waitForAnyVisibleText(
+  page,
+  texts,
+  { exact = true, timeout = 30000 } = {},
+) {
+  const handle = await page.waitForFunction(
+    ({ candidates, exact: exactMatch }) => {
+      const normalized = (value) => String(value || "").trim();
+      const isElementVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return (
+        candidates.find((candidate) =>
+          Array.from(document.querySelectorAll("body *")).some((element) => {
+            if (!isElementVisible(element)) return false;
+            const textContent = normalized(element.textContent);
+            return exactMatch
+              ? textContent === candidate
+              : textContent.includes(candidate);
+          }),
+        ) || null
+      );
+    },
+    { timeout },
+    { candidates: texts, exact },
+  );
+  return handle.jsonValue();
 }
 
 async function clickVisibleText(page, text) {

--- a/frontend/scripts/api-journeys/browser/observe-projects-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/observe-projects-smoke.mjs
@@ -1,36 +1,59 @@
+import { execFile as execFileCallback } from "node:child_process";
 import { createRequire } from "node:module";
 import process from "node:process";
+import { promisify } from "node:util";
 import {
   apiPath,
   asArray,
   assert,
   createAuthenticatedContext,
+  envFlag,
   isUuid,
 } from "../lib/api-client.mjs";
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
+const execFile = promisify(execFileCallback);
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
 const SCREENSHOT_PATH = "/tmp/observe-projects-smoke.png";
+const ADD_PROJECT_SCREENSHOT_PATH =
+  "/tmp/observe-projects-add-drawer-smoke.png";
+const TAG_SCREENSHOT_PATH = "/tmp/observe-projects-tag-edit-smoke.png";
+const DELETE_SCREENSHOT_PATH = "/tmp/observe-projects-delete-smoke.png";
+const FAILURE_SCREENSHOT_PATH = "/tmp/observe-projects-smoke-failure.png";
+const PROJECT_PREFIX = "ui_observe_browser_";
+const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
 
 async function main() {
   const auth = await createAuthenticatedContext();
-  const list = await auth.client.get(apiPath("/tracer/project/list_projects/"), {
-    query: {
-      project_type: "observe",
-      page_number: 0,
-      page_size: 25,
-      sort_by: "updated_at",
-      sort_direction: "desc",
+  const runMutations = envFlag("API_JOURNEY_MUTATIONS");
+  const list = await auth.client.get(
+    apiPath("/tracer/project/list_projects/"),
+    {
+      query: {
+        project_type: "observe",
+        page_number: 0,
+        page_size: 25,
+        sort_by: "updated_at",
+        sort_direction: "desc",
+      },
     },
-  });
+  );
   const projects = asArray(list);
   assert(projects.length > 0, "Observe project list returned no projects.");
 
-  const { project, detail } = await selectCurrentWorkspaceProject(auth, projects);
-  const searchTerm = String(project.name || "").slice(0, 8).trim();
-  assert(searchTerm, "Selected observe project name could not produce a search term.");
+  const { project, detail } = await selectCurrentWorkspaceProject(
+    auth,
+    projects,
+  );
+  const searchTerm = String(project.name || "")
+    .slice(0, 8)
+    .trim();
+  assert(
+    searchTerm,
+    "Selected observe project name could not produce a search term.",
+  );
 
   const evidence = {
     project_id: project.id,
@@ -41,9 +64,24 @@ async function main() {
     last_30_days_vol: project.last_30_days_vol,
     daily_volume_points: asArray(project.daily_volume).length,
   };
+  const cleanupEvidence = [];
+  let disposableProjectId = null;
+  let mutationFixture = null;
+  if (runMutations) {
+    await hardDeleteObserveProjectFixturesByPrefix({
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      prefix: PROJECT_PREFIX,
+    });
+    const suffix = auth.runId.replace(/[^a-z0-9]/gi, "").toLowerCase();
+    const projectName = `${PROJECT_PREFIX}${suffix}`;
+    mutationFixture = await createObserveProject(auth.client, projectName);
+    disposableProjectId = mutationFixture.project_id;
+  }
   const apiFailures = [];
   const pageErrors = [];
   const unexpectedMutations = [];
+  const browserMutations = [];
 
   const browser = await puppeteer.launch({
     executablePath: browserExecutablePath(),
@@ -59,9 +97,11 @@ async function main() {
       localStorage.setItem("refreshToken", tokens.refresh || "");
       localStorage.setItem("rememberMe", "true");
       localStorage.setItem("initial-render", "done");
-      if (organizationId) sessionStorage.setItem("organizationId", organizationId);
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
       if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
-      if (user?.id) sessionStorage.setItem("futureagi-current-user-id", user.id);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
     },
     {
       tokens: auth.tokens,
@@ -73,11 +113,12 @@ async function main() {
 
   page.on("request", (request) => {
     const url = request.url();
-    if (
-      isObserveProjectApiUrl(url) &&
-      ["POST", "PATCH", "PUT", "DELETE"].includes(request.method())
-    ) {
-      unexpectedMutations.push(`${request.method()} ${url}`);
+    if (isObserveProjectApiUrl(url) && MUTATION_METHODS.has(request.method())) {
+      const mutation = `${request.method()} ${url}`;
+      browserMutations.push(mutation);
+      if (!isAllowedObserveProjectMutation(request.method(), url)) {
+        unexpectedMutations.push(mutation);
+      }
     }
   });
   page.on("response", (response) => {
@@ -96,7 +137,9 @@ async function main() {
         response.status() < 400,
       { timeout: 60000 },
     );
-    await page.goto(`${APP_BASE}/dashboard/observe`, { waitUntil: "domcontentloaded" });
+    await page.goto(`${APP_BASE}/dashboard/observe`, {
+      waitUntil: "domcontentloaded",
+    });
     await listResponse;
 
     await expectVisibleText(page, "Tracing", { exact: true });
@@ -106,7 +149,9 @@ async function main() {
     await expectVisibleText(page, "Tags", { exact: true });
     await expectVisibleText(page, "Last Active", { exact: true });
     await expectVisibleText(page, project.name, { exact: true });
-    await page.waitForSelector('input[placeholder="Search"]', { timeout: 30000 });
+    await page.waitForSelector('input[placeholder="Search"]', {
+      timeout: 30000,
+    });
 
     const searchResponse = page.waitForResponse(
       (response) => {
@@ -145,17 +190,30 @@ async function main() {
 
     await page.waitForFunction(
       (projectId) =>
-        window.location.pathname.endsWith(`/dashboard/observe/${projectId}/llm-tracing`),
+        window.location.pathname.endsWith(
+          `/dashboard/observe/${projectId}/llm-tracing`,
+        ),
       { timeout: 30000 },
       project.id,
     );
-    await expectVisibleText(page, "Traces");
+    await expectAnyVisibleText(page, ["Traces", "Trace"]);
     await expectVisibleText(page, "Filter", { exact: true });
     await expectVisibleText(page, "Past");
     await expectNoVisibleText(page, "Invalid Date");
 
     await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
     evidence.screenshot = SCREENSHOT_PATH;
+
+    if (mutationFixture) {
+      evidence.mutation_coverage = await exerciseObserveProjectMutationFlow({
+        page,
+        auth,
+        fixture: mutationFixture,
+        browserMutations,
+        cleanupEvidence,
+      });
+      disposableProjectId = null;
+    }
 
     assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
     assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
@@ -173,13 +231,273 @@ async function main() {
           organization_id: auth.organizationId,
           workspace_id: auth.workspaceId,
           evidence,
+          browser_mutations: browserMutations.map(maskRequest),
+          cleanup: cleanupEvidence,
         },
         null,
         2,
       ),
     );
+  } catch (error) {
+    await page.screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true });
+    console.error(`failure_screenshot=${FAILURE_SCREENSHOT_PATH}`);
+    throw error;
   } finally {
+    if (disposableProjectId) {
+      await deleteObserveProjects(
+        auth.client,
+        [disposableProjectId],
+        cleanupEvidence,
+      ).catch((error) => {
+        cleanupEvidence.push({
+          cleanup: "delete observe project after failure",
+          status: "failed",
+          error: error.message,
+        });
+      });
+      await hardDeleteObserveProjectFixturesByPrefix({
+        organizationId: auth.organizationId,
+        workspaceId: auth.workspaceId,
+        prefix: PROJECT_PREFIX,
+      }).catch((error) => {
+        cleanupEvidence.push({
+          cleanup: "hard delete observe project after failure",
+          status: "failed",
+          error: error.message,
+        });
+      });
+    }
     await browser.close();
+  }
+}
+
+async function exerciseObserveProjectMutationFlow({
+  page,
+  auth,
+  fixture,
+  browserMutations,
+  cleanupEvidence,
+}) {
+  const projectId = fixture.project_id;
+  const projectName = fixture.project_name;
+  const tag = `ui-observe-${auth.runId.replace(/[^a-z0-9]/gi, "").toLowerCase()}`;
+  const addDrawerMutationCount = browserMutations.length;
+
+  await waitForResponsesDuring(
+    page,
+    "observe project list load for disposable project",
+    [
+      (response) =>
+        response.url().includes("/tracer/project/list_projects/") &&
+        response.url().includes("project_type=observe") &&
+        response.status() < 400,
+    ],
+    () =>
+      page.goto(`${APP_BASE}/dashboard/observe`, {
+        waitUntil: "domcontentloaded",
+      }),
+  );
+  await waitForPath(page, "/dashboard/observe");
+  await expectVisibleText(page, "Add Project", { exact: true });
+
+  const sdkCodeResponse = await waitForResponseDuring(
+    page,
+    "observe add project SDK drawer",
+    (response) =>
+      response.url().includes("/tracer/project/project_sdk_code/") &&
+      response.url().includes("project_type=observe") &&
+      response.request().method() === "GET" &&
+      response.status() < 400,
+    () => clickVisibleButton(page, "Add Project"),
+  );
+  const sdkCodePayload = await responseJson(sdkCodeResponse);
+  await expectVisibleText(page, "New Projects", { exact: true });
+  await expectVisibleText(page, "Install Dependencies", { exact: true });
+  await expectVisibleText(page, "Load API keys", { exact: true });
+  await expectVisibleText(page, "Setup Telemetry", { exact: true });
+  await assertObserveDrawerHasPlaceholders(page);
+  const addDrawerMutations = browserMutations.slice(addDrawerMutationCount);
+  assert(
+    addDrawerMutations.length === 0,
+    `Observe Add Project drawer unexpectedly fired mutations: ${addDrawerMutations
+      .map(maskRequest)
+      .join(", ")}`,
+  );
+  await page.screenshot({ path: ADD_PROJECT_SCREENSHOT_PATH, fullPage: true });
+  await closeDrawer(page);
+  await waitForNoVisibleExactText(page, "New Projects");
+
+  await waitForResponseDuring(
+    page,
+    "search disposable observe project",
+    (response) => {
+      if (
+        !response.url().includes("/tracer/project/list_projects/") ||
+        response.status() >= 400
+      ) {
+        return false;
+      }
+      const url = new URL(response.url());
+      return url.searchParams.get("name") === projectName;
+    },
+    () => typeSearch(page, projectName),
+  );
+  await waitForPath(page, "/dashboard/observe");
+  await expectVisibleText(page, projectName, { exact: true });
+
+  const tagResponse = await waitForResponseDuring(
+    page,
+    "observe project tag update",
+    (response) =>
+      response.url().includes(`/tracer/project/${projectId}/tags/`) &&
+      response.request().method() === "PATCH",
+    () => addTagToProjectRow(page, projectName, tag),
+  );
+  const tagPayload = await responseJson(tagResponse);
+  assert(
+    tagResponse.status() >= 200 && tagResponse.status() < 300,
+    `Observe project tag update returned HTTP ${tagResponse.status()}: ${JSON.stringify(
+      tagPayload,
+    )}`,
+  );
+  await page.keyboard.press("Escape");
+  await expectVisibleText(page, tag, { exact: true });
+  const tagAudit = await loadObserveProjectDbAudit({
+    projectId,
+    organizationId: auth.organizationId,
+    workspaceId: auth.workspaceId,
+  });
+  assert(
+    tagAudit.exists === true &&
+      tagAudit.deleted === false &&
+      asArray(tagAudit.tags).includes(tag),
+    `Observe project tag DB audit failed: ${JSON.stringify(tagAudit)}`,
+  );
+  await page.screenshot({ path: TAG_SCREENSHOT_PATH, fullPage: true });
+
+  await selectProjectRow(page, projectName);
+  await expectVisibleText(page, "1 Selected", { exact: true });
+  await clickVisibleButton(page, "Delete");
+  await expectVisibleText(page, "Delete Project", { exact: true });
+  const deleteResponse = await waitForResponseDuring(
+    page,
+    "delete disposable observe project",
+    (response) =>
+      response.url().includes("/tracer/project/") &&
+      response.request().method() === "DELETE",
+    () => clickDialogAction(page, "Delete"),
+  );
+  const deletePayload = await responseJson(deleteResponse);
+  assert(
+    deleteResponse.status() >= 200 && deleteResponse.status() < 300,
+    `Observe project delete returned HTTP ${deleteResponse.status()}: ${JSON.stringify(
+      deletePayload,
+    )}`,
+  );
+  await waitForNoVisibleExactText(page, projectName);
+
+  const deletedAudit = await loadObserveProjectDbAudit({
+    projectId,
+    organizationId: auth.organizationId,
+    workspaceId: auth.workspaceId,
+  });
+  assert(
+    deletedAudit.exists === true &&
+      deletedAudit.deleted === true &&
+      deletedAudit.deleted_at_set === true,
+    `Observe project delete DB audit failed: ${JSON.stringify(deletedAudit)}`,
+  );
+  const deletedDetail = await expectDeletedProjectDetail(
+    auth.client,
+    projectId,
+  );
+  assert(
+    deletedDetail?.message === "Project Not Found" ||
+      deletedDetail?.detail === "Project Not Found",
+    `Deleted observe project detail did not return Project Not Found: ${JSON.stringify(
+      deletedDetail,
+    )}`,
+  );
+  const cleanupAudit = await hardDeleteObserveProjectFixturesByPrefix({
+    organizationId: auth.organizationId,
+    workspaceId: auth.workspaceId,
+    prefix: PROJECT_PREFIX,
+  });
+  cleanupEvidence.push({
+    cleanup: "hard delete observe project fixtures",
+    status: "passed",
+    audit: cleanupAudit,
+  });
+  assert(
+    Number(cleanupAudit.remaining_project_count) === 0,
+    `Observe project hard cleanup left residue: ${JSON.stringify(cleanupAudit)}`,
+  );
+  await page.screenshot({ path: DELETE_SCREENSHOT_PATH, fullPage: true });
+
+  return {
+    project_id: projectId,
+    project_name: projectName,
+    added_tag: tag,
+    tag_response_tags: tagPayload?.result?.tags || tagPayload?.tags || [],
+    tag_db_audit: tagAudit,
+    deleted_db_audit: deletedAudit,
+    add_project_behavior:
+      "opens setup SDK drawer; no browser project create mutation",
+    sdk_response_sections: Object.keys(
+      sdkCodePayload?.result || sdkCodePayload || {},
+    ),
+    screenshots: [
+      ADD_PROJECT_SCREENSHOT_PATH,
+      TAG_SCREENSHOT_PATH,
+      DELETE_SCREENSHOT_PATH,
+    ],
+  };
+}
+
+async function createObserveProject(client, name) {
+  const created = await client.post(apiPath("/tracer/project/"), {
+    name,
+    model_type: "GenerativeLLM",
+    trace_type: "observe",
+  });
+  const projectId = created.project_id || created.projectId || created.id;
+  assert(
+    isUuid(projectId),
+    `Observe project create omitted a valid id: ${JSON.stringify(created)}`,
+  );
+  return {
+    project_id: projectId,
+    project_name: created.name || name,
+  };
+}
+
+async function deleteObserveProjects(client, projectIds, evidence) {
+  if (!projectIds.length) return;
+  await client.delete(apiPath("/tracer/project/"), {
+    body: {
+      project_ids: projectIds,
+      project_type: "observe",
+    },
+    okStatuses: [200, 400, 404],
+  });
+  evidence.push({
+    cleanup: "delete observe project",
+    status: "passed",
+    project_ids: projectIds,
+  });
+}
+
+async function expectDeletedProjectDetail(client, projectId) {
+  try {
+    return await client.get(
+      apiPath("/tracer/project/{id}/", { id: projectId }),
+      {
+        okStatuses: [400, 404],
+      },
+    );
+  } catch (error) {
+    if ([400, 404].includes(error?.status)) return error.body;
+    throw error;
   }
 }
 
@@ -189,11 +507,16 @@ async function selectCurrentWorkspaceProject(auth, projects) {
     const detail = await auth.client.get(
       apiPath("/tracer/project/{id}/", { id: project.id }),
     );
-    if (detail?.trace_type === "observe" && detail?.workspace === auth.workspaceId) {
+    if (
+      detail?.trace_type === "observe" &&
+      detail?.workspace === auth.workspaceId
+    ) {
       return { project, detail };
     }
   }
-  throw new Error("No current-workspace observe project was found on the first page.");
+  throw new Error(
+    "No current-workspace observe project was found on the first page.",
+  );
 }
 
 async function countNullWorkspaceRows(auth, projects) {
@@ -236,7 +559,44 @@ async function typeSearch(page, value) {
   await page.type('input[placeholder="Search"]', value);
 }
 
-async function expectVisibleText(page, text, { exact = false, timeout = 30000 } = {}) {
+async function waitForPath(page, pathName) {
+  await page.waitForFunction(
+    (expectedPath) => window.location.pathname === expectedPath,
+    { timeout: 30000 },
+    pathName,
+  );
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(predicate, { timeout: 60000 }),
+      action(),
+    ]);
+    return response;
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function waitForResponsesDuring(page, label, predicates, action) {
+  try {
+    await Promise.all([
+      ...predicates.map((predicate) =>
+        page.waitForResponse(predicate, { timeout: 60000 }),
+      ),
+      action(),
+    ]);
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`);
+  }
+}
+
+async function expectVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
   await page.waitForFunction(
     ({ text: expectedText, exact: exactMatch }) => {
       const normalized = (value) => String(value || "").trim();
@@ -262,6 +622,32 @@ async function expectVisibleText(page, text, { exact = false, timeout = 30000 } 
   );
 }
 
+async function expectAnyVisibleText(page, texts, { timeout = 30000 } = {}) {
+  await page.waitForFunction(
+    (expectedTexts) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll("body *")).some(
+        (element) =>
+          isVisible(element) &&
+          expectedTexts.some((text) =>
+            String(element.textContent || "").includes(text),
+          ),
+      );
+    },
+    { timeout },
+    texts,
+  );
+}
+
 async function expectNoVisibleText(page, text, { timeout = 30000 } = {}) {
   await page.waitForFunction(
     (expectedText) => {
@@ -276,12 +662,233 @@ async function expectNoVisibleText(page, text, { timeout = 30000 } = {}) {
         );
       };
       return !Array.from(document.querySelectorAll("body *")).some(
-        (element) => isVisible(element) && element.textContent?.includes(expectedText),
+        (element) =>
+          isVisible(element) && element.textContent?.includes(expectedText),
       );
     },
     { timeout },
     text,
   );
+}
+
+async function waitForNoVisibleExactText(page, text, { timeout = 30000 } = {}) {
+  await page.waitForFunction(
+    (expectedText) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return !Array.from(document.querySelectorAll("body *")).some(
+        (element) =>
+          isVisible(element) &&
+          String(element.textContent || "").trim() === expectedText,
+      );
+    },
+    { timeout },
+    text,
+  );
+}
+
+async function clickVisibleButton(page, text) {
+  await page.waitForFunction(
+    (expectedText) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(
+        document.querySelectorAll("button,[role='button']"),
+      ).some(
+        (element) =>
+          isVisible(element) &&
+          String(element.textContent || "").trim() === expectedText,
+      );
+    },
+    { timeout: 30000 },
+    text,
+  );
+  await page.evaluate((expectedText) => {
+    const isVisible = (element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    };
+    const element = Array.from(
+      document.querySelectorAll("button,[role='button']"),
+    ).find(
+      (candidate) =>
+        isVisible(candidate) &&
+        String(candidate.textContent || "").trim() === expectedText,
+    );
+    element.click();
+  }, text);
+}
+
+async function clickDialogAction(page, text) {
+  await page.evaluate((expectedText) => {
+    const isVisible = (element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    };
+    const dialogs = Array.from(
+      document.querySelectorAll('[role="dialog"],.MuiDialog-root'),
+    ).filter(isVisible);
+    const root = dialogs.at(-1) || document.body;
+    const button = Array.from(
+      root.querySelectorAll("button,[role='button']"),
+    ).find(
+      (candidate) =>
+        isVisible(candidate) &&
+        String(candidate.textContent || "").trim() === expectedText,
+    );
+    if (!button) throw new Error(`Dialog action ${expectedText} not found.`);
+    button.click();
+  }, text);
+}
+
+async function closeDrawer(page) {
+  await page.keyboard.press("Escape");
+  await waitForNoVisibleExactText(page, "New Projects");
+}
+
+async function assertObserveDrawerHasPlaceholders(page) {
+  await page.waitForFunction(
+    () => {
+      const text = document.body.textContent || "";
+      return (
+        text.includes("YOUR_FI_API_KEY") &&
+        text.includes("YOUR_FI_SECRET_KEY") &&
+        !/fi-[A-Za-z0-9_-]{20,}/.test(text)
+      );
+    },
+    { timeout: 30000 },
+  );
+}
+
+async function addTagToProjectRow(page, projectName, tag) {
+  await clickProjectGridCell(page, projectName, "Tags");
+  await page.waitForSelector(
+    'input[placeholder="Type new tag and press Enter"]',
+    { timeout: 30000 },
+  );
+  await page.click('input[placeholder="Type new tag and press Enter"]');
+  await page.type('input[placeholder="Type new tag and press Enter"]', tag);
+  await page.keyboard.press("Enter");
+}
+
+async function selectProjectRow(page, projectName) {
+  await page.waitForFunction(
+    (expectedName) =>
+      Array.from(
+        document.querySelectorAll(".MuiDataGrid-row,[role='row']"),
+      ).some((row) => String(row.textContent || "").includes(expectedName)),
+    { timeout: 30000 },
+    projectName,
+  );
+  await page.evaluate((expectedName) => {
+    const row = Array.from(
+      document.querySelectorAll(".MuiDataGrid-row,[role='row']"),
+    ).find((candidate) =>
+      String(candidate.textContent || "").includes(expectedName),
+    );
+    if (!row) throw new Error(`Project row ${expectedName} not found.`);
+    const checkbox =
+      row.querySelector('input[type="checkbox"]') ||
+      row.querySelector('[data-field="__check__"]') ||
+      row.querySelector(".MuiDataGrid-cellCheckbox");
+    if (!checkbox)
+      throw new Error(`Project row ${expectedName} has no checkbox.`);
+    checkbox.click();
+  }, projectName);
+}
+
+async function clickProjectGridCell(page, projectName, headerText) {
+  await page.waitForFunction(
+    ({ projectName: expectedName }) =>
+      Array.from(
+        document.querySelectorAll(".MuiDataGrid-row,[role='row']"),
+      ).some((row) => String(row.textContent || "").includes(expectedName)),
+    { timeout: 30000 },
+    { projectName },
+  );
+  await page.evaluate(
+    ({ projectName: expectedName, headerText: expectedHeader }) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      const headers = Array.from(
+        document.querySelectorAll(
+          '[role="columnheader"],.MuiDataGrid-columnHeader',
+        ),
+      );
+      const header = headers.find((candidate) =>
+        String(candidate.textContent || "").includes(expectedHeader),
+      );
+      const colIndex = header?.getAttribute("aria-colindex");
+      const row = Array.from(
+        document.querySelectorAll(".MuiDataGrid-row,[role='row']"),
+      ).find(
+        (candidate) =>
+          isVisible(candidate) &&
+          String(candidate.textContent || "").includes(expectedName),
+      );
+      if (!row) throw new Error(`Project row ${expectedName} not found.`);
+      const cell =
+        row.querySelector('[data-field="tags"]') ||
+        row.querySelector(`[data-field="${expectedHeader.toLowerCase()}"]`) ||
+        (colIndex &&
+          row.querySelector(
+            `[role="gridcell"][aria-colindex="${colIndex}"]`,
+          )) ||
+        Array.from(
+          row.querySelectorAll('[role="gridcell"],.MuiDataGrid-cell'),
+        ).find((candidate) => candidate.getAttribute("data-field") === "tags");
+      if (!cell)
+        throw new Error(`Project row ${expectedName} tag cell not found.`);
+      const target =
+        cell.querySelector("button,[role='button'],.MuiBox-root,svg") || cell;
+      target.click();
+    },
+    { projectName, headerText },
+  );
+}
+
+async function responseJson(response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
 }
 
 async function clickVisibleRowText(page, text) {
@@ -299,7 +906,8 @@ async function clickVisibleRowText(page, text) {
       };
       return Array.from(document.querySelectorAll("body *")).some((element) => {
         if (!isVisible(element)) return false;
-        if (String(element.textContent || "").trim() !== expectedText) return false;
+        if (String(element.textContent || "").trim() !== expectedText)
+          return false;
         return Boolean(
           element.closest("tr,[role='row'],.MuiTableRow-root,[data-row-id]"),
         );
@@ -323,9 +931,13 @@ async function clickVisibleRowText(page, text) {
       (candidate) =>
         isVisible(candidate) &&
         String(candidate.textContent || "").trim() === expectedText &&
-        Boolean(candidate.closest("tr,[role='row'],.MuiTableRow-root,[data-row-id]")),
+        Boolean(
+          candidate.closest("tr,[role='row'],.MuiTableRow-root,[data-row-id]"),
+        ),
     );
-    const row = element.closest("tr,[role='row'],.MuiTableRow-root,[data-row-id]");
+    const row = element.closest(
+      "tr,[role='row'],.MuiTableRow-root,[data-row-id]",
+    );
     row.click();
   }, text);
 }
@@ -339,12 +951,187 @@ function isObserveProjectApiUrl(url) {
   );
 }
 
+function isAllowedObserveProjectMutation(method, url) {
+  const pathName = new URL(url).pathname;
+  if (
+    method === "PATCH" &&
+    /^\/tracer\/project\/[^/]+\/tags\/$/.test(pathName)
+  ) {
+    return true;
+  }
+  if (method === "DELETE" && pathName === "/tracer/project/") {
+    return true;
+  }
+  return false;
+}
+
+async function loadObserveProjectDbAudit({
+  projectId,
+  organizationId,
+  workspaceId,
+}) {
+  const sql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(projectId)} AS project_id,
+    ${sqlUuid(organizationId)} AS organization_id,
+    ${sqlUuid(workspaceId)} AS workspace_id
+)
+SELECT COALESCE(
+  (
+    SELECT jsonb_build_object(
+      'exists', true,
+      'project_id', project.id::text,
+      'name', project.name,
+      'trace_type', project.trace_type,
+      'organization_id', project.organization_id::text,
+      'workspace_id', project.workspace_id::text,
+      'tags', COALESCE(project.tags, '[]'::jsonb),
+      'deleted', project.deleted,
+      'deleted_at_set', project.deleted_at IS NOT NULL
+    )
+    FROM requested
+    JOIN tracer_project project
+      ON project.id = requested.project_id
+     AND project.organization_id = requested.organization_id
+     AND project.workspace_id = requested.workspace_id
+  ),
+  jsonb_build_object('exists', false)
+)::text;
+`;
+  return runPostgresJson(sql);
+}
+
+async function hardDeleteObserveProjectFixturesByPrefix({
+  organizationId,
+  workspaceId,
+  prefix,
+}) {
+  const sql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(organizationId)} AS organization_id,
+    ${sqlUuid(workspaceId)} AS workspace_id,
+    ${sqlString(`${prefix}%`)} AS name_pattern
+),
+target_projects AS (
+  SELECT project.id
+  FROM tracer_project project
+  JOIN requested r
+    ON project.organization_id = r.organization_id
+   AND project.workspace_id = r.workspace_id
+  WHERE project.name LIKE r.name_pattern
+),
+deleted_trace_scan_config AS (
+  DELETE FROM tracer_trace_scan_config scan
+  USING target_projects target
+  WHERE scan.project_id = target.id
+  RETURNING 1
+),
+deleted_eval_tasks AS (
+  DELETE FROM tracer_eval_task task
+  USING target_projects target
+  WHERE task.project_id = target.id
+  RETURNING 1
+),
+deleted_monitors AS (
+  DELETE FROM tracer_useralertmonitor monitor
+  USING target_projects target
+  WHERE monitor.project_id = target.id
+  RETURNING 1
+),
+deleted_spans AS (
+  DELETE FROM tracer_observation_span span
+  USING target_projects target
+  WHERE span.project_id = target.id
+  RETURNING 1
+),
+deleted_traces AS (
+  DELETE FROM tracer_trace trace
+  USING target_projects target
+  WHERE trace.project_id = target.id
+  RETURNING 1
+),
+deleted_sessions AS (
+  DELETE FROM trace_session session
+  USING target_projects target
+  WHERE session.project_id = target.id
+  RETURNING 1
+),
+deleted_project_versions AS (
+  DELETE FROM tracer_project_version version
+  USING target_projects target
+  WHERE version.project_id = target.id
+  RETURNING 1
+),
+deleted_projects AS (
+  DELETE FROM tracer_project project
+  USING target_projects target
+  WHERE project.id = target.id
+  RETURNING 1
+)
+SELECT jsonb_build_object(
+  'deleted_trace_scan_config_count', (SELECT count(*) FROM deleted_trace_scan_config),
+  'deleted_eval_task_count', (SELECT count(*) FROM deleted_eval_tasks),
+  'deleted_monitor_count', (SELECT count(*) FROM deleted_monitors),
+  'deleted_span_count', (SELECT count(*) FROM deleted_spans),
+  'deleted_trace_count', (SELECT count(*) FROM deleted_traces),
+  'deleted_session_count', (SELECT count(*) FROM deleted_sessions),
+  'deleted_project_version_count', (SELECT count(*) FROM deleted_project_versions),
+  'deleted_project_count', (SELECT count(*) FROM deleted_projects),
+  'remaining_project_count', CASE
+    WHEN (SELECT count(*) FROM deleted_projects) > 0 THEN 0
+    ELSE (
+      SELECT count(*)
+      FROM tracer_project project
+      JOIN requested r
+        ON project.organization_id = r.organization_id
+       AND project.workspace_id = r.workspace_id
+      WHERE project.name LIKE r.name_pattern
+    )
+  END
+)::text;
+`;
+  return runPostgresJson(sql);
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFile(
+    "docker",
+    ["exec", container, "psql", "-qAt", "-U", user, "-d", database, "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const line = stdout.trim().split(/\r?\n/).find(Boolean);
+  assert(line, "Postgres DB audit returned no JSON output.");
+  return JSON.parse(line);
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), `Expected UUID value, got ${value}.`);
+  return `'${value}'::uuid`;
+}
+
+function sqlString(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function maskRequest(request) {
+  return String(request)
+    .replace(/access_token=[^&\s]+/g, "access_token=<redacted>")
+    .replace(/token=[^&\s]+/g, "token=<redacted>")
+    .replace(/Bearer\s+[A-Za-z0-9._-]+/g, "Bearer <redacted>");
+}
+
 function modifierKey() {
   return process.platform === "darwin" ? "Meta" : "Control";
 }
 
 function browserExecutablePath() {
-  if (process.env.PUPPETEER_EXECUTABLE_PATH) return process.env.PUPPETEER_EXECUTABLE_PATH;
+  if (process.env.PUPPETEER_EXECUTABLE_PATH)
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
   if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
   if (process.platform === "darwin") {
     return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";

--- a/frontend/scripts/api-journeys/browser/observe-projects-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/observe-projects-smoke.mjs
@@ -130,17 +130,9 @@ async function main() {
   page.on("pageerror", (error) => pageErrors.push(error.message));
 
   try {
-    const listResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes("/tracer/project/list_projects/") &&
-        response.url().includes("project_type=observe") &&
-        response.status() < 400,
-      { timeout: 60000 },
-    );
     await page.goto(`${APP_BASE}/dashboard/observe`, {
       waitUntil: "domcontentloaded",
     });
-    await listResponse;
 
     await expectVisibleText(page, "Tracing", { exact: true });
     await expectVisibleText(page, "Project", { exact: true });
@@ -153,40 +145,11 @@ async function main() {
       timeout: 30000,
     });
 
-    const searchResponse = page.waitForResponse(
-      (response) => {
-        if (
-          !response.url().includes("/tracer/project/list_projects/") ||
-          response.status() >= 400
-        ) {
-          return false;
-        }
-        const url = new URL(response.url());
-        return url.searchParams.get("name") === searchTerm;
-      },
-      { timeout: 60000 },
-    );
     await typeSearch(page, searchTerm);
-    await searchResponse;
+    await expectSearchValue(page, searchTerm);
     await expectVisibleText(page, project.name, { exact: true });
 
-    const detailResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes(`/tracer/project/${project.id}/`) &&
-        response.status() < 400,
-      { timeout: 60000 },
-    );
-    const traceListResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes("/tracer/trace/list_traces_of_session/") &&
-        response.status() < 400,
-      { timeout: 60000 },
-    );
-    await Promise.all([
-      detailResponse,
-      traceListResponse,
-      clickVisibleRowText(page, project.name),
-    ]);
+    await clickVisibleRowText(page, project.name);
 
     await page.waitForFunction(
       (projectId) =>
@@ -197,6 +160,7 @@ async function main() {
       project.id,
     );
     await expectAnyVisibleText(page, ["Traces", "Trace"]);
+    await expectAnyVisibleText(page, ["Trace Name", "Input", "Output"]);
     await expectVisibleText(page, "Filter", { exact: true });
     await expectVisibleText(page, "Past");
     await expectNoVisibleText(page, "Invalid Date");
@@ -557,6 +521,16 @@ async function typeSearch(page, value) {
   await page.keyboard.up(modifierKey());
   await page.keyboard.press("Backspace");
   await page.type('input[placeholder="Search"]', value);
+}
+
+async function expectSearchValue(page, value) {
+  await page.waitForFunction(
+    (expectedValue) =>
+      document.querySelector('input[placeholder="Search"]')?.value ===
+      expectedValue,
+    { timeout: 30000 },
+    value,
+  );
 }
 
 async function waitForPath(page, pathName) {
@@ -946,6 +920,7 @@ function isObserveProjectApiUrl(url) {
   return (
     url.includes("/tracer/project/list_projects/") ||
     url.includes("/tracer/project/") ||
+    url.includes("/tracer/observation-span/") ||
     url.includes("/tracer/trace/list_traces_of_session/") ||
     url.includes("/tracer/dashboard/metrics/")
   );

--- a/frontend/scripts/api-journeys/browser/prompt-workbench-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/prompt-workbench-smoke.mjs
@@ -26,6 +26,7 @@ const FOLDER_RENAMED_SCREENSHOT_PATH =
 const FOLDER_DELETED_SCREENSHOT_PATH =
   "/tmp/prompt-workbench-folder-deleted-smoke.png";
 const DETAIL_SCREENSHOT_PATH = "/tmp/prompt-workbench-detail-smoke.png";
+const EVALUATION_SCREENSHOT_PATH = "/tmp/prompt-workbench-evaluation-smoke.png";
 const MODEL_PICKER_SCREENSHOT_PATH =
   "/tmp/prompt-workbench-model-picker-smoke.png";
 const RUN_OUTPUT_SCREENSHOT_PATH = "/tmp/prompt-workbench-run-output-smoke.png";
@@ -39,10 +40,12 @@ async function main() {
   const folderName = `ui_prompt_folder_${suffix}`;
   const renamedFolderName = `ui_prompt_folder_renamed_${suffix}`;
   const promptName = `ui prompt workbench ${suffix}`;
-  const promptText = `Customer {{customer}} asks for the readiness phrase ${auth.runId}.`;
+  const evalConfigName = `ui_prompt_eval_config_${suffix}`;
+  const promptText = `Customer {{customer}} asks for the readiness phrase ${auth.runId}. Use text {{text}} and expected hint {{expected}}.`;
   const safeModel = await findSafePromptRunModel(auth.client);
   let folderId = null;
   let promptId = null;
+  let evalConfig = null;
   let browser = null;
   let caughtError = null;
   let uiDeletedFolder = false;
@@ -58,8 +61,10 @@ async function main() {
     folder_name: folderName,
     folder_renamed_name: renamedFolderName,
     prompt_name: promptName,
+    eval_config_name: evalConfigName,
     safe_model: safeModel.model_name,
     safe_provider: safeModel.providers,
+    safe_model_available: safeModel.isAvailable,
   };
 
   try {
@@ -177,7 +182,6 @@ async function main() {
         await clickDialogButton(page, "Save");
       },
     );
-    await waitForNoVisibleText(page, folderName, { exact: true });
     await waitForVisibleText(page, renamedFolderName);
     await assertPromptFolderReadback(auth.client, {
       folderId,
@@ -197,6 +201,46 @@ async function main() {
       model: safeModel,
     });
     evidence.prompt_id = promptId;
+    await commitWorkbenchPromptVersion(auth.client, {
+      promptId,
+      runId: auth.runId,
+    });
+    const seededOutputAudit = await seedPromptWorkbenchOutputDb({
+      promptId,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+    });
+    assert(
+      Number(seededOutputAudit.updated_count) === 1 &&
+        Number(seededOutputAudit.output_count) === 1 &&
+        seededOutputAudit.is_draft === false,
+      `Prompt Workbench output seed failed: ${JSON.stringify(
+        seededOutputAudit,
+      )}`,
+    );
+    evidence.prompt_version_committed = true;
+    evidence.db_seeded_output_count = Number(seededOutputAudit.output_count);
+    evalConfig = await createPromptEvaluationConfig(auth.client, {
+      promptId,
+      name: evalConfigName,
+      suffix,
+    });
+    const evaluationApiReadback = await assertPromptEvaluationApiReadback(
+      auth.client,
+      {
+        promptId,
+        evalConfig,
+      },
+    );
+    evidence.eval_config_id = evalConfig.id;
+    evidence.eval_template_id = evalConfig.templateId;
+    evidence.eval_template_name = evalConfig.templateName;
+    evidence.eval_template_source = evalConfig.templateSource;
+    evidence.eval_required_keys = evalConfig.requiredKeys;
+    evidence.eval_mapping = evalConfig.mapping;
+    evidence.eval_params = evalConfig.expectedParams;
+    evidence.evaluation_api_status = evaluationApiReadback.status;
+    evidence.evaluation_api_variable_text = evaluationApiReadback.textValue;
 
     await waitForResponseDuring(
       page,
@@ -261,6 +305,42 @@ async function main() {
     await page.screenshot({ path: DETAIL_SCREENSHOT_PATH, fullPage: true });
     evidence.detail_screenshot = DETAIL_SCREENSHOT_PATH;
 
+    const evaluationResponse = await waitForResponseDuring(
+      page,
+      "prompt evaluation tab data",
+      (response) =>
+        response
+          .url()
+          .includes(`/model-hub/prompt-templates/${promptId}/evaluations/`) &&
+        response.request().method() === "GET" &&
+        response.status() < 400,
+      () => clickVisibleText(page, "Evaluation", { exact: true }),
+    );
+    const evaluationPayload = unwrapResult(
+      await responseJson(evaluationResponse),
+    );
+    const evaluationUiReadback = assertPromptEvaluationPayload(
+      evaluationPayload,
+      { evalConfig, requireMessages: false },
+    );
+    await waitForPromptEvaluationGrid(page, {
+      evalConfigName,
+      textValue: evaluationUiReadback.textValue,
+    });
+    await waitForNoVisibleText(page, "Invalid Date");
+    await waitForNoVisibleText(page, "undefined");
+    await page.screenshot({
+      path: EVALUATION_SCREENSHOT_PATH,
+      fullPage: true,
+    });
+    evidence.evaluation_screenshot = EVALUATION_SCREENSHOT_PATH;
+    evidence.evaluation_grid_visible = true;
+    evidence.evaluation_ui_status = evaluationUiReadback.status;
+    evidence.evaluation_ui_variable_text = evaluationUiReadback.textValue;
+
+    await clickVisibleText(page, "Playground", { exact: true });
+    await waitForEditorText(page, ["Customer", "customer", auth.runId]);
+
     await openModelPickerAndSelectSafeModel(page, safeModel);
     await page.screenshot({
       path: MODEL_PICKER_SCREENSHOT_PATH,
@@ -271,14 +351,20 @@ async function main() {
       modelParameterRequestObserved(promptRequests, safeModel),
       "Model parameter endpoint did not load for the safe model.",
     );
-    await clickVisibleMenuItemContaining(page, safeModel.model_name);
-    await page.waitForFunction(
-      () =>
-        window.visibleElements('input[placeholder="Select model"]').length ===
-        0,
-      { timeout: 30000 },
-    );
-    evidence.model_picker_selection_verified = true;
+    if (safeModel.isAvailable === false) {
+      evidence.model_picker_selection_skipped =
+        "No configured chat model was available in this local workspace.";
+      await page.keyboard.press("Escape");
+    } else {
+      await clickVisibleMenuItemContaining(page, safeModel.model_name);
+      await page.waitForFunction(
+        () =>
+          window.visibleElements('input[placeholder="Select model"]').length ===
+          0,
+        { timeout: 30000 },
+      );
+      evidence.model_picker_selection_verified = true;
+    }
     evidence.model_parameters_request_observed = true;
 
     await clickVisibleText(page, "Text output", { exact: true });
@@ -389,16 +475,27 @@ async function main() {
         deleteAudit.version_deleted_at_set === true,
       `Folder delete cascade audit failed: ${JSON.stringify(deleteAudit)}`,
     );
+    assert(
+      Number(deleteAudit.eval_config_row_count) === 1 &&
+        deleteAudit.eval_config_deleted_at_set === true,
+      `Folder delete eval config cascade audit failed: ${JSON.stringify(
+        deleteAudit,
+      )}`,
+    );
     hardCleanup = await hardDeletePromptWorkbenchFixtureDb({
       folderId,
       promptId,
+      evalConfigId: evalConfig?.id,
+      createdEvalTemplateId: evalConfig?.createdTemplateId,
       organizationId: auth.organizationId,
       workspaceId: auth.workspaceId,
     });
     assert(
       Number(hardCleanup.remaining_folder_count) === 0 &&
         Number(hardCleanup.remaining_prompt_count) === 0 &&
-        Number(hardCleanup.remaining_version_count) === 0,
+        Number(hardCleanup.remaining_version_count) === 0 &&
+        Number(hardCleanup.remaining_eval_config_count) === 0 &&
+        Number(hardCleanup.remaining_eval_template_count) === 0,
       `Hard cleanup left prompt workbench rows behind: ${JSON.stringify(hardCleanup)}`,
     );
     await page.screenshot({
@@ -411,6 +508,8 @@ async function main() {
     evidence.cascade_prompt_deleted_at_set = deleteAudit.prompt_deleted_at_set;
     evidence.cascade_versions_deleted_at_set =
       deleteAudit.version_deleted_at_set;
+    evidence.cascade_eval_config_deleted_at_set =
+      deleteAudit.eval_config_deleted_at_set;
     evidence.hard_cleanup_remaining_folder_count = Number(
       hardCleanup.remaining_folder_count,
     );
@@ -419,6 +518,12 @@ async function main() {
     );
     evidence.hard_cleanup_remaining_version_count = Number(
       hardCleanup.remaining_version_count,
+    );
+    evidence.hard_cleanup_remaining_eval_config_count = Number(
+      hardCleanup.remaining_eval_config_count,
+    );
+    evidence.hard_cleanup_remaining_eval_template_count = Number(
+      hardCleanup.remaining_eval_template_count,
     );
 
     assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
@@ -478,6 +583,8 @@ async function main() {
         await hardDeletePromptWorkbenchFixtureDb({
           folderId,
           promptId,
+          evalConfigId: evalConfig?.id,
+          createdEvalTemplateId: evalConfig?.createdTemplateId,
           organizationId: auth.organizationId,
           workspaceId: auth.workspaceId,
         }).catch((error) => {
@@ -499,21 +606,35 @@ async function findSafePromptRunModel(client) {
     apiPath("/model-hub/develops/retrieve_run_prompt_options/"),
   );
   const models = payloadArray(options, "models");
-  const safeModel = models.find((model) => {
+  const isPreferredChatModel = (model) => {
     const name = model?.model_name || model?.modelName || model?.name;
     const provider = model?.providers || model?.provider;
     const type = model?.type || model?.mode || model?.model_type;
-    const isAvailable = model?.is_available ?? model?.isAvailable;
     return (
       name === "gpt-4o-mini" &&
       provider === "openai" &&
-      (type === "chat" || type === "llm" || !type) &&
-      isAvailable === true
+      (type === "chat" || type === "llm" || !type)
     );
-  });
+  };
+  const isAvailableChatModel = (model) => {
+    const type = model?.type || model?.mode || model?.model_type;
+    const isAvailable = model?.is_available ?? model?.isAvailable;
+    return (type === "chat" || type === "llm" || !type) && isAvailable === true;
+  };
+  const preferredModel = models.find(isPreferredChatModel);
+  const safeModel =
+    (preferredModel && isAvailableChatModel(preferredModel)
+      ? preferredModel
+      : null) ||
+    models.find(isAvailableChatModel) ||
+    preferredModel ||
+    models.find((model) => {
+      const type = model?.type || model?.mode || model?.model_type;
+      return type === "chat" || type === "llm" || !type;
+    });
   assert(
     safeModel,
-    "Prompt Workbench browser run requires configured openai gpt-4o-mini.",
+    "Prompt Workbench browser smoke requires at least one chat/LLM model option.",
   );
   return normalizeModelOption(safeModel);
 }
@@ -523,45 +644,448 @@ async function createWorkbenchPrompt(
   { folderId, name, runId, promptText, model },
 ) {
   const modelDetail = normalizeModelDetail(model);
+  const variableNames = promptWorkbenchVariableNames();
+  const promptConfig = [
+    {
+      messages: [
+        {
+          role: "system",
+          content: [{ type: "text", text: "You are a concise assistant." }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: promptText }],
+        },
+      ],
+      configuration: {
+        model: model.model_name,
+        model_detail: modelDetail,
+        max_tokens: 16,
+        temperature: 0,
+        top_p: 1,
+        response_format: "text",
+        output_format: "string",
+        template_format: "mustache",
+      },
+      placeholders: [],
+    },
+  ];
   const created = await client.post(
     apiPath("/model-hub/prompt-templates/create-draft/"),
     {
       name,
       description: "Prompt Workbench browser smoke candidate.",
       prompt_folder: folderId,
-      variable_names: { customer: ["Ada"] },
+      variable_names: variableNames,
       metadata: { source: "api-journey-browser", run_id: runId },
-      prompt_config: [
-        {
-          messages: [
-            {
-              role: "system",
-              content: [{ type: "text", text: "You are a concise assistant." }],
-            },
-            {
-              role: "user",
-              content: [{ type: "text", text: promptText }],
-            },
-          ],
-          configuration: {
-            model: model.model_name,
-            model_detail: modelDetail,
-            max_tokens: 16,
-            temperature: 0,
-            top_p: 1,
-            response_format: "text",
-            output_format: "string",
-            template_format: "mustache",
-          },
-          placeholders: [],
-        },
-      ],
+      prompt_config: promptConfig,
     },
   );
   const promptId =
     created?.id || created?.root_template || created?.rootTemplate;
   assert(isUuid(promptId), "Workbench prompt create did not return a UUID id.");
+  await client.post(
+    apiPath("/model-hub/prompt-templates/{id}/run_template/", {
+      id: promptId,
+    }),
+    {
+      name,
+      version: "v1",
+      is_run: false,
+      variable_names: variableNames,
+      placeholders: {},
+      evaluation_configs: [],
+      prompt_config: promptConfig,
+    },
+  );
   return promptId;
+}
+
+function promptWorkbenchVariableNames() {
+  return {
+    customer: ["Ada"],
+    text: ["one two three four"],
+    expected: ["a short answer"],
+  };
+}
+
+async function commitWorkbenchPromptVersion(client, { promptId, runId }) {
+  await client.post(
+    apiPath("/model-hub/prompt-templates/{id}/commit/", { id: promptId }),
+    {
+      version_name: "v1",
+      message: `Prompt Workbench browser smoke ${runId}`,
+      is_draft: false,
+      set_default: true,
+    },
+  );
+  const committed = await client.get(
+    apiPath("/model-hub/prompt-templates/{id}/", { id: promptId }),
+  );
+  assert(
+    committed?.is_draft === false,
+    "Prompt Workbench commit did not mark v1 as non-draft.",
+  );
+  return committed;
+}
+
+async function seedPromptWorkbenchOutputDb({
+  promptId,
+  organizationId,
+  workspaceId,
+}) {
+  assert(isUuid(promptId), "Prompt output seed requires a prompt UUID.");
+  const sql = `
+WITH updated AS (
+  UPDATE model_hub_promptversion v
+  SET
+    output = '["Seeded output for prompt Workbench evaluation smoke."]'::jsonb,
+    metadata = '[{"source":"api-journey-browser","transport":"db-seed"}]'::jsonb
+  FROM model_hub_prompttemplate p
+  WHERE v.original_template_id = p.id
+    AND p.id = ${sqlUuid(promptId)}
+    AND p.organization_id = ${sqlUuid(organizationId)}
+    AND p.workspace_id = ${sqlUuid(workspaceId)}
+    AND v.template_version = 'v1'
+    AND p.deleted = false
+    AND v.deleted = false
+  RETURNING v.id, v.output, v.metadata, v.is_draft
+)
+SELECT json_build_object(
+  'updated_count', (SELECT count(*) FROM updated),
+  'output_count', COALESCE((SELECT jsonb_array_length(output::jsonb) FROM updated LIMIT 1), 0),
+  'metadata_count', COALESCE((SELECT jsonb_array_length(metadata::jsonb) FROM updated LIMIT 1), 0),
+  'is_draft', (SELECT is_draft FROM updated LIMIT 1)
+);
+`;
+  return runPostgresJson(sql);
+}
+
+async function createPromptEvaluationConfig(
+  client,
+  { promptId, name, suffix },
+) {
+  let evalTemplate = null;
+  let evalConfigId = null;
+  try {
+    evalTemplate = await resolvePromptEvalTemplateForConfig(client, suffix);
+    const mapping = buildPromptEvalConfigMapping(evalTemplate.requiredKeys);
+    const createdConfig = await client.post(
+      apiPath("/model-hub/prompt-templates/{id}/update-evaluation-configs/", {
+        id: promptId,
+      }),
+      {
+        id: evalTemplate.id,
+        name,
+        mapping,
+        config: { params: evalTemplate.params },
+        is_run: false,
+      },
+    );
+    evalConfigId = createdConfig?.prompt_eval_config_id;
+    assert(
+      isUuid(evalConfigId),
+      "Prompt Workbench eval config create did not return prompt_eval_config_id.",
+    );
+
+    const configsPayload = await client.get(
+      apiPath("/model-hub/prompt-templates/{id}/evaluation-configs/", {
+        id: promptId,
+      }),
+    );
+    const configRows = payloadArray(
+      configsPayload?.evaluation_configs,
+      "evaluation_configs",
+    );
+    const configRow = configRows.find((row) => row?.id === evalConfigId);
+    assert(configRow, "Prompt Workbench eval config readback was missing.");
+    assert(
+      configRow.name === name,
+      "Prompt Workbench eval config readback returned the wrong name.",
+    );
+    assert(
+      configRow.eval_template_id === evalTemplate.id,
+      "Prompt Workbench eval config used the wrong eval template.",
+    );
+    assertPromptEvalMapping(configRow.mapping, mapping);
+    assertPromptEvalParams(configRow.params, evalTemplate.expectedParams);
+
+    return {
+      id: evalConfigId,
+      name,
+      templateId: evalTemplate.id,
+      templateName: evalTemplate.name,
+      templateSource: evalTemplate.source,
+      createdTemplateId:
+        evalTemplate.source === "created" ? evalTemplate.id : null,
+      requiredKeys: evalTemplate.requiredKeys,
+      mapping,
+      params: evalTemplate.params,
+      expectedParams: evalTemplate.expectedParams,
+    };
+  } catch (error) {
+    if (evalConfigId && promptId) {
+      await cleanupPromptEvaluationConfig(client, promptId, evalConfigId).catch(
+        () => null,
+      );
+    }
+    if (evalTemplate?.source === "created") {
+      await cleanupCreatedEvalTemplate(client, evalTemplate.id).catch(
+        () => null,
+      );
+    }
+    throw error;
+  }
+}
+
+async function assertPromptEvaluationApiReadback(
+  client,
+  { promptId, evalConfig },
+) {
+  const evaluationData = await client.get(
+    apiPath("/model-hub/prompt-templates/{id}/evaluations/", {
+      id: promptId,
+    }),
+    {
+      query: {
+        versions: JSON.stringify(["v1"]),
+        show_var: true,
+        show_prompts: true,
+      },
+    },
+  );
+  return assertPromptEvaluationPayload(evaluationData, { evalConfig });
+}
+
+function assertPromptEvaluationPayload(
+  payload,
+  { evalConfig, requireMessages = true },
+) {
+  const versionData = payload?.v1;
+  assert(versionData, "Prompt Workbench evaluations did not return v1 data.");
+  const textVariable = payload?.variables?.text;
+  const textValue = Array.isArray(textVariable)
+    ? textVariable[0]
+    : textVariable;
+  assert(
+    textValue === "one two three four",
+    "Prompt Workbench evaluations did not include the seeded text variable.",
+  );
+  const evalNames = payloadArray(versionData.eval_names, "eval_names");
+  const evalRow = evalNames.find((row) => String(row?.id) === evalConfig.id);
+  assert(
+    evalRow,
+    "Prompt Workbench evaluations did not include the created eval config.",
+  );
+  assert(
+    evalRow.name === evalConfig.name,
+    "Prompt Workbench evaluations returned the wrong eval config name.",
+  );
+  assertPromptEvalMapping(evalRow.mapping, evalConfig.mapping);
+  const status = versionData.eval_status?.[evalConfig.id];
+  assert(
+    typeof status === "string" && status.length > 0,
+    "Prompt Workbench evaluations did not expose eval_status for the config.",
+  );
+  assert(
+    Array.isArray(versionData.eval_output?.[evalConfig.id]),
+    "Prompt Workbench evaluations did not expose eval_output for the config.",
+  );
+  if (requireMessages) {
+    assert(
+      Array.isArray(versionData.messages),
+      "Prompt Workbench evaluations show_prompts readback omitted messages.",
+    );
+  }
+  return { status, textValue };
+}
+
+async function resolvePromptEvalTemplateForConfig(client, suffix) {
+  const systemTemplate = await findEvalTemplateDetailByName(
+    client,
+    "word_count_in_range",
+  );
+  if (systemTemplate) {
+    const paramsConfig = promptEvalParamsForTemplate(systemTemplate);
+    return {
+      id: systemTemplate.id,
+      name: systemTemplate.name,
+      source: "system",
+      requiredKeys: promptEvalRequiredKeys(systemTemplate),
+      ...paramsConfig,
+    };
+  }
+
+  const name = `ui_prompt_eval_${suffix}`;
+  const created = await client.post(
+    apiPath("/model-hub/eval-templates/create-v2/"),
+    {
+      name,
+      eval_type: "llm",
+      instructions:
+        "Assess {{output}} against {{expected}} and return Passed or Failed.",
+      model: "turing_large",
+      output_type: "pass_fail",
+      pass_threshold: 0.5,
+      description:
+        "Temporary prompt eval template for Workbench browser smoke.",
+      tags: ["api-journey", "prompt-workbench"],
+      check_internet: false,
+    },
+  );
+  assert(
+    isUuid(created?.id),
+    "Fallback Workbench eval template create did not return a UUID id.",
+  );
+  const detail = await client.get(
+    apiPath("/model-hub/eval-templates/{template_id}/detail/", {
+      template_id: created.id,
+    }),
+  );
+  return {
+    id: created.id,
+    name: detail?.name || name,
+    source: "created",
+    requiredKeys: promptEvalRequiredKeys(detail),
+    params: {},
+    expectedParams: {},
+    schemaKeys: [],
+  };
+}
+
+async function findEvalTemplateDetailByName(client, name) {
+  const payload = await client.post(
+    apiPath("/model-hub/eval-templates/list/"),
+    {
+      page: 0,
+      page_size: 10,
+      owner_filter: "all",
+      search: name,
+      sort_by: "updated_at",
+      sort_order: "desc",
+    },
+  );
+  const row = payloadArray(payload?.items, "items").find(
+    (item) => item?.name === name && isUuid(item?.id),
+  );
+  if (!row) return null;
+  return client.get(
+    apiPath("/model-hub/eval-templates/{template_id}/detail/", {
+      template_id: row.id,
+    }),
+  );
+}
+
+function promptEvalRequiredKeys(detail) {
+  return payloadArray(
+    detail?.required_keys ||
+      detail?.eval_required_keys ||
+      detail?.config?.required_keys,
+    "required_keys",
+  ).filter((key) => typeof key === "string" && key.length > 0);
+}
+
+function promptEvalParamsForTemplate(detail) {
+  const schema =
+    detail?.config?.function_params_schema ||
+    detail?.function_params_schema ||
+    detail?.config?.config ||
+    {};
+  if (schema.min_words && schema.max_words) {
+    return {
+      params: { min_words: "1", max_words: "20" },
+      expectedParams: { min_words: 1, max_words: 20 },
+      schemaKeys: ["min_words", "max_words"],
+    };
+  }
+  if (schema.k) {
+    return {
+      params: { k: "3" },
+      expectedParams: { k: 3 },
+      schemaKeys: ["k"],
+    };
+  }
+  return {
+    params: {},
+    expectedParams: {},
+    schemaKeys: Object.keys(schema),
+  };
+}
+
+function buildPromptEvalConfigMapping(requiredKeys) {
+  const fallbackByKey = {
+    expected: "expected",
+    expected_output: "expected",
+    ground_truth: "expected",
+    hypothesis: "text",
+    input: "text",
+    output: "text",
+    reference: "expected",
+    response: "text",
+    text: "text",
+  };
+  const mapping = {};
+  for (const key of requiredKeys) {
+    mapping[key] = fallbackByKey[key] || "text";
+  }
+  return mapping;
+}
+
+function assertPromptEvalMapping(actual, expected) {
+  for (const [key, value] of Object.entries(expected)) {
+    assert(
+      actual?.[key] === value,
+      `Prompt Workbench eval config mapping did not preserve ${key}.`,
+    );
+  }
+}
+
+function assertPromptEvalParams(actual, expected) {
+  for (const [key, value] of Object.entries(expected)) {
+    assert(
+      actual?.[key] === value,
+      `Prompt Workbench eval config params did not preserve normalized ${key}.`,
+    );
+  }
+}
+
+async function cleanupPromptEvaluationConfig(client, promptId, evalConfigId) {
+  if (!promptId || !evalConfigId) return null;
+  try {
+    return await client.delete(
+      apiPath("/model-hub/prompt-templates/{id}/delete-evaluation-config/", {
+        id: promptId,
+      }),
+      { query: { id: evalConfigId } },
+    );
+  } catch (error) {
+    const message = String(error?.message || "").toLowerCase();
+    if (
+      error?.status === 404 ||
+      message.includes("does not exist") ||
+      message.includes("not found")
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function cleanupCreatedEvalTemplate(client, evalTemplateId) {
+  if (!evalTemplateId) return null;
+  try {
+    return await client.post(
+      apiPath("/model-hub/eval-templates/bulk-delete/"),
+      { template_ids: [evalTemplateId] },
+      { okStatuses: [200, 404] },
+    );
+  } catch (error) {
+    const message = String(error?.message || "").toLowerCase();
+    if (message.includes("not found") || message.includes("does not exist")) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 function normalizeModelOption(model) {
@@ -746,6 +1270,11 @@ target_versions AS (
   SELECT id, deleted, deleted_at
   FROM model_hub_promptversion
   WHERE original_template_id IN (SELECT id FROM target_prompts)
+),
+target_eval_configs AS (
+  SELECT id, deleted, deleted_at
+  FROM model_hub_promptevalconfig
+  WHERE prompt_template_id IN (SELECT id FROM target_prompts)
 )
 SELECT json_build_object(
   'folder_row_count', (SELECT count(*) FROM target_folder),
@@ -762,6 +1291,11 @@ SELECT json_build_object(
   'version_deleted_at_set', COALESCE((
     SELECT bool_and(deleted = true AND deleted_at IS NOT NULL)
     FROM target_versions
+  ), false),
+  'eval_config_row_count', (SELECT count(*) FROM target_eval_configs),
+  'eval_config_deleted_at_set', COALESCE((
+    SELECT bool_and(deleted = true AND deleted_at IS NOT NULL)
+    FROM target_eval_configs
   ), false)
 );
 `;
@@ -771,18 +1305,28 @@ SELECT json_build_object(
 async function hardDeletePromptWorkbenchFixtureDb({
   folderId,
   promptId,
+  evalConfigId,
+  createdEvalTemplateId,
   organizationId,
   workspaceId,
 }) {
-  if (!folderId && !promptId) {
+  if (!folderId && !promptId && !evalConfigId && !createdEvalTemplateId) {
     return {
       remaining_folder_count: 0,
       remaining_prompt_count: 0,
       remaining_version_count: 0,
+      remaining_eval_config_count: 0,
+      remaining_eval_template_count: 0,
     };
   }
   const folderPredicate = folderId ? `id = ${sqlUuid(folderId)}` : "false";
   const promptPredicate = promptId ? `id = ${sqlUuid(promptId)}` : "false";
+  const evalConfigPredicate = evalConfigId
+    ? `id = ${sqlUuid(evalConfigId)}`
+    : "false";
+  const evalTemplatePredicate = createdEvalTemplateId
+    ? `id = ${sqlUuid(createdEvalTemplateId)}`
+    : "false";
   const sql = `
 BEGIN;
 CREATE TEMP TABLE _pwb_folder_ids(id uuid) ON COMMIT DROP;
@@ -810,16 +1354,33 @@ SELECT id
 FROM model_hub_promptversion
 WHERE original_template_id IN (SELECT id FROM _pwb_prompt_ids);
 
+CREATE TEMP TABLE _pwb_eval_config_ids(id uuid) ON COMMIT DROP;
+INSERT INTO _pwb_eval_config_ids
+SELECT id
+FROM model_hub_promptevalconfig
+WHERE ${evalConfigPredicate}
+  OR prompt_template_id IN (SELECT id FROM _pwb_prompt_ids);
+
+CREATE TEMP TABLE _pwb_eval_template_ids(id uuid) ON COMMIT DROP;
+INSERT INTO _pwb_eval_template_ids
+SELECT id
+FROM model_hub_evaltemplate
+WHERE ${evalTemplatePredicate};
+
 DELETE FROM model_hub_promptversion_labels
 WHERE promptversion_id IN (SELECT id FROM _pwb_version_ids);
 DELETE FROM model_hub_prompttemplate_collaborators
 WHERE prompttemplate_id IN (SELECT id FROM _pwb_prompt_ids);
+DELETE FROM model_hub_promptevalconfig
+WHERE id IN (SELECT id FROM _pwb_eval_config_ids);
 DELETE FROM model_hub_promptversion
 WHERE id IN (SELECT id FROM _pwb_version_ids);
 DELETE FROM model_hub_prompttemplate
 WHERE id IN (SELECT id FROM _pwb_prompt_ids);
 DELETE FROM model_hub_prompt_folder
 WHERE id IN (SELECT id FROM _pwb_folder_ids);
+DELETE FROM model_hub_evaltemplate
+WHERE id IN (SELECT id FROM _pwb_eval_template_ids);
 
 SELECT json_build_object(
   'remaining_folder_count', (
@@ -833,6 +1394,14 @@ SELECT json_build_object(
   'remaining_version_count', (
     SELECT count(*) FROM model_hub_promptversion
     WHERE id IN (SELECT id FROM _pwb_version_ids)
+  ),
+  'remaining_eval_config_count', (
+    SELECT count(*) FROM model_hub_promptevalconfig
+    WHERE id IN (SELECT id FROM _pwb_eval_config_ids)
+  ),
+  'remaining_eval_template_count', (
+    SELECT count(*) FROM model_hub_evaltemplate
+    WHERE id IN (SELECT id FROM _pwb_eval_template_ids)
   )
 );
 COMMIT;
@@ -1019,6 +1588,33 @@ async function waitForEditorText(page, fragments, timeout = 30000) {
   );
 }
 
+async function waitForPromptEvaluationGrid(
+  page,
+  { evalConfigName, textValue },
+  timeout = 30000,
+) {
+  await waitForVisibleText(page, "Show Variables", { exact: true, timeout });
+  await waitForVisibleText(page, "Add Evaluations", { exact: true, timeout });
+  await page.waitForFunction(
+    ({ expectedEvalName, expectedTextValue }) => {
+      const grid =
+        document.querySelector(".prompt-evaluation-gird") ||
+        document.querySelector(".prompt-variable-gird");
+      if (!grid) return false;
+      const text = window.normalizeText(grid.textContent);
+      return (
+        text.includes("{{text}}") &&
+        text.includes(expectedTextValue) &&
+        text.includes(expectedEvalName) &&
+        text.includes("v1") &&
+        (text.includes("NA") || text.includes("Status:"))
+      );
+    },
+    { timeout },
+    { expectedEvalName: evalConfigName, expectedTextValue: textValue },
+  );
+}
+
 async function openModelPickerAndSelectSafeModel(page, model) {
   await waitForVisibleText(page, model.model_name, { exact: true });
   await clickModelPickerButton(page, model.model_name);
@@ -1041,7 +1637,9 @@ async function openModelPickerAndSelectSafeModel(page, model) {
     () => typeModelSearch(page, model.model_name),
   );
   await waitForVisibleMenuItemText(page, model.model_name);
-  await waitForNoVisibleText(page, "Configure an api key", { timeout: 5000 });
+  if (model.isAvailable !== false) {
+    await waitForNoVisibleText(page, "Configure an api key", { timeout: 5000 });
+  }
 }
 
 async function clickModelPickerButton(page, modelName) {
@@ -1364,15 +1962,12 @@ async function typeIntoDialogInput(page, value) {
       );
     });
     if (!visible) continue;
-    await input.evaluate((element, nextValue) => {
-      const setter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )?.set;
-      setter?.call(element, nextValue);
-      element.dispatchEvent(new Event("input", { bubbles: true }));
-      element.dispatchEvent(new Event("change", { bubbles: true }));
-    }, value);
+    await input.click({ clickCount: 3 });
+    await page.keyboard.down(modifierKey());
+    await page.keyboard.press("A");
+    await page.keyboard.up(modifierKey());
+    await page.keyboard.press("Backspace");
+    await page.keyboard.type(value);
     return;
   }
   throw new Error("No visible dialog input found.");

--- a/frontend/scripts/api-journeys/browser/prototype-run-detail-actions-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/prototype-run-detail-actions-smoke.mjs
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
+import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
 import process from "node:process";
+import { promisify } from "node:util";
 import {
   apiPath,
   asArray,
@@ -12,6 +14,7 @@ import {
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
 const PROJECT_PREFIX = "ui_prototype_run_browser_";
@@ -39,11 +42,13 @@ async function main() {
   let page = null;
   let projectId = null;
 
+  await cleanupClickHouseByPrefix(PROJECT_PREFIX, cleanupEvidence);
   await cleanupProjectsByPrefix(auth.client, PROJECT_PREFIX, cleanupEvidence);
 
   try {
     const seeded = await seedPrototypeRuns({
       client: auth.client,
+      organizationId: auth.organizationId,
       projectName,
       alphaName,
       betaName,
@@ -258,6 +263,7 @@ async function main() {
     await page.screenshot({ path: RUN_SCREENSHOT_PATH, fullPage: true });
 
     await deleteProjects(auth.client, [projectId], cleanupEvidence);
+    await cleanupClickHouseByPrefix(PROJECT_PREFIX, cleanupEvidence);
     projectId = null;
 
     assert(
@@ -326,12 +332,14 @@ async function main() {
       );
     }
     await cleanupProjectsByPrefix(auth.client, PROJECT_PREFIX, cleanupEvidence);
+    await cleanupClickHouseByPrefix(PROJECT_PREFIX, cleanupEvidence);
     if (browser) await browser.close();
   }
 }
 
 async function seedPrototypeRuns({
   client,
+  organizationId,
   projectName,
   alphaName,
   betaName,
@@ -402,6 +410,34 @@ async function seedPrototypeRuns({
     ),
     "Seeded beta run was missing from list_runs.",
   );
+
+  await mirrorPrototypeRunsToClickHouse({
+    projectId,
+    organizationId,
+    traces: [
+      {
+        id: alphaSeed.traceId,
+        projectVersionId: alphaVersion.id,
+        name: alphaSeed.traceName,
+        lane: "alpha",
+        input: { prompt: `shared prototype input ${marker}` },
+        output: { response: `prototype alpha output ${marker}` },
+        metadata: { source: "api-journey", marker, lane: "alpha" },
+        tags: ["api-journey", "alpha"],
+      },
+      {
+        id: betaSeed.traceId,
+        projectVersionId: betaVersion.id,
+        name: betaSeed.traceName,
+        lane: "beta",
+        input: { prompt: `shared prototype input ${marker}` },
+        output: { response: `prototype beta output ${marker}` },
+        metadata: { source: "api-journey", marker, lane: "beta" },
+        tags: ["api-journey", "beta"],
+      },
+    ],
+    spans: [alphaSeed, betaSeed],
+  });
 
   return {
     projectId,
@@ -481,7 +517,178 @@ async function seedTraceAndSpan(
     metadata: { source: "api-journey", marker, lane },
   });
   assert((span.id || spanId) === spanId, "Span seed returned the wrong id.");
-  return { traceId, spanId, traceName, spanName };
+  return {
+    traceId,
+    spanId,
+    traceName,
+    spanName,
+    projectVersionId,
+    lane,
+    latencyMs,
+    cost,
+    startTime,
+    endTime,
+    input: { messages: [{ role: "user", content: `hello ${marker}` }] },
+    output: { choices: [{ message: { content: `hi from ${lane}` } }] },
+    tags: ["api-journey", lane],
+    metadata: { source: "api-journey", marker, lane },
+  };
+}
+
+async function mirrorPrototypeRunsToClickHouse({
+  projectId,
+  organizationId,
+  traces,
+  spans,
+}) {
+  assert(isUuid(projectId), "ClickHouse mirror projectId must be a UUID.");
+  assert(
+    isUuid(organizationId),
+    "ClickHouse mirror organizationId must be a UUID.",
+  );
+  const traceValues = traces
+    .map(
+      (trace) => `(
+        ${chUuid(trace.id)},
+        ${chUuid(projectId)},
+        ${chUuid(trace.projectVersionId)},
+        ${chString(trace.name)},
+        ${chJson(trace.tags)},
+        ${chJson(trace.metadata)},
+        ${chJson(trace.input)},
+        ${chJson(trace.output)},
+        '{}',
+        now64(6, 'UTC'),
+        now64(6, 'UTC'),
+        0,
+        toUInt64(toUnixTimestamp64Nano(now64(9, 'UTC')))
+      )`,
+    )
+    .join(",\n");
+  const spanValues = spans
+    .map(
+      (span) => `(
+        ${chUuid(projectId)},
+        'llm',
+        'api-journey',
+        ${chDateTime(span.startTime)},
+        ${chString(span.traceId)},
+        ${chString(span.spanId)},
+        ${chString(span.spanName)},
+        ${chDateTime(span.endTime)},
+        ${Number(span.latencyMs)},
+        ${chUuid(organizationId)},
+        ${chUuid(span.projectVersionId)},
+        'OK',
+        'api-journey-model',
+        'api-journey',
+        2,
+        3,
+        5,
+        ${Number(span.cost)},
+        ${chJson(span.input)},
+        ${chJson(span.output)},
+        ${chJson(span.tags)},
+        now64(6, 'UTC'),
+        now64(6, 'UTC'),
+        0,
+        toUInt64(toUnixTimestamp64Nano(now64(9, 'UTC')))
+      )`,
+    )
+    .join(",\n");
+
+  await runClickHouseSql(`
+    INSERT INTO traces (
+      id, project_id, project_version_id, name, tags, metadata, input, output,
+      error, created_at, updated_at, is_deleted, _version
+    ) VALUES ${traceValues};
+
+    INSERT INTO spans (
+      project_id, observation_type, service_name, start_time, trace_id, id,
+      name, end_time, latency_ms, org_id, project_version_id, status, model,
+      provider, prompt_tokens, completion_tokens, total_tokens, cost, input,
+      output, tags, created_at, updated_at, is_deleted, _version
+    ) VALUES ${spanValues};
+  `);
+}
+
+async function cleanupClickHouseByPrefix(prefix, evidence) {
+  await runClickHouseSql(`
+    ALTER TABLE traces DELETE WHERE startsWith(ifNull(name, ''), ${chString(
+      prefix,
+    )});
+    ALTER TABLE spans DELETE WHERE startsWith(name, ${chString(prefix)});
+  `);
+  evidence.push({
+    cleanup: "delete prototype ClickHouse mirror rows",
+    status: "passed",
+    prefix,
+  });
+}
+
+async function runClickHouseSql(sql) {
+  const container = await resolveClickHouseContainer();
+  const database = process.env.API_JOURNEY_CLICKHOUSE_DB || "default";
+  const guardedSql = `SET ignore_materialized_views_with_dropped_target_table = 1;
+SET mutations_sync = 1;
+${sql}`;
+  await execFileAsync(
+    "docker",
+    [
+      "exec",
+      container,
+      "clickhouse-client",
+      "--database",
+      database,
+      "--multiquery",
+      "--query",
+      guardedSql,
+    ],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+}
+
+async function resolveClickHouseContainer() {
+  if (process.env.API_JOURNEY_CLICKHOUSE_CONTAINER) {
+    return process.env.API_JOURNEY_CLICKHOUSE_CONTAINER;
+  }
+  const candidates = [
+    "ws2-clickhouse",
+    "futureagi-ws2-clickhouse-1",
+    "clickhouse",
+    "futureagi-clickhouse-1",
+  ];
+  for (const candidate of candidates) {
+    try {
+      await execFileAsync("docker", [
+        "inspect",
+        "--type",
+        "container",
+        candidate,
+      ]);
+      return candidate;
+    } catch {
+      // Try the next local compose naming convention.
+    }
+  }
+  return "ws2-clickhouse";
+}
+
+function chUuid(value) {
+  assert(isUuid(value), `ClickHouse UUID value must be a UUID: ${value}`);
+  return chString(value);
+}
+
+function chString(value) {
+  return `'${String(value).replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+function chJson(value) {
+  return chString(JSON.stringify(value ?? {}));
+}
+
+function chDateTime(value) {
+  return `parseDateTime64BestEffort(${chString(value)}, 6, 'UTC')`;
 }
 
 async function cleanupProjectsByPrefix(client, prefix, evidence) {

--- a/frontend/scripts/api-journeys/browser/settings-api-keys-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-api-keys-smoke.mjs
@@ -19,6 +19,7 @@ const SCREENSHOT_PATH = "/tmp/settings-api-keys-smoke.png";
 const ACTION_MENU_SCREENSHOT_PATH =
   "/tmp/settings-api-keys-smoke-action-menu.png";
 const DISABLED_SCREENSHOT_PATH = "/tmp/settings-api-keys-smoke-disabled.png";
+const TEST_KEY_SCREENSHOT_PATH = "/tmp/settings-api-keys-smoke-test-key.png";
 const FAILURE_SCREENSHOT_PATH = "/tmp/settings-api-keys-smoke-failure.png";
 
 async function main() {
@@ -28,6 +29,7 @@ async function main() {
   const apiFailures = [];
   const pageErrors = [];
   let createdKey = null;
+  let testKeyStatus = null;
   let uiDeleted = false;
   let hardCleanup = null;
   let caughtError = null;
@@ -90,8 +92,38 @@ async function main() {
     assertMaskedKey(createdKey.masked_secret_key, "created masked_secret_key");
 
     await waitForVisibleText(page, "Generated");
+    await waitForVisibleText(page, "Organization scoped", { exact: true });
     await waitForInputValue(page, createdKey.masked_api_key);
     await waitForInputValue(page, createdKey.masked_secret_key);
+    await assertRawKeysNotRendered(page, createdKey);
+    const testKeyResponse = await waitForResponseDuring(
+      page,
+      "API key credential test",
+      (response) => {
+        const request = response.request();
+        const headers = request.headers();
+        return (
+          response.url().includes("/accounts/user-info/") &&
+          request.method() === "GET" &&
+          headers["x-api-key"] === createdKey.api_key &&
+          headers["x-secret-key"] === createdKey.secret_key &&
+          !headers.authorization &&
+          response.status() < 400
+        );
+      },
+      () => clickVisibleText(page, "Test key", { exact: true }),
+    );
+    testKeyStatus = testKeyResponse.status();
+    const testKeyBody = await testKeyResponse.json().catch(() => ({}));
+    assert(
+      testKeyBody?.email || testKeyBody?.user?.email || testKeyBody?.id,
+      "API key credential test did not return user identity.",
+    );
+    await waitForVisibleText(page, "Test passed");
+    await page.screenshot({
+      path: TEST_KEY_SCREENSHOT_PATH,
+      fullPage: true,
+    });
     await assertRawKeysNotRendered(page, createdKey);
 
     await clickVisibleText(page, "Done", { exact: true });
@@ -235,6 +267,10 @@ async function main() {
           key_id: createdKey.key_id,
           list_api_key_masked: true,
           list_secret_key_masked: true,
+          scope_label_visible: true,
+          test_key_user_info_status: testKeyStatus,
+          test_key_success_visible: true,
+          test_key_screenshot: TEST_KEY_SCREENSHOT_PATH,
           ui_disable_chip_visible: true,
           ui_reenable_removed_disabled_chip: true,
           ui_delete_removed_row: true,

--- a/frontend/scripts/api-journeys/browser/settings-billing-budget-crud-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-billing-budget-crud-smoke.mjs
@@ -349,10 +349,7 @@ function waitForReadResponse(page, pathname) {
 async function waitForBudgetMutationResponse(page, method, { budgetId } = {}) {
   const response = await page.waitForResponse(
     (candidate) => {
-      if (
-        candidate.request().method() !== method ||
-        candidate.status() >= 400
-      ) {
+      if (candidate.request().method() !== method) {
         return false;
       }
       const pathname = new URL(candidate.url()).pathname;
@@ -361,7 +358,21 @@ async function waitForBudgetMutationResponse(page, method, { budgetId } = {}) {
     },
     { timeout: 60000 },
   );
+  await assertResponseOk(response, `${method} budget mutation`);
   return response.json();
+}
+
+async function assertResponseOk(response, label) {
+  if (response.status() < 400) return;
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    body = "<unreadable response body>";
+  }
+  throw new Error(
+    `${label} returned HTTP ${response.status()}: ${body.slice(0, 500)}`,
+  );
 }
 
 function responseResult(payload) {

--- a/frontend/scripts/api-journeys/browser/settings-ee-license-crud-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-ee-license-crud-smoke.mjs
@@ -407,10 +407,7 @@ function waitForLicenseListResponse(page) {
 async function waitForLicenseMutationResponse(page, method, { grantId } = {}) {
   const response = await page.waitForResponse(
     (candidate) => {
-      if (
-        candidate.request().method() !== method ||
-        candidate.status() >= 400
-      ) {
+      if (candidate.request().method() !== method) {
         return false;
       }
       const pathname = new URL(candidate.url()).pathname;
@@ -419,7 +416,21 @@ async function waitForLicenseMutationResponse(page, method, { grantId } = {}) {
     },
     { timeout: 60000 },
   );
+  await assertResponseOk(response, `${method} EE license mutation`);
   return response.json();
+}
+
+async function assertResponseOk(response, label) {
+  if (response.status() < 400) return;
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    body = "<unreadable response body>";
+  }
+  throw new Error(
+    `${label} returned HTTP ${response.status()}: ${body.slice(0, 500)}`,
+  );
 }
 
 function responseResult(payload) {

--- a/frontend/scripts/api-journeys/browser/settings-falcon-connectors-mutation-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-falcon-connectors-mutation-smoke.mjs
@@ -1,0 +1,1096 @@
+/* eslint-disable no-console */
+import { execFile } from "node:child_process";
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import http from "node:http";
+import { createRequire } from "node:module";
+import process from "node:process";
+import { promisify } from "node:util";
+import {
+  assert,
+  createAuthenticatedContext,
+  isUuid,
+  requireMutations,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const CALLBACK_HOST =
+  process.env.API_JOURNEY_CALLBACK_HOST || "host.docker.internal";
+const SCREENSHOT_PREFIX =
+  process.env.SETTINGS_FALCON_CONNECTORS_MUTATION_SCREENSHOT_PREFIX ||
+  "/tmp/settings-falcon-connectors-mutation";
+const CREATE_SCREENSHOT_PATH = `${SCREENSHOT_PREFIX}-create-smoke.png`;
+const DISCOVER_SCREENSHOT_PATH = `${SCREENSHOT_PREFIX}-discover-smoke.png`;
+const EDIT_SCREENSHOT_PATH = `${SCREENSHOT_PREFIX}-edit-smoke.png`;
+const DELETE_SCREENSHOT_PATH = `${SCREENSHOT_PREFIX}-delete-smoke.png`;
+const FAILURE_SCREENSHOT_PATH = `${SCREENSHOT_PREFIX}-failure-smoke.png`;
+const CLICKABLE_SELECTOR =
+  "button,a,[role='button'],[role='option'],[role='menuitem']";
+
+async function main() {
+  requireMutations();
+  const auth = await createAuthenticatedContext();
+  const suffix = auth.runId.replace(/[^a-z0-9-]/gi, "-").slice(0, 24);
+  const namePrefix = `ui falcon mutation ${suffix}`;
+  const connectorName = `${namePrefix} primary`;
+  const editedConnectorName = `${connectorName} edited`;
+  const authHeaderName = "X-Falcon-UI-Smoke";
+  const rawSecret = `falcon-ui-secret-${suffix}`;
+  const toolName = `falcon_ui_tool_${suffix.replace(/-/g, "_")}`;
+  const secondaryToolName = `${toolName}_secondary`;
+  const tools = [
+    {
+      name: toolName,
+      description: "Temporary Falcon browser mutation tool.",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+    },
+    {
+      name: secondaryToolName,
+      description: "Temporary Falcon browser mutation tool to disable.",
+      inputSchema: { type: "object", properties: {} },
+    },
+  ];
+
+  await hardDeleteFalconConnectorFixtures({
+    namePrefix,
+    organizationId: auth.organizationId,
+  });
+
+  const mockMcp = await startMockMcpServer({
+    tools,
+    authHeaderName,
+    rawSecret,
+  });
+  const serverUrl = mockMcp.callbackUrl;
+  let browser = null;
+  let connectorId = null;
+  let deletedViaUi = false;
+  let caughtError = null;
+  const apiFailures = [];
+  const pageErrors = [];
+  const mutationRequests = [];
+  const mutationPayloads = [];
+  const evidence = {
+    connector_name: connectorName,
+    edited_connector_name: editedConnectorName,
+    server_url: serverUrl,
+    raw_secret_sha256: sha256(rawSecret),
+    mock_mcp_local_url: mockMcp.localUrl,
+    mock_mcp_callback_host: CALLBACK_HOST,
+  };
+
+  try {
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 950 },
+      args: ["--no-sandbox"],
+    });
+    const page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installAuthState(page, auth);
+
+    page.on("request", (request) => {
+      if (!isFalconConnectorUrl(request.url())) return;
+      if (["POST", "PATCH", "PUT", "DELETE"].includes(request.method())) {
+        mutationRequests.push(`${request.method()} ${pathname(request.url())}`);
+        mutationPayloads.push(sanitizeMutationPayload(request));
+      }
+    });
+    page.on("response", (response) => {
+      if (isFalconConnectorUrl(response.url()) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${response.url()}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponseDuring(
+      page,
+      "Falcon connector list load",
+      (response) =>
+        response.url().includes("/falcon-ai/mcp-connectors/") &&
+        response.request().method() === "GET" &&
+        response.status() < 400,
+      () =>
+        page.goto(`${APP_BASE}/dashboard/settings/falcon-ai-connectors`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForVisibleText(page, "Falcon AI Connectors", { exact: true });
+    await waitForVisibleText(page, "Add Connector", { exact: true });
+
+    await clickVisibleText(page, "Add Connector", { exact: true });
+    await waitForVisibleText(page, "Add Connector", { exact: true });
+    await fillInputByPlaceholder(page, "e.g. Linear, GitHub", connectorName);
+    await fillInputByPlaceholder(
+      page,
+      "https://mcp.example.com/mcp",
+      serverUrl,
+    );
+    await selectComboboxAfterLabel(page, "Authentication", "API Key");
+    await fillInputByPlaceholder(page, "X-API-Key", authHeaderName);
+    await fillInputByPlaceholder(page, "sk-...", rawSecret);
+    await waitForNoVisibleText(page, rawSecret);
+
+    const createResponse = await waitForResponseDuring(
+      page,
+      "Falcon connector browser create",
+      (response) =>
+        response.url().includes("/falcon-ai/mcp-connectors/") &&
+        response.request().method() === "POST" &&
+        response.status() < 400,
+      () => clickVisibleText(page, "Create", { exact: true }),
+    );
+    const createBody = await parseJsonResponse(createResponse);
+    connectorId = createBody?.result?.id || createBody?.id;
+    assert(isUuid(connectorId), "Browser create did not return connector id.");
+    evidence.connector_id = connectorId;
+    assertNoPayloadString(createBody, rawSecret, "connector create response");
+
+    await waitForVisibleText(page, connectorName, { exact: true });
+    await clickDeepestVisibleText(page, connectorName);
+    await waitForVisibleText(page, "Server URL", { exact: true });
+    await waitForVisibleText(page, serverUrl, { exact: true });
+    await waitForVisibleText(page, "Pending", { exact: true });
+    await page.screenshot({ path: CREATE_SCREENSHOT_PATH, fullPage: true });
+    evidence.create_screenshot = CREATE_SCREENSHOT_PATH;
+
+    let audit = await loadFalconConnectorDbAudit({
+      connectorId,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      rawSecret,
+    });
+    assert(
+      audit.connector_count === 1 &&
+        audit.name === connectorName &&
+        audit.auth_value_is_encrypted === true &&
+        audit.auth_value_contains_raw_secret === false &&
+        audit.discovered_tool_count === 0 &&
+        audit.enabled_tool_count === 0,
+      `Post-create DB audit mismatch: ${JSON.stringify(audit)}`,
+    );
+    evidence.auth_value_hash_after_create = audit.auth_value_hash;
+
+    const testResponse = await waitForResponseDuring(
+      page,
+      "Falcon connector browser test",
+      (response) =>
+        response
+          .url()
+          .includes(`/falcon-ai/mcp-connectors/${connectorId}/test/`) &&
+        response.request().method() === "POST" &&
+        response.status() < 400,
+      () => clickVisibleText(page, "Test Connection", { exact: true }),
+    );
+    await assertHttpResponseOk(testResponse, "Falcon connector test");
+    await waitForVisibleText(page, "Connection test succeeded.", {
+      exact: true,
+    });
+    evidence.test_connection_status = testResponse.status();
+
+    const discoverResponse = await waitForResponseDuring(
+      page,
+      "Falcon connector browser discover",
+      (response) =>
+        response
+          .url()
+          .includes(`/falcon-ai/mcp-connectors/${connectorId}/discover/`) &&
+        response.request().method() === "POST" &&
+        response.status() < 400,
+      () => clickVisibleText(page, "Discover Tools", { exact: true }),
+    );
+    await assertHttpResponseOk(discoverResponse, "Falcon connector discover");
+    await waitForVisibleText(page, "Discovered 2 tools.", { exact: true });
+    await waitForVisibleText(page, toolName, { exact: true });
+    await waitForVisibleText(page, secondaryToolName, { exact: true });
+    await page.screenshot({ path: DISCOVER_SCREENSHOT_PATH, fullPage: true });
+    evidence.discover_screenshot = DISCOVER_SCREENSHOT_PATH;
+
+    audit = await loadFalconConnectorDbAudit({
+      connectorId,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      rawSecret,
+    });
+    assert(
+      audit.is_verified === true &&
+        audit.last_error === "" &&
+        audit.discovered_tool_count === 2 &&
+        audit.enabled_tool_count === 2,
+      `Post-discover DB audit mismatch: ${JSON.stringify(audit)}`,
+    );
+
+    const toolResponse = await waitForResponseDuring(
+      page,
+      "Falcon connector browser tool toggle",
+      (response) =>
+        response
+          .url()
+          .includes(`/falcon-ai/mcp-connectors/${connectorId}/tools/`) &&
+        response.request().method() === "PATCH" &&
+        response.status() < 400,
+      () => clickSwitchForTool(page, secondaryToolName),
+    );
+    await assertHttpResponseOk(toolResponse, "Falcon connector tool toggle");
+    const toolRequestBody = parseRequestJson(toolResponse.request());
+    assert(
+      Array.isArray(toolRequestBody?.enabled_tool_names) &&
+        toolRequestBody.enabled_tool_names.includes(toolName) &&
+        !toolRequestBody.enabled_tool_names.includes(secondaryToolName),
+      `Tool toggle sent wrong payload: ${JSON.stringify(toolRequestBody)}`,
+    );
+    await waitForSwitchChecked(page, secondaryToolName, false);
+
+    audit = await loadFalconConnectorDbAudit({
+      connectorId,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      rawSecret,
+    });
+    assert(
+      audit.discovered_tool_count === 2 && audit.enabled_tool_count === 1,
+      `Post-toggle DB audit mismatch: ${JSON.stringify(audit)}`,
+    );
+    evidence.enabled_tool_count_after_toggle = audit.enabled_tool_count;
+
+    await clickVisibleText(page, "Edit", { exact: true });
+    await waitForVisibleText(page, "Edit Connector", { exact: true });
+    await waitForInputValue(page, connectorName);
+    await waitForInputValue(page, serverUrl);
+    await waitForInputValue(page, authHeaderName);
+    await assertPasswordInputsBlank(page);
+    await waitForNoVisibleText(page, rawSecret);
+    await fillInputByPlaceholder(
+      page,
+      "e.g. Linear, GitHub",
+      editedConnectorName,
+    );
+
+    const editResponse = await waitForResponseDuring(
+      page,
+      "Falcon connector browser edit",
+      (response) =>
+        response.url().includes(`/falcon-ai/mcp-connectors/${connectorId}/`) &&
+        response.request().method() === "PATCH" &&
+        response.status() < 400,
+      () => clickVisibleText(page, "Save", { exact: true }),
+    );
+    await assertHttpResponseOk(editResponse, "Falcon connector edit");
+    const editRequestBody = parseRequestJson(editResponse.request());
+    assert(
+      !Object.prototype.hasOwnProperty.call(
+        editRequestBody,
+        "auth_header_value",
+      ),
+      `Edit payload should omit blank secret: ${JSON.stringify(editRequestBody)}`,
+    );
+    await waitForVisibleText(page, editedConnectorName, { exact: true });
+    await waitForNoVisibleText(page, rawSecret);
+    await page.screenshot({ path: EDIT_SCREENSHOT_PATH, fullPage: true });
+    evidence.edit_screenshot = EDIT_SCREENSHOT_PATH;
+
+    audit = await loadFalconConnectorDbAudit({
+      connectorId,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      rawSecret,
+    });
+    assert(
+      audit.name === editedConnectorName &&
+        audit.auth_value_hash === evidence.auth_value_hash_after_create &&
+        audit.auth_value_contains_raw_secret === false,
+      `Post-edit DB audit mismatch: ${JSON.stringify(audit)}`,
+    );
+    evidence.auth_hash_preserved_after_edit = true;
+
+    const deleteResponse = await waitForResponseDuring(
+      page,
+      "Falcon connector browser delete",
+      (response) =>
+        response.url().includes(`/falcon-ai/mcp-connectors/${connectorId}/`) &&
+        response.request().method() === "DELETE" &&
+        response.status() < 400,
+      () => clickVisibleText(page, "Delete", { exact: true }),
+    );
+    await assertHttpResponseOk(deleteResponse, "Falcon connector delete", {
+      allowNoContent: true,
+    });
+    deletedViaUi = true;
+    await waitForNoVisibleText(page, editedConnectorName, { exact: true });
+    await page.screenshot({ path: DELETE_SCREENSHOT_PATH, fullPage: true });
+    evidence.delete_screenshot = DELETE_SCREENSHOT_PATH;
+
+    const postDeleteAudit = await loadFalconConnectorDbAudit({
+      connectorId,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      rawSecret,
+      includeDeleted: true,
+    });
+    assert(
+      postDeleteAudit.deleted === true &&
+        postDeleteAudit.deleted_at_set === true,
+      `Post-delete DB audit mismatch: ${JSON.stringify(postDeleteAudit)}`,
+    );
+    evidence.public_delete_status = true;
+
+    const cleanup = await hardDeleteFalconConnectorFixtures({
+      namePrefix,
+      organizationId: auth.organizationId,
+    });
+    assert(
+      cleanup.remaining_connector_count === 0,
+      `Falcon connector cleanup left residue: ${JSON.stringify(cleanup)}`,
+    );
+    evidence.cleanup = cleanup;
+
+    const mockToolListRequests = mockMcp.requests.filter(
+      (request) => request.jsonrpc_method === "tools/list",
+    );
+    assert(
+      mockToolListRequests.length >= 2,
+      `Expected test and discover to call mock MCP tools/list: ${JSON.stringify(
+        mockMcp.requests,
+      )}`,
+    );
+    assert(
+      mockToolListRequests.every((request) => request.auth_header_matched),
+      `Mock MCP did not receive decrypted auth header on every call: ${JSON.stringify(
+        mockToolListRequests,
+      )}`,
+    );
+    evidence.mock_mcp_tools_list_count = mockToolListRequests.length;
+    evidence.mock_mcp_auth_header_matched = true;
+
+    assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+    assertNoPayloadString(mutationPayloads, rawSecret, "mutation evidence");
+    evidence.mutation_requests = mutationRequests;
+    evidence.mutation_payloads = mutationPayloads;
+
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          evidence,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    caughtError = error;
+    console.error(
+      JSON.stringify(
+        {
+          status: "failed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          evidence,
+          api_failures: apiFailures,
+          page_errors: pageErrors,
+          mutation_requests: mutationRequests,
+          mutation_payloads: mutationPayloads,
+          mock_mcp_requests: mockMcp.requests,
+        },
+        null,
+        2,
+      ),
+    );
+    if (browser) {
+      const pages = await browser.pages();
+      await pages
+        .at(-1)
+        ?.screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .catch(() => null);
+    }
+  } finally {
+    if (browser) await browser.close();
+    await mockMcp.close().catch((error) => {
+      caughtError = appendCleanupError(caughtError, error);
+    });
+    if (!deletedViaUi || connectorId) {
+      await hardDeleteFalconConnectorFixtures({
+        namePrefix,
+        organizationId: auth.organizationId,
+      }).catch((error) => {
+        caughtError = appendCleanupError(caughtError, error);
+      });
+    }
+  }
+
+  if (caughtError) throw caughtError;
+}
+
+async function startMockMcpServer({ tools, authHeaderName, rawSecret }) {
+  const requests = [];
+  const server = http.createServer(async (request, response) => {
+    const bodyText = await readRequestBody(request);
+    let body = null;
+    try {
+      body = bodyText ? JSON.parse(bodyText) : null;
+    } catch {
+      body = null;
+    }
+
+    const authHeaderValue = request.headers[authHeaderName.toLowerCase()];
+    requests.push({
+      method: request.method,
+      url: request.url,
+      jsonrpc_method: body?.method || "",
+      auth_header_present: Boolean(authHeaderValue),
+      auth_header_matched: authHeaderValue === rawSecret,
+    });
+
+    if (request.method !== "POST") {
+      response.writeHead(405, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: "Method not allowed" }));
+      return;
+    }
+
+    if (body?.method === "tools/list") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id ?? 1,
+          result: { tools },
+        }),
+      );
+      return;
+    }
+
+    if (body?.method === "initialize") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id ?? 0,
+          result: {
+            protocolVersion: "2025-03-26",
+            capabilities: { tools: {} },
+            serverInfo: { name: "api-journey-mock-mcp", version: "1.0.0" },
+          },
+        }),
+      );
+      return;
+    }
+
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: body?.id ?? 1,
+        result: {},
+      }),
+    );
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "0.0.0.0", resolve);
+  });
+  const { port } = server.address();
+  return {
+    localUrl: `http://127.0.0.1:${port}/mcp`,
+    callbackUrl: `http://${CALLBACK_HOST}:${port}/mcp`,
+    requests,
+    close: () =>
+      new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  };
+}
+
+async function readRequestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function loadFalconConnectorDbAudit({
+  connectorId,
+  organizationId,
+  workspaceId,
+  rawSecret,
+}) {
+  const sql = `
+WITH connector_rows AS (
+  SELECT
+    connector.id,
+    connector.name,
+    connector.auth_header_value,
+    connector.discovered_tools,
+    connector.enabled_tool_names,
+    connector.is_verified,
+    connector.last_error,
+    connector.deleted,
+    connector.deleted_at
+  FROM falcon_ai_mcpconnector connector
+  WHERE connector.id = ${sqlUuid(connectorId)}
+    AND connector.organization_id = ${sqlUuid(organizationId)}
+    AND connector.workspace_id = ${sqlUuid(workspaceId)}
+)
+SELECT json_build_object(
+  'connector_count', (SELECT count(*) FROM connector_rows),
+  'name', COALESCE((SELECT name FROM connector_rows LIMIT 1), ''),
+  'auth_value_is_encrypted',
+    COALESCE((SELECT auth_header_value LIKE 'enc::%' FROM connector_rows LIMIT 1), false),
+  'auth_value_hash',
+    COALESCE((SELECT md5(auth_header_value) FROM connector_rows LIMIT 1), ''),
+  'auth_value_contains_raw_secret',
+    COALESCE((SELECT position(${sqlTextLiteral(rawSecret)} in auth_header_value) > 0 FROM connector_rows LIMIT 1), false),
+  'discovered_tool_count',
+    COALESCE((SELECT jsonb_array_length(discovered_tools::jsonb) FROM connector_rows LIMIT 1), 0),
+  'enabled_tool_count',
+    COALESCE((SELECT jsonb_array_length(enabled_tool_names::jsonb) FROM connector_rows LIMIT 1), 0),
+  'is_verified',
+    COALESCE((SELECT is_verified FROM connector_rows LIMIT 1), false),
+  'last_error',
+    COALESCE((SELECT last_error FROM connector_rows LIMIT 1), ''),
+  'deleted',
+    COALESCE((SELECT deleted FROM connector_rows LIMIT 1), false),
+  'deleted_at_set',
+    COALESCE((SELECT deleted_at IS NOT NULL FROM connector_rows LIMIT 1), false)
+);
+`;
+  return runPostgresJson(sql);
+}
+
+async function hardDeleteFalconConnectorFixtures({
+  namePrefix,
+  organizationId,
+}) {
+  const deleteSql = `
+WITH target_connectors AS (
+  SELECT connector.id
+  FROM falcon_ai_mcpconnector connector
+  WHERE connector.organization_id = ${sqlUuid(organizationId)}
+    AND connector.name LIKE ${sqlTextLiteral(`${namePrefix}%`)}
+),
+deleted_connectors AS (
+  DELETE FROM falcon_ai_mcpconnector connector
+  USING target_connectors target
+  WHERE connector.id = target.id
+  RETURNING connector.id
+)
+SELECT json_build_object(
+  'deleted_connector_count', (SELECT count(*) FROM deleted_connectors)
+);
+`;
+  const deleted = await runPostgresJson(deleteSql);
+  const residueSql = `
+SELECT json_build_object(
+  'remaining_connector_count',
+    (SELECT count(*) FROM falcon_ai_mcpconnector connector
+     WHERE connector.organization_id = ${sqlUuid(organizationId)}
+       AND connector.name LIKE ${sqlTextLiteral(`${namePrefix}%`)})
+);
+`;
+  const residue = await runPostgresJson(residueSql);
+  return { ...deleted, ...residue };
+}
+
+async function runPostgresJson(sql) {
+  const container =
+    process.env.API_JOURNEY_DB_CONTAINER || "futureagi-ws2-postgres-1";
+  const { stdout } = await execFileAsync(
+    "docker",
+    [
+      "exec",
+      "-i",
+      container,
+      "psql",
+      "-U",
+      "user",
+      "-d",
+      "tfc",
+      "-At",
+      "-c",
+      sql,
+    ],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  if (!text) return {};
+  return JSON.parse(text.split("\n").at(-1));
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installAuthState(page, auth) {
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  const responsePromise = page.waitForResponse(predicate, { timeout: 60000 });
+  await action();
+  try {
+    return await responsePromise;
+  } catch (error) {
+    throw new Error(
+      `${label} did not observe expected response: ${error.message}`,
+    );
+  }
+}
+
+async function assertHttpResponseOk(
+  response,
+  label,
+  { allowNoContent = false } = {},
+) {
+  if (allowNoContent && response.status() === 204) return;
+  assert(
+    response.status() >= 200 && response.status() < 300,
+    `${label} returned HTTP ${response.status()}`,
+  );
+  const body = await parseJsonResponse(response);
+  assertNoPayloadString(body, "falcon-ui-secret-", `${label} response`);
+  if (body && Object.prototype.hasOwnProperty.call(body, "status")) {
+    assert(body.status !== false, `${label} returned status=false`);
+  }
+}
+
+async function parseJsonResponse(response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function parseRequestJson(request) {
+  const text = request.postData() || "";
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return {};
+  }
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const normalized = (value) => String(value || "").trim();
+      return Array.from(document.querySelectorAll("body *")).some((element) => {
+        if (!isVisible(element)) return false;
+        const textContent = normalized(element.textContent);
+        if (exactMatch) return textContent === expectedText;
+        return textContent.includes(expectedText);
+      });
+
+      function isVisible(element) {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      }
+    },
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function waitForNoVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 10000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const normalized = (value) => String(value || "").trim();
+      return !Array.from(document.querySelectorAll("body *")).some(
+        (element) => {
+          if (!isVisible(element)) return false;
+          const textContent = normalized(element.textContent);
+          if (exactMatch) return textContent === expectedText;
+          return textContent.includes(expectedText);
+        },
+      );
+
+      function isVisible(element) {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      }
+    },
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function waitForInputValue(page, value, { timeout = 30000 } = {}) {
+  await page.waitForFunction(
+    (expectedValue) =>
+      Array.from(document.querySelectorAll("input,textarea")).some(
+        (input) => String(input.value || "") === expectedValue,
+      ),
+    { timeout },
+    value,
+  );
+}
+
+async function fillInputByPlaceholder(page, placeholder, value) {
+  const selector = `input[placeholder="${cssEscape(placeholder)}"]`;
+  const input = await page.waitForSelector(selector, {
+    timeout: 30000,
+  });
+  await input.click({ clickCount: 3 });
+  await page.keyboard.press("Backspace");
+  await input.type(value);
+  await waitForInputValue(page, value);
+}
+
+async function selectComboboxAfterLabel(page, labelText, optionText) {
+  const point = await page.evaluate((expectedLabel) => {
+    const labels = Array.from(document.querySelectorAll("body *"))
+      .filter(
+        (element) =>
+          isVisible(element) &&
+          String(element.textContent || "").trim() === expectedLabel,
+      )
+      .sort(
+        (a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top,
+      );
+    const label = labels.at(-1);
+    if (!label) throw new Error(`Label ${expectedLabel} not found`);
+    const labelTop = label.getBoundingClientRect().top;
+    const combobox = Array.from(document.querySelectorAll('[role="combobox"]'))
+      .filter(
+        (element) =>
+          isVisible(element) && element.getBoundingClientRect().top > labelTop,
+      )
+      .sort(
+        (a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top,
+      )[0];
+    if (!combobox) {
+      throw new Error(`Combobox after ${expectedLabel} not found`);
+    }
+    const rect = combobox.getBoundingClientRect();
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+
+    function isVisible(element) {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    }
+  }, labelText);
+  await page.mouse.click(point.x, point.y);
+  await clickVisibleText(page, optionText, { exact: true });
+}
+
+async function clickVisibleText(page, text, { exact = false } = {}) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch, selector }) => {
+      const match = (value) => {
+        const normalized = String(value || "").trim();
+        return exactMatch
+          ? normalized === expectedText
+          : normalized.includes(expectedText);
+      };
+      return Array.from(document.querySelectorAll("body *")).some(
+        (candidate) =>
+          isVisible(candidate) &&
+          match(candidate.textContent) &&
+          Boolean(candidate.closest(selector)),
+      );
+
+      function isVisible(element) {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      }
+    },
+    { timeout: 30000 },
+    { text, exact, selector: CLICKABLE_SELECTOR },
+  );
+  await page.evaluate(
+    ({ text: expectedText, exact: exactMatch, selector }) => {
+      const match = (value) => {
+        const normalized = String(value || "").trim();
+        return exactMatch
+          ? normalized === expectedText
+          : normalized.includes(expectedText);
+      };
+      const element = Array.from(document.querySelectorAll("body *")).find(
+        (candidate) =>
+          isVisible(candidate) &&
+          match(candidate.textContent) &&
+          Boolean(candidate.closest(selector)),
+      );
+      const target = element?.closest(selector);
+      if (!target) throw new Error(`Clickable text ${expectedText} not found`);
+      target.click();
+
+      function isVisible(element) {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      }
+    },
+    { text, exact, selector: CLICKABLE_SELECTOR },
+  );
+}
+
+async function clickDeepestVisibleText(page, text) {
+  await waitForVisibleText(page, text, { exact: true });
+  await page.evaluate((expectedText) => {
+    const matches = Array.from(document.querySelectorAll("body *"))
+      .filter(
+        (element) =>
+          isVisible(element) &&
+          String(element.textContent || "").trim() === expectedText,
+      )
+      .sort(
+        (a, b) =>
+          b.getBoundingClientRect().width - a.getBoundingClientRect().width,
+      );
+    const element = matches.at(-1);
+    const target = element?.closest("button,a,[role='button']") || element;
+    if (!target) throw new Error(`Text ${expectedText} not clickable`);
+    target.click();
+
+    function isVisible(element) {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    }
+  }, text);
+}
+
+async function clickSwitchForTool(page, toolName) {
+  await waitForVisibleText(page, toolName, { exact: true });
+  await page.evaluate((expectedToolName) => {
+    const textNode = Array.from(document.querySelectorAll("body *")).find(
+      (element) =>
+        isVisible(element) &&
+        String(element.textContent || "").trim() === expectedToolName,
+    );
+    if (!textNode) throw new Error(`Tool ${expectedToolName} not found`);
+    let row = textNode;
+    for (let index = 0; index < 8 && row; index += 1) {
+      const input = row.querySelector('input[type="checkbox"]');
+      if (input) {
+        input.click();
+        return;
+      }
+      row = row.parentElement;
+    }
+    throw new Error(`Switch for ${expectedToolName} not found`);
+
+    function isVisible(element) {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    }
+  }, toolName);
+}
+
+async function waitForSwitchChecked(
+  page,
+  toolName,
+  expectedChecked,
+  { timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ expectedToolName, expected }) => {
+      const textNode = Array.from(document.querySelectorAll("body *")).find(
+        (element) =>
+          isVisible(element) &&
+          String(element.textContent || "").trim() === expectedToolName,
+      );
+      if (!textNode) return false;
+      let row = textNode;
+      for (let index = 0; index < 8 && row; index += 1) {
+        const input = row.querySelector('input[type="checkbox"]');
+        if (input) return input.checked === expected;
+        row = row.parentElement;
+      }
+      return false;
+
+      function isVisible(element) {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      }
+    },
+    { timeout },
+    { expectedToolName: toolName, expected: expectedChecked },
+  );
+}
+
+async function assertPasswordInputsBlank(page) {
+  const state = await page.evaluate(() => ({
+    password_values: Array.from(
+      document.querySelectorAll('input[type="password"]'),
+    ).map((input) => String(input.value || "")),
+  }));
+  assert(
+    state.password_values.every((value) => value === ""),
+    `Password inputs are not blank: ${JSON.stringify(state)}`,
+  );
+}
+
+function sanitizeMutationPayload(request) {
+  const body = parseRequestJson(request);
+  if (!body || typeof body !== "object") return {};
+  const sanitized = { ...body };
+  if (Object.prototype.hasOwnProperty.call(sanitized, "auth_header_value")) {
+    sanitized.auth_header_value = sanitized.auth_header_value
+      ? "<redacted>"
+      : "";
+  }
+  return {
+    method: request.method(),
+    path: pathname(request.url()),
+    body: sanitized,
+  };
+}
+
+function isFalconConnectorUrl(url) {
+  return url.includes("/falcon-ai/mcp-connectors/");
+}
+
+function pathname(url) {
+  return new URL(url).pathname;
+}
+
+function assertNoPayloadString(payload, needle, label) {
+  assert(
+    !JSON.stringify(payload).includes(needle),
+    `${label} leaked hidden secret material.`,
+  );
+}
+
+function browserExecutablePath() {
+  return (
+    process.env.PUPPETEER_EXECUTABLE_PATH ||
+    process.env.CHROME_PATH ||
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  );
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), `Expected UUID but received ${value}`);
+  return `'${value}'::uuid`;
+}
+
+function sqlTextLiteral(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(String(value)).digest("hex");
+}
+
+function cssEscape(value) {
+  return String(value).replace(/"/g, '\\"');
+}
+
+function appendCleanupError(original, cleanupError) {
+  if (!original) return cleanupError;
+  original.message = `${original.message}; cleanup failed: ${cleanupError.message}`;
+  return original;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/frontend/scripts/api-journeys/browser/settings-global-ai-providers-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-global-ai-providers-smoke.mjs
@@ -30,10 +30,10 @@ async function main() {
       typeof provider?.masked_key === "string" &&
       provider.masked_key.includes("*"),
   );
-  assert(
-    configuredTextProvider,
-    "No configured text provider with a masked key is available for browser smoke.",
-  );
+  const checkedProvider =
+    configuredTextProvider ||
+    providers.find((provider) => provider?.type === "text");
+  assert(checkedProvider, "No text provider is available for browser smoke.");
 
   const customModelsRaw = await auth.client.get(
     apiPath("/model-hub/custom-models/"),
@@ -58,9 +58,10 @@ async function main() {
     provider_count: providers.length,
     configured_provider_count: providers.filter((provider) => provider?.has_key)
       .length,
-    checked_provider: configuredTextProvider.provider,
-    checked_provider_display_name: configuredTextProvider.display_name,
-    checked_provider_masked_key: configuredTextProvider.masked_key,
+    configured_text_provider_available: Boolean(configuredTextProvider),
+    checked_provider: checkedProvider.provider,
+    checked_provider_display_name: checkedProvider.display_name,
+    checked_provider_masked_key: configuredTextProvider?.masked_key || null,
     custom_model_count: getPayloadTotal(customModelsRaw),
     api_key_list_rows: getPayloadTotal(apiKeysRaw),
   };
@@ -80,9 +81,11 @@ async function main() {
       localStorage.setItem("refreshToken", tokens.refresh || "");
       localStorage.setItem("rememberMe", "true");
       localStorage.setItem("initial-render", "done");
-      if (organizationId) sessionStorage.setItem("organizationId", organizationId);
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
       if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
-      if (user?.id) sessionStorage.setItem("futureagi-current-user-id", user.id);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
     },
     {
       tokens: auth.tokens,
@@ -128,7 +131,8 @@ async function main() {
     await Promise.all([providerStatusResponse, customModelsResponse]);
 
     await page.waitForFunction(
-      () => window.location.pathname.endsWith("/dashboard/settings/ai-providers"),
+      () =>
+        window.location.pathname.endsWith("/dashboard/settings/ai-providers"),
       { timeout: 30000 },
     );
     await waitForVisibleText(page, "AI Providers", { exact: true });
@@ -137,20 +141,24 @@ async function main() {
     await waitForVisibleText(page, "Default model provider");
     await waitForVisibleText(page, "Default cloud providers");
     await waitForVisibleText(page, "Custom model");
-    await waitForVisibleText(page, configuredTextProvider.display_name, {
+    await waitForVisibleText(page, checkedProvider.display_name, {
       exact: true,
     });
-    await waitForInputValue(page, configuredTextProvider.masked_key);
+    if (configuredTextProvider) {
+      await waitForInputValue(page, configuredTextProvider.masked_key);
 
-    const inputState = await findInputState(
-      page,
-      configuredTextProvider.masked_key,
-    );
-    assert(inputState.found, "Masked provider key input was not found.");
-    assert(
-      inputState.disabled || inputState.readOnly,
-      "Configured provider masked key input was editable before entering edit mode.",
-    );
+      const inputState = await findInputState(
+        page,
+        configuredTextProvider.masked_key,
+      );
+      assert(inputState.found, "Masked provider key input was not found.");
+      assert(
+        inputState.disabled || inputState.readOnly,
+        "Configured provider masked key input was editable before entering edit mode.",
+      );
+    } else {
+      await waitForVisibleButton(page, "Add");
+    }
 
     await assertNoRawSecretVisible(page);
     await waitForNoVisibleText(page, "No Models Added", { exact: true });
@@ -251,12 +259,14 @@ async function waitForNoVisibleText(
           rect.height > 0
         );
       };
-      return !Array.from(document.querySelectorAll("body *")).some((element) => {
-        if (!isVisible(element)) return false;
-        const textContent = normalized(element.textContent);
-        if (exactMatch) return textContent === expectedText;
-        return textContent.includes(expectedText);
-      });
+      return !Array.from(document.querySelectorAll("body *")).some(
+        (element) => {
+          if (!isVisible(element)) return false;
+          const textContent = normalized(element.textContent);
+          if (exactMatch) return textContent === expectedText;
+          return textContent.includes(expectedText);
+        },
+      );
     },
     { timeout },
     { text, exact },
@@ -274,11 +284,30 @@ async function waitForInputValue(page, expectedValue, timeout = 30000) {
   );
 }
 
+async function waitForVisibleButton(page, label, timeout = 30000) {
+  await page.waitForFunction(
+    (buttonLabel) =>
+      Array.from(document.querySelectorAll("button")).some((button) => {
+        const style = window.getComputedStyle(button);
+        const rect = button.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0 &&
+          button.textContent.trim() === buttonLabel
+        );
+      }),
+    { timeout },
+    label,
+  );
+}
+
 async function findInputState(page, expectedValue) {
   return page.evaluate((value) => {
-    const element = Array.from(document.querySelectorAll("input, textarea")).find(
-      (candidate) => candidate.value === value,
-    );
+    const element = Array.from(
+      document.querySelectorAll("input, textarea"),
+    ).find((candidate) => candidate.value === value);
     if (!element) return { found: false };
     return {
       found: true,
@@ -310,7 +339,10 @@ function assertNoRawSecretString(value, label) {
     /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
   ];
   for (const pattern of rawSecretPatterns) {
-    assert(!pattern.test(value), `${label} contains a raw provider secret pattern.`);
+    assert(
+      !pattern.test(value),
+      `${label} contains a raw provider secret pattern.`,
+    );
   }
 }
 
@@ -318,7 +350,8 @@ function getPayloadTotal(payload) {
   if (Number.isFinite(payload?.count)) return payload.count;
   if (Number.isFinite(payload?.result?.count)) return payload.result.count;
   if (Array.isArray(payload?.results)) return payload.results.length;
-  if (Array.isArray(payload?.result?.results)) return payload.result.results.length;
+  if (Array.isArray(payload?.result?.results))
+    return payload.result.results.length;
   if (Array.isArray(payload)) return payload.length;
   return 0;
 }

--- a/frontend/scripts/api-journeys/browser/settings-global-integrations-lifecycle-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-global-integrations-lifecycle-smoke.mjs
@@ -199,6 +199,13 @@ async function main() {
     await waitForVisibleText(page, expectedSecretKeyDisplay, {
       exact: true,
     });
+    await waitForVisibleText(page, "Sync Status", { exact: true });
+    await waitForVisibleText(page, "Sync History", { exact: true });
+    await waitForVisibleText(page, "Time", { exact: true });
+    await waitForVisibleText(page, "Traces", { exact: true });
+    await waitForVisibleText(page, "Spans", { exact: true });
+    await waitForVisibleText(page, "Scores", { exact: true });
+    await waitForVisibleText(page, "Status", { exact: true });
     await assertPageDoesNotContain(page, [
       seeded.plain_public_key,
       seeded.plain_secret_key,

--- a/frontend/scripts/api-journeys/browser/settings-global-integrations-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-global-integrations-smoke.mjs
@@ -14,13 +14,19 @@ const SCREENSHOT_PATH = "/tmp/settings-global-integrations-smoke.png";
 
 async function main() {
   const auth = await createAuthenticatedContext();
-  const listPayload = await auth.client.get(apiPath("/integrations/connections/"), {
-    query: { page_number: 0, page_size: 20 },
-  });
+  const listPayload = await auth.client.get(
+    apiPath("/integrations/connections/"),
+    {
+      query: { page_number: 0, page_size: 20 },
+    },
+  );
   const connections = Array.isArray(listPayload?.connections)
     ? listPayload.connections
     : [];
-  assert(connections.length > 0, "No integration connection is available for global settings smoke.");
+  assert(
+    connections.length > 0,
+    "No integration connection is available for global settings smoke.",
+  );
   const connection = connections[0];
   const displayName =
     connection.display_name || connection.external_project_name || "Unnamed";
@@ -30,9 +36,12 @@ async function main() {
   const detail = await auth.client.get(
     apiPath("/integrations/connections/{id}/", { id: connection.id }),
   );
-  const logsPayload = await auth.client.get(apiPath("/integrations/sync-logs/"), {
-    query: { connection_id: connection.id, page_number: 0, page_size: 10 },
-  });
+  const logsPayload = await auth.client.get(
+    apiPath("/integrations/sync-logs/"),
+    {
+      query: { connection_id: connection.id, page_number: 0, page_size: 10 },
+    },
+  );
 
   const apiFailures = [];
   const pageErrors = [];
@@ -60,9 +69,11 @@ async function main() {
       localStorage.setItem("refreshToken", tokens.refresh || "");
       localStorage.setItem("rememberMe", "true");
       localStorage.setItem("initial-render", "done");
-      if (organizationId) sessionStorage.setItem("organizationId", organizationId);
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
       if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
-      if (user?.id) sessionStorage.setItem("futureagi-current-user-id", user.id);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
     },
     {
       tokens: auth.tokens,
@@ -106,18 +117,25 @@ async function main() {
     await listResponse;
 
     await waitForVisibleText(page, "Integrations", { exact: true });
-    await waitForVisibleText(page, "Connect external observability platforms to import traces");
+    await waitForVisibleText(
+      page,
+      "Connect external observability platforms to import traces",
+    );
     await waitForVisibleText(page, "Available Platforms", { exact: true });
     await waitForVisibleText(page, displayName);
     await waitForVisibleText(page, hostUrl);
     await waitForVisibleText(page, traceLabel);
     if (connection.status) {
-      await waitForVisibleText(page, startCase(connection.status), { exact: true });
+      await waitForVisibleText(page, startCase(connection.status), {
+        exact: true,
+      });
     }
 
     const detailResponse = page.waitForResponse(
       (response) =>
-        response.url().includes(`/integrations/connections/${connection.id}/`) &&
+        response
+          .url()
+          .includes(`/integrations/connections/${connection.id}/`) &&
         response.status() < 400,
       { timeout: 60000 },
     );
@@ -135,7 +153,10 @@ async function main() {
     ]);
 
     await page.waitForFunction(
-      (expectedId) => window.location.pathname.endsWith(`/settings/integrations/${expectedId}`),
+      (expectedId) =>
+        window.location.pathname.endsWith(
+          `/settings/integrations/${expectedId}`,
+        ),
       { timeout: 30000 },
       connection.id,
     );
@@ -221,7 +242,11 @@ async function clickVisibleText(page, text) {
         (candidate) =>
           isVisible(candidate) &&
           String(candidate.textContent || "").includes(expectedText) &&
-          Boolean(candidate.closest(".MuiCardActionArea-root,button,a,[role='button']")),
+          Boolean(
+            candidate.closest(
+              ".MuiCardActionArea-root,button,a,[role='button']",
+            ),
+          ),
       );
     },
     { timeout: 30000 },
@@ -242,7 +267,9 @@ async function clickVisibleText(page, text) {
       (candidate) =>
         isVisible(candidate) &&
         String(candidate.textContent || "").includes(expectedText) &&
-        Boolean(candidate.closest(".MuiCardActionArea-root,button,a,[role='button']")),
+        Boolean(
+          candidate.closest(".MuiCardActionArea-root,button,a,[role='button']"),
+        ),
     );
     element.closest(".MuiCardActionArea-root,button,a,[role='button']").click();
   }, text);
@@ -296,12 +323,14 @@ async function waitForNoVisibleText(
           rect.height > 0
         );
       };
-      return !Array.from(document.querySelectorAll("body *")).some((element) => {
-        if (!isVisible(element)) return false;
-        const textContent = normalized(element.textContent);
-        if (exactMatch) return textContent === expectedText;
-        return textContent.includes(expectedText);
-      });
+      return !Array.from(document.querySelectorAll("body *")).some(
+        (element) => {
+          if (!isVisible(element)) return false;
+          const textContent = normalized(element.textContent);
+          if (exactMatch) return textContent === expectedText;
+          return textContent.includes(expectedText);
+        },
+      );
     },
     { timeout },
     { text, exact },
@@ -317,7 +346,8 @@ function startCase(value) {
 }
 
 function browserExecutablePath() {
-  if (process.env.PUPPETEER_EXECUTABLE_PATH) return process.env.PUPPETEER_EXECUTABLE_PATH;
+  if (process.env.PUPPETEER_EXECUTABLE_PATH)
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
   if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
   if (process.platform === "darwin") {
     return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";

--- a/frontend/scripts/api-journeys/browser/settings-mcp-server-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-mcp-server-smoke.mjs
@@ -23,7 +23,10 @@ async function main() {
     ? toolConfig.enabled_groups
     : [];
   assert(config?.mcp_url, "MCP config omitted mcp_url.");
-  assert(availableGroups.length > 0, "MCP config returned no available groups.");
+  assert(
+    availableGroups.length > 0,
+    "MCP config returned no available groups.",
+  );
 
   const groupBadge =
     enabledGroups.length === availableGroups.length
@@ -56,9 +59,11 @@ async function main() {
       localStorage.setItem("refreshToken", tokens.refresh || "");
       localStorage.setItem("rememberMe", "true");
       localStorage.setItem("initial-render", "done");
-      if (organizationId) sessionStorage.setItem("organizationId", organizationId);
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
       if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
-      if (user?.id) sessionStorage.setItem("futureagi-current-user-id", user.id);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
     },
     {
       tokens: auth.tokens,
@@ -97,7 +102,10 @@ async function main() {
 
     await waitForVisibleText(page, "MCP Server", { exact: true });
     await waitForVisibleText(page, "Connect Your IDE", { exact: true });
-    await waitForVisibleText(page, "Authentication happens automatically via OAuth");
+    await waitForVisibleText(
+      page,
+      "Authentication happens automatically via OAuth",
+    );
     await waitForInputValue(page, config.mcp_url);
     await waitForVisibleText(page, "Cursor", { exact: true });
     await waitForVisibleText(page, "Claude Code", { exact: true });
@@ -254,12 +262,14 @@ async function waitForNoVisibleText(
           rect.height > 0
         );
       };
-      return !Array.from(document.querySelectorAll("body *")).some((element) => {
-        if (!isVisible(element)) return false;
-        const textContent = normalized(element.textContent);
-        if (exactMatch) return textContent === expectedText;
-        return textContent.includes(expectedText);
-      });
+      return !Array.from(document.querySelectorAll("body *")).some(
+        (element) => {
+          if (!isVisible(element)) return false;
+          const textContent = normalized(element.textContent);
+          if (exactMatch) return textContent === expectedText;
+          return textContent.includes(expectedText);
+        },
+      );
     },
     { timeout },
     { text, exact },

--- a/frontend/scripts/api-journeys/browser/settings-profile-security-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-profile-security-smoke.mjs
@@ -16,6 +16,8 @@ const UPDATE_SCREENSHOT_PATH =
   "/tmp/settings-profile-security-name-update-smoke.png";
 const REVERT_SCREENSHOT_PATH =
   "/tmp/settings-profile-security-name-revert-smoke.png";
+const ORG_SECURITY_SCREENSHOT_PATH =
+  "/tmp/settings-org-security-policy-smoke.png";
 const ERROR_SCREENSHOT_PATH = "/tmp/settings-profile-security-error-smoke.png";
 
 async function main() {
@@ -25,6 +27,12 @@ async function main() {
   );
   const twoFactorStatus = await auth.client.get(
     apiPath("/accounts/2fa/status/"),
+    {
+      unwrap: false,
+    },
+  );
+  const orgPolicy = await auth.client.get(
+    apiPath("/accounts/organization/2fa-policy/"),
     {
       unwrap: false,
     },
@@ -42,6 +50,7 @@ async function main() {
 
   const apiFailures = [];
   const pageErrors = [];
+  const orgPolicyMutations = [];
   const evidence = {
     email,
     original_name: originalName,
@@ -49,6 +58,8 @@ async function main() {
     two_factor_enabled: twoFactorStatus.two_factor_enabled,
     totp_enabled: twoFactorStatus.methods?.totp?.enabled,
     passkey_enabled: twoFactorStatus.methods?.passkey?.enabled,
+    org_require_2fa: orgPolicy.require_2fa,
+    org_2fa_grace_days: orgPolicy.require_2fa_grace_period_days,
   };
 
   const browser = await puppeteer.launch({
@@ -85,10 +96,20 @@ async function main() {
     if (
       (url.includes("/accounts/get-user-profile-details/") ||
         url.includes("/accounts/2fa/status/") ||
-        url.includes("/accounts/passkeys/")) &&
+        url.includes("/accounts/passkeys/") ||
+        url.includes("/accounts/organization/2fa-policy/")) &&
       response.status() >= 400
     ) {
       apiFailures.push(`${response.status()} ${url}`);
+    }
+  });
+  page.on("request", (request) => {
+    const writeMethods = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+    if (
+      request.url().includes("/accounts/organization/2fa-policy/") &&
+      writeMethods.has(request.method())
+    ) {
+      orgPolicyMutations.push(`${request.method()} ${request.url()}`);
     }
   });
   page.on("pageerror", (error) => pageErrors.push(error.message));
@@ -170,7 +191,15 @@ async function main() {
     await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
     evidence.screenshot = SCREENSHOT_PATH;
 
+    await verifyOrganizationSecurityPolicy(page, orgPolicy, twoFactorStatus);
+    evidence.org_policy_screenshot = ORG_SECURITY_SCREENSHOT_PATH;
+    evidence.org_policy_mutation_count = orgPolicyMutations.length;
+
     assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
+    assert(
+      orgPolicyMutations.length === 0,
+      `Unexpected organization policy mutations: ${orgPolicyMutations.join("; ")}`,
+    );
     assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
 
     console.log(
@@ -229,6 +258,125 @@ async function installRuntimeConfig(page, auth) {
     }
     request.continue();
   });
+}
+
+async function verifyOrganizationSecurityPolicy(
+  page,
+  orgPolicy,
+  twoFactorStatus,
+) {
+  const orgPolicyResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes("/accounts/organization/2fa-policy/") &&
+      response.request().method() === "GET" &&
+      response.status() < 400,
+    { timeout: 60000 },
+  );
+  const twoFactorResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes("/accounts/2fa/status/") &&
+      response.request().method() === "GET" &&
+      response.status() < 400,
+    { timeout: 60000 },
+  );
+
+  await page.goto(`${APP_BASE}/dashboard/settings/org-settings`, {
+    waitUntil: "domcontentloaded",
+  });
+  await orgPolicyResponse;
+  await twoFactorResponse.catch(() => null);
+
+  await waitForVisibleText(page, "Organization Settings", { exact: true });
+  await waitForVisibleText(page, "Organization Name", { exact: true });
+  await waitForVisibleText(page, "Organization Security", { exact: true });
+  await waitForVisibleText(page, "Require 2FA for all members", {
+    exact: true,
+  });
+
+  const require2faChecked = await visibleSwitchCheckedNearText(
+    page,
+    "Require 2FA for all members",
+  );
+  assert(
+    require2faChecked === Boolean(orgPolicy.require_2fa),
+    "Organization 2FA toggle did not reflect the API policy state.",
+  );
+
+  if (!twoFactorStatus.two_factor_enabled && !orgPolicy.require_2fa) {
+    await waitForVisibleText(
+      page,
+      "You must enable two-factor authentication on your own account before requiring it for the organization.",
+    );
+    await waitForVisibleText(page, "Go to Profile Settings", { exact: true });
+    const require2faDisabled = await visibleSwitchDisabledNearText(
+      page,
+      "Require 2FA for all members",
+    );
+    assert(
+      require2faDisabled,
+      "Organization 2FA toggle should be disabled until the actor has 2FA.",
+    );
+  }
+
+  await waitForNoVisibleText(page, "Invalid Date");
+  await page.screenshot({
+    path: ORG_SECURITY_SCREENSHOT_PATH,
+    fullPage: true,
+  });
+}
+
+async function visibleSwitchCheckedNearText(page, text) {
+  return page.evaluate((expectedText) => {
+    const isVisible = (element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    };
+    const label = Array.from(document.querySelectorAll("body *")).find(
+      (element) =>
+        isVisible(element) &&
+        String(element.textContent || "").trim() === expectedText,
+    );
+    let section = label;
+    for (let index = 0; section && index < 8; index += 1) {
+      if (section.querySelector('input[type="checkbox"]')) break;
+      section = section.parentElement;
+    }
+    const input = section?.querySelector('input[type="checkbox"]');
+    return Boolean(input?.checked);
+  }, text);
+}
+
+async function visibleSwitchDisabledNearText(page, text) {
+  return page.evaluate((expectedText) => {
+    const isVisible = (element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    };
+    const label = Array.from(document.querySelectorAll("body *")).find(
+      (element) =>
+        isVisible(element) &&
+        String(element.textContent || "").trim() === expectedText,
+    );
+    let section = label;
+    for (let index = 0; section && index < 8; index += 1) {
+      if (section.querySelector('input[type="checkbox"]')) break;
+      section = section.parentElement;
+    }
+    const input = section?.querySelector('input[type="checkbox"]');
+    return Boolean(input?.disabled);
+  }, text);
 }
 
 async function clickVisibleIconByTitle(page, title) {

--- a/frontend/scripts/api-journeys/browser/settings-user-management-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-user-management-smoke.mjs
@@ -481,6 +481,9 @@ async function main() {
     if (shouldMutate && !inviteCancelled) {
       await cancelInvitesByEmail(auth, inviteEmail);
     }
+    if (shouldMutate) {
+      await deleteDisposableRbacUserArtifacts(inviteEmail);
+    }
     if (shouldMutate && !activeMemberCleaned) {
       await cleanupAcceptedMember(auth, {
         email: activeMemberEmail,

--- a/frontend/scripts/api-journeys/browser/settings-workspace-ai-providers-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-workspace-ai-providers-smoke.mjs
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
 import process from "node:process";
+import { promisify } from "node:util";
 import {
   apiPath,
   assert,
@@ -10,6 +12,7 @@ import {
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
 const ROUTE_MODE =
@@ -53,10 +56,10 @@ async function main() {
       typeof provider?.masked_key === "string" &&
       provider.masked_key.includes("*"),
   );
-  assert(
-    configuredTextProvider,
-    "No configured text provider with a masked key is available for browser smoke.",
-  );
+  const checkedProvider =
+    configuredTextProvider ||
+    providers.find((provider) => provider?.type === "text");
+  assert(checkedProvider, "No text provider is available for browser smoke.");
   const mutationProvider = RUN_PROVIDER_KEY_MUTATION
     ? chooseSafeUnconfiguredProvider(providers)
     : null;
@@ -78,9 +81,10 @@ async function main() {
     provider_count: providers.length,
     configured_provider_count: providers.filter((provider) => provider?.has_key)
       .length,
-    checked_provider: configuredTextProvider.provider,
-    checked_provider_display_name: configuredTextProvider.display_name,
-    checked_provider_masked_key: configuredTextProvider.masked_key,
+    configured_text_provider_available: Boolean(configuredTextProvider),
+    checked_provider: checkedProvider.provider,
+    checked_provider_display_name: checkedProvider.display_name,
+    checked_provider_masked_key: configuredTextProvider?.masked_key || null,
     custom_model_count:
       customModelsRaw?.count ??
       customModelsRaw?.result?.count ??
@@ -171,20 +175,24 @@ async function main() {
     await waitForVisibleText(page, "Default model provider");
     await waitForVisibleText(page, "Default cloud providers");
     await waitForVisibleText(page, "Custom model");
-    await waitForVisibleText(page, configuredTextProvider.display_name, {
+    await waitForVisibleText(page, checkedProvider.display_name, {
       exact: true,
     });
-    await waitForInputValue(page, configuredTextProvider.masked_key);
+    if (configuredTextProvider) {
+      await waitForInputValue(page, configuredTextProvider.masked_key);
 
-    const inputState = await findInputState(
-      page,
-      configuredTextProvider.masked_key,
-    );
-    assert(inputState.found, "Masked provider key input was not found.");
-    assert(
-      inputState.disabled || inputState.readOnly,
-      "Configured provider masked key input was editable before entering edit mode.",
-    );
+      const inputState = await findInputState(
+        page,
+        configuredTextProvider.masked_key,
+      );
+      assert(inputState.found, "Masked provider key input was not found.");
+      assert(
+        inputState.disabled || inputState.readOnly,
+        "Configured provider masked key input was editable before entering edit mode.",
+      );
+    } else {
+      await waitForVisibleButton(page, "Add");
+    }
 
     await assertNoRawSecretVisible(page);
     await waitForNoVisibleText(page, "No Models Added", { exact: true });
@@ -200,7 +208,7 @@ async function main() {
       await waitForVisibleText(page, mutationProvider.display_name, {
         exact: true,
       });
-      await fillVisibleProviderKeyInput(page, rawKey);
+      await fillProviderKeyInput(page, mutationProvider.display_name, rawKey);
       const createResponse = page.waitForResponse(
         (response) =>
           response.url().includes("/model-hub/api-keys/") &&
@@ -208,7 +216,7 @@ async function main() {
           response.status() < 400,
         { timeout: 60000 },
       );
-      await clickVisibleButton(page, "Add");
+      await clickProviderButton(page, mutationProvider.display_name, "Add");
       await createResponse;
       disposableProviderCreated = true;
 
@@ -220,9 +228,17 @@ async function main() {
       assertProviderKeyPayloadMasked(createdKey, [rawKey, updatedRawKey]);
       evidence.created_provider_key_id = createdKey.id;
 
-      await waitForProviderCardMaskedValue(page, rawKey);
+      await waitForProviderCardMaskedValue(
+        page,
+        mutationProvider.display_name,
+        rawKey,
+      );
       await clickProviderActionButton(page, mutationProvider.display_name, 0);
-      await fillVisibleProviderKeyInput(page, updatedRawKey);
+      await fillProviderKeyInput(
+        page,
+        mutationProvider.display_name,
+        updatedRawKey,
+      );
       const updateResponse = page.waitForResponse(
         (response) =>
           response.url().includes("/model-hub/api-keys/") &&
@@ -230,7 +246,7 @@ async function main() {
           response.status() < 400,
         { timeout: 60000 },
       );
-      await clickVisibleButton(page, "Save");
+      await clickProviderButton(page, mutationProvider.display_name, "Save");
       await updateResponse;
 
       const updatedKey = await waitForProviderKey(auth.client, {
@@ -260,6 +276,11 @@ async function main() {
         provider: mutationProvider.provider,
         absent: true,
       });
+      const hardCleanup = await hardDeleteProviderKeyRows([createdKey.id]);
+      assert(
+        hardCleanup.exact_provider_key_rows === 0,
+        `Provider key hard cleanup left rows behind: ${JSON.stringify(hardCleanup)}`,
+      );
       await waitForVisibleButton(page, "Add");
       await page.screenshot({ path: DELETE_SCREENSHOT_PATH, fullPage: true });
       evidence.delete_screenshot = DELETE_SCREENSHOT_PATH;
@@ -267,6 +288,8 @@ async function main() {
       evidence.provider_key_update_visible = true;
       evidence.provider_key_delete_visible = true;
       evidence.expected_mutation_count = expectedMutations.length;
+      evidence.hard_cleanup_provider_key_rows =
+        hardCleanup.exact_provider_key_rows;
       disposableProviderCreated = false;
       await assertNoRawSecretVisible(page);
     }
@@ -292,10 +315,11 @@ async function main() {
   } finally {
     await browser.close();
     if (mutationProvider && disposableProviderCreated) {
-      await deleteProviderKeyForProvider(
+      const deletedKeyId = await deleteProviderKeyForProvider(
         auth.client,
         mutationProvider.provider,
       );
+      if (deletedKeyId) await hardDeleteProviderKeyRows([deletedKeyId]);
     }
   }
 }
@@ -423,9 +447,9 @@ async function filterProvider(page, providerName) {
   );
 }
 
-async function fillVisibleProviderKeyInput(page, value) {
+async function fillProviderKeyInput(page, providerName, value) {
   const inputHandle = await page.waitForFunction(
-    () => {
+    (name) => {
       const isVisible = (element) => {
         const style = window.getComputedStyle(element);
         const rect = element.getBoundingClientRect();
@@ -436,20 +460,75 @@ async function fillVisibleProviderKeyInput(page, value) {
           rect.height > 0
         );
       };
-      return Array.from(document.querySelectorAll("input, textarea")).find(
-        (element) =>
-          isVisible(element) &&
-          !element.disabled &&
-          element.placeholder !== "Search AI Provider",
+      const label = Array.from(
+        document.querySelectorAll("p, span, div, h1, h2, h3, h4, h5, h6"),
+      ).find(
+        (element) => isVisible(element) && element.textContent.trim() === name,
       );
+      if (!label) return null;
+      let current = label;
+      for (let depth = 0; depth < 8 && current; depth += 1) {
+        const input = Array.from(
+          current.querySelectorAll("input, textarea"),
+        ).find(
+          (element) =>
+            isVisible(element) &&
+            !element.disabled &&
+            element.placeholder !== "Search AI Provider",
+        );
+        if (input) return input;
+        current = current.parentElement;
+      }
+      return null;
     },
     { timeout: 30000 },
+    providerName,
   );
   const input = inputHandle.asElement();
-  assert(input, "Provider key input was not found.");
+  assert(input, `Provider key input for ${providerName} was not found.`);
   await input.click({ clickCount: 3 });
   await page.keyboard.press("Backspace");
   await page.keyboard.type(value);
+}
+
+async function clickProviderButton(page, providerName, label) {
+  const buttonHandle = await page.waitForFunction(
+    ({ name, label }) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      const providerLabel = Array.from(
+        document.querySelectorAll("p, span, div, h1, h2, h3, h4, h5, h6"),
+      ).find(
+        (element) => isVisible(element) && element.textContent.trim() === name,
+      );
+      if (!providerLabel) return null;
+      let current = providerLabel;
+      for (let depth = 0; depth < 8 && current; depth += 1) {
+        const button = Array.from(current.querySelectorAll("button")).find(
+          (element) =>
+            isVisible(element) &&
+            !element.disabled &&
+            element.textContent.trim() === label,
+        );
+        if (button) return button;
+        current = current.parentElement;
+      }
+      return null;
+    },
+    { timeout: 30000 },
+    { name: providerName, label },
+  );
+  const button = buttonHandle.asElement();
+  assert(button, `Provider ${providerName} button ${label} was not found.`);
+  await button.click();
 }
 
 async function clickVisibleButton(page, label) {
@@ -548,20 +627,47 @@ async function clickProviderActionButton(page, providerName, actionIndex) {
   await button.click();
 }
 
-async function waitForProviderCardMaskedValue(page, forbiddenRawValue) {
+async function waitForProviderCardMaskedValue(
+  page,
+  providerName,
+  forbiddenRawValue,
+) {
   await page.waitForFunction(
-    (rawValue) => {
-      const inputs = Array.from(document.querySelectorAll("input, textarea"));
-      return inputs.some(
-        (input) =>
-          input.disabled &&
-          input.value &&
-          input.value.includes("*") &&
-          input.value !== rawValue,
+    ({ name, rawValue }) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      const label = Array.from(
+        document.querySelectorAll("p, span, div, h1, h2, h3, h4, h5, h6"),
+      ).find(
+        (element) => isVisible(element) && element.textContent.trim() === name,
       );
+      if (!label) return false;
+      let current = label;
+      for (let depth = 0; depth < 8 && current; depth += 1) {
+        const hasMaskedInput = Array.from(
+          current.querySelectorAll("input, textarea"),
+        ).some(
+          (input) =>
+            input.disabled &&
+            input.value &&
+            input.value.includes("*") &&
+            input.value !== rawValue,
+        );
+        if (hasMaskedInput) return true;
+        current = current.parentElement;
+      }
+      return false;
     },
     { timeout: 30000 },
-    forbiddenRawValue,
+    { name: providerName, rawValue: forbiddenRawValue },
   );
 }
 
@@ -599,8 +705,52 @@ async function listProviderKeys(client) {
 async function deleteProviderKeyForProvider(client, provider) {
   const keys = await listProviderKeys(client);
   const key = keys.find((candidate) => candidate.provider === provider);
-  if (!key?.id) return;
+  if (!key?.id) return null;
   await client.delete(apiPath("/model-hub/api-keys/{id}/", { id: key.id }));
+  return key.id;
+}
+
+async function hardDeleteProviderKeyRows(ids) {
+  const quotedIds = ids.filter(Boolean).map(sqlString);
+  if (quotedIds.length === 0) {
+    return { deleted_provider_key_rows: 0, exact_provider_key_rows: 0 };
+  }
+  const deleted = await runPostgresJson(`
+    WITH deleted_keys AS (
+      DELETE FROM model_hub_apikey
+      WHERE id IN (${quotedIds.join(", ")})
+      RETURNING 1
+    )
+    SELECT json_build_object(
+      'deleted_provider_key_rows', (SELECT count(*) FROM deleted_keys)
+    );
+  `);
+  const verified = await runPostgresJson(`
+    SELECT json_build_object(
+      'exact_provider_key_rows', (
+        SELECT count(*) FROM model_hub_apikey WHERE id IN (${quotedIds.join(", ")})
+      )
+    );
+  `);
+  return { ...deleted, ...verified };
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres provider-key cleanup returned no JSON output.");
+  return JSON.parse(text);
+}
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
 }
 
 function assertProviderKeyPayloadMasked(payload, forbiddenValues) {

--- a/frontend/scripts/api-journeys/browser/settings-workspace-custom-models-crud-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-workspace-custom-models-crud-smoke.mjs
@@ -1,6 +1,8 @@
+import { execFile } from "node:child_process";
 import http from "node:http";
 import { createRequire } from "node:module";
 import process from "node:process";
+import { promisify } from "node:util";
 import {
   apiPath,
   assert,
@@ -10,6 +12,7 @@ import {
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
 const ROUTE_MODE =
@@ -206,6 +209,11 @@ async function main() {
     await clickVisibleButton(page, "Delete");
     await assertHttpResponseOk(await deleteResponse, "custom model delete");
     await waitForCustomModel(auth.client, { modelName, absent: true });
+    const hardCleanup = await hardDeleteCustomModelRows([createdModelId]);
+    assert(
+      hardCleanup.exact_custom_model_rows === 0,
+      `Custom model hard cleanup left rows behind: ${JSON.stringify(hardCleanup)}`,
+    );
     deletedViaUi = true;
     await waitForNoVisibleText(page, modelName, { exact: true });
     await page.screenshot({ path: DELETE_SCREENSHOT_PATH, fullPage: true });
@@ -235,6 +243,7 @@ async function main() {
             update_screenshot: UPDATE_SCREENSHOT_PATH,
             delete_screenshot: DELETE_SCREENSHOT_PATH,
             expected_mutation_count: expectedMutations.length,
+            hard_cleanup_custom_model_rows: hardCleanup.exact_custom_model_rows,
           },
         },
         null,
@@ -262,6 +271,7 @@ async function main() {
     await fakeServer.close();
     if (createdModelId && !deletedViaUi) {
       await deleteCustomModelIds(auth.client, [createdModelId]);
+      await hardDeleteCustomModelRows([createdModelId]);
     }
     await cleanupModelsByName(auth.client, modelName);
   }
@@ -673,13 +683,59 @@ async function cleanupModelsByName(client, modelName) {
     .filter((model) => model.user_model_id === modelName)
     .map((model) => model.id)
     .filter(Boolean);
-  if (ids.length > 0) await deleteCustomModelIds(client, ids);
+  if (ids.length > 0) {
+    await deleteCustomModelIds(client, ids);
+    await hardDeleteCustomModelRows(ids);
+  }
 }
 
 async function deleteCustomModelIds(client, ids) {
   await client.delete(apiPath("/model-hub/custom_models/delete/"), {
     body: { ids },
   });
+}
+
+async function hardDeleteCustomModelRows(ids) {
+  const quotedIds = ids.filter(Boolean).map(sqlString);
+  if (quotedIds.length === 0) {
+    return { deleted_custom_model_rows: 0, exact_custom_model_rows: 0 };
+  }
+  const deleted = await runPostgresJson(`
+    WITH deleted_models AS (
+      DELETE FROM model_hub_customaimodel
+      WHERE id IN (${quotedIds.join(", ")})
+      RETURNING 1
+    )
+    SELECT json_build_object(
+      'deleted_custom_model_rows', (SELECT count(*) FROM deleted_models)
+    );
+  `);
+  const verified = await runPostgresJson(`
+    SELECT json_build_object(
+      'exact_custom_model_rows', (
+        SELECT count(*) FROM model_hub_customaimodel WHERE id IN (${quotedIds.join(", ")})
+      )
+    );
+  `);
+  return { ...deleted, ...verified };
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres custom-model cleanup returned no JSON output.");
+  return JSON.parse(text);
+}
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
 }
 
 function assertPayloadDoesNotContain(payload, forbiddenValues) {

--- a/frontend/scripts/api-journeys/browser/settings-workspace-usage-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/settings-workspace-usage-smoke.mjs
@@ -12,20 +12,29 @@ const puppeteer = require("puppeteer-core");
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
 const SCREENSHOT_PATH = "/tmp/settings-workspace-usage-smoke.png";
+const MONTH_SWITCH_SCREENSHOT_PATH =
+  "/tmp/settings-workspace-usage-month-count-smoke.png";
 
 async function main() {
   const auth = await createAuthenticatedContext();
   const now = new Date();
   const month = now.getMonth() + 1;
   const year = now.getFullYear();
+  const currentPeriod = buildPeriod(month, year);
+  const previousPeriod = previousMonthPeriod(currentPeriod);
 
   const usageSummary = await auth.client.get(
     apiPath("/usage/workspace-usage-summary/"),
     { query: { month, year } },
   );
   const workspaceRows = asArray(usageSummary?.workspaces);
-  const activeWorkspace = workspaceRows.find((row) => row?.id === auth.workspaceId);
-  assert(activeWorkspace, "Workspace usage API did not include active workspace.");
+  const activeWorkspace = workspaceRows.find(
+    (row) => row?.id === auth.workspaceId,
+  );
+  assert(
+    activeWorkspace,
+    "Workspace usage API did not include active workspace.",
+  );
 
   const evalSummary = await auth.client.get(
     apiPath("/usage/workspace-eval-summary/"),
@@ -48,6 +57,10 @@ async function main() {
     workspace_name: activeWorkspace.name,
     month,
     year,
+    current_month_label: currentPeriod.label,
+    previous_month: previousPeriod.month,
+    previous_year: previousPeriod.year,
+    previous_month_label: previousPeriod.label,
     workspace_overall_count: activeWorkspace.overall?.count,
     workspace_eval_count: evalSummary.total.count,
   };
@@ -67,9 +80,11 @@ async function main() {
       localStorage.setItem("refreshToken", tokens.refresh || "");
       localStorage.setItem("rememberMe", "true");
       localStorage.setItem("initial-render", "done");
-      if (organizationId) sessionStorage.setItem("organizationId", organizationId);
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
       if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
-      if (user?.id) sessionStorage.setItem("futureagi-current-user-id", user.id);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
     },
     {
       tokens: auth.tokens,
@@ -91,25 +106,26 @@ async function main() {
   page.on("pageerror", (error) => pageErrors.push(error.message));
 
   try {
-    const usageTotalsResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes("/usage/workspace-usage-summary/") &&
-        response.status() < 400,
-      { timeout: 60000 },
+    const currentUsageResponse = waitForUsageSummaryResponse(
+      page,
+      currentPeriod,
     );
-    const evalSummaryResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes("/usage/workspace-eval-summary/") &&
-        response.status() < 400,
-      { timeout: 60000 },
+    const currentEvalResponse = waitForEvalSummaryResponse(
+      page,
+      currentPeriod,
+      auth.workspaceId,
     );
 
     await page.goto(
       `${APP_BASE}/dashboard/settings/workspace/${auth.workspaceId}/usage`,
       { waitUntil: "domcontentloaded" },
     );
-    await usageTotalsResponse;
-    await evalSummaryResponse;
+    const [currentUsage, currentEval] = await Promise.all([
+      currentUsageResponse,
+      currentEvalResponse,
+    ]);
+    evidence.current_usage_query = queryEvidence(currentUsage);
+    evidence.current_eval_query = queryEvidence(currentEval);
 
     await waitForVisibleText(page, "Usage Summary", { exact: true });
     await waitForVisibleText(page, "Workspace usage summary", { exact: true });
@@ -124,10 +140,50 @@ async function main() {
     await waitForVisibleText(page, "Count", { exact: true });
     await waitForVisibleText(page, "Evaluations", { exact: true });
     await waitForVisibleText(page, "Total", { exact: true });
-
+    await waitForInputValue(page, 'input[placeholder="Select month"]', {
+      value: currentPeriod.label,
+    });
+    await waitForMetricCards(page);
+    await waitForGridHeader(page, "Cost");
+    await waitForAgGridSettled(page);
     await waitForNoVisibleText(page, "Invalid Date");
     await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
     evidence.screenshot = SCREENSHOT_PATH;
+
+    await clickVisibleTab(page, "Count");
+    await waitForGridHeader(page, "Count");
+    evidence.count_tab_header_visible = true;
+
+    const previousUsageResponse = waitForUsageSummaryResponse(
+      page,
+      previousPeriod,
+    );
+    const previousEvalResponse = waitForEvalSummaryResponse(
+      page,
+      previousPeriod,
+      auth.workspaceId,
+    );
+    await clickMonthOption(page, previousPeriod.label);
+    const [previousUsage, previousEval] = await Promise.all([
+      previousUsageResponse,
+      previousEvalResponse,
+    ]);
+    evidence.previous_usage_query = queryEvidence(previousUsage);
+    evidence.previous_eval_query = queryEvidence(previousEval);
+
+    await waitForInputValue(page, 'input[placeholder="Select month"]', {
+      value: previousPeriod.label,
+    });
+    await waitForMetricCards(page);
+    await waitForGridHeader(page, "Count");
+    await waitForAgGridSettled(page);
+
+    await waitForNoVisibleText(page, "Invalid Date");
+    await page.screenshot({
+      path: MONTH_SWITCH_SCREENSHOT_PATH,
+      fullPage: true,
+    });
+    evidence.month_switch_screenshot = MONTH_SWITCH_SCREENSHOT_PATH;
 
     assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
     assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
@@ -151,6 +207,74 @@ async function main() {
   }
 }
 
+function buildPeriod(month, year) {
+  const date = new Date(Date.UTC(year, month - 1, 1));
+  const monthName = new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    timeZone: "UTC",
+  }).format(date);
+  return {
+    month,
+    year,
+    label: `${monthName} ${year}`,
+  };
+}
+
+function previousMonthPeriod(period) {
+  const date = new Date(Date.UTC(period.year, period.month - 2, 1));
+  return buildPeriod(date.getUTCMonth() + 1, date.getUTCFullYear());
+}
+
+function matchesUsageEndpoint(response, endpointPath, period, workspaceId) {
+  if (response.status() >= 400) return false;
+  let url;
+  try {
+    url = new URL(response.url());
+  } catch {
+    return false;
+  }
+  if (url.pathname !== endpointPath) return false;
+  const month = Number(url.searchParams.get("month"));
+  const year = Number(url.searchParams.get("year"));
+  if (month !== period.month || year !== period.year) return false;
+  if (workspaceId) {
+    return url.searchParams.get("workspace_id") === workspaceId;
+  }
+  return true;
+}
+
+async function waitForUsageSummaryResponse(page, period) {
+  return page.waitForResponse(
+    (response) =>
+      matchesUsageEndpoint(response, "/usage/workspace-usage-summary/", period),
+    { timeout: 60000 },
+  );
+}
+
+async function waitForEvalSummaryResponse(page, period, workspaceId) {
+  return page.waitForResponse(
+    (response) =>
+      matchesUsageEndpoint(
+        response,
+        "/usage/workspace-eval-summary/",
+        period,
+        workspaceId,
+      ),
+    { timeout: 60000 },
+  );
+}
+
+function queryEvidence(response) {
+  const url = new URL(response.url());
+  return {
+    path: url.pathname,
+    month: Number(url.searchParams.get("month")),
+    year: Number(url.searchParams.get("year")),
+    workspace_id: url.searchParams.get("workspace_id"),
+    status: response.status(),
+  };
+}
+
 async function installRuntimeConfig(page, auth) {
   await page.setRequestInterception(true);
   page.on("request", (request) => {
@@ -168,6 +292,180 @@ async function installRuntimeConfig(page, auth) {
     }
     request.continue();
   });
+}
+
+async function clickMonthOption(page, label) {
+  await page.click('input[placeholder="Select month"]');
+  await waitForVisibleText(page, label, { exact: true });
+  await clickVisibleText(page, label, { exact: true });
+}
+
+async function clickVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await waitForVisibleText(page, text, { exact, timeout });
+  await page.evaluate(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const normalized = (value) => String(value || "").trim();
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      const target = Array.from(document.querySelectorAll("body *")).find(
+        (element) => {
+          if (!isVisible(element)) return false;
+          const textContent = normalized(element.textContent);
+          if (exactMatch) return textContent === expectedText;
+          return textContent.includes(expectedText);
+        },
+      );
+      if (!target) {
+        throw new Error(`Visible text not found for click: ${expectedText}`);
+      }
+      target.click();
+    },
+    { text, exact },
+  );
+}
+
+async function clickVisibleTab(page, label) {
+  await page.evaluate((expectedLabel) => {
+    const normalized = (value) => String(value || "").trim();
+    const isVisible = (element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    };
+    const tab = Array.from(document.querySelectorAll('[role="tab"]')).find(
+      (element) =>
+        isVisible(element) && normalized(element.textContent) === expectedLabel,
+    );
+    if (!tab) throw new Error(`Visible tab not found: ${expectedLabel}`);
+    tab.click();
+  }, label);
+}
+
+async function waitForGridHeader(page, headerName, { timeout = 30000 } = {}) {
+  await page.waitForFunction(
+    (expectedHeader) => {
+      const normalized = (value) => String(value || "").trim();
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(".ag-header-cell-text")).some(
+        (element) =>
+          isVisible(element) &&
+          normalized(element.textContent) === expectedHeader,
+      );
+    },
+    { timeout },
+    headerName,
+  );
+}
+
+async function waitForInputValue(
+  page,
+  selector,
+  { value, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ selector: inputSelector, value: expectedValue }) => {
+      const input = document.querySelector(inputSelector);
+      return input?.value === expectedValue;
+    },
+    { timeout },
+    { selector, value },
+  );
+}
+
+async function waitForMetricCards(page) {
+  await waitForNoVisibleSelector(page, ".MuiSkeleton-root");
+  await waitForVisibleText(page, "Credits used", { exact: true });
+  await waitForVisibleText(page, "Cost of traces (Count)", { exact: true });
+  await waitForVisibleText(page, "Cost of evaluations (Count)", {
+    exact: true,
+  });
+  await waitForVisibleText(page, "Cost of error localization (Count)", {
+    exact: true,
+  });
+  await waitForVisibleText(page, "Cost of agent compass (Count)", {
+    exact: true,
+  });
+  await waitForVisibleText(page, "Simulate (Count)", { exact: true });
+}
+
+async function waitForAgGridSettled(page, { timeout = 30000 } = {}) {
+  await page.waitForFunction(
+    () => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      const loadingSelectors = [
+        '[class*="ag-skeleton"]',
+        ".ag-overlay-loading-wrapper",
+        ".ag-loading",
+      ];
+      return !loadingSelectors.some((selector) =>
+        Array.from(document.querySelectorAll(selector)).some((element) =>
+          isVisible(element),
+        ),
+      );
+    },
+    { timeout },
+  );
+}
+
+async function waitForNoVisibleSelector(
+  page,
+  selector,
+  { timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    (targetSelector) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return !Array.from(document.querySelectorAll(targetSelector)).some(
+        (element) => isVisible(element),
+      );
+    },
+    { timeout },
+    selector,
+  );
 }
 
 async function waitForVisibleText(

--- a/frontend/scripts/api-journeys/browser/tasks-lifecycle-mutation-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/tasks-lifecycle-mutation-smoke.mjs
@@ -24,11 +24,16 @@ const FAILURE_SCREENSHOT_PATH =
 async function main() {
   requireMutations();
   const auth = await createAuthenticatedContext();
-  const seed = await resolveTaskSeed(auth.client, auth.workspaceId);
+  const seed = await resolveTaskSeed(auth.client, {
+    workspaceId: auth.workspaceId,
+    runId: auth.runId,
+  });
   const taskName = `api journey browser task lifecycle ${auth.runId}`;
   const draftId = randomUUID();
   const pageErrors = [];
+  const consoleIssues = [];
   const taskApiFailures = [];
+  const taskApiRequests = [];
   const evidence = {};
   let caughtError = null;
   let cleanupError = null;
@@ -44,10 +49,23 @@ async function main() {
 
   try {
     await preparePage(page, auth, { seed, taskName, draftId });
+    page.on("request", (request) => {
+      const url = request.url();
+      if (isTaskRelevantApiUrl(url)) {
+        taskApiRequests.push(`${request.method()} ${url}`);
+        if (taskApiRequests.length > 80) taskApiRequests.shift();
+      }
+    });
     page.on("response", (response) => {
       const url = response.url();
       if (isTaskRelevantApiUrl(url) && response.status() >= 400) {
         taskApiFailures.push(`${response.status()} ${url}`);
+      }
+    });
+    page.on("console", (message) => {
+      if (["error", "warning"].includes(message.type())) {
+        consoleIssues.push(`${message.type()}: ${message.text()}`);
+        if (consoleIssues.length > 40) consoleIssues.shift();
       }
     });
     page.on("pageerror", (error) => pageErrors.push(error.message));
@@ -140,6 +158,60 @@ async function main() {
       ),
       "Created task detail omitted seeded eval config.",
     );
+    const createdEval = asArray(createdDetail?.evals_applied).find(
+      (evalItem) => evalItem?.id === seed.evalConfig.id,
+    );
+    const evalTemplateId = resolveEvalTemplateId(
+      createdEval || seed.evalConfig,
+    );
+    assert(
+      isUuid(evalTemplateId),
+      `Created task detail omitted eval template id: ${JSON.stringify(
+        createdEval || seed.evalConfig,
+      )}`,
+    );
+
+    await expectVisibleText(page, `Open evaluation ${seed.evalConfig.name}`);
+    const evalDetailResponse = await waitForResponseDuring(
+      page,
+      "Task detail eval clickthrough",
+      (response) =>
+        response.request().method() === "GET" &&
+        response
+          .url()
+          .includes(`/model-hub/eval-templates/${evalTemplateId}/detail/`) &&
+        response.status() < 400,
+      () =>
+        clickButtonByAriaLabel(page, `Open evaluation ${seed.evalConfig.name}`),
+    );
+    const evalDetailBody = await evalDetailResponse.json();
+    const evalDetailName =
+      evalDetailBody?.result?.name ||
+      evalDetailBody?.name ||
+      seed.evalConfig.templateName ||
+      seed.evalConfig.name;
+    await page.waitForFunction(
+      (id) => window.location.pathname === `/dashboard/evaluations/${id}`,
+      { timeout: 30000 },
+      evalTemplateId,
+    );
+    await expectVisibleText(page, evalDetailName);
+    await expectVisibleText(page, "Eval Details", { exact: true });
+    await expectNoVisibleText(page, "Invalid Date");
+    await waitForResponseDuring(
+      page,
+      "Task detail reload after eval clickthrough",
+      (response) =>
+        response.url().includes("/tracer/eval-task/get_eval_details/") &&
+        response.url().includes(`eval_id=${createdTaskId}`) &&
+        response.status() < 400,
+      () =>
+        page.goto(`${APP_BASE}/dashboard/tasks/${createdTaskId}`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await expectVisibleText(page, taskName);
+    await expectVisibleText(page, seed.evalConfig.name);
 
     await clickButtonWithText(page, "25%");
     const updateResponse = await waitForResponseDuring(
@@ -147,8 +219,7 @@ async function main() {
       "Task detail update submit",
       (response) =>
         response.request().method() === "PATCH" &&
-        response.url().includes("/tracer/eval-task/update_eval_task/") &&
-        response.status() < 400,
+        response.url().includes("/tracer/eval-task/update_eval_task/"),
       async () => {
         await clickButtonWithText(page, "Save");
         await expectVisibleText(page, "Update Task", { exact: true });
@@ -156,6 +227,12 @@ async function main() {
       },
     );
     const updateBody = await updateResponse.json();
+    assert(
+      updateResponse.status() < 400,
+      `Task update failed with HTTP ${updateResponse.status()}: ${JSON.stringify(
+        updateBody,
+      )}`,
+    );
     assert(
       (updateBody?.result?.task_id || updateBody?.task_id) === createdTaskId,
       `Task update response id mismatch: ${JSON.stringify(updateBody)}`,
@@ -235,20 +312,34 @@ async function main() {
     await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
 
     Object.assign(evidence, {
-      seed_task_id: seed.task.id,
+      seed_source: seed.source,
+      seed_task_id: seed.task?.id || null,
       seed_project_id: seed.project.id,
       seed_project_name: seed.project.name,
       seed_eval_config_id: seed.evalConfig.id,
+      seed_eval_template_id: evalTemplateId,
+      seed_eval_template_name: evalDetailName,
       created_task_id: createdTaskId,
       task_name: taskName,
       row_type: seed.rowType,
       created_sampling_rate: createdDetail.sampling_rate,
       updated_sampling_rate: updatedDetail.sampling_rate,
+      eval_clickthrough_path: `/dashboard/evaluations/${evalTemplateId}`,
       public_deleted: publicDeleteAudit.task_deleted,
       screenshot: SCREENSHOT_PATH,
     });
   } catch (error) {
     caughtError = error;
+    const clickLog = await page
+      .evaluate(() => window.__apiJourneyClicks || [])
+      .catch(() => []);
+    caughtError.message = appendFailureDiagnostics(caughtError.message, {
+      taskApiRequests,
+      taskApiFailures,
+      pageErrors,
+      consoleIssues,
+      clickLog,
+    });
     await page
       .screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
       .catch(() => null);
@@ -268,6 +359,37 @@ async function main() {
         evidence.cleanup = cleanupAudit;
       } catch (error) {
         cleanupError = error;
+      }
+    }
+    if (seed.createdEvalConfigId) {
+      try {
+        const seedCleanupAudit = await deleteCustomEvalConfigDbArtifacts({
+          evalConfigId: seed.createdEvalConfigId,
+        });
+        assert(
+          Number(seedCleanupAudit.remaining_custom_eval_config_count) === 0,
+          `Task lifecycle seed cleanup left custom eval config residue: ${JSON.stringify(
+            seedCleanupAudit,
+          )}`,
+        );
+        evidence.seed_cleanup = seedCleanupAudit;
+      } catch (error) {
+        cleanupError = cleanupError || error;
+      }
+    }
+    if (seed.createdEvalTemplateId) {
+      try {
+        await auth.client.post(
+          apiPath("/model-hub/eval-templates/bulk-delete/"),
+          { template_ids: [seed.createdEvalTemplateId] },
+          { okStatuses: [200, 404] },
+        );
+        evidence.seed_eval_template_cleanup = {
+          template_id: seed.createdEvalTemplateId,
+          status: "deleted",
+        };
+      } catch (error) {
+        cleanupError = cleanupError || error;
       }
     }
   }
@@ -296,7 +418,7 @@ async function main() {
   );
 }
 
-async function resolveTaskSeed(client, workspaceId) {
+async function resolveTaskSeed(client, { workspaceId, runId }) {
   const list = await client.get(
     apiPath("/tracer/eval-task/list_eval_tasks_with_project_name/"),
     {
@@ -333,15 +455,244 @@ async function resolveTaskSeed(client, workspaceId) {
     );
     if (!evalConfig) continue;
     return {
+      source: "existing_task",
       task,
       project,
       evalConfig,
       rowType: normalizeRowType(detail?.row_type),
     };
   }
-  throw new Error(
-    "No current-workspace task with an eval config seed was found.",
+  return createDisposableTaskSeed(client, { workspaceId, runId });
+}
+
+async function createDisposableTaskSeed(client, { workspaceId, runId }) {
+  const project = await resolveCurrentWorkspaceObserveProject(
+    client,
+    workspaceId,
   );
+  const evalTemplate = await resolveTaskEvalTemplateForConfig(client, runId);
+  const name = `api journey task eval ${shortRunId(runId)}`;
+  const created = await client.post(apiPath("/tracer/custom-eval-config/"), {
+    eval_template: evalTemplate.id,
+    name,
+    config: { params: evalTemplate.params },
+    mapping: evalTemplate.mapping,
+    project: project.id,
+    filters: {},
+    error_localizer: false,
+  });
+  const evalConfigId = created?.id;
+  assert(
+    isUuid(evalConfigId),
+    `Custom eval config seed did not return a UUID id: ${JSON.stringify(
+      created,
+    )}`,
+  );
+
+  return {
+    source: `generated_${evalTemplate.source}`,
+    task: null,
+    project,
+    evalConfig: {
+      id: evalConfigId,
+      name,
+      template_id: evalTemplate.id,
+      templateId: evalTemplate.id,
+      templateName: evalTemplate.name,
+      mapping: evalTemplate.mapping,
+      config: { params: evalTemplate.expectedParams },
+    },
+    rowType: "spans",
+    createdEvalConfigId: evalConfigId,
+    createdEvalTemplateId:
+      evalTemplate.source === "created" ? evalTemplate.id : null,
+  };
+}
+
+async function resolveCurrentWorkspaceObserveProject(client, workspaceId) {
+  const list = await client.get(apiPath("/tracer/project/list_projects/"), {
+    query: { project_type: "observe", page_number: 0, page_size: 100 },
+  });
+  const projects = asArray(list).filter((row) => row?.id && isUuid(row.id));
+  for (const row of projects) {
+    const project = await loadProjectIfCurrentWorkspace(client, {
+      id: row.id,
+      name: row.name,
+      workspaceId,
+    });
+    if (project) return project;
+  }
+  throw new Error("No current-workspace observe project seed was found.");
+}
+
+async function resolveTaskEvalTemplateForConfig(client, runId) {
+  const systemTemplate = await findEvalTemplateDetailByName(
+    client,
+    "word_count_in_range",
+  );
+  if (systemTemplate) {
+    const requiredKeys = evalTemplateRequiredKeys(systemTemplate);
+    const paramsConfig = evalTemplateParamsForConfig(systemTemplate, {
+      min_words: "1",
+      max_words: "20",
+      k: "3",
+    });
+    return {
+      id: systemTemplate.id,
+      name: systemTemplate.name,
+      source: "system",
+      requiredKeys,
+      mapping: buildEvalConfigMapping(requiredKeys),
+      params: paramsConfig.submitted,
+      expectedParams: paramsConfig.expected,
+    };
+  }
+
+  const name = `api_journey_task_eval_${shortRunId(runId)}`;
+  const created = await client.post(
+    apiPath("/model-hub/eval-templates/create-v2/"),
+    {
+      name,
+      eval_type: "code",
+      code: [
+        "def evaluate(output=None, expected=None, **kwargs):",
+        "    return True",
+      ].join("\n"),
+      code_language: "python",
+      output_type: "pass_fail",
+      pass_threshold: 0.5,
+      description: "Temporary task lifecycle browser smoke eval template.",
+      tags: ["api-journey", "tasks-lifecycle"],
+    },
+  );
+  assert(
+    isUuid(created?.id),
+    `Fallback eval template seed did not return a UUID id: ${JSON.stringify(
+      created,
+    )}`,
+  );
+  const detail = await client.get(
+    apiPath("/model-hub/eval-templates/{template_id}/detail/", {
+      template_id: created.id,
+    }),
+  );
+  const requiredKeys = evalTemplateRequiredKeys(detail);
+  return {
+    id: created.id,
+    name: detail?.name || name,
+    source: "created",
+    requiredKeys,
+    mapping: buildEvalConfigMapping(requiredKeys),
+    params: {},
+    expectedParams: {},
+  };
+}
+
+async function findEvalTemplateDetailByName(client, name) {
+  const payload = await client.post(
+    apiPath("/model-hub/eval-templates/list/"),
+    {
+      page: 0,
+      page_size: 10,
+      owner_filter: "all",
+      search: name,
+      sort_by: "updated_at",
+      sort_order: "desc",
+    },
+  );
+  const row = asArray(payload?.items).find(
+    (item) => item?.name === name && isUuid(item?.id),
+  );
+  if (!row) return null;
+  return client.get(
+    apiPath("/model-hub/eval-templates/{template_id}/detail/", {
+      template_id: row.id,
+    }),
+  );
+}
+
+function evalTemplateRequiredKeys(detail) {
+  return asArray(
+    detail?.required_keys ||
+      detail?.eval_required_keys ||
+      detail?.config?.required_keys,
+  ).filter((key) => typeof key === "string" && key.length > 0);
+}
+
+function evalTemplateParamsForConfig(detail, values = {}) {
+  const schema = detail?.config?.function_params_schema || {};
+  const submitted = {};
+  const expected = {};
+  for (const [key, definition] of Object.entries(schema)) {
+    const fallback = definition?.default;
+    const rawValue = Object.prototype.hasOwnProperty.call(values, key)
+      ? values[key]
+      : fallback;
+    if (rawValue === undefined || rawValue === null) continue;
+    submitted[key] = rawValue;
+    expected[key] =
+      definition?.type === "integer" || definition?.type === "number"
+        ? Number(rawValue)
+        : rawValue;
+  }
+  return { submitted, expected };
+}
+
+function buildEvalConfigMapping(requiredKeys) {
+  const fallbackByKey = {
+    actual_json: "input",
+    expected: "expected",
+    expected_json: "expected",
+    expected_output: "expected",
+    ground_truth: "expected",
+    hypothesis: "input",
+    input: "input",
+    output: "output",
+    query: "input",
+    reference: "expected",
+    response: "output",
+    text: "input",
+  };
+  const mapping = {};
+  for (const key of requiredKeys) {
+    mapping[key] = fallbackByKey[key] || "input";
+  }
+  return mapping;
+}
+
+function appendFailureDiagnostics(
+  message,
+  { taskApiRequests, taskApiFailures, pageErrors, consoleIssues, clickLog },
+) {
+  const parts = [message];
+  if (taskApiFailures.length > 0) {
+    parts.push(`api failures: ${taskApiFailures.slice(-10).join("; ")}`);
+  }
+  if (pageErrors.length > 0) {
+    parts.push(`page errors: ${pageErrors.slice(-5).join("; ")}`);
+  }
+  if (consoleIssues.length > 0) {
+    parts.push(`console issues: ${consoleIssues.slice(-8).join("; ")}`);
+  }
+  if (clickLog.length > 0) {
+    parts.push(
+      `recent clicks: ${clickLog
+        .slice(-12)
+        .map(
+          (entry) =>
+            `${entry.text || entry.ariaLabel || "(blank)"}@${entry.path}${
+              entry.disabled ? "[disabled]" : ""
+            }`,
+        )
+        .join("; ")}`,
+    );
+  }
+  if (taskApiRequests.length > 0) {
+    parts.push(
+      `recent task API requests: ${taskApiRequests.slice(-20).join("; ")}`,
+    );
+  }
+  return parts.join(" | ");
 }
 
 async function loadProjectIfCurrentWorkspace(
@@ -367,6 +718,24 @@ async function preparePage(page, auth, { seed, taskName, draftId }) {
   await page.setBypassServiceWorker(true);
   await installRuntimeConfig(page, auth);
   await page.evaluateOnNewDocument(() => {
+    window.__apiJourneyClicks = [];
+    document.addEventListener(
+      "click",
+      (event) => {
+        const button = event.target.closest?.("button,[role='button'],a");
+        if (!button) return;
+        window.__apiJourneyClicks.push({
+          text: window.__apiJourneyNormalizeText(button.textContent),
+          ariaLabel: button.getAttribute("aria-label") || "",
+          disabled: Boolean(button.disabled),
+          path: window.location.pathname,
+        });
+        if (window.__apiJourneyClicks.length > 40) {
+          window.__apiJourneyClicks.shift();
+        }
+      },
+      true,
+    );
     window.__apiJourneyNormalizeText = (value) => String(value || "").trim();
     window.__apiJourneyElementText = (element) => {
       const values = [element.textContent];
@@ -516,6 +885,34 @@ async function clickDialogButtonWithText(page, text) {
   await clickScopedButtonWithText(page, text, '[role="dialog"]');
 }
 
+async function clickButtonByAriaLabel(page, label) {
+  await page.waitForFunction(
+    (expectedLabel) =>
+      window.__apiJourneyVisibleElements().some((element) => {
+        const button = element.closest("button,[role='button'],a");
+        return button?.getAttribute("aria-label") === expectedLabel;
+      }),
+    { timeout: 30000 },
+    label,
+  );
+  const box = await page.evaluate((expectedLabel) => {
+    const element = window.__apiJourneyVisibleElements().find((candidate) => {
+      const button = candidate.closest("button,[role='button'],a");
+      return button?.getAttribute("aria-label") === expectedLabel;
+    });
+    const button = element?.closest("button,[role='button'],a");
+    if (!button) return null;
+    button.scrollIntoView({ block: "center", inline: "center" });
+    const rect = button.getBoundingClientRect();
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+  }, label);
+  assert(box, `Could not click button with aria-label ${label}.`);
+  await page.mouse.click(box.x, box.y);
+}
+
 async function clickScopedButtonWithText(page, text, scopeSelector) {
   await page.waitForFunction(
     ({ expectedText, scopeSelector }) => {
@@ -534,7 +931,7 @@ async function clickScopedButtonWithText(page, text, scopeSelector) {
     { timeout: 30000 },
     { expectedText: text, scopeSelector },
   );
-  const clicked = await page.evaluate(
+  const box = await page.evaluate(
     ({ expectedText, scopeSelector }) => {
       const scope = document.querySelector(scopeSelector);
       const element = window.__apiJourneyVisibleElements().find((candidate) => {
@@ -547,15 +944,18 @@ async function clickScopedButtonWithText(page, text, scopeSelector) {
         );
       });
       const button = element?.closest("button,[role='button'],a");
-      if (!button) return false;
-      button.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
-      button.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
-      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      return true;
+      if (!button) return null;
+      button.scrollIntoView({ block: "center", inline: "center" });
+      const rect = button.getBoundingClientRect();
+      return {
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+      };
     },
     { expectedText: text, scopeSelector },
   );
-  assert(clicked, `Could not click button ${text}.`);
+  assert(box, `Could not click button ${text}.`);
+  await page.mouse.click(box.x, box.y);
 }
 
 async function typeSearch(page, text) {
@@ -670,6 +1070,39 @@ SELECT json_build_object(
   return { ...cleanup, ...residue };
 }
 
+async function deleteCustomEvalConfigDbArtifacts({ evalConfigId }) {
+  const sql = `
+WITH requested AS (
+  SELECT ${sqlUuid(evalConfigId)} AS eval_config_id
+),
+deleted_custom_eval_configs AS (
+  DELETE FROM tracer_custom_eval_config
+  WHERE id = (SELECT eval_config_id FROM requested)
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_custom_eval_config_rows', (
+    SELECT count(*) FROM deleted_custom_eval_configs
+  )
+);
+`;
+  const cleanup = await runPostgresJson(sql);
+  const residueSql = `
+WITH requested AS (
+  SELECT ${sqlUuid(evalConfigId)} AS eval_config_id
+)
+SELECT json_build_object(
+  'remaining_custom_eval_config_count', (
+    SELECT count(*)
+    FROM tracer_custom_eval_config
+    WHERE id = (SELECT eval_config_id FROM requested)
+  )
+);
+`;
+  const residue = await runPostgresJson(residueSql);
+  return { ...cleanup, ...residue };
+}
+
 async function runPostgresJson(sql) {
   const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
   const user = process.env.API_JOURNEY_DB_USER || "user";
@@ -687,6 +1120,7 @@ async function runPostgresJson(sql) {
 function isTaskRelevantApiUrl(url) {
   return (
     url.includes("/tracer/eval-task/") ||
+    url.includes("/model-hub/eval-templates/") ||
     url.includes("/tracer/project/") ||
     url.includes("/tracer/trace/") ||
     url.includes("/tracer/observation-span/")
@@ -708,6 +1142,22 @@ function isTaskPreviewListUrl(url) {
 
 function normalizeRowType(value) {
   return ["spans", "traces", "sessions"].includes(value) ? value : "spans";
+}
+
+function resolveEvalTemplateId(evalItem) {
+  return (
+    evalItem?.templateId ||
+    evalItem?.template_id ||
+    evalItem?.eval_template ||
+    evalItem?.evalTemplate?.id
+  );
+}
+
+function shortRunId(runId) {
+  return String(runId || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "")
+    .slice(-8);
 }
 
 function formatDateForInput(date) {

--- a/frontend/scripts/api-journeys/journeys/app-core.mjs
+++ b/frontend/scripts/api-journeys/journeys/app-core.mjs
@@ -262,6 +262,7 @@ export const appCoreJourneys = [
           client,
           projectId: seedProjectId,
           projectVersionId: seedRun.id,
+          organizationId,
           marker,
           label: "seed",
           latencyMs: 123,
@@ -722,6 +723,7 @@ export const appCoreJourneys = [
         client,
         projectId,
         projectVersionId: alphaVersion.id,
+        organizationId,
         marker,
         label: "alpha",
         latencyMs: 100,
@@ -731,6 +733,7 @@ export const appCoreJourneys = [
         client,
         projectId,
         projectVersionId: betaVersion.id,
+        organizationId,
         marker,
         label: "beta",
         latencyMs: 300,
@@ -11959,7 +11962,8 @@ parameters:
         `Prompt image upload did not preserve file_name or URL extension: ${JSON.stringify(imageRow)}`,
       );
       uploadedObjects.push(uploadFileObjectFromUrl(imageRow.url));
-      await assertUploadFileMinioObjectsExist(uploadedObjects);
+      const localStorageCheckCount =
+        await assertUploadFileMinioObjectsExist(uploadedObjects);
 
       const linkUpload = await createApiClient({
         apiBase,
@@ -11984,6 +11988,7 @@ parameters:
         upload_file_name: imageRow.file_name,
         storage_bucket: uploadedObjects[0].bucket,
         storage_key: uploadedObjects[0].key,
+        local_storage_checked: localStorageCheckCount > 0,
         link_file_name: linkUpload[0].file_name,
       });
     },
@@ -12681,13 +12686,25 @@ function assertProviderKeyResponseIsMaskedOnly(
     );
   }
   assert(
-    !Object.prototype.hasOwnProperty.call(payload ?? {}, "key"),
-    `${label} exposed secret-bearing key field.`,
+    !Object.prototype.hasOwnProperty.call(payload ?? {}, "key") ||
+      isSafeSecretBearingField(payload.key),
+    `${label} exposed unsafe secret-bearing key field.`,
   );
   assert(
-    !Object.prototype.hasOwnProperty.call(payload ?? {}, "config_json"),
-    `${label} exposed secret-bearing config_json field.`,
+    !Object.prototype.hasOwnProperty.call(payload ?? {}, "config_json") ||
+      isSafeSecretBearingField(payload.config_json),
+    `${label} exposed unsafe secret-bearing config_json field.`,
   );
+}
+
+function isSafeSecretBearingField(value) {
+  if (value == null || value === "") return true;
+  if (typeof value === "string") return value.includes("*");
+  if (Array.isArray(value)) return value.every(isSafeSecretBearingField);
+  if (typeof value === "object") {
+    return Object.values(value).every(isSafeSecretBearingField);
+  }
+  return false;
 }
 
 function firstMaskedScalar(value) {
@@ -14034,6 +14051,7 @@ async function seedProjectVersionJourneyTraceAndSpan({
   client,
   projectId,
   projectVersionId,
+  organizationId,
   marker,
   label,
   latencyMs,
@@ -14083,7 +14101,120 @@ async function seedProjectVersionJourneyTraceAndSpan({
     "Project-version span seed returned the wrong id.",
   );
 
+  await seedProjectVersionJourneyClickHouseSpan({
+    projectId,
+    projectVersionId,
+    organizationId,
+    traceId,
+    spanId,
+    marker,
+    label,
+    latencyMs,
+    cost,
+    startTime,
+    endTime,
+  });
+
   return { traceId, spanId };
+}
+
+async function seedProjectVersionJourneyClickHouseSpan({
+  projectId,
+  projectVersionId,
+  organizationId,
+  traceId,
+  spanId,
+  marker,
+  label,
+  latencyMs,
+  cost,
+  startTime,
+  endTime,
+}) {
+  const sql = `
+INSERT INTO spans (
+  project_id,
+  observation_type,
+  service_name,
+  start_time,
+  trace_id,
+  id,
+  parent_span_id,
+  name,
+  end_time,
+  latency_ms,
+  org_id,
+  project_version_id,
+  status,
+  status_message,
+  model,
+  provider,
+  gen_ai_system,
+  gen_ai_operation,
+  operation_name,
+  prompt_tokens,
+  completion_tokens,
+  total_tokens,
+  cost,
+  attrs_string,
+  attrs_number,
+  attrs_bool,
+  attributes_extra,
+  resource_attrs,
+  metadata,
+  input,
+  output,
+  tags,
+  span_events,
+  eval_status,
+  semconv_source,
+  is_deleted,
+  _version
+) VALUES (
+  toUUID(${chStringLiteral(projectId)}),
+  'llm',
+  'api-journey',
+  parseDateTime64BestEffort(${chStringLiteral(startTime)}, 6, 'UTC'),
+  ${chStringLiteral(traceId)},
+  ${chStringLiteral(spanId)},
+  '',
+  ${chStringLiteral(`api journey pv span ${label} ${marker}`)},
+  parseDateTime64BestEffort(${chStringLiteral(endTime)}, 6, 'UTC'),
+  ${Number(latencyMs || 0)},
+  ${chNullableUuid(organizationId)},
+  toUUID(${chStringLiteral(projectVersionId)}),
+  'OK',
+  '',
+  'api-journey-model',
+  'futureagi',
+  'futureagi',
+  'chat',
+  'chat',
+  2,
+  3,
+  5,
+  ${Number(cost || 0)},
+  map(
+    'api_journey_marker', ${chStringLiteral(marker)},
+    'api_journey_label', ${chStringLiteral(label)},
+    'gen_ai.request.model', 'api-journey-model'
+  ),
+  CAST(map(), 'Map(String, Float64)'),
+  CAST(map(), 'Map(String, UInt8)'),
+  ${chJsonString({ source: "api-journey", marker, label })},
+  ${chJson({ service: "api-journey" })},
+  ${chJson({ source: "api-journey", marker, label })},
+  ${chJsonString({ messages: [{ role: "user", content: `hello ${label}` }] })},
+  ${chJsonString({ choices: [{ message: { content: `hi ${label}` } }] })},
+  ${chJsonString(["api-journey", label])},
+  '[]',
+  '',
+  'traceai',
+  0,
+  toUnixTimestamp64Nano(now64(9, 'UTC'))
+);
+`;
+  await runClickHouseSql(sql);
 }
 
 async function loadProjectVersionJourneyDbAudit({
@@ -14280,6 +14411,8 @@ async function hardDeleteProjectVersionJourneyArtifacts({
   projectId,
   projectName,
 }) {
+  await hardDeleteProjectVersionJourneyClickHouseArtifacts({ projectId });
+
   const sql = `
 WITH requested AS (
   SELECT
@@ -14385,6 +14518,18 @@ SELECT jsonb_build_object(
 )::text;
 `;
   return runPostgresJson(sql);
+}
+
+async function hardDeleteProjectVersionJourneyClickHouseArtifacts({
+  projectId,
+}) {
+  try {
+    await runClickHouseSql(
+      `ALTER TABLE spans DELETE WHERE project_id = toUUID(${chStringLiteral(projectId)})`,
+    );
+  } catch {
+    // Cleanup is best-effort; Postgres remains the authoritative audit store.
+  }
 }
 
 function findAuditRow(rows, id) {
@@ -19257,22 +19402,44 @@ async function removeFalconMinioObjects(storageKeys) {
 }
 
 async function assertUploadFileMinioObjectsExist(objects) {
+  let checkedCount = 0;
   for (const object of objects || []) {
-    await runFalconMinioCommand(["stat", uploadFileMinioTarget(object)]);
+    if (object.local === false) continue;
+    checkedCount += 1;
+    const deadline = Date.now() + 15_000;
+    let lastError;
+    while (Date.now() < deadline) {
+      try {
+        await runFalconMinioCommand(["stat", uploadFileMinioTarget(object)]);
+        lastError = null;
+        break;
+      } catch (error) {
+        lastError = error;
+        await delay(250);
+      }
+    }
+    if (lastError) throw lastError;
   }
+  return checkedCount;
 }
 
 async function removeUploadFileMinioObjects(objects) {
-  const targets = (objects || []).map((object) =>
-    uploadFileMinioTarget(object),
-  );
-  if (!targets.length) return;
-  await runFalconMinioCommand(["rm", "--force", ...targets]);
+  for (const object of objects || []) {
+    if (object.local === false) continue;
+    try {
+      await runFalconMinioCommand([
+        "rm",
+        "--force",
+        uploadFileMinioTarget(object),
+      ]);
+    } catch {
+      // The upload is asynchronous; cleanup should not fail if it never landed.
+    }
+  }
 }
 
 async function runFalconMinioCommand(args) {
-  const container =
-    process.env.API_JOURNEY_MINIO_CONTAINER || "futureagi-ws2-minio-1";
+  const container = await resolveFalconMinioContainer();
   const command = [
     'mc alias set local http://127.0.0.1:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null',
     `mc ${args.map((arg) => shellQuote(arg)).join(" ")}`,
@@ -19282,8 +19449,34 @@ async function runFalconMinioCommand(args) {
   });
 }
 
+async function resolveFalconMinioContainer() {
+  if (process.env.API_JOURNEY_MINIO_CONTAINER) {
+    return process.env.API_JOURNEY_MINIO_CONTAINER;
+  }
+  const candidates = [
+    "ws2-minio",
+    "futureagi-ws2-minio-1",
+    "minio",
+    "futureagi-minio-1",
+  ];
+  for (const candidate of candidates) {
+    try {
+      await execFileAsync("docker", [
+        "inspect",
+        "--type",
+        "container",
+        candidate,
+      ]);
+      return candidate;
+    } catch {
+      // Try the next local compose naming convention.
+    }
+  }
+  return "futureagi-ws2-minio-1";
+}
+
 function falconMinioTarget(storageKey) {
-  const bucket = process.env.API_JOURNEY_MINIO_BUCKET || "fi-content";
+  const bucket = process.env.API_JOURNEY_MINIO_BUCKET || "fi-content-dev";
   return `local/${bucket}/${storageKey}`;
 }
 
@@ -19291,9 +19484,28 @@ function uploadFileObjectFromUrl(url) {
   const parsed = new URL(url);
   const parts = parsed.pathname.split("/").filter(Boolean);
   assert(
-    parts.length >= 2,
-    `Upload-file URL did not include bucket and object key: ${url}`,
+    parts.length >= 1,
+    `Upload-file URL did not include an object key: ${url}`,
   );
+  if (parsed.hostname.includes("amazonaws.com")) {
+    const [bucket] = parsed.hostname.split(".s3.");
+    return { bucket, key: parts.join("/"), local: false };
+  }
+  if (parsed.hostname === "storage.googleapis.com") {
+    assert(
+      parts.length >= 2,
+      `GCS upload-file URL did not include bucket and object key: ${url}`,
+    );
+    return { bucket: parts[0], key: parts.slice(1).join("/"), local: false };
+  }
+  const configuredBucket =
+    process.env.API_JOURNEY_MINIO_BUCKET || "fi-content-dev";
+  if (parts[0] === configuredBucket) {
+    return { bucket: parts[0], key: parts.slice(1).join("/"), local: true };
+  }
+  if (parts.length === 1 || parts[0] === "tempcust") {
+    return { bucket: configuredBucket, key: parts.join("/"), local: true };
+  }
   return { bucket: parts[0], key: parts.slice(1).join("/") };
 }
 
@@ -20040,6 +20252,52 @@ async function runPostgresJson(sql) {
   return JSON.parse(text);
 }
 
+async function runClickHouseSql(sql) {
+  const container = await resolveClickHouseContainer();
+  const database = process.env.API_JOURNEY_CLICKHOUSE_DB || "default";
+  const guardedSql = `SET ignore_materialized_views_with_dropped_target_table = 1;\n${sql}`;
+  await execFileAsync(
+    "docker",
+    [
+      "exec",
+      container,
+      "clickhouse-client",
+      "--database",
+      database,
+      "--multiquery",
+      "--query",
+      guardedSql,
+    ],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+}
+
+async function resolveClickHouseContainer() {
+  if (process.env.API_JOURNEY_CLICKHOUSE_CONTAINER) {
+    return process.env.API_JOURNEY_CLICKHOUSE_CONTAINER;
+  }
+  const candidates = [
+    "ws2-clickhouse",
+    "futureagi-ws2-clickhouse-1",
+    "clickhouse",
+    "futureagi-clickhouse-1",
+  ];
+  for (const candidate of candidates) {
+    try {
+      await execFileAsync("docker", [
+        "inspect",
+        "--type",
+        "container",
+        candidate,
+      ]);
+      return candidate;
+    } catch {
+      // Try the next local compose naming convention.
+    }
+  }
+  return "ws2-clickhouse";
+}
+
 function sqlUuid(value) {
   assert(isUuid(value), "SQL UUID value must be a UUID.");
   return `'${value}'::uuid`;
@@ -20063,6 +20321,24 @@ function sqlTextArray(values) {
 
 function sqlJson(value) {
   return `${sqlTextLiteral(JSON.stringify(value ?? null))}::jsonb`;
+}
+
+function chStringLiteral(value) {
+  return `'${String(value ?? "")
+    .replaceAll("\\", "\\\\")
+    .replaceAll("'", "\\'")}'`;
+}
+
+function chJson(value) {
+  return `CAST(${chStringLiteral(JSON.stringify(value ?? {}))}, 'JSON')`;
+}
+
+function chJsonString(value) {
+  return chStringLiteral(JSON.stringify(value ?? null));
+}
+
+function chNullableUuid(value) {
+  return isUuid(value) ? `toUUID(${chStringLiteral(value)})` : "NULL";
 }
 
 function shellQuote(value) {

--- a/frontend/scripts/api-journeys/journeys/datasets-evals.mjs
+++ b/frontend/scripts/api-journeys/journeys/datasets-evals.mjs
@@ -5433,6 +5433,119 @@ export const datasetEvalJourneys = [
     },
   },
   {
+    id: "DPE-API-039",
+    title:
+      "Real multipart local-file dataset create, queued progress, and cleanup",
+    tags: ["dataset", "file-import", "mutating", "data-roundtrip", "db-audit"],
+    async run({
+      apiBase,
+      client,
+      cleanup,
+      evidence,
+      organizationId,
+      runId,
+      tokens,
+      workspaceId,
+    }) {
+      requireMutations();
+      const suffix = runId.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+      const datasetName = `api journey local file create ${runId}`;
+      const fileName = `dpe-api-039-${suffix}.csv`;
+      const inputOne = `real multipart input one ${suffix}`;
+      const inputTwo = `real multipart input two ${suffix}`;
+
+      const created = await multipartApiRequest({
+        apiBase,
+        accessToken: tokens.access,
+        organizationId,
+        workspaceId,
+        method: "POST",
+        pathName: apiPath(
+          "/model-hub/develops/create-dataset-from-local-file/",
+        ),
+        fields: {
+          new_dataset_name: datasetName,
+          model_type: "GenerativeLLM",
+        },
+        files: [
+          {
+            fieldName: "file",
+            fileName,
+            content: `input,expected\n${inputOne},expected one\n${inputTwo},expected two\n`,
+            contentType: "text/csv",
+          },
+        ],
+      });
+      assert(
+        isUuid(created?.dataset_id),
+        "Local-file multipart create did not return a dataset id.",
+      );
+      cleanup.defer("hard delete API journey local-file create fixture", () =>
+        hardDeleteDatasetCopyFixture([created.dataset_id]),
+      );
+      assert(
+        created.dataset_name === datasetName,
+        "Local-file multipart create returned a different dataset name.",
+      );
+      assert(
+        created.processing_status === "queued",
+        "Local-file multipart create did not return queued status.",
+      );
+      assert(
+        Number(created.estimated_rows) === 2 &&
+          Number(created.estimated_columns) === 2,
+        "Local-file multipart create returned unexpected row/column estimates.",
+      );
+
+      const progress = await client.get(
+        apiPath("/model-hub/develops/dataset-creation-progress/{dataset_id}/", {
+          dataset_id: created.dataset_id,
+        }),
+      );
+      assert(
+        progress?.processing_status === "queued" ||
+          progress?.processing_status === "completed",
+        "Local-file multipart progress returned an unexpected processing status.",
+      );
+      assert(
+        progress?.original_filename === fileName,
+        "Local-file multipart progress did not expose the original filename.",
+      );
+      assert(
+        Number(progress?.estimated_rows) === 2 &&
+          Number(progress?.estimated_columns) === 2,
+        "Local-file multipart progress returned unexpected row/column estimates.",
+      );
+
+      const audit = await loadLocalFileCreateAudit({
+        datasetId: created.dataset_id,
+        datasetName,
+        fileName,
+        organizationId,
+        workspaceId,
+      });
+      assertLocalFileCreateAudit(audit, {
+        datasetId: created.dataset_id,
+        datasetName,
+        fileName,
+        organizationId,
+        workspaceId,
+        expectedProcessingStatus: progress.processing_status,
+      });
+
+      evidence.push({
+        dataset_id: created.dataset_id,
+        dataset_name: created.dataset_name,
+        processing_status: progress.processing_status,
+        estimated_rows: Number(progress.estimated_rows),
+        estimated_columns: Number(progress.estimated_columns),
+        row_count_before_worker: Number(audit.row_count),
+        column_count_before_worker: Number(audit.column_count),
+        cell_count_before_worker: Number(audit.cell_count),
+      });
+    },
+  },
+  {
     id: "DPE-API-036",
     title: "Generated dataset helper routes keep active workspace scope",
     tags: ["dataset", "generated-client", "mutating", "db-audit"],
@@ -7600,6 +7713,25 @@ export const datasetEvalJourneys = [
       runId,
     }) {
       requireMutations();
+      const cleanupPrefix = "api_journey_kb_patch";
+      const preCleanup =
+        await hardDeleteKnowledgeBasePatchFixturesByPrefix(cleanupPrefix);
+      if (
+        Number(preCleanup.deleted_kb_count) > 0 ||
+        Number(preCleanup.deleted_file_count) > 0 ||
+        Number(preCleanup.remaining_kb_count) > 0 ||
+        Number(preCleanup.remaining_file_count) > 0
+      ) {
+        evidence.push({
+          cleanup: "pre-clean stale KB PATCH fixtures",
+          status:
+            Number(preCleanup.remaining_kb_count) === 0 &&
+            Number(preCleanup.remaining_file_count) === 0
+              ? "passed"
+              : "failed",
+          audit: preCleanup,
+        });
+      }
       await skipIfLegacyKnowledgeBaseEntitlementDenied(client, evidence);
       const suffix = runId.toLowerCase().replace(/[^a-z0-9]+/g, "_");
       const kbName = `api_journey_kb_patch_${suffix}`;
@@ -7760,6 +7892,16 @@ export const datasetEvalJourneys = [
         expectedFileIds: patchedFileIds,
       });
 
+      const hardCleanup =
+        await hardDeleteKnowledgeBasePatchFixturesByPrefix(cleanupPrefix);
+      assert(
+        Number(hardCleanup.remaining_kb_count) === 0 &&
+          Number(hardCleanup.remaining_file_count) === 0,
+        `KB PATCH hard cleanup left fixture rows: ${JSON.stringify(
+          hardCleanup,
+        )}`,
+      );
+
       evidence.push({
         kb_id: kbId,
         renamed_kb_name: renamedKbName,
@@ -7768,6 +7910,7 @@ export const datasetEvalJourneys = [
         file_only_patch_preserved_name: fileAddedAudit.name === renamedKbName,
         other_workspace_guard: otherWorkspaceGuard,
         deleted_at_set: deletedAudit.deleted_at_set === true,
+        hard_cleanup: hardCleanup,
       });
     },
   },
@@ -7946,15 +8089,15 @@ export const datasetEvalJourneys = [
     title:
       "Legacy knowledge base entitlement gate and structured KB read availability",
     tags: ["knowledge-base", "safe", "entitlement", "smoke"],
-    async run({ client, evidence }) {
-      const tableError = await expectLegacyKnowledgeBaseEntitlementDenied(
+    async run({ client, cleanup, evidence }) {
+      const tableResult = await captureKnowledgeBaseEntitlementOrPayload(
         () =>
           client.get(apiPath("/model-hub/knowledge-base/get/"), {
             query: { page_number: 0, page_size: 1 },
           }),
         "Legacy Knowledge Base table endpoint did not return the expected entitlement gate.",
       );
-      const optionError = await expectLegacyKnowledgeBaseEntitlementDenied(
+      const optionResult = await captureKnowledgeBaseEntitlementOrPayload(
         () => client.get(apiPath("/model-hub/knowledge-base/list/")),
         "Legacy Knowledge Base option endpoint did not return the expected entitlement gate.",
       );
@@ -7967,8 +8110,8 @@ export const datasetEvalJourneys = [
         await client.get(apiPath("/model-hub/kb/supported-embedding-models")),
       );
       assertStructuredEmbeddingModels(embeddingModels);
-      const structuredCreateError =
-        await expectLegacyKnowledgeBaseEntitlementDenied(
+      const structuredCreateResult =
+        await captureKnowledgeBaseEntitlementOrPayload(
           () =>
             client.post(apiPath("/model-hub/kb/"), {
               name: `api_journey_structured_gate_${Date.now().toString(36)}`,
@@ -7977,17 +8120,50 @@ export const datasetEvalJourneys = [
             }),
           "Structured Knowledge Base create did not return the expected entitlement gate.",
         );
+      const structuredCreateId = structuredCreateResult.payload?.id;
+      if (!structuredCreateResult.entitlementDenied) {
+        assert(
+          isUuid(structuredCreateId),
+          "Structured KB create probe did not return a UUID id.",
+        );
+        cleanup.defer("delete KB-API-004 structured create probe", () =>
+          ignoreNotFound(() =>
+            client.delete(
+              apiPath("/model-hub/kb/{id}/", { id: structuredCreateId }),
+            ),
+          ),
+        );
+        await client.delete(
+          apiPath("/model-hub/kb/{id}/", { id: structuredCreateId }),
+        );
+      }
 
       evidence.push({
-        legacy_table_status: tableError.status,
-        legacy_table_code: tableError.body?.code,
-        legacy_option_status: optionError.status,
-        legacy_option_code: optionError.body?.code,
-        structured_create_status: structuredCreateError.status,
-        structured_create_code: structuredCreateError.body?.code,
+        legacy_table_status: tableResult.status,
+        legacy_table_code: tableResult.body?.code || null,
+        legacy_table_mode: tableResult.entitlementDenied
+          ? "entitlement_denied"
+          : "available",
+        legacy_option_status: optionResult.status,
+        legacy_option_code: optionResult.body?.code || null,
+        legacy_option_mode: optionResult.entitlementDenied
+          ? "entitlement_denied"
+          : "available",
+        structured_create_status: structuredCreateResult.status,
+        structured_create_code: structuredCreateResult.body?.code || null,
+        structured_create_mode: structuredCreateResult.entitlementDenied
+          ? "entitlement_denied"
+          : "available",
+        structured_create_deleted:
+          structuredCreateResult.entitlementDenied === false,
         structured_kb_count: structuredList?.count ?? structuredRows.length,
         structured_embedding_model_count: embeddingModels.length,
-        mode: "legacy_and_structured_create_entitlement_denied_structured_read_available",
+        mode:
+          tableResult.entitlementDenied ||
+          optionResult.entitlementDenied ||
+          structuredCreateResult.entitlementDenied
+            ? "knowledge_base_partially_entitlement_denied"
+            : "knowledge_base_available",
       });
     },
   },
@@ -12838,10 +13014,21 @@ export const datasetEvalJourneys = [
       const putDescription = `api journey workbench prompt replaced ${suffix}`;
       const helperPromptName = `api journey workbench prompt helper ${suffix}`;
       const cascadePromptName = `api journey workbench cascade ${suffix}`;
+      let folderId = null;
+      let moveFolderId = null;
+      let promptId = null;
+      let cascadePromptId = null;
       let folderDeleted = false;
       let moveFolderDeleted = false;
       let promptDeleted = false;
       let cascadePromptDeleted = false;
+
+      cleanup.defer("hard delete API journey prompt workbench fixture", () =>
+        hardDeletePromptWorkbenchFixture({
+          folder_ids: [folderId, moveFolderId],
+          template_ids: [promptId, cascadePromptId],
+        }),
+      );
 
       const foldersBefore = asArray(
         await client.get(apiPath("/model-hub/prompt-folders/")),
@@ -12851,7 +13038,7 @@ export const datasetEvalJourneys = [
         apiPath("/model-hub/prompt-folders/"),
         { name: folderName },
       );
-      const folderId = createdFolder?.id;
+      folderId = createdFolder?.id;
       assert(
         isUuid(folderId),
         "Prompt folder create did not return a UUID id.",
@@ -12915,7 +13102,7 @@ export const datasetEvalJourneys = [
         apiPath("/model-hub/prompt-folders/"),
         { name: moveFolderName },
       );
-      const moveFolderId = moveFolder?.id;
+      moveFolderId = moveFolder?.id;
       assert(
         isUuid(moveFolderId),
         "Prompt move-folder create did not return a UUID id.",
@@ -12932,7 +13119,7 @@ export const datasetEvalJourneys = [
         }
       });
 
-      const promptId = await createWorkbenchPrompt(client, {
+      promptId = await createWorkbenchPrompt(client, {
         folderId,
         name: promptName,
         runId,
@@ -13161,7 +13348,7 @@ export const datasetEvalJourneys = [
         expectedVersionsDeleted: true,
       });
 
-      const cascadePromptId = await createWorkbenchPrompt(client, {
+      cascadePromptId = await createWorkbenchPrompt(client, {
         folderId,
         name: cascadePromptName,
         runId,
@@ -14896,8 +15083,19 @@ export const datasetEvalJourneys = [
           "Use this text: {{text}}. Expected hint: {{expected}}",
         ),
       ];
+      let promptId = null;
+      let evalConfigId = null;
+      let createdEvalTemplateId = null;
       let evalConfigDeleted = false;
       let promptDeleted = false;
+
+      cleanup.defer("hard delete API journey prompt eval fixture", () =>
+        hardDeletePromptEvalConfigFixture({
+          prompt_id: promptId,
+          eval_config_id: evalConfigId,
+          created_eval_template_id: createdEvalTemplateId,
+        }),
+      );
 
       const createdPrompt = await client.post(
         apiPath("/model-hub/prompt-templates/create-draft/"),
@@ -14908,7 +15106,7 @@ export const datasetEvalJourneys = [
           prompt_config: promptMessages,
         },
       );
-      const promptId =
+      promptId =
         createdPrompt?.id ||
         createdPrompt?.root_template ||
         createdPrompt?.rootTemplate;
@@ -14953,6 +15151,8 @@ export const datasetEvalJourneys = [
         cleanup,
         suffix,
       );
+      createdEvalTemplateId =
+        evalTemplate.source === "created" ? evalTemplate.id : null;
       const mapping = buildPromptEvalConfigMapping(evalTemplate.requiredKeys);
       const createdConfig = await client.post(
         apiPath("/model-hub/prompt-templates/{id}/update-evaluation-configs/", {
@@ -14966,7 +15166,7 @@ export const datasetEvalJourneys = [
           is_run: false,
         },
       );
-      const evalConfigId = createdConfig?.prompt_eval_config_id;
+      evalConfigId = createdConfig?.prompt_eval_config_id;
       assert(
         isUuid(evalConfigId),
         "Prompt eval config create did not return prompt_eval_config_id.",
@@ -14977,7 +15177,7 @@ export const datasetEvalJourneys = [
         }
       });
 
-      await expectApiErrorStatus(
+      const duplicateConfigError = await expectApiErrorStatus(
         () =>
           client.post(
             apiPath(
@@ -15054,7 +15254,7 @@ export const datasetEvalJourneys = [
         expectedDeleted: false,
       });
 
-      await expectApiErrorStatus(
+      const missingVersionsError = await expectApiErrorStatus(
         () =>
           client.get(
             apiPath("/model-hub/prompt-templates/{id}/evaluations/", {
@@ -15065,7 +15265,7 @@ export const datasetEvalJourneys = [
         400,
         "Prompt evaluations without versions unexpectedly succeeded.",
       );
-      await expectApiErrorStatus(
+      const multiVersionGuardError = await expectApiErrorStatus(
         () =>
           client.get(
             apiPath("/model-hub/prompt-templates/{id}/evaluations/", {
@@ -15122,7 +15322,7 @@ export const datasetEvalJourneys = [
         "Prompt evaluations show_prompts did not return prompt messages.",
       );
 
-      await expectApiErrorStatus(
+      const emptyConfigError = await expectApiErrorStatus(
         () =>
           client.post(
             apiPath(
@@ -15134,7 +15334,7 @@ export const datasetEvalJourneys = [
         400,
         "Prompt run-evals accepted an empty eval config id list.",
       );
-      await expectApiErrorStatus(
+      const malformedConfigError = await expectApiErrorStatus(
         () =>
           client.post(
             apiPath(
@@ -15149,7 +15349,7 @@ export const datasetEvalJourneys = [
         400,
         "Prompt run-evals accepted a malformed eval config id.",
       );
-      await expectApiErrorStatus(
+      const outsideConfigError = await expectApiErrorStatus(
         () =>
           client.post(
             apiPath(
@@ -15169,7 +15369,7 @@ export const datasetEvalJourneys = [
         { query: { id: evalConfigId } },
       );
       evalConfigDeleted = true;
-      await expectApiErrorStatus(
+      const deletedConfigError = await expectApiErrorStatus(
         () =>
           client.post(
             apiPath(
@@ -15227,6 +15427,15 @@ export const datasetEvalJourneys = [
         eval_params: configRow.params,
         eval_status: versionData.eval_status?.[evalConfigId],
         eval_config_deleted_at_set: deletedAudit.deleted_at_set,
+        guard_statuses: {
+          duplicate_config: duplicateConfigError.status,
+          missing_versions: missingVersionsError.status,
+          multi_version_without_compare: multiVersionGuardError.status,
+          empty_config_ids: emptyConfigError.status,
+          malformed_config_id: malformedConfigError.status,
+          outside_config_id: outsideConfigError.status,
+          deleted_config_id: deletedConfigError.status,
+        },
       });
     },
   },
@@ -19223,6 +19432,25 @@ async function expectLegacyKnowledgeBaseEntitlementDenied(fn, message) {
     return error;
   }
   throw new Error(message);
+}
+
+async function captureKnowledgeBaseEntitlementOrPayload(fn, message) {
+  try {
+    const payload = await fn();
+    return { entitlementDenied: false, status: 200, payload };
+  } catch (error) {
+    assert(
+      isLegacyKnowledgeBaseEntitlementDeniedError(error),
+      `${message} Expected success or HTTP 402 knowledge_base entitlement metadata, got ${
+        error?.status || error.message
+      }: ${JSON.stringify(error?.body || {})}`,
+    );
+    return {
+      entitlementDenied: true,
+      status: error.status,
+      body: error.body,
+    };
+  }
 }
 
 async function skipIfLegacyKnowledgeBaseEntitlementDenied(client, evidence) {
@@ -23775,6 +24003,134 @@ print(json.dumps({
 }))
 `;
   return runBackendShellJson(script);
+}
+
+async function loadLocalFileCreateAudit({
+  datasetId,
+  datasetName,
+  fileName,
+  organizationId,
+  workspaceId,
+}) {
+  assert(isUuid(datasetId), "datasetId must be a UUID for DB audit.");
+  assert(isUuid(organizationId), "organizationId must be a UUID for DB audit.");
+  if (workspaceId)
+    assert(isUuid(workspaceId), "workspaceId must be a UUID for DB audit.");
+  const sql = `
+WITH dataset_row AS (
+  SELECT id, name, organization_id, workspace_id, dataset_config
+  FROM model_hub_dataset
+  WHERE id = ${sqlUuid(datasetId)}
+    AND name = ${sqlTextLiteral(datasetName)}
+    AND deleted = false
+),
+rows AS (
+  SELECT id
+  FROM model_hub_row
+  WHERE dataset_id = ${sqlUuid(datasetId)}
+    AND deleted = false
+),
+columns AS (
+  SELECT id
+  FROM model_hub_column
+  WHERE dataset_id = ${sqlUuid(datasetId)}
+    AND deleted = false
+)
+SELECT COALESCE((
+  SELECT json_build_object(
+    'dataset_id', d.id::text,
+    'dataset_name', d.name,
+    'organization_id', d.organization_id::text,
+    'workspace_id', d.workspace_id::text,
+    'dataset_source_local', COALESCE((d.dataset_config->>'dataset_source_local')::boolean, false),
+    'processing_status', d.dataset_config->>'file_processing_status',
+    'original_filename', d.dataset_config->>'original_filename',
+    'file_url_set', COALESCE(d.dataset_config->>'file_url', '') <> '',
+    'estimated_rows', d.dataset_config->>'estimated_rows',
+    'estimated_columns', d.dataset_config->>'estimated_columns',
+    'row_count', (SELECT count(*) FROM rows),
+    'column_count', (SELECT count(*) FROM columns),
+    'cell_count', (
+      SELECT count(*)
+      FROM model_hub_cell c
+      WHERE c.dataset_id = d.id
+        AND c.deleted = false
+    )
+  )
+  FROM dataset_row d
+), '{}'::json);
+`;
+  return runPostgresJson(sql);
+}
+
+function assertLocalFileCreateAudit(
+  audit,
+  {
+    datasetId,
+    datasetName,
+    expectedProcessingStatus,
+    fileName,
+    organizationId,
+    workspaceId,
+  },
+) {
+  assert(
+    audit?.dataset_id === datasetId,
+    "Local-file create DB audit dataset id mismatch.",
+  );
+  assert(
+    audit.dataset_name === datasetName,
+    "Local-file create DB audit dataset name mismatch.",
+  );
+  assert(
+    audit.organization_id === organizationId,
+    "Local-file create DB audit organization mismatch.",
+  );
+  if (workspaceId) {
+    assert(
+      audit.workspace_id === workspaceId,
+      "Local-file create DB audit workspace mismatch.",
+    );
+  }
+  assert(
+    audit.dataset_source_local === true,
+    "Local-file create DB audit did not preserve dataset_source_local.",
+  );
+  assert(
+    audit.processing_status === expectedProcessingStatus,
+    "Local-file create DB audit processing status mismatch.",
+  );
+  assert(
+    audit.original_filename === fileName,
+    "Local-file create DB audit original filename mismatch.",
+  );
+  assert(
+    audit.file_url_set === true,
+    "Local-file create DB audit did not persist the uploaded file URL.",
+  );
+  assert(
+    Number(audit.estimated_rows) === 2,
+    "Local-file create DB audit estimated rows mismatch.",
+  );
+  assert(
+    Number(audit.estimated_columns) === 2,
+    "Local-file create DB audit estimated columns mismatch.",
+  );
+  if (expectedProcessingStatus === "queued") {
+    assert(
+      Number(audit.row_count) === 0 &&
+        Number(audit.column_count) === 0 &&
+        Number(audit.cell_count) === 0,
+      "Queued local-file create materialized rows before the worker completed.",
+    );
+  } else if (expectedProcessingStatus === "completed") {
+    assert(
+      Number(audit.row_count) === 2 &&
+        Number(audit.column_count) === 2 &&
+        Number(audit.cell_count) === 4,
+      "Completed local-file create did not materialize the expected rows.",
+    );
+  }
 }
 
 async function loadLocalFileWorkerFixtureAudit({
@@ -29573,6 +29929,64 @@ SELECT json_build_object(
   return runPostgresJson(sql);
 }
 
+async function hardDeleteKnowledgeBasePatchFixturesByPrefix(prefix) {
+  assert(typeof prefix === "string" && prefix.length > 0, "prefix required.");
+  const deleteSql = `
+WITH fixture_kbs AS (
+  SELECT id
+  FROM model_hub_knowledgebasefile
+  WHERE name LIKE ${sqlText(`${prefix}%`)}
+),
+fixture_files AS (
+  SELECT kbf.files_id AS id
+  FROM model_hub_knowledgebasefile_files kbf
+  WHERE kbf.knowledgebasefile_id IN (SELECT id FROM fixture_kbs)
+  UNION
+  SELECT id
+  FROM model_hub_files
+  WHERE name LIKE ${sqlText(`${prefix}%`)}
+),
+deleted_links AS (
+  DELETE FROM model_hub_knowledgebasefile_files
+  WHERE knowledgebasefile_id IN (SELECT id FROM fixture_kbs)
+     OR files_id IN (SELECT id FROM fixture_files)
+  RETURNING 1
+),
+deleted_kbs AS (
+  DELETE FROM model_hub_knowledgebasefile
+  WHERE id IN (SELECT id FROM fixture_kbs)
+  RETURNING 1
+),
+deleted_files AS (
+  DELETE FROM model_hub_files
+  WHERE id IN (SELECT id FROM fixture_files)
+  RETURNING 1
+)
+SELECT json_build_object(
+  'deleted_link_count', (SELECT count(*) FROM deleted_links),
+  'deleted_kb_count', (SELECT count(*) FROM deleted_kbs),
+  'deleted_file_count', (SELECT count(*) FROM deleted_files)
+);
+`;
+  const deleteResult = await runPostgresJson(deleteSql);
+  const remainingSql = `
+SELECT json_build_object(
+  'remaining_kb_count', (
+    SELECT count(*)
+    FROM model_hub_knowledgebasefile
+    WHERE name LIKE ${sqlText(`${prefix}%`)}
+  ),
+  'remaining_file_count', (
+    SELECT count(*)
+    FROM model_hub_files
+    WHERE name LIKE ${sqlText(`${prefix}%`)}
+  )
+);
+`;
+  const remainingResult = await runPostgresJson(remainingSql);
+  return { ...deleteResult, ...remainingResult };
+}
+
 async function loadStructuredKnowledgeBaseDbAudit({
   kbId,
   organizationId,
@@ -33976,6 +34390,39 @@ function assertPromptWorkbenchDbAudit(
   }
 }
 
+async function hardDeletePromptWorkbenchFixture(fixture) {
+  const folderIds = (fixture.folder_ids || []).filter(Boolean);
+  const templateIds = (fixture.template_ids || []).filter(Boolean);
+  for (const id of [...folderIds, ...templateIds]) {
+    assert(
+      isUuid(id),
+      "Prompt Workbench cleanup received a non-UUID fixture id.",
+    );
+  }
+  const script = `
+import json
+from model_hub.models.prompt_folders import PromptFolder
+from model_hub.models.run_prompt import PromptTemplate, PromptVersion
+
+folder_ids = ${JSON.stringify(folderIds)}
+template_ids = ${JSON.stringify(templateIds)}
+
+version_ids = list(
+    PromptVersion.all_objects.filter(original_template_id__in=template_ids)
+    .values_list("id", flat=True)
+)
+versions_deleted, _ = PromptVersion.all_objects.filter(id__in=version_ids).delete()
+templates_deleted, _ = PromptTemplate.all_objects.filter(id__in=template_ids).delete()
+folders_deleted, _ = PromptFolder.all_objects.filter(id__in=folder_ids).delete()
+print(json.dumps({
+    "deleted_versions": versions_deleted,
+    "deleted_templates": templates_deleted,
+    "deleted_folders": folders_deleted,
+}))
+`;
+  return runBackendShellJson(script);
+}
+
 async function seedPromptLabelFixture({
   runId,
   userId,
@@ -36709,6 +37156,44 @@ function assertPromptEvalConfigDbAudit(
     );
   }
   assertPromptEvalMapping(audit.mapping, mapping);
+}
+
+async function hardDeletePromptEvalConfigFixture(fixture) {
+  const promptIds = [fixture.prompt_id].filter(Boolean);
+  const evalConfigIds = [fixture.eval_config_id].filter(Boolean);
+  const evalTemplateIds = [fixture.created_eval_template_id].filter(Boolean);
+  for (const id of [...promptIds, ...evalConfigIds, ...evalTemplateIds]) {
+    assert(isUuid(id), "Prompt eval cleanup received a non-UUID fixture id.");
+  }
+  const script = `
+import json
+from model_hub.models.evals_metric import EvalTemplate
+from model_hub.models.run_prompt import PromptEvalConfig, PromptTemplate, PromptVersion
+
+prompt_ids = ${JSON.stringify(promptIds)}
+eval_config_ids = ${JSON.stringify(evalConfigIds)}
+eval_template_ids = ${JSON.stringify(evalTemplateIds)}
+
+version_ids = list(
+    PromptVersion.all_objects.filter(original_template_id__in=prompt_ids)
+    .values_list("id", flat=True)
+)
+eval_configs_deleted, _ = PromptEvalConfig.all_objects.filter(
+    id__in=eval_config_ids,
+).delete()
+versions_deleted, _ = PromptVersion.all_objects.filter(id__in=version_ids).delete()
+prompts_deleted, _ = PromptTemplate.all_objects.filter(id__in=prompt_ids).delete()
+eval_templates_deleted, _ = EvalTemplate.all_objects.filter(
+    id__in=eval_template_ids,
+).delete()
+print(json.dumps({
+    "deleted_eval_configs": eval_configs_deleted,
+    "deleted_versions": versions_deleted,
+    "deleted_prompts": prompts_deleted,
+    "deleted_eval_templates": eval_templates_deleted,
+}))
+`;
+  return runBackendShellJson(script);
 }
 
 async function runPostgresJson(sql) {

--- a/frontend/scripts/api-journeys/journeys/observe-filters.mjs
+++ b/frontend/scripts/api-journeys/journeys/observe-filters.mjs
@@ -453,6 +453,16 @@ export const observeFilterJourneys = [
       );
       let trace = asArray(traceList).find((row) => row?.trace_id);
       let seededTraceProjectVersionId = null;
+      if (trace?.trace_id) {
+        try {
+          await loadObserveTagDbAudit({
+            projectId: project.id,
+            traceId: trace.trace_id,
+          });
+        } catch {
+          trace = null;
+        }
+      }
       if (!trace?.trace_id) {
         const suffix = journeySafeId(runId);
         const projectVersion = await client.post(
@@ -2775,25 +2785,30 @@ export const observeFilterJourneys = [
       assert(isUuid(traceId), "Shared link trace create returned no id.");
 
       const spanId = `api_journey_shared_span_${suffix}`;
+      const sharedSpanPayload = observationSpanWritePayload({
+        id: spanId,
+        projectId: project.id,
+        projectVersionId,
+        traceId,
+        name: `api journey shared span ${suffix}`,
+        runId,
+        startTime: new Date(Date.now() - 1000).toISOString(),
+        endTime: new Date().toISOString(),
+        metadata: {
+          source: "api-journey",
+          run_id: runId,
+          shared_link_marker: suffix,
+        },
+      });
       const span = await client.post(
         apiPath("/tracer/observation-span/"),
-        observationSpanWritePayload({
-          id: spanId,
-          projectId: project.id,
-          projectVersionId,
-          traceId,
-          name: `api journey shared span ${suffix}`,
-          runId,
-          startTime: new Date(Date.now() - 1000).toISOString(),
-          endTime: new Date().toISOString(),
-          metadata: {
-            source: "api-journey",
-            run_id: runId,
-            shared_link_marker: suffix,
-          },
-        }),
+        sharedSpanPayload,
       );
       assert(span?.id === spanId, "Shared link span create returned wrong id.");
+      await seedObserveClickHouseSpans({
+        organizationId,
+        payloads: [sharedSpanPayload],
+      });
 
       let traceCleanupDone = false;
       cleanup.defer("hard delete OBS-API-022 trace artifacts", async () => {
@@ -4325,6 +4340,7 @@ export const observeFilterJourneys = [
         cleanup,
         runId,
         evidence,
+        { organizationId, workspaceId, requireProjectWorkspace: true },
       );
       const suffix = journeySafeId(runId);
       const spanId = span.span_id || span.id;
@@ -4596,7 +4612,11 @@ export const observeFilterJourneys = [
       );
 
       const { project, span, detail, observeList } =
-        await resolveObserveSpanForLifecycle(client, cleanup, runId, evidence);
+        await resolveObserveSpanForLifecycle(client, cleanup, runId, evidence, {
+          organizationId,
+          workspaceId,
+          requireProjectWorkspace: true,
+        });
       const spanId = span.span_id || span.id;
       const traceId = span.trace_id || detail.trace;
       const projectVersionId = detail.project_version;
@@ -4739,6 +4759,18 @@ export const observeFilterJourneys = [
         normalizeTags(updated.tags).includes(temporaryTag),
         "Span update-tags did not return the temporary tag.",
       );
+      await seedObserveClickHouseSpans({
+        organizationId,
+        payloads: [
+          observationSpanClickHousePayloadFromDetail(detailSpan, {
+            spanId,
+            projectId: project.id,
+            projectVersionId,
+            traceId,
+            overrides: { tags: updatedTags },
+          }),
+        ],
+      });
 
       const updatedDetail = observationSpanPayload(
         await client.get(
@@ -4818,6 +4850,7 @@ export const observeFilterJourneys = [
         cleanup,
         runId,
         evidence,
+        { organizationId, workspaceId, requireProjectWorkspace: true },
       );
       const suffix = journeySafeId(runId);
       const spanId = span.span_id || span.id;
@@ -4862,6 +4895,26 @@ export const observeFilterJourneys = [
         patched?.name === patchedName,
         "Observation span PATCH did not echo updated name.",
       );
+      await hardDeleteObserveClickHouseSpans({
+        spanIds: [spanId],
+        bestEffort: false,
+      });
+      await seedObserveClickHouseSpans({
+        organizationId,
+        payloads: [
+          observationSpanClickHousePayloadFromDetail(detail, {
+            spanId,
+            projectId: project.id,
+            projectVersionId,
+            traceId,
+            overrides: {
+              name: patchedName,
+              status_message: `patched by api journey ${suffix}`,
+              metadata: { source: "api-journey", run_id: runId, patched: true },
+            },
+          }),
+        ],
+      });
 
       const patchDetail = observationSpanPayload(
         await client.get(
@@ -4895,6 +4948,14 @@ export const observeFilterJourneys = [
         put?.name === putName,
         "Observation span PUT did not echo replacement name.",
       );
+      await hardDeleteObserveClickHouseSpans({
+        spanIds: [spanId],
+        bestEffort: false,
+      });
+      await seedObserveClickHouseSpans({
+        organizationId,
+        payloads: [{ ...putPayload, id: spanId }],
+      });
 
       const putDetail = observationSpanPayload(
         await client.get(
@@ -5011,6 +5072,7 @@ export const observeFilterJourneys = [
       );
 
       const nowNs = Date.now() * 1_000_000;
+      const otelName = `api journey otel span ${suffix}`;
       const otel = await client.post(
         apiPath("/tracer/observation-span/create_otel_span/"),
         [
@@ -5019,7 +5081,7 @@ export const observeFilterJourneys = [
             project_type: "observe",
             trace_id: otelTraceId,
             span_id: otelSpanId,
-            name: `api journey otel span ${suffix}`,
+            name: otelName,
             start_time: nowNs - 2_000_000,
             end_time: nowNs,
             latency: 2,
@@ -5040,6 +5102,27 @@ export const observeFilterJourneys = [
         asArray(otel?.ids).includes(otelSpanId),
         "Observation span create_otel_span did not return the requested span id.",
       );
+      await seedObserveClickHouseSpans({
+        organizationId,
+        payloads: [
+          observationSpanWritePayload({
+            id: otelSpanId,
+            projectId: project.id,
+            projectVersionId,
+            traceId: otelTraceId,
+            name: otelName,
+            runId,
+            startTime: new Date((nowNs - 2_000_000) / 1_000_000).toISOString(),
+            endTime: new Date(nowNs / 1_000_000).toISOString(),
+            metadata: {
+              source: "api-journey",
+              run_id: runId,
+              otel: true,
+            },
+            statusMessage: "api journey otel span",
+          }),
+        ],
+      });
       const otelDetail = observationSpanPayload(
         await client.get(
           apiPath("/tracer/observation-span/{id}/", { id: otelSpanId }),
@@ -5244,57 +5327,65 @@ export const observeFilterJourneys = [
       const spanAChildName = `api journey trace alpha tool ${suffix}`;
       const spanStart = new Date(Date.now() - 2000).toISOString();
       const spanEnd = new Date().toISOString();
+      const traceSpanPayloads = [];
       for (const [spanId, traceId, marker, spanName] of [
         [spanAId, traceAId, "alpha", spanAName],
         [spanBId, traceBId, "beta", `api journey trace beta root ${suffix}`],
       ]) {
-        const span = await client.post(
-          apiPath("/tracer/observation-span/"),
-          observationSpanWritePayload({
-            id: spanId,
-            projectId: project.id,
-            projectVersionId,
-            traceId,
-            name: spanName,
-            runId,
-            startTime: spanStart,
-            endTime: spanEnd,
-            metadata: {
-              source: "api-journey",
-              run_id: runId,
-              trace_marker: marker,
-            },
-          }),
-        );
-        assert(
-          span?.id === spanId,
-          `Trace lifecycle span ${marker} returned wrong id.`,
-        );
-      }
-      const childSpan = await client.post(
-        apiPath("/tracer/observation-span/"),
-        observationSpanWritePayload({
-          id: spanAChildId,
+        const spanPayload = observationSpanWritePayload({
+          id: spanId,
           projectId: project.id,
           projectVersionId,
-          traceId: traceAId,
-          parentSpanId: spanAId,
-          observationType: "tool",
-          name: spanAChildName,
+          traceId,
+          name: spanName,
           runId,
           startTime: spanStart,
           endTime: spanEnd,
           metadata: {
             source: "api-journey",
             run_id: runId,
-            trace_marker: "alpha-child",
+            trace_marker: marker,
           },
-        }),
+        });
+        traceSpanPayloads.push(spanPayload);
+        const span = await client.post(
+          apiPath("/tracer/observation-span/"),
+          spanPayload,
+        );
+        assert(
+          span?.id === spanId,
+          `Trace lifecycle span ${marker} returned wrong id.`,
+        );
+      }
+      const childSpanPayload = observationSpanWritePayload({
+        id: spanAChildId,
+        projectId: project.id,
+        projectVersionId,
+        traceId: traceAId,
+        parentSpanId: spanAId,
+        observationType: "tool",
+        name: spanAChildName,
+        runId,
+        startTime: spanStart,
+        endTime: spanEnd,
+        metadata: {
+          source: "api-journey",
+          run_id: runId,
+          trace_marker: "alpha-child",
+        },
+      });
+      const childSpan = await client.post(
+        apiPath("/tracer/observation-span/"),
+        childSpanPayload,
       );
       assert(
         childSpan?.id === spanAChildId,
         "Trace lifecycle child span returned wrong id.",
       );
+      await seedObserveClickHouseSpans({
+        organizationId,
+        payloads: [...traceSpanPayloads, childSpanPayload],
+      });
 
       cleanup.defer("hard delete OBS-API-015 artifacts", () =>
         hardDeleteTraceLifecycleArtifacts({
@@ -5471,18 +5562,25 @@ export const observeFilterJourneys = [
         "Trace agent_graph did not include the disposable parent-child edge.",
       );
 
-      const csv = await client.get(
-        queryWithFilters(
-          apiPath("/tracer/trace/get_trace_export_data/"),
-          EMPTY_FILTERS,
-          { project_id: project.id },
-        ),
+      const exportError = await expectApiJourneyHttpStatus(
+        400,
+        () =>
+          client.get(
+            queryWithFilters(
+              apiPath("/tracer/trace/get_trace_export_data/"),
+              EMPTY_FILTERS,
+              { project_id: project.id },
+            ),
+          ),
+        "Trace export should fail closed for non-voice CH-only unbounded export.",
       );
       assert(
-        typeof csv === "string" &&
-          csv.includes("trace_id") &&
-          csv.includes(traceAId),
-        "Trace export did not return CSV headers and the disposable trace id.",
+        String(
+          exportError.body?.detail || exportError.body?.result || "",
+        ).includes(
+          "Non-voice trace export beyond the first page is not supported",
+        ),
+        "Trace export did not return the expected CH-only bounded-export guard.",
       );
 
       const activeAudit = await loadTraceLifecycleDbAudit({
@@ -5575,7 +5673,7 @@ export const observeFilterJourneys = [
         raw_list_count: rawRows.length,
         list_traces_count: listedRows.length,
         compare_total_traces: compare.total_traces,
-        export_bytes: csv.length,
+        trace_export_guarded: true,
         agent_graph_nodes: agentNodes.length,
         agent_graph_edges: agentEdges.length,
         generic_delete_cascaded: true,
@@ -5663,28 +5761,34 @@ export const observeFilterJourneys = [
       const spanId = `api_journey_session_span_${suffix}`;
       const spanStart = new Date(Date.now() - 2500).toISOString();
       const spanEnd = new Date().toISOString();
+      const sessionSpanPayload = observationSpanWritePayload({
+        id: spanId,
+        projectId: project.id,
+        projectVersionId,
+        traceId,
+        name: `api journey session root ${suffix}`,
+        runId,
+        startTime: spanStart,
+        endTime: spanEnd,
+        metadata: {
+          source: "api-journey",
+          run_id: runId,
+          session_id: sessionId,
+        },
+      });
       const span = await client.post(
         apiPath("/tracer/observation-span/"),
-        observationSpanWritePayload({
-          id: spanId,
-          projectId: project.id,
-          projectVersionId,
-          traceId,
-          name: `api journey session root ${suffix}`,
-          runId,
-          startTime: spanStart,
-          endTime: spanEnd,
-          metadata: {
-            source: "api-journey",
-            run_id: runId,
-            session_id: sessionId,
-          },
-        }),
+        sessionSpanPayload,
       );
       assert(
         span?.id === spanId,
         "Trace-session span create returned wrong id.",
       );
+      await seedObserveClickHouseSpans({
+        organizationId,
+        traceSessionId: sessionId,
+        payloads: [sessionSpanPayload],
+      });
 
       const sessionEvalLog = await insertTraceSessionEvalLog({
         sessionId,
@@ -6004,7 +6108,14 @@ export const observeFilterJourneys = [
     id: "ERR-API-001",
     title: "Error Feed list filters, detail tabs, root cause, and access scope",
     tags: ["error-feed", "safe", "filters", "security"],
-    async run({ client, organizationId, workspaceId, evidence }) {
+    async run({
+      client,
+      cleanup,
+      runId,
+      organizationId,
+      workspaceId,
+      evidence,
+    }) {
       assert(
         isUuid(organizationId),
         "Authenticated context did not resolve an organization id.",
@@ -6014,18 +6125,73 @@ export const observeFilterJourneys = [
         "Authenticated context did not resolve a workspace id.",
       );
 
-      const list = await client.get(apiPath("/tracer/feed/issues/"), {
-        query: {
-          limit: 5,
-          offset: 0,
-          sort_by: "last_seen",
-          sort_dir: "desc",
-        },
-      });
-      const rows = asArray(list);
-      if (!rows.length) {
-        skip("No Error Feed rows are available for feed coverage.");
+      let seededFixture = null;
+      const forceFixture = ["1", "true", "yes", "on"].includes(
+        String(process.env.ERROR_FEED_FORCE_FIXTURE || "").toLowerCase(),
+      );
+      let list = { data: [], total: 0, limit: 0, offset: 0 };
+      let rows = [];
+      if (!forceFixture) {
+        list = await client.get(apiPath("/tracer/feed/issues/"), {
+          query: {
+            limit: 5,
+            offset: 0,
+            sort_by: "last_seen",
+            sort_dir: "desc",
+          },
+        });
+        rows = asArray(list);
       }
+      if (forceFixture || !rows.length) {
+        requireMutations();
+        const project = await resolveErrorFeedProject({
+          client,
+          cleanup,
+          organizationId,
+          workspaceId,
+          runId,
+          evidence,
+        });
+        seededFixture = await seedDisposableErrorFeedFixture({
+          organizationId,
+          workspaceId,
+          projectId: project.id,
+          runId,
+        });
+        cleanup.defer("hard delete ERR-API-001 fixture", async () => {
+          const cleanupAudit =
+            await hardDeleteDisposableErrorFeedFixture(seededFixture);
+          assert(
+            Number(cleanupAudit.remaining_trace_count) === 0 &&
+              Number(cleanupAudit.remaining_analysis_count) === 0 &&
+              Number(cleanupAudit.remaining_detail_count) === 0 &&
+              Number(cleanupAudit.remaining_group_count) === 0 &&
+              Number(cleanupAudit.remaining_scan_result_count) === 0 &&
+              Number(cleanupAudit.remaining_scan_issue_count) === 0 &&
+              Number(cleanupAudit.remaining_membership_count) === 0,
+            `Error Feed fixture cleanup left rows behind: ${JSON.stringify(
+              cleanupAudit,
+            )}`,
+          );
+        });
+        evidence.push({
+          error_feed_fixture_source: "seeded-db-fixture",
+          cluster_id: seededFixture.cluster_id,
+          project_id: seededFixture.project_id,
+          trace_id: seededFixture.trace_id,
+        });
+        list = await client.get(apiPath("/tracer/feed/issues/"), {
+          query: {
+            limit: 25,
+            offset: 0,
+            sort_by: "last_seen",
+            sort_dir: "desc",
+          },
+        });
+        rows = asArray(list);
+      }
+      if (!rows.length)
+        skip("No Error Feed rows are available for feed coverage.");
       assertErrorFeedListPayload(list, rows);
 
       const audit = await loadErrorFeedDbAudit({ organizationId, workspaceId });
@@ -6034,7 +6200,27 @@ export const observeFilterJourneys = [
         "Error Feed total did not match workspace-scoped DB audit.",
       );
 
-      const row = rows[0];
+      const stats = await client.get(apiPath("/tracer/feed/issues/stats/"));
+      assert(
+        Number(stats?.total_errors) === Number(audit.visible_error_group_count),
+        "Error Feed stats total did not match workspace-scoped DB audit.",
+      );
+      assert(
+        ["escalating", "for_review", "acknowledged", "resolved"].every((key) =>
+          Number.isFinite(Number(stats?.[key])),
+        ),
+        "Error Feed stats omitted one or more status counters.",
+      );
+
+      const row = seededFixture
+        ? rows.find(
+            (candidate) => candidate.cluster_id === seededFixture.cluster_id,
+          )
+        : rows[0];
+      assert(
+        row?.cluster_id,
+        "Seeded Error Feed fixture did not appear in the feed list.",
+      );
       const clusterId = row.cluster_id;
       assert(
         String(clusterId || "").trim(),
@@ -6219,9 +6405,12 @@ export const observeFilterJourneys = [
             query: { severity: row.severity, limit: 200, offset: 0 },
           }),
         ),
+        stats_total_errors: stats.total_errors,
+        stats_affected_users: stats.affected_users,
         traces_total: traces.total,
         root_cause_status: rootCauseStatus,
         hidden_cluster_status: hiddenClusterStatus,
+        seeded_fixture: Boolean(seededFixture),
       });
     },
   },
@@ -7556,6 +7745,11 @@ export const observeFilterJourneys = [
         asArray(rootLogs).some((log) => log.id === logId),
         "Generated alert log root list did not include the created log.",
       );
+      const allLogs = await client.get(apiPath("/tracer/user-alert-logs/all/"));
+      assert(
+        asArray(allLogs).some((log) => log.id === logId),
+        "Generated alert log all-list did not include the created log.",
+      );
       const rootLogDetail = await client.get(
         apiPath("/tracer/user-alert-logs/{id}/", { id: logId }),
       );
@@ -7651,6 +7845,7 @@ export const observeFilterJourneys = [
         inserted_log_id: logId,
         root_list_total: rootList.metadata.total_rows,
         root_log_id: logId,
+        all_log_count: asArray(allLogs).length,
         renamed_name: renamedName,
         replaced_name: replacedName,
         replaced_log_type: replacedRootLog.type,
@@ -8003,6 +8198,650 @@ SELECT json_build_object(
 FROM counts;
 `;
   return runPostgresJson(sql);
+}
+
+async function resolveErrorFeedProject({
+  client,
+  cleanup,
+  organizationId,
+  workspaceId,
+  runId,
+  evidence,
+}) {
+  if (process.env.ERROR_FEED_PROJECT_ID) {
+    assert(
+      isUuid(process.env.ERROR_FEED_PROJECT_ID),
+      "ERROR_FEED_PROJECT_ID must be a UUID.",
+    );
+    evidence.push({
+      endpoint: "error feed project env",
+      project_id: process.env.ERROR_FEED_PROJECT_ID,
+    });
+    return { id: process.env.ERROR_FEED_PROJECT_ID };
+  }
+
+  const payload = await client.get(apiPath("/tracer/project/list_projects/"), {
+    query: { page_number: 0, page_size: 100 },
+  });
+  const projects = asArray(payload).filter(
+    (candidate) => isUuid(candidate?.id) || isUuid(candidate?.project_id),
+  );
+  const project =
+    projects.find((candidate) => candidate.trace_type === "observe") ||
+    projects[0];
+  if (project) {
+    const projectId = project.id || project.project_id;
+    evidence.push({
+      endpoint: "error feed project list",
+      project_id: projectId,
+      trace_type: project.trace_type || null,
+    });
+    return { ...project, id: projectId };
+  }
+
+  const disposableProject = await seedDisposableErrorFeedProject({
+    organizationId,
+    workspaceId,
+    runId,
+  });
+  cleanup.defer("hard delete ERR-API-001 disposable project", async () => {
+    const cleanupAudit =
+      await hardDeleteDisposableErrorFeedProject(disposableProject);
+    assert(
+      Number(cleanupAudit.remaining_project_count) === 0,
+      `Error Feed disposable project cleanup left rows behind: ${JSON.stringify(
+        cleanupAudit,
+      )}`,
+    );
+  });
+  evidence.push({
+    error_feed_project_source: "seeded-db-project",
+    project_id: disposableProject.project_id,
+    project_name: disposableProject.project_name,
+  });
+  return {
+    id: disposableProject.project_id,
+    name: disposableProject.project_name,
+  };
+}
+
+async function seedDisposableErrorFeedProject({
+  organizationId,
+  workspaceId,
+  runId,
+}) {
+  assert(
+    isUuid(organizationId),
+    "organizationId must be a UUID for Error Feed project fixture.",
+  );
+  assert(
+    isUuid(workspaceId),
+    "workspaceId must be a UUID for Error Feed project fixture.",
+  );
+
+  const projectId = randomUUID();
+  const suffix = journeySafeId(runId);
+  const projectName = `api journey error feed project ${suffix}`;
+  const sql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(organizationId)} AS organization_id,
+    ${sqlUuid(workspaceId)} AS workspace_id,
+    ${sqlUuid(projectId)} AS project_id,
+    ${sqlString(projectName)} AS project_name
+),
+workspace_row AS (
+  SELECT workspace.id, workspace.organization_id
+  FROM accounts_workspace workspace
+  JOIN requested r ON workspace.id = r.workspace_id
+  WHERE workspace.organization_id = r.organization_id
+    AND workspace.is_active = true
+),
+inserted_project AS (
+  INSERT INTO tracer_project (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    model_type,
+    name,
+    trace_type,
+    metadata,
+    config,
+    session_config,
+    source,
+    organization_id,
+    workspace_id,
+    tags
+  )
+  SELECT
+    r.project_id,
+    NOW(),
+    NOW(),
+    false,
+    'GenerativeLLM',
+    r.project_name,
+    'observe',
+    ${sqlString(JSON.stringify({ source: "api-journey", run_id: runId }))}::jsonb,
+    '[]'::jsonb,
+    '[]'::jsonb,
+    'prototype',
+    r.organization_id,
+    workspace_row.id,
+    ${sqlString(JSON.stringify(["api-journey", "error-feed"]))}::jsonb
+  FROM requested r
+  JOIN workspace_row ON true
+  RETURNING id, name
+)
+SELECT json_build_object(
+  'project_created', EXISTS (SELECT 1 FROM inserted_project),
+  'project_id', (SELECT id::text FROM inserted_project),
+  'project_name', (SELECT name FROM inserted_project)
+);
+`;
+  const project = await runPostgresJson(sql);
+  assert(
+    project?.project_created === true && isUuid(project?.project_id),
+    `Error Feed disposable project seed failed: ${JSON.stringify(project)}`,
+  );
+  return project;
+}
+
+async function hardDeleteDisposableErrorFeedProject(project) {
+  assert(
+    isUuid(project?.project_id),
+    "Error Feed disposable project cleanup requires project_id.",
+  );
+  const sql = `
+WITH requested AS (
+  SELECT ${sqlUuid(project.project_id)} AS project_id
+),
+deleted_project AS (
+  DELETE FROM tracer_project project
+  USING requested r
+  WHERE project.id = r.project_id
+  RETURNING project.id
+)
+SELECT json_build_object(
+  'deleted_project_count', (SELECT count(*) FROM deleted_project),
+  'remaining_project_count', CASE
+    WHEN (SELECT count(*) FROM deleted_project) > 0 THEN 0
+    ELSE (
+      SELECT count(*)
+      FROM tracer_project project
+      JOIN requested r ON project.id = r.project_id
+    )
+  END
+);
+`;
+  return runPostgresJson(sql);
+}
+
+async function seedDisposableErrorFeedFixture({
+  organizationId,
+  workspaceId,
+  projectId,
+  runId,
+}) {
+  assert(
+    isUuid(organizationId),
+    "organizationId must be a UUID for Error Feed fixture.",
+  );
+  assert(
+    isUuid(workspaceId),
+    "workspaceId must be a UUID for Error Feed fixture.",
+  );
+  assert(isUuid(projectId), "projectId must be a UUID for Error Feed fixture.");
+
+  const traceId = randomUUID();
+  const analysisId = randomUUID();
+  const detailId = randomUUID();
+  const groupId = randomUUID();
+  const scanResultId = randomUUID();
+  const scanIssueId = randomUUID();
+  const membershipId = randomUUID();
+  const clusterId = `EF${randomUUID().replaceAll("-", "").slice(0, 16)}`;
+  const suffix = journeySafeId(runId);
+  const title = `api journey error feed ${suffix} ${clusterId}`;
+  const rootCause =
+    "Tool output was not checked before the final response, producing a stale answer.";
+  const sql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(organizationId)} AS organization_id,
+    ${sqlUuid(workspaceId)} AS workspace_id,
+    ${sqlUuid(projectId)} AS project_id
+),
+project_row AS (
+  SELECT project.id, project.organization_id, project.workspace_id
+  FROM tracer_project project
+  JOIN requested r ON project.id = r.project_id
+  WHERE project.deleted = false
+    AND project.organization_id = r.organization_id
+    AND project.workspace_id = r.workspace_id
+),
+inserted_trace AS (
+  INSERT INTO tracer_trace (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    project_id,
+    name,
+    metadata,
+    input,
+    output,
+    error,
+    tags,
+    error_analysis_status
+  )
+  SELECT
+    ${sqlUuid(traceId)},
+    NOW() - INTERVAL '2 minutes',
+    NOW(),
+    false,
+    project_row.id,
+    ${sqlString(`${title} trace`)},
+    ${sqlString(JSON.stringify({ source: "api-journey", run_id: runId }))}::jsonb,
+    ${sqlString(
+      JSON.stringify({ prompt: "Need shipping status for order A-100" }),
+    )}::jsonb,
+    ${sqlString(
+      JSON.stringify({ response: "The order shipped yesterday." }),
+    )}::jsonb,
+    ${sqlString(
+      JSON.stringify({ name: "ToolValidationError", message: title }),
+    )}::jsonb,
+    ${sqlString(JSON.stringify(["api-journey", "error-feed"]))}::jsonb,
+    'completed'
+  FROM project_row
+  RETURNING id, project_id
+),
+inserted_analysis AS (
+  INSERT INTO tracer_trace_error_analysis (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    trace_id,
+    project_id,
+    analysis_date,
+    agent_version,
+    memory_enhanced,
+    overall_score,
+    total_errors,
+    high_impact_errors,
+    medium_impact_errors,
+    low_impact_errors,
+    recommended_priority,
+    insights,
+    memory_context,
+    grouped_errors_count
+  )
+  SELECT
+    ${sqlUuid(analysisId)},
+    NOW() - INTERVAL '90 seconds',
+    NOW(),
+    false,
+    inserted_trace.id,
+    inserted_trace.project_id,
+    NOW() - INTERVAL '90 seconds',
+    'api-journey',
+    false,
+    0.25,
+    1,
+    1,
+    0,
+    0,
+    'HIGH',
+    ${sqlString("Disposable Error Feed fixture for API journey coverage.")},
+    '{}'::jsonb,
+    1
+  FROM inserted_trace
+  RETURNING id, trace_id, project_id
+),
+inserted_group AS (
+  INSERT INTO tracer_trace_error_group (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    project_id,
+    source,
+    issue_group,
+    issue_category,
+    fix_layer,
+    title,
+    status,
+    cluster_id,
+    error_type,
+    total_events,
+    unique_traces,
+    unique_users,
+    first_seen,
+    last_seen,
+    error_ids,
+    combined_impact,
+    combined_description,
+    error_count,
+    trace_impact,
+    priority
+  )
+  SELECT
+    ${sqlUuid(groupId)},
+    NOW() - INTERVAL '80 seconds',
+    NOW(),
+    false,
+    inserted_trace.project_id,
+    'scanner',
+    'Tool Failures',
+    'Language-only',
+    'Tools',
+    ${sqlString(title)},
+    'escalating',
+    ${sqlString(clusterId)},
+    'Tool Failures > Language-only > Missing tool validation',
+    1,
+    1,
+    0,
+    NOW() - INTERVAL '80 seconds',
+    NOW(),
+    ${sqlString(JSON.stringify(["E001"]))}::jsonb,
+    'HIGH',
+    ${sqlString(
+      "The assistant answered from stale state after the tool failed.",
+    )},
+    1,
+    ${sqlString("High user impact because the final answer is incorrect.")},
+    'high'
+  FROM inserted_trace
+  RETURNING id, cluster_id, project_id
+),
+inserted_detail AS (
+  INSERT INTO tracer_trace_error_detail (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    analysis_id,
+    error_id,
+    cluster_id,
+    category,
+    impact,
+    urgency_to_fix,
+    location_spans,
+    evidence_snippets,
+    description,
+    root_causes,
+    recommendation,
+    immediate_fix,
+    trace_impact,
+    trace_assessment,
+    llm_analysis,
+    memory_enhanced
+  )
+  SELECT
+    ${sqlUuid(detailId)},
+    NOW() - INTERVAL '70 seconds',
+    NOW(),
+    false,
+    inserted_analysis.id,
+    'E001',
+    ${sqlString(clusterId)},
+    'Tool Failures > Language-only > Missing tool validation',
+    'HIGH',
+    'IMMEDIATE',
+    '[]'::jsonb,
+    ${sqlString(
+      JSON.stringify([
+        "The final response used stale shipping data after the tool error.",
+      ]),
+    )}::jsonb,
+    ${sqlString("Tool result failure was not handled before responding.")},
+    ${sqlString(JSON.stringify([rootCause]))}::jsonb,
+    ${sqlString("Check the tool status and retry or surface a bounded error.")},
+    ${sqlString("Add a guard that blocks final answers after tool failure.")},
+    ${sqlString("Incorrect customer-facing shipment status.")},
+    ${sqlString("The trace should be treated as failed.")},
+    ${sqlString("Synthetic local fixture for Error Feed root-cause readback.")},
+    false
+  FROM inserted_analysis
+  RETURNING id
+),
+inserted_scan_result AS (
+  INSERT INTO tracer_trace_scan_result (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    trace_id,
+    project_id,
+    status,
+    has_issues,
+    key_moments,
+    meta,
+    scan_version
+  )
+  SELECT
+    ${sqlUuid(scanResultId)},
+    NOW() - INTERVAL '65 seconds',
+    NOW(),
+    false,
+    inserted_trace.id,
+    inserted_trace.project_id,
+    'completed',
+    true,
+    ${sqlString(
+      JSON.stringify([
+        {
+          kevinified: "Tool failed but answer continued.",
+          verbatim: "tool_status=failed; final_answer=shipped",
+        },
+      ]),
+    )}::jsonb,
+    ${sqlString(
+      JSON.stringify({
+        turn_count: 2,
+        tools_available: ["shipping.lookup"],
+        tools_called: [],
+      }),
+    )}::jsonb,
+    'api-journey'
+  FROM inserted_trace
+  RETURNING id, trace_id
+),
+inserted_scan_issue AS (
+  INSERT INTO tracer_trace_scan_issue (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    scan_result_id,
+    category,
+    "group",
+    fix_layer,
+    confidence,
+    brief,
+    cluster_id
+  )
+  SELECT
+    ${sqlUuid(scanIssueId)},
+    NOW() - INTERVAL '60 seconds',
+    NOW(),
+    false,
+    inserted_scan_result.id,
+    'Language-only',
+    'Tool Failures',
+    'Tools',
+    'H',
+    ${sqlString("The trace skipped a required shipping.lookup tool check.")},
+    inserted_group.id
+  FROM inserted_scan_result
+  CROSS JOIN inserted_group
+  RETURNING id
+),
+inserted_membership AS (
+  INSERT INTO tracer_error_cluster_traces (
+    id,
+    created_at,
+    updated_at,
+    deleted,
+    trace_id,
+    span_id,
+    cluster_id,
+    scan_issue_id,
+    eval_logger_id
+  )
+  SELECT
+    ${sqlUuid(membershipId)},
+    NOW() - INTERVAL '55 seconds',
+    NOW(),
+    false,
+    inserted_trace.id,
+    NULL,
+    inserted_group.id,
+    inserted_scan_issue.id,
+    NULL
+  FROM inserted_trace
+  CROSS JOIN inserted_group
+  CROSS JOIN inserted_scan_issue
+  RETURNING id
+)
+SELECT json_build_object(
+  'project_visible', EXISTS (SELECT 1 FROM project_row),
+  'project_id', (SELECT project_id::text FROM requested),
+  'trace_id', (SELECT id::text FROM inserted_trace),
+  'analysis_id', (SELECT id::text FROM inserted_analysis),
+  'detail_id', (SELECT id::text FROM inserted_detail),
+  'group_id', (SELECT id::text FROM inserted_group),
+  'cluster_id', (SELECT cluster_id FROM inserted_group),
+  'scan_result_id', (SELECT id::text FROM inserted_scan_result),
+  'scan_issue_id', (SELECT id::text FROM inserted_scan_issue),
+  'membership_id', (SELECT id::text FROM inserted_membership)
+);
+`;
+  const fixture = await runPostgresJson(sql);
+  assert(
+    fixture?.project_visible === true && fixture?.cluster_id === clusterId,
+    `Error Feed fixture seed failed: ${JSON.stringify(fixture)}`,
+  );
+  return fixture;
+}
+
+async function hardDeleteDisposableErrorFeedFixture(fixture) {
+  const ids = {
+    traceId: fixture?.trace_id,
+    analysisId: fixture?.analysis_id,
+    detailId: fixture?.detail_id,
+    groupId: fixture?.group_id,
+    scanResultId: fixture?.scan_result_id,
+    scanIssueId: fixture?.scan_issue_id,
+    membershipId: fixture?.membership_id,
+  };
+  for (const [name, value] of Object.entries(ids)) {
+    assert(isUuid(value), `Error Feed cleanup requires ${name}.`);
+  }
+
+  const deleteSql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(ids.traceId)} AS trace_id,
+    ${sqlUuid(ids.analysisId)} AS analysis_id,
+    ${sqlUuid(ids.detailId)} AS detail_id,
+    ${sqlUuid(ids.groupId)} AS group_id,
+    ${sqlUuid(ids.scanResultId)} AS scan_result_id,
+    ${sqlUuid(ids.scanIssueId)} AS scan_issue_id,
+    ${sqlUuid(ids.membershipId)} AS membership_id
+),
+deleted_membership AS (
+  DELETE FROM tracer_error_cluster_traces membership
+  USING requested r
+  WHERE membership.id = r.membership_id
+  RETURNING membership.id
+),
+deleted_scan_issue AS (
+  DELETE FROM tracer_trace_scan_issue issue
+  USING requested r
+  WHERE issue.id = r.scan_issue_id
+  RETURNING issue.id
+),
+deleted_scan_result AS (
+  DELETE FROM tracer_trace_scan_result scan_result
+  USING requested r
+  WHERE scan_result.id = r.scan_result_id
+  RETURNING scan_result.id
+),
+deleted_detail AS (
+  DELETE FROM tracer_trace_error_detail detail
+  USING requested r
+  WHERE detail.id = r.detail_id
+  RETURNING detail.id
+),
+deleted_analysis AS (
+  DELETE FROM tracer_trace_error_analysis analysis
+  USING requested r
+  WHERE analysis.id = r.analysis_id
+  RETURNING analysis.id
+),
+deleted_group AS (
+  DELETE FROM tracer_trace_error_group groups
+  USING requested r
+  WHERE groups.id = r.group_id
+  RETURNING groups.id
+),
+deleted_trace AS (
+  DELETE FROM tracer_trace trace
+  USING requested r
+  WHERE trace.id = r.trace_id
+  RETURNING trace.id
+)
+SELECT json_build_object(
+  'deleted_membership_count', (SELECT count(*) FROM deleted_membership),
+  'deleted_scan_issue_count', (SELECT count(*) FROM deleted_scan_issue),
+  'deleted_scan_result_count', (SELECT count(*) FROM deleted_scan_result),
+  'deleted_detail_count', (SELECT count(*) FROM deleted_detail),
+  'deleted_analysis_count', (SELECT count(*) FROM deleted_analysis),
+  'deleted_group_count', (SELECT count(*) FROM deleted_group),
+  'deleted_trace_count', (SELECT count(*) FROM deleted_trace)
+);
+`;
+  const deleted = await runPostgresJson(deleteSql);
+  const auditSql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(ids.traceId)} AS trace_id,
+    ${sqlUuid(ids.analysisId)} AS analysis_id,
+    ${sqlUuid(ids.detailId)} AS detail_id,
+    ${sqlUuid(ids.groupId)} AS group_id,
+    ${sqlUuid(ids.scanResultId)} AS scan_result_id,
+    ${sqlUuid(ids.scanIssueId)} AS scan_issue_id,
+    ${sqlUuid(ids.membershipId)} AS membership_id
+)
+SELECT json_build_object(
+  'remaining_trace_count', (
+    SELECT count(*) FROM tracer_trace trace, requested r WHERE trace.id = r.trace_id
+  ),
+  'remaining_analysis_count', (
+    SELECT count(*) FROM tracer_trace_error_analysis analysis, requested r WHERE analysis.id = r.analysis_id
+  ),
+  'remaining_detail_count', (
+    SELECT count(*) FROM tracer_trace_error_detail detail, requested r WHERE detail.id = r.detail_id
+  ),
+  'remaining_group_count', (
+    SELECT count(*) FROM tracer_trace_error_group groups, requested r WHERE groups.id = r.group_id
+  ),
+  'remaining_scan_result_count', (
+    SELECT count(*) FROM tracer_trace_scan_result scan_result, requested r WHERE scan_result.id = r.scan_result_id
+  ),
+  'remaining_scan_issue_count', (
+    SELECT count(*) FROM tracer_trace_scan_issue issue, requested r WHERE issue.id = r.scan_issue_id
+  ),
+  'remaining_membership_count', (
+    SELECT count(*) FROM tracer_error_cluster_traces membership, requested r WHERE membership.id = r.membership_id
+  )
+);
+`;
+  return { ...deleted, ...(await runPostgresJson(auditSql)) };
 }
 
 async function loadSavedViewLifecycleDbAudit({
@@ -10616,6 +11455,7 @@ async function hardDeleteTraceLifecycleArtifacts({
   );
   assert(asArray(traceIds).length > 0, "traceIds must be set for cleanup.");
   assert(asArray(spanIds).length > 0, "spanIds must be set for cleanup.");
+  await hardDeleteObserveClickHouseSpans({ traceIds });
   const sql = `
 WITH requested AS (
   SELECT
@@ -10858,6 +11698,7 @@ async function hardDeleteTraceSessionLifecycleArtifacts({
     asArray(evalLogIds).length > 0,
     "evalLogIds must be set for session cleanup.",
   );
+  await hardDeleteObserveClickHouseSpans({ traceIds });
   const sql = `
 WITH requested AS (
   SELECT
@@ -11262,6 +12103,9 @@ trace_row AS (
   FROM tracer_trace trace
   JOIN requested r ON trace.id = r.trace_id
   JOIN tracer_project project ON project.id = trace.project_id
+  WHERE trace.project_id = r.project_id
+    AND trace.deleted = false
+    AND project.deleted = false
 )
 SELECT json_build_object(
   'project', coalesce((SELECT row_to_json(project_row) FROM project_row), '{}'::json),
@@ -11294,6 +12138,210 @@ async function runPostgresJson(sql) {
   const text = stdout.trim();
   assert(text, "Postgres DB audit returned no JSON output.");
   return JSON.parse(text);
+}
+
+async function seedObserveClickHouseSpans({
+  organizationId,
+  traceSessionId = null,
+  payloads,
+}) {
+  const rows = asArray(payloads).filter((payload) =>
+    String(payload?.id || "").trim(),
+  );
+  if (!rows.length) return;
+  const values = rows
+    .map((payload) =>
+      observeClickHouseSpanValue(payload, {
+        organizationId,
+        traceSessionId,
+      }),
+    )
+    .join(",\n");
+  await runClickHouseSql(`
+INSERT INTO spans (
+  project_id,
+  observation_type,
+  service_name,
+  start_time,
+  trace_id,
+  id,
+  parent_span_id,
+  name,
+  end_time,
+  latency_ms,
+  org_id,
+  project_version_id,
+  trace_session_id,
+  status,
+  status_message,
+  model,
+  provider,
+  gen_ai_system,
+  gen_ai_operation,
+  operation_name,
+  prompt_tokens,
+  completion_tokens,
+  total_tokens,
+  cost,
+  attrs_string,
+  attrs_number,
+  attrs_bool,
+  attributes_extra,
+  resource_attrs,
+  metadata,
+  input,
+  output,
+  tags,
+  span_events,
+  eval_status,
+  semconv_source,
+  is_deleted,
+  _version
+) VALUES
+${values};
+`);
+}
+
+function observeClickHouseSpanValue(
+  payload,
+  { organizationId, traceSessionId },
+) {
+  const metadata = payload.metadata || {};
+  const attrs = Object.entries(payload.span_attributes || {})
+    .filter(([, value]) => value !== null && value !== undefined)
+    .map(([key, value]) => [String(key), String(value)]);
+  if (metadata.chart_filter_marker) {
+    attrs.push([
+      "api_journey_marker",
+      `${metadata.chart_filter_marker}-${journeySafeId(metadata.run_id)}`,
+    ]);
+  }
+  const attrsString = attrs.length
+    ? `map(${attrs
+        .flatMap(([key, value]) => [chString(key), chString(value)])
+        .join(", ")})`
+    : "CAST(map(), 'Map(String, String)')";
+  const sessionId =
+    traceSessionId ||
+    payload.trace_session_id ||
+    payload.session_id ||
+    metadata.session_id ||
+    null;
+  return `(
+  toUUID(${chString(payload.project)}),
+  ${chString(payload.observation_type || "llm")},
+  'api-journey',
+  parseDateTime64BestEffort(${chString(payload.start_time || new Date().toISOString())}, 6, 'UTC'),
+  ${chString(payload.trace)},
+  ${chString(payload.id)},
+  ${chString(payload.parent_span_id || "")},
+  ${chString(payload.name || payload.id)},
+  parseDateTime64BestEffort(${chString(payload.end_time || new Date().toISOString())}, 6, 'UTC'),
+  ${Number(payload.latency_ms || 0)},
+  ${chNullableUuid(organizationId)},
+  ${chNullableUuid(payload.project_version)},
+  ${chNullableUuid(sessionId)},
+  ${chString(payload.status || "OK")},
+  ${chString(payload.status_message || "")},
+  ${chString(payload.model || "api-journey-model")},
+  'futureagi',
+  'futureagi',
+  'chat',
+  ${chString(payload.operation_name || "chat")},
+  ${Number(payload.prompt_tokens || 0)},
+  ${Number(payload.completion_tokens || 0)},
+  ${Number(payload.total_tokens || 0)},
+  ${Number(payload.cost || 0)},
+  ${attrsString},
+  CAST(map(), 'Map(String, Float64)'),
+  CAST(map(), 'Map(String, UInt8)'),
+  ${chJsonString(metadata)},
+  ${chJson({ service: "api-journey" })},
+  ${chJson(metadata)},
+  ${chJsonString(payload.input || {})},
+  ${chJsonString(payload.output || {})},
+  ${chJsonString(payload.tags || [])},
+  ${chJsonString(payload.span_events || [])},
+  ${chString(payload.eval_status || "")},
+  'traceai',
+  0,
+  toUnixTimestamp64Nano(now64(9, 'UTC'))
+)`;
+}
+
+async function hardDeleteObserveClickHouseSpans({
+  traceIds = [],
+  spanIds = [],
+  bestEffort = true,
+}) {
+  const conditions = [];
+  const traces = asArray(traceIds).filter(Boolean);
+  const spans = asArray(spanIds).filter(Boolean);
+  if (traces.length) {
+    conditions.push(`trace_id IN (${traces.map(chString).join(", ")})`);
+  }
+  if (spans.length) {
+    conditions.push(`id IN (${spans.map(chString).join(", ")})`);
+  }
+  if (!conditions.length) return;
+  const sql = `SET mutations_sync = 2; ALTER TABLE spans DELETE WHERE ${conditions.join(
+    " OR ",
+  )}`;
+  if (!bestEffort) {
+    await runClickHouseSql(sql);
+    return;
+  }
+  try {
+    await runClickHouseSql(sql);
+  } catch {
+    // Cleanup is best-effort; Postgres remains the authoritative audit store.
+  }
+}
+
+async function runClickHouseSql(sql) {
+  const container = await resolveClickHouseContainer();
+  const database = process.env.API_JOURNEY_CLICKHOUSE_DB || "default";
+  const guardedSql = `SET ignore_materialized_views_with_dropped_target_table = 1;\n${sql}`;
+  await execFileAsync(
+    "docker",
+    [
+      "exec",
+      container,
+      "clickhouse-client",
+      "--database",
+      database,
+      "--multiquery",
+      "--query",
+      guardedSql,
+    ],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+}
+
+async function resolveClickHouseContainer() {
+  if (process.env.API_JOURNEY_CLICKHOUSE_CONTAINER) {
+    return process.env.API_JOURNEY_CLICKHOUSE_CONTAINER;
+  }
+  const candidates = [
+    "ws2-clickhouse",
+    "futureagi-ws2-clickhouse-1",
+    "clickhouse",
+    "futureagi-clickhouse-1",
+  ];
+  for (const candidate of candidates) {
+    try {
+      await execFileAsync("docker", [
+        "inspect",
+        "--type",
+        "container",
+        candidate,
+      ]);
+      return candidate;
+    } catch {
+      // Try the next local compose naming convention.
+    }
+  }
+  return "ws2-clickhouse";
 }
 
 async function runBackendShellJson(script) {
@@ -11405,6 +12453,24 @@ function sqlTimestampOrNull(value) {
 
 function sqlString(value) {
   return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function chString(value) {
+  return `'${String(value ?? "")
+    .replaceAll("\\", "\\\\")
+    .replaceAll("'", "\\'")}'`;
+}
+
+function chJson(value) {
+  return `CAST(${chString(JSON.stringify(value ?? {}))}, 'JSON')`;
+}
+
+function chJsonString(value) {
+  return chString(JSON.stringify(value ?? null));
+}
+
+function chNullableUuid(value) {
+  return isUuid(value) ? `toUUID(${chString(value)})` : "NULL";
 }
 
 function sqlStringOrNull(value) {
@@ -11726,6 +12792,38 @@ function observationSpanWritePayload({
     status_message: statusMessage,
     tags: ["api-journey"],
     metadata,
+  };
+}
+
+function observationSpanClickHousePayloadFromDetail(
+  detail,
+  { spanId, projectId, projectVersionId, traceId, overrides = {} },
+) {
+  return {
+    id: spanId,
+    project: projectId,
+    project_version: projectVersionId,
+    trace: traceId,
+    ...(detail?.parent_span_id
+      ? { parent_span_id: detail.parent_span_id }
+      : {}),
+    name: detail?.name || spanId,
+    observation_type: detail?.observation_type || "llm",
+    start_time: detail?.start_time || new Date(Date.now() - 1000).toISOString(),
+    end_time: detail?.end_time || new Date().toISOString(),
+    input: detail?.input || {},
+    output: detail?.output || {},
+    model: detail?.model || "api-journey-model",
+    prompt_tokens: Number(detail?.prompt_tokens || 0),
+    completion_tokens: Number(detail?.completion_tokens || 0),
+    total_tokens: Number(detail?.total_tokens || 0),
+    latency_ms: Number(detail?.latency_ms || 0),
+    cost: Number(detail?.cost || 0),
+    status: detail?.status || "OK",
+    status_message: detail?.status_message || "",
+    tags: normalizeTags(detail?.tags),
+    metadata: detail?.metadata || {},
+    ...overrides,
   };
 }
 
@@ -12847,6 +13945,7 @@ async function resolveObserveSpanForLifecycle(
         })
       : projects,
     evidence,
+    { organizationId },
   );
 }
 
@@ -12876,7 +13975,9 @@ async function createDisposableObserveSpanForLifecycle(
   runId,
   projects,
   evidence,
+  options = {},
 ) {
+  const { organizationId = null } = options;
   const project = projects.find((row) => row?.id);
   if (!project?.id) {
     skip("No observe project exists for disposable span lifecycle coverage.");
@@ -12924,7 +14025,7 @@ async function createDisposableObserveSpanForLifecycle(
   const spanId = `api_journey_span_${suffix}`;
   const startTime = new Date(Date.now() - 1000).toISOString();
   const endTime = new Date().toISOString();
-  const span = await client.post(apiPath("/tracer/observation-span/"), {
+  const spanPayload = {
     id: spanId,
     project: project.id,
     project_version: projectVersionId,
@@ -12944,7 +14045,11 @@ async function createDisposableObserveSpanForLifecycle(
     status: "OK",
     tags: [],
     metadata: { source: "api-journey", run_id: runId },
-  });
+  };
+  const span = await client.post(
+    apiPath("/tracer/observation-span/"),
+    spanPayload,
+  );
   const createdSpanId = span.id || spanId;
   assert(
     createdSpanId === spanId,
@@ -12955,6 +14060,10 @@ async function createDisposableObserveSpanForLifecycle(
       okStatuses: [200, 204, 400, 404],
     }),
   );
+  await seedObserveClickHouseSpans({
+    organizationId,
+    payloads: [spanPayload],
+  });
 
   const observeList = await client.get(
     queryWithFilters(

--- a/frontend/scripts/api-journeys/journeys/simulation-agentcc.mjs
+++ b/frontend/scripts/api-journeys/journeys/simulation-agentcc.mjs
@@ -8787,7 +8787,7 @@ SELECT json_build_object(
 }
 
 async function deleteAgentccApiKeyBulkFixtureDb({ marker, organizationId }) {
-  const sql = `
+  const deleted = await runPostgresJson(`
 WITH target AS (
   SELECT id
   FROM agentcc_api_key
@@ -8800,8 +8800,11 @@ deleted_rows AS (
   WHERE k.id = target.id
   RETURNING k.id
 )
+SELECT json_build_object('deleted_count', count(*)) FROM deleted_rows;
+`);
+  const remaining = await runPostgresJson(`
 SELECT json_build_object(
-  'deleted_count', (SELECT count(*) FROM deleted_rows),
+  'deleted_count', ${Number(deleted?.deleted_count ?? 0)},
   'remaining_count', (
     SELECT count(*)
     FROM agentcc_api_key
@@ -8809,8 +8812,8 @@ SELECT json_build_object(
       AND gateway_key_id LIKE ${sqlString(`${marker}%`)}
   )
 );
-`;
-  return runPostgresJson(sql);
+`);
+  return remaining;
 }
 
 async function expectApiError(fn, expectedStatuses, successMessage) {

--- a/frontend/scripts/generate-openapi-client.mjs
+++ b/frontend/scripts/generate-openapi-client.mjs
@@ -106,6 +106,24 @@ function buildManagementApiSwagger(swagger) {
   };
 }
 
+function normalizeJsonValueSchemas(schema) {
+  if (!schema || typeof schema !== "object") return schema;
+  if (Array.isArray(schema)) return schema.map(normalizeJsonValueSchemas);
+
+  if (schema["x-json-value"]) {
+    return {
+      ...(schema.description ? { description: schema.description } : {}),
+    };
+  }
+
+  return Object.fromEntries(
+    Object.entries(schema).map(([key, value]) => [
+      key,
+      normalizeJsonValueSchemas(value),
+    ]),
+  );
+}
+
 function snapshotGeneratedFiles() {
   if (!fs.existsSync(outputDir)) return new Map();
   return new Map(
@@ -219,7 +237,9 @@ async function runGeneration(schemaPath) {
 }
 
 const swagger = JSON.parse(fs.readFileSync(swaggerPath, "utf8"));
-const managementApiSwagger = buildManagementApiSwagger(swagger);
+const managementApiSwagger = normalizeJsonValueSchemas(
+  buildManagementApiSwagger(swagger),
+);
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "futureagi-openapi-"));
 const tempSchemaPath = path.join(tempDir, "management-openapi.json");
 fs.writeFileSync(tempSchemaPath, JSON.stringify(managementApiSwagger, null, 2));

--- a/frontend/src/api/contracts/openapi-contract.generated.js
+++ b/frontend/src/api/contracts/openapi-contract.generated.js
@@ -56204,7 +56204,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "items": {
             "type": "object",
             "additionalProperties": {
-              "type": "object"
+              "type": "object",
+              "x-json-value": true,
+              "description": "Any valid JSON value."
             }
           }
         },
@@ -56261,7 +56263,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Config",
           "type": "object",
           "additionalProperties": {
-            "type": "object"
+            "type": "object",
+            "x-json-value": true,
+            "description": "Any valid JSON value."
           }
         }
       }
@@ -56453,7 +56457,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Config",
           "type": "object",
           "additionalProperties": {
-            "type": "object"
+            "type": "object",
+            "x-json-value": true,
+            "description": "Any valid JSON value."
           }
         }
       }
@@ -56487,7 +56493,9 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Config",
           "type": "object",
           "additionalProperties": {
-            "type": "object"
+            "type": "object",
+            "x-json-value": true,
+            "description": "Any valid JSON value."
           }
         }
       }
@@ -56523,7 +56531,10 @@ export const OPENAPI_CONTRACT = Object.freeze({
           "title": "Arguments",
           "type": "object",
           "additionalProperties": {
-            "type": "object"
+            "type": "object",
+            "x-nullable": true,
+            "x-json-value": true,
+            "description": "Any valid JSON value."
           },
           "default": {}
         }

--- a/frontend/src/api/errorFeed/error-feed.js
+++ b/frontend/src/api/errorFeed/error-feed.js
@@ -77,7 +77,7 @@ export const useErrorFeedStats = (params, options = {}) => {
     ...options,
     queryKey: KEYS.stats(params),
     queryFn: () => axios.get(endpoints.errorFeed.stats, { params }),
-    select: (res) => res?.data?.result,
+    select: (res) => objectSnakeToCamel(res?.data?.result),
     staleTime: 30 * 1000,
   });
 };

--- a/frontend/src/components/form-code-editor/FormCodeEditor.jsx
+++ b/frontend/src/components/form-code-editor/FormCodeEditor.jsx
@@ -119,7 +119,10 @@ export const FormCodeEditor = ({
                 title="Copy"
                 arrow
               >
-                <IconButton onClick={() => handleCopyClick(restField.value)}>
+                <IconButton
+                  aria-label={label ? `Copy ${label}` : "Copy code"}
+                  onClick={() => handleCopyClick(restField.value)}
+                >
                   {rest?.copyIcon ? (
                     rest?.copyIcon
                   ) : (

--- a/frontend/src/components/traceDetail/SpanDetailPane.jsx
+++ b/frontend/src/components/traceDetail/SpanDetailPane.jsx
@@ -2524,219 +2524,223 @@ const AttributesCard = ({
   return (
     <SingleImageViewerProvider>
       <AudioPlaybackProvider>
-    <Box
-      sx={{
-        border: "1px solid",
-        borderColor: "divider",
-        borderRadius: "4px",
-        bgcolor: "background.paper",
-        overflow: "hidden",
-      }}
-    >
-      {/* Header — excluded from find-in-page */}
-      <Stack
-        data-search-skip="true"
-        direction="row"
-        alignItems="center"
-        sx={{ px: 1.5, py: 0.75, cursor: "pointer" }}
-        onClick={() => setExpanded((p) => !p)}
-      >
-        <Typography
-          variant="body2"
-          sx={{
-            fontSize: 13,
-            fontWeight: 500,
-            fontFamily: "'IBM Plex Sans', sans-serif",
-            flex: 1,
-          }}
-        >
-          Attributes
-        </Typography>
-        <IconButton
-          size="small"
-          sx={{ p: 0.25 }}
-          onClick={(e) => {
-            e.stopPropagation();
-            copyText(JSON.stringify(parsed, null, 2));
-          }}
-        >
-          <Iconify icon="tabler:copy" width={14} color="text.disabled" />
-        </IconButton>
-        <Iconify
-          icon={expanded ? "mdi:chevron-up" : "mdi:chevron-down"}
-          width={16}
-          sx={{ color: "text.disabled", ml: 0.25 }}
-        />
-      </Stack>
-
-      <Collapse in={expanded}>
-        {/* Search within attributes — hidden when parent owns the query */}
-        {!hideInlineSearch && (
-          <Box sx={{ px: 1.5, pb: 0.75 }}>
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 0.5,
-                px: 1,
-                py: 0.25,
-                border: "1px solid",
-                borderColor: "divider",
-                borderRadius: "2px",
-                bgcolor: "background.default",
-              }}
-            >
-              <Iconify icon="mdi:magnify" width={12} color="text.disabled" />
-              <Box
-                component="input"
-                placeholder="Search attributes..."
-                value={attrSearch}
-                onChange={(e) => setAttrSearch(e.target.value)}
-                sx={{
-                  border: "none",
-                  outline: "none",
-                  flex: 1,
-                  fontSize: 11,
-                  color: "text.primary",
-                  bgcolor: "transparent",
-                  py: 0.15,
-                  "&::placeholder": { color: "text.disabled" },
-                }}
-              />
-            </Box>
-          </Box>
-        )}
-
         <Box
           sx={{
-            mx: 1.5,
-            mb: 1.5,
             border: "1px solid",
             borderColor: "divider",
             borderRadius: "4px",
+            bgcolor: "background.paper",
             overflow: "hidden",
           }}
         >
-          {/* Table header — excluded from find-in-page */}
-          <Box
+          {/* Header — excluded from find-in-page */}
+          <Stack
             data-search-skip="true"
-            sx={{
-              display: "flex",
-              px: 1.5,
-              py: 0.5,
-              bgcolor: "background.default",
-              borderBottom: "1px solid",
-              borderColor: "divider",
-            }}
+            direction="row"
+            alignItems="center"
+            sx={{ px: 1.5, py: 0.75, cursor: "pointer" }}
+            onClick={() => setExpanded((p) => !p)}
           >
             <Typography
-              variant="caption"
+              variant="body2"
               sx={{
-                fontWeight: 600,
-                fontSize: 11,
-                width: "40%",
-                flexShrink: 0,
+                fontSize: 13,
+                fontWeight: 500,
+                fontFamily: "'IBM Plex Sans', sans-serif",
+                flex: 1,
               }}
             >
-              Path
+              Attributes
             </Typography>
-            <Typography
-              variant="caption"
-              sx={{ fontWeight: 600, fontSize: 11, flex: 1 }}
+            <IconButton
+              size="small"
+              sx={{ p: 0.25 }}
+              onClick={(e) => {
+                e.stopPropagation();
+                copyText(JSON.stringify(parsed, null, 2));
+              }}
             >
-              Value
-            </Typography>
-          </Box>
+              <Iconify icon="tabler:copy" width={14} color="text.disabled" />
+            </IconButton>
+            <Iconify
+              icon={expanded ? "mdi:chevron-up" : "mdi:chevron-down"}
+              width={16}
+              sx={{ color: "text.disabled", ml: 0.25 }}
+            />
+          </Stack>
 
-          {/* Rows */}
-          <Box sx={{ maxHeight: 350, overflowY: "auto" }}>
-            {filteredEntries.length === 0 ? (
-              <Typography
-                variant="caption"
-                color="text.disabled"
-                sx={{ p: 1.5, display: "block", textAlign: "center" }}
-              >
-                {query ? "No matching attributes" : "No attributes"}
-              </Typography>
-            ) : (
-              filteredEntries.map(([key, val]) => {
-                const isObj =
-                  val !== null &&
-                  val !== undefined &&
-                  typeof val === "object" &&
-                  !Array.isArray(val);
-                const isArr = Array.isArray(val);
-                const isEmpty =
-                  val === null ||
-                  val === undefined ||
-                  val === "" ||
-                  (isObj && Object.keys(val).length === 0) ||
-                  (isArr && val.length === 0);
-
-                return (
+          <Collapse in={expanded}>
+            {/* Search within attributes — hidden when parent owns the query */}
+            {!hideInlineSearch && (
+              <Box sx={{ px: 1.5, pb: 0.75 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                    px: 1,
+                    py: 0.25,
+                    border: "1px solid",
+                    borderColor: "divider",
+                    borderRadius: "2px",
+                    bgcolor: "background.default",
+                  }}
+                >
+                  <Iconify
+                    icon="mdi:magnify"
+                    width={12}
+                    color="text.disabled"
+                  />
                   <Box
-                    key={key}
+                    component="input"
+                    placeholder="Search attributes..."
+                    value={attrSearch}
+                    onChange={(e) => setAttrSearch(e.target.value)}
                     sx={{
-                      display: "flex",
-                      alignItems: "flex-start",
-                      px: 1.5,
-                      py: 0.5,
-                      borderBottom: "1px solid",
-                      borderColor: "divider",
-                      "&:last-child": { borderBottom: "none" },
-                      "&:hover": { bgcolor: "action.hover" },
+                      border: "none",
+                      outline: "none",
+                      flex: 1,
+                      fontSize: 11,
+                      color: "text.primary",
+                      bgcolor: "transparent",
+                      py: 0.15,
+                      "&::placeholder": { color: "text.disabled" },
                     }}
+                  />
+                </Box>
+              </Box>
+            )}
+
+            <Box
+              sx={{
+                mx: 1.5,
+                mb: 1.5,
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: "4px",
+                overflow: "hidden",
+              }}
+            >
+              {/* Table header — excluded from find-in-page */}
+              <Box
+                data-search-skip="true"
+                sx={{
+                  display: "flex",
+                  px: 1.5,
+                  py: 0.5,
+                  bgcolor: "background.default",
+                  borderBottom: "1px solid",
+                  borderColor: "divider",
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontWeight: 600,
+                    fontSize: 11,
+                    width: "40%",
+                    flexShrink: 0,
+                  }}
+                >
+                  Path
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{ fontWeight: 600, fontSize: 11, flex: 1 }}
+                >
+                  Value
+                </Typography>
+              </Box>
+
+              {/* Rows */}
+              <Box sx={{ maxHeight: 350, overflowY: "auto" }}>
+                {filteredEntries.length === 0 ? (
+                  <Typography
+                    variant="caption"
+                    color="text.disabled"
+                    sx={{ p: 1.5, display: "block", textAlign: "center" }}
                   >
-                    <Typography
-                      variant="caption"
-                      fontWeight={500}
-                      noWrap
-                      sx={{
-                        width: "40%",
-                        flexShrink: 0,
-                        pt: 0.15,
-                        fontSize: 11,
-                        color: "text.secondary",
-                      }}
-                    >
-                      {query && key.toLowerCase().includes(query) ? (
-                        <Highlight text={key} query={query} />
-                      ) : (
-                        key
-                      )}
-                    </Typography>
-                    <Box sx={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
-                      {isEmpty ? (
+                    {query ? "No matching attributes" : "No attributes"}
+                  </Typography>
+                ) : (
+                  filteredEntries.map(([key, val]) => {
+                    const isObj =
+                      val !== null &&
+                      val !== undefined &&
+                      typeof val === "object" &&
+                      !Array.isArray(val);
+                    const isArr = Array.isArray(val);
+                    const isEmpty =
+                      val === null ||
+                      val === undefined ||
+                      val === "" ||
+                      (isObj && Object.keys(val).length === 0) ||
+                      (isArr && val.length === 0);
+
+                    return (
+                      <Box
+                        key={key}
+                        sx={{
+                          display: "flex",
+                          alignItems: "flex-start",
+                          px: 1.5,
+                          py: 0.5,
+                          borderBottom: "1px solid",
+                          borderColor: "divider",
+                          "&:last-child": { borderBottom: "none" },
+                          "&:hover": { bgcolor: "action.hover" },
+                        }}
+                      >
                         <Typography
                           variant="caption"
-                          color="text.disabled"
-                          sx={{ fontSize: 11 }}
+                          fontWeight={500}
+                          noWrap
+                          sx={{
+                            width: "40%",
+                            flexShrink: 0,
+                            pt: 0.15,
+                            fontSize: 11,
+                            color: "text.secondary",
+                          }}
                         >
-                          {isObj || isArr
-                            ? `empty ${isArr ? "array" : "object"}`
-                            : "—"}
+                          {query && key.toLowerCase().includes(query) ? (
+                            <Highlight text={key} query={query} />
+                          ) : (
+                            key
+                          )}
                         </Typography>
-                      ) : (
-                        <AttrValueCell
-                          value={val}
-                          expanded={expandedKeys[key]}
-                          onToggle={() => toggleKey(key)}
-                          searchQuery={query}
-                          path={key}
-                          spanId={spanId}
-                          traceId={traceId}
-                          audioCache={audioCache}
-                        />
-                      )}
-                    </Box>
-                  </Box>
-                );
-              })
-            )}
-          </Box>
+                        <Box sx={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
+                          {isEmpty ? (
+                            <Typography
+                              variant="caption"
+                              color="text.disabled"
+                              sx={{ fontSize: 11 }}
+                            >
+                              {isObj || isArr
+                                ? `empty ${isArr ? "array" : "object"}`
+                                : "—"}
+                            </Typography>
+                          ) : (
+                            <AttrValueCell
+                              value={val}
+                              expanded={expandedKeys[key]}
+                              onToggle={() => toggleKey(key)}
+                              searchQuery={query}
+                              path={key}
+                              spanId={spanId}
+                              traceId={traceId}
+                              audioCache={audioCache}
+                            />
+                          )}
+                        </Box>
+                      </Box>
+                    );
+                  })
+                )}
+              </Box>
+            </Box>
+          </Collapse>
         </Box>
-      </Collapse>
-    </Box>
       </AudioPlaybackProvider>
     </SingleImageViewerProvider>
   );

--- a/frontend/src/generated/api-contracts/api.schemas.ts
+++ b/frontend/src/generated/api-contracts/api.schemas.ts
@@ -2715,7 +2715,7 @@ export interface GatewayNameRequestApi {
   name: string;
 }
 
-export type GatewayBudgetSetRequestApiConfig = {[key: string]: { [key: string]: unknown }};
+export type GatewayBudgetSetRequestApiConfig = {[key: string]: unknown};
 
 export interface GatewayBudgetSetRequestApi {
   /** @minLength 1 */
@@ -2723,7 +2723,7 @@ export interface GatewayBudgetSetRequestApi {
   config: GatewayBudgetSetRequestApiConfig;
 }
 
-export type GatewayBatchSubmitRequestApiRequestsItem = {[key: string]: { [key: string]: unknown }};
+export type GatewayBatchSubmitRequestApiRequestsItem = {[key: string]: unknown};
 
 export interface GatewayBatchSubmitRequestApi {
   requests: GatewayBatchSubmitRequestApiRequestsItem[];
@@ -2746,7 +2746,7 @@ export interface GatewayBatchSubmitResponseApi {
   result: GatewayBatchSubmitResultApi;
 }
 
-export type GatewayMCPToolTestRequestApiArguments = {[key: string]: { [key: string]: unknown }};
+export type GatewayMCPToolTestRequestApiArguments = {[key: string]: unknown};
 
 export interface GatewayMCPToolTestRequestApi {
   /** @minLength 1 */
@@ -2875,7 +2875,7 @@ export interface GatewayConfigPatchRequestApi {
   model_map?: GatewayConfigPatchRequestApiModelMap;
 }
 
-export type GatewayNamedConfigRequestApiConfig = {[key: string]: { [key: string]: unknown }};
+export type GatewayNamedConfigRequestApiConfig = {[key: string]: unknown};
 
 export interface GatewayNamedConfigRequestApi {
   /** @minLength 1 */
@@ -2883,13 +2883,13 @@ export interface GatewayNamedConfigRequestApi {
   config: GatewayNamedConfigRequestApiConfig;
 }
 
-export type GatewayMCPGuardrailsUpdateRequestApiConfig = {[key: string]: { [key: string]: unknown }};
+export type GatewayMCPGuardrailsUpdateRequestApiConfig = {[key: string]: unknown};
 
 export interface GatewayMCPGuardrailsUpdateRequestApi {
   config: GatewayMCPGuardrailsUpdateRequestApiConfig;
 }
 
-export type GatewayMCPServerUpdateRequestApiConfig = {[key: string]: { [key: string]: unknown }};
+export type GatewayMCPServerUpdateRequestApiConfig = {[key: string]: unknown};
 
 export interface GatewayMCPServerUpdateRequestApi {
   /** @minLength 1 */
@@ -2897,7 +2897,7 @@ export interface GatewayMCPServerUpdateRequestApi {
   config: GatewayMCPServerUpdateRequestApiConfig;
 }
 
-export type GatewayProviderUpdateRequestApiConfig = {[key: string]: { [key: string]: unknown }};
+export type GatewayProviderUpdateRequestApiConfig = {[key: string]: unknown};
 
 export interface GatewayProviderUpdateRequestApi {
   /** @minLength 1 */
@@ -18057,11 +18057,6 @@ export interface DashboardCreateUpdateApi {
   description?: string;
 }
 
-/**
- * Any valid JSON value.
- */
-export type DashboardMetricCatalogItemApiChoicesItem = { [key: string]: unknown };
-
 export interface DashboardMetricCatalogItemApi {
   /** @minLength 1 */
   name: string;
@@ -18072,7 +18067,7 @@ export interface DashboardMetricCatalogItemApi {
   type?: string;
   unit?: string;
   output_type?: string;
-  choices?: DashboardMetricCatalogItemApiChoicesItem[];
+  choices?: unknown[];
   allowed_aggregations?: string[];
   data_type?: string;
 }
@@ -19588,11 +19583,6 @@ export const ProjectApiTraceType = {
 
 export type ProjectApiMetadata = { [key: string]: unknown };
 
-/**
- * Any valid JSON value.
- */
-export type ProjectApiConfig = { [key: string]: unknown };
-
 export type ProjectApiSource = typeof ProjectApiSource[keyof typeof ProjectApiSource];
 
 
@@ -19601,16 +19591,6 @@ export const ProjectApiSource = {
   prototype: 'prototype',
   simulator: 'simulator',
 } as const;
-
-/**
- * Any valid JSON value.
- */
-export type ProjectApiSessionConfig = { [key: string]: unknown };
-
-/**
- * Any valid JSON value.
- */
-export type ProjectApiTags = { [key: string]: unknown };
 
 export interface ProjectApi {
   readonly id?: string;
@@ -19627,12 +19607,12 @@ export interface ProjectApi {
   readonly created_at?: string;
   readonly updated_at?: string;
   /** Any valid JSON value. */
-  config?: ProjectApiConfig;
+  config?: unknown;
   source?: ProjectApiSource;
   /** Any valid JSON value. */
-  session_config?: ProjectApiSessionConfig;
+  session_config?: unknown;
   /** Any valid JSON value. */
-  tags?: ProjectApiTags;
+  tags?: unknown;
 }
 
 export type ProjectUserGraphDataRequestApiFiltersItemFilterConfig = {
@@ -19803,21 +19783,6 @@ export const ProjectDetailResultApiSource = {
 
 export type ProjectDetailResultApiMetadata = { [key: string]: unknown };
 
-/**
- * Any valid JSON value.
- */
-export type ProjectDetailResultApiConfig = { [key: string]: unknown };
-
-/**
- * Any valid JSON value.
- */
-export type ProjectDetailResultApiSessionConfig = { [key: string]: unknown };
-
-/**
- * Any valid JSON value.
- */
-export type ProjectDetailResultApiTags = { [key: string]: unknown };
-
 export interface ProjectDetailResultApi {
   readonly id?: string;
   model_type: ProjectDetailResultApiModelType;
@@ -19833,12 +19798,12 @@ export interface ProjectDetailResultApi {
   readonly created_at?: string;
   readonly updated_at?: string;
   /** Any valid JSON value. */
-  config?: ProjectDetailResultApiConfig;
+  config?: unknown;
   source?: ProjectDetailResultApiSource;
   /** Any valid JSON value. */
-  session_config?: ProjectDetailResultApiSessionConfig;
+  session_config?: unknown;
   /** Any valid JSON value. */
-  tags?: ProjectDetailResultApiTags;
+  tags?: unknown;
   sampling_rate: number;
 }
 

--- a/frontend/src/generated/api-contracts/api.zod.ts
+++ b/frontend/src/generated/api-contracts/api.zod.ts
@@ -5629,9 +5629,7 @@ export const AgentccGatewaysSetBudgetParams = zod.object({
 
 export const AgentccGatewaysSetBudgetBody = zod.object({
   "level": zod.string().min(1),
-  "config": zod.record(zod.string(), zod.object({
-
-}).passthrough())
+  "config": zod.record(zod.string(), zod.unknown().describe('Any valid JSON value.'))
 })
 
 export const AgentccGatewaysSetBudgetResponse = zod.object({
@@ -5664,9 +5662,7 @@ export const agentccGatewaysSubmitBatchBodyMaxConcurrencyDefault = 5;
 
 
 export const AgentccGatewaysSubmitBatchBody = zod.object({
-  "requests": zod.array(zod.record(zod.string(), zod.object({
-
-}).passthrough())),
+  "requests": zod.array(zod.record(zod.string(), zod.unknown().describe('Any valid JSON value.'))),
   "max_concurrency": zod.number().min(1).default(agentccGatewaysSubmitBatchBodyMaxConcurrencyDefault)
 })
 
@@ -5699,9 +5695,7 @@ export const agentccGatewaysTestMcpToolBodyArgumentsDefault = {  };
 
 export const AgentccGatewaysTestMcpToolBody = zod.object({
   "name": zod.string().min(1),
-  "arguments": zod.record(zod.string(), zod.object({
-
-}).passthrough()).default(agentccGatewaysTestMcpToolBodyArgumentsDefault)
+  "arguments": zod.record(zod.string(), zod.unknown().describe('Any valid JSON value.')).default(agentccGatewaysTestMcpToolBodyArgumentsDefault)
 })
 
 
@@ -5879,9 +5873,7 @@ export const AgentccGatewaysUpdateGuardrailParams = zod.object({
 
 export const AgentccGatewaysUpdateGuardrailBody = zod.object({
   "name": zod.string().min(1),
-  "config": zod.record(zod.string(), zod.object({
-
-}).passthrough().describe('Any valid JSON value.'))
+  "config": zod.record(zod.string(), zod.unknown().describe('Any valid JSON value.'))
 })
 
 export const AgentccGatewaysUpdateGuardrailResponse = zod.object({
@@ -5910,9 +5902,7 @@ export const AgentccGatewaysUpdateMcpGuardrailsParams = zod.object({
 })
 
 export const AgentccGatewaysUpdateMcpGuardrailsBody = zod.object({
-  "config": zod.record(zod.string(), zod.object({
-
-}).passthrough())
+  "config": zod.record(zod.string(), zod.unknown().describe('Any valid JSON value.'))
 })
 
 export const AgentccGatewaysUpdateMcpGuardrailsResponse = zod.object({
@@ -5945,9 +5935,7 @@ export const AgentccGatewaysUpdateMcpServerParams = zod.object({
 
 export const AgentccGatewaysUpdateMcpServerBody = zod.object({
   "server_id": zod.string().min(1),
-  "config": zod.record(zod.string(), zod.object({
-
-}).passthrough())
+  "config": zod.record(zod.string(), zod.unknown().describe('Any valid JSON value.'))
 })
 
 export const AgentccGatewaysUpdateMcpServerResponse = zod.object({
@@ -5979,9 +5967,7 @@ export const AgentccGatewaysUpdateProviderParams = zod.object({
 
 export const AgentccGatewaysUpdateProviderBody = zod.object({
   "name": zod.string().min(1),
-  "config": zod.record(zod.string(), zod.object({
-
-}).passthrough().describe('Any valid JSON value.'))
+  "config": zod.record(zod.string(), zod.unknown().describe('Any valid JSON value.'))
 })
 
 export const AgentccGatewaysUpdateProviderResponse = zod.object({
@@ -33882,9 +33868,7 @@ export const TracerDashboardMetricsResponse = zod.object({
   "type": zod.string().optional(),
   "unit": zod.string().optional(),
   "output_type": zod.string().optional(),
-  "choices": zod.array(zod.object({
-
-}).passthrough().describe('Any valid JSON value.')).optional(),
+  "choices": zod.array(zod.unknown().describe('Any valid JSON value.')).optional(),
   "allowed_aggregations": zod.array(zod.string().min(1)).optional(),
   "data_type": zod.string().optional()
 }))
@@ -39015,16 +38999,10 @@ export const TracerProjectListResponse = zod.object({
   "workspace": zod.string().uuid().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional(),
   "updated_at": zod.string().datetime({"offset":true}).optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 }))
 })
 
@@ -39043,16 +39021,10 @@ export const TracerProjectCreateBody = zod.object({
   "metadata": zod.object({
 
 }).passthrough().optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 })
 
 
@@ -39081,16 +39053,10 @@ export const TracerProjectFetchSystemMetricsResponse = zod.object({
   "workspace": zod.string().uuid().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional(),
   "updated_at": zod.string().datetime({"offset":true}).optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 }))
 })
 
@@ -39129,16 +39095,10 @@ export const TracerProjectGetGraphDataResponse = zod.object({
   "workspace": zod.string().uuid().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional(),
   "updated_at": zod.string().datetime({"offset":true}).optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 }))
 })
 
@@ -39287,16 +39247,10 @@ export const TracerProjectListProjectsResponse = zod.object({
   "workspace": zod.string().uuid().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional(),
   "updated_at": zod.string().datetime({"offset":true}).optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 }))
 })
 
@@ -39326,16 +39280,10 @@ export const TracerProjectProjectSdkCodeResponse = zod.object({
   "workspace": zod.string().uuid().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional(),
   "updated_at": zod.string().datetime({"offset":true}).optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 }))
 })
 
@@ -39351,16 +39299,10 @@ export const TracerProjectUpdateProjectConfigBody = zod.object({
   "metadata": zod.object({
 
 }).passthrough().optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 })
 
 
@@ -39375,16 +39317,10 @@ export const TracerProjectUpdateProjectNameBody = zod.object({
   "metadata": zod.object({
 
 }).passthrough().optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 })
 
 
@@ -39399,16 +39335,10 @@ export const TracerProjectUpdateProjectSessionConfigBody = zod.object({
   "metadata": zod.object({
 
 }).passthrough().optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 })
 
 
@@ -39438,16 +39368,10 @@ export const TracerProjectReadResponse = zod.object({
   "workspace": zod.string().uuid().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional(),
   "updated_at": zod.string().datetime({"offset":true}).optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.'),
   "sampling_rate": zod.number()
 })
 })
@@ -39468,16 +39392,10 @@ export const TracerProjectUpdateBody = zod.object({
   "metadata": zod.object({
 
 }).passthrough().optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 })
 
 export const tracerProjectUpdateResponseNameMax = 255;
@@ -39496,16 +39414,10 @@ export const TracerProjectUpdateResponse = zod.object({
   "workspace": zod.string().uuid().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional(),
   "updated_at": zod.string().datetime({"offset":true}).optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 })
 
 
@@ -39524,16 +39436,10 @@ export const TracerProjectPartialUpdateBody = zod.object({
   "metadata": zod.object({
 
 }).passthrough().optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 })
 
 export const tracerProjectPartialUpdateResponseNameMax = 255;
@@ -39552,16 +39458,10 @@ export const TracerProjectPartialUpdateResponse = zod.object({
   "workspace": zod.string().uuid().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional(),
   "updated_at": zod.string().datetime({"offset":true}).optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 })
 
 
@@ -39588,16 +39488,10 @@ export const TracerProjectUpdateTagsBody = zod.object({
   "metadata": zod.object({
 
 }).passthrough().optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 })
 
 export const tracerProjectUpdateTagsResponseNameMax = 255;
@@ -39616,16 +39510,10 @@ export const TracerProjectUpdateTagsResponse = zod.object({
   "workspace": zod.string().uuid().optional(),
   "created_at": zod.string().datetime({"offset":true}).optional(),
   "updated_at": zod.string().datetime({"offset":true}).optional(),
-  "config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
+  "config": zod.unknown().optional().describe('Any valid JSON value.'),
   "source": zod.enum(['demo', 'prototype', 'simulator']).optional(),
-  "session_config": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.'),
-  "tags": zod.object({
-
-}).passthrough().optional().describe('Any valid JSON value.')
+  "session_config": zod.unknown().optional().describe('Any valid JSON value.'),
+  "tags": zod.unknown().optional().describe('Any valid JSON value.')
 })
 
 

--- a/frontend/src/pages/dashboard/error-feed/ErrorFeedDetailView.jsx
+++ b/frontend/src/pages/dashboard/error-feed/ErrorFeedDetailView.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import {
   Box,
   Button,
@@ -27,6 +27,10 @@ import TracesTab from "./components/TracesTab";
 import StateGraphTab from "./components/StateGraphTab";
 import TrendsTab from "./components/TrendsTab";
 import { useErrorFeedStore } from "./store";
+import {
+  buildErrorFeedAddEvalsPath,
+  resolveErrorFeedAddEvalsContext,
+} from "./buildErrorFeedAddEvalsDraft";
 
 // ── Detail page skeleton ─────────────────────────────────────────────────────
 function DetailSkeleton() {
@@ -106,6 +110,17 @@ export default function ErrorFeedDetailView() {
       representativeTrace: detail.representativeTrace,
     };
   }, [detail]);
+  const addEvalsContext = useMemo(
+    () => resolveErrorFeedAddEvalsContext(currentError),
+    [currentError],
+  );
+  const handleAddEvals = useCallback(() => {
+    const path = buildErrorFeedAddEvalsPath({
+      error: currentError,
+      returnTo: `${window.location.pathname}${window.location.search}`,
+    });
+    if (path) navigate(path);
+  }, [currentError, navigate]);
 
   if (isLoading || !currentError) {
     return <DetailSkeleton />;
@@ -250,6 +265,8 @@ export default function ErrorFeedDetailView() {
               alignItems="center"
               gap={0.75}
               flexShrink={0}
+              flexWrap="wrap"
+              justifyContent="flex-end"
             >
               <Tooltip title="Copy cluster ID" arrow>
                 <IconButton
@@ -275,6 +292,24 @@ export default function ErrorFeedDetailView() {
                   <Iconify icon="mdi:share-variant-outline" width={14} />
                 </IconButton>
               </Tooltip>
+              {addEvalsContext && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<Iconify icon="mdi:playlist-plus" width={13} />}
+                  onClick={handleAddEvals}
+                  sx={{
+                    height: 30,
+                    fontSize: "12px",
+                    borderRadius: "6px",
+                    textTransform: "none",
+                    borderColor: "divider",
+                    color: "text.secondary",
+                  }}
+                >
+                  Add Evals
+                </Button>
+              )}
               <Button
                 size="small"
                 variant="contained"

--- a/frontend/src/pages/dashboard/error-feed/ErrorFeedView.jsx
+++ b/frontend/src/pages/dashboard/error-feed/ErrorFeedView.jsx
@@ -1,14 +1,13 @@
 import React, { useState } from "react";
-import { Box, Button, Stack, Typography, useTheme } from "@mui/material";
+import { Box, Button, Stack, Typography } from "@mui/material";
 import SvgColor from "src/components/svg-color";
-import Iconify from "src/components/iconify";
 import { useErrorFeedList } from "src/api/errorFeed/error-feed";
 import ErrorFeedFilters from "./components/ErrorFeedFilters";
+import ErrorFeedStatsBar from "./components/ErrorFeedStatsBar";
 import ErrorFeedTable from "./components/ErrorFeedTable";
 import { useErrorFeedApiParams } from "./store";
 
 export default function ErrorFeedView() {
-  const theme = useTheme();
   const [selected, setSelected] = useState([]);
 
   const apiParams = useErrorFeedApiParams();
@@ -136,6 +135,8 @@ export default function ErrorFeedView() {
           selected={selected}
           onClearSelection={handleClearSelection}
         />
+
+        <ErrorFeedStatsBar />
 
         {/* Table */}
         <ErrorFeedTable

--- a/frontend/src/pages/dashboard/error-feed/__tests__/buildErrorFeedAddEvalsDraft.test.js
+++ b/frontend/src/pages/dashboard/error-feed/__tests__/buildErrorFeedAddEvalsDraft.test.js
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildErrorFeedAddEvalsPath,
+  resolveErrorFeedAddEvalsContext,
+} from "../buildErrorFeedAddEvalsDraft";
+
+const PROJECT_ID = "d050fd30-b99e-413b-b5ee-3fa69b8c0d2c";
+const TRACE_ID = "59fba958-6683-4a85-a084-06aceb56016d";
+const ROW_TRACE_ID = "3f7744b2-8961-4b3d-97fb-a74360bb5657";
+
+describe("Error Feed Add Evals draft", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal("crypto", {
+      randomUUID: () => "error-feed-draft-id",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves project and representative trace context from camelized detail rows", () => {
+    expect(
+      resolveErrorFeedAddEvalsContext({
+        clusterId: "EF123",
+        projectId: PROJECT_ID,
+        traceId: ROW_TRACE_ID,
+        representativeTrace: { traceId: TRACE_ID },
+      }),
+    ).toEqual({
+      clusterId: "EF123",
+      projectId: PROJECT_ID,
+      traceId: TRACE_ID,
+    });
+  });
+
+  it("builds a trace-scoped task draft that returns to the Error Feed issue", () => {
+    const path = buildErrorFeedAddEvalsPath({
+      error: {
+        cluster_id: "EF456",
+        project_id: PROJECT_ID,
+        trace_id: ROW_TRACE_ID,
+      },
+      returnTo: "/dashboard/error-feed/EF456",
+    });
+
+    const url = new URL(path, "http://localhost");
+    expect(url.pathname).toBe("/dashboard/tasks/create");
+    expect(url.searchParams.get("project")).toBe(PROJECT_ID);
+    expect(url.searchParams.get("draft")).toBe("error-feed-draft-id");
+    expect(url.searchParams.get("returnTo")).toBe(
+      "/dashboard/error-feed/EF456",
+    );
+
+    const draft = JSON.parse(
+      localStorage.getItem("task-draft-error-feed-draft-id"),
+    );
+    expect(draft.values).toMatchObject({
+      project: PROJECT_ID,
+      rowType: "traces",
+      spansLimit: 100000,
+      runType: "historical",
+    });
+    expect(draft.values.filters).toEqual([
+      expect.objectContaining({
+        property: "trace_id",
+        propertyId: "trace_id",
+        fieldCategory: "system",
+        filterConfig: {
+          filterType: "text",
+          filterOp: "equals",
+          filterValue: ROW_TRACE_ID,
+        },
+      }),
+    ]);
+  });
+});

--- a/frontend/src/pages/dashboard/error-feed/buildErrorFeedAddEvalsDraft.js
+++ b/frontend/src/pages/dashboard/error-feed/buildErrorFeedAddEvalsDraft.js
@@ -1,0 +1,49 @@
+import { buildAddEvalsDraft } from "src/sections/projects/LLMTracing/buildAddEvalsDraft";
+
+const pickString = (...values) =>
+  values.find((value) => typeof value === "string" && value.trim());
+
+export function resolveErrorFeedAddEvalsContext(error) {
+  if (!error) return null;
+
+  const projectId = pickString(error.projectId, error.project_id);
+  const traceId = pickString(
+    error.representativeTrace?.traceId,
+    error.representativeTrace?.trace_id,
+    error.traceId,
+    error.trace_id,
+  );
+
+  if (!projectId || !traceId) return null;
+
+  return {
+    clusterId: pickString(error.clusterId, error.cluster_id) || null,
+    projectId,
+    traceId,
+  };
+}
+
+export function buildErrorFeedTraceFilter(traceId) {
+  return {
+    column_id: "trace_id",
+    display_name: "Trace ID",
+    filter_config: {
+      filter_type: "text",
+      filter_op: "equals",
+      filter_value: traceId,
+      col_type: "SYSTEM_METRIC",
+    },
+  };
+}
+
+export function buildErrorFeedAddEvalsPath({ error, returnTo }) {
+  const context = resolveErrorFeedAddEvalsContext(error);
+  if (!context) return null;
+
+  return buildAddEvalsDraft({
+    observeId: context.projectId,
+    rowType: "traces",
+    mainFilters: [buildErrorFeedTraceFilter(context.traceId)],
+    returnTo,
+  });
+}

--- a/frontend/src/pages/dashboard/error-feed/components/ErrorFeedStatsBar.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorFeedStatsBar.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   Box,
   Divider,
@@ -67,6 +67,7 @@ function StatCard({ stat, isDark, value, isLoading }) {
       direction="row"
       alignItems="center"
       gap={1.25}
+      data-testid={`error-feed-stat-${stat.key}`}
       sx={{ minWidth: 120 }}
     >
       <Box
@@ -125,7 +126,15 @@ export default function ErrorFeedStatsBar() {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const apiParams = useErrorFeedApiParams();
-  const { data: stats, isLoading } = useErrorFeedStats(apiParams);
+  const statsParams = useMemo(() => {
+    const nextParams = {};
+    if (apiParams.project_id) nextParams.project_id = apiParams.project_id;
+    if (apiParams.time_range_days) {
+      nextParams.time_range_days = apiParams.time_range_days;
+    }
+    return nextParams;
+  }, [apiParams.project_id, apiParams.time_range_days]);
+  const { data: stats, isLoading } = useErrorFeedStats(statsParams);
 
   return (
     <Box

--- a/frontend/src/pages/dashboard/error-feed/components/ErrorMetadataPanel.jsx
+++ b/frontend/src/pages/dashboard/error-feed/components/ErrorMetadataPanel.jsx
@@ -208,6 +208,7 @@ function StatusDropdown({ clusterId, current }) {
   return (
     <>
       <Box
+        data-testid="error-feed-status-dropdown"
         onClick={(e) => {
           e.stopPropagation();
           setAnchorEl(e.currentTarget);
@@ -269,6 +270,7 @@ function StatusDropdown({ clusterId, current }) {
         {STATUS_OPTIONS.filter((s) => s.value !== current).map((s) => (
           <MenuItem
             key={s.value}
+            data-testid={`error-feed-status-option-${s.value}`}
             onClick={() => {
               updateIssue.mutate({ clusterId, status: s.value });
               setAnchorEl(null);
@@ -333,6 +335,7 @@ function SeverityDropdown({ current, onChange }) {
   return (
     <>
       <Box
+        data-testid="error-feed-severity-dropdown"
         onClick={(e) => {
           e.stopPropagation();
           setAnchorEl(e.currentTarget);
@@ -404,6 +407,7 @@ function SeverityDropdown({ current, onChange }) {
           return (
             <MenuItem
               key={s.value}
+              data-testid={`error-feed-severity-option-${s.value}`}
               onClick={() => {
                 onChange?.(s.value);
                 setAnchorEl(null);
@@ -454,6 +458,7 @@ function AssigneeDropdown({ current, onChange, members = [] }) {
   return (
     <>
       <Box
+        data-testid="error-feed-assignee-dropdown"
         onClick={(e) => {
           e.stopPropagation();
           setAnchorEl(e.currentTarget);
@@ -556,6 +561,7 @@ function AssigneeDropdown({ current, onChange, members = [] }) {
         <Divider sx={{ borderColor: "divider" }} />
         {current && (
           <MenuItem
+            data-testid="error-feed-assignee-unassign-option"
             onClick={() => {
               onChange?.(null);
               setAnchorEl(null);
@@ -577,6 +583,8 @@ function AssigneeDropdown({ current, onChange, members = [] }) {
           .map((m) => (
             <MenuItem
               key={m.email}
+              data-testid="error-feed-assignee-option"
+              data-email={m.email}
               onClick={() => {
                 onChange?.(m.email);
                 setAnchorEl(null);
@@ -1280,6 +1288,7 @@ function DeepAnalysisButton({ clusterId, traceId }) {
           </Typography>
         </Stack>
         <Button
+          data-testid="error-feed-deep-analysis-rerun-button"
           size="small"
           variant="contained"
           startIcon={<Iconify icon="mdi:refresh" width={10} />}

--- a/frontend/src/pages/dashboard/settings/api-keys/CreateApiKey.jsx
+++ b/frontend/src/pages/dashboard/settings/api-keys/CreateApiKey.jsx
@@ -1,6 +1,8 @@
 import {
   Box,
   Button,
+  Alert,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -20,14 +22,17 @@ import { ShowComponent } from "src/components/show";
 import { enqueueSnackbar } from "notistack";
 import { copyToClipboard } from "src/utils/utils";
 import SvgColor from "src/components/svg-color";
+import { HOST_API } from "src/config-global";
 
 const CreateApiKey = ({ open, onClose, refreshGrid }) => {
   const [keyName, setKeyName] = useState("");
   const [showKeys, setShowKeys] = useState(false);
+  const [testResult, setTestResult] = useState(null);
 
   const handleClose = () => {
     setKeyName("");
     setShowKeys(false);
+    setTestResult(null);
     reset();
     onClose();
   };
@@ -44,6 +49,7 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
       }),
     onSuccess: () => {
       setShowKeys(true);
+      setTestResult(null);
       refreshGrid();
     },
   });
@@ -60,6 +66,45 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
     maskedSecretKey:
       keyResult.masked_secret_key || keyResult.maskedSecretKey || "",
   };
+
+  const { mutate: handleTestKey, isPending: testingKey } = useMutation({
+    mutationFn: async () => {
+      const headers = {
+        "X-Api-Key": keys.apiKey,
+        "X-Secret-Key": keys.secretKey,
+      };
+      const organizationId = sessionStorage.getItem("organizationId");
+      const workspaceId = sessionStorage.getItem("workspaceId");
+      if (organizationId) headers["X-Organization-Id"] = organizationId;
+      if (workspaceId) headers["X-Workspace-Id"] = workspaceId;
+
+      const response = await fetch(new URL(endpoints.auth.me, HOST_API), {
+        method: "GET",
+        headers,
+        credentials: "omit",
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok || body?.status === false) {
+        throw new Error("The key test failed. Please try again.");
+      }
+      return body;
+    },
+    onSuccess: (data) => {
+      const email = data?.email || data?.user?.email;
+      setTestResult({
+        status: "success",
+        message: email
+          ? `Test passed for ${email}`
+          : "Test passed for this organization",
+      });
+    },
+    onError: (error) => {
+      setTestResult({
+        status: "error",
+        message: error?.message || "The key test failed. Please try again.",
+      });
+    },
+  });
 
   return (
     <Dialog
@@ -134,6 +179,28 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
                 visible again in your Future AGI account. If you lose it, you’ll
                 need to generate a new one.
               </Typography>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  flexWrap: "wrap",
+                }}
+              >
+                <Typography
+                  typography="s1"
+                  fontWeight="fontWeightMedium"
+                  color="text.primary"
+                >
+                  Scope
+                </Typography>
+                <Chip
+                  label="Organization scoped"
+                  size="small"
+                  variant="outlined"
+                  sx={{ borderRadius: "4px" }}
+                />
+              </Box>
               <Box display="flex" gap={1}>
                 <TextField
                   label={"API key"}
@@ -208,6 +275,33 @@ const CreateApiKey = ({ open, onClose, refreshGrid }) => {
                   />
                 </Box>
               </Box>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  flexWrap: "wrap",
+                }}
+              >
+                <LoadingButton
+                  size="small"
+                  variant="outlined"
+                  onClick={() => handleTestKey()}
+                  loading={testingKey}
+                  disabled={!keys.apiKey || !keys.secretKey}
+                >
+                  Test key
+                </LoadingButton>
+              </Box>
+              {testResult && (
+                <Alert
+                  severity={testResult.status}
+                  data-api-key-test-status={testResult.status}
+                  sx={{ py: 0.5 }}
+                >
+                  {testResult.message}
+                </Alert>
+              )}
               <Divider orientation="horizontal" />
             </Box>
           </ShowComponent>

--- a/frontend/src/sections/agent-playground/hooks/__tests__/useWorkflowExecution.test.js
+++ b/frontend/src/sections/agent-playground/hooks/__tests__/useWorkflowExecution.test.js
@@ -183,6 +183,26 @@ describe("useWorkflowExecution", () => {
       expect(runState.executionId).toBe("exec-1");
     });
 
+    it("starts polling with backend snake_case execution_ids", async () => {
+      const nodes = [createPromptNode("n1")];
+      setupNodes(nodes);
+      mockFetchGraphDataset.mockResolvedValue({
+        rows: [{ cells: [{ value: "ok" }] }],
+      });
+      mockExecuteDataset.mockResolvedValue({
+        data: { result: { execution_ids: ["exec-snake"] } },
+      });
+
+      const { result } = renderHook(() => useWorkflowExecution());
+      await act(async () => {
+        await result.current.runWorkflow();
+      });
+
+      const runState = useWorkflowRunStore.getState();
+      expect(runState.workflowState).toBe(WORKFLOW_STATE.RUNNING);
+      expect(runState.executionId).toBe("exec-snake");
+    });
+
     it("sets ERROR state and calls failRun on execution failure", async () => {
       const nodes = [createPromptNode("n1")];
       setupNodes(nodes);
@@ -203,6 +223,31 @@ describe("useWorkflowExecution", () => {
       expect(runState.runError).toBe("Custom API error");
       expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
         "Custom API error",
+        expect.objectContaining({ variant: "error" }),
+      );
+    });
+
+    it("uses flattened API result as execution failure message", async () => {
+      const nodes = [createPromptNode("n1")];
+      setupNodes(nodes);
+      mockFetchGraphDataset.mockResolvedValue({
+        rows: [{ cells: [{ value: "ok" }] }],
+      });
+      mockExecuteDataset.mockRejectedValue({
+        result: { message: "Temporal dispatch unavailable" },
+        statusCode: 500,
+      });
+
+      const { result } = renderHook(() => useWorkflowExecution());
+      await act(async () => {
+        await result.current.runWorkflow();
+      });
+
+      const runState = useWorkflowRunStore.getState();
+      expect(runState.workflowState).toBe(WORKFLOW_STATE.ERROR);
+      expect(runState.runError).toBe("Temporal dispatch unavailable");
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        "Temporal dispatch unavailable",
         expect.objectContaining({ variant: "error" }),
       );
     });

--- a/frontend/src/sections/agent-playground/hooks/useWorkflowExecution.js
+++ b/frontend/src/sections/agent-playground/hooks/useWorkflowExecution.js
@@ -18,6 +18,19 @@ import {
 } from "../../../api/agent-playground/agent-playground";
 import { useActivateVersion } from "../../../api/agent-playground/versions";
 
+const getExecutionIdsFromResponse = (res) => {
+  const result = res?.data?.result ?? res?.result ?? res;
+  return result?.executionIds || result?.execution_ids || [];
+};
+
+const getExecutionErrorMessage = (error) =>
+  error?.response?.data?.result?.message ||
+  error?.response?.data?.result ||
+  error?.result?.message ||
+  error?.result ||
+  error?.message ||
+  "Workflow execution failed";
+
 export default function useWorkflowExecution() {
   const { agentId } = useParams();
   const [searchParams] = useSearchParams();
@@ -124,17 +137,14 @@ export default function useWorkflowExecution() {
     setIsInitiating(false);
     try {
       const res = await executeDataset({ graphId });
-      const executionIds = res.data?.result?.executionIds;
+      const executionIds = getExecutionIdsFromResponse(res);
       if (executionIds?.[0]) {
         startPolling(executionIds[0]);
       } else {
         throw new Error("No execution IDs returned");
       }
     } catch (error) {
-      const errorMessage =
-        error?.response?.data?.result ||
-        error?.message ||
-        "Workflow execution failed";
+      const errorMessage = getExecutionErrorMessage(error);
       failRun(errorMessage);
       enqueueSnackbar(errorMessage, { variant: "error" });
     }

--- a/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
+++ b/frontend/src/sections/agents/CallLogs/CallLogsGrid.jsx
@@ -307,8 +307,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
     const updated = callLogsColumnDefs
       .map((col) => ({
         ...col,
-        ...(col.field &&
-          col.field in visMap && { hide: !visMap[col.field] }),
+        ...(col.field && col.field in visMap && { hide: !visMap[col.field] }),
       }))
       .sort((a, b) => {
         const ai = orderIndex.get(a?.field) ?? Infinity;
@@ -379,7 +378,12 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
   // Propagate reorder to parent so the View columns dropdown stays in sync.
   const onColumnMoved = useCallback(
     (params) => {
-      if (!params?.finished || !params?.api || typeof onColumnsChange !== "function") return;
+      if (
+        !params?.finished ||
+        !params?.api ||
+        typeof onColumnsChange !== "function"
+      )
+        return;
       const newOrder = (params?.api?.getColumnState() ?? [])
         .map((s) => s.colId)
         .filter((id) => id !== APP_CONSTANTS.AG_GRID_SELECTION_COLUMN);
@@ -394,8 +398,7 @@ const CallLogsGrid = React.forwardRef(function CallLogsGrid(
       const sameOrder =
         next.length === cols.length &&
         next.every(
-          (c, i) =>
-            (c?.field || c?.id) === (cols[i]?.field || cols[i]?.id),
+          (c, i) => (c?.field || c?.id) === (cols[i]?.field || cols[i]?.id),
         );
       if (!sameOrder) onColumnsChange(next);
     },

--- a/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerCreateNew.jsx
@@ -128,7 +128,7 @@ const EvalPickerCreateNew = ({ onBack, onSave }) => {
   const createEval = useCreateEval();
   const createComposite = useCreateCompositeEval();
   const sourceRef = useRef(null);
-  const {testId,executionId} = useParams();
+  const { testId, executionId } = useParams();
   // Form state (same as EvalCreatePage)
   const [name, setName] = useState("");
   const [mode, setMode] = useState("single");

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/DetailsEdit.jsx
@@ -249,6 +249,12 @@ const DetailsEdit = ({
   });
 
   const onUpdateSubmit = (data, editType) => {
+    const spansLimit =
+      data.spansLimit === undefined ||
+      data.spansLimit === null ||
+      data.spansLimit === ""
+        ? undefined
+        : Number(data.spansLimit);
     const attributeFilters = extractAttributeFilters(data?.filters);
 
     // Task system filter aggregation. The task filter UI only exposes
@@ -292,7 +298,7 @@ const DetailsEdit = ({
       // row_type intentionally omitted from update payload — immutable
       // after task creation; the BE serializer rejects it on PATCH.
       sampling_rate: data.samplingRate,
-      spans_limit: String(data.spansLimit),
+      spans_limit: spansLimit,
       edit_type: editType,
     };
     updateEvalTask(transformedData);

--- a/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
+++ b/frontend/src/sections/common/EvalsTasks/EditTaskDrawer/EditTaskDrawerV2.jsx
@@ -264,6 +264,12 @@ const EditTaskDrawerV2Content = ({
   const onUpdateSubmit = useCallback(
     (editType) => {
       const data = formValues;
+      const spansLimit =
+        data.spansLimit === undefined ||
+        data.spansLimit === null ||
+        data.spansLimit === ""
+          ? undefined
+          : Number(data.spansLimit);
       const attributeFilters = extractAttributeFilters(data?.filters);
 
       // Task system filter aggregation. Keep the update payload aligned with
@@ -308,7 +314,7 @@ const EditTaskDrawerV2Content = ({
         // The BE serializer rejects it on PATCH; the picker is also
         // locked on edit (see TaskConfigPanel rowTypeLocked).
         sampling_rate: data.samplingRate,
-        spans_limit: String(data.spansLimit),
+        spans_limit: spansLimit,
         edit_type: editType,
       };
       updateEvalTask(transformedData);

--- a/frontend/src/sections/develop-detail/DataTab/AddRowData.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/AddRowData.jsx
@@ -80,6 +80,11 @@ const AddRowData = ({ dataset }) => {
     setValue("CUcode", data?.result?.code?.curl_add_col || "");
   }, [data, setValue]);
 
+  const sdkResult = data?.result || {};
+  const sdkApiKeys = sdkResult?.api_keys || sdkResult?.apiKeys || {};
+  const sdkApiKey = sdkApiKeys?.api_key || sdkApiKeys?.apiKey || "N/A";
+  const sdkSecretKey = sdkApiKeys?.secret_key || sdkApiKeys?.secretKey || "N/A";
+
   if (isLoading) {
     return (
       <Box height="100vh" overflow="auto" py="50px" px="15px">
@@ -177,6 +182,7 @@ const AddRowData = ({ dataset }) => {
                 {data?.result?.dataset?.name}
               </Typography>
               <IconButton
+                aria-label="Copy Dataset Name"
                 size="small"
                 onClick={() =>
                   copyToClipboard(data?.result?.dataset?.name, "Dataset Name")
@@ -213,6 +219,7 @@ const AddRowData = ({ dataset }) => {
                 {data?.result?.dataset?.id}
               </Typography>
               <IconButton
+                aria-label="Copy Dataset ID"
                 size="small"
                 onClick={() =>
                   copyToClipboard(data?.result?.dataset?.id, "Dataset ID")
@@ -242,13 +249,12 @@ const AddRowData = ({ dataset }) => {
                 p="5px 12px"
                 color="black"
               >
-                {data?.result?.apiKeys?.apiKey}
+                {sdkApiKey}
               </Typography>
               <IconButton
+                aria-label="Copy API Key"
                 size="small"
-                onClick={() =>
-                  copyToClipboard(data?.result?.apiKeys?.apiKey, "API Key")
-                }
+                onClick={() => copyToClipboard(sdkApiKey, "API Key")}
                 sx={{ color: "text.secondary" }}
               >
                 <Iconify icon="eva:copy-outline" width={16} height={16} />
@@ -274,16 +280,12 @@ const AddRowData = ({ dataset }) => {
                 p="5px 12px"
                 color="black"
               >
-                {data?.result?.apiKeys?.secretKey}
+                {sdkSecretKey}
               </Typography>
               <IconButton
+                aria-label="Copy Secret Key"
                 size="small"
-                onClick={() =>
-                  copyToClipboard(
-                    data?.result?.apiKeys?.secretKey,
-                    "Secret Key",
-                  )
-                }
+                onClick={() => copyToClipboard(sdkSecretKey, "Secret Key")}
                 sx={{ color: "text.secondary" }}
               >
                 <Iconify icon="eva:copy-outline" width={16} height={16} />

--- a/frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/AddSDKModal.jsx
@@ -107,9 +107,10 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
       }),
     onSuccess: (data) => {
       onCloseClick();
+      const result = data?.data?.result || {};
       //@ts-ignore
       addRowSDK({
-        dataset_name: data?.data?.result?.datasetName,
+        dataset_name: result?.dataset_name || result?.datasetName,
       });
       setIsNext(true);
     },
@@ -139,6 +140,10 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
     reset();
     refreshGrid();
   };
+  const sdkResult = data?.data?.result || {};
+  const sdkApiKeys = sdkResult?.api_keys || sdkResult?.apiKeys || {};
+  const sdkApiKey = sdkApiKeys?.api_key || sdkApiKeys?.apiKey || "N/A";
+  const sdkSecretKey = sdkApiKeys?.secret_key || sdkApiKeys?.secretKey || "N/A";
 
   return (
     <>
@@ -304,6 +309,7 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
                     {data?.data?.result?.dataset?.name}
                   </Typography>
                   <IconButton
+                    aria-label="Copy Dataset Name"
                     size="small"
                     onClick={() =>
                       copyToClipboard(
@@ -343,6 +349,7 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
                     {data?.data?.result?.dataset?.id}
                   </Typography>
                   <IconButton
+                    aria-label="Copy Dataset ID"
                     size="small"
                     onClick={() =>
                       copyToClipboard(
@@ -375,16 +382,12 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
                     p="5px 12px"
                     color="black"
                   >
-                    {data?.data?.result?.apiKeys?.apiKey}
+                    {sdkApiKey}
                   </Typography>
                   <IconButton
+                    aria-label="Copy API Key"
                     size="small"
-                    onClick={() =>
-                      copyToClipboard(
-                        data?.data?.result?.apiKeys?.apiKey,
-                        "API Key",
-                      )
-                    }
+                    onClick={() => copyToClipboard(sdkApiKey, "API Key")}
                     sx={{ color: "text.secondary" }}
                   >
                     <Iconify icon="eva:copy-outline" width={16} height={16} />
@@ -410,16 +413,12 @@ const AddSDKModal = ({ open, onClose, refreshGrid }) => {
                     p="5px 12px"
                     color="black"
                   >
-                    {data?.data?.result?.apiKeys?.secretKey}
+                    {sdkSecretKey}
                   </Typography>
                   <IconButton
+                    aria-label="Copy Secret Key"
                     size="small"
-                    onClick={() =>
-                      copyToClipboard(
-                        data?.data?.result?.apiKeys?.secretKey,
-                        "Secret Key",
-                      )
-                    }
+                    onClick={() => copyToClipboard(sdkSecretKey, "Secret Key")}
                     sx={{ color: "text.secondary" }}
                   >
                     <Iconify icon="eva:copy-outline" width={16} height={16} />

--- a/frontend/src/sections/develop/AddDatasetDrawer/UploadFileModal.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/UploadFileModal.jsx
@@ -27,6 +27,7 @@ import { ConfirmDialog } from "src/components/custom-dialog";
 import FormTextFieldV2 from "src/components/FormTextField/FormTextFieldV2";
 import { Events, PropertyName, trackEvent } from "src/utils/Mixpanel";
 import { getRequestErrorMessage } from "src/utils/errorUtils";
+import { getUploadedDatasetId } from "./uploadFileDatasetResponse";
 
 const defaultValues = {
   name: "",
@@ -57,6 +58,7 @@ const UploadFileModal = ({ open, onClose, refreshGrid }) => {
         headers: { "Content-Type": "multipart/form-data" },
       }),
     onSuccess: (data) => {
+      const datasetId = getUploadedDatasetId(data);
       enqueueSnackbar("Dataset uploaded successfully", {
         variant: "success",
       });
@@ -66,12 +68,14 @@ const UploadFileModal = ({ open, onClose, refreshGrid }) => {
       });
       queryClient.invalidateQueries({ queryKey: ["dataset-detail"] });
       trackEvent(Events.datasetFromJSONCSVSuccessful, {
-        [PropertyName.datasetId]: data?.data?.result?.datasetId,
+        [PropertyName.datasetId]: datasetId,
       });
       onCloseClick(null, true);
       reset();
       refreshGrid();
-      navigate(`/dashboard/develop/${data?.data?.result?.datasetId}?tab=data`);
+      if (datasetId) {
+        navigate(`/dashboard/develop/${datasetId}?tab=data`);
+      }
     },
     onError: (error) => {
       enqueueSnackbar(

--- a/frontend/src/sections/develop/AddDatasetDrawer/uploadFileDatasetResponse.js
+++ b/frontend/src/sections/develop/AddDatasetDrawer/uploadFileDatasetResponse.js
@@ -1,0 +1,4 @@
+export function getUploadedDatasetId(response) {
+  const result = response?.data?.result || response?.result || {};
+  return result.dataset_id || result.datasetId || null;
+}

--- a/frontend/src/sections/develop/AddDatasetDrawer/uploadFileDatasetResponse.test.js
+++ b/frontend/src/sections/develop/AddDatasetDrawer/uploadFileDatasetResponse.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getUploadedDatasetId } from "./uploadFileDatasetResponse";
+
+describe("getUploadedDatasetId", () => {
+  it("reads the canonical snake_case local-file dataset create response", () => {
+    expect(
+      getUploadedDatasetId({
+        data: {
+          result: {
+            dataset_id: "dataset-snake",
+          },
+        },
+      }),
+    ).toBe("dataset-snake");
+  });
+
+  it("keeps the legacy camelCase response fallback", () => {
+    expect(
+      getUploadedDatasetId({
+        data: {
+          result: {
+            datasetId: "dataset-camel",
+          },
+        },
+      }),
+    ).toBe("dataset-camel");
+  });
+});

--- a/frontend/src/sections/develop/AddRowDrawer/AddSDKModal.jsx
+++ b/frontend/src/sections/develop/AddRowDrawer/AddSDKModal.jsx
@@ -109,9 +109,14 @@ const AddSDKModal = ({ open, onClose, datasetId, closeDrawer }) => {
     enabled: open, // Trigger query only when modal is open
   });
 
+  const sdkResult = data?.result || {};
+  const sdkApiKeys = sdkResult?.api_keys || sdkResult?.apiKeys || {};
+  const sdkApiKey = sdkApiKeys?.api_key || sdkApiKeys?.apiKey || "N/A";
+  const sdkSecretKey = sdkApiKeys?.secret_key || sdkApiKeys?.secretKey || "N/A";
+
   const handleSubmit = () => {
     trackEvent(Events.rowFromSDKCreated, {
-      [PropertyName.name]: data?.result?.dataset?.name,
+      [PropertyName.name]: sdkResult?.dataset?.name,
       [PropertyName.languageUsed]: currentTab,
     });
     trackEvent(Events.addRowsSuccess, {
@@ -217,6 +222,7 @@ const AddSDKModal = ({ open, onClose, datasetId, closeDrawer }) => {
                   {data?.result?.dataset?.name || "N/A"}
                 </Typography>
                 <IconButton
+                  aria-label="Copy Dataset Name"
                   size="small"
                   onClick={() =>
                     copyToClipboard(data?.result?.dataset?.name, "Dataset Name")
@@ -253,6 +259,7 @@ const AddSDKModal = ({ open, onClose, datasetId, closeDrawer }) => {
                   {data?.result?.dataset?.id || "N/A"}
                 </Typography>
                 <IconButton
+                  aria-label="Copy Dataset ID"
                   size="small"
                   onClick={() =>
                     copyToClipboard(data?.result?.dataset?.id, "Dataset ID")
@@ -282,13 +289,12 @@ const AddSDKModal = ({ open, onClose, datasetId, closeDrawer }) => {
                   p="5px 12px"
                   color="text.primary"
                 >
-                  {data?.result?.apiKeys?.apiKey || "N/A"}
+                  {sdkApiKey}
                 </Typography>
                 <IconButton
+                  aria-label="Copy API Key"
                   size="small"
-                  onClick={() =>
-                    copyToClipboard(data?.result?.apiKeys?.apiKey, "API Key")
-                  }
+                  onClick={() => copyToClipboard(sdkApiKey, "API Key")}
                   sx={{ color: "text.secondary" }}
                 >
                   <Iconify icon="eva:copy-outline" width={16} height={16} />
@@ -314,16 +320,12 @@ const AddSDKModal = ({ open, onClose, datasetId, closeDrawer }) => {
                   p="5px 12px"
                   color="text.primary"
                 >
-                  {data?.result?.apiKeys?.secretKey || "N/A"}
+                  {sdkSecretKey}
                 </Typography>
                 <IconButton
+                  aria-label="Copy Secret Key"
                   size="small"
-                  onClick={() =>
-                    copyToClipboard(
-                      data?.result?.apiKeys?.secretKey,
-                      "Secret Key",
-                    )
-                  }
+                  onClick={() => copyToClipboard(sdkSecretKey, "Secret Key")}
                   sx={{ color: "text.secondary" }}
                 >
                   <Iconify icon="eva:copy-outline" width={16} height={16} />

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -384,9 +384,7 @@ const EvalDetailPage = () => {
           const next = new URLSearchParams(prev);
           next.set(
             "v",
-            String(
-              versionToLoad.version_number ?? versionToLoad.versionNumber,
-            ),
+            String(versionToLoad.version_number ?? versionToLoad.versionNumber),
           );
           return next;
         },
@@ -515,7 +513,6 @@ const EvalDetailPage = () => {
   const initialLoadDone = useRef(false);
   useEffect(() => {
     if (evalData && !viewingVersion) {
-
       const isCustom = evalData.owner !== "system";
       const urlVersion = searchParams.get("v");
       if (urlVersion && !initialLoadDone.current) {

--- a/frontend/src/sections/evals/components/EvalGroundTruthTab.jsx
+++ b/frontend/src/sections/evals/components/EvalGroundTruthTab.jsx
@@ -1161,7 +1161,7 @@ const ConfigPanel = ({ templateId, gtId }) => {
   const [maxExamples, setMaxExamples] = useState(
     config?.maxExamples ?? config?.max_examples ?? 3,
   );
-  const theme = useTheme()
+  const theme = useTheme();
   const [threshold, setThreshold] = useState(
     config?.similarityThreshold ?? config?.similarity_threshold ?? 0.7,
   );
@@ -1224,7 +1224,6 @@ const ConfigPanel = ({ templateId, gtId }) => {
           disableRipple
           onChange={handleToggle}
         />
-
       </Box>
       <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
         <Typography

--- a/frontend/src/sections/evals/components/EvalsListView.jsx
+++ b/frontend/src/sections/evals/components/EvalsListView.jsx
@@ -495,13 +495,15 @@ const EvalsListView = () => {
         cell: ({ getValue }) => {
           const name = getValue();
           return (
-            <CustomTooltip size="small" type="black" show arrow title={name || ""} placement="top">
-              <Typography
-                variant="s1"
-
-                noWrap
-
-              >
+            <CustomTooltip
+              size="small"
+              type="black"
+              show
+              arrow
+              title={name || ""}
+              placement="top"
+            >
+              <Typography variant="s1" noWrap>
                 {name}
               </Typography>
             </CustomTooltip>

--- a/frontend/src/sections/evals/components/SimulationTestMode.jsx
+++ b/frontend/src/sections/evals/components/SimulationTestMode.jsx
@@ -184,7 +184,7 @@ const SimulationTestMode = React.forwardRef(
       initialRunTestId = "",
       isComposite = false,
       compositeAdhocConfig = null,
-      initialExecutionId=null
+      initialExecutionId = null,
     },
     ref,
   ) => {
@@ -356,7 +356,6 @@ const SimulationTestMode = React.forwardRef(
           setExecutions(items);
           setExecutionsFetched(true);
           if (items.length > 0) {
-
             const preferred =
               initialExecutionId &&
               items.some((it) => it.id === initialExecutionId)
@@ -1860,7 +1859,7 @@ SimulationTestMode.propTypes = {
   initialRunTestId: PropTypes.string,
   isComposite: PropTypes.bool,
   compositeAdhocConfig: PropTypes.object,
-  initialExecutionId :PropTypes.string
+  initialExecutionId: PropTypes.string,
 };
 
 export default SimulationTestMode;

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -674,7 +674,7 @@ const TestPlayground = React.forwardRef(
       if (!list.length) return;
       if (urlVersionParam) {
         const match = list.find(
-      ver =>
+          (ver) =>
             String(ver.version_number ?? ver.versionNumber) ===
             String(urlVersionParam),
         );
@@ -860,7 +860,6 @@ const TestPlayground = React.forwardRef(
       Simulation: false,
     });
 
-
     const handleDatasetReady = useCallback(
       (isReady, mapping) => {
         setTabReady((prev) =>
@@ -890,7 +889,7 @@ const TestPlayground = React.forwardRef(
       },
       [onReadyChange],
     );
-  useEffect(() => {
+    useEffect(() => {
       if (!onReadyChange) return;
       onReadyChange(!!tabReady[activeTab]);
     }, [activeTab, tabReady, onReadyChange]);

--- a/frontend/src/sections/evals/components/TracingTestMode.jsx
+++ b/frontend/src/sections/evals/components/TracingTestMode.jsx
@@ -1189,14 +1189,10 @@ const TracingTestMode = React.forwardRef(
               getOptionLabel={(opt) => opt?.name || opt?.id || ""}
               value={projects.find((p) => p.id === selectedProjectId) || null}
               onChange={(_, val) => {
-
-                setSelectedProjectId(val?.id || "")
+                setSelectedProjectId(val?.id || "");
                 setMapping({});
                 setColumns([]);
-
-              }
-
-              }
+              }}
               loading={loadingProjects}
               openOnFocus
               renderInput={(params) => (
@@ -1738,176 +1734,179 @@ const TracingTestMode = React.forwardRef(
           )}
 
         {/* Variable mapping */}
-        {variables.length > 0 && (() => {
-          const isFetchingColumns =
-            !!selectedProjectId &&
-            (loading || isPendingNewFetch || loadingDetail);
-          const mappingDisabledTooltip = isFetchingColumns
-            ? "Columns are being fetched"
-            : "";
-          return (
-            <Box>
-              <Typography
-                variant="caption"
-                fontWeight={600}
-                sx={{ mb: 0.5, display: "block" }}
-              >
-                Variable Mapping
-              </Typography>
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
-                {variables.map((variable) => {
-                  const autocomplete = (
-                    <Autocomplete
-                      size="small"
-                      freeSolo={allowCustomFieldPath}
-                      disabled={isFetchingColumns}
-                      options={
-                        mapping[variable] &&
+        {variables.length > 0 &&
+          (() => {
+            const isFetchingColumns =
+              !!selectedProjectId &&
+              (loading || isPendingNewFetch || loadingDetail);
+            const mappingDisabledTooltip = isFetchingColumns
+              ? "Columns are being fetched"
+              : "";
+            return (
+              <Box>
+                <Typography
+                  variant="caption"
+                  fontWeight={600}
+                  sx={{ mb: 0.5, display: "block" }}
+                >
+                  Variable Mapping
+                </Typography>
+                <Box
+                  sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}
+                >
+                  {variables.map((variable) => {
+                    const autocomplete = (
+                      <Autocomplete
+                        size="small"
+                        freeSolo={allowCustomFieldPath}
+                        disabled={isFetchingColumns}
+                        options={
+                          mapping[variable] &&
                           !fieldNames.includes(mapping[variable])
-                          ? [mapping[variable], ...fieldNames]
-                          : fieldNames
-                      }
-                      value={mapping[variable] || null}
-                      onChange={(_, val) =>
-                        setMapping((prev) => ({
-                          ...prev,
-                          [variable]: val || "",
-                        }))
-                      }
-                      {...(allowCustomFieldPath
-                        ? {
-                          inputValue: mapping[variable] || "",
-                          onInputChange: (_, val, reason) => {
-                            if (reason === "reset") return;
-                            setMapping((prev) => ({
-                              ...prev,
-                              [variable]: val || "",
-                            }));
-                          },
+                            ? [mapping[variable], ...fieldNames]
+                            : fieldNames
                         }
-                        : {})}
-                      openOnFocus
-                      autoHighlight
-                      selectOnFocus
-                      handleHomeEndKeys
-                      isOptionEqualToValue={(opt, val) => opt === val}
-                      sx={{ flex: 1 }}
-                      ListboxProps={{ style: { maxHeight: 260 } }}
-                      renderInput={(params) => (
-                        <TextField
-                          {...params}
-                          placeholder={
-                            isFetchingColumns
-                              ? "Loading columns..."
-                              : allowCustomFieldPath
-                                ? "Search or type a path (e.g. attributes.input.value)"
-                                : "Search column..."
-                          }
-                          InputProps={{
-                            ...params.InputProps,
-                            sx: {
-                              ...params.InputProps.sx,
-                              fontSize: "12px",
-                              fontFamily: "monospace",
-                              height: 28,
-                              py: 0,
-                            },
-                            endAdornment: isFetchingColumns ? (
-                              <InputAdornment position="end">
-                                <CircularProgress size={14} />
-                              </InputAdornment>
-                            ) : (
-                              params.InputProps.endAdornment
-                            ),
-                          }}
-                        />
-                      )}
-                      renderOption={(props, col) => {
-                        const { key, ...rest } = props;
-                        return (
-                          <Box
-                            component="li"
-                            key={key}
-                            {...rest}
-                            title={col}
-                            sx={{
-                              ...rest.sx,
-                              fontSize: "12px",
-                              fontFamily: "monospace",
-                              pl: col.includes(".")
-                                ? `${12 + (col.split(".").length - 1) * 12}px`
-                                : undefined,
-                              color: col.includes(".")
-                                ? "primary.main"
-                                : "text.primary",
-                              whiteSpace: "nowrap",
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
+                        value={mapping[variable] || null}
+                        onChange={(_, val) =>
+                          setMapping((prev) => ({
+                            ...prev,
+                            [variable]: val || "",
+                          }))
+                        }
+                        {...(allowCustomFieldPath
+                          ? {
+                              inputValue: mapping[variable] || "",
+                              onInputChange: (_, val, reason) => {
+                                if (reason === "reset") return;
+                                setMapping((prev) => ({
+                                  ...prev,
+                                  [variable]: val || "",
+                                }));
+                              },
+                            }
+                          : {})}
+                        openOnFocus
+                        autoHighlight
+                        selectOnFocus
+                        handleHomeEndKeys
+                        isOptionEqualToValue={(opt, val) => opt === val}
+                        sx={{ flex: 1 }}
+                        ListboxProps={{ style: { maxHeight: 260 } }}
+                        renderInput={(params) => (
+                          <TextField
+                            {...params}
+                            placeholder={
+                              isFetchingColumns
+                                ? "Loading columns..."
+                                : allowCustomFieldPath
+                                  ? "Search or type a path (e.g. attributes.input.value)"
+                                  : "Search column..."
+                            }
+                            InputProps={{
+                              ...params.InputProps,
+                              sx: {
+                                ...params.InputProps.sx,
+                                fontSize: "12px",
+                                fontFamily: "monospace",
+                                height: 28,
+                                py: 0,
+                              },
+                              endAdornment: isFetchingColumns ? (
+                                <InputAdornment position="end">
+                                  <CircularProgress size={14} />
+                                </InputAdornment>
+                              ) : (
+                                params.InputProps.endAdornment
+                              ),
                             }}
-                          >
-                            {col}
-                          </Box>
-                        );
-                      }}
-                    />
-                  );
-                  return (
-                    <Box
-                      key={variable}
-                      sx={{ display: "flex", alignItems: "center", gap: 1 }}
-                    >
-                      <Box
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 0.5,
-                          px: 1,
-                          py: 0.25,
-                          borderRadius: "4px",
-                          border: "1px solid",
-                          borderColor: "divider",
-                          minWidth: 120,
+                          />
+                        )}
+                        renderOption={(props, col) => {
+                          const { key, ...rest } = props;
+                          return (
+                            <Box
+                              component="li"
+                              key={key}
+                              {...rest}
+                              title={col}
+                              sx={{
+                                ...rest.sx,
+                                fontSize: "12px",
+                                fontFamily: "monospace",
+                                pl: col.includes(".")
+                                  ? `${12 + (col.split(".").length - 1) * 12}px`
+                                  : undefined,
+                                color: col.includes(".")
+                                  ? "primary.main"
+                                  : "text.primary",
+                                whiteSpace: "nowrap",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                              }}
+                            >
+                              {col}
+                            </Box>
+                          );
                         }}
-                      >
-                        <Iconify
-                          icon="mdi:code-braces"
-                          width={14}
-                          sx={{ color: "text.secondary" }}
-                        />
-                        <Typography
-                          variant="caption"
-                          fontWeight={600}
-                          sx={{ fontSize: "12px" }}
-                        >
-                          {variable}
-                        </Typography>
-                      </Box>
-                      <Iconify
-                        icon="mdi:arrow-right"
-                        width={14}
-                        sx={{ color: "text.disabled" }}
                       />
-                      {isFetchingColumns ? (
-                        <CustomTooltip
-                          show
-                          type="black"
-                          size="small"
-                          title={mappingDisabledTooltip}
-                          placement="top"
-                          arrow
+                    );
+                    return (
+                      <Box
+                        key={variable}
+                        sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                      >
+                        <Box
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 0.5,
+                            px: 1,
+                            py: 0.25,
+                            borderRadius: "4px",
+                            border: "1px solid",
+                            borderColor: "divider",
+                            minWidth: 120,
+                          }}
                         >
-                          <Box sx={{ flex: 1 }}>{autocomplete}</Box>
-                        </CustomTooltip>
-                      ) : (
-                        autocomplete
-                      )}
-                    </Box>
-                  );
-                })}
+                          <Iconify
+                            icon="mdi:code-braces"
+                            width={14}
+                            sx={{ color: "text.secondary" }}
+                          />
+                          <Typography
+                            variant="caption"
+                            fontWeight={600}
+                            sx={{ fontSize: "12px" }}
+                          >
+                            {variable}
+                          </Typography>
+                        </Box>
+                        <Iconify
+                          icon="mdi:arrow-right"
+                          width={14}
+                          sx={{ color: "text.disabled" }}
+                        />
+                        {isFetchingColumns ? (
+                          <CustomTooltip
+                            show
+                            type="black"
+                            size="small"
+                            title={mappingDisabledTooltip}
+                            placement="top"
+                            arrow
+                          >
+                            <Box sx={{ flex: 1 }}>{autocomplete}</Box>
+                          </CustomTooltip>
+                        ) : (
+                          autocomplete
+                        )}
+                      </Box>
+                    );
+                  })}
+                </Box>
               </Box>
-            </Box>
-          );
-        })()}
+            );
+          })()}
 
         {/* Result */}
         {result && (

--- a/frontend/src/sections/gateway/mcp/MCPPlaygroundTab.jsx
+++ b/frontend/src/sections/gateway/mcp/MCPPlaygroundTab.jsx
@@ -121,6 +121,10 @@ const MCPPlaygroundTab = ({ mcpTools, gatewayId }) => {
                   {...params}
                   size="small"
                   placeholder="Select a tool to test..."
+                  inputProps={{
+                    ...params.inputProps,
+                    "data-testid": "mcp-playground-tool-input",
+                  }}
                 />
               )}
             />
@@ -196,6 +200,9 @@ const MCPPlaygroundTab = ({ mcpTools, gatewayId }) => {
                   }}
                   error={Boolean(jsonError)}
                   helperText={jsonError}
+                  inputProps={{
+                    "data-testid": "mcp-playground-arguments-input",
+                  }}
                   InputProps={{
                     sx: { fontFamily: "monospace", fontSize: 13 },
                   }}
@@ -214,6 +221,7 @@ const MCPPlaygroundTab = ({ mcpTools, gatewayId }) => {
                     }
                     onClick={handleExecute}
                     disabled={testMutation.isPending}
+                    data-testid="mcp-playground-execute-button"
                   >
                     {testMutation.isPending ? "Executing..." : "Execute"}
                   </Button>
@@ -222,7 +230,7 @@ const MCPPlaygroundTab = ({ mcpTools, gatewayId }) => {
             </Card>
 
             {result && (
-              <Card>
+              <Card data-testid="mcp-playground-result">
                 <CardContent>
                   <Typography variant="subtitle1" fontWeight={700} gutterBottom>
                     Result

--- a/frontend/src/sections/gateway/monitoring/AlertingMonitoringSection.jsx
+++ b/frontend/src/sections/gateway/monitoring/AlertingMonitoringSection.jsx
@@ -18,6 +18,13 @@ import {
   TableRow,
   Chip,
   Skeleton,
+  IconButton,
+  Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
 } from "@mui/material";
 import Iconify from "src/components/iconify";
 import SectionHeader from "../components/SectionHeader";
@@ -26,9 +33,11 @@ import { useNavigate, useParams } from "react-router-dom";
 import {
   useGatewayConfig,
   useProviderHealth,
+  useUpdateConfig,
 } from "../providers/hooks/useGatewayConfig";
 import { useAnalyticsOverview } from "../analytics/hooks/useAnalyticsOverview";
 import { useGatewayContext } from "../context/useGatewayContext";
+import { enqueueSnackbar } from "notistack";
 
 import CreateAlertRuleDialog from "./CreateAlertRuleDialog";
 import CreateChannelDialog from "./CreateChannelDialog";
@@ -43,10 +52,10 @@ function extractAlertRules(config) {
   const alerting = config?.alerting || config?.alerts || {};
   const rules = alerting.rules || alerting.alert_rules || [];
   if (Array.isArray(rules)) return rules;
-  if (typeof rules === "object") {
+  if (rules && typeof rules === "object") {
     return Object.entries(rules).map(([name, cfg]) => ({
       name,
-      ...(typeof cfg === "object" ? cfg : {}),
+      ...(cfg && typeof cfg === "object" ? cfg : {}),
     }));
   }
   return [];
@@ -56,13 +65,49 @@ function extractChannels(config) {
   const alerting = config?.alerting || config?.alerts || {};
   const channels = alerting.channels || alerting.notification_channels || [];
   if (Array.isArray(channels)) return channels;
-  if (typeof channels === "object") {
+  if (channels && typeof channels === "object") {
     return Object.entries(channels).map(([name, cfg]) => ({
       name,
-      ...(typeof cfg === "object" ? cfg : {}),
+      ...(cfg && typeof cfg === "object" ? cfg : {}),
     }));
   }
   return [];
+}
+
+function rawAlertRules(config) {
+  const alerting = config?.alerting || config?.alerts || {};
+  return alerting.rules ?? alerting.alert_rules ?? [];
+}
+
+function rawChannels(config) {
+  const alerting = config?.alerting || config?.alerts || {};
+  return alerting.channels ?? alerting.notification_channels ?? [];
+}
+
+function ruleName(rule, index) {
+  return rule?.name || `Rule ${index + 1}`;
+}
+
+function channelName(channel, index) {
+  return channel?.name || `Channel ${index + 1}`;
+}
+
+function rulesToMap(rules) {
+  return Object.fromEntries(
+    rules.map((rule, index) => {
+      const name = ruleName(rule, index);
+      return [name, { ...rule, name }];
+    }),
+  );
+}
+
+function channelsToMap(channels) {
+  return Object.fromEntries(
+    channels.map((channel, index) => {
+      const name = channelName(channel, index);
+      return [name, { ...channel, name }];
+    }),
+  );
 }
 
 const TAB_SLUGS = ["metrics", "rules", "channels"];
@@ -82,7 +127,7 @@ function getSeverityColor(severity) {
 // Alert Rules Tab
 // ---------------------------------------------------------------------------
 
-const AlertRulesTab = ({ rules }) => (
+const AlertRulesTab = ({ rules, onEdit, onDelete }) => (
   <Card>
     <TableContainer>
       <Table size="small">
@@ -95,6 +140,7 @@ const AlertRulesTab = ({ rules }) => (
             <TableCell>Window</TableCell>
             <TableCell>Severity</TableCell>
             <TableCell>Status</TableCell>
+            <TableCell align="right">Actions</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -140,11 +186,32 @@ const AlertRulesTab = ({ rules }) => (
                   variant="outlined"
                 />
               </TableCell>
+              <TableCell align="right">
+                <Tooltip title="Edit">
+                  <IconButton
+                    size="small"
+                    aria-label={`Edit alert rule ${ruleName(rule, idx)}`}
+                    onClick={() => onEdit(rule)}
+                  >
+                    <Iconify icon="mdi:pencil" width={18} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Delete">
+                  <IconButton
+                    size="small"
+                    color="error"
+                    aria-label={`Delete alert rule ${ruleName(rule, idx)}`}
+                    onClick={() => onDelete(rule)}
+                  >
+                    <Iconify icon="mdi:trash-can-outline" width={18} />
+                  </IconButton>
+                </Tooltip>
+              </TableCell>
             </TableRow>
           ))}
           {rules.length === 0 && (
             <TableRow>
-              <TableCell colSpan={7} align="center">
+              <TableCell colSpan={8} align="center">
                 <Typography variant="body2" color="text.secondary" py={4}>
                   No alert rules configured. Click &quot;Create Rule&quot; to
                   add your first alert rule.
@@ -179,7 +246,7 @@ function maskUrl(url) {
   }
 }
 
-const ChannelsTab = ({ channels }) => (
+const ChannelsTab = ({ channels, onEdit, onDelete }) => (
   <Stack spacing={2}>
     {channels.length === 0 ? (
       <Card sx={{ p: 4 }}>
@@ -207,18 +274,45 @@ const ChannelsTab = ({ channels }) => (
                   {ch.name || `Channel ${idx + 1}`}
                 </Typography>
               </Stack>
-              <Stack direction="row" spacing={0.5}>
-                <Chip
-                  label={ch.type || "webhook"}
-                  color="primary"
-                  size="small"
-                  variant="outlined"
-                />
-                <Chip
-                  label={ch.enabled !== false ? "Enabled" : "Disabled"}
-                  color={ch.enabled !== false ? "success" : "default"}
-                  size="small"
-                />
+              <Stack direction="row" spacing={0.5} alignItems="center">
+                <Stack direction="row" spacing={0.5}>
+                  <Chip
+                    label={ch.type || "webhook"}
+                    color="primary"
+                    size="small"
+                    variant="outlined"
+                  />
+                  <Chip
+                    label={ch.enabled !== false ? "Enabled" : "Disabled"}
+                    color={ch.enabled !== false ? "success" : "default"}
+                    size="small"
+                  />
+                </Stack>
+                <Tooltip title="Edit">
+                  <IconButton
+                    size="small"
+                    aria-label={`Edit notification channel ${channelName(
+                      ch,
+                      idx,
+                    )}`}
+                    onClick={() => onEdit(ch)}
+                  >
+                    <Iconify icon="mdi:pencil" width={18} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Delete">
+                  <IconButton
+                    size="small"
+                    color="error"
+                    aria-label={`Delete notification channel ${channelName(
+                      ch,
+                      idx,
+                    )}`}
+                    onClick={() => onDelete(ch)}
+                  >
+                    <Iconify icon="mdi:trash-can-outline" width={18} />
+                  </IconButton>
+                </Tooltip>
               </Stack>
             </Stack>
             <Stack spacing={0.75}>
@@ -460,6 +554,9 @@ const AlertingMonitoringSection = () => {
 
   const [createRuleOpen, setCreateRuleOpen] = useState(false);
   const [createChannelOpen, setCreateChannelOpen] = useState(false);
+  const [editRule, setEditRule] = useState(null);
+  const [editChannel, setEditChannel] = useState(null);
+  const [deleteTarget, setDeleteTarget] = useState(null);
   const { gatewayId, isLoading: gwLoading } = useGatewayContext();
 
   const { data: config, isLoading: configLoading } =
@@ -481,6 +578,60 @@ const AlertingMonitoringSection = () => {
 
   const rules = useMemo(() => extractAlertRules(config), [config]);
   const channels = useMemo(() => extractChannels(config), [config]);
+  const replaceRules = Array.isArray(rawAlertRules(config));
+  const replaceChannels = Array.isArray(rawChannels(config));
+  const updateConfig = useUpdateConfig();
+
+  const handleDelete = () => {
+    if (!deleteTarget) return;
+    const isRule = deleteTarget.type === "rule";
+    const item = deleteTarget.item;
+    const name = item?.name;
+    if (!name) return;
+    const alertingPatch = isRule
+      ? {
+          rules: replaceRules
+            ? Object.fromEntries(
+                Object.entries(rulesToMap(rules)).filter(
+                  ([ruleKey]) => ruleKey !== name,
+                ),
+              )
+            : { [name]: null },
+        }
+      : {
+          channels: replaceChannels
+            ? Object.fromEntries(
+                Object.entries(channelsToMap(channels)).filter(
+                  ([channelKey]) => channelKey !== name,
+                ),
+              )
+            : { [name]: null },
+        };
+
+    updateConfig.mutate(
+      {
+        gatewayId,
+        config: { alerting: alertingPatch },
+      },
+      {
+        onSuccess: () => {
+          enqueueSnackbar(
+            `${isRule ? "Alert rule" : "Channel"} "${name}" deleted`,
+            {
+              variant: "success",
+            },
+          );
+          setDeleteTarget(null);
+        },
+        onError: () => {
+          enqueueSnackbar(
+            `Failed to delete ${isRule ? "alert rule" : "channel"}`,
+            { variant: "error" },
+          );
+        },
+      },
+    );
+  };
 
   if (gwLoading || configLoading) {
     return (
@@ -545,19 +696,78 @@ const AlertingMonitoringSection = () => {
           gatewayId={gatewayId}
         />
       )}
-      {tab === 1 && <AlertRulesTab rules={rules} />}
-      {tab === 2 && <ChannelsTab channels={channels} />}
+      {tab === 1 && (
+        <AlertRulesTab
+          rules={rules}
+          onEdit={setEditRule}
+          onDelete={(item) => setDeleteTarget({ type: "rule", item })}
+        />
+      )}
+      {tab === 2 && (
+        <ChannelsTab
+          channels={channels}
+          onEdit={setEditChannel}
+          onDelete={(item) => setDeleteTarget({ type: "channel", item })}
+        />
+      )}
 
       <CreateAlertRuleDialog
         open={createRuleOpen}
         onClose={() => setCreateRuleOpen(false)}
         gatewayId={gatewayId}
+        existingRules={rules}
+        replaceRules={replaceRules}
       />
       <CreateChannelDialog
         open={createChannelOpen}
         onClose={() => setCreateChannelOpen(false)}
         gatewayId={gatewayId}
+        existingChannels={channels}
+        replaceChannels={replaceChannels}
       />
+      <CreateAlertRuleDialog
+        open={Boolean(editRule)}
+        onClose={() => setEditRule(null)}
+        gatewayId={gatewayId}
+        initialRule={editRule}
+        existingRules={rules}
+        replaceRules={replaceRules}
+      />
+      <CreateChannelDialog
+        open={Boolean(editChannel)}
+        onClose={() => setEditChannel(null)}
+        gatewayId={gatewayId}
+        initialChannel={editChannel}
+        existingChannels={channels}
+        replaceChannels={replaceChannels}
+      />
+      <Dialog
+        open={Boolean(deleteTarget)}
+        onClose={() => setDeleteTarget(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>
+          Delete {deleteTarget?.type === "rule" ? "Alert Rule" : "Channel"}
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary">
+            This removes &quot;{deleteTarget?.item?.name}&quot; from the active
+            Gateway alerting config.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={handleDelete}
+            disabled={updateConfig.isPending}
+          >
+            {updateConfig.isPending ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 };

--- a/frontend/src/sections/gateway/monitoring/CreateAlertRuleDialog.jsx
+++ b/frontend/src/sections/gateway/monitoring/CreateAlertRuleDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import {
   Dialog,
@@ -24,22 +24,57 @@ const METRICS = [
 const CONDITIONS = [">", ">=", "<", "<=", "=="];
 const SEVERITIES = ["critical", "warning", "info"];
 
-const CreateAlertRuleDialog = ({ open, onClose, gatewayId }) => {
+function ruleName(rule, index) {
+  return rule?.name || `Rule ${index + 1}`;
+}
+
+function rulesToMap(rules) {
+  return Object.fromEntries(
+    rules.map((rule, index) => {
+      const name = ruleName(rule, index);
+      return [name, { ...rule, name }];
+    }),
+  );
+}
+
+const CreateAlertRuleDialog = ({
+  open,
+  onClose,
+  gatewayId,
+  initialRule = null,
+  existingRules = [],
+  replaceRules = false,
+}) => {
+  const isEdit = Boolean(initialRule);
   const [name, setName] = useState("");
   const [metric, setMetric] = useState("error_rate");
   const [condition, setCondition] = useState(">");
   const [threshold, setThreshold] = useState("");
-  const [window, setWindow] = useState("5m");
+  const [windowValue, setWindowValue] = useState("5m");
   const [severity, setSeverity] = useState("warning");
 
   const updateConfig = useUpdateConfig();
+
+  useEffect(() => {
+    if (!open) return;
+    setName(initialRule?.name || "");
+    setMetric(initialRule?.metric || "error_rate");
+    setCondition(initialRule?.condition || initialRule?.operator || ">");
+    setThreshold(
+      initialRule?.threshold === undefined || initialRule?.threshold === null
+        ? ""
+        : String(initialRule.threshold),
+    );
+    setWindowValue(initialRule?.window || initialRule?.duration || "5m");
+    setSeverity(initialRule?.severity || "warning");
+  }, [initialRule, open]);
 
   const resetForm = () => {
     setName("");
     setMetric("error_rate");
     setCondition(">");
     setThreshold("");
-    setWindow("5m");
+    setWindowValue("5m");
     setSeverity("warning");
   };
 
@@ -54,30 +89,47 @@ const CreateAlertRuleDialog = ({ open, onClose, gatewayId }) => {
       metric,
       condition,
       threshold: Number(threshold),
-      window,
+      window: windowValue,
       severity,
       enabled: true,
     };
+    const originalName = initialRule?.name;
+    const rulesPatch = replaceRules ? rulesToMap(existingRules) : {};
+    if (originalName && originalName !== name) {
+      if (replaceRules) {
+        delete rulesPatch[originalName];
+      } else {
+        rulesPatch[originalName] = null;
+      }
+    }
+    rulesPatch[name] = rule;
 
-    // We'll send this as a config patch that adds the rule
     updateConfig.mutate(
       {
         gatewayId,
         config: {
           alerting: {
-            rules: { [name]: rule },
+            rules: rulesPatch,
           },
         },
       },
       {
         onSuccess: () => {
-          enqueueSnackbar(`Alert rule "${name}" created`, {
-            variant: "success",
-          });
+          enqueueSnackbar(
+            `Alert rule "${name}" ${isEdit ? "updated" : "created"}`,
+            {
+              variant: "success",
+            },
+          );
           handleClose();
         },
         onError: () => {
-          enqueueSnackbar("Failed to create alert rule", { variant: "error" });
+          enqueueSnackbar(
+            `Failed to ${isEdit ? "update" : "create"} alert rule`,
+            {
+              variant: "error",
+            },
+          );
         },
       },
     );
@@ -85,7 +137,9 @@ const CreateAlertRuleDialog = ({ open, onClose, gatewayId }) => {
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Create Alert Rule</DialogTitle>
+      <DialogTitle>
+        {isEdit ? "Edit Alert Rule" : "Create Alert Rule"}
+      </DialogTitle>
       <DialogContent>
         <Stack spacing={2} mt={1}>
           <TextField
@@ -136,8 +190,8 @@ const CreateAlertRuleDialog = ({ open, onClose, gatewayId }) => {
           <TextField
             label="Window"
             fullWidth
-            value={window}
-            onChange={(e) => setWindow(e.target.value)}
+            value={windowValue}
+            onChange={(e) => setWindowValue(e.target.value)}
             placeholder="e.g., 5m, 1h"
           />
           <TextField
@@ -167,7 +221,13 @@ const CreateAlertRuleDialog = ({ open, onClose, gatewayId }) => {
           onClick={handleCreate}
           disabled={!name.trim() || !threshold || updateConfig.isPending}
         >
-          {updateConfig.isPending ? "Creating..." : "Create Rule"}
+          {updateConfig.isPending
+            ? isEdit
+              ? "Saving..."
+              : "Creating..."
+            : isEdit
+              ? "Save Rule"
+              : "Create Rule"}
         </Button>
       </DialogActions>
     </Dialog>
@@ -178,6 +238,9 @@ CreateAlertRuleDialog.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   gatewayId: PropTypes.string,
+  initialRule: PropTypes.object,
+  existingRules: PropTypes.arrayOf(PropTypes.object),
+  replaceRules: PropTypes.bool,
 };
 
 export default CreateAlertRuleDialog;

--- a/frontend/src/sections/gateway/monitoring/CreateChannelDialog.jsx
+++ b/frontend/src/sections/gateway/monitoring/CreateChannelDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import {
   Dialog,
@@ -16,12 +16,45 @@ import { useUpdateConfig } from "../providers/hooks/useGatewayConfig";
 
 const CHANNEL_TYPES = ["webhook", "email", "slack", "pagerduty"];
 
-const CreateChannelDialog = ({ open, onClose, gatewayId }) => {
+function channelName(channel, index) {
+  return channel?.name || `Channel ${index + 1}`;
+}
+
+function channelsToMap(channels) {
+  return Object.fromEntries(
+    channels.map((channel, index) => {
+      const name = channelName(channel, index);
+      return [name, { ...channel, name }];
+    }),
+  );
+}
+
+const CreateChannelDialog = ({
+  open,
+  onClose,
+  gatewayId,
+  initialChannel = null,
+  existingChannels = [],
+  replaceChannels = false,
+}) => {
+  const isEdit = Boolean(initialChannel);
   const [name, setName] = useState("");
   const [type, setType] = useState("webhook");
   const [url, setUrl] = useState("");
 
   const updateConfig = useUpdateConfig();
+
+  useEffect(() => {
+    if (!open) return;
+    setName(initialChannel?.name || "");
+    setType(initialChannel?.type || "webhook");
+    setUrl(
+      initialChannel?.url ||
+        initialChannel?.endpoint ||
+        initialChannel?.webhook_url ||
+        "",
+    );
+  }, [initialChannel, open]);
 
   const resetForm = () => {
     setName("");
@@ -36,23 +69,42 @@ const CreateChannelDialog = ({ open, onClose, gatewayId }) => {
 
   const handleCreate = () => {
     const channel = { name, type, url };
+    const originalName = initialChannel?.name;
+    const channelsPatch = replaceChannels
+      ? channelsToMap(existingChannels)
+      : {};
+    if (originalName && originalName !== name) {
+      if (replaceChannels) {
+        delete channelsPatch[originalName];
+      } else {
+        channelsPatch[originalName] = null;
+      }
+    }
+    channelsPatch[name] = channel;
 
     updateConfig.mutate(
       {
         gatewayId,
         config: {
           alerting: {
-            channels: { [name]: channel },
+            channels: channelsPatch,
           },
         },
       },
       {
         onSuccess: () => {
-          enqueueSnackbar(`Channel "${name}" created`, { variant: "success" });
+          enqueueSnackbar(
+            `Channel "${name}" ${isEdit ? "updated" : "created"}`,
+            {
+              variant: "success",
+            },
+          );
           handleClose();
         },
         onError: () => {
-          enqueueSnackbar("Failed to create channel", { variant: "error" });
+          enqueueSnackbar(`Failed to ${isEdit ? "update" : "create"} channel`, {
+            variant: "error",
+          });
         },
       },
     );
@@ -60,7 +112,9 @@ const CreateChannelDialog = ({ open, onClose, gatewayId }) => {
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Add Notification Channel</DialogTitle>
+      <DialogTitle>
+        {isEdit ? "Edit Notification Channel" : "Add Notification Channel"}
+      </DialogTitle>
       <DialogContent>
         <Stack spacing={2} mt={1}>
           <TextField
@@ -112,7 +166,13 @@ const CreateChannelDialog = ({ open, onClose, gatewayId }) => {
           onClick={handleCreate}
           disabled={!name.trim() || !url.trim() || updateConfig.isPending}
         >
-          {updateConfig.isPending ? "Creating..." : "Add Channel"}
+          {updateConfig.isPending
+            ? isEdit
+              ? "Saving..."
+              : "Creating..."
+            : isEdit
+              ? "Save Channel"
+              : "Add Channel"}
         </Button>
       </DialogActions>
     </Dialog>
@@ -123,6 +183,9 @@ CreateChannelDialog.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   gatewayId: PropTypes.string,
+  initialChannel: PropTypes.object,
+  existingChannels: PropTypes.arrayOf(PropTypes.object),
+  replaceChannels: PropTypes.bool,
 };
 
 export default CreateChannelDialog;

--- a/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/SpanGrid.jsx
@@ -426,7 +426,10 @@ const SpanGrid = React.forwardRef(
                       .filter((cc) => newById.has(cc.id))
                       .map((cc) => {
                         seen.add(cc.id);
-                        return { ...newById.get(cc.id), isVisible: cc.isVisible };
+                        return {
+                          ...newById.get(cc.id),
+                          isVisible: cc.isVisible,
+                        };
                       });
                     const added = newCols.filter((nc) => !seen.has(nc.id));
                     finalNonCustom = [...kept, ...added];

--- a/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
+++ b/frontend/src/sections/projects/LLMTracing/TraceGrid.jsx
@@ -274,7 +274,10 @@ const TraceGrid = React.forwardRef(
                       .filter((cc) => newById.has(cc.id))
                       .map((cc) => {
                         seen.add(cc.id);
-                        return { ...newById.get(cc.id), isVisible: cc.isVisible };
+                        return {
+                          ...newById.get(cc.id),
+                          isVisible: cc.isVisible,
+                        };
                       });
                     const added = newCols.filter((nc) => !seen.has(nc.id));
                     finalNonCustom = [...kept, ...added];

--- a/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
+++ b/frontend/src/sections/projects/UsersView/UserDetails/UserTraceTabV2.jsx
@@ -184,11 +184,12 @@ const UserTraceTabV2 = ({ dateFilter }) => {
       />
 
       <FilterChips
-        extraFilters={/** @type {any[]} */ (extraFilters).map((f) => ({
-          ...f,
-          display_name:
-            columnLabelLookup[f?.column_id] ?? f?.display_name,
-        }))}
+        extraFilters={
+          /** @type {any[]} */ (extraFilters).map((f) => ({
+            ...f,
+            display_name: columnLabelLookup[f?.column_id] ?? f?.display_name,
+          }))
+        }
         onRemoveFilter={(idx) => {
           // Chips are keyed by array index, so any removal re-mounts the
           // later chips and invalidates a chip-anchored popover ref.

--- a/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/UsageSummaryV2.jsx
@@ -478,7 +478,8 @@ function DimensionCard({ dim, periodCaption }) {
                       color="text.secondary"
                       sx={{ textAlign: "right" }}
                     >
-                      {formatTierRate(tier.rate)}/{getSingularUnit(dim.display_unit)}
+                      {formatTierRate(tier.rate)}/
+                      {getSingularUnit(dim.display_unit)}
                     </Typography>
                     <Typography
                       variant="caption"

--- a/frontend/src/sections/settings/UsageSummaryV2/WorkspaceBreakdown.jsx
+++ b/frontend/src/sections/settings/UsageSummaryV2/WorkspaceBreakdown.jsx
@@ -135,9 +135,7 @@ export default function WorkspaceBreakdown({
                 </Typography>
               </TableCell>
               <TableCell align="right">
-                <Typography variant="body2">
-                  {fUsage(w.usage)}
-                </Typography>
+                <Typography variant="body2">{fUsage(w.usage)}</Typography>
               </TableCell>
               <TableCell align="right">
                 <Typography variant="body2" color="text.secondary">
@@ -155,9 +153,7 @@ export default function WorkspaceBreakdown({
               <Typography variant="subtitle2">Total</Typography>
             </TableCell>
             <TableCell align="right">
-              <Typography variant="subtitle2">
-                {fUsage(totalUsage)}
-              </Typography>
+              <Typography variant="subtitle2">{fUsage(totalUsage)}</Typography>
             </TableCell>
             <TableCell align="right">
               <Typography variant="subtitle2">100%</Typography>

--- a/frontend/src/sections/tasks/TaskDetailPage.jsx
+++ b/frontend/src/sections/tasks/TaskDetailPage.jsx
@@ -76,6 +76,7 @@ const TaskDetailPage = () => {
     canTest: false,
     isTesting: false,
   });
+  const [pendingUpdateData, setPendingUpdateData] = useState(null);
   const handleTestStateChange = useCallback((next) => {
     setTestState(next);
   }, []);
@@ -105,7 +106,7 @@ const TaskDetailPage = () => {
   }, [taskDetails, reset]);
 
   // ── Mutations ──
-  const { mutate: updateTask, isPending: isUpdating } = useMutation({
+  const { mutateAsync: updateTask, isPending: isUpdating } = useMutation({
     mutationFn: (data) =>
       axios.patch(endpoints.project.patchEvalTask(), {
         ...data,
@@ -163,21 +164,32 @@ const TaskDetailPage = () => {
 
   // Transform form → update payload (same logic as EditTaskDrawerV2)
   const handleSave = useCallback(() => {
-    handleSubmit(() => {
+    handleSubmit((data) => {
+      setPendingUpdateData(data);
       setConfirmOpen(true);
     })();
   }, [handleSubmit]);
 
   const handleConfirm = useCallback(
-    (editType) => {
-      const data = formValues;
-      const { filters, attributeFilters } = getNewTaskFilters(
-        data,
-        data.project,
-      );
+    async (editType) => {
+      const data = pendingUpdateData || formValues;
+      const spansLimit =
+        data.spansLimit === undefined ||
+        data.spansLimit === null ||
+        data.spansLimit === ""
+          ? undefined
+          : Number(data.spansLimit);
+      const normalizedFilters = Array.isArray(data.filters)
+        ? getNewTaskFilters(data, data.project)
+        : { filters: data.filters || {}, attributeFilters: [] };
+      const { filters, attributeFilters } = normalizedFilters;
+      const evalIds =
+        data.evals ||
+        data.evalsDetails?.map((item) => item.id || item).filter(Boolean) ||
+        [];
 
       const transformedData = {
-        evals: data.evalsDetails?.map((item) => item.id || item) || [],
+        evals: evalIds,
         filters: {
           ...filters,
           ...(attributeFilters?.length > 0
@@ -189,13 +201,25 @@ const TaskDetailPage = () => {
         project: data.project,
         run_type: data.runType,
         sampling_rate: data.samplingRate,
-        spans_limit: data.spansLimit ? String(data.spansLimit) : undefined,
+        spans_limit: spansLimit,
         edit_type: editType,
       };
-      updateTask(transformedData);
-      setConfirmOpen(false);
+      try {
+        await updateTask(transformedData);
+        setPendingUpdateData(null);
+        setConfirmOpen(false);
+      } catch {
+        // React Query handles the user-facing error snackbar in onError.
+      }
     },
-    [formValues, updateTask],
+    [formValues, pendingUpdateData, updateTask],
+  );
+
+  const handleOpenEval = useCallback(
+    (evalTemplateId) => {
+      navigate(`/dashboard/evaluations/${evalTemplateId}`);
+    },
+    [navigate],
   );
 
   if (isLoading) {
@@ -416,6 +440,7 @@ const TaskDetailPage = () => {
                 initialProjectName={
                   taskDetails.project_name ?? taskDetails.projectName
                 }
+                onOpenEval={handleOpenEval}
               />
             }
             rightPanel={
@@ -485,7 +510,10 @@ const TaskDetailPage = () => {
         title="Update Task"
         content="Select one of the options"
         open={confirmOpen}
-        onClose={() => setConfirmOpen(false)}
+        onClose={() => {
+          setPendingUpdateData(null);
+          setConfirmOpen(false);
+        }}
         onConfirm={handleConfirm}
         isLoading={isUpdating}
       />

--- a/frontend/src/sections/tasks/__tests__/TaskDetailPage.test.jsx
+++ b/frontend/src/sections/tasks/__tests__/TaskDetailPage.test.jsx
@@ -80,7 +80,15 @@ vi.mock("../components/TaskUsageTab", () => ({
 }));
 
 vi.mock("src/sections/common/EvalsTasks/EditTaskDrawer/TaskConfirmBox", () => ({
-  default: () => null,
+  default: ({ open, title, onConfirm }) =>
+    open ? (
+      <div role="dialog" aria-label={title}>
+        <h2>{title}</h2>
+        <button type="button" onClick={() => onConfirm("fresh_run")}>
+          Run task
+        </button>
+      </div>
+    ) : null,
 }));
 
 const renderTaskDetail = (taskId = "missing-task") => {
@@ -157,6 +165,39 @@ describe("TaskDetailPage", () => {
       expect(axiosPatchMock).toHaveBeenCalledWith("/tracer/eval-task/task-1/", {
         name: "Renamed Inline Task",
       });
+    });
+  });
+
+  it("uses the update PATCH route after save confirmation", async () => {
+    useGetTaskData.mockReturnValue({
+      data: loadedTask({
+        evals_applied: [{ id: "eval-1", name: "Eval One" }],
+      }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderTaskDetail("task-1");
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent("Update Task");
+    fireEvent.click(screen.getByRole("button", { name: /run task/i }));
+
+    await waitFor(() => {
+      expect(axiosPatchMock).toHaveBeenCalledWith(
+        "/tracer/eval-task/update_eval_task/",
+        expect.objectContaining({
+          edit_type: "fresh_run",
+          eval_task_id: "task-1",
+          evals: ["eval-1"],
+          name: "Original Task",
+          project: "project-1",
+          project_id: "project-1",
+          run_type: "continuous",
+          sampling_rate: 100,
+          spans_limit: 100,
+        }),
+      );
     });
   });
 

--- a/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
+++ b/frontend/src/sections/tasks/components/TaskConfigPanel.jsx
@@ -95,15 +95,21 @@ const EVAL_TYPE_META = {
   code: { icon: "solar:code-square-linear", label: "Code" },
 };
 
+const resolveEvalTemplateId = (evalItem) =>
+  evalItem?.templateId ||
+  evalItem?.template_id ||
+  evalItem?.eval_template ||
+  evalItem?.evalTemplate?.id;
+
 // ── Configured Eval Card ──
-const ConfiguredEvalCard = ({ evalItem, onEdit, onRemove }) => {
+const ConfiguredEvalCard = ({ evalItem, onEdit, onOpenEval, onRemove }) => {
   const theme = useTheme();
-  const invalid = !evalItem?.id;
   const name =
     evalItem?.name ||
     evalItem?.evalTemplate?.name ||
     evalItem?.evalTemplateName ||
     "Evaluation";
+  const templateId = resolveEvalTemplateId(evalItem);
   const mappedKeys = evalItem?.mapping ? Object.keys(evalItem.mapping) : [];
 
   const evalType = (
@@ -257,6 +263,18 @@ const ConfiguredEvalCard = ({ evalItem, onEdit, onRemove }) => {
         )}
       </Box>
       <Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
+        {onOpenEval && templateId && (
+          <Tooltip title="Open evaluation">
+            <IconButton
+              size="small"
+              aria-label={`Open evaluation ${name}`}
+              onClick={() => onOpenEval(templateId)}
+              sx={{ p: 0.25, color: "text.secondary" }}
+            >
+              <Iconify icon="mingcute:external-link-line" width={15} />
+            </IconButton>
+          </Tooltip>
+        )}
         {onEdit && (
           <Tooltip title="Edit evaluation">
             <IconButton
@@ -285,6 +303,7 @@ const ConfiguredEvalCard = ({ evalItem, onEdit, onRemove }) => {
 ConfiguredEvalCard.propTypes = {
   evalItem: PropTypes.object.isRequired,
   onEdit: PropTypes.func,
+  onOpenEval: PropTypes.func,
   onRemove: PropTypes.func.isRequired,
 };
 
@@ -296,6 +315,7 @@ const TaskConfigPanel = ({
   getValues: _getValues,
   projectLocked = false,
   initialProjectName = null,
+  onOpenEval,
 }) => {
   const [evalPickerOpen, setEvalPickerOpen] = useState(false);
   // Index of the eval currently being edited. null means "add mode".
@@ -758,6 +778,7 @@ const TaskConfigPanel = ({
                     key={evalItem.id || index}
                     evalItem={evalItem}
                     onEdit={() => handleEditEval(index)}
+                    onOpenEval={onOpenEval}
                     onRemove={() => removeEval(index)}
                   />
                 ))}
@@ -859,6 +880,7 @@ TaskConfigPanel.propTypes = {
   getValues: PropTypes.func.isRequired,
   projectLocked: PropTypes.bool,
   initialProjectName: PropTypes.string,
+  onOpenEval: PropTypes.func,
 };
 
 export default TaskConfigPanel;

--- a/frontend/src/utils/format-number.js
+++ b/frontend/src/utils/format-number.js
@@ -40,7 +40,6 @@ export function fCurrency(number, showThreeDecimals = false) {
   return formatted;
 }
 
-
 export function fUsage(value, unit) {
   const suffix = unit ? ` ${unit}` : "";
   if (value == null || value === 0) return `0${suffix}`;
@@ -49,7 +48,6 @@ export function fUsage(value, unit) {
   if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K${suffix}`;
   if (Number.isInteger(value)) return `${value.toLocaleString()}${suffix}`;
   if (value < 1) {
-
     const order = Math.floor(Math.log10(Math.abs(value)));
     const decimals = Math.min(6, Math.max(2, -order + 1));
     return `${Number(value.toFixed(decimals))}${suffix}`;

--- a/futureagi/agentcc/serializers/contracts.py
+++ b/futureagi/agentcc/serializers/contracts.py
@@ -1,12 +1,11 @@
 from rest_framework import serializers
 
-from tfc.utils.serializer_fields import JsonValueField
-
 from tfc.utils.api_serializers import (
     ApiErrorResponseSerializer,
     EmptyRequestSerializer,
     StrictInputSerializer,
 )
+from tfc.utils.serializer_fields import JsonValueField
 
 API_FORMAT_HELP_TEXT = (
     "Gateway protocol adapter name. This intentionally remains a string because "
@@ -287,24 +286,16 @@ class GatewayMutationResponseSerializer(serializers.Serializer):
 
 
 class GatewayConfigPatchRequestSerializer(serializers.Serializer):
-    guardrails = serializers.DictField(
-        child=serializers.JSONField(), required=False
-    )
+    guardrails = serializers.DictField(child=serializers.JSONField(), required=False)
     routing = serializers.DictField(child=serializers.JSONField(), required=False)
     cache = serializers.DictField(child=serializers.JSONField(), required=False)
-    rate_limiting = serializers.DictField(
-        child=serializers.JSONField(), required=False
-    )
+    rate_limiting = serializers.DictField(child=serializers.JSONField(), required=False)
     budgets = serializers.DictField(child=serializers.JSONField(), required=False)
-    cost_tracking = serializers.DictField(
-        child=serializers.JSONField(), required=False
-    )
+    cost_tracking = serializers.DictField(child=serializers.JSONField(), required=False)
     ip_acl = serializers.DictField(child=serializers.JSONField(), required=False)
     alerting = serializers.DictField(child=serializers.JSONField(), required=False)
     privacy = serializers.DictField(child=serializers.JSONField(), required=False)
-    tool_policy = serializers.DictField(
-        child=serializers.JSONField(), required=False
-    )
+    tool_policy = serializers.DictField(child=serializers.JSONField(), required=False)
     mcp = serializers.DictField(child=serializers.JSONField(), required=False)
     a2a = serializers.DictField(child=serializers.JSONField(), required=False)
     audit = serializers.DictField(child=serializers.JSONField(), required=False)
@@ -341,7 +332,7 @@ class GatewayPlaygroundTestRequestSerializer(serializers.Serializer):
 
 class GatewayBudgetSetRequestSerializer(serializers.Serializer):
     level = serializers.CharField()
-    config = serializers.DictField(child=serializers.JSONField())
+    config = serializers.DictField(child=JsonValueField())
 
 
 class GatewayBudgetRemoveRequestSerializer(serializers.Serializer):
@@ -350,7 +341,7 @@ class GatewayBudgetRemoveRequestSerializer(serializers.Serializer):
 
 class GatewayBatchSubmitRequestSerializer(serializers.Serializer):
     requests = serializers.ListField(
-        child=serializers.DictField(child=serializers.JSONField())
+        child=serializers.DictField(child=JsonValueField())
     )
     max_concurrency = serializers.IntegerField(required=False, min_value=1, default=5)
 
@@ -361,7 +352,7 @@ class GatewayBatchRequestSerializer(serializers.Serializer):
 
 class GatewayMCPServerUpdateRequestSerializer(serializers.Serializer):
     server_id = serializers.CharField()
-    config = serializers.DictField(child=serializers.JSONField())
+    config = serializers.DictField(child=JsonValueField())
 
 
 class GatewayMCPServerRemoveRequestSerializer(serializers.Serializer):
@@ -369,13 +360,13 @@ class GatewayMCPServerRemoveRequestSerializer(serializers.Serializer):
 
 
 class GatewayMCPGuardrailsUpdateRequestSerializer(serializers.Serializer):
-    config = serializers.DictField(child=serializers.JSONField())
+    config = serializers.DictField(child=JsonValueField())
 
 
 class GatewayMCPToolTestRequestSerializer(serializers.Serializer):
     name = serializers.CharField()
     arguments = serializers.DictField(
-        child=serializers.JSONField(), required=False, default=dict
+        child=JsonValueField(allow_null=True), required=False, default=dict
     )
 
 

--- a/futureagi/agentcc/tests/test_contract_serializers.py
+++ b/futureagi/agentcc/tests/test_contract_serializers.py
@@ -4,6 +4,7 @@ from agentcc.serializers.contracts import (
     APIKeyBulkResponseSerializer,
     GatewayConfigProviderSerializer,
     GatewayMCPStatusResponseSerializer,
+    GatewayMCPToolTestRequestSerializer,
     GatewayProviderStatusSerializer,
     OrgConfigBulkResponseSerializer,
 )
@@ -69,6 +70,25 @@ def test_gateway_mcp_status_accepts_empty_server_list():
     )
 
     assert serializer.is_valid(), serializer.errors
+
+
+def test_gateway_mcp_tool_request_accepts_json_primitive_arguments():
+    serializer = GatewayMCPToolTestRequestSerializer(
+        data={
+            "name": "echo",
+            "arguments": {
+                "input": "hello",
+                "count": 3,
+                "flag": True,
+                "empty": None,
+                "metadata": {"source": "browser"},
+                "items": ["a", "b"],
+            },
+        }
+    )
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["arguments"]["count"] == 3
 
 
 def test_gateway_config_provider_uses_uuid_database_id():

--- a/futureagi/docker-compose.dev.yml
+++ b/futureagi/docker-compose.dev.yml
@@ -20,7 +20,7 @@ services:
       dockerfile: Dockerfile
     working_dir: /app/backend
     volumes:
-      - '.:/app/backend'
+      - ".:/app/backend"
     env_file:
       - .env
     environment:
@@ -29,6 +29,8 @@ services:
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - TEMPORAL_ALL_QUEUES=true
       - FAST_STARTUP=${FAST_STARTUP:-true}
+      - CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}
+      - CH_USE_REPLICATED_ENGINES=${CH_USE_REPLICATED_ENGINES:-false}
       # Lower concurrency for dev (saves memory)
       - TEMPORAL_MAX_CONCURRENT_ACTIVITIES=${TEMPORAL_DEV_MAX_ACTIVITIES:-20}
       - TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASKS=${TEMPORAL_DEV_MAX_WORKFLOWS:-20}

--- a/futureagi/docker-compose.test.yml
+++ b/futureagi/docker-compose.test.yml
@@ -55,7 +55,15 @@ services:
       - "18123:8123"
       - "19000:9000"
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8123/ping"]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--quiet",
+          "--tries=1",
+          "--spider",
+          "http://127.0.0.1:8123/ping",
+        ]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - "8888:8888"
       - "50051:50051"
     volumes:
-      - '.:/app/backend'
+      - ".:/app/backend"
     env_file:
       - .env
     environment:
@@ -56,6 +56,8 @@ services:
       - TEMPORAL_HOST=temporal:7233
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - FAST_STARTUP=${FAST_STARTUP:-true}
+      - CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}
+      - CH_USE_REPLICATED_ENGINES=${CH_USE_REPLICATED_ENGINES:-false}
       - AGENTCC_INTERNAL_URL=http://agentcc-gateway:8080
       - AGENTCC_GATEWAY_INTERNAL_URL=http://agentcc-gateway:8080
       - AGENTCC_INTERNAL_API_KEY=${AGENTCC_INTERNAL_API_KEY:-}
@@ -74,6 +76,8 @@ services:
         condition: service_healthy
       clickhouse:
         condition: service_healthy
+      minio:
+        condition: service_started
       rabbitmq:
         condition: service_healthy
       redis:
@@ -140,7 +144,7 @@ services:
       resources:
         limits:
           memory: 1G
-          cpus: '2'
+          cpus: "2"
 
   # ===========================================
   # Celery Workers (commented - using Temporal instead)
@@ -317,8 +321,12 @@ services:
       - ./config/userlist.txt:/etc/pgbouncer/userlist.txt
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.10.2.80
+    image: clickhouse/clickhouse-server:25.3-alpine
     container_name: clickhouse
+    environment:
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+      CLICKHOUSE_SKIP_USER_SETUP: "1"
+      CLICKHOUSE_DB: ${CH_DATABASE:-default}
     ports:
       - "${CH_HTTP_PORT:-8123}:8123"
       - "${CH_PORT:-9000}:9000"
@@ -326,10 +334,12 @@ services:
       - clickhouse_data:/var/lib/clickhouse
       - ./config/clickhouse/config.xml:/etc/clickhouse-server/config.d/custom.xml:ro
       - ./config/clickhouse/users.xml:/etc/clickhouse-server/users.d/custom.xml:ro
+      # The v2 spans schema declares `SETTINGS storage_policy = 'tiered'`.
+      - ./.ci/clickhouse-storage-policy.xml:/etc/clickhouse-server/config.d/storage-policy.xml:ro
     deploy:
       resources:
         limits:
-          cpus: '2.0'
+          cpus: "2.0"
           memory: 4G
     healthcheck:
       test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
@@ -472,7 +482,7 @@ services:
       dockerfile: Dockerfile
     working_dir: /app/backend
     volumes:
-      - '.:/app/backend'
+      - ".:/app/backend"
     env_file:
       - .env
     environment:
@@ -498,7 +508,7 @@ services:
       dockerfile: Dockerfile
     working_dir: /app/backend
     volumes:
-      - '.:/app/backend'
+      - ".:/app/backend"
     env_file:
       - .env
     environment:
@@ -524,7 +534,7 @@ services:
       dockerfile: Dockerfile
     working_dir: /app/backend
     volumes:
-      - '.:/app/backend'
+      - ".:/app/backend"
     env_file:
       - .env
     environment:
@@ -550,7 +560,7 @@ services:
       dockerfile: Dockerfile
     working_dir: /app/backend
     volumes:
-      - '.:/app/backend'
+      - ".:/app/backend"
     env_file:
       - .env
     environment:
@@ -576,7 +586,7 @@ services:
       dockerfile: Dockerfile
     working_dir: /app/backend
     volumes:
-      - '.:/app/backend'
+      - ".:/app/backend"
     env_file:
       - .env
     environment:
@@ -602,7 +612,7 @@ services:
       dockerfile: Dockerfile
     working_dir: /app/backend
     volumes:
-      - '.:/app/backend'
+      - ".:/app/backend"
     env_file:
       - .env
     environment:

--- a/futureagi/model_hub/tests/test_develop_annotations_api.py
+++ b/futureagi/model_hub/tests/test_develop_annotations_api.py
@@ -285,7 +285,9 @@ class TestAnnotationsLabelsViewSet:
             "/model-hub/annotations-labels/", payload, format="json"
         )
         assert response.status_code == status.HTTP_200_OK
-        assert AnnotationsLabels.objects.filter(name="Text Label").exists()
+        label = AnnotationsLabels.objects.get(name="Text Label")
+        assert response.data["result"]["id"] == str(label.id)
+        assert response.data["result"]["name"] == "Text Label"
 
     def test_create_categorical_label(self, auth_client, categorical_label_settings):
         """Test creating a categorical annotation label."""
@@ -800,7 +802,10 @@ class TestAnnotationsViewSetActions:
             payload,
             format="json",
         )
-        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
 
     def test_update_cells_rejects_legacy_label_values_alias(
         self, auth_client, annotation, row
@@ -1183,9 +1188,7 @@ class TestAnnotationSummaryView:
 
         # Mock the summary service response
         mock_summary_service.return_value = {
-            "header_data": pd.DataFrame(
-                {"label_id": [], "type": [], "name": []}
-            ),
+            "header_data": pd.DataFrame({"label_id": [], "type": [], "name": []}),
             "metric_calc": pd.DataFrame(
                 {"label_id": [], "row_id": [], "user_id": [], "value": []}
             ),

--- a/futureagi/model_hub/tests/test_kb_helpers.py
+++ b/futureagi/model_hub/tests/test_kb_helpers.py
@@ -156,6 +156,35 @@ class TestScheduleKbIngestionOnCommit:
             task_id="kb-ingest-kb-123",
         )
 
+    @patch("model_hub.utils.kb_helpers.KnowledgeBaseFile.objects.filter")
+    @patch("tfc.temporal.drop_in.start_activity")
+    @patch("model_hub.utils.kb_helpers.transaction.on_commit")
+    def test_callback_marks_kb_failed_when_temporal_scheduling_fails(
+        self, mock_on_commit, mock_start, mock_filter
+    ):
+        """A post-commit Temporal outage must not make the HTTP create fail."""
+        from model_hub.models.choices import StatusType
+        from model_hub.utils.kb_helpers import schedule_kb_ingestion_on_commit
+
+        mock_start.side_effect = RuntimeError("temporal unavailable")
+        mock_queryset = mock_filter.return_value
+
+        schedule_kb_ingestion_on_commit(
+            file_metadata={"file-1": {"name": "test.pdf", "extension": "pdf"}},
+            kb_id="kb-123",
+            org_id="org-456",
+        )
+
+        callback = mock_on_commit.call_args[0][0]
+        callback()
+
+        mock_start.assert_called_once()
+        mock_filter.assert_called_once_with(id="kb-123", deleted=False)
+        mock_queryset.update.assert_called_once()
+        update_kwargs = mock_queryset.update.call_args.kwargs
+        assert update_kwargs["status"] == StatusType.FAILED.value
+        assert "temporal unavailable" in update_kwargs["last_error"]
+
 
 class TestIngestKbFilesImpl:
     """Tests for ingest_kb_files_impl function."""

--- a/futureagi/model_hub/tests/test_knowledge_base_contracts.py
+++ b/futureagi/model_hub/tests/test_knowledge_base_contracts.py
@@ -116,6 +116,28 @@ class TestLegacyKnowledgeBaseLifecycle:
         assert other_kb.deleted is False
         assert other_kb.deleted_at is None
 
+    @patch("model_hub.views.develop_dataset.remove_kb_files.delay")
+    def test_delete_soft_deletes_when_file_removal_scheduling_fails(
+        self, mock_remove_kb_files, auth_client, organization, workspace
+    ):
+        kb = _create_kb(organization, workspace, name="delete-temporal-down")
+        mock_remove_kb_files.side_effect = RuntimeError("temporal unavailable")
+
+        response = auth_client.delete(
+            "/model-hub/knowledge-base/",
+            {"kb_ids": [str(kb.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_remove_kb_files.assert_called_once_with(
+            None, str(organization.id), [str(kb.id)]
+        )
+
+        kb.refresh_from_db()
+        assert kb.deleted is True
+        assert kb.deleted_at is not None
+
     def test_files_endpoint_rejects_deleted_kb(
         self, auth_client, organization, workspace
     ):

--- a/futureagi/model_hub/tests/test_prompt_workbench_lifecycle_contracts.py
+++ b/futureagi/model_hub/tests/test_prompt_workbench_lifecycle_contracts.py
@@ -90,11 +90,19 @@ def _create_eval_template(organization, workspace):
 
 
 @pytest.mark.django_db
-def test_prompt_bulk_delete_stamps_deleted_at_on_template_and_versions(
+def test_prompt_bulk_delete_stamps_deleted_at_on_template_versions_and_eval_configs(
     auth_client, organization, workspace, user
 ):
     template, version = _create_prompt_template(
         organization, workspace, user, "Prompt bulk delete contract"
+    )
+    eval_template = _create_eval_template(organization, workspace)
+    eval_config = PromptEvalConfig.no_workspace_objects.create(
+        name="Prompt bulk delete eval config",
+        prompt_template=template,
+        eval_template=eval_template,
+        user=user,
+        mapping={"text": "name"},
     )
 
     response = auth_client.post(
@@ -110,10 +118,13 @@ def test_prompt_bulk_delete_stamps_deleted_at_on_template_and_versions(
     assert template.deleted_at is not None
     assert version.deleted is True
     assert version.deleted_at is not None
+    eval_config.refresh_from_db()
+    assert eval_config.deleted is True
+    assert eval_config.deleted_at is not None
 
 
 @pytest.mark.django_db
-def test_prompt_folder_delete_stamps_deleted_at_and_cascades_prompt_versions(
+def test_prompt_folder_delete_stamps_deleted_at_and_cascades_prompt_versions_and_eval_configs(
     auth_client, organization, workspace, user
 ):
     folder = PromptFolder.no_workspace_objects.create(
@@ -124,6 +135,14 @@ def test_prompt_folder_delete_stamps_deleted_at_and_cascades_prompt_versions(
     )
     template, version = _create_prompt_template(
         organization, workspace, user, "Prompt folder cascade contract", folder
+    )
+    eval_template = _create_eval_template(organization, workspace)
+    eval_config = PromptEvalConfig.no_workspace_objects.create(
+        name="Prompt folder delete eval config",
+        prompt_template=template,
+        eval_template=eval_template,
+        user=user,
+        mapping={"text": "name"},
     )
 
     response = auth_client.delete(f"/model-hub/prompt-folders/{folder.id}/")
@@ -138,6 +157,9 @@ def test_prompt_folder_delete_stamps_deleted_at_and_cascades_prompt_versions(
     assert template.deleted_at is not None
     assert version.deleted is True
     assert version.deleted_at is not None
+    eval_config.refresh_from_db()
+    assert eval_config.deleted is True
+    assert eval_config.deleted_at is not None
 
 
 @pytest.mark.django_db

--- a/futureagi/model_hub/utils/kb_helpers.py
+++ b/futureagi/model_hub/utils/kb_helpers.py
@@ -5,7 +5,6 @@ This module contains shared utility functions for KB operations,
 used by both views and tasks.
 """
 
-import os
 import time
 
 import structlog
@@ -157,12 +156,33 @@ def schedule_kb_ingestion_on_commit(file_metadata, kb_id, org_id):
         import tfc.temporal.background_tasks.activities  # noqa: F401
         from tfc.temporal.drop_in import start_activity
 
-        start_activity(
-            "ingest_kb_files_activity",
-            args=(metadata, kb_id_str, org_id_str),
-            queue="default",
-            task_id=workflow_id,
-        )
+        try:
+            start_activity(
+                "ingest_kb_files_activity",
+                args=(metadata, kb_id_str, org_id_str),
+                queue="default",
+                task_id=workflow_id,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Failed to schedule KB ingestion activity",
+                kb_id=kb_id_str,
+                org_id=org_id_str,
+                workflow_id=workflow_id,
+            )
+            try:
+                KnowledgeBaseFile.objects.filter(
+                    id=kb_id_str,
+                    deleted=False,
+                ).update(
+                    status=StatusType.FAILED.value,
+                    last_error=f"Failed to schedule ingestion: {exc}"[:10000],
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to mark KB as failed after ingestion scheduling error",
+                    kb_id=kb_id_str,
+                )
 
     transaction.on_commit(_start_ingestion)
 

--- a/futureagi/model_hub/views/develop_annotations.py
+++ b/futureagi/model_hub/views/develop_annotations.py
@@ -37,20 +37,20 @@ from model_hub.models.develop_annotations import Annotations, AnnotationsLabels
 from model_hub.models.develop_dataset import Cell, Column, Dataset, Row
 from model_hub.serializers.annotation import AnnotationTaskSerializer
 from model_hub.serializers.develop_annotations import (
+    AnnotateRowQuerySerializer,
+    AnnotationActionMessageResponseSerializer,
     AnnotationLabelRestoreResponseSerializer,
     AnnotationLabelsListQuerySerializer,
-    AnnotationActionMessageResponseSerializer,
+    AnnotationsLabelsSerializer,
+    AnnotationsSerializer,
+    AnnotationSummaryResponseSerializer,
     AnnotationTaskListQuerySerializer,
-    AnnotateRowQuerySerializer,
     BulkDestroyAnnotationsRequestSerializer,
     BulkDestroyAnnotationsResponseSerializer,
     PreviewAnnotationsRequestSerializer,
     PreviewAnnotationsResponseSerializer,
     ResetAnnotationsRequestSerializer,
     UpdateAnnotationCellsRequestSerializer,
-    AnnotationsLabelsSerializer,
-    AnnotationsSerializer,
-    AnnotationSummaryResponseSerializer,
     UserSerializer,
 )
 from model_hub.utils.auto_annotate import generate_annotations_task
@@ -413,7 +413,7 @@ class AnnotationsLabelsViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelV
             )
 
         try:
-            serializer.save(
+            label = serializer.save(
                 organization=getattr(request, "organization", None)
                 or request.user.organization
             )
@@ -430,7 +430,7 @@ class AnnotationsLabelsViewSet(BaseModelViewSetMixinWithUserOrg, viewsets.ModelV
             logger.warning(f"Annotation label save failed (model validation): {detail}")
             return self._gm.bad_request(f"Annotation label creation failed: {detail}")
 
-        return self._gm.success_response("Annotation label created successfully")
+        return self._gm.success_response(self.get_serializer(label).data)
 
     @validated_request(
         request_serializer=EmptyRequestSerializer,

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -11506,9 +11506,8 @@ class FeedbackViewSet(viewsets.ModelViewSet):
             )[:5]
             for feedback in recent_feedback:
                 feedback_user = feedback.user
-                user_name = (
-                    getattr(feedback_user, "name", "")
-                    or getattr(feedback_user, "email", "")
+                user_name = getattr(feedback_user, "name", "") or getattr(
+                    feedback_user, "email", ""
                 )
                 summary["recent_feedback"].append(
                     {
@@ -15333,13 +15332,20 @@ class CreateKnowledgeBaseView(APIView):
                 for kb_id in processing_kbs:
                     cancel_kb_ingestion_workflow(kb_id)
 
-                remove_kb_files.delay(
-                    None, str(org.id), [str(kb_id) for kb_id in target_kb_ids]
-                )
                 KnowledgeBaseFile.objects.filter(id__in=target_kb_ids).update(
                     deleted=True,
                     deleted_at=timezone.now(),
                 )
+                try:
+                    remove_kb_files.delay(
+                        None, str(org.id), [str(kb_id) for kb_id in target_kb_ids]
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to schedule KB file removal after soft delete",
+                        organization_id=str(org.id),
+                        kb_ids=[str(kb_id) for kb_id in target_kb_ids],
+                    )
             return self._gm.success_response("Successfully deleted the Knowledge Base")
 
         except Exception as e:

--- a/futureagi/model_hub/views/prompt_folder.py
+++ b/futureagi/model_hub/views/prompt_folder.py
@@ -7,7 +7,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 
 from model_hub.models.prompt_folders import PromptFolder
-from model_hub.models.run_prompt import PromptTemplate, PromptVersion
+from model_hub.models.run_prompt import PromptEvalConfig, PromptTemplate, PromptVersion
 from model_hub.serializers.prompt_folder import PromptFolderSerializer
 from model_hub.utils.workspace_scope import (
     request_organization,
@@ -56,8 +56,9 @@ class PromptFolderViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 with transaction.atomic():
                     self.perform_create(serializer)
             except IntegrityError as e:
-                if "unique_prompt_folder_name_organization_workspace_not_deleted" in str(
-                    e
+                if (
+                    "unique_prompt_folder_name_organization_workspace_not_deleted"
+                    in str(e)
                 ):
                     return self._duplicate_name_response()
                 raise
@@ -115,8 +116,9 @@ class PromptFolderViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 with transaction.atomic():
                     self.perform_update(serializer)
             except IntegrityError as e:
-                if "unique_prompt_folder_name_organization_workspace_not_deleted" in str(
-                    e
+                if (
+                    "unique_prompt_folder_name_organization_workspace_not_deleted"
+                    in str(e)
                 ):
                     return self._duplicate_name_response()
                 raise
@@ -163,6 +165,12 @@ class PromptFolderViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
         prompt_template_ids = list(prompt_templates.values_list("id", flat=True))
 
         if prompt_template_ids:
+            PromptEvalConfig.objects.filter(
+                prompt_template_id__in=prompt_template_ids
+            ).update(
+                deleted=True,
+                deleted_at=now,
+            )
             PromptVersion.objects.filter(
                 original_template_id__in=prompt_template_ids
             ).update(

--- a/futureagi/model_hub/views/prompt_template.py
+++ b/futureagi/model_hub/views/prompt_template.py
@@ -1,4 +1,6 @@
+import atexit
 import base64
+import concurrent.futures
 import json  # Add this import at the top of the file
 import re
 import time
@@ -26,7 +28,7 @@ except ImportError:
     PromptSuggestionGenerator = _ee_stub("PromptSuggestionGenerator")
     SyntheticDataAgent = _ee_stub("SyntheticDataAgent")
 from django.core.cache import cache
-from django.db import close_old_connections, models, transaction
+from django.db import close_old_connections, connection, models, transaction
 from django.db.models import Case, IntegerField, Prefetch, Q, Value, When
 from django.db.models.functions import Cast, Substr
 from django.forms.models import model_to_dict
@@ -43,13 +45,6 @@ from rest_framework.views import APIView
 
 from accounts.models import User
 from accounts.models.organization import Organization
-
-logger = structlog.get_logger(__name__)
-import atexit
-import concurrent.futures
-
-from django.db import connection
-
 from agentic_eval.core_evals.fi_evals import *  # noqa: F403
 from agentic_eval.core_evals.run_prompt.litellm_response import RunPrompt
 from analytics.utils import (
@@ -74,7 +69,6 @@ from model_hub.models.choices import ModalityType, OwnerChoices, StatusType
 from model_hub.models.develop_dataset import (
     Cell,
     Column,
-    Dataset,
     KnowledgeBaseFile,
     Row,
 )
@@ -119,15 +113,16 @@ from model_hub.utils.utils import (
     submit_with_retry,
     track_running_eval_count,
 )
+from model_hub.utils.websocket_manager import (
+    get_websocket_manager,
+)
 from model_hub.utils.workspace_scope import (
     request_workspace_filter,
     scoped_column_queryset,
     scoped_dataset_queryset,
 )
-from model_hub.utils.websocket_manager import (
-    get_websocket_manager,
-)
 from model_hub.views.eval_runner import EvaluationRunner
+from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
 from tfc.settings.settings import BASE_URL
 from tfc.temporal import temporal_activity
 from tfc.utils.api_contracts import validated_request
@@ -147,6 +142,22 @@ from tfc.utils.storage import (
     upload_document_to_s3,
     upload_image_to_s3,
 )
+
+try:
+    from ee.usage.schemas.event_types import BillingEventType
+except ImportError:
+    BillingEventType = None
+
+try:
+    from ee.usage.utils.usage_entries import (
+        count_text_tokens,
+        log_and_deduct_cost_for_api_request,
+    )
+except ImportError:
+    count_text_tokens = None
+    log_and_deduct_cost_for_api_request = None
+
+logger = structlog.get_logger(__name__)
 
 # Module-level ThreadPoolExecutor for background tasks that use instance methods
 # These can't be migrated to Temporal as they require 'self' context
@@ -173,16 +184,9 @@ def _safe_background_task(func, *args, **kwargs):
     return wrapped
 
 
-from tfc.constants.api_calls import APICallStatusChoices, APICallTypeChoices
+def _empty_token_usage_properties(token_usage):
+    return {}
 
-try:
-    from ee.usage.utils.usage_entries import (
-        count_text_tokens,
-        log_and_deduct_cost_for_api_request,
-    )
-except ImportError:
-    count_text_tokens = None
-    log_and_deduct_cost_for_api_request = None
 
 MIME_TO_EXT = {
     # Documents
@@ -2420,14 +2424,14 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
             except (TypeError, ValueError):
                 return self._gm.bad_request("Invalid evaluation configuration id.")
 
-            existing_eval_configs = set(
+            existing_eval_configs = {
                 str(config_id)
                 for config_id in PromptEvalConfig.objects.filter(
                     id__in=prompt_eval_config_ids,
                     prompt_template=template,
                     deleted=False,
                 ).values_list("id", flat=True)
-            )
+            }
             missing_eval_configs = [
                 config_id
                 for config_id in prompt_eval_config_ids
@@ -2754,7 +2758,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 try:
                     from ee.usage.utils.event_properties import token_usage_properties
                 except ImportError:
-                    token_usage_properties = lambda token_usage: {}
+                    token_usage_properties = _empty_token_usage_properties
 
                 if (
                     emit is not None
@@ -3346,6 +3350,10 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
             deleted=True,
             deleted_at=now,
         )
+        PromptEvalConfig.objects.filter(prompt_template=instance).update(
+            deleted=True,
+            deleted_at=now,
+        )
 
     @action(detail=False, methods=["post"], url_path="generate-prompt")
     def generate_prompt(self, request):
@@ -3403,7 +3411,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 try:
                     from ee.usage.utils.event_properties import token_usage_properties
                 except ImportError:
-                    token_usage_properties = lambda token_usage: {}
+                    token_usage_properties = _empty_token_usage_properties
 
                 _org = (
                     getattr(request, "organization", None) or request.user.organization
@@ -3541,7 +3549,7 @@ class PromptTemplateViewSet(BaseModelViewSetMixin, viewsets.ModelViewSet):
                 try:
                     from ee.usage.utils.event_properties import token_usage_properties
                 except ImportError:
-                    token_usage_properties = lambda token_usage: {}
+                    token_usage_properties = _empty_token_usage_properties
 
                 _org = (
                     getattr(request, "organization", None) or request.user.organization

--- a/futureagi/scripts/run-e2e.sh
+++ b/futureagi/scripts/run-e2e.sh
@@ -63,7 +63,7 @@ if [ "$SKIP_INFRA" = false ]; then
     RETRIES=0
     MAX_RETRIES=30
     until docker compose -f docker-compose.test.yml -p futureagi-test \
-          exec -T test-clickhouse wget --quiet --tries=1 --spider http://localhost:8123/ping 2>/dev/null; do
+          exec -T test-clickhouse wget --quiet --tries=1 --spider http://127.0.0.1:8123/ping 2>/dev/null; do
         RETRIES=$((RETRIES + 1))
         if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
             error "ClickHouse did not become healthy after ${MAX_RETRIES} attempts"

--- a/futureagi/tracer/queries/feed.py
+++ b/futureagi/tracer/queries/feed.py
@@ -241,8 +241,17 @@ def _fetch_users_affected_batch(cluster_ids: list[str]) -> dict:
     #       dict[trace_id, set[end_user_id]]
     # which would push the DISTINCT into CH and return only the user-ids,
     # not the full span payload.
-    with get_reader() as reader:
-        spans = reader.list_by_trace_ids(list(trace_to_clusters.keys()))
+    try:
+        with get_reader() as reader:
+            spans = reader.list_by_trace_ids(list(trace_to_clusters.keys()))
+    except Exception as exc:
+        logger.warning(
+            "feed_users_affected_clickhouse_failed",
+            error=str(exc),
+            cluster_count=len(cluster_ids),
+            trace_count=len(trace_to_clusters),
+        )
+        return {}
 
     # Distinct end_user_id per cluster_id — a span contributes its
     # end_user to every cluster the trace is in (fan-out matches the
@@ -1636,11 +1645,12 @@ def _fetch_trace_rows(
     roots_by_trace = _get_root_spans_batch(page_trace_ids)
     scans_by_trace = {
         str(sr.trace_id): sr
-        for sr in TraceScanResult.objects.filter(trace_id__in=page_trace_ids)
-        .only("trace_id", "meta")
+        for sr in TraceScanResult.objects.filter(trace_id__in=page_trace_ids).only(
+            "trace_id", "meta"
+        )
     }
 
-    rows: List[TracesListRow] = []
+    rows: list[TracesListRow] = []
     for trace in page_traces:
         tid = str(trace.id)
 
@@ -2058,7 +2068,7 @@ def _fetch_sidebar_ai_metadata(
         # are case-sensitive, so the iexact="llm" is reproduced with a
         # Python lower() comparison (the same idiom analyze_errors uses
         # for status).
-        llm_span: Optional[CHSpan] = None
+        llm_span: CHSpan | None = None
         with get_reader() as reader:
             for s in reader.list_by_trace(focus_trace_id):
                 if (s.observation_type or "").lower() == "llm":

--- a/futureagi/tracer/tests/test_e2e_collector_to_django.py
+++ b/futureagi/tracer/tests/test_e2e_collector_to_django.py
@@ -22,10 +22,9 @@ import json
 import time
 import uuid
 
+import clickhouse_connect
 import pytest
 import requests
-
-import clickhouse_connect
 
 from tracer.services.clickhouse.v2 import get_v2_config
 from tracer.tests._ch_seed import truncate_ch_spans
@@ -51,14 +50,22 @@ TEST_ORG_ID = "e2e00000-e2e0-4e2e-8e2e-e2e000000002"
 
 @pytest.fixture(scope="session", autouse=True)
 def _require_collector():
-    """Skip entire module if fi-collector is not reachable."""
+    """Skip entire module if fi-collector is not reachable or not test-wired."""
     try:
         # Try HTTP endpoint health (simpler than gRPC probe)
-        resp = requests.get("http://localhost:4318/", timeout=2)
+        requests.get("http://localhost:4318/", timeout=2)
         # Collector typically returns 404 or 405 on root but the socket is open
     except requests.ConnectionError:
+        pytest.skip("fi-collector not running at localhost:4318 — skipping E2E tests")
+    try:
+        if not _collector_writes_to_test_clickhouse():
+            pytest.skip(
+                "fi-collector at localhost:4318 is not wired to the test "
+                "ClickHouse sidecar — skipping collector E2E tests"
+            )
+    except Exception as exc:
         pytest.skip(
-            "fi-collector not running at localhost:4318 — skipping E2E tests"
+            f"fi-collector wiring probe failed; skipping collector E2E tests: {exc}"
         )
 
 
@@ -209,9 +216,30 @@ def wait_for_ch_row(
         if result.row_count > 0:
             columns = result.column_names
             row = result.first_row
-            return dict(zip(columns, row))
+            return dict(zip(columns, row, strict=False))
         time.sleep(0.5)
     return None
+
+
+def _collector_writes_to_test_clickhouse() -> bool:
+    """Confirm the reachable collector writes to the same CH client used here."""
+    cfg = get_v2_config()
+    client = clickhouse_connect.get_client(
+        host=cfg["host"],
+        port=cfg["http_port"],
+        username=cfg["user"],
+        password=cfg["password"],
+        database=cfg["database"],
+    )
+    try:
+        _, span_id = send_otlp_span(
+            span_name="e2e-collector-wiring-probe",
+            attributes={"openinference.span.kind": "CHAIN"},
+        )
+        return wait_for_ch_row(client, span_id, timeout=5) is not None
+    finally:
+        client.close()
+        truncate_ch_spans()
 
 
 # ---------------------------------------------------------------------------
@@ -278,9 +306,7 @@ class TestE2ESpanVisibleViaDjangoListSpans:
         assert response.status_code == 200
         data = response.json()
         span_ids = [s.get("id") for s in data.get("result", {}).get("data", [])]
-        assert span_id in span_ids, (
-            f"Span {span_id} not visible via list_spans_observe"
-        )
+        assert span_id in span_ids, f"Span {span_id} not visible via list_spans_observe"
 
 
 class TestE2ETraceAggregateConsistent:

--- a/futureagi/tracer/tests/test_e2e_eval_lifecycle.py
+++ b/futureagi/tracer/tests/test_e2e_eval_lifecycle.py
@@ -25,9 +25,8 @@ import json
 import time
 import uuid
 
-import pytest
-
 import clickhouse_connect
+import pytest
 
 from tracer.services.clickhouse.v2 import get_v2_config
 from tracer.tests._ch_seed import seed_ch_span, truncate_ch_spans
@@ -39,6 +38,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.e2e, pytest.mark.slow]
 # ---------------------------------------------------------------------------
 
 COLLECTOR_HTTP_URL = "http://localhost:4318/v1/traces"
+_COLLECTOR_COMPATIBLE_WITH_TEST_CH: bool | None = None
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -68,14 +68,48 @@ def _truncate_between_tests():
 
 
 def _collector_available() -> bool:
-    """Check if fi-collector is reachable."""
+    """Check if fi-collector is reachable and writes to the test ClickHouse."""
+    global _COLLECTOR_COMPATIBLE_WITH_TEST_CH
+    if _COLLECTOR_COMPATIBLE_WITH_TEST_CH is not None:
+        return _COLLECTOR_COMPATIBLE_WITH_TEST_CH
+
     try:
         import requests
 
         requests.get("http://localhost:4318/", timeout=1)
-        return True
     except Exception:
+        _COLLECTOR_COMPATIBLE_WITH_TEST_CH = False
         return False
+
+    trace_id = uuid.uuid4().hex[:32]
+    span_id = uuid.uuid4().hex[:16]
+    cfg = get_v2_config()
+    client = None
+    try:
+        client = clickhouse_connect.get_client(
+            host=cfg["host"],
+            port=cfg["http_port"],
+            username=cfg["user"],
+            password=cfg["password"],
+            database=cfg["database"],
+        )
+        _send_otlp_span_http(
+            trace_id=trace_id,
+            span_id=span_id,
+            project_id="e2e00000-e2e0-4e2e-8e2e-e2e000000001",
+            span_name="eval-collector-wiring-probe",
+            attributes={"openinference.span.kind": "CHAIN"},
+        )
+        _COLLECTOR_COMPATIBLE_WITH_TEST_CH = (
+            _wait_for_ch_row(client, span_id, timeout=5) is not None
+        )
+    except Exception:
+        _COLLECTOR_COMPATIBLE_WITH_TEST_CH = False
+    finally:
+        if client is not None:
+            client.close()
+        truncate_ch_spans()
+    return _COLLECTOR_COMPATIBLE_WITH_TEST_CH
 
 
 def _send_otlp_span_http(
@@ -108,8 +142,16 @@ def _send_otlp_span_http(
                     "attributes": [
                         {"key": "service.name", "value": {"stringValue": "eval-e2e"}},
                         {"key": "fi.project_id", "value": {"stringValue": project_id}},
-                        {"key": "fi.org_id", "value": {"stringValue": "e2e00000-e2e0-4e2e-8e2e-e2e000000002"}},
-                        {"key": "fi.semconv", "value": {"stringValue": "openinference"}},
+                        {
+                            "key": "fi.org_id",
+                            "value": {
+                                "stringValue": "e2e00000-e2e0-4e2e-8e2e-e2e000000002"
+                            },
+                        },
+                        {
+                            "key": "fi.semconv",
+                            "value": {"stringValue": "openinference"},
+                        },
                     ]
                 },
                 "scopeSpans": [
@@ -188,7 +230,8 @@ def _seed_span_directly(
         cost=0.001,
         latency_ms=500,
         status="OK",
-        span_attributes=attributes or {
+        span_attributes=attributes
+        or {
             "input": "eval test",
             "output": "eval response",
             "model_name": "gpt-4o",
@@ -211,7 +254,7 @@ def _ingest_span(
     """
     trace_id = uuid.uuid4().hex + uuid.uuid4().hex[:16]
     trace_id = trace_id[:32]
-    span_id = f"eval_{uuid.uuid4().hex[:12]}"
+    span_id = uuid.uuid4().hex[:16]
 
     if _collector_available():
         _send_otlp_span_http(
@@ -249,7 +292,7 @@ def _wait_for_ch_row(ch_client, span_id: str, timeout: float = 10) -> dict | Non
             parameters={"sid": span_id},
         )
         if result.row_count > 0:
-            return dict(zip(result.column_names, result.first_row))
+            return dict(zip(result.column_names, result.first_row, strict=False))
         time.sleep(0.5)
     return None
 
@@ -264,12 +307,11 @@ def _wait_for_eval_logger_row(
     while time.monotonic() < deadline:
         try:
             result = ch_client.query(
-                "SELECT * FROM eval_logger FINAL "
-                "WHERE span_id = {sid:String} LIMIT 1",
+                "SELECT * FROM eval_logger FINAL WHERE span_id = {sid:String} LIMIT 1",
                 parameters={"sid": span_id},
             )
             if result.row_count > 0:
-                return dict(zip(result.column_names, result.first_row))
+                return dict(zip(result.column_names, result.first_row, strict=False))
         except Exception:
             # eval_logger table may not exist yet in all environments
             pass

--- a/futureagi/tracer/tests/test_error_analysis.py
+++ b/futureagi/tracer/tests/test_error_analysis.py
@@ -5,6 +5,7 @@ Tests for trace error analysis endpoints.
 """
 
 import uuid
+from types import SimpleNamespace
 
 import pytest
 from django.utils import timezone
@@ -28,6 +29,7 @@ from tracer.models.trace_error_analysis_task import (
     TraceErrorAnalysisTask,
     TraceErrorTaskStatus,
 )
+from tracer.views.feed._permissions import resolve_requested_project_ids
 
 AUTH_REQUIRED_STATUS_CODES = (
     status.HTTP_401_UNAUTHORIZED,
@@ -173,6 +175,37 @@ class TestErrorClusterFeedAPI:
             "TEST-HIGH",
             "TEST-LOW",
         ]
+
+    def test_get_cluster_feed_degrades_when_clickhouse_user_counts_fail(
+        self, auth_client, project, monkeypatch
+    ):
+        """CH user-count failures should not make the feed list fail."""
+        cluster = make_feed_group(project, "TEST-CH-FALLBACK")
+        trace = Trace.objects.create(project=project, name="CH fallback trace")
+        ErrorClusterTraces.objects.create(cluster=cluster, trace=trace)
+
+        def fail_get_reader():
+            raise RuntimeError("clickhouse unavailable")
+
+        monkeypatch.setattr("tracer.queries.feed.get_reader", fail_get_reader)
+
+        response = auth_client.get(self.url, {"project_id": str(project.id)})
+
+        assert response.status_code == status.HTTP_200_OK
+        rows = get_result(response)["data"]
+        row = next(item for item in rows if item["cluster_id"] == "TEST-CH-FALLBACK")
+        assert row["users_affected"] == 0
+
+    def test_feed_project_scope_uses_workspace_org_when_user_org_missing(
+        self, user, workspace, project
+    ):
+        """Workspace-authenticated requests should not require user.organization."""
+        user.organization = None
+        request = SimpleNamespace(user=user, workspace=workspace)
+
+        project_ids = resolve_requested_project_ids(request, None)
+
+        assert project_ids == [str(project.id)]
 
 
 @pytest.mark.integration

--- a/futureagi/tracer/views/feed/_permissions.py
+++ b/futureagi/tracer/views/feed/_permissions.py
@@ -2,34 +2,35 @@
 Shared helper for resolving the set of project IDs a request is allowed to see.
 """
 
-from typing import List, Optional
-
 from tracer.models.project import Project
 
 
-def get_accessible_project_ids(request) -> List[str]:
+def get_accessible_project_ids(request) -> list[str]:
     """
     Return list of project IDs the request's user has access to.
 
-    Scoped by organization (+ workspace if present on the request).
-    Returns empty list if the user has no organization.
+    Scoped by organization (+ workspace if present on the request). Some auth
+    paths attach only request.workspace, so derive organization from the
+    workspace before falling back to the legacy user.organization field.
     """
-    org = getattr(request, "organization", None) or getattr(
-        request.user, "organization", None
+    workspace = getattr(request, "workspace", None)
+    org = (
+        getattr(request, "organization", None)
+        or (getattr(workspace, "organization", None) if workspace is not None else None)
+        or getattr(request.user, "organization", None)
     )
     if not org:
         return []
 
     qs = Project.objects.filter(organization_id=org.id)
-    workspace = getattr(request, "workspace", None)
     if workspace is not None:
         qs = qs.filter(workspace_id=workspace.id)
     return [str(pid) for pid in qs.values_list("id", flat=True)]
 
 
 def resolve_requested_project_ids(
-    request, requested_project_id: Optional[str]
-) -> Optional[List[str]]:
+    request, requested_project_id: str | None
+) -> list[str] | None:
     """
     Given an optional `project_id` filter, return the effective list of project
     IDs to query, or None if the user is forbidden from the requested project.

--- a/futureagi/tracer/views/observation_span.py
+++ b/futureagi/tracer/views/observation_span.py
@@ -478,7 +478,7 @@ class ObservationSpanView(BaseModelViewSetMixin, ModelViewSet):
                 toJSONString(metadata) AS metadata_json,
                 custom_eval_config_id,
                 attrs_string, attrs_number, attrs_bool
-            FROM spans
+            FROM spans FINAL
             WHERE id = %(span_id)s
               AND is_deleted = 0
             LIMIT 1


### PR DESCRIPTION
## Summary
- harden TH-4812 API/UI/e2e coverage across browser API journeys, frontend tests, backend contract coverage, and API route journeys
- keep the Observe Projects browser smoke stable after the dev rewrite by asserting rendered UI state and expanding API failure capture
- preserve the SessionListQueryBuilder end-user subquery compatibility path and update generated/API contract evidence for the current dev branch
- companion EE PR: https://github.com/future-agi/ee/pull/119

## Validation
- GitHub API Contracts rerun passed: backend-contracts and frontend-contracts
- EE focused usage tests passed: 105 passed
- yarn lint passed with 413 existing warnings and 0 errors
- yarn type-check passed/no-op: no tsconfig.json found
- yarn test:run passed: 211 files, 1735 tests
- yarn contracts:check passed
- make test passed: 11886 passed, 90 skipped, 690 deselected, 7 xfailed, 7 xpassed
- node --check across frontend API journey mjs files passed
- prettier check for observe-projects-smoke.mjs passed
- API journey preflight passed against http://localhost:8003 with 4 container-name warnings for non-active legacy service names
- Focused API journeys passed: OBS-API-011, OBS-API-013, ERR-API-001; AQ-API-001/002 skipped because no annotation queue exists in this workspace, TSK-API-003 skipped because no Observe task seed exists
- Browser mjs smoke passed: observe-projects-smoke.mjs against APP_BASE=http://127.0.0.1:3043 and API_BASE=http://localhost:8003