### PR TITLE
TH-4812: Cover dashboard widget actions smoke

### DIFF
--- a/frontend/scripts/api-journeys/browser/dashboard-widget-actions-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/dashboard-widget-actions-smoke.mjs
@@ -1,0 +1,626 @@
+/* eslint-disable no-console */
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import process from "node:process";
+import { promisify } from "node:util";
+import {
+  apiPath,
+  asArray,
+  assert,
+  createAuthenticatedContext,
+  isUuid,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const SCREENSHOT_PATH = "/tmp/dashboard-widget-actions-smoke.png";
+const FAILURE_SCREENSHOT_PATH =
+  "/tmp/dashboard-widget-actions-smoke-failure.png";
+const EXPECTED_RESIZED_WIDTH = 6;
+const MIN_RESIZED_HEIGHT = 360;
+
+async function main() {
+  const auth = await createAuthenticatedContext();
+  const runSuffix = auth.runId;
+  const dashboardName = `TH-4812 widget actions ${runSuffix}`;
+  const widgetName = `TH-4812 actions widget ${runSuffix}`;
+  const copiedWidgetName = `${widgetName} (Copy)`;
+  let dashboardId = null;
+  let originalWidgetId = null;
+  let copiedWidgetId = null;
+  let dashboardDeleted = false;
+
+  const dashboard = await auth.client.post(apiPath("/tracer/dashboard/"), {
+    name: dashboardName,
+    description: "Disposable dashboard for widget action browser smoke.",
+  });
+  dashboardId = dashboard?.id;
+  assert(isUuid(dashboardId), "Dashboard create did not return a UUID id.");
+
+  const widget = await auth.client.post(
+    apiPath("/tracer/dashboard/{dashboard_pk}/widgets/", {
+      dashboard_pk: dashboardId,
+    }),
+    {
+      name: widgetName,
+      description: "Disposable widget for duplicate and resize actions.",
+      position: 0,
+      width: 12,
+      height: 320,
+      query_config: {},
+      chart_config: { chart_type: "line" },
+    },
+  );
+  originalWidgetId = widget?.id;
+  assert(isUuid(originalWidgetId), "Widget create did not return a UUID id.");
+
+  const apiFailures = [];
+  const pageErrors = [];
+  const mutationRequests = [];
+  const browser = await puppeteer.launch({
+    executablePath: browserExecutablePath(),
+    headless: process.env.HEADLESS !== "0",
+    defaultViewport: { width: 1440, height: 950 },
+    args: ["--no-sandbox"],
+  });
+  const page = await browser.newPage();
+  await page.setBypassServiceWorker(true);
+  await installRuntimeConfig(page, auth);
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+
+  page.on("request", (request) => {
+    if (isDashboardWidgetMutationUrl(request.url(), dashboardId)) {
+      mutationRequests.push(`${request.method()} ${request.url()}`);
+    }
+  });
+  page.on("response", (response) => {
+    if (
+      isDashboardApiUrl(response.url(), dashboardId) &&
+      response.status() >= 400
+    ) {
+      apiFailures.push(`${response.status()} ${response.url()}`);
+    }
+  });
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  try {
+    await waitForResponseDuring(
+      page,
+      "dashboard detail",
+      (response) =>
+        response.request().method() === "GET" &&
+        response.url().includes(`/tracer/dashboard/${dashboardId}/`) &&
+        response.status() < 400,
+      () =>
+        page.goto(`${APP_BASE}/dashboard/dashboards/${dashboardId}`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await expectVisibleText(page, dashboardName, { exact: true });
+    await expectVisibleText(page, widgetName, { exact: true });
+    await waitForWidgetCard(page, originalWidgetId);
+
+    await openWidgetMenu(page, originalWidgetId);
+    const duplicateResponse = await waitForResponseDuring(
+      page,
+      "duplicate widget",
+      (response) =>
+        response.request().method() === "POST" &&
+        response
+          .url()
+          .includes(
+            `/tracer/dashboard/${dashboardId}/widgets/${originalWidgetId}/duplicate/`,
+          ) &&
+        response.status() < 400,
+      () => clickVisibleText(page, "Duplicate", { exact: true }),
+    );
+    const duplicatePayload = await duplicateResponse.json();
+    copiedWidgetId = duplicatePayload?.result?.id;
+    assert(
+      isUuid(copiedWidgetId),
+      "Duplicate response did not return a widget id.",
+    );
+    await waitForWidgetByName(auth.client, dashboardId, copiedWidgetName);
+    await waitForWidgetCard(page, copiedWidgetId);
+    await expectVisibleText(page, copiedWidgetName, { exact: true });
+
+    await openWidgetMenu(page, originalWidgetId);
+    await clickVisibleText(page, "Resize Width", { exact: true });
+    await waitForResponseDuring(
+      page,
+      "width resize",
+      (response) =>
+        response.request().method() === "PATCH" &&
+        response
+          .url()
+          .includes(
+            `/tracer/dashboard/${dashboardId}/widgets/${originalWidgetId}/`,
+          ) &&
+        response.status() < 400,
+      () => clickVisibleText(page, "1/2 width", { exact: true }),
+    );
+    const resizedWidget = await waitForWidgetShape(auth.client, dashboardId, {
+      id: originalWidgetId,
+      width: EXPECTED_RESIZED_WIDTH,
+    });
+    assert(
+      resizedWidget.name === widgetName,
+      "Width resize mutated the wrong widget.",
+    );
+
+    await waitForResponseDuring(
+      page,
+      "row height resize",
+      (response) =>
+        response.request().method() === "PATCH" &&
+        response
+          .url()
+          .includes(
+            `/tracer/dashboard/${dashboardId}/widgets/${originalWidgetId}/`,
+          ) &&
+        response.status() < 400,
+      () => dragFirstRowResizeHandle(page),
+    );
+    const heightResizedWidget = await waitForWidgetShape(
+      auth.client,
+      dashboardId,
+      {
+        id: originalWidgetId,
+        minHeight: MIN_RESIZED_HEIGHT,
+      },
+    );
+
+    const detail = await auth.client.get(
+      apiPath("/tracer/dashboard/{id}/", { id: dashboardId }),
+    );
+    const widgets = asArray(detail.widgets);
+    assert(
+      widgets.length === 2,
+      `Expected two active widgets after duplicate, found ${widgets.length}.`,
+    );
+    const copiedWidget = widgets.find(
+      (candidate) => candidate.id === copiedWidgetId,
+    );
+    assert(copiedWidget, "Copied widget was missing from dashboard detail.");
+    assert(
+      copiedWidget.name === copiedWidgetName,
+      "Copied widget name did not preserve the API duplicate suffix.",
+    );
+    assert(
+      copiedWidget.width === 12 && copiedWidget.height === 320,
+      "Width/height actions unexpectedly mutated the copied widget.",
+    );
+
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+
+    await auth.client.delete(
+      apiPath("/tracer/dashboard/{id}/", { id: dashboardId }),
+    );
+    dashboardDeleted = true;
+    const cleanupAudit = await loadDashboardCleanupAudit({
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      dashboardId,
+    });
+    assertCleanupAudit(cleanupAudit, {
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      dashboardId,
+    });
+
+    assert(
+      apiFailures.length === 0,
+      `Dashboard widget action API failures: ${apiFailures.join("; ")}`,
+    );
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          evidence: {
+            dashboard_id: dashboardId,
+            original_widget_id: originalWidgetId,
+            copied_widget_id: copiedWidgetId,
+            copied_widget_name: copiedWidgetName,
+            original_width: heightResizedWidget.width,
+            original_height: heightResizedWidget.height,
+            mutation_count: mutationRequests.length,
+            screenshot: SCREENSHOT_PATH,
+            cleanup_audit: cleanupAudit,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    await captureFailureDiagnostics(page, error);
+    throw error;
+  } finally {
+    await browser.close();
+    if (!dashboardDeleted && dashboardId) {
+      await auth.client
+        .delete(apiPath("/tracer/dashboard/{id}/", { id: dashboardId }))
+        .catch(() => null);
+    }
+  }
+}
+
+async function openWidgetMenu(page, widgetId) {
+  await waitForWidgetCard(page, widgetId);
+  await page.hover(`[data-widget-id="${widgetId}"]`);
+  const clicked = await page.evaluate((id) => {
+    const card = document.querySelector(`[data-widget-id="${id}"]`);
+    if (!card) return false;
+    const buttons = Array.from(card.querySelectorAll("button"));
+    const moreButton = buttons[buttons.length - 1];
+    if (!moreButton) return false;
+    moreButton.click();
+    return true;
+  }, widgetId);
+  assert(clicked, `Unable to open widget menu for ${widgetId}.`);
+  await expectVisibleText(page, "Duplicate", { exact: true });
+  await expectVisibleText(page, "Resize Width", { exact: true });
+}
+
+async function dragFirstRowResizeHandle(page) {
+  await page.waitForSelector(".row-resize-bar", {
+    visible: true,
+    timeout: 30000,
+  });
+  const dispatched = await page.evaluate(() => {
+    const bar = document.querySelector(".row-resize-bar");
+    const handle = bar?.parentElement;
+    if (!handle) return false;
+    const rect = handle.getBoundingClientRect();
+    const clientX = rect.left + rect.width / 2;
+    const clientY = rect.top + rect.height / 2;
+    const eventInit = {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      clientX,
+      clientY,
+    };
+    handle.dispatchEvent(new MouseEvent("mousedown", eventInit));
+    document.dispatchEvent(
+      new MouseEvent("mousemove", { ...eventInit, clientY: clientY + 90 }),
+    );
+    document.dispatchEvent(
+      new MouseEvent("mouseup", { ...eventInit, clientY: clientY + 90 }),
+    );
+    return true;
+  });
+  assert(dispatched, "Row resize handle was not found.");
+}
+
+async function waitForWidgetCard(page, widgetId) {
+  await page.waitForSelector(`[data-widget-id="${widgetId}"]`, {
+    visible: true,
+    timeout: 30000,
+  });
+}
+
+async function waitForWidgetByName(client, dashboardId, name) {
+  let lastWidgets = [];
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const detail = await client.get(
+      apiPath("/tracer/dashboard/{id}/", { id: dashboardId }),
+    );
+    const widgets = asArray(detail.widgets);
+    lastWidgets = widgets;
+    const match = widgets.find((widget) => widget.name === name);
+    if (match) return match;
+    await delay(250);
+  }
+  throw new Error(
+    `Dashboard detail never contained widget ${name}. Widgets: ${lastWidgets
+      .map((widget) => widget.name)
+      .join(", ")}`,
+  );
+}
+
+async function waitForWidgetShape(client, dashboardId, expected) {
+  let lastWidget = null;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const detail = await client.get(
+      apiPath("/tracer/dashboard/{id}/", { id: dashboardId }),
+    );
+    const widget = asArray(detail.widgets).find(
+      (candidate) => candidate.id === expected.id,
+    );
+    lastWidget = widget || null;
+    if (
+      widget &&
+      (expected.width === undefined || widget.width === expected.width) &&
+      (expected.height === undefined || widget.height === expected.height) &&
+      (expected.minHeight === undefined || widget.height >= expected.minHeight)
+    ) {
+      return widget;
+    }
+    await delay(250);
+  }
+  throw new Error(
+    `Widget ${expected.id} did not reach expected shape. Last value: ${JSON.stringify(
+      lastWidget,
+    )}`,
+  );
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = request.url();
+    if (url.endsWith("/config.js") || url.endsWith("/runtime-config.js")) {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  const responsePromise = page.waitForResponse(predicate, { timeout: 30000 });
+  await action();
+  try {
+    return await responsePromise;
+  } catch (error) {
+    throw new Error(`Timed out waiting for ${label}: ${error.message}`);
+  }
+}
+
+async function expectVisibleText(page, text, { exact = false } = {}) {
+  await page.waitForFunction(
+    ({ expected, exactMatch }) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll("body *")).some((element) => {
+        if (!isVisible(element)) return false;
+        const value = element.textContent.trim();
+        return exactMatch ? value === expected : value.includes(expected);
+      });
+    },
+    { timeout: 30000 },
+    { expected: text, exactMatch: exact },
+  );
+}
+
+async function clickVisibleText(page, text, { exact = false } = {}) {
+  await expectVisibleText(page, text, { exact });
+  const clicked = await page.evaluate(
+    ({ expected, exactMatch }) => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      const elements = Array.from(document.querySelectorAll("body *")).filter(
+        (element) => {
+          if (!isVisible(element)) return false;
+          const value = element.textContent.trim();
+          return exactMatch ? value === expected : value.includes(expected);
+        },
+      );
+      const target =
+        elements.find((element) =>
+          ["BUTTON", "A", "LI"].includes(element.tagName),
+        ) ||
+        elements.find((element) => element.closest("[role='menuitem']")) ||
+        elements[elements.length - 1];
+      if (!target) return false;
+      target.click();
+      return true;
+    },
+    { expected: text, exactMatch: exact },
+  );
+  assert(clicked, `Unable to click visible text: ${text}`);
+}
+
+async function captureFailureDiagnostics(page, error) {
+  const diagnostics = await page
+    .evaluate(() => ({
+      url: window.location.href,
+      title: document.title,
+      bodyText: document.body?.innerText?.slice(0, 1500) || "",
+      widgets: Array.from(document.querySelectorAll("[data-widget-id]")).map(
+        (element) => ({
+          id: element.getAttribute("data-widget-id"),
+          text: element.textContent.trim().slice(0, 300),
+          rect: (() => {
+            const { x, y, width, height } = element.getBoundingClientRect();
+            return { x, y, width, height };
+          })(),
+        }),
+      ),
+    }))
+    .catch((diagnosticError) => ({
+      diagnostic_error: diagnosticError.message,
+    }));
+  await page
+    .screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+    .catch(() => null);
+  console.error(
+    JSON.stringify(
+      {
+        status: "failed",
+        error: error.message,
+        screenshot: FAILURE_SCREENSHOT_PATH,
+        diagnostics,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function isDashboardApiUrl(url, dashboardId) {
+  return (
+    Boolean(dashboardId) &&
+    (url.includes(`/tracer/dashboard/${dashboardId}/`) ||
+      url.includes("/tracer/dashboard/query/"))
+  );
+}
+
+function isDashboardWidgetMutationUrl(url, dashboardId) {
+  if (!dashboardId) return false;
+  return url.includes(`/tracer/dashboard/${dashboardId}/widgets/`);
+}
+
+async function loadDashboardCleanupAudit({
+  organizationId,
+  workspaceId,
+  dashboardId,
+}) {
+  const sql = `
+WITH requested AS (
+  SELECT
+    ${sqlUuid(organizationId)} AS organization_id,
+    ${sqlUuid(workspaceId)} AS workspace_id,
+    ${sqlUuid(dashboardId)} AS dashboard_id
+),
+dashboard_row AS (
+  SELECT
+    dashboard.id,
+    dashboard.workspace_id,
+    workspace.organization_id,
+    dashboard.deleted,
+    dashboard.deleted_at IS NOT NULL AS deleted_at_set
+  FROM tracer_dashboard dashboard
+  JOIN accounts_workspace workspace ON workspace.id = dashboard.workspace_id
+  JOIN requested ON requested.dashboard_id = dashboard.id
+),
+widget_rows AS (
+  SELECT widget.id, widget.deleted, widget.deleted_at IS NOT NULL AS deleted_at_set
+  FROM tracer_dashboardwidget widget
+  JOIN requested ON requested.dashboard_id = widget.dashboard_id
+)
+SELECT json_build_object(
+  'dashboard_id', (SELECT id::text FROM dashboard_row),
+  'dashboard_workspace_id', (SELECT workspace_id::text FROM dashboard_row),
+  'dashboard_organization_id', (SELECT organization_id::text FROM dashboard_row),
+  'dashboard_deleted', COALESCE((SELECT deleted FROM dashboard_row), false),
+  'dashboard_deleted_at_set', COALESCE((SELECT deleted_at_set FROM dashboard_row), false),
+  'widget_row_count', (SELECT count(*) FROM widget_rows),
+  'active_widget_count', (SELECT count(*) FROM widget_rows WHERE deleted = false),
+  'soft_deleted_widget_count', (
+    SELECT count(*)
+    FROM widget_rows
+    WHERE deleted = true AND deleted_at_set = true
+  )
+)
+FROM requested;
+`;
+  return runPostgresJson(sql);
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-qAt", "-U", user, "-d", database, "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const line = stdout.trim().split(/\r?\n/).find(Boolean);
+  assert(line, "Postgres audit returned no rows.");
+  return JSON.parse(line);
+}
+
+function assertCleanupAudit(
+  audit,
+  { organizationId, workspaceId, dashboardId },
+) {
+  assert(
+    audit?.dashboard_id === dashboardId,
+    "Cleanup audit returned wrong dashboard id.",
+  );
+  assert(
+    audit?.dashboard_organization_id === organizationId,
+    "Cleanup audit returned wrong organization id.",
+  );
+  assert(
+    audit?.dashboard_workspace_id === workspaceId,
+    "Cleanup audit returned wrong workspace id.",
+  );
+  assert(
+    audit?.dashboard_deleted === true &&
+      audit?.dashboard_deleted_at_set === true,
+    "Dashboard cleanup did not soft-delete the dashboard.",
+  );
+  assert(
+    Number(audit?.widget_row_count) === 2 &&
+      Number(audit?.active_widget_count) === 0 &&
+      Number(audit?.soft_deleted_widget_count) === 2,
+    "Dashboard cleanup did not soft-delete exactly the two child widgets.",
+  );
+}
+
+function sqlUuid(value) {
+  assert(isUuid(value), `Expected UUID for SQL literal, received ${value}`);
+  return `'${String(value).replace(/'/g, "''")}'::uuid`;
+}
+
+function browserExecutablePath() {
+  return (
+    process.env.PUPPETEER_EXECUTABLE_PATH ||
+    process.env.CHROME_BIN ||
+    process.env.CHROME_PATH ||
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  );
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a browser API journey smoke for dashboard widget actions.
- Exercises real UI duplicate, width resize, and row-height resize flows against the API.
- Audits cleanup through Postgres so the temporary dashboard/widgets are soft-deleted.

## Validation
- `node --check scripts/api-journeys/browser/dashboard-widget-actions-smoke.mjs`
- `./node_modules/.bin/prettier --check scripts/api-journeys/browser/dashboard-widget-actions-smoke.mjs`
- `yarn eslint scripts/api-journeys/browser/dashboard-widget-actions-smoke.mjs`
- `yarn type-check` (no tsconfig found; script skipped)
- `yarn test:api-journeys:list`
- `yarn test:api-journeys:preflight -- --json /tmp/th4812-dashboard-widget-actions-preflight.json`
- `node scripts/api-journeys/browser/dashboard-widget-actions-smoke.mjs`
- `yarn test:run`
- `yarn contracts:check`
- `make test`

Stacked on #849 (`fix/TH-4812-models-route-smoke`).