### PR TITLE
chore(ch25): unify compose stacks on the futureagi v2 database + fi-collector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,10 @@
 # COMPOSE_PROFILES=full
 
 # ClickHouse database used by the CH25 schema/read path and fi-collector
-# writer. Keep these two values identical if you override them.
-CH25_DATABASE=default
-FI_CH_DATABASE=default
+# writer. Keep these two values identical if you override them. `default`
+# is reserved for the legacy PeerDB analytics tables.
+CH25_DATABASE=futureagi
+FI_CH_DATABASE=futureagi
 
 # Each image has an independent version. Empty = use `:latest`. Pin per
 # service to lock a specific release.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -58,7 +58,7 @@ x-dev-backend-env: &dev-backend-env
   CH_PASSWORD: ""
   CH_DATABASE: default
   # CH25 schema/read path. Must match fi-collector's FI_CH_DATABASE.
-  CH25_DATABASE: ${CH25_DATABASE:-${CH_DATABASE:-default}}
+  CH25_DATABASE: ${CH25_DATABASE:-futureagi}
   CH_USE_REPLICATED_ENGINES: ${CH_USE_REPLICATED_ENGINES:-false}
 
   REDIS_HOST: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,8 @@ x-backend-env: &backend-env
   CH_DATABASE: default
   # CH25 schema/read path. Keep this aligned with FI_CH_DATABASE so the
   # backend and fi-collector read/write the same ClickHouse database.
-  CH25_DATABASE: ${CH25_DATABASE:-${CH_DATABASE:-default}}
+  # `default` stays the legacy PeerDB analytics DB (CH_DATABASE above).
+  CH25_DATABASE: ${CH25_DATABASE:-futureagi}
   CH_USE_REPLICATED_ENGINES: ${CH_USE_REPLICATED_ENGINES:-false}
 
   # CH25 cutover (dev/local default). When True the boot-time schema
@@ -367,7 +368,7 @@ services:
     environment:
       # Point at the same ClickHouse the backend uses (HTTP port 8123).
       FI_CH_URL: http://clickhouse:8123
-      FI_CH_DATABASE: ${FI_CH_DATABASE:-${CH25_DATABASE:-${CH_DATABASE:-default}}}
+      FI_CH_DATABASE: ${FI_CH_DATABASE:-${CH25_DATABASE:-futureagi}}
       FI_GRPC_ADDR: ":4317"
       # OTLP/HTTP receiver — needed by browser SDKs + lightweight clients.
       # `FI_HTTP_ADDR=disable` turns the listener off if you front the

--- a/futureagi/.env.example
+++ b/futureagi/.env.example
@@ -141,6 +141,9 @@ CH_USERNAME=default
 CH_PASSWORD=
 CH_DATABASE=default               # legacy analytics DB (PeerDB CDC tables live here)
 CH25_DATABASE=futureagi           # v2 (CH25) analytics DB — must NOT be 'default'; unset resolves to 'default' and breaks v2 reads
+# Drop the legacy CDC span chain at boot and auto-apply the v2 schema
+# (fi-collector becomes the sole spans writer). Dev/local default.
+CH25_DROP_LEGACY_CDC_CHAIN=true
 CH_USE_REPLICATED_ENGINES=false   # true only if shard/replica macros are configured
 # Memory limit for ClickHouse container (default: 2g, increase if OOM)
 # CLICKHOUSE_MEM_LIMIT=2g

--- a/futureagi/docker-compose.observability.yml
+++ b/futureagi/docker-compose.observability.yml
@@ -21,8 +21,10 @@ services:
     container_name: jaeger
     ports:
       - "${JAEGER_UI_PORT:-16686}:16686" # Jaeger UI
-      - "${JAEGER_OTLP_GRPC_PORT:-4317}:4317" # OTLP gRPC receiver
-      - "${JAEGER_OTLP_HTTP_PORT:-4318}:4318" # OTLP HTTP receiver
+      # Host ports moved off 4317/4318 — fi-collector (product OTLP ingest)
+      # owns the standard ports. In-stack services still use jaeger:4317.
+      - "${JAEGER_OTLP_GRPC_PORT:-14317}:4317" # OTLP gRPC receiver
+      - "${JAEGER_OTLP_HTTP_PORT:-14318}:4318" # OTLP HTTP receiver
     volumes:
       - ./config/jaeger-ui-config.json:/etc/jaeger/jaeger-ui-config.json:ro
     environment:

