### PR TITLE
fix: dataset upload redirects to /undefined instead of /dataset_id

### DIFF
--- a/frontend/src/sections/develop/AddDatasetDrawer/CloneDevelopDataset.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/CloneDevelopDataset.jsx
@@ -67,7 +67,7 @@ const CloneDevelopDataset = ({ open, onClose, refreshGrid }) => {
       queryClient.invalidateQueries({
         queryKey: ["develop", "dataset-name-list"],
       });
-      navigate(`/dashboard/develop/${data?.data?.result?.dataset_id ?? data?.data?.result?.datasetId}?tab=data`);
+      navigate(`/dashboard/develop/${data?.data?.result?.dataset_id}?tab=data`);
       refreshGrid();
     },
   });

--- a/frontend/src/sections/develop/AddDatasetDrawer/CloneDevelopDataset.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/CloneDevelopDataset.jsx
@@ -67,7 +67,7 @@ const CloneDevelopDataset = ({ open, onClose, refreshGrid }) => {
       queryClient.invalidateQueries({
         queryKey: ["develop", "dataset-name-list"],
       });
-      navigate(`/dashboard/develop/${data?.data?.result?.datasetId}?tab=data`);
+      navigate(`/dashboard/develop/${data?.data?.result?.dataset_id ?? data?.data?.result?.datasetId}?tab=data`);
       refreshGrid();
     },
   });

--- a/frontend/src/sections/develop/AddDatasetDrawer/ImportFromHuggingFace.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/ImportFromHuggingFace.jsx
@@ -96,7 +96,7 @@ const ImportFromHuggingFace = ({ open, onClose, refreshGrid }) => {
       queryClient.invalidateQueries({
         queryKey: ["develop", "dataset-name-list"],
       });
-      navigate(`/dashboard/develop/${data?.data?.result?.dataset_id ?? data?.data?.result?.datasetId}?tab=data`);
+      navigate(`/dashboard/develop/${data?.data?.result?.dataset_id}?tab=data`);
       onCloseClick();
     },
     onError: (error) => {

--- a/frontend/src/sections/develop/AddDatasetDrawer/ImportFromHuggingFace.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/ImportFromHuggingFace.jsx
@@ -96,7 +96,7 @@ const ImportFromHuggingFace = ({ open, onClose, refreshGrid }) => {
       queryClient.invalidateQueries({
         queryKey: ["develop", "dataset-name-list"],
       });
-      navigate(`/dashboard/develop/${data?.data?.result?.datasetId}?tab=data`);
+      navigate(`/dashboard/develop/${data?.data?.result?.dataset_id ?? data?.data?.result?.datasetId}?tab=data`);
       onCloseClick();
     },
     onError: (error) => {

--- a/frontend/src/sections/develop/AddDatasetDrawer/UploadFileModal.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/UploadFileModal.jsx
@@ -66,12 +66,12 @@ const UploadFileModal = ({ open, onClose, refreshGrid }) => {
       });
       queryClient.invalidateQueries({ queryKey: ["dataset-detail"] });
       trackEvent(Events.datasetFromJSONCSVSuccessful, {
-        [PropertyName.datasetId]: data?.data?.result?.datasetId,
+        [PropertyName.datasetId]: data?.data?.result?.dataset_id,
       });
       onCloseClick(null, true);
       reset();
       refreshGrid();
-      navigate(`/dashboard/develop/${data?.data?.result?.datasetId}?tab=data`);
+      navigate(`/dashboard/develop/${data?.data?.result?.dataset_id}?tab=data`);
     },
     onError: (error) => {
       enqueueSnackbar(


### PR DESCRIPTION
## Summary

- After uploading a dataset file, the app redirects to `/dashboard/develop/undefined?tab=data` instead of `/dashboard/develop/{dataset_id}?tab=data`
- Root cause: backend returns `dataset_id` (snake_case) but `UploadFileModal.jsx` was reading `datasetId` (camelCase), which resolved to `undefined`
- Fixed by using `data?.data?.result?.dataset_id` instead of `data?.data?.result?.datasetId`

## Linked issues

Closes TH-5831

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested?

- Verified backend returns `dataset_id` in snake_case from `CreateDatasetFromLocalFileView`
- Confirmed `ManuallyCreateDataset.jsx` already works because it uses a helper (`getCreatedDatasetId`) that handles both formats
- `UploadFileModal.jsx` was the only path not using the helper

## Checklist

- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)