### PR TITLE
TH-4812: Cover observe trace export diagnostic

### DIFF
--- a/frontend/scripts/api-journeys/browser/observe-trace-detail-tag-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/observe-trace-detail-tag-smoke.mjs
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import { Buffer } from "node:buffer";
 import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
 import process from "node:process";
@@ -33,6 +32,7 @@ async function main() {
   const pageErrors = [];
   const consoleMessages = [];
   const traceRequests = [];
+  const expectedExportFailures = [];
   const evidence = {
     project_id: fixture.projectId,
     project_name: fixture.projectName,
@@ -66,6 +66,10 @@ async function main() {
     page.on("response", (response) => {
       const url = response.url();
       if (isObserveApiUrl(url) && response.status() >= 400) {
+        if (isTraceExportUrl(url) && response.status() === 400) {
+          expectedExportFailures.push(`${response.status()} ${url}`);
+          return;
+        }
         apiFailures.push(`${response.status()} ${url}`);
       }
     });
@@ -134,6 +138,26 @@ async function main() {
     await page.keyboard.press("Escape");
     await waitForTraceGridRow(page, traceRowLabel);
 
+    const exportResponse = await waitForResponseDuring(
+      page,
+      "observe trace CSV export diagnostic",
+      traceExportResponse(fixture.projectId),
+      () => clickExportCsvButton(page),
+    );
+    assert(
+      exportResponse.status() === 400,
+      `Trace CSV export returned unexpected HTTP ${exportResponse.status()}.`,
+    );
+    const exportBody = await readResponseJson(exportResponse);
+    const exportDiagnostic = stringifyDiagnostic(exportBody);
+    assertTraceExportDiagnostic(exportDiagnostic);
+    await waitForVisibleText(page, "Export failed:", { exact: false });
+    await waitForVisibleText(page, "Non-voice trace export", { exact: false });
+    evidence.export_diagnostic = {
+      status: exportResponse.status(),
+      message: exportDiagnostic,
+    };
+
     const detailResponse = await waitForResponseDuring(
       page,
       "open observe trace drawer",
@@ -178,6 +202,7 @@ async function main() {
           workspace_id: auth.workspaceId,
           evidence,
           observe_trace_request_count: traceRequests.length,
+          expected_export_failures: expectedExportFailures,
         },
         null,
         2,
@@ -200,6 +225,7 @@ async function main() {
           page_errors: pageErrors,
           browser_console_messages: consoleMessages.slice(-20),
           observe_trace_requests: traceRequests,
+          expected_export_failures: expectedExportFailures,
           failure_screenshot: FAILURE_SCREENSHOT_PATH,
         },
         null,
@@ -984,6 +1010,17 @@ function traceTagUpdateResponse(traceId) {
   };
 }
 
+function traceExportResponse(projectId) {
+  return (response) => {
+    const url = new URL(response.url());
+    return (
+      url.pathname === "/tracer/trace/get_trace_export_data/" &&
+      response.request().method() === "GET" &&
+      url.searchParams.get("project_id") === projectId
+    );
+  };
+}
+
 async function waitForResponseDuring(page, label, predicate, action) {
   const responsePromise = page.waitForResponse(predicate, { timeout: 60000 });
   try {
@@ -1042,6 +1079,50 @@ async function waitForTraceGridRow(page, rowLabel) {
     { timeout: 60000 },
     rowLabel,
   );
+}
+
+async function clickExportCsvButton(page) {
+  await page.waitForFunction(
+    () =>
+      document.querySelector(
+        'button[aria-label="Export CSV"]:not(:disabled)',
+      ) ||
+      window.visibleElements(".component-iconify").some((icon) => {
+        const iconName =
+          icon.getAttribute("icon") || icon.getAttribute("data-icon") || "";
+        const button = icon.closest("button");
+        return (
+          iconName === "mdi:download-outline" && button && !button.disabled
+        );
+      }),
+    { timeout: 30000 },
+  );
+  const clicked = await page.evaluate(() => {
+    const labeledButton = document.querySelector(
+      'button[aria-label="Export CSV"]:not(:disabled)',
+    );
+    if (labeledButton) {
+      window.dispatchClick(labeledButton);
+      return true;
+    }
+    const icon = window
+      .visibleElements(".component-iconify")
+      .find((candidate) => {
+        const iconName =
+          candidate.getAttribute("icon") ||
+          candidate.getAttribute("data-icon") ||
+          "";
+        const button = candidate.closest("button");
+        return (
+          iconName === "mdi:download-outline" && button && !button.disabled
+        );
+      });
+    const button = icon?.closest("button");
+    if (!button) return false;
+    window.dispatchClick(button);
+    return true;
+  });
+  assert(clicked, "Could not click trace export CSV button.");
 }
 
 async function clickTraceGridRow(page, rowLabel) {
@@ -1206,6 +1287,22 @@ function assertTraceCsv(text, fixture) {
   );
 }
 
+function stringifyDiagnostic(body) {
+  if (typeof body === "string") return body;
+  if (typeof body?.message === "string") return body.message;
+  if (typeof body?.detail === "string") return body.detail;
+  if (typeof body?.error === "string") return body.error;
+  if (typeof body?.result === "string") return body.result;
+  return JSON.stringify(body || {});
+}
+
+function assertTraceExportDiagnostic(diagnostic) {
+  assert(
+    /unsupported|not supported|unbounded|CH-only/i.test(diagnostic),
+    `Trace export 400 did not include the CH diagnostic: ${diagnostic}`,
+  );
+}
+
 async function apiGetRaw(auth, pathName, query = {}) {
   const url = new URL(pathName, auth.apiBase);
   for (const [key, value] of Object.entries(query)) {
@@ -1293,6 +1390,10 @@ function isObserveApiUrl(url) {
 
 function isObserveTraceApiUrl(url) {
   return url.includes("/tracer/trace/");
+}
+
+function isTraceExportUrl(url) {
+  return url.includes("/tracer/trace/get_trace_export_data/");
 }
 
 function buildObserveTraceListUrl(projectId) {

--- a/frontend/src/sections/projects/ObserveHeader.jsx
+++ b/frontend/src/sections/projects/ObserveHeader.jsx
@@ -36,6 +36,25 @@ import { useGetProjectDetails } from "src/api/project/project-detail";
 
 // CustomBackButton removed — replaced with inline Box button
 
+function exportErrorMessage(error) {
+  const data = error?.response?.data;
+  if (typeof data === "string" && data.trim()) return data;
+  if (typeof data?.message === "string" && data.message.trim()) {
+    return data.message;
+  }
+  if (typeof data?.detail === "string" && data.detail.trim()) {
+    return data.detail;
+  }
+  if (typeof data?.error === "string" && data.error.trim()) return data.error;
+  if (typeof data?.result === "string" && data.result.trim()) {
+    return data.result;
+  }
+  if (typeof error?.message === "string" && error.message.trim()) {
+    return error.message;
+  }
+  return "Failed to export data";
+}
+
 const ProjectDropdownButton = styled(Button)(({ theme }) => ({
   minWidth: 200,
   height: 26,
@@ -273,6 +292,11 @@ const ObserveHeader = ({
 
       link.remove();
       window.URL.revokeObjectURL(url);
+    },
+    onError: (error) => {
+      enqueueSnackbar(`Export failed: ${exportErrorMessage(error)}`, {
+        variant: "error",
+      });
     },
   });
 
@@ -604,6 +628,7 @@ const ObserveHeader = ({
                     size="small"
                     onClick={handleExportClick}
                     disabled={isExportData}
+                    aria-label={isExportData ? "Exporting data" : "Export CSV"}
                   >
                     <Iconify icon="mdi:download-outline" width={16} />
                   </ObserveIconButton>


### PR DESCRIPTION
## Summary

- Surface trace export failures in Observe as a snackbar instead of a silent mutation failure.
- Extend the real browser observe trace smoke to click Export CSV, assert the expected CH-only diagnostic 400, and verify the snackbar copy.
- Preserve the existing trace tag/detail/cleanup journey evidence around the new export diagnostic check.

## Validation

- `node --check scripts/api-journeys/browser/observe-trace-detail-tag-smoke.mjs`
- `./node_modules/.bin/eslint scripts/api-journeys/browser/observe-trace-detail-tag-smoke.mjs src/sections/projects/ObserveHeader.jsx`
- `./node_modules/.bin/prettier --check scripts/api-journeys/browser/observe-trace-detail-tag-smoke.mjs src/sections/projects/ObserveHeader.jsx`
- `git diff --check`
- `yarn type-check`
- `yarn contracts:check`
- `yarn test:run`
- `API_BASE=http://localhost:8003 APP_BASE=http://127.0.0.1:3033 FUTURE_AGI_TOKEN_FILE=/tmp/futureagi-ws2-api-journey-token.error-feed-stats.clean.json API_JOURNEY_BACKEND_CONTAINER=ws2-backend-current API_JOURNEY_DB_CONTAINER=ws2-postgres API_JOURNEY_CH_CONTAINER=ws2-clickhouse node scripts/api-journeys/browser/observe-trace-detail-tag-smoke.mjs`
- `bin/test`