### PR TITLE
fix(eval-playground): drop stale multi_choice field from playground POST (TH-5823)

### DIFF
--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -636,7 +636,6 @@ const TestPlayground = React.forwardRef(
       codeLanguage = "python",
       isSystemEval = false,
       onReadyChange,
-      multiChoice = false,
     },
     ref,
   ) => {
@@ -961,7 +960,6 @@ const TestPlayground = React.forwardRef(
             template_id: tid,
             model,
             error_localizer: errorLocalizerEnabled,
-            multi_choice: multiChoice,
             config: {
               mapping,
               ...(evalType === "code" ? { params } : {}),
@@ -1017,7 +1015,6 @@ const TestPlayground = React.forwardRef(
       compositeAdhocConfig,
       executeCompositeAdhoc,
       handleCreditError,
-      multiChoice,
     ]);
 
     // Expose runTest and switchToVersion to parent via ref
@@ -1890,7 +1887,6 @@ TestPlayground.propTypes = {
   codeLanguage: PropTypes.string,
   onReadyChange: PropTypes.func,
   isSystemEval: PropTypes.bool,
-  multiChoice: PropTypes.bool,
 };
 
 export default TestPlayground;


### PR DESCRIPTION
## Summary

The eval-playground request serializer (`EvalPlayGroundSerializer`, `model_hub/serializers/eval_runner.py:228-258`) doesn't declare a `multi_choice` field, and the view runs with `reject_unknown_fields=True` (`model_hub/views/separate_evals.py:5941-5945`). The FE was sending `multi_choice` in every Test Evaluation POST, so DRF was rejecting the request with:

```
{
  "type": "validation_error",
  "code": "invalid",
  "detail": "multi_choice: Unknown field.",
  "attr": "multi_choice"
}
```

`multi_choice` is a property of the eval template itself — the playground endpoint resolves it server-side from the `template_id`, never from the request payload.

## Change

`frontend/src/sections/evals/components/TestPlayground.jsx` — four small deletions:

| Line (before) | What it was |
|---|---|
| 639 | `multiChoice = false,` prop destructure |
| 964 | `multi_choice: multiChoice,` in the request body |
| 1020 | `multiChoice,` in the `useCallback` deps array |
| 1893 | `multiChoice: PropTypes.bool,` in propTypes |

Nothing else inside `TestPlayground.jsx` reads `multiChoice` — the value was only being forwarded into the body, so all four refs are dead path together.

## Why this is safe

Verified the complete list of every BE consumer that reads `multi_choice` from a request payload:

| Consumer | Endpoint | Hit by TestPlayground? |
|---|---|---|
| `CustomEvalTemplateCreateView` (`eval_runner.py:3326`) | template **create** | No |
| `UpdateEvalTemplateView` (`separate_evals.py:6706`) | template **update** | No |
| `TestEvaluationTemplateAPIView` (`separate_evals.py:7064`) | `/model-hub/test-evaluation/` | No |
| `EvalPlayGroundAPIView` (`separate_evals.py:5937`) | `/model-hub/eval-playground/` | **Yes — and it does NOT consume `multi_choice`** |

Confirmed via `grep` that `EvalPlayGroundAPIView` body (lines 5937 through the next class boundary) has zero `multi_choice` references.

Confirmed that `TestPlayground.jsx` only has two `axios.post` calls — `aiEvalWriter` (line 215) and `evalPlayground` (line 957). It never calls `/test-evaluation/`.

`EvalCreatePage.jsx` and `EvalDetailPage.jsx` still send `multi_choice` in their template create / update payloads (unchanged). They also still pass `multiChoice` as a prop into `TestPlayground` — that prop is now ignored, which is harmless.

## Test plan

- [x] `yarn test:run` — 212 files / 1774 tests pass
- [x] `yarn contracts:check` — passes
- [x] Open an eval, click Test Evaluation → confirm 200 instead of 400
- [x] Open the same eval, edit and save → confirm `multi_choice` still persists on the template (template create / update flow is untouched)
- [ ] On a Choices / multi-choice eval template, confirm the playground returns the multi-choice eval result correctly (BE loads `multi_choice` from the template, not the request)

## Related

Closes TH-5823.