### PR TITLE
fix(simulate): align frontend to snake_case API responses, persona select-all, and scenario data-view fixes

### DIFF
--- a/frontend/src/components/VoiceDetailDrawerV2/FlowAnalysisPanel.jsx
+++ b/frontend/src/components/VoiceDetailDrawerV2/FlowAnalysisPanel.jsx
@@ -35,14 +35,14 @@ const FlowAnalysisPanel = ({ scenarioId, openedExecutionId, enabled }) => {
     select: (res) => res.data,
   });
 
-  const scenarioGraphs = kpis?.scenarioGraphs;
+  const scenarioGraphs = kpis?.scenario_graphs;
   const scenarioGraph = scenarioGraphs?.[scenarioId];
 
   const { nodes, edges } = useMemo(() => {
-    const currentPath = flowAnalysis?.analysis?.currentPath;
-    const expectedPath = flowAnalysis?.analysis?.expectedPath;
-    const newNodes = flowAnalysis?.analysis?.newNodes;
-    const newEdges = flowAnalysis?.analysis?.newEdges;
+    const currentPath = flowAnalysis?.analysis?.current_path;
+    const expectedPath = flowAnalysis?.analysis?.expected_path;
+    const newNodes = flowAnalysis?.analysis?.new_nodes;
+    const newEdges = flowAnalysis?.analysis?.new_edges;
 
     if (
       !scenarioGraph?.nodes ||

--- a/frontend/src/components/simulator-agent/EditSimulatorAgentDialog.jsx
+++ b/frontend/src/components/simulator-agent/EditSimulatorAgentDialog.jsx
@@ -47,16 +47,16 @@ const EditSimulatorAgentDialog = ({ open, onClose, agent, onEditSuccess }) => {
       setFormData({
         name: agent.name || "",
         prompt: agent.prompt || "",
-        voiceProvider: agent.voiceProvider || "",
-        voiceName: agent.voiceName || "",
-        interruptSensitivity: agent.interruptSensitivity || 0.5,
-        conversationSpeed: agent.conversationSpeed || 1.0,
-        finishedSpeakingSensitivity: agent.finishedSpeakingSensitivity || 0.5,
+        voiceProvider: agent.voice_provider || "",
+        voiceName: agent.voice_name || "",
+        interruptSensitivity: agent.interrupt_sensitivity || 0.5,
+        conversationSpeed: agent.conversation_speed || 1.0,
+        finishedSpeakingSensitivity: agent.finished_speaking_sensitivity || 0.5,
         model: agent.model || "",
-        llmTemperature: agent.llmTemperature || 0.7,
-        maxCallDurationInMinutes: agent.maxCallDurationInMinutes || 30,
-        initialMessageDelay: agent.initialMessageDelay || 0,
-        initialMessage: agent.initialMessage || "",
+        llmTemperature: agent.llm_temperature || 0.7,
+        maxCallDurationInMinutes: agent.max_call_duration_in_minutes || 30,
+        initialMessageDelay: agent.initial_message_delay || 0,
+        initialMessage: agent.initial_message || "",
       });
     }
   }, [agent]);
@@ -69,16 +69,16 @@ const EditSimulatorAgentDialog = ({ open, onClose, agent, onEditSuccess }) => {
         setFormData({
           name: agent.name || "",
           prompt: agent.prompt || "",
-          voiceProvider: agent.voiceProvider || "",
-          voiceName: agent.voiceName || "",
-          interruptSensitivity: agent.interruptSensitivity || 0.5,
-          conversationSpeed: agent.conversationSpeed || 1.0,
-          finishedSpeakingSensitivity: agent.finishedSpeakingSensitivity || 0.5,
+          voiceProvider: agent.voice_provider || "",
+          voiceName: agent.voice_name || "",
+          interruptSensitivity: agent.interrupt_sensitivity || 0.5,
+          conversationSpeed: agent.conversation_speed || 1.0,
+          finishedSpeakingSensitivity: agent.finished_speaking_sensitivity || 0.5,
           model: agent.model || "",
-          llmTemperature: agent.llmTemperature || 0.7,
-          maxCallDurationInMinutes: agent.maxCallDurationInMinutes || 30,
-          initialMessageDelay: agent.initialMessageDelay || 0,
-          initialMessage: agent.initialMessage || "",
+          llmTemperature: agent.llm_temperature || 0.7,
+          maxCallDurationInMinutes: agent.max_call_duration_in_minutes || 30,
+          initialMessageDelay: agent.initial_message_delay || 0,
+          initialMessage: agent.initial_message || "",
         });
       }
       onClose();

--- a/frontend/src/sections/agents/CreateNewAgent/AgentBasicInfoStep/LanguageMultiSelect.jsx
+++ b/frontend/src/sections/agents/CreateNewAgent/AgentBasicInfoStep/LanguageMultiSelect.jsx
@@ -346,7 +346,7 @@ const LanguageMultiSelect = ({
                           icon={
                             <Iconify
                               icon="system-uicons:checkbox-empty"
-                              color="action.selected"
+                              color="action.default"
                               width={24}
                               height={24}
                               style={{ display: "block" }}

--- a/frontend/src/sections/common/EvalPicker/EvalPickerList.jsx
+++ b/frontend/src/sections/common/EvalPicker/EvalPickerList.jsx
@@ -488,7 +488,9 @@ const SkeletonRows = (
 // ── Main Component ──
 
 const EvalPickerList = ({ onSelectEval }) => {
-  const { existingEvals, sourceId, lockedFilters } = useEvalPickerContext();
+  const { existingEvals, source, sourceId, lockedFilters } =
+    useEvalPickerContext();
+  const useScopedEvals = source === "dataset" || source === "experiment";
   const {
     items,
     total,
@@ -504,7 +506,11 @@ const EvalPickerList = ({ onSelectEval }) => {
     setSorting,
     filters,
     setFilters,
-  } = useEvalPickerData({ sourceId, lockedFilters });
+  } = useEvalPickerData({
+    sourceId: useScopedEvals ? sourceId : null,
+    enabled: true,
+    lockedFilters,
+  });
 
   const [filterAnchorEl, setFilterAnchorEl] = useState(null);
   const [expandedEvalId, setExpandedEvalId] = useState(null);

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -283,16 +283,12 @@ const getDataSource = (
           if (getResultIsSyntheticDataset(result)) {
             updateProcessingSyntheticData(false);
           }
-          // Infinite-scroll: don't expose total upfront
           const fetchedRows = rows || [];
           const isLastPage = fetchedRows.length < DATASET_ROWS_LIMIT;
-          const lastRow = isLastPage
-            ? request.startRow + fetchedRows.length
-            : -1;
 
           params.success({
             rowData: fetchedRows,
-            rowCount: lastRow,
+            rowCount: totalRows,
           });
 
           // Prefetch the next two pages so scrolling stays ahead of the
@@ -574,7 +570,11 @@ const DevelopDataV2 = ({ datasetId, viewOptions }) => {
   // (CustomCellRender) and the datapoint drawer can synchronously look up
   // the eval_type for an eval column. This is the same query key the
   // EvaluationDrawer uses, so the request is deduped.
-  useEvalsList(dataset, { eval_type: "user" }, "dataset");
+  useEvalsList(
+    _viewOptions.showEvals ? dataset : undefined,
+    { eval_type: "user" },
+    "dataset",
+  );
   const isRefreshingColumns = useRef(false);
   const { setGridApi, setRefetchTable } = useDevelopDetailContext();
   const setEditCell = useEditCellStoreShallow((s) => s.setEditCell);

--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -1068,6 +1068,8 @@ export const getDatasetViewOptions = (viewOptions) => {
       viewOptions?.showDrawer !== undefined ? viewOptions?.showDrawer : true,
     bottomRow:
       viewOptions?.bottomRow !== undefined ? viewOptions?.bottomRow : true,
+    showEvals:
+      viewOptions?.showEvals !== undefined ? viewOptions?.showEvals : true,
   };
 };
 

--- a/frontend/src/sections/develop-detail/DatasetSummaryTab/ChartsContainer/constant.js
+++ b/frontend/src/sections/develop-detail/DatasetSummaryTab/ChartsContainer/constant.js
@@ -29,10 +29,13 @@ export const getSuffixForCharts = (header, considerIndex = null) => {
   //this is a temporary implementation
   let newHeader = header;
   if (considerIndex || Array.isArray(header)) {
+    const target = header?.[considerIndex || 0];
     newHeader = {
-      ...header?.[considerIndex || 0],
+      ...target,
       isNumericEval:
-        header?.[considerIndex || 0]?.outputType === OutputTypes.NUMERIC,
+        (target?.outputType ?? target?.output_type) === OutputTypes.NUMERIC,
+      isNumericEvalPercentage:
+        target?.isNumericEvalPercentage ?? target?.is_numeric_eval_percentage,
     };
   }
 

--- a/frontend/src/sections/develop-detail/DatasetSummaryTab/CriticalIssues.jsx
+++ b/frontend/src/sections/develop-detail/DatasetSummaryTab/CriticalIssues.jsx
@@ -114,7 +114,7 @@ const CriticalIssues = ({ mode = "develop" }) => {
 
   const isCriticalIssueFetchingAllowed =
     mode === "simulate"
-      ? kpis?.totalCalls >= MinimumTotalCallsForCriticalIssue
+      ? kpis?.total_calls >= MinimumTotalCallsForCriticalIssue
       : true;
 
   const { data, isLoading, refetch, isRefetching } = useQuery({

--- a/frontend/src/sections/develop-detail/DatasetSummaryTab/EvalsCard/EvalsCardGraphs.jsx
+++ b/frontend/src/sections/develop-detail/DatasetSummaryTab/EvalsCard/EvalsCardGraphs.jsx
@@ -33,17 +33,17 @@ const EvalsCardGraphs = ({
     data?.forEach((item) => {
       if (mode === "develop" && !item?.isVisible) return;
       if (
-        item.outputType === "score" ||
-        item.outputType === OutputTypes.NUMERIC
+        item.output_type === "score" ||
+        item.output_type === OutputTypes.NUMERIC
       ) {
-        redarData.push(item.totalAvg);
+        redarData.push(item.total_avg);
         redarLabel.push(item.name);
       }
-      if (item.outputType === "Pass/Fail") {
+      if (item.output_type === "Pass/Fail") {
         redarLabel.push(item.name);
-        redarData.push(item.totalPassRate);
+        redarData.push(item.total_pass_rate);
       }
-      radarOutputType.push(item.outputType);
+      radarOutputType.push(item.output_type);
     });
 
     if (redarLabel.length < 3) {
@@ -205,20 +205,20 @@ const EvalsCardGraphs = ({
               const headerData = {
                 name: item.name,
                 average:
-                  item.outputType == "choices"
-                    ? item.totalChoicesAvg
-                    : item.outputType == "Pass/Fail"
-                      ? item.totalPassRate
-                      : item.totalAvg,
+                  item.output_type == "choices"
+                    ? item.total_choices_avg
+                    : item.output_type == "Pass/Fail"
+                      ? item.total_pass_rate
+                      : item.total_avg,
                 isNumericEval:
-                  item.outputType == OutputTypes.NUMERIC
+                  item.output_type == OutputTypes.NUMERIC
                     ? true
-                    : item?.isNumericEval,
-                isNumericEvalPercentage: item?.isNumericEvalPercentage,
+                    : item?.is_numeric_eval,
+                isNumericEvalPercentage: item?.is_numeric_eval_percentage,
               };
-              const applySort = Boolean(item?.isNumericEval);
+              const applySort = Boolean(item?.is_numeric_eval);
               const { graphLabels, graphData } =
-                item.outputType == "Pass/Fail"
+                item.output_type == "Pass/Fail"
                   ? getPassFailChartData(item?.result)
                   : getChartData(item?.result, applySort);
 
@@ -234,7 +234,7 @@ const EvalsCardGraphs = ({
                     bgcolor: "background.paper",
                   }}
                 >
-                  <ShowComponent condition={item.outputType == "choices"}>
+                  <ShowComponent condition={item.output_type == "choices"}>
                     <DonutChart
                       height={300}
                       data={graphData}
@@ -243,7 +243,7 @@ const EvalsCardGraphs = ({
                       datasetIndex={datasetIndex}
                     />
                   </ShowComponent>
-                  <ShowComponent condition={item.outputType == "Pass/Fail"}>
+                  <ShowComponent condition={item.output_type == "Pass/Fail"}>
                     <StackBarChart
                       height={350}
                       data={graphData}
@@ -254,8 +254,8 @@ const EvalsCardGraphs = ({
                   </ShowComponent>
                   <ShowComponent
                     condition={
-                      item.outputType == "score" ||
-                      item.outputType === OutputTypes.NUMERIC
+                      item.output_type == "score" ||
+                      item.output_type === OutputTypes.NUMERIC
                     }
                   >
                     <AreaChartWrapper

--- a/frontend/src/sections/persona/PersonaDrawer.jsx
+++ b/frontend/src/sections/persona/PersonaDrawer.jsx
@@ -15,6 +15,7 @@ import PersonaCreateEditForm from "./PersonaCreateEdit/PersonaCreateEditForm";
 
 const PersonaListContent = ({
   personaCreateEditType,
+  lockedFilters,
   onClose,
   onAddPersonas,
   onCreatePersona,
@@ -25,11 +26,14 @@ const PersonaListContent = ({
   );
 
   const handleToggleSelect = (persona, newValue) => {
-    if (newValue) {
-      setSelectedPersonas([...selectedPersonas, persona]);
-    } else {
-      setSelectedPersonas(selectedPersonas.filter((p) => p.id !== persona.id));
-    }
+    setSelectedPersonas((prev) => {
+      if (newValue) {
+        return prev.some((p) => p.id === persona.id)
+          ? prev
+          : [...prev, persona];
+      }
+      return prev.filter((p) => p.id !== persona.id);
+    });
   };
 
   const handleAddPersonas = () => {
@@ -73,6 +77,7 @@ const PersonaListContent = ({
           onToggleSelect={handleToggleSelect}
           isSelectable
           personaCreateEditType={personaCreateEditType}
+          lockedFilters={lockedFilters}
         />
       </Box>
       <Divider flexItem orientation="horizontal" />
@@ -118,6 +123,7 @@ const PersonaListContent = ({
 
 PersonaListContent.propTypes = {
   personaCreateEditType: PropTypes.string,
+  lockedFilters: PropTypes.object,
   onClose: PropTypes.func,
   onAddPersonas: PropTypes.func,
   onCreatePersona: PropTypes.func,
@@ -157,6 +163,7 @@ const PersonaDrawer = ({
   onClose,
   onAddPersonas,
   personaCreateEditType,
+  lockedFilters = null,
   preSelectedPersonas = [],
 }) => {
   const [createEditOpen, setCreateEditOpen] = useState(false);
@@ -189,6 +196,7 @@ const PersonaDrawer = ({
       >
         <PersonaListContent
           personaCreateEditType={personaCreateEditType}
+          lockedFilters={lockedFilters}
           onClose={handleDrawerClose}
           onAddPersonas={onAddPersonas}
           onCreatePersona={() => setCreateEditOpen(true)}
@@ -204,6 +212,7 @@ PersonaDrawer.propTypes = {
   onClose: PropTypes.func,
   onAddPersonas: PropTypes.func,
   personaCreateEditType: PropTypes.string,
+  lockedFilters: PropTypes.object,
   preSelectedPersonas: PropTypes.array,
 };
 

--- a/frontend/src/sections/persona/PersonaListView.jsx
+++ b/frontend/src/sections/persona/PersonaListView.jsx
@@ -83,18 +83,23 @@ const PersonaListView = ({
   onToggleSelect,
   onCreatePersona,
   personaCreateEditType = null,
+  lockedFilters = null,
 }) => {
   const { role } = useAuthContext();
   const canCreate = RolePermission.SIMULATION_AGENT[PERMISSIONS.CREATE][role];
+
+  const pickLockedValue = (v) => (Array.isArray(v) ? v[0] : v) ?? null;
+  const lockedSimulationType =
+    pickLockedValue(lockedFilters?.simulation_type) ??
+    (isSelectable ? personaCreateEditType : null);
+  const lockedType = pickLockedValue(lockedFilters?.type);
 
   // State
   const [searchQuery, setSearchQuery] = useState("");
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(25);
-  const [typeFilter, setTypeFilter] = useState(null);
-  const [simulationFilter, setSimulationFilter] = useState(
-    isSelectable ? personaCreateEditType : null,
-  );
+  const [typeFilter, setTypeFilter] = useState(lockedType);
+  const [simulationFilter, setSimulationFilter] = useState(lockedSimulationType);
   const [rowSelection, setRowSelection] = useState({});
   const [columnVisibility, setColumnVisibility] = useState({});
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -118,8 +123,8 @@ const PersonaListView = ({
     page: page + 1,
     pageSize,
     search: debouncedSearch || null,
-    type: typeFilter,
-    simulationType: simulationFilter,
+    type: lockedType ?? typeFilter,
+    simulationType: lockedSimulationType ?? simulationFilter,
   });
 
   const items = useMemo(() => data?.results || [], [data]);
@@ -434,22 +439,21 @@ const PersonaListView = ({
   );
 
   const filterFields = useMemo(() => {
-    const fields = [
-      {
+    const fields = [];
+    if (!lockedType) {
+      fields.push({
         value: "type",
         label: "Category",
         type: "enum",
         choices: ["prebuilt", "custom"],
-      },
-    ];
-    if (!(isSelectable && personaCreateEditType)) {
+      });
+    }
+    if (!lockedSimulationType) {
       fields.push({
         value: "simulation_type",
         label: "Agent Type",
         type: "enum",
         choices: [AGENT_TYPES.VOICE, AGENT_TYPES.CHAT],
-        // Bridge the legacy API value "text" to the user-facing label
-        // "Chat" so the AI filter can resolve "chat personas" → text.
         choiceLabels: {
           [AGENT_TYPES.VOICE]: "Voice",
           [AGENT_TYPES.CHAT]: "Chat",
@@ -457,24 +461,25 @@ const PersonaListView = ({
       });
     }
     return fields;
-  }, [isSelectable, personaCreateEditType]);
+  }, [lockedType, lockedSimulationType]);
 
   const currentFilters = useMemo(() => {
     const f = {};
-    if (typeFilter) f.type = [typeFilter];
-    if (simulationFilter) f.simulation_type = [simulationFilter];
+    if (!lockedType && typeFilter) f.type = [typeFilter];
+    if (!lockedSimulationType && simulationFilter)
+      f.simulation_type = [simulationFilter];
     return Object.keys(f).length ? f : null;
-  }, [typeFilter, simulationFilter]);
+  }, [typeFilter, simulationFilter, lockedType, lockedSimulationType]);
 
-  const activeFilterCount = (typeFilter ? 1 : 0) + (simulationFilter ? 1 : 0);
+  const activeFilterCount =
+    (lockedType ? 0 : typeFilter ? 1 : 0) +
+    (lockedSimulationType ? 0 : simulationFilter ? 1 : 0);
 
   const handleFilterApply = useCallback(
     (result) => {
-      const lockedSim =
-        isSelectable && personaCreateEditType ? personaCreateEditType : null;
       if (!result) {
-        setTypeFilter(null);
-        setSimulationFilter(lockedSim);
+        setTypeFilter(lockedType ?? null);
+        setSimulationFilter(lockedSimulationType ?? null);
         setPage(0);
         return;
       }
@@ -489,15 +494,19 @@ const PersonaListView = ({
               : [];
           if (val.length) flat[t.field] = val;
         }
-        setTypeFilter(pickFirst(flat.type));
-        setSimulationFilter(lockedSim ?? pickFirst(flat.simulation_type));
+        setTypeFilter(lockedType ?? pickFirst(flat.type));
+        setSimulationFilter(
+          lockedSimulationType ?? pickFirst(flat.simulation_type),
+        );
       } else {
-        setTypeFilter(pickFirst(result.type));
-        setSimulationFilter(lockedSim ?? pickFirst(result.simulation_type));
+        setTypeFilter(lockedType ?? pickFirst(result.type));
+        setSimulationFilter(
+          lockedSimulationType ?? pickFirst(result.simulation_type),
+        );
       }
       setPage(0);
     },
-    [isSelectable, personaCreateEditType],
+    [lockedType, lockedSimulationType],
   );
 
   const handleToggleColumn = useCallback((field) => {
@@ -618,26 +627,27 @@ const PersonaListView = ({
           alignItems: "center",
         }}
       >
-        {QUICK_FILTERS.map((f) => {
-          const isActive = typeFilter === f.value;
-          return (
-            <Chip
-              key={f.label}
-              icon={<Iconify icon={f.icon} width={14} />}
-              label={f.label}
-              size="small"
-              variant={isActive ? "filled" : "outlined"}
-              color={isActive ? "primary" : "default"}
-              onClick={() => {
-                setTypeFilter(f.value);
-                setPage(0);
-              }}
-              sx={{ fontSize: "11px", height: 26, cursor: "pointer" }}
-            />
-          );
-        })}
+        {!lockedType &&
+          QUICK_FILTERS.map((f) => {
+            const isActive = typeFilter === f.value;
+            return (
+              <Chip
+                key={f.label}
+                icon={<Iconify icon={f.icon} width={14} />}
+                label={f.label}
+                size="small"
+                variant={isActive ? "filled" : "outlined"}
+                color={isActive ? "primary" : "default"}
+                onClick={() => {
+                  setTypeFilter(f.value);
+                  setPage(0);
+                }}
+                sx={{ fontSize: "11px", height: 26, cursor: "pointer" }}
+              />
+            );
+          })}
 
-        {!(isSelectable && personaCreateEditType) && (
+        {!lockedSimulationType && (
           <>
             <Box
               sx={{
@@ -778,6 +788,7 @@ const PersonaListView = ({
 
 PersonaListView.propTypes = {
   isSelectable: PropTypes.bool,
+  lockedFilters: PropTypes.object,
   selectedPersonas: PropTypes.array,
   onToggleSelect: PropTypes.func,
   onCreatePersona: PropTypes.func,

--- a/frontend/src/sections/projects/SessionsView/ReplaySessions/GeneratedScenarios.jsx
+++ b/frontend/src/sections/projects/SessionsView/ReplaySessions/GeneratedScenarios.jsx
@@ -117,6 +117,7 @@ export const GeneratedScenarios = React.memo(({ scenarioDetail: scenario }) => {
                 showDrawer: false,
                 bottomRow: false,
                 showCheckbox: false,
+                showEvals: false,
               }}
             />
           </Box>

--- a/frontend/src/sections/scenarios/CreateScenarioView.jsx
+++ b/frontend/src/sections/scenarios/CreateScenarioView.jsx
@@ -159,7 +159,7 @@ const CreateScenarioView = () => {
     return agentDefVersions?.pages?.reduce((acc, curr) => {
       const newOptions =
         curr.results?.map((result) => ({
-          label: result.versionNameDisplay,
+          label: result.version_name_display,
           value: result.id,
         })) ?? [];
       return [...acc, ...newOptions];
@@ -274,10 +274,10 @@ const CreateScenarioView = () => {
     const agentOptions = agentDefinitionsLoading
       ? []
       : agentDefinitions?.map((agent) => ({
-          label: agent?.agentName,
+          label: agent?.agent_name,
           value: agent?.id,
           sourceType: SourceType.AGENT_DEFINITION,
-          agentType: agent?.agentType,
+          agentType: agent?.agent_type,
         })) ?? [];
 
     const promptOptions = isLoadingPrompts

--- a/frontend/src/sections/scenarios/scenario-detail/AddColumnScenario.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/AddColumnScenario.jsx
@@ -18,11 +18,11 @@ import { enqueueSnackbar } from "notistack";
 import { LoadingButton } from "@mui/lab";
 import { useMutation } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
-import { useDevelopDetailContext } from "src/sections/develop-detail/Context/DevelopDetailContext";
+import { useRefreshScenarioGrid } from "./useRefreshScenarioGrid";
 import { addColumnSchema, columnGenerationOptions } from "./common";
 
 const AddColumnScenario = ({ open, onClose, datasetId, scenarioId }) => {
-  const { refreshGrid } = useDevelopDetailContext();
+  const refreshGrid = useRefreshScenarioGrid(scenarioId);
 
   const addColumnForm = useForm({
     mode: "onSubmit",

--- a/frontend/src/sections/scenarios/scenario-detail/AddRowScenario.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/AddRowScenario.jsx
@@ -2,7 +2,7 @@ import { Box, Drawer, IconButton, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useMemo, useState } from "react";
 import Iconify from "src/components/iconify";
-import { useDevelopDetailContext } from "src/sections/develop-detail/Context/DevelopDetailContext";
+import { useRefreshScenarioGrid } from "./useRefreshScenarioGrid";
 import DatasetOptions from "src/sections/develop/AddRowDrawer/DatasetOptions";
 import ExistingDatasetModal from "src/sections/develop/AddRowDrawer/ExistingDatasetModal";
 import SetEmptyRow from "src/sections/develop/AddRowDrawer/SetEmptyRow";
@@ -52,7 +52,7 @@ const AddRowScenario = ({
     return options;
   }, [scenarioType]);
 
-  const { refreshGrid } = useDevelopDetailContext();
+  const refreshGrid = useRefreshScenarioGrid(scenarioId);
 
   const [emptyRow, setEmptyRow] = useState(false);
   const [existingDataset, setExistingDataset] = useState(false);

--- a/frontend/src/sections/scenarios/scenario-detail/AddRowUsingAi.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/AddRowUsingAi.jsx
@@ -16,7 +16,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import axios, { endpoints } from "src/utils/axios";
 import { enqueueSnackbar } from "src/components/snackbar";
-import { useDevelopDetailContext } from "src/sections/develop-detail/Context/DevelopDetailContext";
+import { useRefreshScenarioGrid } from "./useRefreshScenarioGrid";
 import { LoadingButton } from "@mui/lab";
 
 const AddRowUsingAiForm = ({ scenarioId, onClose }) => {
@@ -28,7 +28,7 @@ const AddRowUsingAiForm = ({ scenarioId, onClose }) => {
     resolver: zodResolver(AddRowUsingAiValidationSchema),
   });
 
-  const { refreshGrid } = useDevelopDetailContext();
+  const refreshGrid = useRefreshScenarioGrid(scenarioId);
 
   const { mutate: addRowUsingAi, isPending } = useMutation({
     mutationFn: (data) =>

--- a/frontend/src/sections/scenarios/scenario-detail/DatasetScenarioView.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/DatasetScenarioView.jsx
@@ -12,7 +12,7 @@ const DatasetScenarioView = () => {
 
   useEffect(() => {
     // If scenario is loaded and it's not a dataset type, redirect back
-    if (scenario && scenario.scenarioType !== "dataset") {
+    if (scenario && scenario.scenario_type !== "dataset") {
       navigate("/dashboard/simulate/scenarios");
     }
   }, [scenario, navigate]);

--- a/frontend/src/sections/scenarios/scenario-detail/PromptPreview.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/PromptPreview.jsx
@@ -19,11 +19,11 @@ const PromptPreview = ({ scenario }) => {
   );
 
   const allowedVariables = useMemo(() => {
-    const columnConfig = tableData?.data?.result?.columnConfig ?? [];
+    const columnConfig = tableData?.data?.result?.column_config ?? [];
 
     const allowedVariables = columnConfig.map((col) => col.name);
     return allowedVariables;
-  }, [tableData?.data?.result?.columnConfig]);
+  }, [tableData?.data?.result?.column_config]);
 
   const isLoading =
     isLoadingTable ||

--- a/frontend/src/sections/scenarios/scenario-detail/ScenarioDatasetView.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/ScenarioDatasetView.jsx
@@ -237,6 +237,7 @@ const ScenarioDatasetView = () => {
               viewOptions={{
                 showDrawer: false,
                 bottomRow: false,
+                showEvals: false,
               }}
             />
             <AddRowScenario

--- a/frontend/src/sections/scenarios/scenario-detail/ScenarioDetailSelectionView.jsx
+++ b/frontend/src/sections/scenarios/scenario-detail/ScenarioDetailSelectionView.jsx
@@ -5,7 +5,9 @@ import SvgColor from "src/components/svg-color";
 import { trackEvent } from "src/utils/Mixpanel";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
+import { useParams } from "react-router";
 import { useDevelopDetailContext } from "src/sections/develop-detail/Context/DevelopDetailContext";
+import { useRefreshScenarioGrid } from "./useRefreshScenarioGrid";
 import { useDevelopSelectedRowsStoreShallow } from "src/sections/develop-detail/states";
 import { useAuthContext } from "src/auth/hooks";
 import { PERMISSIONS, RolePermission } from "src/utils/rolePermissionMapping";
@@ -43,7 +45,8 @@ const StyledButton = styled(Button)(({ theme }) => ({
 const ScenarioDetailSelectionView = ({ dataset }) => {
   const [isDelete, setIsDelete] = useState(false);
 
-  const { refreshGrid } = useDevelopDetailContext();
+  const { scenarioId } = useParams();
+  const refreshGrid = useRefreshScenarioGrid(scenarioId);
   const { selectAll, toggledNodes, resetSelectedRows } =
     useDevelopSelectedRowsStoreShallow((s) => ({
       selectAll: s.selectAll,

--- a/frontend/src/sections/scenarios/scenario-detail/useRefreshScenarioGrid.js
+++ b/frontend/src/sections/scenarios/scenario-detail/useRefreshScenarioGrid.js
@@ -1,0 +1,17 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useDevelopDetailContext } from "src/sections/develop-detail/Context/DevelopDetailContext";
+
+export const useRefreshScenarioGrid = (scenarioId) => {
+  const queryClient = useQueryClient();
+  const { refreshGrid } = useDevelopDetailContext();
+
+  return useCallback(() => {
+    if (scenarioId) {
+      queryClient.invalidateQueries({
+        queryKey: ["scenario-detail", scenarioId],
+      });
+    }
+    refreshGrid();
+  }, [queryClient, refreshGrid, scenarioId]);
+};

--- a/frontend/src/sections/test-detail/CreateEditOptimization/common.js
+++ b/frontend/src/sections/test-detail/CreateEditOptimization/common.js
@@ -204,3 +204,26 @@ export const OptimizerConfigurationMapping = {
     maxMetricCalls: 40,
   },
 };
+
+export const ConfigurationSnakeToCamel = {
+  num_variations: "numVariations",
+  min_examples: "minExamples",
+  max_examples: "maxExamples",
+  n_trials: "nTrials",
+  num_gradients: "numGradients",
+  errors_per_gradient: "errorsPerGradient",
+  prompts_per_gradient: "promptsPerGradient",
+  task_description: "taskDescription",
+  mutate_rounds: "mutateRounds",
+  refine_iterations: "refineIterations",
+  beam_size: "beamSize",
+  num_rounds: "numRounds",
+  max_metric_calls: "maxMetricCalls",
+};
+
+export const mapConfigurationToForm = (configuration = {}) =>
+  Object.entries(configuration || {}).reduce((acc, [key, value]) => {
+    const camelKey = ConfigurationSnakeToCamel[key] ?? key;
+    acc[camelKey] = value;
+    return acc;
+  }, {});

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/EachOptimizationComponent.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/EachOptimizationComponent.jsx
@@ -78,7 +78,7 @@ const EachOptimizationComponent = ({
         >
           <OptmizationLoaderComponent
             optimizationStatus={optimizationData?.status}
-            reason={optimizationData?.errorMessage}
+            reason={optimizationData?.error_message}
           />
         </ShowComponent>
         <ShowComponent

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/FixMyAgentSections.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/FixMyAgentSections.jsx
@@ -7,15 +7,15 @@ import NonFixableRecommendations from "./NonFixableRecommendations";
 
 const FixMyAgentSections = ({ refetch, optimizerAnalysis }) => {
   const agentLevelFixableRecommendations =
-    optimizerAnalysis?.response?.agentLevel?.actionableRecommendations ?? [];
+    optimizerAnalysis?.response?.agent_level?.actionable_recommendations ?? [];
   const domainLevelFixableRecommendations =
-    optimizerAnalysis?.response?.domainLevel?.actionableRecommendations ?? [];
+    optimizerAnalysis?.response?.domain_level?.actionable_recommendations ?? [];
   const fixableActionableRecommendations = [
     ...(agentLevelFixableRecommendations ?? []),
     ...(domainLevelFixableRecommendations ?? []),
   ];
   const notFixableActionableRecommendations =
-    optimizerAnalysis?.response?.systemLevel?.actionableRecommendations || [];
+    optimizerAnalysis?.response?.system_level?.actionable_recommendations || [];
 
   const lastUpdated =
     optimizerAnalysis?.last_updated ?? optimizerAnalysis?.lastUpdated;
@@ -60,8 +60,8 @@ const FixMyAgentSections = ({ refetch, optimizerAnalysis }) => {
 
             <NonFixableRecommendations
               humanComparisonSummary={
-                optimizerAnalysis?.response?.systemLevel
-                  ?.humanComparisonSummary ?? ""
+                optimizerAnalysis?.response?.system_level
+                  ?.human_comparison_summary ?? ""
               }
               notFixableActionableRecommendations={
                 notFixableActionableRecommendations

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/FixableRecommendations.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/FixableRecommendations.jsx
@@ -293,7 +293,7 @@ const FixableRecommendations = ({
                           key={recommendation.heading}
                           title={recommendation.heading}
                           description={recommendation.recommendation}
-                          breakdown={recommendation.breakingPoints}
+                          breakdown={recommendation.breaking_points}
                           isPriority={
                             recommendation.priority === PriorityStatus.HIGH
                           }
@@ -315,7 +315,7 @@ const FixableRecommendations = ({
                             );
                             gridApi?.onFilterChanged?.();
                           }}
-                          branchCategory={recommendation?.branchCategory}
+                          branchCategory={recommendation?.branch_category}
                         />
                       );
                     },

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/NonFixableRecommendations.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/NonFixableRecommendations.jsx
@@ -163,7 +163,7 @@ const NonFixableRecommendations = ({
                         isPriority={
                           recommendation.priority === PriorityStatus.HIGH
                         }
-                        breakdown={recommendation.breakingPoints}
+                        breakdown={recommendation.breaking_points}
                         callExecutionIds={recommendation?.call_execution_ids}
                         isSelected={selectedNonFixableRecommendations.find(
                           (r) => r.index === index,

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationDetail/OptimizationDetailComponent.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationDetail/OptimizationDetailComponent.jsx
@@ -72,20 +72,20 @@ const OptimizationDetailComponent = ({
             color="text.primary"
           />
           <Typography typography="s1" fontWeight="fontWeightMedium">
-            {trailPromptData?.trialName}
+            {trailPromptData?.trial_name}
           </Typography>
         </Box>
       </ShowComponent>
       <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
         <Typography typography="m3" fontWeight="fontWeightSemiBold">
-          {trailPromptData?.trialName}
+          {trailPromptData?.trial_name}
         </Typography>
         <Box sx={{ display: "flex", gap: 1 }}>
           <Typography typography="s1">
-            Optimization Name: {trailPromptData?.optimisationName}
+            Optimization Name: {trailPromptData?.optimisation_name}
           </Typography>
           <Growth
-            value={trailPromptData?.scorePercentageChange}
+            value={trailPromptData?.score_percentage_change}
             getText={(value) => {
               if (value > 0) {
                 return `+${value}% improved from baseline prompt`;

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationDetail/PrompDetails/PromptDetails.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationDetail/PrompDetails/PromptDetails.jsx
@@ -13,8 +13,8 @@ const PromptDetails = ({ optimizationId, trialId, showDiff }) => {
   if (showDiff) {
     return (
       <PromptDiffView
-        originalPrompt={trailPromptData?.basePrompt}
-        optimizedPrompt={trailPromptData?.trialPrompt}
+        originalPrompt={trailPromptData?.base_prompt}
+        optimizedPrompt={trailPromptData?.trial_prompt}
       />
     );
   }
@@ -24,7 +24,7 @@ const PromptDetails = ({ optimizationId, trialId, showDiff }) => {
       <Box sx={{ flex: 1 }}>
         <PromptPanel
           title="OPTIMIZED AGENT PROMPT"
-          prompt={trailPromptData?.trialPrompt}
+          prompt={trailPromptData?.trial_prompt}
         />
       </Box>
     </Box>

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationDetail/TrialItems/TrialItems.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationDetail/TrialItems/TrialItems.jsx
@@ -87,8 +87,8 @@ const TrialItems = ({ optimizationId, trialId }) => {
   );
 
   const columnDefs = useMemo(() => {
-    return getTrialItemsColumnConfig(trialItems?.columnConfig);
-  }, [trialItems?.columnConfig]);
+    return getTrialItemsColumnConfig(trialItems?.column_config);
+  }, [trialItems?.column_config]);
 
   return (
     <Box

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationResults/CellRenderers/AverageEvalCellRenderer.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationResults/CellRenderers/AverageEvalCellRenderer.jsx
@@ -24,11 +24,11 @@ const AverageEvalCellRenderer = ({ value }) => {
       <Typography typography="s1">{formatScore(value)}</Typography>
       <ShowComponent
         condition={
-          value?.percentageChange !== null &&
-          value?.percentageChange !== undefined
+          value?.percentage_change !== null &&
+          value?.percentage_change !== undefined
         }
       >
-        <Growth value={value?.percentageChange} />
+        <Growth value={value?.percentage_change} />
       </ShowComponent>
     </Box>
   );

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationResults/OptimizationResultBar.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationResults/OptimizationResultBar.jsx
@@ -20,8 +20,8 @@ const OptimizationResultBar = ({ optimizationData }) => {
     color: isData ? "text.primary" : "divider",
   };
   const bestOptimization = useMemo(() => {
-    const bestItem = optimizationData?.table?.find((item) => item?.isBest);
-    return bestItem?.scorePercentageChange;
+    const bestItem = optimizationData?.table?.find((item) => item?.is_best);
+    return bestItem?.score_percentage_change;
   }, [optimizationData]);
   const [gridColumnDefs, setGridColumnDefs] = useState([]);
   const gridApi = getGridApi();

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationResults/OptimizationResultGrid.jsx
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationResults/OptimizationResultGrid.jsx
@@ -42,7 +42,7 @@ const OptimizationResultGrid = ({ optimizationId, isDrawer = true }) => {
   }));
 
   const columnDefs = useMemo(() => {
-    return getOptimizationResultColumnConfig(optimizationData?.columnConfig);
+    return getOptimizationResultColumnConfig(optimizationData?.column_config);
   }, [optimizationData]);
 
   return (

--- a/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationResults/common.js
+++ b/frontend/src/sections/test-detail/FixMyAgentDrawer/OptimizationResults/common.js
@@ -37,8 +37,8 @@ export const getOptimizationResultColumnConfig = (optimizationColumns) => {
           valueGetter: (params) => {
             return {
               title: params.data?.trial,
-              improvement: params.data?.scorePercentageChange,
-              isBest: params.data?.isBest,
+              improvement: params.data?.score_percentage_change,
+              isBest: params.data?.is_best,
             };
           },
         };

--- a/frontend/src/sections/test-detail/OptimizationDetail/OptimizationDetail.jsx
+++ b/frontend/src/sections/test-detail/OptimizationDetail/OptimizationDetail.jsx
@@ -44,7 +44,7 @@ const OptimizationDetail = () => {
               href: `/dashboard/simulate/test/${testId}/${executionId}/optimization_runs`,
             },
             {
-              label: optimizationData?.optimiserName ?? optimizationId,
+              label: optimizationData?.optimiser_name ?? optimizationId,
               isLoading: isLoading,
             },
           ]}

--- a/frontend/src/sections/test-detail/OptimizationRunDetail/CellRenderers/StatusCellRenderer.jsx
+++ b/frontend/src/sections/test-detail/OptimizationRunDetail/CellRenderers/StatusCellRenderer.jsx
@@ -66,9 +66,9 @@ const StatusCellRenderer = ({ value, data }) => {
             className="optimization-run-detail-refresh-button"
             onClick={() =>
               setOpenOptimizationRerun({
-                name: `${data?.optimisationName} - Rerun - ${format(new Date(), "dd MMM yyyy")}`,
+                name: `${data?.optimisation_name} - Rerun - ${format(new Date(), "dd MMM yyyy")}`,
                 model: data?.model,
-                optimiserType: data?.optimiserType,
+                optimiserType: data?.optimiser_type,
                 configuration: data?.configuration,
               })
             }

--- a/frontend/src/sections/test-detail/OptimizationRunDetail/common.js
+++ b/frontend/src/sections/test-detail/OptimizationRunDetail/common.js
@@ -8,21 +8,21 @@ export const getOptimizationRunDetailColumDef = () => {
       field: "optimizations",
       headerName: "Optimizations",
       valueGetter: (params) => ({
-        title: params.data?.optimisationName,
-        startedAt: params.data?.startedAt,
+        title: params.data?.optimisation_name,
+        startedAt: params.data?.started_at,
       }),
       flex: 1,
       cellRenderer: OptimizationNameRenderer,
     },
     {
-      field: "noOfTrials",
+      field: "no_of_trials",
       headerName: "No. of Trials",
       minWidth: 150,
     },
     {
-      field: "optimizationType",
+      field: "optimization_type",
       headerName: "Optimization Type",
-      valueGetter: (params) => KeyOptimizerMapping[params.data?.optimiserType],
+      valueGetter: (params) => KeyOptimizerMapping[params.data?.optimiser_type],
       minWidth: 200,
     },
     {

--- a/frontend/src/sections/test-detail/OptimizeAgentDrawer.jsx/OptimizeAgentHeaderComponent.jsx
+++ b/frontend/src/sections/test-detail/OptimizeAgentDrawer.jsx/OptimizeAgentHeaderComponent.jsx
@@ -29,8 +29,14 @@ import { getDocsLinkBasedOnOptimizer } from "./common";
 import { formatStartTimeByRequiredFormat } from "src/utils/utils";
 
 const OptimizeAgentHeaderComponent = ({ optimization, isLoading }) => {
-  const { optimiserType, model, status, optimiserName, providerLogo } =
-    optimization || {};
+  const {
+    model,
+    status,
+    optimiser_type: optimiserType,
+    optimiser_name: optimiserName,
+    provider_logo: providerLogo,
+    start_time: startTime,
+  } = optimization || {};
   const [feedbackModalOpen, setFeedbackModalOpen] = useState(false);
   const [createEditOptimizationModalOpen, setCreateEditOptimizationModalOpen] =
     useState(null);
@@ -44,9 +50,9 @@ const OptimizeAgentHeaderComponent = ({ optimization, isLoading }) => {
 
   const getDefaultValues = (optimization) => {
     return {
-      name: `${optimization?.optimiserName} - Rerun - ${format(new Date(), "dd MMM yyyy")}`,
+      name: `${optimiserName} - Rerun - ${format(new Date(), "dd MMM yyyy")}`,
       model: optimization?.model,
-      optimiserType: optimization?.optimiserType,
+      optimiserType: optimiserType,
       configuration: optimization?.configuration,
     };
   };
@@ -55,7 +61,7 @@ const OptimizeAgentHeaderComponent = ({ optimization, isLoading }) => {
     return <OptimizeAgentHeaderComponentSkeleton />;
   }
   const formattedStartTime = formatStartTimeByRequiredFormat(
-    optimization?.start_time,
+    startTime,
     "MMM dd, yyyy 'at' h:mm a",
   );
   return (
@@ -74,9 +80,7 @@ const OptimizeAgentHeaderComponent = ({ optimization, isLoading }) => {
           <CallStatus value={status ?? "Completed"} />
         </Box>
 
-        <ShowComponent
-          condition={!!optimization?.start_time && !!formattedStartTime}
-        >
+        <ShowComponent condition={!!startTime && !!formattedStartTime}>
           <Typography typography={"s3"} fontWeight={"fontWeightRegular"}>
             Optimization ran on {formattedStartTime}
           </Typography>

--- a/frontend/src/sections/test-detail/OptimizeAgentDrawer.jsx/OptimizeAgentHeaderComponent.jsx
+++ b/frontend/src/sections/test-detail/OptimizeAgentDrawer.jsx/OptimizeAgentHeaderComponent.jsx
@@ -19,7 +19,10 @@ import ModalWrapper from "src/components/ModalWrapper/ModalWrapper";
 import { ShowComponent } from "src/components/show";
 import SvgColor from "src/components/svg-color";
 import CallStatus from "src/sections/test/CallLogs/CallStatus";
-import { KeyOptimizerMapping } from "../CreateEditOptimization/common";
+import {
+  KeyOptimizerMapping,
+  mapConfigurationToForm,
+} from "../CreateEditOptimization/common";
 import RerunOptimizationModal from "../CreateEditOptimization/RerunOptimizationModal";
 import OptimizeAgentHeaderComponentSkeleton from "./OptimizeAgentHeaderComponentSkeleton";
 import { AgentPromptOptimizerRerunStatus } from "../FixMyAgentDrawer/common";
@@ -53,7 +56,7 @@ const OptimizeAgentHeaderComponent = ({ optimization, isLoading }) => {
       name: `${optimiserName} - Rerun - ${format(new Date(), "dd MMM yyyy")}`,
       model: optimization?.model,
       optimiserType: optimiserType,
-      configuration: optimization?.configuration,
+      configuration: mapConfigurationToForm(optimization?.configuration),
     };
   };
 

--- a/frontend/src/sections/test-detail/OptimizeAgentDrawer.jsx/OptimizingAgentSteps.jsx
+++ b/frontend/src/sections/test-detail/OptimizeAgentDrawer.jsx/OptimizingAgentSteps.jsx
@@ -121,12 +121,18 @@ const OptimizingAgentSteps = ({ status, optimizationId }) => {
               },
             }}
           >
-            {steps?.map(({ status, name, description, updatedAt }, index) => {
+            {steps?.map(({ status, name, description, updated_at: updatedAt }, index) => {
               const isFailedStep =
                 steps
                   .slice(0, index)
                   .some((step) => step?.status === "failed") || //check if any previous step has failed or current step is failed then render failed status
                 status === "failed";
+
+              const updatedDate = updatedAt ? new Date(updatedAt) : null;
+              const formattedUpdatedAt =
+                updatedDate && isValid(updatedDate)
+                  ? format(updatedDate, "dd/MM/yyyy,HH:mm:ss")
+                  : null;
 
               return (
                 <Step key={index} completed={status === "completed"} expanded>
@@ -191,8 +197,7 @@ const OptimizingAgentSteps = ({ status, optimizationId }) => {
 
                     <ShowComponent
                       condition={
-                        Boolean(updatedAt) &&
-                        isValid(new Date(updatedAt)) &&
+                        Boolean(formattedUpdatedAt) &&
                         [
                           AgentPromptOptimizerStatus.COMPLETED,
                           AgentPromptOptimizerStatus.FAILED,
@@ -204,7 +209,7 @@ const OptimizingAgentSteps = ({ status, optimizationId }) => {
                         color="text.disabled"
                         fontSize="13px"
                       >
-                        {format(new Date(updatedAt), "dd/MM/yyyy,HH:mm:ss")}
+                        {formattedUpdatedAt}
                       </Typography>
                     </ShowComponent>
                   </StepContent>

--- a/frontend/src/sections/test-detail/PerformanceDetails.jsx
+++ b/frontend/src/sections/test-detail/PerformanceDetails.jsx
@@ -102,7 +102,7 @@ const PerformanceDetails = () => {
                 />
               }
               caption="Pass Rate"
-              value={`${data?.testRunPerformanceMetrics?.passRate}%`}
+              value={`${data?.test_run_performance_metrics?.pass_rate}%`}
             />
             <PerformanceCard
               icon={
@@ -114,7 +114,7 @@ const PerformanceDetails = () => {
                 />
               }
               caption="Total Test Runs"
-              value={data?.testRunPerformanceMetrics?.totalTestRuns}
+              value={data?.test_run_performance_metrics?.total_test_runs}
             />
             <PerformanceCard
               icon={
@@ -126,7 +126,7 @@ const PerformanceDetails = () => {
                 />
               }
               caption="Latest Fail Rate"
-              value={data?.testRunPerformanceMetrics?.latestFailRate}
+              value={data?.test_run_performance_metrics?.latest_fail_rate}
             />
           </Box>
           <Typography typography="s1" fontWeight={500}>
@@ -139,9 +139,9 @@ const PerformanceDetails = () => {
               gap: "1px",
             }}
           >
-            {data?.topPerformingScenarios?.map((scenario) => (
+            {data?.top_performing_scenarios?.map((scenario) => (
               <Box
-                key={scenario.scenarioName}
+                key={scenario.scenario_name}
                 sx={{
                   backgroundColor: "background.default",
                   borderRadius: 1,
@@ -154,16 +154,16 @@ const PerformanceDetails = () => {
               >
                 <Box sx={{ display: "flex", flexDirection: "column" }}>
                   <Typography typography="s1" fontWeight={500}>
-                    {scenario.scenarioName}
+                    {scenario.scenario_name}
                   </Typography>
                   <Typography typography="s2" color="text.disabled">
-                    {scenario.testCount} Tests
+                    {scenario.test_count} Tests
                   </Typography>
                 </Box>
                 <ShowComponent
                   condition={
-                    scenario.performanceScore !== null ||
-                    scenario.performanceScore !== undefined
+                    scenario.performance_score !== null ||
+                    scenario.performance_score !== undefined
                   }
                 >
                   <Box>
@@ -173,13 +173,13 @@ const PerformanceDetails = () => {
                         borderRadius: 1,
                         paddingX: 1,
                         paddingY: 0.2,
-                        backgroundColor: `${colorMap(parseFloat(scenario.performanceScore))}.50`,
-                        color: `${colorMap(parseFloat(scenario.performanceScore))}.500`,
-                        borderColor: `${colorMap(parseFloat(scenario.performanceScore))}.10`,
+                        backgroundColor: `${colorMap(parseFloat(scenario.performance_score))}.50`,
+                        color: `${colorMap(parseFloat(scenario.performance_score))}.500`,
+                        borderColor: `${colorMap(parseFloat(scenario.performance_score))}.10`,
                       }}
                     >
                       <Typography typography="s2">
-                        {scenario.performanceScore}
+                        {scenario.performance_score}
                       </Typography>
                     </Box>
                   </Box>

--- a/frontend/src/sections/test-detail/TestDetailDrawer/BasLineCompare/BaseLineVsReplay.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/BasLineCompare/BaseLineVsReplay.jsx
@@ -143,7 +143,7 @@ export default function BaseLineVsReplay({ rowData }) {
       />
       <Suspense fallback={<PerformanceMetricsSkeleton />}>
         <PerformanceMetrics
-          data={baselineVsReplayData?.comparisonMetrics}
+          data={baselineVsReplayData?.comparison_metrics}
           isLoading={isLoadingBaselineVsReplay}
           simulationCallType={rowData?.simulation_call_type}
         />

--- a/frontend/src/sections/test-detail/TestDetailDrawer/EvalSection.jsx
+++ b/frontend/src/sections/test-detail/TestDetailDrawer/EvalSection.jsx
@@ -74,11 +74,11 @@ const EvalDrawerSection = () => {
           },
         },
       ),
-    select: (data) => data?.data?.errorLocalizerTasks || [],
+    select: (data) => data?.data?.error_localizer_tasks || [],
     refetchInterval: ({ state }) => {
-      const errorLocalizerTasks = state?.data?.data?.errorLocalizerTasks;
+      const errorLocalizerTasks = state?.data?.data?.error_localizer_tasks;
       const errorLocalizerTask = errorLocalizerTasks?.find(
-        (task) => task.evalConfigId === evalView?.metricDetail?.id,
+        (task) => task.eval_config_id === evalView?.metricDetail?.id,
       );
       if (ERROR_LOCALIZER_REFETCH_STATUS.includes(errorLocalizerTask?.status)) {
         return ERROR_LOCALIZER_REFETCH_INTERVAL;
@@ -89,10 +89,10 @@ const EvalDrawerSection = () => {
   });
 
   const errorLocalizerTask = errorLocalizerDataList?.find(
-    (task) => task.evalConfigId === evalView?.metricDetail?.id,
+    (task) => task.eval_config_id === evalView?.metricDetail?.id,
   );
   const errorLocalizerTaskStatus = errorLocalizerTask?.status;
-  const errorAnalysis = errorLocalizerTask?.errorAnalysis;
+  const errorAnalysis = errorLocalizerTask?.error_analysis;
   const isErrorLocalizerTaskRunning = ERROR_LOCALIZER_REFETCH_STATUS.includes(
     errorLocalizerTaskStatus,
   );

--- a/frontend/src/sections/test-detail/TestRunDetailHeader.jsx
+++ b/frontend/src/sections/test-detail/TestRunDetailHeader.jsx
@@ -349,18 +349,18 @@ const TestRunDetailHeader = () => {
                   {
                     id: "run-start",
                     condition: true,
-                    value: `${formatDurationSafe(kpis?.totalDuration || 0)}`,
+                    value: `${formatDurationSafe(kpis?.total_duration || 0)}`,
                     iconSrc: "/assets/icons/ic_clock.svg",
                     iconSx: { width: 12 },
                   },
                   {
                     id: "direction",
                     condition:
-                      agentType !== AGENT_TYPES.CHAT && kpis?.isInbound != null,
-                    value: kpis?.isInbound === false ? "Outbound" : "Inbound",
+                      agentType !== AGENT_TYPES.CHAT && kpis?.is_inbound != null,
+                    value: kpis?.is_inbound === false ? "Outbound" : "Inbound",
                     variant: "chip",
                     iconSrc:
-                      kpis?.isInbound === false
+                      kpis?.is_inbound === false
                         ? "/assets/icons/ic_call_outbound.svg"
                         : "/assets/icons/ic_call_inbound.svg",
                   },

--- a/frontend/src/sections/test-detail/TrialDetail/TrialDetail.jsx
+++ b/frontend/src/sections/test-detail/TrialDetail/TrialDetail.jsx
@@ -53,12 +53,12 @@ const TrialDetail = () => {
               href: `/dashboard/simulate/test/${testId}/${executionId}/optimization_runs`,
             },
             {
-              label: optimizationData?.optimiserName ?? optimizationId,
+              label: optimizationData?.optimiser_name ?? optimizationId,
               isLoading: isLoadingOptimization,
               href: `/dashboard/simulate/test/${testId}/${executionId}/${optimizationId}`,
             },
             {
-              label: trailPromptData?.trialName ?? trialId,
+              label: trailPromptData?.trial_name ?? trialId,
               isLoading: isLoadingTrial,
             },
           ]}

--- a/frontend/src/sections/test/Analytics/TestAnalyticsEvalsCard.jsx
+++ b/frontend/src/sections/test/Analytics/TestAnalyticsEvalsCard.jsx
@@ -91,14 +91,14 @@ const TestAnalyticsEvalsCard = (props) => {
     if (isCompare) {
       Object.entries(data || {}).map(([id, item], index) => {
         item.forEach((temp) => {
-          if (temp.outputType === "score") {
+          if (temp.output_type === "score") {
             if (!obj[temp.name]) {
               obj[temp.name] = [
                 {
                   datasetId: id,
                   name: temp.name,
                   datasetIndex: index,
-                  average: temp.totalAvg || 0,
+                  average: temp.total_avg || 0,
                 },
               ];
             } else {
@@ -106,18 +106,18 @@ const TestAnalyticsEvalsCard = (props) => {
                 datasetId: id,
                 name: temp.name,
                 datasetIndex: index,
-                average: temp.totalAvg || 0,
+                average: temp.total_avg || 0,
               });
             }
           }
-          if (temp.outputType === "Pass/Fail") {
+          if (temp.output_type === "Pass/Fail") {
             if (!obj[temp.name]) {
               obj[temp.name] = [
                 {
                   datasetId: id,
                   name: temp.name,
                   datasetIndex: index,
-                  average: temp.totalPassRate || 0,
+                  average: temp.total_pass_rate || 0,
                 },
               ];
             } else {
@@ -125,7 +125,7 @@ const TestAnalyticsEvalsCard = (props) => {
                 datasetId: id,
                 name: temp.name,
                 datasetIndex: index,
-                average: temp.totalPassRate || 0,
+                average: temp.total_pass_rate || 0,
               });
             }
           }
@@ -136,13 +136,13 @@ const TestAnalyticsEvalsCard = (props) => {
       const redarLabel = [];
       const redarData = [];
       graphData?.forEach((item) => {
-        if (item.outputType === "score") {
-          redarData.push(item.totalAvg);
+        if (item.output_type === "score") {
+          redarData.push(item.total_avg);
           redarLabel.push(item.name);
         }
-        if (item.outputType === "Pass/Fail") {
+        if (item.output_type === "Pass/Fail") {
           redarLabel.push(item.name);
-          redarData.push(item.totalPassRate);
+          redarData.push(item.total_pass_rate);
         }
       });
 
@@ -395,20 +395,20 @@ const TestAnalyticsEvalsCard = (props) => {
                 const headerData = {
                   name: item.name,
                   average:
-                    item.outputType == "choices"
-                      ? item.totalChoicesAvg
-                      : item.outputType == "Pass/Fail"
-                        ? item.totalPassRate || 0
-                        : item.totalAvg || 0,
+                    item.output_type == "choices"
+                      ? item.total_choices_avg
+                      : item.output_type == "Pass/Fail"
+                        ? item.total_pass_rate || 0
+                        : item.total_avg || 0,
                   isNumericEval:
-                    item.outputType == OutputTypes.NUMERIC
+                    item.output_type == OutputTypes.NUMERIC
                       ? true
-                      : item?.isNumericEval,
-                  isNumericEvalPercentage: item?.isNumericEvalPercentage,
+                      : item?.is_numeric_eval,
+                  isNumericEvalPercentage: item?.is_numeric_eval_percentage,
                 };
-                const applySort = Boolean(item?.isNumericEval);
+                const applySort = Boolean(item?.is_numeric_eval);
                 const { graphLabels, graphData } =
-                  item.outputType == "Pass/Fail"
+                  item.output_type == "Pass/Fail"
                     ? getPassFailChartData(item?.result)
                     : getChartData(item?.result, applySort);
 
@@ -423,7 +423,7 @@ const TestAnalyticsEvalsCard = (props) => {
                       padding: "16px",
                     }}
                   >
-                    <ShowComponent condition={item.outputType == "choices"}>
+                    <ShowComponent condition={item.output_type == "choices"}>
                       <DonutChart
                         height={300}
                         data={graphData}
@@ -432,7 +432,7 @@ const TestAnalyticsEvalsCard = (props) => {
                         datasetIndex={selectedIndex}
                       />
                     </ShowComponent>
-                    <ShowComponent condition={item.outputType == "Pass/Fail"}>
+                    <ShowComponent condition={item.output_type == "Pass/Fail"}>
                       <StackBarChart
                         height={300}
                         data={graphData}
@@ -441,7 +441,7 @@ const TestAnalyticsEvalsCard = (props) => {
                         datasetIndex={selectedIndex}
                       />
                     </ShowComponent>
-                    <ShowComponent condition={item.outputType == "score"}>
+                    <ShowComponent condition={item.output_type == "score"}>
                       <AreaChartWrapper
                         data={graphData}
                         graphLabels={graphLabels}

--- a/frontend/src/sections/test/TestRuns/AgenetDefinitionVersionPopover.jsx
+++ b/frontend/src/sections/test/TestRuns/AgenetDefinitionVersionPopover.jsx
@@ -57,7 +57,7 @@ const AgentDefinitionVersionPopoverChild = ({ selectedAgent }) => {
     return agentDefVersions?.pages?.reduce((acc, curr) => {
       const newOptions = curr?.results
         ?.map((result) => ({
-          label: result?.versionNameDisplay,
+          label: result?.version_name_display,
           value: result?.id,
         }))
         ?.filter(

--- a/frontend/src/sections/test/TestRuns/AgentDefinitionPopover.jsx
+++ b/frontend/src/sections/test/TestRuns/AgentDefinitionPopover.jsx
@@ -149,7 +149,7 @@ const AgentDefinitionPopoverChild = ({ simulationType }) => {
           </ShowComponent>
           <ShowComponent condition={!isPending}>
             {agentDefinitions?.map((agent) => {
-              const { id, agentName } = agent;
+              const { id, agent_name: agentName } = agent;
               const labelId = `checkbox-list-label-${id}`;
               const isSelected = selectedAgentDefinition?.id === id;
 
@@ -193,7 +193,7 @@ const AgentDefinitionPopoverChild = ({ simulationType }) => {
                           <ListItemText
                             id={labelId}
                             primary={
-                              agentName.length > 30
+                              agentName?.length > 30
                                 ? agentName.slice(0, 30) + "..."
                                 : agentName
                             }

--- a/frontend/src/sections/test/TestRuns/SDkComponentVoiceTestRun.jsx
+++ b/frontend/src/sections/test/TestRuns/SDkComponentVoiceTestRun.jsx
@@ -40,13 +40,13 @@ const SDkComponentVoiceTestRun = () => {
     >
       <InstructionTitle title="Step 1: Install the SDK" />
       <InstructionCodeCopy
-        text={getCodeBySection("installationGuide")}
+        text={getCodeBySection("installation_guide")}
         language={languageTab}
       />
 
       <InstructionTitle title="Step 2: Create a simulation run" />
       <InstructionCodeCopy
-        text={getCodeBySection("sdkCode")}
+        text={getCodeBySection("sdk_code")}
         language={languageTab}
       />
     </Box>

--- a/frontend/src/sections/test/TestRuns/ScenarioPopover.jsx
+++ b/frontend/src/sections/test/TestRuns/ScenarioPopover.jsx
@@ -76,6 +76,7 @@ const ScenarioPopoverChild = ({ simulationType, testId: testIdProp }) => {
       scenarios: newSelectedScenarios,
     });
   };
+
   return (
     <Box>
       <Box>
@@ -110,7 +111,7 @@ const ScenarioPopoverChild = ({ simulationType, testId: testIdProp }) => {
           <ScenarioSkeletonItem />
         </ShowComponent>
         <ShowComponent condition={!isPending}>
-          {scenarios?.map(({ id, name, datasetRows }) => {
+          {scenarios?.map(({ id, name, dataset_rows:datasetRows }) => {
             const labelId = `checkbox-list-label-${id}`;
             const isSelected = selectedScenarios?.includes(id);
 


### PR DESCRIPTION
Backend responses are now snake_case (post camelCase-middleware removal);
update every consumer that still read camelCase, plus several related bug
fixes across optimization, test-run selectors, the persona/eval pickers, and
the scenario data view.

## Snake_case API alignment

### Optimization (Fix My Agent / Optimize Agent)
- OptimizationResultGrid: read `column_config` (was `columnConfig` → blank grid)
- OptimizationResults common.js: `score_percentage_change`, `is_best`
- AverageEvalCellRenderer: `percentage_change`
- OptimizationResultBar: `is_best`, `score_percentage_change`
- OptimizeAgentHeaderComponent: `optimiser_name`/`optimiser_type`/`provider_logo`/`start_time`; drop stray console.log
- OptimizeAgentHeaderComponent (rerun): map snake `configuration` back to the
  form's camelCase fields via `mapConfigurationToForm` so rerun pre-fills params
- EachOptimizationComponent: `error_message`
- OptimizationDetail / TrialDetail breadcrumbs: `optimiser_name`, `trial_name`
- OptimizationDetailComponent: `trial_name`, `optimisation_name`, `score_percentage_change`
- TrialItems: `column_config`
- OptimizationRunDetail common.js + StatusCellRenderer: `optimisation_name`,
  `started_at`, `no_of_trials`, `optimization_type`, `optimiser_type`
- OptimizingAgentSteps: read `updated_at` and guard date format against null
  (fixes `RangeError: Invalid time value` crash)
- Fix My Agent recommendations (FixMyAgentSections / FixableRecommendations /
  NonFixableRecommendations): `agent_level`, `domain_level`, `system_level`,
  `actionable_recommendations`, `breaking_points`, `branch_category`,
  `human_comparison_summary`

### Eval summary charts
- TestAnalyticsEvalsCard, EvalsCardGraphs, AnalyticsDetails: `output_type`,
  `total_avg`, `total_pass_rate`, `total_choices_avg`, `is_numeric_eval`,
  `is_numeric_eval_percentage` (fixes blank analytics/eval-summary charts across
  simulate analytics, develop-detail, and agent performance analytics)
- getSuffixForCharts: read both casings (shared with camelCase `headerData` callers)

### Test execution detail / KPIs
- KPIs (CriticalIssues, TestRunDetailHeader, FlowAnalysisPanel): `total_calls`,
  `total_duration`, `is_inbound`, `scenario_graphs`
- PerformanceDetails: `test_run_performance_metrics`, `pass_rate`,
  `total_test_runs`, `latest_fail_rate`, `top_performing_scenarios`,
  `scenario_name`, `test_count`, `performance_score`
- FlowAnalysisPanel (branch analysis): `current_path`, `expected_path`,
  `new_nodes`, `new_edges`
- EvalSection (error localizer): `error_localizer_tasks`, `eval_config_id`,
  `error_analysis`
- BaseLineVsReplay (session comparison): `comparison_metrics`
- SDkComponentVoiceTestRun: `installation_guide`, `sdk_code`

### Simulator agents
- EditSimulatorAgentDialog: `voice_provider`, `voice_name`,
  `interrupt_sensitivity`, `conversation_speed`, `finished_speaking_sensitivity`,
  `llm_temperature`, `max_call_duration_in_minutes`, `initial_message_delay`,
  `initial_message`

### Test-run selectors
- AgentDefinitionPopover: `agent_name`
- AgenetDefinitionVersionPopover / CreateScenarioView: `version_name_display`
- ScenarioPopover: `dataset_rows`
- CreateScenarioView: `agent_name`, `agent_type`
- LanguageMultiSelect: checkbox icon color action.selected → action.default

### Scenario detail
- DatasetScenarioView: `scenario_type` (was redirecting away from dataset scenarios)

## Persona picker
- Fix header select-all selecting only the last row (functional state updater in
  handleToggleSelect)
- Add explicit `lockedFilters` prop (always-sent, hidden, non-removable),
  mirroring the EvalPicker pattern; backward-compatible with personaCreateEditType

## Eval picker
- Use the scoped get_evals_list endpoint only for source dataset/experiment;
  other sources fall back to listEvalTemplates

## Scenario data view
- Report true `total_rows` to the server-side grid so added / AI-generated rows
  reflect without a reload or purge flash (DevelopDataV2 datasource)
- Invalidate `["scenario-detail", scenarioId]` on row add/delete and column add
  via useRefreshScenarioGrid so the "No of Datapoints" count stays in sync
- Add showEvals view option (default true); scenario view sets it false to skip
  the get_evals_list?eval_type=user call it doesn't need

Note: backend reads converted to snake_case only; local variable names,
react-hook-form field names, chart-component prop contracts, and the
frontend-only `isVisible` flag are intentionally left camelCase.

Closes TH-5908, TH-5818, TH-5847, TH-5867, TH-5892, TH-5870, TH-5887, TH-5840, TH-5878, TH-5874, TH-5872, TH-5896, TH-5856
