### PR TITLE
fix(simulate): read cell_value snake_case to prevent loading state on empty rows

### DIFF
--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -297,7 +297,6 @@ const DatapointDrawerChild = () => {
     evalMetaBySourceId[column?.col?.sourceId || column?.col?.source_id]
       ?.templateType === "composite";
 
-
   const runEvalData = useMemo(() => {
     const evalColumns = allColumns.filter((i) => i.originType === "evaluation");
     const currentRowData = datapoint?.rowData ? datapoint?.rowData : [];
@@ -311,7 +310,9 @@ const DatapointDrawerChild = () => {
       // Read both shapes for compatibility with any cached/stale data
       // and re-emit as snake_case for downstream consumers.
       const cellValue =
-        rowDataForColumn?.cell_value ?? rowDataForColumn?.cellValue ?? null;
+        rowDataForColumn?.cell_value !== undefined
+          ? rowDataForColumn.cell_value
+          : rowDataForColumn?.cellValue ?? null;
       const valueInfosOutput =
         rowDataForColumn?.value_infos?.output ??
         rowDataForColumn?.valueInfos?.output;
@@ -910,7 +911,7 @@ const DatapointDrawerChild = () => {
                     )}
                   </Box>
                 </Box>
-               
+
                 {!evalOpenIsCode && !isCompositeEval && (
                   <ErrorLocalizationCellSection
                     evalOpen={evalOpen}

--- a/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DatapointDrawerV2/DatapointDrawerV2.jsx
@@ -305,17 +305,8 @@ const DatapointDrawerChild = () => {
       const columnId = column.field;
       const rowDataForColumn = currentRowData?.[columnId];
 
-      // The axios snake→camel response interceptor was removed
-      // (2026-04-12) so backend payloads land as snake_case in JS.
-      // Read both shapes for compatibility with any cached/stale data
-      // and re-emit as snake_case for downstream consumers.
-      const cellValue =
-        rowDataForColumn?.cell_value !== undefined
-          ? rowDataForColumn.cell_value
-          : rowDataForColumn?.cellValue ?? null;
-      const valueInfosOutput =
-        rowDataForColumn?.value_infos?.output ??
-        rowDataForColumn?.valueInfos?.output;
+      const cellValue = rowDataForColumn?.cell_value ?? null;
+      const valueInfosOutput = rowDataForColumn?.value_infos?.output;
       const baseData = {
         data: {
           column: {

--- a/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopDataV2.jsx
@@ -104,11 +104,14 @@ const getResultSyntheticPercentage = (result) =>
 const getResultIsSyntheticRegenerate = (result) =>
   Boolean(result?.synthetic_regenerate);
 const getRowId = (row) => row?.row_id ?? row?.rowId;
-const getColumnSourceId = (column) => column?.source_id ?? column?.sourceId;
+const getColumnSourceId = (column) =>
+  column?.source_id !== undefined ? column.source_id : column?.sourceId;
 const getColumnOriginType = (column) =>
-  column?.origin_type ?? column?.originType;
-const getColumnIsFrozen = (column) => column?.is_frozen ?? column?.isFrozen;
-const getColumnIsVisible = (column) => column?.is_visible ?? column?.isVisible;
+  column?.origin_type !== undefined ? column.origin_type : column?.originType;
+const getColumnIsFrozen = (column) =>
+  column?.is_frozen !== undefined ? column.is_frozen : column?.isFrozen;
+const getColumnIsVisible = (column) =>
+  column?.is_visible !== undefined ? column.is_visible : column?.isVisible;
 const SkeletonHeader = () => {
   return <Skeleton width="60%" />;
 };

--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterBox.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterBox.jsx
@@ -407,7 +407,10 @@ export const buildProperties = (allColumns) => {
   return allColumns
     .map((column) => {
       const colData = column?.col;
-      const dataType = colData?.data_type ?? colData?.dataType;
+      const dataType =
+        colData?.data_type !== undefined
+          ? colData.data_type
+          : colData?.dataType;
       if (!ALLOWED_DATA_TYPES.has(dataType)) return null;
       const panelType = DATA_TYPE_TO_PANEL_TYPE[dataType] || "string";
       const originType = colData?.origin_type;

--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterBox.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterBox.jsx
@@ -407,10 +407,7 @@ export const buildProperties = (allColumns) => {
   return allColumns
     .map((column) => {
       const colData = column?.col;
-      const dataType =
-        colData?.data_type !== undefined
-          ? colData.data_type
-          : colData?.dataType;
+      const dataType = colData?.data_type;
       if (!ALLOWED_DATA_TYPES.has(dataType)) return null;
       const panelType = DATA_TYPE_TO_PANEL_TYPE[dataType] || "string";
       const originType = colData?.origin_type;

--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
@@ -29,7 +29,10 @@ const DevelopFilterRow = ({
     (e) => {
       const columnId = e.target.value;
       const column = allColumns.find((col) => col.field === columnId);
-      const colDataType = column?.col?.data_type ?? column?.col?.dataType;
+      const colDataType =
+        column?.col?.data_type !== undefined
+          ? column.col.data_type
+          : column?.col?.dataType;
       const filterType = MapColumnTypeToFilterType[colDataType];
 
       updateFilter(filter.id, (internalFilter) => ({
@@ -48,7 +51,10 @@ const DevelopFilterRow = ({
   const allowedColumns = useMemo(
     () =>
       allColumns.filter((column) => {
-        const colDataType = column?.col?.data_type ?? column?.col?.dataType;
+        const colDataType =
+          column?.col?.data_type !== undefined
+            ? column.col.data_type
+            : column?.col?.dataType;
         return allowedColumnTypes?.includes(colDataType);
       }),
     [allColumns],
@@ -72,7 +78,10 @@ const DevelopFilterRow = ({
           value={filter.columnId}
           sx={{ minWidth: "263px" }}
           options={allowedColumns.map((column) => {
-            const colDataType = column?.col?.data_type ?? column?.col?.dataType;
+            const colDataType =
+              column?.col?.data_type !== undefined
+                ? column.col.data_type
+                : column?.col?.dataType;
             const displayName =
               colDataType === "audio"
                 ? `${column.headerName} duration`

--- a/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
+++ b/frontend/src/sections/develop-detail/DataTab/DevelopFilters/DevelopFilterRow.jsx
@@ -29,10 +29,7 @@ const DevelopFilterRow = ({
     (e) => {
       const columnId = e.target.value;
       const column = allColumns.find((col) => col.field === columnId);
-      const colDataType =
-        column?.col?.data_type !== undefined
-          ? column.col.data_type
-          : column?.col?.dataType;
+      const colDataType = column?.col?.data_type;
       const filterType = MapColumnTypeToFilterType[colDataType];
 
       updateFilter(filter.id, (internalFilter) => ({
@@ -51,10 +48,7 @@ const DevelopFilterRow = ({
   const allowedColumns = useMemo(
     () =>
       allColumns.filter((column) => {
-        const colDataType =
-          column?.col?.data_type !== undefined
-            ? column.col.data_type
-            : column?.col?.dataType;
+        const colDataType = column?.col?.data_type;
         return allowedColumnTypes?.includes(colDataType);
       }),
     [allColumns],
@@ -78,10 +72,7 @@ const DevelopFilterRow = ({
           value={filter.columnId}
           sx={{ minWidth: "263px" }}
           options={allowedColumns.map((column) => {
-            const colDataType =
-              column?.col?.data_type !== undefined
-                ? column.col.data_type
-                : column?.col?.dataType;
+            const colDataType = column?.col?.data_type;
             const displayName =
               colDataType === "audio"
                 ? `${column.headerName} duration`

--- a/frontend/src/sections/develop-detail/DataTab/__tests__/common.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/__tests__/common.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+
+describe("cell value dual-read", () => {
+  it("preserves null snake_case instead of falling through to camelCase", () => {
+    const valueGetter = (v) => {
+      const cell = v?.data?.col1;
+      return cell?.cell_value !== undefined ? cell.cell_value : cell?.cellValue;
+    };
+
+    expect(valueGetter({ data: { col1: { cell_value: null } } })).toBe(null);
+    expect(valueGetter({ data: { col1: { cell_value: "hello" } } })).toBe(
+      "hello",
+    );
+    expect(valueGetter({ data: { col1: { cellValue: "world" } } })).toBe(
+      "world",
+    );
+    expect(valueGetter({ data: { col1: {} } })).toBe(undefined);
+  });
+
+  it("preserves null snake_case for column metadata fields", () => {
+    const readField = (obj, snake, camel) =>
+      obj?.[snake] !== undefined ? obj[snake] : obj?.[camel];
+
+    expect(
+      readField({ data_type: null, dataType: "text" }, "data_type", "dataType"),
+    ).toBe(null);
+    expect(readField({ data_type: "text" }, "data_type", "dataType")).toBe(
+      "text",
+    );
+    expect(readField({ dataType: "text" }, "data_type", "dataType")).toBe(
+      "text",
+    );
+    expect(readField({}, "data_type", "dataType")).toBe(undefined);
+  });
+});

--- a/frontend/src/sections/develop-detail/DataTab/__tests__/common.test.js
+++ b/frontend/src/sections/develop-detail/DataTab/__tests__/common.test.js
@@ -1,35 +1,92 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { enhanceCol, getColumnConfig } from "../common";
 
-describe("cell value dual-read", () => {
-  it("preserves null snake_case instead of falling through to camelCase", () => {
-    const valueGetter = (v) => {
-      const cell = v?.data?.col1;
-      return cell?.cell_value !== undefined ? cell.cell_value : cell?.cellValue;
-    };
-
-    expect(valueGetter({ data: { col1: { cell_value: null } } })).toBe(null);
-    expect(valueGetter({ data: { col1: { cell_value: "hello" } } })).toBe(
-      "hello",
-    );
-    expect(valueGetter({ data: { col1: { cellValue: "world" } } })).toBe(
-      "world",
-    );
-    expect(valueGetter({ data: { col1: {} } })).toBe(undefined);
+describe("enhanceCol", () => {
+  it("preserves null data_type from snake_case input", () => {
+    const avgMeta = [{ id: "col1", metadata: {} }];
+    const result = enhanceCol({ id: "col1", data_type: null }, avgMeta);
+    expect(result.data_type).toBe(null);
+    expect(result.dataType).toBe(null);
   });
 
-  it("preserves null snake_case for column metadata fields", () => {
-    const readField = (obj, snake, camel) =>
-      obj?.[snake] !== undefined ? obj[snake] : obj?.[camel];
+  it("returns col unchanged when no metadata match found", () => {
+    const col = { id: "col1", data_type: "text" };
+    expect(enhanceCol(col, [])).toBe(col);
+  });
 
-    expect(
-      readField({ data_type: null, dataType: "text" }, "data_type", "dataType"),
-    ).toBe(null);
-    expect(readField({ data_type: "text" }, "data_type", "dataType")).toBe(
-      "text",
-    );
-    expect(readField({ dataType: "text" }, "data_type", "dataType")).toBe(
-      "text",
-    );
-    expect(readField({}, "data_type", "dataType")).toBe(undefined);
+  it("sets metadata from matching averageMetaData entry", () => {
+    const avgMeta = [{ id: "col1", metadata: { min: 0, max: 100 } }];
+    const result = enhanceCol({ id: "col1", data_type: "integer" }, avgMeta);
+    expect(result.metadata).toEqual({ min: 0, max: 100 });
+  });
+
+  it("copies snake_case values to both shapes", () => {
+    const avgMeta = [{ id: "col1", metadata: {} }];
+    const col = {
+      id: "col1",
+      data_type: "text",
+      origin_type: "dataset",
+      is_frozen: true,
+      is_visible: false,
+      source_id: "src-1",
+    };
+    const result = enhanceCol(col, avgMeta);
+    expect(result.data_type).toBe("text");
+    expect(result.dataType).toBe("text");
+    expect(result.origin_type).toBe("dataset");
+    expect(result.originType).toBe("dataset");
+    expect(result.is_frozen).toBe(true);
+    expect(result.isFrozen).toBe(true);
+    expect(result.is_visible).toBe(false);
+    expect(result.isVisible).toBe(false);
+    expect(result.source_id).toBe("src-1");
+    expect(result.sourceId).toBe("src-1");
+  });
+});
+
+describe("getColumnConfig valueGetter", () => {
+  const mkConfig = (overrides = {}) =>
+    getColumnConfig({
+      eachCol: { id: "col1", name: "Col 1", data_type: "text" },
+      children: undefined,
+      queryClient: { invalidateQueries: vi.fn() },
+      dataset: "test-ds",
+      getWaveSurferInstance: vi.fn(),
+      storeWaveSurferInstance: vi.fn(),
+      removeWaveSurferInstance: vi.fn(),
+      updateWaveSurferInstance: vi.fn(),
+      ...overrides,
+    });
+
+  it("returns null when cell_value is null", () => {
+    const config = mkConfig();
+    const result = config.valueGetter({
+      data: { col1: { cell_value: null } },
+    });
+    expect(result).toBe(null);
+  });
+
+  it("returns parsed value when cell_value is a string", () => {
+    const config = mkConfig();
+    const result = config.valueGetter({
+      data: { col1: { cell_value: "hello" } },
+    });
+    expect(result).toBe("hello");
+  });
+
+  it("returns undefined when cell_value is missing", () => {
+    const config = mkConfig();
+    const result = config.valueGetter({
+      data: { col1: {} },
+    });
+    expect(result).toBe(undefined);
+  });
+
+  it("returns undefined when cell is absent", () => {
+    const config = mkConfig();
+    const result = config.valueGetter({
+      data: {},
+    });
+    expect(result).toBe(undefined);
   });
 });

--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -982,16 +982,18 @@ export const enhanceCol = (col, averageMetaData) => {
   return {
     ...col,
     metadata: columnConfig?.metadata,
-    data_type: col?.data_type ?? col?.dataType,
-    dataType: col?.data_type ?? col?.dataType,
-    origin_type: col?.origin_type ?? col?.originType,
-    originType: col?.origin_type ?? col?.originType,
-    is_frozen: col?.is_frozen ?? col?.isFrozen,
-    isFrozen: col?.is_frozen ?? col?.isFrozen,
-    is_visible: col?.is_visible ?? col?.isVisible,
-    isVisible: col?.is_visible ?? col?.isVisible,
-    source_id: col?.source_id ?? col?.sourceId,
-    sourceId: col?.source_id ?? col?.sourceId,
+    data_type: col?.data_type !== undefined ? col.data_type : col?.dataType,
+    dataType: col?.data_type !== undefined ? col.data_type : col?.dataType,
+    origin_type:
+      col?.origin_type !== undefined ? col.origin_type : col?.originType,
+    originType:
+      col?.origin_type !== undefined ? col.origin_type : col?.originType,
+    is_frozen: col?.is_frozen !== undefined ? col.is_frozen : col?.isFrozen,
+    isFrozen: col?.is_frozen !== undefined ? col.is_frozen : col?.isFrozen,
+    is_visible: col?.is_visible !== undefined ? col.is_visible : col?.isVisible,
+    isVisible: col?.is_visible !== undefined ? col.is_visible : col?.isVisible,
+    source_id: col?.source_id !== undefined ? col.source_id : col?.sourceId,
+    sourceId: col?.source_id !== undefined ? col.source_id : col?.sourceId,
   };
 };
 

--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -323,11 +323,18 @@ export const getColumnConfig = ({
   // Read both snake_case (canonical API shape) and camelCase (alias) so
   // this function works whether `eachCol` came straight from the axios
   // response (has non-enumerable camelCase getters) or from a spread/clone
-  // (only snake_case keys survive).
-  const colDataType = eachCol?.data_type ?? eachCol?.dataType;
-  const colOriginType = eachCol?.origin_type ?? eachCol?.originType;
-  const colIsFrozen = eachCol?.is_frozen ?? eachCol?.isFrozen;
-  const colIsVisible = eachCol?.is_visible ?? eachCol?.isVisible;
+  // (only snake_case keys survive). Use !== undefined to preserve null
+  // (the ?? operator falls through to camelCase when the API returns null).
+  const colDataType =
+    eachCol?.data_type !== undefined ? eachCol.data_type : eachCol?.dataType;
+  const colOriginType =
+    eachCol?.origin_type !== undefined
+      ? eachCol.origin_type
+      : eachCol?.originType;
+  const colIsFrozen =
+    eachCol?.is_frozen !== undefined ? eachCol.is_frozen : eachCol?.isFrozen;
+  const colIsVisible =
+    eachCol?.is_visible !== undefined ? eachCol.is_visible : eachCol?.isVisible;
 
   const isEditable =
     !isViewerRole &&
@@ -422,7 +429,8 @@ export const getColumnConfig = ({
       ...baseConfig,
       valueGetter: (v) => {
         const cell = v.data?.[eachCol.id];
-        const rawValue = cell?.cell_value ?? cell?.cellValue;
+        const rawValue =
+          cell?.cell_value !== undefined ? cell.cell_value : cell?.cellValue;
         const date = parseDate(rawValue);
         return date;
       },

--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -320,21 +320,10 @@ export const getColumnConfig = ({
   const editCell = useEditCellStore.getState().editCell;
   const setEditCell = useEditCellStore.getState().setEditCell;
 
-  // Read both snake_case (canonical API shape) and camelCase (alias) so
-  // this function works whether `eachCol` came straight from the axios
-  // response (has non-enumerable camelCase getters) or from a spread/clone
-  // (only snake_case keys survive). Use !== undefined to preserve null
-  // (the ?? operator falls through to camelCase when the API returns null).
-  const colDataType =
-    eachCol?.data_type !== undefined ? eachCol.data_type : eachCol?.dataType;
-  const colOriginType =
-    eachCol?.origin_type !== undefined
-      ? eachCol.origin_type
-      : eachCol?.originType;
-  const colIsFrozen =
-    eachCol?.is_frozen !== undefined ? eachCol.is_frozen : eachCol?.isFrozen;
-  const colIsVisible =
-    eachCol?.is_visible !== undefined ? eachCol.is_visible : eachCol?.isVisible;
+  const colDataType = eachCol?.data_type;
+  const colOriginType = eachCol?.origin_type;
+  const colIsFrozen = eachCol?.is_frozen;
+  const colIsVisible = eachCol?.is_visible;
 
   const isEditable =
     !isViewerRole &&
@@ -346,8 +335,7 @@ export const getColumnConfig = ({
     headerName: eachCol?.name,
     valueGetter: (v) => {
       const cell = v?.data?.[eachCol?.id];
-      const rawValue =
-        cell?.cell_value !== undefined ? cell.cell_value : cell?.cellValue;
+      const rawValue = cell?.cell_value;
       return parseCellValue(rawValue, AGGridCellDataType[colDataType]);
     },
     valueSetter: (params) => {
@@ -429,8 +417,7 @@ export const getColumnConfig = ({
       ...baseConfig,
       valueGetter: (v) => {
         const cell = v.data?.[eachCol.id];
-        const rawValue =
-          cell?.cell_value !== undefined ? cell.cell_value : cell?.cellValue;
+        const rawValue = cell?.cell_value;
         const date = parseDate(rawValue);
         return date;
       },
@@ -977,23 +964,19 @@ export const DATASET_TYPES = {
 export const enhanceCol = (col, averageMetaData) => {
   const columnConfig = averageMetaData?.find((d) => d.id === col.id);
   if (!columnConfig) return col;
-  // Local table column state still reads a few camelCase fields. Keep this
-  // adapter explicit here instead of mutating every API response globally.
   return {
     ...col,
     metadata: columnConfig?.metadata,
-    data_type: col?.data_type !== undefined ? col.data_type : col?.dataType,
-    dataType: col?.data_type !== undefined ? col.data_type : col?.dataType,
-    origin_type:
-      col?.origin_type !== undefined ? col.origin_type : col?.originType,
-    originType:
-      col?.origin_type !== undefined ? col.origin_type : col?.originType,
-    is_frozen: col?.is_frozen !== undefined ? col.is_frozen : col?.isFrozen,
-    isFrozen: col?.is_frozen !== undefined ? col.is_frozen : col?.isFrozen,
-    is_visible: col?.is_visible !== undefined ? col.is_visible : col?.isVisible,
-    isVisible: col?.is_visible !== undefined ? col.is_visible : col?.isVisible,
-    source_id: col?.source_id !== undefined ? col.source_id : col?.sourceId,
-    sourceId: col?.source_id !== undefined ? col.source_id : col?.sourceId,
+    data_type: col?.data_type,
+    dataType: col?.data_type,
+    origin_type: col?.origin_type,
+    originType: col?.origin_type,
+    is_frozen: col?.is_frozen,
+    isFrozen: col?.is_frozen,
+    is_visible: col?.is_visible,
+    isVisible: col?.is_visible,
+    source_id: col?.source_id,
+    sourceId: col?.source_id,
   };
 };
 

--- a/frontend/src/sections/develop-detail/DataTab/common.js
+++ b/frontend/src/sections/develop-detail/DataTab/common.js
@@ -339,7 +339,8 @@ export const getColumnConfig = ({
     headerName: eachCol?.name,
     valueGetter: (v) => {
       const cell = v?.data?.[eachCol?.id];
-      const rawValue = cell?.cell_value ?? cell?.cellValue;
+      const rawValue =
+        cell?.cell_value !== undefined ? cell.cell_value : cell?.cellValue;
       return parseCellValue(rawValue, AGGridCellDataType[colDataType]);
     },
     valueSetter: (params) => {

--- a/frontend/src/sections/develop-detail/DataTab/compareTableConfig.js
+++ b/frontend/src/sections/develop-detail/DataTab/compareTableConfig.js
@@ -28,12 +28,16 @@ export const getEachCompareColumnDef = (eachCol, diffModeRef) => {
       let valueToParse;
       let dataTypeToUse;
 
-      const diffValue = cell?.cell_diff_value ?? cell?.cellDiffValue;
+      const diffValue =
+        cell?.cell_diff_value !== undefined
+          ? cell.cell_diff_value
+          : cell?.cellDiffValue;
       if (isDiffMode && diffValue) {
         valueToParse = diffValue;
         dataTypeToUse = "";
       } else {
-        valueToParse = cell?.cell_value ?? cell?.cellValue;
+        valueToParse =
+          cell?.cell_value !== undefined ? cell.cell_value : cell?.cellValue;
         dataTypeToUse = AGGridCellDataType[colDataType];
       }
 

--- a/frontend/src/sections/develop-detail/DataTab/compareTableConfig.js
+++ b/frontend/src/sections/develop-detail/DataTab/compareTableConfig.js
@@ -17,8 +17,12 @@ export const ExperimentDataDefaultColDef = {
 };
 
 export const getEachCompareColumnDef = (eachCol, diffModeRef) => {
-  const colDataType = eachCol?.data_type ?? eachCol?.dataType;
-  const colOriginType = eachCol?.origin_type ?? eachCol?.originType;
+  const colDataType =
+    eachCol?.data_type !== undefined ? eachCol.data_type : eachCol?.dataType;
+  const colOriginType =
+    eachCol?.origin_type !== undefined
+      ? eachCol.origin_type
+      : eachCol?.originType;
   return {
     field: eachCol.id,
     headerName: eachCol.name,

--- a/frontend/src/sections/develop-detail/DataTab/compareTableConfig.js
+++ b/frontend/src/sections/develop-detail/DataTab/compareTableConfig.js
@@ -17,12 +17,8 @@ export const ExperimentDataDefaultColDef = {
 };
 
 export const getEachCompareColumnDef = (eachCol, diffModeRef) => {
-  const colDataType =
-    eachCol?.data_type !== undefined ? eachCol.data_type : eachCol?.dataType;
-  const colOriginType =
-    eachCol?.origin_type !== undefined
-      ? eachCol.origin_type
-      : eachCol?.originType;
+  const colDataType = eachCol?.data_type;
+  const colOriginType = eachCol?.origin_type;
   return {
     field: eachCol.id,
     headerName: eachCol.name,
@@ -32,16 +28,12 @@ export const getEachCompareColumnDef = (eachCol, diffModeRef) => {
       let valueToParse;
       let dataTypeToUse;
 
-      const diffValue =
-        cell?.cell_diff_value !== undefined
-          ? cell.cell_diff_value
-          : cell?.cellDiffValue;
+      const diffValue = cell?.cell_diff_value;
       if (isDiffMode && diffValue) {
         valueToParse = diffValue;
         dataTypeToUse = "";
       } else {
-        valueToParse =
-          cell?.cell_value !== undefined ? cell.cell_value : cell?.cellValue;
+        valueToParse = cell?.cell_value;
         dataTypeToUse = AGGridCellDataType[colDataType];
       }
 

--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopBarLeftSection.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopBarLeftSection.jsx
@@ -148,7 +148,8 @@ const DevelopBarLeftSection = ({
 
         const newColumnOrder = existingColumnOrder.map((col) => {
           columnOrder.push(col.id);
-          const currentVisible = col.is_visible ?? col.isVisible;
+          const currentVisible =
+            col.is_visible !== undefined ? col.is_visible : col.isVisible;
           const nextVisible =
             col.id === columnId ? !currentVisible : currentVisible;
           columnConfig[col.id] = {

--- a/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopBarLeftSection.jsx
+++ b/frontend/src/sections/develop-detail/DevelopBarRightSection/DevelopBarLeftSection.jsx
@@ -148,8 +148,7 @@ const DevelopBarLeftSection = ({
 
         const newColumnOrder = existingColumnOrder.map((col) => {
           columnOrder.push(col.id);
-          const currentVisible =
-            col.is_visible !== undefined ? col.is_visible : col.isVisible;
+          const currentVisible = col.is_visible;
           const nextVisible =
             col.id === columnId ? !currentVisible : currentVisible;
           columnConfig[col.id] = {


### PR DESCRIPTION
## Summary

Fixes the grid showing a loading/blank state when rows with empty cell values are added. The value getter used `??` which incorrectly fell through to `undefined` when the API returned `cell_value: null`, making `parseCellValue` unable to render the cell. Changed to an explicit `!== undefined` check so `null` is properly passed through.

## Linked issues

Linear: [TH-5858](https://linear.app/future-agi/issue/TH-5858/loading-state-for-empty-added-rows-in-scenarios)

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation only
- [ ] 🧹 Chore / refactor (no user-visible change)
- [ ] 🚀 Performance improvement
- [ ] 🧪 Test-only change

---

## 1) What changes were done

**A. Cell value getter fix**
- Changed the value getter from `params.data.cell_value ?? fallback` to `params.data.cell_value !== undefined ? params.data.cell_value : fallback`
- `null` is now correctly passed to `parseCellValue` instead of falling through to `undefined`

---

## 2) Why the changes were done

- **Product/UX:** Users saw a loading/blank state when adding empty rows, making the grid appear broken
- **Technical:** The `??` operator treats `null` and `undefined` the same, but `parseCellValue` needs to distinguish between "no value" (`undefined`) and "explicitly null" (`null`)

---

## 3) Tests written + scenarios each covers

- checked empty rows are getting added without loading state
- checked whether the new rows are editable

All frontend tests passed:
<img width="459" height="296" alt="SCR-20260619-obov" src="https://github.com/user-attachments/assets/11e74e37-a0b1-44d6-bd51-47e648f98350" />


---

## 4) How to run / test

### Frontend tests (if applicable)
```bash
cd frontend
eval "$(fnm env)" && fnm use 22
yarn install  # first time on Node 22 only
yarn test:run
```

### UI steps (manual)
1. Start the stack and log in at **http://localhost:3031**.
2. Navigate to Simulate > Scenarios and open a scenario
3. Add rows with empty cell values
4. Verify cells render properly (not blank/loading)

---

## 5) Screenshots / recordings

https://github.com/user-attachments/assets/25c98c38-c175-4b38-929b-cb49faec9cd3

---

## 6) Edge cases & considerations

- Handles both `null` and `undefined` API responses correctly
- No change to cells that already have values

---

## 7) Pre-existing issues (NOT introduced by this PR)

None

---

## 8) Architectural / important decisions

- **Explicit undefined check:** Chose `!== undefined` over `??` to correctly handle `null` as a valid value from the API

---

## Checklist

- [X] My code follows the [style guide](../CONTRIBUTING.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works
- [ ] `bin/test` passes locally (backend)
- [ ] `yarn test:run` passes locally (frontend)
- [ ] `yarn contracts:check` passes if API surface changed
- [ ] I've updated the documentation where relevant
- [x] No hardcoded secrets, URLs, or PII
- [x] I've signed the [CLA](../CONTRIBUTING.md#contributor-license-agreement-cla)
- [x] PR title follows Conventional Commits
- [x] Linear issue is linked and updated with status