### PR TITLE
fix(metrics): show prompt metrics when SDK omits template_label

### DIFF
--- a/futureagi/model_hub/queries/prompt/prompt_metrics.py
+++ b/futureagi/model_hub/queries/prompt/prompt_metrics.py
@@ -247,7 +247,6 @@ def fetch_prompt_metrics_span_query(
             prompt_version__original_template=prompt_template,
             prompt_version__deleted=False,
             prompt_version_id__isnull=False,
-            prompt_label_id__isnull=False,
         )
         .select_related("prompt_version", "project", "prompt_label")
         .prefetch_related("prompt_version__labels", "eval_logs__custom_eval_config")

--- a/futureagi/model_hub/tests/test_prompt_metrics_label_optional.py
+++ b/futureagi/model_hub/tests/test_prompt_metrics_label_optional.py
@@ -1,0 +1,154 @@
+"""Regression tests for TH-5655 — prompt metrics must surface spans even
+when prompt_label_id is NULL (i.e., the SDK didn't pass `template_label`).
+
+Two halves of the fix:
+
+1. Ingestion (`tracer.utils.trace_ingestion._fetch_prompt_versions`) must
+   resolve `prompt_version_id` from `template_name` alone — `template_label`
+   stays optional. When the SDK omits the label, the span row still gets
+   tagged with `prompt_version_id`, `prompt_label_id` stays NULL.
+
+2. Retrieval (`SQL_queries.prompt_metrics_cte_base_query`) must surface
+   those NULL-label rows by LEFT-JOINing `model_hub_promptlabel` instead
+   of INNER-JOINing. The metric row reports `prompt_label_name = NULL`.
+"""
+
+import uuid
+
+import pytest
+
+from accounts.models.organization import Organization
+from accounts.models.workspace import Workspace
+from model_hub.models.choices import OwnerChoices
+from model_hub.models.evals_metric import EvalTemplateVersion  # noqa: F401
+from model_hub.models.run_prompt import (
+    PromptLabel,
+    PromptTemplate,
+    PromptVersion,
+)
+from tracer.utils.trace_ingestion import _fetch_prompt_versions
+
+
+@pytest.fixture
+def organization(db):
+    return Organization.objects.create(name=f"th5655-org-{uuid.uuid4().hex[:6]}")
+
+
+@pytest.fixture
+def workspace(db, organization):
+    return Workspace.objects.create(
+        name="Default Workspace",
+        organization=organization,
+        is_default=True,
+    )
+
+
+@pytest.fixture
+def prompt_template(db, organization, workspace):
+    return PromptTemplate.objects.create(
+        name=f"tpl-{uuid.uuid4().hex[:6]}",
+        organization=organization,
+        workspace=workspace,
+        owner=OwnerChoices.USER.value,
+    )
+
+
+@pytest.fixture
+def prompt_version(db, prompt_template):
+    return PromptVersion.objects.create(
+        original_template=prompt_template,
+        template_version="v1",
+        is_default=True,
+    )
+
+
+# ── Storage half: ingestion resolves version_id without a label ────────────
+
+
+@pytest.mark.django_db
+class TestFetchPromptVersionsLabelOptional:
+    def test_no_label_still_resolves_version(self, prompt_template, prompt_version):
+        """SDK omitted template_label → version_id set, label_id stays None."""
+        parsed = [
+            {
+                "observation_span": {"observation_type": "llm"},
+                "prompt_details": {
+                    "prompt_template_name": prompt_template.name,
+                    "prompt_template_version": "v1",
+                    # template_label intentionally absent
+                },
+            }
+        ]
+
+        result = _fetch_prompt_versions(parsed, str(prompt_template.organization_id))
+
+        assert len(result) == 1
+        ((key, entry),) = result.items()
+        assert entry["prompt_version_id"] == str(prompt_version.id)
+        assert entry["prompt_label_id"] is None
+
+    def test_with_label_resolves_both(
+        self, prompt_template, prompt_version, organization, workspace
+    ):
+        """When label is provided and exists, both ids are set."""
+        label = PromptLabel.objects.create(
+            name="production",
+            type="CUSTOM",
+            organization=organization,
+            workspace=workspace,
+        )
+        prompt_version.labels.add(label)
+
+        parsed = [
+            {
+                "observation_span": {"observation_type": "llm"},
+                "prompt_details": {
+                    "prompt_template_name": prompt_template.name,
+                    "prompt_template_version": "v1",
+                    "prompt_template_label": "production",
+                },
+            }
+        ]
+
+        result = _fetch_prompt_versions(parsed, str(prompt_template.organization_id))
+
+        assert len(result) == 1
+        entry = next(iter(result.values()))
+        assert entry["prompt_version_id"] == str(prompt_version.id)
+        assert entry["prompt_label_id"] == str(label.id)
+
+    def test_no_template_name_returns_empty(self, prompt_template):
+        """Without a name there's nothing to match — early return."""
+        parsed = [
+            {
+                "observation_span": {"observation_type": "llm"},
+                "prompt_details": {"prompt_template_version": "v1"},
+            }
+        ]
+        assert _fetch_prompt_versions(parsed, str(prompt_template.organization_id)) == {}
+
+    def test_non_llm_spans_ignored(self, prompt_template):
+        """Only llm spans carry prompt_details — others skipped."""
+        parsed = [
+            {
+                "observation_span": {"observation_type": "tool"},
+                "prompt_details": {
+                    "prompt_template_name": prompt_template.name,
+                    "prompt_template_version": "v1",
+                },
+            }
+        ]
+        assert _fetch_prompt_versions(parsed, str(prompt_template.organization_id)) == {}
+
+
+# ── Retrieval half: CTE must LEFT-JOIN prompt_label, not INNER-JOIN ────────
+
+
+class TestMetricsCteLabelJoin:
+    """Static guard against the INNER JOIN regressing back into the CTE."""
+
+    def test_cte_uses_left_join_on_prompt_label(self):
+        from model_hub.utils.SQL_queries import prompt_metrics_cte_base_query
+
+        assert "LEFT JOIN model_hub_promptlabel" in prompt_metrics_cte_base_query
+        assert "INNER JOIN model_hub_promptlabel" not in prompt_metrics_cte_base_query

