### PR TITLE
fix(observe): keep deselected columns in a saved view from reverting

### DIFF
--- a/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
+++ b/frontend/src/sections/projects/LLMTracing/LLMTracingView.jsx
@@ -157,6 +157,11 @@ import {
   FILTER_FOR_NON_ANNOTATED,
   FILTER_FOR_HAS_EVAL,
 } from "./common";
+import {
+  columnStateToHideMap,
+  restampColumns,
+  isColumnVisibilityDirty,
+} from "./savedViewColumns";
 import TracingControls from "./TracingControls";
 import ObserveToolbar from "./ObserveToolbar";
 import { buildAddEvalsDraft } from "./buildAddEvalsDraft";
@@ -941,6 +946,10 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   // getTraceListColumnDefs sets hide explicitly from col.isVisible, so we
   // need to update col.isVisible in the columns state for hide to stick.
   const pendingHideMapRef = useRef(null);
+  // Col ids the user manually showed/hid since the saved view loaded. The
+  // saved-view re-stamp skips these so a manual toggle isn't reverted. Reset
+  // on view change / exit.
+  const userToggledColsRef = useRef(new Set());
 
   const {
     setHeaderConfig,
@@ -1640,6 +1649,17 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   }, [selectedGraph, selectedTab]);
 
   const onColumnVisibilityChange = (updatedData) => {
+    // Record cols whose visibility the user just changed so the saved-view
+    // re-stamp (the [columns] drain below) won't revert them.
+    (columns[columnKey] || []).forEach((col) => {
+      const next = updatedData[col.id];
+      if (
+        next !== undefined &&
+        (col.isVisible !== false) !== (next !== false)
+      ) {
+        userToggledColsRef.current.add(col.id);
+      }
+    });
     setColumns((cols) => {
       const newCols =
         cols[columnKey]?.map((col) => ({
@@ -1757,6 +1777,7 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
       setViewMode(DEFAULT_DISPLAY_CONFIG.viewMode);
       pendingColumnStateRef.current = null;
       pendingHideMapRef.current = null;
+      userToggledColsRef.current = new Set();
       primaryTracePendingRef.current = [];
       compareTracePendingRef.current = [];
       primarySpansPendingRef.current = [];
@@ -1919,33 +1940,14 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     // col.isVisible, which wins over applied state). The [columns] drain
     // effect below updates col.isVisible from this map.
     if (Array.isArray(display.columnState) && display.columnState.length > 0) {
-      const hideMap = {};
-      display.columnState.forEach((entry) => {
-        if (entry && entry.colId) hideMap[entry.colId] = !!entry.hide;
-      });
-      // Apply hideMap immediately so view→view switches with identical
-      // backend cols (no merge → no drain) still pick up the hide intent.
-      setColumns((prev) => {
-        let anyChanged = false;
-        const next = {};
-        Object.keys(prev).forEach((ck) => {
-          let slotChanged = false;
-          const updated = (prev[ck] || []).map((col) => {
-            if (col && col.id in hideMap) {
-              const desiredVisible = !hideMap[col.id];
-              if (col.isVisible !== desiredVisible) {
-                slotChanged = true;
-                return { ...col, isVisible: desiredVisible };
-              }
-            }
-            return col;
-          });
-          next[ck] = slotChanged ? updated : prev[ck];
-          if (slotChanged) anyChanged = true;
-        });
-        return anyChanged ? next : prev;
-      });
-      // Queue for cols that arrive later via TraceGrid's merge.
+      const hideMap = columnStateToHideMap(display.columnState);
+      // New view → drop the previous view's manual-toggle exemptions.
+      userToggledColsRef.current = new Set();
+      // Apply now (a view→view switch with identical cols has no drain), then
+      // queue the map for cols that merge in later.
+      setColumns((prev) =>
+        restampColumns(prev, hideMap, userToggledColsRef.current),
+      );
       pendingHideMapRef.current = hideMap;
 
       const activeApi =
@@ -2057,35 +2059,16 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
   // overrides applyColumnState's hide flag from col.isVisible.
   useEffect(() => {
     if (pendingHideMapRef.current) {
-      const hideMap = pendingHideMapRef.current;
-      // Only clear pendingHideMapRef if at least one col matched —
-      // otherwise a cold-load drain on empty slots would wipe the queue
-      // before TraceGrid/SpanGrid's first setColumns lands the cols.
-      let sawMatch = false;
-      setColumns((prev) => {
-        let anyChanged = false;
-        const next = {};
-        Object.keys(prev).forEach((ck) => {
-          let slotChanged = false;
-          const updated = (prev[ck] || []).map((col) => {
-            if (col && col.id in hideMap) {
-              sawMatch = true;
-              const desiredVisible = !hideMap[col.id];
-              if (col.isVisible !== desiredVisible) {
-                slotChanged = true;
-                return { ...col, isVisible: desiredVisible };
-              }
-            }
-            return col;
-          });
-          next[ck] = slotChanged ? updated : prev[ck];
-          if (slotChanged) anyChanged = true;
-        });
-        return anyChanged ? next : prev;
-      });
-      if (sawMatch) {
-        pendingHideMapRef.current = null;
-      }
+      // Stays armed for the view's lifetime: each columnDefs rebuild resets
+      // hide from col.isVisible, so we re-stamp on every columns change.
+      // User-toggled cols are skipped so a manual deselect isn't reverted.
+      setColumns((prev) =>
+        restampColumns(
+          prev,
+          pendingHideMapRef.current,
+          userToggledColsRef.current,
+        ),
+      );
     }
     if (!pendingColumnStateRef.current) return;
     const api =
@@ -2554,6 +2537,12 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     ) {
       return true;
     }
+    // Did the user show/hide a regular column since the saved view?
+    if (
+      isColumnVisibilityDirty(columns[columnKey], baselineDisplay.columnState)
+    ) {
+      return true;
+    }
     // Custom columns: did the user add/remove a custom column since the
     // saved view? Compare by id, not deep shape.
     const baselineCustom = Array.isArray(baselineDisplay.customColumns)
@@ -2583,6 +2572,8 @@ const LLMTracingView = ({ mode = "project", userIdForUserMode = null }) => {
     showCompare,
     hasEvalFilter,
     getCustomColumns,
+    columns,
+    columnKey,
   ]);
 
   // Defer the visibility signal so it catches up with activeViewConfig

--- a/frontend/src/sections/projects/LLMTracing/__tests__/savedViewColumns.test.js
+++ b/frontend/src/sections/projects/LLMTracing/__tests__/savedViewColumns.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  columnStateToHideMap,
+  restampColumns,
+  isColumnVisibilityDirty,
+} from "../savedViewColumns";
+
+describe("columnStateToHideMap", () => {
+  it("maps colId -> hide boolean", () => {
+    expect(
+      columnStateToHideMap([
+        { colId: "a", hide: true },
+        { colId: "b", hide: false },
+      ]),
+    ).toEqual({ a: true, b: false });
+  });
+
+  it("coerces a missing hide flag to false", () => {
+    expect(columnStateToHideMap([{ colId: "a" }])).toEqual({ a: false });
+  });
+
+  it("ignores entries without a colId and non-array input", () => {
+    expect(columnStateToHideMap([{ hide: true }, null])).toEqual({});
+    expect(columnStateToHideMap(undefined)).toEqual({});
+  });
+});
+
+describe("restampColumns", () => {
+  const makeCols = () => ({
+    "primary-trace": [
+      { id: "a", isVisible: true },
+      { id: "b", isVisible: true },
+    ],
+  });
+
+  it("hides a column the saved view marks hidden", () => {
+    const cols = makeCols();
+    const next = restampColumns(cols, { b: true });
+    expect(next["primary-trace"][1].isVisible).toBe(false);
+    expect(next["primary-trace"][0].isVisible).toBe(true);
+  });
+
+  it("shows a column the saved view marks visible", () => {
+    const cols = {
+      "primary-trace": [{ id: "a", isVisible: false }],
+    };
+    const next = restampColumns(cols, { a: false });
+    expect(next["primary-trace"][0].isVisible).toBe(true);
+  });
+
+  // TH-5919: the deselect must survive the saved-view re-stamp.
+  it("does not revert a user-toggled column", () => {
+    const cols = {
+      // user just hid "b"; saved view still wants it visible
+      "primary-trace": [
+        { id: "a", isVisible: true },
+        { id: "b", isVisible: false },
+      ],
+    };
+    const next = restampColumns(cols, { a: false, b: false }, new Set(["b"]));
+    expect(next["primary-trace"][1].isVisible).toBe(false);
+  });
+
+  it("still stamps non-toggled columns when others are exempt", () => {
+    const cols = makeCols();
+    const next = restampColumns(cols, { a: true, b: true }, new Set(["b"]));
+    expect(next["primary-trace"][0].isVisible).toBe(false);
+    expect(next["primary-trace"][1].isVisible).toBe(true);
+  });
+
+  it("returns the same reference when nothing changed (no re-render churn)", () => {
+    const cols = makeCols();
+    expect(restampColumns(cols, { a: false, b: false })).toBe(cols);
+  });
+
+  it("keeps untouched slot arrays referentially stable", () => {
+    const cols = {
+      "primary-trace": [{ id: "a", isVisible: true }],
+      "primary-spans": [{ id: "x", isVisible: true }],
+    };
+    const next = restampColumns(cols, { a: true });
+    expect(next["primary-spans"]).toBe(cols["primary-spans"]);
+    expect(next["primary-trace"]).not.toBe(cols["primary-trace"]);
+  });
+
+  it("ignores ids the hideMap does not mention", () => {
+    const cols = makeCols();
+    expect(restampColumns(cols, { c: true })).toBe(cols);
+  });
+
+  it("returns the input untouched when columnsObj or hideMap is missing", () => {
+    const cols = makeCols();
+    expect(restampColumns(cols, null)).toBe(cols);
+    expect(restampColumns(null, { a: true })).toBe(null);
+  });
+});
+
+describe("isColumnVisibilityDirty", () => {
+  const columnState = [
+    { colId: "a", hide: false },
+    { colId: "b", hide: false },
+  ];
+
+  it("is dirty when a column was hidden vs the saved view", () => {
+    const cols = [
+      { id: "a", isVisible: true },
+      { id: "b", isVisible: false },
+    ];
+    expect(isColumnVisibilityDirty(cols, columnState)).toBe(true);
+  });
+
+  it("is clean when visibility matches the saved view", () => {
+    const cols = [
+      { id: "a", isVisible: true },
+      { id: "b", isVisible: true },
+    ];
+    expect(isColumnVisibilityDirty(cols, columnState)).toBe(false);
+  });
+
+  it("treats undefined isVisible as visible", () => {
+    const cols = [{ id: "a" }, { id: "b" }];
+    expect(isColumnVisibilityDirty(cols, columnState)).toBe(false);
+  });
+
+  it("ignores custom columns", () => {
+    const cols = [{ id: "a", isVisible: false, groupBy: "Custom Columns" }];
+    expect(isColumnVisibilityDirty(cols, [{ colId: "a", hide: false }])).toBe(
+      false,
+    );
+  });
+
+  it("ignores columns the baseline does not know about", () => {
+    const cols = [{ id: "z", isVisible: false }];
+    expect(isColumnVisibilityDirty(cols, columnState)).toBe(false);
+  });
+
+  it("is clean when there is no saved columnState", () => {
+    const cols = [{ id: "a", isVisible: false }];
+    expect(isColumnVisibilityDirty(cols, undefined)).toBe(false);
+  });
+});

--- a/frontend/src/sections/projects/LLMTracing/savedViewColumns.js
+++ b/frontend/src/sections/projects/LLMTracing/savedViewColumns.js
@@ -1,0 +1,54 @@
+export const columnStateToHideMap = (columnState) => {
+  const hideMap = {};
+  (Array.isArray(columnState) ? columnState : []).forEach((entry) => {
+    if (entry && entry.colId) hideMap[entry.colId] = !!entry.hide;
+  });
+  return hideMap;
+};
+
+// Re-stamp the saved view's visibility onto every slot in `columnsObj`,
+// skipping ids in `userToggled`. Returns the same object/slot reference when
+// nothing changed so React can bail out of re-renders.
+export const restampColumns = (
+  columnsObj,
+  hideMap,
+  userToggled = new Set(),
+) => {
+  if (!columnsObj || !hideMap) return columnsObj;
+  let anyChanged = false;
+  const next = {};
+  Object.keys(columnsObj).forEach((slotKey) => {
+    const slot = columnsObj[slotKey] || [];
+    let slotChanged = false;
+    const updated = slot.map((col) => {
+      if (col && col.id in hideMap && !userToggled.has(col.id)) {
+        const desiredVisible = !hideMap[col.id];
+        if (col.isVisible !== desiredVisible) {
+          slotChanged = true;
+          return { ...col, isVisible: desiredVisible };
+        }
+      }
+      return col;
+    });
+    next[slotKey] = slotChanged ? updated : columnsObj[slotKey];
+    if (slotChanged) anyChanged = true;
+  });
+  return anyChanged ? next : columnsObj;
+};
+
+// True when a current column's visibility diverges from the saved view's
+// columnState. Only compares cols the baseline knows about; ignores custom cols.
+export const isColumnVisibilityDirty = (slotColumns, columnState) => {
+  if (!Array.isArray(columnState)) return false;
+  const baselineVisible = {};
+  columnState.forEach((entry) => {
+    if (entry && entry.colId) baselineVisible[entry.colId] = !entry.hide;
+  });
+  return (slotColumns || []).some(
+    (col) =>
+      col &&
+      col.groupBy !== "Custom Columns" &&
+      col.id in baselineVisible &&
+      (col.isVisible !== false) !== baselineVisible[col.id],
+  );
+};


### PR DESCRIPTION
**Linear:** [TH-5919 — Cannot deselect display columns for Mudflap account](https://linear.app/future-agi/issue/TH-5919/cannot-deselect-display-columns-for-mudflap-account)

## TH-5919 — Cannot deselect display columns on a saved view

### Problem
On a saved view in the LLM-tracing/observe grids, deselecting a column in the Display panel reverted immediately — the column reappeared.

### Cause
A saved view stores column visibility as an AG-Grid `columnState`. On load this is re-stamped onto the grid columns on **every** `columns` change (so the view survives refetches / late-loading columns). That re-stamp also overwrote a column the user had just manually hidden, snapping it back to the saved state.

### Fix
- Track columns the user manually toggled since the view loaded and **exempt them** from the saved-view re-stamp, so a manual hide/show sticks for the session. An actual refresh (no save) still discards the unsaved change — intended.
- Surface the **Save view** button when a column's visibility diverges from the saved view (works on existing views, which store `columnState`).
- Extract the visibility logic into pure helpers in `savedViewColumns.js` and add unit tests; the inline re-stamp / dirty-check now call these helpers (net fewer lines in the component, refresh behavior unchanged).

### Tests
`savedViewColumns.test.js` — 17 cases covering: a user-toggled deselect is not reverted, non-toggled columns are still stamped, referential stability (no grid churn), and the Save-view dirty check (flags a hide vs the view, ignores custom/unknown columns and `undefined` visibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)