### PR TITLE
[TH-5814] Fix SDK code blocks not rendering (snake_case API key mismatch)

### DIFF
--- a/frontend/src/sections/project/NewProject/NewExperiment.jsx
+++ b/frontend/src/sections/project/NewProject/NewExperiment.jsx
@@ -104,7 +104,7 @@ const NewExperiment = () => {
         </TabWrapper>
 
         <InstructionCodeCopy
-          text={getCodeBySection("installationGuide")}
+          text={getCodeBySection("installation_guide")}
           language={languageTab}
           // onCopy={() => trackEvent(Events.installDependenciesCopied)}
         />
@@ -158,7 +158,7 @@ const NewExperiment = () => {
         </TabWrapper>
 
         <InstructionCodeCopy
-          text={getCodeBySection("projectAddCode")}
+          text={getCodeBySection("project_add_code")}
           language={languageTab}
           // onCopy={() => trackEvent(Events.setupTelemetryCopied)}
         />

--- a/frontend/src/sections/project/NewProject/NewObserve.jsx
+++ b/frontend/src/sections/project/NewProject/NewObserve.jsx
@@ -106,7 +106,7 @@ const NewObserve = () => {
         </TabWrapper>
 
         <InstructionCodeCopy
-          text={getCodeBySection("installationGuide")}
+          text={getCodeBySection("installation_guide")}
           language={languageTab}
           // onCopy={() => trackEvent(Events.installDependenciesCopied)}
         />
@@ -160,7 +160,7 @@ const NewObserve = () => {
         </TabWrapper>
 
         <InstructionCodeCopy
-          text={getCodeBySection("projectAddCode")}
+          text={getCodeBySection("project_add_code")}
           language={languageTab}
           // onCopy={() => trackEvent(Events.setupTelemetryCopied)}
         />

--- a/frontend/src/sections/project/NewProject/__tests__/NewExperiment.test.jsx
+++ b/frontend/src/sections/project/NewProject/__tests__/NewExperiment.test.jsx
@@ -1,0 +1,71 @@
+/* eslint-disable react/prop-types */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "src/utils/test-utils";
+import NewExperiment from "../NewExperiment";
+
+const mocks = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock("src/utils/axios", () => ({
+  default: { get: mocks.get },
+  endpoints: {
+    project: { getCodeBlockTracer: "/tracer/project/project_sdk_code/" },
+  },
+}));
+
+vi.mock("src/utils/Mixpanel", () => ({
+  Events: {},
+  trackEvent: vi.fn(),
+  handleOnDocsClicked: vi.fn(),
+}));
+
+vi.mock("react-syntax-highlighter", () => ({
+  Prism: ({ children }) => <pre>{children}</pre>,
+}));
+
+vi.mock("src/components/iconify", () => ({ default: () => <span /> }));
+
+// Mirrors the live /tracer/project/project_sdk_code/?project_type=experiment response.
+const tracerFixture = {
+  installation_guide: {
+    Python: "INSTALL_GUIDE_PY_MARKER",
+    TypeScript: "INSTALL_GUIDE_TS_MARKER",
+  },
+  project_add_code: {
+    Python: "TELEMETRY_PY_MARKER",
+    TypeScript: "TELEMETRY_TS_MARKER",
+  },
+  keys: { Python: "API_KEYS_PY_MARKER", TypeScript: "API_KEYS_TS_MARKER" },
+  instruments: {},
+};
+
+const renderExperiment = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NewExperiment />
+    </QueryClientProvider>,
+  );
+};
+
+describe("NewExperiment FTUX SDK code (TH-5814)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.get.mockResolvedValue({ data: { result: tracerFixture } });
+  });
+
+  it("renders install and telemetry code from the snake_case response", async () => {
+    const { container } = renderExperiment();
+
+    // installation_guide (regressed from installationGuide)
+    await waitFor(() =>
+      expect(container.textContent).toContain("INSTALL_GUIDE_PY_MARKER"),
+    );
+    // project_add_code (regressed from projectAddCode)
+    expect(container.textContent).toContain("TELEMETRY_PY_MARKER");
+    expect(container.textContent).toContain("API_KEYS_PY_MARKER");
+    expect(container.textContent).not.toContain("Code not available");
+  });
+});

