### PR TITLE
[TH-5885] Keep Add tool button text on one line

### DIFF
--- a/frontend/src/components/custom-model-tools/EditTool.jsx
+++ b/frontend/src/components/custom-model-tools/EditTool.jsx
@@ -373,7 +373,7 @@ const EditTool = ({ onCancel, editTool }) => {
           color="primary"
           type="submit"
           sx={{
-            width: editTool ? "90px" : "95px",
+            minWidth: "90px",
             height: "30px",
             ...theme.typography["s2"],
             fontWeight: (theme) => theme.typography["fontWeightSemiBold"],


### PR DESCRIPTION
## Summary
- The custom-tool submit button used a fixed, per-label pixel width (`editTool ? "90px" : "95px"`). At that width the **"Add tool"** label didn't fit alongside the button's horizontal padding, so the text wrapped to two lines.
- Replaced it with `minWidth: "90px"` so the button keeps a sensible floor (aligned with the 90px Cancel button) but sizes to its content — "Add tool" now stays on one line, "Update" stays at 90px.

Closes TH-5885

## Files Changed
- `frontend/src/components/custom-model-tools/EditTool.jsx`

## Test plan
- [ ] Open the custom tool drawer in **add** mode — "Add tool" button text is on a single line
- [ ] Open in **edit** mode — "Update" button is unchanged and aligned with Cancel
