### PR TITLE
fix: align auth rate-limit window and ttl

### DIFF
--- a/futureagi/accounts/authentication.py
+++ b/futureagi/accounts/authentication.py
@@ -33,6 +33,7 @@ logger = structlog.get_logger(__name__)
 # Rate limiting settings with defaults
 MAX_LOGIN_ATTEMPTS_PER_HOUR: int = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOUR", 10)
 IP_BLOCK_DURATION: int = getattr(settings, "IP_BLOCK_DURATION", 3600)
+RATE_LIMIT_WINDOW_SECONDS: int = 3600
 
 
 class APIKeyAuthentication(BaseAuthentication):
@@ -608,7 +609,9 @@ class AuthMonitoringMiddleware:
             now = time.time()
 
             # Remove requests older than 1 hour
-            requests = [req for req in requests if now - req < 1000]
+            requests = [
+                req for req in requests if now - req < RATE_LIMIT_WINDOW_SECONDS
+            ]
 
             if len(requests) >= MAX_LOGIN_ATTEMPTS_PER_HOUR:
                 cache.set(f"rate_limit_{client_ip}", True, IP_BLOCK_DURATION)
@@ -618,7 +621,9 @@ class AuthMonitoringMiddleware:
                 )
 
             requests.append(now)
-            cache.set(f"rate_limit_requests_{client_ip}", requests, 1200)
+            cache.set(
+                f"rate_limit_requests_{client_ip}", requests, RATE_LIMIT_WINDOW_SECONDS
+            )
 
         if (
             request.path.endswith("login/")
@@ -638,7 +643,9 @@ class AuthMonitoringMiddleware:
             now = time.time()
 
             # Remove requests older than 1 hour
-            requests = [req for req in requests if now - req < 1000]
+            requests = [
+                req for req in requests if now - req < RATE_LIMIT_WINDOW_SECONDS
+            ]
 
             if len(requests) >= MAX_LOGIN_ATTEMPTS_PER_HOUR:
                 cache.set(f"blocked_ip_{client_ip}", True, IP_BLOCK_DURATION)
@@ -649,7 +656,7 @@ class AuthMonitoringMiddleware:
                 )
 
             requests.append(now)
-            cache.set(f"ip_requests_{client_ip}", requests, 1200)
+            cache.set(f"ip_requests_{client_ip}", requests, RATE_LIMIT_WINDOW_SECONDS)
 
         return self.get_response(request)
 

--- a/futureagi/accounts/tests/test_login_error_codes.py
+++ b/futureagi/accounts/tests/test_login_error_codes.py
@@ -15,7 +15,7 @@ Covers:
 
 import json
 import time
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from django.core.cache import cache
@@ -480,6 +480,7 @@ class TestMiddlewareIpBlockedRouting:
     def test_ip_rate_limited_error_code(self):
         """When IP requests hit the threshold, middleware returns LOGIN_IP_RATE_LIMITED."""
         from django.conf import settings
+        from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
 
         max_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOUR", 10)
         now = time.time()
@@ -488,7 +489,7 @@ class TestMiddlewareIpBlockedRouting:
         cache.set(
             f"ip_requests_{self.TEST_IP}",
             [now - i for i in range(max_attempts)],
-            1200,
+            RATE_LIMIT_WINDOW_SECONDS,
         )
         middleware = self._middleware()
         resp = middleware(self._request("/api/accounts/token/"))
@@ -496,6 +497,38 @@ class TestMiddlewareIpBlockedRouting:
         body = json.loads(resp.content)
         assert body["result"]["error_code"] == "LOGIN_IP_RATE_LIMITED"
         assert body["result"]["blocked"] is True