--- a/frontend/src/sections/project/NewProject/__tests__/NewObserve.test.jsx
+++ b/frontend/src/sections/project/NewProject/__tests__/NewObserve.test.jsx
@@ -1,0 +1,73 @@
+/* eslint-disable react/prop-types */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "src/utils/test-utils";
+import NewObserve from "../NewObserve";
+
+const mocks = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock("src/utils/axios", () => ({
+  default: { get: mocks.get },
+  endpoints: {
+    project: { getCodeBlockTracer: "/tracer/project/project_sdk_code/" },
+  },
+}));
+
+vi.mock("src/utils/Mixpanel", () => ({
+  Events: {},
+  trackEvent: vi.fn(),
+  handleOnDocsClicked: vi.fn(),
+}));
+
+// Render the raw code text instead of running the syntax highlighter.
+vi.mock("react-syntax-highlighter", () => ({
+  Prism: ({ children }) => <pre>{children}</pre>,
+}));
+
+vi.mock("src/components/iconify", () => ({ default: () => <span /> }));
+
+// Mirrors the live /tracer/project/project_sdk_code/ response (snake_case).
+const tracerFixture = {
+  installation_guide: {
+    Python: "INSTALL_GUIDE_PY_MARKER",
+    TypeScript: "INSTALL_GUIDE_TS_MARKER",
+  },
+  project_add_code: {
+    Python: "TELEMETRY_PY_MARKER",
+    TypeScript: "TELEMETRY_TS_MARKER",
+  },
+  keys: { Python: "API_KEYS_PY_MARKER", TypeScript: "API_KEYS_TS_MARKER" },
+  instruments: {},
+};
+
+const renderObserve = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NewObserve />
+    </QueryClientProvider>,
+  );
+};
+
+describe("NewObserve FTUX SDK code (TH-5814)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.get.mockResolvedValue({ data: { result: tracerFixture } });
+  });
+
+  it("renders install, telemetry and keys code from the snake_case response", async () => {
+    const { container } = renderObserve();
+
+    // installation_guide (regressed from installationGuide)
+    await waitFor(() =>
+      expect(container.textContent).toContain("INSTALL_GUIDE_PY_MARKER"),
+    );
+    // project_add_code (regressed from projectAddCode)
+    expect(container.textContent).toContain("TELEMETRY_PY_MARKER");
+    expect(container.textContent).toContain("API_KEYS_PY_MARKER");
+    // a key-casing mismatch would surface as this fallback string
+    expect(container.textContent).not.toContain("Code not available");
+  });
+});

