### PR TITLE
chore(frontend): bump Node 20.17 → 22.18 in Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile
 
 # Stage 1: Build the React app
-FROM node:20.17 AS build
+FROM node:22.18 AS build
 
 # Build args forwarded from docker-compose. Vite reads env vars prefixed
 # VITE_ at build time and bakes them into the bundle.
@@ -22,7 +22,7 @@ RUN yarn build
 # `target: dev` in docker-compose.dev.yml. Source is bind-mounted at runtime;
 # this stage just provides node + a baked-in node_modules so HMR works without
 # a host-side `yarn install`.
-FROM node:20.17 AS dev
+FROM node:22.18 AS dev
 WORKDIR /app
 COPY package.json yarn.lock ./
 RUN yarn install


### PR DESCRIPTION
## What
Upgrade the frontend `Dockerfile` base image from `node:20.17` to `node:22.18` in both the `build` and `dev` stages.

## Why
Move the frontend build/runtime onto the current Node 22 LTS line.

## Scope
- Only `frontend/Dockerfile` (both `FROM node:...` lines).
- No source, dependency, or compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)