### PR TITLE
chore(docker-compose): revert agentcc-gateway port to 8090

### DIFF
--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -56,8 +56,8 @@ services:
       - TEMPORAL_HOST=temporal:7233
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - FAST_STARTUP=${FAST_STARTUP:-true}
-      - AGENTCC_INTERNAL_URL=http://agentcc-gateway:8080
-      - AGENTCC_GATEWAY_INTERNAL_URL=http://agentcc-gateway:8080
+      - AGENTCC_INTERNAL_URL=http://agentcc-gateway:8090
+      - AGENTCC_GATEWAY_INTERNAL_URL=http://agentcc-gateway:8090
       - AGENTCC_INTERNAL_API_KEY=${AGENTCC_INTERNAL_API_KEY:-}
       # Read replica: uncomment to test read/write split locally (points to same DB).
       # Both PGBOUNCER_READ_HOST and READ_REPLICA_OPT_IN must be set for any
@@ -106,7 +106,7 @@ services:
       context: ../agentcc-gateway
       dockerfile: Dockerfile
     ports:
-      - "${AGENTCC_GATEWAY_PORT:-8090}:8080"
+      - "${AGENTCC_GATEWAY_PORT:-8090}:8090"
     volumes:
       - ../${AGENTCC_CONFIG_PATH:-agentcc-gateway/config.example.yaml}:/app/config.yaml:ro
       - ${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}:/app/Vertex_AI_Creds.json:ro

--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       context: ../agentcc-gateway
       dockerfile: Dockerfile
     ports:
-      - "${AGENTCC_GATEWAY_PORT:-8090}:8090"
+      - "${AGENTCC_GATEWAY_PORT:-8090}:8080"
     volumes:
       - ../${AGENTCC_CONFIG_PATH:-agentcc-gateway/config.example.yaml}:/app/config.yaml:ro
       - ${GOOGLE_APPLICATION_CREDENTIALS:-/dev/null}:/app/Vertex_AI_Creds.json:ro


### PR DESCRIPTION
Reverts the agentcc-gateway internal URLs in docker-compose.yml back to 8090 (matching main).

Two env vars:
- `AGENTCC_INTERNAL_URL`: 8080 -> 8090
- `AGENTCC_GATEWAY_INTERNAL_URL`: 8080 -> 8090

Host port mapping (`8090:8080`) unchanged.