### PR TITLE
fix(develop): restore dataset page cache-reuse lost in snake_case refactor

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -236,7 +236,12 @@ const getDataSource = (
           search,
           { enabled: true, staleTime: 5 * 1000, pageSize: DATASET_ROWS_LIMIT },
         );
-        const data = await queryClient.fetchQuery({ ...queryOptions });
+        const cachedState = queryClient.getQueryState(queryOptions.queryKey);
+        const servedFromCache =
+          cachedState?.data !== undefined && !cachedState.isInvalidated;
+        const data = servedFromCache
+          ? cachedState.data
+          : await queryClient.fetchQuery({ ...queryOptions });
         const result = data?.data?.result;
         const processingData = getResultIsProcessingData(result);
 


### PR DESCRIPTION
## Summary
- PR #612 made dataset scrolling instant by reusing already-cached pages
  (`getQueryState`) instead of always hitting the network.
- The snake_case refactor on `dev` rewrote `getRows` to always
  `await fetchQuery`, silently dropping that cache-reuse. Prefetched pages
  were then re-fetched once stale (past the 5s window), bringing back the
  2-3s block loader on scroll.
- This restores the cache-reuse on top of the snake_case code: a page is
  served from cache instantly when present and not invalidated; otherwise
  it is fetched. Column-run invalidation still forces a refetch, so live
  updates are unaffected.

## Test plan
- [x] Open a dataset and scroll down — new pages appear with no 2-3s loader.
- [x] Scroll back up to earlier pages — still instant, no refetch.
- [x] Run a prompt/eval on a column — rows still update live while it runs.
- [x] Scroll forward two pages during a column run — cell values stay live, not snapshot-frozen.
