### PR TITLE
TH-4812: Cover eval summary template selection

### DIFF
--- a/frontend/scripts/api-journeys/browser/eval-summary-template-smoke.mjs
+++ b/frontend/scripts/api-journeys/browser/eval-summary-template-smoke.mjs
@@ -1,0 +1,737 @@
+/* eslint-disable no-console */
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import process from "node:process";
+import { promisify } from "node:util";
+import {
+  apiPath,
+  assert,
+  createAuthenticatedContext,
+  isUuid,
+  requireMutations,
+} from "../lib/api-client.mjs";
+
+const require = createRequire(import.meta.url);
+const puppeteer = require("puppeteer-core");
+const execFileAsync = promisify(execFile);
+
+const APP_BASE = process.env.APP_BASE || "http://127.0.0.1:3032";
+const FIXTURE_PREFIX = "ui_eval_summary_template_";
+const SCREENSHOT_PATH = "/tmp/eval-summary-template-smoke.png";
+const FAILURE_SCREENSHOT_PATH = "/tmp/eval-summary-template-smoke-failure.png";
+const MUTATION_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+
+let expectedApiOrigin = new URL(process.env.API_BASE || "http://localhost:8003")
+  .origin;
+
+async function main() {
+  requireMutations();
+  const auth = await createAuthenticatedContext();
+  expectedApiOrigin = new URL(auth.apiBase).origin;
+  const suffix = shortRunId(auth.runId);
+  const evalName = `${FIXTURE_PREFIX}${suffix}_eval`;
+  const templateName = `${FIXTURE_PREFIX}${suffix}_summary`;
+  const criteria = `Group ${suffix} failures by root cause and severity.`;
+  const evidence = { cleanup: [], browser_mutations: [] };
+  const apiFailures = [];
+  const pageErrors = [];
+  const unexpectedMutations = [];
+  let browser = null;
+  let page = null;
+  let evalId = null;
+  let summaryTemplateId = null;
+  let cleanupComplete = false;
+  let caughtError = null;
+
+  await hardDeleteFixturesByPrefix(FIXTURE_PREFIX, evidence.cleanup);
+
+  try {
+    const createdEval = await auth.client.post(
+      apiPath("/model-hub/eval-templates/create-v2/"),
+      {
+        name: evalName,
+        eval_type: "agent",
+        instructions: "Evaluate {{output}} and return a pass/fail decision.",
+        output_type: "pass_fail",
+        model: "gpt-4o-mini",
+        pass_threshold: 0.5,
+        description: "Eval summary template browser smoke.",
+        tags: ["api-journey", "eval-summary-template"],
+        mode: "quick",
+        data_injection: { variables_only: true },
+        summary: { type: "concise" },
+      },
+    );
+    evalId = createdEval?.id;
+    assert(isUuid(evalId), "Agent eval create did not return a UUID id.");
+    evidence.eval_id = evalId;
+
+    const createdTemplate = await auth.client.post(
+      apiPath("/model-hub/eval-summary-templates/"),
+      {
+        name: templateName,
+        description: "Browser smoke reusable summary template.",
+        criteria,
+      },
+    );
+    summaryTemplateId = createdTemplate?.id;
+    assert(
+      isUuid(summaryTemplateId),
+      "Summary template create did not return a UUID id.",
+    );
+    evidence.summary_template_id = summaryTemplateId;
+
+    browser = await puppeteer.launch({
+      executablePath: browserExecutablePath(),
+      headless: process.env.HEADLESS !== "0",
+      defaultViewport: { width: 1440, height: 1050 },
+      args: ["--no-sandbox"],
+    });
+    page = await browser.newPage();
+    await page.setBypassServiceWorker(true);
+    await installRuntimeConfig(page, auth);
+    await installBrowserState(page, auth);
+
+    page.on("request", (request) => {
+      const url = request.url();
+      if (
+        isExpectedApiOriginUrl(url) &&
+        MUTATION_METHODS.has(request.method())
+      ) {
+        const mutation = {
+          method: request.method(),
+          url: maskUrl(url),
+          body: parseJsonBody(request.postData()),
+        };
+        if (isEvalSummarySmokeMutation(request.method(), url)) {
+          evidence.browser_mutations.push(mutation);
+        }
+        if (!isAllowedMutation(request.method(), url, evalId)) {
+          unexpectedMutations.push(`${request.method()} ${maskUrl(url)}`);
+        }
+      }
+    });
+    page.on("response", (response) => {
+      const url = response.url();
+      if (isRelevantApiUrl(url) && response.status() >= 400) {
+        apiFailures.push(`${response.status()} ${maskUrl(url)}`);
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await waitForResponseDuring(
+      page,
+      "eval detail load",
+      (response) =>
+        response
+          .url()
+          .includes(`/model-hub/eval-templates/${evalId}/detail/`) &&
+        response.request().method() === "GET" &&
+        response.status() < 400,
+      () =>
+        page.goto(`${APP_BASE}/dashboard/evaluations/${evalId}`, {
+          waitUntil: "domcontentloaded",
+        }),
+    );
+    await waitForVisibleText(page, evalName, { exact: true });
+    await waitForVisibleText(page, "Save Version", { exact: true });
+
+    await clickByAriaLabel(page, "Open evaluation runtime options");
+    await clickVisibleText(page, "Summary", { exact: true });
+    await waitForVisibleText(page, "Saved Templates", { exact: true });
+    await waitForVisibleText(page, templateName, { exact: true });
+    await waitForVisibleText(page, criteria, { exact: true });
+    await clickVisibleText(page, templateName, { exact: true });
+    await waitForVisibleText(page, templateName, { exact: true });
+
+    const [, updateResponse, versionResponse] = await waitForResponsesDuring(
+      page,
+      "save eval summary template selection",
+      [
+        (response) =>
+          isEvalUpdateResponse(response, evalId) &&
+          response.request().method() === "PUT" &&
+          response.status() < 400,
+        (response) =>
+          isEvalVersionCreateResponse(response, evalId) &&
+          response.request().method() === "POST" &&
+          response.status() < 400,
+      ],
+      () => clickEnabledButtonByText(page, "Save Version"),
+    );
+    const versionPayload = await responseJson(versionResponse);
+    evidence.version_number =
+      versionPayload?.result?.version_number ||
+      versionPayload?.result?.versionNumber ||
+      null;
+    await page.waitForFunction(
+      () => new URL(window.location.href).searchParams.has("v"),
+      { timeout: 10000 },
+    );
+    const updateRequest = requestBody(updateResponse);
+    assertSavedTemplateSummary(updateRequest?.summary, {
+      summaryTemplateId,
+      criteria,
+      label: "browser update request",
+    });
+
+    const detail = await auth.client.get(
+      apiPath("/model-hub/eval-templates/{template_id}/detail/", {
+        template_id: evalId,
+      }),
+    );
+    assertSavedTemplateSummary(detail?.config?.summary, {
+      summaryTemplateId,
+      criteria,
+      label: "detail readback",
+    });
+    evidence.detail_summary = detail.config.summary;
+
+    await waitForResponseDuring(
+      page,
+      "eval detail reload",
+      (response) =>
+        response
+          .url()
+          .includes(`/model-hub/eval-templates/${evalId}/detail/`) &&
+        response.status() < 400,
+      () => page.reload({ waitUntil: "domcontentloaded" }),
+    );
+    await waitForVisibleText(page, templateName, { exact: true });
+    await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
+    evidence.screenshot = SCREENSHOT_PATH;
+
+    assert(apiFailures.length === 0, `API failures: ${apiFailures.join("; ")}`);
+    assert(pageErrors.length === 0, `Page errors: ${pageErrors.join("; ")}`);
+    assert(
+      unexpectedMutations.length === 0,
+      `Unexpected browser mutations: ${unexpectedMutations.join("; ")}`,
+    );
+
+    await publicDeleteFixtures(auth.client, {
+      evalId,
+      summaryTemplateId,
+      evidence: evidence.cleanup,
+    });
+    const cleanupAudit = await hardDeleteFixturesByPrefix(
+      FIXTURE_PREFIX,
+      evidence.cleanup,
+    );
+    assert(
+      Number(cleanupAudit.remaining_eval_count) === 0 &&
+        Number(cleanupAudit.remaining_summary_template_count) === 0,
+      `Fixture cleanup left residue: ${JSON.stringify(cleanupAudit)}`,
+    );
+    cleanupComplete = true;
+
+    console.log(
+      JSON.stringify(
+        {
+          status: "passed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          evidence,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    caughtError = error;
+    console.error(
+      JSON.stringify(
+        {
+          status: "failed",
+          app_base: APP_BASE,
+          api_base: auth.apiBase,
+          organization_id: auth.organizationId,
+          workspace_id: auth.workspaceId,
+          evidence,
+          api_failures: apiFailures,
+          page_errors: pageErrors,
+          unexpected_mutations: unexpectedMutations,
+        },
+        null,
+        2,
+      ),
+    );
+    if (page) {
+      await page
+        .screenshot({ path: FAILURE_SCREENSHOT_PATH, fullPage: true })
+        .catch(() => null);
+    }
+  } finally {
+    if (browser) await browser.close();
+    if (!cleanupComplete) {
+      await publicDeleteFixtures(auth.client, {
+        evalId,
+        summaryTemplateId,
+        evidence: evidence.cleanup,
+      }).catch((error) => {
+        caughtError = appendCleanupError(caughtError, error);
+      });
+      await hardDeleteFixturesByPrefix(FIXTURE_PREFIX, evidence.cleanup).catch(
+        (error) => {
+          caughtError = appendCleanupError(caughtError, error);
+        },
+      );
+    }
+  }
+
+  if (caughtError) throw caughtError;
+}
+
+function assertSavedTemplateSummary(
+  summary,
+  { summaryTemplateId, criteria, label },
+) {
+  assert(summary && typeof summary === "object", `${label} summary missing.`);
+  assert(summary.type === "custom", `${label} summary type mismatch.`);
+  assert(
+    summary.template_id === summaryTemplateId,
+    `${label} summary template_id mismatch: ${JSON.stringify(summary)}`,
+  );
+  assert(
+    summary.custom === criteria,
+    `${label} summary custom criteria mismatch: ${JSON.stringify(summary)}`,
+  );
+}
+
+async function publicDeleteFixtures(
+  client,
+  { evalId, summaryTemplateId, evidence },
+) {
+  if (evalId) {
+    await client.post(
+      apiPath("/model-hub/eval-templates/bulk-delete/"),
+      { template_ids: [evalId] },
+      { okStatuses: [200, 404] },
+    );
+    evidence.push({
+      cleanup: "public delete eval summary smoke eval",
+      status: "passed",
+      eval_id: evalId,
+    });
+  }
+  if (summaryTemplateId) {
+    await client.delete(
+      apiPath("/model-hub/eval-summary-templates/{template_id}/", {
+        template_id: summaryTemplateId,
+      }),
+      { okStatuses: [200, 404] },
+    );
+    evidence.push({
+      cleanup: "public delete eval summary smoke template",
+      status: "passed",
+      summary_template_id: summaryTemplateId,
+    });
+  }
+}
+
+async function hardDeleteFixturesByPrefix(prefix, evidence) {
+  const deleteSql = `
+WITH fixture_templates AS (
+  SELECT id
+  FROM model_hub_evaltemplate
+  WHERE name LIKE ${sqlTextLiteral(`${prefix}%`)}
+),
+deleted_eval_settings AS (
+  DELETE FROM eval_settings
+  WHERE eval_id IN (SELECT id FROM fixture_templates)
+  RETURNING id
+),
+deleted_versions AS (
+  DELETE FROM model_hub_eval_template_version
+  WHERE eval_template_id IN (SELECT id FROM fixture_templates)
+  RETURNING id
+),
+deleted_evaluators AS (
+  DELETE FROM model_hub_evaluator
+  WHERE eval_template_id IN (SELECT id FROM fixture_templates)
+  RETURNING id
+),
+deleted_templates AS (
+  DELETE FROM model_hub_evaltemplate
+  WHERE id IN (SELECT id FROM fixture_templates)
+  RETURNING id
+),
+deleted_summary_templates AS (
+  DELETE FROM model_hub_evalsummarytemplate
+  WHERE name LIKE ${sqlTextLiteral(`${prefix}%`)}
+  RETURNING id
+)
+SELECT json_build_object(
+  'deleted_eval_setting_count', (SELECT count(*) FROM deleted_eval_settings),
+  'deleted_version_count', (SELECT count(*) FROM deleted_versions),
+  'deleted_evaluator_count', (SELECT count(*) FROM deleted_evaluators),
+  'deleted_eval_count', (SELECT count(*) FROM deleted_templates),
+  'deleted_summary_template_count', (
+    SELECT count(*) FROM deleted_summary_templates
+  )
+);
+`;
+  const countSql = `
+SELECT json_build_object(
+  'remaining_eval_count', (
+    SELECT count(*)
+    FROM model_hub_evaltemplate
+    WHERE name LIKE ${sqlTextLiteral(`${prefix}%`)}
+  ),
+  'remaining_summary_template_count', (
+    SELECT count(*)
+    FROM model_hub_evalsummarytemplate
+    WHERE name LIKE ${sqlTextLiteral(`${prefix}%`)}
+  )
+);
+`;
+  const result = {
+    ...(await runPostgresJson(deleteSql)),
+    ...(await runPostgresJson(countSql)),
+  };
+  if (
+    Number(result.deleted_eval_count) > 0 ||
+    Number(result.deleted_summary_template_count) > 0 ||
+    Number(result.remaining_eval_count) > 0 ||
+    Number(result.remaining_summary_template_count) > 0
+  ) {
+    evidence.push({
+      cleanup: "hard delete eval summary smoke fixtures by prefix",
+      status:
+        Number(result.remaining_eval_count) === 0 &&
+        Number(result.remaining_summary_template_count) === 0
+          ? "passed"
+          : "failed",
+      audit: result,
+    });
+  }
+  return result;
+}
+
+async function runPostgresJson(sql) {
+  const container = process.env.API_JOURNEY_DB_CONTAINER || "ws2-postgres";
+  const user = process.env.API_JOURNEY_DB_USER || "user";
+  const database = process.env.API_JOURNEY_DB_NAME || "tfc";
+  const { stdout } = await execFileAsync(
+    "docker",
+    ["exec", container, "psql", "-U", user, "-d", database, "-At", "-c", sql],
+    { maxBuffer: 10 * 1024 * 1024 },
+  );
+  const text = stdout.trim();
+  assert(text, "Postgres DB cleanup returned no JSON output.");
+  return JSON.parse(text);
+}
+
+async function installRuntimeConfig(page, auth) {
+  await page.setRequestInterception(true);
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/config.js") {
+      request.respond({
+        status: 200,
+        contentType: "application/javascript",
+        body: `window.__FUTURE_AGI_CONFIG__ = ${JSON.stringify({
+          VITE_HOST_API: auth.apiBase,
+          VITE_ASSETS_API: APP_BASE,
+        })};`,
+      });
+      return;
+    }
+    request.continue();
+  });
+}
+
+async function installBrowserState(page, auth) {
+  await page.evaluateOnNewDocument(() => {
+    window.normalizeText = (value) =>
+      String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+    window.dispatchClick = (element) => {
+      element.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("mouseup", { bubbles: true, cancelable: true }),
+      );
+      element.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    };
+    window.visibleElements = (selector = "body *") => {
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+      return Array.from(document.querySelectorAll(selector)).filter(isVisible);
+    };
+  });
+  await page.evaluateOnNewDocument(
+    ({ tokens, organizationId, workspaceId, user }) => {
+      localStorage.setItem("accessToken", tokens.access);
+      localStorage.setItem("refreshToken", tokens.refresh || "");
+      localStorage.setItem("rememberMe", "true");
+      localStorage.setItem("initial-render", "done");
+      localStorage.setItem("TanstackQueryDevtools.open", "false");
+      if (organizationId)
+        sessionStorage.setItem("organizationId", organizationId);
+      if (workspaceId) sessionStorage.setItem("workspaceId", workspaceId);
+      if (user?.id)
+        sessionStorage.setItem("futureagi-current-user-id", user.id);
+    },
+    {
+      tokens: auth.tokens,
+      organizationId: auth.organizationId,
+      workspaceId: auth.workspaceId,
+      user: auth.user,
+    },
+  );
+}
+
+async function waitForResponseDuring(page, label, predicate, action) {
+  try {
+    const responsePromise = page.waitForResponse(predicate, { timeout: 60000 });
+    const actionResult = await action();
+    const response = await responsePromise;
+    return [actionResult, response];
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`, { cause: error });
+  }
+}
+
+async function waitForResponsesDuring(page, label, predicates, action) {
+  try {
+    const responsePromises = predicates.map((predicate) =>
+      page.waitForResponse(predicate, { timeout: 60000 }),
+    );
+    const actionResult = await action();
+    const responses = await Promise.all(responsePromises);
+    return [actionResult, ...responses];
+  } catch (error) {
+    throw new Error(`${label} failed: ${error.message}`, { cause: error });
+  }
+}
+
+async function waitForVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await page.waitForFunction(
+    ({ text: expectedText, exact: exactMatch }) =>
+      window.visibleElements().some((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      }),
+    { timeout },
+    { text, exact },
+  );
+}
+
+async function clickByAriaLabel(page, label, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedLabel) =>
+      window
+        .visibleElements("[aria-label]")
+        .some(
+          (element) =>
+            element.getAttribute("aria-label") === expectedLabel &&
+            !element.disabled,
+        ),
+    { timeout },
+    label,
+  );
+  const clicked = await page.evaluate((expectedLabel) => {
+    const element = window
+      .visibleElements("[aria-label]")
+      .find(
+        (candidate) =>
+          candidate.getAttribute("aria-label") === expectedLabel &&
+          !candidate.disabled,
+      );
+    if (!element) return false;
+    element.scrollIntoView({ block: "center", inline: "center" });
+    window.dispatchClick(element);
+    return true;
+  }, label);
+  assert(clicked, `Could not click aria-label: ${label}`);
+}
+
+async function clickVisibleText(
+  page,
+  text,
+  { exact = false, timeout = 30000 } = {},
+) {
+  await waitForVisibleText(page, text, { exact, timeout });
+  const clicked = await page.evaluate(
+    ({ text: expectedText, exact: exactMatch }) => {
+      const matches = window.visibleElements().filter((element) => {
+        const textContent = window.normalizeText(element.textContent);
+        return exactMatch
+          ? textContent === expectedText
+          : textContent.includes(expectedText);
+      });
+      const element =
+        matches.find((candidate) =>
+          ["menuitem", "button"].includes(candidate.getAttribute("role")),
+        ) || matches[0];
+      if (!element) return false;
+      element.scrollIntoView({ block: "center", inline: "center" });
+      window.dispatchClick(element);
+      return true;
+    },
+    { text, exact },
+  );
+  assert(clicked, `Could not click visible text: ${text}`);
+}
+
+async function clickEnabledButtonByText(page, text, timeout = 30000) {
+  await page.waitForFunction(
+    (expectedText) =>
+      window
+        .visibleElements('button, [role="button"]')
+        .some(
+          (button) =>
+            window.normalizeText(button.textContent) === expectedText &&
+            !button.disabled &&
+            button.getAttribute("aria-disabled") !== "true",
+        ),
+    { timeout },
+    text,
+  );
+  const clicked = await page.evaluate((expectedText) => {
+    const button = window
+      .visibleElements('button, [role="button"]')
+      .find(
+        (candidate) =>
+          window.normalizeText(candidate.textContent) === expectedText &&
+          !candidate.disabled &&
+          candidate.getAttribute("aria-disabled") !== "true",
+      );
+    if (!button) return false;
+    button.scrollIntoView({ block: "center", inline: "center" });
+    window.dispatchClick(button);
+    return true;
+  }, text);
+  assert(clicked, `Could not click enabled button: ${text}`);
+}
+
+async function responseJson(response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function requestBody(response) {
+  return parseJsonBody(response.request().postData());
+}
+
+function parseJsonBody(raw) {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function isRelevantApiUrl(url) {
+  return (
+    isEvalUpdateUrl(url) || url.includes("/model-hub/eval-summary-templates/")
+  );
+}
+
+function isEvalUpdateUrl(url) {
+  return url.includes("/model-hub/eval-templates/") && url.includes("/update/");
+}
+
+function isEvalUpdateResponse(response, evalId) {
+  return response.url().includes(`/model-hub/eval-templates/${evalId}/update/`);
+}
+
+function isEvalVersionCreateResponse(response, evalId) {
+  return response
+    .url()
+    .includes(`/model-hub/eval-templates/${evalId}/versions/create/`);
+}
+
+function isEvalSummarySmokeMutation(method, url) {
+  return (
+    (method === "PUT" && isEvalUpdateUrl(url)) ||
+    (method === "POST" &&
+      url.includes("/model-hub/eval-templates/") &&
+      url.includes("/versions/create/"))
+  );
+}
+
+function isAllowedMutation(method, url, evalId) {
+  if (method === "PUT" && isEvalUpdateResponse({ url: () => url }, evalId)) {
+    return true;
+  }
+  if (
+    method === "POST" &&
+    isEvalVersionCreateResponse({ url: () => url }, evalId)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isExpectedApiOriginUrl(url) {
+  try {
+    return new URL(url).origin === expectedApiOrigin;
+  } catch {
+    return false;
+  }
+}
+
+function maskUrl(url) {
+  return String(url).replace(/([?&](?:token|access|refresh)=)[^&]+/gi, "$1***");
+}
+
+function sqlTextLiteral(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function shortRunId(runId) {
+  return String(runId || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "")
+    .slice(-8);
+}
+
+function appendCleanupError(caughtError, cleanupError) {
+  if (!caughtError) return cleanupError;
+  caughtError.message = `${caughtError.message}; cleanup failed: ${cleanupError.message}`;
+  return caughtError;
+}
+
+function browserExecutablePath() {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  if (process.platform === "darwin") {
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+  }
+  if (process.platform === "linux") {
+    return "/usr/bin/google-chrome";
+  }
+  return undefined;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/frontend/src/sections/evals/components/EvalCreatePage.jsx
+++ b/frontend/src/sections/evals/components/EvalCreatePage.jsx
@@ -21,6 +21,11 @@ import { useNavigate, useParams } from "react-router";
 import { useSnackbar } from "notistack";
 import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 import { FAGI_MODEL_VALUES } from "./ModelSelector";
+import {
+  buildSummaryConfig,
+  getSummaryTemplateId,
+  resolveSummarySelection,
+} from "./summaryConfig";
 
 import { useCreateEval } from "../hooks/useCreateEval";
 import { useUpdateEval } from "../hooks/useEvalDetail";
@@ -101,14 +106,6 @@ const buildToolsPayload = (selectedTools) =>
     return acc;
   }, {});
 
-const resolveSummaryType = (summary) => {
-  if (summary && typeof summary === "object" && summary.type) {
-    return summary.type;
-  }
-  if (typeof summary === "string" && summary.trim()) return summary;
-  return "concise";
-};
-
 const resolveContextOptions = (dataInjection) => {
   if (!dataInjection || typeof dataInjection !== "object") {
     return ["variables_only"];
@@ -161,6 +158,7 @@ const EvalCreatePage = () => {
   const [agentMode, setAgentMode] = useState("agent");
   const [summaryType, setSummaryType] = useState("concise");
   const [customSummary, setCustomSummary] = useState("");
+  const [summaryTemplateId, setSummaryTemplateId] = useState(null);
   const [connectorIds, setConnectorIds] = useState([]);
   const [knowledgeBaseIds, setKnowledgeBaseIds] = useState([]);
   const [contextOptions, setContextOptions] = useState(["variables_only"]);
@@ -267,8 +265,11 @@ const EvalCreatePage = () => {
             setDescription(d.description || "");
             setCheckInternet(config.check_internet ?? false);
             setAgentMode(config.agent_mode || "agent");
-            setSummaryType(resolveSummaryType(config.summary));
+            setSummaryType(resolveSummarySelection(config.summary));
             setCustomSummary(config.summary?.custom || "");
+            setSummaryTemplateId(
+              config.summary?.template_id || config.summary?.templateId || null,
+            );
             setConnectorIds(extractSelectedTools(config.tools));
             setKnowledgeBaseIds(
               Array.isArray(config.knowledge_bases)
@@ -325,16 +326,27 @@ const EvalCreatePage = () => {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const handleSummaryChange = useCallback((value, template) => {
+    setSummaryType(value);
+    const templateId = getSummaryTemplateId(value);
+    setSummaryTemplateId(templateId);
+    if (templateId && template?.criteria) {
+      setCustomSummary(template.criteria);
+    } else if (value !== "custom") {
+      setCustomSummary("");
+    }
+  }, []);
+
   // Auto-save config to draft (debounced, skip initial load)
   const autoSaveTimer = useRef(null);
   const autoSaveSkipFirst = useRef(!!urlDraftId); // skip first trigger when loading existing draft
   const buildUpdatePayload = useCallback(() => {
     const dataInjection = buildDataInjection(contextOptions);
 
-    const summary =
-      summaryType === "custom"
-        ? { type: "custom", custom: customSummary }
-        : { type: summaryType };
+    const summary = buildSummaryConfig(summaryType, {
+      customSummary,
+      templateId: summaryTemplateId,
+    });
 
     const tools = buildToolsPayload(connectorIds);
 
@@ -385,6 +397,7 @@ const EvalCreatePage = () => {
     agentMode,
     summaryType,
     customSummary,
+    summaryTemplateId,
     connectorIds,
     knowledgeBaseIds,
     contextOptions,
@@ -904,7 +917,7 @@ const EvalCreatePage = () => {
                       useInternet={checkInternet}
                       onUseInternetChange={setCheckInternet}
                       activeSummary={summaryType}
-                      onActiveSummaryChange={setSummaryType}
+                      onActiveSummaryChange={handleSummaryChange}
                       activeConnectorIds={connectorIds}
                       onActiveConnectorIdsChange={setConnectorIds}
                       selectedKBs={knowledgeBaseIds}

--- a/frontend/src/sections/evals/components/EvalDetailPage.jsx
+++ b/frontend/src/sections/evals/components/EvalDetailPage.jsx
@@ -58,6 +58,11 @@ import BulkDeleteDialog from "./BulkDeleteDialog";
 import { EVAL_TAGS } from "../constant";
 import { FAGI_MODEL_VALUES } from "./ModelSelector";
 import { buildDataInjection } from "src/sections/common/EvalPicker/evalPickerConfigUtils";
+import {
+  buildSummaryConfig,
+  getSummaryTemplateId,
+  resolveSummarySelection,
+} from "./summaryConfig";
 
 const extract_selected_tools = (tools) => {
   if (Array.isArray(tools)) return tools;
@@ -74,14 +79,6 @@ const build_tools_payload = (selected_tools) =>
     if (tool_name) acc[tool_name] = true;
     return acc;
   }, {});
-
-const resolve_summary_type = (summary) => {
-  if (summary && typeof summary === "object" && summary.type) {
-    return summary.type;
-  }
-  if (typeof summary === "string" && summary.trim()) return summary;
-  return "concise";
-};
 
 const resolve_context_options = (data_injection) => {
   if (!data_injection || typeof data_injection !== "object") {
@@ -141,6 +138,8 @@ const EvalDetailPage = () => {
   const [checkInternet, setCheckInternet] = useState(false);
   const [agentMode, setAgentMode] = useState("agent");
   const [summaryType, setSummaryType] = useState("concise");
+  const [customSummary, setCustomSummary] = useState("");
+  const [summaryTemplateId, setSummaryTemplateId] = useState(null);
   const [connectorIds, setConnectorIds] = useState([]);
   const [knowledgeBaseIds, setKnowledgeBaseIds] = useState([]);
   const [contextOptions, setContextOptions] = useState(["variables_only"]);
@@ -235,6 +234,21 @@ const EvalDetailPage = () => {
       setTestPassed(false);
     }
   }, []);
+
+  const handleSummaryChange = useCallback(
+    (value, template) => {
+      setSummaryType(value);
+      const templateId = getSummaryTemplateId(value);
+      setSummaryTemplateId(templateId);
+      if (templateId && template?.criteria) {
+        setCustomSummary(template.criteria);
+      } else if (value !== "custom") {
+        setCustomSummary("");
+      }
+      markDirty();
+    },
+    [markDirty],
+  );
 
   // Derived flags — must be above handleVersionSelect which uses isComposite
   const isComposite = evalData?.template_type === "composite";
@@ -346,7 +360,11 @@ const EvalDetailPage = () => {
           setDescription(evalData.description || "");
           setCheckInternet(config.check_internet ?? false);
           setAgentMode(config.agent_mode || "agent");
-          setSummaryType(resolve_summary_type(config.summary));
+          setSummaryType(resolveSummarySelection(config.summary));
+          setCustomSummary(config.summary?.custom || "");
+          setSummaryTemplateId(
+            config.summary?.template_id || config.summary?.templateId || null,
+          );
           setConnectorIds(extract_selected_tools(config.tools));
           setKnowledgeBaseIds(
             Array.isArray(config.knowledge_bases) ? config.knowledge_bases : [],
@@ -390,8 +408,12 @@ const EvalDetailPage = () => {
         },
         { replace: true },
       );
-      const config =
+      const versionSnapshot =
         versionToLoad.config_snapshot || versionToLoad.configSnapshot || {};
+      const config = {
+        ...(evalData?.config || {}),
+        ...versionSnapshot,
+      };
       const promptText = versionToLoad.criteria || config.rule_prompt || "";
 
       // Composite versions: load aggregation + children from snapshot
@@ -477,7 +499,11 @@ const EvalDetailPage = () => {
       }
       setCheckInternet(config.check_internet ?? false);
       setAgentMode(config.agent_mode || "agent");
-      setSummaryType(resolve_summary_type(config.summary));
+      setSummaryType(resolveSummarySelection(config.summary));
+      setCustomSummary(config.summary?.custom || "");
+      setSummaryTemplateId(
+        config.summary?.template_id || config.summary?.templateId || null,
+      );
       setConnectorIds(extract_selected_tools(config.tools));
       setKnowledgeBaseIds(
         Array.isArray(config.knowledge_bases) ? config.knowledge_bases : [],
@@ -608,7 +634,11 @@ const EvalDetailPage = () => {
         setDescription(evalData.description || "");
         setCheckInternet(config.check_internet ?? false);
         setAgentMode(config.agent_mode || "agent");
-        setSummaryType(resolve_summary_type(config.summary));
+        setSummaryType(resolveSummarySelection(config.summary));
+        setCustomSummary(config.summary?.custom || "");
+        setSummaryTemplateId(
+          config.summary?.template_id || config.summary?.templateId || null,
+        );
         setConnectorIds(extract_selected_tools(config.tools));
         setKnowledgeBaseIds(
           Array.isArray(config.knowledge_bases) ? config.knowledge_bases : [],
@@ -743,10 +773,10 @@ const EvalDetailPage = () => {
     }
     try {
       const dataInjection = buildDataInjection(contextOptions);
-      const summary =
-        summaryType === "custom"
-          ? { type: "custom", custom: "" }
-          : { type: summaryType };
+      const summary = buildSummaryConfig(summaryType, {
+        customSummary,
+        templateId: summaryTemplateId,
+      });
       const tools = build_tools_payload(connectorIds);
       // Update the template first
       const payload = {
@@ -860,6 +890,8 @@ const EvalDetailPage = () => {
     checkInternet,
     agentMode,
     summaryType,
+    customSummary,
+    summaryTemplateId,
     connectorIds,
     knowledgeBaseIds,
     contextOptions,
@@ -937,10 +969,10 @@ const EvalDetailPage = () => {
       // state.
       if (!isSystemEval && !isComposite) {
         const dataInjection = buildDataInjection(contextOptions);
-        const summary =
-          summaryType === "custom"
-            ? { type: "custom", custom: "" }
-            : { type: summaryType };
+        const summary = buildSummaryConfig(summaryType, {
+          customSummary,
+          templateId: summaryTemplateId,
+        });
         const tools = build_tools_payload(connectorIds);
         await updateEval.mutateAsync({
           instructions: evalType === "code" ? "" : instructions,
@@ -1012,6 +1044,8 @@ const EvalDetailPage = () => {
     checkInternet,
     agentMode,
     summaryType,
+    customSummary,
+    summaryTemplateId,
     connectorIds,
     knowledgeBaseIds,
     contextOptions,
@@ -1497,10 +1531,7 @@ const EvalDetailPage = () => {
                       markDirty();
                     }}
                     activeSummary={summaryType}
-                    onActiveSummaryChange={(v) => {
-                      setSummaryType(v);
-                      markDirty();
-                    }}
+                    onActiveSummaryChange={handleSummaryChange}
                     activeConnectorIds={connectorIds}
                     onActiveConnectorIdsChange={(v) => {
                       setConnectorIds(v);

--- a/frontend/src/sections/evals/components/ModelSelector.jsx
+++ b/frontend/src/sections/evals/components/ModelSelector.jsx
@@ -26,6 +26,7 @@ import { useDebounce } from "src/hooks/use-debounce";
 import { useDeploymentMode } from "src/hooks/useDeploymentMode";
 import { useNavigate } from "react-router";
 import axios, { endpoints } from "src/utils/axios";
+import { getSummaryTemplateId } from "./summaryConfig";
 
 // ---------------------------------------------------------------------------
 // Modes — how the evaluator runs
@@ -196,6 +197,10 @@ const CHIP_STYLES = {
 };
 
 const DELETE_ICON = <Iconify icon="mdi:close" width={12} />;
+const SUMMARY_SELECTION_PROP_TYPE = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.oneOf([null]),
+]);
 
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
@@ -271,12 +276,16 @@ function SummarySubmenu({ activeSummary, onSelect }) {
       }
       return axios.post(endpoints.develop.eval.summaryTemplates, payload);
     },
-    onSuccess: () => {
+    onSuccess: (response) => {
       queryClient.invalidateQueries({ queryKey: ["eval-summary-templates"] });
       setCustomMode(false);
       setEditId(null);
       setEditName("");
       setEditCriteria("");
+      const template = response?.data?.result;
+      if (template?.id) {
+        onSelect(`custom:${template.id}`, template);
+      }
     },
   });
 
@@ -284,8 +293,12 @@ function SummarySubmenu({ activeSummary, onSelect }) {
   const deleteMutation = useMutation({
     mutationFn: (id) =>
       axios.delete(endpoints.develop.eval.summaryTemplate(id)),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["eval-summary-templates"] }),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: ["eval-summary-templates"] });
+      if (getSummaryTemplateId(activeSummary) === id) {
+        onSelect("concise");
+      }
+    },
   });
 
   const handleSave = () => {
@@ -343,6 +356,7 @@ function SummarySubmenu({ activeSummary, onSelect }) {
         />
         <Box sx={{ display: "flex", gap: 0.5, justifyContent: "flex-end" }}>
           <IconButton
+            aria-label="Cancel summary template edit"
             size="small"
             onClick={() => {
               setCustomMode(false);
@@ -354,6 +368,7 @@ function SummarySubmenu({ activeSummary, onSelect }) {
             <Iconify icon="mdi:close" width={16} />
           </IconButton>
           <IconButton
+            aria-label="Save summary template"
             size="small"
             onClick={handleSave}
             disabled={
@@ -463,7 +478,7 @@ function SummarySubmenu({ activeSummary, onSelect }) {
             return (
               <MenuItem
                 key={tmpl.id}
-                onClick={() => onSelect(`custom:${tmpl.id}`)}
+                onClick={() => onSelect(`custom:${tmpl.id}`, tmpl)}
                 selected={isSelected}
                 sx={{ borderRadius: "6px", py: 0.75, gap: 1 }}
               >
@@ -494,6 +509,7 @@ function SummarySubmenu({ activeSummary, onSelect }) {
                 </Box>
                 <Box sx={{ display: "flex", gap: 0.25, flexShrink: 0 }}>
                   <IconButton
+                    aria-label={`Edit summary template ${tmpl.name}`}
                     size="small"
                     onClick={(e) => {
                       e.stopPropagation();
@@ -508,6 +524,7 @@ function SummarySubmenu({ activeSummary, onSelect }) {
                     />
                   </IconButton>
                   <IconButton
+                    aria-label={`Delete summary template ${tmpl.name}`}
                     size="small"
                     onClick={(e) => {
                       e.stopPropagation();
@@ -547,7 +564,7 @@ function SummarySubmenu({ activeSummary, onSelect }) {
 }
 
 SummarySubmenu.propTypes = {
-  activeSummary: PropTypes.string,
+  activeSummary: SUMMARY_SELECTION_PROP_TYPE,
   onSelect: PropTypes.func.isRequired,
 };
 
@@ -608,8 +625,8 @@ const ModelSelector = ({
   const [activeSummaryLocal, setActiveSummaryLocal] = useState("concise");
   const activeSummary =
     activeSummaryProp !== undefined ? activeSummaryProp : activeSummaryLocal;
-  const setActiveSummary = (v) => {
-    if (onActiveSummaryChange) onActiveSummaryChange(v);
+  const setActiveSummary = (v, template) => {
+    if (onActiveSummaryChange) onActiveSummaryChange(v, template);
     else setActiveSummaryLocal(v);
   };
 
@@ -836,6 +853,7 @@ const ModelSelector = ({
       {/* ── + button + config chips (hidden when showPlus=false, e.g. LLM tab) ── */}
       {showPlus && (
         <IconButton
+          aria-label="Open evaluation runtime options"
           size="small"
           disabled={disabled}
           onClick={(e) => setPlusAnchor(e.currentTarget)}
@@ -1779,8 +1797,8 @@ const ModelSelector = ({
             {plusSubmenu === "summary" && (
               <SummarySubmenu
                 activeSummary={activeSummary}
-                onSelect={(val) => {
-                  setActiveSummary(val);
+                onSelect={(val, template) => {
+                  setActiveSummary(val, template);
                   setPlusSubmenu(null);
                   setPlusAnchor(null);
                 }}
@@ -1802,6 +1820,8 @@ const ModelSelector = ({
 ModelSelector.propTypes = {
   model: PropTypes.string.isRequired,
   onModelChange: PropTypes.func.isRequired,
+  activeSummary: SUMMARY_SELECTION_PROP_TYPE,
+  onActiveSummaryChange: PropTypes.func,
   disabled: PropTypes.bool,
   showMode: PropTypes.bool,
   showPlus: PropTypes.bool,

--- a/frontend/src/sections/evals/components/__tests__/summaryConfig.test.js
+++ b/frontend/src/sections/evals/components/__tests__/summaryConfig.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSummaryConfig,
+  getSummaryTemplateId,
+  resolveSummarySelection,
+} from "../summaryConfig";
+
+describe("summaryConfig", () => {
+  it("round-trips saved custom summary templates through UI selection state", () => {
+    const templateId = "6ea6f892-c6b7-47cf-a74a-f89ce7f1f47a";
+    const selection = resolveSummarySelection({
+      type: "custom",
+      custom: "Group failures by root cause.",
+      template_id: templateId,
+    });
+
+    expect(selection).toBe(`custom:${templateId}`);
+    expect(getSummaryTemplateId(selection)).toBe(templateId);
+    expect(
+      buildSummaryConfig(selection, {
+        customSummary: "Group failures by root cause.",
+      }),
+    ).toEqual({
+      type: "custom",
+      custom: "Group failures by root cause.",
+      template_id: templateId,
+    });
+  });
+
+  it("preserves built-in and disabled summary selections", () => {
+    expect(resolveSummarySelection({ type: "long" })).toBe("long");
+    expect(buildSummaryConfig("short")).toEqual({ type: "short" });
+    expect(resolveSummarySelection({ type: null })).toBeNull();
+    expect(buildSummaryConfig(null)).toEqual({ type: null });
+  });
+});

--- a/frontend/src/sections/evals/components/summaryConfig.js
+++ b/frontend/src/sections/evals/components/summaryConfig.js
@@ -1,0 +1,45 @@
+export const CUSTOM_SUMMARY_PREFIX = "custom:";
+export const DEFAULT_SUMMARY_TYPE = "concise";
+
+export function resolveSummarySelection(summary) {
+  if (summary && typeof summary === "object") {
+    const templateId = summary.template_id || summary.templateId;
+    if (summary.type === "custom" && templateId) {
+      return `${CUSTOM_SUMMARY_PREFIX}${templateId}`;
+    }
+    if (Object.prototype.hasOwnProperty.call(summary, "type")) {
+      return summary.type;
+    }
+  }
+  if (typeof summary === "string" && summary.trim()) return summary;
+  return DEFAULT_SUMMARY_TYPE;
+}
+
+export function getSummaryTemplateId(selection) {
+  if (
+    typeof selection === "string" &&
+    selection.startsWith(CUSTOM_SUMMARY_PREFIX)
+  ) {
+    return selection.slice(CUSTOM_SUMMARY_PREFIX.length);
+  }
+  return null;
+}
+
+export function buildSummaryConfig(
+  selection,
+  { customSummary, templateId } = {},
+) {
+  if (selection === null) return { type: null };
+  const selectedTemplateId = getSummaryTemplateId(selection);
+  if (selectedTemplateId) {
+    return {
+      type: "custom",
+      custom: customSummary || "",
+      template_id: templateId || selectedTemplateId,
+    };
+  }
+  if (selection === "custom") {
+    return { type: "custom", custom: customSummary || "" };
+  }
+  return { type: selection || DEFAULT_SUMMARY_TYPE };
+}


### PR DESCRIPTION
## Summary
- Preserve saved custom eval summary template selection through create, detail, version save, and reload flows.
- Add a shared summary config helper plus focused unit coverage for built-in, disabled, and saved custom template states.
- Add an API-backed browser smoke that creates a real eval/template, selects the saved template in the UI, verifies save payloads/readback, and checks reload persistence.

## Validation
- `./node_modules/.bin/prettier --check ...`
- `./node_modules/.bin/vitest run src/sections/evals/components/__tests__/summaryConfig.test.js`
- `./node_modules/.bin/eslint ...` (passed with existing warnings)
- `yarn lint` (passed with warnings only)
- `yarn type-check` (passed; no `tsconfig.json` found, skipped)
- `yarn test:run` (passed: 1740 tests)
- `yarn contracts:check`
- `yarn test:api-journeys -- --only EVAL-API-005 ...`
- `node scripts/api-journeys/browser/eval-summary-template-smoke.mjs`
- `make test` in `futureagi` (passed: 11887 passed, 90 skipped, 690 deselected, 7 xfailed, 7 xpassed)

## Notes
- API journey preflight auth/backend/db/redis checks passed; host disk-space preflight was low in the local environment.