### PR TITLE
[TH-5923] Fix custom date range in dashboard widget editor

### DIFF
--- a/frontend/src/components/custom-datepicker/DatePicker.jsx
+++ b/frontend/src/components/custom-datepicker/DatePicker.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { addMonths, subMonths, format, parseISO, isValid } from "date-fns";
 import Calendar from "./Calender.jsx";
 import { Box, Button, Divider, Popover } from "@mui/material";
@@ -12,11 +12,27 @@ export default function CustomDateRangePicker({
   anchorEl,
   setDateFilter,
   setDateOption,
+  value,
 }) {
   const { control } = useForm();
   const [range, setRange] = useState({ start: null, end: null });
   const [currentDate1, setCurrentDate1] = useState(new Date());
   const [currentDate2, setCurrentDate2] = useState(addMonths(new Date(), 1));
+
+  // Seed only on the open false→true transition so a caller passing a fresh
+  // value array each render can't clobber an in-progress selection.
+  const prevOpenRef = useRef(false);
+  useEffect(() => {
+    const justOpened = open && !prevOpenRef.current;
+    prevOpenRef.current = open;
+    if (!justOpened || !value?.[0] || !value?.[1]) return;
+    const start = new Date(value[0]);
+    const end = new Date(value[1]);
+    if (!isValid(start) || !isValid(end)) return;
+    setRange({ start, end });
+    setCurrentDate1(start);
+    setCurrentDate2(addMonths(start, 1));
+  }, [open, value]);
 
   const handleSelectDate = (date) => {
     if (!range.start || (range.start && range.end)) {
@@ -198,4 +214,5 @@ CustomDateRangePicker.propTypes = {
   anchorEl: PropType.any,
   setDateFilter: PropType.func,
   setDateOption: PropType.func,
+  value: PropType.arrayOf(PropType.instanceOf(Date)),
 };

--- a/frontend/src/components/custom-datepicker/__tests__/DatePicker.test.jsx
+++ b/frontend/src/components/custom-datepicker/__tests__/DatePicker.test.jsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "src/utils/test-utils";
+import CustomDateRangePicker from "../DatePicker";
+
+const noop = () => {};
+
+function renderPicker(props) {
+  return render(
+    <CustomDateRangePicker
+      open={false}
+      onClose={noop}
+      anchorEl={document.body}
+      setDateFilter={vi.fn()}
+      setDateOption={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+const MARCH = [new Date("2026-03-10T12:00:00Z"), new Date("2026-04-10T12:00:00Z")];
+const AUGUST = [new Date("2026-08-10T12:00:00Z"), new Date("2026-09-10T12:00:00Z")];
+
+describe("CustomDateRangePicker seeding effect", () => {
+  it("seeds the calendars from value on the open false→true transition", () => {
+    const { rerender } = renderPicker({ value: MARCH });
+    rerender(
+      <CustomDateRangePicker
+        open
+        onClose={noop}
+        anchorEl={document.body}
+        setDateFilter={vi.fn()}
+        setDateOption={vi.fn()}
+        value={MARCH}
+      />,
+    );
+    expect(screen.getByText("March 2026")).toBeInTheDocument();
+    expect(screen.getByText("April 2026")).toBeInTheDocument();
+  });
+
+  it("does NOT reseed when value changes while already open", () => {
+    const { rerender } = renderPicker({ value: MARCH });
+    // open false→true: seeds March
+    rerender(
+      <CustomDateRangePicker
+        open
+        onClose={noop}
+        anchorEl={document.body}
+        setDateFilter={vi.fn()}
+        setDateOption={vi.fn()}
+        value={MARCH}
+      />,
+    );
+    expect(screen.getByText("March 2026")).toBeInTheDocument();
+
+    // value changes while still open → must keep March, not jump to August
+    rerender(
+      <CustomDateRangePicker
+        open
+        onClose={noop}
+        anchorEl={document.body}
+        setDateFilter={vi.fn()}
+        setDateOption={vi.fn()}
+        value={AUGUST}
+      />,
+    );
+    expect(screen.getByText("March 2026")).toBeInTheDocument();
+    expect(screen.queryByText("August 2026")).not.toBeInTheDocument();
+  });
+
+  it("ignores a malformed value (no seed, Done stays disabled, no crash)", () => {
+    const bad = [new Date("nope"), new Date("nope")];
+    const { rerender } = renderPicker({ value: bad });
+    rerender(
+      <CustomDateRangePicker
+        open
+        onClose={noop}
+        anchorEl={document.body}
+        setDateFilter={vi.fn()}
+        setDateOption={vi.fn()}
+        value={bad}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Done" })).toBeDisabled();
+  });
+});

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -40,6 +40,10 @@ import {
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import ReactApexChart from "react-apexcharts";
 import ChartLegend from "./ChartLegend";
+import {
+  buildTimeRangePayload,
+  resolveInitialTimeRange,
+} from "./dashboardDateRange";
 import { paths } from "src/routes/paths";
 import {
   useDashboardDetail,
@@ -1361,12 +1365,13 @@ export default function WidgetEditorView() {
         setChartDescription(widget.description || "");
         const qc = widget.queryConfig || widget.query_config || {};
         const cc = widget.chartConfig || widget.chart_config || {};
-        setTimePreset(
-          searchParams.get("timePreset") ||
-            qc.timeRange?.preset ||
-            qc.time_range?.preset ||
-            "30D",
-        );
+        const { timePreset: initialPreset, customDateRange: initialRange } =
+          resolveInitialTimeRange(
+            qc.timeRange || qc.time_range,
+            searchParams.get("timePreset"),
+          );
+        setTimePreset(initialPreset);
+        if (initialRange) setCustomDateRange(initialRange);
         setGranularity(qc.granularity || "day");
         setChartType(cc.chartType || cc.chart_type || "line");
         // Restore axis config if saved
@@ -1768,13 +1773,7 @@ export default function WidgetEditorView() {
   };
 
   const buildQueryConfig = useCallback(() => {
-    const timeRange =
-      timePreset === "custom" && customDateRange
-        ? {
-            custom_start: customDateRange[0].toISOString(),
-            custom_end: customDateRange[1].toISOString(),
-          }
-        : { preset: timePreset };
+    const timeRange = buildTimeRangePayload(timePreset, customDateRange);
     return {
       project_ids: [],
       time_range: timeRange,
@@ -1801,7 +1800,8 @@ export default function WidgetEditorView() {
   // Auto-preview when config changes (debounced)
   const previewTimerRef = useRef(null);
   useEffect(() => {
-    if (metrics.length > 0) {
+    const customWithoutRange = timePreset === "custom" && !customDateRange;
+    if (metrics.length > 0 && !customWithoutRange) {
       clearTimeout(previewTimerRef.current);
       previewTimerRef.current = setTimeout(() => {
         queryMutation.mutate(buildQueryConfig());
@@ -3231,6 +3231,7 @@ export default function WidgetEditorView() {
               open={isDatePickerOpen}
               onClose={() => setIsDatePickerOpen(false)}
               anchorEl={customDateAnchorRef.current}
+              value={customDateRange}
               setDateFilter={(filter) => {
                 if (filter && filter[0] && filter[1]) {
                   setCustomDateRange([


### PR DESCRIPTION
## Summary
The dashboard widget editor mishandled custom date ranges:

1. **Invalid payload** — it sent `time_range: { preset: "custom" }`, but the API's preset enum has no `"custom"` (custom ranges use `custom_start`/`custom_end`) → `400 "preset: 'custom' is not a valid choice."` → blank chart.
2. **Edit mode dropped the range** — a saved `{ custom_start, custom_end }` (no `preset`) silently reverted to **30D** and lost the dates.
3. **Picker opened blank** — `CustomDateRangePicker` had no initial-value prop, so the Start/End inputs weren't seeded from the saved range.

Verified live: `{preset:"custom"}` → 400, `{custom_start, custom_end}` → 200.

## Changes
- **`widgetTimeRange.js`** (new pure helpers):
  - `buildTimeRangePayload` — never emits `preset:"custom"` (falls back to `30D` until a range is picked); otherwise sends `custom_start`/`custom_end`.
  - `resolveInitialTimeRange` — restores a saved custom range as `"custom"` + dates; preset/default otherwise (URL `timePreset` still wins).
- **`WidgetEditorView.jsx`** — hydration uses `resolveInitialTimeRange`; `buildQueryConfig` uses `buildTimeRangePayload` (covers preview/save/run); auto-preview guarded so it won't fire while custom has no range; passes `value={customDateRange}` to the picker.
- **`DatePicker.jsx`** (shared) — optional `value` prop + effect to seed the inputs/calendars on open. Backward-compatible: the other 9 consumers don't pass `value`, so the guarded effect is inert for them.
- **Tests** — `widgetTimeRange.test.js` (7) guard both bugs (never `preset:"custom"`, custom range restores as `custom`+dates).

Closes TH-5923

## Test plan
- [ ] Create a widget with a custom range → reopen in edit: shows **Custom** with the dates, chart loads (no 30D, no 400)
- [ ] Open the date picker on that widget → Start/End inputs + calendars pre-filled
- [ ] Fresh widget → click Custom → picker opens, no error before a range is chosen
- [ ] Other date pickers (tracing, charts, users, performance) unchanged