--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -828,12 +828,17 @@ services:
       peerdb-temporal:
         condition: service_healthy
     environment:
-      - TEMPORAL_CLI_ADDRESS=peerdb-temporal:7233
+      - TEMPORAL_ADDRESS=peerdb-temporal:7233
+    # `tctl` was removed from current temporalio/admin-tools images — the old
+    # entrypoint failed silently and mirrors then died with "no mapping
+    # defined for search attribute MirrorName". The trailing list|grep makes
+    # a registration failure fail this container (peerdb-init gates on it).
     entrypoint: >
       /bin/sh -c "
-      echo 'Registering MirrorName search attribute...' &&
-      echo Y | tctl admin cluster add-search-attributes --name MirrorName --type Text 2>/dev/null;
-      echo 'Done (may already exist)'
+      echo 'Registering MirrorName search attribute...';
+      temporal operator search-attribute create --name MirrorName --type Text --namespace default ||
+      echo 'create failed (may already exist)';
+      temporal operator search-attribute list --namespace default | grep MirrorName
       "
 
   peerdb-init:

--- a/futureagi/docker-compose.yml
+++ b/futureagi/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       - AGENTCC_GATEWAY_INTERNAL_URL=http://agentcc-gateway:8090
       - AGENTCC_INTERNAL_API_KEY=${AGENTCC_INTERNAL_API_KEY:-}
       - CH25_DATABASE=${CH25_DATABASE:-futureagi}
+      - CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}
       # Read replica: uncomment to test read/write split locally (points to same DB).
       # Both PGBOUNCER_READ_HOST and READ_REPLICA_OPT_IN must be set for any
       # routing to happen. See .env.example for the full list of feature keys.
@@ -79,6 +80,10 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      # OTLP ingest path. service_started (not _healthy) — distroless image
+      # has no shell for an exec healthcheck and starts fast.
+      fi-collector:
+        condition: service_started
 
   serving:
     platform: linux/amd64
@@ -123,6 +128,36 @@ services:
       # already passed through via env_file above — no per-provider entries
       # needed here. See INSTALLATION.md → "Vertex AI" for the bearer-token
       # pattern and the warning about mounting Vertex_AI_Creds.json.
+    restart: unless-stopped
+
+  # ===========================================
+  # fi-collector (OTLP span ingest → CH 25.3)
+  # ===========================================
+
+  # fi-collector — OTLP receiver that writes spans directly to CH 25.3
+  # (v2 schema, database `futureagi`). Same service as the root compose;
+  # see docs/CH25_MIGRATION.md.
+  fi-collector:
+    container_name: fi-collector
+    build:
+      context: ../fi-collector
+      dockerfile: Dockerfile
+    ports:
+      - "${FI_COLLECTOR_OTLP_PORT:-4317}:4317"
+      - "${FI_COLLECTOR_OTLP_HTTP_PORT:-4318}:4318"
+      - "${FI_COLLECTOR_ADMIN_PORT:-9464}:9464"
+    environment:
+      - FI_CH_URL=http://clickhouse:8123
+      - FI_CH_DATABASE=${FI_CH_DATABASE:-${CH25_DATABASE:-futureagi}}
+      - FI_GRPC_ADDR=:4317
+      - FI_HTTP_ADDR=:4318
+      - FI_ADMIN_ADDR=:9464
+      - FI_DEAD_LETTER_FILE=/var/lib/fi-collector/dead_letter.jsonl
+    volumes:
+      - fi-collector-data:/var/lib/fi-collector
+    depends_on:
+      clickhouse:
+        condition: service_healthy
     restart: unless-stopped
 
   # Sandboxed code executor — nsjail-based isolation for eval code
@@ -480,6 +515,9 @@ services:
       - .env
     environment:
       - SERVICE_TYPE=temporal-worker
+      # Must match backend: a worker booting with the flag unset would
+      # re-create the legacy CDC span chain the backend just dropped.
+      - CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}
       - TEMPORAL_HOST=temporal:7233
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - TEMPORAL_TASK_QUEUE=default
@@ -506,6 +544,9 @@ services:
       - .env
     environment:
       - SERVICE_TYPE=temporal-worker
+      # Must match backend: a worker booting with the flag unset would
+      # re-create the legacy CDC span chain the backend just dropped.
+      - CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}
       - TEMPORAL_HOST=temporal:7233
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - TEMPORAL_TASK_QUEUE=tasks_l
@@ -532,6 +573,9 @@ services:
       - .env
     environment:
       - SERVICE_TYPE=temporal-worker
