### PR TITLE
fix(develop-detail): Add Feedback button broken across dataset, experiment, compare-dataset (TH-5929)

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/AddEvaluationFeeback/AddEvaluationFeeback.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/AddEvaluationFeeback/AddEvaluationFeeback.jsx
@@ -46,7 +46,7 @@ const AddEvaluationFeeback = ({ module = "dataset", onRefreshGrid }) => {
   };
   const { experimentId } = useParams();
   const metricId = isExperimentModule ? data?.userEvalMetricId : data?.sourceId;
-  const rowId = data?.rowData?.row_id ?? data?.rowData?.rowId;
+  const rowId = data?.rowData?.row_id;
   const detailsEndpoint = isExperimentModule
     ? endpoints.develop.experiment.feedback.getDetails(experimentId)
     : endpoints.develop.eval.getFeedbackDetails;
@@ -143,7 +143,7 @@ const EvaluationFeeback = ({
   const existingFeedbackId = existingFeedback?.id;
   const { dataset, experimentId } = useParams();
   const metricId = isExperimentModule ? data?.userEvalMetricId : data?.sourceId;
-  const rowId = data?.rowData?.row_id ?? data?.rowData?.rowId;
+  const rowId = data?.rowData?.row_id;
   const feedbackEndpoints = isExperimentModule
     ? {
         getTemplate:

--- a/frontend/src/sections/develop-detail/DataTab/AddEvaluationFeeback/AddEvaluationFeeback.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/AddEvaluationFeeback/AddEvaluationFeeback.jsx
@@ -46,6 +46,7 @@ const AddEvaluationFeeback = ({ module = "dataset", onRefreshGrid }) => {
   };
   const { experimentId } = useParams();
   const metricId = isExperimentModule ? data?.userEvalMetricId : data?.sourceId;
+  const rowId = data?.rowData?.row_id ?? data?.rowData?.rowId;
   const detailsEndpoint = isExperimentModule
     ? endpoints.develop.experiment.feedback.getDetails(experimentId)
     : endpoints.develop.eval.getFeedbackDetails;
@@ -54,20 +55,20 @@ const AddEvaluationFeeback = ({ module = "dataset", onRefreshGrid }) => {
     queryKey: [
       "fetch-feedback-details",
       metricId,
-      data?.rowData?.rowId,
+      rowId,
       isExperimentModule ? experimentId : null,
     ],
     queryFn: () =>
       axios.get(detailsEndpoint, {
         params: {
           user_eval_metric_id: metricId,
-          row_id: data?.rowData?.rowId,
+          row_id: rowId,
         },
       }),
     enabled:
       !!(isExperimentModule
         ? data?.userEvalMetricId && experimentId
-        : data?.sourceId) && !!data?.rowData?.rowId,
+        : data?.sourceId) && !!rowId,
     select: (d) => d.data?.result?.feedback?.[0],
   });
 
@@ -142,6 +143,7 @@ const EvaluationFeeback = ({
   const existingFeedbackId = existingFeedback?.id;
   const { dataset, experimentId } = useParams();
   const metricId = isExperimentModule ? data?.userEvalMetricId : data?.sourceId;
+  const rowId = data?.rowData?.row_id ?? data?.rowData?.rowId;
   const feedbackEndpoints = isExperimentModule
     ? {
         getTemplate:
@@ -157,7 +159,7 @@ const EvaluationFeeback = ({
   const feedbackQueryKey = [
     "fetch-feedback-details",
     metricId,
-    data?.rowData?.rowId,
+    rowId,
     isExperimentModule ? experimentId : null,
   ];
 
@@ -230,12 +232,12 @@ const EvaluationFeeback = ({
       user_eval_metric: metricId,
       source: isExperimentModule ? "experiment" : "dataset",
       source_id: isExperimentModule ? data.sourceId : data.id,
-      row_id: data.rowData.rowId,
+      row_id: rowId,
     };
     trackEvent(Events.datasetSubmitFeedbackClicked, {
       [PropertyName.datasetId]: dataset,
       [PropertyName.evalId]: data?.sourceId,
-      [PropertyName.rowIdentifier]: data?.rowData.rowId,
+      [PropertyName.rowIdentifier]: rowId,
     });
     if (existingFeedbackId) {
       newFeedback.current = payload;
@@ -254,6 +256,7 @@ const EvaluationFeeback = ({
       action_type: formData.value,
       user_eval_metric_id: metricId,
       feedback_id: feedbackId,
+      row_id: rowId,
     };
     if (newFeedback?.current?.value) {
       payload.value = newFeedback?.current?.value;
@@ -375,7 +378,7 @@ const FeedBackForm = ({ control, data, feedbackData }) => {
       </Box>
 
       <div style={{ borderBottom: "1px solid var(--border-light)" }} />
-      {feedbackData?.outputType === "reason" && (
+      {feedbackData?.output_type === "reason" && (
         <AllInputField
           label="Write a right value"
           placeholder="Improve the tone and grammar of the prompt"
@@ -387,7 +390,7 @@ const FeedBackForm = ({ control, data, feedbackData }) => {
           rows={3}
         />
       )}
-      {feedbackData?.outputType === "score" && (
+      {feedbackData?.output_type === "score" && (
         <AllInputField
           label="Write a right value"
           placeholder="Add Number"
@@ -420,8 +423,8 @@ const FeedBackForm = ({ control, data, feedbackData }) => {
             );
           })}
       </Box>
-      {(feedbackData?.outputType === "Pass/Fail" ||
-        feedbackData?.outputType === "choices") && (
+      {(feedbackData?.output_type === "Pass/Fail" ||
+        feedbackData?.output_type === "choices") && (
         <RadioField
           label="Select a right value"
           control={control}
@@ -432,7 +435,7 @@ const FeedBackForm = ({ control, data, feedbackData }) => {
           }))}
         />
       )}
-      {feedbackData?.outputType === "select" && (
+      {feedbackData?.output_type === "select" && (
         <AllSelectField
           label="Select a right value"
           control={control}

--- a/frontend/src/sections/develop-detail/DataTab/CompareDatasetDetailDrawer/CompareDatasetEvalsAddFeedbackForm.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/CompareDatasetDetailDrawer/CompareDatasetEvalsAddFeedbackForm.jsx
@@ -263,7 +263,7 @@ const FeedBackForm = ({ control, data, feedbackData }) => {
         </Typography>
       </Stack>
 
-      {feedbackData?.outputType === "reason" && (
+      {feedbackData?.output_type === "reason" && (
         <AllInputField
           label="Write a right value"
           placeholder="Improve the tone and grammar of the prompt"
@@ -275,7 +275,7 @@ const FeedBackForm = ({ control, data, feedbackData }) => {
           rows={3}
         />
       )}
-      {feedbackData?.outputType === "score" && (
+      {feedbackData?.output_type === "score" && (
         <AllInputField
           label="Write a right value"
           placeholder="Add Number"
@@ -308,8 +308,8 @@ const FeedBackForm = ({ control, data, feedbackData }) => {
         </Box>
       )}
 
-      {(feedbackData?.outputType === "Pass/Fail" ||
-        feedbackData?.outputType === "choices") && (
+      {(feedbackData?.output_type === "Pass/Fail" ||
+        feedbackData?.output_type === "choices") && (
         <RadioField
           label="Select a right value"
           control={control}
@@ -320,7 +320,7 @@ const FeedBackForm = ({ control, data, feedbackData }) => {
           }))}
         />
       )}
-      {feedbackData?.outputType === "select" && (
+      {feedbackData?.output_type === "select" && (
         <AllSelectField
           label="Select a right value"
           control={control}
@@ -538,6 +538,7 @@ export default function CompareDatasetEvalsAddFeedbackForm({
       action_type: formData.value,
       user_eval_metric_id: evalDetail?.sourceId,
       feedback_id: feedbackId,
+      row_id: evalDetail?.cellRowId,
     };
     if (newFeedback?.current?.value) {
       payload.value = newFeedback?.current?.value;

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -297,6 +297,7 @@ const DatapointDrawerChild = () => {
     evalMetaBySourceId[column?.col?.sourceId || column?.col?.source_id]
       ?.templateType === "composite";
 
+
   const runEvalData = useMemo(() => {
     const evalColumns = allColumns.filter((i) => i.originType === "evaluation");
     const currentRowData = datapoint?.rowData ? datapoint?.rowData : [];
@@ -367,9 +368,7 @@ const DatapointDrawerChild = () => {
       return null;
     }
   });
-  const evalValueInfos = evalOpen?.value_infos ?? evalOpen?.valueInfos;
-  const evalCellValue = evalOpen?.cell_value ?? evalOpen?.cellValue;
-  const evalOutput = evalValueInfos?.output;
+  const evalOutput = evalOpen?.valueInfos?.output;
 
   const loading = false;
 
@@ -455,9 +454,9 @@ const DatapointDrawerChild = () => {
   };
 
   const finalArray = useMemo(() => {
-    const v = normalizeEvalCellValue(evalCellValue);
+    const v = normalizeEvalCellValue(evalOpen?.cellValue);
     return Array.isArray(v) ? v : undefined;
-  }, [evalCellValue]);
+  }, [evalOpen?.cellValue]);
 
   const onNavigate = async (direction) => {
     isNavigatingRef.current = true;
@@ -775,19 +774,19 @@ const DatapointDrawerChild = () => {
                         Error
                       </Box>
                     ) : (
-                      hasRenderableCellValue(evalCellValue) && (
+                      hasRenderableCellValue(evalOpen?.cellValue) && (
                         <>
                           <ShowComponent condition={!Array.isArray(finalArray)}>
                             <Chip
                               variant="soft"
-                              label={getLabel(evalCellValue)}
+                              label={getLabel(evalOpen?.cellValue)}
                               size="small"
                               sx={{
-                                ...getStatusColor(evalCellValue, theme),
+                                ...getStatusColor(evalOpen?.cellValue, theme),
                                 transition: "none",
                                 "&:hover": {
                                   backgroundColor: getStatusColor(
-                                    evalCellValue,
+                                    evalOpen?.cellValue,
                                     theme,
                                   ).backgroundColor,
                                   boxShadow: "none",
@@ -823,12 +822,15 @@ const DatapointDrawerChild = () => {
                                   label={val}
                                   size="small"
                                   sx={{
-                                    ...getStatusColor(evalCellValue, theme),
+                                    ...getStatusColor(
+                                      evalOpen?.cellValue,
+                                      theme,
+                                    ),
                                     marginRight: theme.spacing(1),
                                     transition: "none",
                                     "&:hover": {
                                       backgroundColor: getStatusColor(
-                                        evalCellValue,
+                                        evalOpen?.cellValue,
                                         theme,
                                       ).backgroundColor,
                                       boxShadow: "none",
@@ -867,25 +869,26 @@ const DatapointDrawerChild = () => {
                       borderRadius: "4px",
                     }}
                   >
-                    {Array.isArray(evalValueInfos?.children) &&
-                    evalValueInfos.children.length > 0 ? (
+                    {Array.isArray(evalOpen?.valueInfos?.children) &&
+                    evalOpen.valueInfos.children.length > 0 ? (
                       (() => {
                         /** @type {any[]} */
-                        const compositeChildren = evalValueInfos.children || [];
+                        const compositeChildren =
+                          evalOpen.valueInfos.children || [];
                         return (
                           <CompositeResultView
                             compositeResult={{
-                              ...evalValueInfos,
+                              ...evalOpen.valueInfos,
                               total_children:
-                                evalValueInfos.total_children ??
+                                evalOpen.valueInfos.total_children ??
                                 compositeChildren.length,
                               completed_children:
-                                evalValueInfos.completed_children ??
+                                evalOpen.valueInfos.completed_children ??
                                 compositeChildren.filter(
                                   (child) => child.status === "completed",
                                 ).length,
                               failed_children:
-                                evalValueInfos.failed_children ??
+                                evalOpen.valueInfos.failed_children ??
                                 compositeChildren.filter(
                                   (child) => child.status === "failed",
                                 ).length,
@@ -893,18 +896,21 @@ const DatapointDrawerChild = () => {
                           />
                         );
                       })()
-                    ) : evalValueInfos?.reason?.trim() ||
-                      evalValueInfos?.summary ? (
+                    ) : evalOpen?.valueInfos?.reason?.trim() ||
+                      evalOpen?.valueInfos?.summary ? (
                       <CellMarkdown
                         spacing={0}
-                        text={evalValueInfos?.reason || evalValueInfos?.summary}
+                        text={
+                          evalOpen?.valueInfos?.reason ||
+                          evalOpen?.valueInfos?.summary
+                        }
                       />
                     ) : (
                       "Unable to fetch Explanation"
                     )}
                   </Box>
                 </Box>
-
+               
                 {!evalOpenIsCode && !isCompositeEval && (
                   <ErrorLocalizationCellSection
                     evalOpen={evalOpen}
@@ -1290,7 +1296,7 @@ const ErrorLocalizationCellSection = ({ evalOpen, onAnalysisLoaded }) => {
   useEffect(() => {
     onAnalysisLoadedRef.current = onAnalysisLoaded;
   }, [onAnalysisLoaded]);
-  const valueInfos = evalOpen?.value_infos ?? evalOpen?.valueInfos;
+  const valueInfos = evalOpen?.valueInfos;
   const inlineAnalysis = valueInfos?.errorAnalysis;
   const hasInlineAnalysis = !!(
     inlineAnalysis &&

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -297,6 +297,7 @@ const DatapointDrawerChild = () => {
     evalMetaBySourceId[column?.col?.sourceId || column?.col?.source_id]
       ?.templateType === "composite";
 
+
   const runEvalData = useMemo(() => {
     const evalColumns = allColumns.filter((i) => i.originType === "evaluation");
     const currentRowData = datapoint?.rowData ? datapoint?.rowData : [];
@@ -367,9 +368,7 @@ const DatapointDrawerChild = () => {
       return null;
     }
   });
-  const evalValueInfos = evalOpen?.value_infos;
-  const evalCellValue = evalOpen?.cell_value;
-  const evalOutput = evalValueInfos?.output;
+  const evalOutput = evalOpen?.valueInfos?.output;
 
   const loading = false;
 
@@ -455,9 +454,9 @@ const DatapointDrawerChild = () => {
   };
 
   const finalArray = useMemo(() => {
-    const v = normalizeEvalCellValue(evalCellValue);
+    const v = normalizeEvalCellValue(evalOpen?.cellValue);
     return Array.isArray(v) ? v : undefined;
-  }, [evalCellValue]);
+  }, [evalOpen?.cellValue]);
 
   const onNavigate = async (direction) => {
     isNavigatingRef.current = true;
@@ -775,19 +774,19 @@ const DatapointDrawerChild = () => {
                         Error
                       </Box>
                     ) : (
-                      hasRenderableCellValue(evalCellValue) && (
+                      hasRenderableCellValue(evalOpen?.cellValue) && (
                         <>
                           <ShowComponent condition={!Array.isArray(finalArray)}>
                             <Chip
                               variant="soft"
-                              label={getLabel(evalCellValue)}
+                              label={getLabel(evalOpen?.cellValue)}
                               size="small"
                               sx={{
-                                ...getStatusColor(evalCellValue, theme),
+                                ...getStatusColor(evalOpen?.cellValue, theme),
                                 transition: "none",
                                 "&:hover": {
                                   backgroundColor: getStatusColor(
-                                    evalCellValue,
+                                    evalOpen?.cellValue,
                                     theme,
                                   ).backgroundColor,
                                   boxShadow: "none",
@@ -823,12 +822,15 @@ const DatapointDrawerChild = () => {
                                   label={val}
                                   size="small"
                                   sx={{
-                                    ...getStatusColor(evalCellValue, theme),
+                                    ...getStatusColor(
+                                      evalOpen?.cellValue,
+                                      theme,
+                                    ),
                                     marginRight: theme.spacing(1),
                                     transition: "none",
                                     "&:hover": {
                                       backgroundColor: getStatusColor(
-                                        evalCellValue,
+                                        evalOpen?.cellValue,
                                         theme,
                                       ).backgroundColor,
                                       boxShadow: "none",
@@ -867,25 +869,26 @@ const DatapointDrawerChild = () => {
                       borderRadius: "4px",
                     }}
                   >
-                    {Array.isArray(evalValueInfos?.children) &&
-                    evalValueInfos.children.length > 0 ? (
+                    {Array.isArray(evalOpen?.valueInfos?.children) &&
+                    evalOpen.valueInfos.children.length > 0 ? (
                       (() => {
                         /** @type {any[]} */
-                        const compositeChildren = evalValueInfos.children || [];
+                        const compositeChildren =
+                          evalOpen.valueInfos.children || [];
                         return (
                           <CompositeResultView
                             compositeResult={{
-                              ...evalValueInfos,
+                              ...evalOpen.valueInfos,
                               total_children:
-                                evalValueInfos.total_children ??
+                                evalOpen.valueInfos.total_children ??
                                 compositeChildren.length,
                               completed_children:
-                                evalValueInfos.completed_children ??
+                                evalOpen.valueInfos.completed_children ??
                                 compositeChildren.filter(
                                   (child) => child.status === "completed",
                                 ).length,
                               failed_children:
-                                evalValueInfos.failed_children ??
+                                evalOpen.valueInfos.failed_children ??
                                 compositeChildren.filter(
                                   (child) => child.status === "failed",
                                 ).length,
@@ -893,18 +896,21 @@ const DatapointDrawerChild = () => {
                           />
                         );
                       })()
-                    ) : evalValueInfos?.reason?.trim() ||
-                      evalValueInfos?.summary ? (
+                    ) : evalOpen?.valueInfos?.reason?.trim() ||
+                      evalOpen?.valueInfos?.summary ? (
                       <CellMarkdown
                         spacing={0}
-                        text={evalValueInfos?.reason || evalValueInfos?.summary}
+                        text={
+                          evalOpen?.valueInfos?.reason ||
+                          evalOpen?.valueInfos?.summary
+                        }
                       />
                     ) : (
                       "Unable to fetch Explanation"
                     )}
                   </Box>
                 </Box>
-
+               
                 {!evalOpenIsCode && !isCompositeEval && (
                   <ErrorLocalizationCellSection
                     evalOpen={evalOpen}
@@ -919,9 +925,9 @@ const DatapointDrawerChild = () => {
                         prev
                           ? {
                               ...prev,
-                              value_infos: {
-                                ...(prev.value_infos || {}),
-                                error_analysis: details?.error_analysis,
+                              valueInfos: {
+                                ...(prev.valueInfos || {}),
+                                errorAnalysis: details?.error_analysis,
                                 input_data: details?.input_data,
                                 input_types: details?.input_types,
                                 selected_input_key: details?.selected_input_key,
@@ -1290,8 +1296,8 @@ const ErrorLocalizationCellSection = ({ evalOpen, onAnalysisLoaded }) => {
   useEffect(() => {
     onAnalysisLoadedRef.current = onAnalysisLoaded;
   }, [onAnalysisLoaded]);
-  const valueInfos = evalOpen?.value_infos;
-  const inlineAnalysis = valueInfos?.error_analysis;
+  const valueInfos = evalOpen?.valueInfos;
+  const inlineAnalysis = valueInfos?.errorAnalysis;
   const hasInlineAnalysis = !!(
     inlineAnalysis &&
     typeof inlineAnalysis === "object" &&

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -919,9 +919,9 @@ const DatapointDrawerChild = () => {
                         prev
                           ? {
                               ...prev,
-                              valueInfos: {
-                                ...(prev.valueInfos || {}),
-                                errorAnalysis: details?.error_analysis,
+                              value_infos: {
+                                ...(prev.value_infos || {}),
+                                error_analysis: details?.error_analysis,
                                 input_data: details?.input_data,
                                 input_types: details?.input_types,
                                 selected_input_key: details?.selected_input_key,

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -297,7 +297,6 @@ const DatapointDrawerChild = () => {
     evalMetaBySourceId[column?.col?.sourceId || column?.col?.source_id]
       ?.templateType === "composite";
 
-
   const runEvalData = useMemo(() => {
     const evalColumns = allColumns.filter((i) => i.originType === "evaluation");
     const currentRowData = datapoint?.rowData ? datapoint?.rowData : [];
@@ -368,7 +367,9 @@ const DatapointDrawerChild = () => {
       return null;
     }
   });
-  const evalOutput = evalOpen?.valueInfos?.output;
+  const evalValueInfos = evalOpen?.value_infos ?? evalOpen?.valueInfos;
+  const evalCellValue = evalOpen?.cell_value ?? evalOpen?.cellValue;
+  const evalOutput = evalValueInfos?.output;
 
   const loading = false;
 
@@ -454,9 +455,9 @@ const DatapointDrawerChild = () => {
   };
 
   const finalArray = useMemo(() => {
-    const v = normalizeEvalCellValue(evalOpen?.cellValue);
+    const v = normalizeEvalCellValue(evalCellValue);
     return Array.isArray(v) ? v : undefined;
-  }, [evalOpen?.cellValue]);
+  }, [evalCellValue]);
 
   const onNavigate = async (direction) => {
     isNavigatingRef.current = true;
@@ -774,19 +775,19 @@ const DatapointDrawerChild = () => {
                         Error
                       </Box>
                     ) : (
-                      hasRenderableCellValue(evalOpen?.cellValue) && (
+                      hasRenderableCellValue(evalCellValue) && (
                         <>
                           <ShowComponent condition={!Array.isArray(finalArray)}>
                             <Chip
                               variant="soft"
-                              label={getLabel(evalOpen?.cellValue)}
+                              label={getLabel(evalCellValue)}
                               size="small"
                               sx={{
-                                ...getStatusColor(evalOpen?.cellValue, theme),
+                                ...getStatusColor(evalCellValue, theme),
                                 transition: "none",
                                 "&:hover": {
                                   backgroundColor: getStatusColor(
-                                    evalOpen?.cellValue,
+                                    evalCellValue,
                                     theme,
                                   ).backgroundColor,
                                   boxShadow: "none",
@@ -822,15 +823,12 @@ const DatapointDrawerChild = () => {
                                   label={val}
                                   size="small"
                                   sx={{
-                                    ...getStatusColor(
-                                      evalOpen?.cellValue,
-                                      theme,
-                                    ),
+                                    ...getStatusColor(evalCellValue, theme),
                                     marginRight: theme.spacing(1),
                                     transition: "none",
                                     "&:hover": {
                                       backgroundColor: getStatusColor(
-                                        evalOpen?.cellValue,
+                                        evalCellValue,
                                         theme,
                                       ).backgroundColor,
                                       boxShadow: "none",
@@ -869,26 +867,25 @@ const DatapointDrawerChild = () => {
                       borderRadius: "4px",
                     }}
                   >
-                    {Array.isArray(evalOpen?.valueInfos?.children) &&
-                    evalOpen.valueInfos.children.length > 0 ? (
+                    {Array.isArray(evalValueInfos?.children) &&
+                    evalValueInfos.children.length > 0 ? (
                       (() => {
                         /** @type {any[]} */
-                        const compositeChildren =
-                          evalOpen.valueInfos.children || [];
+                        const compositeChildren = evalValueInfos.children || [];
                         return (
                           <CompositeResultView
                             compositeResult={{
-                              ...evalOpen.valueInfos,
+                              ...evalValueInfos,
                               total_children:
-                                evalOpen.valueInfos.total_children ??
+                                evalValueInfos.total_children ??
                                 compositeChildren.length,
                               completed_children:
-                                evalOpen.valueInfos.completed_children ??
+                                evalValueInfos.completed_children ??
                                 compositeChildren.filter(
                                   (child) => child.status === "completed",
                                 ).length,
                               failed_children:
-                                evalOpen.valueInfos.failed_children ??
+                                evalValueInfos.failed_children ??
                                 compositeChildren.filter(
                                   (child) => child.status === "failed",
                                 ).length,
@@ -896,21 +893,18 @@ const DatapointDrawerChild = () => {
                           />
                         );
                       })()
-                    ) : evalOpen?.valueInfos?.reason?.trim() ||
-                      evalOpen?.valueInfos?.summary ? (
+                    ) : evalValueInfos?.reason?.trim() ||
+                      evalValueInfos?.summary ? (
                       <CellMarkdown
                         spacing={0}
-                        text={
-                          evalOpen?.valueInfos?.reason ||
-                          evalOpen?.valueInfos?.summary
-                        }
+                        text={evalValueInfos?.reason || evalValueInfos?.summary}
                       />
                     ) : (
                       "Unable to fetch Explanation"
                     )}
                   </Box>
                 </Box>
-               
+
                 {!evalOpenIsCode && !isCompositeEval && (
                   <ErrorLocalizationCellSection
                     evalOpen={evalOpen}
@@ -1296,7 +1290,7 @@ const ErrorLocalizationCellSection = ({ evalOpen, onAnalysisLoaded }) => {
   useEffect(() => {
     onAnalysisLoadedRef.current = onAnalysisLoaded;
   }, [onAnalysisLoaded]);
-  const valueInfos = evalOpen?.valueInfos;
+  const valueInfos = evalOpen?.value_infos ?? evalOpen?.valueInfos;
   const inlineAnalysis = valueInfos?.errorAnalysis;
   const hasInlineAnalysis = !!(
     inlineAnalysis &&

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -297,7 +297,6 @@ const DatapointDrawerChild = () => {
     evalMetaBySourceId[column?.col?.sourceId || column?.col?.source_id]
       ?.templateType === "composite";
 
-
   const runEvalData = useMemo(() => {
     const evalColumns = allColumns.filter((i) => i.originType === "evaluation");
     const currentRowData = datapoint?.rowData ? datapoint?.rowData : [];
@@ -368,7 +367,9 @@ const DatapointDrawerChild = () => {
       return null;
     }
   });
-  const evalOutput = evalOpen?.valueInfos?.output;
+  const evalValueInfos = evalOpen?.value_infos;
+  const evalCellValue = evalOpen?.cell_value;
+  const evalOutput = evalValueInfos?.output;
 
   const loading = false;
 
@@ -454,9 +455,9 @@ const DatapointDrawerChild = () => {
   };
 
   const finalArray = useMemo(() => {
-    const v = normalizeEvalCellValue(evalOpen?.cellValue);
+    const v = normalizeEvalCellValue(evalCellValue);
     return Array.isArray(v) ? v : undefined;
-  }, [evalOpen?.cellValue]);
+  }, [evalCellValue]);
 
   const onNavigate = async (direction) => {
     isNavigatingRef.current = true;
@@ -774,19 +775,19 @@ const DatapointDrawerChild = () => {
                         Error
                       </Box>
                     ) : (
-                      hasRenderableCellValue(evalOpen?.cellValue) && (
+                      hasRenderableCellValue(evalCellValue) && (
                         <>
                           <ShowComponent condition={!Array.isArray(finalArray)}>
                             <Chip
                               variant="soft"
-                              label={getLabel(evalOpen?.cellValue)}
+                              label={getLabel(evalCellValue)}
                               size="small"
                               sx={{
-                                ...getStatusColor(evalOpen?.cellValue, theme),
+                                ...getStatusColor(evalCellValue, theme),
                                 transition: "none",
                                 "&:hover": {
                                   backgroundColor: getStatusColor(
-                                    evalOpen?.cellValue,
+                                    evalCellValue,
                                     theme,
                                   ).backgroundColor,
                                   boxShadow: "none",
@@ -822,15 +823,12 @@ const DatapointDrawerChild = () => {
                                   label={val}
                                   size="small"
                                   sx={{
-                                    ...getStatusColor(
-                                      evalOpen?.cellValue,
-                                      theme,
-                                    ),
+                                    ...getStatusColor(evalCellValue, theme),
                                     marginRight: theme.spacing(1),
                                     transition: "none",
                                     "&:hover": {
                                       backgroundColor: getStatusColor(
-                                        evalOpen?.cellValue,
+                                        evalCellValue,
                                         theme,
                                       ).backgroundColor,
                                       boxShadow: "none",
@@ -869,26 +867,25 @@ const DatapointDrawerChild = () => {
                       borderRadius: "4px",
                     }}
                   >
-                    {Array.isArray(evalOpen?.valueInfos?.children) &&
-                    evalOpen.valueInfos.children.length > 0 ? (
+                    {Array.isArray(evalValueInfos?.children) &&
+                    evalValueInfos.children.length > 0 ? (
                       (() => {
                         /** @type {any[]} */
-                        const compositeChildren =
-                          evalOpen.valueInfos.children || [];
+                        const compositeChildren = evalValueInfos.children || [];
                         return (
                           <CompositeResultView
                             compositeResult={{
-                              ...evalOpen.valueInfos,
+                              ...evalValueInfos,
                               total_children:
-                                evalOpen.valueInfos.total_children ??
+                                evalValueInfos.total_children ??
                                 compositeChildren.length,
                               completed_children:
-                                evalOpen.valueInfos.completed_children ??
+                                evalValueInfos.completed_children ??
                                 compositeChildren.filter(
                                   (child) => child.status === "completed",
                                 ).length,
                               failed_children:
-                                evalOpen.valueInfos.failed_children ??
+                                evalValueInfos.failed_children ??
                                 compositeChildren.filter(
                                   (child) => child.status === "failed",
                                 ).length,
@@ -896,21 +893,18 @@ const DatapointDrawerChild = () => {
                           />
                         );
                       })()
-                    ) : evalOpen?.valueInfos?.reason?.trim() ||
-                      evalOpen?.valueInfos?.summary ? (
+                    ) : evalValueInfos?.reason?.trim() ||
+                      evalValueInfos?.summary ? (
                       <CellMarkdown
                         spacing={0}
-                        text={
-                          evalOpen?.valueInfos?.reason ||
-                          evalOpen?.valueInfos?.summary
-                        }
+                        text={evalValueInfos?.reason || evalValueInfos?.summary}
                       />
                     ) : (
                       "Unable to fetch Explanation"
                     )}
                   </Box>
                 </Box>
-               
+
                 {!evalOpenIsCode && !isCompositeEval && (
                   <ErrorLocalizationCellSection
                     evalOpen={evalOpen}
@@ -1296,8 +1290,8 @@ const ErrorLocalizationCellSection = ({ evalOpen, onAnalysisLoaded }) => {
   useEffect(() => {
     onAnalysisLoadedRef.current = onAnalysisLoaded;
   }, [onAnalysisLoaded]);
-  const valueInfos = evalOpen?.valueInfos;
-  const inlineAnalysis = valueInfos?.errorAnalysis;
+  const valueInfos = evalOpen?.value_infos;
+  const inlineAnalysis = valueInfos?.error_analysis;
   const hasInlineAnalysis = !!(
     inlineAnalysis &&
     typeof inlineAnalysis === "object" &&


### PR DESCRIPTION
## Summary

The Add Feedback drawer in the dataset row view (and the equivalent drawers on the experiment and compare-dataset surfaces) silently no-ops on Submit. Two underlying bugs, same root cause: callers were still reading camelCase keys from BE responses that the axios snake-to-camel interceptor used to translate. The interceptor was removed on 2026-04-12 to enforce snake_case at the contract boundary; these call sites were missed. Strict snake_case reads, no camelCase fallback.

## Bugs fixed

### Symptom 1: Submit button does nothing

| File | Bad read | What happens |
|---|---|---|
| `AddEvaluationFeeback.jsx` (×5 sites) | `feedbackData?.outputType` | BE returns `output_type` (`"score"`, `"reason"`, `"Pass/Fail"`, `"choices"`, `"select"`). Every conditional value-input branch evaluates false, no value field is rendered, Zod validation fails silently on the empty string, `handleSubmit` aborts, no network call. |
| `CompareDatasetEvalsAddFeedbackForm.jsx` (×5 sites) | same | same |

### Symptom 2: "Row ID is required for this operation" error on Re-calculate

| File | Bad read | What happens |
|---|---|---|
| `AddEvaluationFeeback.jsx` | `data?.rowData?.rowId` | BE response carries `row_id` snake_case. FE sent `row_id: undefined` in both stage-1 (`POST /model-hub/feedback/`) and stage-2 (`POST /model-hub/feedback/submit-feedback/`). PG `model_hub_feedback` rows saved with empty `row_id`; stage-2 `submit_feedback_action` reads `feedback.row_id` from PG and returns `400 ROW_ID_MISSING` for `action_type=recalculate_row`. Even when it did not error, `Cell.objects.filter(row_id="", dataset_id=...)` returned 0 rows so `EmbeddingManager.parallel_process_metadata` wrote a CH `feedbacks` entry with only `feedback_comment` + `feedback_value`, no input/output context, useless for retrieval. |
| `CompareDatasetEvalsAddFeedbackForm.jsx` | second-stage submit-feedback payload was missing `row_id` entirely | same parity issue. |

## Fix

Strict snake_case reads matching the contract boundary. No `?? camelCase` fallbacks.

- `AddEvaluationFeeback.jsx`: derive `const rowId = data?.rowData?.row_id` once per component (outer + inner), use in: existing-feedback query key, query param, `enabled` flag, mixpanel `rowIdentifier`, stage-1 `row_id` payload, stage-2 `row_id` payload. Replace 5 `feedbackData?.outputType` references with `feedbackData?.output_type`.
- `CompareDatasetEvalsAddFeedbackForm.jsx`: same 5 `outputType` to `output_type` replacements, plus add `row_id: evalDetail?.cellRowId` to the stage-2 payload for parity with the dataset side.

No new abstractions, no new files, no new endpoints, no axios entries touched. Wire shape unchanged on either side; the BE already returns the snake_case keys we now read.

## Verification end-to-end on local dev stack

Tested with eval template `0a7ec6b6-6c86-4b96-a468-0ada1724afe8` on dataset `8328a7c0-5990-4a14-a38c-b368436886b6`:

1. Click Add Feedback on an eval cell. Drawer renders the value input matched to the template's `output_type` (number input for `score`, multi-line for `reason`, radio for `Pass/Fail` and `choices`).
2. Enter value `34` + comment `karthik.avinash@01gmail.com`, Submit. Stage-1 POST returns 200, snackbar success.
3. PG `model_hub_feedback` row `c6e72d67-3dbd-4c3e-8b31-4eeaa27e2fb3` saved with `value=34`, `explanation=karthik.avinash@01gmail.com`, `row_id=d31fed82-4855-4092-88d2-260373741039` (populated end-to-end).
4. Pick "Re-calculate for this row", Submit. Stage-2 POST returns 200, snackbar "Row queued for recalculation". No `ROW_ID_MISSING` error.
5. CH `futureagi.feedbacks` receives a new alive row with full metadata: `input`, `output`, `feedback_value`, `feedback_comment`, `item_id`, `index_column`, `input_type`, `organization_id`, `workspace_id`.

## Test plan

- [x] ESLint clean on both touched files.
- [x] Prettier clean.
- [x] Manual smoke: Add Feedback renders the right value field for `score`, `reason`, `Pass/Fail`, `choices` templates.
- [x] Manual smoke: stage-1 Submit fires network call; PG row has `row_id` populated.
- [x] Manual smoke: stage-2 Re-calculate succeeds with no error toast.
- [x] CH inspection: `futureagi.feedbacks` receives a row with input/output cell metadata after stage-2 submit.

## Test

Screen recording - added in linear.

## Linear

- TH-5929 Add Feedback button is not working in datasets