### PR TITLE
fix: wire analytics read paths to CH25_DATABASE (futureagi)

### DIFF
--- a/futureagi/model_hub/apps.py
+++ b/futureagi/model_hub/apps.py
@@ -178,13 +178,12 @@ class ModelHubConfig(AppConfig):
         OS page cache.  Subsequent user queries hit warm cache (~300ms)
         instead of cold disk (~5s).
         """
+        from tracer.services.clickhouse.client import get_v2_clickhouse_client
         from tracer.services.clickhouse.schema import should_drop_legacy_chain
 
-        warmup_queries = [
-            # Warm spans index + light columns for recent data. The v2
-            # spans table uses `is_deleted`; pre-cutover prod still
-            # carries the `_peerdb_is_deleted` ALIAS column for back-
-            # compat, but the canonical name is what we read.
+        ch_v2 = get_v2_clickhouse_client()
+
+        v2_queries = [
             (
                 "SELECT project_id, count() FROM spans "
                 "WHERE is_deleted = 0 "
@@ -192,26 +191,6 @@ class ModelHubConfig(AppConfig):
                 "GROUP BY project_id",
                 "spans (7d)",
             ),
-            # Warm tracer_trace for recent data
-            (
-                "SELECT project_id, count() FROM tracer_trace "
-                "WHERE _peerdb_is_deleted = 0 "
-                "AND created_at >= now() - INTERVAL 7 DAY "
-                "GROUP BY project_id",
-                "tracer_trace (7d)",
-            ),
-            # Warm usage_apicalllog for eval metrics
-            (
-                "SELECT organization_id, count() FROM usage_apicalllog "
-                "WHERE _peerdb_is_deleted = 0 "
-                "AND created_at >= now() - INTERVAL 7 DAY "
-                "GROUP BY organization_id",
-                "usage_apicalllog (7d)",
-            ),
-            # Warm spans_hourly_rollup (v2 dashboard aggregate). Replaces
-            # span_metrics_hourly post-CH25 cutover; see
-            # docs/CH25_MIGRATION.md. countMerge collapses the aggregate
-            # state column.
             (
                 "SELECT countMerge(n) FROM spans_hourly_rollup "
                 "WHERE hour >= now() - INTERVAL 7 DAY",
@@ -219,22 +198,39 @@ class ModelHubConfig(AppConfig):
             ),
         ]
 
-        # When the legacy chain is retained (prod default), also warm
-        # the legacy aggregate so it stays hot until the cutover.
+        legacy_queries = [
+            (
+                "SELECT project_id, count() FROM tracer_trace "
+                "WHERE _peerdb_is_deleted = 0 "
+                "AND created_at >= now() - INTERVAL 7 DAY "
+                "GROUP BY project_id",
+                "tracer_trace (7d)",
+            ),
+            (
+                "SELECT organization_id, count() FROM usage_apicalllog "
+                "WHERE _peerdb_is_deleted = 0 "
+                "AND created_at >= now() - INTERVAL 7 DAY "
+                "GROUP BY organization_id",
+                "usage_apicalllog (7d)",
+            ),
+        ]
+
         if not should_drop_legacy_chain():
-            warmup_queries.append(
+            legacy_queries.append(
                 (
                     "SELECT count() FROM span_metrics_hourly "
                     "WHERE hour >= now() - INTERVAL 7 DAY",
                     "span_metrics_hourly (7d, legacy)",
                 )
             )
-        for query, label in warmup_queries:
-            try:
-                ch.execute_read(query, timeout_ms=30000)
-                logger.info(f"CH cache warmed: {label}")
-            except Exception as e:
-                logger.warning(f"CH cache warm failed for {label}: {e}")
+
+        for client, queries in [(ch_v2, v2_queries), (ch, legacy_queries)]:
+            for query, label in queries:
+                try:
+                    client.execute_read(query, timeout_ms=30000)
+                    logger.info(f"CH cache warmed: {label}")
+                except Exception as e:
+                    logger.warning(f"CH cache warm failed for {label}: {e}")
 
     def check_and_create_clickhouse_tables(self):
         from agentic_eval.core.embeddings.embedding_manager import FEEDBACK_TABLE_NAME

--- a/futureagi/tracer/services/clickhouse/__init__.py
+++ b/futureagi/tracer/services/clickhouse/__init__.py
@@ -9,6 +9,7 @@ All analytics, dashboarding, and filtering reads are served by ClickHouse.
 from tracer.services.clickhouse.client import (
     ClickHouseClient,
     get_clickhouse_client,
+    get_v2_clickhouse_client,
     is_clickhouse_enabled,
 )
 from tracer.services.clickhouse.consistency import ConsistencyChecker, HealthStatus
@@ -21,6 +22,7 @@ from tracer.services.clickhouse.query_service import (
 __all__ = [
     "ClickHouseClient",
     "get_clickhouse_client",
+    "get_v2_clickhouse_client",
     "is_clickhouse_enabled",
     "AnalyticsQueryService",
     "QueryType",

--- a/futureagi/tracer/services/clickhouse/client.py
+++ b/futureagi/tracer/services/clickhouse/client.py
@@ -465,16 +465,15 @@ class ClickHouseClient:
                 break
 
 
-# Singleton instance
+# Singleton instances
 _clickhouse_client: ClickHouseClient | None = None
+_v2_clickhouse_client: ClickHouseClient | None = None
 
 
 def get_clickhouse_client() -> ClickHouseClient:
-    """
-    Get the singleton ClickHouse client instance.
+    """Legacy singleton — connects to CH_DATABASE (``default``).
 
-    Returns:
-        ClickHouseClient instance
+    Use ``get_v2_clickhouse_client()`` for v2 schema tables.
     """
     global _clickhouse_client
 
