### PR TITLE
fix: bound model serving and observability HTTP calls

### DIFF
--- a/futureagi/agentic_eval/clients/model_serving_client.py
+++ b/futureagi/agentic_eval/clients/model_serving_client.py
@@ -1,8 +1,11 @@
+import os
 from typing import Any
 
 import requests
 
-from ..clients.constants import MODEL_SERVING_BASE_URL
+from .constants import MODEL_SERVING_BASE_URL
+
+MODEL_SERVING_TIMEOUT = int(os.getenv("MODEL_SERVING_TIMEOUT", "120"))
 
 
 class ModelServingClient:
@@ -21,13 +24,20 @@ class ModelServingClient:
         """
         if cls._instance is None:
             if base_url is None:
-                raise ValueError("base_url must be provided for the first instance creation.")
+                raise ValueError(
+                    "base_url must be provided for the first instance creation."
+                )
             _instance = super().__new__(cls)
             _instance.base_url = base_url
             cls._instance = _instance
         return cls._instance
 
-    def get(self, endpoint: str, params: dict[str, Any] | None = None, headers: dict[str, str] | None = None) -> dict[str, Any]:
+    def get(
+        self,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
         """
         Sends a GET request to the specified endpoint.
 
@@ -44,13 +54,25 @@ class ModelServingClient:
             requests.HTTPError: If the server responds with a non-2xx status code.
         """
         try:
-            response = requests.get(f"{self.base_url}/{endpoint}", params=params, headers=headers)
+            response = requests.get(
+                f"{self.base_url}/{endpoint}",
+                params=params,
+                headers=headers,
+                timeout=MODEL_SERVING_TIMEOUT,
+            )
             response.raise_for_status()  # Raise an exception for HTTP errors
             return response.json()  # Return the JSON response as a dictionary
         except requests.RequestException as exc:
-            raise RuntimeError(f"An error occurred while requesting {exc.request.url!r}.") from exc
+            raise RuntimeError(
+                f"An error occurred while requesting {exc.request.url!r}."
+            ) from exc
 
-    def post(self, endpoint: str, json: dict[str, Any] | None = None, headers: dict[str, str] | None = None) -> dict[str, Any]:
+    def post(
+        self,
+        endpoint: str,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
         """
         Sends a POST request to the specified endpoint.
 
