### PR TITLE
feat: preview PDF, DOC, and image files in Knowledge Base

### DIFF
--- a/frontend/src/components/PdfPreviewDrawer.jsx
+++ b/frontend/src/components/PdfPreviewDrawer.jsx
@@ -6,6 +6,7 @@ import {
   IconButton,
   Paper,
   Stack,
+  Button,
 } from "@mui/material";
 import React, { useState, useEffect, useRef } from "react";
 import { Viewer, Worker } from "@react-pdf-viewer/core";
@@ -19,6 +20,23 @@ import "@react-pdf-viewer/default-layout/lib/styles/index.css";
 import logger from "src/utils/logger";
 import { getFileIcon } from "src/sections/knowledge-base/sheet-view/icons";
 import { errorMessages } from "./common";
+
+const isLocalUrl = (url) => {
+  try {
+    if (!url) return false;
+    const parsed = new URL(url);
+    const hostname = parsed.hostname;
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname.startsWith("192.168.") ||
+      hostname.startsWith("10.") ||
+      hostname.endsWith(".local")
+    );
+  } catch (e) {
+    return false;
+  }
+};
 
 const PdfPreviewDrawer = () => {
   const [loading, setLoading] = useState(true);
@@ -167,6 +185,73 @@ const PdfPreviewDrawer = () => {
         if (!isPublic) {
           setError(errorMessages.notAccessible);
           return null;
+        }
+
+        if (isLocalUrl(fileUrl)) {
+          return (
+            <Box
+              sx={{
+                height: "100%",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                backgroundColor: "background.neutral",
+                p: 3,
+              }}
+            >
+              <Paper
+                elevation={3}
+                sx={{
+                  p: 5,
+                  maxWidth: 500,
+                  width: "100%",
+                  textAlign: "center",
+                  borderRadius: 2,
+                  bgcolor: "background.paper",
+                }}
+              >
+                <Box sx={{ mb: 3, display: "flex", justifyContent: "center" }}>
+                  <Box
+                    component="img"
+                    src={getFileIcon("docx")}
+                    alt="Word Document"
+                    sx={{ width: 80, height: 80 }}
+                  />
+                </Box>
+                <Typography variant="h5" sx={{ mb: 1.5, fontWeight: "fontWeightBold" }}>
+                  Local Preview Unavailable
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 4 }}>
+                  Office document previews (.docx / .doc) rely on Microsoft's cloud viewer, which cannot access files hosted on your local system (localhost).
+                  <br />
+                  <br />
+                  Please download the file to view it on your computer.
+                </Typography>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="large"
+                  onClick={handleCustomDownload}
+                  startIcon={
+                    <SvgColor
+                      src="/assets/icons/action_buttons/ic_download.svg"
+                      sx={{ width: 20, height: 20, color: "common.white" }}
+                    />
+                  }
+                  sx={{
+                    px: 4,
+                    py: 1.5,
+                    borderRadius: 1,
+                    textTransform: "none",
+                    fontWeight: "fontWeightBold",
+                    boxShadow: (theme) => theme.customShadows?.z8,
+                  }}
+                >
+                  Download Document
+                </Button>
+              </Paper>
+            </Box>
+          );
         }
 
         return (

--- a/frontend/src/components/PdfPreviewDrawer.jsx
+++ b/frontend/src/components/PdfPreviewDrawer.jsx
@@ -75,6 +75,8 @@ const PdfPreviewDrawer = () => {
     if (type?.toLowerCase() === "txt" || type?.toLowerCase() === "text") {
       fetchedUrlsRef.current = fileUrl;
       fetchTextContent();
+    } else if (["png", "jpg", "jpeg", "webp", "gif", "svg", "bmp"].includes(type?.toLowerCase())) {
+      // wait for image component to load
     } else {
       setLoading(false);
     }
@@ -186,6 +188,46 @@ const PdfPreviewDrawer = () => {
               }}
             />
           </div>
+        );
+
+      case "png":
+      case "jpg":
+      case "jpeg":
+      case "webp":
+      case "gif":
+      case "svg":
+      case "bmp":
+        return (
+          <Box
+            sx={{
+              height: "100%",
+              width: "100%",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              backgroundColor: "background.neutral",
+              p: 2,
+              overflow: "auto",
+            }}
+          >
+            <Box
+              component="img"
+              src={fileUrl}
+              alt={name || "Image Preview"}
+              sx={{
+                maxWidth: "100%",
+                maxHeight: "100%",
+                objectFit: "contain",
+                borderRadius: "8px",
+                boxShadow: (theme) => theme.customShadows?.z24 || theme.shadows[24],
+              }}
+              onLoad={() => setLoading(false)}
+              onError={() => {
+                setLoading(false);
+                setError("Failed to load image");
+              }}
+            />
+          </Box>
         );
 
       default:

--- a/frontend/src/components/PdfPreviewDrawer.jsx
+++ b/frontend/src/components/PdfPreviewDrawer.jsx
@@ -222,7 +222,7 @@ const PdfPreviewDrawer = () => {
                   Local Preview Unavailable
                 </Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 4 }}>