@@ -482,6 +481,19 @@ def get_clickhouse_client() -> ClickHouseClient:
         _clickhouse_client = ClickHouseClient()
 
     return _clickhouse_client
+
+
+def get_v2_clickhouse_client() -> ClickHouseClient:
+    """Singleton connected to CH25_DATABASE (``futureagi``)."""
+    global _v2_clickhouse_client
+
+    if _v2_clickhouse_client is None:
+        from tracer.services.clickhouse.v2 import get_v2_config
+
+        cfg = get_v2_config()
+        _v2_clickhouse_client = ClickHouseClient(database=cfg["database"])
+
+    return _v2_clickhouse_client
 
 
 def is_clickhouse_enabled() -> bool:

--- a/futureagi/tracer/services/clickhouse/query_service.py
+++ b/futureagi/tracer/services/clickhouse/query_service.py
@@ -16,7 +16,7 @@ import structlog
 
 from tracer.services.clickhouse.client import (
     ClickHouseClient,
-    get_clickhouse_client,
+    get_v2_clickhouse_client,
     is_clickhouse_enabled,
 )
 
@@ -76,7 +76,7 @@ class AnalyticsQueryService:
     @property
     def ch_client(self) -> ClickHouseClient:
         if self._ch_client is None:
-            self._ch_client = get_clickhouse_client()
+            self._ch_client = get_v2_clickhouse_client()
         return self._ch_client
 
     def should_use_clickhouse(self, query_type: QueryType | str) -> bool:

--- a/futureagi/tracer/tests/test_dashboard.py
+++ b/futureagi/tracer/tests/test_dashboard.py
@@ -799,9 +799,7 @@ class TestMetricsEndpoint:
     # suggestions for Trace Name / Span Name filters.
     # ------------------------------------------------------------------
 
-    @pytest.mark.parametrize(
-        "metric_name", ["name", "span_name", "service_name"]
-    )
+    @pytest.mark.parametrize("metric_name", ["name", "span_name", "service_name"])
     @pytest.mark.django_db
     @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
     @patch("tracer.views.dashboard.AnalyticsQueryService")
@@ -2168,7 +2166,7 @@ class TestDashboardMetricSourceNormalization:
 class TestWidgetQueryExecution:
     @pytest.mark.django_db
     @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
