### PR TITLE
fix(agentcc-gateway): enforce control-plane key expiry on synced keys

### DIFF
--- a/agentcc-gateway/internal/auth/keystore.go
+++ b/agentcc-gateway/internal/auth/keystore.go
@@ -367,6 +367,27 @@ type SyncedKey struct {
 	Models    []string          `json:"models"`
 	Providers []string          `json:"providers"`
 	Metadata  map[string]string `json:"metadata"`
+	ExpiresAt *time.Time        `json:"expires_at"`
+}
+
+// syncedKeyToAPIKey is the single construction site for both sync paths, so a
+// field can't be wired into one and missed in the other.
+func syncedKeyToAPIKey(sk SyncedKey, id string) *APIKey {
+	return &APIKey{
+		ID:               id,
+		KeyHash:          sk.KeyHash,
+		Name:             sk.Name,
+		Owner:            sk.Owner,
+		Status:           "active",
+		KeyType:          "byok",
+		Source:           "sync",
+		AllowedModels:    sk.Models,
+		AllowedProviders: sk.Providers,
+		Metadata:         sk.Metadata,
+		ExpiresAt:        sk.ExpiresAt,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
 }
 
 // LoadFromHashes merges control-plane keys (identified by pre-computed hashes)
@@ -392,20 +413,7 @@ func (ks *KeyStore) LoadFromHashes(keys []SyncedKey) int {
 			id = fmt.Sprintf("key_%d", ks.counter)
 		}
 
-		key := &APIKey{
-			ID:               id,
-			KeyHash:          sk.KeyHash,
-			Name:             sk.Name,
-			Owner:            sk.Owner,
-			Status:           "active",
-			KeyType:          "byok",
-			Source:           "sync",
-			AllowedModels:    sk.Models,
-			AllowedProviders: sk.Providers,
-			Metadata:         sk.Metadata,
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
-		}
+		key := syncedKeyToAPIKey(sk, id)
 
 		ks.byHash[sk.KeyHash] = key
 		ks.byID[id] = key
@@ -468,20 +476,7 @@ func (ks *KeyStore) SyncFromHashes(keys []SyncedKey) int {
 			id = fmt.Sprintf("key_%d", ks.counter)
 		}
 
-		key := &APIKey{
-			ID:               id,
-			KeyHash:          sk.KeyHash,
-			Name:             sk.Name,
-			Owner:            sk.Owner,
-			Status:           "active",
-			KeyType:          "byok",
-			Source:           "sync",
-			AllowedModels:    sk.Models,
-			AllowedProviders: sk.Providers,
-			Metadata:         sk.Metadata,
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
-		}
+		key := syncedKeyToAPIKey(sk, id)
 
 		ks.byHash[sk.KeyHash] = key
 		ks.byID[id] = key

--- a/agentcc-gateway/internal/auth/keystore_test.go
+++ b/agentcc-gateway/internal/auth/keystore_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"math"
 	"strings"
 	"sync"
@@ -426,6 +427,137 @@ func TestExpiresAt_FromConfig(t *testing.T) {
 	expected, _ := time.Parse(time.RFC3339, expiresStr)
 	if !k.ExpiresAt.Equal(expected) {
 		t.Errorf("expected ExpiresAt %v, got %v", expected, *k.ExpiresAt)
+	}
+}
+
+// ---------- Synced-key expiry (control-plane path) ----------
+
+func syncKeyStore() *KeyStore {
+	return NewKeyStore(authCfg())
+}
+
+// Decoding the wire payload is where the original bug lived (the field was
+// dropped); DRF emits RFC3339 with offset + fractional seconds.
+func TestSyncedKey_DecodesExpiresAt(t *testing.T) {
+	const payload = `{
+		"id": "ck_1",
+		"name": "contractor",
+		"key_hash": "abc123",
+		"expires_at": "2030-06-15T12:30:45.123456Z"
+	}`
+
+	var sk SyncedKey
+	if err := json.Unmarshal([]byte(payload), &sk); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if sk.ExpiresAt == nil {
+		t.Fatal("expected ExpiresAt to decode from the wire, got nil")
+	}
+	want, _ := time.Parse(time.RFC3339, "2030-06-15T12:30:45.123456Z")
+	if !sk.ExpiresAt.Equal(want) {
+		t.Errorf("expected ExpiresAt %v, got %v", want, *sk.ExpiresAt)
+	}
+
+	// Null expiry must decode to nil (never-expiring keys).
+	var nullSk SyncedKey
+	if err := json.Unmarshal([]byte(`{"key_hash":"h","expires_at":null}`), &nullSk); err != nil {
+		t.Fatalf("unmarshal null failed: %v", err)
+	}
+	if nullSk.ExpiresAt != nil {
+		t.Errorf("expected nil ExpiresAt for null wire value, got %v", *nullSk.ExpiresAt)
+	}
+}
+
+// Real wire payload with a past expiry, decoded then synced, must be rejected.
+func TestSyncedExpiredKey_DecodeToReject(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-expired"
+	payload := `{"id":"ck_exp","name":"c","key_hash":"` + HashKey(rawKey) +
+		`","expires_at":"2000-01-01T00:00:00Z"}`
+
+	var sk SyncedKey
+	if err := json.Unmarshal([]byte(payload), &sk); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{sk})
+
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired synced key (decoded from wire) to be rejected")
+	}
+}
+
+func TestSyncFromHashes_ExpiredKeyRejected(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-expired-2"
+	past := time.Now().Add(-1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:        "ck_expired",
+		Name:      "contractor",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &past,
+	}})
+
+	if k := ks.Get("ck_expired"); k == nil || k.ExpiresAt == nil {
+		t.Fatal("expected synced key to carry ExpiresAt")
+	}
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired synced key to be rejected")
+	}
+}
+
+func TestSyncFromHashes_FutureExpiryAccepted(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-future"
+	future := time.Now().Add(1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:        "ck_future",
+		Name:      "valid",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &future,
+	}})
+
+	if got := ks.Authenticate(rawKey); got == nil {
+		t.Fatal("expected synced key with future expiry to authenticate")
+	}
+}
+
+func TestSyncFromHashes_NilExpiryNeverExpires(t *testing.T) {
+	const rawKey = "sk-agentcc-synced-noexpiry"
+
+	ks := syncKeyStore()
+	ks.SyncFromHashes([]SyncedKey{{
+		ID:      "ck_noexpiry",
+		Name:    "perpetual",
+		KeyHash: HashKey(rawKey),
+		// ExpiresAt nil — must remain non-expiring.
+	}})
+
+	k := ks.Get("ck_noexpiry")
+	if k == nil || k.ExpiresAt != nil {
+		t.Fatal("expected nil ExpiresAt on synced key")
+	}
+	if got := ks.Authenticate(rawKey); got == nil {
+		t.Fatal("expected non-expiring synced key to authenticate")
+	}
+}
+
+func TestLoadFromHashes_PropagatesExpiry(t *testing.T) {
+	const rawKey = "sk-agentcc-loaded-expired"
+	past := time.Now().Add(-1 * time.Hour)
+
+	ks := syncKeyStore()
+	ks.LoadFromHashes([]SyncedKey{{
+		ID:        "ck_loaded",
+		Name:      "loaded",
+		KeyHash:   HashKey(rawKey),
+		ExpiresAt: &past,
+	}})
+
+	if got := ks.Authenticate(rawKey); got != nil {
+		t.Fatal("expected expired key loaded via LoadFromHashes to be rejected")
 	}
 }
 

