### PR TITLE
fix: decouple team invite email failures

### DIFF
--- a/futureagi/accounts/tests/test_workspace_management.py
+++ b/futureagi/accounts/tests/test_workspace_management.py
@@ -13,6 +13,8 @@ Comprehensive tests for workspace_management.py endpoints:
 - ManageTeamView
 """
 
+from unittest.mock import patch
+
 import pytest
 from rest_framework import status
 
@@ -828,6 +830,47 @@ class TestManageTeamViewPost:
             status.HTTP_400_BAD_REQUEST,  # May fail due to email sending
             status.HTTP_429_TOO_MANY_REQUESTS,  # User limit reached
         ]
+
+    @patch(
+        "accounts.views.workspace_management.email_helper",
+        side_effect=RuntimeError("email delivery failed"),
+    )
+    def test_add_team_member_persists_when_invite_email_fails(
+        self,
+        mock_email_helper,
+        auth_client,
+        workspace,
+        django_capture_on_commit_callbacks,
+    ):
+        """Invite email failure should not undo the user or workspace membership."""
+        email = "emailfailteam@futureagi.com"
+
+        with django_capture_on_commit_callbacks(execute=True):
+            response = auth_client.post(
+                "/accounts/team/users/",
+                {
+                    "members": [
+                        {
+                            "email": email,
+                            "name": "Email Failure Team Member",
+                            "organization_role": OrganizationRoles.MEMBER,
+                        }
+                    ]
+                },
+                format="json",
+            )
+
+        assert response.status_code in [
+            status.HTTP_200_OK,
+            status.HTTP_201_CREATED,
+        ]
+        new_member = User.objects.get(email=email, organization=workspace.organization)
+        assert WorkspaceMembership.no_workspace_objects.filter(
+            workspace=workspace,
+            user=new_member,
+            is_active=True,
+        ).exists()
+        mock_email_helper.assert_called_once()
 
     def test_add_team_member_as_admin_forbidden(self, admin_client, workspace):
         """Admin cannot add team members (owner only)."""

--- a/futureagi/accounts/views/workspace_management.py
+++ b/futureagi/accounts/views/workspace_management.py
@@ -1777,6 +1777,19 @@ class ManageTeamView(APIView):
     permission_classes = [IsAuthenticated]
     _gm = GeneralMethods()
 
+    @staticmethod
+    def _send_member_invite_after_commit(subject, template, context, recipients):
+        def send_invite():
+            try:
+                email_helper(subject, template, context, recipients)
+            except Exception:
+                logger.exception(
+                    "Failed to send workspace member invite email",
+                    recipients=recipients,
+                )
+
+        transaction.on_commit(send_invite)
+
     def get(self, request, *args, **kwargs):
         user = request.user
         organization = resolve_org(request)
@@ -2233,43 +2246,44 @@ class ManageTeamView(APIView):
                             #     )
                             #     continue
 
-                        # Create new user for this organization
-                        new_member = User.objects.create(
-                            email=member_data["email"],
-                            name=member_data["name"],
-                            organization=organization,
-                            organization_role=org_role,  # None for workspace-level roles
-                            is_active=False,
-                            invited_by=request.user,
-                        )
-                        password = generate_password()
-                        new_member.set_password(password)
-                        new_member.save()
+                        with transaction.atomic():
+                            # Create new user for this organization
+                            new_member = User.objects.create(
+                                email=member_data["email"],
+                                name=member_data["name"],
+                                organization=organization,
+                                organization_role=org_role,  # None for workspace-level roles
+                                is_active=False,
+                                invited_by=request.user,
+                            )
+                            password = generate_password()
+                            new_member.set_password(password)
+                            new_member.save()
 
-                        # Add user to workspace with determined workspace role
-                        self._add_user_to_workspace(
-                            new_member,
-                            workspace,
-                            workspace_role,
-                            request.user,
-                        )
+                            # Add user to workspace with determined workspace role
+                            self._add_user_to_workspace(
+                                new_member,
+                                workspace,
+                                workspace_role,
+                                request.user,
+                            )
 
-                        token = default_token_generator.make_token(new_member)
-                        uidb64 = urlsafe_base64_encode(force_bytes(new_member.pk))
-                        email_helper(
-                            f"You are invited by {organization.display_name if organization.display_name else organization.name} - Future AGI",
-                            "member_invite.html",
-                            {
-                                "password": password,
-                                "email": member_data["email"],
-                                "uid": str(uidb64),
-                                "token": token,
-                                "workspace_name": workspace.name,
-                                "app_url": settings.APP_URL,
-                                "ssl": ssl,
-                            },
-                            [member_data["email"]],
-                        )
+                            token = default_token_generator.make_token(new_member)
+                            uidb64 = urlsafe_base64_encode(force_bytes(new_member.pk))
+                            self._send_member_invite_after_commit(
+                                f"You are invited by {organization.display_name if organization.display_name else organization.name} - Future AGI",
+                                "member_invite.html",
+                                {
+                                    "password": password,
+                                    "email": member_data["email"],
+                                    "uid": str(uidb64),
+                                    "token": token,
+                                    "workspace_name": workspace.name,
+                                    "app_url": settings.APP_URL,
+                                    "ssl": ssl,
+                                },
+                                [member_data["email"]],
+                            )
                         created_members.append(UserSerializer(new_member).data)
 
                     except IntegrityError:


### PR DESCRIPTION
Fixes #159.

Summary:
- wrap the new-member and workspace-membership write in an explicit atomic block
- send the invite email from an `on_commit` callback and log delivery failures instead of failing the request
- add a regression where `email_helper` raises and the member plus workspace membership still persist

Validation:
- `python -m py_compile futureagi/accounts/views/workspace_management.py futureagi/accounts/tests/test_workspace_management.py`
- `git diff --check`