+      # Must match backend: a worker booting with the flag unset would
+      # re-create the legacy CDC span chain the backend just dropped.
+      - CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}
       - TEMPORAL_HOST=temporal:7233
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - TEMPORAL_TASK_QUEUE=tasks_xl
@@ -558,6 +602,9 @@ services:
       - .env
     environment:
       - SERVICE_TYPE=temporal-worker
+      # Must match backend: a worker booting with the flag unset would
+      # re-create the legacy CDC span chain the backend just dropped.
+      - CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}
       - TEMPORAL_HOST=temporal:7233
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - TEMPORAL_TASK_QUEUE=tasks_s
@@ -584,6 +631,9 @@ services:
       - .env
     environment:
       - SERVICE_TYPE=temporal-worker
+      # Must match backend: a worker booting with the flag unset would
+      # re-create the legacy CDC span chain the backend just dropped.
+      - CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}
       - TEMPORAL_HOST=temporal:7233
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - TEMPORAL_TASK_QUEUE=trace_ingestion
@@ -610,6 +660,9 @@ services:
       - .env
     environment:
       - SERVICE_TYPE=temporal-worker
+      # Must match backend: a worker booting with the flag unset would
+      # re-create the legacy CDC span chain the backend just dropped.
+      - CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}
       - TEMPORAL_HOST=temporal:7233
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - TEMPORAL_TASK_QUEUE=agent_compass
@@ -809,6 +862,9 @@ services:
       - DST_CH_USER=default
       - DST_CH_PASSWORD=
       - DST_CH_DB=${CH_DATABASE:-default}
+      # Skip the tracer_observation_span mirror — fi-collector owns spans
+      # ingest (see scripts/peerdb-setup-mirrors.sh). Must match backend.
+      - CH25_DROP_LEGACY_CDC_CHAIN=${CH25_DROP_LEGACY_CDC_CHAIN:-true}
       - PEERDB_HOST=peerdb-server
       - PEERDB_PORT=9900
     volumes:
@@ -851,6 +907,10 @@ volumes:
   peerdb-catalog-data:
     driver: local
   peerdb-minio-data:
+    driver: local
+  # fi-collector dead-letter queue: spans the collector couldn't write
+  # to ClickHouse, persisted for replay.
+  fi-collector-data:
     driver: local
 
 # ===========================================