@@ -67,8 +89,15 @@ class ModelServingClient:
             requests.HTTPError: If the server responds with a non-2xx status code.
         """
         try:
-            response = requests.post(f"{self.base_url}/{endpoint}", json=json, headers=headers)
+            response = requests.post(
+                f"{self.base_url}/{endpoint}",
+                json=json,
+                headers=headers,
+                timeout=MODEL_SERVING_TIMEOUT,
+            )
             response.raise_for_status()  # Raise an exception for HTTP errors
             return response.json()  # Return the JSON response as a dictionary
         except requests.RequestException as exc:
-            raise RuntimeError(f"An error occurred while requesting {exc.request.url!r}.")
+            raise RuntimeError(
+                f"An error occurred while requesting {exc.request.url!r}."
+            )

--- a/futureagi/agentic_eval/clients/tests/test_model_serving_client.py
+++ b/futureagi/agentic_eval/clients/tests/test_model_serving_client.py
@@ -1,0 +1,71 @@
+import importlib
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agentic_eval.clients import model_serving_client
+
+
+@pytest.fixture(autouse=True)
+def reset_model_serving_client_singleton():
+    model_serving_client.ModelServingClient._instance = None
+    yield
+    model_serving_client.ModelServingClient._instance = None
+
+
+def test_timeout_reads_shared_model_serving_env_var(monkeypatch):
+    monkeypatch.setenv("MODEL_SERVING_TIMEOUT", "45")
+    reloaded = importlib.reload(model_serving_client)
+
+    try:
+        assert reloaded.MODEL_SERVING_TIMEOUT == 45
+    finally:
+        monkeypatch.delenv("MODEL_SERVING_TIMEOUT", raising=False)
+        importlib.reload(model_serving_client)
+
+
+def test_get_passes_default_timeout():
+    response = Mock()
+    response.json.return_value = {"ok": True}
+
+    with patch(
+        "agentic_eval.clients.model_serving_client.requests.get",
+        return_value=response,
+    ) as mock_get:
+        client = model_serving_client.ModelServingClient(
+            "https://model-serving.example"
+        )
+
+        assert client.get("health", params={"check": "ready"}) == {"ok": True}
+
+    mock_get.assert_called_once_with(
+        "https://model-serving.example/health",
+        params={"check": "ready"},
+        headers=None,
+        timeout=model_serving_client.MODEL_SERVING_TIMEOUT,
+    )
+    response.raise_for_status.assert_called_once()
+
+
+def test_post_passes_default_timeout():
+    response = Mock()
+    response.json.return_value = {"id": "completion-1"}
+
+    with patch(
+        "agentic_eval.clients.model_serving_client.requests.post",
+        return_value=response,
+    ) as mock_post:
+        client = model_serving_client.ModelServingClient(
+            "https://model-serving.example"
+        )
+
+        result = client.post("generate", json={"prompt": "hello"})
+
+    assert result == {"id": "completion-1"}
+    mock_post.assert_called_once_with(
+        "https://model-serving.example/generate",
+        json={"prompt": "hello"},
+        headers=None,
+        timeout=model_serving_client.MODEL_SERVING_TIMEOUT,
+    )
+    response.raise_for_status.assert_called_once()

--- a/futureagi/tracer/services/observability_providers.py
+++ b/futureagi/tracer/services/observability_providers.py
@@ -15,6 +15,7 @@ logger = structlog.get_logger(__name__)
 
 VAPI_PAGE_LIMIT = 100
 VAPI_MAX_PAGES = 10
+OBSERVABILITY_VERIFY_TIMEOUT_SECONDS = 30
 
 
 class ObservabilityService:
@@ -36,7 +37,11 @@ class ObservabilityService:
         else:
             raise ValueError(f"Invalid choice for provider: {provider}")
         headers = {"Authorization": f"Bearer {api_key}"}
-        response = requests.get(api_endpoint, headers=headers)
+        response = requests.get(
+            api_endpoint,
+            headers=headers,
+            timeout=OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+        )
         return response.status_code
 
     @staticmethod
@@ -59,7 +64,7 @@ class ObservabilityService:
         response = requests.get(
             endpoint,
             headers=headers,
-            timeout=30,
+            timeout=OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
         )
         return response.status_code
 

--- a/futureagi/tracer/tests/test_observability_providers.py
+++ b/futureagi/tracer/tests/test_observability_providers.py
@@ -76,6 +76,58 @@ class TestValidateAgentApiKey:
         assert result is None
 
 
+class TestVerifyApiKey:
+    """Tests for provider API key verification requests."""
+
+    @patch("tracer.services.observability_providers.requests.get")
+    def test_vapi_verification_request_uses_timeout(self, mock_requests_get):
+        from tracer.constants.external_endpoints import ObservabilityRoutes
+        from tracer.services.observability_providers import (
+            OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+            ObservabilityService,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 204
+        mock_requests_get.return_value = mock_response
+
+        result = ObservabilityService.verify_api_key(
+            ProviderChoices.VAPI,
+            "vapi-api-key",
+        )
+
+        assert result == 204
+        mock_requests_get.assert_called_once_with(
+            f"{ObservabilityRoutes.VAPI_CALL_URL.value}?limit=0",
+            headers={"Authorization": "Bearer vapi-api-key"},
+            timeout=OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+        )
+
+    @patch("tracer.services.observability_providers.requests.get")
+    def test_retell_verification_request_uses_timeout(self, mock_requests_get):
+        from tracer.constants.external_endpoints import ObservabilityRoutes
+        from tracer.services.observability_providers import (
+            OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+            ObservabilityService,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_requests_get.return_value = mock_response
+
+        result = ObservabilityService.verify_api_key(
+            ProviderChoices.RETELL,
+            "retell-api-key",
+        )
+
+        assert result == 200
+        mock_requests_get.assert_called_once_with(
+            f"{ObservabilityRoutes.RETELL_LIST_ASSISTANTS_URL.value}?limit=1",
+            headers={"Authorization": "Bearer retell-api-key"},
+            timeout=OBSERVABILITY_VERIFY_TIMEOUT_SECONDS,
+        )
+
+
 class TestFetchVapiLogs:
     """Tests for _fetch_vapi_logs method."""
 


### PR DESCRIPTION
## Summary

Part of #499.

This adds bounded HTTP waits to the two hot paths called out in the issue:

- `ModelServingClient.get()` / `.post()` now pass a shared 120s timeout.
- `ObservabilityService.verify_api_key()` now uses the same 30s timeout as assistant verification.
- Regression tests assert the timeout kwargs for the new model-serving client calls and provider verification calls.

## Why

`requests` waits indefinitely when no timeout is provided. A slow or half-open upstream can pin a Django or eval worker instead of failing in a bounded amount of time.

## Validation

- `python -m pytest futureagi/agentic_eval/clients/tests/test_model_serving_client.py -q --confcutdir=futureagi/agentic_eval/clients/tests`
- `python -m py_compile futureagi/agentic_eval/clients/model_serving_client.py futureagi/agentic_eval/clients/tests/test_model_serving_client.py futureagi/tracer/services/observability_providers.py futureagi/tracer/tests/test_observability_providers.py`
- `python -m black --check --target-version py312 futureagi/agentic_eval/clients/model_serving_client.py futureagi/agentic_eval/clients/tests/test_model_serving_client.py futureagi/tracer/services/observability_providers.py futureagi/tracer/tests/test_observability_providers.py`
- `git diff --check`