### PR TITLE
fix(gateway): improve formatting for sub-cent costs

### DIFF
--- a/frontend/src/sections/gateway/utils/formatters.js
+++ b/frontend/src/sections/gateway/utils/formatters.js
@@ -16,9 +16,16 @@ export function formatCost(value) {
   if (value == null) return "$0.00";
   const num = Number(value);
   if (Number.isNaN(num)) return "$0.00";
-  if (num >= 1000) return `$${(num / 1000).toFixed(1)}K`;
-  if (num >= 1) return `$${num.toFixed(2)}`;
-  return `$${num.toFixed(4)}`;
+
+  const abs = Math.abs(num);
+
+  if (abs >= 1000) return `$${(num / 1000).toFixed(1)}K`;
+  if (abs >= 1) return `$${num.toFixed(2)}`;
+  if (abs >= 0.01) return `$${num.toFixed(4)}`;
+  if (abs >= 0.001) return `$${num.toFixed(5)}`;
+  if (abs > 0) return `$${num.toFixed(7).replace(/0+$/, "0")}`;
+
+  return "$0.00";
 }
 
 export function formatPercent(value, decimals = 1) {


### PR DESCRIPTION
## Summary

This PR updates the shared `formatCost()` utility used by the Gateway Request Logs table to improve the display of sub-cent request costs.

Previously, values smaller than `$0.0001` were rounded to `$0.0000`, making low-cost requests appear free. This change introduces escalating precision for small values while preserving existing formatting for larger values.

## Linked issues

Closes #921

## Type of change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How was this tested?

* Verified the updated formatting logic manually against the issue requirements.
* Started the frontend locally using `npm run dev`.
* Confirmed the project builds successfully after the change.
* Checked expected outputs for:

  * Values >= $1000 → `$X.XK`
  * Values >= $1 → 2 decimal places
  * Small values (< $1) → increased precision
  * `null`, `NaN`, and `0` → `$0.00`

## Screenshots / recordings (if UI)

N/A

## Checklist

* [x] My code follows the style guide
* [ ] I've added tests that prove my fix is effective or that my feature works
* [ ] `make check-all` / `yarn check-all` passes locally
* [ ] I've updated the documentation where relevant
* [x] No hardcoded secrets, URLs, or PII
* [ ] I've signed the CLA
