### PR TITLE
fix(evals): UI fixes — scoring direction, multi-select params, composite child-eval help

### DIFF
--- a/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
+++ b/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
@@ -408,7 +408,7 @@ const CompositeDetailPanel = ({
 
       {/* Child list */}
       <Box>
-        <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+        <Typography sx={{ typography: "body2", fontWeight: 600, mb: 0.5 }}>
           Children ({childrenList.length})
         </Typography>
         <Typography
@@ -416,10 +416,8 @@ const CompositeDetailPanel = ({
           color="text.secondary"
           sx={{ display: "block", mb: 1 }}
         >
-          Each child is a regular eval that scores the same input. Add the ones
-          you want to measure together (e.g. accuracy, tone, safety) — their
-          scores show side by side, and turning on aggregation above combines
-          them into one score.
+          Add evals that score the same input on different dimensions (e.g.
+          accuracy, tone, safety); aggregation above combines them.
         </Typography>
         <Stack spacing={1}>
           {childrenList.map((child) => {
@@ -578,8 +576,7 @@ const CompositeDetailPanel = ({
                 borderColor: "divider",
               }}
             >
-              No child evals yet — add 2 or more to measure different dimensions
-              of the same input and combine them into one composite score.
+              No child evals yet — add 2 or more to combine into one score.
             </Typography>
           )}
 

--- a/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
+++ b/frontend/src/sections/evals/components/CompositeDetailPanel.jsx
@@ -240,8 +240,9 @@ const CompositeDetailPanel = ({
           color="text.secondary"
           sx={{ display: "block" }}
         >
-          A composite eval runs multiple child evals against the same input and
-          optionally aggregates their scores into a single value.
+          A composite eval bundles several child evals that all score the same
+          input — each on a different dimension (e.g. accuracy, tone, safety) —
+          and optionally rolls them into one combined score.
         </Typography>
       </Box>
 
@@ -407,8 +408,18 @@ const CompositeDetailPanel = ({
 
       {/* Child list */}
       <Box>
-        <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
+        <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
           Children ({childrenList.length})
+        </Typography>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: "block", mb: 1 }}
+        >
+          Each child is a regular eval that scores the same input. Add the ones
+          you want to measure together (e.g. accuracy, tone, safety) — their
+          scores show side by side, and turning on aggregation above combines
+          them into one score.
         </Typography>
         <Stack spacing={1}>
           {childrenList.map((child) => {
@@ -553,6 +564,24 @@ const CompositeDetailPanel = ({
               </Box>
             );
           })}
+
+          {childrenList.length === 0 && (
+            <Typography
+              variant="caption"
+              color="text.disabled"
+              sx={{
+                display: "block",
+                py: 1.5,
+                px: 1.25,
+                borderRadius: 1,
+                border: "1px dashed",
+                borderColor: "divider",
+              }}
+            >
+              No child evals yet — add 2 or more to measure different dimensions
+              of the same input and combine them into one composite score.
+            </Typography>
+          )}
 
           {editable && (
             <Button

--- a/frontend/src/sections/evals/components/OutputTypeConfig.jsx
+++ b/frontend/src/sections/evals/components/OutputTypeConfig.jsx
@@ -14,7 +14,7 @@ import {
   Typography,
 } from "@mui/material";
 import PropTypes from "prop-types";
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import Iconify from "src/components/iconify";
 import CustomTooltip from "src/components/tooltip/CustomTooltip";
 
@@ -37,6 +37,21 @@ const OutputTypeConfig = ({
   // Category radio is locked if either the whole component is disabled OR
   // categoryLocked is explicitly set.
   const radioDisabled = disabled || categoryLocked;
+
+  // Direction of the score scale for the Scoring output type. Default: higher
+  // score is better (1 = good/green, 0 = bad/red). For negative-meaning evals
+  // (e.g. toxicity, hallucination) the user flips this so a lower score is the
+  // good outcome and the chip colours invert. Creation-time hint only.
+  const [lowerIsBetter, setLowerIsBetter] = useState(false);
+
+  const scoreChipColor = useCallback(
+    (score) => {
+      const isGood = lowerIsBetter ? score <= 0.3 : score >= 0.7;
+      const isMid = lowerIsBetter ? score <= 0.7 : score >= 0.3;
+      return isGood ? "success" : isMid ? "warning" : "error";
+    },
+    [lowerIsBetter],
+  );
   // Add an empty row — user types the label inline
   const handleAddEmptyRow = useCallback(
     (defaultScore = 0.5) => {
@@ -181,8 +196,30 @@ const OutputTypeConfig = ({
               sx={{ mb: 1, display: "block" }}
             >
               Create a list of predefined categories. Each choice maps to a
-              score between 0 and 1.
+              score between 0 and 1. All choices and scores must be unique.
             </Typography>
+
+            {/* Score direction — flips the colour scale for negative metrics */}
+            <FormControlLabel
+              control={
+                <Checkbox
+                  size="small"
+                  checked={lowerIsBetter}
+                  onChange={(e) => setLowerIsBetter(e.target.checked)}
+                  disabled={disabled}
+                  sx={{ mt: -0.25 }}
+                />
+              }
+              label={
+                <Typography variant="caption" color="text.secondary">
+                  By default a higher score is better — 1 shows green (good) and
+                  0 shows red (bad). Turn this on for metrics where a low score
+                  is the good outcome (e.g. toxicity, hallucination): the
+                  colours flip so 0 is green and 1 is red.
+                </Typography>
+              }
+              sx={{ alignItems: "flex-start", mb: 1.5, mx: 0 }}
+            />
 
             {Object.entries(choiceScores || {}).map(([label, score]) => (
               <Box
@@ -229,13 +266,7 @@ const OutputTypeConfig = ({
                 <Chip
                   label={score.toFixed(1)}
                   size="small"
-                  color={
-                    score >= 0.7
-                      ? "success"
-                      : score >= 0.3
-                        ? "warning"
-                        : "error"
-                  }
+                  color={scoreChipColor(score)}
                   sx={{
                     minWidth: 40,
                     fontSize: "12px",

--- a/frontend/src/sections/evals/components/OutputTypeConfig.jsx
+++ b/frontend/src/sections/evals/components/OutputTypeConfig.jsx
@@ -212,10 +212,8 @@ const OutputTypeConfig = ({
               }
               label={
                 <Typography variant="caption" color="text.secondary">
-                  By default a higher score is better — 1 shows green (good) and
-                  0 shows red (bad). Turn this on for metrics where a low score
-                  is the good outcome (e.g. toxicity, hallucination): the
-                  colours flip so 0 is green and 1 is red.
+                  On for metrics where a low score is good (e.g. toxicity) —
+                  flips the colours so 0 is green and 1 is red.
                 </Typography>
               }
               sx={{ alignItems: "flex-start", mb: 1.5, mx: 0 }}

--- a/frontend/src/sections/evals/components/TestPlayground.jsx
+++ b/frontend/src/sections/evals/components/TestPlayground.jsx
@@ -1,8 +1,10 @@
 import {
   Box,
+  Checkbox,
   Chip,
   CircularProgress,
   IconButton,
+  ListItemText,
   Menu,
   MenuItem,
   Select,
@@ -53,6 +55,22 @@ const camelizeKey = (key = "") =>
   key.replace(/_([a-z])/g, (_, char) => char.toUpperCase());
 
 const formatParamLabel = (key) => camelCaseToTitleCase(camelizeKey(key));
+
+// Some code-eval params are comma-separated lists with a fixed set of allowed
+// values declared in their description as "... Options: a, b, c". Parse those
+// out so we can render a multi-select checkbox dropdown instead of a free-text
+// box, and use the remaining text as helper copy. Returns { options, helper }.
+const parseParamOptions = (description) => {
+  const desc = String(description || "");
+  const match = desc.match(/options?\s*:\s*(.+)$/is);
+  if (!match) return { options: [], helper: desc.trim() };
+  const options = match[1]
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+  const helper = desc.slice(0, match.index).trim();
+  return { options, helper };
+};
 
 // ── Custom JSON Input with AI bar ──
 const CustomJsonInput = ({
@@ -1452,77 +1470,161 @@ const TestPlayground = React.forwardRef(
                     <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
                       Parameters
                     </Typography>
-                    {visibleFunctionParamEntries.map(([key, schema]) => (
-                      <Box
-                        key={key}
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 1,
-                          mb: 0.75,
-                        }}
-                      >
-                        <Tooltip
-                          title={
-                            configParamsDesc?.[key] || schema?.description || ""
-                          }
-                          placement="top"
-                        >
-                          <Typography
-                            variant="caption"
-                            sx={{
-                              minWidth: 90,
-                              fontFamily: "monospace",
-                              color: "primary.main",
-                            }}
-                          >
-                            {formatParamLabel(key)}
-                          </Typography>
-                        </Tooltip>
+                    {visibleFunctionParamEntries.map(([key, schema]) => {
+                      const desc =
+                        configParamsDesc?.[key] || schema?.description || "";
+                      const { options, helper } = parseParamOptions(desc);
+
+                      // Params that declare a fixed option set (e.g. detect_types)
+                      // render as a multi-select checkbox dropdown — all options
+                      // selected by default — with the description shown as a
+                      // helper line below instead of a hover tooltip.
+                      if (options.length > 0) {
+                        const raw = codeParams[key];
+                        const selected =
+                          raw === undefined ||
+                          raw === null ||
+                          String(raw).trim() === ""
+                            ? options
+                            : String(raw)
+                                .split(",")
+                                .map((v) => v.trim())
+                                .filter((v) => options.includes(v));
+                        return (
+                          <Box key={key} sx={{ mb: 1 }}>
+                            <Typography
+                              variant="caption"
+                              sx={{
+                                display: "block",
+                                mb: 0.5,
+                                fontFamily: "monospace",
+                                color: "primary.main",
+                              }}
+                            >
+                              {formatParamLabel(key)}
+                            </Typography>
+                            <Select
+                              multiple
+                              size="small"
+                              fullWidth
+                              value={selected}
+                              onChange={(e) => {
+                                const val = e.target.value;
+                                const next = (
+                                  typeof val === "string" ? val.split(",") : val
+                                ).filter(Boolean);
+                                handleCodeParamChange(key, next.join(","));
+                              }}
+                              renderValue={(vals) => vals.join(", ")}
+                              sx={{
+                                fontSize: "12px",
+                                fontFamily: "monospace",
+                                bgcolor: "background.paper",
+                                "& .MuiSelect-select": { py: 0.75 },
+                              }}
+                            >
+                              {options.map((opt) => (
+                                <MenuItem
+                                  key={opt}
+                                  value={opt}
+                                  dense
+                                  sx={{ fontSize: "12px" }}
+                                >
+                                  <Checkbox
+                                    size="small"
+                                    checked={selected.includes(opt)}
+                                    sx={{ p: 0.5, mr: 1 }}
+                                  />
+                                  <ListItemText
+                                    primary={opt}
+                                    primaryTypographyProps={{
+                                      fontSize: "12px",
+                                      fontFamily: "monospace",
+                                    }}
+                                  />
+                                </MenuItem>
+                              ))}
+                            </Select>
+                            {helper && (
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ display: "block", mt: 0.5 }}
+                              >
+                                {helper}
+                              </Typography>
+                            )}
+                          </Box>
+                        );
+                      }
+
+                      return (
                         <Box
-                          component="input"
-                          type={
-                            schema?.type === "integer" ||
-                            schema?.type === "number"
-                              ? "number"
-                              : "text"
-                          }
-                          placeholder={
-                            schema?.nullable
-                              ? "optional"
-                              : String(schema?.default ?? "")
-                          }
-                          value={codeParams[key] ?? ""}
-                          onChange={(e) => {
-                            // BE's `type: number` schema rejects strings; coerce here.
-                            const raw = e.target.value;
-                            const isNumeric =
-                              schema?.type === "integer" ||
-                              schema?.type === "number";
-                            let next = raw;
-                            if (isNumeric && raw !== "") {
-                              const n = Number(raw);
-                              if (!Number.isNaN(n)) next = n;
-                            }
-                            handleCodeParamChange(key, next);
-                          }}
+                          key={key}
                           sx={{
-                            flex: 1,
-                            px: 1,
-                            py: 0.5,
-                            fontSize: "12px",
-                            fontFamily: "monospace",
-                            border: "1px solid",
-                            borderColor: "divider",
-                            borderRadius: "6px",
-                            bgcolor: "background.paper",
-                            color: "text.primary",
-                            outline: "none",
-                            "&:focus": { borderColor: "primary.main" },
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 1,
+                            mb: 0.75,
                           }}
-                        />
-                      </Box>
-                    ))}
+                        >
+                          <Tooltip title={desc} placement="top">
+                            <Typography
+                              variant="caption"
+                              sx={{
+                                minWidth: 90,
+                                fontFamily: "monospace",
+                                color: "primary.main",
+                              }}
+                            >
+                              {formatParamLabel(key)}
+                            </Typography>
+                          </Tooltip>
+                          <Box
+                            component="input"
+                            type={
+                              schema?.type === "integer" ||
+                              schema?.type === "number"
+                                ? "number"
+                                : "text"
+                            }
+                            placeholder={
+                              schema?.nullable
+                                ? "optional"
+                                : String(schema?.default ?? "")
+                            }
+                            value={codeParams[key] ?? ""}
+                            onChange={(e) => {
+                              // BE's `type: number` schema rejects strings; coerce here.
+                              const rawVal = e.target.value;
+                              const isNumeric =
+                                schema?.type === "integer" ||
+                                schema?.type === "number";
+                              let next = rawVal;
+                              if (isNumeric && rawVal !== "") {
+                                const n = Number(rawVal);
+                                if (!Number.isNaN(n)) next = n;
+                              }
+                              handleCodeParamChange(key, next);
+                            }}
+                            sx={{
+                              flex: 1,
+                              px: 1,
+                              py: 0.5,
+                              fontSize: "12px",
+                              fontFamily: "monospace",
+                              border: "1px solid",
+                              borderColor: "divider",
+                              borderRadius: "6px",
+                              bgcolor: "background.paper",
+                              color: "text.primary",
+                              outline: "none",
+                              "&:focus": { borderColor: "primary.main" },
+                            }}
+                          />
+                        </Box>
+                      );
+                    })}
                   </Box>
                 )}
             </Box>


### PR DESCRIPTION
UI fixes in the eval creation / detail flow (sub-issues of **TH-5505 — UX issues with current Eval flows**).

## 1. Why

Three UX papercuts in the eval creation/detail flow: score colours were misleading for "lower-is-better" metrics, code-eval option params were free-text (error-prone), and composite evals never explained the parent/child relationship.

## 2. What changed

**1. Scoring output type — score-direction toggle** (`OutputTypeConfig.jsx`)
- Added a **"lower score is better"** checkbox above the choice list. Default: higher is better (1 = green/good, 0 = red/bad). Enabled: inverts chip colours for negative metrics like toxicity/hallucination (0 green, 1 red).
- Creation-time **colour guide only** — intentionally **not** added to the save payload (backend rejects unknown fields, same class as the `status: Unknown field` issue). Clarified choices help text: *"All choices and scores must be unique."*

**2. Code-eval params — multi-select dropdown** (`TestPlayground.jsx`)
- Params whose description declares a fixed option set (`… Options: a, b, c`, e.g. `detect_types`) now render as a **multi-select checkbox dropdown**, all options selected by default; description shows as a **helper line below** (was a hover tooltip); trigger lists selected values comma-separated. Params without options keep the existing text/number input + tooltip.

**3. Composite eval — explain child evals** (`CompositeDetailPanel.jsx`)
- Added **inline help**: sharpened intro (each child scores the same input on a different dimension — accuracy/tone/safety — rolling up to one score), an inline helper under **Children**, and an **empty-state hint** when there are no children.

## 3. Tests written (new & old)

- **New automated tests:** none added — UI-only changes, verified via ESLint + manual testing on the dev server.
- **Existing / regression:** repo vitest suite passes unchanged; ESLint clean on the 3 changed files (`OutputTypeConfig.jsx`, `TestPlayground.jsx`, `CompositeDetailPanel.jsx`).

## 4. Test scenarios covered (manual)

- **Score direction:** toggle off → 1 green / 0 red; toggle on → 0 green / 1 red. Confirm the flag is **not** sent in the create payload (no "Unknown field" error).
- **Multi-select params:** a param with `Options:` renders as a checkbox dropdown, all checked by default; unchecking updates the comma-separated trigger; description shows as helper text. A param without options still renders text/number input.
- **Composite help:** intro + children helper + empty-state hint render; empty-state hint disappears once a child is added.

## 5. Commands to run tests

```bash
cd frontend
yarn lint "src/sections/evals/components/OutputTypeConfig.jsx" "src/sections/evals/components/TestPlayground.jsx" "src/sections/evals/components/CompositeDetailPanel.jsx"
yarn test:run
yarn dev
```

## 6. Steps to test on local/dev

1. `cd frontend && yarn dev`, open **Evals → Create**.
2. Choose **Scoring** output type → toggle "lower score is better" and watch chip colours invert; create the eval and confirm no field-rejection error.
3. Select a code eval with an option param (e.g. `detect_types`) → confirm the multi-select dropdown + helper line.
4. Create/open a **Composite** eval → confirm the intro/help text and empty-state hint.

## 7. Screenshots & videos

**Change 1 — score-direction toggle** ("lower score is better" colour guide on the Scoring output type):

<img width="797" height="497" alt="Score-direction toggle on Scoring output type" src="https://github.com/user-attachments/assets/cc8aed6d-3917-448a-9876-ffac4287e512" />

**Change 2 — code-eval params multi-select dropdown** (checkbox options, all selected by default, description as a helper line):

<img width="799" height="467" alt="Multi-select param dropdown — open with checkbox options" src="https://github.com/user-attachments/assets/f33b0e02-75db-4ab6-8c03-44e0eca35392" />

<img width="808" height="503" alt="Multi-select param dropdown — selected values with helper line" src="https://github.com/user-attachments/assets/f2866e80-c4ef-46d8-915b-4ae42be09b98" />

**Change 3 — composite eval child-eval help** (inline explanation of the parent/child relationship + empty-state hint):

<img width="813" height="506" alt="Composite eval inline child-eval help" src="https://github.com/user-attachments/assets/398d8e1b-4883-4f9a-8a9a-94672a185451" />

## 8. Key decisions & rationale

- **Score-direction is presentation-only, not persisted** — the backend rejects unknown fields today; persisting it requires a backend field first, so we ship the visual guide now and avoid breaking create.
- **Parse options from the description's `Options:` segment** because the param schema has no structured `enum` today — minimal-footprint way to get a real multi-select without a backend change.
- **Inline help over tooltips/doc links** for composites — the relationship is non-obvious and deserves always-visible explanation.