--- a/agentcc-gateway/internal/auth/keystore_test.go
+++ b/agentcc-gateway/internal/auth/keystore_test.go
@@ -399,8 +399,8 @@ func TestKeyPrefix(t *testing.T) {
 
 	// Long key: len > 12, prefix is first 12 + "..."
 	long := keyPrefix("sk-agentcc-abcdef1234567890")
-	if long != "sk-agentcc-abc..." {
-		t.Errorf("expected long key prefix 'sk-agentcc-abc...', got '%s'", long)
+	if long != "sk-agentcc-a..." {
+		t.Errorf("expected long key prefix 'sk-agentcc-a...', got '%s'", long)
 	}
 }
 

--- a/futureagi/agentcc/tests/test_api_key_bulk.py
+++ b/futureagi/agentcc/tests/test_api_key_bulk.py
@@ -1,0 +1,78 @@
+"""Bulk API-key sync endpoint: expires_at wire format and expired-key filtering."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from agentcc.models import AgentccAPIKey
+
+ADMIN_TOKEN = "agentcc-admin-secret"
+
+
+@pytest.fixture(autouse=True)
+def set_agentcc_admin_token():
+    with patch("agentcc.permissions.AGENTCC_ADMIN_TOKEN", ADMIN_TOKEN):
+        yield
+
+
+@pytest.fixture
+def admin_client():
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {ADMIN_TOKEN}")
+    return client
+
+
+def _make_key(organization, workspace, gateway_key_id, key_hash, expires_at):
+    return AgentccAPIKey.objects.create(
+        gateway_key_id=gateway_key_id,
+        name=gateway_key_id,
+        organization=organization,
+        workspace=workspace,
+        key_hash=key_hash,
+        status=AgentccAPIKey.ACTIVE,
+        expires_at=expires_at,
+    )
+
+
+class TestAPIKeyBulkExpiresAt:
+    def test_future_and_null_expiry_are_serialized_on_the_wire(
+        self, admin_client, organization, workspace
+    ):
+        future = timezone.now() + timedelta(days=7)
+        _make_key(organization, workspace, "gw-expiring", "a" * 64, future)
+        _make_key(organization, workspace, "gw-perpetual", "b" * 64, None)
+
+        response = admin_client.get("/agentcc/api-keys/bulk/")
+        assert response.status_code == status.HTTP_200_OK
+
+        # Assert on the rendered JSON the gateway actually receives, not the
+        # pre-render Python datetime.
+        by_id = {item["id"]: item for item in response.json()["result"]}
+
+        # Future-expiry key: expires_at is an ISO 8601 string the gateway can
+        # parse as RFC3339 (DRF renders aware datetimes with a 'Z'/offset).
+        expiring = by_id["gw-expiring"]["expires_at"]
+        assert isinstance(expiring, str)
+        parsed = datetime.fromisoformat(expiring.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None  # must be timezone-aware
+
+        # Null expiry stays null (never-expiring keys).
+        assert by_id["gw-perpetual"]["expires_at"] is None
+
+    def test_expired_keys_are_not_shipped(
+        self, admin_client, organization, workspace
+    ):
+        past = timezone.now() - timedelta(days=1)
+        _make_key(organization, workspace, "gw-expired", "c" * 64, past)
+        _make_key(organization, workspace, "gw-live", "d" * 64, None)
+
+        ids = {item["id"] for item in admin_client.get(
+            "/agentcc/api-keys/bulk/"
+        ).json()["result"]}
+
+        assert "gw-expired" not in ids  # filtered at the query level
+        assert "gw-live" in ids

--- a/futureagi/agentcc/views/api_key_bulk.py
+++ b/futureagi/agentcc/views/api_key_bulk.py
@@ -1,4 +1,6 @@
 import structlog
+from django.db.models import Q
+from django.utils import timezone
 from rest_framework.renderers import JSONRenderer
 from rest_framework.views import APIView
 
@@ -25,10 +27,13 @@ class APIKeyBulkView(APIView):
 
     def get(self, request):
         try:
+            # Don't ship already-expired keys, even to gateways that predate
+            # real-time expiry enforcement.
+            now = timezone.now()
             keys = AgentccAPIKey.no_workspace_objects.filter(
                 status=AgentccAPIKey.ACTIVE,
                 deleted=False,
-            )
+            ).filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
 
             result = []
             for key in keys:
@@ -43,6 +48,7 @@ class APIKeyBulkView(APIView):
                         "models": key.allowed_models or [],
                         "providers": key.allowed_providers or [],
                         "metadata": key.metadata or {},
+                        "expires_at": key.expires_at,
                     }
                 )
 

--- a/futureagi/agentcc/views/api_key_bulk.py
+++ b/futureagi/agentcc/views/api_key_bulk.py
@@ -55,4 +55,4 @@ class APIKeyBulkView(APIView):
             return self._gm.success_response(result)
         except Exception as e:
             logger.exception("api_key_bulk_error", error=str(e))
-            return self._gm.bad_request(str(e))
+            return self._gm.internal_server_error_response("Internal server error")


### PR DESCRIPTION
## Summary

Expired API keys synced from the Django control plane authenticated **indefinitely** at the gateway. A key's `expires_at` set in the control plane was never enforced on the data plane — it failed open, silently, with no log.

Reported privately by an external contributor (Nikhil) against the OSS repo. **Targeted at `main` as a hotfix** since the gap is live in prod; `dev` carries the same bug and a different (contract-based) bulk view, and will pick this up on the next `main` → `dev` sync.

### Root cause (three compounding gaps)
1. `agentcc/views/api_key_bulk.py` built the bulk sync response **without** `expires_at` — the field exists on the model but never left Django.
2. `SyncedKey` (Go) had **no `ExpiresAt` field**, so the JSON decoder dropped it even if Django sent it.
3. `SyncFromHashes` / `LoadFromHashes` built the in-memory `APIKey` **without** `ExpiresAt` (two verbatim-duplicated blocks), so it was always nil → `IsExpired()` short-circuits false → the existing `IsActive()` gate had nothing to act on.

Config-file keys were unaffected — `NewKeyStore` parses expiry on load.

## Changes
- **Gateway**: add `ExpiresAt` to `SyncedKey` (decoded from the wire); extract `syncedKeyToAPIKey()` so both sync paths share one construction site — the duplication is what let the field go missing in both.
- **Django**: send `expires_at` (ISO 8601 / null) in the bulk response, and filter already-expired keys out of the query (`Q(expires_at__isnull=True) | Q(expires_at__gt=now)`) so they aren't even shipped — defense for gateways that predate this fix. Also stop echoing the raw exception to the caller.
- **Tests**: decode a real Django-rendered RFC3339 payload into `SyncedKey` (the exact spot the bug lived); sync-path enforcement (expired / future / nil × both paths); Django test asserting the serialized wire shape and that expired keys are dropped.
- Separate commit corrects a pre-existing stale `TestKeyPrefix` expectation (unrelated; `dev` already has it).

## Behavior (verified end-to-end against a running gateway)

| Scenario | Before | After |
|---|---|---|
| Expired (past), ACTIVE, synced from control plane | **200 — authenticates** | **401 — rejected** |
| Expired key in the bulk response at all | shipped | **not shipped** (query filter) |
| Future-expiry synced key | 200 | 200 |
| Null / no expiry (permanent keys) | 200 | 200 |
| Revoked / garbage key | 401 | 401 |
| Wire decode: RFC3339 + tz offset + fractional seconds | dropped → nil | parsed → enforced |

Note: this endpoint isn't contracted in swagger on `main` (no serializer), so no contract regen is involved here.

## Type of change
- [x] 🐛 Bug fix (security; non-breaking)