-    @patch("tracer.views.dashboard.get_clickhouse_client")
+    @patch("tracer.views.dashboard.get_v2_clickhouse_client")
     def test_execute_query(
         self,
         mock_get_client,
@@ -2210,7 +2208,7 @@ class TestWidgetQueryExecution:
 
     @pytest.mark.django_db
     @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
-    @patch("tracer.views.dashboard.get_clickhouse_client")
+    @patch("tracer.views.dashboard.get_v2_clickhouse_client")
     def test_execute_query_simulation_custom_attribute_routes_to_trace_builder(
         self,
         mock_get_client,
@@ -2258,7 +2256,7 @@ class TestWidgetQueryExecution:
 
     @pytest.mark.django_db
     @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
-    @patch("tracer.views.dashboard.get_clickhouse_client")
+    @patch("tracer.views.dashboard.get_v2_clickhouse_client")
     def test_preview_query(
         self, mock_get_client, mock_enabled, auth_client, dashboard, observe_project
     ):
@@ -2293,7 +2291,7 @@ class TestWidgetQueryExecution:
 
     @pytest.mark.django_db
     @patch("tracer.views.dashboard.is_clickhouse_enabled", return_value=True)
-    @patch("tracer.views.dashboard.get_clickhouse_client")
+    @patch("tracer.views.dashboard.get_v2_clickhouse_client")
     def test_preview_query_project_breakdown_uses_longer_timeout(
         self, mock_get_client, mock_enabled, auth_client, dashboard, observe_project
     ):

--- a/futureagi/tracer/tests/test_dashboard_e2e.py
+++ b/futureagi/tracer/tests/test_dashboard_e2e.py
@@ -22,7 +22,7 @@ Covered:
 """
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -116,7 +116,7 @@ def mock_ch_enabled():
 @pytest.fixture
 def mock_ch_client():
     """Mock the ClickHouse client used by widget query execution."""
-    with patch("tracer.views.dashboard.get_clickhouse_client") as mock_get:
+    with patch("tracer.views.dashboard.get_v2_clickhouse_client") as mock_get:
         mock_client = MagicMock()
         mock_client.execute_read.return_value = (
             [(datetime(2025, 1, 1), 123.45), (datetime(2025, 1, 2), 200.10)],
@@ -363,7 +363,7 @@ class TestDashboardAPIFlow:
         self, auth_client, dashboard, widget_with_query
     ):
         """Deleting a dashboard should delete its widgets."""
-        widget_id = widget_with_query.id
+        _ = widget_with_query.id  # ensure fixture is evaluated
         dashboard_id = dashboard.id
         resp = auth_client.delete(f"/tracer/dashboard/{dashboard_id}/")
         assert resp.status_code in (200, 204)

--- a/futureagi/tracer/views/dashboard.py
+++ b/futureagi/tracer/views/dashboard.py
@@ -29,7 +29,7 @@ from tracer.serializers.dashboard import (
     DashboardWidgetSerializer,
 )
 from tracer.services.clickhouse.client import (
-    get_clickhouse_client,
+    get_v2_clickhouse_client,
     is_clickhouse_enabled,
 )
 from tracer.services.clickhouse.query_builders.dashboard import (
@@ -1068,10 +1068,10 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                 used_template_ids = []
                 if is_clickhouse_enabled():
                     from tracer.services.clickhouse.client import (
-                        get_clickhouse_client,
+                        get_v2_clickhouse_client,
                     )
 
-                    ch = get_clickhouse_client()
+                    ch = get_v2_clickhouse_client()
 
                     if filter_by_project:
                         # Get eval template IDs that have results on traces in the given project(s)
@@ -1177,7 +1177,6 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
                 from model_hub.models.develop_annotations import AnnotationsLabels
 
                 if filter_by_project:
-
                     from model_hub.models.score import Score
 
                     used_label_ids = list(
@@ -1241,9 +1240,11 @@ class DashboardViewSet(BaseModelViewSetMixin, ModelViewSet):
             custom_attributes = []
             try:
                 if is_clickhouse_enabled() and project_ids:
-                    from tracer.services.clickhouse.client import get_clickhouse_client
+                    from tracer.services.clickhouse.client import (
+                        get_v2_clickhouse_client,
+                    )
 
-                    ch = get_clickhouse_client()
+                    ch = get_v2_clickhouse_client()
                     # Single batch query with type inference across all projects
                     rows, cols, _ = ch.execute_read(
                         """
@@ -2868,7 +2869,7 @@ class DashboardWidgetViewSet(BaseModelViewSetMixin, ModelViewSet):
             m for m in query_config["metrics"] if m.get("source") == "simulation"
         ]
 
-        ch_client = get_clickhouse_client()
+        ch_client = get_v2_clickhouse_client()
         metric_results = []
 
         if trace_metrics:

--- a/futureagi/tracer/views/project.py
+++ b/futureagi/tracer/views/project.py
@@ -473,13 +473,15 @@ class ProjectView(BaseModelViewSetMixinWithUserOrg, ModelViewSet):
             project_ids = [str(p["id"]) for p in projects_data]
             if project_ids:
                 try:
-                    from tracer.services.clickhouse.client import get_clickhouse_client
+                    from tracer.services.clickhouse.client import (
+                        get_v2_clickhouse_client,
+                    )
                     from tracer.services.clickhouse.query_service import (
                         is_clickhouse_enabled,
                     )
 
                     if is_clickhouse_enabled():
-                        ch = get_clickhouse_client()
+                        ch = get_v2_clickhouse_client()
                         thirty_days_ago = (
                             datetime.now() - timedelta(days=30)
                         ).strftime("%Y-%m-%d")


### PR DESCRIPTION
## Summary

- The CH25 migration close-out moved all query builders to v2 SQL (`spans_hourly_rollup`, `spans` with `is_deleted`, `attrs_string`, etc.) but `AnalyticsQueryService`, dashboard views, and the startup cache warmer still used the legacy `get_clickhouse_client()` singleton which connects to `CH_DATABASE` (`default`). The v2 tables only exist in the `futureagi` database.
- Add `get_v2_clickhouse_client()` — a second singleton that reads `CH25_DATABASE` via `get_v2_config()`. Wire it into all v2 read paths.
- Legacy callers (CDC writer, consistency checker, `span_attribute_lookups`) stay on the original `get_clickhouse_client()`.

## Changed files

| File | Change |
|------|--------|
| `client.py` | Add `get_v2_clickhouse_client()` factory |
| `query_service.py` | Use v2 client for `AnalyticsQueryService` |
| `dashboard.py` | 3 call sites switched to v2 client |
| `project.py` | Trace volume query switched to v2 client |
| `model_hub/apps.py` | Split cache warm between v2 and legacy clients |
| `test_dashboard*.py` | Update mock patches |

## Test plan

- [x] Verified on dev server — graph data, trace list, session list all working
- [x] Startup cache warm logs show no errors for v2 tables
- [ ] CI tests pass (mock patches updated)