### PR TITLE
fix: use stable eval keys for preprocessing

### DIFF
--- a/futureagi/evaluations/engine/preprocessing.py
+++ b/futureagi/evaluations/engine/preprocessing.py
@@ -187,22 +187,25 @@ def _resolve_fid_input(value):
     return resolved
 
 
-def register_preprocessor(eval_name):
-    """Decorator to register a preprocessor for an eval type."""
+def register_preprocessor(*eval_names):
+    """Decorator to register a preprocessor for one or more eval keys."""
 
     def decorator(func):
-        PREPROCESSORS[eval_name] = func
+        for eval_name in eval_names:
+            PREPROCESSORS[eval_name] = func
         return func
 
     return decorator
 
 
-def preprocess_inputs(eval_name, inputs):
+def preprocess_inputs(eval_name, inputs, fallback_eval_name=None):
     """
     Run preprocessing for a specific eval if a preprocessor is registered.
     Returns the inputs dict with any additional computed fields.
     """
     preprocessor = PREPROCESSORS.get(eval_name)
+    if not preprocessor and fallback_eval_name:
+        preprocessor = PREPROCESSORS.get(fallback_eval_name)
     if not preprocessor:
         return inputs
 
@@ -213,7 +216,7 @@ def preprocess_inputs(eval_name, inputs):
         return inputs
 
 
-@register_preprocessor("clip_score")
+@register_preprocessor("clip_score", "ClipScore")
 def _preprocess_clip(inputs):
     """
     Pre-compute CLIP embeddings for images and text.
@@ -290,7 +293,7 @@ def _preprocess_clip(inputs):
     return inputs
 
 
-@register_preprocessor("fid_score")
+@register_preprocessor("fid_score", "FidScore")
 def _preprocess_fid(inputs):
     """
     Pre-compute Inception features for FID.
@@ -367,14 +370,14 @@ def _preprocess_fid(inputs):
     return inputs
 
 
-@register_preprocessor("image_properties")
+@register_preprocessor("image_properties", "ImageProperties")
 def _preprocess_image_properties(inputs):
     """Resolve URL input to base64 for the image_properties eval."""
     inputs["text"] = _resolve_image_input(inputs.get("text"))
     return inputs
 
 
-@register_preprocessor("psnr")
+@register_preprocessor("psnr", "Psnr")
 def _preprocess_psnr(inputs):
     """Resolve URL inputs to base64 for PSNR (output, expected)."""
     inputs["output"] = _resolve_image_input(inputs.get("output"))
@@ -382,7 +385,7 @@ def _preprocess_psnr(inputs):
     return inputs
 
 
-@register_preprocessor("ssim")
+@register_preprocessor("ssim", "Ssim")
 def _preprocess_ssim(inputs):
     """Resolve URL inputs to base64 for SSIM (output, expected)."""
     inputs["output"] = _resolve_image_input(inputs.get("output"))
@@ -488,7 +491,7 @@ def _preprocess_dead_air_detection(inputs):
     return inputs
 
 
