### PR TITLE
fix(gateway): auto-enable auth from AGENTCC_INTERNAL_API_KEY, fail closed (TH-5712)

### DIFF
--- a/agentcc-gateway/config.example.yaml
+++ b/agentcc-gateway/config.example.yaml
@@ -250,7 +250,9 @@ providers:
 
 # Virtual API key authentication.
 # When enabled, all requests must include Authorization: Bearer sk-agentcc-xxx
-# When disabled (default), the gateway runs in open mode.
+# Setting AGENTCC_INTERNAL_API_KEY in the environment turns this on automatically
+# and registers that key. Running with no key and no auth block leaves the
+# gateway open — only do that on a trusted, non-public network.
 # auth:
 #   enabled: true
 #   keys:

--- a/agentcc-gateway/internal/config/config.go
+++ b/agentcc-gateway/internal/config/config.go
@@ -939,6 +939,18 @@ func loadFromFile(cfg *Config, path string) error {
 	return yaml.Unmarshal([]byte(expanded), cfg)
 }
 
+// authKeyConfigured reports whether an auth key with the given raw value is
+// already present (e.g. loaded from config.yaml), so env seeding doesn't
+// clobber an operator's explicit entry.
+func authKeyConfigured(keys []AuthKeyConfig, raw string) bool {
+	for i := range keys {
+		if keys[i].Key == raw {
+			return true
+		}
+	}
+	return false
+}
+
 func loadFromEnv(cfg *Config) {
 	if v := os.Getenv("AGENTCC_PORT"); v != "" {
 		if port, err := strconv.Atoi(v); err == nil {
@@ -984,15 +996,27 @@ func loadFromEnv(cfg *Config) {
 	// on. A configured key can therefore never leave the gateway open, even if
 	// AGENTCC_AUTH_ENABLED=false is also set (fail closed).
 	if v := os.Getenv("AGENTCC_AUTH_ENABLED"); v != "" {
-		cfg.Auth.Enabled = v == "true" || v == "1"
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			cfg.Auth.Enabled = enabled
+		}
 	}
 	if v := os.Getenv("AGENTCC_INTERNAL_API_KEY"); v != "" {
 		cfg.Auth.Enabled = true
-		cfg.Auth.Keys = append(cfg.Auth.Keys, AuthKeyConfig{
-			Name:  "internal-backend",
-			Key:   v,
-			Owner: "futureagi-backend",
-		})
+		// Seed as an "internal" key: byok (the keystore's default type) is barred
+		// from the global, FutureAGI-credentialed providers, so a mistyped seed
+		// authenticates and then 403s the backend's own LLM route.
+		//
+		// Skip when this key is already configured (e.g. in config.yaml): the
+		// keystore is last-write-wins by hash, so appending here would override
+		// — and could re-type — an operator's explicit entry.
+		if !authKeyConfigured(cfg.Auth.Keys, v) {
+			cfg.Auth.Keys = append(cfg.Auth.Keys, AuthKeyConfig{
+				Name:    "internal-backend",
+				Key:     v,
+				Owner:   "futureagi-backend",
+				KeyType: "internal",
+			})
+		}
 	}
 
 	// Redis state env overrides.

--- a/agentcc-gateway/internal/config/config.go
+++ b/agentcc-gateway/internal/config/config.go
@@ -979,6 +979,22 @@ func loadFromEnv(cfg *Config) {
 		cfg.ControlPlane.WebhookSecret = v
 	}
 
+	// Auth env overrides. Evaluate the explicit toggle first, then let a present
+	// internal API key have the final say: it seeds the key store and forces auth
+	// on. A configured key can therefore never leave the gateway open, even if
+	// AGENTCC_AUTH_ENABLED=false is also set (fail closed).
+	if v := os.Getenv("AGENTCC_AUTH_ENABLED"); v != "" {
+		cfg.Auth.Enabled = v == "true" || v == "1"
+	}
+	if v := os.Getenv("AGENTCC_INTERNAL_API_KEY"); v != "" {
+		cfg.Auth.Enabled = true
+		cfg.Auth.Keys = append(cfg.Auth.Keys, AuthKeyConfig{
+			Name:  "internal-backend",
+			Key:   v,
+			Owner: "futureagi-backend",
+		})
+	}
+
 	// Redis state env overrides.
 	if v := os.Getenv("AGENTCC_REDIS_ADDRESS"); v != "" {
 		cfg.Redis.Address = v

--- a/agentcc-gateway/internal/config/config_test.go
+++ b/agentcc-gateway/internal/config/config_test.go
@@ -171,14 +171,19 @@ func TestLoadFromEnvAuthFailsClosedWhenKeyPresent(t *testing.T) {
 	if !cfg.Auth.Enabled {
 		t.Fatal("auth must be enabled when AGENTCC_INTERNAL_API_KEY is set, even with AGENTCC_AUTH_ENABLED=false")
 	}
-	seeded := false
-	for _, k := range cfg.Auth.Keys {
-		if k.Key == "test-internal-key" {
-			seeded = true
+	var seeded *AuthKeyConfig
+	for i := range cfg.Auth.Keys {
+		if cfg.Auth.Keys[i].Key == "test-internal-key" {
+			seeded = &cfg.Auth.Keys[i]
 		}
 	}
-	if !seeded {
+	if seeded == nil {
 		t.Fatal("internal API key must be seeded into the key store")
+	}
+	// Must be typed "internal": a byok key (the keystore default) is barred from
+	// the global providers, so the backend would authenticate then 403 its own route.
+	if seeded.KeyType != "internal" {
+		t.Fatalf("seeded key KeyType = %q, want \"internal\"", seeded.KeyType)
 	}
 }
 
@@ -192,5 +197,34 @@ func TestLoadFromEnvAuthToggleHonoredWhenNoKey(t *testing.T) {
 
 	if cfg.Auth.Enabled {
 		t.Fatal("auth should stay off when no key is set and the toggle is false")
+	}
+}
+
+// An explicit config.yaml entry for the same key must not be clobbered by the
+// env seed — the keystore is last-write-wins by hash, so a duplicate would
+// override (and could re-type) the operator's entry.
+func TestLoadFromEnvDoesNotClobberExplicitInternalKey(t *testing.T) {
+	t.Setenv("AGENTCC_INTERNAL_API_KEY", "test-internal-key")
+
+	cfg := DefaultConfig()
+	cfg.Auth.Keys = []AuthKeyConfig{{
+		Name:    "ops-configured",
+		Key:     "test-internal-key",
+		Owner:   "ops",
+		KeyType: "internal",
+	}}
+	loadFromEnv(cfg)
+
+	n := 0
+	for _, k := range cfg.Auth.Keys {
+		if k.Key == "test-internal-key" {
+			n++
+			if k.Name != "ops-configured" {
+				t.Fatalf("explicit config entry overwritten: Name = %q, want \"ops-configured\"", k.Name)
+			}
+		}
+	}
+	if n != 1 {
+		t.Fatalf("got %d entries for the key, want 1 (env seed must not duplicate an explicit config key)", n)
 	}
 }

--- a/agentcc-gateway/internal/config/config_test.go
+++ b/agentcc-gateway/internal/config/config_test.go
@@ -157,3 +157,40 @@ func TestAddr(t *testing.T) {
 		t.Errorf("Addr() = %q, want %q", addr, "0.0.0.0:8080")
 	}
 }
+
+// A present internal API key must force auth ON, even when AGENTCC_AUTH_ENABLED=false
+// is also set. Before the precedence fix the toggle ran last and could silently
+// re-open a gateway that had a key configured.
+func TestLoadFromEnvAuthFailsClosedWhenKeyPresent(t *testing.T) {
+	t.Setenv("AGENTCC_AUTH_ENABLED", "false")
+	t.Setenv("AGENTCC_INTERNAL_API_KEY", "test-internal-key")
+
+	cfg := DefaultConfig()
+	loadFromEnv(cfg)
+
+	if !cfg.Auth.Enabled {
+		t.Fatal("auth must be enabled when AGENTCC_INTERNAL_API_KEY is set, even with AGENTCC_AUTH_ENABLED=false")
+	}
+	seeded := false
+	for _, k := range cfg.Auth.Keys {
+		if k.Key == "test-internal-key" {
+			seeded = true
+		}
+	}
+	if !seeded {
+		t.Fatal("internal API key must be seeded into the key store")
+	}
+}
+
+// The explicit toggle still applies on its own when no key is configured.
+func TestLoadFromEnvAuthToggleHonoredWhenNoKey(t *testing.T) {
+	t.Setenv("AGENTCC_INTERNAL_API_KEY", "")
+	t.Setenv("AGENTCC_AUTH_ENABLED", "false")
+
+	cfg := DefaultConfig()
+	loadFromEnv(cfg)
+
+	if cfg.Auth.Enabled {
+		t.Fatal("auth should stay off when no key is set and the toggle is false")
+	}
+}

--- a/agentcc-gateway/internal/server/server_test.go
+++ b/agentcc-gateway/internal/server/server_test.go
@@ -1270,6 +1270,45 @@ func TestChatCompletionByokKeyCannotUseGlobalProvider(t *testing.T) {
 	}
 }
 
+// The env-seeded internal key (AGENTCC_INTERNAL_API_KEY) must reach the global,
+// FutureAGI-credentialed providers — i.e. loadFromEnv types it "internal", not
+// byok. This goes through the real path (config.Load -> keystore -> resolveProvider),
+// so a mistyped seed surfaces as a 403 here, not just a config-struct mismatch.
+func TestChatCompletionEnvSeededInternalKeyReachesGlobalProvider(t *testing.T) {
+	mock := startMockOpenAI(t)
+	defer mock.Close()
+
+	t.Setenv("AGENTCC_INTERNAL_API_KEY", "sk-agentcc-internal-test")
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	cfg.Providers["openai"] = config.ProviderConfig{
+		BaseURL:   mock.URL,
+		APIFormat: "openai",
+		Models:    []string{"gpt-4o", "gpt-4o-mini"},
+	}
+
+	registry, err := providers.NewRegistry(cfg)
+	if err != nil {
+		t.Fatalf("creating registry: %v", err)
+	}
+	srv := New(cfg, "", registry, pipeline.NewEngine(), nil, nil, nil, nil, testModelDBPtr(), nil, nil)
+	srv.ready.Store(true)
+
+	reqBody := `{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sk-agentcc-internal-test")
+	w := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 — the env-seeded internal key must reach the global provider (a byok-typed seed 403s here). Body: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestA2AByokKeyDoesNotLeakInternalPermissionMessage(t *testing.T) {
 	mock := startMockOpenAI(t)
 	defer mock.Close()


### PR DESCRIPTION
## Summary

The agentcc gateway (the LLM proxy) shipped **open by default**. `AGENTCC_INTERNAL_API_KEY` was passed to every gateway deploy via compose, but the gateway's config loader never read it — so `Auth.Enabled` stayed `false` and the proxy served any request with no credential. Anyone who could reach `:8090` could use it.

The fix makes a present key **seed the key store and force auth on**, evaluating `AGENTCC_AUTH_ENABLED` **first** and the key check **last** (fail closed). The seed is typed **`internal`** so it can reach the global, FutureAGI-credentialed providers (a `byok`-typed key is barred there), and it won't clobber an operator's explicit config entry. Single-purpose, gateway config only, on latest `dev`.

## Why the changes are done — what is the problem

### Reproduce on dev / main today (before this PR)

1. Bring the gateway up with `AGENTCC_INTERNAL_API_KEY` set (as every compose deploy does).
2. Hit it with no credential: `curl -s -o /dev/null -w "%{http_code}" http://localhost:8090/v1/models`.
3. Response is **`200`** — the proxy serves the request. No `Authorization` header required.

### Where it breaks — gateway config (Go)

`loadFromEnv` (`internal/config/config.go`) applied every other env override but **never read `AGENTCC_INTERNAL_API_KEY`**, so `Auth.Enabled` kept its `false` default → open mode. There was also no fail-closed precedence (a toggle evaluated after the key could re-open a keyed gateway).

### Where it breaks — the internal route (why `KeyType` matters)

Enabling auth + seeding a key is not enough: `resolveProvider` (`internal/server/handlers.go`) **bars any non-`internal` key from the global providers**, and the keystore defaults an untyped key to `byok`. So a key seeded without a type authenticates and then **403s the backend's own LLM route**. The seed must be typed `internal`.

## What changed

### `internal/config/config.go` — read the key, fail-closed precedence, internal type, no clobber

```go
if v := os.Getenv("AGENTCC_AUTH_ENABLED"); v != "" {
    if enabled, err := strconv.ParseBool(v); err == nil { cfg.Auth.Enabled = enabled }
}
if v := os.Getenv("AGENTCC_INTERNAL_API_KEY"); v != "" {
    cfg.Auth.Enabled = true
    if !authKeyConfigured(cfg.Auth.Keys, v) {           // don't clobber an explicit config entry
        cfg.Auth.Keys = append(cfg.Auth.Keys, AuthKeyConfig{
            Name: "internal-backend", Key: v, Owner: "futureagi-backend",
            KeyType: "internal",                          // reach global providers, not 403
        })
    }
}
```

- Toggle parsed with `strconv.ParseBool` (robust for a security flag).
- A present key forces auth on (toggle can't re-open it) and is seeded as **`internal`**.
- The append is **skipped when the key is already configured** — the keystore is last-write-wins by hash, so a duplicate would override (and could re-type) an operator's explicit entry.

### `internal/config/config_test.go` — regression tests (KeyType + clobber)

### `internal/server/server_test.go` — end-to-end: the env-seeded internal key reaches a global provider

## Tests included — what each scenario covers

| # | Test | Setup | Action | What it pins |
|---|---|---|---|---|
| 1 | `TestLoadFromEnvAuthFailsClosedWhenKeyPresent` | key **+** `AGENTCC_AUTH_ENABLED=false` | `loadFromEnv` | auth ends **on** (key wins) and the key is seeded as **`KeyType: "internal"`** |
| 2 | `TestLoadFromEnvAuthToggleHonoredWhenNoKey` | no key, toggle false | `loadFromEnv` | toggle still works alone → auth **off** |
| 3 | `TestLoadFromEnvDoesNotClobberExplicitInternalKey` | config.yaml already has the same key | `loadFromEnv` | env seed **doesn't duplicate / overwrite** the operator's explicit entry (Blocker 2) |
| 4 | `TestChatCompletionEnvSeededInternalKeyReachesGlobalProvider` | env key set, mock global provider | `POST /v1/chat/completions` with the key | the env-seeded internal key **reaches the global provider → 200** end-to-end; a `byok`-typed seed 403s here (Blocker 1) |
| 5 | `TestChatCompletionByokKeyCannotUseGlobalProvider` | a `byok` key | `POST` for a global model | `byok` → **403** (the negative half) |

## Commands to run tests

```bash
# review-fix tests (config + the end-to-end server test)
go test ./internal/config/ ./internal/server/ \
  -run 'TestLoadFromEnv|EnvSeededInternalKey|ByokKeyCannotUseGlobalProvider|ShouldApplyOrgProviderOverride' -v

# full gateway suite
go test ./...
```

### Local verification results

```
ok  internal/config   PASS TestLoadFromEnvAuthFailsClosedWhenKeyPresent
                       PASS TestLoadFromEnvAuthToggleHonoredWhenNoKey
                       PASS TestLoadFromEnvDoesNotClobberExplicitInternalKey
ok  internal/server   PASS TestChatCompletionEnvSeededInternalKeyReachesGlobalProvider
                       PASS TestChatCompletionByokKeyCannotUseGlobalProvider
                       PASS TestShouldApplyOrgProviderOverride
```

> Full `go test ./...` passes in CI ("Gateway contracts and tests" ✓). One unrelated test (`TestCreateEmbedding_InternalKeySkipsOrgProviderOverride`) is flaky in a bare local container but green in CI; it pre-exists this PR.

## Video

**Live e2e (200 open → 401 closed → 401 precedence):**

https://github.com/user-attachments/assets/dbd45278-ae9b-4d44-ba49-f6acf3826e13

**Manual-test recording:**

https://github.com/user-attachments/assets/43486846-11ba-4a1c-af48-a204e0d0381e

## Screenshot of test suite run

**Review-fix tests — Blockers 1 & 2 (`go test ./internal/config ./internal/server`):**

![review-fix tests green](https://github.com/user-attachments/assets/edacedd6-739f-4829-a53c-b4d5f1bf6cc4)

**Full gateway suite — `go test ./...` (76 packages ok, 0 failed):**

![go test ./... — 76 packages ok, 0 failed](https://github.com/user-attachments/assets/4d150758-0bf6-4a1a-97e7-cdf8d314a23b)

**Precedence unit test — RED (buggy ordering) → GREEN (fix):**

![Precedence unit test RED to GREEN](https://github.com/user-attachments/assets/bb88ed14-6ed6-4392-8180-3a81e6a86bf0)

## Backwards compatibility

Gateway **behavior** changes without changing any request/response **schema**.

| Caller | Pre-PR behavior | Post-PR behavior |
|---|---|---|
| Gateway deploy with `AGENTCC_INTERNAL_API_KEY` set | Open — key never read | **Closed** — auth on; unauth → 401 |
| Backend / serving calling the gateway | Worked (gateway open) | Works — internal-typed key reaches the global providers |
| Deploy with **no** key set | Open | Still open (no key → no auth); key provisioning tracked in #799 |
| `AGENTCC_AUTH_ENABLED=false` **+** a key set | env block didn't exist | Auth stays **on** — key wins (fail closed) |
| Operator who set the same key as `internal` in config.yaml | n/a | Preserved — env seed no longer clobbers it |

## Manual verification

Against a gateway built from this branch with a key set:

| # | Env | Request | Expected | Result |
|---|-----|---------|----------|--------|
| 1 | key set | no auth header | 401 | ✅ 401 |
| 2 | key set | correct `Bearer` | 200 | ✅ 200 |
| 3 | key set + `AGENTCC_AUTH_ENABLED=false` | no auth header | 401 (key wins) | ✅ 401 |
| — | before fix | no auth header | — | 200 (open) |

```bash
# gateway up with AGENTCC_INTERNAL_API_KEY set (compose maps the gateway to :8090)
curl -i http://localhost:8090/v1/models                                   # no auth  -> 401
curl -i -H 'Authorization: Bearer <AGENTCC_INTERNAL_API_KEY>' \
     http://localhost:8090/v1/models                                      # with key -> 200
# precedence: restart the gateway with AGENTCC_AUTH_ENABLED=false AND the key still set
curl -i http://localhost:8090/v1/models                                   # still    -> 401 (key wins)
```

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

## Checklist

- [x] My code follows the style guide
- [x] I've added tests that prove my fix is effective (fail-closed precedence, internal-key reach, clobber guard)
- [x] No hardcoded secrets, URLs, or PII

## Backout / rollback

- The change is a self-contained block in `loadFromEnv` (+ a helper) plus tests — reverting removes it cleanly with no orphaned references.
- No DB schema change, no migration to roll back.
- Reverting returns the gateway to prior (open-by-default) behavior with no data loss.

## Linear

Closes TH-5712
