### PR TITLE
fix(dashboards): add delete confirmations across dashboard & widget flows

### DIFF
--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -600,7 +600,11 @@ function DraggableWidgetCard({
                 </IconButton>
               </Tooltip>
               <Tooltip title="More">
-                <IconButton size="small" onClick={(e) => onMenuOpen(e, widget)}>
+                <IconButton
+                  size="small"
+                  aria-label="Widget options"
+                  onClick={(e) => onMenuOpen(e, widget)}
+                >
                   <Iconify icon="mdi:dots-vertical" width={16} />
                 </IconButton>
               </Tooltip>
@@ -702,11 +706,11 @@ export default function DashboardDetailView() {
   // Dashboard more menu
   const [dashMenuAnchor, setDashMenuAnchor] = useState(null);
 
-  // Delete-dashboard confirmation
-  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
-
-  // Delete-widget confirmation (target stashed since closeWidgetMenu clears menuWidget)
-  const [deleteWidgetTarget, setDeleteWidgetTarget] = useState(null);
+  const [confirmDelete, setConfirmDelete] = useState(null);
+  const lastConfirmDeleteRef = useRef(null);
+  
+  if (confirmDelete) lastConfirmDeleteRef.current = confirmDelete;
+  const confirmDeleteView = confirmDelete ?? lastConfirmDeleteRef.current;
 
   // Grid container ref (for measuring column widths during resize)
   const gridContainerRef = useRef(null);
@@ -898,21 +902,8 @@ export default function DashboardDetailView() {
   };
 
   const handleDeleteWidget = () => {
-    setDeleteWidgetTarget(menuWidget);
+    setConfirmDelete({ type: "widget", target: menuWidget });
     closeWidgetMenu();
-  };
-
-  const confirmDeleteWidget = () => {
-    if (deleteWidgetTarget) {
-      deleteWidget.mutate(
-        { dashboardId, widgetId: deleteWidgetTarget.id },
-        {
-          onSuccess: () =>
-            enqueueSnackbar("Widget deleted", { variant: "success" }),
-        },
-      );
-    }
-    setDeleteWidgetTarget(null);
   };
 
   const handleDuplicateWidget = () => {
@@ -935,17 +926,31 @@ export default function DashboardDetailView() {
 
   const handleDeleteDashboard = () => {
     setDashMenuAnchor(null);
-    setConfirmDeleteOpen(true);
+    setConfirmDelete({ type: "dashboard" });
   };
 
-  const confirmDeleteDashboard = () => {
-    deleteDashboard.mutate(dashboardId, {
-      onSuccess: () => {
-        enqueueSnackbar("Dashboard deleted", { variant: "success" });
-        navigate(paths.dashboard.dashboards.root);
-      },
-    });
-    setConfirmDeleteOpen(false);
+  // Single confirm handler for both delete dialogs; branches on the key.
+  // Closes only once the request settles (not synchronously mid-flight).
+  const handleConfirmDelete = () => {
+    if (confirmDelete?.type === "widget") {
+      if (!confirmDelete.target) return;
+      deleteWidget.mutate(
+        { dashboardId, widgetId: confirmDelete.target.id },
+        {
+          onSuccess: () =>
+            enqueueSnackbar("Widget deleted", { variant: "success" }),
+          onSettled: () => setConfirmDelete(null),
+        },
+      );
+    } else if (confirmDelete?.type === "dashboard") {
+      deleteDashboard.mutate(dashboardId, {
+        onSuccess: () => {
+          enqueueSnackbar("Dashboard deleted", { variant: "success" });
+          navigate(paths.dashboard.dashboards.root);
+        },
+        onSettled: () => setConfirmDelete(null),
+      });
+    }
   };
 
   const handleRowResize = useCallback(
@@ -1130,6 +1135,7 @@ export default function DashboardDetailView() {
           <Tooltip title="More options">
             <IconButton
               size="small"
+              aria-label="Dashboard options"
               onClick={(e) => setDashMenuAnchor(e.currentTarget)}
             >
               <Iconify icon="mdi:dots-horizontal" width={20} />
@@ -1543,33 +1549,25 @@ export default function DashboardDetailView() {
       </Menu>
 
       <ConfirmDialog
-        open={confirmDeleteOpen}
-        onClose={() => setConfirmDeleteOpen(false)}
-        title="Delete Dashboard"
-        content={`Are you sure you want to delete "${dashboard?.name}"? This action cannot be undone.`}
-        action={
-          <Button
-            variant="contained"
-            color="error"
-            size="small"
-            onClick={confirmDeleteDashboard}
-          >
-            Delete
-          </Button>
+        open={!!confirmDelete}
+        onClose={() => setConfirmDelete(null)}
+        title={
+          confirmDeleteView?.type === "widget"
+            ? "Delete Widget"
+            : "Delete Dashboard"
         }
-      />
-
-      <ConfirmDialog
-        open={!!deleteWidgetTarget}
-        onClose={() => setDeleteWidgetTarget(null)}
-        title="Delete Widget"
-        content={`Are you sure you want to delete "${deleteWidgetTarget?.name}"? This action cannot be undone.`}
+        content={
+          confirmDeleteView?.type === "widget"
+            ? `Are you sure you want to delete "${confirmDeleteView.target?.name}"? This action cannot be undone.`
+            : `Are you sure you want to delete "${dashboard?.name}"? This action cannot be undone.`
+        }
         action={
           <Button
             variant="contained"
             color="error"
             size="small"
-            onClick={confirmDeleteWidget}
+            onClick={handleConfirmDelete}
+            disabled={deleteWidget.isPending || deleteDashboard.isPending}
           >
             Delete
           </Button>

--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -42,6 +42,8 @@ import {
   useCreateWidget,
 } from "src/hooks/useDashboards";
 import Iconify from "src/components/iconify";
+import { ConfirmDialog } from "src/components/custom-dialog";
+import { useSnackbar } from "src/components/snackbar";
 import WidgetChart from "./WidgetChart";
 import {
   DndContext,
@@ -671,6 +673,7 @@ function DragOverlayCard({ widget }) {
 export default function DashboardDetailView() {
   const navigate = useNavigate();
   const { dashboardId } = useParams();
+  const { enqueueSnackbar } = useSnackbar();
 
   const { data: dashboard, isLoading } = useDashboardDetail(dashboardId);
   const updateDashboard = useUpdateDashboard();
@@ -698,6 +701,9 @@ export default function DashboardDetailView() {
 
   // Dashboard more menu
   const [dashMenuAnchor, setDashMenuAnchor] = useState(null);
+
+  // Delete-dashboard confirmation
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   // Grid container ref (for measuring column widths during resize)
   const gridContainerRef = useRef(null);
@@ -915,9 +921,17 @@ export default function DashboardDetailView() {
 
   const handleDeleteDashboard = () => {
     setDashMenuAnchor(null);
+    setConfirmDeleteOpen(true);
+  };
+
+  const confirmDeleteDashboard = () => {
     deleteDashboard.mutate(dashboardId, {
-      onSuccess: () => navigate(paths.dashboard.dashboards.root),
+      onSuccess: () => {
+        enqueueSnackbar("Dashboard deleted", { variant: "success" });
+        navigate(paths.dashboard.dashboards.root);
+      },
     });
+    setConfirmDeleteOpen(false);
   };
 
   const handleRowResize = useCallback(
@@ -1513,6 +1527,23 @@ export default function DashboardDetailView() {
           <ListItemText>Delete Dashboard</ListItemText>
         </MenuItem>
       </Menu>
+
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onClose={() => setConfirmDeleteOpen(false)}
+        title="Delete Dashboard"
+        content={`Are you sure you want to delete "${dashboard?.name}"? This action cannot be undone.`}
+        action={
+          <Button
+            variant="contained"
+            color="error"
+            size="small"
+            onClick={confirmDeleteDashboard}
+          >
+            Delete
+          </Button>
+        }
+      />
     </Box>
   );
 }

--- a/frontend/src/sections/dashboards/DashboardDetailView.jsx
+++ b/frontend/src/sections/dashboards/DashboardDetailView.jsx
@@ -705,6 +705,9 @@ export default function DashboardDetailView() {
   // Delete-dashboard confirmation
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
+  // Delete-widget confirmation (target stashed since closeWidgetMenu clears menuWidget)
+  const [deleteWidgetTarget, setDeleteWidgetTarget] = useState(null);
+
   // Grid container ref (for measuring column widths during resize)
   const gridContainerRef = useRef(null);
 
@@ -895,10 +898,21 @@ export default function DashboardDetailView() {
   };
 
   const handleDeleteWidget = () => {
-    if (menuWidget) {
-      deleteWidget.mutate({ dashboardId, widgetId: menuWidget.id });
-    }
+    setDeleteWidgetTarget(menuWidget);
     closeWidgetMenu();
+  };
+
+  const confirmDeleteWidget = () => {
+    if (deleteWidgetTarget) {
+      deleteWidget.mutate(
+        { dashboardId, widgetId: deleteWidgetTarget.id },
+        {
+          onSuccess: () =>
+            enqueueSnackbar("Widget deleted", { variant: "success" }),
+        },
+      );
+    }
+    setDeleteWidgetTarget(null);
   };
 
   const handleDuplicateWidget = () => {
@@ -1539,6 +1553,23 @@ export default function DashboardDetailView() {
             color="error"
             size="small"
             onClick={confirmDeleteDashboard}
+          >
+            Delete
+          </Button>
+        }
+      />
+
+      <ConfirmDialog
+        open={!!deleteWidgetTarget}
+        onClose={() => setDeleteWidgetTarget(null)}
+        title="Delete Widget"
+        content={`Are you sure you want to delete "${deleteWidgetTarget?.name}"? This action cannot be undone.`}
+        action={
+          <Button
+            variant="contained"
+            color="error"
+            size="small"
+            onClick={confirmDeleteWidget}
           >
             Delete
           </Button>

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -1123,8 +1123,10 @@ export default function WidgetEditorView() {
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const confirmDeleteWidget = () => {
-    setConfirmDeleteOpen(false);
-    if (!isEditing) return;
+    if (!isEditing) {
+      setConfirmDeleteOpen(false);
+      return;
+    }
     deleteMutation.mutate(
       { dashboardId, widgetId: effectiveWidgetId },
       {
@@ -1132,6 +1134,8 @@ export default function WidgetEditorView() {
           enqueueSnackbar("Widget deleted", { variant: "success" });
           navigate(paths.dashboard.dashboards.detail(dashboardId));
         },
+        // Close once the request settles, not before it starts.
+        onSettled: () => setConfirmDeleteOpen(false),
       },
     );
   };
@@ -3130,6 +3134,7 @@ export default function WidgetEditorView() {
               color="error"
               size="small"
               onClick={confirmDeleteWidget}
+              disabled={deleteMutation.isPending}
             >
               Delete
             </Button>

--- a/frontend/src/sections/dashboards/WidgetEditorView.jsx
+++ b/frontend/src/sections/dashboards/WidgetEditorView.jsx
@@ -54,6 +54,7 @@ import {
 } from "src/hooks/useDashboards";
 import Iconify from "src/components/iconify";
 import { useSnackbar } from "src/components/snackbar";
+import { ConfirmDialog } from "src/components/custom-dialog";
 import { format } from "date-fns";
 import CustomDateRangePicker from "src/components/custom-datepicker/DatePicker";
 import {
@@ -1119,6 +1120,21 @@ export default function WidgetEditorView() {
   const [editingName, setEditingName] = useState(false);
   const [editingDesc, setEditingDesc] = useState(false);
   const [moreMenuAnchor, setMoreMenuAnchor] = useState(null);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
+  const confirmDeleteWidget = () => {
+    setConfirmDeleteOpen(false);
+    if (!isEditing) return;
+    deleteMutation.mutate(
+      { dashboardId, widgetId: effectiveWidgetId },
+      {
+        onSuccess: () => {
+          enqueueSnackbar("Widget deleted", { variant: "success" });
+          navigate(paths.dashboard.dashboards.detail(dashboardId));
+        },
+      },
+    );
+  };
   const [timePreset, setTimePreset] = useState(
     searchParams.get("timePreset") || "30D",
   );
@@ -2964,40 +2980,24 @@ export default function WidgetEditorView() {
           transformOrigin={{ vertical: "top", horizontal: "right" }}
           slotProps={{ paper: { sx: { minWidth: 180 } } }}
         >
-          <MenuItem
-            onClick={() => {
-              setMoreMenuAnchor(null);
-              if (
-                !window.confirm("Are you sure you want to delete this widget?")
-              )
-                return;
-              if (effectiveWidgetId && effectiveWidgetId !== "new") {
-                deleteMutation
-                  .mutateAsync({ dashboardId, widgetId: effectiveWidgetId })
-                  .then(() => {
-                    enqueueSnackbar("Widget deleted", { variant: "success" });
-                    navigate(paths.dashboard.dashboards.detail(dashboardId));
-                  })
-                  .catch(() => {
-                    enqueueSnackbar("Failed to delete widget", {
-                      variant: "error",
-                    });
-                  });
-              } else {
-                navigate(paths.dashboard.dashboards.detail(dashboardId));
-              }
-            }}
-            sx={{ color: "error.main" }}
-          >
-            <ListItemIcon>
-              <Iconify
-                icon="mdi:delete-outline"
-                width={18}
-                sx={{ color: "error.main" }}
-              />
-            </ListItemIcon>
-            <ListItemText>Delete</ListItemText>
-          </MenuItem>
+          {isEditing && (
+            <MenuItem
+              onClick={() => {
+                setMoreMenuAnchor(null);
+                setConfirmDeleteOpen(true);
+              }}
+              sx={{ color: "error.main" }}
+            >
+              <ListItemIcon>
+                <Iconify
+                  icon="mdi:delete-outline"
+                  width={18}
+                  sx={{ color: "error.main" }}
+                />
+              </ListItemIcon>
+              <ListItemText>Delete</ListItemText>
+            </MenuItem>
+          )}
           <MenuItem
             onClick={() => {
               setMoreMenuAnchor(null);
@@ -3118,6 +3118,23 @@ export default function WidgetEditorView() {
             <ListItemText>Refresh Data</ListItemText>
           </MenuItem>
         </Menu>
+
+        <ConfirmDialog
+          open={confirmDeleteOpen}
+          onClose={() => setConfirmDeleteOpen(false)}
+          title="Delete Widget"
+          content={`Are you sure you want to delete "${chartName || "this widget"}"? This action cannot be undone.`}
+          action={
+            <Button
+              variant="contained"
+              color="error"
+              size="small"
+              onClick={confirmDeleteWidget}
+            >
+              Delete
+            </Button>
+          }
+        />
 
         <Button
           onClick={() =>

--- a/frontend/src/sections/dashboards/__tests__/DashboardDetailView.test.jsx
+++ b/frontend/src/sections/dashboards/__tests__/DashboardDetailView.test.jsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "src/utils/test-utils";
+import DashboardDetailView from "../DashboardDetailView";
+
+// Controlled mutation stubs (hoisted so the vi.mock factory can see them).
+const h = vi.hoisted(() => ({
+  deleteWidget: { mutate: vi.fn(), isPending: false },
+  deleteDashboard: { mutate: vi.fn(), isPending: false },
+}));
+
+vi.mock("src/hooks/useDashboards", () => ({
+  useDashboardDetail: () => ({
+    data: {
+      id: "dash-1",
+      name: "My Dash",
+      widgets: [{ id: "w-1", name: "Tokens", position: 0, width: 12 }],
+    },
+    isLoading: false,
+  }),
+  useUpdateDashboard: () => ({ mutate: vi.fn() }),
+  useUpdateWidget: () => ({ mutate: vi.fn() }),
+  useDeleteWidget: () => h.deleteWidget,
+  useDeleteDashboard: () => h.deleteDashboard,
+  useReorderWidgets: () => ({ mutate: vi.fn() }),
+  useDuplicateWidget: () => ({ mutate: vi.fn() }),
+  useCreateWidget: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("react-router-dom", async (orig) => ({
+  ...(await orig()),
+  useParams: () => ({ dashboardId: "dash-1" }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("../WidgetChart", () => ({
+  default: () => <div data-testid="widget-chart" />,
+}));
+
+vi.mock("src/components/snackbar", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: vi.fn() }),
+}));
+
+const openWidgetDeleteDialog = () => {
+  fireEvent.click(screen.getByRole("button", { name: /widget options/i }));
+  // The widget menu item is labelled just "Delete" (dashboard's is "Delete Dashboard").
+  fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+};
+
+describe("DashboardDetailView — delete confirmation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.deleteWidget.isPending = false;
+    h.deleteDashboard.isPending = false;
+  });
+
+  it("widget delete: opens the keyed dialog with the widget's name", () => {
+    render(<DashboardDetailView />);
+    openWidgetDeleteDialog();
+    expect(
+      screen.getByText(/Are you sure you want to delete "Tokens"/),
+    ).toBeInTheDocument();
+  });
+
+  it("widget delete: confirms with the right id and closes on settle (not synchronously)", () => {
+    render(<DashboardDetailView />);
+    openWidgetDeleteDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(h.deleteWidget.mutate).toHaveBeenCalledWith(
+      { dashboardId: "dash-1", widgetId: "w-1" },
+      // close happens in onSettled — pins the reviewer's fix (reverting to a
+      // synchronous setConfirmDelete(null) would drop this callback).
+      expect.objectContaining({ onSettled: expect.any(Function) }),
+    );
+  });
+
+  it("widget delete: Delete button is disabled while the mutation is pending", () => {
+    h.deleteWidget.isPending = true;
+    render(<DashboardDetailView />);
+    openWidgetDeleteDialog();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
+  });
+
+  it("dashboard delete: deletes the dashboard by id, closing on settle", () => {
+    render(<DashboardDetailView />);
+    fireEvent.click(screen.getByRole("button", { name: /dashboard options/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /delete dashboard/i }));
+    expect(
+      screen.getByText(/Are you sure you want to delete "My Dash"/),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(h.deleteDashboard.mutate).toHaveBeenCalledWith(
+      "dash-1",
+      expect.objectContaining({ onSettled: expect.any(Function) }),
+    );
+    expect(h.deleteWidget.mutate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Linear:** [TH-5918 — Delete Dashboard: no confirmation dialog](https://linear.app/future-agi/issue/TH-5918/delete-dashboard-no-confirmation-dialog)

## Problem
Deleting a **dashboard** from the canvas `...` menu fired immediately with no confirmation (the list-row trash icon already confirmed). While here, two related delete flows were also inconsistent:
- The **widget** `⋮` → Delete on the dashboard canvas deleted instantly, no prompt.
- The **widget editor**'s `⋮` → Delete used a native `window.confirm()` browser alert, off-pattern with the rest of the app.

## Fix — one consistent flow everywhere
All three now use the app's `ConfirmDialog` (same component/copy as the list-row delete), with a **success** snackbar; **failures** surface via the global mutation error handler (verified both delete endpoints return a `result` field, so it toasts the backend message — no per-call `onError`, no double toast).

### `DashboardDetailView.jsx`
- **Dashboard delete:** `...` → Delete now opens a `ConfirmDialog`; deletes on confirm + `"Dashboard deleted"` toast.
- **Widget delete:** `⋮` → Delete opens a `ConfirmDialog`. The target is stashed before `closeWidgetMenu()` (which clears `menuWidget`); deletes on confirm + `"Widget deleted"` toast.

### `WidgetEditorView.jsx`
- Replaced `window.confirm()` with `ConfirmDialog`; converted `mutateAsync().then().catch()` → `mutate(..., { onSuccess })` (no floating promise, no explicit failure toast).
- **Hid the Delete item in create mode:** an unsaved draft (`/widget/new`, no created id yet) has nothing to delete — **Close** already discards it. Delete only shows once a real widget exists (`isEditing`).

## Notes
- The editor `⋮` menu is local to `WidgetEditorView` (not a shared component), so hiding Delete is isolated; the menu keeps its other items (Rename, Duplicate, Export/Copy CSV, Refresh Data).
- Same delete API in every path (`useDeleteDashboard` / `useDeleteWidget` from `src/hooks/useDashboards`).

## Verification
- ESLint 0 errors on both files (remaining warnings are pre-existing).
- Prettier clean.
- Related tests pass (`dashboard-routes.test.jsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)