-@register_preprocessor("meteor_score")
+@register_preprocessor("meteor_score", "MeteorScore")
 def _preprocess_meteor(inputs):
     """Compute METEOR via NLTK on the backend, inject the score as a kwarg.
 

--- a/futureagi/evaluations/engine/runner.py
+++ b/futureagi/evaluations/engine/runner.py
@@ -158,7 +158,9 @@ def run_eval(request: EvalRequest) -> EvalResult:
     # 3.5. Preprocess inputs (e.g., compute embeddings for CLIP/FID)
     from evaluations.engine.preprocessing import preprocess_inputs
 
-    run_params = preprocess_inputs(eval_template.name, run_params)
+    run_params = preprocess_inputs(
+        eval_type_id, run_params, fallback_eval_name=eval_template.name
+    )
 
     # 4. Execute
     start_time = time.time()

--- a/futureagi/evaluations/engine/tests/test_image_preprocessing.py
+++ b/futureagi/evaluations/engine/tests/test_image_preprocessing.py
@@ -28,8 +28,54 @@ from evaluations.engine.preprocessing import (
 
 
 def test_image_preprocessors_registered():
-    for name in ("image_properties", "psnr", "ssim"):
+    for name in (
+        "clip_score",
+        "ClipScore",
+        "fid_score",
+        "FidScore",
+        "image_properties",
+        "ImageProperties",
+        "psnr",
+        "Psnr",
+        "ssim",
+        "Ssim",
+    ):
         assert name in PREPROCESSORS, f"{name} preprocessor must be registered"
+
+
+def test_preprocess_inputs_prefers_stable_eval_type_id(monkeypatch):
+    calls = []
+
+    def stable_preprocessor(inputs):
+        calls.append("stable")
+        return inputs
+
+    def editable_name_preprocessor(inputs):
+        calls.append("editable")
+        return inputs
+
+    monkeypatch.setitem(PREPROCESSORS, "ClipScore", stable_preprocessor)
+    monkeypatch.setitem(
+        PREPROCESSORS, "Renamed Image Quality Eval", editable_name_preprocessor
+    )
+
+    preprocess_inputs("ClipScore", {}, fallback_eval_name="Renamed Image Quality Eval")
+
+    assert calls == ["stable"]
+
+
+def test_preprocess_inputs_falls_back_to_template_slug(monkeypatch):
+    calls = []
+
+    def slug_preprocessor(inputs):
+        calls.append("slug")
+        return inputs
+
+    monkeypatch.setitem(PREPROCESSORS, "clip_score", slug_preprocessor)
+
+    preprocess_inputs("CustomCodeEval", {}, fallback_eval_name="clip_score")
+
+    assert calls == ["slug"]
 
 
 # ---------------------------------------------------------------------------

--- a/futureagi/model_hub/views/eval_runner.py
+++ b/futureagi/model_hub/views/eval_runner.py
@@ -2109,7 +2109,10 @@ class EvaluationRunner:
             # Preprocess inputs for code evals that need external data (e.g. CLIP embeddings)
             from evaluations.engine.preprocessing import preprocess_inputs
 
-            _mapped = preprocess_inputs(self.eval_template.name, _mapped)
+            eval_type_id = (self.eval_template.config or {}).get("eval_type_id")
+            _mapped = preprocess_inputs(
+                eval_type_id, _mapped, fallback_eval_name=self.eval_template.name
+            )
 
         # Inject row_context when full_row data injection is enabled.
         # data_injection lives in the user's eval metric config (run_config)

--- a/futureagi/model_hub/views/utils/evals.py
+++ b/futureagi/model_hub/views/utils/evals.py
@@ -335,7 +335,10 @@ def run_eval_func(
         if _is_code_eval:
             from evaluations.engine.preprocessing import preprocess_inputs
 
-            _run_kwargs = preprocess_inputs(template.name, _run_kwargs)
+            eval_type_id = (template.config or {}).get("eval_type_id")
+            _run_kwargs = preprocess_inputs(
+                eval_type_id, _run_kwargs, fallback_eval_name=template.name
+            )
 
         # Apply the shared empty-input rules so the playground (and
         # every other caller of run_eval_func — composite children,


### PR DESCRIPTION
Fixes #301.

Summary:
- dispatch preprocessing by stable eval type ids before falling back to the template slug
- register ClipScore/FidScore aliases alongside the existing snake_case keys
- keep the slug fallback for current CustomCodeEval-backed system templates
- add regression coverage for stable-key dispatch and fallback behavior

Validation:
- focused preprocessing tests: 41 passed
- `python -m py_compile futureagi/evaluations/engine/preprocessing.py futureagi/evaluations/engine/runner.py futureagi/evaluations/engine/tests/test_image_preprocessing.py futureagi/model_hub/views/eval_runner.py futureagi/model_hub/views/utils/evals.py`
- `git diff --check`