### PR TITLE
fix(gateway): de-duplicate user metadata keys in detail drawers

### DIFF
--- a/frontend/src/sections/gateway/keys/KeyDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/keys/KeyDetailDrawer.jsx
@@ -17,6 +17,7 @@ import {
   IconButton,
 } from "@mui/material";
 import Iconify from "src/components/iconify";
+import { canonicalObject } from "src/utils/utils";
 import Chart from "react-apexcharts";
 import { useTheme } from "@mui/material/styles";
 import { useNavigate } from "react-router-dom";
@@ -298,7 +299,7 @@ const KeyDetailDrawer = ({ keyId, open, onClose, gatewayId }) => {
                     overflowX: "auto",
                   }}
                 >
-                  {JSON.stringify(keyData.metadata, null, 2)}
+                  {JSON.stringify(canonicalObject(keyData.metadata), null, 2)}
                 </Box>
               </Box>
             )}

--- a/frontend/src/sections/gateway/logs/RequestDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/logs/RequestDetailDrawer.jsx
@@ -26,6 +26,7 @@ import {
   CardContent,
 } from "@mui/material";
 import Iconify from "src/components/iconify";
+import { canonicalObject } from "src/utils/utils";
 import useRequestDetail from "./hooks/useRequestDetail";
 import FeedbackWidget from "../guardrails/FeedbackWidget";
 import { formatCost } from "../utils/formatters";
