### PR TITLE
[TH-5894] Allow removing the last prompt tag + dark-theme tag styling fixes

### DIFF
--- a/frontend/src/sections/workbench/createPrompt/VersionHistory/LabelDropdown/LabelPopperContent.jsx
+++ b/frontend/src/sections/workbench/createPrompt/VersionHistory/LabelDropdown/LabelPopperContent.jsx
@@ -83,10 +83,12 @@ const LabelPopperContent = ({
                   justifyContent: "space-between",
                   alignItems: "center",
                   backgroundColor: isLabelSelected(label.id)
-                    ? "background.default"
+                    ? "background.neutral"
                     : "transparent",
                   "&:hover": {
-                    backgroundColor: "background.default",
+                    backgroundColor: isLabelSelected(label.id)
+                      ? "background.neutral"
+                      : "action.hover",
                   },
                   borderRadius: "6px",
                   mb: 0.5,

--- a/frontend/src/sections/workbench/createPrompt/VersionHistory/LabelDropdown/LabelSelectContent.jsx
+++ b/frontend/src/sections/workbench/createPrompt/VersionHistory/LabelDropdown/LabelSelectContent.jsx
@@ -49,6 +49,11 @@ const LabelSelectContent = ({
     return [];
   });
 
+  const originalLabelIds = new Set((selectedLabels ?? []).map((l) => l.id));
+  const hasChanges =
+    selectedLabelsList.length !== originalLabelIds.size ||
+    selectedLabelsList.some((l) => !originalLabelIds.has(l.id));
+
   const { mutate: assignLabel, isPending: isAssigning } = useMutation({
     mutationFn: (labelIds) =>
       axios.post(endpoints.develop.runPrompt.assignMultipleLabels, {
@@ -107,11 +112,6 @@ const LabelSelectContent = ({
   );
 
   const handleSave = useCallback(() => {
-    if (selectedLabelsList.length === 0) {
-      return enqueueSnackbar("Please select at least one label", {
-        variant: "warning",
-      });
-    }
     const labelIds = selectedLabelsList.map((label) => label.id);
     assignLabel(labelIds);
   }, [selectedLabelsList, assignLabel]);
@@ -199,6 +199,9 @@ const LabelSelectContent = ({
                   color: colorMap?.color,
                   borderRadius: "100px",
                   zIndex: 10,
+                  "&:hover": {
+                    backgroundColor: colorMap?.hoverBackgroundColor,
+                  },
                   "& .MuiChip-deleteIcon": {
                     color: colorMap?.color,
                   },
@@ -261,7 +264,7 @@ const LabelSelectContent = ({
       </Box>
 
       <LoadingButton
-        disabled={selectedLabelsList?.length === 0}
+        disabled={!hasChanges}
         loading={isAssigning}
         color="primary"
         variant="contained"

--- a/frontend/src/sections/workbench/createPrompt/VersionHistory/LabelDropdown/__tests__/LabelSelectContent.test.jsx
+++ b/frontend/src/sections/workbench/createPrompt/VersionHistory/LabelDropdown/__tests__/LabelSelectContent.test.jsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, fireEvent } from "src/utils/test-utils";
+import LabelSelectContent from "../LabelSelectContent";
+
+const mocks = vi.hoisted(() => ({ post: vi.fn() }));
+
+vi.mock("src/utils/axios", () => ({
+  default: { post: mocks.post },
+  endpoints: {
+    develop: {
+      runPrompt: {
+        assignMultipleLabels: "/model-hub/prompt-labels/assign-multiple-labels/",
+        createPromptLabel: "/model-hub/prompt-labels/",
+      },
+    },
+  },
+}));
+
+vi.mock("notistack", () => ({ enqueueSnackbar: vi.fn() }));
+
+vi.mock("src/auth/hooks", () => ({
+  useAuthContext: () => ({ role: "admin" }),
+}));
+
+vi.mock("src/utils/rolePermissionMapping", () => ({
+  PERMISSIONS: { DEPLOY: "DEPLOY" },
+  RolePermission: { PROMPTS: { DEPLOY: { admin: true } } },
+}));
+
+// Forward MUI-injected className/onClick so the chip delete icon is clickable.
+vi.mock("src/components/iconify", () => ({
+  default: ({ className, onClick }) => (
+    <span className={className} onClick={onClick} data-testid="iconify" />
+  ),
+}));
+
+const ALPHA = { id: "a", name: "alpha" };
+const BETA = { id: "b", name: "beta" };
+
+const renderContent = (props = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LabelSelectContent
+        promptId="prompt-1"
+        versionId="version-1"
+        labels={[ALPHA, BETA]}
+        version={{ id: "version-1", template_version: "v1" }}
+        isPending={false}
+        isFetchingNextPage={false}
+        fetchNextPage={vi.fn()}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+};
+
+const saveButton = () => screen.getByRole("button", { name: /save/i });
+const deleteIcons = (container) =>
+  container.querySelectorAll(".MuiChip-deleteIcon");
+
+describe("LabelSelectContent — Save button (TH-5894)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.post.mockResolvedValue({ data: {} });
+  });
+
+  it("disables Save when there were no labels and none are selected", () => {
+    renderContent({ selectedLabels: [] });
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it("disables Save when the selection matches the original (no change)", () => {
+    renderContent({ selectedLabels: [ALPHA] });
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it("enables Save and submits an empty list when the only tag is removed", async () => {
+    const { container } = renderContent({ selectedLabels: [ALPHA] });
+    expect(saveButton()).toBeDisabled();
+
+    fireEvent.click(deleteIcons(container)[0]);
+
+    expect(saveButton()).toBeEnabled();
+
+    fireEvent.click(saveButton());
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith(
+        "/model-hub/prompt-labels/assign-multiple-labels/",
+        { template_version_id: "version-1", label_ids: [] },
+      );
+    });
+  });
+
+  it("submits the remaining ids when one of several tags is removed", async () => {
+    const { container } = renderContent({ selectedLabels: [ALPHA, BETA] });
+
+    // remove the first chip (alpha), leaving beta
+    fireEvent.click(deleteIcons(container)[0]);
+
+    expect(saveButton()).toBeEnabled();
+    fireEvent.click(saveButton());
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith(
+        "/model-hub/prompt-labels/assign-multiple-labels/",
+        { template_version_id: "version-1", label_ids: ["b"] },
+      );
+    });
+  });
+});

--- a/frontend/src/sections/workbench/createPrompt/VersionHistory/common.js
+++ b/frontend/src/sections/workbench/createPrompt/VersionHistory/common.js
@@ -8,18 +8,27 @@ export const getColorMap = (name, theme) => {
         backgroundColor: isDark
           ? theme.palette.green.o10
           : theme.palette.green[50],
+        hoverBackgroundColor: isDark
+          ? theme.palette.green.o20
+          : theme.palette.green[100],
         color: isDark ? theme.palette.green[400] : theme.palette.green[700],
       },
       Staging: {
         backgroundColor: isDark
           ? theme.palette.orange.o10
           : theme.palette.orange[50],
+        hoverBackgroundColor: isDark
+          ? theme.palette.orange.o20
+          : theme.palette.orange[100],
         color: isDark ? theme.palette.orange[400] : theme.palette.orange[700],
       },
       Development: {
         backgroundColor: isDark
           ? theme.palette.blue.o10
           : theme.palette.blue[50],
+        hoverBackgroundColor: isDark
+          ? theme.palette.blue.o20
+          : theme.palette.blue[100],
         color: isDark ? theme.palette.blue[400] : theme.palette.blue[700],
       },
     };
@@ -28,6 +37,7 @@ export const getColorMap = (name, theme) => {
   }
   return {
     backgroundColor: theme.palette.action.hover,
+    hoverBackgroundColor: theme.palette.action.selected,
     color: theme.palette.text.primary,
   };
 };

--- a/frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx
+++ b/frontend/src/sections/workbench/createPrompt/promptActions/PromptActions.jsx
@@ -494,7 +494,7 @@ const PromptActions = () => {
                           height: 24,
                           "&:hover": {
                             backgroundColor: getTagColorMap(label?.name, theme)
-                              ?.backgroundColor,
+                              ?.hoverBackgroundColor,
                             cursor: "default",
                           },
                         }}


### PR DESCRIPTION
## Summary
- Save in the version tag selector is now driven by a **dirty-check**: enabled whenever the selection differs from the version's current labels (including removing all tags), instead of requiring a non-empty selection. This is what lets you remove the last/only tag.
- Submitting an empty selection now sends `label_ids: []` to clear all tags.
- Fix the tag chip rendering **white-on-white on hover in dark theme** — `getColorMap` now returns a dedicated `hoverBackgroundColor` (next opacity/shade step); applied to both the selector chip and the PromptActions tag chip.
- Fix the dropdown **active row being darker than the menu (invisible)** in dark theme — use `action.selected`/`action.hover` instead of `background.default`.
- Add tests for the Save enable/disable and empty-submit behavior.

> Note: clearing the last tag depends on the backend accepting an empty `label_ids` (TH-5927) — they ship together.

Closes TH-5894

## Test plan
- [ ] Add a single tag, then remove it — Save enables and the tag clears
- [ ] No change to the selection — Save stays disabled
- [ ] Dark theme: hover a selected tag chip — text stays readable
- [ ] Dark theme: the selected row in the dropdown is clearly highlighted
