### PR TITLE
[TH-5921] Navigate back to dashboard after saving a widget

### DIFF
--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -80,6 +80,8 @@ const escapeCsvField = (field) => {
   return str;
 };
 
+const SAVED_NAV_DELAY_MS = 400;
+
 const TIME_PRESETS = [
   { label: "Custom", value: "custom" },
   { label: "30 mins", value: "30m" },
@@ -2084,7 +2086,8 @@ export default function WidgetEditorView() {
       clearTimeout(saveNavTimerRef.current);
       saveNavTimerRef.current = setTimeout(() => {
         navigate(paths.dashboard.dashboards.detail(dashboardId));
-      }, 400);
+        setSaveStatus("idle");
+      }, SAVED_NAV_DELAY_MS);
     } catch {
       setSaveStatus("idle");
       enqueueSnackbar(`Failed to ${isEditing ? "update" : "create"} widget`, {

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -1156,6 +1156,8 @@ export default function WidgetEditorView() {
   const customDateAnchorRef = useRef(null);
   const pieChartRef = useRef(null);
   const lineChartRef = useRef(null);
+  const saveNavTimerRef = useRef(null);
+  useEffect(() => () => clearTimeout(saveNavTimerRef.current), []);
   const [pieConnectors, setPieConnectors] = useState([]);
 
   // Auto-set granularity when time preset changes
@@ -2079,7 +2081,10 @@ export default function WidgetEditorView() {
         }
       }
       setSaveStatus("saved");
-      setTimeout(() => setSaveStatus("idle"), 2000);
+      clearTimeout(saveNavTimerRef.current);
+      saveNavTimerRef.current = setTimeout(() => {
+        navigate(paths.dashboard.dashboards.detail(dashboardId));
+      }, 400);
     } catch {
       setSaveStatus("idle");
       enqueueSnackbar(`Failed to ${isEditing ? "update" : "create"} widget`, {
@@ -3130,7 +3135,7 @@ export default function WidgetEditorView() {
         <Button
           variant="contained"
           onClick={handleSave}
-          disabled={saveStatus === "saving"}
+          disabled={saveStatus !== "idle"}
           color={saveStatus === "saved" ? "success" : "primary"}
           startIcon={
             saveStatus === "saved" ? (


### PR DESCRIPTION
## Summary
Clicking **Save** in the widget editor saved the widget but kept the user on the editor — they had to click **Close** separately to return to the dashboard (two actions where one is expected).

Now, on a successful save (both **create** and **edit**):
- the Save button shows its green **"Saved"** state as feedback, then
- after 400ms, navigates back to the dashboard (`paths.dashboard.dashboards.detail(dashboardId)` — same destination as Close).

## Changes (`WidgetEditorView.jsx`)
- `handleSave`: on success, navigate back after a short "Saved" beat (only on success — the error path is unchanged).
- The navigate timeout is stored in `saveNavTimerRef`, cleared on unmount and before re-scheduling → no navigate-after-unmount, no stacked timers.
- Save button `disabled={saveStatus !== "idle"}` (was `=== "saving"`) so the 400ms "Saved" window can't be double-clicked into a duplicate create.

Closes TH-5921

## Test plan
- [ ] Edit a widget → change something → Save → see "Saved", then land back on the dashboard
- [ ] Create a new widget → Save → same: "Saved" → dashboard
- [ ] Click Close during the brief "Saved" window → no errors (timer is cancelled on unmount)
- [ ] Error case (save fails) → stays on editor with the error toast (unchanged)
