### PR TITLE
fix(eval-task): cascade EvalSettings on bulk-delete + restore trace_id/span_id filter handlers (TH-5937)

### DIFF
--- a/futureagi/model_hub/views/separate_evals.py
+++ b/futureagi/model_hub/views/separate_evals.py
@@ -207,8 +207,11 @@ def apply_filters(row_data, filters):
                 }
 
                 if filter_op not in text_ops:
-                    message = "Invalid filter operation. \
-                        Allowed operations are: " + ", ".join(text_ops.keys())
+                    message = (
+                        "Invalid filter operation. \
+                        Allowed operations are: "
+                        + ", ".join(text_ops.keys())
+                    )
                     raise ValueError(message)
 
                 result = []
@@ -1906,6 +1909,11 @@ class EvalTemplateBulkDeleteView(APIView):
                     UserEvalMetric.objects.filter(
                         id__in=[m[0] for m in metrics]
                     ).update(deleted=True, deleted_at=timezone.now())
+
+                # Soft-delete EvalSettings rows attached to deleted templates.
+                EvalSettings.objects.filter(
+                    eval_id__in=req.template_ids, deleted=False
+                ).update(deleted=True, deleted_at=timezone.now())
 
             response = BulkDeleteResponse(deleted_count=deleted_count)
             return self._gm.success_response(response.model_dump())

--- a/futureagi/tracer/utils/eval_tasks.py
+++ b/futureagi/tracer/utils/eval_tasks.py
@@ -133,6 +133,14 @@ def compute_drain_state(eval_task, eval_task_logger=None):
     }
 
 
+def _as_list(value):
+    if value is None or value == "":
+        return []
+    if isinstance(value, list):
+        return [item for item in value if item not in (None, "")]
+    return [value]
+
+
 def parsing_evaltask_filters(filters: dict) -> tuple[Q, dict]:
     """Combine eval-task filter JSON into ``(Q, annotation_kwargs)``.
 
@@ -218,8 +226,17 @@ def parsing_evaltask_filters(filters: dict) -> tuple[Q, dict]:
                     "Invalid value for observation_type filter; expected list or string"
                 )
         elif key == "session_id":
-            traces = Trace.objects.filter(session_id=value).values_list("id", flat=True)
+            session_ids = _as_list(value)
+            traces = Trace.objects.filter(session_id__in=session_ids).values_list(
+                "id", flat=True
+            )
             combined_q &= Q(trace_id__in=list(traces))
+        elif key == "trace_id":
+            trace_ids = _as_list(value)
+            combined_q &= Q(trace_id__in=trace_ids)
+        elif key == "span_id":
+            span_ids = _as_list(value)
+            combined_q &= Q(id__in=span_ids)
         elif key == "date_range":
             if isinstance(value, list) and len(value) == 2:
                 start_date, end_date = value
@@ -249,13 +266,6 @@ def parsing_monitor_filters(filters: dict) -> Q:
 
     if filters is None:
         return combined_q
-
-    def _as_list(value):
-        if value is None or value == "":
-            return []
-        if isinstance(value, list):
-            return [item for item in value if item not in (None, "")]
-        return [value]
 
     for key, value in filters.items():
         if (


### PR DESCRIPTION
> **Status: Draft / parked.** Pausing this PR until the scope is reviewed; tracked under [TH-5937](https://linear.app/future-agi/issue/TH-5937) so it doesn't fall off the radar.

---

## Summary

Two unrelated bugs surfaced by the TH-5500 PR's 19-file test sweep.

### `model_hub/views/separate_evals.py`

`EvalTemplateBulkDeleteView` cascades soft-delete to `Cell` / `Column` / `UserEvalMetric` but not to `EvalSettings`. A deleted template's settings rows stay alive forever in PG. Added the cascade.

### `tracer/utils/eval_tasks.py`

`parsing_evaltask_filters` has no `trace_id` or `span_id` handlers, so task filters on those fields are silently dropped and `process_eval_task` dispatches on the whole project instead of the requested scope. The `session_id` handler accepts only scalar values; list-shaped task filters (the UI's actual shape) crash with `ValidationError: "['<uuid>'] is not a valid UUID"`. Added the missing handlers and made `session_id` list-aware via the existing `_as_list` helper (promoted to module-level so both parsers share it).

## Test plan

<img width="918" height="624" alt="image" src="https://github.com/user-attachments/assets/e2164f19-e7fc-4c41-b090-ed9d8998ae27" />

19-file sweep on this branch: **446 passed, 0 failed** (was 442 passed, 4 failed). The 4 inherited failures are resolved.

## Linear

[TH-5937](https://linear.app/future-agi/issue/TH-5937) (parent: TH-5500)