--- a/futureagi/model_hub/utils/SQL_queries.py
+++ b/futureagi/model_hub/utils/SQL_queries.py
@@ -1561,7 +1561,7 @@ base AS (
         ) AS row_avg_cost
     FROM tracer_observation_span os
     INNER JOIN model_hub_promptversion pv ON os.prompt_version_id = pv.id
-    INNER JOIN model_hub_promptlabel pl ON os.prompt_label_id = pl.id
+    LEFT JOIN model_hub_promptlabel pl ON os.prompt_label_id = pl.id
     WHERE
         pv.original_template_id = %s
         AND pv.deleted = FALSE

--- a/futureagi/tracer/utils/trace_ingestion.py
+++ b/futureagi/tracer/utils/trace_ingestion.py
@@ -413,41 +413,48 @@ def _fetch_prompt_versions(
             )
             prompt_template_label = prompt_details.get("prompt_template_label", None)
 
-            if prompt_template_name and prompt_template_label:
+            if prompt_template_name:
                 filters = {
                     "original_template__name": prompt_template_name,
                     "original_template__organization": organization_id,
-                    "labels__name": prompt_template_label,
                 }
 
                 if prompt_template_version:
                     filters["template_version"] = prompt_template_version
+
+                if prompt_template_label:
+                    filters["labels__name"] = prompt_template_label
 
                 prompt_version_filters.append(filters)
 
     if not prompt_version_filters or len(prompt_version_filters) == 0:
         return {}
 
-    # Use a cache to avoid redundant queries for the same filter set
+    # Use a cache to avoid redundant queries for the same filter set.
+    # prompt_label_id is optional — when the SDK didn't pass template_label,
+    # we still resolve prompt_version_id so the span shows up in metrics
+    # (LEFT-joined to label in the metrics CTE).
     prompt_versions_cache = {}
     for filters in prompt_version_filters:
         key = tuple(sorted(filters.items()))
         if key not in prompt_versions_cache:
             prompt_version = PromptVersion.objects.filter(**filters).first()
             if prompt_version:
-                # Fetch the required prompt_label with the specific name
+                prompt_label_id = None
                 label_name = filters.get("labels__name")
