### PR TITLE
TH-4812: Cover Models route browser smoke

### DIFF
--- a/frontend/scripts/api-journeys/browser/models-route-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/models-route-smoke.mjs
@@ -1,6 +1,9 @@
 /* eslint-disable no-console */
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import process from "node:process";
+import { promisify } from "node:util";
 import {
   apiPath,
   asArray,
@@ -11,27 +14,82 @@ import {
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
 
 const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
-const SCREENSHOT_PATH = "/tmp/models-route-smoke.png";
-const DETAIL_SCREENSHOT_PATH = "/tmp/models-route-detail-smoke.png";
-const FAILURE_SCREENSHOT_PATH = "/tmp/models-route-smoke-failure.png";
+const ENABLE_MUTATING_SEED = process.env.API_JOURNEY_MUTATIONS === "1";
+const SCREENSHOT_PATH = "/tmp/th4812-models-route-smoke.png";
+const DETAIL_SCREENSHOT_PATH = "/tmp/th4812-models-route-detail-smoke.png";
+const CUSTOM_METRICS_SCREENSHOT_PATH =
+  "/tmp/th4812-models-route-custom-metrics-smoke.png";
+const FAILURE_SCREENSHOT_PATH = "/tmp/th4812-models-route-smoke-failure.png";
 
 async function main() {
   const auth = await createAuthenticatedContext();
+  const marker = `th4812_model_route_${normalizeRunId(auth.runId)}`;
+  let seededFixture = null;
+  let fixtureCleaned = false;
+  if (ENABLE_MUTATING_SEED) {
+    const userId = auth.user?.id;
+    assert(
+      isUuid(userId),
+      "Models route seed requires an authenticated user id.",
+    );
+    await hardDeleteModelsRouteFixture({
+      marker,
+      organizationId: auth.organizationId,
+    });
+    seededFixture = await seedModelsRouteFixture({
+      marker,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      userId,
+    });
+  }
+
   const modelsPayload = await auth.client.get(
     apiPath("/model-hub/custom-models/"),
-    { unwrap: false },
+    {
+      query: seededFixture
+        ? { search_query: seededFixture.active_name, page_size: 20 }
+        : undefined,
+      unwrap: false,
+    },
   );
   const models = asArray(modelsPayload?.results || modelsPayload);
-  const firstModel = models.find((model) => isUuid(model?.id)) || null;
+  const firstModel = seededFixture
+    ? models.find((model) => model?.id === seededFixture.active_model_id) ||
+      null
+    : models.find((model) => isUuid(model?.id)) || null;
   const firstModelName = modelDisplayName(firstModel);
+  if (seededFixture) {
+    assert(
+      firstModel,
+      `Seeded Models route fixture was not returned by the list API: ${JSON.stringify(models)}`,
+    );
+    const hiddenPayload = await auth.client.get(
+      apiPath("/model-hub/custom-models/"),
+      {
+        query: { search_query: seededFixture.hidden_name, page_size: 20 },
+        unwrap: false,
+      },
+    );
+    const hiddenModels = asArray(hiddenPayload?.results || hiddenPayload);
+    assert(
+      !hiddenModels.some(
+        (model) => model?.id === seededFixture.hidden_model_id,
+      ),
+      "Models route list leaked a same-org other-workspace custom model.",
+    );
+  }
   const apiFailures = [];
   const pageErrors = [];
   const evidence = {
     model_count: models.length,
     first_model_id: firstModel?.id || null,
     first_model_name: firstModelName || null,
+    seeded_fixture: Boolean(seededFixture),
+    hidden_model_id: seededFixture?.hidden_model_id || null,
   };
 
   const browser = await puppeteer.launch({
@@ -71,7 +129,9 @@ async function main() {
   page.on("response", (response) => {
     const path = safePathname(response.url());
     if (
-      path?.startsWith("/model-hub/custom-models/") &&
+      (path?.startsWith("/model-hub/custom-models/") ||
+        path?.startsWith("/model-hub/custom-metric/") ||
+        path?.startsWith("/model-hub/performance/options/")) &&
       response.status() >= 400
     ) {
       apiFailures.push(`${response.status()} ${response.url()}`);
@@ -104,6 +164,26 @@ async function main() {
     await waitForVisibleText(page, "Add Model", { exact: true });
 
     if (firstModel) {
+      if (seededFixture) {
+        await waitForResponseDuring(
+          page,
+          "models list search",
+          (response) =>
+            response.url().includes("/model-hub/custom-models/") &&
+            response
+              .url()
+              .includes(
+                `search_query=${encodeURIComponent(seededFixture.active_name)}`,
+              ) &&
+            response.request().method() === "GET" &&
+            response.status() < 400,
+          () =>
+            setInputByPlaceholder(page, "Search", seededFixture.active_name),
+        );
+        await waitForNoVisibleText(page, seededFixture.hidden_name, {
+          exact: true,
+        });
+      }
       await waitForVisibleText(page, firstModelName);
       await waitForResponseDuring(
         page,
@@ -126,8 +206,46 @@ async function main() {
       await waitForVisibleText(page, "Performance", { exact: true });
       await waitForVisibleText(page, "Custom Metrics", { exact: true });
       await waitForVisibleText(page, "Datasets", { exact: true });
+      if (seededFixture) {
+        await waitForVisibleText(page, seededFixture.active_name, {
+          exact: true,
+        });
+        await waitForNoVisibleText(page, "New Model", { exact: true });
+      }
       await page.screenshot({ path: DETAIL_SCREENSHOT_PATH, fullPage: true });
       evidence.detail_screenshot = DETAIL_SCREENSHOT_PATH;
+
+      if (seededFixture) {
+        await waitForResponseDuring(
+          page,
+          "custom metrics list",
+          (response) =>
+            response
+              .url()
+              .includes(
+                `/model-hub/custom-metric/${seededFixture.active_model_id}/`,
+              ) &&
+            response.request().method() === "GET" &&
+            response.status() < 400,
+          () => clickTabByLabel(page, "Custom Metrics"),
+        );
+        await page.waitForFunction(
+          (modelId) =>
+            window.location.pathname ===
+            `/dashboard/models/${modelId}/custom-metrics`,
+          { timeout: 30000 },
+          seededFixture.active_model_id,
+        );
+        await waitForVisibleText(page, seededFixture.metric_name);
+        await waitForNoVisibleText(page, seededFixture.hidden_name, {
+          exact: true,
+        });
+        await page.screenshot({
+          path: CUSTOM_METRICS_SCREENSHOT_PATH,
+          fullPage: true,
+        });
+        evidence.custom_metrics_screenshot = CUSTOM_METRICS_SCREENSHOT_PATH;
+      }
     } else {
       await waitForVisibleText(page, "You need to create a Model.", {
         exact: true,
@@ -140,6 +258,29 @@ async function main() {
 
     assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
     assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+
+    if (seededFixture) {
+      const cleanupAudit = await hardDeleteModelsRouteFixture({
+        marker,
+        organizationId: auth.organizationId,
+        customModelIds: [
+          seededFixture.active_model_id,
+          seededFixture.hidden_model_id,
+        ],
+        aiModelIds: [seededFixture.active_model_id],
+        metricIds: [seededFixture.metric_id],
+        workspaceIds: [seededFixture.hidden_workspace_id],
+      });
+      fixtureCleaned = true;
+      assert(
+        Number(cleanupAudit.remaining_custom_model_count) === 0 &&
+          Number(cleanupAudit.remaining_ai_model_count) === 0 &&
+          Number(cleanupAudit.remaining_metric_count) === 0 &&
+          Number(cleanupAudit.remaining_workspace_count) === 0,
+        `Models route cleanup left residue: ${JSON.stringify(cleanupAudit)}`,
+      );
+      evidence.cleanup = cleanupAudit;
+    }
 
     console.log(
       JSON.stringify(
@@ -171,6 +312,19 @@ async function main() {
     );
     throw error;
   } finally {
+    if (seededFixture && !fixtureCleaned) {
+      await hardDeleteModelsRouteFixture({
+        marker,
+        organizationId: auth.organizationId,
+        customModelIds: [
+          seededFixture.active_model_id,
+          seededFixture.hidden_model_id,
+        ],
+        aiModelIds: [seededFixture.active_model_id],
+        metricIds: [seededFixture.metric_id],
+        workspaceIds: [seededFixture.hidden_workspace_id],
+      });
+    }
     await browser.close();
   }
 }
@@ -301,6 +455,73 @@ async function clickVisibleText(page, text) {
   await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
 }
 
+async function clickTabByLabel(page, label) {
+  const clicked = await page.evaluate((expectedLabel) => {
+    const normalized = (value) => String(value || "").trim();
+    const isElementVisible = (element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.visibility !== "hidden" &&
+        style.display !== "none" &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    };
+    const tab = Array.from(document.querySelectorAll('[role="tab"]')).find(
+      (element) =>
+        isElementVisible(element) &&
+        normalized(element.textContent) === expectedLabel,
+    );
+    if (!tab) return false;
+    tab.click();
+    return true;
+  }, label);
+  assert(clicked, `Could not click tab "${label}".`);
+}
+
+async function setInputByPlaceholder(page, placeholder, value) {
+  await page.waitForSelector(`input[placeholder="${placeholder}"]`, {
+    visible: true,
+    timeout: 30000,
+  });
+  await page.click(`input[placeholder="${placeholder}"]`, { clickCount: 3 });
+  await page.keyboard.press("Backspace");
+  await page.keyboard.type(value);
+}
+
+async function waitForNoVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const normalized = (value) => String(value || "").trim();
+      const isElementVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return !Array.from(document.querySelectorAll("body *")).some(
+        (element) => {
+          if (!isElementVisible(element)) return false;
+          const textContent = normalized(element.textContent);
+          if (exactMatch) return textContent === expectedText;
+          return textContent.includes(expectedText);
+        },
+      );
+    },
+    { timeout },
+    { text, exact },
+  );
+}
+
 async function collectDebugState(page) {
   return page.evaluate(() => ({
     path: window.location.pathname,
@@ -332,6 +553,376 @@ function browserExecutablePath() {
     return "/usr/bin/google-chrome";
   }
   return undefined;
+}
+
+async function seedModelsRouteFixture({
+  marker,
+  organizationId,
+  workspaceId,
+  userId,
+}) {
+  assert(isUuid(organizationId), "Models route seed requires organization id.");
+  assert(isUuid(workspaceId), "Models route seed requires workspace id.");
+  assert(isUuid(userId), "Models route seed requires user id.");
+
+  const hiddenWorkspaceId = randomUUID();
+  const activeModelId = randomUUID();
+  const hiddenModelId = randomUUID();
+  const metricId = randomUUID();
+  const activeName = `${marker}_active_model`;
+  const hiddenName = `${marker}_hidden_model`;
+  const hiddenWorkspaceName = `${marker}_hidden_workspace`;
+  const metricName = `${marker}_quality_metric`;
+
+  const seeded = await runPostgresJson(`
+WITH inserted_workspace AS (
+  INSERT INTO accounts_workspace (
+    created_at,
+    updated_at,
+    deleted,
+    deleted_at,
+    id,
+    name,
+    display_name,
+    description,
+    is_active,
+    is_default,
+    created_by_id,
+    organization_id
+  )
+  VALUES (
+    NOW(),
+    NOW(),
+    false,
+    NULL,
+    ${sqlUuid(hiddenWorkspaceId)},
+    ${sqlTextLiteral(hiddenWorkspaceName)},
+    ${sqlTextLiteral(hiddenWorkspaceName)},
+    ${sqlTextLiteral("Temporary workspace for TH-4812 Models route smoke.")},
+    true,
+    false,
+    ${sqlUuid(userId)},
+    ${sqlUuid(organizationId)}
+  )
+  RETURNING id
+),
+inserted_custom_models AS (
+  INSERT INTO model_hub_customaimodel (
+    created_at,
+    updated_at,
+    deleted,
+    deleted_at,
+    id,
+    user_model_id,
+    key_config,
+    provider,
+    input_token_cost,
+    output_token_cost,
+    user_id,
+    organization_id,
+    workspace_id,
+    baseline_model_environment,
+    baseline_model_version,
+    default_metric_id
+  )
+  VALUES
+    (
+      NOW(),
+      NOW(),
+      false,
+      NULL,
+      ${sqlUuid(activeModelId)},
+      ${sqlTextLiteral(activeName)},
+      NULL,
+      'openai',
+      0.011,
+      0.021,
+      ${sqlUuid(userId)},
+      ${sqlUuid(organizationId)},
+      ${sqlUuid(workspaceId)},
+      NULL,
+      NULL,
+      NULL
+    ),
+    (
+      NOW(),
+      NOW(),
+      false,
+      NULL,
+      ${sqlUuid(hiddenModelId)},
+      ${sqlTextLiteral(hiddenName)},
+      NULL,
+      'openai',
+      0.012,
+      0.022,
+      ${sqlUuid(userId)},
+      ${sqlUuid(organizationId)},
+      ${sqlUuid(hiddenWorkspaceId)},
+      NULL,
+      NULL,
+      NULL
+    )
+  RETURNING id
+),
+inserted_ai_model AS (
+  INSERT INTO model_hub_aimodel (
+    id,
+    created_at,
+    user_model_id,
+    deleted,
+    model_type,
+    baseline_model_environment,
+    baseline_model_version,
+    organization_id,
+    workspace_id,
+    default_metric_id
+  )
+  VALUES (
+    ${sqlUuid(activeModelId)},
+    NOW(),
+    ${sqlTextLiteral(activeName)},
+    false,
+    'GenerativeLLM',
+    NULL,
+    NULL,
+    ${sqlUuid(organizationId)},
+    ${sqlUuid(workspaceId)},
+    NULL
+  )
+  RETURNING id
+),
+inserted_metric AS (
+  INSERT INTO model_hub_metric (
+    id,
+    name,
+    created_at,
+    updated_at,
+    text_prompt,
+    criteria_breakdown,
+    model_id,
+    develop_id,
+    metric_type,
+    used_in,
+    evaluation_type,
+    datasets,
+    eval_rag_context,
+    eval_rag_output,
+    eval_prompt_template,
+    tags
+  )
+  VALUES (
+    ${sqlUuid(metricId)},
+    ${sqlTextLiteral(metricName)},
+    NOW(),
+    NOW(),
+    ${sqlTextLiteral("Score the TH-4812 model route output.")},
+    ARRAY[]::varchar[],
+    ${sqlUuid(activeModelId)},
+    NULL,
+    'WholeUserOutput',
+    'model',
+    'EvalOutput',
+    '[]'::jsonb,
+    false,
+    false,
+    false,
+    ARRAY['quality:good', 'quality:bad']::varchar[]
+  )
+  RETURNING id
+)
+SELECT json_build_object(
+  'active_model_id', ${sqlTextLiteral(activeModelId)},
+  'hidden_model_id', ${sqlTextLiteral(hiddenModelId)},
+  'hidden_workspace_id', ${sqlTextLiteral(hiddenWorkspaceId)},
+  'metric_id', ${sqlTextLiteral(metricId)},
+  'active_name', ${sqlTextLiteral(activeName)},
+  'hidden_name', ${sqlTextLiteral(hiddenName)},
+  'metric_name', ${sqlTextLiteral(metricName)},
+  'inserted_workspace_count', (SELECT count(*) FROM inserted_workspace),
+  'inserted_custom_model_count', (SELECT count(*) FROM inserted_custom_models),
+  'inserted_ai_model_count', (SELECT count(*) FROM inserted_ai_model),
+  'inserted_metric_count', (SELECT count(*) FROM inserted_metric)
+);
+`);
+
+  assert(
+    Number(seeded.inserted_workspace_count) === 1 &&
+      Number(seeded.inserted_custom_model_count) === 2 &&
+      Number(seeded.inserted_ai_model_count) === 1 &&
+      Number(seeded.inserted_metric_count) === 1,
+    `Models route seed failed: ${JSON.stringify(seeded)}`,
+  );
+  return seeded;
+}
+
+async function hardDeleteModelsRouteFixture({
+  marker,
+  organizationId,
+  customModelIds = [],
+  aiModelIds = [],
+  metricIds = [],
+  workspaceIds = [],
+}) {
+  assert(
+    isUuid(organizationId),
+    "Models route cleanup requires organization id.",
+  );
+  const customIdPredicate = customModelIds.length
+    ? `OR custom.id = ANY(${sqlUuidArray(customModelIds)})`
+    : "";
+  const aiModelIdPredicate = aiModelIds.length
+    ? `OR model.id = ANY(${sqlUuidArray(aiModelIds)})`
+    : "";
+  const metricIdPredicate = metricIds.length
+    ? `OR metric.id = ANY(${sqlUuidArray(metricIds)})`
+    : "";
+  const workspaceIdPredicate = workspaceIds.length
+    ? `OR workspace.id = ANY(${sqlUuidArray(workspaceIds)})`
+    : "";
+
+  const deleted = await runPostgresJson(`
+WITH target_custom AS (
+  SELECT custom.id
+  FROM model_hub_customaimodel custom
+  WHERE custom.organization_id = ${sqlUuid(organizationId)}
+    AND (
+      custom.user_model_id LIKE ${sqlTextLiteral(`${marker}%`)}
+      ${customIdPredicate}
+    )
+),
+target_ai_models AS (
+  SELECT model.id
+  FROM model_hub_aimodel model
+  WHERE model.organization_id = ${sqlUuid(organizationId)}
+    AND (
+      model.user_model_id LIKE ${sqlTextLiteral(`${marker}%`)}
+      ${aiModelIdPredicate}
+    )
+),
+target_metrics AS (
+  SELECT metric.id
+  FROM model_hub_metric metric
+  LEFT JOIN target_ai_models model ON model.id = metric.model_id
+  WHERE model.id IS NOT NULL
+     OR metric.name LIKE ${sqlTextLiteral(`${marker}%`)}
+     ${metricIdPredicate}
+),
+target_workspaces AS (
+  SELECT workspace.id
+  FROM accounts_workspace workspace
+  WHERE workspace.organization_id = ${sqlUuid(organizationId)}
+    AND (
+      workspace.name LIKE ${sqlTextLiteral(`${marker}%`)}
+      ${workspaceIdPredicate}
+    )
+),
+deleted_custom AS (
+  DELETE FROM model_hub_customaimodel custom
+  USING target_custom target
+  WHERE custom.id = target.id
+  RETURNING custom.id
+),
+deleted_metrics AS (
+  DELETE FROM model_hub_metric metric
+  USING target_metrics target
+  WHERE metric.id = target.id
+  RETURNING metric.id
+),
+deleted_ai_models AS (
+  DELETE FROM model_hub_aimodel model
+  USING target_ai_models target
+  WHERE model.id = target.id
+  RETURNING model.id
+),
+deleted_workspaces AS (
+  DELETE FROM accounts_workspace workspace
+  USING target_workspaces target
+  WHERE workspace.id = target.id
+  RETURNING workspace.id
+)
+SELECT json_build_object(
+  'deleted_custom_model_count', (SELECT count(*) FROM deleted_custom),
+  'deleted_metric_count', (SELECT count(*) FROM deleted_metrics),
+  'deleted_ai_model_count', (SELECT count(*) FROM deleted_ai_models),
+  'deleted_workspace_count', (SELECT count(*) FROM deleted_workspaces)
+);
+`);
+
+  const remaining = await runPostgresJson(`
+SELECT json_build_object(
+  'remaining_custom_model_count', (
+    SELECT count(*)::int
+    FROM model_hub_customaimodel custom
+    WHERE custom.organization_id = ${sqlUuid(organizationId)}
+      AND (
+        custom.user_model_id LIKE ${sqlTextLiteral(`${marker}%`)}
+        ${customIdPredicate}
+      )
+  ),
+  'remaining_metric_count', (
+    SELECT count(*)::int
+    FROM model_hub_metric metric
+    WHERE metric.name LIKE ${sqlTextLiteral(`${marker}%`)}
+       ${metricIdPredicate}
+  ),
+  'remaining_ai_model_count', (
+    SELECT count(*)::int
+    FROM model_hub_aimodel model
+    WHERE model.organization_id = ${sqlUuid(organizationId)}
+      AND (
+        model.user_model_id LIKE ${sqlTextLiteral(`${marker}%`)}
+        ${aiModelIdPredicate}
+      )
+  ),
+  'remaining_workspace_count', (
+    SELECT count(*)::int
+    FROM accounts_workspace workspace
+    WHERE workspace.organization_id = ${sqlUuid(organizationId)}
+      AND (
+        workspace.name LIKE ${sqlTextLiteral(`${marker}%`)}
+        ${workspaceIdPredicate}
+      )
+  )
+);
+`);
+
+  return { ...deleted, ...remaining };
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres Models route helper returned no JSON output.");
+  return JSON.parse(text);
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), `Expected UUID SQL value, got ${value}`);
+  return `'${value}'::uuid`;
+}
+
+function sqlUuidArray(values) {
+  const filtered = values.filter(Boolean);
+  if (filtered.length === 0) return "ARRAY[]::uuid[]";
+  return `ARRAY[${filtered.map(sqlUuid).join(", ")}]`;
+}
+
+function sqlTextLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function normalizeRunId(value) {
+  return String(value || Date.now().toString(36))
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .slice(0, 48);
 }
 
 main().catch((error) => {

--- a/frontend/src/pages/dashboard/models/ModelDetail.jsx
+++ b/frontend/src/pages/dashboard/models/ModelDetail.jsx
@@ -95,14 +95,19 @@ const ModelDetail = () => {
   }, [error]);
 
   const links = useMemo(() => {
+    const modelName =
+      state?.model?.userModelId ||
+      state?.model?.user_model_id ||
+      modelDetails?.userModelId ||
+      modelDetails?.user_model_id ||
+      "New Model";
     const l = [
       {
         name: "Model",
         href: "/dashboard/models",
       },
       {
-        name:
-          state?.model?.userModelId || modelDetails?.userModelId || "New Model",
+        name: modelName,
         href: `/dashboard/models/${id}/performance`,
       },
     ];
@@ -168,7 +173,8 @@ const ModelDetail = () => {
                   navigate(`/dashboard/models/${id}/datasets`);
                 }}
               />
-              {modelDetails?.modelType === "GenerativeLLM" && (
+              {(modelDetails?.modelType || modelDetails?.model_type) ===
+                "GenerativeLLM" && (
                 <Tab
                   label={
                     <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>


### PR DESCRIPTION
## Summary

Stacked on #848.

This adds a mutating real-browser Models route smoke that seeds disposable model data, verifies active-workspace visibility, verifies same-org other-workspace models stay hidden, opens the model detail route, and checks the Custom Metrics tab against the live API.

It also fixes the Models detail breadcrumb/type checks to handle the snake_case fields returned by the live API.

## Validation

- `node --check scripts/api-journeys/browser/models-route-smoke.mjs`
- `./node_modules/.bin/prettier --check scripts/api-journeys/browser/models-route-smoke.mjs src/pages/dashboard/models/ModelDetail.jsx`
- `yarn eslint scripts/api-journeys/browser/models-route-smoke.mjs src/pages/dashboard/models/ModelDetail.jsx`
- `API_BASE=http://localhost:8003 FUTURE_AGI_TOKEN_FILE=/tmp/futureagi-ws2-api-journey-token.error-feed-stats.clean.json yarn test:api-journeys:preflight -- --json /tmp/th4812-models-route-preflight.json`
- `API_BASE=http://localhost:8003 APP_BASE=http://127.0.0.1:3033 API_JOURNEY_MUTATIONS=1 API_JOURNEY_DB_CONTAINER=ws2-postgres FUTURE_AGI_TOKEN_FILE=/tmp/futureagi-ws2-api-journey-token.error-feed-stats.clean.json node scripts/api-journeys/browser/models-route-smoke.mjs > /tmp/th4812-models-route-smoke.json`
- `git diff --check`
- `yarn type-check` (configured no-op: no `frontend/tsconfig.json`)
- `yarn test:api-journeys:list`
- `yarn test:run` (211 files, 1,735 tests passed)
- `yarn contracts:check`
- `make test` from `futureagi` (11,886 passed, 90 skipped, 690 deselected, 7 xfailed, 7 xpassed)

## Evidence

The mutating browser smoke cleaned up its seeded DB rows and independently verified no residue remained for the TH-4812 marker.