+
+    def test_ip_rate_limit_keeps_requests_for_full_hour(self):
+        """Requests older than 1000s but inside the 1h window still count."""
+        from django.conf import settings
+        from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
+
+        max_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOUR", 10)
+        now = time.time()
+        cache.set(
+            f"ip_requests_{self.TEST_IP}",
+            [now - (RATE_LIMIT_WINDOW_SECONDS - 1) + i for i in range(max_attempts)],
+            RATE_LIMIT_WINDOW_SECONDS,
+        )
+        middleware = self._middleware()
+        resp = middleware(self._request("/api/accounts/token/"))
+        assert resp.status_code == 403
+        body = json.loads(resp.content)
+        assert body["result"]["error_code"] == "LOGIN_IP_RATE_LIMITED"
+
+    def test_ip_request_cache_ttl_matches_full_window(self):
+        from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
+
+        middleware = self._middleware()
+        with patch("accounts.authentication.cache.set", wraps=cache.set) as cache_set:
+            resp = middleware(self._request("/api/accounts/token/"))
+
+        assert resp.status_code == 200
+        cache_set.assert_any_call(
+            f"ip_requests_{self.TEST_IP}",
+            ANY,
+            RATE_LIMIT_WINDOW_SECONDS,
+        )
 
     def test_non_blocked_ip_passes_through(self):
         """Unblocked IP is not intercepted — passes through to next handler."""
@@ -535,6 +568,7 @@ class TestMiddlewarePasswordResetRouting:
 
     def test_rate_limit_trigger_on_password_reset(self):
         from django.conf import settings
+        from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
 
         max_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOUR", 10)
         now = time.time()
@@ -543,13 +577,45 @@ class TestMiddlewarePasswordResetRouting:
         cache.set(
             f"rate_limit_requests_{self.TEST_IP}",
             [now - i for i in range(max_attempts)],
-            1200,
+            RATE_LIMIT_WINDOW_SECONDS,
         )
         middleware = self._middleware()
         resp = middleware(self._request())
         assert resp.status_code == 403
         body = json.loads(resp.content)
         assert body["result"]["error_code"] == "LOGIN_PASSWORD_RESET_RATE_LIMITED"
+
+    def test_password_reset_rate_limit_keeps_requests_for_full_hour(self):
+        """Requests older than 1000s but inside the 1h window still count."""
+        from django.conf import settings
+        from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
+
+        max_attempts = getattr(settings, "MAX_LOGIN_ATTEMPTS_PER_HOUR", 10)
+        now = time.time()
+        cache.set(
+            f"rate_limit_requests_{self.TEST_IP}",
+            [now - (RATE_LIMIT_WINDOW_SECONDS - 1) + i for i in range(max_attempts)],
+            RATE_LIMIT_WINDOW_SECONDS,
+        )
+        middleware = self._middleware()
+        resp = middleware(self._request())
+        assert resp.status_code == 403
+        body = json.loads(resp.content)
+        assert body["result"]["error_code"] == "LOGIN_PASSWORD_RESET_RATE_LIMITED"
+
+    def test_password_reset_request_cache_ttl_matches_full_window(self):
+        from accounts.authentication import RATE_LIMIT_WINDOW_SECONDS
+
+        middleware = self._middleware()
+        with patch("accounts.authentication.cache.set", wraps=cache.set) as cache_set:
+            resp = middleware(self._request())
+
+        assert resp.status_code == 200
+        cache_set.assert_any_call(
+            f"rate_limit_requests_{self.TEST_IP}",
+            ANY,
+            RATE_LIMIT_WINDOW_SECONDS,
+        )
 
     def test_password_reset_response_shape(self):
         cache.set(f"rate_limit_{self.TEST_IP}", True, 3600)


### PR DESCRIPTION
Fixes #383.

Summary:
- add a shared one-hour rate-limit window constant
- use that same window for request pruning and cache TTLs in both auth middleware paths
- add regressions where requests older than 1000s but still inside one hour continue to count
- assert the login/token/signup and password-reset request caches use the full one-hour TTL

Validation:
- `python -m py_compile futureagi/accounts/authentication.py futureagi/accounts/tests/test_login_error_codes.py`
- `git diff --check`