### PR TITLE
fix: huggingface subset/split dropdowns + experiment version snake_case

### DIFF
--- a/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/AgentPromptRenderer.jsx
+++ b/frontend/src/sections/develop-detail/Experiment/StepperComponentExperiment/AgentPromptRenderer.jsx
@@ -173,9 +173,7 @@ const AgentPromptRenderer = ({
   // Mirror the selected version's draft flag + version label onto the
   // form item so the schema's superRefine can block "Next" when a draft
   // version is picked, and emit a per-item error naming the exact
-  // version the user needs to save or swap (TH-4334). The backend
-  // exposes `is_draft` / `template_version` on each version; axios'
-  // camelCase transform surfaces them as `isDraft` / `templateVersion`.
+  // version the user needs to save or swap (TH-4334).
   useEffect(() => {
     if (type !== PROMPT_CONFIG_TYPE.PROMPT) return;
     const selected = versionsOptions?.find(
@@ -185,10 +183,10 @@ const AgentPromptRenderer = ({
     // need to revalidate on it. isDraft drives the schema's draft guard,
     // so validate immediately: the card goes red the moment the user
     // picks a draft version, instead of waiting for the next Next-click.
-    setValue(`${fieldPrefix}.versionLabel`, selected?.templateVersion || "", {
+    setValue(`${fieldPrefix}.versionLabel`, selected?.template_version || "", {
       shouldValidate: false,
     });
-    setValue(`${fieldPrefix}.isDraft`, Boolean(selected?.isDraft), {
+    setValue(`${fieldPrefix}.isDraft`, Boolean(selected?.is_draft), {
       shouldValidate: true,
     });
   }, [type, watchedPromptVersion, versionsOptions, setValue, fieldPrefix]);
@@ -301,9 +299,9 @@ const AgentPromptRenderer = ({
               searchQuery={search}
               onSearchChange={setSearch}
               getOptionLabel={(v) =>
-                v?.isDefault === true
-                  ? `${v?.templateVersion} (default)`
-                  : v?.templateVersion ?? ""
+                v?.is_default === true
+                  ? `${v?.template_version} (default)`
+                  : v?.template_version ?? ""
               }
               getOptionValue={(v) => v?.id}
               placeholder="Select version"

--- a/frontend/src/sections/develop-detail/RunPrompt/Modals/ImportPrompt.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/Modals/ImportPrompt.jsx
@@ -194,15 +194,15 @@ export default function ImportPrompt({
   const [, setHasUserChangedVersion] = useState(false);
 
   useEffect(() => {
-    if (open && data?.prompt?.id && data?.promptVersion?.templateVersion) {
+    if (open && data?.prompt?.id && data?.promptVersion?.template_version) {
       setValue("prompt", data?.prompt?.id, {
         shouldValidate: true,
       });
-      setValue("promptVersion", data?.promptVersion?.templateVersion, {
+      setValue("promptVersion", data?.promptVersion?.template_version, {
         shouldValidate: true,
       });
     }
-  }, [data?.prompt?.id, data?.promptVersion?.templateVersion, open, setValue]);
+  }, [data?.prompt?.id, data?.promptVersion?.template_version, open, setValue]);
 
   const {
     data: promptsData,
@@ -242,18 +242,18 @@ export default function ImportPrompt({
 
   const versions =
     versionRes?.map((version) => ({
-      label: version?.templateVersion,
-      value: version?.templateVersion,
+      label: version?.template_version,
+      value: version?.template_version,
     })) ?? [];
 
   useEffect(() => {
     if (versionRes?.length === 0) return;
-    const latestVersionId = versionRes?.[0]?.templateVersion;
+    const latestVersionId = versionRes?.[0]?.template_version;
     if (selectedVersionId !== latestVersionId) {
       setValue("promptVersion", latestVersionId, {
         shouldValidate: true,
       });
-    } else if (!selectedPromptId && !data?.promptVersion?.templateVersion) {
+    } else if (!selectedPromptId && !data?.promptVersion?.template_version) {
       setValue("promptVersion", "", {
         shouldValidate: true,
       });
@@ -266,7 +266,7 @@ export default function ImportPrompt({
     if (!selectedPromptId || !selectedVersionId || versionRes?.length < 0)
       return;
     const selectedVersion = versionRes.find(
-      (v) => v?.templateVersion === selectedVersionId,
+      (v) => v?.template_version === selectedVersionId,
     );
     const messages = selectedVersion?.promptConfigSnapshot?.messages || [];
     setPromptMessages(messages);
@@ -290,7 +290,7 @@ export default function ImportPrompt({
       return data?.prompt === prompt?.id;
     });
     const promptVersion = versionRes.find(
-      (version) => version?.templateVersion === data?.promptVersion,
+      (version) => version?.template_version === data?.promptVersion,
     );
     handleApplyImportedPrompt({
       prompt,

--- a/frontend/src/sections/develop-detail/RunPrompt/Modals/ImportPrompt.jsx
+++ b/frontend/src/sections/develop-detail/RunPrompt/Modals/ImportPrompt.jsx
@@ -268,7 +268,7 @@ export default function ImportPrompt({
     const selectedVersion = versionRes.find(
       (v) => v?.template_version === selectedVersionId,
     );
-    const messages = selectedVersion?.promptConfigSnapshot?.messages || [];
+    const messages = selectedVersion?.prompt_config_snapshot?.messages || [];
     setPromptMessages(messages);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedVersionId, selectedPromptId, versionRes?.length]);

--- a/frontend/src/sections/develop/AddDatasetDrawer/ImportFromHuggingFace.jsx
+++ b/frontend/src/sections/develop/AddDatasetDrawer/ImportFromHuggingFace.jsx
@@ -130,7 +130,7 @@ const ImportFromHuggingFace = ({ open, onClose, refreshGrid }) => {
     let subsetOptions = [];
     let splitOptions = [];
 
-    const datasetInfo = loadedDataset?.data?.result?.datasetInfo?.splits;
+    const datasetInfo = loadedDataset?.data?.result?.dataset_info?.splits;
 
     if (datasetInfo) {
       subsetOptions = Object.keys(datasetInfo)?.map((subset) => ({

--- a/frontend/src/sections/huggingface/HuggingFaceView.jsx
+++ b/frontend/src/sections/huggingface/HuggingFaceView.jsx
@@ -381,7 +381,7 @@ const HuggingFaceView = () => {
     let subsetOptions = [];
     let splitOptions = [];
 
-    const datasetInfo = loadedDataset?.data?.result?.datasetInfo?.splits;
+    const datasetInfo = loadedDataset?.data?.result?.dataset_info?.splits;
 
     if (datasetInfo) {
       subsetOptions = Object.keys(datasetInfo).map((subset) => ({


### PR DESCRIPTION
## Summary

The HuggingFace subset/split dropdowns and the experiment version dropdowns were using camelCase field reads against APIs that return snake_case.

### 1. HuggingFace subset & split dropdowns (TH-5854)

Backend returns `dataset_info` (snake_case). Both `HuggingFaceView.jsx` and `ImportFromHuggingFace.jsx` were reading `datasetInfo` (camelCase) → `splits` was always `undefined` → dropdowns empty.

**Fix:** Read `dataset_info` directly.

### 2. Experiment version dropdowns (TH-5881)

Backend returns `template_version` / `is_draft` / `prompt_config_snapshot` (snake_case). FE was reading `templateVersion` / `isDraft` / `promptConfigSnapshot` → version label blank, draft guard never fired, messages not loaded on import.

**Fix:** Read snake_case directly — `template_version`, `is_draft`, `prompt_config_snapshot`.

## Linked issues

Closes TH-5854
Closes TH-5881

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guide
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA