### PR TITLE
fix: bound websocket eval aggregation query

### DIFF
--- a/futureagi/tracer/socket.py
+++ b/futureagi/tracer/socket.py
@@ -13,6 +13,8 @@ from tracer.utils.filters import FilterEngine
 
 # from tracer.models.observation_span import ObservationSpan
 
+EVALUATION_QUERY_ROW_LIMIT = 5000
+
 
 class GraphDataConsumer(DataConsumer):
     async def receive_json(self, content):
@@ -331,10 +333,24 @@ class GraphDataConsumer(DataConsumer):
         query, having = FilterEngine.get_sql_filter_conditions_for_eval_metrics(
             self.filters, query
         )
-        query += f"""
-        GROUP BY timestamp, config_id, tcec.name{", id_trace" if self.graph == 'trace' else ''}{", id_span" if self.graph == 'span' else ""}{';' if not having else " "+having}"""
+        group_by = (
+            "timestamp, config_id, tcec.name"
+            f"{', id_trace' if self.graph == 'trace' else ''}"
+            f"{', id_span' if self.graph == 'span' else ''}"
+        )
+        having_clause = f" {having.strip().rstrip(';')}" if having else ""
+        query = f"""
+        SELECT *
+        FROM (
+            {query}
+            GROUP BY {group_by}{having_clause}
+            ORDER BY timestamp DESC
+            LIMIT %s
+        ) bounded_eval_metrics
+        ORDER BY timestamp ASC;
+        """
 
-        params = [self.project_id for _ in range(5)]
+        params = [self.project_id for _ in range(5)] + [EVALUATION_QUERY_ROW_LIMIT]
         rows = await self.fetch_raw_data(query, params)
 
         if self.eval_id:

--- a/futureagi/tracer/tests/test_graph_data_consumer.py
+++ b/futureagi/tracer/tests/test_graph_data_consumer.py
@@ -1,0 +1,26 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tracer.socket import EVALUATION_QUERY_ROW_LIMIT, GraphDataConsumer
+
+
+@pytest.mark.asyncio
+async def test_send_evaluation_data_limits_grouped_query():
+    consumer = GraphDataConsumer()
+    consumer.project_id = "project-1"
+    consumer.filters = []
+    consumer.interval = "hour"
+    consumer.property = ""
+    consumer.graph = "charts"
+    consumer.eval_id = ""
+    consumer.fetch_raw_data = AsyncMock(return_value=[])
+    consumer.send_json = AsyncMock()
+
+    await consumer.send_evaluation_data()
+
+    query, params = consumer.fetch_raw_data.call_args.args
+    assert "bounded_eval_metrics" in query
+    assert "LIMIT %s" in query
+    assert params[-1] == EVALUATION_QUERY_ROW_LIMIT
+    consumer.send_json.assert_called_once()


### PR DESCRIPTION
Fixes #307.

## Summary
- bounds the WebSocket evaluation aggregation with a parameterized row limit
- keeps the existing response order by wrapping the limited result set and sorting by timestamp ascending
- adds coverage that the evaluation query includes the bound and passes the limit as a query parameter

## Validation
- python -m py_compile futureagi\tracer\socket.py futureagi\tracer\tests\test_graph_data_consumer.py