--- a/frontend/src/sections/test/TestRuns/SDkComponentVoiceTestRun.jsx
+++ b/frontend/src/sections/test/TestRuns/SDkComponentVoiceTestRun.jsx
@@ -40,13 +40,13 @@ const SDkComponentVoiceTestRun = () => {
     >
       <InstructionTitle title="Step 1: Install the SDK" />
       <InstructionCodeCopy
-        text={getCodeBySection("installationGuide")}
+        text={getCodeBySection("installation_guide")}
         language={languageTab}
       />
 
       <InstructionTitle title="Step 2: Create a simulation run" />
       <InstructionCodeCopy
-        text={getCodeBySection("sdkCode")}
+        text={getCodeBySection("sdk_code")}
         language={languageTab}
       />
     </Box>

--- a/frontend/src/sections/test/TestRuns/__tests__/SDkComponentVoiceTestRun.test.jsx
+++ b/frontend/src/sections/test/TestRuns/__tests__/SDkComponentVoiceTestRun.test.jsx
@@ -1,0 +1,60 @@
+/* eslint-disable react/prop-types */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "src/utils/test-utils";
+import SDkComponentVoiceTestRun from "../SDkComponentVoiceTestRun";
+
+const mocks = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock("src/utils/axios", () => ({
+  default: { get: mocks.get },
+  endpoints: {
+    runTests: {
+      getVoiceSDKCode: (id) => `/simulate/run-tests/${id}/sdk-code/`,
+    },
+  },
+}));
+
+vi.mock("react-syntax-highlighter", () => ({
+  Prism: ({ children }) => <pre>{children}</pre>,
+}));
+
+vi.mock("src/components/iconify", () => ({ default: () => <span /> }));
+
+// Mirrors the live /simulate/run-tests/{id}/sdk-code/ response (snake_case).
+const voiceFixture = {
+  installation_guide: "VOICE_INSTALL_MARKER",
+  sdk_code: "VOICE_SDK_MARKER",
+  run_test_id: "rt-1",
+  run_test_name: "Run Test",
+};
+
+const renderVoice = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SDkComponentVoiceTestRun />
+    </QueryClientProvider>,
+  );
+};
+
+describe("SDkComponentVoiceTestRun SDK code (TH-5814)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.get.mockResolvedValue({ data: { result: voiceFixture } });
+  });
+
+  it("renders both step code blocks from the snake_case response", async () => {
+    const { container } = renderVoice();
+
+    // installation_guide (regressed from installationGuide)
+    await waitFor(() =>
+      expect(container.textContent).toContain("VOICE_INSTALL_MARKER"),
+    );
+    // sdk_code (regressed from sdkCode)
+    expect(container.textContent).toContain("VOICE_SDK_MARKER");
+    expect(container.textContent).not.toContain("Code not available");
+  });
+});


### PR DESCRIPTION
## Summary
A backend change flipped the SDK-code API response keys from camelCase to snake_case. Several frontend consumers still read them in camelCase, so those lookups returned `undefined` and the code blocks rendered the `"Code not available"` fallback instead of the snippet.

Renamed the read keys to snake_case in the three affected components:

| Component | Surface | Keys fixed |
|---|---|---|
| `NewObserve.jsx` | Observe FTUX (`/tracer/project/project_sdk_code/`) | `installationGuide`→`installation_guide`, `projectAddCode`→`project_add_code` |
| `NewExperiment.jsx` | Experiment/Prototype FTUX | `installationGuide`→`installation_guide`, `projectAddCode`→`project_add_code` |
| `SDkComponentVoiceTestRun.jsx` | Voice test-run SDK panel (`/simulate/run-tests/{id}/sdk-code/`) | `installationGuide`→`installation_guide`, `sdkCode`→`sdk_code` |

Verified against the live responses (both endpoints return snake_case keys).

`NewObserve` is the ticketed observe FTUX (TH-5814); the experiment and voice fixes are the **same root cause** surfaced by a sweep for other consumers of the snake_case migration, so they're bundled here.

## Why it wasn't caught
The contract/zod layer (`assertContractedResponse`) validates the **server response shape** (which is correctly snake_case), not how a component reads it. These are untyped `.jsx` reading raw axios data, and `cleanCode(undefined)` returns a graceful fallback — so a wrong key name is silent. Added render tests to close that gap.

## Tests
Added 3 render tests (under `__tests__/`) that mock each endpoint with a **snake_case fixture** and assert the code blocks render the real code **and not** `"Code not available"`. They fail if any read reverts to camelCase (verified empirically during review).

- Full frontend suite: **1784 tests passing**
- Reviewer agent: APPROVE (no blockers)

Closes TH-5814

## Test plan
- [ ] Observe FTUX: open **Add Project** drawer → Install Dependencies + Setup Telemetry blocks show code (Python & TypeScript)
- [ ] Experiment FTUX: open **Add Prototype** drawer → same two blocks show code
- [ ] Voice: `…/simulate/test/<id>/runs` SDK panel → Step 1 + Step 2 blocks show code
