### PR TITLE
TH-4812: Wire eval playground SDK copy

### DIFF
--- a/frontend/src/sections/evals/EvalPlayground/BottomEvaluationSection/BottomEvaluationSection.jsx
+++ b/frontend/src/sections/evals/EvalPlayground/BottomEvaluationSection/BottomEvaluationSection.jsx
@@ -7,6 +7,8 @@ import axios, { endpoints } from "src/utils/axios";
 import SvgColor from "src/components/svg-color";
 import Iconify from "src/components/iconify";
 import { Editor } from "@monaco-editor/react";
+import { enqueueSnackbar } from "notistack";
+import { copyToClipboard } from "src/utils/utils";
 
 const editorOptions = {
   selectOnLineNumbers: true,
@@ -51,11 +53,13 @@ const BottomEvaluationSection = ({
 
   const { data, isPending, isLoading, isRefetching } = useQuery({
     queryFn: ({ signal }) => {
+      const { mapping, ...restSelectedData } = selectedData || {};
       const params = {
         template_id: evaluation?.id,
-        ...selectedData,
+        ...restSelectedData,
+        mapping: { ...(mapping || {}) },
       };
-      delete params["mapping"]["model"];
+      delete params.mapping.model;
       return axios.get(endpoints.develop.eval.evalsSDKCode, {
         params,
         signal,
@@ -78,6 +82,7 @@ const BottomEvaluationSection = ({
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes (formerly cacheTime)
   });
+  const activeCode = activeTab ? data?.[activeTab] || "" : "";
 
   const handleEditorMount = (editor, monaco) => {
     editorRef.current = editor;
@@ -95,6 +100,14 @@ const BottomEvaluationSection = ({
       domReadOnly: true,
     });
   };
+
+  const handleCopy = React.useCallback(async () => {
+    if (!activeCode) return;
+    const copied = await copyToClipboard(activeCode);
+    enqueueSnackbar(copied ? "Copied to clipboard" : "Failed to copy", {
+      variant: copied ? "success" : "error",
+    });
+  }, [activeCode]);
 
   return (
     <Box
@@ -159,20 +172,27 @@ const BottomEvaluationSection = ({
               position: "relative",
             }}
           >
-            <SvgColor
-              // @ts-ignore
-              src="/assets/icons/ic_copy.svg"
-              alt="Copy"
+            <IconButton
+              aria-label={`Copy ${activeTab} SDK code`}
+              disabled={!activeCode}
+              onClick={handleCopy}
               sx={{
-                width: "16px",
-                height: "16px",
                 position: "absolute",
-                top: "10px",
-                right: "10px",
-                cursor: "pointer",
+                top: "4px",
+                right: "4px",
                 zIndex: 1,
               }}
-            />
+            >
+              <SvgColor
+                // @ts-ignore
+                src="/assets/icons/ic_copy.svg"
+                alt=""
+                sx={{
+                  width: "16px",
+                  height: "16px",
+                }}
+              />
+            </IconButton>
             <Box>
               <Editor
                 ref={editorRef}

--- a/frontend/src/sections/evals/EvalPlayground/BottomEvaluationSection/BottomEvaluationSection.test.jsx
+++ b/frontend/src/sections/evals/EvalPlayground/BottomEvaluationSection/BottomEvaluationSection.test.jsx
@@ -1,0 +1,140 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import BottomEvaluationSection from "./BottomEvaluationSection";
+
+const mocks = vi.hoisted(() => ({
+  axiosGet: vi.fn(),
+  copyToClipboard: vi.fn(),
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("@monaco-editor/react", async () => {
+  const ReactModule = await import("react");
+  const Editor = ReactModule.forwardRef(({ value, onMount }, ref) => {
+    ReactModule.useEffect(() => {
+      onMount?.(
+        { updateOptions: vi.fn() },
+        {
+          editor: {
+            defineTheme: vi.fn(),
+            setTheme: vi.fn(),
+          },
+        },
+      );
+    }, [onMount]);
+    return (
+      <pre ref={ref} data-testid="sdk-code">
+        {value}
+      </pre>
+    );
+  });
+  Editor.displayName = "MockMonacoEditor";
+  return {
+    Editor,
+  };
+});
+
+vi.mock("src/utils/axios", () => ({
+  default: {
+    get: mocks.axiosGet,
+  },
+  endpoints: {
+    develop: {
+      eval: {
+        evalsSDKCode: "/model-hub/eval-sdk-code/",
+      },
+    },
+  },
+}));
+
+vi.mock("src/utils/utils", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    copyToClipboard: mocks.copyToClipboard,
+  };
+});
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: mocks.enqueueSnackbar,
+}));
+
+vi.mock("../../EvalDetails/EvalsLog/LogsTabGrid", () => ({
+  default: () => <div data-testid="logs-tab-grid" />,
+}));
+
+function renderWithQueryClient(ui) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe("BottomEvaluationSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.copyToClipboard.mockResolvedValue(true);
+    mocks.axiosGet.mockResolvedValue({
+      data: {
+        result: {
+          python: "futureagi.eval(template_id='eval-123')",
+          javascript: "futureagi.eval({ templateId: 'eval-123' })",
+          curl: "curl https://api.futureagi.com/eval",
+        },
+      },
+    });
+  });
+
+  it("copies the active SDK snippet from the eval playground", async () => {
+    const selectedData = {
+      mapping: {
+        output: "answer",
+        model: "gpt-4o-mini",
+      },
+      source: "playground",
+    };
+
+    renderWithQueryClient(
+      <BottomEvaluationSection
+        evaluation={{ id: "eval-123", name: "SDK Copy Eval" }}
+        selectedData={selectedData}
+        setInitialLeftWidth={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Python" }));
+
+    await screen.findByText("futureagi.eval(template_id='eval-123')");
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      "/model-hub/eval-sdk-code/",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          template_id: "eval-123",
+          mapping: { output: "answer" },
+          source: "playground",
+        }),
+      }),
+    );
+    expect(selectedData.mapping.model).toBe("gpt-4o-mini");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy Python SDK code" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith(
+        "futureagi.eval(template_id='eval-123')",
+      ),
+    );
+    expect(mocks.enqueueSnackbar).toHaveBeenCalledWith("Copied to clipboard", {
+      variant: "success",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Makes the eval playground SDK copy icon an accessible button that copies the active Python, JavaScript, or cURL snippet and reports success/failure via snackbar.
- Clones SDK-code request params before dropping `mapping.model`, avoiding mutation of `selectedData.mapping`.
- Adds focused RTL/Vitest coverage for copy behavior and request params.

## Validation
- `frontend/node_modules/.bin/prettier --check ...`
- focused `eslint` on touched JSX/test files
- focused `vitest` for `BottomEvaluationSection.test.jsx`
- `cd frontend && yarn type-check` (no `tsconfig.json`, skipped)
- `cd frontend && yarn test:run` (213 files / 1738 tests passed)
- `cd frontend && yarn lint` (passed with existing repo warnings, no errors)
- `yarn contracts:check`
- `cd futureagi && make test` (11887 passed, 90 skipped, 690 deselected, 7 xfailed, 7 xpassed)
- live API journey `EVAL-API-004` passed for Python/JS/cURL placeholder SDK snippets and no user key mutation

## Note
- I checked the current dev UI rewrite: dataset Evaluate now opens the newer Select Evaluation picker, and the old group Playground button is commented out. I did not keep a browser smoke for this legacy EvalPlayground path because it is no longer reachable from the current dataset UI.