--- a/futureagi/tfc/settings/settings.py
+++ b/futureagi/tfc/settings/settings.py
@@ -801,7 +801,7 @@ CLICKHOUSE_V2 = {
     "CH25_TCP_PORT":  os.getenv("CH25_TCP_PORT", "9000"),
     "CH25_USER":      os.getenv("CH25_USER", "default"),
     "CH25_PASSWORD":  os.getenv("CH25_PASSWORD", ""),
-    "CH25_DATABASE":  os.getenv("CH25_DATABASE", "default"),
+    "CH25_DATABASE":  os.getenv("CH25_DATABASE", "futureagi"),
     # ─── Per-query-type routing for the shadow-mode rollout ──────────────────
     # Comma-separated query type names. See tracer/services/clickhouse/v2/shadow.py
     # for RoutingMode definitions. Anything not listed defaults to V1_ONLY.

--- a/futureagi/tracer/services/clickhouse/v2/apply_schema.py
+++ b/futureagi/tracer/services/clickhouse/v2/apply_schema.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import os
+import re
 import sys
 import time
 from dataclasses import dataclass
@@ -233,11 +234,55 @@ def apply_file(client, sf: SchemaFile, applied_by: str, *,
     return len(statements)
 
 
+_DB_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def ensure_database(args) -> int:
+    """CREATE DATABASE IF NOT EXISTS for the target db.
+
+    Uses a bootstrap connection with NO `database=` (clickhouse_connect then
+    targets the server-side `default` db, which always exists) — a client
+    bound to a missing db fails its first command with UNKNOWN_DATABASE (81).
+    Returns 0 on success/skip, 1 on invalid identifier.
+    """
+    db = args.ch_database
+    if not _DB_NAME_RE.match(db):
+        log.error("invalid_database_name", database=db)
+        return 1
+    if db == "default":
+        return 0  # always exists; also avoids needing CREATE grants
+    bootstrap = clickhouse_connect.get_client(
+        host=args.ch_host,
+        port=args.ch_http_port,
+        username=args.ch_user,
+        password=args.ch_password,
+        send_receive_timeout=120,
+    )
+    # Replicated mode: the database must exist on every replica BEFORE
+    # ensure_versions_table's ON CLUSTER table DDL fans out.
+    on_cluster = f" ON CLUSTER '{args.cluster}'" if args.replicated else ""
+    try:
+        bootstrap.command(f"CREATE DATABASE IF NOT EXISTS `{db}`{on_cluster}")
+        log.info("database_ensured", database=db, replicated=args.replicated)
+    except Exception as e:
+        # e.g. user lacks CREATE DATABASE grant but the db was pre-provisioned
+        # (prod). Proceed — the real connect below fails loudly if it's
+        # genuinely missing.
+        log.warning("database_ensure_failed", database=db, err=str(e))
+    finally:
+        bootstrap.close()
+    return 0
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Main
 # ──────────────────────────────────────────────────────────────────────────────
 def main(argv: list[str] | None = None) -> int:
     args = build_argparser().parse_args(argv)
+
+    rc = ensure_database(args)
+    if rc:
+        return rc
 
     log.info("connect", host=args.ch_host, port=args.ch_http_port, database=args.ch_database)
     client = clickhouse_connect.get_client(


### PR DESCRIPTION
## What & why

The CH25 work merged to `dev` left the two compose stacks diverging on the v2 spans architecture. This branch brings both to the documented end-state: the v2 spans database is **`futureagi`** everywhere (auto-created), `default` stays the legacy PeerDB analytics DB, and **fi-collector** runs in both stacks.

Reference: internal-docs `clickhouse-analytics/migration-to-ch25` (DEV_SERVER_CH25_BRINGUP §5, STEP2 runbook §0/§8.3 — the canonical `futureagi` target and the settings "trap").

## Changes

**Auto-create the v2 database** (`apply_schema.py`)
Nothing in the migration / boot-hook / management-command / test-conftest paths ever ran `CREATE DATABASE`, so a fresh target db failed with `UNKNOWN_DATABASE`. New `ensure_database()` creates it via a bootstrap connection (no `database=` bound) before the main client connects — validates the identifier, skips `default`, and fans out `ON CLUSTER` in replicated mode.

**Settings default → `futureagi`** (`settings.py`)
`CLICKHOUSE_V2["CH25_DATABASE"]` defaulted to the literal `"default"`, shadowing the `"futureagi"` fallback in `get_v2_config()`. Flipped so every Django process (incl. workers with no per-service env) resolves the canonical db. Test settings (`test_tfc`) are unaffected.

**Compose unification** (outer + inner stacks)
- `CH25_DATABASE` / `FI_CH_DATABASE` default to `futureagi` in the outer stack (anchor, fi-collector, dev overlay, `.env.example`).
- Inner stack gains the fi-collector OTLP service (build `../fi-collector`, ports 4317/4318/9464, dead-letter volume); backend depends on it.
- `CH25_DROP_LEGACY_CDC_CHAIN=true` on the inner backend, **all six temporal-workers**, and peerdb-init — workers re-create the legacy chain otherwise; peerdb-init skips the `tracer_observation_span` mirror.
- Jaeger's host OTLP ports move to 14317/14318 so fi-collector owns the standard 4317/4318.

**PeerDB temporal-init fix**
`peerdb-temporal-init` used `tctl` (removed from current `temporalio/admin-tools`); it failed silently, so `MirrorName` was never registered and every `CREATE MIRROR` died with *"no mapping defined for search attribute MirrorName"*. Rewritten to `temporal operator search-attribute create`, and now fails the container on error so peerdb-init doesn't run against a broken namespace.

## Notes for reviewers
- The settings flip makes `get_v2_config()`'s legacy `CH_DATABASE` fallback unreachable — single-db deployments must now set `CH25_DATABASE` explicitly (matches prod, which already does).
- No data-migration mitigation for outer-stack users with prior v2 spans in `default` — throwaway pre-GA, by decision.
- CDC stays partial by design: only `tracer_observation_span` is excluded (fi-collector owns spans); the other trace tables keep replicating into `default`.

## Verification
Both stacks brought up fresh on CH 25.3: `futureagi` db auto-created, 18 schema files applied, fi-collector `/healthz` green, OTLP smoke span lands in `futureagi.spans`, and all PeerDB CDC workflows running with active replication slots after the temporal-init fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)