-                prompt_labels_ids = prompt_version.labels.through.objects.filter(
-                    promptversion_id=prompt_version,
-                ).values_list("promptlabel_id", flat=True)
-
-                req_label = PromptLabel.no_workspace_objects.filter(
-                    id__in=prompt_labels_ids, name=label_name
-                ).first()
+                if label_name:
+                    prompt_labels_ids = prompt_version.labels.through.objects.filter(
+                        promptversion_id=prompt_version,
+                    ).values_list("promptlabel_id", flat=True)
+                    req_label = PromptLabel.no_workspace_objects.filter(
+                        id__in=prompt_labels_ids, name=label_name
+                    ).first()
+                    if req_label:
+                        prompt_label_id = str(req_label.id)
 
                 prompt_versions_cache[key] = {
                     "prompt_version_id": str(prompt_version.id),
-                    "prompt_label_id": str(req_label.id),
+                    "prompt_label_id": prompt_label_id,
                 }
 
     return prompt_versions_cache
@@ -557,15 +564,17 @@ def _link_prompt_version(
         prompt_template_version = prompt_details.get("prompt_template_version", None)
         prompt_template_label = prompt_details.get("prompt_template_label", None)
 
-        if prompt_template_name and prompt_template_label:
+        if prompt_template_name:
             filters = {
                 "original_template__name": prompt_template_name,
                 "original_template__organization": organization_id,
-                "labels__name": prompt_template_label,
             }
 
             if prompt_template_version:
                 filters["template_version"] = prompt_template_version
+
+            if prompt_template_label:
+                filters["labels__name"] = prompt_template_label
 
             key = tuple(sorted(filters.items()))
             if (


### PR DESCRIPTION
## Summary

The Metrics tab on a prompt was empty for any user who instrumented their LLM calls without passing `template_label` — which is everyone following the onboarding snippet returned by `/model-hub/prompt/metrics/empty-screen`, because that snippet doesn't include a label argument. Two backend gates were silently dropping their spans before any metric ever showed up:

1. **Ingestion gate** (`tracer/utils/trace_ingestion.py:416, :560`) required both `prompt_template_name` AND `prompt_template_label` to set the span's `prompt_version_id`. When the SDK didn't pass a label, the span was ingested with `prompt_version_id = NULL` and `prompt_label_id = NULL`, completely untagged.
2. **Metrics CTE** (`model_hub/utils/SQL_queries.py:1564`) used `INNER JOIN model_hub_promptlabel` in the base aggregation, so even spans that *did* have a `prompt_version_id` were dropped whenever `prompt_label_id` was NULL.

Net effect: a user instruments their app per the docs, runs it, opens the Metrics tab, sees the empty-state code snippet again — and has no idea why.

## What this PR does

- **`tracer/utils/trace_ingestion.py`** — relax the gate to require only `prompt_template_name`. If `prompt_template_label` is provided, it's still looked up and attached; if not, the span is tagged with `prompt_version_id` only (and `prompt_label_id` stays NULL). Two call sites updated for parity.
- **`model_hub/utils/SQL_queries.py`** — `INNER JOIN model_hub_promptlabel` → `LEFT JOIN`. Spans without a label now appear under a row with `prompt_label_name = NULL`, grouped alongside any labeled rows for the same version.

## Linked issues

Closes TH-5655

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## How was this tested

End-to-end against local docker:

1. Logged in as `tanmay@futureagi.com`, fetched user/org/workspace context.
2. Confirmed DB starts at 0 observation spans for the org's only prompt — API correctly returned `table: []` with HTTP 200.
3. Seeded 3 spans tagged with both `prompt_version_id` and `prompt_label_id` → API returned 1 metric row with the labeled name.
4. Replaced them with 3 spans having `prompt_version_id` but **NULL** `prompt_label_id` (simulating the onboarding-snippet case) → before fix: `table: []` again. After fix: 1 metric row with `prompt_label_name: null`, 3 spans, correct latency/tokens/cost averages.
5. Added 2 more labeled spans alongside the 3 unlabeled → API returned 2 grouped rows (labeled + unlabeled) with correct aggregates each.

No serializer change — the response shape is unchanged. The `table` field is already `ListField(child=JSONField())`, and `prompt_label_name` was already a column in the default config; it just happens to be `null` for the unlabeled group now. No FE change required — AG Grid renders NULL as an empty cell.

## Checklist

- [x] My code follows the style guide
- [ ] I've added tests that prove my fix is effective or that my feature works
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the CLA