@@ -325,7 +326,9 @@ function ResponseTab({ log }) {
 MetadataTab.propTypes = { log: PropTypes.object.isRequired };
 
 function MetadataTab({ log }) {
-  const entries = Object.entries(log.metadata || {});
+  // Drop the response interceptor's camelCase aliases so user metadata keys
+  // don't render as duplicate rows (including nested object values).
+  const entries = Object.entries(canonicalObject(log.metadata || {}));
 
   if (entries.length === 0) {
     return (

--- a/frontend/src/sections/gateway/sessions/SessionDetailDrawer.jsx
+++ b/frontend/src/sections/gateway/sessions/SessionDetailDrawer.jsx
@@ -20,6 +20,7 @@ import {
 } from "@mui/material";
 import PropTypes from "prop-types";
 import Iconify from "src/components/iconify";
+import { canonicalObject } from "src/utils/utils";
 import { useSessionDetail, useSessionRequests } from "./hooks/useSessions";
 import {
   formatDateTime as formatDate,
@@ -151,7 +152,7 @@ const SessionDetailDrawer = ({ sessionId, open, onClose }) => {
                       whiteSpace: "pre-wrap",
                     }}
                   >
-                    {JSON.stringify(session.metadata, null, 2)}
+                    {JSON.stringify(canonicalObject(session.metadata), null, 2)}
                   </Typography>
                 </Card>
               </Box>

--- a/frontend/src/utils/__tests__/axios.test.js
+++ b/frontend/src/utils/__tests__/axios.test.js
@@ -5,7 +5,14 @@ vi.mock("../Mixpanel", () => ({
 }));
 
 import axiosInstance from "../axios";
-import { canonicalKeys } from "../utils";
+import { canonicalKeys, canonicalObject } from "../utils";
+
+const runResponseInterceptor = (data) => {
+  const fulfilled = axiosInstance.interceptors.response.handlers.find(
+    (handler) => handler.fulfilled,
+  )?.fulfilled;
+  return fulfilled({ data }).data;
+};
 
 describe("axios response shape", () => {
   it("adds camelCase aliases while canonicalKeys still hides duplicates", () => {
@@ -36,5 +43,38 @@ describe("axios response shape", () => {
     expect(Object.keys(result.data.span_attributes)).toEqual([
       "gen_ai.usage.total_tokens",
     ]);
+  });
+});
+
+// The interceptor injects camelCase aliases into user-controlled `metadata`,
+// which the gateway drawers render. canonicalObject removes those aliases so
+// the original keys round-trip unchanged at every level.
+describe("user-controlled metadata rendering (gateway drawers)", () => {
+  it("interceptor injects phantom aliases into metadata, including nested", () => {
+    const { metadata } = runResponseInterceptor({
+      metadata: { user_id: "abc", nested: { inner_key: 1 } },
+    });
+
+    expect(metadata.userId).toBe("abc");
+    expect(metadata.nested.innerKey).toBe(1);
+  });
+
+  it("canonicalObject strips aliases at every level for display", () => {
+    const { metadata } = runResponseInterceptor({
+      metadata: { user_id: "abc", nested: { inner_key: 1 } },
+    });
+
+    expect(canonicalObject(metadata)).toEqual({
+      user_id: "abc",
+      nested: { inner_key: 1 },
+    });
+  });
+
+  it("preserves user-supplied camelCase keys that have no snake twin", () => {
+    const { metadata } = runResponseInterceptor({
+      metadata: { alreadyCamel: 1 },
+    });
+
+    expect(canonicalObject(metadata)).toEqual({ alreadyCamel: 1 });
   });
 });

--- a/frontend/src/utils/__tests__/canonicalKeys.test.js
+++ b/frontend/src/utils/__tests__/canonicalKeys.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { canonicalKeys, canonicalEntries, canonicalValues } from "../utils";
+import {
+  canonicalKeys,
+  canonicalEntries,
+  canonicalValues,
+  canonicalObject,
+} from "../utils";
 
 // Helper that simulates a legacy object containing both canonical keys and
 // old alias keys so iteration sees both.
@@ -92,5 +97,44 @@ describe("canonicalKeys / canonicalEntries / canonicalValues", () => {
     const obj = withAliases({ tone_17_apr_2026: { neutral: 10 } });
     expect(Object.keys(obj)).toContain("tone17Apr2026");
     expect(canonicalKeys(obj)).toEqual(["tone_17_apr_2026"]);
+  });
+
+  describe("canonicalObject", () => {
+    it("returns a copy with alias keys removed", () => {
+      const obj = withAliases({ user_id: 1, total_rows: 10 });
+      expect(canonicalObject(obj)).toEqual({ user_id: 1, total_rows: 10 });
+    });
+
+    it("removes aliases from nested objects and arrays", () => {
+      const obj = withAliases({
+        user_id: 1,
+        nested: withAliases({ inner_key: 2 }),
+        items: [withAliases({ row_id: 3 })],
+      });
+      expect(canonicalObject(obj)).toEqual({
+        user_id: 1,
+        nested: { inner_key: 2 },
+        items: [{ row_id: 3 }],
+      });
+    });
+
+    it("does not mutate the input object", () => {
+      const obj = withAliases({ user_id: 1 });
+      const before = Object.keys(obj).length;
+      canonicalObject(obj);
+      expect(Object.keys(obj).length).toBe(before);
+    });
+
+    it("preserves genuine camelCase keys with no snake twin", () => {
+      expect(canonicalObject({ alreadyCamel: 1, plain: 2 })).toEqual({
+        alreadyCamel: 1,
+        plain: 2,
+      });
+    });
+
+    it("passes through null and primitives unchanged", () => {
+      expect(canonicalObject(null)).toBe(null);
+      expect(canonicalObject("x")).toBe("x");
+    });
   });
 });

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -808,6 +808,17 @@ export const canonicalValues = (obj) => {
   return canonicalKeys(obj).map((key) => obj[key]);
 };
 
+// Deep variant: returns a copy with alias keys removed at every level, so the
+// result can be serialized (e.g. JSON.stringify) without exposing duplicates
+// from nested objects. Does not mutate the input.
+export const canonicalObject = (obj) => {
+  if (!obj || typeof obj !== "object") return obj;
+  if (Array.isArray(obj)) return obj.map(canonicalObject);
+  return Object.fromEntries(
+    canonicalEntries(obj).map(([key, value]) => [key, canonicalObject(value)]),
+  );
+};
+
 export const objectCamelToSnake = (obj) => {
   if (obj === null || obj === undefined) {
     return obj;


### PR DESCRIPTION
## Summary

The Axios response interceptor (`addCamelAliases` in `src/utils/axios.js`) adds camelCase aliases to every snake_case key, recursing into nested objects. It skips the fields in `USER_KEYED_MAP_FIELDS`, but `metadata` isn't one of them — so user-supplied metadata keys get aliased too. The gateway log/session/key drawers render `metadata` raw, so a user key like `user_id` shows a phantom `userId` duplicate (at every nesting level).

`metadata` can't simply be added to the skip-list: the same field name carries system-computed keys read via their camel aliases in the experiment/develop views (`metadata.average_cost`, `metadata.is_winner_chosen`, …), so skip-listing it would break those. Instead this renders the gateway drawers' metadata through the existing `canonical*` helpers (the pattern already used in `SessionsView/MetadataContent.jsx`), and adds a deep `canonicalObject` for the nested / `JSON.stringify` cases.

## Linked issues

Closes #907

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- `yarn lint` and `yarn type-check`: pass.
- New unit tests pass (`yarn test:run src/utils/__tests__/axios.test.js src/utils/__tests__/canonicalKeys.test.js`): one test drives the real response interceptor and asserts the phantom alias is injected (top-level and nested); the rest assert `canonicalObject` strips aliases at every level and preserves genuine camelCase keys.
- Full `yarn test:run`: this change adds no failures. The suite has pre-existing, unrelated failures not touched here — a flaky `render-performance` timing assertion (208ms vs a 200ms threshold) and a few stores that throw on `localStorage` access under jsdom at import time.

## Screenshots / recordings (if UI)

Reproduces only with live gateway data, so the behavior is captured as a deterministic unit test instead (see `axios.test.js`). Before: a `user_id` metadata entry also renders a `userId` row. After: only `user_id`.

## Checklist

- [x] My code follows the style guide (lint passes)
- [x] I've added tests that prove my fix is effective
- [x] No hardcoded secrets, URLs, or PII
- [ ] `yarn check-all` passes locally — lint + type-check + the new/affected tests pass; the full suite's only failures are the pre-existing/flaky ones noted above
