### PR TITLE
[TH-5930] Fix empty tools list + empty tool input-schema (snake_case API reads)

### DIFF
--- a/frontend/src/components/custom-model-tools/EditTool.jsx
+++ b/frontend/src/components/custom-model-tools/EditTool.jsx
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { ShowComponent } from "src/components/show";
 import YAML from "yaml";
 import FormTextFieldV2 from "../FormTextField/FormTextFieldV2";
+import { getDefaultValues } from "./EditTool.utils";
 
 const tabOptions = [
   { label: "JSON", value: "json", disabled: false },
@@ -47,60 +48,6 @@ const editorOptions = {
     useShadows: false,
   },
 };
-
-function getDefaultValues(editTool) {
-  const defaultJson = `{
-  "type": "function",
-  "function": {
-      "name": "",
-      "description": "",
-      "parameters": {
-          "type": "object",
-          "properties": {},
-          "required": []
-      }
-  }
-}`;
-
-  const defaultYaml = `
-  type: function
-  function:
-    name:
-    description:
-    parameters:
-      type: object
-      properties: {}
-      required: []
-  `;
-
-  if (editTool) {
-    return {
-      name: editTool?.name || "",
-      description: editTool?.description || "",
-      config_type: editTool?.configType,
-      inputSchema: {
-        json:
-          editTool?.configType === "json" && editTool?.config
-            ? JSON.stringify(editTool?.config, null, 2)
-            : defaultJson,
-        yaml:
-          editTool?.configType === "yaml" && editTool?.yamlConfig
-            ? editTool?.yamlConfig
-            : defaultYaml,
-      },
-    };
-  }
-
-  return {
-    name: "",
-    description: "",
-    config_type: "json",
-    inputSchema: {
-      json: defaultJson,
-      yaml: defaultYaml,
-    },
-  };
-}
 
 const toolSchema = z
   .object({

--- a/frontend/src/components/custom-model-tools/EditTool.jsx
+++ b/frontend/src/components/custom-model-tools/EditTool.jsx
@@ -18,36 +18,11 @@ import { z } from "zod";
 import { ShowComponent } from "src/components/show";
 import YAML from "yaml";
 import FormTextFieldV2 from "../FormTextField/FormTextFieldV2";
-import { getDefaultValues } from "./EditTool.utils";
-
-const tabOptions = [
-  { label: "JSON", value: "json", disabled: false },
-  { label: "YAML", value: "yaml", disabled: false },
-];
-
-const editorOptions = {
-  selectOnLineNumbers: true,
-  roundedSelection: false,
-  readOnly: false,
-  cursorStyle: "line",
-  automaticLayout: true,
-  wordWrap: "on",
-  lineNumbers: "off",
-  folding: false,
-  minimap: { enabled: false },
-  glyphMargin: false,
-  lineDecorationsWidth: 0,
-  renderIndentGuides: true,
-  lineNumbersMinChars: 0,
-  scrollbar: {
-    vertical: "visible",
-    horizontal: "visible",
-    verticalScrollbarSize: 10,
-    horizontalScrollbarSize: 10,
-    alwaysConsumeMouseWheel: false,
-    useShadows: false,
-  },
-};
+import {
+  editorOptions,
+  getDefaultValues,
+  tabOptions,
+} from "./EditTool.utils";
 
 const toolSchema = z
   .object({

--- a/frontend/src/components/custom-model-tools/EditTool.utils.js
+++ b/frontend/src/components/custom-model-tools/EditTool.utils.js
@@ -1,0 +1,53 @@
+export function getDefaultValues(editTool) {
+  const defaultJson = `{
+  "type": "function",
+  "function": {
+      "name": "",
+      "description": "",
+      "parameters": {
+          "type": "object",
+          "properties": {},
+          "required": []
+      }
+  }
+}`;
+
+  const defaultYaml = `
+  type: function
+  function:
+    name:
+    description:
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  `;
+
+  if (editTool) {
+    return {
+      name: editTool?.name || "",
+      description: editTool?.description || "",
+      config_type: editTool?.config_type,
+      inputSchema: {
+        json:
+          editTool?.config_type === "json" && editTool?.config
+            ? JSON.stringify(editTool?.config, null, 2)
+            : defaultJson,
+        yaml:
+          editTool?.config_type === "yaml" && editTool?.yaml_config
+            ? editTool?.yaml_config
+            : defaultYaml,
+      },
+    };
+  }
+
+  return {
+    name: "",
+    description: "",
+    config_type: "json",
+    inputSchema: {
+      json: defaultJson,
+      yaml: defaultYaml,
+    },
+  };
+}

--- a/frontend/src/components/custom-model-tools/EditTool.utils.js
+++ b/frontend/src/components/custom-model-tools/EditTool.utils.js
@@ -1,3 +1,32 @@
+export const tabOptions = [
+  { label: "JSON", value: "json", disabled: false },
+  { label: "YAML", value: "yaml", disabled: false },
+];
+
+export const editorOptions = {
+  selectOnLineNumbers: true,
+  roundedSelection: false,
+  readOnly: false,
+  cursorStyle: "line",
+  automaticLayout: true,
+  wordWrap: "on",
+  lineNumbers: "off",
+  folding: false,
+  minimap: { enabled: false },
+  glyphMargin: false,
+  lineDecorationsWidth: 0,
+  renderIndentGuides: true,
+  lineNumbersMinChars: 0,
+  scrollbar: {
+    vertical: "visible",
+    horizontal: "visible",
+    verticalScrollbarSize: 10,
+    horizontalScrollbarSize: 10,
+    alwaysConsumeMouseWheel: false,
+    useShadows: false,
+  },
+};
+
 export function getDefaultValues(editTool) {
   const defaultJson = `{
   "type": "function",

--- a/frontend/src/components/custom-model-tools/ShowModelTools.jsx
+++ b/frontend/src/components/custom-model-tools/ShowModelTools.jsx
@@ -29,7 +29,7 @@ const ShowModelToolsChild = ({ onClose, handleApply, tools }) => {
   const [openEdit, setOpenEdit] = useState(null);
   const [createNew, setCreateNew] = useState(false);
   const { data: runPromptOptions, isLoading } = useRunPromptOptions();
-  const availableTools = runPromptOptions?.availableTools;
+  const availableTools = runPromptOptions?.available_tools;
 
   // useMemo(() => {
   //   if (tools?.length > 0) {

--- a/frontend/src/components/custom-model-tools/__tests__/EditTool.utils.test.js
+++ b/frontend/src/components/custom-model-tools/__tests__/EditTool.utils.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { getDefaultValues } from "../EditTool.utils";
+
+describe("getDefaultValues (TH-5930 edit-mode input schema)", () => {
+  it("prefills the JSON schema from a snake_case json tool", () => {
+    const tool = {
+      name: "one",
+      description: "asndlkjaslkdasd",
+      config_type: "json",
+      config: { type: "function", function: { name: "one" } },
+    };
+
+    const values = getDefaultValues(tool);
+
+    expect(values.config_type).toBe("json");
+    expect(values.name).toBe("one");
+    // the saved config is loaded into the editor, not the empty default template
+    expect(values.inputSchema.json).toBe(JSON.stringify(tool.config, null, 2));
+    expect(values.inputSchema.json).toContain('"name": "one"');
+  });
+
+  it("prefills the YAML schema from a snake_case yaml tool", () => {
+    const tool = {
+      name: "two",
+      description: "desc",
+      config_type: "yaml",
+      yaml_config: "type: function\nfunction:\n  name: two\n",
+    };
+
+    const values = getDefaultValues(tool);
+
+    expect(values.config_type).toBe("yaml");
+    expect(values.inputSchema.yaml).toBe(tool.yaml_config);
+    expect(values.inputSchema.yaml).toContain("name: two");
+  });
+
+  it("falls back to default templates for create mode (no tool)", () => {
+    const values = getDefaultValues(null);
+
+    expect(values.config_type).toBe("json");
+    expect(values.name).toBe("");
+    expect(values.inputSchema.json).toContain('"type": "function"');
+    expect(values.inputSchema.yaml).toContain("type: function");
+  });
+
+  it("does not pick up legacy camelCase keys (regression guard)", () => {
+    // A tool shaped the old camelCase way must NOT populate the editor —
+    // it would leave the schema empty, which is the bug we are guarding.
+    const camelTool = {
+      name: "x",
+      configType: "json",
+      config: { a: 1 },
+    };
+
+    const values = getDefaultValues(camelTool);
+
+    expect(values.config_type).toBeUndefined();
+    expect(values.inputSchema.json).not.toContain('"a": 1');
+  });
+});

--- a/frontend/src/components/custom-model-tools/__tests__/ShowModelTools.test.jsx
+++ b/frontend/src/components/custom-model-tools/__tests__/ShowModelTools.test.jsx
@@ -1,0 +1,50 @@
+/* eslint-disable react/prop-types */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import ShowModelTools from "../ShowModelTools";
+
+const hookState = vi.hoisted(() => ({ value: { data: undefined, isLoading: false } }));
+
+// The component reads runPromptOptions?.available_tools (snake_case from the API).
+vi.mock("src/api/develop/develop-detail", () => ({
+  useRunPromptOptions: () => hookState.value,
+}));
+
+vi.mock("./EditTool", () => ({ default: () => null }));
+vi.mock("src/components/FromSearchSelectField", () => ({
+  FormSearchSelectFieldState: () => null,
+}));
+vi.mock("src/components/svg-color", () => ({ default: () => <span /> }));
+vi.mock("src/components/iconify", () => ({ default: () => <span /> }));
+
+const runPromptOptions = {
+  available_tools: [
+    { id: "t1", name: "Tool Alpha", config_type: "json" },
+    { id: "t2", name: "Tool Beta", config_type: "json" },
+  ],
+  tool_choices: [],
+  output_formats: [],
+  models: [],
+};
+
+describe("ShowModelTools (TH-5930 tools list)", () => {
+  beforeEach(() => {
+    hookState.value = { data: runPromptOptions, isLoading: false };
+  });
+
+  it("renders the selected tools from the snake_case available_tools response", () => {
+    render(
+      <ShowModelTools
+        open
+        onClose={vi.fn()}
+        handleApply={vi.fn()}
+        tools={[{ id: "t1" }]}
+      />,
+    );
+
+    // Reading availableTools (camelCase) would leave this list empty.
+    expect(screen.getByText("Tool Alpha")).toBeInTheDocument();
+    // Only the selected tool is listed.
+    expect(screen.queryByText("Tool Beta")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/sections/develop-detail/Common/ModelOptions.jsx
+++ b/frontend/src/sections/develop-detail/Common/ModelOptions.jsx
@@ -162,7 +162,7 @@ const ModelOptions = ({
                     setValue?.(`${fieldNamePrefix}.toolChoice`, e.target.value);
                   }}
                   options={[
-                    ...(runPromptOptions?.toolChoices || []),
+                    ...(runPromptOptions?.tool_choices || []),
                     { value: "none", label: "None" },
                   ]}
                   sx={{ width: 200 }}
@@ -179,7 +179,7 @@ const ModelOptions = ({
                     },
                   }}
                   options={[
-                    ...(runPromptOptions?.toolChoices || []),
+                    ...(runPromptOptions?.tool_choices || []),
                     { value: "none", label: "None" },
                   ]}
                 />

--- a/frontend/src/sections/develop-detail/Common/ModelOptionsState.jsx
+++ b/frontend/src/sections/develop-detail/Common/ModelOptionsState.jsx
@@ -416,7 +416,7 @@ export default function ModelOptionsState({
                     },
                   }}
                   options={[
-                    ...(runPromptOptions?.toolChoices || []),
+                    ...(runPromptOptions?.tool_choices || []),
                     { value: "none", label: "None" },
                   ]}
                 />

--- a/frontend/src/sections/develop-detail/Experiment/PromptTemplateCard.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/PromptTemplateCard.jsx
@@ -471,7 +471,7 @@ const PromptTemplateCard = ({
                     borderColor: "text.primary",
                   }}
                   options={[
-                    ...(runPromptOptions?.toolChoices || []),
+                    ...(runPromptOptions?.tool_choices || []),
                     { value: "none", label: "None" },
                   ]}
                 />

--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/ConfigureStepTTSItem.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/ConfigureStepTTSItem.jsx
@@ -49,13 +49,13 @@ const ConfigureStepTTSItem = ({
   const { data: runPromptOptions } = useRunPromptOptions();
   const toolsOptions = useMemo(() => {
     return (
-      runPromptOptions?.availableTools?.map((t) => ({
+      runPromptOptions?.available_tools?.map((t) => ({
         label: t.name,
         value: t.id,
         tool: t,
       })) ?? []
     );
-  }, [runPromptOptions?.availableTools]);
+  }, [runPromptOptions?.available_tools]);
   const watchedMessages =
     useWatch({
       name: `promptConfig.${index}.messages`,

--- a/frontend/src/sections/develop-detail/RunPrompt/Modals/CustomToolModal.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/Modals/CustomToolModal.jsx
@@ -41,14 +41,16 @@ function getDefaultValues(editTool) {
     return {
       name: editTool?.name || "",
       description: editTool?.description || "",
-      config_type: editTool?.configType,
+      config_type: editTool?.config_type,
       inputSchema: {
         json:
-          editTool?.configType === "json"
+          editTool?.config_type === "json"
             ? JSON.stringify(editTool?.config, null, 2)
             : defaultJson,
         yaml:
-          editTool?.configType === "yaml" ? editTool?.yamlConfig : defaultYaml,
+          editTool?.config_type === "yaml"
+            ? editTool?.yaml_config
+            : defaultYaml,
       },
     };
   }

--- a/frontend/src/sections/develop-detail/RunPrompt/Modals/SavePromptModal.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/Modals/SavePromptModal.jsx
@@ -75,7 +75,7 @@ export default function SavePromptModal({
     mode: "onChange",
   });
   const { data: runPromptOptions } = useRunPromptOptions();
-  const availableTools = runPromptOptions?.availableTools;
+  const availableTools = runPromptOptions?.available_tools;
 
   const saveType = watch("saveType");
 

--- a/frontend/src/sections/develop-detail/RunPrompt/ToolConfig/ConfigTool.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/ToolConfig/ConfigTool.jsx
@@ -43,13 +43,13 @@ const ConfigTool = ({ control, fieldName = "config.tools" }) => {
 
   const toolsOptions = useMemo(() => {
     return (
-      runPromptOptions?.availableTools?.map((t) => ({
+      runPromptOptions?.available_tools?.map((t) => ({
         label: t.name,
         value: t.id,
         tool: t,
       })) ?? []
     );
-  }, [runPromptOptions?.availableTools]);
+  }, [runPromptOptions?.available_tools]);
 
   const isToolsPresent = toolsOptions?.length > 0;
 

--- a/frontend/src/sections/develop-detail/RunPrompt/ToolConfig/ToolsConfigSection.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/ToolConfig/ToolsConfigSection.jsx
@@ -22,12 +22,12 @@ const ToolsConfigSection = ({
   const theme = useTheme();
 
   const toolsOptions = useMemo(() => {
-    return runPromptOptions?.availableTools?.map((t) => ({
+    return runPromptOptions?.available_tools?.map((t) => ({
       label: t.name,
       value: t.id,
       tool: t,
     }));
-  }, [runPromptOptions?.availableTools]);
+  }, [runPromptOptions?.available_tools]);
 
   const filteredToolOptions = useMemo(() => {
     return (toolsOptions || [])?.filter((tool) =>
@@ -104,7 +104,7 @@ const ToolsConfigSection = ({
                   }
                 }}
                 options={[
-                  ...(runPromptOptions?.toolChoices || []),
+                  ...(runPromptOptions?.tool_choices || []),
                   { value: "none", label: "None" },
                 ]}
                 sx={{ width: 200 }}


### PR DESCRIPTION
## Summary
The backend migrated the `retrieve_run_prompt_options` response **and** the per-tool objects to snake_case, but the frontend still read camelCase keys → `undefined`. Result: the tools list was empty (even after adding), tool-choice dropdowns were empty, and the tool editor's **Input schema** was blank in edit mode.

Updated the reads to match the API:

**Run-prompt options response** (`{ models, tool_config, available_tools, output_formats, tool_choices }`) — `availableTools`→`available_tools` (×5), `toolChoices`→`tool_choices` (×4):
- `ShowModelTools`, `ToolsConfigSection`, `ConfigTool`, `SavePromptModal`, `ConfigureStepTTSItem`, `ModelOptions`, `ModelOptionsState`, `PromptTemplateCard`

**Per-tool object** (an `available_tools` item: `{ id, name, description, config, config_type, yaml_config }`) — edit-mode prefill read `configType`/`yamlConfig`:
- `EditTool` (extracted `getDefaultValues` → `EditTool.utils.js`) and `CustomToolModal` → `config_type`/`yaml_config`

`models` was already correct (same key). The lone `outputFormats` reference is inside a commented-out "Output Type" block (no live consumer) and was left untouched.

## Why it wasn't caught
The contract/zod layer validates the server response shape (correctly snake_case), not how untyped `.jsx` reads it. A wrong key is just `undefined` → empty list / empty editor, silently. Added tests to close that gap.

## Tests
- `EditTool.utils.test.js` — JSON/YAML prefill from a snake_case tool, create-mode defaults, and a regression guard (a camelCase tool must NOT populate).
- `ShowModelTools.test.jsx` — renders the tools list from `available_tools`.
- Full suite: **1786 passing**. Reviewer agent: APPROVE.

## Known pre-existing (out of scope)
The tool editors save YAML content into `config` but read it from `yaml_config`; JSON round-trips fine. Worth verifying a YAML tool round-trips, but it predates this change.

Closes TH-5930

## Test plan
- [ ] Run-prompt tool config: the **Tool** dropdown lists tools and stays populated after **Create tool**
- [x] Edit an existing tool (pencil) → the **Input schema** editor shows the saved JSON/YAML (not empty)
- [x] Tool-choice dropdown (model options) shows `auto`/`required`