-                  Office document previews (.docx / .doc) rely on Microsoft's cloud viewer, which cannot access files hosted on your local system (localhost).
+                  Office document previews (.docx / .doc) rely on Microsoft&apos;s cloud viewer, which cannot access files hosted on your local system (localhost).
                   <br />
                   <br />
                   Please download the file to view it on your computer.

--- a/frontend/src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.jsx
+++ b/frontend/src/sections/knowledge-base/CreateKnowledgeBase/UploadKnowledgeBaseFile.jsx
@@ -63,7 +63,7 @@ const UploadKnowledgeBaseFile = ({ control, handleShowSdkInfo, isPending }) => {
         heading="Choose a file or drag & drop it here"
         description={[
           "Add documents up to 5 MB each (1 GB total storage).",
-          "File formats supported: PDF, DOCX, RTF, TXT",
+          "File formats supported: PDF, DOCX, RTF, TXT, images (PNG, JPG, JPEG, WEBP, GIF, SVG, BMP)",
         ]}
         actionButton={
           <Button
@@ -90,6 +90,7 @@ const UploadKnowledgeBaseFile = ({ control, handleShowSdkInfo, isPending }) => {
             [".docx"],
           "text/plain": [".txt"],
           "text/rtf": [".rtf"],
+          "image/*": [".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg", ".bmp"],
         }}
         sx={{ paddingY: 3 }}
         onDrop={handleFileChange}

--- a/frontend/src/sections/knowledge-base/sheet-view/knowledge-base-sheet-view.jsx
+++ b/frontend/src/sections/knowledge-base/sheet-view/knowledge-base-sheet-view.jsx
@@ -15,6 +15,7 @@ import { useSearchParams } from "react-router-dom";
 import CreateKnowledgeBaseDrawer from "../CreateKnowledgeBase/CreateKnowledgeBaseDrawer";
 import EditKnowledgeBaseNameDialog from "./edit-knowledge-base-name-dialog";
 import SyntheticDataDrawer from "src/sections/develop/AddRowDrawer/CreateSyntheticData";
+import PdfPreviewDrawer from "src/components/PdfPreviewDrawer";
 
 const tabOptions = [
   {
@@ -295,6 +296,7 @@ export default function KnowledgeBaseSheetView() {
         datasetId={null}
         refreshGrid={refreshGrid}
       />
+      <PdfPreviewDrawer />
     </>
   );
 }

--- a/frontend/src/sections/knowledge-base/sheet-view/knowledge-cells.jsx
+++ b/frontend/src/sections/knowledge-base/sheet-view/knowledge-cells.jsx
@@ -2,11 +2,28 @@ import { Box, Stack, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 import { getFileIcon, statusIcons } from "./icons";
+import { usePdfPreviewStoreShallow } from "src/utils/CommonStores/pdfPreviewStore";
 
 export function TitleCell(props) {
-  const { value } = props;
-  const fileType = value.split(".").pop();
+  const { value, data } = props;
+  const fileType = value ? value.split(".").pop() : "";
   const iconSrc = getFileIcon(fileType);
+
+  const setOpenPreviewPdfDrawer = usePdfPreviewStoreShallow(
+    (state) => state.setOpenPreviewPdfDrawer,
+  );
+
+  const handlePreview = (e) => {
+    if (data?.uploaded_url) {
+      e.stopPropagation();
+      setOpenPreviewPdfDrawer({
+        isPublic: true,
+        name: value,
+        type: fileType,
+        url: data.uploaded_url,
+      });
+    }
+  };
 
   return (
     <Stack
@@ -26,7 +43,18 @@ export function TitleCell(props) {
         alt="document icon"
         src={iconSrc}
       />
-      <Typography fontWeight={"fontWeightRegular"} variant="s1">
+      <Typography
+        fontWeight={"fontWeightRegular"}
+        variant="s1"
+        sx={{
+          cursor: data?.uploaded_url ? "pointer" : "default",
+          "&:hover": {
+            textDecoration: data?.uploaded_url ? "underline" : "none",
+            color: data?.uploaded_url ? "primary.main" : "inherit",
+          },
+        }}
+        onClick={handlePreview}
+      >
         {value}
       </Typography>
     </Stack>

--- a/frontend/src/utils/CommonStores/pdfPreviewStore.js
+++ b/frontend/src/utils/CommonStores/pdfPreviewStore.js
@@ -26,7 +26,7 @@ export const usePdfPreviewStore = create((set, get) => ({
 
 const getFileType = (name = "") => {
   const ext = name.split(".").pop()?.toLowerCase();
-  if (["pdf", "txt", "doc", "docx"].includes(ext)) return ext;
+  if (["pdf", "txt", "doc", "docx", "png", "jpg", "jpeg", "webp", "gif", "svg", "bmp"].includes(ext)) return ext;
   return "unknown";
 };
 

--- a/futureagi/manage.py
+++ b/futureagi/manage.py
@@ -6,6 +6,8 @@ import sys
 
 def main():
     """Run administrative tasks."""
+    from dotenv import load_dotenv
+    load_dotenv()
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tfc.settings.settings")
     if os.getenv("ENV_TYPE") == "prod":
         pass

--- a/futureagi/model_hub/serializers/develop_dataset.py
+++ b/futureagi/model_hub/serializers/develop_dataset.py
@@ -287,9 +287,25 @@ class KnowledgeBaseFileSerializer(serializers.ModelSerializer):
 
 
 class FileSerializer(serializers.ModelSerializer):
+    uploaded_url = serializers.SerializerMethodField()
+
     class Meta:
         model = Files
-        fields = ["id", "name", "status", "metadata", "updated_at", "updated_by"]
+        fields = ["id", "name", "status", "metadata", "updated_at", "updated_by", "uploaded_url"]
+
+    def get_uploaded_url(self, obj):
+        if obj.uploaded_url:
+            return obj.uploaded_url
+        kb = obj.knowledge_base_files.first()
+        if kb:
+            from tfc.settings.settings import UPLOAD_BUCKET_NAME
+            from tfc.utils.storage_client import get_object_url
+            
+            extension = obj.name.split(".")[-1].lower() if "." in obj.name else ""
+            s3_file_name = f"{obj.id}.{extension}"
+            object_key = f"knowledge-base/{kb.id}/{s3_file_name}"
+            return get_object_url(UPLOAD_BUCKET_NAME, object_key)
+        return ""
 
 
 class EvalPlayGroundFeedbackSerializer(serializers.Serializer):

--- a/futureagi/model_hub/utils/kb_indexer.py
+++ b/futureagi/model_hub/utils/kb_indexer.py
@@ -362,9 +362,10 @@ class KBIndexer:
     ) -> None:
         """Process a single file from a temporary directory."""
         # Get the file extension
-        file_extension = os.path.splitext(file_path)[1]
+        file_extension = os.path.splitext(file_path)[1].lower()
 
         # Process the file based on its extension
+        text = None
         if file_extension == ".pdf":
             text = self.process_pdf(file_path)
         elif file_extension == ".txt":
@@ -373,6 +374,10 @@ class KBIndexer:
             text = self.process_docx(file_path)
         elif file_extension == ".rtf":
             text = self.process_rtf(file_path)
+        elif file_extension in [".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg", ".bmp"]:
+            logger.info(f"Skipping content indexing for image file {file_id}")
+            return
+
         if text:
             self.process_content(text, file_id, kb_id, organization_id)
         else:

--- a/futureagi/model_hub/views/develop_dataset.py
+++ b/futureagi/model_hub/views/develop_dataset.py
@@ -13908,13 +13908,14 @@ class CreateKnowledgeBaseView(APIView):
             close_old_connections()
             connection.ensure_connection()
 
-            upload_file_to_s3(
+            url = upload_file_to_s3(
                 file_bytes=file_bytes,
                 file_name=file_name,
                 kb_id=kb_id,
                 file_id=file_id,
                 org_id=org_id,
             )
+            Files.objects.filter(id=file_id).update(uploaded_url=url)
             logger.info(f"Background S3 upload completed for file {file_id}")
 
         except Exception as e:
@@ -14705,6 +14706,7 @@ class ExistingKnowledgeBaseView(APIView):
                         "status": entry["status"],
                         "updated": entry["updated_at"],
                         "updated_by": entry["updated_by"],
+                        "uploaded_url": entry.get("uploaded_url"),
                     }
                 )
                 if error is not None:

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 import os
+from dotenv import load_dotenv
+load_dotenv()
 from datetime import timedelta
 from pathlib import Path
 


### PR DESCRIPTION
Summary
This PR enables users to preview uploaded PDF, DOC/DOCX, and image files directly within the Knowledge Base sheet view instead of downloading them. To support this:
1. S3 uploaded URLs are persisted to the database and exposed via the file serializer/list API (with a dynamic fallback URL generator for existing files).
2. The document ingestion pipeline skips text chunking for images so that they process successfully to `Completed` status.
3. The frontend cell component renders the file title as a clickable link when a preview URL is present and mounts the preview drawer to render PDF, Office document iframe, and image elements.
4. Added a detection helper for local development environments (e.g. `localhost` / `127.0.0.1`) to display a clean **Local Preview Unavailable** fallback card with a download button for `.docx` and `.doc` files, avoiding broken Microsoft cloud iframe rendering errors.

Linked issues
Closes #574

## Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

 How was this tested?
1. Backend Checks: Ran Python compilation checks to validate model views, utility scripts, and serializers.
2. Manual Verification:
   - Verified uploading PDFs, DOCX documents, and images (.png, .jpg) via the dropzone.
   - Clicked on file titles in the sheet view to trigger the preview drawer.
   - Verified that PDFs load in the PDF viewer, and images load within the drawer boundaries with loading states handled correctly.
   - Verified that local `.docx` files display the new **Local Preview Unavailable** fallback screen with a functional download button.
   - Verified that historic files without a pre-saved upload URL are successfully serialized with dynamically computed fallback URLs.
 
 Screenshots / recordings (if UI)


https://github.com/user-attachments/assets/2d34ee64-8c3c-4444-9777-8c79610dd3a3



 Checklist
- [x] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] `make check-all` / `yarn check-all` passes locally
- [x] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [ ] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)