### PR TITLE
fix(bedrock): honor AWS_BEDROCK_REGION for the aws_bedrock provider

### DIFF
--- a/futureagi/agentic_eval/core/llm/llm.py
+++ b/futureagi/agentic_eval/core/llm/llm.py
@@ -289,7 +289,7 @@ class LLM:
             "aws_bedrock": {
                 "aws_access_key": os.getenv("AWS_ACCESS_KEY_ID"),
                 "aws_secret_key": os.getenv("AWS_SECRET_ACCESS_KEY"),
-                "aws_region": "us-west-2",
+                "aws_region": os.getenv("AWS_BEDROCK_REGION", "us-west-2"),
             },
         }
 

--- a/futureagi/agentic_eval/core/llm/tests/test_bedrock_region.py
+++ b/futureagi/agentic_eval/core/llm/tests/test_bedrock_region.py
@@ -1,0 +1,57 @@
+"""Regression tests for AWS Bedrock region resolution in LLM._init_client.
+
+The ``aws_bedrock`` provider must honor the ``AWS_BEDROCK_REGION`` environment
+variable the same way its sibling ``aws_bedrock_anthropic`` already does,
+instead of always pinning the client to ``us-west-2``.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from agentic_eval.core.llm import llm as llm_module
+from agentic_eval.core.llm.llm import LLM
+
+
+def _build_bedrock_llm():
+    """Run the real _init_client so provider_api_keys/region resolution runs."""
+    llm = LLM.__new__(LLM)
+    LLM.__init__(llm, provider="aws_bedrock", model_name="anthropic.claude-3-5-sonnet")
+    return llm
+
+
+class TestBedrockRegionResolution:
+    def test_aws_bedrock_honors_region_env(self):
+        """A user-set AWS_BEDROCK_REGION must reach the bedrock-runtime client."""
+        with patch.dict(os.environ, {"AWS_BEDROCK_REGION": "eu-central-1"}):
+            with patch.object(llm_module.boto3, "Session") as mock_session:
+                mock_session.return_value.client.return_value = MagicMock()
+                llm = _build_bedrock_llm()
+
+        assert llm.provider_api_keys["aws_bedrock"]["aws_region"] == "eu-central-1"
+        # the resolved region is what actually configures the boto3 session
+        assert mock_session.call_args.kwargs["region_name"] == "eu-central-1"
+
+    def test_aws_bedrock_defaults_to_us_west_2(self):
+        """Without the env var the historical us-west-2 default is preserved."""
+        env_without_region = {
+            k: v for k, v in os.environ.items() if k != "AWS_BEDROCK_REGION"
+        }
+        with patch.dict(os.environ, env_without_region, clear=True):
+            with patch.object(llm_module.boto3, "Session") as mock_session:
+                mock_session.return_value.client.return_value = MagicMock()
+                llm = _build_bedrock_llm()
+
+        assert llm.provider_api_keys["aws_bedrock"]["aws_region"] == "us-west-2"
+
+    def test_aws_bedrock_matches_anthropic_sibling(self):
+        """Both Bedrock providers resolve region from the same env var."""
+        with patch.dict(os.environ, {"AWS_BEDROCK_REGION": "ap-northeast-2"}):
+            with patch.object(llm_module.boto3, "Session") as mock_session:
+                mock_session.return_value.client.return_value = MagicMock()
+                llm = _build_bedrock_llm()
+
+        assert (
+            llm.provider_api_keys["aws_bedrock"]["aws_region"]
+            == llm.provider_api_keys["aws_bedrock_anthropic"]["aws_region"]
+            == "ap-northeast-2"
+        )


### PR DESCRIPTION
## Summary

The `aws_bedrock` provider hard-coded the Bedrock client region to `"us-west-2"`, ignoring user configuration. Its sibling `aws_bedrock_anthropic` provider already resolves the region from `AWS_BEDROCK_REGION`, so this aligns `aws_bedrock` with that established pattern. `us-west-2` is kept as the default, so behavior is unchanged for anyone who does not set the variable.

Thanks again @NikhilParekh for the invitation to contribute. 🙏

## Linked issues

Closes #938

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## The change

```python
# futureagi/agentic_eval/core/llm/llm.py  (_init_client → provider_api_keys)
 "aws_bedrock": {
     "aws_access_key": os.getenv("AWS_ACCESS_KEY_ID"),
     "aws_secret_key": os.getenv("AWS_SECRET_ACCESS_KEY"),
-    "aws_region": "us-west-2",
+    "aws_region": os.getenv("AWS_BEDROCK_REGION", "us-west-2"),
 },
```

This mirrors the sibling `aws_bedrock_anthropic` entry, which already uses `os.getenv("AWS_BEDROCK_REGION", ...)`.

## How was this tested?

Added `agentic_eval/core/llm/tests/test_bedrock_region.py` (3 regression tests). I verified the tests actually catch the bug by reverting **only** the source line and re-running them:

| Test | Before (hard-coded) | After (fix) |
|------|:---:|:---:|
| `test_aws_bedrock_honors_region_env` — a user-set `AWS_BEDROCK_REGION` reaches the boto3 session | ❌ FAIL (pinned to `us-west-2`) | ✅ PASS |
| `test_aws_bedrock_defaults_to_us_west_2` — default preserved when env unset (regression guard) | ✅ PASS | ✅ PASS |
| `test_aws_bedrock_matches_anthropic_sibling` — both Bedrock providers resolve the same region | ❌ FAIL | ✅ PASS |

The two region-resolution tests fail on the old code and pass after the fix; the default-preservation test passes in both, confirming **no behavior change** for existing users. `black --target-version py312` and `isort --profile black` are clean on both files.

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective
- [x] Lint/format clean locally (`black`, `isort`)
- [ ] I've updated the documentation where relevant (N/A — no public API/behavior change)
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA

---
*This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the reasoning, and the test results before submitting.*
